### PR TITLE
Global history panel, persistent top bar, agent loop repeat guard

### DIFF
--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -137,9 +137,17 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 	effort := ""
 	toolCallCount := 0
 	coerced := false
+	var repeats tools.RepeatGuard
+	stuck := false
 
 	for step := 1; ; step++ {
 		directive := tools.CeilingFor(step, a.maxSteps)
+		// A model retrying the same call over and over (e.g. hoping a
+		// search tool will "book" something on a later attempt) forces
+		// synthesis early rather than burning steps up to the ceiling.
+		if stuck && directive == tools.StepProceed {
+			directive = tools.StepForceSynthesis
+		}
 		sreq := gwclient.StreamRequest{
 			TaskCategory: req.TaskCategory,
 			Purpose:      "chat",
@@ -243,6 +251,7 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 		}
 
 		toolCallCount += len(calls)
+		stuck = repeats.Record(calls)
 		results := a.executeAll(ctx, req.SessionID, calls, emit)
 
 		msgs = append(msgs, provider.Message{

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -302,10 +302,13 @@ func TestAgentParallelCallsRunConcurrently(t *testing.T) {
 
 func TestAgentStepCeilingForcesSynthesis(t *testing.T) {
 	t.Parallel()
-	// The model calls a tool on every step; the loop must cut it off.
+	// The model calls a tool on every step with distinct arguments each
+	// time — genuine exploration, not a stuck retry loop — so this
+	// isolates the step-count ceiling from the repeat guard, which
+	// would otherwise cut the run short on its own.
 	var scripts [][]stream.StreamEvent
-	for range tools.DefaultMaxSteps {
-		scripts = append(scripts, toolCallStep([2]string{"echo", `{"text":"again"}`}))
+	for i := range tools.DefaultMaxSteps {
+		scripts = append(scripts, toolCallStep([2]string{"echo", fmt.Sprintf(`{"text":"call %d"}`, i)}))
 	}
 	scripts = append(scripts, finalStep("forced answer"))
 	gw := &scriptedGateway{scripts: scripts}
@@ -333,6 +336,41 @@ func TestAgentStepCeilingForcesSynthesis(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("no finalize warning injected at max_steps-1")
+	}
+}
+
+// TestAgentForcesSynthesisOnRepeatedIdenticalCalls reproduces a live
+// loop: a model retrying the exact same tool call (e.g. web_search
+// hoping a later attempt "books" something it structurally cannot)
+// must be cut off well before the full step ceiling, not burn all
+// DefaultMaxSteps steps first.
+func TestAgentForcesSynthesisOnRepeatedIdenticalCalls(t *testing.T) {
+	t.Parallel()
+	var scripts [][]stream.StreamEvent
+	for range tools.DefaultMaxSteps {
+		scripts = append(scripts, toolCallStep([2]string{"echo", `{"text":"book hotel in Nairobi"}`}))
+	}
+	scripts = append(scripts, finalStep("gave up retrying"))
+	gw := &scriptedGateway{scripts: scripts}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", TaskCategory: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	if len(ofType(evs, stream.EventDone)) != 1 {
+		t.Fatal("no clean terminal event")
+	}
+	// 3 identical calls trips the guard; the 4th request must have no
+	// tool schemas, forced far short of the 16-step default ceiling.
+	if len(gw.requests) >= tools.DefaultMaxSteps {
+		t.Fatalf("loop ran %d requests before stopping — repeat guard did not cut it short", len(gw.requests))
+	}
+	last := gw.requests[len(gw.requests)-1]
+	if len(last.Tools) != 0 {
+		t.Fatalf("final step still offered %d tools — repeat guard must force synthesis", len(last.Tools))
 	}
 }
 

--- a/internal/brain/tools/builtin/websearch.go
+++ b/internal/brain/tools/builtin/websearch.go
@@ -49,6 +49,13 @@ prices, recent releases, anything past your knowledge — or asks you to
 "search the internet". Returns titles, URLs, and short snippets, not
 full page text; call web_fetch on a promising URL to read further.
 
+This is read-only lookup, never a transaction: it cannot book a
+flight, reserve a hotel, purchase anything, or fill in a form. If the
+user asks you to "book" or "buy" something, use this tool (and
+web_fetch) to find options and prices, then tell the user what you
+found and that they need to complete the booking themselves — do not
+retry the search hoping for a different kind of result.
+
 Arguments:
 - query (string, required): the search query.
 

--- a/internal/brain/tools/constraints.go
+++ b/internal/brain/tools/constraints.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 )
 
 // Violation is a constraint breach reported back to the model as a
@@ -181,6 +183,43 @@ func CeilingFor(step, maxSteps int) StepDirective {
 	default:
 		return StepProceed
 	}
+}
+
+// repeatThreshold: the same tool called with the same arguments this
+// many times in one turn forces synthesis early — a model retrying an
+// unproductive call (e.g. hoping a search engine will "book" something
+// on a later attempt) would otherwise burn steps up to the full
+// ceiling before answering.
+const repeatThreshold = 3
+
+// RepeatGuard tracks (tool, args) signatures across a turn's steps and
+// reports when the same call has repeated too many times in a row.
+type RepeatGuard struct {
+	lastSig   string
+	lastCount int
+}
+
+// Record folds in one step's calls and returns true once any single
+// call signature has repeated repeatThreshold times consecutively.
+// Consecutive, not merely "seen before": a model that tries A, B, A
+// is exploring, not stuck; A, A, A is stuck. Signatures compare the
+// tool name and raw argument JSON — args differing by whitespace only
+// would already have been re-marshaled identically by the model.
+func (g *RepeatGuard) Record(calls []provider.ToolCall) bool {
+	stuck := false
+	for _, c := range calls {
+		sig := c.Name + ":" + string(c.Input)
+		if sig == g.lastSig {
+			g.lastCount++
+		} else {
+			g.lastSig = sig
+			g.lastCount = 1
+		}
+		if g.lastCount >= repeatThreshold {
+			stuck = true
+		}
+	}
+	return stuck
 }
 
 // MinToolCallsFor is the per-category floor of tool calls before a

--- a/internal/brain/tools/constraints_test.go
+++ b/internal/brain/tools/constraints_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 )
 
 func constrainedEcho(t *testing.T) *Constrained {
@@ -173,6 +175,50 @@ func TestCeilingFor(t *testing.T) {
 			t.Errorf("CeilingFor(%d, %d) = %v, want %v", tc.step, tc.max, got, tc.want)
 		}
 	}
+}
+
+func TestRepeatGuard(t *testing.T) {
+	t.Parallel()
+	call := func(name, input string) provider.ToolCall {
+		return provider.ToolCall{Name: name, Input: json.RawMessage(input)}
+	}
+
+	t.Run("same call three times in a row trips", func(t *testing.T) {
+		t.Parallel()
+		var g RepeatGuard
+		if g.Record([]provider.ToolCall{call("web_search", `{"query":"book hotel in Nairobi"}`)}) {
+			t.Fatal("tripped on first occurrence")
+		}
+		if g.Record([]provider.ToolCall{call("web_search", `{"query":"book hotel in Nairobi"}`)}) {
+			t.Fatal("tripped on second occurrence")
+		}
+		if !g.Record([]provider.ToolCall{call("web_search", `{"query":"book hotel in Nairobi"}`)}) {
+			t.Fatal("did not trip on third identical occurrence")
+		}
+	})
+
+	t.Run("different args resets the run", func(t *testing.T) {
+		t.Parallel()
+		var g RepeatGuard
+		g.Record([]provider.ToolCall{call("web_search", `{"query":"a"}`)})
+		g.Record([]provider.ToolCall{call("web_search", `{"query":"a"}`)})
+		if g.Record([]provider.ToolCall{call("web_search", `{"query":"b"}`)}) {
+			t.Fatal("tripped after a genuinely different call broke the run")
+		}
+	})
+
+	t.Run("exploring different tools never trips", func(t *testing.T) {
+		t.Parallel()
+		var g RepeatGuard
+		for range 5 {
+			if g.Record([]provider.ToolCall{call("web_search", `{"query":"a"}`)}) {
+				t.Fatal("tripped despite alternating calls")
+			}
+			if g.Record([]provider.ToolCall{call("web_fetch", `{"url":"https://example.com"}`)}) {
+				t.Fatal("tripped despite alternating calls")
+			}
+		}
+	})
 }
 
 func TestNeedsRetrievalCoercion(t *testing.T) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,10 +1,13 @@
 import {
   Analytics01Icon,
+  ArrowLeft01Icon,
   Brain02Icon,
   BubbleChatIcon,
+  Cancel01Icon,
   ComputerIcon,
   Home01Icon,
   Key01Icon,
+  Menu01Icon,
   Moon02Icon,
   PlusSignIcon,
   Settings02Icon,
@@ -12,24 +15,20 @@ import {
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useCallback, useEffect, useState } from 'react'
-import { Link, Navigate, Route, Routes, useLocation, useParams } from 'react-router'
+import { Link, Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router'
 import { getToken } from './api/client'
 import { SessionList } from './components/SessionList'
 import { SessionsProvider } from './components/SessionsProvider'
 import { SettingsDialog } from './components/SettingsDialog'
 import {
-  Sidebar,
-  SidebarContent,
   SidebarGroup,
   SidebarGroupContent,
-  SidebarHeader,
-  SidebarInset,
   SidebarMenu,
   SidebarMenuBadge,
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarProvider,
-  SidebarTrigger,
+  useSidebar,
 } from './components/ui/sidebar'
 import { usePendingMemories } from './lib/memory'
 import { getTheme, nextTheme, setTheme, type Theme } from './lib/theme'
@@ -57,9 +56,54 @@ function isActive(pathname: string, href: string): boolean {
   return pathname === href
 }
 
-// Rail is the desktop workspace navigation: a slim icon column, every
-// destination one glance away. Mobile navigation lives in the sheet
-// the header trigger opens.
+// TopBar is the one persistent strip above everything: logo, back (only
+// meaningful inside a chat session), and the history toggle. The
+// toggle works from any page — it drives the same sidebar the history
+// panel renders in, via useSidebar, so it opens the mobile sheet or
+// the desktop panel correctly without tracking its own open state.
+function TopBar() {
+  const { pathname } = useLocation()
+  const navigate = useNavigate()
+  const { toggleSidebar, open, openMobile, isMobile } = useSidebar()
+  const historyOpen = isMobile ? openMobile : open
+  const inSession = pathname.startsWith('/chat/')
+
+  return (
+    <header className="flex h-12 w-full shrink-0 items-center gap-1 border-b border-border px-3">
+      <Link to="/" aria-label="Timothy home" className="mr-1 flex size-8 items-center justify-center">
+        <span className="size-3 rounded-full bg-gradient-to-br from-blue-500 to-violet-600" />
+      </Link>
+      {inSession && (
+        <button
+          type="button"
+          onClick={() => navigate('/')}
+          aria-label="Back to home"
+          className="flex size-8 items-center justify-center rounded-md text-zinc-500 transition hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+        >
+          <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={toggleSidebar}
+        aria-label={historyOpen ? 'Hide chat history' : 'Show chat history'}
+        aria-pressed={historyOpen}
+        className={cn(
+          'flex size-8 items-center justify-center rounded-md transition',
+          historyOpen
+            ? 'bg-zinc-200/70 text-zinc-900 dark:bg-zinc-800 dark:text-zinc-50'
+            : 'text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100',
+        )}
+      >
+        <HugeiconsIcon icon={Menu01Icon} className="size-4" />
+      </button>
+    </header>
+  )
+}
+
+// Rail is the desktop workspace navigation: a slim icon column below
+// the top bar, every destination one glance away. Mobile navigation
+// lives in the sheet the top bar's toggle opens.
 function Rail({
   pendingMemories,
   theme,
@@ -86,9 +130,6 @@ function Rail({
       aria-label="Workspace"
       className="hidden w-18 shrink-0 flex-col items-center gap-1 border-r border-border px-2 py-3 md:flex"
     >
-      <Link to="/" aria-label="Timothy home" className="mb-2 flex size-9 items-center justify-center">
-        <span className="size-3 rounded-full bg-gradient-to-br from-blue-500 to-violet-600" />
-      </Link>
       <Link
         to="/chat"
         aria-label="New chat"
@@ -136,10 +177,8 @@ function LegacySessionRedirect() {
 function App() {
   const [tokenOpen, setTokenOpen] = useState(false)
   const [theme, setThemeState] = useState<Theme>(() => getTheme())
-  const [sessionsOpen, setSessionsOpen] = useState(true)
   const { pathname } = useLocation()
   const pendingMemories = usePendingMemories()
-  const onChat = isActive(pathname, '/chat')
 
   useEffect(() => {
     if (getToken() === '') setTokenOpen(true)
@@ -156,73 +195,57 @@ function App() {
 
   return (
     <SessionsProvider>
-      <div className="flex h-dvh w-full">
-        <Rail
-          pendingMemories={pendingMemories}
-          theme={theme}
-          onCycleTheme={cycleTheme}
-          onToken={openToken}
-        />
-        {/* Desktop: the sidebar holds sessions and only appears on chat
-            routes. Mobile: the same sidebar is the navigation sheet —
-            nav links ride above the session list. */}
-        <SidebarProvider
-          open={onChat && sessionsOpen}
-          onOpenChange={setSessionsOpen}
-          className="min-h-0 min-w-0 flex-1"
-        >
-          <Sidebar>
-            <SidebarHeader>
-              <Link to="/" className="flex items-center gap-2.5 px-2 py-1.5">
-                <span className="size-2.5 rounded-full bg-gradient-to-br from-blue-500 to-violet-600" />
-                <span className="text-base font-semibold tracking-tight">Timothy</span>
-              </Link>
-            </SidebarHeader>
-            <SidebarContent>
-              <SidebarGroup className="md:hidden">
-                <SidebarGroupContent>
-                  <SidebarMenu>
-                    {railNav.map((item) => (
-                      <SidebarMenuItem key={item.href}>
-                        <SidebarMenuButton asChild isActive={isActive(pathname, item.href)}>
-                          <Link to={item.href}>
-                            <HugeiconsIcon icon={item.icon} />
-                            <span>{item.label}</span>
-                          </Link>
-                        </SidebarMenuButton>
-                        {item.href === '/memory' && pendingMemories > 0 && (
-                          <SidebarMenuBadge>{pendingMemories}</SidebarMenuBadge>
-                        )}
-                      </SidebarMenuItem>
-                    ))}
-                    <SidebarMenuItem>
-                      <SidebarMenuButton onClick={cycleTheme}>
-                        <HugeiconsIcon icon={themeIcon[theme]} />
-                        <span>{themeLabel[theme]}</span>
+      {/* The history panel is a global overlay: SidebarProvider wraps
+          the top bar too so its toggle button can drive the same
+          sidebar state via useSidebar, on both desktop and mobile.
+          Closes on every navigation — opening it again is always an
+          explicit click, never state carried from a previous page. */}
+      <SidebarProvider defaultOpen={false} className="flex h-dvh w-full flex-col">
+        <RouteClosesHistory />
+        <TopBar />
+        <div className="flex min-h-0 flex-1">
+          <Rail
+            pendingMemories={pendingMemories}
+            theme={theme}
+            onCycleTheme={cycleTheme}
+            onToken={openToken}
+          />
+          <HistoryPanel>
+            <SidebarGroup className="md:hidden">
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  {railNav.map((item) => (
+                    <SidebarMenuItem key={item.href}>
+                      <SidebarMenuButton asChild isActive={isActive(pathname, item.href)}>
+                        <Link to={item.href}>
+                          <HugeiconsIcon icon={item.icon} />
+                          <span>{item.label}</span>
+                        </Link>
                       </SidebarMenuButton>
+                      {item.href === '/memory' && pendingMemories > 0 && (
+                        <SidebarMenuBadge>{pendingMemories}</SidebarMenuBadge>
+                      )}
                     </SidebarMenuItem>
-                    <SidebarMenuItem>
-                      <SidebarMenuButton onClick={() => setTokenOpen(true)}>
-                        <HugeiconsIcon icon={Key01Icon} />
-                        <span>API token</span>
-                      </SidebarMenuButton>
-                    </SidebarMenuItem>
-                  </SidebarMenu>
-                </SidebarGroupContent>
-              </SidebarGroup>
-              <SessionList />
-            </SidebarContent>
-          </Sidebar>
+                  ))}
+                  <SidebarMenuItem>
+                    <SidebarMenuButton onClick={cycleTheme}>
+                      <HugeiconsIcon icon={themeIcon[theme]} />
+                      <span>{themeLabel[theme]}</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton onClick={() => setTokenOpen(true)}>
+                      <HugeiconsIcon icon={Key01Icon} />
+                      <span>API token</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+            <SessionList />
+          </HistoryPanel>
 
-          <SidebarInset className="min-w-0">
-            <header
-              className={cn('flex h-12 shrink-0 items-center gap-2 px-3', !onChat && 'md:hidden')}
-            >
-              <SidebarTrigger />
-              <Link to="/" className="text-sm font-semibold tracking-tight md:hidden">
-                Timothy
-              </Link>
-            </header>
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
             <div className="min-h-0 flex-1 overflow-hidden px-4">
               <Routes>
                 <Route path="/" element={<Home />} />
@@ -245,11 +268,64 @@ function App() {
               </Routes>
             </div>
             <SettingsDialog open={tokenOpen} onClose={() => setTokenOpen(false)} />
-          </SidebarInset>
-        </SidebarProvider>
-      </div>
+          </div>
+        </div>
+      </SidebarProvider>
     </SessionsProvider>
   )
+}
+
+// HistoryPanel is a plain flex drawer, not the shadcn Sidebar: that
+// primitive is fixed-position and assumes it owns the full viewport
+// height, which fights a persistent TopBar above it. This one just
+// renders inline in the flex row beside Rail, confined to the space
+// below the top bar like everything else on the page.
+function HistoryPanel({ children }: { children: React.ReactNode }) {
+  const { open, openMobile, isMobile, toggleSidebar } = useSidebar()
+  const panelOpen = isMobile ? openMobile : open
+  if (!panelOpen) return null
+
+  return (
+    <aside
+      aria-label="Chat history"
+      className={cn(
+        'flex h-full flex-col overflow-y-auto border-r border-border bg-sidebar text-sidebar-foreground',
+        isMobile ? 'w-full' : 'w-64 shrink-0',
+      )}
+    >
+      {isMobile && (
+        <div className="flex items-center justify-end px-2 py-1.5">
+          <button
+            type="button"
+            onClick={toggleSidebar}
+            aria-label="Close chat history"
+            className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
+          >
+            <HugeiconsIcon icon={Cancel01Icon} className="size-4" />
+          </button>
+        </div>
+      )}
+      {children}
+    </aside>
+  )
+}
+
+// RouteClosesHistory closes the history panel on every navigation —
+// opening it is always an explicit click on the top bar's toggle,
+// never state carried over from a previous page.
+function RouteClosesHistory() {
+  const { pathname } = useLocation()
+  const { setOpen, setOpenMobile } = useSidebar()
+
+  useEffect(() => {
+    setOpen(false)
+    setOpenMobile(false)
+    // Route changes alone close the panel; opening it is never part of
+    // the effect that reacts to them.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname])
+
+  return null
 }
 
 export default App

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,6 +1,7 @@
 import {
   Add01Icon,
   Archive02Icon,
+  BubbleChatIcon,
   MoreHorizontalIcon,
   PencilEdit01Icon,
   Search01Icon,
@@ -31,7 +32,6 @@ import { Input } from './ui/input'
 import {
   SidebarGroup,
   SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuAction,
   SidebarMenuButton,
@@ -72,74 +72,83 @@ export function SessionList() {
     if (!s.archived && pathname === `/chat/${s.id}`) navigate('/chat')
   }
 
+  // Flat, dated rows (not day-sectioned): each session carries its own
+  // label directly beneath its title, same shape SessionList always
+  // had via groupByDay, just rendered per-row instead of per-section.
+  const dated = groupByDay(sessions).flatMap((group) =>
+    group.sessions.map((s) => ({ session: s, label: group.label })),
+  )
+
   return (
     <>
-      <SidebarGroup>
+      <div className="flex items-center justify-between px-3 pt-1 pb-2">
+        <span className="text-sm font-semibold tracking-tight">Chats</span>
+        <Link
+          to="/chat"
+          aria-label="New chat"
+          className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
+        >
+          <HugeiconsIcon icon={Add01Icon} className="size-4" />
+        </Link>
+      </div>
+
+      <SidebarGroup className="pt-0">
         <SidebarGroupContent>
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <SidebarMenuButton asChild isActive={pathname === '/chat'}>
-                <Link to="/chat">
-                  <HugeiconsIcon icon={Add01Icon} />
-                  <span>New chat</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          </SidebarMenu>
-          <div className="relative mt-1 px-1">
+          <div className="relative px-1">
             <HugeiconsIcon icon={Search01Icon} className="pointer-events-none absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground" />
             <Input
               aria-label="Search sessions"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search…"
+              placeholder="Search chats…"
               className="h-8 pl-8"
             />
           </div>
         </SidebarGroupContent>
       </SidebarGroup>
 
-      {groupByDay(sessions).map((group) => (
-        <SidebarGroup key={group.label}>
-          <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {group.sessions.map((s) => (
-                <SidebarMenuItem key={s.id}>
-                  <SidebarMenuButton asChild isActive={pathname === `/chat/${s.id}`}>
-                    <Link to={`/chat/${s.id}`}>
-                      <span className="truncate">{s.title || 'New session'}</span>
+      <SidebarGroup className="pt-0">
+        <SidebarGroupContent>
+          <SidebarMenu className="gap-3">
+            {dated.map(({ session: s, label }) => (
+              <SidebarMenuItem key={s.id}>
+                <SidebarMenuButton asChild isActive={pathname === `/chat/${s.id}`} className="h-auto flex-col items-start gap-0.5 py-1.5">
+                  <Link to={`/chat/${s.id}`}>
+                    <span className="flex w-full items-center gap-1.5">
+                      <HugeiconsIcon icon={BubbleChatIcon} className="size-3.5 shrink-0 text-muted-foreground" />
+                      <span className="truncate font-medium">{s.title || 'New session'}</span>
                       {s.archived && <Badge variant="outline">archived</Badge>}
-                    </Link>
-                  </SidebarMenuButton>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <SidebarMenuAction showOnHover aria-label={`Actions for ${s.title || 'session'}`}>
-                        <HugeiconsIcon icon={MoreHorizontalIcon} />
-                      </SidebarMenuAction>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent side="right" align="start">
-                      <DropdownMenuItem
-                        onClick={() => {
-                          setTitle(s.title)
-                          setRenaming(s)
-                        }}
-                      >
-                        <HugeiconsIcon icon={PencilEdit01Icon} />
-                        Rename
-                      </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => void archive(s)}>
-                        <HugeiconsIcon icon={s.archived ? Unarchive03Icon : Archive02Icon} />
-                        {s.archived ? 'Unarchive' : 'Archive'}
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-      ))}
+                    </span>
+                    <span className="pl-5 text-xs text-muted-foreground">{label}</span>
+                  </Link>
+                </SidebarMenuButton>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <SidebarMenuAction showOnHover aria-label={`Actions for ${s.title || 'session'}`}>
+                      <HugeiconsIcon icon={MoreHorizontalIcon} />
+                    </SidebarMenuAction>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent side="right" align="start">
+                    <DropdownMenuItem
+                      onClick={() => {
+                        setTitle(s.title)
+                        setRenaming(s)
+                      }}
+                    >
+                      <HugeiconsIcon icon={PencilEdit01Icon} />
+                      Rename
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => void archive(s)}>
+                      <HugeiconsIcon icon={s.archived ? Unarchive03Icon : Archive02Icon} />
+                      {s.archived ? 'Unarchive' : 'Archive'}
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
 
       {sessions.length === 0 && query !== '' && (
         <p className="px-4 py-1 text-xs text-muted-foreground">No sessions match.</p>


### PR DESCRIPTION
## Summary
- Chat history is now a global panel toggled from a persistent top bar (logo, back-in-session arrow, hamburger) instead of a slide-over sidebar scoped to /chat routes only
- Replaced the shadcn Sidebar primitive for this panel with a plain flex drawer — the primitive is fixed-position and assumes it owns the full viewport, which conflicted with the new top bar above it
- Agent loop: a RepeatGuard now forces early synthesis when the same tool call repeats 3 times in a row, so a model stuck retrying an unproductive call (e.g. asking web_search to "book" something it structurally can't) stops well short of the full step ceiling
- web_search's tool description clarifies it's read-only lookup, never a transaction

## Test plan
- [x] `go build`, `go vet`, `go test -race ./...` all green
- [x] `golangci-lint` — 0 issues on touched packages
- [x] Web: `tsc --noEmit`, `oxlint`, `vitest` (53/53) all green
- [x] New tests: RepeatGuard unit tests (trips on 3 identical repeats, resets on a different call, never trips while exploring), loop-level integration test reproducing the live stuck-retry scenario
- [x] Live-verified: history panel toggles from any page without covering the top bar/rail, back arrow shows only inside a chat session