### PR TITLE
CI: fix merge gate to require explicit success from every job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,11 +101,20 @@ jobs:
 
   # Umbrella gate with a stable name for branch rulesets: matrix legs
   # report as "images (brain)" etc., which rulesets can't reference.
+  # ALLOWLIST, not blocklist: every needed job must report exactly
+  # "success" — failure, cancelled, skipped, and any future state all
+  # fail the gate. (A cancelled run once reported skipped needs, the
+  # old blocklist missed it, and auto-merge fired on red jobs.)
   ci-ok:
     runs-on: ubuntu-latest
     needs: [go, lint, web, images]
     if: always()
     steps:
-      - name: All jobs green
+      - name: All jobs succeeded
         run: |
-          [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "false" ]
+          results="${{ join(needs.*.result, ' ') }}"
+          echo "needs results: $results"
+          [ -n "$results" ] || { echo "no results reported"; exit 1; }
+          for r in $results; do
+            [ "$r" = "success" ] || { echo "gate failed: job result '$r'"; exit 1; }
+          done


### PR DESCRIPTION
## Bug

PR #10 auto-merged despite every job being cancelled. The ci-ok gate blocklisted `failure` and `cancelled` results — but never-started jobs in a cancelled run report `skipped`, which passed the blocklist, turned ci-ok green, and satisfied the ruleset's required check.

## Fix

Invert to an allowlist: every needed job must report exactly `success`; failure, cancelled, skipped, and any future result state fail the gate. Also fails on an empty result set.

## Verification

- actionlint clean
- This PR's own run exercises the happy path; the failure path is the exact scenario from #10 (any non-success result now exits 1)