### PR TITLE
fix: web review follow-ups for copy button and settings dialog

### DIFF
--- a/deploy/env.example
+++ b/deploy/env.example
@@ -14,4 +14,5 @@ XAI_API_KEY=
 # Bearer token for brain's public API (generate: openssl rand -hex 32)
 TIMOTHY_API_TOKEN=
 
+# npm auth token for HugeIcons Pro packages (from your hugeicons.com account)
 HUGEICONS_TOKEN=

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ChatEvent } from '../api/types'
 import { applyEvent, type AssistantState } from '../lib/chat'
@@ -130,5 +130,59 @@ describe('copy buttons', () => {
     const msg = play([{ type: 'chunk', text: 'partial' }])
     render(<AssistantMessage msg={msg} />)
     expect(screen.queryByTestId('copy-button')).toBeNull()
+  })
+
+  it('copies the interrupted partial text', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+
+    render(<InterruptedMessage text="Once upon a" />)
+    fireEvent.click(screen.getByTestId('copy-button'))
+    expect(writeText).toHaveBeenCalledWith('Once upon a')
+    vi.unstubAllGlobals()
+  })
+
+  it('confirms the copy then reverts after two seconds', async () => {
+    vi.useFakeTimers()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+
+    render(<UserMessage text="hi" />)
+    const btn = screen.getByTestId('copy-button')
+    fireEvent.click(btn)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(btn).toHaveAttribute('data-copied', 'true')
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+    expect(btn).toHaveAttribute('data-copied', 'false')
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('stays quiet when the clipboard rejects', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+
+    render(<UserMessage text="hi" />)
+    const btn = screen.getByTestId('copy-button')
+    fireEvent.click(btn)
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(btn).toHaveAttribute('data-copied', 'false')
+    vi.unstubAllGlobals()
+  })
+
+  it('renders no footer for a finished turn with no text and no meta', () => {
+    const msg = play([
+      { type: 'error', error: { code: 'chain_exhausted', message: 'all failed', retryable: false } },
+      { type: 'meta', session_id: 's' },
+    ])
+    render(<AssistantMessage msg={msg} />)
+    expect(screen.queryByTestId('copy-button')).toBeNull()
+    expect(screen.queryByTestId('meta-badge')).toBeNull()
   })
 })

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -1,6 +1,6 @@
 import { Copy01Icon, Tick02Icon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import rehypeHighlight from 'rehype-highlight'
 import { Badge } from './ui/badge'
@@ -10,11 +10,14 @@ import 'highlight.js/styles/github-dark.css'
 // CopyButton copies a message's raw text; the check confirms briefly.
 function CopyButton({ text, label }: { text: string; label: string }) {
   const [copied, setCopied] = useState(false)
+  const timer = useRef<number | undefined>(undefined)
+  useEffect(() => () => window.clearTimeout(timer.current), [])
   const copy = async () => {
     try {
       await navigator.clipboard.writeText(text)
       setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      window.clearTimeout(timer.current)
+      timer.current = window.setTimeout(() => setCopied(false), 2000)
     } catch {
       // Clipboard unavailable (permissions, insecure context): the
       // button simply does nothing rather than throwing.
@@ -25,6 +28,7 @@ function CopyButton({ text, label }: { text: string; label: string }) {
       type="button"
       aria-label={label}
       data-testid="copy-button"
+      data-copied={copied}
       onClick={() => void copy()}
       className="rounded p-1 text-muted-foreground opacity-0 transition group-hover/message:opacity-100 hover:bg-accent hover:text-foreground focus-visible:opacity-100"
     >
@@ -111,7 +115,7 @@ export function AssistantMessage({ msg }: { msg: AssistantState }) {
           {msg.error}
         </Badge>
       )}
-      {!msg.streaming && (
+      {!msg.streaming && (Boolean(msg.meta?.provider) || msg.text !== '') && (
         <div className="flex items-center gap-1.5">
           {msg.meta?.provider && (
             <div className="flex gap-1.5" data-testid="meta-badge">

--- a/web/src/components/SettingsDialog.test.tsx
+++ b/web/src/components/SettingsDialog.test.tsx
@@ -1,0 +1,22 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { setToken } from '../api/client'
+import { SettingsDialog } from './SettingsDialog'
+
+afterEach(cleanup)
+
+describe('SettingsDialog', () => {
+  it('discards unsaved edits when reopened', () => {
+    setToken('saved-token')
+    const { rerender } = render(<SettingsDialog open onClose={() => {}} />)
+
+    const input = screen.getByLabelText('API token')
+    fireEvent.change(input, { target: { value: 'half-typed' } })
+    expect(input).toHaveValue('half-typed')
+
+    rerender(<SettingsDialog open={false} onClose={() => {}} />)
+    rerender(<SettingsDialog open onClose={() => {}} />)
+
+    expect(screen.getByLabelText('API token')).toHaveValue('saved-token')
+  })
+})

--- a/web/src/components/SettingsDialog.tsx
+++ b/web/src/components/SettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { getToken, setToken } from '../api/client'
 import { Button } from './ui/button'
 import {
@@ -14,6 +14,12 @@ import { Label } from './ui/label'
 
 export function SettingsDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
   const [value, setValue] = useState(getToken())
+
+  // The component stays mounted across opens, so discard any unsaved
+  // edits from the previous open.
+  useEffect(() => {
+    if (open) setValue(getToken())
+  }, [open])
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>


### PR DESCRIPTION
## What

Four small post-merge fixes in the web UI:

- **CopyButton timer** (`Message.tsx`): the 2s confirmation `setTimeout` now lives in a ref, is cleared on unmount and on re-click, so no state updates fire after the component is gone and rapid re-copies don't revert early. Added `data-copied` for testability.
- **Empty footer** (`Message.tsx`): the finished-turn footer row only renders when there are meta badges or a copy button to show — error-only turns no longer leave a blank gap.
- **SettingsDialog**: the token input resets to the saved value each time the dialog opens; unsaved edits from a cancelled open no longer linger (the component stays mounted, so mount-only `useState` wasn't enough).
- **env.example**: `HUGEICONS_TOKEN` now has a comment explaining what it's for and where it comes from, matching the other non-obvious vars.

## Tests

New cases: interrupted-message copy, confirm-then-revert with fake timers, clipboard rejection stays quiet, no footer for error-only turns, settings dialog discards unsaved edits. Build, typecheck, oxlint, and all 31 web tests green in the containerized runner.