### PR TITLE
Fix zero latency in streamed ledger rows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
         run: npm run build
       - name: Lint
         run: npm run lint
+      - name: Test
+        run: npm test
 
   images:
     runs-on: ubuntu-latest

--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -164,8 +164,10 @@ func (r attemptResult) failedOver() bool { return r.failed && !r.streamed }
 // (nothing emitted to the client); once content has been sent, the
 // stream is never restarted on another provider — errors after content
 // are relayed honestly instead.
-func streamAttempt(ctx context.Context, att router.Attempt, completion provider.CompletionRequest, entry ledger.Entry, send func(stream.StreamEvent)) attemptResult {
-	res := attemptResult{entry: entry}
+// The named return is load-bearing: the deferred latency stamp must
+// mutate the value the caller receives, not a dead local copy.
+func streamAttempt(ctx context.Context, att router.Attempt, completion provider.CompletionRequest, entry ledger.Entry, send func(stream.StreamEvent)) (res attemptResult) {
+	res = attemptResult{entry: entry}
 	start := time.Now()
 	defer func() { res.entry.LatencyMS = time.Since(start).Milliseconds() }()
 

--- a/internal/gateway/api/api_test.go
+++ b/internal/gateway/api/api_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/ledger"
 	"github.com/SumonMSelim/timothy/internal/gateway/router"
@@ -45,10 +46,12 @@ func (m *memRecorder) all() []ledger.Entry {
 
 func discard() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
 
-// oaiOK serves a minimal successful chat/completions SSE stream.
+// oaiOK serves a minimal successful chat/completions SSE stream. The
+// small sleep makes latency measurable for the ledger assertion.
 func oaiOK(t *testing.T, text string) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(15 * time.Millisecond)
 		if strings.HasSuffix(r.URL.Path, "/embeddings") {
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"data":  []map[string]any{{"index": 0, "embedding": []float32{0.1, 0.2}}, {"index": 1, "embedding": []float32{0.3, 0.4}}},
@@ -165,6 +168,11 @@ func TestStreamHappyPathWithLedger(t *testing.T) {
 	// priced model: 10/1e6*1 + 5/1e6*2
 	if e.CostUSD == nil || *e.CostUSD != 10.0/1e6+2*5.0/1e6 {
 		t.Fatalf("cost = %v", e.CostUSD)
+	}
+	// The fake server sleeps before responding: a zero here means the
+	// deferred latency stamp mutated a dead copy again.
+	if e.LatencyMS <= 0 {
+		t.Fatalf("latency_ms = %d, want > 0", e.LatencyMS)
 	}
 }
 

--- a/internal/gateway/router/store_integration_test.go
+++ b/internal/gateway/router/store_integration_test.go
@@ -72,20 +72,30 @@ func TestStoreLoadsSeededConfig(t *testing.T) {
 
 func TestStoreReloadReflectsSQLChanges(t *testing.T) {
 	s := integrationStore(t)
-	db, _ := s.db.Get()
-
-	if _, err := db.Exec(t.Context(),
-		"UPDATE providers SET enabled = true WHERE name = 'zai-glm'"); err != nil {
-		t.Fatalf("enable: %v", err)
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
 	}
-	if _, err := db.Exec(t.Context(),
-		"UPDATE task_routes SET enabled = true WHERE task_category = 'coding'"); err != nil {
-		t.Fatalf("enable route: %v", err)
+
+	// Fixture rows OWNED by this test: the dev database's real
+	// providers and routes are live configuration and must never be
+	// toggled by tests.
+	var providerID string
+	if err := db.QueryRow(t.Context(), `INSERT INTO providers
+		(name, kind, driver, base_url, default_model, credential_ref, enabled)
+		VALUES ('itest-prov', 'api', 'openaicompat', 'https://itest.invalid/v1', 'itest-model', 'ITEST_KEY', true)
+		RETURNING id`).Scan(&providerID); err != nil {
+		t.Fatalf("insert provider: %v", err)
+	}
+	if _, err := db.Exec(t.Context(), `INSERT INTO task_routes (task_category, chain, enabled)
+		VALUES ('itest-cat', jsonb_build_array(jsonb_build_object('provider_id', $1::uuid, 'model', 'itest-model')), true)`,
+		providerID); err != nil {
+		t.Fatalf("insert route: %v", err)
 	}
 	t.Cleanup(func() {
 		// t.Context is canceled before cleanups run and the pool's
 		// watcher may already have closed it — use an independent
-		// connection so the reset cannot be lost.
+		// connection so the cleanup cannot be lost.
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		conn, err := pgx.Connect(ctx, os.Getenv("DATABASE_URL"))
@@ -94,30 +104,24 @@ func TestStoreReloadReflectsSQLChanges(t *testing.T) {
 			return
 		}
 		defer func() { _ = conn.Close(ctx) }()
-		if _, err := conn.Exec(ctx, "UPDATE providers SET enabled = false WHERE name = 'zai-glm'"); err != nil {
-			t.Errorf("cleanup provider: %v", err)
-		}
-		if _, err := conn.Exec(ctx, "UPDATE task_routes SET enabled = false WHERE task_category = 'coding'"); err != nil {
+		if _, err := conn.Exec(ctx, "DELETE FROM task_routes WHERE task_category = 'itest-cat'"); err != nil {
 			t.Errorf("cleanup route: %v", err)
+		}
+		if _, err := conn.Exec(ctx, "DELETE FROM providers WHERE name = 'itest-prov'"); err != nil {
+			t.Errorf("cleanup provider: %v", err)
 		}
 	})
 
-	t.Setenv("ZAI_API_KEY", "test-key-value") // healthy via env lookup
+	t.Setenv("ITEST_KEY", "test-key-value") // healthy via env lookup
 	if err := s.Load(t.Context()); err != nil {
 		t.Fatalf("reload: %v", err)
 	}
 
-	attempts, err := s.Snapshot().Resolve("coding", "")
+	attempts, err := s.Snapshot().Resolve("itest-cat", "")
 	if err != nil {
-		t.Fatalf("Resolve after enable: %v", err)
+		t.Fatalf("Resolve after insert: %v", err)
 	}
-	found := false
-	for _, a := range attempts {
-		if a.ProviderName == "zai-glm" && a.Model == "glm-4.7" {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatalf("zai-glm/glm-4.7 not in attempts after enable: %+v", attempts)
+	if len(attempts) != 1 || attempts[0].ProviderName != "itest-prov" || attempts[0].Model != "itest-model" {
+		t.Fatalf("attempts = %+v, want itest-prov/itest-model", attempts)
 	}
 }


### PR DESCRIPTION
## Bug

streamAttempt returned its result by value, then a deferred closure stamped latency onto the dead local — every streamed request since the extraction recorded `latency_ms = 0`. Tokens and cost were unaffected. Found by review; reproduced live (`SELECT latency_ms FROM cost_ledger` → 0 across recent rows).

## Fix

- Named return so the deferred stamp mutates what the caller receives; comment marks it load-bearing
- Happy-path test now asserts positive latency against a deliberately slow fake provider (this exact gap let the bug ship green)
- Web unit tests added to CI (build+lint ran, vitest didn't)
- Store integration test creates and deletes its own provider/route fixture rows instead of toggling live routing config (its cleanup was silently disabling the coding route on the dev database)

## Verification

- Live: streamed request now records `latency_ms = 6522`; fixture rows verified cleaned
- Full gateway suite + integration suite `-race` green, lint 0, actionlint clean