### PR TITLE
CI: cancel superseded runs on PR pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: read
 
+# A new push to a PR cancels that PR's in-flight run; pushes to main
+# never cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   go:
     runs-on: ubuntu-latest


### PR DESCRIPTION
A new push to a PR branch cancels that PR's in-flight workflow run instead of burning runner minutes on a stale commit. Pushes to main never cancel each other (every merge gets a full run).

Verification: actionlint clean; this PR's own run exercises the group key.