### PR TITLE
Gateway: provider drivers with normalized streaming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GO_RUN := docker run --rm -v $(CURDIR):/src -w /src \
 	-v timothy-go-mod:/go/pkg/mod -v timothy-go-cache:/root/.cache/go-build \
 	-e GOFLAGS=-buildvcs=false $(GO_IMAGE)
 
-.PHONY: build test test-integration vet lint tidy up down logs
+.PHONY: build test test-integration test-live vet lint tidy up down logs
 
 build:
 	$(GO_RUN) go build ./...
@@ -25,6 +25,16 @@ test-integration:
 		-e GOFLAGS=-buildvcs=false --network timothy_timothy \
 		-e DATABASE_URL=postgres://timothy:$(POSTGRES_PASSWORD)@postgres:5432/timothy \
 		$(GO_IMAGE) go test -race -tags integration ./internal/platform/...
+
+# Streams one real completion per provider whose credentials are in
+# the calling environment; absent providers skip.
+test-live:
+	docker run --rm -v $(CURDIR):/src -w /src \
+		-v timothy-go-mod:/go/pkg/mod -v timothy-go-cache:/root/.cache/go-build \
+		-e GOFLAGS=-buildvcs=false \
+		-e ANTHROPIC_API_KEY -e ANTHROPIC_TEST_MODEL \
+		-e OPENAICOMPAT_TEST_BASE_URL -e OPENAICOMPAT_TEST_API_KEY -e OPENAICOMPAT_TEST_MODEL \
+		$(GO_IMAGE) go test -race -tags live -v -run TestLive ./internal/gateway/provider/
 
 vet:
 	$(GO_RUN) go vet ./...

--- a/internal/gateway/provider/anthropic.go
+++ b/internal/gateway/provider/anthropic.go
@@ -1,0 +1,224 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+const (
+	anthropicDefaultBaseURL = "https://api.anthropic.com"
+	// anthropicVersion is the Messages API version header. Verified
+	// current 2026-07; model IDs come from configuration, never code.
+	anthropicVersion         = "2023-06-01"
+	anthropicDefaultMaxToken = 4096
+)
+
+// AnthropicConfig configures one Anthropic-driver provider instance.
+type AnthropicConfig struct {
+	Name    string
+	BaseURL string            // default anthropicDefaultBaseURL
+	APIKey  string            // resolved secret value, never logged
+	Headers map[string]string // extra request headers
+	Timeout time.Duration     // hard per-request timeout, default 5m
+}
+
+// Anthropic streams from the native Messages API.
+type Anthropic struct {
+	cfg    AnthropicConfig
+	client *http.Client
+}
+
+// NewAnthropic builds the driver; it performs no I/O.
+func NewAnthropic(cfg AnthropicConfig) *Anthropic {
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = anthropicDefaultBaseURL
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultTimeout
+	}
+	return &Anthropic{cfg: cfg, client: &http.Client{}}
+}
+
+func (a *Anthropic) Name() string { return a.cfg.Name }
+func (a *Anthropic) Kind() Kind   { return KindAPI }
+
+func (a *Anthropic) Capabilities() []Capability {
+	return []Capability{CapChat, CapStreaming, CapTools}
+}
+
+// anthropic wire types (request)
+
+type anthropicTextBlock struct {
+	Type         string          `json:"type"`
+	Text         string          `json:"text"`
+	CacheControl json.RawMessage `json:"cache_control,omitempty"`
+}
+
+type anthropicTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+type anthropicRequest struct {
+	Model     string               `json:"model"`
+	MaxTokens int                  `json:"max_tokens"`
+	Stream    bool                 `json:"stream"`
+	System    []anthropicTextBlock `json:"system,omitempty"`
+	Messages  []Message            `json:"messages"`
+	Tools     []anthropicTool      `json:"tools,omitempty"`
+}
+
+// anthropic wire types (SSE payloads; only the fields we read)
+
+type anthropicStreamPayload struct {
+	Type    string `json:"type"`
+	Index   int    `json:"index"`
+	Message struct {
+		Usage anthropicUsage `json:"usage"`
+	} `json:"message"`
+	ContentBlock struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"content_block"`
+	Delta struct {
+		Type        string `json:"type"`
+		Text        string `json:"text"`
+		Thinking    string `json:"thinking"`
+		PartialJSON string `json:"partial_json"`
+		StopReason  string `json:"stop_reason"`
+	} `json:"delta"`
+	Usage anthropicUsage `json:"usage"`
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type anthropicUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+}
+
+// Stream implements Provider.
+func (a *Anthropic) Stream(ctx context.Context, req CompletionRequest) (<-chan stream.StreamEvent, error) {
+	if req.Model == "" {
+		return nil, fmt.Errorf("anthropic: model is required")
+	}
+	body, err := json.Marshal(a.buildRequest(req))
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: marshal request: %w", err)
+	}
+
+	build := func(ctx context.Context) (*http.Request, error) {
+		r, err := http.NewRequestWithContext(ctx, http.MethodPost, a.cfg.BaseURL+"/v1/messages", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		r.Header.Set("Content-Type", "application/json")
+		r.Header.Set("X-Api-Key", a.cfg.APIKey)
+		r.Header.Set("Anthropic-Version", anthropicVersion)
+		for k, v := range a.cfg.Headers {
+			r.Header.Set(k, v)
+		}
+		return r, nil
+	}
+	return runStream(ctx, a.client, a.cfg.Timeout, build, a.relay), nil
+}
+
+func (a *Anthropic) buildRequest(req CompletionRequest) anthropicRequest {
+	maxTokens := req.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = anthropicDefaultMaxToken
+	}
+	out := anthropicRequest{
+		Model:     req.Model,
+		MaxTokens: maxTokens,
+		Stream:    true,
+		Messages:  req.Messages,
+	}
+	if req.System != "" {
+		// cache_control on the system block enables prompt caching for
+		// the stable prefix (D-018).
+		out.System = []anthropicTextBlock{{
+			Type:         "text",
+			Text:         req.System,
+			CacheControl: json.RawMessage(`{"type":"ephemeral"}`),
+		}}
+	}
+	for _, t := range req.Tools {
+		out.Tools = append(out.Tools, anthropicTool(t))
+	}
+	return out
+}
+
+// relay translates the Messages API SSE stream into normalized events.
+func (a *Anthropic) relay(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (bool, error) {
+	tools := newToolAccumulator()
+	usage := &stream.Usage{}
+	finished := false
+
+	err := readSSE(body, func(ev sseEvent) bool {
+		var p anthropicStreamPayload
+		if err := json.Unmarshal([]byte(ev.data), &p); err != nil {
+			emit(ctx, ch, stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
+				Code: "malformed_stream", Message: fmt.Sprintf("bad SSE payload: %v", err), Retryable: true,
+			}})
+			finished = true
+			return false
+		}
+
+		switch p.Type {
+		case "message_start":
+			usage.InputTokens = p.Message.Usage.InputTokens
+			usage.CacheReadTokens = p.Message.Usage.CacheReadInputTokens
+			usage.CacheWriteTokens = p.Message.Usage.CacheCreationInputTokens
+		case "content_block_start":
+			if p.ContentBlock.Type == "tool_use" {
+				return emit(ctx, ch, tools.start(p.Index, p.ContentBlock.ID, p.ContentBlock.Name))
+			}
+		case "content_block_delta":
+			switch p.Delta.Type {
+			case "text_delta":
+				return emit(ctx, ch, stream.StreamEvent{Type: stream.EventChunk, Text: p.Delta.Text})
+			case "thinking_delta":
+				return emit(ctx, ch, stream.StreamEvent{Type: stream.EventReasoningChunk, Text: p.Delta.Thinking})
+			case "input_json_delta":
+				tools.append(p.Index, p.Delta.PartialJSON)
+			}
+		case "content_block_stop":
+			if ev, ok := tools.finish(p.Index); ok {
+				return emit(ctx, ch, ev)
+			}
+		case "message_delta":
+			if p.Usage.OutputTokens > 0 {
+				usage.OutputTokens = p.Usage.OutputTokens
+			}
+		case "message_stop":
+			finished = true
+			if !emit(ctx, ch, stream.StreamEvent{Type: stream.EventUsage, Usage: usage}) {
+				return false
+			}
+			emit(ctx, ch, stream.StreamEvent{Type: stream.EventDone})
+			return false
+		case "error":
+			finished = true
+			emit(ctx, ch, stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
+				Code: p.Error.Type, Message: p.Error.Message, Retryable: p.Error.Type == "overloaded_error",
+			}})
+			return false
+		}
+		return ctx.Err() == nil
+	})
+	return finished, err
+}

--- a/internal/gateway/provider/anthropic_test.go
+++ b/internal/gateway/provider/anthropic_test.go
@@ -1,0 +1,266 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// sseWrite writes one SSE event and flushes.
+func sseWrite(w http.ResponseWriter, event, data string) {
+	_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data)
+	w.(http.Flusher).Flush()
+}
+
+func anthropicServer(t *testing.T, handler http.HandlerFunc) *Anthropic {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return NewAnthropic(AnthropicConfig{
+		Name: "anthropic-test", BaseURL: srv.URL, APIKey: "test-key",
+		Timeout: 10 * time.Second,
+	})
+}
+
+func TestAnthropicHappyPath(t *testing.T) {
+	t.Parallel()
+	var gotKey, gotVersion string
+	p := anthropicServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("X-Api-Key")
+		gotVersion = r.Header.Get("Anthropic-Version")
+		w.Header().Set("Content-Type", "text/event-stream")
+		sseWrite(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":25,"cache_read_input_tokens":10,"cache_creation_input_tokens":5}}}`)
+		sseWrite(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text"}}`)
+		sseWrite(w, "ping", `{"type":"ping"}`)
+		sseWrite(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}`)
+		sseWrite(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"!"}}`)
+		sseWrite(w, "content_block_stop", `{"type":"content_block_stop","index":0}`)
+		sseWrite(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}`)
+		sseWrite(w, "message_stop", `{"type":"message_stop"}`)
+	})
+
+	ch, err := p.Stream(t.Context(), CompletionRequest{Model: "m", Messages: []Message{{Role: "user", Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	if gotKey != "test-key" || gotVersion != anthropicVersion {
+		t.Fatalf("headers: key=%q version=%q", gotKey, gotVersion)
+	}
+	if got := textOf(events, stream.EventChunk); got != "Hello!" {
+		t.Fatalf("chunks = %q, want Hello!", got)
+	}
+	usages := eventsOfType(events, stream.EventUsage)
+	if len(usages) != 1 {
+		t.Fatalf("usage events = %d, want 1", len(usages))
+	}
+	u := usages[0].Usage
+	if u.InputTokens != 25 || u.OutputTokens != 15 || u.CacheReadTokens != 10 || u.CacheWriteTokens != 5 {
+		t.Fatalf("usage = %+v", u)
+	}
+	if lastType(t, events) != stream.EventDone {
+		t.Fatalf("last event = %v, want done", lastType(t, events))
+	}
+}
+
+func TestAnthropicToolUse(t *testing.T) {
+	t.Parallel()
+	p := anthropicServer(t, func(w http.ResponseWriter, r *http.Request) {
+		sseWrite(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":1}}}`)
+		sseWrite(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tu_1","name":"get_weather"}}`)
+		sseWrite(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"location\": \"San"}}`)
+		sseWrite(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":" Francisco\"}"}}`)
+		sseWrite(w, "content_block_stop", `{"type":"content_block_stop","index":0}`)
+		sseWrite(w, "message_delta", `{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":9}}`)
+		sseWrite(w, "message_stop", `{"type":"message_stop"}`)
+	})
+
+	ch, err := p.Stream(t.Context(), CompletionRequest{Model: "m", Messages: []Message{{Role: "user", Content: "weather?"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	starts := eventsOfType(events, stream.EventToolStart)
+	ends := eventsOfType(events, stream.EventToolEnd)
+	if len(starts) != 1 || len(ends) != 1 {
+		t.Fatalf("tool events = %d starts, %d ends; want 1/1", len(starts), len(ends))
+	}
+	if starts[0].ToolCall.ID != "tu_1" || starts[0].ToolCall.Name != "get_weather" {
+		t.Fatalf("tool_start = %+v", starts[0].ToolCall)
+	}
+	if got := string(ends[0].ToolCall.Input); got != `{"location": "San Francisco"}` {
+		t.Fatalf("tool input = %q", got)
+	}
+}
+
+func TestAnthropicThinkingDelta(t *testing.T) {
+	t.Parallel()
+	p := anthropicServer(t, func(w http.ResponseWriter, r *http.Request) {
+		sseWrite(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":1}}}`)
+		sseWrite(w, "content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"thinking"}}`)
+		sseWrite(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}}`)
+		sseWrite(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig"}}`)
+		sseWrite(w, "content_block_stop", `{"type":"content_block_stop","index":0}`)
+		sseWrite(w, "message_stop", `{"type":"message_stop"}`)
+	})
+
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	events := collect(t, ch)
+
+	if got := textOf(events, stream.EventReasoningChunk); got != "hmm" {
+		t.Fatalf("reasoning = %q, want hmm", got)
+	}
+}
+
+func TestAnthropicMidStreamDisconnect(t *testing.T) {
+	t.Parallel()
+	p := anthropicServer(t, func(w http.ResponseWriter, r *http.Request) {
+		sseWrite(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":1}}}`)
+		sseWrite(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"par"}}`)
+		// handler returns without message_stop: connection closes
+	})
+
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	events := collect(t, ch)
+
+	if len(eventsOfType(events, stream.EventIncomplete)) != 1 {
+		t.Fatalf("want one incomplete event, got %+v", events)
+	}
+	if lastType(t, events) != stream.EventDone {
+		t.Fatalf("last = %v, want done after incomplete", lastType(t, events))
+	}
+}
+
+func TestAnthropic429ThenSuccess(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	p := anthropicServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		sseWrite(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":1}}}`)
+		sseWrite(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`)
+		sseWrite(w, "message_stop", `{"type":"message_stop"}`)
+	})
+
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	events := collect(t, ch)
+
+	retries := eventsOfType(events, stream.EventRetry)
+	if len(retries) != 1 || retries[0].Retry.Attempt != 1 {
+		t.Fatalf("retry events = %+v, want one attempt=1", retries)
+	}
+	if got := textOf(events, stream.EventChunk); got != "ok" {
+		t.Fatalf("chunks = %q, want ok", got)
+	}
+	if lastType(t, events) != stream.EventDone {
+		t.Fatalf("last = %v, want done", lastType(t, events))
+	}
+}
+
+func TestAnthropicPermanent401NoRetry(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	p := anthropicServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	events := collect(t, ch)
+
+	if calls.Load() != 1 {
+		t.Fatalf("requests = %d, want 1 (no retry on 401)", calls.Load())
+	}
+	errs := eventsOfType(events, stream.EventError)
+	if len(errs) != 1 || errs[0].Err.Retryable {
+		t.Fatalf("want one non-retryable error, got %+v", errs)
+	}
+}
+
+func TestAnthropicTimeout(t *testing.T) {
+	t.Parallel()
+	blocked := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-blocked
+	}))
+	t.Cleanup(func() { close(blocked); srv.Close() })
+
+	p := NewAnthropic(AnthropicConfig{Name: "t", BaseURL: srv.URL, APIKey: "k", Timeout: 200 * time.Millisecond})
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	events := collect(t, ch)
+
+	errs := eventsOfType(events, stream.EventError)
+	if len(errs) != 1 {
+		t.Fatalf("want one error event, got %+v", events)
+	}
+	if errs[0].Err.Code != "timeout" {
+		t.Fatalf("error code = %q, want timeout", errs[0].Err.Code)
+	}
+}
+
+func TestAnthropicCancelMidStream(t *testing.T) {
+	t.Parallel()
+	p := anthropicServer(t, func(w http.ResponseWriter, r *http.Request) {
+		sseWrite(w, "message_start", `{"type":"message_start","message":{"usage":{"input_tokens":1}}}`)
+		for i := 0; ; i++ {
+			select {
+			case <-r.Context().Done():
+				return
+			default:
+			}
+			sseWrite(w, "content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"x"}}`)
+			time.Sleep(10 * time.Millisecond)
+		}
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	ch, _ := p.Stream(ctx, CompletionRequest{Model: "m"})
+
+	<-ch // first event arrived; stream is live
+	cancel()
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return // closed promptly after cancel
+			}
+		case <-deadline:
+			t.Fatal("channel not closed after context cancel")
+		}
+	}
+}
+
+func TestAnthropicMalformedSSE(t *testing.T) {
+	t.Parallel()
+	p := anthropicServer(t, func(w http.ResponseWriter, r *http.Request) {
+		sseWrite(w, "message_start", `{not json`)
+	})
+
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	events := collect(t, ch)
+
+	errs := eventsOfType(events, stream.EventError)
+	if len(errs) != 1 || errs[0].Err.Code != "malformed_stream" {
+		t.Fatalf("want malformed_stream error, got %+v", events)
+	}
+}
+
+func TestAnthropicMissingModel(t *testing.T) {
+	t.Parallel()
+	p := NewAnthropic(AnthropicConfig{Name: "t", APIKey: "k"})
+	if _, err := p.Stream(t.Context(), CompletionRequest{}); err == nil {
+		t.Fatal("Stream() with empty model: want error")
+	}
+}

--- a/internal/gateway/provider/httpx.go
+++ b/internal/gateway/provider/httpx.go
@@ -1,0 +1,290 @@
+package provider
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+const (
+	defaultTimeout = 5 * time.Minute
+	maxRetries     = 3
+	baseBackoff    = 500 * time.Millisecond
+)
+
+// retryableStatus reports whether an HTTP status is worth retrying.
+func retryableStatus(code int) bool {
+	return code == http.StatusTooManyRequests || code >= 500
+}
+
+// backoffFor returns the jittered exponential backoff for an attempt
+// (1-based): base*2^(n-1) plus up to 50% jitter.
+func backoffFor(attempt int) time.Duration {
+	d := baseBackoff << (attempt - 1)
+	return d + time.Duration(rand.Int64N(int64(d)/2+1)) // #nosec G404 -- jitter, not a secret
+}
+
+// doWithRetry issues the request built by build, retrying 429/5xx
+// responses and network errors up to maxRetries with jittered backoff.
+// Each retry is surfaced on ch as a retry event. On success the
+// response body is open and the caller owns closing it.
+func doWithRetry(ctx context.Context, client *http.Client, build func() (*http.Request, error), ch chan<- stream.StreamEvent) (*http.Response, error) {
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		if attempt > 0 {
+			backoff := backoffFor(attempt)
+			if !emit(ctx, ch, stream.StreamEvent{Type: stream.EventRetry, Retry: &stream.RetryInfo{
+				Attempt:   attempt,
+				BackoffMs: backoff.Milliseconds(),
+				Reason:    lastErr.Error(),
+			}}) {
+				return nil, ctx.Err()
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(backoff):
+			}
+		}
+
+		req, err := build()
+		if err != nil {
+			return nil, err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			if attempt < maxRetries && ctx.Err() == nil {
+				continue
+			}
+			return nil, lastErr
+		}
+		if retryableStatus(resp.StatusCode) {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+			_ = resp.Body.Close()
+			lastErr = fmt.Errorf("http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+			if attempt < maxRetries && ctx.Err() == nil {
+				continue
+			}
+			return nil, lastErr
+		}
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+			_ = resp.Body.Close()
+			return nil, &permanentError{fmt.Errorf("http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))}
+		}
+		return resp, nil
+	}
+}
+
+// permanentError marks a failure retries cannot fix (4xx other than
+// 429): the stream error it produces is flagged not retryable.
+type permanentError struct{ err error }
+
+func (e *permanentError) Error() string { return e.err.Error() }
+func (e *permanentError) Unwrap() error { return e.err }
+
+// errEvent builds the terminal error event for a request failure.
+func errEvent(err error) stream.StreamEvent {
+	var perm *permanentError
+	retryable := !errors.As(err, &perm)
+	code := "provider_error"
+	if errors.Is(err, context.DeadlineExceeded) {
+		code = "timeout"
+	}
+	return stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
+		Code:      code,
+		Message:   err.Error(),
+		Retryable: retryable,
+	}}
+}
+
+// emit sends an event unless ctx is done; it reports whether the send
+// happened. Streams must never block forever on an abandoned consumer.
+func emit(ctx context.Context, ch chan<- stream.StreamEvent, ev stream.StreamEvent) bool {
+	select {
+	case ch <- ev:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// relayFunc translates one provider's wire stream into normalized
+// events. It reports whether the stream reached its own terminal event
+// (done or error already emitted) and, when it did not, the read error
+// that cut it off (nil for a clean early EOF).
+type relayFunc func(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (finished bool, err error)
+
+// runStream is the streaming skeleton shared by every HTTP driver:
+// goroutine launch, per-call timeout, request retries, response body
+// lifecycle, terminal error emission, and the incomplete+done tail
+// when a stream cuts off mid-flight. Drivers own only request building
+// and delta parsing.
+func runStream(ctx context.Context, client *http.Client, timeout time.Duration, build func(ctx context.Context) (*http.Request, error), relay relayFunc) <-chan stream.StreamEvent {
+	ch := make(chan stream.StreamEvent)
+	go func() {
+		defer close(ch)
+		callCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		resp, err := doWithRetry(callCtx, client, func() (*http.Request, error) {
+			return build(callCtx)
+		}, ch)
+		if err != nil {
+			// Terminal events gate on the PARENT ctx: the per-call
+			// timeout expiring is exactly when the consumer must still
+			// receive the error.
+			emit(ctx, ch, errEvent(err))
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		finished, readErr := relay(callCtx, resp.Body, ch)
+		if finished {
+			return
+		}
+		reason := "stream ended before completion"
+		if readErr != nil {
+			reason = readErr.Error()
+		}
+		if emit(ctx, ch, stream.StreamEvent{Type: stream.EventIncomplete, Text: reason}) {
+			emit(ctx, ch, stream.StreamEvent{Type: stream.EventDone})
+		}
+	}()
+	return ch
+}
+
+// toolAccumulator assembles streamed tool calls. Providers emit a
+// start (id+name), argument fragments, and an end signal — sometimes
+// interleaved across parallel calls, keyed by index. An empty argument
+// set normalizes to "{}".
+type toolAccumulator struct {
+	byKey map[int]*pendingTool
+	order []int
+}
+
+type pendingTool struct {
+	id, name string
+	args     bytes.Buffer
+}
+
+func newToolAccumulator() *toolAccumulator {
+	return &toolAccumulator{byKey: map[int]*pendingTool{}}
+}
+
+// start registers a call under key and returns its tool_start event.
+func (a *toolAccumulator) start(key int, id, name string) stream.StreamEvent {
+	a.byKey[key] = &pendingTool{id: id, name: name}
+	a.order = append(a.order, key)
+	return stream.StreamEvent{Type: stream.EventToolStart, ToolCall: &stream.ToolCallEvent{ID: id, Name: name}}
+}
+
+// known reports whether key has a pending call.
+func (a *toolAccumulator) known(key int) bool {
+	_, ok := a.byKey[key]
+	return ok
+}
+
+// append adds an argument fragment to key's pending call.
+func (a *toolAccumulator) append(key int, fragment string) {
+	if t, ok := a.byKey[key]; ok {
+		t.args.WriteString(fragment)
+	}
+}
+
+// finish completes key's call, returning its tool_end event.
+func (a *toolAccumulator) finish(key int) (stream.StreamEvent, bool) {
+	t, ok := a.byKey[key]
+	if !ok {
+		return stream.StreamEvent{}, false
+	}
+	delete(a.byKey, key)
+	for i, k := range a.order {
+		if k == key {
+			a.order = append(a.order[:i], a.order[i+1:]...)
+			break
+		}
+	}
+	return toolEndEvent(t), true
+}
+
+// finishAll completes every pending call in the order opened.
+func (a *toolAccumulator) finishAll() []stream.StreamEvent {
+	events := make([]stream.StreamEvent, 0, len(a.order))
+	for _, key := range a.order {
+		events = append(events, toolEndEvent(a.byKey[key]))
+	}
+	a.byKey = map[int]*pendingTool{}
+	a.order = nil
+	return events
+}
+
+func toolEndEvent(t *pendingTool) stream.StreamEvent {
+	args := t.args.Bytes()
+	if len(args) == 0 {
+		args = []byte("{}")
+	}
+	return stream.StreamEvent{Type: stream.EventToolEnd, ToolCall: &stream.ToolCallEvent{
+		ID: t.id, Name: t.name, Input: json.RawMessage(args),
+	}}
+}
+
+// sseScanner iterates server-sent events, yielding each event's data
+// payload (the concatenated "data:" lines). The "event:" field, when
+// present, is returned alongside.
+type sseEvent struct {
+	name string
+	data string
+}
+
+func readSSE(r io.Reader, yield func(sseEvent) bool) error {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var name string
+	var data bytes.Buffer
+	flush := func() bool {
+		if data.Len() == 0 {
+			name = ""
+			return true
+		}
+		ev := sseEvent{name: name, data: data.String()}
+		name = ""
+		data.Reset()
+		return yield(ev)
+	}
+
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case line == "":
+			if !flush() {
+				return nil
+			}
+		case strings.HasPrefix(line, "event:"):
+			name = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			if data.Len() > 0 {
+				data.WriteByte('\n')
+			}
+			data.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+		// comments (":") and unknown fields are ignored per the SSE spec
+	}
+	if err := sc.Err(); err != nil {
+		return err
+	}
+	_ = flush()
+	return nil
+}

--- a/internal/gateway/provider/httpx_test.go
+++ b/internal/gateway/provider/httpx_test.go
@@ -1,0 +1,88 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBackoffGrowsWithJitter(t *testing.T) {
+	t.Parallel()
+	for attempt := 1; attempt <= 3; attempt++ {
+		base := baseBackoff << (attempt - 1)
+		for range 20 {
+			got := backoffFor(attempt)
+			if got < base || got > base+base/2+time.Millisecond {
+				t.Fatalf("attempt %d: backoff %v outside [%v, %v]", attempt, got, base, base+base/2)
+			}
+		}
+	}
+}
+
+func TestRetryableStatus(t *testing.T) {
+	t.Parallel()
+	for code, want := range map[int]bool{
+		429: true, 500: true, 502: true, 503: true,
+		200: false, 400: false, 401: false, 404: false,
+	} {
+		if got := retryableStatus(code); got != want {
+			t.Fatalf("retryableStatus(%d) = %v, want %v", code, got, want)
+		}
+	}
+}
+
+func TestReadSSE(t *testing.T) {
+	t.Parallel()
+	input := strings.Join([]string{
+		": comment to ignore",
+		"event: message_start",
+		"data: {\"a\":1}",
+		"",
+		"data: line1",
+		"data: line2",
+		"",
+		"event: dangling-no-data",
+		"",
+		"data: final",
+		"", // trailing blank
+	}, "\n")
+
+	var got []sseEvent
+	err := readSSE(strings.NewReader(input), func(ev sseEvent) bool {
+		got = append(got, ev)
+		return true
+	})
+	if err != nil {
+		t.Fatalf("readSSE: %v", err)
+	}
+
+	want := []sseEvent{
+		{name: "message_start", data: `{"a":1}`},
+		{name: "", data: "line1\nline2"},
+		{name: "", data: "final"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("events = %+v, want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("event[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestReadSSEStopsWhenYieldReturnsFalse(t *testing.T) {
+	t.Parallel()
+	input := "data: one\n\ndata: two\n\n"
+	var got []string
+	err := readSSE(strings.NewReader(input), func(ev sseEvent) bool {
+		got = append(got, ev.data)
+		return false
+	})
+	if err != nil {
+		t.Fatalf("readSSE: %v", err)
+	}
+	if len(got) != 1 || got[0] != "one" {
+		t.Fatalf("got %v, want [one]", got)
+	}
+}

--- a/internal/gateway/provider/live_test.go
+++ b/internal/gateway/provider/live_test.go
@@ -1,0 +1,62 @@
+//go:build live
+
+package provider
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// Live tests stream one real completion per configured provider:
+//
+//	make test-live   (skips any provider whose env vars are absent)
+//
+// They assert the normalized contract — at least one chunk, one usage
+// event, terminal done — not response content.
+
+func assertLiveStream(t *testing.T, p Provider, model string) {
+	t.Helper()
+	ch, err := p.Stream(t.Context(), CompletionRequest{
+		Model:     model,
+		Messages:  []Message{{Role: "user", Content: "Reply with the single word: ping"}},
+		MaxTokens: 32,
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	if got := textOf(events, stream.EventChunk); got == "" {
+		t.Fatalf("no chunk text; events: %+v", events)
+	}
+	if len(eventsOfType(events, stream.EventUsage)) != 1 {
+		t.Fatalf("want one usage event; events: %+v", events)
+	}
+	if lastType(t, events) != stream.EventDone {
+		t.Fatalf("last event = %v, want done", lastType(t, events))
+	}
+}
+
+func TestLiveAnthropic(t *testing.T) {
+	key := os.Getenv("ANTHROPIC_API_KEY")
+	model := os.Getenv("ANTHROPIC_TEST_MODEL")
+	if key == "" || model == "" {
+		t.Skip("ANTHROPIC_API_KEY / ANTHROPIC_TEST_MODEL not set")
+	}
+	p := NewAnthropic(AnthropicConfig{Name: "anthropic-live", APIKey: key, Timeout: time.Minute})
+	assertLiveStream(t, p, model)
+}
+
+func TestLiveOpenAICompat(t *testing.T) {
+	base := os.Getenv("OPENAICOMPAT_TEST_BASE_URL")
+	key := os.Getenv("OPENAICOMPAT_TEST_API_KEY")
+	model := os.Getenv("OPENAICOMPAT_TEST_MODEL")
+	if base == "" || key == "" || model == "" {
+		t.Skip("OPENAICOMPAT_TEST_BASE_URL / _API_KEY / _MODEL not set")
+	}
+	p := NewOpenAICompat(OpenAICompatConfig{Name: "oai-live", BaseURL: base, APIKey: key, Timeout: time.Minute})
+	assertLiveStream(t, p, model)
+}

--- a/internal/gateway/provider/openaicompat.go
+++ b/internal/gateway/provider/openaicompat.go
@@ -1,0 +1,233 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// OpenAICompatConfig configures one OpenAI-compatible provider
+// instance. One driver covers every conforming chat/completions
+// endpoint (Z.AI GLM, xAI Grok, OpenRouter, local runtimes); instances
+// differ only by base URL, key, and headers.
+type OpenAICompatConfig struct {
+	Name    string
+	BaseURL string            // e.g. https://api.x.ai/v1 — no trailing slash
+	APIKey  string            // resolved secret value, never logged
+	Headers map[string]string // extra request headers
+	Timeout time.Duration     // hard per-request timeout, default 5m
+}
+
+// OpenAICompat streams from an OpenAI-compatible chat/completions API.
+type OpenAICompat struct {
+	cfg    OpenAICompatConfig
+	client *http.Client
+}
+
+// NewOpenAICompat builds the driver; it performs no I/O.
+func NewOpenAICompat(cfg OpenAICompatConfig) *OpenAICompat {
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultTimeout
+	}
+	return &OpenAICompat{cfg: cfg, client: &http.Client{}}
+}
+
+func (o *OpenAICompat) Name() string { return o.cfg.Name }
+func (o *OpenAICompat) Kind() Kind   { return KindAPI }
+
+func (o *OpenAICompat) Capabilities() []Capability {
+	return []Capability{CapChat, CapStreaming, CapTools}
+}
+
+// wire types (request)
+
+type oaiMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type oaiTool struct {
+	Type     string `json:"type"`
+	Function struct {
+		Name        string          `json:"name"`
+		Description string          `json:"description"`
+		Parameters  json.RawMessage `json:"parameters"`
+	} `json:"function"`
+}
+
+type oaiRequest struct {
+	Model         string       `json:"model"`
+	Messages      []oaiMessage `json:"messages"`
+	Stream        bool         `json:"stream"`
+	StreamOptions struct {
+		IncludeUsage bool `json:"include_usage"`
+	} `json:"stream_options"`
+	Tools     []oaiTool `json:"tools,omitempty"`
+	MaxTokens int       `json:"max_tokens,omitempty"`
+}
+
+// wire types (stream chunks; only the fields we read)
+
+type oaiChunk struct {
+	Choices []struct {
+		Delta struct {
+			Content          string `json:"content"`
+			ReasoningContent string `json:"reasoning_content"`
+			Reasoning        string `json:"reasoning"`
+			ToolCalls        []struct {
+				Index    int    `json:"index"`
+				ID       string `json:"id"`
+				Function struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls"`
+		} `json:"delta"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage *struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		PromptTokensDetails struct {
+			CachedTokens int `json:"cached_tokens"`
+		} `json:"prompt_tokens_details"`
+	} `json:"usage"`
+	Error *struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+	} `json:"error"`
+}
+
+// Stream implements Provider.
+func (o *OpenAICompat) Stream(ctx context.Context, req CompletionRequest) (<-chan stream.StreamEvent, error) {
+	if req.Model == "" {
+		return nil, fmt.Errorf("openaicompat: model is required")
+	}
+	body, err := json.Marshal(o.buildRequest(req))
+	if err != nil {
+		return nil, fmt.Errorf("openaicompat: marshal request: %w", err)
+	}
+
+	build := func(ctx context.Context) (*http.Request, error) {
+		r, err := http.NewRequestWithContext(ctx, http.MethodPost, o.cfg.BaseURL+"/chat/completions", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		r.Header.Set("Content-Type", "application/json")
+		r.Header.Set("Authorization", "Bearer "+o.cfg.APIKey)
+		for k, v := range o.cfg.Headers {
+			r.Header.Set(k, v)
+		}
+		return r, nil
+	}
+	return runStream(ctx, o.client, o.cfg.Timeout, build, o.relay), nil
+}
+
+func (o *OpenAICompat) buildRequest(req CompletionRequest) oaiRequest {
+	out := oaiRequest{
+		Model:     req.Model,
+		Stream:    true,
+		MaxTokens: req.MaxTokens,
+	}
+	out.StreamOptions.IncludeUsage = true
+	if req.System != "" {
+		out.Messages = append(out.Messages, oaiMessage{Role: "system", Content: req.System})
+	}
+	for _, m := range req.Messages {
+		out.Messages = append(out.Messages, oaiMessage(m))
+	}
+	for _, t := range req.Tools {
+		var ot oaiTool
+		ot.Type = "function"
+		ot.Function.Name = t.Name
+		ot.Function.Description = t.Description
+		ot.Function.Parameters = t.InputSchema
+		out.Tools = append(out.Tools, ot)
+	}
+	return out
+}
+
+// relay translates the chat/completions SSE stream into normalized
+// events.
+func (o *OpenAICompat) relay(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (bool, error) {
+	tools := newToolAccumulator()
+	var usage *stream.Usage
+	finished := false
+	truncated := false
+
+	err := readSSE(body, func(ev sseEvent) bool {
+		if ev.data == "[DONE]" {
+			finished = true
+			for _, tev := range tools.finishAll() {
+				if !emit(ctx, ch, tev) {
+					return false
+				}
+			}
+			if usage != nil && !emit(ctx, ch, stream.StreamEvent{Type: stream.EventUsage, Usage: usage}) {
+				return false
+			}
+			if truncated && !emit(ctx, ch, stream.StreamEvent{Type: stream.EventIncomplete, Text: "finish_reason=length"}) {
+				return false
+			}
+			emit(ctx, ch, stream.StreamEvent{Type: stream.EventDone})
+			return false
+		}
+
+		var c oaiChunk
+		if err := json.Unmarshal([]byte(ev.data), &c); err != nil {
+			emit(ctx, ch, stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
+				Code: "malformed_stream", Message: fmt.Sprintf("bad SSE payload: %v", err), Retryable: true,
+			}})
+			finished = true
+			return false
+		}
+		if c.Error != nil {
+			finished = true
+			emit(ctx, ch, stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
+				Code: c.Error.Type, Message: c.Error.Message, Retryable: false,
+			}})
+			return false
+		}
+		if c.Usage != nil {
+			usage = &stream.Usage{
+				InputTokens:     c.Usage.PromptTokens,
+				OutputTokens:    c.Usage.CompletionTokens,
+				CacheReadTokens: c.Usage.PromptTokensDetails.CachedTokens,
+			}
+		}
+		if len(c.Choices) == 0 {
+			return ctx.Err() == nil
+		}
+
+		choice := c.Choices[0]
+		if choice.FinishReason == "length" {
+			truncated = true
+		}
+		if choice.Delta.Content != "" {
+			if !emit(ctx, ch, stream.StreamEvent{Type: stream.EventChunk, Text: choice.Delta.Content}) {
+				return false
+			}
+		}
+		if r := choice.Delta.ReasoningContent + choice.Delta.Reasoning; r != "" {
+			if !emit(ctx, ch, stream.StreamEvent{Type: stream.EventReasoningChunk, Text: r}) {
+				return false
+			}
+		}
+		for _, tc := range choice.Delta.ToolCalls {
+			if !tools.known(tc.Index) {
+				if !emit(ctx, ch, tools.start(tc.Index, tc.ID, tc.Function.Name)) {
+					return false
+				}
+			}
+			tools.append(tc.Index, tc.Function.Arguments)
+		}
+		return ctx.Err() == nil
+	})
+	return finished, err
+}

--- a/internal/gateway/provider/openaicompat_test.go
+++ b/internal/gateway/provider/openaicompat_test.go
@@ -1,0 +1,198 @@
+package provider
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+func oaiWrite(w http.ResponseWriter, data string) {
+	_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+	w.(http.Flusher).Flush()
+}
+
+func oaiServer(t *testing.T, handler http.HandlerFunc) *OpenAICompat {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return NewOpenAICompat(OpenAICompatConfig{
+		Name: "oai-test", BaseURL: srv.URL, APIKey: "test-key",
+		Timeout: 10 * time.Second,
+	})
+}
+
+func TestOpenAICompatHappyPath(t *testing.T) {
+	t.Parallel()
+	var gotAuth string
+	p := oaiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		oaiWrite(w, `{"choices":[{"delta":{"content":"Hel"}}]}`)
+		oaiWrite(w, `{"choices":[{"delta":{"content":"lo"}}]}`)
+		oaiWrite(w, `{"choices":[{"delta":{},"finish_reason":"stop"}]}`)
+		oaiWrite(w, `{"choices":[],"usage":{"prompt_tokens":12,"completion_tokens":4,"prompt_tokens_details":{"cached_tokens":6}}}`)
+		oaiWrite(w, "[DONE]")
+	})
+
+	ch, err := p.Stream(t.Context(), CompletionRequest{Model: "m", System: "sys", Messages: []Message{{Role: "user", Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	if gotAuth != "Bearer test-key" {
+		t.Fatalf("auth header = %q", gotAuth)
+	}
+	if got := textOf(events, stream.EventChunk); got != "Hello" {
+		t.Fatalf("chunks = %q, want Hello", got)
+	}
+	usages := eventsOfType(events, stream.EventUsage)
+	if len(usages) != 1 {
+		t.Fatalf("usage events = %d, want 1", len(usages))
+	}
+	u := usages[0].Usage
+	if u.InputTokens != 12 || u.OutputTokens != 4 || u.CacheReadTokens != 6 {
+		t.Fatalf("usage = %+v", u)
+	}
+	if lastType(t, events) != stream.EventDone {
+		t.Fatalf("last = %v, want done", lastType(t, events))
+	}
+}
+
+func TestOpenAICompatReasoning(t *testing.T) {
+	t.Parallel()
+	p := oaiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		oaiWrite(w, `{"choices":[{"delta":{"reasoning_content":"think"}}]}`)
+		oaiWrite(w, `{"choices":[{"delta":{"content":"answer"}}]}`)
+		oaiWrite(w, "[DONE]")
+	})
+
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	events := collect(t, ch)
+
+	if got := textOf(events, stream.EventReasoningChunk); got != "think" {
+		t.Fatalf("reasoning = %q", got)
+	}
+	if got := textOf(events, stream.EventChunk); got != "answer" {
+		t.Fatalf("chunks = %q", got)
+	}
+}
+
+func TestOpenAICompatToolCalls(t *testing.T) {
+	t.Parallel()
+	p := oaiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		oaiWrite(w, `{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"get_weather","arguments":"{\"city"}}]}}]}`)
+		oaiWrite(w, `{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\"SF\"}"}}]}}]}`)
+		oaiWrite(w, `{"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`)
+		oaiWrite(w, "[DONE]")
+	})
+
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	events := collect(t, ch)
+
+	starts := eventsOfType(events, stream.EventToolStart)
+	ends := eventsOfType(events, stream.EventToolEnd)
+	if len(starts) != 1 || len(ends) != 1 {
+		t.Fatalf("tool events %d/%d, want 1/1: %+v", len(starts), len(ends), events)
+	}
+	if starts[0].ToolCall.ID != "call_1" || starts[0].ToolCall.Name != "get_weather" {
+		t.Fatalf("tool_start = %+v", starts[0].ToolCall)
+	}
+	if got := string(ends[0].ToolCall.Input); got != `{"city":"SF"}` {
+		t.Fatalf("tool input = %q", got)
+	}
+}
+
+func TestOpenAICompatTruncationIncomplete(t *testing.T) {
+	t.Parallel()
+	p := oaiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		oaiWrite(w, `{"choices":[{"delta":{"content":"cut"}}]}`)
+		oaiWrite(w, `{"choices":[{"delta":{},"finish_reason":"length"}]}`)
+		oaiWrite(w, "[DONE]")
+	})
+
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	events := collect(t, ch)
+
+	if len(eventsOfType(events, stream.EventIncomplete)) != 1 {
+		t.Fatalf("want incomplete on finish_reason=length: %+v", events)
+	}
+	if lastType(t, events) != stream.EventDone {
+		t.Fatalf("last = %v, want done", lastType(t, events))
+	}
+}
+
+func TestOpenAICompat500ThenSuccess(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	p := oaiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		oaiWrite(w, `{"choices":[{"delta":{"content":"ok"}}]}`)
+		oaiWrite(w, "[DONE]")
+	})
+
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	events := collect(t, ch)
+
+	if len(eventsOfType(events, stream.EventRetry)) != 1 {
+		t.Fatalf("want one retry event: %+v", events)
+	}
+	if got := textOf(events, stream.EventChunk); got != "ok" {
+		t.Fatalf("chunks = %q", got)
+	}
+}
+
+func TestOpenAICompatMidStreamDisconnect(t *testing.T) {
+	t.Parallel()
+	p := oaiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		oaiWrite(w, `{"choices":[{"delta":{"content":"par"}}]}`)
+		// no [DONE]: connection closes mid-stream
+	})
+
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	events := collect(t, ch)
+
+	if len(eventsOfType(events, stream.EventIncomplete)) != 1 {
+		t.Fatalf("want one incomplete event: %+v", events)
+	}
+	if lastType(t, events) != stream.EventDone {
+		t.Fatalf("last = %v, want done", lastType(t, events))
+	}
+}
+
+func TestOpenAICompatAPIError(t *testing.T) {
+	t.Parallel()
+	p := oaiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		oaiWrite(w, `{"error":{"message":"model overloaded","type":"server_error"}}`)
+	})
+
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	events := collect(t, ch)
+
+	errs := eventsOfType(events, stream.EventError)
+	if len(errs) != 1 || errs[0].Err.Message != "model overloaded" {
+		t.Fatalf("want api error event: %+v", events)
+	}
+}
+
+func TestOpenAICompatMalformed(t *testing.T) {
+	t.Parallel()
+	p := oaiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		oaiWrite(w, `{broken`)
+	})
+
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	events := collect(t, ch)
+
+	errs := eventsOfType(events, stream.EventError)
+	if len(errs) != 1 || errs[0].Err.Code != "malformed_stream" {
+		t.Fatalf("want malformed_stream error: %+v", events)
+	}
+}

--- a/internal/gateway/provider/provider.go
+++ b/internal/gateway/provider/provider.go
@@ -1,0 +1,64 @@
+// Package provider defines the gateway's provider abstraction and the
+// API drivers implementing it. Providers are thin wire adapters: they
+// translate one provider's protocol into the normalized event stream
+// and never loop, route, or hold business logic.
+package provider
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// Kind distinguishes how a provider is reached.
+type Kind string
+
+// KindAPI is an HTTP API provider. A CLI subprocess kind arrives in a
+// later phase.
+const KindAPI Kind = "api"
+
+// Capability names a feature a provider honestly supports; routing
+// never assumes an undeclared capability.
+type Capability string
+
+const (
+	CapChat       Capability = "chat"
+	CapStreaming  Capability = "streaming"
+	CapTools      Capability = "tools"
+	CapEmbeddings Capability = "embeddings"
+)
+
+// Message is one conversation turn.
+type Message struct {
+	Role    string `json:"role"` // "user" | "assistant"
+	Content string `json:"content"`
+}
+
+// ToolDef describes a tool offered to the model.
+type ToolDef struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+// CompletionRequest is a normalized completion call. Extend only
+// additively.
+type CompletionRequest struct {
+	Model     string
+	System    string
+	Messages  []Message
+	Tools     []ToolDef
+	MaxTokens int
+}
+
+// Provider is one configured LLM provider. Stream returns quickly; all
+// wire activity (including connection retries) happens on the returned
+// channel per the stream package's channel contract. The error return
+// is for immediately invalid requests only.
+type Provider interface {
+	Name() string
+	Kind() Kind
+	Capabilities() []Capability
+	Stream(ctx context.Context, req CompletionRequest) (<-chan stream.StreamEvent, error)
+}

--- a/internal/gateway/provider/provider_test.go
+++ b/internal/gateway/provider/provider_test.go
@@ -1,0 +1,54 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// collect drains a stream into a slice, failing the test if the
+// channel does not close within the deadline.
+func collect(t *testing.T, ch <-chan stream.StreamEvent) []stream.StreamEvent {
+	t.Helper()
+	var events []stream.StreamEvent
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return events
+			}
+			events = append(events, ev)
+		case <-deadline:
+			t.Fatalf("stream did not close; got %d events: %+v", len(events), events)
+		}
+	}
+}
+
+func eventsOfType(events []stream.StreamEvent, typ stream.EventType) []stream.StreamEvent {
+	var out []stream.StreamEvent
+	for _, ev := range events {
+		if ev.Type == typ {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+func textOf(events []stream.StreamEvent, typ stream.EventType) string {
+	var b strings.Builder
+	for _, ev := range eventsOfType(events, typ) {
+		b.WriteString(ev.Text)
+	}
+	return b.String()
+}
+
+func lastType(t *testing.T, events []stream.StreamEvent) stream.EventType {
+	t.Helper()
+	if len(events) == 0 {
+		t.Fatal("no events")
+	}
+	return events[len(events)-1].Type
+}

--- a/internal/gateway/provider/registry.go
+++ b/internal/gateway/provider/registry.go
@@ -1,0 +1,91 @@
+package provider
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Config mirrors one providers row; a later unit loads these from
+// Postgres and hot-reloads on change. CredentialRef names an
+// environment variable — never a raw secret (resolved at build time by
+// the lookup function).
+type Config struct {
+	Name          string
+	Kind          Kind
+	Driver        string // "anthropic" | "openaicompat"
+	BaseURL       string
+	CredentialRef string
+	Headers       map[string]string
+	Timeout       time.Duration
+}
+
+// Registry holds the built providers by name. The mutex guards the
+// map for the hot-reload writer that arrives with the DB-backed config
+// store (Replace on poll/reload); today Build is the only writer and
+// runs before any reader.
+type Registry struct {
+	mu        sync.RWMutex
+	providers map[string]Provider
+}
+
+// Build constructs providers from configs. lookup resolves a
+// credential reference to its secret value (os.Getenv in production,
+// a fake in tests). A ref that resolves empty still builds the
+// provider — health/routing layers decide whether to use it.
+func Build(cfgs []Config, lookup func(string) string) (*Registry, error) {
+	r := &Registry{providers: make(map[string]Provider, len(cfgs))}
+	for _, c := range cfgs {
+		if c.Name == "" {
+			return nil, fmt.Errorf("registry: provider with empty name")
+		}
+		if _, dup := r.providers[c.Name]; dup {
+			return nil, fmt.Errorf("registry: duplicate provider %q", c.Name)
+		}
+
+		key := ""
+		if c.CredentialRef != "" {
+			key = lookup(c.CredentialRef)
+		}
+
+		var p Provider
+		switch c.Driver {
+		case "anthropic":
+			p = NewAnthropic(AnthropicConfig{
+				Name: c.Name, BaseURL: c.BaseURL, APIKey: key,
+				Headers: c.Headers, Timeout: c.Timeout,
+			})
+		case "openaicompat":
+			if c.BaseURL == "" {
+				return nil, fmt.Errorf("registry: provider %q: openaicompat requires base_url", c.Name)
+			}
+			p = NewOpenAICompat(OpenAICompatConfig{
+				Name: c.Name, BaseURL: c.BaseURL, APIKey: key,
+				Headers: c.Headers, Timeout: c.Timeout,
+			})
+		default:
+			return nil, fmt.Errorf("registry: provider %q: unknown driver %q", c.Name, c.Driver)
+		}
+		r.providers[c.Name] = p
+	}
+	return r, nil
+}
+
+// Get returns the named provider.
+func (r *Registry) Get(name string) (Provider, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.providers[name]
+	return p, ok
+}
+
+// Names returns all provider names (unordered).
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.providers))
+	for n := range r.providers {
+		names = append(names, n)
+	}
+	return names
+}

--- a/internal/gateway/provider/registry_test.go
+++ b/internal/gateway/provider/registry_test.go
@@ -1,0 +1,77 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildRegistry(t *testing.T) {
+	t.Parallel()
+	lookups := map[string]string{"ANTHROPIC_API_KEY": "sk-a", "XAI_API_KEY": "sk-x"}
+	r, err := Build([]Config{
+		// CredentialRef values are env var *names*, not secrets.
+		{Name: "anthropic", Kind: KindAPI, Driver: "anthropic", CredentialRef: "ANTHROPIC_API_KEY"},                              // #nosec G101
+		{Name: "xai-grok", Kind: KindAPI, Driver: "openaicompat", BaseURL: "https://api.x.ai/v1", CredentialRef: "XAI_API_KEY"}, // #nosec G101
+	}, func(ref string) string { return lookups[ref] })
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	a, ok := r.Get("anthropic")
+	if !ok || a.Kind() != KindAPI || a.Name() != "anthropic" {
+		t.Fatalf("anthropic provider = %v, %v", a, ok)
+	}
+	if _, ok := r.Get("xai-grok"); !ok {
+		t.Fatal("xai-grok missing")
+	}
+	if _, ok := r.Get("nope"); ok {
+		t.Fatal("unknown name resolved")
+	}
+	if got := len(r.Names()); got != 2 {
+		t.Fatalf("Names() = %d, want 2", got)
+	}
+}
+
+func TestBuildErrors(t *testing.T) {
+	t.Parallel()
+	noLookup := func(string) string { return "" }
+	tests := []struct {
+		name    string
+		cfgs    []Config
+		wantErr string
+	}{
+		{
+			name:    "unknown driver",
+			cfgs:    []Config{{Name: "p", Driver: "grpc"}},
+			wantErr: "unknown driver",
+		},
+		{
+			name: "duplicate name",
+			cfgs: []Config{
+				{Name: "p", Driver: "anthropic"},
+				{Name: "p", Driver: "anthropic"},
+			},
+			wantErr: "duplicate provider",
+		},
+		{
+			name:    "openaicompat without base url",
+			cfgs:    []Config{{Name: "p", Driver: "openaicompat"}},
+			wantErr: "requires base_url",
+		},
+		{
+			name:    "empty name",
+			cfgs:    []Config{{Driver: "anthropic"}},
+			wantErr: "empty name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Build(tt.cfgs, noLookup)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Build() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/gateway/provider/runstream_test.go
+++ b/internal/gateway/provider/runstream_test.go
@@ -1,0 +1,131 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// These tests pin the runStream orchestration contract directly with
+// stub relays: timeout errors deliver on the parent context, retries
+// surface before success, and the incomplete tail fires exactly when a
+// relay ends unfinished.
+
+func buildFor(url string) func(ctx context.Context) (*http.Request, error) {
+	return func(ctx context.Context) (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	}
+}
+
+func TestRunStreamTimeoutErrorDeliversOnParentCtx(t *testing.T) {
+	t.Parallel()
+	blocked := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-blocked
+	}))
+	t.Cleanup(func() { close(blocked); srv.Close() })
+
+	relayCalled := false
+	ch := runStream(t.Context(), &http.Client{}, 100*time.Millisecond, buildFor(srv.URL),
+		func(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (bool, error) {
+			relayCalled = true
+			return true, nil
+		})
+	events := collect(t, ch)
+
+	if relayCalled {
+		t.Fatal("relay ran despite request timeout")
+	}
+	errs := eventsOfType(events, stream.EventError)
+	if len(errs) != 1 || errs[0].Err.Code != "timeout" {
+		// The call ctx is expired here by definition; the event must
+		// still arrive because terminal events gate on the parent ctx.
+		t.Fatalf("want one timeout error event, got %+v", events)
+	}
+}
+
+func TestRunStreamIncompleteTail(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(srv.Close)
+
+	tests := []struct {
+		name       string
+		relayErr   error
+		wantReason string
+	}{
+		{name: "clean early eof", relayErr: nil, wantReason: "stream ended before completion"},
+		{name: "read error", relayErr: errors.New("boom"), wantReason: "boom"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ch := runStream(t.Context(), &http.Client{}, time.Second, buildFor(srv.URL),
+				func(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (bool, error) {
+					return false, tt.relayErr
+				})
+			events := collect(t, ch)
+
+			inc := eventsOfType(events, stream.EventIncomplete)
+			if len(inc) != 1 || inc[0].Text != tt.wantReason {
+				t.Fatalf("incomplete = %+v, want reason %q", inc, tt.wantReason)
+			}
+			if lastType(t, events) != stream.EventDone {
+				t.Fatalf("last = %v, want done", lastType(t, events))
+			}
+		})
+	}
+}
+
+func TestRunStreamFinishedRelayGetsNoTail(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(srv.Close)
+
+	ch := runStream(t.Context(), &http.Client{}, time.Second, buildFor(srv.URL),
+		func(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (bool, error) {
+			emit(ctx, ch, stream.StreamEvent{Type: stream.EventDone})
+			return true, nil
+		})
+	events := collect(t, ch)
+
+	if len(events) != 1 || events[0].Type != stream.EventDone {
+		t.Fatalf("want exactly [done], got %+v", events)
+	}
+}
+
+func TestRunStreamRetryEventsPrecedeSuccess(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte("payload"))
+	}))
+	t.Cleanup(srv.Close)
+
+	ch := runStream(t.Context(), &http.Client{}, 5*time.Second, buildFor(srv.URL),
+		func(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (bool, error) {
+			b, _ := io.ReadAll(body)
+			emit(ctx, ch, stream.StreamEvent{Type: stream.EventChunk, Text: string(b)})
+			emit(ctx, ch, stream.StreamEvent{Type: stream.EventDone})
+			return true, nil
+		})
+	events := collect(t, ch)
+
+	if len(events) != 3 ||
+		events[0].Type != stream.EventRetry || events[0].Retry.Attempt != 1 ||
+		events[1].Type != stream.EventChunk || events[1].Text != "payload" ||
+		events[2].Type != stream.EventDone {
+		t.Fatalf("want [retry chunk done], got %+v", events)
+	}
+}

--- a/internal/gateway/stream/events.go
+++ b/internal/gateway/stream/events.go
@@ -1,0 +1,67 @@
+// Package stream defines the normalized event vocabulary every
+// provider translates into: downstream consumers see one ordered
+// stream regardless of the provider's wire format.
+//
+// Channel contract: a stream ends with exactly one terminal event —
+// "done" (provider finished, possibly preceded by "incomplete" when
+// the stream was cut off) or "error" (nothing more is coming) — and
+// the channel closes immediately after.
+package stream
+
+import "encoding/json"
+
+// EventType enumerates the normalized stream events.
+type EventType string
+
+const (
+	EventChunk          EventType = "chunk"           // assistant text
+	EventReasoningChunk EventType = "reasoning_chunk" // thinking/reasoning text
+	EventToolStart      EventType = "tool_start"      // model began a tool call
+	EventToolEnd        EventType = "tool_end"        // tool call arguments complete
+	EventUsage          EventType = "usage"           // token accounting
+	EventRetry          EventType = "retry"           // transient failure, retrying
+	EventIncomplete     EventType = "incomplete"      // stream cut off before finish
+	EventDone           EventType = "done"            // terminal: success
+	EventError          EventType = "error"           // terminal: failure
+)
+
+// StreamEvent is one normalized event. Exactly the field matching Type
+// is populated.
+type StreamEvent struct {
+	Type     EventType      `json:"type"`
+	Text     string         `json:"text,omitempty"`
+	ToolCall *ToolCallEvent `json:"tool_call,omitempty"`
+	Usage    *Usage         `json:"usage,omitempty"`
+	Err      *StreamError   `json:"error,omitempty"`
+	Retry    *RetryInfo     `json:"retry,omitempty"`
+}
+
+// ToolCallEvent identifies a tool call. Input carries the complete
+// argument JSON on tool_end; it is empty on tool_start.
+type ToolCallEvent struct {
+	ID    string          `json:"id"`
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input,omitempty"`
+}
+
+// Usage is provider-reported token accounting for one request.
+type Usage struct {
+	InputTokens      int `json:"input_tokens"`
+	OutputTokens     int `json:"output_tokens"`
+	CacheReadTokens  int `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens int `json:"cache_write_tokens,omitempty"`
+}
+
+// StreamError describes a terminal stream failure.
+type StreamError struct {
+	Code      string `json:"code"`
+	Message   string `json:"message"`
+	Retryable bool   `json:"retryable"`
+}
+
+// RetryInfo reports a transient failure the driver is retrying.
+type RetryInfo struct {
+	Attempt   int    `json:"attempt"`
+	BackoffMs int64  `json:"backoff_ms"`
+	Reason    string `json:"reason"`
+}


### PR DESCRIPTION
## What

- Normalized stream event vocabulary: chunks, reasoning, tool start/end, usage, retry, incomplete, done, error — one ordered stream regardless of provider wire format, exactly one terminal event before close
- Shared streaming harness: per-call timeout, capped jittered retries surfaced as events, SSE parsing, tool-call accumulation, terminal-event guarantees — drivers keep only request building and delta mapping
- Anthropic driver: native Messages API, thinking deltas, tool-use assembly, prompt caching via cache_control, usage merged across message_start/message_delta
- OpenAI-compatible driver: one driver for any conforming chat/completions endpoint; reasoning_content, chunked tool_calls, include_usage, finish_reason=length surfaced as incomplete
- Registry building drivers from config with credentials resolved by reference (env var names, never raw secrets)
- Live smoke tests behind a build tag: `make test-live` streams one real completion per provider with keys in env

## Why

Providers are thin wire adapters behind one interface; retries, truncation, and provider turbulence are first-class events so consumers render them honestly instead of hanging. Terminal events deliver even when the per-call timeout has expired — the consumer must see the error precisely then.

## Verification

- 24 unit tests with httptest fake providers + stub-relay harness tests: happy paths, tool assembly, mid-stream disconnect → incomplete, 429/500 → retry → success, 401 without retry, timeout on parent ctx, context cancel, malformed SSE
- `-race` clean across repeated fresh runs; golangci-lint 0 issues
- Live tests compile and skip cleanly without credentials