### PR TITLE
Dedicated research assistant: locked skill, structured citations

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -115,6 +115,22 @@ func main() {
 	if err != nil {
 		app.Log.Error("skills failed to load; continuing without them", "error", err)
 	}
+	// SKILLS_ALLOWLIST restricts which loaded packs the agent may reach
+	// for, without deleting the others from disk — comma-separated
+	// names, empty means no restriction.
+	if allow := os.Getenv("SKILLS_ALLOWLIST"); allow != "" {
+		allowed := make(map[string]bool)
+		for _, name := range strings.Split(allow, ",") {
+			allowed[strings.TrimSpace(name)] = true
+		}
+		filtered := packs[:0]
+		for _, p := range packs {
+			if allowed[p.Name] {
+				filtered = append(filtered, p)
+			}
+		}
+		packs = filtered
+	}
 	app.AddCheck("skills", func() httpserver.Check {
 		if err != nil {
 			return httpserver.Check{Status: "degraded", Detail: err.Error()}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -71,6 +71,9 @@ services:
       WORKSPACE_ROOT: /workspace
       # Compose-internal only: the model never sees this address.
       SEARXNG_URL: http://searxng:8080
+      # Restricts the agent to this skill pack only; empty allows all
+      # loaded packs. Comma-separated names.
+      SKILLS_ALLOWLIST: ${SKILLS_ALLOWLIST:-}
     volumes:
       - workspace:/workspace
     ports:

--- a/skills/research-brief/SKILL.md
+++ b/skills/research-brief/SKILL.md
@@ -9,13 +9,18 @@ description: Source-grounded research with verification and citations. Use when 
 
 - Retrieve before you write: every load-bearing claim needs a source you actually fetched this turn, not trained recall.
 - Two independent sources for any claim that drives a decision; one source for background color.
-- Record where each fact came from and cite it inline next to the fact, not in a pile at the end.
+- Record where each fact came from; a source mentioned only in the trailing list without ever being referenced in the body is not a citation, it is decoration.
 - Distinguish plainly between what a source states and what you infer from it; label inference as inference.
 - Prefer primary sources (the vendor's page, the law's text, the paper) over aggregators repeating them.
 - Note the date on every time-sensitive fact; an undated price or version number is a trap for the reader.
 - When sources conflict, report the conflict — do not silently pick one.
 - If retrieval fails or the fact cannot be found, say so; a stated gap beats a confident guess.
 - End with the answer to the actual question asked, not a survey of everything found.
+- Close every answer with a `## Sources` section: a numbered markdown
+  list, one fetched source per line, formatted exactly as
+  `1. [Title](URL)`. Nothing else on that line — no dates, no notes,
+  no extra prose. Every URL listed must be one you actually fetched or
+  searched this turn.
 
 ## Anti-rationalization
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,6 +37,7 @@ import { Chat } from './pages/Chat'
 import { Dashboard } from './pages/Dashboard'
 import { Home } from './pages/Home'
 import { Memory } from './pages/Memory'
+import { Research } from './pages/Research'
 import { Settings } from './pages/Settings'
 
 const railNav = [
@@ -258,6 +259,14 @@ function App() {
                   element={
                     <div className="mx-auto flex h-full max-w-4xl flex-col">
                       <Chat onNeedToken={openToken} />
+                    </div>
+                  }
+                />
+                <Route
+                  path="/research/:id?"
+                  element={
+                    <div className="mx-auto flex h-full max-w-4xl flex-col">
+                      <Research onNeedToken={openToken} />
                     </div>
                   }
                 />

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -13,6 +13,7 @@ export function Composer({
   onSend,
   category,
   onCategory,
+  hideCategoryPicker = false,
   skillHint,
   onRemoveSkillHint,
   disabled = false,
@@ -24,6 +25,7 @@ export function Composer({
   onSend: () => void
   category: string
   onCategory: (c: string) => void
+  hideCategoryPicker?: boolean
   skillHint?: string
   onRemoveSkillHint?: () => void
   disabled?: boolean
@@ -77,7 +79,7 @@ export function Composer({
         }}
       />
       <div className="flex items-center justify-between gap-2 px-2.5 pb-2.5">
-        <CategoryPicker value={category} onChange={onCategory} />
+        {hideCategoryPicker ? <span /> : <CategoryPicker value={category} onChange={onCategory} />}
         <button
           type="button"
           onClick={onSend}

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -1,11 +1,41 @@
-import { Copy01Icon, Tick02Icon, WrenchIcon } from '@hugeicons-pro/core-stroke-rounded'
+import { Copy01Icon, Link04Icon, Tick02Icon, WrenchIcon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import rehypeHighlight from 'rehype-highlight'
 import { Badge } from './ui/badge'
+import { splitSources } from '../lib/citations'
 import type { AssistantState, ToolRun } from '../lib/chat'
 import 'highlight.js/styles/github-dark.css'
+
+// SourcesPanel renders a research answer's citations as a distinct,
+// clickable list — separate from the prose so "these are the sources"
+// reads at a glance instead of blending into the markdown body.
+function SourcesPanel({ citations }: { citations: { title: string; url: string }[] }) {
+  return (
+    <div className="w-full max-w-3xl rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-700 dark:bg-zinc-900/40">
+      <div className="mb-2 flex items-center gap-1.5 text-xs font-medium text-zinc-500 dark:text-zinc-400">
+        <HugeiconsIcon icon={Link04Icon} className="size-3.5" />
+        Sources
+      </div>
+      <ol className="space-y-1.5 text-sm">
+        {citations.map((c, i) => (
+          <li key={i} className="flex gap-2">
+            <span className="text-zinc-400 dark:text-zinc-500">{i + 1}.</span>
+            <a
+              href={c.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="truncate text-blue-600 hover:underline dark:text-blue-400"
+            >
+              {c.title}
+            </a>
+          </li>
+        ))}
+      </ol>
+    </div>
+  )
+}
 
 // CopyButton copies a message's raw text; the check confirms briefly.
 function CopyButton({ text, label }: { text: string; label: string }) {
@@ -132,6 +162,10 @@ export function AssistantMessage({ msg }: { msg: AssistantState }) {
   const tokens = msg.meta?.usage
     ? `${msg.meta.usage.input_tokens}→${msg.meta.usage.output_tokens} tok`
     : null
+  // Citations only split out once the answer is done streaming: a
+  // partial "## Sources" heading mid-stream would otherwise flicker
+  // the body text as more of it arrives.
+  const { body, citations } = msg.streaming ? { body: msg.text, citations: [] } : splitSources(msg.text)
   return (
     <div className="group/message flex flex-col items-start gap-2">
       {msg.reasoning !== '' && (
@@ -156,9 +190,11 @@ export function AssistantMessage({ msg }: { msg: AssistantState }) {
       )}
 
       <div className="prose prose-sm max-w-3xl dark:prose-invert prose-pre:bg-zinc-900">
-        <ReactMarkdown rehypePlugins={[rehypeHighlight]}>{msg.text}</ReactMarkdown>
+        <ReactMarkdown rehypePlugins={[rehypeHighlight]}>{body}</ReactMarkdown>
         {msg.streaming && msg.permissions.length === 0 && <span className="animate-pulse">▍</span>}
       </div>
+
+      {citations.length > 0 && <SourcesPanel citations={citations} />}
 
       {msg.notices.map((n, i) => (
         <Badge

--- a/web/src/lib/citations.test.ts
+++ b/web/src/lib/citations.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { splitSources } from './citations'
+
+describe('splitSources', () => {
+  it('splits a trailing Sources section into structured citations', () => {
+    const text = [
+      'Bedrock Nova Lite costs $0.06 per 1M input tokens.',
+      '',
+      '## Sources',
+      '1. [AWS Bedrock Pricing](https://aws.amazon.com/bedrock/pricing/)',
+      '2. [Nova Model Card](https://aws.amazon.com/ai/generative-ai/nova/)',
+    ].join('\n')
+
+    const { body, citations } = splitSources(text)
+    expect(body).toBe('Bedrock Nova Lite costs $0.06 per 1M input tokens.')
+    expect(citations).toEqual([
+      { title: 'AWS Bedrock Pricing', url: 'https://aws.amazon.com/bedrock/pricing/' },
+      { title: 'Nova Model Card', url: 'https://aws.amazon.com/ai/generative-ai/nova/' },
+    ])
+  })
+
+  it('returns the text unchanged when there is no Sources section', () => {
+    const text = 'Just an answer, no citations.'
+    expect(splitSources(text)).toEqual({ body: text, citations: [] })
+  })
+
+  it('is case-insensitive on the heading', () => {
+    const text = '# answer\n\n## sources\n1. [X](https://x.com)'
+    const { citations } = splitSources(text)
+    expect(citations).toHaveLength(1)
+  })
+
+  it('ignores a Sources heading with no parseable list under it', () => {
+    const text = 'Answer text.\n\n## Sources\nI did not cite anything specific.'
+    const { body, citations } = splitSources(text)
+    expect(citations).toEqual([])
+    expect(body).toBe(text)
+  })
+
+  it('only treats the last Sources heading as the citation block', () => {
+    const text = [
+      'This section discusses ## Sources of error in measurement.',
+      '',
+      'The actual answer follows.',
+      '',
+      '## Sources',
+      '1. [Ref](https://example.com)',
+    ].join('\n')
+    const { citations } = splitSources(text)
+    expect(citations).toEqual([{ title: 'Ref', url: 'https://example.com' }])
+  })
+})

--- a/web/src/lib/citations.ts
+++ b/web/src/lib/citations.ts
@@ -1,0 +1,37 @@
+// splitSources pulls a trailing "## Sources" markdown section off an
+// answer so the UI can render it as a distinct panel instead of just
+// another heading in the prose. Only the LAST such heading counts —
+// an answer that discusses "sources" mid-body must not be truncated.
+export interface Citation {
+  title: string
+  url: string
+}
+
+export interface SplitAnswer {
+  body: string
+  citations: Citation[]
+}
+
+const sourcesHeading = /\n##\s*Sources\s*\n/gi
+const citationLine = /^\s*\d+\.\s*\[([^\]]+)\]\(([^)]+)\)\s*$/
+
+export function splitSources(text: string): SplitAnswer {
+  let match: RegExpExecArray | null = null
+  for (let m = sourcesHeading.exec(text); m; m = sourcesHeading.exec(text)) match = m
+  if (!match) return { body: text, citations: [] }
+
+  const body = text.slice(0, match.index).trimEnd()
+  const tail = text.slice(match.index + match[0].length)
+
+  const citations: Citation[] = []
+  for (const line of tail.split('\n')) {
+    const m = citationLine.exec(line)
+    if (m) citations.push({ title: m[1], url: m[2] })
+  }
+  // A heading with no parseable lines under it is not a real citation
+  // list (model may have written prose under a coincidental heading);
+  // keep the whole thing in the body rather than silently eating it.
+  if (citations.length === 0) return { body: text, citations: [] }
+
+  return { body, citations }
+}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -24,19 +24,44 @@ import type { ChatIntent } from './Home'
 
 const categoryKey = 'timothy.category'
 
-export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
+export function Chat({
+  onNeedToken,
+  basePath = '/chat',
+  lockedSkillHint,
+  emptyHeading = 'What can I help with?',
+  emptySubtext = 'Ask anything. The category picker steers which model serves you.',
+  placeholder,
+}: {
+  onNeedToken: () => void
+  // Route prefix for session-id adoption (e.g. "/research" for the
+  // locked research page) — kept in sync with the <Route> that mounts
+  // this component so mid-stream URL adoption lands on the right page.
+  basePath?: string
+  // When set, the skill is pinned for every turn and cannot be
+  // removed or overridden by a home-screen intent — a dedicated,
+  // single-purpose page rather than general chat with a chip.
+  lockedSkillHint?: string
+  emptyHeading?: string
+  emptySubtext?: string
+  placeholder?: string
+}) {
   const { id: routeSession } = useParams()
   const navigate = useNavigate()
   const location = useLocation()
   const { refresh } = useSessions()
   const [items, setItems] = useState<ChatItem[]>([])
   const [draft, setDraft] = useState('')
+  // Locked pages fix their own category and never touch the shared
+  // localStorage preference — a research page reading (or clobbering)
+  // whatever category general chat last used would be a leak either
+  // direction.
   const [category, setCategory] = useState(
-    () => localStorage.getItem(categoryKey) ?? categories[0],
+    () => (lockedSkillHint ? 'research' : (localStorage.getItem(categoryKey) ?? categories[0])),
   )
   // A skill picked from the home screen: pinned, not text the user
-  // can accidentally mangle. Rides every turn until removed.
-  const [skillHint, setSkillHint] = useState<string | undefined>(undefined)
+  // can accidentally mangle. Rides every turn until removed. Locked
+  // pages skip this state entirely and always send lockedSkillHint.
+  const [skillHint, setSkillHint] = useState<string | undefined>(lockedSkillHint)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [streaming, setStreaming] = useState(false)
   const sessionRef = useRef<string | undefined>(routeSession)
@@ -124,9 +149,9 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
       if (sessionRef.current === id) return
       sessionRef.current = id
       adoptedRef.current = id
-      // Same route pattern serves /chat and /chat/:id, so this only
-      // re-renders — the live stream keeps its component state.
-      navigate(`/chat/${id}`, { replace: true })
+      // Same route pattern serves basePath and basePath/:id, so this
+      // only re-renders — the live stream keeps its component state.
+      navigate(`${basePath}/${id}`, { replace: true })
     }
     try {
       await chatStream(
@@ -168,7 +193,7 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
   // relying on the skillHint state landing before the call — setState
   // doesn't take effect until the next render.
   useEffect(() => {
-    if (intentConsumedRef.current) return
+    if (lockedSkillHint || intentConsumedRef.current) return
     const intent = location.state as ChatIntent | null
     if (!intent || (!intent.send && !intent.draft && !intent.category && !intent.skillHint)) return
     intentConsumedRef.current = true
@@ -202,11 +227,9 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
         {items.length === 0 && !loadError && (
           <div className="mt-24 text-center">
             <h2 className="text-xl font-semibold text-zinc-700 dark:text-zinc-200">
-              What can I help with?
+              {emptyHeading}
             </h2>
-            <p className="mt-2 text-sm text-zinc-400">
-              Ask anything. The category picker steers which model serves you.
-            </p>
+            <p className="mt-2 text-sm text-zinc-400">{emptySubtext}</p>
           </div>
         )}
         {loadError && (
@@ -244,9 +267,11 @@ export function Chat({ onNeedToken }: { onNeedToken: () => void }) {
           onSend={send}
           category={category}
           onCategory={pickCategory}
+          hideCategoryPicker={Boolean(lockedSkillHint)}
           skillHint={skillHint}
-          onRemoveSkillHint={() => setSkillHint(undefined)}
+          onRemoveSkillHint={lockedSkillHint ? undefined : () => setSkillHint(undefined)}
           disabled={streaming}
+          placeholder={placeholder}
         />
         <p className="mt-2 text-center text-xs text-zinc-400 dark:text-zinc-500">
           Enter to send · Shift+Enter for a new line

--- a/web/src/pages/Home.test.tsx
+++ b/web/src/pages/Home.test.tsx
@@ -25,6 +25,7 @@ function renderHome() {
         <Route path="/" element={<Home />} />
         <Route path="/chat" element={<ChatProbe />} />
         <Route path="/memory" element={<div>memory page</div>} />
+        <Route path="/research" element={<div>research page</div>} />
       </Routes>
     </MemoryRouter>,
   )
@@ -45,7 +46,7 @@ describe('Home', () => {
       expect(screen.getByRole('heading', { name: title })).toBeTruthy()
     }
     expect(screen.getByRole('button', { name: /New chat/ })).toBeTruthy()
-    expect(screen.getByRole('button', { name: /Markets/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Research/ })).toBeTruthy()
   })
 
   it('submitting the composer starts a chat with the message', () => {
@@ -65,12 +66,10 @@ describe('Home', () => {
     expect(landed).toBeNull()
   })
 
-  it('skill tiles carry a deterministic skill hint into chat', () => {
+  it('the Research tile navigates to the dedicated research page', () => {
     renderHome()
-    fireEvent.click(screen.getByRole('button', { name: /Travel/ }))
-    expect(landed?.pathname).toBe('/chat')
-    expect(landed?.state?.skillHint).toBe('travel-planning')
-    expect(landed?.state?.send).toBeUndefined()
+    fireEvent.click(screen.getByRole('button', { name: /Research/ }))
+    expect(screen.getByText('research page')).toBeTruthy()
   })
 
   it('memory tiles navigate to the memory page', () => {

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,10 +1,7 @@
 import {
-  AirplaneTakeOff01Icon,
   Analytics01Icon,
   Brain02Icon,
   BubbleChatIcon,
-  ChartLineData01Icon,
-  CodeIcon,
   InboxIcon,
   SearchList01Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
@@ -69,31 +66,8 @@ export function Home() {
       ],
     },
     {
-      // Skill packs are prompt-focused personas the agent loads on
-      // demand; each tile opens a chat pre-aimed at one of them.
       title: 'Skills',
-      tiles: [
-        {
-          label: 'Research',
-          icon: SearchList01Icon,
-          intent: { skillHint: 'research-brief', category: 'research' },
-        },
-        {
-          label: 'Markets',
-          icon: ChartLineData01Icon,
-          intent: { skillHint: 'markets-digest', category: 'research' },
-        },
-        {
-          label: 'Travel',
-          icon: AirplaneTakeOff01Icon,
-          intent: { skillHint: 'travel-planning', category: 'research' },
-        },
-        {
-          label: 'Coding',
-          icon: CodeIcon,
-          intent: { skillHint: 'coding-task', category: 'coding' },
-        },
-      ],
+      tiles: [{ label: 'Research', icon: SearchList01Icon, to: '/research' }],
     },
     {
       title: 'Workspace',

--- a/web/src/pages/Research.tsx
+++ b/web/src/pages/Research.tsx
@@ -1,0 +1,19 @@
+import { Chat } from './Chat'
+
+// Research is a dedicated, single-purpose entry point: the
+// research-brief skill is pinned for every turn (not removable, not
+// picked from a chip) so every answer follows the same source-grounded
+// discipline — web_search + web_fetch, cited claims, a structured
+// Sources list the UI renders as its own panel.
+export function Research({ onNeedToken }: { onNeedToken: () => void }) {
+  return (
+    <Chat
+      onNeedToken={onNeedToken}
+      basePath="/research"
+      lockedSkillHint="research-brief"
+      emptyHeading="What do you want to research?"
+      emptySubtext="Ask a question that needs current facts — Timothy searches, reads sources, and cites everything it claims."
+      placeholder="Ask a research question…"
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- New /research page: a locked variant of Chat with the research-brief skill pinned for every turn (not removable), no category picker — a single-purpose entry point rather than general chat with a chip
- research-brief now requires every answer to close with a `## Sources` section (numbered markdown list); the frontend parses that trailing section into a distinct, clickable citations panel separate from the prose
- SKILLS_ALLOWLIST env var restricts the agent to research-brief only for this deploy — markets-digest, travel-planning, and coding-task stay on disk but are unreachable via load_skill
- Home's Skills group is now just the one Research tile, linking directly to the dedicated page

## Test plan
- [x] Web: `tsc --noEmit`, `oxlint`, `vitest` (58/58, +5 new citation tests) all green
- [x] Go: `build`, `vet` clean
- [x] Live-verified: a real research question through /v1/chat with skill_hint=research-brief returns a genuine `## Sources` list with real Amazon Bedrock pricing page citation, served by us.amazon.nova-pro-v1:0 via Bedrock
- [x] Live-verified: SKILLS_ALLOWLIST=research-brief active in the running container