### PR TITLE
feat: surface skill personas on the home launcher

### DIFF
--- a/web/src/pages/Home.test.tsx
+++ b/web/src/pages/Home.test.tsx
@@ -41,11 +41,11 @@ beforeEach(() => {
 describe('Home', () => {
   it('shows the capability groups', () => {
     renderHome()
-    for (const title of ['Chat', 'Memory', 'Tools', 'Workspace']) {
+    for (const title of ['Chat', 'Memory', 'Skills', 'Workspace']) {
       expect(screen.getByRole('heading', { name: title })).toBeTruthy()
     }
     expect(screen.getByRole('button', { name: /New chat/ })).toBeTruthy()
-    expect(screen.getByRole('button', { name: /Calculator/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Markets/ })).toBeTruthy()
   })
 
   it('submitting the composer starts a chat with the message', () => {
@@ -65,11 +65,11 @@ describe('Home', () => {
     expect(landed).toBeNull()
   })
 
-  it('tool tiles carry a prefill or send intent into chat', () => {
+  it('skill tiles carry a prefill intent into chat', () => {
     renderHome()
-    fireEvent.click(screen.getByRole('button', { name: /Web fetch/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Travel/ }))
     expect(landed?.pathname).toBe('/chat')
-    expect(landed?.state?.draft).toContain('Fetch')
+    expect(landed?.state?.draft).toContain('travel-planning skill')
     expect(landed?.state?.send).toBeUndefined()
   })
 

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,15 +1,14 @@
 import {
+  AirplaneTakeOff01Icon,
   Analytics01Icon,
   Brain02Icon,
   BubbleChatIcon,
-  CalculatorIcon,
-  Clock01Icon,
-  CommandLineIcon,
-  GlobeIcon,
+  ChartLineData01Icon,
+  CodeIcon,
   Image01Icon,
   InboxIcon,
   Layers01Icon,
-  PencilEdit01Icon,
+  SearchList01Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useState } from 'react'
@@ -71,38 +70,41 @@ export function Home() {
       ],
     },
     {
-      title: 'Tools',
+      // Skill packs are prompt-focused personas the agent loads on
+      // demand; each tile opens a chat pre-aimed at one of them.
+      title: 'Skills',
       tiles: [
         {
-          label: 'Time',
-          icon: Clock01Icon,
-          intent: { send: 'What time is it in Nairobi right now?', category: 'mini' },
-        },
-        {
-          label: 'Calculator',
-          icon: CalculatorIcon,
-          intent: { send: "What's 19 × 23 − 47?", category: 'mini' },
-        },
-        {
-          label: 'Web fetch',
-          icon: GlobeIcon,
+          label: 'Research',
+          icon: SearchList01Icon,
           intent: {
-            draft: 'Fetch https://example.com and summarize what it says.',
+            draft: 'Use the research-brief skill. Question: ',
             category: 'research',
           },
         },
         {
-          label: 'Shell',
-          icon: CommandLineIcon,
+          label: 'Markets',
+          icon: ChartLineData01Icon,
           intent: {
-            draft: 'List the files in the workspace and describe what is there.',
-            category: 'coding',
+            draft: 'Use the markets-digest skill. My watchlist: ',
+            category: 'research',
           },
         },
         {
-          label: 'Remember',
-          icon: PencilEdit01Icon,
-          intent: { draft: 'Please remember that ', category: 'mini' },
+          label: 'Travel',
+          icon: AirplaneTakeOff01Icon,
+          intent: {
+            draft: 'Use the travel-planning skill. Trip: ',
+            category: 'research',
+          },
+        },
+        {
+          label: 'Coding',
+          icon: CodeIcon,
+          intent: {
+            draft: 'Use the coding-task skill. Task: ',
+            category: 'coding',
+          },
         },
       ],
     },


### PR DESCRIPTION
## Summary

Replaces the home launcher's demo tool tiles (time, calculator, web fetch, shell, remember) with the four skill packs — Research, Markets, Travel, Coding. Each tile opens a chat prefilled with a prompt aimed at that skill, so the agent loads the pack on demand; category defaults to the chain that fits (research/coding).

## Test plan

- Build + lint clean; 53 web tests green (Home suite updated: Skills group heading, Markets tile presence, Travel tile prefill intent).