### PR TITLE
Brain: bearer-authenticated pass-through chat

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -11,6 +11,10 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/SumonMSelim/timothy/internal/brain/api"
+	"github.com/SumonMSelim/timothy/internal/brain/chat"
+	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/platform/httpserver"
 	"github.com/SumonMSelim/timothy/internal/platform/service"
 	"github.com/SumonMSelim/timothy/migrations"
 )
@@ -36,6 +40,25 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	token := os.Getenv("TIMOTHY_API_TOKEN")
+	if token == "" {
+		app.Log.Warn("TIMOTHY_API_TOKEN not set; API requests will be rejected")
+	}
+	app.AddCheck("auth", func() httpserver.Check {
+		if token == "" {
+			return httpserver.Check{Status: "degraded", Detail: "TIMOTHY_API_TOKEN not set"}
+		}
+		return httpserver.Check{Status: "ok"}
+	})
+
+	gatewayURL := os.Getenv("GATEWAY_URL")
+	if gatewayURL == "" {
+		gatewayURL = "http://gateway:8081"
+	}
+	svc := chat.New(gwclient.New(gatewayURL), app.DB, app.Log)
+	api.Register(app.Server, svc, token, app.Log)
+
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)
 		os.Exit(1)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -20,6 +20,10 @@ x-go-service: &go-service
     retries: 3
     start_period: 10s
 
+x-db-env: &db-env
+  DATABASE_URL: postgres://timothy:${POSTGRES_PASSWORD}@postgres:5432/timothy
+  LOG_LEVEL: ${LOG_LEVEL:-info}
+
 services:
   postgres:
     <<: *service
@@ -42,10 +46,12 @@ services:
       context: ..
       dockerfile: deploy/Dockerfile
       args: {SERVICE: brain}
-    environment: &db-env
+    environment:
+      <<: *db-env
       PORT: "8080"
-      DATABASE_URL: postgres://timothy:${POSTGRES_PASSWORD}@postgres:5432/timothy
-      LOG_LEVEL: ${LOG_LEVEL:-info}
+      GATEWAY_URL: http://gateway:8081
+      # Brain-only secret: the public API bearer token.
+      TIMOTHY_API_TOKEN: ${TIMOTHY_API_TOKEN:-}
     ports:
       - "${BRAIN_PORT:-8300}:8080"
 

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -10,3 +10,6 @@ BRAIN_PORT=8300
 ANTHROPIC_API_KEY=
 ZAI_API_KEY=
 XAI_API_KEY=
+
+# Bearer token for brain's public API (generate: openssl rand -hex 32)
+TIMOTHY_API_TOKEN=

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -1,0 +1,115 @@
+// Package api is brain's public HTTP surface: bearer-authenticated
+// chat over SSE. /health and /metrics stay open (mounted by the
+// platform server before auth exists).
+package api
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/SumonMSelim/timothy/internal/brain/chat"
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+	"github.com/SumonMSelim/timothy/internal/platform/httpserver"
+)
+
+// API serves brain's public routes.
+type API struct {
+	svc   *chat.Service
+	token string
+	log   *slog.Logger
+}
+
+// Register mounts the routes, each wrapped in bearer auth.
+func Register(srv *httpserver.Server, svc *chat.Service, token string, log *slog.Logger) {
+	a := &API{svc: svc, token: token, log: log}
+	srv.Handle("POST /v1/chat", a.auth(http.HandlerFunc(a.handleChat)))
+}
+
+// auth enforces the single bearer token. An unconfigured token fails
+// closed with 503 — never open.
+func (a *API) auth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if a.token == "" {
+			jsonError(w, http.StatusServiceUnavailable, "auth_not_configured", "TIMOTHY_API_TOKEN is not set")
+			return
+		}
+		got, ok := bearerToken(r)
+		if !ok || subtle.ConstantTimeCompare([]byte(got), []byte(a.token)) != 1 {
+			jsonError(w, http.StatusUnauthorized, "unauthorized", "missing or invalid bearer token")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func bearerToken(r *http.Request) (string, bool) {
+	const prefix = "Bearer "
+	h := r.Header.Get("Authorization")
+	if len(h) <= len(prefix) || h[:len(prefix)] != prefix {
+		return "", false
+	}
+	return h[len(prefix):], true
+}
+
+func jsonError(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": code, "message": msg})
+}
+
+// meta is brain's terminal SSE event: session identity plus whatever
+// the gateway attributed on done.
+type meta struct {
+	Type      string        `json:"type"` // always "meta"
+	SessionID string        `json:"session_id"`
+	Provider  string        `json:"provider,omitempty"`
+	Model     string        `json:"model,omitempty"`
+	Usage     *stream.Usage `json:"usage,omitempty"`
+	LedgerID  string        `json:"ledger_id,omitempty"`
+}
+
+func (a *API) handleChat(w http.ResponseWriter, r *http.Request) {
+	var req chat.Request
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+
+	sessionID, events, err := a.svc.Chat(r.Context(), req)
+	if err != nil {
+		jsonError(w, http.StatusBadGateway, "chat_failed", err.Error())
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		jsonError(w, http.StatusInternalServerError, "streaming_unsupported", "response writer cannot flush")
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+
+	send := func(v any) {
+		data, err := json.Marshal(v)
+		if err != nil {
+			return
+		}
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+	}
+
+	m := meta{Type: "meta", SessionID: sessionID}
+	for ev := range events {
+		if ev.Type == stream.EventUsage {
+			m.Usage = ev.Usage
+		}
+		if ev.Meta != nil {
+			m.Provider, m.Model, m.LedgerID = ev.Meta.Provider, ev.Meta.Model, ev.Meta.LedgerID
+		}
+		send(ev)
+	}
+	send(m)
+}

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/chat"
+	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+func discard() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// fakeGateway yields a canned event sequence.
+type fakeGateway struct {
+	events []stream.StreamEvent
+	got    gwclient.StreamRequest
+}
+
+func (f *fakeGateway) Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+	f.got = req
+	ch := make(chan stream.StreamEvent, len(f.events))
+	for _, ev := range f.events {
+		ch <- ev
+	}
+	close(ch)
+	return ch, nil
+}
+
+func testAPI(t *testing.T, token string, events []stream.StreamEvent) (*API, *fakeGateway) {
+	t.Helper()
+	gw := &fakeGateway{events: events}
+	svc := chat.New(gw, pgpool.New(t.Context(), "", discard()), discard())
+	return &API{svc: svc, token: token, log: discard()}, gw
+}
+
+func doChat(a *API, authHeader, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat", strings.NewReader(body))
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	w := httptest.NewRecorder()
+	a.auth(http.HandlerFunc(a.handleChat)).ServeHTTP(w, req)
+	return w
+}
+
+func TestAuthRejectsBadTokens(t *testing.T) {
+	t.Parallel()
+	a, _ := testAPI(t, "secret-token", nil)
+
+	for name, header := range map[string]string{
+		"missing":      "",
+		"wrong scheme": "Basic secret-token",
+		"wrong token":  "Bearer nope",
+		"empty bearer": "Bearer ",
+	} {
+		if w := doChat(a, header, `{}`); w.Code != http.StatusUnauthorized {
+			t.Fatalf("%s: code = %d, want 401", name, w.Code)
+		}
+	}
+}
+
+func TestAuthFailsClosedWhenUnconfigured(t *testing.T) {
+	t.Parallel()
+	a, _ := testAPI(t, "", nil)
+
+	w := doChat(a, "Bearer anything", `{}`)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("code = %d, want 503 (fail closed)", w.Code)
+	}
+}
+
+func TestChatRelaysEventsAndAppendsMeta(t *testing.T) {
+	t.Parallel()
+	a, gw := testAPI(t, "tok", []stream.StreamEvent{
+		{Type: stream.EventChunk, Text: "hi "},
+		{Type: stream.EventChunk, Text: "there"},
+		{Type: stream.EventUsage, Usage: &stream.Usage{InputTokens: 5, OutputTokens: 2}},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod", LedgerID: "led-1"}},
+	})
+
+	w := doChat(a, "Bearer tok", `{"session_id":"s-1","message":"hello","task_category":"mini"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d body=%s", w.Code, w.Body.String())
+	}
+	if gw.got.TaskCategory != "mini" || gw.got.SessionID != "s-1" {
+		t.Fatalf("gateway request = %+v", gw.got)
+	}
+	if gw.got.System == "" || !strings.Contains(gw.got.System, "Timothy") {
+		t.Fatal("system prompt missing from gateway request")
+	}
+
+	lines := strings.Split(strings.TrimSpace(w.Body.String()), "\n\n")
+	last := strings.TrimPrefix(lines[len(lines)-1], "data: ")
+	var m meta
+	if err := json.Unmarshal([]byte(last), &m); err != nil {
+		t.Fatalf("terminal event not meta JSON: %v (%s)", err, last)
+	}
+	if m.Type != "meta" || m.SessionID != "s-1" || m.Provider != "prov" ||
+		m.Model != "mod" || m.LedgerID != "led-1" || m.Usage == nil || m.Usage.InputTokens != 5 {
+		t.Fatalf("meta = %+v", m)
+	}
+}
+
+func TestChatValidation(t *testing.T) {
+	t.Parallel()
+	a, _ := testAPI(t, "tok", nil)
+
+	if w := doChat(a, "Bearer tok", `{"session_id":"s-1","message":"  "}`); w.Code != http.StatusBadGateway {
+		t.Fatalf("blank message: code = %d", w.Code)
+	}
+	if w := doChat(a, "Bearer tok", `{not json`); w.Code != http.StatusBadRequest {
+		t.Fatalf("bad json: code = %d", w.Code)
+	}
+}

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -1,0 +1,141 @@
+// Package chat is brain's pass-through chat: assemble a prompt from
+// the in-memory session buffer, stream through the gateway, remember
+// the exchange. Event-sourced persistence replaces the buffer in the
+// next slice; the buffer is DELIBERATELY temporary.
+package chat
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+const (
+	// defaultCategory serves plain chat turns when the caller picks
+	// nothing; the web UI exposes a per-message picker.
+	defaultCategory = "coding"
+	// maxBufferedMessages bounds the temporary per-session history.
+	maxBufferedMessages = 20
+)
+
+// Gateway is what chat needs from the gateway client.
+type Gateway interface {
+	Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error)
+}
+
+// Service holds the temporary in-memory conversation buffers.
+type Service struct {
+	gw  Gateway
+	db  *pgpool.Pool
+	log *slog.Logger
+
+	mu      sync.Mutex
+	buffers map[string][]provider.Message
+}
+
+func New(gw Gateway, db *pgpool.Pool, log *slog.Logger) *Service {
+	log.Info("chat service ready", "system_prompt_version", systemPromptVersion)
+	return &Service{gw: gw, db: db, log: log, buffers: map[string][]provider.Message{}}
+}
+
+// Request is one chat turn.
+type Request struct {
+	SessionID    string `json:"session_id,omitempty"`
+	Message      string `json:"message"`
+	TaskCategory string `json:"task_category,omitempty"`
+	ModelHint    string `json:"model_hint,omitempty"`
+}
+
+// Chat streams one turn. A missing session id creates a session row
+// and the returned id identifies it. The returned channel follows the
+// stream package's terminal contract.
+func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.StreamEvent, error) {
+	if strings.TrimSpace(req.Message) == "" {
+		return "", nil, fmt.Errorf("chat: message is required")
+	}
+	category := req.TaskCategory
+	if category == "" {
+		category = defaultCategory
+	}
+
+	sessionID := req.SessionID
+	if sessionID == "" {
+		id, err := s.createSession(ctx)
+		if err != nil {
+			return "", nil, err
+		}
+		sessionID = id
+	}
+
+	userMsg := provider.Message{Role: "user", Content: req.Message}
+	messages := append(s.history(sessionID), userMsg)
+
+	upstream, err := s.gw.Stream(ctx, gwclient.StreamRequest{
+		TaskCategory: category,
+		ModelHint:    req.ModelHint,
+		System:       systemPrompt,
+		Messages:     messages,
+		SessionID:    sessionID,
+	})
+	if err != nil {
+		return "", nil, err
+	}
+
+	out := make(chan stream.StreamEvent)
+	go func() {
+		defer close(out)
+		var reply strings.Builder
+		for ev := range upstream {
+			if ev.Type == stream.EventChunk {
+				reply.WriteString(ev.Text)
+			}
+			select {
+			case out <- ev:
+			case <-ctx.Done():
+				return
+			}
+		}
+		if reply.Len() > 0 {
+			s.remember(sessionID, userMsg, provider.Message{Role: "assistant", Content: reply.String()})
+		}
+	}()
+	return sessionID, out, nil
+}
+
+func (s *Service) createSession(ctx context.Context) (string, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return "", fmt.Errorf("chat: create session: %w", err)
+	}
+	var id string
+	if err := db.QueryRow(ctx, "INSERT INTO sessions DEFAULT VALUES RETURNING id").Scan(&id); err != nil {
+		return "", fmt.Errorf("chat: create session: %w", err)
+	}
+	return id, nil
+}
+
+func (s *Service) history(sessionID string) []provider.Message {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	buf := s.buffers[sessionID]
+	out := make([]provider.Message, len(buf), len(buf)+1)
+	copy(out, buf)
+	return out
+}
+
+func (s *Service) remember(sessionID string, exchange ...provider.Message) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	buf := append(s.buffers[sessionID], exchange...)
+	if len(buf) > maxBufferedMessages {
+		buf = buf[len(buf)-maxBufferedMessages:]
+	}
+	s.buffers[sessionID] = buf
+}

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -1,0 +1,130 @@
+package chat
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+func discard() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+type scriptedGateway struct {
+	requests []gwclient.StreamRequest
+	reply    string
+}
+
+func (g *scriptedGateway) Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+	g.requests = append(g.requests, req)
+	ch := make(chan stream.StreamEvent, 3)
+	ch <- stream.StreamEvent{Type: stream.EventChunk, Text: g.reply}
+	ch <- stream.StreamEvent{Type: stream.EventDone}
+	close(ch)
+	return ch, nil
+}
+
+func drain(t *testing.T, ch <-chan stream.StreamEvent) {
+	t.Helper()
+	for range ch {
+	}
+}
+
+func newTestService(t *testing.T, gw Gateway) *Service {
+	t.Helper()
+	return New(gw, pgpool.New(t.Context(), "", discard()), discard())
+}
+
+func TestChatBuffersHistoryAcrossTurns(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{reply: "first answer"}
+	s := newTestService(t, gw)
+
+	id, ch, err := s.Chat(t.Context(), Request{SessionID: "sess", Message: "question one"})
+	if err != nil {
+		t.Fatalf("Chat 1: %v", err)
+	}
+	if id != "sess" {
+		t.Fatalf("session id = %q", id)
+	}
+	drain(t, ch)
+
+	gw.reply = "second answer"
+	_, ch, err = s.Chat(t.Context(), Request{SessionID: "sess", Message: "question two"})
+	if err != nil {
+		t.Fatalf("Chat 2: %v", err)
+	}
+	drain(t, ch)
+
+	second := gw.requests[1]
+	if len(second.Messages) != 3 {
+		t.Fatalf("second request messages = %d, want 3 (q1, a1, q2): %+v", len(second.Messages), second.Messages)
+	}
+	if second.Messages[0].Content != "question one" ||
+		second.Messages[1].Role != "assistant" || second.Messages[1].Content != "first answer" ||
+		second.Messages[2].Content != "question two" {
+		t.Fatalf("history wrong: %+v", second.Messages)
+	}
+}
+
+func TestChatSessionsAreIsolated(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{reply: "a"}
+	s := newTestService(t, gw)
+
+	_, ch, _ := s.Chat(t.Context(), Request{SessionID: "one", Message: "in session one"})
+	drain(t, ch)
+	_, ch, _ = s.Chat(t.Context(), Request{SessionID: "two", Message: "in session two"})
+	drain(t, ch)
+
+	if len(gw.requests[1].Messages) != 1 {
+		t.Fatalf("session two saw session one's history: %+v", gw.requests[1].Messages)
+	}
+}
+
+func TestChatBufferIsBounded(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{reply: "r"}
+	s := newTestService(t, gw)
+
+	for range maxBufferedMessages { // each turn adds 2 buffered messages
+		_, ch, err := s.Chat(t.Context(), Request{SessionID: "sess", Message: "m"})
+		if err != nil {
+			t.Fatalf("Chat: %v", err)
+		}
+		drain(t, ch)
+	}
+
+	last := gw.requests[len(gw.requests)-1]
+	if got := len(last.Messages); got > maxBufferedMessages+1 {
+		t.Fatalf("request messages = %d, exceeds bound %d", got, maxBufferedMessages+1)
+	}
+}
+
+func TestChatDefaultsCategory(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{reply: "r"}
+	s := newTestService(t, gw)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s", Message: "hi"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	if gw.requests[0].TaskCategory != defaultCategory {
+		t.Fatalf("category = %q, want %q", gw.requests[0].TaskCategory, defaultCategory)
+	}
+}
+
+func TestChatNewSessionRequiresDatabase(t *testing.T) {
+	t.Parallel()
+	s := newTestService(t, &scriptedGateway{reply: "r"}) // degraded pool
+
+	if _, _, err := s.Chat(t.Context(), Request{Message: "hi"}); err == nil {
+		t.Fatal("Chat without session id and without database: want error")
+	}
+}

--- a/internal/brain/chat/systemprompt.go
+++ b/internal/brain/chat/systemprompt.go
@@ -1,0 +1,13 @@
+package chat
+
+// systemPromptVersion increments with any change to the prompt text.
+const systemPromptVersion = 1
+
+// systemPrompt is Timothy's identity. Additions APPEND after the
+// existing text and the terseness steer stays the LAST line: the
+// stable prefix is what provider prompt caches key on (D-018).
+const systemPrompt = `You are Timothy, a self-hosted personal AI assistant serving a single owner.
+
+Answer from knowledge when confident; say plainly when you are unsure or lack access to current information. You currently have no tools, no memory of prior sessions, and no web access — do not pretend otherwise.
+
+Be concise; do not restate context or repeat the question.`

--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -1,0 +1,93 @@
+// Package gwclient is brain's client for the gateway's internal API.
+// It relays the gateway's normalized SSE stream as typed events; all
+// provider handling (retries, failover, accounting) already happened
+// on the gateway side, so this client stays a thin reader.
+package gwclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+	"github.com/SumonMSelim/timothy/internal/platform/sse"
+)
+
+// StreamRequest mirrors the gateway's /v1/stream request contract.
+type StreamRequest struct {
+	TaskCategory string             `json:"task_category"`
+	ModelHint    string             `json:"model_hint,omitempty"`
+	System       string             `json:"system,omitempty"`
+	Messages     []provider.Message `json:"messages"`
+	MaxTokens    int                `json:"max_tokens,omitempty"`
+	SessionID    string             `json:"session_id,omitempty"`
+}
+
+// Client talks to one gateway base URL.
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+func New(baseURL string) *Client {
+	return &Client{baseURL: baseURL, http: &http.Client{}}
+}
+
+// Stream posts the request and yields the gateway's normalized events.
+// The channel closes when the gateway stream ends; a transport failure
+// mid-stream surfaces as a terminal error event.
+func (c *Client) Stream(ctx context.Context, req StreamRequest) (<-chan stream.StreamEvent, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("gwclient: marshal: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/stream", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("gwclient: request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("gwclient: gateway unreachable: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("gwclient: gateway http %d: %s", resp.StatusCode, string(msg))
+	}
+
+	ch := make(chan stream.StreamEvent)
+	go func() {
+		defer close(ch)
+		defer func() { _ = resp.Body.Close() }()
+
+		err := sse.Read(resp.Body, func(ev sse.Event) bool {
+			var se stream.StreamEvent
+			if err := json.Unmarshal([]byte(ev.Data), &se); err != nil {
+				se = stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
+					Code: "malformed_gateway_stream", Message: err.Error(),
+				}}
+			}
+			select {
+			case ch <- se:
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		})
+		if err != nil && ctx.Err() == nil {
+			select {
+			case ch <- stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
+				Code: "gateway_stream_cut", Message: err.Error(), Retryable: true,
+			}}:
+			case <-ctx.Done():
+			}
+		}
+	}()
+	return ch, nil
+}

--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -119,6 +119,7 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 	for _, att := range attempts {
 		completion.Model = att.Model
 		res := streamAttempt(r.Context(), att, completion, ledger.Entry{
+			ID:       ledger.NewID(),
 			Provider: att.ProviderName, Model: att.Model,
 			TaskCategory: req.TaskCategory,
 			SessionID:    req.SessionID, LaneID: req.LaneID,
@@ -194,6 +195,15 @@ func streamAttempt(ctx context.Context, att router.Attempt, completion provider.
 			send(ev)
 		case stream.EventChunk, stream.EventReasoningChunk, stream.EventToolStart, stream.EventToolEnd:
 			res.streamed = true
+			send(ev)
+		case stream.EventDone:
+			// Attribute the serving provider on the terminal event so
+			// callers need no second lookup.
+			ev.Meta = &stream.Meta{
+				Provider: att.ProviderName,
+				Model:    att.Model,
+				LedgerID: entry.ID,
+			}
 			send(ev)
 		default:
 			send(ev)

--- a/internal/gateway/ledger/ledger.go
+++ b/internal/gateway/ledger/ledger.go
@@ -5,6 +5,8 @@ package ledger
 
 import (
 	"context"
+	"crypto/rand"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -15,8 +17,11 @@ import (
 
 const writeTimeout = 5 * time.Second
 
-// Entry is one request's accounting.
+// Entry is one request's accounting. ID may be pre-generated (NewID)
+// so callers can reference the row before it is written; empty lets
+// the database assign one.
 type Entry struct {
+	ID           string
 	Provider     string
 	Model        string
 	TaskCategory string
@@ -62,15 +67,27 @@ func (l *Ledger) Record(ctx context.Context, e Entry) {
 		in, out, cr, cw = &e.Usage.InputTokens, &e.Usage.OutputTokens, &e.Usage.CacheReadTokens, &e.Usage.CacheWriteTokens
 	}
 	_, err = db.Exec(wctx, `INSERT INTO cost_ledger
-		(provider, model, task_category, session_id, lane_id,
+		(id, provider, model, task_category, session_id, lane_id,
 		 input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
 		 latency_ms, status, error_code, cost_usd)
-		VALUES ($1, $2, $3, NULLIF($4, ''), NULLIF($5, ''), $6, $7, $8, $9, $10, $11, NULLIF($12, ''), $13)`,
-		e.Provider, e.Model, e.TaskCategory, e.SessionID, e.LaneID,
+		VALUES (COALESCE(NULLIF($1, '')::uuid, gen_random_uuid()),
+		 $2, $3, $4, NULLIF($5, ''), NULLIF($6, ''), $7, $8, $9, $10, $11, $12, NULLIF($13, ''), $14)`,
+		e.ID, e.Provider, e.Model, e.TaskCategory, e.SessionID, e.LaneID,
 		in, out, cr, cw, e.LatencyMS, e.Status, e.ErrorCode, e.CostUSD)
 	if err != nil {
 		l.log.Warn("ledger write failed", "error", err, "provider", e.Provider, "status", e.Status)
 	}
+}
+
+// NewID returns a random UUIDv4 for pre-assigning ledger rows.
+func NewID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "" // database assigns instead
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }
 
 // Cost computes USD for usage under a price table. nil prices or nil

--- a/internal/gateway/provider/anthropic.go
+++ b/internal/gateway/provider/anthropic.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+	"github.com/SumonMSelim/timothy/internal/platform/sse"
 )
 
 const (
@@ -168,9 +169,9 @@ func (a *Anthropic) relay(ctx context.Context, body io.Reader, ch chan<- stream.
 	usage := &stream.Usage{}
 	finished := false
 
-	err := readSSE(body, func(ev sseEvent) bool {
+	err := sse.Read(body, func(ev sse.Event) bool {
 		var p anthropicStreamPayload
-		if err := json.Unmarshal([]byte(ev.data), &p); err != nil {
+		if err := json.Unmarshal([]byte(ev.Data), &p); err != nil {
 			emit(ctx, ch, stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
 				Code: "malformed_stream", Message: fmt.Sprintf("bad SSE payload: %v", err), Retryable: true,
 			}})

--- a/internal/gateway/provider/httpx.go
+++ b/internal/gateway/provider/httpx.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -241,53 +240,4 @@ func toolEndEvent(t *pendingTool) stream.StreamEvent {
 	return stream.StreamEvent{Type: stream.EventToolEnd, ToolCall: &stream.ToolCallEvent{
 		ID: t.id, Name: t.name, Input: json.RawMessage(args),
 	}}
-}
-
-// sseScanner iterates server-sent events, yielding each event's data
-// payload (the concatenated "data:" lines). The "event:" field, when
-// present, is returned alongside.
-type sseEvent struct {
-	name string
-	data string
-}
-
-func readSSE(r io.Reader, yield func(sseEvent) bool) error {
-	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-
-	var name string
-	var data bytes.Buffer
-	flush := func() bool {
-		if data.Len() == 0 {
-			name = ""
-			return true
-		}
-		ev := sseEvent{name: name, data: data.String()}
-		name = ""
-		data.Reset()
-		return yield(ev)
-	}
-
-	for sc.Scan() {
-		line := sc.Text()
-		switch {
-		case line == "":
-			if !flush() {
-				return nil
-			}
-		case strings.HasPrefix(line, "event:"):
-			name = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
-		case strings.HasPrefix(line, "data:"):
-			if data.Len() > 0 {
-				data.WriteByte('\n')
-			}
-			data.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
-		}
-		// comments (":") and unknown fields are ignored per the SSE spec
-	}
-	if err := sc.Err(); err != nil {
-		return err
-	}
-	_ = flush()
-	return nil
 }

--- a/internal/gateway/provider/httpx_test.go
+++ b/internal/gateway/provider/httpx_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"strings"
 	"testing"
 	"time"
 )
@@ -28,61 +27,5 @@ func TestRetryableStatus(t *testing.T) {
 		if got := retryableStatus(code); got != want {
 			t.Fatalf("retryableStatus(%d) = %v, want %v", code, got, want)
 		}
-	}
-}
-
-func TestReadSSE(t *testing.T) {
-	t.Parallel()
-	input := strings.Join([]string{
-		": comment to ignore",
-		"event: message_start",
-		"data: {\"a\":1}",
-		"",
-		"data: line1",
-		"data: line2",
-		"",
-		"event: dangling-no-data",
-		"",
-		"data: final",
-		"", // trailing blank
-	}, "\n")
-
-	var got []sseEvent
-	err := readSSE(strings.NewReader(input), func(ev sseEvent) bool {
-		got = append(got, ev)
-		return true
-	})
-	if err != nil {
-		t.Fatalf("readSSE: %v", err)
-	}
-
-	want := []sseEvent{
-		{name: "message_start", data: `{"a":1}`},
-		{name: "", data: "line1\nline2"},
-		{name: "", data: "final"},
-	}
-	if len(got) != len(want) {
-		t.Fatalf("events = %+v, want %+v", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("event[%d] = %+v, want %+v", i, got[i], want[i])
-		}
-	}
-}
-
-func TestReadSSEStopsWhenYieldReturnsFalse(t *testing.T) {
-	t.Parallel()
-	input := "data: one\n\ndata: two\n\n"
-	var got []string
-	err := readSSE(strings.NewReader(input), func(ev sseEvent) bool {
-		got = append(got, ev.data)
-		return false
-	})
-	if err != nil {
-		t.Fatalf("readSSE: %v", err)
-	}
-	if len(got) != 1 || got[0] != "one" {
-		t.Fatalf("got %v, want [one]", got)
 	}
 }

--- a/internal/gateway/provider/openaicompat.go
+++ b/internal/gateway/provider/openaicompat.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+	"github.com/SumonMSelim/timothy/internal/platform/sse"
 )
 
 // OpenAICompatConfig configures one OpenAI-compatible provider
@@ -233,8 +234,8 @@ func (o *OpenAICompat) relay(ctx context.Context, body io.Reader, ch chan<- stre
 	finished := false
 	truncated := false
 
-	err := readSSE(body, func(ev sseEvent) bool {
-		if ev.data == "[DONE]" {
+	err := sse.Read(body, func(ev sse.Event) bool {
+		if ev.Data == "[DONE]" {
 			finished = true
 			for _, tev := range tools.finishAll() {
 				if !emit(ctx, ch, tev) {
@@ -252,7 +253,7 @@ func (o *OpenAICompat) relay(ctx context.Context, body io.Reader, ch chan<- stre
 		}
 
 		var c oaiChunk
-		if err := json.Unmarshal([]byte(ev.data), &c); err != nil {
+		if err := json.Unmarshal([]byte(ev.Data), &c); err != nil {
 			emit(ctx, ch, stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
 				Code: "malformed_stream", Message: fmt.Sprintf("bad SSE payload: %v", err), Retryable: true,
 			}})

--- a/internal/gateway/stream/events.go
+++ b/internal/gateway/stream/events.go
@@ -26,7 +26,8 @@ const (
 )
 
 // StreamEvent is one normalized event. Exactly the field matching Type
-// is populated.
+// is populated; Meta additionally rides the terminal done event when
+// the gateway API attributes the serving provider.
 type StreamEvent struct {
 	Type     EventType      `json:"type"`
 	Text     string         `json:"text,omitempty"`
@@ -34,6 +35,15 @@ type StreamEvent struct {
 	Usage    *Usage         `json:"usage,omitempty"`
 	Err      *StreamError   `json:"error,omitempty"`
 	Retry    *RetryInfo     `json:"retry,omitempty"`
+	Meta     *Meta          `json:"meta,omitempty"`
+}
+
+// Meta identifies who served a request — attached to the done event by
+// the gateway API so callers attribute without a second lookup.
+type Meta struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+	LedgerID string `json:"ledger_id,omitempty"`
 }
 
 // ToolCallEvent identifies a tool call. Input carries the complete

--- a/internal/platform/service/service.go
+++ b/internal/platform/service/service.go
@@ -35,6 +35,19 @@ type App struct {
 	mu             sync.RWMutex
 	migrationsDone bool
 	migrationsErr  error
+	extraChecks    map[string]func() httpserver.Check
+}
+
+// AddCheck registers a service-specific health check merged into
+// /health beside the platform's postgres and migrations checks.
+// Register before Run.
+func (a *App) AddCheck(name string, fn func() httpserver.Check) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.extraChecks == nil {
+		a.extraChecks = map[string]func() httpserver.Check{}
+	}
+	a.extraChecks[name] = fn
 }
 
 // New loads configuration and wires logging, metrics, the database
@@ -72,6 +85,11 @@ func (a *App) health() httpserver.Health {
 		"postgres":   {Status: dbStatus, Detail: dbDetail},
 		"migrations": a.migrationsCheck(),
 	}
+	a.mu.RLock()
+	for name, fn := range a.extraChecks {
+		checks[name] = fn()
+	}
+	a.mu.RUnlock()
 
 	status := "ok"
 	for _, c := range checks {

--- a/internal/platform/sse/sse.go
+++ b/internal/platform/sse/sse.go
@@ -1,0 +1,61 @@
+// Package sse parses server-sent event streams. Shared by the gateway
+// provider drivers (reading upstream APIs) and the brain's gateway
+// client (reading the gateway's own stream).
+package sse
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"strings"
+)
+
+// Event is one server-sent event: the optional "event:" name and the
+// concatenated "data:" payload.
+type Event struct {
+	Name string
+	Data string
+}
+
+// Read iterates events, calling yield for each; return false to stop
+// early. Comments and unknown fields are ignored per the SSE spec;
+// multi-line data concatenates with newlines.
+func Read(r io.Reader, yield func(Event) bool) error {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var name string
+	var data bytes.Buffer
+	flush := func() bool {
+		if data.Len() == 0 {
+			name = ""
+			return true
+		}
+		ev := Event{Name: name, Data: data.String()}
+		name = ""
+		data.Reset()
+		return yield(ev)
+	}
+
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case line == "":
+			if !flush() {
+				return nil
+			}
+		case strings.HasPrefix(line, "event:"):
+			name = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			if data.Len() > 0 {
+				data.WriteByte('\n')
+			}
+			data.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return err
+	}
+	_ = flush()
+	return nil
+}

--- a/internal/platform/sse/sse_test.go
+++ b/internal/platform/sse/sse_test.go
@@ -1,0 +1,62 @@
+package sse
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRead(t *testing.T) {
+	t.Parallel()
+	input := strings.Join([]string{
+		": comment to ignore",
+		"event: message_start",
+		"data: {\"a\":1}",
+		"",
+		"data: line1",
+		"data: line2",
+		"",
+		"event: dangling-no-data",
+		"",
+		"data: final",
+		"",
+	}, "\n")
+
+	var got []Event
+	err := Read(strings.NewReader(input), func(ev Event) bool {
+		got = append(got, ev)
+		return true
+	})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	want := []Event{
+		{Name: "message_start", Data: `{"a":1}`},
+		{Name: "", Data: "line1\nline2"},
+		{Name: "", Data: "final"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("events = %+v, want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("event[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestReadStopsWhenYieldReturnsFalse(t *testing.T) {
+	t.Parallel()
+	input := "data: one\n\ndata: two\n\n"
+	var got []string
+	err := Read(strings.NewReader(input), func(ev Event) bool {
+		got = append(got, ev.Data)
+		return false
+	})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(got) != 1 || got[0] != "one" {
+		t.Fatalf("got %v, want [one]", got)
+	}
+}

--- a/migrations/0003_brain.sql
+++ b/migrations/0003_brain.sql
@@ -1,0 +1,7 @@
+-- Minimal sessions table: real event-sourced sessions replace these
+-- semantics next; this only anchors session ids for ledger attribution.
+CREATE TABLE IF NOT EXISTS sessions (
+    id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    title      text,
+    created_at timestamptz NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
## What

- `POST /v1/chat` on brain: bearer auth (constant-time compare, fails closed with 503 when the token is unconfigured), SSE relay of the gateway's normalized events, terminal `meta` event carrying session_id, provider, model, usage, and ledger id
- Chat service: versioned system prompt (terseness steer as the last line so future additions append after the cached prefix), bounded in-memory per-session history — a documented stopgap until event-sourced sessions land
- Sessions table (minimal anchor for ledger attribution); omitted session_id creates a row and returns the id
- SSE parser extracted to `internal/platform/sse` (second consumer: brain's gateway client)
- Gateway now stamps provider/model/ledger-id onto the terminal done event; ledger rows can be pre-assigned ids
- Pluggable health checks on the service bootstrap; brain reports auth configuration state
- Compose: brain-only `TIMOTHY_API_TOKEN` (kept out of the shared env anchor), `GATEWAY_URL`

## Verification

- Unit: auth (wrong/missing/unconfigured), event relay + meta assembly, history across turns, session isolation, buffer bound, category default — `-race` clean, lint 0
- E2E on compose: token → streamed real answer; 401 on bad token; ledger row carries session_id with computed cost; second turn recalled first-turn content through the buffer