### PR TITLE
fix: bedrock live-run fixes — credential health, nova thinking tags, sso cache

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -82,11 +82,12 @@ services:
     # Bedrock (driver 'bedrock') reads the AWS default credential
     # chain. Local dev: run `aws sso login --profile <name>` on the
     # host and set the bedrock provider's credential_ref to that
-    # profile; the read-only mount exposes the shared config and SSO
-    # token cache. An expired SSO session is refreshed on the HOST,
-    # never by the container.
+    # profile. Config and credentials mount read-only; the SDK rotates
+    # SSO access tokens itself and must write them back, so the token
+    # cache alone is writable.
     volumes:
       - ${HOME}/.aws:/home/nonroot/.aws:ro
+      - ${HOME}/.aws/sso/cache:/home/nonroot/.aws/sso/cache
     # internal-only: no published ports
 
   memoryd:

--- a/internal/gateway/provider/bedrock.go
+++ b/internal/gateway/provider/bedrock.go
@@ -139,13 +139,16 @@ func (b *Bedrock) Stream(ctx context.Context, req CompletionRequest) (<-chan str
 
 		var currentToolID, currentToolName string
 		var toolInput []byte
+		splitter := &thinkTagSplitter{}
 
 		for event := range events.Events() {
 			switch v := event.(type) {
 			case *types.ConverseStreamOutputMemberContentBlockDelta:
 				if delta, ok := v.Value.Delta.(*types.ContentBlockDeltaMemberText); ok {
-					if !emit(sctx, outCh, stream.StreamEvent{Type: stream.EventChunk, Text: delta.Value}) {
-						return
+					for _, ev := range splitter.Feed(delta.Value) {
+						if !emit(sctx, outCh, ev) {
+							return
+						}
 					}
 				}
 				if toolDelta, ok := v.Value.Delta.(*types.ContentBlockDeltaMemberToolUse); ok {
@@ -171,6 +174,11 @@ func (b *Bedrock) Stream(ctx context.Context, req CompletionRequest) (<-chan str
 				}
 
 			case *types.ConverseStreamOutputMemberContentBlockStop:
+				for _, ev := range splitter.Flush() {
+					if !emit(sctx, outCh, ev) {
+						return
+					}
+				}
 				if currentToolID != "" && currentToolName != "" {
 					if len(toolInput) == 0 {
 						// Zero-argument calls still need valid JSON downstream.
@@ -217,6 +225,11 @@ func (b *Bedrock) Stream(ctx context.Context, req CompletionRequest) (<-chan str
 			}
 		}
 
+		for _, ev := range splitter.Flush() {
+			if !emit(sctx, outCh, ev) {
+				return
+			}
+		}
 		// A closed event channel is not success: a mid-stream failure
 		// surfaces only via Err(). Without this check a dropped
 		// connection would masquerade as a clean EventDone.

--- a/internal/gateway/provider/thinktag.go
+++ b/internal/gateway/provider/thinktag.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"strings"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// Nova models emit chain-of-thought as literal <thinking>…</thinking>
+// spans inside the text stream — Converse has no separate reasoning
+// channel for them. thinkTagSplitter rewrites those spans into
+// reasoning events so the UI treats them like every other model's
+// hidden reasoning instead of showing them as answer text. Tags can
+// straddle chunk boundaries, so a small carry buffer holds any suffix
+// that could still become a tag.
+type thinkTagSplitter struct {
+	carry    string
+	thinking bool
+}
+
+const (
+	thinkOpen  = "<thinking>"
+	thinkClose = "</thinking>"
+)
+
+// Feed consumes one text delta and returns the events it resolves to.
+func (s *thinkTagSplitter) Feed(text string) []stream.StreamEvent {
+	s.carry += text
+	var out []stream.StreamEvent
+	for {
+		tag := thinkOpen
+		if s.thinking {
+			tag = thinkClose
+		}
+		if i := strings.Index(s.carry, tag); i >= 0 {
+			if seg := s.carry[:i]; seg != "" {
+				out = append(out, s.event(seg))
+			}
+			s.carry = s.carry[i+len(tag):]
+			s.thinking = !s.thinking
+			continue
+		}
+		// No full tag: emit everything except a tail that could still
+		// grow into one on the next delta.
+		keep := partialTagSuffix(s.carry, tag)
+		if seg := s.carry[:len(s.carry)-keep]; seg != "" {
+			out = append(out, s.event(seg))
+		}
+		s.carry = s.carry[len(s.carry)-keep:]
+		return out
+	}
+}
+
+// Flush drains whatever the stream ended on, including a dangling
+// partial tag — at end-of-stream it can no longer complete.
+func (s *thinkTagSplitter) Flush() []stream.StreamEvent {
+	if s.carry == "" {
+		return nil
+	}
+	ev := s.event(s.carry)
+	s.carry = ""
+	return []stream.StreamEvent{ev}
+}
+
+func (s *thinkTagSplitter) event(text string) stream.StreamEvent {
+	if s.thinking {
+		return stream.StreamEvent{Type: stream.EventReasoningChunk, Text: text}
+	}
+	return stream.StreamEvent{Type: stream.EventChunk, Text: text}
+}
+
+// partialTagSuffix reports how many trailing bytes of s are a proper
+// prefix of tag (and might complete on the next chunk).
+func partialTagSuffix(s, tag string) int {
+	max := len(tag) - 1
+	if len(s) < max {
+		max = len(s)
+	}
+	for n := max; n > 0; n-- {
+		if strings.HasSuffix(s, tag[:n]) {
+			return n
+		}
+	}
+	return 0
+}

--- a/internal/gateway/provider/thinktag_test.go
+++ b/internal/gateway/provider/thinktag_test.go
@@ -1,0 +1,101 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// run feeds the chunks and returns the concatenated reasoning and
+// answer text the splitter produced.
+func runSplitter(t *testing.T, chunks []string) (reasoning, answer string) {
+	t.Helper()
+	s := &thinkTagSplitter{}
+	collect := func(evs []stream.StreamEvent) {
+		for _, ev := range evs {
+			switch ev.Type {
+			case stream.EventReasoningChunk:
+				reasoning += ev.Text
+			case stream.EventChunk:
+				answer += ev.Text
+			default:
+				t.Fatalf("unexpected event type %v", ev.Type)
+			}
+		}
+	}
+	for _, c := range chunks {
+		collect(s.Feed(c))
+	}
+	collect(s.Flush())
+	return reasoning, answer
+}
+
+func TestThinkTagSplitter(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		chunks        []string
+		wantReasoning string
+		wantAnswer    string
+	}{
+		{
+			name:       "no tags pass through",
+			chunks:     []string{"hello ", "world"},
+			wantAnswer: "hello world",
+		},
+		{
+			name:          "single span one chunk",
+			chunks:        []string{"<thinking>hmm</thinking>answer"},
+			wantReasoning: "hmm",
+			wantAnswer:    "answer",
+		},
+		{
+			name:          "tags straddle chunk boundaries",
+			chunks:        []string{"<thin", "king>deep ", "thought</think", "ing>the answer"},
+			wantReasoning: "deep thought",
+			wantAnswer:    "the answer",
+		},
+		{
+			name:          "multiple spans",
+			chunks:        []string{"<thinking>a</thinking>one<thinking>b</thinking>two"},
+			wantReasoning: "ab",
+			wantAnswer:    "onetwo",
+		},
+		{
+			name:          "unterminated thinking flushes as reasoning",
+			chunks:        []string{"<thinking>never closed"},
+			wantReasoning: "never closed",
+		},
+		{
+			name:       "dangling partial tag flushes as text",
+			chunks:     []string{"answer <thin"},
+			wantAnswer: "answer <thin",
+		},
+		{
+			name:       "angle brackets that are not tags",
+			chunks:     []string{"a < b and <thing> stays"},
+			wantAnswer: "a < b and <thing> stays",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			reasoning, answer := runSplitter(t, tc.chunks)
+			if reasoning != tc.wantReasoning || answer != tc.wantAnswer {
+				t.Fatalf("reasoning=%q answer=%q, want %q / %q",
+					reasoning, answer, tc.wantReasoning, tc.wantAnswer)
+			}
+		})
+	}
+}
+
+func TestThinkTagSplitterByteAtATime(t *testing.T) {
+	t.Parallel()
+	// Worst-case chunking: every byte its own delta.
+	full := "<thinking>plan the reply</thinking>Here you go.<thinking>x</thinking>!"
+	reasoning, answer := runSplitter(t, strings.Split(full, ""))
+	if reasoning != "plan the replyx" || answer != "Here you go.!" {
+		t.Fatalf("reasoning=%q answer=%q", reasoning, answer)
+	}
+}

--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -106,7 +106,12 @@ func BuildSnapshot(provRows []ProviderRow, routeRows []RouteRow, lookup func(str
 	for _, row := range provRows {
 		s.rows[row.ID] = row
 		s.byName[row.Name] = row
-		s.healthy[row.Name] = row.CredentialRef == "" || lookup(row.CredentialRef) != ""
+		// credential_ref names an env var for API-key drivers, but the
+		// bedrock driver reuses it as an AWS profile name that the SDK
+		// resolves itself — an unresolved env lookup must not mark it
+		// unhealthy.
+		s.healthy[row.Name] = row.Driver == "bedrock" ||
+			row.CredentialRef == "" || lookup(row.CredentialRef) != ""
 		cfgs = append(cfgs, provider.Config{
 			Name:          row.Name,
 			Kind:          provider.Kind(row.Kind),

--- a/internal/gateway/router/router_test.go
+++ b/internal/gateway/router/router_test.go
@@ -296,3 +296,31 @@ func TestRoutesListing(t *testing.T) {
 		t.Fatal("disabled route listed")
 	}
 }
+
+func TestBedrockHealthyWithoutEnvCredential(t *testing.T) {
+	t.Parallel()
+	// bedrock's credential_ref is an AWS profile name, not an env var:
+	// the SDK resolves it, so an unresolvable lookup must not sideline
+	// the provider.
+	provRows := []ProviderRow{{
+		ID: "p1", Name: "bedrock", Kind: "api", Driver: "bedrock",
+		BaseURL: "us-east-1", DefaultModel: "us.amazon.nova-pro-v1:0",
+		CredentialRef: "some-aws-profile", Enabled: true,
+		Models: []ModelInfo{{ID: "titan-embed", Capabilities: []string{"embeddings"}}},
+	}}
+	routeRows := []RouteRow{{TaskCategory: "embedding", Chain: []ChainEntry{
+		{ProviderID: "p1", Model: "titan-embed"},
+	}, Enabled: true}}
+	snap, err := BuildSnapshot(provRows, routeRows, func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("BuildSnapshot: %v", err)
+	}
+
+	attempts, err := snap.Resolve("embedding", "")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(attempts) != 1 || attempts[0].ProviderName != "bedrock" {
+		t.Fatalf("attempts = %v, want bedrock", attempts)
+	}
+}


### PR DESCRIPTION
## Summary

Three issues found running Bedrock against the live stack:

- **Provider health**: the routing snapshot treats `credential_ref` as an env-var name for every driver; bedrock reuses it as an AWS profile name resolved by the SDK, so enabling the provider sidelined it as "credential unresolved" before any call. Health is now driver-aware; regression test pins a bedrock provider with an unresolvable ref staying routable.
- **Nova thinking tags**: with tools configured, Nova inlines chain-of-thought as literal `<thinking>` spans in answer text (Converse has no reasoning channel for it) — users saw raw tags. A stateful splitter rewrites the spans into normalized reasoning events; handles tags straddling chunk boundaries, multiple spans, unterminated spans, and byte-at-a-time chunking (all tested).
- **SSO token cache**: the AWS SDK rotates SSO access tokens and writes them back to `~/.aws/sso/cache`; the fully read-only mount failed every call once the cached token expired. Only the token cache directory is writable now — config and credentials stay read-only.

## Test plan

- `go test -race ./internal/gateway/...` green; new splitter table tests + worst-case chunking; router health regression test.
- Verified live: bedrock serves chat (Nova via inference profiles) and embeddings (Titan v1) end to end; thinking spans render as collapsed reasoning in the web UI; token refresh works across expiry without host re-login.