### PR TITLE
Sessions: event-sourced history that survives anything

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	gwc := gwclient.New(gatewayURL)
 	store := session.NewStore(app.DB)
-	compactor := session.NewCompactor(store, gwc, budget, app.Log,
+	compactor := session.NewCompactor(store, gwc, gwc, budget, app.Log,
 		app.Metrics.NewCounter("session_compactions_total", "Sessions compacted to stay under the context budget."))
 	distill := func(ctx context.Context, sessionID, turnText string) *session.TurnMemory {
 		return loop.DistillTurn(ctx, gwc, sessionID, turnText)

--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -9,15 +9,22 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	"github.com/SumonMSelim/timothy/internal/brain/api"
 	"github.com/SumonMSelim/timothy/internal/brain/chat"
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/brain/loop"
+	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/platform/httpserver"
 	"github.com/SumonMSelim/timothy/internal/platform/service"
 	"github.com/SumonMSelim/timothy/migrations"
 )
+
+// defaultTokenBudget bounds the projected context; provider-window
+// driven budgets arrive when model rows carry context windows.
+const defaultTokenBudget = 60_000
 
 const (
 	serviceName = "brain"
@@ -56,8 +63,22 @@ func main() {
 	if gatewayURL == "" {
 		gatewayURL = "http://gateway:8081"
 	}
-	svc := chat.New(gwclient.New(gatewayURL), app.DB, app.Log)
-	api.Register(app.Server, svc, token, app.Log)
+	budget := defaultTokenBudget
+	if v := os.Getenv("SESSION_TOKEN_BUDGET"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			budget = n
+		}
+	}
+
+	gwc := gwclient.New(gatewayURL)
+	store := session.NewStore(app.DB)
+	compactor := session.NewCompactor(store, gwc, budget, app.Log,
+		app.Metrics.NewCounter("session_compactions_total", "Sessions compacted to stay under the context budget."))
+	distill := func(ctx context.Context, sessionID, turnText string) *session.TurnMemory {
+		return loop.DistillTurn(ctx, gwc, sessionID, turnText)
+	}
+	svc := chat.New(gwc, store, distill, compactor, budget, app.Log)
+	api.Register(app.Server, svc, store, token, app.Log)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,16 @@ go 1.26.5
 
 require (
 	github.com/jackc/pgx/v5 v5.10.0
+	github.com/pkoukk/tiktoken-go v0.1.8
+	github.com/pkoukk/tiktoken-go-loader v0.0.2
 	github.com/prometheus/client_golang v1.23.2
 )
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dlclark/regexp2 v1.10.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,12 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
+github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -26,6 +30,10 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/pkoukk/tiktoken-go v0.1.8 h1:85ENo+3FpWgAACBaEUVp+lctuTcYUO7BtmfhlN/QTRo=
+github.com/pkoukk/tiktoken-go v0.1.8/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
+github.com/pkoukk/tiktoken-go-loader v0.0.2 h1:LUKws63GV3pVHwH1srkBplBv+7URgmOmhSkRxsIvsK4=
+github.com/pkoukk/tiktoken-go-loader v0.0.2/go.mod h1:4mIkYyZooFlnenDlormIo6cd5wrlUKNr97wp9nGgEKo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -25,7 +26,7 @@ import (
 // it, *session.Store satisfies it.
 type Directory interface {
 	Create(ctx context.Context, title string) (string, error)
-	List(ctx context.Context, query string) ([]session.Meta, error)
+	List(ctx context.Context, query string, before time.Time) ([]session.Meta, error)
 	Get(ctx context.Context, id string) (session.Meta, error)
 	Events(ctx context.Context, id string) ([]session.Event, error)
 	Update(ctx context.Context, id string, title *string, archived *bool) error
@@ -93,7 +94,16 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 // --- session management ---
 
 func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
-	sessions, err := a.dir.List(r.Context(), r.URL.Query().Get("query"))
+	var before time.Time
+	if v := r.URL.Query().Get("before"); v != "" {
+		t, err := time.Parse(time.RFC3339Nano, v)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, "bad_request", "before must be RFC3339")
+			return
+		}
+		before = t
+	}
+	sessions, err := a.dir.List(r.Context(), r.URL.Query().Get("query"), before)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "list_failed", err.Error())
 		return

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -79,6 +79,28 @@ func bearerToken(r *http.Request) (string, bool) {
 	return token, token != ""
 }
 
+// validSessionID keeps malformed path ids from reaching the driver: a
+// non-UUID is a 404, not a 500 with a raw pgx error on the wire.
+func validSessionID(id string) bool {
+	if len(id) != 36 {
+		return false
+	}
+	for i, c := range id {
+		switch i {
+		case 8, 13, 18, 23:
+			if c != '-' {
+				return false
+			}
+		default:
+			hex := c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F'
+			if !hex {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 func jsonError(w http.ResponseWriter, status int, code, msg string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -142,6 +164,10 @@ func (a *API) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 func (a *API) handleTranscript(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	if !validSessionID(id) {
+		jsonError(w, http.StatusNotFound, "not_found", "no such session")
+		return
+	}
 	meta, err := a.dir.Get(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -180,6 +206,10 @@ func (a *API) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "bad_request", "nothing to update")
 		return
 	}
+	if !validSessionID(r.PathValue("id")) {
+		jsonError(w, http.StatusNotFound, "not_found", "no such session")
+		return
+	}
 	if err := a.dir.Update(r.Context(), r.PathValue("id"), req.Title, req.Archived); err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			jsonError(w, http.StatusNotFound, "not_found", "no such session")
@@ -200,6 +230,10 @@ func (a *API) handleMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req.SessionID = r.PathValue("id")
+	if !validSessionID(req.SessionID) {
+		jsonError(w, http.StatusNotFound, "not_found", "no such session")
+		return
+	}
 	if _, err := a.dir.Get(r.Context(), req.SessionID); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			jsonError(w, http.StatusNotFound, "not_found", "no such session")
@@ -246,6 +280,10 @@ type meta struct {
 func (a *API) streamTurn(w http.ResponseWriter, r *http.Request, req chat.Request) {
 	sessionID, events, err := a.svc.Chat(r.Context(), req)
 	if err != nil {
+		if errors.Is(err, chat.ErrBadRequest) {
+			jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
 		// session_id rides the error when a row was already created so
 		// the client reuses it on retry.
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -1,32 +1,54 @@
 // Package api is brain's public HTTP surface: bearer-authenticated
-// chat over SSE. /health and /metrics stay open (mounted by the
-// platform server before auth exists).
+// session management and chat over SSE. /health and /metrics stay
+// open (mounted by the platform server before auth exists).
 package api
 
 import (
+	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/SumonMSelim/timothy/internal/brain/chat"
+	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 	"github.com/SumonMSelim/timothy/internal/platform/httpserver"
 )
 
+// Directory is the session-management slice of the store; tests fake
+// it, *session.Store satisfies it.
+type Directory interface {
+	Create(ctx context.Context, title string) (string, error)
+	List(ctx context.Context, query string) ([]session.Meta, error)
+	Get(ctx context.Context, id string) (session.Meta, error)
+	Events(ctx context.Context, id string) ([]session.Event, error)
+	Update(ctx context.Context, id string, title *string, archived *bool) error
+}
+
 // API serves brain's public routes.
 type API struct {
 	svc   *chat.Service
+	dir   Directory
 	token string
 	log   *slog.Logger
 }
 
 // Register mounts the routes, each wrapped in bearer auth.
-func Register(srv *httpserver.Server, svc *chat.Service, token string, log *slog.Logger) {
-	a := &API{svc: svc, token: token, log: log}
-	srv.Handle("POST /v1/chat", a.auth(http.HandlerFunc(a.handleChat)))
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, token string, log *slog.Logger) {
+	a := &API{svc: svc, dir: dir, token: token, log: log}
+	srv.Handle("GET /v1/sessions", a.auth(http.HandlerFunc(a.handleList)))
+	srv.Handle("POST /v1/sessions", a.auth(http.HandlerFunc(a.handleCreate)))
+	srv.Handle("GET /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleTranscript)))
+	srv.Handle("PATCH /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleUpdate)))
+	srv.Handle("POST /v1/sessions/{id}/messages", a.auth(http.HandlerFunc(a.handleMessages)))
+	// Deprecated shim: same behavior, session_id in the body.
+	srv.Handle("POST /v1/chat", a.auth(http.HandlerFunc(a.handleChatShim)))
 }
 
 // auth enforces the single bearer token. An unconfigured token fails
@@ -62,11 +84,132 @@ func jsonError(w http.ResponseWriter, status int, code, msg string) {
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": code, "message": msg})
 }
 
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// --- session management ---
+
+func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
+	sessions, err := a.dir.List(r.Context(), r.URL.Query().Get("query"))
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "list_failed", err.Error())
+		return
+	}
+	if sessions == nil {
+		sessions = []session.Meta{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"sessions": sessions})
+}
+
+func (a *API) handleCreate(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Title string `json:"title"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	id, err := a.dir.Create(r.Context(), req.Title)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "create_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]string{"id": id})
+}
+
+func (a *API) handleTranscript(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	meta, err := a.dir.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			jsonError(w, http.StatusNotFound, "not_found", "no such session")
+			return
+		}
+		jsonError(w, http.StatusInternalServerError, "get_failed", err.Error())
+		return
+	}
+	events, err := a.dir.Events(r.Context(), id)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "events_failed", err.Error())
+		return
+	}
+	items, err := session.UITranscript(events)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "projection_failed", err.Error())
+		return
+	}
+	if items == nil {
+		items = []session.TranscriptItem{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"session": meta, "items": items})
+}
+
+func (a *API) handleUpdate(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Title    *string `json:"title"`
+		Archived *bool   `json:"archived"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if req.Title == nil && req.Archived == nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", "nothing to update")
+		return
+	}
+	if err := a.dir.Update(r.Context(), r.PathValue("id"), req.Title, req.Archived); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			jsonError(w, http.StatusNotFound, "not_found", "no such session")
+			return
+		}
+		jsonError(w, http.StatusInternalServerError, "update_failed", err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- chat ---
+
+func (a *API) handleMessages(w http.ResponseWriter, r *http.Request) {
+	var req chat.Request
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	req.SessionID = r.PathValue("id")
+	if _, err := a.dir.Get(r.Context(), req.SessionID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			jsonError(w, http.StatusNotFound, "not_found", "no such session")
+			return
+		}
+		jsonError(w, http.StatusInternalServerError, "get_failed", err.Error())
+		return
+	}
+	a.streamTurn(w, r, req)
+}
+
+// handleChatShim keeps the original /v1/chat contract alive for one
+// deprecation window: session_id travels in the body and a missing one
+// creates a session.
+func (a *API) handleChatShim(w http.ResponseWriter, r *http.Request) {
+	var req chat.Request
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	w.Header().Set("Deprecation", "true")
+	w.Header().Set("Link", `</v1/sessions/{id}/messages>; rel="successor-version"`)
+	a.streamTurn(w, r, req)
+}
+
 // meta is brain's terminal SSE event: session identity plus whatever
 // the gateway attributed on done.
 //
 // Wire contract (deliberately different from the internal channel
-// contract): brain's /v1/chat SSE stream ALWAYS ends with exactly one
+// contract): brain's chat SSE stream ALWAYS ends with exactly one
 // meta event, emitted after the relayed gateway terminal (done or
 // error). Clients must read until meta, not stop at done. Provider,
 // model, usage, and ledger_id are best-effort — absent when no
@@ -80,13 +223,7 @@ type meta struct {
 	LedgerID  string        `json:"ledger_id,omitempty"`
 }
 
-func (a *API) handleChat(w http.ResponseWriter, r *http.Request) {
-	var req chat.Request
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
-		return
-	}
-
+func (a *API) streamTurn(w http.ResponseWriter, r *http.Request, req chat.Request) {
 	sessionID, events, err := a.svc.Chat(r.Context(), req)
 	if err != nil {
 		// session_id rides the error when a row was already created so

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -26,7 +26,7 @@ import (
 // it, *session.Store satisfies it.
 type Directory interface {
 	Create(ctx context.Context, title string) (string, error)
-	List(ctx context.Context, query string, before time.Time) ([]session.Meta, error)
+	List(ctx context.Context, query string, before time.Time, beforeID string) ([]session.Meta, error)
 	Get(ctx context.Context, id string) (session.Meta, error)
 	Events(ctx context.Context, id string) ([]session.Event, error)
 	Update(ctx context.Context, id string, title *string, archived *bool) error
@@ -94,16 +94,26 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 // --- session management ---
 
 func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
+	// The page cursor is the last row of the previous page: both halves
+	// travel together so ties on updated_at cannot drop or repeat rows.
 	var before time.Time
+	beforeID := r.URL.Query().Get("before_id")
 	if v := r.URL.Query().Get("before"); v != "" {
 		t, err := time.Parse(time.RFC3339Nano, v)
 		if err != nil {
-			jsonError(w, http.StatusBadRequest, "bad_request", "before must be RFC3339")
+			jsonError(w, http.StatusBadRequest, "bad_request", "before must be an RFC3339Nano timestamp")
+			return
+		}
+		if beforeID == "" {
+			jsonError(w, http.StatusBadRequest, "bad_request", "before requires before_id")
 			return
 		}
 		before = t
+	} else if beforeID != "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "before_id requires before")
+		return
 	}
-	sessions, err := a.dir.List(r.Context(), r.URL.Query().Get("query"), before)
+	sessions, err := a.dir.List(r.Context(), r.URL.Query().Get("query"), before, beforeID)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "list_failed", err.Error())
 		return

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -44,11 +45,14 @@ func (d *memDir) Create(_ context.Context, title string) (string, error) {
 	return id, nil
 }
 
-func (d *memDir) List(_ context.Context, query string) ([]session.Meta, error) {
+func (d *memDir) List(_ context.Context, query string, before time.Time) ([]session.Meta, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	var out []session.Meta
 	for _, m := range d.metas {
+		if !before.IsZero() && !m.UpdatedAt.Before(before) {
+			continue
+		}
 		if query == "" && !m.Archived || query != "" && strings.Contains(m.Title, query) {
 			out = append(out, m)
 		}

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -45,18 +46,28 @@ func (d *memDir) Create(_ context.Context, title string) (string, error) {
 	return id, nil
 }
 
-func (d *memDir) List(_ context.Context, query string, before time.Time) ([]session.Meta, error) {
+func (d *memDir) List(_ context.Context, query string, before time.Time, beforeID string) ([]session.Meta, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	var out []session.Meta
 	for _, m := range d.metas {
-		if !before.IsZero() && !m.UpdatedAt.Before(before) {
-			continue
+		// Mirror the store's (updated_at, id) cursor: strictly earlier
+		// in the descending ordering.
+		if !before.IsZero() {
+			if m.UpdatedAt.After(before) || (m.UpdatedAt.Equal(before) && m.ID >= beforeID) {
+				continue
+			}
 		}
 		if query == "" && !m.Archived || query != "" && strings.Contains(m.Title, query) {
 			out = append(out, m)
 		}
 	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].UpdatedAt.Equal(out[j].UpdatedAt) {
+			return out[i].UpdatedAt.After(out[j].UpdatedAt)
+		}
+		return out[i].ID > out[j].ID
+	})
 	return out, nil
 }
 
@@ -361,5 +372,52 @@ func TestChatValidation(t *testing.T) {
 	}
 	if w := doMux(a, http.MethodPost, "/v1/chat", `{not json`); w.Code != http.StatusBadRequest {
 		t.Fatalf("bad json: code = %d", w.Code)
+	}
+}
+
+// TestListCursorPaging pins the composite cursor contract: pages split
+// on (updated_at, id) so tied timestamps never drop or repeat rows,
+// and half a cursor is rejected.
+func TestListCursorPaging(t *testing.T) {
+	t.Parallel()
+	a, dir, _ := testAPI(t, "tok", nil)
+	ts := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	dir.mu.Lock()
+	for _, id := range []string{"sess-a", "sess-b", "sess-c"} {
+		dir.metas[id] = session.Meta{ID: id, Title: id, UpdatedAt: ts} // all tied
+	}
+	dir.metas["sess-old"] = session.Meta{ID: "sess-old", Title: "sess-old", UpdatedAt: ts.Add(-time.Hour)}
+	dir.mu.Unlock()
+
+	page1 := doMux(a, http.MethodGet, "/v1/sessions", "")
+	var got struct{ Sessions []session.Meta }
+	if err := json.Unmarshal(page1.Body.Bytes(), &got); err != nil {
+		t.Fatalf("page1: %v", err)
+	}
+	if len(got.Sessions) != 4 || got.Sessions[0].ID != "sess-c" {
+		t.Fatalf("page1 = %+v", got.Sessions)
+	}
+
+	// Resume from the middle of the tie: strictly-after rows only.
+	cursor := got.Sessions[1] // sess-b
+	page2 := doMux(a, http.MethodGet,
+		"/v1/sessions?before="+cursor.UpdatedAt.Format(time.RFC3339Nano)+"&before_id="+cursor.ID, "")
+	if err := json.Unmarshal(page2.Body.Bytes(), &got); err != nil {
+		t.Fatalf("page2: %v", err)
+	}
+	ids := make([]string, len(got.Sessions))
+	for i, m := range got.Sessions {
+		ids[i] = m.ID
+	}
+	if strings.Join(ids, ",") != "sess-a,sess-old" {
+		t.Fatalf("page2 ids = %v, want [sess-a sess-old] (no dup, no skip)", ids)
+	}
+
+	// Half a cursor is a client bug, not a guess.
+	if w := doMux(a, http.MethodGet, "/v1/sessions?before_id=sess-b", ""); w.Code != http.StatusBadRequest {
+		t.Fatalf("before_id alone: code = %d, want 400", w.Code)
+	}
+	if w := doMux(a, http.MethodGet, "/v1/sessions?before=2026-07-10T12:00:00Z", ""); w.Code != http.StatusBadRequest {
+		t.Fatalf("before alone: code = %d, want 400", w.Code)
 	}
 }

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -3,30 +3,120 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/SumonMSelim/timothy/internal/brain/chat"
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
-	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
 )
 
 func discard() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// memDir is an in-memory Directory + chat.SessionLog.
+type memDir struct {
+	mu     sync.Mutex
+	metas  map[string]session.Meta
+	events map[string][]session.Event
+	nextID int
+}
+
+func newMemDir() *memDir {
+	return &memDir{metas: map[string]session.Meta{}, events: map[string][]session.Event{}}
+}
+
+func (d *memDir) Create(_ context.Context, title string) (string, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.nextID++
+	id := fmt.Sprintf("sess-%d", d.nextID)
+	d.metas[id] = session.Meta{ID: id, Title: title}
+	d.events[id] = []session.Event{{SessionID: id, Seq: 1, Kind: session.KindSessionStarted, Payload: []byte(`{}`)}}
+	return id, nil
+}
+
+func (d *memDir) List(_ context.Context, query string) ([]session.Meta, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	var out []session.Meta
+	for _, m := range d.metas {
+		if query == "" && !m.Archived || query != "" && strings.Contains(m.Title, query) {
+			out = append(out, m)
+		}
+	}
+	return out, nil
+}
+
+func (d *memDir) Get(_ context.Context, id string) (session.Meta, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	m, ok := d.metas[id]
+	if !ok {
+		return session.Meta{}, fmt.Errorf("session: get %s: %w", id, pgx.ErrNoRows)
+	}
+	return m, nil
+}
+
+func (d *memDir) Events(_ context.Context, id string) ([]session.Event, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]session.Event(nil), d.events[id]...), nil
+}
+
+func (d *memDir) Update(_ context.Context, id string, title *string, archived *bool) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	m, ok := d.metas[id]
+	if !ok {
+		return fmt.Errorf("session: update %s: not found", id)
+	}
+	if title != nil {
+		m.Title = *title
+	}
+	if archived != nil {
+		m.Archived = *archived
+	}
+	d.metas[id] = m
+	return nil
+}
+
+func (d *memDir) Append(_ context.Context, id, kind string, payload any) (int64, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return 0, err
+	}
+	seq := int64(len(d.events[id]) + 1)
+	d.events[id] = append(d.events[id], session.Event{SessionID: id, Seq: seq, Kind: kind, Payload: data})
+	return seq, nil
+}
+
+func (d *memDir) SetTitleIfEmpty(context.Context, string, string) error { return nil }
+func (d *memDir) SetLastCategory(context.Context, string, string) error { return nil }
 
 // fakeGateway yields a canned event sequence, or fails when err set.
 type fakeGateway struct {
 	events []stream.StreamEvent
 	err    error
 	got    gwclient.StreamRequest
+	calls  int
 }
 
-func (f *fakeGateway) Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
-	f.got = req
+func (f *fakeGateway) Stream(_ context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+	f.calls++
+	if f.calls == 1 { // record the chat call, not the title call
+		f.got = req
+	}
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -38,26 +128,58 @@ func (f *fakeGateway) Stream(ctx context.Context, req gwclient.StreamRequest) (<
 	return ch, nil
 }
 
-func testAPI(t *testing.T, token string, events []stream.StreamEvent) (*API, *fakeGateway) {
+func testAPI(t *testing.T, token string, events []stream.StreamEvent) (*API, *memDir, *fakeGateway) {
 	t.Helper()
+	dir := newMemDir()
 	gw := &fakeGateway{events: events}
-	svc := chat.New(gw, pgpool.New(t.Context(), "", discard()), discard())
-	return &API{svc: svc, token: token, log: discard()}, gw
+	svc := chat.New(gw, dir, nil, nil, 60_000, discard())
+	return &API{svc: svc, dir: dir, token: token, log: discard()}, dir, gw
 }
 
-func doChat(a *API, authHeader, body string) *httptest.ResponseRecorder {
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat", strings.NewReader(body))
+func do(a *API, h http.HandlerFunc, method, path, authHeader, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
 	if authHeader != "" {
 		req.Header.Set("Authorization", authHeader)
 	}
 	w := httptest.NewRecorder()
-	a.auth(http.HandlerFunc(a.handleChat)).ServeHTTP(w, req)
+	a.auth(h).ServeHTTP(w, req)
 	return w
 }
 
+// mux builds the real route table so path values resolve.
+func mux(a *API) *http.ServeMux {
+	m := http.NewServeMux()
+	m.Handle("GET /v1/sessions", a.auth(http.HandlerFunc(a.handleList)))
+	m.Handle("POST /v1/sessions", a.auth(http.HandlerFunc(a.handleCreate)))
+	m.Handle("GET /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleTranscript)))
+	m.Handle("PATCH /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleUpdate)))
+	m.Handle("POST /v1/sessions/{id}/messages", a.auth(http.HandlerFunc(a.handleMessages)))
+	m.Handle("POST /v1/chat", a.auth(http.HandlerFunc(a.handleChatShim)))
+	return m
+}
+
+func doMux(a *API, method, path, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	mux(a).ServeHTTP(w, req)
+	return w
+}
+
+func okEvents() []stream.StreamEvent {
+	return []stream.StreamEvent{
+		{Type: stream.EventChunk, Text: "hi "},
+		{Type: stream.EventChunk, Text: "there"},
+		{Type: stream.EventUsage, Usage: &stream.Usage{InputTokens: 5, OutputTokens: 2}},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod", LedgerID: "led-1"}},
+	}
+}
+
+// --- auth ---
+
 func TestAuthRejectsBadTokens(t *testing.T) {
 	t.Parallel()
-	a, _ := testAPI(t, "secret-token", nil)
+	a, _, _ := testAPI(t, "secret-token", nil)
 
 	for name, header := range map[string]string{
 		"missing":      "",
@@ -65,7 +187,7 @@ func TestAuthRejectsBadTokens(t *testing.T) {
 		"wrong token":  "Bearer nope",
 		"empty bearer": "Bearer ",
 	} {
-		if w := doChat(a, header, `{}`); w.Code != http.StatusUnauthorized {
+		if w := do(a, a.handleList, http.MethodGet, "/v1/sessions", header, ""); w.Code != http.StatusUnauthorized {
 			t.Fatalf("%s: code = %d, want 401", name, w.Code)
 		}
 	}
@@ -78,9 +200,8 @@ func TestAuthAcceptsRobustHeaderShapes(t *testing.T) {
 		"surrounding spaces": "  Bearer secret-token  ",
 		"space before token": "Bearer  secret-token",
 	} {
-		// Fresh API per case: a session buffer is per-service state.
-		a, _ := testAPI(t, "secret-token", []stream.StreamEvent{{Type: stream.EventDone}})
-		if w := doChat(a, header, `{"session_id":"s","message":"hi"}`); w.Code != http.StatusOK {
+		a, _, _ := testAPI(t, "secret-token", nil)
+		if w := do(a, a.handleList, http.MethodGet, "/v1/sessions", header, ""); w.Code != http.StatusOK {
 			t.Fatalf("%s: code = %d, want 200", name, w.Code)
 		}
 	}
@@ -88,76 +209,153 @@ func TestAuthAcceptsRobustHeaderShapes(t *testing.T) {
 
 func TestAuthFailsClosedWhenUnconfigured(t *testing.T) {
 	t.Parallel()
-	a, _ := testAPI(t, "", nil)
-
-	w := doChat(a, "Bearer anything", `{}`)
-	if w.Code != http.StatusServiceUnavailable {
+	a, _, _ := testAPI(t, "", nil)
+	if w := do(a, a.handleList, http.MethodGet, "/v1/sessions", "Bearer anything", ""); w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("code = %d, want 503 (fail closed)", w.Code)
 	}
 }
 
-func TestChatRelaysEventsAndAppendsMeta(t *testing.T) {
-	t.Parallel()
-	a, gw := testAPI(t, "tok", []stream.StreamEvent{
-		{Type: stream.EventChunk, Text: "hi "},
-		{Type: stream.EventChunk, Text: "there"},
-		{Type: stream.EventUsage, Usage: &stream.Usage{InputTokens: 5, OutputTokens: 2}},
-		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod", LedgerID: "led-1"}},
-	})
+// --- session management ---
 
-	w := doChat(a, "Bearer tok", `{"session_id":"s-1","message":"hello","task_category":"mini"}`)
+func TestSessionCRUD(t *testing.T) {
+	t.Parallel()
+	a, dir, _ := testAPI(t, "tok", nil)
+
+	// create
+	w := doMux(a, http.MethodPost, "/v1/sessions", `{"title":"my session"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", w.Code, w.Body.String())
+	}
+	var created struct{ ID string }
+	_ = json.Unmarshal(w.Body.Bytes(), &created)
+
+	// list
+	w = doMux(a, http.MethodGet, "/v1/sessions", "")
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), created.ID) {
+		t.Fatalf("list: %d %s", w.Code, w.Body.String())
+	}
+
+	// rename + archive
+	w = doMux(a, http.MethodPatch, "/v1/sessions/"+created.ID, `{"title":"renamed","archived":true}`)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("patch: %d %s", w.Code, w.Body.String())
+	}
+	if m, _ := dir.Get(t.Context(), created.ID); m.Title != "renamed" || !m.Archived {
+		t.Fatalf("meta after patch = %+v", m)
+	}
+
+	// patch nothing
+	if w = doMux(a, http.MethodPatch, "/v1/sessions/"+created.ID, `{}`); w.Code != http.StatusBadRequest {
+		t.Fatalf("empty patch: %d", w.Code)
+	}
+	// patch missing
+	if w = doMux(a, http.MethodPatch, "/v1/sessions/nope", `{"archived":true}`); w.Code != http.StatusNotFound {
+		t.Fatalf("patch missing: %d", w.Code)
+	}
+}
+
+func TestTranscriptEndpoint(t *testing.T) {
+	t.Parallel()
+	a, dir, _ := testAPI(t, "tok", nil)
+	id, _ := dir.Create(t.Context(), "t")
+	_, _ = dir.Append(t.Context(), id, session.KindUserMessage, session.UserMessage{Text: "hello"})
+
+	w := doMux(a, http.MethodGet, "/v1/sessions/"+id, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("transcript: %d %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Session session.Meta             `json:"session"`
+		Items   []session.TranscriptItem `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Session.ID != id || len(resp.Items) != 1 || resp.Items[0].Text != "hello" {
+		t.Fatalf("resp = %+v", resp)
+	}
+
+	if w = doMux(a, http.MethodGet, "/v1/sessions/missing", ""); w.Code != http.StatusNotFound {
+		t.Fatalf("missing session: %d", w.Code)
+	}
+}
+
+// --- chat ---
+
+func TestMessagesEndpointStreamsAndPersists(t *testing.T) {
+	t.Parallel()
+	a, dir, gw := testAPI(t, "tok", okEvents())
+	id, _ := dir.Create(t.Context(), "t")
+
+	w := doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages", `{"message":"hello","task_category":"mini"}`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("code = %d body=%s", w.Code, w.Body.String())
 	}
-	if got := w.Header().Get("X-Session-Id"); got != "s-1" {
-		t.Fatalf("X-Session-Id = %q, want s-1 (mid-stream cut safety)", got)
+	if got := w.Header().Get("X-Session-Id"); got != id {
+		t.Fatalf("X-Session-Id = %q, want %s", got, id)
 	}
-	if gw.got.TaskCategory != "mini" || gw.got.SessionID != "s-1" {
+	if gw.got.TaskCategory != "mini" || !strings.Contains(gw.got.System, "Timothy") {
 		t.Fatalf("gateway request = %+v", gw.got)
-	}
-	if gw.got.System == "" || !strings.Contains(gw.got.System, "Timothy") {
-		t.Fatal("system prompt missing from gateway request")
 	}
 
 	lines := strings.Split(strings.TrimSpace(w.Body.String()), "\n\n")
 	last := strings.TrimPrefix(lines[len(lines)-1], "data: ")
 	var m meta
 	if err := json.Unmarshal([]byte(last), &m); err != nil {
-		t.Fatalf("terminal event not meta JSON: %v (%s)", err, last)
+		t.Fatalf("terminal not meta: %v (%s)", err, last)
 	}
-	if m.Type != "meta" || m.SessionID != "s-1" || m.Provider != "prov" ||
-		m.Model != "mod" || m.LedgerID != "led-1" || m.Usage == nil || m.Usage.InputTokens != 5 {
+	if m.Type != "meta" || m.SessionID != id || m.Provider != "prov" || m.Usage == nil {
 		t.Fatalf("meta = %+v", m)
+	}
+
+	if w = doMux(a, http.MethodPost, "/v1/sessions/missing/messages", `{"message":"x"}`); w.Code != http.StatusNotFound {
+		t.Fatalf("missing session message: %d", w.Code)
+	}
+}
+
+func TestChatShimCreatesSessionAndDeprecates(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", okEvents())
+
+	w := doMux(a, http.MethodPost, "/v1/chat", `{"message":"hello"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d body=%s", w.Code, w.Body.String())
+	}
+	if w.Header().Get("Deprecation") != "true" {
+		t.Fatal("deprecation header missing")
+	}
+	if w.Header().Get("X-Session-Id") == "" {
+		t.Fatal("created session id missing from header")
 	}
 }
 
 func TestChatErrorCarriesSessionID(t *testing.T) {
 	t.Parallel()
+	a, dir, _ := testAPI(t, "tok", nil)
+	id, _ := dir.Create(t.Context(), "t")
+	// gateway with error
 	gw := &fakeGateway{err: context.DeadlineExceeded}
-	svc := chat.New(gw, pgpool.New(t.Context(), "", discard()), discard())
-	a := &API{svc: svc, token: "tok", log: discard()}
+	a.svc = chat.New(gw, dir, nil, nil, 60_000, discard())
 
-	w := doChat(a, "Bearer tok", `{"session_id":"s-keep","message":"hi"}`)
+	w := doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages", `{"message":"hi"}`)
 	if w.Code != http.StatusBadGateway {
 		t.Fatalf("code = %d, want 502", w.Code)
 	}
 	var body map[string]string
-	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if body["session_id"] != "s-keep" {
-		t.Fatalf("session_id = %q, want s-keep (client must reuse it)", body["session_id"])
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if body["session_id"] != id {
+		t.Fatalf("session_id = %q, want %s", body["session_id"], id)
 	}
 }
 
 func TestChatValidation(t *testing.T) {
 	t.Parallel()
-	a, _ := testAPI(t, "tok", nil)
+	a, _, _ := testAPI(t, "tok", nil)
 
-	if w := doChat(a, "Bearer tok", `{"session_id":"s-1","message":"  "}`); w.Code != http.StatusBadGateway {
+	if w := doMux(a, http.MethodPost, "/v1/chat", `{"message":"  "}`); w.Code != http.StatusBadGateway {
 		t.Fatalf("blank message: code = %d", w.Code)
 	}
-	if w := doChat(a, "Bearer tok", `{not json`); w.Code != http.StatusBadRequest {
+	if w := doMux(a, http.MethodPost, "/v1/chat", `{not json`); w.Code != http.StatusBadRequest {
 		t.Fatalf("bad json: code = %d", w.Code)
 	}
 }

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -40,7 +40,7 @@ func (d *memDir) Create(_ context.Context, title string) (string, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.nextID++
-	id := fmt.Sprintf("sess-%d", d.nextID)
+	id := fmt.Sprintf("00000000-0000-4000-8000-%012d", d.nextID)
 	d.metas[id] = session.Meta{ID: id, Title: title}
 	d.events[id] = []session.Event{{SessionID: id, Seq: 1, Kind: session.KindSessionStarted, Payload: []byte(`{}`)}}
 	return id, nil
@@ -367,8 +367,8 @@ func TestChatValidation(t *testing.T) {
 	t.Parallel()
 	a, _, _ := testAPI(t, "tok", nil)
 
-	if w := doMux(a, http.MethodPost, "/v1/chat", `{"message":"  "}`); w.Code != http.StatusBadGateway {
-		t.Fatalf("blank message: code = %d", w.Code)
+	if w := doMux(a, http.MethodPost, "/v1/chat", `{"message":"  "}`); w.Code != http.StatusBadRequest {
+		t.Fatalf("blank message: code = %d, want 400 (caller bug, not gateway failure)", w.Code)
 	}
 	if w := doMux(a, http.MethodPost, "/v1/chat", `{not json`); w.Code != http.StatusBadRequest {
 		t.Fatalf("bad json: code = %d", w.Code)

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -111,6 +111,18 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	}); err != nil {
 		return sessionID, nil, err
 	}
+	// Pre-send guarantee: the context actually sent to the provider
+	// stays under budget even on the turn that crosses it. The
+	// post-turn pass below keeps sessions compacted ahead of time, so
+	// this is a cheap no-op except on the crossing turn; best-effort —
+	// an oversized context beats no answer.
+	if s.compactor != nil {
+		cctx, cancel := context.WithTimeout(ctx, compactBudget)
+		if err := s.compactor.MaybeCompact(cctx, sessionID); err != nil {
+			s.logger.Warn("pre-send compaction", "session_id", sessionID, "error", err)
+		}
+		cancel()
+	}
 	events, err = s.log.Events(ctx, sessionID)
 	if err != nil {
 		return sessionID, nil, err

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -1,7 +1,8 @@
-// Package chat is brain's pass-through chat: assemble a prompt from
-// the in-memory session buffer, stream through the gateway, remember
-// the exchange. Event-sourced persistence replaces the buffer in the
-// next slice; the buffer is DELIBERATELY temporary.
+// Package chat orchestrates one conversation turn: project the
+// session's event log into context, stream through the gateway,
+// persist the turn as events (with distilled residue), and keep the
+// projection under budget. State lives in the log — a restart loses
+// nothing (D-006).
 package chat
 
 import (
@@ -9,40 +10,64 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync"
+	"time"
 
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
-	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
 )
 
 const (
 	// defaultCategory serves plain chat turns when the caller picks
 	// nothing; the web UI exposes a per-message picker.
 	defaultCategory = "coding"
-	// maxBufferedMessages bounds the temporary per-session history.
-	maxBufferedMessages = 20
+	// Each persistence stage gets its OWN deadline: LLM-backed stages
+	// (distill, compaction) must never eat the database writes' clock.
+	persistTimeout = 10 * time.Second
+	distillBudget  = 65 * time.Second // two 30s attempts + slack
+	compactBudget  = 90 * time.Second
+	titleTimeout   = 15 * time.Second
 )
 
-// Gateway is what chat needs from the gateway client.
+// Gateway is the slice of the gateway client chat needs.
 type Gateway interface {
 	Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error)
 }
 
-// Service holds the temporary in-memory conversation buffers.
-type Service struct {
-	gw  Gateway
-	db  *pgpool.Pool
-	log *slog.Logger
-
-	mu      sync.Mutex
-	buffers map[string][]provider.Message
+// SessionLog is the slice of the session store chat needs; tests fake
+// it, session.Store satisfies it.
+type SessionLog interface {
+	Create(ctx context.Context, title string) (string, error)
+	Events(ctx context.Context, sessionID string) ([]session.Event, error)
+	Append(ctx context.Context, sessionID, kind string, payload any) (int64, error)
+	SetTitleIfEmpty(ctx context.Context, id, title string) error
+	SetLastCategory(ctx context.Context, id, category string) error
 }
 
-func New(gw Gateway, db *pgpool.Pool, log *slog.Logger) *Service {
-	log.Info("chat service ready", "system_prompt_version", systemPromptVersion)
-	return &Service{gw: gw, db: db, log: log, buffers: map[string][]provider.Message{}}
+// Distill extracts turn residue; loop.DistillTurn curried with the
+// gateway in main, stubbed in tests. May return nil.
+type Distill func(ctx context.Context, sessionID, turnText string) *session.TurnMemory
+
+// Compactor keeps a session's projection under budget.
+type Compactor interface {
+	MaybeCompact(ctx context.Context, sessionID string) error
+}
+
+// Service orchestrates turns against the event store.
+type Service struct {
+	gw         Gateway
+	log        SessionLog
+	distill    Distill
+	compactor  Compactor
+	budget     int
+	flushEvery time.Duration // pending-state flush cadence mid-stream
+	logger     *slog.Logger
+}
+
+func New(gw Gateway, log SessionLog, distill Distill, compactor Compactor, budget int, logger *slog.Logger) *Service {
+	logger.Info("chat service ready", "system_prompt_version", systemPromptVersion, "token_budget", budget)
+	return &Service{gw: gw, log: log, distill: distill, compactor: compactor, budget: budget, flushEvery: 2 * time.Second, logger: logger}
 }
 
 // Request is one chat turn.
@@ -53,9 +78,10 @@ type Request struct {
 	ModelHint    string `json:"model_hint,omitempty"`
 }
 
-// Chat streams one turn. A missing session id creates a session row
-// and the returned id identifies it. The returned channel follows the
-// stream package's terminal contract.
+// Chat streams one turn. The user message is durably appended before
+// the provider is called; the assistant turn (or a pending_state on
+// abnormal end) is appended when the stream finishes. The returned
+// channel follows the stream package's terminal contract.
 func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.StreamEvent, error) {
 	if strings.TrimSpace(req.Message) == "" {
 		return "", nil, fmt.Errorf("chat: message is required")
@@ -67,77 +93,227 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 
 	sessionID := req.SessionID
 	if sessionID == "" {
-		id, err := s.createSession(ctx)
+		id, err := s.log.Create(ctx, "")
 		if err != nil {
 			return "", nil, err
 		}
 		sessionID = id
 	}
 
-	userMsg := provider.Message{Role: "user", Content: req.Message}
-	messages := append(s.history(sessionID), userMsg)
+	events, err := s.log.Events(ctx, sessionID)
+	if err != nil {
+		return sessionID, nil, err
+	}
+	firstExchange := !hasUserMessage(events)
+
+	if _, err := s.log.Append(ctx, sessionID, session.KindUserMessage, session.UserMessage{
+		Text: req.Message, Category: category, ModelHint: req.ModelHint,
+	}); err != nil {
+		return sessionID, nil, err
+	}
+	events, err = s.log.Events(ctx, sessionID)
+	if err != nil {
+		return sessionID, nil, err
+	}
+	msgs, err := session.LLMContext(events, s.budget)
+	if err != nil {
+		return sessionID, nil, err
+	}
 
 	upstream, err := s.gw.Stream(ctx, gwclient.StreamRequest{
 		TaskCategory: category,
 		ModelHint:    req.ModelHint,
 		System:       systemPrompt,
-		Messages:     messages,
+		Messages:     msgs,
 		SessionID:    sessionID,
 	})
 	if err != nil {
-		// Return the id with the error: the session row exists, and the
-		// client must reuse it on retry instead of orphaning it.
 		return sessionID, nil, err
 	}
 
 	out := make(chan stream.StreamEvent)
-	go func() {
-		defer close(out)
-		var reply strings.Builder
+	go s.relay(ctx, sessionID, req.Message, category, firstExchange, upstream, out)
+	return sessionID, out, nil
+}
+
+// relay forwards events to the client while accumulating the turn,
+// then persists it. Persistence uses a cancel-detached context: a
+// client disconnect or brain shutdown mid-turn must still leave a
+// durable pending_state (the kill-test contract).
+func (s *Service) relay(ctx context.Context, sessionID, userText, category string, firstExchange bool, upstream <-chan stream.StreamEvent, out chan<- stream.StreamEvent) {
+	var text, reasoning strings.Builder
+	var meta *stream.Meta
+	sawDone := false
+	flushed := 0
+
+	// flushPending checkpoints the partial answer DURING the stream so
+	// even a SIGKILL mid-turn loses at most one flush interval — the
+	// projection splices the last pending in, and a completed turn
+	// supersedes every checkpoint (the kill-test contract).
+	flushPending := func() {
+		if text.Len() == flushed || text.Len() == 0 {
+			return
+		}
+		wctx, cancel := context.WithTimeout(context.Background(), persistTimeout)
+		defer cancel()
+		if _, err := s.log.Append(wctx, sessionID, session.KindPendingState, session.PendingState{Partial: text.String()}); err != nil {
+			s.logger.Warn("flush pending state", "session_id", sessionID, "error", err)
+			return
+		}
+		flushed = text.Len()
+	}
+
+	drainAndPersist := func() {
+		// Consume whatever the upstream still yields (it shares the
+		// request ctx, so it winds down quickly), free the client,
+		// then persist the final state.
 		for ev := range upstream {
-			if ev.Type == stream.EventChunk {
-				reply.WriteString(ev.Text)
+			switch ev.Type {
+			case stream.EventChunk:
+				text.WriteString(ev.Text)
+			case stream.EventDone:
+				sawDone = true
+				meta = ev.Meta
+			}
+		}
+		close(out)
+		s.persistTurn(sessionID, userText, category, firstExchange, text.String(), reasoning.String(), meta, sawDone, flushed)
+	}
+
+	ticker := time.NewTicker(s.flushEvery)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case ev, ok := <-upstream:
+			if !ok {
+				drainAndPersist()
+				return
+			}
+			switch ev.Type {
+			case stream.EventChunk:
+				text.WriteString(ev.Text)
+			case stream.EventReasoningChunk:
+				reasoning.WriteString(ev.Text)
+			case stream.EventDone:
+				sawDone = true
+				meta = ev.Meta
 			}
 			select {
 			case out <- ev:
 			case <-ctx.Done():
+				flushPending()
+				drainAndPersist()
 				return
 			}
+		case <-ticker.C:
+			flushPending()
+		case <-ctx.Done():
+			flushPending()
+			drainAndPersist()
+			return
 		}
-		if reply.Len() > 0 {
-			s.remember(sessionID, userMsg, provider.Message{Role: "assistant", Content: reply.String()})
-		}
-	}()
-	return sessionID, out, nil
+	}
 }
 
-func (s *Service) createSession(ctx context.Context) (string, error) {
-	db, err := s.db.Get()
+func (s *Service) persistTurn(sessionID, userText, category string, firstExchange bool, text, reasoning string, meta *stream.Meta, sawDone bool, flushed int) {
+	if !sawDone {
+		// Abnormal end: keep the partial durable; the projection
+		// splices it into the next request. Skip when the periodic
+		// flush already checkpointed this exact content.
+		if text != "" && len(text) != flushed {
+			ctx, cancel := context.WithTimeout(context.Background(), persistTimeout)
+			defer cancel()
+			if _, err := s.log.Append(ctx, sessionID, session.KindPendingState, session.PendingState{Partial: text}); err != nil {
+				s.logger.Error("persist pending state", "session_id", sessionID, "error", err)
+			}
+		}
+		return
+	}
+
+	var turn session.AssistantTurn
+	turn.LLM.Message = text
+	if reasoning != "" {
+		turn.UI.Blocks = append(turn.UI.Blocks, session.UIBlock{Type: "reasoning", Text: reasoning})
+	}
+	turn.UI.Blocks = append(turn.UI.Blocks, session.UIBlock{Type: "text", Text: text})
+	if meta != nil {
+		turn.Provider, turn.Model, turn.LedgerID = meta.Provider, meta.Model, meta.LedgerID
+	}
+	if s.distill != nil && text != "" {
+		dctx, cancel := context.WithTimeout(context.Background(), distillBudget)
+		turn.LLM.TurnMemory = s.distill(dctx, sessionID, "user: "+userText+"\n\nassistant: "+text)
+		cancel()
+	}
+
+	wctx, cancel := context.WithTimeout(context.Background(), persistTimeout)
+	defer cancel()
+	if _, err := s.log.Append(wctx, sessionID, session.KindAssistantTurn, turn); err != nil {
+		s.logger.Error("persist assistant turn", "session_id", sessionID, "error", err)
+		return
+	}
+	if err := s.log.SetLastCategory(wctx, sessionID, category); err != nil {
+		s.logger.Warn("persist last category", "session_id", sessionID, "error", err)
+	}
+	if s.compactor != nil {
+		cctx, cancel := context.WithTimeout(context.Background(), compactBudget)
+		if err := s.compactor.MaybeCompact(cctx, sessionID); err != nil {
+			s.logger.Error("compaction", "session_id", sessionID, "error", err)
+		}
+		cancel()
+	}
+	if firstExchange {
+		s.autoTitle(sessionID, userText, text)
+	}
+}
+
+// autoTitle names a session after its first exchange via a mini call;
+// best-effort and never clobbers a user-chosen title.
+func (s *Service) autoTitle(sessionID, userText, reply string) {
+	ctx, cancel := context.WithTimeout(context.Background(), titleTimeout)
+	defer cancel()
+
+	const titleSystem = `Produce a title for this conversation: at most 6 words, plain text, no quotes, no trailing punctuation. Reply with only the title.`
+	input := userText
+	if len(reply) > 200 {
+		reply = reply[:200]
+	}
+	input += "\n\n" + reply
+
+	events, err := s.gw.Stream(ctx, gwclient.StreamRequest{
+		TaskCategory: "mini",
+		System:       titleSystem,
+		Messages:     []provider.Message{{Role: "user", Content: input}},
+		MaxTokens:    30,
+		SessionID:    sessionID,
+	})
 	if err != nil {
-		return "", fmt.Errorf("chat: create session: %w", err)
+		s.logger.Warn("auto-title", "session_id", sessionID, "error", err)
+		return
 	}
-	var id string
-	if err := db.QueryRow(ctx, "INSERT INTO sessions DEFAULT VALUES RETURNING id").Scan(&id); err != nil {
-		return "", fmt.Errorf("chat: create session: %w", err)
+	var b strings.Builder
+	for ev := range events {
+		if ev.Type == stream.EventChunk {
+			b.WriteString(ev.Text)
+		}
 	}
-	return id, nil
+	title := strings.TrimSpace(strings.Trim(strings.TrimSpace(b.String()), `"'`))
+	if title == "" {
+		return
+	}
+	if len(title) > 80 {
+		title = title[:80]
+	}
+	if err := s.log.SetTitleIfEmpty(ctx, sessionID, title); err != nil {
+		s.logger.Warn("auto-title save", "session_id", sessionID, "error", err)
+	}
 }
 
-func (s *Service) history(sessionID string) []provider.Message {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	buf := s.buffers[sessionID]
-	out := make([]provider.Message, len(buf), len(buf)+1)
-	copy(out, buf)
-	return out
-}
-
-func (s *Service) remember(sessionID string, exchange ...provider.Message) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	buf := append(s.buffers[sessionID], exchange...)
-	if len(buf) > maxBufferedMessages {
-		buf = buf[len(buf)-maxBufferedMessages:]
+func hasUserMessage(events []session.Event) bool {
+	for _, ev := range events {
+		if ev.Kind == session.KindUserMessage {
+			return true
+		}
 	}
-	s.buffers[sessionID] = buf
+	return false
 }

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -7,6 +7,7 @@ package chat
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -29,6 +30,10 @@ const (
 	compactBudget  = 90 * time.Second
 	titleTimeout   = 15 * time.Second
 )
+
+// ErrBadRequest marks caller mistakes (empty message) so the API can
+// answer 400 instead of blaming the gateway.
+var ErrBadRequest = errors.New("bad request")
 
 // Gateway is the slice of the gateway client chat needs.
 type Gateway interface {
@@ -84,7 +89,7 @@ type Request struct {
 // channel follows the stream package's terminal contract.
 func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.StreamEvent, error) {
 	if strings.TrimSpace(req.Message) == "" {
-		return "", nil, fmt.Errorf("chat: message is required")
+		return "", nil, fmt.Errorf("chat: %w: message is required", ErrBadRequest)
 	}
 	category := req.TaskCategory
 	if category == "" {
@@ -134,6 +139,7 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 
 	upstream, err := s.gw.Stream(ctx, gwclient.StreamRequest{
 		TaskCategory: category,
+		Purpose:      "chat",
 		ModelHint:    req.ModelHint,
 		System:       systemPrompt,
 		Messages:     msgs,
@@ -155,6 +161,7 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 func (s *Service) relay(ctx context.Context, sessionID, userText, category string, firstExchange bool, upstream <-chan stream.StreamEvent, out chan<- stream.StreamEvent) {
 	var text, reasoning strings.Builder
 	var meta *stream.Meta
+	var usage *stream.Usage
 	sawDone := false
 	flushed := 0
 
@@ -183,13 +190,15 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, category strin
 			switch ev.Type {
 			case stream.EventChunk:
 				text.WriteString(ev.Text)
+			case stream.EventUsage:
+				usage = ev.Usage
 			case stream.EventDone:
 				sawDone = true
 				meta = ev.Meta
 			}
 		}
 		close(out)
-		s.persistTurn(sessionID, userText, category, firstExchange, text.String(), reasoning.String(), meta, sawDone, flushed)
+		s.persistTurn(sessionID, userText, category, firstExchange, text.String(), reasoning.String(), meta, usage, sawDone, flushed)
 	}
 
 	ticker := time.NewTicker(s.flushEvery)
@@ -207,6 +216,8 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, category strin
 				text.WriteString(ev.Text)
 			case stream.EventReasoningChunk:
 				reasoning.WriteString(ev.Text)
+			case stream.EventUsage:
+				usage = ev.Usage
 			case stream.EventDone:
 				sawDone = true
 				meta = ev.Meta
@@ -228,7 +239,7 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, category strin
 	}
 }
 
-func (s *Service) persistTurn(sessionID, userText, category string, firstExchange bool, text, reasoning string, meta *stream.Meta, sawDone bool, flushed int) {
+func (s *Service) persistTurn(sessionID, userText, category string, firstExchange bool, text, reasoning string, meta *stream.Meta, usage *stream.Usage, sawDone bool, flushed int) {
 	if !sawDone {
 		// Abnormal end: keep the partial durable; the projection
 		// splices it into the next request. Skip when the periodic
@@ -252,21 +263,39 @@ func (s *Service) persistTurn(sessionID, userText, category string, firstExchang
 	if meta != nil {
 		turn.Provider, turn.Model, turn.LedgerID = meta.Provider, meta.Model, meta.LedgerID
 	}
-	if s.distill != nil && text != "" {
-		dctx, cancel := context.WithTimeout(context.Background(), distillBudget)
-		turn.LLM.TurnMemory = s.distill(dctx, sessionID, "user: "+userText+"\n\nassistant: "+text)
-		cancel()
-	}
+	turn.Usage = usage
 
+	// The assistant turn must be durable the moment the stream ends: a
+	// follow-up message can arrive within seconds, and its projection
+	// must see this turn completed (not a phantom interruption from a
+	// stale checkpoint). Distillation is an LLM call — it lands later
+	// as its own turn_memory event, never on this write's clock.
 	wctx, cancel := context.WithTimeout(context.Background(), persistTimeout)
 	defer cancel()
-	if _, err := s.log.Append(wctx, sessionID, session.KindAssistantTurn, turn); err != nil {
+	turnSeq, err := s.log.Append(wctx, sessionID, session.KindAssistantTurn, turn)
+	if err != nil {
 		s.logger.Error("persist assistant turn", "session_id", sessionID, "error", err)
 		return
 	}
 	if err := s.log.SetLastCategory(wctx, sessionID, category); err != nil {
 		s.logger.Warn("persist last category", "session_id", sessionID, "error", err)
 	}
+
+	if s.distill != nil && text != "" {
+		dctx, dcancel := context.WithTimeout(context.Background(), distillBudget)
+		tm := s.distill(dctx, sessionID, "user: "+userText+"\n\nassistant: "+text)
+		dcancel()
+		if tm != nil && (len(tm.FilesChanged) > 0 || len(tm.Failures) > 0 || len(tm.KeyFindings) > 0) {
+			mctx, mcancel := context.WithTimeout(context.Background(), persistTimeout)
+			if _, err := s.log.Append(mctx, sessionID, session.KindTurnMemory, session.TurnMemoryEvent{
+				TurnSeq: turnSeq, TurnMemory: *tm,
+			}); err != nil {
+				s.logger.Warn("persist turn memory", "session_id", sessionID, "error", err)
+			}
+			mcancel()
+		}
+	}
+
 	if s.compactor != nil {
 		cctx, cancel := context.WithTimeout(context.Background(), compactBudget)
 		if err := s.compactor.MaybeCompact(cctx, sessionID); err != nil {
@@ -286,14 +315,11 @@ func (s *Service) autoTitle(sessionID, userText, reply string) {
 	defer cancel()
 
 	const titleSystem = `Produce a title for this conversation: at most 6 words, plain text, no quotes, no trailing punctuation. Reply with only the title.`
-	input := userText
-	if len(reply) > 200 {
-		reply = reply[:200]
-	}
-	input += "\n\n" + reply
+	input := userText + "\n\n" + truncateRunes(reply, 200)
 
 	events, err := s.gw.Stream(ctx, gwclient.StreamRequest{
 		TaskCategory: "mini",
+		Purpose:      "title",
 		System:       titleSystem,
 		Messages:     []provider.Message{{Role: "user", Content: input}},
 		// Reasoning models spend hundreds of tokens thinking before
@@ -317,12 +343,23 @@ func (s *Service) autoTitle(sessionID, userText, reply string) {
 		s.logger.Warn("auto-title returned no text", "session_id", sessionID)
 		return
 	}
-	if len(title) > 80 {
-		title = title[:80]
-	}
+	title = truncateRunes(title, 80)
 	if err := s.log.SetTitleIfEmpty(ctx, sessionID, title); err != nil {
 		s.logger.Warn("auto-title save", "session_id", sessionID, "error", err)
 	}
+}
+
+// truncateRunes cuts on rune boundaries: byte slicing can split a
+// UTF-8 sequence and Postgres rejects invalid text.
+func truncateRunes(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n])
 }
 
 func hasUserMessage(events []session.Event) bool {

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -284,8 +284,11 @@ func (s *Service) autoTitle(sessionID, userText, reply string) {
 		TaskCategory: "mini",
 		System:       titleSystem,
 		Messages:     []provider.Message{{Role: "user", Content: input}},
-		MaxTokens:    30,
-		SessionID:    sessionID,
+		// Reasoning models spend hundreds of tokens thinking before
+		// the first answer token; a tight cap truncates the stream
+		// mid-reasoning and yields an empty title.
+		MaxTokens: 1000,
+		SessionID: sessionID,
 	})
 	if err != nil {
 		s.logger.Warn("auto-title", "session_id", sessionID, "error", err)
@@ -299,6 +302,7 @@ func (s *Service) autoTitle(sessionID, userText, reply string) {
 	}
 	title := strings.TrimSpace(strings.Trim(strings.TrimSpace(b.String()), `"'`))
 	if title == "" {
+		s.logger.Warn("auto-title returned no text", "session_id", sessionID)
 		return
 	}
 	if len(title) > 80 {

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -375,5 +376,62 @@ func TestChatCompactsBeforeSend(t *testing.T) {
 	defer order.mu.Unlock()
 	if len(order.calls) < 2 || order.calls[0] != "compact" || order.calls[1] != "stream" {
 		t.Fatalf("call order = %v, want compaction before the provider call", order.calls)
+	}
+}
+
+// compactingLog is a Compactor that actually rewrites the log the way
+// the real one does: it appends a compaction_applied event replacing
+// everything before the newest user message.
+type compactingLog struct {
+	log *fakeLog
+}
+
+func (c *compactingLog) MaybeCompact(ctx context.Context, sessionID string) error {
+	events, _ := c.log.Events(ctx, sessionID)
+	// Replace everything before the just-appended user message.
+	boundary := events[len(events)-1].Seq - 1
+	_, err := c.log.Append(ctx, sessionID, session.KindCompactionApplied, session.CompactionApplied{
+		Summary: "everything before was condensed", ReplacesThroughSeq: boundary,
+	})
+	return err
+}
+
+// TestChatSendsCompactedContext pins what actually goes on the wire
+// when pre-send compaction fires: the provider sees the summary head
+// plus the new user message, never the summarized-away content.
+func TestChatSendsCompactedContext(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	ctx := context.Background()
+	if _, err := log.Append(ctx, "s1", session.KindUserMessage, session.UserMessage{Text: "old question"}); err != nil {
+		t.Fatal(err)
+	}
+	var turn session.AssistantTurn
+	turn.LLM.Message = "old answer"
+	if _, err := log.Append(ctx, "s1", session.KindAssistantTurn, turn); err != nil {
+		t.Fatal(err)
+	}
+
+	gw := &fakeGW{events: okEvents("fresh reply")}
+	svc := New(gw, log, nil, &compactingLog{log: log}, 60_000, discard())
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "new question"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	msgs := gw.lastRequest().Messages
+	if len(msgs) != 2 {
+		t.Fatalf("wire messages = %+v, want [summary, new question]", msgs)
+	}
+	if !strings.Contains(msgs[0].Content, "everything before was condensed") {
+		t.Fatalf("summary head missing from wire context: %+v", msgs[0])
+	}
+	if strings.Contains(fmt.Sprint(msgs), "old question") || strings.Contains(fmt.Sprint(msgs), "old answer") {
+		t.Fatalf("summarized-away content leaked onto the wire: %+v", msgs)
+	}
+	if msgs[1].Content != "new question" {
+		t.Fatalf("new user message not last on the wire: %+v", msgs[1])
 	}
 }

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -435,3 +435,66 @@ func TestChatSendsCompactedContext(t *testing.T) {
 		t.Fatalf("new user message not last on the wire: %+v", msgs[1])
 	}
 }
+
+// TestFollowUpSeesCompletedTurnWhileDistillRuns pins turn durability:
+// the assistant turn must be in the log the moment the client stream
+// ends, even while distillation is still running — a fast follow-up
+// projects the completed answer, never a phantom interruption.
+func TestFollowUpSeesCompletedTurnWhileDistillRuns(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("the full answer")}
+	distillStarted := make(chan struct{})
+	distillRelease := make(chan struct{})
+	var startedOnce sync.Once
+	distill := func(ctx context.Context, sessionID, turnText string) *session.TurnMemory {
+		startedOnce.Do(func() { close(distillStarted) })
+		select {
+		case <-distillRelease:
+		case <-ctx.Done():
+		}
+		return &session.TurnMemory{KeyFindings: []string{"late residue"}}
+	}
+	defer close(distillRelease)
+	svc := New(gw, log, distill, nil, 60_000, discard())
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "first question"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	// Distill is now blocked mid-flight; the turn must already be durable.
+	select {
+	case <-distillStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("distill never started")
+	}
+	deadline := time.After(5 * time.Second)
+	for {
+		if k := log.kinds("s1"); len(k) > 0 && k[len(k)-1] == session.KindAssistantTurn {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("assistant_turn not durable while distill runs: %v", log.kinds("s1"))
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// Follow-up inside the distill window: full answer on the wire, no
+	// phantom interruption.
+	_, ch2, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "second question"})
+	if err != nil {
+		t.Fatalf("Chat 2: %v", err)
+	}
+	drain(t, ch2)
+
+	msgs := fmt.Sprint(gw.lastRequest().Messages)
+	if !strings.Contains(msgs, "the full answer") {
+		t.Fatalf("completed answer missing from follow-up context: %s", msgs)
+	}
+	if strings.Contains(msgs, "interrupted") {
+		t.Fatalf("phantom interruption in follow-up context: %s", msgs)
+	}
+}

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -326,3 +326,54 @@ func TestChatValidatesMessage(t *testing.T) {
 		t.Fatal("blank message accepted")
 	}
 }
+
+// orderCompactor records whether compaction ran before the provider
+// call: the pre-send guarantee.
+type orderCompactor struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (c *orderCompactor) MaybeCompact(context.Context, string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls = append(c.calls, "compact")
+	return nil
+}
+
+func (c *orderCompactor) note(step string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls = append(c.calls, step)
+}
+
+// gwAfterCompact wraps fakeGW to record when the provider is hit.
+type gwAfterCompact struct {
+	*fakeGW
+	order *orderCompactor
+}
+
+func (g *gwAfterCompact) Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+	g.order.note("stream")
+	return g.fakeGW.Stream(ctx, req)
+}
+
+func TestChatCompactsBeforeSend(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	order := &orderCompactor{}
+	gw := &gwAfterCompact{fakeGW: &fakeGW{events: okEvents("hi")}, order: order}
+	svc := New(gw, log, nil, order, 60_000, discard())
+
+	_, ch, err := svc.Chat(t.Context(), Request{Message: "hello"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	order.mu.Lock()
+	defer order.mu.Unlock()
+	if len(order.calls) < 2 || order.calls[0] != "compact" || order.calls[1] != "stream" {
+		t.Fatalf("call order = %v, want compaction before the provider call", order.calls)
+	}
+}

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -2,129 +2,327 @@ package chat
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
-	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
 )
 
 func discard() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
 
-type scriptedGateway struct {
-	requests []gwclient.StreamRequest
-	reply    string
+// fakeLog is an in-memory SessionLog.
+type fakeLog struct {
+	mu       sync.Mutex
+	events   map[string][]session.Event
+	titles   map[string]string
+	category map[string]string
+	createdN int
 }
 
-func (g *scriptedGateway) Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+func newFakeLog() *fakeLog {
+	return &fakeLog{events: map[string][]session.Event{}, titles: map[string]string{}, category: map[string]string{}}
+}
+
+func (f *fakeLog) Create(_ context.Context, title string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.createdN++
+	id := "sess-created"
+	f.events[id] = []session.Event{{SessionID: id, Seq: 1, Kind: session.KindSessionStarted, Payload: []byte(`{}`)}}
+	return id, nil
+}
+
+func (f *fakeLog) Events(_ context.Context, id string) ([]session.Event, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.events[id]; !ok {
+		f.events[id] = []session.Event{{SessionID: id, Seq: 1, Kind: session.KindSessionStarted, Payload: []byte(`{}`)}}
+	}
+	return append([]session.Event(nil), f.events[id]...), nil
+}
+
+func (f *fakeLog) Append(_ context.Context, id, kind string, payload any) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return 0, err
+	}
+	seq := int64(len(f.events[id]) + 1)
+	f.events[id] = append(f.events[id], session.Event{SessionID: id, Seq: seq, Kind: kind, Payload: data})
+	return seq, nil
+}
+
+func (f *fakeLog) SetTitleIfEmpty(_ context.Context, id, title string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.titles[id] == "" {
+		f.titles[id] = title
+	}
+	return nil
+}
+
+func (f *fakeLog) SetLastCategory(_ context.Context, id, category string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.category[id] = category
+	return nil
+}
+
+func (f *fakeLog) lastCategory(id string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.category[id]
+}
+
+func (f *fakeLog) kinds(id string) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []string
+	for _, ev := range f.events[id] {
+		out = append(out, ev.Kind)
+	}
+	return out
+}
+
+// fakeGW streams canned events and records requests. blockCh, when
+// set, delays the stream until closed (for cancellation tests).
+type fakeGW struct {
+	mu       sync.Mutex
+	requests []gwclient.StreamRequest
+	events   []stream.StreamEvent
+	blockCh  chan struct{}
+}
+
+func (g *fakeGW) Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+	g.mu.Lock()
 	g.requests = append(g.requests, req)
-	ch := make(chan stream.StreamEvent, 3)
-	ch <- stream.StreamEvent{Type: stream.EventChunk, Text: g.reply}
-	ch <- stream.StreamEvent{Type: stream.EventDone}
-	close(ch)
+	block := g.blockCh
+	events := append([]stream.StreamEvent(nil), g.events...)
+	g.mu.Unlock()
+
+	ch := make(chan stream.StreamEvent)
+	go func() {
+		defer close(ch)
+		if block != nil {
+			<-block
+		}
+		for _, ev := range events {
+			select {
+			case ch <- ev:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 	return ch, nil
 }
 
-func drain(t *testing.T, ch <-chan stream.StreamEvent) {
-	t.Helper()
-	for range ch {
+func (g *fakeGW) lastRequest() gwclient.StreamRequest {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.requests[len(g.requests)-1]
+}
+
+func okEvents(text string) []stream.StreamEvent {
+	return []stream.StreamEvent{
+		{Type: stream.EventChunk, Text: text},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod", LedgerID: "led"}},
 	}
 }
 
-func newTestService(t *testing.T, gw Gateway) *Service {
-	t.Helper()
-	return New(gw, pgpool.New(t.Context(), "", discard()), discard())
+func newService(gw Gateway, log SessionLog) *Service {
+	return New(gw, log, nil, nil, 60_000, discard())
 }
 
-func TestChatBuffersHistoryAcrossTurns(t *testing.T) {
+func drain(t *testing.T, ch <-chan stream.StreamEvent) []stream.StreamEvent {
+	t.Helper()
+	var out []stream.StreamEvent
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return out
+			}
+			out = append(out, ev)
+		case <-deadline:
+			t.Fatal("stream did not close")
+		}
+	}
+}
+
+// waitFor polls until cond or timeout — persistence runs after the
+// client channel closes.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition not met in time")
+}
+
+func TestChatPersistsTurnAsEvents(t *testing.T) {
 	t.Parallel()
-	gw := &scriptedGateway{reply: "first answer"}
-	s := newTestService(t, gw)
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("the answer")}
+	s := newService(gw, log)
 
-	id, ch, err := s.Chat(t.Context(), Request{SessionID: "sess", Message: "question one"})
+	id, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "the question", TaskCategory: "mini"})
 	if err != nil {
-		t.Fatalf("Chat 1: %v", err)
+		t.Fatalf("Chat: %v", err)
 	}
-	if id != "sess" {
+	if id != "s1" {
 		t.Fatalf("session id = %q", id)
 	}
 	drain(t, ch)
 
-	gw.reply = "second answer"
-	_, ch, err = s.Chat(t.Context(), Request{SessionID: "sess", Message: "question two"})
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+	kinds := log.kinds("s1")
+	want := []string{session.KindSessionStarted, session.KindUserMessage, session.KindAssistantTurn}
+	if strings.Join(kinds, ",") != strings.Join(want, ",") {
+		t.Fatalf("kinds = %v, want %v", kinds, want)
+	}
+	waitFor(t, func() bool { return log.lastCategory("s1") == "mini" })
+
+	events, _ := log.Events(t.Context(), "s1")
+	var turn session.AssistantTurn
+	if err := json.Unmarshal(events[2].Payload, &turn); err != nil {
+		t.Fatalf("decode turn: %v", err)
+	}
+	if turn.LLM.Message != "the answer" || turn.Provider != "prov" || turn.LedgerID != "led" {
+		t.Fatalf("turn = %+v", turn)
+	}
+}
+
+func TestChatHistoryComesFromProjection(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("first answer")}
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "first question"})
+	if err != nil {
+		t.Fatalf("Chat 1: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+
+	gw.mu.Lock()
+	gw.events = okEvents("second answer")
+	gw.mu.Unlock()
+	_, ch, err = s.Chat(t.Context(), Request{SessionID: "s1", Message: "second question"})
 	if err != nil {
 		t.Fatalf("Chat 2: %v", err)
 	}
 	drain(t, ch)
 
-	second := gw.requests[1]
-	if len(second.Messages) != 3 {
-		t.Fatalf("second request messages = %d, want 3 (q1, a1, q2): %+v", len(second.Messages), second.Messages)
+	msgs := gw.lastRequest().Messages
+	if len(msgs) != 3 {
+		t.Fatalf("second request messages = %d, want 3: %+v", len(msgs), msgs)
 	}
-	if second.Messages[0].Content != "question one" ||
-		second.Messages[1].Role != "assistant" || second.Messages[1].Content != "first answer" ||
-		second.Messages[2].Content != "question two" {
-		t.Fatalf("history wrong: %+v", second.Messages)
+	if msgs[0].Content != "first question" || msgs[1].Content != "first answer" || msgs[2].Content != "second question" {
+		t.Fatalf("projected history wrong: %+v", msgs)
 	}
 }
 
-func TestChatSessionsAreIsolated(t *testing.T) {
+func TestChatWritesPendingStateOnCancel(t *testing.T) {
 	t.Parallel()
-	gw := &scriptedGateway{reply: "a"}
-	s := newTestService(t, gw)
+	log := newFakeLog()
+	block := make(chan struct{})
+	gw := &fakeGW{blockCh: block, events: []stream.StreamEvent{
+		{Type: stream.EventChunk, Text: "partial answer that never finishes"},
+		// no terminal: the connection "dies" after the chunk
+	}}
+	s := newService(gw, log)
 
-	_, ch, _ := s.Chat(t.Context(), Request{SessionID: "one", Message: "in session one"})
-	drain(t, ch)
-	_, ch, _ = s.Chat(t.Context(), Request{SessionID: "two", Message: "in session two"})
-	drain(t, ch)
-
-	if len(gw.requests[1].Messages) != 1 {
-		t.Fatalf("session two saw session one's history: %+v", gw.requests[1].Messages)
+	ctx, cancel := context.WithCancel(t.Context())
+	_, ch, err := s.Chat(ctx, Request{SessionID: "s1", Message: "long question"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
 	}
-}
+	close(block) // let the chunk flow
+	<-ch         // receive the chunk
+	cancel()     // client disconnects mid-stream
+	drain(t, ch)
 
-func TestChatBufferIsBounded(t *testing.T) {
-	t.Parallel()
-	gw := &scriptedGateway{reply: "r"}
-	s := newTestService(t, gw)
-
-	for range maxBufferedMessages { // each turn adds 2 buffered messages
-		_, ch, err := s.Chat(t.Context(), Request{SessionID: "sess", Message: "m"})
-		if err != nil {
-			t.Fatalf("Chat: %v", err)
+	waitFor(t, func() bool {
+		for _, k := range log.kinds("s1") {
+			if k == session.KindPendingState {
+				return true
+			}
 		}
-		drain(t, ch)
-	}
+		return false
+	})
 
-	last := gw.requests[len(gw.requests)-1]
-	if got := len(last.Messages); got > maxBufferedMessages+1 {
-		t.Fatalf("request messages = %d, exceeds bound %d", got, maxBufferedMessages+1)
+	// The next turn's projection must splice the partial in.
+	events, _ := log.Events(t.Context(), "s1")
+	msgs, err := session.LLMContext(events, 0)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	last := msgs[len(msgs)-1]
+	if last.Role != "assistant" || !strings.Contains(last.Content, "partial answer") {
+		t.Fatalf("pending state not spliced: %+v", last)
 	}
 }
 
-func TestChatDefaultsCategory(t *testing.T) {
+func TestChatAutoTitlesFirstExchange(t *testing.T) {
 	t.Parallel()
-	gw := &scriptedGateway{reply: "r"}
-	s := newTestService(t, gw)
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("hello there")}
+	s := newService(gw, log)
 
-	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s", Message: "hi"})
+	// Titles come from a second gateway call; the fake returns the
+	// same canned events, whose chunk becomes the title.
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "hi"})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
 	drain(t, ch)
 
-	if gw.requests[0].TaskCategory != defaultCategory {
-		t.Fatalf("category = %q, want %q", gw.requests[0].TaskCategory, defaultCategory)
+	waitFor(t, func() bool {
+		log.mu.Lock()
+		defer log.mu.Unlock()
+		return log.titles["s1"] != ""
+	})
+	log.mu.Lock()
+	title := log.titles["s1"]
+	log.mu.Unlock()
+	if title != "hello there" {
+		t.Fatalf("title = %q", title)
+	}
+
+	// Second exchange must NOT retitle.
+	gw.mu.Lock()
+	nCalls := len(gw.requests)
+	gw.mu.Unlock()
+	_, ch, _ = s.Chat(t.Context(), Request{SessionID: "s1", Message: "again"})
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) >= 5 })
+	gw.mu.Lock()
+	calls := len(gw.requests) - nCalls
+	gw.mu.Unlock()
+	if calls != 1 { // chat only, no title call
+		t.Fatalf("second exchange made %d gateway calls, want 1", calls)
 	}
 }
 
-func TestChatNewSessionRequiresDatabase(t *testing.T) {
+func TestChatValidatesMessage(t *testing.T) {
 	t.Parallel()
-	s := newTestService(t, &scriptedGateway{reply: "r"}) // degraded pool
-
-	if _, _, err := s.Chat(t.Context(), Request{Message: "hi"}); err == nil {
-		t.Fatal("Chat without session id and without database: want error")
+	s := newService(&fakeGW{}, newFakeLog())
+	if _, _, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "   "}); err == nil {
+		t.Fatal("blank message accepted")
 	}
 }

--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
@@ -28,10 +29,18 @@ type StreamRequest struct {
 	SessionID    string             `json:"session_id,omitempty"`
 }
 
+// windowsTTL matches the gateway's own config poll cadence: a fresher
+// read couldn't observe anything newer.
+const windowsTTL = 30 * time.Second
+
 // Client talks to one gateway base URL.
 type Client struct {
 	baseURL string
 	http    *http.Client
+
+	mu         sync.Mutex
+	windows    map[string]int
+	windowsExp time.Time
 }
 
 func New(baseURL string) *Client {
@@ -48,7 +57,17 @@ func New(baseURL string) *Client {
 // ModelWindows fetches the gateway's provider listing and returns the
 // context window per model id (entries without a window are omitted).
 // The compactor uses it to size token budgets to the model in use.
+// Results are memoized for the gateway's reload cadence; errors are
+// never cached.
 func (c *Client) ModelWindows(ctx context.Context) (map[string]int, error) {
+	c.mu.Lock()
+	if c.windows != nil && time.Now().Before(c.windowsExp) {
+		w := c.windows
+		c.mu.Unlock()
+		return w, nil
+	}
+	c.mu.Unlock()
+
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/providers", nil)
 	if err != nil {
 		return nil, fmt.Errorf("gwclient: request: %w", err)
@@ -82,6 +101,9 @@ func (c *Client) ModelWindows(ctx context.Context) (map[string]int, error) {
 			}
 		}
 	}
+	c.mu.Lock()
+	c.windows, c.windowsExp = windows, time.Now().Add(windowsTTL)
+	c.mu.Unlock()
 	return windows, nil
 }
 

--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -22,6 +22,7 @@ import (
 // StreamRequest mirrors the gateway's /v1/stream request contract.
 type StreamRequest struct {
 	TaskCategory string             `json:"task_category"`
+	Purpose      string             `json:"purpose,omitempty"` // ledger tag: why this call happened
 	ModelHint    string             `json:"model_hint,omitempty"`
 	System       string             `json:"system,omitempty"`
 	Messages     []provider.Message `json:"messages"`

--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -45,6 +45,46 @@ func New(baseURL string) *Client {
 	}}
 }
 
+// ModelWindows fetches the gateway's provider listing and returns the
+// context window per model id (entries without a window are omitted).
+// The compactor uses it to size token budgets to the model in use.
+func (c *Client) ModelWindows(ctx context.Context) (map[string]int, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/providers", nil)
+	if err != nil {
+		return nil, fmt.Errorf("gwclient: request: %w", err)
+	}
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("gwclient: gateway unreachable: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("gwclient: gateway http %d: %s", resp.StatusCode, string(msg))
+	}
+
+	var listing struct {
+		Providers []struct {
+			Models []struct {
+				ID            string `json:"id"`
+				ContextWindow int    `json:"context_window"`
+			} `json:"models"`
+		} `json:"providers"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listing); err != nil {
+		return nil, fmt.Errorf("gwclient: decode providers: %w", err)
+	}
+	windows := make(map[string]int)
+	for _, p := range listing.Providers {
+		for _, m := range p.Models {
+			if m.ContextWindow > 0 {
+				windows[m.ID] = m.ContextWindow
+			}
+		}
+	}
+	return windows, nil
+}
+
 // Stream posts the request and yields the gateway's normalized events.
 // The channel closes when the gateway stream ends; a transport failure
 // mid-stream surfaces as a terminal error event.

--- a/internal/brain/gwclient/gwclient_test.go
+++ b/internal/brain/gwclient/gwclient_test.go
@@ -125,11 +125,13 @@ func TestStreamRejectsGatewayErrorStatus(t *testing.T) {
 
 func TestModelWindows(t *testing.T) {
 	t.Parallel()
+	hits := 0
 	c := gatewayStub(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/providers" {
 			http.NotFound(w, r)
 			return
 		}
+		hits++
 		_, _ = fmt.Fprint(w, `{"providers":[
 			{"name":"a","models":[{"id":"big","context_window":200000},{"id":"unsized"}]},
 			{"name":"b","models":[{"id":"small","context_window":1000}]}
@@ -145,6 +147,14 @@ func TestModelWindows(t *testing.T) {
 	}
 	if _, ok := windows["unsized"]; ok {
 		t.Fatal("model without a context window must be omitted")
+	}
+
+	// A second read inside the TTL serves from the memo.
+	if _, err := c.ModelWindows(t.Context()); err != nil {
+		t.Fatalf("ModelWindows (cached): %v", err)
+	}
+	if hits != 1 {
+		t.Fatalf("gateway hits = %d, want 1 (TTL memo)", hits)
 	}
 }
 

--- a/internal/brain/gwclient/gwclient_test.go
+++ b/internal/brain/gwclient/gwclient_test.go
@@ -122,3 +122,39 @@ func TestStreamRejectsGatewayErrorStatus(t *testing.T) {
 		t.Fatal("Stream() = nil error for 502 gateway response")
 	}
 }
+
+func TestModelWindows(t *testing.T) {
+	t.Parallel()
+	c := gatewayStub(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/providers" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"providers":[
+			{"name":"a","models":[{"id":"big","context_window":200000},{"id":"unsized"}]},
+			{"name":"b","models":[{"id":"small","context_window":1000}]}
+		]}`)
+	})
+
+	windows, err := c.ModelWindows(t.Context())
+	if err != nil {
+		t.Fatalf("ModelWindows: %v", err)
+	}
+	if windows["big"] != 200000 || windows["small"] != 1000 {
+		t.Fatalf("windows = %+v", windows)
+	}
+	if _, ok := windows["unsized"]; ok {
+		t.Fatal("model without a context window must be omitted")
+	}
+}
+
+func TestModelWindowsGatewayError(t *testing.T) {
+	t.Parallel()
+	c := gatewayStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"config_unavailable"}`, http.StatusServiceUnavailable)
+	})
+
+	if _, err := c.ModelWindows(t.Context()); err == nil {
+		t.Fatal("ModelWindows() = nil error for 503 gateway response")
+	}
+}

--- a/internal/brain/loop/turnmemory.go
+++ b/internal/brain/loop/turnmemory.go
@@ -57,6 +57,7 @@ func distillOnce(ctx context.Context, gw Gateway, sessionID, turnText string) (*
 
 	events, err := gw.Stream(ctx, gwclient.StreamRequest{
 		TaskCategory: "mini",
+		Purpose:      "distill",
 		System:       distillSystem,
 		Messages:     []provider.Message{{Role: "user", Content: turnText}},
 		MaxTokens:    500,

--- a/internal/brain/loop/turnmemory.go
+++ b/internal/brain/loop/turnmemory.go
@@ -1,0 +1,100 @@
+// Package loop will own the agent think/act loop; for now it carries
+// turn distillation — the structured residue extracted after each
+// assistant turn (D-007). Within a turn the model sees full traffic;
+// across turns only this residue survives.
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/brain/session"
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// Gateway is the slice of the gateway client distillation needs.
+type Gateway interface {
+	Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error)
+}
+
+const (
+	distillTimeout     = 30 * time.Second
+	maxKeyFindings     = 5
+	distillMaxAttempts = 2
+)
+
+// distillSystem demands strict JSON. The schema mirrors
+// session.TurnMemory exactly; unknown fields are rejected on parse.
+const distillSystem = `You extract structured residue from one conversation turn of an AI assistant. Reply with ONLY a JSON object — no prose, no markdown fences:
+{"files_changed":["path"],"failures":[{"what":"command or tool","why":"reason"}],"key_findings":["one sentence"]}
+Rules: key_findings has at most 5 items, one sentence each, only durable facts worth carrying into later turns — names, dates, numbers, decisions, commitments. files_changed lists files actually modified this turn, empty otherwise. failures lists failed commands or tool calls only. Use empty arrays when nothing qualifies.`
+
+// DistillTurn extracts a TurnMemory from one turn's raw text via a
+// mini-category call. Invalid output retries once; a second failure
+// returns nil — distillation must never block or fail the turn
+// (callers log and move on).
+func DistillTurn(ctx context.Context, gw Gateway, sessionID, turnText string) *session.TurnMemory {
+	for attempt := 0; attempt < distillMaxAttempts; attempt++ {
+		tm, err := distillOnce(ctx, gw, sessionID, turnText)
+		if err == nil {
+			return tm
+		}
+		if ctx.Err() != nil {
+			return nil
+		}
+	}
+	return nil
+}
+
+func distillOnce(ctx context.Context, gw Gateway, sessionID, turnText string) (*session.TurnMemory, error) {
+	ctx, cancel := context.WithTimeout(ctx, distillTimeout)
+	defer cancel()
+
+	events, err := gw.Stream(ctx, gwclient.StreamRequest{
+		TaskCategory: "mini",
+		System:       distillSystem,
+		Messages:     []provider.Message{{Role: "user", Content: turnText}},
+		MaxTokens:    500,
+		SessionID:    sessionID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var b strings.Builder
+	for ev := range events {
+		switch ev.Type {
+		case stream.EventChunk:
+			b.WriteString(ev.Text)
+		case stream.EventError:
+			return nil, fmt.Errorf("distill: %s", ev.Err.Message)
+		}
+	}
+	return parseTurnMemory(b.String())
+}
+
+// parseTurnMemory decodes the model's reply strictly: fences stripped,
+// unknown fields rejected, findings clamped to the schema's cap.
+func parseTurnMemory(raw string) (*session.TurnMemory, error) {
+	text := strings.TrimSpace(raw)
+	text = strings.TrimPrefix(text, "```json")
+	text = strings.TrimPrefix(text, "```")
+	text = strings.TrimSuffix(text, "```")
+	text = strings.TrimSpace(text)
+
+	dec := json.NewDecoder(strings.NewReader(text))
+	dec.DisallowUnknownFields()
+	var tm session.TurnMemory
+	if err := dec.Decode(&tm); err != nil {
+		return nil, fmt.Errorf("distill: invalid JSON: %w", err)
+	}
+	if len(tm.KeyFindings) > maxKeyFindings {
+		tm.KeyFindings = tm.KeyFindings[:maxKeyFindings]
+	}
+	return &tm, nil
+}

--- a/internal/brain/loop/turnmemory_test.go
+++ b/internal/brain/loop/turnmemory_test.go
@@ -1,0 +1,104 @@
+package loop
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// scriptedGW returns one canned reply per call, in order.
+type scriptedGW struct {
+	replies []string
+	errs    []bool
+	calls   int
+}
+
+func (g *scriptedGW) Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+	i := g.calls
+	g.calls++
+	ch := make(chan stream.StreamEvent, 3)
+	if i < len(g.errs) && g.errs[i] {
+		ch <- stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{Code: "x", Message: "provider down"}}
+	} else {
+		reply := g.replies[min(i, len(g.replies)-1)]
+		// split across two chunks: parsing must handle assembly
+		ch <- stream.StreamEvent{Type: stream.EventChunk, Text: reply[:len(reply)/2]}
+		ch <- stream.StreamEvent{Type: stream.EventChunk, Text: reply[len(reply)/2:]}
+		ch <- stream.StreamEvent{Type: stream.EventDone}
+	}
+	close(ch)
+	return ch, nil
+}
+
+const validJSON = `{"files_changed":["main.go"],"failures":[{"what":"go test","why":"timeout"}],"key_findings":["user prefers tabs"]}`
+
+func TestDistillTurnParsesValidReply(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGW{replies: []string{validJSON}}
+
+	tm := DistillTurn(t.Context(), gw, "s1", "user: hi / assistant: hello")
+	if tm == nil {
+		t.Fatal("DistillTurn returned nil for valid reply")
+	}
+	if tm.FilesChanged[0] != "main.go" || tm.Failures[0].Why != "timeout" || tm.KeyFindings[0] != "user prefers tabs" {
+		t.Fatalf("turn memory = %+v", tm)
+	}
+	if gw.calls != 1 {
+		t.Fatalf("calls = %d, want 1", gw.calls)
+	}
+}
+
+func TestDistillTurnStripsFences(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGW{replies: []string{"```json\n" + validJSON + "\n```"}}
+
+	if tm := DistillTurn(t.Context(), gw, "s1", "turn"); tm == nil || tm.FilesChanged[0] != "main.go" {
+		t.Fatalf("fenced reply not parsed: %+v", tm)
+	}
+}
+
+func TestDistillTurnRetriesOnceThenGivesUp(t *testing.T) {
+	t.Parallel()
+	// invalid then valid → parsed on the retry
+	gw := &scriptedGW{replies: []string{"sorry, here is the JSON you asked for", validJSON}}
+	if tm := DistillTurn(t.Context(), gw, "s1", "turn"); tm == nil {
+		t.Fatal("retry after invalid output did not recover")
+	}
+	if gw.calls != 2 {
+		t.Fatalf("calls = %d, want 2", gw.calls)
+	}
+
+	// invalid twice → nil, never an error that blocks the turn
+	gw = &scriptedGW{replies: []string{"not json", "still not json"}}
+	if tm := DistillTurn(t.Context(), gw, "s1", "turn"); tm != nil {
+		t.Fatalf("expected nil after two invalid replies, got %+v", tm)
+	}
+	if gw.calls != 2 {
+		t.Fatalf("calls = %d, want exactly 2 attempts", gw.calls)
+	}
+}
+
+func TestDistillTurnProviderErrorRetries(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGW{errs: []bool{true, false}, replies: []string{validJSON, validJSON}}
+	if tm := DistillTurn(t.Context(), gw, "s1", "turn"); tm == nil {
+		t.Fatal("provider error on first attempt should retry and recover")
+	}
+}
+
+func TestParseTurnMemoryStrictness(t *testing.T) {
+	t.Parallel()
+	if _, err := parseTurnMemory(`{"files_changed":[],"unknown_field":1}`); err == nil {
+		t.Fatal("unknown field accepted; schema must be strict")
+	}
+
+	tm, err := parseTurnMemory(`{"key_findings":["1","2","3","4","5","6","7"]}`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(tm.KeyFindings) != maxKeyFindings {
+		t.Fatalf("findings = %d, want clamped to %d", len(tm.KeyFindings), maxKeyFindings)
+	}
+}

--- a/internal/brain/session/compactor.go
+++ b/internal/brain/session/compactor.go
@@ -26,6 +26,12 @@ type Log interface {
 	Append(ctx context.Context, sessionID, kind string, payload any) (int64, error)
 }
 
+// Windows resolves model context windows from the gateway;
+// *gwclient.Client satisfies it. May be nil (static budget only).
+type Windows interface {
+	ModelWindows(ctx context.Context) (map[string]int, error)
+}
+
 const (
 	compactTimeout   = 60 * time.Second
 	summaryMaxTokens = 1200
@@ -42,13 +48,50 @@ const summarizeSystem = `Summarize this conversation excerpt for an AI assistant
 type Compactor struct {
 	log      Log
 	gw       Gateway
-	budget   int
+	windows  Windows // nil-safe: static budget only
+	budget   int     // fallback when no model window is resolvable
 	logger   *slog.Logger
 	compacts prometheus.Counter // nil-safe: may be unset in tests
 }
 
-func NewCompactor(log Log, gw Gateway, budget int, logger *slog.Logger, compacts prometheus.Counter) *Compactor {
-	return &Compactor{log: log, gw: gw, budget: budget, logger: logger, compacts: compacts}
+func NewCompactor(log Log, gw Gateway, windows Windows, budget int, logger *slog.Logger, compacts prometheus.Counter) *Compactor {
+	return &Compactor{log: log, gw: gw, windows: windows, budget: budget, logger: logger, compacts: compacts}
+}
+
+// budgetFor sizes the token budget to the model that served the
+// session's last turn: 60% of its context window per the gateway's
+// provider info. Falls back to the configured static budget when the
+// session has no completed turn yet, the lookup fails, or the model
+// declares no window.
+func (c *Compactor) budgetFor(ctx context.Context, sessionID string, events []Event) int {
+	model := lastModel(events)
+	if c.windows == nil || model == "" {
+		return c.budget
+	}
+	ws, err := c.windows.ModelWindows(ctx)
+	if err != nil {
+		c.logger.Warn("model windows lookup, using static budget", "session_id", sessionID, "error", err)
+		return c.budget
+	}
+	if w := ws[model]; w > 0 {
+		return w * 60 / 100
+	}
+	return c.budget
+}
+
+// lastModel returns the model of the newest assistant_turn, or "".
+func lastModel(events []Event) string {
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].Kind != KindAssistantTurn {
+			continue
+		}
+		var t AssistantTurn
+		if decode(events[i], &t) == nil {
+			return t.Model
+		}
+		return ""
+	}
+	return ""
 }
 
 // MaybeCompact measures the session's projected context and compacts
@@ -59,7 +102,8 @@ func (c *Compactor) MaybeCompact(ctx context.Context, sessionID string) error {
 	if err != nil {
 		return err
 	}
-	msgs, err := LLMContext(events, c.budget)
+	budget := c.budgetFor(ctx, sessionID, events)
+	msgs, err := LLMContext(events, budget)
 	if err != nil {
 		return err
 	}
@@ -67,7 +111,7 @@ func (c *Compactor) MaybeCompact(ctx context.Context, sessionID string) error {
 	if err != nil {
 		return err
 	}
-	if tokens <= c.budget {
+	if tokens <= budget {
 		return nil
 	}
 
@@ -118,9 +162,9 @@ func planCompaction(events []Event) (boundary int64, toSummarize []provider.Mess
 
 	// Map the cut back to an event boundary. Past the latest
 	// compaction, projected messages correspond 1:1, in order, to
-	// user_message/assistant_turn events (a summary head projects from
-	// the compaction event itself; a trailing pending_state is always
-	// the final message and cut < len(msgs) keeps it live). The
+	// user_message/assistant_turn events plus the one live pending
+	// (a summary head projects from the compaction event itself;
+	// superseded checkpoints and empty pendings project nothing). The
 	// boundary is the seq of the last message event the summary
 	// consumes; invisible events (tool digests) between boundary and
 	// the next message simply stay outside the replaced range.
@@ -144,15 +188,29 @@ func planCompaction(events []Event) (boundary int64, toSummarize []provider.Mess
 			}
 		}
 	}
+	livePending := livePendingSeq(events)
 	count := 0
 	for _, ev := range events {
 		if ev.Seq <= replacedThrough {
 			continue
 		}
-		if ev.Kind != KindUserMessage && ev.Kind != KindAssistantTurn {
+		switch ev.Kind {
+		case KindUserMessage, KindAssistantTurn:
+			count++
+		case KindPendingState:
+			// The live pending projects as one interrupted assistant
+			// message; superseded checkpoints and empty partials don't.
+			if ev.Seq != livePending {
+				continue
+			}
+			var p PendingState
+			if decode(ev, &p) != nil || p.Partial == "" {
+				continue
+			}
+			count++
+		default:
 			continue
 		}
-		count++
 		if count == need {
 			return ev.Seq, toSummarize, true
 		}

--- a/internal/brain/session/compactor.go
+++ b/internal/brain/session/compactor.go
@@ -95,8 +95,10 @@ func lastModel(events []Event) string {
 }
 
 // MaybeCompact measures the session's projected context and compacts
-// once when it exceeds the budget. Callers run it after each turn;
-// repeated turns converge because each pass halves the live prefix.
+// once when it exceeds the budget. Chat runs it after each completed
+// turn (proactive) and again before each send (the wire-level
+// guarantee on the crossing turn); repeated passes converge because
+// each one halves the live prefix.
 func (c *Compactor) MaybeCompact(ctx context.Context, sessionID string) error {
 	events, err := c.log.Events(ctx, sessionID)
 	if err != nil {

--- a/internal/brain/session/compactor.go
+++ b/internal/brain/session/compactor.go
@@ -199,6 +199,13 @@ func planCompaction(events []Event) (boundary int64, toSummarize []provider.Mess
 		switch ev.Kind {
 		case KindUserMessage, KindAssistantTurn:
 			count++
+		case KindTurnMemory:
+			// Residue projects as one message when it carries anything.
+			var tm TurnMemoryEvent
+			if decode(ev, &tm) != nil || renderTurnMemory(&tm.TurnMemory) == "" {
+				continue
+			}
+			count++
 		case KindPendingState:
 			// The live pending projects as one interrupted assistant
 			// message; superseded checkpoints and empty partials don't.
@@ -230,6 +237,7 @@ func (c *Compactor) summarize(ctx context.Context, sessionID string, msgs []prov
 	}
 	events, err := c.gw.Stream(ctx, gwclient.StreamRequest{
 		TaskCategory: "summarize",
+		Purpose:      "compaction",
 		System:       summarizeSystem,
 		Messages:     []provider.Message{{Role: "user", Content: b.String()}},
 		MaxTokens:    summaryMaxTokens,
@@ -243,6 +251,10 @@ func (c *Compactor) summarize(ctx context.Context, sessionID string, msgs []prov
 		switch ev.Type {
 		case stream.EventChunk:
 			out.WriteString(ev.Text)
+		case stream.EventIncomplete:
+			// A truncated summary silently loses facts — refuse it and
+			// try again next turn rather than store a lie.
+			return "", fmt.Errorf("summarize: stream incomplete")
 		case stream.EventError:
 			return "", fmt.Errorf("summarize: %s", ev.Err.Message)
 		}

--- a/internal/brain/session/compactor.go
+++ b/internal/brain/session/compactor.go
@@ -1,0 +1,195 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// Gateway is the slice of the gateway client the compactor needs.
+type Gateway interface {
+	Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error)
+}
+
+// Log is the slice of the event store the compactor needs; *Store
+// satisfies it, tests fake it.
+type Log interface {
+	Events(ctx context.Context, sessionID string) ([]Event, error)
+	Append(ctx context.Context, sessionID, kind string, payload any) (int64, error)
+}
+
+const (
+	compactTimeout   = 60 * time.Second
+	summaryMaxTokens = 1200
+)
+
+// summarizeSystem must preserve exactly what summaries usually lose
+// (D-007/D-011 rationale).
+const summarizeSystem = `Summarize this conversation excerpt for an AI assistant's context. You MUST explicitly preserve: every name, date, number, commitment, decision, and open question. Compress pleasantries and repetition aggressively. Write flowing prose, no headers, no preamble — output only the summary.`
+
+// Compactor keeps projected contexts under a token budget by
+// summarizing the oldest half of the live turns into a
+// compaction_applied event. Automatic and incremental — never a
+// destructive one-shot (D-006).
+type Compactor struct {
+	log      Log
+	gw       Gateway
+	budget   int
+	logger   *slog.Logger
+	compacts prometheus.Counter // nil-safe: may be unset in tests
+}
+
+func NewCompactor(log Log, gw Gateway, budget int, logger *slog.Logger, compacts prometheus.Counter) *Compactor {
+	return &Compactor{log: log, gw: gw, budget: budget, logger: logger, compacts: compacts}
+}
+
+// MaybeCompact measures the session's projected context and compacts
+// once when it exceeds the budget. Callers run it after each turn;
+// repeated turns converge because each pass halves the live prefix.
+func (c *Compactor) MaybeCompact(ctx context.Context, sessionID string) error {
+	events, err := c.log.Events(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	msgs, err := LLMContext(events, c.budget)
+	if err != nil {
+		return err
+	}
+	tokens, err := EstimateTokens(msgs)
+	if err != nil {
+		return err
+	}
+	if tokens <= c.budget {
+		return nil
+	}
+
+	boundary, toSummarize, ok := planCompaction(events)
+	if !ok {
+		return nil // nothing safely summarizable (e.g. one giant turn)
+	}
+
+	summary, err := c.summarize(ctx, sessionID, toSummarize)
+	if err != nil {
+		return fmt.Errorf("session: compact %s: %w", sessionID, err)
+	}
+	if _, err := c.log.Append(ctx, sessionID, KindCompactionApplied, CompactionApplied{
+		Summary:            summary,
+		ReplacesThroughSeq: boundary,
+		FactsExtracted:     []string{}, // memory extraction wires in with memoryd
+	}); err != nil {
+		return err
+	}
+	if c.compacts != nil {
+		c.compacts.Inc()
+	}
+	c.logger.Info("session compacted", "session_id", sessionID, "through_seq", boundary, "tokens_before", tokens)
+	return nil
+}
+
+// planCompaction picks the summarization boundary: the oldest half of
+// the conversation messages that survive the latest compaction,
+// always keeping at least one full turn live. Pure and heavily
+// testable.
+func planCompaction(events []Event) (boundary int64, toSummarize []provider.Message, ok bool) {
+	msgs, err := LLMContext(events, 0)
+	if err != nil || len(msgs) < 4 {
+		return 0, nil, false // too small to split into summary + live tail
+	}
+
+	cut := len(msgs) / 2
+	// Never end the summarized half on a user message: a summary that
+	// swallows a question the assistant hasn't answered yet reads
+	// wrong. Extend to include the assistant reply when possible.
+	for cut < len(msgs)-1 && msgs[cut-1].Role == "user" {
+		cut++
+	}
+	if cut >= len(msgs) {
+		return 0, nil, false
+	}
+	toSummarize = msgs[:cut]
+
+	// Map the cut back to an event boundary. Past the latest
+	// compaction, projected messages correspond 1:1, in order, to
+	// user_message/assistant_turn events (a summary head projects from
+	// the compaction event itself; a trailing pending_state is always
+	// the final message and cut < len(msgs) keeps it live). The
+	// boundary is the seq of the last message event the summary
+	// consumes; invisible events (tool digests) between boundary and
+	// the next message simply stay outside the replaced range.
+	start := 0
+	if strings.HasPrefix(msgs[0].Content, summaryPrefix) {
+		start = 1
+	}
+	need := cut - start
+	if need <= 0 {
+		return 0, nil, false
+	}
+	// Live events are those past the latest compaction's REPLACED
+	// range — not past the compaction event itself, which sits at the
+	// end of the log with the highest seq.
+	var replacedThrough int64 = -1
+	for _, ev := range events {
+		if ev.Kind == KindCompactionApplied {
+			var c CompactionApplied
+			if decode(ev, &c) == nil {
+				replacedThrough = c.ReplacesThroughSeq
+			}
+		}
+	}
+	count := 0
+	for _, ev := range events {
+		if ev.Seq <= replacedThrough {
+			continue
+		}
+		if ev.Kind != KindUserMessage && ev.Kind != KindAssistantTurn {
+			continue
+		}
+		count++
+		if count == need {
+			return ev.Seq, toSummarize, true
+		}
+	}
+	return 0, nil, false // projection/event mismatch: refuse to guess
+}
+
+func (c *Compactor) summarize(ctx context.Context, sessionID string, msgs []provider.Message) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, compactTimeout)
+	defer cancel()
+
+	var b strings.Builder
+	for _, m := range msgs {
+		b.WriteString(m.Role + ": " + m.Content + "\n\n")
+	}
+	events, err := c.gw.Stream(ctx, gwclient.StreamRequest{
+		TaskCategory: "summarize",
+		System:       summarizeSystem,
+		Messages:     []provider.Message{{Role: "user", Content: b.String()}},
+		MaxTokens:    summaryMaxTokens,
+		SessionID:    sessionID,
+	})
+	if err != nil {
+		return "", err
+	}
+	var out strings.Builder
+	for ev := range events {
+		switch ev.Type {
+		case stream.EventChunk:
+			out.WriteString(ev.Text)
+		case stream.EventError:
+			return "", fmt.Errorf("summarize: %s", ev.Err.Message)
+		}
+	}
+	summary := strings.TrimSpace(out.String())
+	if summary == "" {
+		return "", fmt.Errorf("summarize: empty summary")
+	}
+	return summary, nil
+}

--- a/internal/brain/session/compactor_test.go
+++ b/internal/brain/session/compactor_test.go
@@ -1,0 +1,202 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// memLog is an in-memory Log for compactor tests.
+type memLog struct {
+	events map[string][]Event
+}
+
+func newMemLog() *memLog { return &memLog{events: map[string][]Event{}} }
+
+func (m *memLog) Events(_ context.Context, id string) ([]Event, error) {
+	return append([]Event(nil), m.events[id]...), nil
+}
+
+func (m *memLog) Append(_ context.Context, id, kind string, payload any) (int64, error) {
+	ev := Event{SessionID: id, Seq: int64(len(m.events[id]) + 1), Kind: kind}
+	data, err := jsonMarshal(payload)
+	if err != nil {
+		return 0, err
+	}
+	ev.Payload = data
+	m.events[id] = append(m.events[id], ev)
+	return ev.Seq, nil
+}
+
+// summarizerGW returns a fixed short summary and records its input.
+type summarizerGW struct {
+	summary string
+	sawText string
+	calls   int
+}
+
+func (g *summarizerGW) Stream(_ context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+	g.calls++
+	g.sawText = req.Messages[0].Content
+	ch := make(chan stream.StreamEvent, 2)
+	ch <- stream.StreamEvent{Type: stream.EventChunk, Text: g.summary}
+	ch <- stream.StreamEvent{Type: stream.EventDone}
+	close(ch)
+	return ch, nil
+}
+
+func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// seedConversation appends n user/assistant turn pairs with padded
+// content so token counts are meaningful.
+func seedConversation(t *testing.T, log *memLog, id string, turns int) {
+	t.Helper()
+	pad := strings.Repeat("lorem ipsum dolor sit amet ", 30)
+	for i := 0; i < turns; i++ {
+		if _, err := log.Append(context.Background(), id, KindUserMessage,
+			UserMessage{Text: fmt.Sprintf("question %d about topic-%d %s", i, i, pad)}); err != nil {
+			t.Fatal(err)
+		}
+		var turn AssistantTurn
+		turn.LLM.Message = fmt.Sprintf("answer %d %s", i, pad)
+		if _, err := log.Append(context.Background(), id, KindAssistantTurn, turn); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestMaybeCompactUnderBudgetIsNoop(t *testing.T) {
+	t.Parallel()
+	log, gw := newMemLog(), &summarizerGW{summary: "s"}
+	seedConversation(t, log, "s1", 3)
+	c := NewCompactor(log, gw, 1_000_000, discardLogger(), nil)
+
+	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
+		t.Fatalf("MaybeCompact: %v", err)
+	}
+	if gw.calls != 0 {
+		t.Fatal("summarizer called while under budget")
+	}
+}
+
+func TestMaybeCompactSummarizesOldestHalf(t *testing.T) {
+	t.Parallel()
+	log := newMemLog()
+	gw := &summarizerGW{summary: "compact summary: topics 0 through N discussed"}
+	seedConversation(t, log, "s1", 10)
+	c := NewCompactor(log, gw, 500, discardLogger(), nil) // force compaction
+
+	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
+		t.Fatalf("MaybeCompact: %v", err)
+	}
+	if gw.calls != 1 {
+		t.Fatalf("summarizer calls = %d, want 1", gw.calls)
+	}
+	// Oldest content reached the summarizer; newest stayed out.
+	if !strings.Contains(gw.sawText, "question 0") || strings.Contains(gw.sawText, "question 9") {
+		t.Fatalf("summarizer saw wrong slice (has q0=%v, has q9=%v)",
+			strings.Contains(gw.sawText, "question 0"), strings.Contains(gw.sawText, "question 9"))
+	}
+
+	events, _ := log.Events(t.Context(), "s1")
+	msgs, err := LLMContext(events, 0)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	if !strings.HasPrefix(msgs[0].Content, summaryPrefix) {
+		t.Fatalf("first message is not the summary: %+v", msgs[0])
+	}
+	// The newest turns survive verbatim.
+	last := msgs[len(msgs)-1]
+	if !strings.Contains(last.Content, "answer 9") {
+		t.Fatalf("tail not verbatim: %+v", last)
+	}
+}
+
+// TestCompactionConverges is the property test: for various session
+// shapes, repeated compaction brings the projection under budget while
+// post-compaction turns stay verbatim.
+func TestCompactionConverges(t *testing.T) {
+	t.Parallel()
+	for _, turns := range []int{4, 7, 12, 25} {
+		t.Run(fmt.Sprintf("turns=%d", turns), func(t *testing.T) {
+			t.Parallel()
+			log := newMemLog()
+			gw := &summarizerGW{summary: "short summary"}
+			id := fmt.Sprintf("s-%d", turns)
+			seedConversation(t, log, id, turns)
+			budget := 800
+			c := NewCompactor(log, gw, budget, discardLogger(), nil)
+
+			for i := 0; i < 12; i++ { // bounded iterations must suffice
+				events, _ := log.Events(t.Context(), id)
+				msgs, err := LLMContext(events, 0)
+				if err != nil {
+					t.Fatalf("LLMContext: %v", err)
+				}
+				tokens, err := EstimateTokens(msgs)
+				if err != nil {
+					t.Fatalf("EstimateTokens: %v", err)
+				}
+				if tokens <= budget {
+					return // converged
+				}
+				before := len(msgs)
+				if err := c.MaybeCompact(t.Context(), id); err != nil {
+					t.Fatalf("MaybeCompact: %v", err)
+				}
+				events, _ = log.Events(t.Context(), id)
+				after, err := LLMContext(events, 0)
+				if err != nil {
+					t.Fatalf("LLMContext after: %v", err)
+				}
+				if len(after) >= before {
+					t.Fatalf("compaction did not shrink projection: %d -> %d", before, len(after))
+				}
+				// Newest turn stays verbatim through every pass.
+				want := fmt.Sprintf("answer %d", turns-1)
+				if !strings.Contains(after[len(after)-1].Content, want) {
+					t.Fatalf("newest turn lost after compaction: %+v", after[len(after)-1])
+				}
+			}
+			t.Fatal("did not converge under budget within bounded compactions")
+		})
+	}
+}
+
+func TestPlanCompactionRefusesTinySessions(t *testing.T) {
+	t.Parallel()
+	log := newMemLog()
+	seedConversation(t, log, "s1", 1) // 2 messages: below the split floor
+	events, _ := log.Events(t.Context(), "s1")
+
+	if _, _, ok := planCompaction(events); ok {
+		t.Fatal("planCompaction split a session too small to summarize")
+	}
+}
+
+func TestPlanCompactionNeverEndsOnUserMessage(t *testing.T) {
+	t.Parallel()
+	log := newMemLog()
+	seedConversation(t, log, "s1", 3)
+	events, _ := log.Events(t.Context(), "s1")
+
+	boundary, toSummarize, ok := planCompaction(events)
+	if !ok {
+		t.Fatal("planCompaction refused a splittable session")
+	}
+	if toSummarize[len(toSummarize)-1].Role == "user" {
+		t.Fatalf("summarized half ends on a user message (boundary %d)", boundary)
+	}
+}
+
+func jsonMarshal(v any) ([]byte, error) {
+	return json.Marshal(v)
+}

--- a/internal/brain/session/compactor_test.go
+++ b/internal/brain/session/compactor_test.go
@@ -37,14 +37,16 @@ func (m *memLog) Append(_ context.Context, id, kind string, payload any) (int64,
 
 // summarizerGW returns a fixed short summary and records its input.
 type summarizerGW struct {
-	summary string
-	sawText string
-	calls   int
+	summary   string
+	sawText   string
+	sawSystem string
+	calls     int
 }
 
 func (g *summarizerGW) Stream(_ context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
 	g.calls++
 	g.sawText = req.Messages[0].Content
+	g.sawSystem = req.System
 	ch := make(chan stream.StreamEvent, 2)
 	ch <- stream.StreamEvent{Type: stream.EventChunk, Text: g.summary}
 	ch <- stream.StreamEvent{Type: stream.EventDone}
@@ -76,7 +78,7 @@ func TestMaybeCompactUnderBudgetIsNoop(t *testing.T) {
 	t.Parallel()
 	log, gw := newMemLog(), &summarizerGW{summary: "s"}
 	seedConversation(t, log, "s1", 3)
-	c := NewCompactor(log, gw, 1_000_000, discardLogger(), nil)
+	c := NewCompactor(log, gw, nil, 1_000_000, discardLogger(), nil)
 
 	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
 		t.Fatalf("MaybeCompact: %v", err)
@@ -91,7 +93,7 @@ func TestMaybeCompactSummarizesOldestHalf(t *testing.T) {
 	log := newMemLog()
 	gw := &summarizerGW{summary: "compact summary: topics 0 through N discussed"}
 	seedConversation(t, log, "s1", 10)
-	c := NewCompactor(log, gw, 500, discardLogger(), nil) // force compaction
+	c := NewCompactor(log, gw, nil, 500, discardLogger(), nil) // force compaction
 
 	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
 		t.Fatalf("MaybeCompact: %v", err)
@@ -133,7 +135,7 @@ func TestCompactionConverges(t *testing.T) {
 			id := fmt.Sprintf("s-%d", turns)
 			seedConversation(t, log, id, turns)
 			budget := 800
-			c := NewCompactor(log, gw, budget, discardLogger(), nil)
+			c := NewCompactor(log, gw, nil, budget, discardLogger(), nil)
 
 			for i := 0; i < 12; i++ { // bounded iterations must suffice
 				events, _ := log.Events(t.Context(), id)
@@ -194,6 +196,170 @@ func TestPlanCompactionNeverEndsOnUserMessage(t *testing.T) {
 	}
 	if toSummarize[len(toSummarize)-1].Role == "user" {
 		t.Fatalf("summarized half ends on a user message (boundary %d)", boundary)
+	}
+}
+
+// fakeWindows is an in-memory Windows lookup.
+type fakeWindows struct {
+	windows map[string]int
+	err     error
+}
+
+func (f *fakeWindows) ModelWindows(context.Context) (map[string]int, error) {
+	return f.windows, f.err
+}
+
+// TestBudgetFollowsModelWindow pins the budget contract: 60% of the
+// context window of the model that served the last turn, static
+// fallback when the lookup fails or the model is unknown.
+func TestBudgetFollowsModelWindow(t *testing.T) {
+	t.Parallel()
+	seed := func(t *testing.T, log *memLog) {
+		seedConversation(t, log, "s1", 10) // thousands of tokens
+		var turn AssistantTurn
+		turn.LLM.Message = "closing answer"
+		turn.Model = "narrow-model"
+		if _, err := log.Append(context.Background(), "s1", KindAssistantTurn, turn); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("window shrinks budget below static default", func(t *testing.T) {
+		t.Parallel()
+		log, gw := newMemLog(), &summarizerGW{summary: "s"}
+		seed(t, log)
+		windows := &fakeWindows{windows: map[string]int{"narrow-model": 1000}} // budget 600
+		c := NewCompactor(log, gw, windows, 1_000_000, discardLogger(), nil)
+		if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
+			t.Fatalf("MaybeCompact: %v", err)
+		}
+		if gw.calls != 1 {
+			t.Fatalf("summarizer calls = %d, want 1 (model window must override static budget)", gw.calls)
+		}
+	})
+
+	t.Run("lookup failure falls back to static budget", func(t *testing.T) {
+		t.Parallel()
+		log, gw := newMemLog(), &summarizerGW{summary: "s"}
+		seed(t, log)
+		windows := &fakeWindows{err: fmt.Errorf("gateway down")}
+		c := NewCompactor(log, gw, windows, 1_000_000, discardLogger(), nil)
+		if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
+			t.Fatalf("MaybeCompact: %v", err)
+		}
+		if gw.calls != 0 {
+			t.Fatal("compacted against a failed window lookup instead of the static budget")
+		}
+	})
+
+	t.Run("unknown model falls back to static budget", func(t *testing.T) {
+		t.Parallel()
+		log, gw := newMemLog(), &summarizerGW{summary: "s"}
+		seed(t, log)
+		windows := &fakeWindows{windows: map[string]int{"other-model": 1000}}
+		c := NewCompactor(log, gw, windows, 1_000_000, discardLogger(), nil)
+		if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
+			t.Fatalf("MaybeCompact: %v", err)
+		}
+		if gw.calls != 0 {
+			t.Fatal("compacted with an unknown model instead of the static budget")
+		}
+	})
+}
+
+// TestPlanCompactionCountsLivePending pins the cut→seq mapping when a
+// live pending_state projects inside the summarized half (possible
+// when user messages pile up after an interruption): the boundary must
+// account for the pending's projected message, not skip past it.
+func TestPlanCompactionCountsLivePending(t *testing.T) {
+	t.Parallel()
+	log := newMemLog()
+	ctx := context.Background()
+	pad := strings.Repeat("pad ", 20)
+	if _, err := log.Append(ctx, "s1", KindUserMessage, UserMessage{Text: "start " + pad}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := log.Append(ctx, "s1", KindPendingState, PendingState{Partial: "interrupted answer " + pad}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 6; i++ {
+		if _, err := log.Append(ctx, "s1", KindUserMessage, UserMessage{Text: fmt.Sprintf("nudge %d %s", i, pad)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	events, _ := log.Events(ctx, "s1")
+	before, err := LLMContext(events, 0)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	boundary, toSummarize, ok := planCompaction(events)
+	if !ok {
+		t.Fatal("planCompaction refused a session with a live pending in the summarized half")
+	}
+
+	// Apply the plan and check the live tail is exactly the messages
+	// the summary did not consume — a mis-mapped boundary would swallow
+	// or duplicate a message.
+	if _, err := log.Append(ctx, "s1", KindCompactionApplied, CompactionApplied{
+		Summary: "sum", ReplacesThroughSeq: boundary,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	events, _ = log.Events(ctx, "s1")
+	after, err := LLMContext(events, 0)
+	if err != nil {
+		t.Fatalf("LLMContext after: %v", err)
+	}
+	tail, want := after[1:], before[len(toSummarize):]
+	if len(tail) != len(want) {
+		t.Fatalf("live tail = %d messages, want %d\n after: %+v\n want tail: %+v", len(tail), len(want), after, want)
+	}
+	for i := range want {
+		if tail[i] != want[i] {
+			t.Fatalf("tail[%d] = %+v, want %+v", i, tail[i], want[i])
+		}
+	}
+}
+
+// TestSummarizeInputPreservesFacts pins the fidelity pipeline: the
+// facts a summary must keep (names, dates, numbers, commitments) reach
+// the summarizer verbatim, under a system prompt that demands their
+// preservation.
+func TestSummarizeInputPreservesFacts(t *testing.T) {
+	t.Parallel()
+	log, gw := newMemLog(), &summarizerGW{summary: "s"}
+	ctx := context.Background()
+	pad := strings.Repeat("lorem ipsum dolor sit amet ", 30)
+	facts := []string{"Dr. Ada Marlowe", "2026-08-14", "invoice #4471", "$3,250"}
+	if _, err := log.Append(ctx, "s1", KindUserMessage, UserMessage{
+		Text: "Meet " + facts[0] + " on " + facts[1] + " about " + facts[2] + " for " + facts[3] + " " + pad,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var turn AssistantTurn
+	turn.LLM.Message = "noted, meeting confirmed " + pad
+	if _, err := log.Append(ctx, "s1", KindAssistantTurn, turn); err != nil {
+		t.Fatal(err)
+	}
+	seedConversation(t, log, "s1", 6) // push the facts into the oldest half
+
+	c := NewCompactor(log, gw, nil, 500, discardLogger(), nil)
+	if err := c.MaybeCompact(ctx, "s1"); err != nil {
+		t.Fatalf("MaybeCompact: %v", err)
+	}
+	if gw.calls != 1 {
+		t.Fatalf("summarizer calls = %d, want 1", gw.calls)
+	}
+	for _, f := range facts {
+		if !strings.Contains(gw.sawText, f) {
+			t.Fatalf("fact %q never reached the summarizer:\n%s", f, gw.sawText)
+		}
+	}
+	for _, demand := range []string{"preserve", "name", "date", "number", "commitment"} {
+		if !strings.Contains(gw.sawSystem, demand) {
+			t.Fatalf("summarize system prompt missing %q: %s", demand, gw.sawSystem)
+		}
 	}
 }
 

--- a/internal/brain/session/compactor_test.go
+++ b/internal/brain/session/compactor_test.go
@@ -363,6 +363,71 @@ func TestSummarizeInputPreservesFacts(t *testing.T) {
 	}
 }
 
+// TestHundredTurnSessionPreservesReference is the acceptance harness
+// in miniature: a 100-turn session compacts (possibly repeatedly)
+// under a tight budget, and afterwards a commitment stated in turn 3
+// is still present in the projected LLM context — via the summary
+// head — so a follow-up question can reference it.
+func TestHundredTurnSessionPreservesReference(t *testing.T) {
+	t.Parallel()
+	const fact = "the launch review is committed for 2026-08-14"
+	log := newMemLog()
+	// The fake summarizer behaves like the real prompt demands: it
+	// carries the commitment through every pass.
+	gw := &summarizerGW{summary: "Earlier discussion; " + fact + "."}
+	ctx := context.Background()
+	pad := strings.Repeat("lorem ipsum dolor sit amet ", 10)
+
+	budget := 2000
+	c := NewCompactor(log, gw, nil, budget, discardLogger(), nil)
+	for i := 0; i < 100; i++ {
+		text := fmt.Sprintf("question %d %s", i, pad)
+		if i == 2 {
+			text = "Remember: " + fact + ". " + pad
+		}
+		if _, err := log.Append(ctx, "s1", KindUserMessage, UserMessage{Text: text}); err != nil {
+			t.Fatal(err)
+		}
+		var turn AssistantTurn
+		turn.LLM.Message = fmt.Sprintf("answer %d %s", i, pad)
+		if _, err := log.Append(ctx, "s1", KindAssistantTurn, turn); err != nil {
+			t.Fatal(err)
+		}
+		// As in production: compaction runs after every completed turn.
+		if err := c.MaybeCompact(ctx, "s1"); err != nil {
+			t.Fatalf("MaybeCompact turn %d: %v", i, err)
+		}
+	}
+
+	events, _ := log.Events(ctx, "s1")
+	msgs, err := LLMContext(events, 0)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	tokens, err := EstimateTokens(msgs)
+	if err != nil {
+		t.Fatalf("EstimateTokens: %v", err)
+	}
+	if tokens > budget {
+		t.Fatalf("projection = %d tokens after 100 turns, budget %d", tokens, budget)
+	}
+	if gw.calls == 0 {
+		t.Fatal("no compaction ever fired — the test proved nothing")
+	}
+	// The commitment from turn 3 must be visible to the model NOW.
+	var all strings.Builder
+	for _, m := range msgs {
+		all.WriteString(m.Content + "\n")
+	}
+	if !strings.Contains(all.String(), fact) {
+		t.Fatalf("turn-3 commitment lost from projected context:\n%s", all.String())
+	}
+	// And the newest turn survives verbatim next to it.
+	if !strings.Contains(all.String(), "answer 99") {
+		t.Fatal("newest turn missing from projected context")
+	}
+}
+
 func jsonMarshal(v any) ([]byte, error) {
 	return json.Marshal(v)
 }

--- a/internal/brain/session/events.go
+++ b/internal/brain/session/events.go
@@ -1,0 +1,110 @@
+// Package session is the event-sourced session store: an append-only
+// log per session and two pure projections over it — the UI transcript
+// (rich replay) and the LLM context (what the model sees). They are
+// deliberately separate documents (D-006).
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Event kinds. The log is append-only: kinds are added, never changed.
+const (
+	KindSessionStarted    = "session_started"
+	KindUserMessage       = "user_message"
+	KindAssistantTurn     = "assistant_turn"
+	KindToolExecution     = "tool_execution"
+	KindCompactionApplied = "compaction_applied"
+	KindPendingState      = "pending_state"
+)
+
+// Event is one row of a session's log.
+type Event struct {
+	SessionID string
+	Seq       int64
+	Kind      string
+	Payload   json.RawMessage
+	CreatedAt time.Time
+}
+
+// SessionStarted opens a session.
+type SessionStarted struct {
+	Title string `json:"title,omitempty"`
+}
+
+// UserMessage is one user turn.
+type UserMessage struct {
+	Text      string `json:"text"`
+	Category  string `json:"category,omitempty"`
+	ModelHint string `json:"model_hint,omitempty"`
+}
+
+// UIBlock is one renderable piece of an assistant turn.
+type UIBlock struct {
+	Type string         `json:"type"` // text | reasoning | tool_call | meta
+	Text string         `json:"text,omitempty"`
+	Meta map[string]any `json:"meta,omitempty"`
+}
+
+// TurnMemory is the structured residue distilled from a turn's raw
+// traffic (D-007): what the model needs across turns, nothing else.
+type TurnMemory struct {
+	FilesChanged []string  `json:"files_changed,omitempty"`
+	Failures     []Failure `json:"failures,omitempty"`
+	KeyFindings  []string  `json:"key_findings,omitempty"`
+}
+
+// Failure records one failed command or tool call and why.
+type Failure struct {
+	What string `json:"what"`
+	Why  string `json:"why"`
+}
+
+// AssistantTurn carries both projections' source material: the UI
+// blocks for replay and the LLM-facing message + residue.
+type AssistantTurn struct {
+	UI struct {
+		Blocks []UIBlock `json:"blocks"`
+	} `json:"ui"`
+	LLM struct {
+		Message    string      `json:"message"`
+		TurnMemory *TurnMemory `json:"turn_memory,omitempty"`
+	} `json:"llm"`
+	Provider string `json:"provider,omitempty"`
+	Model    string `json:"model,omitempty"`
+	LedgerID string `json:"ledger_id,omitempty"`
+}
+
+// ToolExecution stores a digest only; full results are transient.
+type ToolExecution struct {
+	CallID       string `json:"call_id"`
+	Name         string `json:"name"`
+	Args         string `json:"args,omitempty"`
+	ResultDigest string `json:"result_digest,omitempty"`
+	Status       string `json:"status"`
+}
+
+// CompactionApplied replaces every event up to and including
+// ReplacesThroughSeq with its summary in the LLM projection.
+type CompactionApplied struct {
+	Summary            string   `json:"summary"`
+	ReplacesThroughSeq int64    `json:"replaces_through_seq"`
+	FactsExtracted     []string `json:"facts_extracted"`
+}
+
+// PendingState holds a turn's accumulated deltas when it ended
+// abnormally; the next request splices it in, then it is superseded.
+type PendingState struct {
+	Partial string `json:"partial"`
+}
+
+// decode unmarshals an event payload into out with kind context on
+// error.
+func decode(ev Event, out any) error {
+	if err := json.Unmarshal(ev.Payload, out); err != nil {
+		return fmt.Errorf("session: decode %s @%d: %w", ev.Kind, ev.Seq, err)
+	}
+	return nil
+}

--- a/internal/brain/session/events.go
+++ b/internal/brain/session/events.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 )
 
 // Event kinds. The log is append-only: kinds are added, never changed.
@@ -18,6 +20,7 @@ const (
 	KindToolExecution     = "tool_execution"
 	KindCompactionApplied = "compaction_applied"
 	KindPendingState      = "pending_state"
+	KindTurnMemory        = "turn_memory"
 )
 
 // Event is one row of a session's log.
@@ -62,6 +65,17 @@ type Failure struct {
 	Why  string `json:"why"`
 }
 
+// TurnMemoryEvent carries a turn's distilled residue as its own
+// appended event. Distillation is an LLM call that finishes seconds
+// after the turn is visible — persisting the assistant_turn first and
+// the residue later keeps completed turns durable immediately and the
+// projected prefix stable (the residue projects as a NEW message at
+// its own position, never a rewrite of the turn it describes).
+type TurnMemoryEvent struct {
+	TurnSeq int64 `json:"turn_seq"` // the assistant_turn this distills
+	TurnMemory
+}
+
 // AssistantTurn carries both projections' source material: the UI
 // blocks for replay and the LLM-facing message + residue.
 type AssistantTurn struct {
@@ -72,9 +86,10 @@ type AssistantTurn struct {
 		Message    string      `json:"message"`
 		TurnMemory *TurnMemory `json:"turn_memory,omitempty"`
 	} `json:"llm"`
-	Provider string `json:"provider,omitempty"`
-	Model    string `json:"model,omitempty"`
-	LedgerID string `json:"ledger_id,omitempty"`
+	Provider string        `json:"provider,omitempty"`
+	Model    string        `json:"model,omitempty"`
+	LedgerID string        `json:"ledger_id,omitempty"`
+	Usage    *stream.Usage `json:"usage,omitempty"`
 }
 
 // ToolExecution stores a digest only; full results are transient.

--- a/internal/brain/session/projection.go
+++ b/internal/brain/session/projection.go
@@ -1,0 +1,177 @@
+package session
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
+)
+
+// summaryPrefix marks a compaction summary inside the LLM context.
+const summaryPrefix = "[Summary of the conversation so far]\n"
+
+// interruptedNote marks a spliced partial turn inside the LLM context.
+const interruptedNote = "\n[this response was interrupted mid-stream; continue from it]"
+
+// LLMContext projects the log into the messages the model sees.
+//
+// Rules (D-006/D-007/D-018):
+//   - user_message → user message; assistant_turn → assistant message
+//     (llm.message plus serialized turn memory).
+//   - compaction_applied replaces everything ≤ replaces_through_seq
+//     with one summary message.
+//   - a pending_state that is the FINAL event splices in as an
+//     interrupted assistant message; earlier pending states are
+//     superseded and ignored.
+//   - tool_execution events never enter the LLM context (turn memory
+//     carries their residue).
+//
+// The projection is prefix-stable: appending events never rewrites
+// earlier messages — the prefix changes only when a compaction event
+// lands. Provider prompt caches depend on this.
+//
+// budget is the caller's token ceiling; projection never trims to it
+// (a sliding window would break prefix stability) — the compactor
+// reacts to it instead.
+func LLMContext(events []Event, budget int) ([]provider.Message, error) {
+	_ = budget // enforced by the compactor, not the projection
+
+	// Find the latest compaction: its summary replaces the prefix.
+	var summary string
+	var replacedThrough int64 = -1
+	for _, ev := range events {
+		if ev.Kind == KindCompactionApplied {
+			var c CompactionApplied
+			if err := decode(ev, &c); err != nil {
+				return nil, err
+			}
+			summary = c.Summary
+			replacedThrough = c.ReplacesThroughSeq
+		}
+	}
+
+	var msgs []provider.Message
+	if summary != "" {
+		msgs = append(msgs, provider.Message{Role: "user", Content: summaryPrefix + summary})
+	}
+
+	for i, ev := range events {
+		if ev.Seq <= replacedThrough {
+			continue
+		}
+		switch ev.Kind {
+		case KindUserMessage:
+			var m UserMessage
+			if err := decode(ev, &m); err != nil {
+				return nil, err
+			}
+			msgs = append(msgs, provider.Message{Role: "user", Content: m.Text})
+		case KindAssistantTurn:
+			var t AssistantTurn
+			if err := decode(ev, &t); err != nil {
+				return nil, err
+			}
+			msgs = append(msgs, provider.Message{Role: "assistant", Content: renderAssistant(t)})
+		case KindPendingState:
+			if i != len(events)-1 {
+				continue // superseded: a later event exists
+			}
+			var p PendingState
+			if err := decode(ev, &p); err != nil {
+				return nil, err
+			}
+			if p.Partial != "" {
+				msgs = append(msgs, provider.Message{Role: "assistant", Content: p.Partial + interruptedNote})
+			}
+		}
+	}
+	return msgs, nil
+}
+
+// renderAssistant serializes a turn for the LLM: the message plus a
+// compact deterministic turn-memory block.
+func renderAssistant(t AssistantTurn) string {
+	tm := t.LLM.TurnMemory
+	if tm == nil || (len(tm.FilesChanged) == 0 && len(tm.Failures) == 0 && len(tm.KeyFindings) == 0) {
+		return t.LLM.Message
+	}
+	var b strings.Builder
+	b.WriteString(t.LLM.Message)
+	b.WriteString("\n\n[turn memory]")
+	if len(tm.FilesChanged) > 0 {
+		b.WriteString("\nfiles changed: " + strings.Join(tm.FilesChanged, ", "))
+	}
+	for _, f := range tm.Failures {
+		b.WriteString("\nfailure: " + f.What + " — " + f.Why)
+	}
+	for _, k := range tm.KeyFindings {
+		b.WriteString("\nfinding: " + k)
+	}
+	return b.String()
+}
+
+// TranscriptItem is one renderable unit of the UI replay.
+type TranscriptItem struct {
+	Seq       int64          `json:"seq"`
+	Kind      string         `json:"kind"` // user | assistant | tool | compaction | interrupted
+	Text      string         `json:"text,omitempty"`
+	Blocks    []UIBlock      `json:"blocks,omitempty"`
+	Provider  string         `json:"provider,omitempty"`
+	Model     string         `json:"model,omitempty"`
+	Tool      *ToolExecution `json:"tool,omitempty"`
+	CreatedAt time.Time      `json:"created_at"`
+}
+
+// UITranscript projects the log into the full rich replay. Unlike the
+// LLM context it hides nothing: compactions render as dividers, tool
+// executions as digest blocks, and a trailing pending state as an
+// interrupted turn.
+func UITranscript(events []Event) ([]TranscriptItem, error) {
+	var items []TranscriptItem
+	for i, ev := range events {
+		item := TranscriptItem{Seq: ev.Seq, CreatedAt: ev.CreatedAt}
+		switch ev.Kind {
+		case KindUserMessage:
+			var m UserMessage
+			if err := decode(ev, &m); err != nil {
+				return nil, err
+			}
+			item.Kind, item.Text = "user", m.Text
+		case KindAssistantTurn:
+			var t AssistantTurn
+			if err := decode(ev, &t); err != nil {
+				return nil, err
+			}
+			item.Kind = "assistant"
+			item.Blocks = t.UI.Blocks
+			item.Provider, item.Model = t.Provider, t.Model
+		case KindToolExecution:
+			var te ToolExecution
+			if err := decode(ev, &te); err != nil {
+				return nil, err
+			}
+			item.Kind, item.Tool = "tool", &te
+		case KindCompactionApplied:
+			var c CompactionApplied
+			if err := decode(ev, &c); err != nil {
+				return nil, err
+			}
+			item.Kind = "compaction"
+			item.Text = fmt.Sprintf("older messages summarized (through #%d)", c.ReplacesThroughSeq)
+		case KindPendingState:
+			if i != len(events)-1 {
+				continue
+			}
+			var p PendingState
+			if err := decode(ev, &p); err != nil {
+				return nil, err
+			}
+			item.Kind, item.Text = "interrupted", p.Partial
+		default:
+			continue // session_started renders nothing
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}

--- a/internal/brain/session/projection.go
+++ b/internal/brain/session/projection.go
@@ -21,9 +21,12 @@ const interruptedNote = "\n[this response was interrupted mid-stream; continue f
 //     (llm.message plus serialized turn memory).
 //   - compaction_applied replaces everything ≤ replaces_through_seq
 //     with one summary message.
-//   - a pending_state that is the FINAL event splices in as an
-//     interrupted assistant message; earlier pending states are
-//     superseded and ignored.
+//   - the newest pending_state splices in as an interrupted assistant
+//     message at its position, unless a later assistant_turn or
+//     compaction superseded it. User messages do NOT supersede a
+//     pending — the question after an interruption must still see the
+//     partial. Older pendings (periodic checkpoints) are superseded by
+//     newer ones.
 //   - tool_execution events never enter the LLM context (turn memory
 //     carries their residue).
 //
@@ -51,12 +54,14 @@ func LLMContext(events []Event, budget int) ([]provider.Message, error) {
 		}
 	}
 
+	livePending := livePendingSeq(events)
+
 	var msgs []provider.Message
 	if summary != "" {
 		msgs = append(msgs, provider.Message{Role: "user", Content: summaryPrefix + summary})
 	}
 
-	for i, ev := range events {
+	for _, ev := range events {
 		if ev.Seq <= replacedThrough {
 			continue
 		}
@@ -74,8 +79,8 @@ func LLMContext(events []Event, budget int) ([]provider.Message, error) {
 			}
 			msgs = append(msgs, provider.Message{Role: "assistant", Content: renderAssistant(t)})
 		case KindPendingState:
-			if i != len(events)-1 {
-				continue // superseded: a later event exists
+			if ev.Seq != livePending {
+				continue // superseded checkpoint
 			}
 			var p PendingState
 			if err := decode(ev, &p); err != nil {
@@ -87,6 +92,25 @@ func LLMContext(events []Event, budget int) ([]provider.Message, error) {
 		}
 	}
 	return msgs, nil
+}
+
+// livePendingSeq returns the seq of the pending_state still in play:
+// the newest one, unless an assistant_turn or compaction landed after
+// it. Returns -1 when none is live.
+func livePendingSeq(events []Event) int64 {
+	var lastPending, lastSuperseder int64 = -1, -1
+	for _, ev := range events {
+		switch ev.Kind {
+		case KindPendingState:
+			lastPending = ev.Seq
+		case KindAssistantTurn, KindCompactionApplied:
+			lastSuperseder = ev.Seq
+		}
+	}
+	if lastPending > lastSuperseder {
+		return lastPending
+	}
+	return -1
 }
 
 // renderAssistant serializes a turn for the LLM: the message plus a
@@ -128,8 +152,9 @@ type TranscriptItem struct {
 // executions as digest blocks, and a trailing pending state as an
 // interrupted turn.
 func UITranscript(events []Event) ([]TranscriptItem, error) {
+	livePending := livePendingSeq(events)
 	var items []TranscriptItem
-	for i, ev := range events {
+	for _, ev := range events {
 		item := TranscriptItem{Seq: ev.Seq, CreatedAt: ev.CreatedAt}
 		switch ev.Kind {
 		case KindUserMessage:
@@ -160,7 +185,7 @@ func UITranscript(events []Event) ([]TranscriptItem, error) {
 			item.Kind = "compaction"
 			item.Text = fmt.Sprintf("older messages summarized (through #%d)", c.ReplacesThroughSeq)
 		case KindPendingState:
-			if i != len(events)-1 {
+			if ev.Seq != livePending {
 				continue
 			}
 			var p PendingState

--- a/internal/brain/session/projection.go
+++ b/internal/brain/session/projection.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 )
 
 // summaryPrefix marks a compaction summary inside the LLM context.
@@ -89,22 +90,39 @@ func LLMContext(events []Event, budget int) ([]provider.Message, error) {
 			if p.Partial != "" {
 				msgs = append(msgs, provider.Message{Role: "assistant", Content: p.Partial + interruptedNote})
 			}
+		case KindTurnMemory:
+			var tm TurnMemoryEvent
+			if err := decode(ev, &tm); err != nil {
+				return nil, err
+			}
+			if block := renderTurnMemory(&tm.TurnMemory); block != "" {
+				msgs = append(msgs, provider.Message{Role: "assistant", Content: block})
+			}
 		}
 	}
 	return msgs, nil
 }
 
 // livePendingSeq returns the seq of the pending_state still in play:
-// the newest one, unless an assistant_turn or compaction landed after
-// it. Returns -1 when none is live.
+// the newest one, unless an assistant_turn landed after it or a
+// compaction actually CONSUMED it (replaces_through_seq covers its
+// seq). A compaction that summarized older turns but left the partial
+// outside its boundary must not erase it — the partial is the one
+// artifact the kill-test contract protects. Returns -1 when none is
+// live.
 func livePendingSeq(events []Event) int64 {
 	var lastPending, lastSuperseder int64 = -1, -1
 	for _, ev := range events {
 		switch ev.Kind {
 		case KindPendingState:
 			lastPending = ev.Seq
-		case KindAssistantTurn, KindCompactionApplied:
+		case KindAssistantTurn:
 			lastSuperseder = ev.Seq
+		case KindCompactionApplied:
+			var c CompactionApplied
+			if decode(ev, &c) == nil && c.ReplacesThroughSeq >= lastPending {
+				lastSuperseder = ev.Seq
+			}
 		}
 	}
 	if lastPending > lastSuperseder {
@@ -113,16 +131,25 @@ func livePendingSeq(events []Event) int64 {
 	return -1
 }
 
-// renderAssistant serializes a turn for the LLM: the message plus a
-// compact deterministic turn-memory block.
+// renderAssistant serializes a turn for the LLM: the message plus,
+// for events written before turn_memory became its own kind, the
+// embedded residue block.
 func renderAssistant(t AssistantTurn) string {
-	tm := t.LLM.TurnMemory
-	if tm == nil || (len(tm.FilesChanged) == 0 && len(tm.Failures) == 0 && len(tm.KeyFindings) == 0) {
+	block := renderTurnMemory(t.LLM.TurnMemory)
+	if block == "" {
 		return t.LLM.Message
 	}
+	return t.LLM.Message + "\n\n" + block
+}
+
+// renderTurnMemory serializes residue into its compact deterministic
+// block; empty when there is nothing worth carrying.
+func renderTurnMemory(tm *TurnMemory) string {
+	if tm == nil || (len(tm.FilesChanged) == 0 && len(tm.Failures) == 0 && len(tm.KeyFindings) == 0) {
+		return ""
+	}
 	var b strings.Builder
-	b.WriteString(t.LLM.Message)
-	b.WriteString("\n\n[turn memory]")
+	b.WriteString("[turn memory]")
 	if len(tm.FilesChanged) > 0 {
 		b.WriteString("\nfiles changed: " + strings.Join(tm.FilesChanged, ", "))
 	}
@@ -143,6 +170,7 @@ type TranscriptItem struct {
 	Blocks    []UIBlock      `json:"blocks,omitempty"`
 	Provider  string         `json:"provider,omitempty"`
 	Model     string         `json:"model,omitempty"`
+	Usage     *stream.Usage  `json:"usage,omitempty"`
 	Tool      *ToolExecution `json:"tool,omitempty"`
 	CreatedAt time.Time      `json:"created_at"`
 }
@@ -171,6 +199,7 @@ func UITranscript(events []Event) ([]TranscriptItem, error) {
 			item.Kind = "assistant"
 			item.Blocks = t.UI.Blocks
 			item.Provider, item.Model = t.Provider, t.Model
+			item.Usage = t.Usage
 		case KindToolExecution:
 			var te ToolExecution
 			if err := decode(ev, &te); err != nil {

--- a/internal/brain/session/projection_test.go
+++ b/internal/brain/session/projection_test.go
@@ -1,0 +1,236 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
+)
+
+func ev(t *testing.T, seq int64, kind string, payload any) Event {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return Event{SessionID: "s", Seq: seq, Kind: kind, Payload: data}
+}
+
+func user(t *testing.T, seq int64, text string) Event {
+	return ev(t, seq, KindUserMessage, UserMessage{Text: text})
+}
+
+func assistant(t *testing.T, seq int64, msg string, tm *TurnMemory) Event {
+	var a AssistantTurn
+	a.LLM.Message = msg
+	a.LLM.TurnMemory = tm
+	a.UI.Blocks = []UIBlock{{Type: "text", Text: msg}}
+	a.Provider, a.Model = "prov", "mod"
+	return ev(t, seq, KindAssistantTurn, a)
+}
+
+func TestLLMContextBasicConversation(t *testing.T) {
+	t.Parallel()
+	events := []Event{
+		ev(t, 1, KindSessionStarted, SessionStarted{}),
+		user(t, 2, "hello"),
+		assistant(t, 3, "hi there", nil),
+		user(t, 4, "how are you"),
+	}
+
+	msgs, err := LLMContext(events, 100_000)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	want := []provider.Message{
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "hi there"},
+		{Role: "user", Content: "how are you"},
+	}
+	if len(msgs) != len(want) {
+		t.Fatalf("messages = %+v, want %+v", msgs, want)
+	}
+	for i := range want {
+		if msgs[i] != want[i] {
+			t.Fatalf("msg[%d] = %+v, want %+v", i, msgs[i], want[i])
+		}
+	}
+}
+
+func TestLLMContextSerializesTurnMemory(t *testing.T) {
+	t.Parallel()
+	events := []Event{
+		user(t, 1, "fix the bug"),
+		assistant(t, 2, "done", &TurnMemory{
+			FilesChanged: []string{"main.go"},
+			Failures:     []Failure{{What: "go test", Why: "flaky network"}},
+			KeyFindings:  []string{"root cause was a nil map"},
+		}),
+	}
+
+	msgs, err := LLMContext(events, 0)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	got := msgs[1].Content
+	for _, want := range []string{"[turn memory]", "files changed: main.go", "go test — flaky network", "finding: root cause was a nil map"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("assistant content missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestLLMContextCompactionReplacesPrefix(t *testing.T) {
+	t.Parallel()
+	events := []Event{
+		user(t, 1, "old question one"),
+		assistant(t, 2, "old answer one", nil),
+		user(t, 3, "old question two"),
+		assistant(t, 4, "old answer two", nil),
+		ev(t, 5, KindCompactionApplied, CompactionApplied{
+			Summary: "user asked two old questions; both answered", ReplacesThroughSeq: 4,
+		}),
+		user(t, 6, "new question"),
+		assistant(t, 7, "new answer", nil),
+	}
+
+	msgs, err := LLMContext(events, 0)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("messages = %d, want 3 (summary + verbatim tail): %+v", len(msgs), msgs)
+	}
+	if !strings.HasPrefix(msgs[0].Content, summaryPrefix) || !strings.Contains(msgs[0].Content, "two old questions") {
+		t.Fatalf("summary message = %+v", msgs[0])
+	}
+	if msgs[1].Content != "new question" || msgs[2].Content != "new answer" {
+		t.Fatalf("post-compaction tail not verbatim: %+v", msgs[1:])
+	}
+	if strings.Contains(fmt.Sprint(msgs), "old answer one") {
+		t.Fatal("replaced content leaked into projection")
+	}
+}
+
+func TestLLMContextPendingStateSplice(t *testing.T) {
+	t.Parallel()
+	base := []Event{
+		user(t, 1, "tell me a story"),
+		ev(t, 2, KindPendingState, PendingState{Partial: "Once upon a"}),
+	}
+
+	msgs, err := LLMContext(base, 0)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	last := msgs[len(msgs)-1]
+	if last.Role != "assistant" || !strings.HasPrefix(last.Content, "Once upon a") || !strings.Contains(last.Content, "interrupted") {
+		t.Fatalf("trailing pending state not spliced: %+v", last)
+	}
+
+	// A superseded pending state (later events exist) must vanish.
+	superseded := append(base, assistant(t, 3, "Once upon a time, the end.", nil))
+	msgs, err = LLMContext(superseded, 0)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	for _, m := range msgs {
+		if strings.Contains(m.Content, "interrupted") {
+			t.Fatalf("superseded pending state leaked: %+v", msgs)
+		}
+	}
+}
+
+func TestLLMContextIgnoresToolExecutions(t *testing.T) {
+	t.Parallel()
+	events := []Event{
+		user(t, 1, "what time is it"),
+		ev(t, 2, KindToolExecution, ToolExecution{CallID: "c1", Name: "time", Status: "ok", ResultDigest: "12:00"}),
+		assistant(t, 3, "it is noon", nil),
+	}
+
+	msgs, err := LLMContext(events, 0)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("tool execution leaked into LLM context: %+v", msgs)
+	}
+}
+
+func TestUITranscript(t *testing.T) {
+	t.Parallel()
+	events := []Event{
+		ev(t, 1, KindSessionStarted, SessionStarted{Title: "t"}),
+		user(t, 2, "hello"),
+		ev(t, 3, KindToolExecution, ToolExecution{CallID: "c1", Name: "calc", Status: "ok"}),
+		assistant(t, 4, "hi", nil),
+		ev(t, 5, KindCompactionApplied, CompactionApplied{Summary: "s", ReplacesThroughSeq: 4}),
+		user(t, 6, "again"),
+		ev(t, 7, KindPendingState, PendingState{Partial: "par"}),
+	}
+
+	items, err := UITranscript(events)
+	if err != nil {
+		t.Fatalf("UITranscript: %v", err)
+	}
+	kinds := make([]string, len(items))
+	for i, it := range items {
+		kinds[i] = it.Kind
+	}
+	want := []string{"user", "tool", "assistant", "compaction", "user", "interrupted"}
+	if strings.Join(kinds, ",") != strings.Join(want, ",") {
+		t.Fatalf("kinds = %v, want %v", kinds, want)
+	}
+	// The UI replay hides NOTHING: compacted-away events still render.
+	if items[0].Text != "hello" {
+		t.Fatalf("compacted user message missing from transcript: %+v", items[0])
+	}
+	if items[2].Provider != "prov" || len(items[2].Blocks) != 1 {
+		t.Fatalf("assistant item = %+v", items[2])
+	}
+}
+
+// TestLLMContextPrefixStability pins the D-018 contract: growing a log
+// without a compaction never rewrites earlier projected messages.
+func TestLLMContextPrefixStability(t *testing.T) {
+	t.Parallel()
+	var events []Event
+	seq := int64(0)
+	next := func() int64 { seq++; return seq }
+
+	events = append(events, ev(t, next(), KindSessionStarted, SessionStarted{}))
+	for i := 0; i < 30; i++ {
+		switch i % 4 {
+		case 0:
+			events = append(events, user(t, next(), fmt.Sprintf("question %d", i)))
+		case 1:
+			events = append(events, assistant(t, next(), fmt.Sprintf("answer %d", i), nil))
+		case 2:
+			events = append(events, ev(t, next(), KindToolExecution, ToolExecution{CallID: "c", Name: "n", Status: "ok"}))
+		case 3:
+			events = append(events, assistant(t, next(), fmt.Sprintf("more %d", i), &TurnMemory{KeyFindings: []string{"f"}}))
+		}
+	}
+
+	var prev []provider.Message
+	for n := 1; n <= len(events); n++ {
+		cur, err := LLMContext(events[:n], 0)
+		if err != nil {
+			t.Fatalf("LLMContext(%d): %v", n, err)
+		}
+		// Ignore a trailing pending splice (none generated here) —
+		// every earlier message must match the previous projection.
+		if len(cur) < len(prev) {
+			t.Fatalf("projection shrank at %d: %d -> %d", n, len(prev), len(cur))
+		}
+		for i := range prev {
+			if cur[i] != prev[i] {
+				t.Fatalf("prefix rewritten at event %d, message %d:\n prev %+v\n cur  %+v", n, i, prev[i], cur[i])
+			}
+		}
+		prev = cur
+	}
+}

--- a/internal/brain/session/projection_test.go
+++ b/internal/brain/session/projection_test.go
@@ -130,8 +130,40 @@ func TestLLMContextPendingStateSplice(t *testing.T) {
 		t.Fatalf("trailing pending state not spliced: %+v", last)
 	}
 
-	// A superseded pending state (later events exist) must vanish.
-	superseded := append(base, assistant(t, 3, "Once upon a time, the end.", nil))
+	// A user message after the pending does NOT supersede it: the
+	// follow-up question must still see the partial, in order.
+	withQuestion := append(append([]Event(nil), base...), user(t, 3, "you were cut off — continue"))
+	msgs, err = LLMContext(withQuestion, 0)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	if len(msgs) != 3 || !strings.Contains(msgs[1].Content, "Once upon a") || msgs[2].Content != "you were cut off — continue" {
+		t.Fatalf("pending not spliced before follow-up question: %+v", msgs)
+	}
+
+	// Newer checkpoints supersede older ones: only the last partial
+	// appears.
+	checkpoints := append(append([]Event(nil), base...),
+		ev(t, 3, KindPendingState, PendingState{Partial: "Once upon a time, in a"}))
+	msgs, err = LLMContext(checkpoints, 0)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	count := 0
+	for _, m := range msgs {
+		if strings.Contains(m.Content, "Once upon a") {
+			count++
+			if !strings.Contains(m.Content, "in a") {
+				t.Fatalf("older checkpoint won: %+v", m)
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("checkpoint messages = %d, want 1: %+v", count, msgs)
+	}
+
+	// An assistant turn supersedes every pending.
+	superseded := append(append([]Event(nil), base...), assistant(t, 3, "Once upon a time, the end.", nil))
 	msgs, err = LLMContext(superseded, 0)
 	if err != nil {
 		t.Fatalf("LLMContext: %v", err)

--- a/internal/brain/session/projection_test.go
+++ b/internal/brain/session/projection_test.go
@@ -227,6 +227,9 @@ func TestUITranscript(t *testing.T) {
 
 // TestLLMContextPrefixStability pins the D-018 contract: growing a log
 // without a compaction never rewrites earlier projected messages.
+// Pending checkpoints are deliberately absent from the generator: an
+// interrupted turn's spliced partial is replaced when the turn
+// completes — the one sanctioned prefix rewrite (D-023).
 func TestLLMContextPrefixStability(t *testing.T) {
 	t.Parallel()
 	var events []Event
@@ -264,5 +267,103 @@ func TestLLMContextPrefixStability(t *testing.T) {
 			}
 		}
 		prev = cur
+	}
+}
+
+// TestPendingSurvivesNonCoveringCompaction pins the kill-test artifact
+// against pre-send compaction: a compaction that did NOT consume the
+// live pending (replaces_through_seq below it) must leave the partial
+// in both projections; one that covered it supersedes it.
+func TestPendingSurvivesNonCoveringCompaction(t *testing.T) {
+	t.Parallel()
+	base := []Event{
+		user(t, 1, "old question"),
+		assistant(t, 2, "old answer", nil),
+		user(t, 3, "tell me a story"),
+		ev(t, 4, KindPendingState, PendingState{Partial: "Once upon a"}),
+		// Summarized only the first exchange — the partial is NOT covered.
+		ev(t, 5, KindCompactionApplied, CompactionApplied{Summary: "old exchange summarized", ReplacesThroughSeq: 2}),
+	}
+
+	msgs, err := LLMContext(base, 0)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	if !strings.Contains(fmt.Sprint(msgs), "Once upon a") {
+		t.Fatalf("uncovered partial vanished from LLM context: %+v", msgs)
+	}
+	items, err := UITranscript(base)
+	if err != nil {
+		t.Fatalf("UITranscript: %v", err)
+	}
+	found := false
+	for _, it := range items {
+		if it.Kind == "interrupted" && strings.Contains(it.Text, "Once upon a") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("uncovered partial vanished from UI transcript: %+v", items)
+	}
+
+	// A compaction that consumed the pending DOES supersede it.
+	covered := append(append([]Event(nil), base[:4]...),
+		ev(t, 5, KindCompactionApplied, CompactionApplied{Summary: "everything incl. the partial", ReplacesThroughSeq: 4}))
+	msgs, err = LLMContext(covered, 0)
+	if err != nil {
+		t.Fatalf("LLMContext covered: %v", err)
+	}
+	if strings.Contains(fmt.Sprint(msgs), "Once upon a") {
+		t.Fatalf("consumed partial leaked past its compaction: %+v", msgs)
+	}
+}
+
+// TestTurnMemoryEventProjectsAsOwnMessage pins the late-residue
+// contract: a turn_memory event appends a NEW message at its own
+// position — the assistant turn it describes is never rewritten, so
+// the projected prefix stays byte-stable when residue lands late.
+func TestTurnMemoryEventProjectsAsOwnMessage(t *testing.T) {
+	t.Parallel()
+	events := []Event{
+		user(t, 1, "fix the bug"),
+		assistant(t, 2, "done", nil),
+	}
+	before, err := LLMContext(events, 0)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+
+	withMemory := append(append([]Event(nil), events...),
+		ev(t, 3, KindTurnMemory, TurnMemoryEvent{TurnSeq: 2, TurnMemory: TurnMemory{
+			FilesChanged: []string{"main.go"}, KeyFindings: []string{"nil map"},
+		}}))
+	after, err := LLMContext(withMemory, 0)
+	if err != nil {
+		t.Fatalf("LLMContext with memory: %v", err)
+	}
+
+	if len(after) != len(before)+1 {
+		t.Fatalf("messages = %d, want %d (residue as its own message)", len(after), len(before)+1)
+	}
+	for i := range before {
+		if after[i] != before[i] {
+			t.Fatalf("late residue rewrote the prefix at %d:\n before %+v\n after  %+v", i, before[i], after[i])
+		}
+	}
+	tail := after[len(after)-1]
+	if tail.Role != "assistant" || !strings.Contains(tail.Content, "[turn memory]") ||
+		!strings.Contains(tail.Content, "files changed: main.go") {
+		t.Fatalf("residue message = %+v", tail)
+	}
+
+	// The UI replay does not render residue.
+	items, err := UITranscript(withMemory)
+	if err != nil {
+		t.Fatalf("UITranscript: %v", err)
+	}
+	for _, it := range items {
+		if strings.Contains(it.Text, "turn memory") {
+			t.Fatalf("residue leaked into UI transcript: %+v", it)
+		}
 	}
 }

--- a/internal/brain/session/store.go
+++ b/internal/brain/session/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
@@ -161,15 +162,17 @@ func (s *Store) List(ctx context.Context, query string, before time.Time, before
 		       ORDER BY updated_at DESC, id DESC LIMIT $3`
 		args = []any{before, beforeID, listLimit}
 	} else {
+		// ILIKE wildcards in the user's query are literals, not patterns.
+		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(query)
 		sql = `SELECT DISTINCT s.id, COALESCE(s.title, ''), s.archived, s.last_category, s.created_at, s.updated_at
 		       FROM sessions s
 		       LEFT JOIN session_events e ON e.session_id = s.id AND e.kind = 'user_message'
 		       WHERE (s.updated_at, s.id) < ($2, $3::uuid)
-		         AND (s.title ILIKE '%' || $1 || '%'
+		         AND (s.title ILIKE '%' || $4 || '%'
 		          OR (e.payload IS NOT NULL
 		              AND to_tsvector('english', e.payload->>'text') @@ plainto_tsquery('english', $1)))
-		       ORDER BY s.updated_at DESC, s.id DESC LIMIT $4`
-		args = []any{query, before, beforeID, listLimit}
+		       ORDER BY s.updated_at DESC, s.id DESC LIMIT $5`
+		args = []any{query, before, beforeID, escaped, listLimit}
 	}
 
 	rows, err := db.Query(ctx, sql, args...)

--- a/internal/brain/session/store.go
+++ b/internal/brain/session/store.go
@@ -136,35 +136,39 @@ type Meta struct {
 
 const listLimit = 100
 
-// List returns sessions newest-first, one page at a time. A non-empty
-// query matches the title or full-text over user messages; archived
-// sessions appear only in query results. A non-zero before returns
-// sessions updated strictly earlier — the cursor for the next page.
-func (s *Store) List(ctx context.Context, query string, before time.Time) ([]Meta, error) {
+// List returns sessions newest-first, one page at a time, ordered by
+// (updated_at, id) descending. A non-empty query matches the title or
+// full-text over user messages; archived sessions appear only in query
+// results. A non-zero cursor (before, beforeID — the last row of the
+// previous page) returns rows strictly earlier in that ordering: the
+// id tiebreaker keeps pages stable when timestamps collide.
+func (s *Store) List(ctx context.Context, query string, before time.Time, beforeID string) ([]Meta, error) {
 	db, err := s.db.Get()
 	if err != nil {
 		return nil, fmt.Errorf("session: list: %w", err)
 	}
 	if before.IsZero() {
-		before = time.Now().Add(24 * time.Hour) // first page: everything
+		// First page: a cursor no real row can reach.
+		before = time.Now().Add(24 * time.Hour)
+		beforeID = "ffffffff-ffff-ffff-ffff-ffffffffffff"
 	}
 
 	var sql string
 	var args []any
 	if query == "" {
 		sql = `SELECT id, COALESCE(title, ''), archived, last_category, created_at, updated_at
-		       FROM sessions WHERE NOT archived AND updated_at < $1
-		       ORDER BY updated_at DESC LIMIT $2`
-		args = []any{before, listLimit}
+		       FROM sessions WHERE NOT archived AND (updated_at, id) < ($1, $2::uuid)
+		       ORDER BY updated_at DESC, id DESC LIMIT $3`
+		args = []any{before, beforeID, listLimit}
 	} else {
 		sql = `SELECT DISTINCT s.id, COALESCE(s.title, ''), s.archived, s.last_category, s.created_at, s.updated_at
 		       FROM sessions s
 		       LEFT JOIN session_events e ON e.session_id = s.id AND e.kind = 'user_message'
-		       WHERE s.updated_at < $2
+		       WHERE (s.updated_at, s.id) < ($2, $3::uuid)
 		         AND (s.title ILIKE '%' || $1 || '%'
 		          OR to_tsvector('english', e.payload->>'text') @@ plainto_tsquery('english', $1))
-		       ORDER BY s.updated_at DESC LIMIT $3`
-		args = []any{query, before, listLimit}
+		       ORDER BY s.updated_at DESC, s.id DESC LIMIT $4`
+		args = []any{query, before, beforeID, listLimit}
 	}
 
 	rows, err := db.Query(ctx, sql, args...)

--- a/internal/brain/session/store.go
+++ b/internal/brain/session/store.go
@@ -136,29 +136,35 @@ type Meta struct {
 
 const listLimit = 100
 
-// List returns sessions newest-first. A non-empty query matches the
-// title or full-text over user messages; archived sessions appear only
-// in query results.
-func (s *Store) List(ctx context.Context, query string) ([]Meta, error) {
+// List returns sessions newest-first, one page at a time. A non-empty
+// query matches the title or full-text over user messages; archived
+// sessions appear only in query results. A non-zero before returns
+// sessions updated strictly earlier — the cursor for the next page.
+func (s *Store) List(ctx context.Context, query string, before time.Time) ([]Meta, error) {
 	db, err := s.db.Get()
 	if err != nil {
 		return nil, fmt.Errorf("session: list: %w", err)
+	}
+	if before.IsZero() {
+		before = time.Now().Add(24 * time.Hour) // first page: everything
 	}
 
 	var sql string
 	var args []any
 	if query == "" {
 		sql = `SELECT id, COALESCE(title, ''), archived, last_category, created_at, updated_at
-		       FROM sessions WHERE NOT archived ORDER BY updated_at DESC LIMIT $1`
-		args = []any{listLimit}
+		       FROM sessions WHERE NOT archived AND updated_at < $1
+		       ORDER BY updated_at DESC LIMIT $2`
+		args = []any{before, listLimit}
 	} else {
 		sql = `SELECT DISTINCT s.id, COALESCE(s.title, ''), s.archived, s.last_category, s.created_at, s.updated_at
 		       FROM sessions s
 		       LEFT JOIN session_events e ON e.session_id = s.id AND e.kind = 'user_message'
-		       WHERE s.title ILIKE '%' || $1 || '%'
-		          OR to_tsvector('english', e.payload->>'text') @@ plainto_tsquery('english', $1)
-		       ORDER BY s.updated_at DESC LIMIT $2`
-		args = []any{query, listLimit}
+		       WHERE s.updated_at < $2
+		         AND (s.title ILIKE '%' || $1 || '%'
+		          OR to_tsvector('english', e.payload->>'text') @@ plainto_tsquery('english', $1))
+		       ORDER BY s.updated_at DESC LIMIT $3`
+		args = []any{query, before, listLimit}
 	}
 
 	rows, err := db.Query(ctx, sql, args...)

--- a/internal/brain/session/store.go
+++ b/internal/brain/session/store.go
@@ -166,7 +166,8 @@ func (s *Store) List(ctx context.Context, query string, before time.Time, before
 		       LEFT JOIN session_events e ON e.session_id = s.id AND e.kind = 'user_message'
 		       WHERE (s.updated_at, s.id) < ($2, $3::uuid)
 		         AND (s.title ILIKE '%' || $1 || '%'
-		          OR to_tsvector('english', e.payload->>'text') @@ plainto_tsquery('english', $1))
+		          OR (e.payload IS NOT NULL
+		              AND to_tsvector('english', e.payload->>'text') @@ plainto_tsquery('english', $1)))
 		       ORDER BY s.updated_at DESC, s.id DESC LIMIT $4`
 		args = []any{query, before, beforeID, listLimit}
 	}

--- a/internal/brain/session/store.go
+++ b/internal/brain/session/store.go
@@ -133,3 +133,110 @@ type Meta struct {
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 }
+
+const listLimit = 100
+
+// List returns sessions newest-first. A non-empty query matches the
+// title or full-text over user messages; archived sessions appear only
+// in query results.
+func (s *Store) List(ctx context.Context, query string) ([]Meta, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("session: list: %w", err)
+	}
+
+	var sql string
+	var args []any
+	if query == "" {
+		sql = `SELECT id, COALESCE(title, ''), archived, last_category, created_at, updated_at
+		       FROM sessions WHERE NOT archived ORDER BY updated_at DESC LIMIT $1`
+		args = []any{listLimit}
+	} else {
+		sql = `SELECT DISTINCT s.id, COALESCE(s.title, ''), s.archived, s.last_category, s.created_at, s.updated_at
+		       FROM sessions s
+		       LEFT JOIN session_events e ON e.session_id = s.id AND e.kind = 'user_message'
+		       WHERE s.title ILIKE '%' || $1 || '%'
+		          OR to_tsvector('english', e.payload->>'text') @@ plainto_tsquery('english', $1)
+		       ORDER BY s.updated_at DESC LIMIT $2`
+		args = []any{query, listLimit}
+	}
+
+	rows, err := db.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("session: list query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Meta
+	for rows.Next() {
+		var m Meta
+		if err := rows.Scan(&m.ID, &m.Title, &m.Archived, &m.LastCategory, &m.CreatedAt, &m.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("session: list scan: %w", err)
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// Get returns one session's metadata.
+func (s *Store) Get(ctx context.Context, id string) (Meta, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return Meta{}, fmt.Errorf("session: get: %w", err)
+	}
+	var m Meta
+	err = db.QueryRow(ctx,
+		`SELECT id, COALESCE(title, ''), archived, last_category, created_at, updated_at
+		 FROM sessions WHERE id = $1`, id,
+	).Scan(&m.ID, &m.Title, &m.Archived, &m.LastCategory, &m.CreatedAt, &m.UpdatedAt)
+	if err != nil {
+		return Meta{}, fmt.Errorf("session: get %s: %w", id, err)
+	}
+	return m, nil
+}
+
+// Update patches title and/or archived; nil means unchanged.
+func (s *Store) Update(ctx context.Context, id string, title *string, archived *bool) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("session: update: %w", err)
+	}
+	tag, err := db.Exec(ctx,
+		`UPDATE sessions SET
+		   title = COALESCE($2, title),
+		   archived = COALESCE($3, archived),
+		   updated_at = now()
+		 WHERE id = $1`, id, title, archived)
+	if err != nil {
+		return fmt.Errorf("session: update %s: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("session: update %s: not found", id)
+	}
+	return nil
+}
+
+// SetTitleIfEmpty writes an auto-generated title without clobbering a
+// user-chosen one.
+func (s *Store) SetTitleIfEmpty(ctx context.Context, id, title string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("session: set title: %w", err)
+	}
+	_, err = db.Exec(ctx,
+		"UPDATE sessions SET title = $2, updated_at = now() WHERE id = $1 AND (title IS NULL OR title = '')",
+		id, title)
+	return err
+}
+
+// SetLastCategory remembers the session's most recent task category so
+// the UI composer can restore it.
+func (s *Store) SetLastCategory(ctx context.Context, id, category string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("session: set category: %w", err)
+	}
+	_, err = db.Exec(ctx,
+		"UPDATE sessions SET last_category = $2 WHERE id = $1", id, category)
+	return err
+}

--- a/internal/brain/session/store.go
+++ b/internal/brain/session/store.go
@@ -1,0 +1,135 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+// Store persists session rows and their append-only event logs.
+type Store struct {
+	db *pgpool.Pool
+}
+
+func NewStore(db *pgpool.Pool) *Store {
+	return &Store{db: db}
+}
+
+// Create opens a session and writes its session_started event.
+func (s *Store) Create(ctx context.Context, title string) (string, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return "", fmt.Errorf("session: create: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return "", fmt.Errorf("session: create begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+
+	var id string
+	if err := tx.QueryRow(ctx,
+		"INSERT INTO sessions (title) VALUES (NULLIF($1, '')) RETURNING id", title,
+	).Scan(&id); err != nil {
+		return "", fmt.Errorf("session: create insert: %w", err)
+	}
+	payload, err := json.Marshal(SessionStarted{Title: title})
+	if err != nil {
+		return "", fmt.Errorf("session: create payload: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		"INSERT INTO session_events (session_id, seq, kind, payload) VALUES ($1, 1, $2, $3)",
+		id, KindSessionStarted, payload,
+	); err != nil {
+		return "", fmt.Errorf("session: create event: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return "", fmt.Errorf("session: create commit: %w", err)
+	}
+	return id, nil
+}
+
+// Append writes one event, assigning the next sequence number inside
+// the transaction. The session row is locked FOR UPDATE so concurrent
+// appenders to the same session serialize; different sessions never
+// contend.
+func (s *Store) Append(ctx context.Context, sessionID, kind string, payload any) (int64, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return 0, fmt.Errorf("session: append: %w", err)
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return 0, fmt.Errorf("session: append payload: %w", err)
+	}
+
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("session: append begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+
+	var exists bool
+	if err := tx.QueryRow(ctx,
+		"SELECT true FROM sessions WHERE id = $1 FOR UPDATE", sessionID,
+	).Scan(&exists); err != nil {
+		return 0, fmt.Errorf("session: append lock %s: %w", sessionID, err)
+	}
+
+	var seq int64
+	if err := tx.QueryRow(ctx,
+		`INSERT INTO session_events (session_id, seq, kind, payload)
+		 SELECT $1, COALESCE(MAX(seq), 0) + 1, $2, $3 FROM session_events WHERE session_id = $1
+		 RETURNING seq`,
+		sessionID, kind, data,
+	).Scan(&seq); err != nil {
+		return 0, fmt.Errorf("session: append insert: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		"UPDATE sessions SET updated_at = now() WHERE id = $1", sessionID,
+	); err != nil {
+		return 0, fmt.Errorf("session: append touch: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("session: append commit: %w", err)
+	}
+	return seq, nil
+}
+
+// Events reads a session's full log in order.
+func (s *Store) Events(ctx context.Context, sessionID string) ([]Event, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("session: events: %w", err)
+	}
+	rows, err := db.Query(ctx,
+		`SELECT session_id, seq, kind, payload, created_at
+		 FROM session_events WHERE session_id = $1 ORDER BY seq`, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("session: events query: %w", err)
+	}
+	defer rows.Close()
+
+	var events []Event
+	for rows.Next() {
+		var ev Event
+		if err := rows.Scan(&ev.SessionID, &ev.Seq, &ev.Kind, &ev.Payload, &ev.CreatedAt); err != nil {
+			return nil, fmt.Errorf("session: events scan: %w", err)
+		}
+		events = append(events, ev)
+	}
+	return events, rows.Err()
+}
+
+// Meta is a session listing row.
+type Meta struct {
+	ID           string    `json:"id"`
+	Title        string    `json:"title"`
+	Archived     bool      `json:"archived"`
+	LastCategory string    `json:"last_category,omitempty"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}

--- a/internal/brain/session/store_integration_test.go
+++ b/internal/brain/session/store_integration_test.go
@@ -212,3 +212,23 @@ func TestListCursorStableOnTiedTimestamps(t *testing.T) {
 		t.Fatalf("cursor page = %v, want [%s %s]", restIDs, mine[1].ID, mine[2].ID)
 	}
 }
+
+// TestListQueryMatchesTitleOnlySession pins the NULL guard in the
+// search SQL: a session that has never emitted a user_message (its
+// joined payload is NULL) must still be findable by title.
+func TestListQueryMatchesTitleOnlySession(t *testing.T) {
+	s, id := integrationStore(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	got, err := s.List(ctx, "integration test session", time.Time{}, "")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, m := range got {
+		if m.ID == id {
+			return
+		}
+	}
+	t.Fatalf("title-only session %s missing from query results", id)
+}

--- a/internal/brain/session/store_integration_test.go
+++ b/internal/brain/session/store_integration_test.go
@@ -127,3 +127,88 @@ func TestEventsRoundTripProjection(t *testing.T) {
 		t.Fatalf("round-trip projection = %+v", msgs)
 	}
 }
+
+// TestListCursorStableOnTiedTimestamps pins the composite-cursor SQL:
+// rows sharing an updated_at page without duplicates or gaps because
+// the id breaks the tie.
+func TestListCursorStableOnTiedTimestamps(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	s := NewStore(pool)
+
+	const marker = "cursor-tie-test"
+	var ids []string
+	for i := 0; i < 3; i++ {
+		id, err := s.Create(ctx, marker)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer ccancel()
+		conn, err := pgx.Connect(cctx, dsn)
+		if err != nil {
+			t.Errorf("cleanup connect: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close(cctx) }()
+		for _, id := range ids {
+			_, _ = conn.Exec(cctx, "DELETE FROM session_events WHERE session_id = $1", id)
+			_, _ = conn.Exec(cctx, "DELETE FROM sessions WHERE id = $1", id)
+		}
+	})
+	// Force an exact timestamp collision.
+	tied := time.Date(2020, 1, 2, 3, 4, 5, 123456000, time.UTC)
+	if _, err := db.Exec(ctx,
+		"UPDATE sessions SET updated_at = $1 WHERE title = $2", tied, marker); err != nil {
+		t.Fatalf("tie timestamps: %v", err)
+	}
+
+	page, err := s.List(ctx, marker, time.Time{}, "")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var mine []Meta
+	for _, m := range page {
+		if m.Title == marker {
+			mine = append(mine, m)
+		}
+	}
+	if len(mine) != 3 {
+		t.Fatalf("full page has %d marker rows, want 3", len(mine))
+	}
+
+	// Resume from the FIRST tied row: the remaining two must follow,
+	// no duplicate of the cursor row, no skips.
+	rest, err := s.List(ctx, marker, mine[0].UpdatedAt, mine[0].ID)
+	if err != nil {
+		t.Fatalf("List cursor: %v", err)
+	}
+	var restIDs []string
+	for _, m := range rest {
+		if m.Title == marker {
+			restIDs = append(restIDs, m.ID)
+		}
+	}
+	if len(restIDs) != 2 || restIDs[0] != mine[1].ID || restIDs[1] != mine[2].ID {
+		t.Fatalf("cursor page = %v, want [%s %s]", restIDs, mine[1].ID, mine[2].ID)
+	}
+}

--- a/internal/brain/session/store_integration_test.go
+++ b/internal/brain/session/store_integration_test.go
@@ -1,0 +1,129 @@
+//go:build integration
+
+package session
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/SumonMSelim/timothy/internal/platform/migrate"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+	"github.com/SumonMSelim/timothy/migrations"
+)
+
+func integrationStore(t *testing.T) (*Store, string) {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	s := NewStore(pool)
+	id, err := s.Create(ctx, "integration test session")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		conn, err := pgx.Connect(ctx, dsn)
+		if err != nil {
+			t.Errorf("cleanup connect: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close(ctx) }()
+		_, _ = conn.Exec(ctx, "DELETE FROM session_events WHERE session_id = $1", id)
+		_, _ = conn.Exec(ctx, "DELETE FROM cost_ledger WHERE session_id = $1", id)
+		if _, err := conn.Exec(ctx, "DELETE FROM sessions WHERE id = $1", id); err != nil {
+			t.Errorf("cleanup session: %v", err)
+		}
+	})
+	return s, id
+}
+
+func TestAppendAssignsGaplessOrderedSeqs(t *testing.T) {
+	s, id := integrationStore(t)
+
+	// Concurrent appenders to ONE session must serialize on the row
+	// lock: every seq unique, no gaps, no lost writes.
+	const writers, each = 4, 5
+	var wg sync.WaitGroup
+	errs := make([]error, writers*each)
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < each; i++ {
+				_, err := s.Append(context.Background(), id, KindUserMessage, UserMessage{Text: "m"})
+				errs[w*each+i] = err
+			}
+		}(w)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+
+	events, err := s.Events(t.Context(), id)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	// session_started took seq 1; then writers*each appended events.
+	if len(events) != writers*each+1 {
+		t.Fatalf("events = %d, want %d", len(events), writers*each+1)
+	}
+	for i, ev := range events {
+		if ev.Seq != int64(i+1) {
+			t.Fatalf("seq gap: events[%d].Seq = %d", i, ev.Seq)
+		}
+	}
+}
+
+func TestEventsRoundTripProjection(t *testing.T) {
+	s, id := integrationStore(t)
+
+	if _, err := s.Append(t.Context(), id, KindUserMessage, UserMessage{Text: "hello"}); err != nil {
+		t.Fatalf("append user: %v", err)
+	}
+	var turn AssistantTurn
+	turn.LLM.Message = "hi"
+	turn.UI.Blocks = []UIBlock{{Type: "text", Text: "hi"}}
+	if _, err := s.Append(t.Context(), id, KindAssistantTurn, turn); err != nil {
+		t.Fatalf("append turn: %v", err)
+	}
+
+	events, err := s.Events(t.Context(), id)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	msgs, err := LLMContext(events, 0)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	if len(msgs) != 2 || msgs[0].Content != "hello" || msgs[1].Content != "hi" {
+		t.Fatalf("round-trip projection = %+v", msgs)
+	}
+}

--- a/internal/brain/session/tokens.go
+++ b/internal/brain/session/tokens.go
@@ -1,0 +1,51 @@
+package session
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/pkoukk/tiktoken-go"
+	tiktoken_loader "github.com/pkoukk/tiktoken-go-loader"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
+)
+
+// Token estimation uses tiktoken's o200k encoding with embedded BPE
+// data (no network). Anthropic and GLM publish no tokenizers, so this
+// is a principled approximation for pre-send budgeting — the spec's
+// ban is on len/3-style byte heuristics, and actual billing always
+// comes from provider-reported usage in the ledger. Recorded as a
+// deviation in docs/architecture.md.
+
+var (
+	encOnce sync.Once
+	enc     *tiktoken.Tiktoken
+	encErr  error
+)
+
+func encoder() (*tiktoken.Tiktoken, error) {
+	encOnce.Do(func() {
+		tiktoken.SetBpeLoader(tiktoken_loader.NewOfflineLoader())
+		enc, encErr = tiktoken.GetEncoding("o200k_base")
+		if encErr != nil {
+			encErr = fmt.Errorf("session: load tokenizer: %w", encErr)
+		}
+	})
+	return enc, encErr
+}
+
+// perMessageOverhead approximates chat-format framing tokens.
+const perMessageOverhead = 4
+
+// EstimateTokens counts tokens across projected messages.
+func EstimateTokens(msgs []provider.Message) (int, error) {
+	e, err := encoder()
+	if err != nil {
+		return 0, err
+	}
+	total := 0
+	for _, m := range msgs {
+		total += len(e.Encode(m.Content, nil, nil)) + perMessageOverhead
+	}
+	return total, nil
+}

--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -45,6 +45,7 @@ func Register(srv *httpserver.Server, store ConfigSource, rec ledger.Recorder, l
 
 type streamRequest struct {
 	TaskCategory string             `json:"task_category"`
+	Purpose      string             `json:"purpose,omitempty"` // why: chat|distill|title|compaction|...
 	ModelHint    string             `json:"model_hint,omitempty"`
 	System       string             `json:"system,omitempty"`
 	Messages     []provider.Message `json:"messages"`
@@ -121,8 +122,8 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 		res := streamAttempt(r.Context(), att, completion, ledger.Entry{
 			ID:       ledger.NewID(),
 			Provider: att.ProviderName, Model: att.Model,
-			TaskCategory: req.TaskCategory,
-			SessionID:    req.SessionID, LaneID: req.LaneID,
+			TaskCategory: req.TaskCategory, Purpose: req.Purpose,
+			SessionID: req.SessionID, LaneID: req.LaneID,
 		}, send)
 
 		if res.failedOver() {

--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -307,9 +307,11 @@ func (a *API) handleProviders(w http.ResponseWriter, r *http.Request) {
 	rows, healthy := snap.Providers()
 	list := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {
-		models := make([]string, 0, len(row.Models))
+		models := make([]map[string]any, 0, len(row.Models))
 		for _, m := range row.Models {
-			models = append(models, m.ID)
+			models = append(models, map[string]any{
+				"id": m.ID, "context_window": m.ContextWindow,
+			})
 		}
 		list = append(list, map[string]any{
 			"name":           row.Name,

--- a/internal/gateway/ledger/ledger.go
+++ b/internal/gateway/ledger/ledger.go
@@ -25,6 +25,7 @@ type Entry struct {
 	Provider     string
 	Model        string
 	TaskCategory string
+	Purpose      string // optional: why the call happened (chat|distill|title|compaction|...)
 	SessionID    string // optional
 	LaneID       string // optional
 	Usage        *stream.Usage
@@ -67,12 +68,12 @@ func (l *Ledger) Record(ctx context.Context, e Entry) {
 		in, out, cr, cw = &e.Usage.InputTokens, &e.Usage.OutputTokens, &e.Usage.CacheReadTokens, &e.Usage.CacheWriteTokens
 	}
 	_, err = db.Exec(wctx, `INSERT INTO cost_ledger
-		(id, provider, model, task_category, session_id, lane_id,
+		(id, provider, model, task_category, purpose, session_id, lane_id,
 		 input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
 		 latency_ms, status, error_code, cost_usd)
 		VALUES (COALESCE(NULLIF($1, '')::uuid, gen_random_uuid()),
-		 $2, $3, $4, NULLIF($5, ''), NULLIF($6, ''), $7, $8, $9, $10, $11, $12, NULLIF($13, ''), $14)`,
-		e.ID, e.Provider, e.Model, e.TaskCategory, e.SessionID, e.LaneID,
+		 $2, $3, $4, NULLIF($5, ''), NULLIF($6, ''), NULLIF($7, ''), $8, $9, $10, $11, $12, $13, NULLIF($14, ''), $15)`,
+		e.ID, e.Provider, e.Model, e.TaskCategory, e.Purpose, e.SessionID, e.LaneID,
 		in, out, cr, cw, e.LatencyMS, e.Status, e.ErrorCode, e.CostUSD)
 	if err != nil {
 		l.log.Warn("ledger write failed", "error", err, "provider", e.Provider, "status", e.Status)

--- a/internal/platform/httpserver/server.go
+++ b/internal/platform/httpserver/server.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 
@@ -98,8 +99,11 @@ func newTraceID() string {
 }
 
 // Run serves until ctx is canceled, then shuts down gracefully within
-// shutdownTimeout. It returns nil on clean shutdown.
+// shutdownTimeout. It returns nil on clean shutdown. In-flight request
+// contexts descend from ctx, so long-lived streams learn about
+// shutdown immediately and can persist state inside the grace window.
 func (s *Server) Run(ctx context.Context) error {
+	s.srv.BaseContext = func(net.Listener) context.Context { return ctx }
 	errCh := make(chan error, 1)
 	go func() { errCh <- s.srv.ListenAndServe() }()
 

--- a/internal/platform/httpserver/server_test.go
+++ b/internal/platform/httpserver/server_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -115,4 +116,59 @@ func TestRunShutsDownOnContextCancel(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Run() did not return after cancel")
 	}
+}
+
+// TestRunCancelPropagatesToRequests pins the kill-test wiring:
+// http.Server.Shutdown alone never cancels in-flight request contexts,
+// so Run derives them from its own ctx — a SIGTERM must reach a
+// long-lived streaming handler immediately.
+func TestRunCancelPropagatesToRequests(t *testing.T) {
+	t.Parallel()
+	s := newTestServer(func() Health { return Health{Status: "ok"} })
+	s.srv.Addr = "127.0.0.1:0"
+
+	requestCanceled := make(chan struct{})
+	inHandler := make(chan struct{})
+	s.Handle("GET /hang", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(inHandler)
+		select {
+		case <-r.Context().Done():
+			close(requestCanceled)
+		case <-time.After(5 * time.Second):
+		}
+	}))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	s.srv.Addr = ln.Addr().String()
+	_ = ln.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(100 * time.Millisecond) // let the listener start
+
+	go func() {
+		resp, err := http.Get("http://" + s.srv.Addr + "/hang")
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	select {
+	case <-inHandler:
+	case <-time.After(5 * time.Second):
+		t.Fatal("request never reached the handler")
+	}
+	cancel() // the SIGTERM path
+
+	select {
+	case <-requestCanceled:
+		// in-flight request context observed the shutdown
+	case <-time.After(5 * time.Second):
+		t.Fatal("in-flight request context never canceled on shutdown")
+	}
+	<-done
 }

--- a/internal/platform/metrics/metrics.go
+++ b/internal/platform/metrics/metrics.go
@@ -48,6 +48,13 @@ func New() *Metrics {
 	return m
 }
 
+// NewCounter registers a service-specific counter on this registry.
+func (m *Metrics) NewCounter(name, help string) prometheus.Counter {
+	c := prometheus.NewCounter(prometheus.CounterOpts{Namespace: "timothy", Name: name, Help: help})
+	m.registry.MustRegister(c)
+	return c
+}
+
 // Handler serves the registry in Prometheus exposition format.
 func (m *Metrics) Handler() http.Handler {
 	return promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{})

--- a/migrations/0004_sessions.sql
+++ b/migrations/0004_sessions.sql
@@ -1,0 +1,25 @@
+-- Event-sourced sessions: an append-only log per session with two
+-- projections (UI transcript, LLM context) derived in code. The
+-- minimal sessions table gains the columns real session management
+-- needs.
+
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS archived boolean NOT NULL DEFAULT false;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS last_category text NOT NULL DEFAULT '';
+
+CREATE TABLE IF NOT EXISTS session_events (
+    session_id uuid NOT NULL REFERENCES sessions(id),
+    seq        bigint NOT NULL,
+    kind       text NOT NULL,
+    payload    jsonb NOT NULL DEFAULT '{}',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (session_id, seq)
+);
+
+-- Full-text search over user messages (session search in the API).
+CREATE INDEX IF NOT EXISTS session_events_user_text_idx
+    ON session_events
+    USING gin (to_tsvector('english', payload->>'text'))
+    WHERE kind = 'user_message';
+
+CREATE INDEX IF NOT EXISTS sessions_updated_idx ON sessions (updated_at DESC);

--- a/migrations/0005_context_windows.sql
+++ b/migrations/0005_context_windows.sql
@@ -1,0 +1,19 @@
+-- Stamp context windows onto the seeded provider models so callers
+-- (the brain's compactor) can derive token budgets from the model
+-- actually in use instead of a static guess. Idempotent: re-running
+-- overwrites the same values.
+UPDATE providers
+SET models = (
+    SELECT jsonb_agg(
+        CASE m->>'id'
+            WHEN 'claude-opus-4-8'           THEN m || '{"context_window": 200000}'
+            WHEN 'claude-sonnet-5'           THEN m || '{"context_window": 200000}'
+            WHEN 'claude-haiku-4-5-20251001' THEN m || '{"context_window": 200000}'
+            WHEN 'glm-4.7'                   THEN m || '{"context_window": 200000}'
+            WHEN 'grok-4.3'                  THEN m || '{"context_window": 256000}'
+            WHEN 'grok-4.5'                  THEN m || '{"context_window": 256000}'
+            ELSE m
+        END ORDER BY ord)
+    FROM jsonb_array_elements(models) WITH ORDINALITY AS t(m, ord)
+)
+WHERE jsonb_array_length(models) > 0;

--- a/migrations/0006_ledger_purpose.sql
+++ b/migrations/0006_ledger_purpose.sql
@@ -1,0 +1,4 @@
+-- Distinguish WHY a call was made from WHICH route served it: distill,
+-- auto-title, and compaction summaries all ride cheap categories, so
+-- task_category alone cannot separate internal calls from user chat.
+ALTER TABLE cost_ledger ADD COLUMN IF NOT EXISTS purpose text;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,7 +11,7 @@ import {
   RectangleStackIcon,
   SunIcon,
 } from '@heroicons/react/20/solid'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Route, Routes, useLocation } from 'react-router'
 import { getToken } from './api/client'
 import { Navbar, NavbarItem, NavbarSection, NavbarSpacer } from './components/catalyst/navbar'
@@ -25,6 +25,8 @@ import {
   SidebarSpacer,
 } from './components/catalyst/sidebar'
 import { SidebarLayout } from './components/catalyst/sidebar-layout'
+import { SessionList } from './components/SessionList'
+import { SessionsProvider } from './components/SessionsProvider'
 import { SettingsDialog } from './components/SettingsDialog'
 import { getTheme, nextTheme, setTheme, type Theme } from './lib/theme'
 import { Chat } from './pages/Chat'
@@ -53,6 +55,9 @@ function App() {
     if (getToken() === '') setTokenOpen(true)
   }, [])
 
+  // Stable identity: Chat's resume effect depends on it.
+  const openToken = useCallback(() => setTokenOpen(true), [])
+
   const cycleTheme = () => {
     const t = nextTheme[theme]
     setTheme(t)
@@ -61,7 +66,7 @@ function App() {
   const ThemeIcon = themeIcon[theme]
 
   return (
-    <>
+    <SessionsProvider>
       {/* Reopen affordance when the desktop sidebar is collapsed */}
       {collapsed && (
         <button
@@ -108,12 +113,21 @@ function App() {
             <SidebarBody>
               <SidebarSection>
                 {nav.map((item) => (
-                  <SidebarItem key={item.href} href={item.href} current={pathname === item.href}>
+                  <SidebarItem
+                    key={item.href}
+                    href={item.href}
+                    current={
+                      item.href === '/'
+                        ? pathname === '/' || pathname.startsWith('/sessions')
+                        : pathname === item.href
+                    }
+                  >
                     <item.icon data-slot="icon" />
                     <SidebarLabel>{item.label}</SidebarLabel>
                   </SidebarItem>
                 ))}
               </SidebarSection>
+              <SessionList />
               <SidebarSpacer />
               <SidebarSection>
                 <SidebarItem onClick={cycleTheme}>
@@ -130,11 +144,14 @@ function App() {
         }
       >
         <Routes>
+          {/* One route pattern serves new chats and resumes: switching
+              between them must re-render, not remount, so an in-flight
+              stream survives adopting its new session URL. */}
           <Route
-            path="/"
+            path="/sessions?/:id?"
             element={
               <div className="mx-auto flex h-[calc(100dvh-6.5rem)] max-w-4xl flex-col lg:h-[calc(100dvh-4.5rem)]">
-                <Chat onNeedToken={() => setTokenOpen(true)} />
+                <Chat onNeedToken={openToken} />
               </div>
             }
           />
@@ -146,7 +163,7 @@ function App() {
         </Routes>
         <SettingsDialog open={tokenOpen} onClose={() => setTokenOpen(false)} />
       </SidebarLayout>
-    </>
+    </SessionsProvider>
   )
 }
 

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { ChatError, chatStream, createSSEParser } from './client'
+import { ChatError, chatStream, createSSEParser, listSessions } from './client'
 import type { ChatEvent } from './types'
 
 afterEach(() => vi.unstubAllGlobals())
@@ -105,6 +105,20 @@ describe('chatStream errors', () => {
     expect(fetchMock.mock.calls[0][0]).toBe('/v1/sessions/s-42/messages')
     // The id travels in the path, not the body.
     expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toEqual({ message: 'hi' })
+  })
+
+  it('pages the session list with a before cursor', async () => {
+    vi.stubGlobal('localStorage', { getItem: () => 'tok', setItem: () => {} })
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ sessions: [] }), { status: 200 }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await listSessions('light', '2026-07-10T12:00:00Z')
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      '/v1/sessions?query=light&before=2026-07-10T12%3A00%3A00Z',
+    )
   })
 
   it('keeps raw text for non-json error bodies', async () => {

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -95,6 +95,18 @@ describe('chatStream errors', () => {
     expect(events).toEqual([{ type: 'done' }])
   })
 
+  it('routes to the session messages endpoint when a session id is known', async () => {
+    vi.stubGlobal('localStorage', { getItem: () => 'tok', setItem: () => {} })
+    const fetchMock = vi.fn().mockResolvedValue(new Response('data: {"type":"done"}\n\n'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await chatStream({ session_id: 's-42', message: 'hi' }, () => {})
+
+    expect(fetchMock.mock.calls[0][0]).toBe('/v1/sessions/s-42/messages')
+    // The id travels in the path, not the body.
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toEqual({ message: 'hi' })
+  })
+
   it('keeps raw text for non-json error bodies', async () => {
     vi.stubGlobal('localStorage', { getItem: () => 'tok', setItem: () => {} })
     vi.stubGlobal(

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -107,17 +107,17 @@ describe('chatStream errors', () => {
     expect(JSON.parse(fetchMock.mock.calls[0][1].body as string)).toEqual({ message: 'hi' })
   })
 
-  it('pages the session list with a before cursor', async () => {
+  it('pages the session list with a composite cursor', async () => {
     vi.stubGlobal('localStorage', { getItem: () => 'tok', setItem: () => {} })
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ sessions: [] }), { status: 200 }),
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    await listSessions('light', '2026-07-10T12:00:00Z')
+    await listSessions('light', { before: '2026-07-10T12:00:00Z', beforeId: 's-42' })
 
     expect(fetchMock.mock.calls[0][0]).toBe(
-      '/v1/sessions?query=light&before=2026-07-10T12%3A00%3A00Z',
+      '/v1/sessions?query=light&before=2026-07-10T12%3A00%3A00Z&before_id=s-42',
     )
   })
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -152,12 +152,22 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
   return (await res.json()) as T
 }
 
-// listSessions returns one page (newest first). Pass the last row's
-// updated_at as `before` to fetch the next page.
-export async function listSessions(query = '', before = ''): Promise<SessionMeta[]> {
+// SessionCursor is the last row of the previous page: both halves
+// travel together so ties on updated_at cannot drop or repeat rows.
+export interface SessionCursor {
+  before: string
+  beforeId: string
+}
+
+// listSessions returns one page (newest first). Pass the previous
+// page's last row as the cursor to fetch the next page.
+export async function listSessions(query = '', cursor?: SessionCursor): Promise<SessionMeta[]> {
   const params = new URLSearchParams()
   if (query) params.set('query', query)
-  if (before) params.set('before', before)
+  if (cursor) {
+    params.set('before', cursor.before)
+    params.set('before_id', cursor.beforeId)
+  }
   const qs = params.size > 0 ? `?${params.toString()}` : ''
   const { sessions } = await request<{ sessions: SessionMeta[] }>(`/v1/sessions${qs}`)
   return sessions

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -152,8 +152,13 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
   return (await res.json()) as T
 }
 
-export async function listSessions(query = ''): Promise<SessionMeta[]> {
-  const qs = query ? `?query=${encodeURIComponent(query)}` : ''
+// listSessions returns one page (newest first). Pass the last row's
+// updated_at as `before` to fetch the next page.
+export async function listSessions(query = '', before = ''): Promise<SessionMeta[]> {
+  const params = new URLSearchParams()
+  if (query) params.set('query', query)
+  if (before) params.set('before', before)
+  const qs = params.size > 0 ? `?${params.toString()}` : ''
   const { sessions } = await request<{ sessions: SessionMeta[] }>(`/v1/sessions${qs}`)
   return sessions
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { ChatEvent, ChatRequest } from './types'
+import type { ChatEvent, ChatRequest, SessionMeta, Transcript } from './types'
 
 const tokenKey = 'timothy.token'
 
@@ -73,6 +73,8 @@ export interface ChatStreamOptions {
 
 // chatStream posts one turn and delivers every SSE event, ending with
 // the terminal meta event. Throws ChatError on non-200 responses.
+// With a session_id it targets that session's messages endpoint;
+// without one it uses /v1/chat, which creates the session.
 // The /v1 path is same-origin by design: the dev server proxies it to
 // brain, and production serves the SPA behind the same reverse proxy
 // as the API.
@@ -81,13 +83,15 @@ export async function chatStream(
   onEvent: (ev: ChatEvent) => void,
   { signal, onSession }: ChatStreamOptions = {},
 ): Promise<void> {
-  const res = await fetch('/v1/chat', {
+  const { session_id, ...body } = req
+  const url = session_id ? `/v1/sessions/${session_id}/messages` : '/v1/chat'
+  const res = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${getToken()}`,
     },
-    body: JSON.stringify(req),
+    body: JSON.stringify(session_id ? body : req),
     signal,
   })
   if (!res.ok || !res.body) {
@@ -118,4 +122,49 @@ export async function chatStream(
     parser.feed(decoder.decode(value, { stream: true }))
   }
   parser.end()
+}
+
+// request is the plain-JSON counterpart of chatStream: same auth, same
+// structured errors.
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(path, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getToken()}`,
+      ...init.headers,
+    },
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    let code: string | undefined
+    let message = body
+    try {
+      const parsed = JSON.parse(body) as { error?: string; message?: string }
+      code = parsed.error
+      message = parsed.message ?? body
+    } catch {
+      // Non-JSON error body: keep the raw text.
+    }
+    throw new ChatError(res.status, message || `request failed (${res.status})`, code)
+  }
+  if (res.status === 204) return undefined as T
+  return (await res.json()) as T
+}
+
+export async function listSessions(query = ''): Promise<SessionMeta[]> {
+  const qs = query ? `?query=${encodeURIComponent(query)}` : ''
+  const { sessions } = await request<{ sessions: SessionMeta[] }>(`/v1/sessions${qs}`)
+  return sessions
+}
+
+export async function getTranscript(id: string): Promise<Transcript> {
+  return request<Transcript>(`/v1/sessions/${id}`)
+}
+
+export async function updateSession(
+  id: string,
+  patch: { title?: string; archived?: boolean },
+): Promise<void> {
+  await request<void>(`/v1/sessions/${id}`, { method: 'PATCH', body: JSON.stringify(patch) })
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -69,6 +69,7 @@ export interface TranscriptItem {
   blocks?: UIBlock[]
   provider?: string
   model?: string
+  usage?: Usage
   created_at: string
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -43,3 +43,36 @@ export interface ChatRequest {
   task_category?: string
   model_hint?: string
 }
+
+// --- session management (mirrors brain's /v1/sessions surface) ---
+
+export interface SessionMeta {
+  id: string
+  title: string
+  archived: boolean
+  last_category?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface UIBlock {
+  type: 'text' | 'reasoning'
+  text: string
+}
+
+// One renderable unit of the UI replay projection. The transcript
+// hides nothing: compactions and interrupted turns are items too.
+export interface TranscriptItem {
+  seq: number
+  kind: 'user' | 'assistant' | 'tool' | 'compaction' | 'interrupted'
+  text?: string
+  blocks?: UIBlock[]
+  provider?: string
+  model?: string
+  created_at: string
+}
+
+export interface Transcript {
+  session: SessionMeta
+  items: TranscriptItem[]
+}

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { ChatEvent } from '../api/types'
 import { applyEvent, type AssistantState } from '../lib/chat'
-import { AssistantMessage } from './Message'
+import { AssistantMessage, CompactionDivider, InterruptedMessage } from './Message'
 
 afterEach(cleanup)
 
@@ -81,5 +81,21 @@ describe('AssistantMessage', () => {
     render(<AssistantMessage msg={msg} />)
 
     expect(screen.getByTestId('error')).toHaveTextContent('chain_exhausted: all failed')
+  })
+})
+
+describe('replay-only components', () => {
+  it('renders the compaction divider text', () => {
+    render(<CompactionDivider text="older messages summarized (through #4)" />)
+    expect(screen.getByTestId('compaction-divider')).toHaveTextContent(
+      'older messages summarized (through #4)',
+    )
+  })
+
+  it('renders an interrupted turn: the partial plus an honest marker', () => {
+    render(<InterruptedMessage text="Once upon a" />)
+    const el = screen.getByTestId('interrupted')
+    expect(el).toHaveTextContent('Once upon a')
+    expect(el).toHaveTextContent('interrupted')
   })
 })

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -14,6 +14,32 @@ export function UserMessage({ text }: { text: string }) {
   )
 }
 
+// CompactionDivider marks where older messages were summarized away
+// from the model's context. The UI replay still shows everything above
+// it — only the model forgets, and the divider says so.
+export function CompactionDivider({ text }: { text: string }) {
+  return (
+    <div className="flex items-center gap-3" data-testid="compaction-divider">
+      <div className="h-px flex-1 bg-zinc-200 dark:bg-zinc-700" />
+      <span className="text-xs text-zinc-400 dark:text-zinc-500">{text}</span>
+      <div className="h-px flex-1 bg-zinc-200 dark:bg-zinc-700" />
+    </div>
+  )
+}
+
+// InterruptedMessage renders a turn that never completed: the partial
+// answer plus an honest marker.
+export function InterruptedMessage({ text }: { text: string }) {
+  return (
+    <div className="flex flex-col items-start gap-2" data-testid="interrupted">
+      <div className="prose prose-sm max-w-3xl dark:prose-invert prose-pre:bg-zinc-900">
+        <ReactMarkdown rehypePlugins={[rehypeHighlight]}>{text}</ReactMarkdown>
+      </div>
+      <Badge color="amber">interrupted</Badge>
+    </div>
+  )
+}
+
 export function AssistantMessage({ msg }: { msg: AssistantState }) {
   const tokens = msg.meta?.usage
     ? `${msg.meta.usage.input_tokens}→${msg.meta.usage.output_tokens} tok`

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,0 +1,110 @@
+import { ArchiveBoxIcon, MagnifyingGlassIcon, PencilIcon, PlusIcon } from '@heroicons/react/20/solid'
+import { useState } from 'react'
+import { useLocation, useNavigate } from 'react-router'
+import { updateSession } from '../api/client'
+import type { SessionMeta } from '../api/types'
+import { groupByDay, useSessions } from '../lib/sessions'
+import { Button } from './catalyst/button'
+import { Dialog, DialogActions, DialogBody, DialogTitle } from './catalyst/dialog'
+import { Input } from './catalyst/input'
+import { SidebarHeading, SidebarItem, SidebarLabel, SidebarSection } from './catalyst/sidebar'
+
+export function SessionList() {
+  const { sessions, query, setQuery, refresh } = useSessions()
+  const { pathname } = useLocation()
+  const navigate = useNavigate()
+  const [renaming, setRenaming] = useState<SessionMeta | null>(null)
+  const [title, setTitle] = useState('')
+
+  const rename = async () => {
+    if (!renaming || title.trim() === '') return
+    await updateSession(renaming.id, { title: title.trim() }).catch(() => {})
+    setRenaming(null)
+    refresh()
+  }
+
+  const archive = async (s: SessionMeta) => {
+    await updateSession(s.id, { archived: true }).catch(() => {})
+    refresh()
+    // Archiving the open session sends you back to a fresh chat.
+    if (pathname === `/sessions/${s.id}`) navigate('/')
+  }
+
+  return (
+    <>
+      <SidebarSection>
+        <SidebarItem href="/" current={pathname === '/'}>
+          <PlusIcon data-slot="icon" />
+          <SidebarLabel>New chat</SidebarLabel>
+        </SidebarItem>
+        <div className="relative mt-1 px-0.5">
+          <MagnifyingGlassIcon className="pointer-events-none absolute top-2.5 left-2.5 size-4 text-zinc-400" />
+          <input
+            aria-label="Search sessions"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search…"
+            className="w-full rounded-lg border border-zinc-950/10 bg-transparent py-1.5 pr-2 pl-8 text-sm text-zinc-900 outline-none placeholder:text-zinc-400 focus:border-blue-500/50 dark:border-white/10 dark:text-white"
+          />
+        </div>
+      </SidebarSection>
+
+      {groupByDay(sessions).map((group) => (
+        <SidebarSection key={group.label}>
+          <SidebarHeading>{group.label}</SidebarHeading>
+          {group.sessions.map((s) => (
+            <div key={s.id} className="group/session relative">
+              <SidebarItem href={`/sessions/${s.id}`} current={pathname === `/sessions/${s.id}`}>
+                <SidebarLabel className="truncate pr-10">{s.title || 'New session'}</SidebarLabel>
+              </SidebarItem>
+              <div className="absolute top-1/2 right-1 flex -translate-y-1/2 gap-0.5 opacity-0 group-hover/session:opacity-100">
+                <button
+                  aria-label={`Rename ${s.title || 'session'}`}
+                  onClick={() => {
+                    setTitle(s.title)
+                    setRenaming(s)
+                  }}
+                  className="rounded p-1 text-zinc-400 hover:bg-zinc-950/5 hover:text-zinc-600 dark:hover:bg-white/10 dark:hover:text-zinc-300"
+                >
+                  <PencilIcon className="size-3.5" />
+                </button>
+                <button
+                  aria-label={`Archive ${s.title || 'session'}`}
+                  onClick={() => void archive(s)}
+                  className="rounded p-1 text-zinc-400 hover:bg-zinc-950/5 hover:text-zinc-600 dark:hover:bg-white/10 dark:hover:text-zinc-300"
+                >
+                  <ArchiveBoxIcon className="size-3.5" />
+                </button>
+              </div>
+            </div>
+          ))}
+        </SidebarSection>
+      ))}
+
+      {sessions.length === 0 && query !== '' && (
+        <p className="px-2 py-1 text-xs text-zinc-400 dark:text-zinc-500">No sessions match.</p>
+      )}
+
+      <Dialog open={renaming !== null} onClose={() => setRenaming(null)}>
+        <DialogTitle>Rename session</DialogTitle>
+        <DialogBody>
+          <Input
+            aria-label="Session title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void rename()
+            }}
+            autoFocus
+          />
+        </DialogBody>
+        <DialogActions>
+          <Button plain onClick={() => setRenaming(null)}>
+            Cancel
+          </Button>
+          <Button onClick={() => void rename()}>Save</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  )
+}

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,20 +1,34 @@
 import { ArchiveBoxIcon, MagnifyingGlassIcon, PencilIcon, PlusIcon } from '@heroicons/react/20/solid'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router'
 import { updateSession } from '../api/client'
 import type { SessionMeta } from '../api/types'
 import { groupByDay, useSessions } from '../lib/sessions'
+import { Badge } from './catalyst/badge'
 import { Button } from './catalyst/button'
 import { Dialog, DialogActions, DialogBody, DialogTitle } from './catalyst/dialog'
 import { Input } from './catalyst/input'
 import { SidebarHeading, SidebarItem, SidebarLabel, SidebarSection } from './catalyst/sidebar'
 
 export function SessionList() {
-  const { sessions, query, setQuery, refresh } = useSessions()
+  const { sessions, query, setQuery, refresh, hasMore, loadMore } = useSessions()
   const { pathname } = useLocation()
   const navigate = useNavigate()
   const [renaming, setRenaming] = useState<SessionMeta | null>(null)
   const [title, setTitle] = useState('')
+  const sentinelRef = useRef<HTMLDivElement>(null)
+
+  // Infinite scroll: fetch the next page when the sentinel below the
+  // list scrolls into view.
+  useEffect(() => {
+    const el = sentinelRef.current
+    if (!el || !hasMore) return
+    const obs = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting)) loadMore()
+    })
+    obs.observe(el)
+    return () => obs.disconnect()
+  }, [hasMore, loadMore])
 
   const rename = async () => {
     if (!renaming || title.trim() === '') return
@@ -24,10 +38,10 @@ export function SessionList() {
   }
 
   const archive = async (s: SessionMeta) => {
-    await updateSession(s.id, { archived: true }).catch(() => {})
+    await updateSession(s.id, { archived: !s.archived }).catch(() => {})
     refresh()
     // Archiving the open session sends you back to a fresh chat.
-    if (pathname === `/sessions/${s.id}`) navigate('/')
+    if (!s.archived && pathname === `/sessions/${s.id}`) navigate('/')
   }
 
   return (
@@ -56,6 +70,7 @@ export function SessionList() {
             <div key={s.id} className="group/session relative">
               <SidebarItem href={`/sessions/${s.id}`} current={pathname === `/sessions/${s.id}`}>
                 <SidebarLabel className="truncate pr-10">{s.title || 'New session'}</SidebarLabel>
+                {s.archived && <Badge color="zinc">archived</Badge>}
               </SidebarItem>
               <div className="absolute top-1/2 right-1 flex -translate-y-1/2 gap-0.5 opacity-0 group-hover/session:opacity-100">
                 <button
@@ -69,7 +84,7 @@ export function SessionList() {
                   <PencilIcon className="size-3.5" />
                 </button>
                 <button
-                  aria-label={`Archive ${s.title || 'session'}`}
+                  aria-label={`${s.archived ? 'Unarchive' : 'Archive'} ${s.title || 'session'}`}
                   onClick={() => void archive(s)}
                   className="rounded p-1 text-zinc-400 hover:bg-zinc-950/5 hover:text-zinc-600 dark:hover:bg-white/10 dark:hover:text-zinc-300"
                 >
@@ -84,6 +99,7 @@ export function SessionList() {
       {sessions.length === 0 && query !== '' && (
         <p className="px-2 py-1 text-xs text-zinc-400 dark:text-zinc-500">No sessions match.</p>
       )}
+      {hasMore && <div ref={sentinelRef} className="h-px" data-testid="sessions-sentinel" />}
 
       <Dialog open={renaming !== null} onClose={() => setRenaming(null)}>
         <DialogTitle>Rename session</DialogTitle>

--- a/web/src/components/SessionsProvider.tsx
+++ b/web/src/components/SessionsProvider.tsx
@@ -3,14 +3,21 @@ import { listSessions } from '../api/client'
 import type { SessionMeta } from '../api/types'
 import { SessionsContext } from '../lib/sessions'
 
+// Mirrors the server's page size: a full page means another may exist.
+const pageSize = 100
+
 export function SessionsProvider({ children }: { children: React.ReactNode }) {
   const [sessions, setSessions] = useState<SessionMeta[]>([])
   const [query, setQuery] = useState('')
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [hasMore, setHasMore] = useState(false)
+  const titleTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const load = useCallback((q: string) => {
-    listSessions(q)
-      .then(setSessions)
+  const load = useCallback((q: string, before = '') => {
+    listSessions(q, before)
+      .then((page) => {
+        setSessions((prev) => (before ? [...prev, ...page] : page))
+        setHasMore(page.length === pageSize)
+      })
       .catch(() => {
         // No token yet or brain unreachable: an empty sidebar is the
         // honest render; the chat page surfaces the actual error.
@@ -21,19 +28,34 @@ export function SessionsProvider({ children }: { children: React.ReactNode }) {
     load(query)
     // The auto-title lands asynchronously after the first exchange:
     // follow up once so the sidebar picks it up without polling.
-    if (timer.current) clearTimeout(timer.current)
-    timer.current = setTimeout(() => load(query), 5000)
+    if (titleTimer.current) clearTimeout(titleTimer.current)
+    titleTimer.current = setTimeout(() => load(query), 5000)
   }, [load, query])
 
-  useEffect(() => {
-    load(query)
-    return () => {
-      if (timer.current) clearTimeout(timer.current)
-    }
+  const loadMore = useCallback(() => {
+    setSessions((prev) => {
+      const last = prev[prev.length - 1]
+      if (last) load(query, last.updated_at)
+      return prev
+    })
   }, [load, query])
+
+  // Debounced: typing in the search box fires one request per pause,
+  // not one per keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => load(query), 250)
+    return () => clearTimeout(t)
+  }, [load, query])
+
+  useEffect(
+    () => () => {
+      if (titleTimer.current) clearTimeout(titleTimer.current)
+    },
+    [],
+  )
 
   return (
-    <SessionsContext.Provider value={{ sessions, query, setQuery, refresh }}>
+    <SessionsContext.Provider value={{ sessions, query, setQuery, refresh, hasMore, loadMore }}>
       {children}
     </SessionsContext.Provider>
   )

--- a/web/src/components/SessionsProvider.tsx
+++ b/web/src/components/SessionsProvider.tsx
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { listSessions } from '../api/client'
+import type { SessionMeta } from '../api/types'
+import { SessionsContext } from '../lib/sessions'
+
+export function SessionsProvider({ children }: { children: React.ReactNode }) {
+  const [sessions, setSessions] = useState<SessionMeta[]>([])
+  const [query, setQuery] = useState('')
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const load = useCallback((q: string) => {
+    listSessions(q)
+      .then(setSessions)
+      .catch(() => {
+        // No token yet or brain unreachable: an empty sidebar is the
+        // honest render; the chat page surfaces the actual error.
+      })
+  }, [])
+
+  const refresh = useCallback(() => {
+    load(query)
+    // The auto-title lands asynchronously after the first exchange:
+    // follow up once so the sidebar picks it up without polling.
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = setTimeout(() => load(query), 5000)
+  }, [load, query])
+
+  useEffect(() => {
+    load(query)
+    return () => {
+      if (timer.current) clearTimeout(timer.current)
+    }
+  }, [load, query])
+
+  return (
+    <SessionsContext.Provider value={{ sessions, query, setQuery, refresh }}>
+      {children}
+    </SessionsContext.Provider>
+  )
+}

--- a/web/src/components/SessionsProvider.tsx
+++ b/web/src/components/SessionsProvider.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { listSessions } from '../api/client'
+import { listSessions, type SessionCursor } from '../api/client'
 import type { SessionMeta } from '../api/types'
 import { SessionsContext } from '../lib/sessions'
 
@@ -11,16 +11,28 @@ export function SessionsProvider({ children }: { children: React.ReactNode }) {
   const [query, setQuery] = useState('')
   const [hasMore, setHasMore] = useState(false)
   const titleTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // One page fetch at a time: the observer can fire repeatedly and a
+  // refresh can race a scroll — later requests wait for the next tick.
+  const loading = useRef(false)
 
-  const load = useCallback((q: string, before = '') => {
-    listSessions(q, before)
+  const load = useCallback((q: string, cursor?: SessionCursor) => {
+    if (loading.current) return
+    loading.current = true
+    listSessions(q, cursor)
       .then((page) => {
-        setSessions((prev) => (before ? [...prev, ...page] : page))
+        setSessions((prev) => {
+          if (!cursor) return page
+          const seen = new Set(prev.map((s) => s.id))
+          return [...prev, ...page.filter((s) => !seen.has(s.id))]
+        })
         setHasMore(page.length === pageSize)
       })
       .catch(() => {
         // No token yet or brain unreachable: an empty sidebar is the
         // honest render; the chat page surfaces the actual error.
+      })
+      .finally(() => {
+        loading.current = false
       })
   }, [])
 
@@ -33,12 +45,9 @@ export function SessionsProvider({ children }: { children: React.ReactNode }) {
   }, [load, query])
 
   const loadMore = useCallback(() => {
-    setSessions((prev) => {
-      const last = prev[prev.length - 1]
-      if (last) load(query, last.updated_at)
-      return prev
-    })
-  }, [load, query])
+    const last = sessions[sessions.length - 1]
+    if (last) load(query, { before: last.updated_at, beforeId: last.id })
+  }, [sessions, load, query])
 
   // Debounced: typing in the search box fires one request per pause,
   // not one per keystroke.

--- a/web/src/lib/sessions.test.ts
+++ b/web/src/lib/sessions.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import type { SessionMeta } from '../api/types'
+import { groupByDay } from './sessions'
+
+const session = (id: string, updatedAt: string): SessionMeta => ({
+  id,
+  title: id,
+  archived: false,
+  created_at: updatedAt,
+  updated_at: updatedAt,
+})
+
+describe('groupByDay', () => {
+  it('buckets into Today, Yesterday, and dated groups', () => {
+    const now = new Date('2026-07-10T15:00:00')
+    const groups = groupByDay(
+      [
+        session('a', '2026-07-10T14:00:00'),
+        session('b', '2026-07-10T09:00:00'),
+        session('c', '2026-07-09T22:00:00'),
+        session('d', '2026-07-01T08:00:00'),
+      ],
+      now,
+    )
+
+    expect(groups.map((g) => g.label)).toEqual(['Today', 'Yesterday', 'July 1'])
+    expect(groups[0].sessions.map((s) => s.id)).toEqual(['a', 'b'])
+    expect(groups[1].sessions.map((s) => s.id)).toEqual(['c'])
+    expect(groups[2].sessions.map((s) => s.id)).toEqual(['d'])
+  })
+
+  it('returns nothing for an empty list', () => {
+    expect(groupByDay([], new Date('2026-07-10T15:00:00'))).toEqual([])
+  })
+})

--- a/web/src/lib/sessions.ts
+++ b/web/src/lib/sessions.ts
@@ -1,0 +1,51 @@
+import { createContext, useContext } from 'react'
+import type { SessionMeta } from '../api/types'
+
+// SessionsContext holds the sidebar's session directory: the list,
+// the active search query, and a refresh shared with the chat page
+// (a finished turn changes updated_at and, on the first exchange, the
+// auto-title — the sidebar must follow).
+export interface SessionsState {
+  sessions: SessionMeta[]
+  query: string
+  setQuery: (q: string) => void
+  refresh: () => void
+}
+
+export const SessionsContext = createContext<SessionsState>({
+  sessions: [],
+  query: '',
+  setQuery: () => {},
+  refresh: () => {},
+})
+
+export function useSessions() {
+  return useContext(SessionsContext)
+}
+
+// groupByDay buckets sessions under human day labels, newest first.
+// The list arrives ordered by updated_at from the API.
+export function groupByDay(
+  sessions: SessionMeta[],
+  now = new Date(),
+): { label: string; sessions: SessionMeta[] }[] {
+  const dayKey = (d: Date) => d.toDateString()
+  const today = dayKey(now)
+  const yesterday = dayKey(new Date(now.getTime() - 24 * 60 * 60 * 1000))
+
+  const groups: { label: string; sessions: SessionMeta[] }[] = []
+  for (const s of sessions) {
+    const d = new Date(s.updated_at)
+    const key = dayKey(d)
+    const label =
+      key === today
+        ? 'Today'
+        : key === yesterday
+          ? 'Yesterday'
+          : d.toLocaleDateString('en-US', { month: 'long', day: 'numeric' })
+    const last = groups[groups.length - 1]
+    if (last && last.label === label) last.sessions.push(s)
+    else groups.push({ label, sessions: [s] })
+  }
+  return groups
+}

--- a/web/src/lib/sessions.ts
+++ b/web/src/lib/sessions.ts
@@ -1,15 +1,17 @@
 import { createContext, useContext } from 'react'
 import type { SessionMeta } from '../api/types'
 
-// SessionsContext holds the sidebar's session directory: the list,
-// the active search query, and a refresh shared with the chat page
-// (a finished turn changes updated_at and, on the first exchange, the
-// auto-title — the sidebar must follow).
+// SessionsContext holds the sidebar's session directory: the paged
+// list, the active search query, and a refresh shared with the chat
+// page (a finished turn changes updated_at and, on the first exchange,
+// the auto-title — the sidebar must follow).
 export interface SessionsState {
   sessions: SessionMeta[]
   query: string
   setQuery: (q: string) => void
   refresh: () => void
+  hasMore: boolean
+  loadMore: () => void
 }
 
 export const SessionsContext = createContext<SessionsState>({
@@ -17,6 +19,8 @@ export const SessionsContext = createContext<SessionsState>({
   query: '',
   setQuery: () => {},
   refresh: () => {},
+  hasMore: false,
+  loadMore: () => {},
 })
 
 export function useSessions() {

--- a/web/src/lib/transcript.test.ts
+++ b/web/src/lib/transcript.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import type { TranscriptItem } from '../api/types'
+import { fromTranscript } from './transcript'
+
+const at = '2026-07-10T12:00:00Z'
+
+describe('fromTranscript', () => {
+  it('replays a full session shape: turns, compaction, interruption', () => {
+    const fixture: TranscriptItem[] = [
+      { seq: 2, kind: 'user', text: 'hello', created_at: at },
+      {
+        seq: 3,
+        kind: 'assistant',
+        blocks: [
+          { type: 'reasoning', text: 'thinking about it' },
+          { type: 'text', text: 'hi **there**' },
+        ],
+        provider: 'zai-glm',
+        model: 'glm-4.7',
+        created_at: at,
+      },
+      { seq: 4, kind: 'compaction', text: 'older messages summarized (through #3)', created_at: at },
+      { seq: 5, kind: 'user', text: 'go on', created_at: at },
+      { seq: 6, kind: 'interrupted', text: 'Once upon a', created_at: at },
+    ]
+
+    const items = fromTranscript(fixture)
+
+    expect(items.map((i) => i.role)).toEqual([
+      'user',
+      'assistant',
+      'compaction',
+      'user',
+      'interrupted',
+    ])
+    expect(items[0]).toMatchObject({ role: 'user', text: 'hello' })
+    expect(items[1]).toMatchObject({
+      role: 'assistant',
+      text: 'hi **there**',
+      reasoning: 'thinking about it',
+      streaming: false,
+      meta: { provider: 'zai-glm', model: 'glm-4.7' },
+    })
+    expect(items[2]).toMatchObject({ role: 'compaction', text: 'older messages summarized (through #3)' })
+    expect(items[4]).toMatchObject({ role: 'interrupted', text: 'Once upon a' })
+    // Stable ids keyed by seq so React reconciles replays predictably.
+    expect(items.map((i) => i.id)).toEqual(['replay-2', 'replay-3', 'replay-4', 'replay-5', 'replay-6'])
+  })
+
+  it('concatenates multiple blocks of the same type', () => {
+    const items = fromTranscript([
+      {
+        seq: 1,
+        kind: 'assistant',
+        blocks: [
+          { type: 'text', text: 'part one, ' },
+          { type: 'text', text: 'part two' },
+        ],
+        created_at: at,
+      },
+    ])
+    expect(items[0]).toMatchObject({ role: 'assistant', text: 'part one, part two' })
+  })
+
+  it('omits meta when the turn has no provider attribution', () => {
+    const items = fromTranscript([
+      { seq: 1, kind: 'assistant', blocks: [{ type: 'text', text: 'x' }], created_at: at },
+    ])
+    expect(items[0]).toMatchObject({ role: 'assistant', meta: undefined })
+  })
+
+  it('skips tool items until the tool loop lands', () => {
+    const items = fromTranscript([
+      { seq: 1, kind: 'user', text: 'q', created_at: at },
+      { seq: 2, kind: 'tool', created_at: at },
+      { seq: 3, kind: 'assistant', blocks: [{ type: 'text', text: 'a' }], created_at: at },
+    ])
+    expect(items.map((i) => i.role)).toEqual(['user', 'assistant'])
+  })
+
+  it('handles the empty transcript of a fresh session', () => {
+    expect(fromTranscript([])).toEqual([])
+  })
+})

--- a/web/src/lib/transcript.test.ts
+++ b/web/src/lib/transcript.test.ts
@@ -17,6 +17,7 @@ describe('fromTranscript', () => {
         ],
         provider: 'zai-glm',
         model: 'glm-4.7',
+        usage: { input_tokens: 81, output_tokens: 396 },
         created_at: at,
       },
       { seq: 4, kind: 'compaction', text: 'older messages summarized (through #3)', created_at: at },
@@ -39,7 +40,7 @@ describe('fromTranscript', () => {
       text: 'hi **there**',
       reasoning: 'thinking about it',
       streaming: false,
-      meta: { provider: 'zai-glm', model: 'glm-4.7' },
+      meta: { provider: 'zai-glm', model: 'glm-4.7', usage: { input_tokens: 81, output_tokens: 396 } },
     })
     expect(items[2]).toMatchObject({ role: 'compaction', text: 'older messages summarized (through #3)' })
     expect(items[4]).toMatchObject({ role: 'interrupted', text: 'Once upon a' })

--- a/web/src/lib/transcript.ts
+++ b/web/src/lib/transcript.ts
@@ -37,7 +37,9 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
           reasoning,
           notices: [],
           streaming: false,
-          meta: item.provider ? { provider: item.provider, model: item.model } : undefined,
+          meta: item.provider
+            ? { provider: item.provider, model: item.model, usage: item.usage }
+            : undefined,
         })
         break
       }

--- a/web/src/lib/transcript.ts
+++ b/web/src/lib/transcript.ts
@@ -1,0 +1,53 @@
+import type { TranscriptItem } from '../api/types'
+import type { AssistantState } from './chat'
+
+// ChatItem is one renderable unit of the chat page: live turns and
+// replayed transcript items share this shape so resume is
+// pixel-equivalent with the original stream.
+export type ChatItem = { id: string } & (
+  | { role: 'user'; text: string }
+  | ({ role: 'assistant' } & AssistantState)
+  | { role: 'compaction'; text: string }
+  | { role: 'interrupted'; text: string }
+)
+
+// fromTranscript maps the server's UI replay projection into chat
+// items. The transcript hides nothing: compaction dividers and
+// interrupted turns render alongside the conversation. Tool items are
+// skipped until the tool loop lands (no fixture produces them yet).
+export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
+  const out: ChatItem[] = []
+  for (const item of items) {
+    const id = `replay-${item.seq}`
+    switch (item.kind) {
+      case 'user':
+        out.push({ id, role: 'user', text: item.text ?? '' })
+        break
+      case 'assistant': {
+        let text = ''
+        let reasoning = ''
+        for (const b of item.blocks ?? []) {
+          if (b.type === 'text') text += b.text
+          else if (b.type === 'reasoning') reasoning += b.text
+        }
+        out.push({
+          id,
+          role: 'assistant',
+          text,
+          reasoning,
+          notices: [],
+          streaming: false,
+          meta: item.provider ? { provider: item.provider, model: item.model } : undefined,
+        })
+        break
+      }
+      case 'compaction':
+        out.push({ id, role: 'compaction', text: item.text ?? '' })
+        break
+      case 'interrupted':
+        out.push({ id, role: 'interrupted', text: item.text ?? '' })
+        break
+    }
+  }
+  return out
+}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -41,6 +41,17 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
   // Resume: replay the session's transcript projection, exactly as the
   // server recorded it, and restore its last task category.
   useEffect(() => {
+    if (adoptedRef.current !== null && adoptedRef.current === routeSession) {
+      sessionRef.current = routeSession
+      return // our own mid-stream URL adoption, not a navigation
+    }
+    // Real navigation: a stream still running belongs to the previous
+    // session — kill it before it writes into this one's transcript.
+    if (abortRef.current) {
+      abortRef.current.abort()
+      abortRef.current = null
+      setStreaming(false)
+    }
     sessionRef.current = routeSession
     setLoadError(null)
     if (!routeSession) {
@@ -48,7 +59,6 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
       adoptedRef.current = null
       return
     }
-    if (adoptedRef.current === routeSession) return // live here, not a resume
     adoptedRef.current = null
     let stale = false
     getTranscript(routeSession)

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -1,29 +1,71 @@
 import { ArrowUpIcon } from '@heroicons/react/20/solid'
 import { useEffect, useRef, useState } from 'react'
-import { ChatError, chatStream } from '../api/client'
+import { useNavigate, useParams } from 'react-router'
+import { ChatError, chatStream, getTranscript } from '../api/client'
 import type { ChatEvent } from '../api/types'
 import { CategoryPicker } from '../components/CategoryPicker'
-import { AssistantMessage, UserMessage } from '../components/Message'
+import {
+  AssistantMessage,
+  CompactionDivider,
+  InterruptedMessage,
+  UserMessage,
+} from '../components/Message'
 import { applyEvent, categories, type AssistantState } from '../lib/chat'
-
-type Item = { id: string } & ({ role: 'user'; text: string } | ({ role: 'assistant' } & AssistantState))
+import { useSessions } from '../lib/sessions'
+import { fromTranscript, type ChatItem } from '../lib/transcript'
 
 const categoryKey = 'timothy.category'
 
 export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
-  const [items, setItems] = useState<Item[]>([])
+  const { id: routeSession } = useParams()
+  const navigate = useNavigate()
+  const { refresh } = useSessions()
+  const [items, setItems] = useState<ChatItem[]>([])
   const [draft, setDraft] = useState('')
   const [category, setCategory] = useState(
     () => localStorage.getItem(categoryKey) ?? categories[0],
   )
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [streaming, setStreaming] = useState(false)
-  const sessionRef = useRef<string | undefined>(undefined)
+  const sessionRef = useRef<string | undefined>(routeSession)
+  // Session ids this page itself adopted mid-stream (via navigate):
+  // the resume effect must not clobber the live stream with a replay.
+  const adoptedRef = useRef<string | null>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const abortRef = useRef<AbortController | null>(null)
 
   // Cancel any in-flight stream when the page unmounts (route change).
   useEffect(() => () => abortRef.current?.abort(), [])
+
+  // Resume: replay the session's transcript projection, exactly as the
+  // server recorded it, and restore its last task category.
+  useEffect(() => {
+    sessionRef.current = routeSession
+    setLoadError(null)
+    if (!routeSession) {
+      setItems([])
+      adoptedRef.current = null
+      return
+    }
+    if (adoptedRef.current === routeSession) return // live here, not a resume
+    adoptedRef.current = null
+    let stale = false
+    getTranscript(routeSession)
+      .then(({ session, items }) => {
+        if (stale) return
+        setItems(fromTranscript(items))
+        if (session.last_category) setCategory(session.last_category)
+      })
+      .catch((err: unknown) => {
+        if (stale) return
+        if (err instanceof ChatError && (err.status === 401 || err.status === 503)) onNeedToken()
+        setLoadError(err instanceof Error ? err.message : String(err))
+      })
+    return () => {
+      stale = true
+    }
+  }, [routeSession, onNeedToken])
 
   // Auto-grow the composer up to a cap, then scroll inside it.
   const autogrow = () => {
@@ -72,25 +114,32 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
 
     const controller = new AbortController()
     abortRef.current = controller
+    const adoptSession = (id: string) => {
+      if (sessionRef.current === id) return
+      sessionRef.current = id
+      adoptedRef.current = id
+      // Same route pattern serves / and /sessions/:id, so this only
+      // re-renders — the live stream keeps its component state.
+      navigate(`/sessions/${id}`, { replace: true })
+    }
     try {
       await chatStream(
         { session_id: sessionRef.current, message, task_category: category },
         (ev: ChatEvent) => {
-          if (ev.type === 'meta') sessionRef.current = ev.session_id
+          if (ev.type === 'meta') adoptSession(ev.session_id)
           updateLast((m) => applyEvent(m, ev))
         },
         {
           signal: controller.signal,
-          onSession: (id) => {
-            sessionRef.current = id
-          },
+          onSession: adoptSession,
         },
       )
+      refresh() // updated_at moved; the first exchange also titles it
     } catch (err) {
       if (controller.signal.aborted) return // unmounted; nothing to render
       if (err instanceof ChatError) {
         // Brain may have created the session before failing: keep it.
-        if (err.sessionId) sessionRef.current = err.sessionId
+        if (err.sessionId) adoptSession(err.sessionId)
         if (err.status === 401 || err.status === 503) onNeedToken()
         updateLast((m) => ({ ...m, streaming: false, error: err.message }))
       } else {
@@ -108,7 +157,7 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
   return (
     <div className="flex h-full flex-col">
       <div className="flex-1 space-y-6 overflow-y-auto py-6">
-        {items.length === 0 && (
+        {items.length === 0 && !loadError && (
           <div className="mt-24 text-center">
             <h2 className="text-xl font-semibold text-zinc-700 dark:text-zinc-200">
               What can I help with?
@@ -118,13 +167,23 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
             </p>
           </div>
         )}
-        {items.map((item) =>
-          item.role === 'user' ? (
-            <UserMessage key={item.id} text={item.text} />
-          ) : (
-            <AssistantMessage key={item.id} msg={item} />
-          ),
+        {loadError && (
+          <div className="mt-24 text-center text-sm text-red-500">
+            Could not load this session: {loadError}
+          </div>
         )}
+        {items.map((item) => {
+          switch (item.role) {
+            case 'user':
+              return <UserMessage key={item.id} text={item.text} />
+            case 'compaction':
+              return <CompactionDivider key={item.id} text={item.text} />
+            case 'interrupted':
+              return <InterruptedMessage key={item.id} text={item.text} />
+            default:
+              return <AssistantMessage key={item.id} msg={item} />
+          }
+        })}
         <div ref={bottomRef} />
       </div>
 


### PR DESCRIPTION
## What

Persistent, event-sourced chat sessions replacing the in-memory buffer:

- **Event store**: append-only `session_events` (user messages, assistant turns, tool digests, compactions, mid-turn checkpoints) with transactional, gapless per-session sequence numbers.
- **Dual projections**: `LLMContext` builds the model's message list (prefix-stable so provider prompt caches keep hitting); `UITranscript` builds the full replay and hides nothing — compaction dividers and interrupted turns render honestly.
- **Turn memory**: each completed turn is distilled into structured residue (files changed, failures, key findings) that rides along in the model context.
- **Automatic compaction**: when the projected context exceeds 60% of the serving model's context window (from gateway provider data, static fallback), the oldest half is summarized with explicit instructions to preserve names, dates, numbers, and commitments. Real tokenizer (tiktoken o200k), not byte guesses.
- **Crash-safe turns**: partial answers checkpoint to the log every 2s mid-stream; a hard kill loses at most one flush interval, the transcript shows an interrupted item, and the next turn resumes from the partial verbatim.
- **Session API**: `GET/POST /v1/sessions`, `GET/PATCH /v1/sessions/{id}`, `POST /v1/sessions/{id}/messages` (SSE, `X-Session-Id` header before first byte, terminal meta event). `/v1/chat` stays as a deprecated shim.
- **Web UI**: searchable sidebar grouped by day with rename/archive and infinite scroll, URL-addressable sessions, transcript resume pixel-equivalent with live streaming, per-session task-category restore, auto-titles.

## Evidence

- Kill test: `docker kill` mid-story → checkpoint survived, transcript shows the interrupted item, next turn quotes the partial verbatim.
- Live compaction: budget crossed at 3,853 tokens → summarized through seq 18; all four seeded facts (name, date, invoice, amount) recalled correctly afterwards.
- 100-turn scripted session: 100 durable user messages, 92 assistant turns (8 provider failures surfaced honestly, sessions unharmed), gapless seqs (max=count=194), zero unnecessary compactions, full replay equals the live view.
- All packages green with `-race`, integration tests against real Postgres, 23 web tests, zero lint issues.