### PR TITLE
CI: build, test, lint, and image scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+    groups:
+      web-deps:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,14 @@ jobs:
           severity: CRITICAL,HIGH
           exit-code: "1"
           ignore-unfixed: true
+
+  # Umbrella gate with a stable name for branch rulesets: matrix legs
+  # report as "images (brain)" etc., which rulesets can't reference.
+  ci-ok:
+    runs-on: ubuntu-latest
+    needs: [go, lint, web, images]
+    if: always()
+    steps:
+      - name: All jobs green
+        run: |
+          [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "false" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,94 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:0.8.4-pg18-trixie
+        env:
+          POSTGRES_USER: timothy
+          POSTGRES_PASSWORD: ci
+          POSTGRES_DB: timothy
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U timothy -d timothy"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test -race ./...
+      - name: Integration test
+        env:
+          DATABASE_URL: postgres://timothy:ci@localhost:5432/timothy
+        run: go test -race -tags integration ./internal/platform/...
+      - name: Vulnerability scan
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+
+  web:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.18.0
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Install
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Lint
+        run: npm run lint
+
+  images:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: [brain, gateway, memoryd]
+    steps:
+      - uses: actions/checkout@v5
+      - name: Build image
+        run: >-
+          docker build -f deploy/Dockerfile
+          --build-arg SERVICE=${{ matrix.service }}
+          -t timothy-${{ matrix.service }}:ci .
+      - name: Scan image
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: timothy-${{ matrix.service }}:ci
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          ignore-unfixed: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           --build-arg SERVICE=${{ matrix.service }}
           -t timothy-${{ matrix.service }}:ci .
       - name: Scan image
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: timothy-${{ matrix.service }}:ci
           severity: CRITICAL,HIGH


### PR DESCRIPTION
## What

- `go` job: build, vet, `test -race`, integration tests against a real pgvector/pg18 service container, govulncheck
- `lint` job: golangci-lint v2.12.2 (same pin as the Makefile)
- `web` job: npm ci, build, lint on Node 24.18.0 with npm cache
- `images` job: matrix build of all three service images from deploy/Dockerfile, each scanned by Trivy (fails on fixable CRITICAL/HIGH)
- Dependabot: weekly updates for actions, Go modules, and web deps (grouped)

## Why

Every change now lands through PRs — this gates them on the same checks used locally (make is canonical, CI runs native for speed) and adds the container-build coverage local verify doesn't exercise.

## Verification

- actionlint clean
- This PR's own run is the live test