### PR TITLE
Brain: stream terminal fidelity and bearer parsing hardening

### DIFF
--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/SumonMSelim/timothy/internal/brain/chat"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
@@ -47,11 +48,12 @@ func (a *API) auth(next http.Handler) http.Handler {
 
 func bearerToken(r *http.Request) (string, bool) {
 	const prefix = "Bearer "
-	h := r.Header.Get("Authorization")
-	if len(h) <= len(prefix) || h[:len(prefix)] != prefix {
+	h := strings.TrimSpace(r.Header.Get("Authorization"))
+	if len(h) <= len(prefix) || !strings.EqualFold(h[:len(prefix)], prefix) {
 		return "", false
 	}
-	return h[len(prefix):], true
+	token := strings.TrimSpace(h[len(prefix):])
+	return token, token != ""
 }
 
 func jsonError(w http.ResponseWriter, status int, code, msg string) {
@@ -62,6 +64,13 @@ func jsonError(w http.ResponseWriter, status int, code, msg string) {
 
 // meta is brain's terminal SSE event: session identity plus whatever
 // the gateway attributed on done.
+//
+// Wire contract (deliberately different from the internal channel
+// contract): brain's /v1/chat SSE stream ALWAYS ends with exactly one
+// meta event, emitted after the relayed gateway terminal (done or
+// error). Clients must read until meta, not stop at done. Provider,
+// model, usage, and ledger_id are best-effort — absent when no
+// provider attempt succeeded.
 type meta struct {
 	Type      string        `json:"type"` // always "meta"
 	SessionID string        `json:"session_id"`

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -67,6 +67,21 @@ func TestAuthRejectsBadTokens(t *testing.T) {
 	}
 }
 
+func TestAuthAcceptsRobustHeaderShapes(t *testing.T) {
+	t.Parallel()
+	for name, header := range map[string]string{
+		"lowercase scheme":   "bearer secret-token",
+		"surrounding spaces": "  Bearer secret-token  ",
+		"space before token": "Bearer  secret-token",
+	} {
+		// Fresh API per case: a session buffer is per-service state.
+		a, _ := testAPI(t, "secret-token", []stream.StreamEvent{{Type: stream.EventDone}})
+		if w := doChat(a, header, `{"session_id":"s","message":"hi"}`); w.Code != http.StatusOK {
+			t.Fatalf("%s: code = %d, want 200", name, w.Code)
+		}
+	}
+}
+
 func TestAuthFailsClosedWhenUnconfigured(t *testing.T) {
 	t.Parallel()
 	a, _ := testAPI(t, "", nil)

--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
@@ -34,7 +35,14 @@ type Client struct {
 }
 
 func New(baseURL string) *Client {
-	return &Client{baseURL: baseURL, http: &http.Client{}}
+	return &Client{baseURL: baseURL, http: &http.Client{
+		// No overall timeout (streams run long); bound the phases that
+		// can hang before any byte arrives.
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			ResponseHeaderTimeout: 30 * time.Second,
+		},
+	}}
 }
 
 // Stream posts the request and yields the gateway's normalized events.
@@ -66,12 +74,16 @@ func (c *Client) Stream(ctx context.Context, req StreamRequest) (<-chan stream.S
 		defer close(ch)
 		defer func() { _ = resp.Body.Close() }()
 
+		sawTerminal := false
 		err := sse.Read(resp.Body, func(ev sse.Event) bool {
 			var se stream.StreamEvent
 			if err := json.Unmarshal([]byte(ev.Data), &se); err != nil {
 				se = stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
 					Code: "malformed_gateway_stream", Message: err.Error(),
 				}}
+			}
+			if se.Type == stream.EventDone || se.Type == stream.EventError {
+				sawTerminal = true
 			}
 			select {
 			case ch <- se:
@@ -80,7 +92,10 @@ func (c *Client) Stream(ctx context.Context, req StreamRequest) (<-chan stream.S
 				return false
 			}
 		})
-		if err != nil && ctx.Err() == nil {
+		// A read error AFTER the gateway's own terminal is just the
+		// connection tearing down — emitting another terminal would
+		// break the exactly-one-terminal contract.
+		if err != nil && !sawTerminal && ctx.Err() == nil {
 			select {
 			case ch <- stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
 				Code: "gateway_stream_cut", Message: err.Error(), Retryable: true,

--- a/internal/brain/gwclient/gwclient_test.go
+++ b/internal/brain/gwclient/gwclient_test.go
@@ -1,0 +1,124 @@
+package gwclient
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+func collect(t *testing.T, ch <-chan stream.StreamEvent) []stream.StreamEvent {
+	t.Helper()
+	var events []stream.StreamEvent
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return events
+			}
+			events = append(events, ev)
+		case <-deadline:
+			t.Fatalf("stream did not close; got %+v", events)
+		}
+	}
+}
+
+func terminals(events []stream.StreamEvent) int {
+	n := 0
+	for _, ev := range events {
+		if ev.Type == stream.EventDone || ev.Type == stream.EventError {
+			n++
+		}
+	}
+	return n
+}
+
+func gatewayStub(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return New(srv.URL)
+}
+
+func TestStreamRelaysEvents(t *testing.T) {
+	t.Parallel()
+	c := gatewayStub(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, "data: {\"type\":\"chunk\",\"text\":\"hi\"}\n\n")
+		_, _ = fmt.Fprint(w, "data: {\"type\":\"done\",\"meta\":{\"provider\":\"p\",\"model\":\"m\"}}\n\n")
+	})
+
+	ch, err := c.Stream(t.Context(), StreamRequest{TaskCategory: "mini"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	if len(events) != 2 || events[0].Text != "hi" || events[1].Type != stream.EventDone {
+		t.Fatalf("events = %+v", events)
+	}
+	if events[1].Meta == nil || events[1].Meta.Provider != "p" {
+		t.Fatalf("meta lost in relay: %+v", events[1])
+	}
+}
+
+func TestStreamNoSecondTerminalWhenConnectionDropsAfterDone(t *testing.T) {
+	t.Parallel()
+	c := gatewayStub(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, "data: {\"type\":\"done\"}\n\n")
+		w.(http.Flusher).Flush()
+		// Abort the connection uncleanly: the client sees a read error
+		// AFTER the terminal already arrived.
+		panic(http.ErrAbortHandler)
+	})
+
+	ch, err := c.Stream(t.Context(), StreamRequest{TaskCategory: "mini"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	if n := terminals(events); n != 1 {
+		t.Fatalf("terminals = %d, want exactly 1: %+v", n, events)
+	}
+	if events[len(events)-1].Type != stream.EventDone {
+		t.Fatalf("last = %v, want done", events[len(events)-1].Type)
+	}
+}
+
+func TestStreamEmitsTerminalWhenCutBeforeDone(t *testing.T) {
+	t.Parallel()
+	c := gatewayStub(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, "data: {\"type\":\"chunk\",\"text\":\"par\"}\n\n")
+		w.(http.Flusher).Flush()
+		panic(http.ErrAbortHandler)
+	})
+
+	ch, err := c.Stream(t.Context(), StreamRequest{TaskCategory: "mini"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	if n := terminals(events); n != 1 {
+		t.Fatalf("terminals = %d, want exactly 1: %+v", n, events)
+	}
+	last := events[len(events)-1]
+	if last.Type != stream.EventError || last.Err.Code != "gateway_stream_cut" {
+		t.Fatalf("last = %+v, want gateway_stream_cut error", last)
+	}
+}
+
+func TestStreamRejectsGatewayErrorStatus(t *testing.T) {
+	t.Parallel()
+	c := gatewayStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"no_route"}`, http.StatusBadGateway)
+	})
+
+	if _, err := c.Stream(t.Context(), StreamRequest{TaskCategory: "mini"}); err == nil {
+		t.Fatal("Stream() = nil error for 502 gateway response")
+	}
+}


### PR DESCRIPTION
## What

- Gateway client no longer emits a second terminal when the connection tears down after the gateway's own done/error (sawTerminal guard); exactly-one-terminal now holds on every path
- Bearer parsing: whitespace-tolerant, case-insensitive scheme, empty-after-trim rejected — constant-time compare unchanged
- Gateway client bounds the response-header wait (30s) while leaving stream lifetime unbounded
- Brain's /v1/chat wire contract documented: the SSE stream always ends with exactly one meta event after the relayed terminal — clients read until meta

## Verification

- New gwclient tests: relay fidelity, drop-after-done → one terminal, cut-before-done → one gateway_stream_cut terminal, non-200 rejection
- New auth tests: lowercase scheme, surrounding whitespace, space-padded token all accepted; negative cases unchanged
- `-race` clean, lint 0