### PR TITLE
Document HugeIcons token in env example

### DIFF
--- a/deploy/env.example
+++ b/deploy/env.example
@@ -13,3 +13,5 @@ XAI_API_KEY=
 
 # Bearer token for brain's public API (generate: openssl rand -hex 32)
 TIMOTHY_API_TOKEN=
+
+HUGEICONS_TOKEN=


### PR DESCRIPTION
One line: web/.npmrc references HUGEICONS_TOKEN by name; the example file should list it so a fresh checkout knows to set it.