### PR TITLE
feat: workspace shell with home launcher and tiered mode picker

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,25 +3,33 @@ import {
   Brain02Icon,
   BubbleChatIcon,
   ComputerIcon,
+  Home01Icon,
   Image01Icon,
   InboxIcon,
   Key01Icon,
   Layers01Icon,
   Moon02Icon,
+  MoreHorizontalIcon,
+  PlusSignIcon,
   Settings02Icon,
   Sun03Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useCallback, useEffect, useState } from 'react'
-import { Link, Route, Routes, useLocation } from 'react-router'
-import { getToken, listMemories } from './api/client'
+import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router'
+import { getToken } from './api/client'
 import { SessionList } from './components/SessionList'
 import { SessionsProvider } from './components/SessionsProvider'
 import { SettingsDialog } from './components/SettingsDialog'
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from './components/ui/dropdown-menu'
+import {
   Sidebar,
   SidebarContent,
-  SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
   SidebarHeader,
@@ -33,54 +41,138 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from './components/ui/sidebar'
-import { memoryChangedEvent } from './lib/memory'
+import { usePendingMemories } from './lib/memory'
 import { getTheme, nextTheme, setTheme, type Theme } from './lib/theme'
+import { cn } from './lib/utils'
 import { Chat } from './pages/Chat'
 import { Dashboard } from './pages/Dashboard'
+import { Home } from './pages/Home'
 import { Memory } from './pages/Memory'
 import { Lanes, Library, Queues, Settings } from './pages/Stubs'
 
-const nav = [
-  { label: 'Chat', href: '/', icon: BubbleChatIcon },
-  { label: 'Dashboard', href: '/dashboard', icon: Analytics01Icon },
+const railNav = [
+  { label: 'Home', href: '/', icon: Home01Icon },
+  { label: 'Chat', href: '/chat', icon: BubbleChatIcon },
   { label: 'Memory', href: '/memory', icon: Brain02Icon },
+  { label: 'Dashboard', href: '/dashboard', icon: Analytics01Icon },
+]
+
+const moreNav = [
   { label: 'Lanes', href: '/lanes', icon: Layers01Icon },
   { label: 'Library', href: '/library', icon: Image01Icon },
   { label: 'Queues', href: '/queues', icon: InboxIcon },
   { label: 'Settings', href: '/settings', icon: Settings02Icon },
 ]
 
-// usePendingMemories keeps the sidebar badge current: initial fetch,
-// a slow poll, and an instant refresh when the Memory page acts.
-function usePendingMemories(): number {
-  const [count, setCount] = useState(0)
-  useEffect(() => {
-    let live = true
-    const refresh = () => {
-      listMemories('pending')
-        .then((pending) => live && setCount(pending.length))
-        .catch(() => {})
-    }
-    refresh()
-    const timer = setInterval(refresh, 60_000)
-    window.addEventListener(memoryChangedEvent, refresh)
-    return () => {
-      live = false
-      clearInterval(timer)
-      window.removeEventListener(memoryChangedEvent, refresh)
-    }
-  }, [])
-  return count
-}
-
 const themeIcon = { system: ComputerIcon, light: Sun03Icon, dark: Moon02Icon }
 const themeLabel = { system: 'System theme', light: 'Light theme', dark: 'Dark theme' }
+
+function isActive(pathname: string, href: string): boolean {
+  if (href === '/') return pathname === '/'
+  if (href === '/chat') return pathname === '/chat' || pathname.startsWith('/chat/')
+  return pathname === href
+}
+
+// Rail is the desktop workspace navigation: a slim icon column, every
+// destination one glance away. Mobile navigation lives in the sheet
+// the header trigger opens.
+function Rail({
+  pendingMemories,
+  theme,
+  onCycleTheme,
+  onToken,
+}: {
+  pendingMemories: number
+  theme: Theme
+  onCycleTheme: () => void
+  onToken: () => void
+}) {
+  const { pathname } = useLocation()
+  const moreActive = moreNav.some((item) => pathname === item.href)
+
+  const itemClass = (active: boolean) =>
+    cn(
+      'flex w-full flex-col items-center gap-1 rounded-lg py-2 text-[10px] font-medium transition',
+      active
+        ? 'bg-zinc-200/70 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50'
+        : 'text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100',
+    )
+
+  return (
+    <nav
+      aria-label="Workspace"
+      className="hidden w-18 shrink-0 flex-col items-center gap-1 border-r border-border px-2 py-3 md:flex"
+    >
+      <Link to="/" aria-label="Timothy home" className="mb-2 flex size-9 items-center justify-center">
+        <span className="size-3 rounded-full bg-gradient-to-br from-blue-500 to-violet-600" />
+      </Link>
+      <Link
+        to="/chat"
+        aria-label="New chat"
+        className="mb-2 flex size-10 items-center justify-center rounded-xl border border-border text-zinc-600 transition hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+      >
+        <HugeiconsIcon icon={PlusSignIcon} className="size-5" />
+      </Link>
+      {railNav.map((item) => (
+        <Link key={item.href} to={item.href} className={itemClass(isActive(pathname, item.href))}>
+          <span className="relative">
+            <HugeiconsIcon icon={item.icon} className="size-5" />
+            {item.href === '/memory' && pendingMemories > 0 && (
+              <span
+                data-testid="memory-badge"
+                className="absolute -top-1.5 -right-2 flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-600 px-1 text-[9px] font-medium text-white"
+              >
+                {pendingMemories}
+              </span>
+            )}
+          </span>
+          {item.label}
+        </Link>
+      ))}
+      <DropdownMenu>
+        <DropdownMenuTrigger className={itemClass(moreActive)} aria-label="More">
+          <HugeiconsIcon icon={MoreHorizontalIcon} className="size-5" />
+          More
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="right" align="start">
+          {moreNav.map((item) => (
+            <DropdownMenuItem key={item.href} asChild>
+              <Link to={item.href}>
+                <HugeiconsIcon icon={item.icon} className="size-4" />
+                {item.label}
+              </Link>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <div className="mt-auto flex w-full flex-col items-center gap-1">
+        <button type="button" onClick={onCycleTheme} className={itemClass(false)} aria-label={themeLabel[theme]}>
+          <HugeiconsIcon icon={themeIcon[theme]} className="size-5" />
+          Theme
+        </button>
+        <button type="button" onClick={onToken} className={itemClass(false)} aria-label="API token">
+          <HugeiconsIcon icon={Key01Icon} className="size-5" />
+          Token
+        </button>
+      </div>
+    </nav>
+  )
+}
+
+// LegacySessionRedirect keeps old /sessions/{id} links working.
+function LegacySessionRedirect() {
+  const { id } = useParams()
+  return <Navigate to={`/chat/${id}`} replace />
+}
 
 function App() {
   const [tokenOpen, setTokenOpen] = useState(false)
   const [theme, setThemeState] = useState<Theme>(() => getTheme())
+  const [sessionsOpen, setSessionsOpen] = useState(true)
   const { pathname } = useLocation()
   const pendingMemories = usePendingMemories()
+  const onChat = isActive(pathname, '/chat')
 
   useEffect(() => {
     if (getToken() === '') setTokenOpen(true)
@@ -97,91 +189,99 @@ function App() {
 
   return (
     <SessionsProvider>
-      <SidebarProvider>
-        <Sidebar>
-          <SidebarHeader>
-            <div className="flex items-center gap-2.5 px-2 py-1.5">
-              <span className="size-2.5 rounded-full bg-gradient-to-br from-blue-500 to-violet-600" />
-              <span className="text-base font-semibold tracking-tight">Timothy</span>
-            </div>
-          </SidebarHeader>
-          <SidebarContent>
-            <SidebarGroup>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  {nav.map((item) => (
-                    <SidebarMenuItem key={item.href}>
-                      <SidebarMenuButton
-                        asChild
-                        isActive={
-                          item.href === '/'
-                            ? pathname === '/' || pathname.startsWith('/sessions')
-                            : pathname === item.href
-                        }
-                      >
-                        <Link to={item.href}>
-                          <HugeiconsIcon icon={item.icon} />
-                          <span>{item.label}</span>
-                        </Link>
+      <div className="flex h-dvh w-full">
+        <Rail
+          pendingMemories={pendingMemories}
+          theme={theme}
+          onCycleTheme={cycleTheme}
+          onToken={openToken}
+        />
+        {/* Desktop: the sidebar holds sessions and only appears on chat
+            routes. Mobile: the same sidebar is the navigation sheet —
+            nav links ride above the session list. */}
+        <SidebarProvider
+          open={onChat && sessionsOpen}
+          onOpenChange={setSessionsOpen}
+          className="min-h-0 min-w-0 flex-1"
+        >
+          <Sidebar>
+            <SidebarHeader>
+              <div className="flex items-center gap-2.5 px-2 py-1.5">
+                <span className="size-2.5 rounded-full bg-gradient-to-br from-blue-500 to-violet-600" />
+                <span className="text-base font-semibold tracking-tight">Timothy</span>
+              </div>
+            </SidebarHeader>
+            <SidebarContent>
+              <SidebarGroup className="md:hidden">
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    {[...railNav, ...moreNav].map((item) => (
+                      <SidebarMenuItem key={item.href}>
+                        <SidebarMenuButton asChild isActive={isActive(pathname, item.href)}>
+                          <Link to={item.href}>
+                            <HugeiconsIcon icon={item.icon} />
+                            <span>{item.label}</span>
+                          </Link>
+                        </SidebarMenuButton>
+                        {item.href === '/memory' && pendingMemories > 0 && (
+                          <SidebarMenuBadge>{pendingMemories}</SidebarMenuBadge>
+                        )}
+                      </SidebarMenuItem>
+                    ))}
+                    <SidebarMenuItem>
+                      <SidebarMenuButton onClick={cycleTheme}>
+                        <HugeiconsIcon icon={themeIcon[theme]} />
+                        <span>{themeLabel[theme]}</span>
                       </SidebarMenuButton>
-                      {item.href === '/memory' && pendingMemories > 0 && (
-                        <SidebarMenuBadge data-testid="memory-badge">
-                          {pendingMemories}
-                        </SidebarMenuBadge>
-                      )}
                     </SidebarMenuItem>
-                  ))}
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
-            <SessionList />
-          </SidebarContent>
-          <SidebarFooter>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton onClick={cycleTheme}>
-                  <HugeiconsIcon icon={themeIcon[theme]} />
-                  <span>{themeLabel[theme]}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton onClick={() => setTokenOpen(true)}>
-                  <HugeiconsIcon icon={Key01Icon} />
-                  <span>API token</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarFooter>
-        </Sidebar>
+                    <SidebarMenuItem>
+                      <SidebarMenuButton onClick={() => setTokenOpen(true)}>
+                        <HugeiconsIcon icon={Key01Icon} />
+                        <span>API token</span>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </SidebarGroup>
+              <SessionList />
+            </SidebarContent>
+          </Sidebar>
 
-        <SidebarInset>
-          <header className="flex h-12 shrink-0 items-center gap-2 px-3">
-            <SidebarTrigger />
-          </header>
-          <div className="flex-1 overflow-hidden px-4">
-            <Routes>
-              {/* One route pattern serves new chats and resumes: switching
-                  between them must re-render, not remount, so an in-flight
-                  stream survives adopting its new session URL. */}
-              <Route
-                path="/sessions?/:id?"
-                element={
-                  <div className="mx-auto flex h-[calc(100dvh-3.5rem)] max-w-4xl flex-col">
-                    <Chat onNeedToken={openToken} />
-                  </div>
-                }
-              />
-              <Route path="/dashboard" element={<Dashboard />} />
-              <Route path="/memory" element={<Memory />} />
-              <Route path="/lanes" element={<Lanes />} />
-              <Route path="/library" element={<Library />} />
-              <Route path="/queues" element={<Queues />} />
-              <Route path="/settings" element={<Settings />} />
-            </Routes>
-          </div>
-          <SettingsDialog open={tokenOpen} onClose={() => setTokenOpen(false)} />
-        </SidebarInset>
-      </SidebarProvider>
+          <SidebarInset className="min-w-0">
+            <header
+              className={cn('flex h-12 shrink-0 items-center gap-2 px-3', !onChat && 'md:hidden')}
+            >
+              <SidebarTrigger />
+              <span className="text-sm font-semibold tracking-tight md:hidden">Timothy</span>
+            </header>
+            <div className="min-h-0 flex-1 overflow-hidden px-4">
+              <Routes>
+                <Route path="/" element={<Home />} />
+                {/* One route pattern serves new chats and resumes:
+                    switching between them must re-render, not remount,
+                    so an in-flight stream survives adopting its new
+                    session URL. */}
+                <Route
+                  path="/chat/:id?"
+                  element={
+                    <div className="mx-auto flex h-full max-w-4xl flex-col">
+                      <Chat onNeedToken={openToken} />
+                    </div>
+                  }
+                />
+                <Route path="/sessions/:id" element={<LegacySessionRedirect />} />
+                <Route path="/dashboard" element={<Dashboard />} />
+                <Route path="/memory" element={<Memory />} />
+                <Route path="/lanes" element={<Lanes />} />
+                <Route path="/library" element={<Library />} />
+                <Route path="/queues" element={<Queues />} />
+                <Route path="/settings" element={<Settings />} />
+              </Routes>
+            </div>
+            <SettingsDialog open={tokenOpen} onClose={() => setTokenOpen(false)} />
+          </SidebarInset>
+        </SidebarProvider>
+      </div>
     </SessionsProvider>
   )
 }

--- a/web/src/components/CategoryPicker.tsx
+++ b/web/src/components/CategoryPicker.tsx
@@ -1,6 +1,19 @@
-import { categories } from '../lib/chat'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select'
+import { ArrowDown01Icon, Tick02Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { categoryMeta, categoryOrder, type Category } from '../lib/categories'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from './ui/dropdown-menu'
 
+// CategoryPicker steers which route chain serves the next message. It
+// reads as a mode picker — Standard / Fast / Deep with plain-language
+// descriptions and a relative cost — so choosing needs no knowledge
+// of the routing table underneath.
 export function CategoryPicker({
   value,
   onChange,
@@ -8,18 +21,65 @@ export function CategoryPicker({
   value: string
   onChange: (v: string) => void
 }) {
+  const current = categoryMeta[value as Category] ?? categoryMeta.coding
+  const everyday = categoryOrder.filter((c) => !categoryMeta[c].specialized)
+  const specialized = categoryOrder.filter((c) => categoryMeta[c].specialized)
+
+  const item = (c: Category) => {
+    const meta = categoryMeta[c]
+    const selected = c === value
+    return (
+      <DropdownMenuItem
+        key={c}
+        onSelect={() => onChange(c)}
+        data-selected={selected || undefined}
+        className="items-start gap-3 rounded-lg px-2.5 py-2 data-selected:bg-zinc-100 dark:data-selected:bg-zinc-800"
+      >
+        <HugeiconsIcon icon={meta.icon} className="mt-0.5 size-4.5 shrink-0" />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium">{meta.label}</span>
+            <span className="rounded bg-zinc-100 px-1.5 py-px text-[10px] font-medium text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+              {meta.cost}
+            </span>
+            {meta.recommended && (
+              <span className="rounded bg-blue-500/10 px-1.5 py-px text-[10px] font-medium text-blue-600 dark:text-blue-400">
+                Recommended
+              </span>
+            )}
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">{meta.description}</p>
+        </div>
+        {selected && <HugeiconsIcon icon={Tick02Icon} className="mt-1 size-4 shrink-0" />}
+      </DropdownMenuItem>
+    )
+  }
+
   return (
-    <Select value={value} onValueChange={onChange}>
-      <SelectTrigger aria-label="Task category" size="sm" className="w-40">
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        {categories.map((c) => (
-          <SelectItem key={c} value={c}>
-            {c}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label="Task category"
+        className="flex h-8 items-center gap-1.5 rounded-full border border-zinc-950/10 px-3 text-sm text-zinc-700 transition hover:bg-zinc-100 dark:border-white/10 dark:text-zinc-200 dark:hover:bg-zinc-700/50"
+      >
+        <HugeiconsIcon icon={current.icon} className="size-4" />
+        <span>{current.label}</span>
+        <HugeiconsIcon icon={ArrowDown01Icon} className="size-3.5 opacity-60" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-[min(92vw,22rem)] p-1.5">
+        <DropdownMenuLabel className="px-2.5 pt-1.5">
+          <div className="text-sm font-semibold">Mode</div>
+          <p className="mt-0.5 text-xs font-normal text-muted-foreground">
+            Picks the models serving your next message. Faster modes cost less; deeper modes think
+            harder.
+          </p>
+        </DropdownMenuLabel>
+        {everyday.map(item)}
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="px-2.5 text-xs font-medium text-muted-foreground">
+          Specialized
+        </DropdownMenuLabel>
+        {specialized.map(item)}
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -1,0 +1,71 @@
+import { ArrowUp01Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useEffect, useRef } from 'react'
+import { CategoryPicker } from './CategoryPicker'
+
+// Composer is the one message box: the chat page's docked input and
+// the home page's hero input are the same component so behavior
+// (autogrow, Enter-to-send, category pill) never drifts.
+export function Composer({
+  draft,
+  onDraft,
+  onSend,
+  category,
+  onCategory,
+  disabled = false,
+  autoFocus = false,
+  placeholder = 'Message Timothy…',
+}: {
+  draft: string
+  onDraft: (v: string) => void
+  onSend: () => void
+  category: string
+  onCategory: (c: string) => void
+  disabled?: boolean
+  autoFocus?: boolean
+  placeholder?: string
+}) {
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+
+  // Auto-grow up to a cap, then scroll inside. Runs on every draft
+  // change so programmatic clears (post-send) shrink it back.
+  useEffect(() => {
+    const el = inputRef.current
+    if (!el) return
+    el.style.height = 'auto'
+    el.style.height = `${Math.min(el.scrollHeight, 200)}px`
+  }, [draft])
+
+  return (
+    <div className="rounded-2xl border border-zinc-950/10 bg-white shadow-sm transition focus-within:border-blue-500/50 focus-within:ring-4 focus-within:ring-blue-500/10 dark:border-white/10 dark:bg-zinc-800/60 dark:focus-within:border-blue-400/40">
+      <textarea
+        ref={inputRef}
+        aria-label="Message"
+        rows={1}
+        value={draft}
+        autoFocus={autoFocus}
+        placeholder={placeholder}
+        className="max-h-50 w-full resize-none bg-transparent px-4 pt-3.5 pb-1.5 text-base/6 text-zinc-900 outline-none placeholder:text-zinc-400 sm:text-sm/6 dark:text-white dark:placeholder:text-zinc-500"
+        onChange={(e) => onDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault()
+            onSend()
+          }
+        }}
+      />
+      <div className="flex items-center justify-between gap-2 px-2.5 pb-2.5">
+        <CategoryPicker value={category} onChange={onCategory} />
+        <button
+          type="button"
+          onClick={onSend}
+          aria-label="Send"
+          disabled={disabled || draft.trim() === ''}
+          className="flex size-9 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 disabled:bg-zinc-200 disabled:text-zinc-400 dark:disabled:bg-zinc-700 dark:disabled:text-zinc-500"
+        >
+          <HugeiconsIcon icon={ArrowUp01Icon} className="size-4" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -69,7 +69,7 @@ export function SessionList() {
     await updateSession(s.id, { archived: !s.archived }).catch(() => {})
     refresh()
     // Archiving the open session sends you back to a fresh chat.
-    if (!s.archived && pathname === `/sessions/${s.id}`) navigate('/')
+    if (!s.archived && pathname === `/chat/${s.id}`) navigate('/chat')
   }
 
   return (
@@ -78,8 +78,8 @@ export function SessionList() {
         <SidebarGroupContent>
           <SidebarMenu>
             <SidebarMenuItem>
-              <SidebarMenuButton asChild isActive={pathname === '/'}>
-                <Link to="/">
+              <SidebarMenuButton asChild isActive={pathname === '/chat'}>
+                <Link to="/chat">
                   <HugeiconsIcon icon={Add01Icon} />
                   <span>New chat</span>
                 </Link>
@@ -106,8 +106,8 @@ export function SessionList() {
             <SidebarMenu>
               {group.sessions.map((s) => (
                 <SidebarMenuItem key={s.id}>
-                  <SidebarMenuButton asChild isActive={pathname === `/sessions/${s.id}`}>
-                    <Link to={`/sessions/${s.id}`}>
+                  <SidebarMenuButton asChild isActive={pathname === `/chat/${s.id}`}>
+                    <Link to={`/chat/${s.id}`}>
                       <span className="truncate">{s.title || 'New session'}</span>
                       {s.archived && <Badge variant="outline">archived</Badge>}
                     </Link>

--- a/web/src/lib/categories.ts
+++ b/web/src/lib/categories.ts
@@ -1,0 +1,78 @@
+import {
+  BrainIcon,
+  Clock01Icon,
+  FlashIcon,
+  ListViewIcon,
+  Search01Icon,
+  SparklesIcon,
+} from '@hugeicons-pro/core-stroke-rounded'
+import type { categories } from './chat'
+
+export type Category = (typeof categories)[number]
+
+// The picker speaks user language (how fast / how smart / how much),
+// not routing plumbing. Values stay the real task categories the
+// server routes on — only the presentation is tiered: three everyday
+// modes up top, specialized chains behind a divider.
+export const categoryMeta: Record<
+  Category,
+  {
+    label: string
+    description: string
+    cost: string
+    icon: typeof BrainIcon
+    recommended?: boolean
+    specialized?: boolean
+  }
+> = {
+  coding: {
+    label: 'Standard',
+    description: 'Everyday questions and code on a strong all-round model. Balanced quality and cost.',
+    cost: '2x',
+    icon: SparklesIcon,
+    recommended: true,
+  },
+  mini: {
+    label: 'Fast',
+    description: 'Quick answers and small tasks on the cheapest capable model.',
+    cost: '1x',
+    icon: FlashIcon,
+  },
+  reasoning: {
+    label: 'Deep',
+    description: 'Hard multi-step problems on the strongest chain. Slowest and priciest.',
+    cost: '3x',
+    icon: BrainIcon,
+  },
+  research: {
+    label: 'Research',
+    description: 'Consults tools and sources before answering, never from memory alone.',
+    cost: '3x',
+    icon: Search01Icon,
+    specialized: true,
+  },
+  summarize: {
+    label: 'Summarize',
+    description: 'Condense long content faithfully on a cheap chain.',
+    cost: '1x',
+    icon: ListViewIcon,
+    specialized: true,
+  },
+  realtime: {
+    label: 'Realtime',
+    description: 'Snappy back-and-forth where latency beats depth.',
+    cost: '1x',
+    icon: Clock01Icon,
+    specialized: true,
+  },
+}
+
+// Picker display order: everyday tiers first, specialized after.
+export const categoryOrder: Category[] = [
+  'coding',
+  'mini',
+  'reasoning',
+  'research',
+  'summarize',
+  'realtime',
+]

--- a/web/src/lib/memory.ts
+++ b/web/src/lib/memory.ts
@@ -1,3 +1,6 @@
+import { useEffect, useState } from 'react'
+import { listMemories } from '../api/client'
+
 // memoryChangedEvent links the Memory page to the sidebar badge
 // without a shared provider: queue actions dispatch, the badge
 // listens.
@@ -5,4 +8,27 @@ export const memoryChangedEvent = 'timothy:memory-changed'
 
 export function notifyMemoryChanged() {
   window.dispatchEvent(new Event(memoryChangedEvent))
+}
+
+// usePendingMemories keeps badges current: initial fetch, a slow
+// poll, and an instant refresh when the Memory page acts.
+export function usePendingMemories(): number {
+  const [count, setCount] = useState(0)
+  useEffect(() => {
+    let live = true
+    const refresh = () => {
+      listMemories('pending')
+        .then((pending) => live && setCount(pending.length))
+        .catch(() => {})
+    }
+    refresh()
+    const timer = setInterval(refresh, 60_000)
+    window.addEventListener(memoryChangedEvent, refresh)
+    return () => {
+      live = false
+      clearInterval(timer)
+      window.removeEventListener(memoryChangedEvent, refresh)
+    }
+  }, [])
+  return count
 }

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -1,10 +1,8 @@
-import { ArrowUp01Icon } from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useRef, useState } from 'react'
-import { useNavigate, useParams } from 'react-router'
+import { useLocation, useNavigate, useParams } from 'react-router'
 import { answerPermission, ChatError, chatStream, getTranscript } from '../api/client'
 import type { ChatEvent } from '../api/types'
-import { CategoryPicker } from '../components/CategoryPicker'
+import { Composer } from '../components/Composer'
 import {
   AssistantMessage,
   CompactionDivider,
@@ -22,12 +20,14 @@ import {
 } from '../lib/chat'
 import { useSessions } from '../lib/sessions'
 import { fromTranscript, type ChatItem } from '../lib/transcript'
+import type { ChatIntent } from './Home'
 
 const categoryKey = 'timothy.category'
 
 export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
   const { id: routeSession } = useParams()
   const navigate = useNavigate()
+  const location = useLocation()
   const { refresh } = useSessions()
   const [items, setItems] = useState<ChatItem[]>([])
   const [draft, setDraft] = useState('')
@@ -40,8 +40,8 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
   // Session ids this page itself adopted mid-stream (via navigate):
   // the resume effect must not clobber the live stream with a replay.
   const adoptedRef = useRef<string | null>(null)
+  const intentConsumedRef = useRef(false)
   const bottomRef = useRef<HTMLDivElement>(null)
-  const inputRef = useRef<HTMLTextAreaElement>(null)
   const abortRef = useRef<AbortController | null>(null)
 
   // Cancel any in-flight stream when the page unmounts (route change).
@@ -86,14 +86,6 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
     }
   }, [routeSession, onNeedToken])
 
-  // Auto-grow the composer up to a cap, then scroll inside it.
-  const autogrow = () => {
-    const el = inputRef.current
-    if (!el) return
-    el.style.height = 'auto'
-    el.style.height = `${Math.min(el.scrollHeight, 200)}px`
-  }
-
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [items])
@@ -112,11 +104,10 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
       return next
     })
 
-  const send = async () => {
-    const message = draft.trim()
+  const sendMessage = async (text: string, cat: string) => {
+    const message = text.trim()
     if (!message || streaming) return
     setDraft('')
-    requestAnimationFrame(autogrow)
     setStreaming(true)
     setItems((prev) => [
       ...prev,
@@ -130,13 +121,13 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
       if (sessionRef.current === id) return
       sessionRef.current = id
       adoptedRef.current = id
-      // Same route pattern serves / and /sessions/:id, so this only
+      // Same route pattern serves /chat and /chat/:id, so this only
       // re-renders — the live stream keeps its component state.
-      navigate(`/sessions/${id}`, { replace: true })
+      navigate(`/chat/${id}`, { replace: true })
     }
     try {
       await chatStream(
-        { session_id: sessionRef.current, message, task_category: category },
+        { session_id: sessionRef.current, message, task_category: cat },
         (ev: ChatEvent) => {
           if (ev.type === 'meta') adoptSession(ev.session_id)
           updateLast((m) => applyEvent(m, ev))
@@ -165,6 +156,25 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
       }
     }
   }
+
+  const send = () => void sendMessage(draft, category)
+
+  // Consume a home-screen intent exactly once: `send` fires the
+  // message immediately, `draft` prefills the composer.
+  useEffect(() => {
+    if (intentConsumedRef.current) return
+    const intent = location.state as ChatIntent | null
+    if (!intent || (!intent.send && !intent.draft && !intent.category)) return
+    intentConsumedRef.current = true
+    window.history.replaceState(null, '') // don't refire on back/refresh
+    const cat = intent.category ?? category
+    if (intent.category) pickCategory(intent.category)
+    if (intent.send) void sendMessage(intent.send, cat)
+    else if (intent.draft) setDraft(intent.draft)
+    // Mount-time only by design: the intent rides the navigation that
+    // created this page instance; the ref guards strict-mode replays.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // The permission modal shows the oldest unanswered prompt of the
   // live turn; answering posts the decision and drops it locally.
@@ -218,40 +228,17 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
         className="pb-3"
         onSubmit={(e) => {
           e.preventDefault()
-          void send()
+          send()
         }}
       >
-        <div className="rounded-2xl border border-zinc-950/10 bg-white shadow-sm transition focus-within:border-blue-500/50 focus-within:ring-4 focus-within:ring-blue-500/10 dark:border-white/10 dark:bg-zinc-800/60 dark:focus-within:border-blue-400/40">
-          <textarea
-            ref={inputRef}
-            aria-label="Message"
-            rows={1}
-            value={draft}
-            placeholder="Message Timothy…"
-            className="max-h-50 w-full resize-none bg-transparent px-4 pt-3.5 pb-1.5 text-base/6 text-zinc-900 outline-none placeholder:text-zinc-400 sm:text-sm/6 dark:text-white dark:placeholder:text-zinc-500"
-            onChange={(e) => {
-              setDraft(e.target.value)
-              autogrow()
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault()
-                void send()
-              }
-            }}
-          />
-          <div className="flex items-center justify-between gap-2 px-2.5 pb-2.5">
-            <CategoryPicker value={category} onChange={pickCategory} />
-            <button
-              type="submit"
-              aria-label="Send"
-              disabled={streaming || draft.trim() === ''}
-              className="flex size-9 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 disabled:bg-zinc-200 disabled:text-zinc-400 dark:disabled:bg-zinc-700 dark:disabled:text-zinc-500"
-            >
-              <HugeiconsIcon icon={ArrowUp01Icon} className="size-4" />
-            </button>
-          </div>
-        </div>
+        <Composer
+          draft={draft}
+          onDraft={setDraft}
+          onSend={send}
+          category={category}
+          onCategory={pickCategory}
+          disabled={streaming}
+        />
         <p className="mt-2 text-center text-xs text-zinc-400 dark:text-zinc-500">
           Enter to send · Shift+Enter for a new line
         </p>

--- a/web/src/pages/Home.test.tsx
+++ b/web/src/pages/Home.test.tsx
@@ -1,0 +1,81 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ChatIntent } from './Home'
+import { Home } from './Home'
+
+vi.mock('../api/client', () => ({
+  listMemories: vi.fn(),
+}))
+
+import { listMemories } from '../api/client'
+
+let landed: { pathname: string; state: ChatIntent | null } | null = null
+
+function ChatProbe() {
+  const location = useLocation()
+  landed = { pathname: location.pathname, state: location.state as ChatIntent | null }
+  return <div>chat page</div>
+}
+
+function renderHome() {
+  return render(
+    <MemoryRouter initialEntries={['/']}>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/chat" element={<ChatProbe />} />
+        <Route path="/memory" element={<div>memory page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  landed = null
+  vi.clearAllMocks()
+  vi.mocked(listMemories).mockResolvedValue([])
+  localStorage.clear()
+})
+
+describe('Home', () => {
+  it('shows the capability groups', () => {
+    renderHome()
+    for (const title of ['Chat', 'Memory', 'Tools', 'Workspace']) {
+      expect(screen.getByRole('heading', { name: title })).toBeTruthy()
+    }
+    expect(screen.getByRole('button', { name: /New chat/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Calculator/ })).toBeTruthy()
+  })
+
+  it('submitting the composer starts a chat with the message', () => {
+    renderHome()
+    const input = screen.getByLabelText('Message')
+    fireEvent.change(input, { target: { value: 'hello there' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(landed?.pathname).toBe('/chat')
+    expect(landed?.state?.send).toBe('hello there')
+    expect(landed?.state?.category).toBeTruthy()
+  })
+
+  it('an empty composer does not navigate', () => {
+    renderHome()
+    const input = screen.getByLabelText('Message')
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(landed).toBeNull()
+  })
+
+  it('tool tiles carry a prefill or send intent into chat', () => {
+    renderHome()
+    fireEvent.click(screen.getByRole('button', { name: /Web fetch/ }))
+    expect(landed?.pathname).toBe('/chat')
+    expect(landed?.state?.draft).toContain('Fetch')
+    expect(landed?.state?.send).toBeUndefined()
+  })
+
+  it('memory tiles navigate to the memory page', () => {
+    renderHome()
+    fireEvent.click(screen.getByRole('button', { name: /Queue/ }))
+    expect(screen.getByText('memory page')).toBeTruthy()
+  })
+})

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,0 +1,178 @@
+import {
+  Analytics01Icon,
+  Brain02Icon,
+  BubbleChatIcon,
+  CalculatorIcon,
+  Clock01Icon,
+  CommandLineIcon,
+  GlobeIcon,
+  Image01Icon,
+  InboxIcon,
+  Layers01Icon,
+  PencilEdit01Icon,
+} from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useState } from 'react'
+import { useNavigate } from 'react-router'
+import { Composer } from '../components/Composer'
+import { categories } from '../lib/chat'
+import { usePendingMemories } from '../lib/memory'
+
+const categoryKey = 'timothy.category'
+
+// ChatIntent carries a home-screen action into the chat page: `send`
+// fires immediately, `draft` only prefills the composer.
+export interface ChatIntent {
+  send?: string
+  draft?: string
+  category?: string
+}
+
+interface Tile {
+  label: string
+  icon: typeof BubbleChatIcon
+  to?: string
+  intent?: ChatIntent
+  badge?: number
+  soon?: boolean
+}
+
+// Home is the workspace launcher: a hero composer that starts a chat,
+// and the capability map — only what exists today, stubs say so.
+export function Home() {
+  const navigate = useNavigate()
+  const pending = usePendingMemories()
+  const [draft, setDraft] = useState('')
+  const [category, setCategory] = useState(
+    () => localStorage.getItem(categoryKey) ?? categories[0],
+  )
+
+  const pickCategory = (c: string) => {
+    setCategory(c)
+    localStorage.setItem(categoryKey, c)
+  }
+
+  const send = () => {
+    const message = draft.trim()
+    if (!message) return
+    navigate('/chat', { state: { send: message, category } satisfies ChatIntent })
+  }
+
+  const groups: { title: string; tiles: Tile[] }[] = [
+    {
+      title: 'Chat',
+      tiles: [{ label: 'New chat', icon: BubbleChatIcon, to: '/chat' }],
+    },
+    {
+      title: 'Memory',
+      tiles: [
+        { label: 'Queue', icon: InboxIcon, to: '/memory', badge: pending },
+        { label: 'Browse', icon: Brain02Icon, to: '/memory' },
+      ],
+    },
+    {
+      title: 'Tools',
+      tiles: [
+        {
+          label: 'Time',
+          icon: Clock01Icon,
+          intent: { send: 'What time is it in Nairobi right now?', category: 'mini' },
+        },
+        {
+          label: 'Calculator',
+          icon: CalculatorIcon,
+          intent: { send: "What's 19 × 23 − 47?", category: 'mini' },
+        },
+        {
+          label: 'Web fetch',
+          icon: GlobeIcon,
+          intent: {
+            draft: 'Fetch https://example.com and summarize what it says.',
+            category: 'research',
+          },
+        },
+        {
+          label: 'Shell',
+          icon: CommandLineIcon,
+          intent: {
+            draft: 'List the files in the workspace and describe what is there.',
+            category: 'coding',
+          },
+        },
+        {
+          label: 'Remember',
+          icon: PencilEdit01Icon,
+          intent: { draft: 'Please remember that ', category: 'mini' },
+        },
+      ],
+    },
+    {
+      title: 'Workspace',
+      tiles: [
+        { label: 'Dashboard', icon: Analytics01Icon, to: '/dashboard' },
+        { label: 'Lanes', icon: Layers01Icon, to: '/lanes', soon: true },
+        { label: 'Library', icon: Image01Icon, to: '/library', soon: true },
+      ],
+    },
+  ]
+
+  const open = (tile: Tile) => {
+    if (tile.intent) navigate('/chat', { state: tile.intent })
+    else if (tile.to) navigate(tile.to)
+  }
+
+  return (
+    <div className="flex h-full flex-col items-center overflow-y-auto px-4">
+      <div className="mt-[max(3rem,14vh)] w-full max-w-2xl text-center">
+        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Timothy</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Ask anything. Chats remember what matters.
+        </p>
+        <div className="mt-8 text-left">
+          <Composer
+            draft={draft}
+            onDraft={setDraft}
+            onSend={send}
+            category={category}
+            onCategory={pickCategory}
+            autoFocus
+            placeholder="Ask anything…"
+          />
+        </div>
+      </div>
+
+      <div className="mt-14 mb-10 flex w-full max-w-5xl flex-col gap-10 lg:flex-row lg:justify-center lg:gap-0 lg:divide-x lg:divide-border">
+        {groups.map((group) => (
+          <section key={group.title} className="lg:px-10 lg:first:pl-0 lg:last:pr-0">
+            <h2 className="text-center text-xs font-medium tracking-wider text-muted-foreground uppercase">
+              {group.title}
+            </h2>
+            <div className="mt-5 flex flex-wrap justify-center gap-x-8 gap-y-6">
+              {group.tiles.map((tile) => (
+                <button
+                  key={tile.label}
+                  type="button"
+                  onClick={() => open(tile)}
+                  className="group flex w-16 flex-col items-center gap-2"
+                >
+                  <span className="relative flex size-11 items-center justify-center rounded-xl border border-transparent text-zinc-600 transition group-hover:border-border group-hover:bg-zinc-100 dark:text-zinc-300 dark:group-hover:bg-zinc-800">
+                    <HugeiconsIcon icon={tile.icon} className="size-5.5" />
+                    {tile.badge != null && tile.badge > 0 && (
+                      <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-600 px-1 text-[10px] font-medium text-white">
+                        {tile.badge}
+                      </span>
+                    )}
+                  </span>
+                  <span className="text-xs text-zinc-600 dark:text-zinc-300">
+                    {tile.label}
+                    {tile.soon && <span className="block text-[10px] text-zinc-400">soon</span>}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Icon rail** (desktop): slim navigation column — new chat, Home, Chat, Memory (pending-count badge), Dashboard, More flyout for the stub surfaces, theme/token pinned at the bottom.
- **Home launcher** at `/`: hero composer that starts a chat straight into streaming, and a capability grid grouped by what actually exists today — Chat, Memory (queue badge), Tools (tiles fire or prefill real tool prompts), Workspace (stubs marked "soon").
- **Tiered mode picker** replaces the raw category dropdown: Standard (recommended) / Fast / Deep with plain-language descriptions and relative cost chips, specialized chains (Research, Summarize, Realtime) behind a divider. Values map to the unchanged server routing categories.
- **Routing**: chat lives at `/chat/:id?` (one pattern for new + resume so mid-stream URL adoption re-renders instead of remounting); legacy `/sessions/{id}` links redirect.
- **Responsive**: rail hides below `md`; a single sheet carries nav + theme + token + session list on mobile; the home grid stacks; the composer is one shared component on both pages.

## Test plan

- `npm run build`, lint (0 warnings), 53 tests green — new Home suite covers capability groups, composer submit → chat intent, empty-submit guard, tool-tile prefill, memory navigation.
- Verified in the browser on desktop and narrow viewport (rail/sheet swap, grid stacking, picker width clamp).