### PR TITLE
Deterministic skill selection + load_skill redaction

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -138,7 +138,7 @@ func main() {
 	go runOutputGC(ctx, outputs, app.Log)
 
 	svc := chat.New(turnRouter{agent: agent, gw: gwc, flags: flags}, store, distill,
-		gatedCompactor{inner: compactor, flags: flags}, budget, skills.Index(packs), app.Log)
+		gatedCompactor{inner: compactor, flags: flags}, budget, packs, app.Log)
 	svc.SetMemoryExtract(func(ctx context.Context, sessionID string, seq int64, text string) {
 		if !flags.Enabled(ctx, settings.KeyMemoryExtraction) {
 			return

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -147,7 +147,7 @@ func testAPI(t *testing.T, token string, events []stream.StreamEvent) (*API, *me
 	t.Helper()
 	dir := newMemDir()
 	gw := &fakeGateway{events: events}
-	svc := chat.New(gw, dir, nil, nil, 60_000, "", discard())
+	svc := chat.New(gw, dir, nil, nil, 60_000, nil, discard())
 	return &API{svc: svc, dir: dir, token: token, log: discard()}, dir, gw
 }
 
@@ -501,7 +501,7 @@ func TestChatErrorCarriesSessionID(t *testing.T) {
 	id, _ := dir.Create(t.Context(), "t")
 	// gateway with error
 	gw := &fakeGateway{err: context.DeadlineExceeded}
-	a.svc = chat.New(gw, dir, nil, nil, 60_000, "", discard())
+	a.svc = chat.New(gw, dir, nil, nil, 60_000, nil, discard())
 
 	w := doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages", `{"message":"hi"}`)
 	if w.Code != http.StatusBadGateway {

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
 	"github.com/SumonMSelim/timothy/internal/brain/session"
+	"github.com/SumonMSelim/timothy/internal/brain/skills"
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 )
@@ -78,16 +79,17 @@ type MemoryRetrieve func(ctx context.Context, sessionID, query string) string
 
 // Service orchestrates turns against the event store.
 type Service struct {
-	gw         Gateway
-	log        SessionLog
-	distill    Distill
-	compactor  Compactor
-	memory     MemoryExtract  // nil: long-term memory off
-	recall     MemoryRetrieve // nil: no memory injection
-	budget     int
-	system     string
-	flushEvery time.Duration // pending-state flush cadence mid-stream
-	logger     *slog.Logger
+	gw          Gateway
+	log         SessionLog
+	distill     Distill
+	compactor   Compactor
+	memory      MemoryExtract  // nil: long-term memory off
+	recall      MemoryRetrieve // nil: no memory injection
+	budget      int
+	system      string
+	skillBodies map[string]string // name -> full pack body, for skill_hint
+	flushEvery  time.Duration     // pending-state flush cadence mid-stream
+	logger      *slog.Logger
 }
 
 // SetMemoryExtract wires the memoryd hook. Optional — nil leaves
@@ -97,14 +99,20 @@ func (s *Service) SetMemoryExtract(fn MemoryExtract) { s.memory = fn }
 // SetMemoryRetrieve wires per-turn memory recall. Optional.
 func (s *Service) SetMemoryRetrieve(fn MemoryRetrieve) { s.recall = fn }
 
-// New builds the service. skillsIndex is the one-line-per-skill
-// section appended to the system prompt (empty = no skills).
-func New(gw Gateway, log SessionLog, distill Distill, compactor Compactor, budget int, skillsIndex string, logger *slog.Logger) *Service {
+// New builds the service. packs are the loaded skill definitions: their
+// one-line index goes into the system prompt, and their bodies back
+// skill_hint (nil/empty = no skills).
+func New(gw Gateway, log SessionLog, distill Distill, compactor Compactor, budget int, packs []skills.Skill, logger *slog.Logger) *Service {
 	logger.Info("chat service ready", "system_prompt_version", systemPromptVersion, "token_budget", budget)
+	bodies := make(map[string]string, len(packs))
+	for _, p := range packs {
+		bodies[p.Name] = p.Body
+	}
 	return &Service{
 		gw: gw, log: log, distill: distill, compactor: compactor, budget: budget,
-		system:     assembleSystem(skillsIndex),
-		flushEvery: 2 * time.Second, logger: logger,
+		system:      assembleSystem(skills.Index(packs)),
+		skillBodies: bodies,
+		flushEvery:  2 * time.Second, logger: logger,
 	}
 }
 
@@ -114,6 +122,12 @@ type Request struct {
 	Message      string `json:"message"`
 	TaskCategory string `json:"task_category,omitempty"`
 	ModelHint    string `json:"model_hint,omitempty"`
+	// SkillHint names a skill pack to force-load for this turn — set
+	// when the user picked one explicitly (a UI chip, not parsed
+	// text). Unlike load_skill, this is not a choice the model can
+	// skip: the pack's body is in the system prompt before the first
+	// token streams.
+	SkillHint string `json:"skill_hint,omitempty"`
 }
 
 // Chat streams one turn. The user message is durably appended before
@@ -123,6 +137,14 @@ type Request struct {
 func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.StreamEvent, error) {
 	if strings.TrimSpace(req.Message) == "" {
 		return "", nil, fmt.Errorf("chat: %w: message is required", ErrBadRequest)
+	}
+	var skillBody string
+	if req.SkillHint != "" {
+		body, ok := s.skillBodies[req.SkillHint]
+		if !ok {
+			return "", nil, fmt.Errorf("chat: %w: unknown skill %q", ErrBadRequest, req.SkillHint)
+		}
+		skillBody = body
 	}
 	category := req.TaskCategory
 	if category == "" {
@@ -170,11 +192,17 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 		return sessionID, nil, err
 	}
 
-	// Retrieved memory rides the system prompt's TAIL: the stable
-	// prefix stays byte-identical for provider prompt caches (D-018)
-	// while the per-turn block varies after it. The block is fenced
-	// DATA, never instructions (D-011 poisoning defense).
+	// Retrieved memory and a hinted skill both ride the system
+	// prompt's TAIL: the stable prefix stays byte-identical for
+	// provider prompt caches (D-018) while the per-turn additions vary
+	// after it. The memory block is fenced DATA, never instructions
+	// (D-011 poisoning defense); the skill body is instructions the
+	// user explicitly selected, deterministically loaded rather than
+	// left to the model's load_skill judgment.
 	system := s.system
+	if skillBody != "" {
+		system += "\n\n# Skill: " + req.SkillHint + "\n\n" + skillBody
+	}
 	if s.recall != nil {
 		if block := s.recall(ctx, sessionID, req.Message); block != "" {
 			system += "\n\n" + block

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
 	"github.com/SumonMSelim/timothy/internal/brain/session"
+	"github.com/SumonMSelim/timothy/internal/brain/skills"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 )
 
@@ -140,7 +141,7 @@ func okEvents(text string) []stream.StreamEvent {
 }
 
 func newService(gw Gateway, log SessionLog) *Service {
-	return New(gw, log, nil, nil, 60_000, "", discard())
+	return New(gw, log, nil, nil, 60_000, nil, discard())
 }
 
 func drain(t *testing.T, ch <-chan stream.StreamEvent) []stream.StreamEvent {
@@ -328,6 +329,43 @@ func TestChatValidatesMessage(t *testing.T) {
 	}
 }
 
+// TestChatSkillHintInjectsBodyDeterministically proves skill_hint does
+// not depend on the model choosing to call load_skill: the pack body
+// lands in the system prompt sent to the provider before any tokens
+// stream, on the very first request.
+func TestChatSkillHintInjectsBodyDeterministically(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGW{events: okEvents("planned")}
+	s := New(gw, newFakeLog(), nil, nil, 60_000, []skills.Skill{
+		{Name: "travel-planning", Description: "Use when planning a trip", Body: "Ask about dates, budget, destination."},
+	}, discard())
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "Tokyo, 5 days", SkillHint: "travel-planning"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	// The first request is the chat turn itself; a first-exchange
+	// autoTitle call may follow on its own goroutine, so index by
+	// position rather than "last".
+	gw.mu.Lock()
+	sys := gw.requests[0].System
+	gw.mu.Unlock()
+	if !strings.Contains(sys, "travel-planning") || !strings.Contains(sys, "Ask about dates, budget, destination.") {
+		t.Fatalf("system prompt missing the hinted skill body:\n%s", sys)
+	}
+}
+
+func TestChatSkillHintRefusesUnknownSkill(t *testing.T) {
+	t.Parallel()
+	s := newService(&fakeGW{}, newFakeLog())
+	_, _, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "hi", SkillHint: "no-such-skill"})
+	if err == nil {
+		t.Fatal("unknown skill_hint accepted")
+	}
+}
+
 // orderCompactor records whether compaction ran before the provider
 // call: the pre-send guarantee.
 type orderCompactor struct {
@@ -364,7 +402,7 @@ func TestChatCompactsBeforeSend(t *testing.T) {
 	log := newFakeLog()
 	order := &orderCompactor{}
 	gw := &gwAfterCompact{fakeGW: &fakeGW{events: okEvents("hi")}, order: order}
-	svc := New(gw, log, nil, order, 60_000, "", discard())
+	svc := New(gw, log, nil, order, 60_000, nil, discard())
 
 	_, ch, err := svc.Chat(t.Context(), Request{Message: "hello"})
 	if err != nil {
@@ -413,7 +451,7 @@ func TestChatSendsCompactedContext(t *testing.T) {
 	}
 
 	gw := &fakeGW{events: okEvents("fresh reply")}
-	svc := New(gw, log, nil, &compactingLog{log: log}, 60_000, "", discard())
+	svc := New(gw, log, nil, &compactingLog{log: log}, 60_000, nil, discard())
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "new question"})
 	if err != nil {
@@ -456,7 +494,7 @@ func TestFollowUpSeesCompletedTurnWhileDistillRuns(t *testing.T) {
 		return &session.TurnMemory{KeyFindings: []string{"late residue"}}
 	}
 	defer close(distillRelease)
-	svc := New(gw, log, distill, nil, 60_000, "", discard())
+	svc := New(gw, log, distill, nil, 60_000, nil, discard())
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "first question"})
 	if err != nil {
@@ -506,7 +544,7 @@ func TestMemoryExtractGetsUserTextAndResidue(t *testing.T) {
 	distill := func(context.Context, string, string) *session.TurnMemory {
 		return &session.TurnMemory{KeyFindings: []string{"user moved to Porto"}}
 	}
-	svc := New(gw, log, distill, nil, 60_000, "", discard())
+	svc := New(gw, log, distill, nil, 60_000, nil, discard())
 
 	type call struct {
 		sessionID string

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -301,9 +301,17 @@ func (a *Agent) executeOne(ctx context.Context, sessionID string, call provider.
 	}
 
 	duration := time.Since(start)
-	digest := content
-	if len(digest) > 1000 {
-		digest = digest[:1000] + "…"
+	// load_skill's result is the pack's full rule text — useful to the
+	// model, never to the client. Every other tool's result is fair to
+	// show (truncated) in the audit trail and the UI.
+	var digest string
+	if call.Name == "load_skill" {
+		digest = "skill loaded"
+	} else {
+		digest = content
+		if len(digest) > 1000 {
+			digest = digest[:1000] + "…"
+		}
 	}
 
 	// Bookkeeping uses a detached context: a client disconnect must

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -508,6 +508,54 @@ func TestAgentRetrieveOutputBetweenThresholdAndCap(t *testing.T) {
 	}
 }
 
+// TestAgentRedactsLoadSkillDigest proves the skill pack's rule text
+// never reaches the client — not in the live SSE tool_result event,
+// not in what gets persisted for later replay. The model still gets
+// the real content via the returned tool result.
+func TestAgentRedactsLoadSkillDigest(t *testing.T) {
+	t.Parallel()
+	loadSkill := &tools.Tool{
+		Name:        "load_skill",
+		Description: "stands in for the real load_skill tool",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}},"required":["name"],"additionalProperties":false}`),
+		Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+			return "# Skill: travel-planning\n\nSecret internal rule text.", nil
+		},
+	}
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"load_skill", `{"name":"travel-planning"}`}),
+		finalStep("done"),
+	}}
+	a, _, _, _ := testAgent(t, gw, loadSkill)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", TaskCategory: "coding", Messages: []provider.Message{{Role: "user", Content: "load the travel skill"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := collect(t, ch)
+
+	for _, ev := range events {
+		if ev.Type == stream.EventToolResult && ev.ToolResult != nil {
+			if strings.Contains(ev.ToolResult.Digest, "Secret internal rule text") {
+				t.Fatalf("skill body leaked into the live tool_result digest: %q", ev.ToolResult.Digest)
+			}
+		}
+	}
+
+	// The model itself must still see the real content — the redaction
+	// is client-facing only.
+	second := gw.requests[1]
+	var sawRealContent bool
+	for _, m := range second.Messages {
+		if m.ToolResult != nil && strings.Contains(m.ToolResult.Content, "Secret internal rule text") {
+			sawRealContent = true
+		}
+	}
+	if !sawRealContent {
+		t.Fatal("model did not receive the real skill body")
+	}
+}
+
 func TestAgentPermissionDenyBecomesFeedback(t *testing.T) {
 	t.Parallel()
 	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -70,6 +70,7 @@ export interface ChatRequest {
   message: string
   task_category?: string
   model_hint?: string
+  skill_hint?: string
 }
 
 // --- session management (mirrors brain's /v1/sessions surface) ---

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -1,6 +1,7 @@
-import { ArrowUp01Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { ArrowUp01Icon, Cancel01Icon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useRef } from 'react'
+import { skillLabels } from '../lib/skills'
 import { CategoryPicker } from './CategoryPicker'
 
 // Composer is the one message box: the chat page's docked input and
@@ -12,6 +13,8 @@ export function Composer({
   onSend,
   category,
   onCategory,
+  skillHint,
+  onRemoveSkillHint,
   disabled = false,
   autoFocus = false,
   placeholder = 'Message Timothy…',
@@ -21,6 +24,8 @@ export function Composer({
   onSend: () => void
   category: string
   onCategory: (c: string) => void
+  skillHint?: string
+  onRemoveSkillHint?: () => void
   disabled?: boolean
   autoFocus?: boolean
   placeholder?: string
@@ -38,6 +43,23 @@ export function Composer({
 
   return (
     <div className="rounded-2xl border border-zinc-950/10 bg-white shadow-sm transition focus-within:border-blue-500/50 focus-within:ring-4 focus-within:ring-blue-500/10 dark:border-white/10 dark:bg-zinc-800/60 dark:focus-within:border-blue-400/40">
+      {skillHint && (
+        <div className="flex items-center gap-1 px-3 pt-2.5">
+          <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 py-1 pr-1.5 pl-2.5 text-xs font-medium text-blue-700 dark:bg-blue-500/10 dark:text-blue-300">
+            {skillLabels[skillHint] ?? skillHint}
+            {onRemoveSkillHint && (
+              <button
+                type="button"
+                onClick={onRemoveSkillHint}
+                aria-label={`Remove ${skillLabels[skillHint] ?? skillHint} skill`}
+                className="flex size-4 items-center justify-center rounded-full text-blue-700/70 hover:bg-blue-100 hover:text-blue-900 dark:text-blue-300/70 dark:hover:bg-blue-500/20 dark:hover:text-blue-100"
+              >
+                <HugeiconsIcon icon={Cancel01Icon} className="size-3" />
+              </button>
+            )}
+          </span>
+        </div>
+      )}
       <textarea
         ref={inputRef}
         aria-label="Message"

--- a/web/src/lib/skills.ts
+++ b/web/src/lib/skills.ts
@@ -1,0 +1,8 @@
+// skillLabels maps a skill's slug (the name the backend and skill_hint
+// both use) to the display text the chip shows.
+export const skillLabels: Record<string, string> = {
+  'research-brief': 'Research brief',
+  'markets-digest': 'Markets digest',
+  'travel-planning': 'Travel planning',
+  'coding-task': 'Coding task',
+}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -34,6 +34,9 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
   const [category, setCategory] = useState(
     () => localStorage.getItem(categoryKey) ?? categories[0],
   )
+  // A skill picked from the home screen: pinned, not text the user
+  // can accidentally mangle. Rides every turn until removed.
+  const [skillHint, setSkillHint] = useState<string | undefined>(undefined)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [streaming, setStreaming] = useState(false)
   const sessionRef = useRef<string | undefined>(routeSession)
@@ -104,7 +107,7 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
       return next
     })
 
-  const sendMessage = async (text: string, cat: string) => {
+  const sendMessage = async (text: string, cat: string, hint = skillHint) => {
     const message = text.trim()
     if (!message || streaming) return
     setDraft('')
@@ -127,7 +130,7 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
     }
     try {
       await chatStream(
-        { session_id: sessionRef.current, message, task_category: cat },
+        { session_id: sessionRef.current, message, task_category: cat, skill_hint: hint },
         (ev: ChatEvent) => {
           if (ev.type === 'meta') adoptSession(ev.session_id)
           updateLast((m) => applyEvent(m, ev))
@@ -160,16 +163,20 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
   const send = () => void sendMessage(draft, category)
 
   // Consume a home-screen intent exactly once: `send` fires the
-  // message immediately, `draft` prefills the composer.
+  // message immediately, `draft` prefills the composer, `skillHint`
+  // pins the chip. sendMessage takes hint explicitly here rather than
+  // relying on the skillHint state landing before the call — setState
+  // doesn't take effect until the next render.
   useEffect(() => {
     if (intentConsumedRef.current) return
     const intent = location.state as ChatIntent | null
-    if (!intent || (!intent.send && !intent.draft && !intent.category)) return
+    if (!intent || (!intent.send && !intent.draft && !intent.category && !intent.skillHint)) return
     intentConsumedRef.current = true
     window.history.replaceState(null, '') // don't refire on back/refresh
     const cat = intent.category ?? category
     if (intent.category) pickCategory(intent.category)
-    if (intent.send) void sendMessage(intent.send, cat)
+    if (intent.skillHint) setSkillHint(intent.skillHint)
+    if (intent.send) void sendMessage(intent.send, cat, intent.skillHint)
     else if (intent.draft) setDraft(intent.draft)
     // Mount-time only by design: the intent rides the navigation that
     // created this page instance; the ref guards strict-mode replays.
@@ -237,6 +244,8 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
           onSend={send}
           category={category}
           onCategory={pickCategory}
+          skillHint={skillHint}
+          onRemoveSkillHint={() => setSkillHint(undefined)}
           disabled={streaming}
         />
         <p className="mt-2 text-center text-xs text-zinc-400 dark:text-zinc-500">

--- a/web/src/pages/Home.test.tsx
+++ b/web/src/pages/Home.test.tsx
@@ -65,11 +65,11 @@ describe('Home', () => {
     expect(landed).toBeNull()
   })
 
-  it('skill tiles carry a prefill intent into chat', () => {
+  it('skill tiles carry a deterministic skill hint into chat', () => {
     renderHome()
     fireEvent.click(screen.getByRole('button', { name: /Travel/ }))
     expect(landed?.pathname).toBe('/chat')
-    expect(landed?.state?.draft).toContain('travel-planning skill')
+    expect(landed?.state?.skillHint).toBe('travel-planning')
     expect(landed?.state?.send).toBeUndefined()
   })
 

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -18,11 +18,13 @@ import { usePendingMemories } from '../lib/memory'
 const categoryKey = 'timothy.category'
 
 // ChatIntent carries a home-screen action into the chat page: `send`
-// fires immediately, `draft` only prefills the composer.
+// fires immediately, `draft` only prefills the composer, `skillHint`
+// pins a skill chip (deterministic — never text the user can mangle).
 export interface ChatIntent {
   send?: string
   draft?: string
   category?: string
+  skillHint?: string
 }
 
 interface Tile {
@@ -74,34 +76,22 @@ export function Home() {
         {
           label: 'Research',
           icon: SearchList01Icon,
-          intent: {
-            draft: 'Use the research-brief skill. Question: ',
-            category: 'research',
-          },
+          intent: { skillHint: 'research-brief', category: 'research' },
         },
         {
           label: 'Markets',
           icon: ChartLineData01Icon,
-          intent: {
-            draft: 'Use the markets-digest skill. My watchlist: ',
-            category: 'research',
-          },
+          intent: { skillHint: 'markets-digest', category: 'research' },
         },
         {
           label: 'Travel',
           icon: AirplaneTakeOff01Icon,
-          intent: {
-            draft: 'Use the travel-planning skill. Trip: ',
-            category: 'research',
-          },
+          intent: { skillHint: 'travel-planning', category: 'research' },
         },
         {
           label: 'Coding',
           icon: CodeIcon,
-          intent: {
-            draft: 'Use the coding-task skill. Task: ',
-            category: 'coding',
-          },
+          intent: { skillHint: 'coding-task', category: 'coding' },
         },
       ],
     },


### PR DESCRIPTION
## Summary
- Skill selection no longer relies on the model parsing a text hint from the user's own message: a pinned chip carries a real skill_hint field that force-loads the pack's body into the system prompt before the first token streams
- Skill tiles on the home screen set the hint via navigation state instead of prefilling editable text the user could mangle or delete
- load_skill's full rule text (the entire SKILL.md body) no longer reaches the client in either the live SSE stream or the persisted transcript used for replay — a fixed placeholder digest replaces it; the model is unaffected, still receiving the real body

## Test plan
- [x] `go build`, `go vet`, `go test -race ./...` all green
- [x] `golangci-lint` — 0 issues
- [x] Web: `tsc --noEmit`, `oxlint`, `vitest` (53/53) all green
- [x] New regression tests: deterministic skill_hint injection (known + unknown hint), load_skill digest redaction (client never sees the body, model still does)
- [x] Live-verified: known skill_hint reaches the model via the system prompt; unknown hint is refused with a 400