### PR TITLE
Web: HugeIcons Pro icons and message copy buttons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
 
   web:
     runs-on: ubuntu-latest
+    env:
+      # HugeIcons Pro registry auth (web/.npmrc references it by name)
+      HUGEICONS_TOKEN: ${{ secrets.HUGEICONS_TOKEN }}
     defaults:
       run:
         working-directory: web

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -89,6 +89,9 @@ services:
     environment:
       # Vite dev proxy target for /v1 (browser stays same-origin)
       BRAIN_URL: http://brain:8080
+      # HugeIcons Pro registry auth for npm install (name-only ref;
+      # the value lives in deploy/.env, never in the repo)
+      HUGEICONS_TOKEN: ${HUGEICONS_TOKEN}
     # npm install, not ci: ci wipes node_modules first, defeating the
     # cache volume. install syncs against the lockfile and is fast when
     # the volume is already populated.

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,2 @@
+@hugeicons-pro:registry=https://npm.hugeicons.com/
+//npm.hugeicons.com/:_authToken=${HUGEICONS_TOKEN}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.9",
+        "@hugeicons-pro/core-stroke-rounded": "^4.2.2",
+        "@hugeicons/react": "^1.1.9",
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.2",
         "class-variance-authority": "^0.7.1",
@@ -962,6 +964,21 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@hugeicons-pro/core-stroke-rounded": {
+      "version": "4.2.2",
+      "resolved": "https://npm.hugeicons.com/@hugeicons-pro/core-stroke-rounded/-/core-stroke-rounded-4.2.2.tgz",
+      "integrity": "sha512-+TruczzkMDuo1PVTAQWNOkjzPhOkTE/mGsk3OU1kwGnm66c+pgSrLpSRpp0OWmKaHCDCnKfdufFroK7+gs8oWQ==",
+      "license": "MIT"
+    },
+    "node_modules/@hugeicons/react": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@hugeicons/react/-/react-1.1.9.tgz",
+      "integrity": "sha512-O+lWSWjbijoAvMCxn4K2bQWCGN5+mP1y5j+X99j23mXMj+s0X25fs71T6t9YJLaBodwmZdaewD27dzS/PiboQw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.9",
+    "@hugeicons-pro/core-stroke-rounded": "^4.2.2",
+    "@hugeicons/react": "^1.1.9",
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.2",
     "class-variance-authority": "^0.7.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,15 +1,16 @@
 import {
-  BarChart3,
-  Image,
-  Inbox,
-  KeyRound,
-  Layers,
-  MessageSquare,
-  Monitor,
-  Moon,
-  Settings as SettingsIcon,
-  Sun,
-} from 'lucide-react'
+  Analytics01Icon,
+  BubbleChatIcon,
+  ComputerIcon,
+  Image01Icon,
+  InboxIcon,
+  Key01Icon,
+  Layers01Icon,
+  Moon02Icon,
+  Settings02Icon,
+  Sun03Icon,
+} from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
 import { useCallback, useEffect, useState } from 'react'
 import { Link, Route, Routes, useLocation } from 'react-router'
 import { getToken } from './api/client'
@@ -36,15 +37,15 @@ import { Dashboard } from './pages/Dashboard'
 import { Lanes, Library, Queues, Settings } from './pages/Stubs'
 
 const nav = [
-  { label: 'Chat', href: '/', icon: MessageSquare },
-  { label: 'Dashboard', href: '/dashboard', icon: BarChart3 },
-  { label: 'Lanes', href: '/lanes', icon: Layers },
-  { label: 'Library', href: '/library', icon: Image },
-  { label: 'Queues', href: '/queues', icon: Inbox },
-  { label: 'Settings', href: '/settings', icon: SettingsIcon },
+  { label: 'Chat', href: '/', icon: BubbleChatIcon },
+  { label: 'Dashboard', href: '/dashboard', icon: Analytics01Icon },
+  { label: 'Lanes', href: '/lanes', icon: Layers01Icon },
+  { label: 'Library', href: '/library', icon: Image01Icon },
+  { label: 'Queues', href: '/queues', icon: InboxIcon },
+  { label: 'Settings', href: '/settings', icon: Settings02Icon },
 ]
 
-const themeIcon = { system: Monitor, light: Sun, dark: Moon }
+const themeIcon = { system: ComputerIcon, light: Sun03Icon, dark: Moon02Icon }
 const themeLabel = { system: 'System theme', light: 'Light theme', dark: 'Dark theme' }
 
 function App() {
@@ -64,7 +65,6 @@ function App() {
     setTheme(t)
     setThemeState(t)
   }
-  const ThemeIcon = themeIcon[theme]
 
   return (
     <SessionsProvider>
@@ -91,7 +91,7 @@ function App() {
                         }
                       >
                         <Link to={item.href}>
-                          <item.icon />
+                          <HugeiconsIcon icon={item.icon} />
                           <span>{item.label}</span>
                         </Link>
                       </SidebarMenuButton>
@@ -106,13 +106,13 @@ function App() {
             <SidebarMenu>
               <SidebarMenuItem>
                 <SidebarMenuButton onClick={cycleTheme}>
-                  <ThemeIcon />
+                  <HugeiconsIcon icon={themeIcon[theme]} />
                   <span>{themeLabel[theme]}</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
               <SidebarMenuItem>
                 <SidebarMenuButton onClick={() => setTokenOpen(true)}>
-                  <KeyRound />
+                  <HugeiconsIcon icon={Key01Icon} />
                   <span>API token</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -1,8 +1,8 @@
-import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ChatEvent } from '../api/types'
 import { applyEvent, type AssistantState } from '../lib/chat'
-import { AssistantMessage, CompactionDivider, InterruptedMessage } from './Message'
+import { AssistantMessage, CompactionDivider, InterruptedMessage, UserMessage } from './Message'
 
 afterEach(cleanup)
 
@@ -97,5 +97,38 @@ describe('replay-only components', () => {
     const el = screen.getByTestId('interrupted')
     expect(el).toHaveTextContent('Once upon a')
     expect(el).toHaveTextContent('interrupted')
+  })
+})
+
+describe('copy buttons', () => {
+  it('copies the assistant reply text', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+
+    const msg = play([
+      { type: 'chunk', text: 'the answer' },
+      { type: 'meta', session_id: 's' },
+    ])
+    render(<AssistantMessage msg={msg} />)
+
+    fireEvent.click(screen.getByTestId('copy-button'))
+    expect(writeText).toHaveBeenCalledWith('the answer')
+    vi.unstubAllGlobals()
+  })
+
+  it('copies the user message text', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+
+    render(<UserMessage text="my question" />)
+    fireEvent.click(screen.getByTestId('copy-button'))
+    expect(writeText).toHaveBeenCalledWith('my question')
+    vi.unstubAllGlobals()
+  })
+
+  it('hides the copy button while streaming', () => {
+    const msg = play([{ type: 'chunk', text: 'partial' }])
+    render(<AssistantMessage msg={msg} />)
+    expect(screen.queryByTestId('copy-button')).toBeNull()
   })
 })

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -1,12 +1,42 @@
+import { Copy01Icon, Tick02Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import rehypeHighlight from 'rehype-highlight'
 import { Badge } from './ui/badge'
 import type { AssistantState } from '../lib/chat'
 import 'highlight.js/styles/github-dark.css'
 
+// CopyButton copies a message's raw text; the check confirms briefly.
+function CopyButton({ text, label }: { text: string; label: string }) {
+  const [copied, setCopied] = useState(false)
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard unavailable (permissions, insecure context): the
+      // button simply does nothing rather than throwing.
+    }
+  }
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      data-testid="copy-button"
+      onClick={() => void copy()}
+      className="rounded p-1 text-muted-foreground opacity-0 transition group-hover/message:opacity-100 hover:bg-accent hover:text-foreground focus-visible:opacity-100"
+    >
+      <HugeiconsIcon icon={copied ? Tick02Icon : Copy01Icon} className="size-3.5" />
+    </button>
+  )
+}
+
 export function UserMessage({ text }: { text: string }) {
   return (
-    <div className="flex justify-end">
+    <div className="group/message flex items-end justify-end gap-1">
+      <CopyButton text={text} label="Copy message" />
       <div className="max-w-2xl rounded-2xl bg-blue-600 px-4 py-2.5 text-sm/6 whitespace-pre-wrap text-white">
         {text}
       </div>
@@ -31,16 +61,19 @@ export function CompactionDivider({ text }: { text: string }) {
 // answer plus an honest marker.
 export function InterruptedMessage({ text }: { text: string }) {
   return (
-    <div className="flex flex-col items-start gap-2" data-testid="interrupted">
+    <div className="group/message flex flex-col items-start gap-2" data-testid="interrupted">
       <div className="prose prose-sm max-w-3xl dark:prose-invert prose-pre:bg-zinc-900">
         <ReactMarkdown rehypePlugins={[rehypeHighlight]}>{text}</ReactMarkdown>
       </div>
-      <Badge
-        variant="outline"
-        className="border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400"
-      >
-        interrupted
-      </Badge>
+      <div className="flex items-center gap-1.5">
+        <Badge
+          variant="outline"
+          className="border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+        >
+          interrupted
+        </Badge>
+        <CopyButton text={text} label="Copy partial message" />
+      </div>
     </div>
   )
 }
@@ -50,7 +83,7 @@ export function AssistantMessage({ msg }: { msg: AssistantState }) {
     ? `${msg.meta.usage.input_tokens}→${msg.meta.usage.output_tokens} tok`
     : null
   return (
-    <div className="flex flex-col items-start gap-2">
+    <div className="group/message flex flex-col items-start gap-2">
       {msg.reasoning !== '' && (
         <details className="w-full max-w-3xl rounded-lg border border-zinc-200 px-3 py-2 text-xs text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">
           <summary className="cursor-pointer select-none">Reasoning</summary>
@@ -78,11 +111,16 @@ export function AssistantMessage({ msg }: { msg: AssistantState }) {
           {msg.error}
         </Badge>
       )}
-      {!msg.streaming && msg.meta?.provider && (
-        <div className="flex gap-1.5" data-testid="meta-badge">
-          <Badge variant="secondary">{msg.meta.provider}</Badge>
-          <Badge variant="secondary">{msg.meta.model}</Badge>
-          {tokens && <Badge variant="secondary">{tokens}</Badge>}
+      {!msg.streaming && (
+        <div className="flex items-center gap-1.5">
+          {msg.meta?.provider && (
+            <div className="flex gap-1.5" data-testid="meta-badge">
+              <Badge variant="secondary">{msg.meta.provider}</Badge>
+              <Badge variant="secondary">{msg.meta.model}</Badge>
+              {tokens && <Badge variant="secondary">{tokens}</Badge>}
+            </div>
+          )}
+          {msg.text !== '' && <CopyButton text={msg.text} label="Copy reply" />}
         </div>
       )}
     </div>

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,4 +1,12 @@
-import { Archive, ArchiveRestore, MoreHorizontal, Pencil, Plus, Search } from 'lucide-react'
+import {
+  Add01Icon,
+  Archive02Icon,
+  MoreHorizontalIcon,
+  PencilEdit01Icon,
+  Search01Icon,
+  Unarchive03Icon,
+} from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useRef, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router'
 import { updateSession } from '../api/client'
@@ -72,14 +80,14 @@ export function SessionList() {
             <SidebarMenuItem>
               <SidebarMenuButton asChild isActive={pathname === '/'}>
                 <Link to="/">
-                  <Plus />
+                  <HugeiconsIcon icon={Add01Icon} />
                   <span>New chat</span>
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>
           <div className="relative mt-1 px-1">
-            <Search className="pointer-events-none absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <HugeiconsIcon icon={Search01Icon} className="pointer-events-none absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground" />
             <Input
               aria-label="Search sessions"
               value={query}
@@ -107,7 +115,7 @@ export function SessionList() {
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <SidebarMenuAction showOnHover aria-label={`Actions for ${s.title || 'session'}`}>
-                        <MoreHorizontal />
+                        <HugeiconsIcon icon={MoreHorizontalIcon} />
                       </SidebarMenuAction>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent side="right" align="start">
@@ -117,11 +125,11 @@ export function SessionList() {
                           setRenaming(s)
                         }}
                       >
-                        <Pencil />
+                        <HugeiconsIcon icon={PencilEdit01Icon} />
                         Rename
                       </DropdownMenuItem>
                       <DropdownMenuItem onClick={() => void archive(s)}>
-                        {s.archived ? <ArchiveRestore /> : <Archive />}
+                        <HugeiconsIcon icon={s.archived ? Unarchive03Icon : Archive02Icon} />
                         {s.archived ? 'Unarchive' : 'Archive'}
                       </DropdownMenuItem>
                     </DropdownMenuContent>

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -1,4 +1,5 @@
-import { ArrowUp } from 'lucide-react'
+import { ArrowUp01Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { ChatError, chatStream, getTranscript } from '../api/client'
@@ -231,7 +232,7 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
               disabled={streaming || draft.trim() === ''}
               className="flex size-9 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 disabled:bg-zinc-200 disabled:text-zinc-400 dark:disabled:bg-zinc-700 dark:disabled:text-zinc-500"
             >
-              <ArrowUp className="size-4" />
+              <HugeiconsIcon icon={ArrowUp01Icon} className="size-4" />
             </button>
           </div>
         </div>


### PR DESCRIPTION
## What

**HugeIcons Pro.** App-level icons (sidebar nav, session actions, theme/token buttons, composer send) move to the stroke-rounded Pro set. The registry token travels by reference only: `web/.npmrc` names the env var, compose forwards it from `deploy/.env`, CI reads the `HUGEICONS_TOKEN` repository secret. shadcn's generated components keep importing lucide for their internal chevrons/checks.

**Copy buttons.** Every user message, assistant reply, and interrupted partial gets a hover copy button with a brief check confirmation. Hidden while a reply is still streaming. Clipboard failures (permissions, insecure context) no-op instead of throwing.

26 web tests green (3 new for copy behavior), build clean, lint 0/0. Verified live: the dev container authenticated against the private registry and pulled the Pro package via the compose-forwarded token.