### PR TITLE
Fix: merge parallel tool results into one Bedrock turn

### DIFF
--- a/internal/gateway/provider/bedrock.go
+++ b/internal/gateway/provider/bedrock.go
@@ -285,23 +285,49 @@ func converseMessages(msgs []Message) []types.Message {
 			if m.ToolResult == nil {
 				continue
 			}
-			resultBlock := types.ToolResultBlock{
+			resultBlock := types.ContentBlock(&types.ContentBlockMemberToolResult{Value: types.ToolResultBlock{
 				ToolUseId: aws.String(m.ToolResult.ID),
 				Content: []types.ToolResultContentBlock{
 					&types.ToolResultContentBlockMemberText{Value: m.ToolResult.Content},
 				},
-				Status: types.ToolResultStatusSuccess,
-			}
-			if m.ToolResult.IsError {
-				resultBlock.Status = types.ToolResultStatusError
+				Status: toolResultStatus(m.ToolResult.IsError),
+			}})
+			// Bedrock requires every toolResult for one assistant turn's
+			// parallel toolUse blocks to land in a SINGLE following user
+			// turn — one user turn per tool result (the normalized
+			// message shape agent.go builds) is invalid and Converse
+			// rejects it with "Expected toolResult blocks ... for the
+			// following Ids". Merge consecutive tool messages together.
+			if n := len(out); n > 0 && out[n-1].Role == types.ConversationRoleUser && isToolResultTurn(out[n-1]) {
+				out[n-1].Content = append(out[n-1].Content, resultBlock)
+				continue
 			}
 			out = append(out, types.Message{
 				Role:    types.ConversationRoleUser,
-				Content: []types.ContentBlock{&types.ContentBlockMemberToolResult{Value: resultBlock}},
+				Content: []types.ContentBlock{resultBlock},
 			})
 		}
 	}
 	return out
+}
+
+func toolResultStatus(isError bool) types.ToolResultStatus {
+	if isError {
+		return types.ToolResultStatusError
+	}
+	return types.ToolResultStatusSuccess
+}
+
+// isToolResultTurn reports whether a user turn is made entirely of
+// tool results (as opposed to plain user text) — only these are safe
+// to append more tool results onto.
+func isToolResultTurn(msg types.Message) bool {
+	for _, c := range msg.Content {
+		if _, ok := c.(*types.ContentBlockMemberToolResult); !ok {
+			return false
+		}
+	}
+	return len(msg.Content) > 0
 }
 
 // converseSystem builds the system blocks. Nova models get a cache

--- a/internal/gateway/provider/bedrock_test.go
+++ b/internal/gateway/provider/bedrock_test.go
@@ -43,6 +43,67 @@ func TestConverseMessages(t *testing.T) {
 	}
 }
 
+// TestConverseMessagesMergesParallelToolResults reproduces a live
+// crash: two tool calls in one assistant turn produced two separate
+// user turns (one toolResult block each), which Bedrock's Converse API
+// rejects with "Expected toolResult blocks ... for the following Ids"
+// — it requires every result for one turn's parallel tool calls in a
+// SINGLE following user turn.
+func TestConverseMessagesMergesParallelToolResults(t *testing.T) {
+	t.Parallel()
+	msgs := []Message{
+		{Role: "assistant", ToolCalls: []ToolCall{
+			{ID: "t1", Name: "calc", Input: json.RawMessage(`{}`)},
+			{ID: "t2", Name: "calc", Input: json.RawMessage(`{}`)},
+		}},
+		{Role: "tool", ToolResult: &ToolResult{ID: "t1", Content: "4"}},
+		{Role: "tool", ToolResult: &ToolResult{ID: "t2", Content: "9"}},
+	}
+
+	out := converseMessages(msgs)
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2 (one assistant turn, one merged user turn)", len(out))
+	}
+	if out[1].Role != types.ConversationRoleUser {
+		t.Fatalf("msg 1 role = %v", out[1].Role)
+	}
+	if len(out[1].Content) != 2 {
+		t.Fatalf("merged user turn has %d blocks, want 2", len(out[1].Content))
+	}
+	first, ok := out[1].Content[0].(*types.ContentBlockMemberToolResult)
+	if !ok || *first.Value.ToolUseId != "t1" {
+		t.Fatalf("block 0 = %#v", out[1].Content[0])
+	}
+	second, ok := out[1].Content[1].(*types.ContentBlockMemberToolResult)
+	if !ok || *second.Value.ToolUseId != "t2" {
+		t.Fatalf("block 1 = %#v", out[1].Content[1])
+	}
+}
+
+// TestConverseMessagesDoesNotMergeIntoRealUserText proves the merge
+// only fires between consecutive tool-result turns — a plain user
+// message must never absorb a tool result or vice versa.
+func TestConverseMessagesDoesNotMergeIntoRealUserText(t *testing.T) {
+	t.Parallel()
+	msgs := []Message{
+		{Role: "assistant", ToolCalls: []ToolCall{{ID: "t1", Name: "calc", Input: json.RawMessage(`{}`)}}},
+		{Role: "tool", ToolResult: &ToolResult{ID: "t1", Content: "4"}},
+		{Role: "user", Content: "thanks, one more question"},
+	}
+
+	out := converseMessages(msgs)
+	if len(out) != 3 {
+		t.Fatalf("len = %d, want 3 (assistant, tool result, plain user text kept separate)", len(out))
+	}
+	if len(out[1].Content) != 1 {
+		t.Fatalf("tool result turn has %d blocks, want 1", len(out[1].Content))
+	}
+	txt, ok := out[2].Content[0].(*types.ContentBlockMemberText)
+	if !ok || txt.Value != "thanks, one more question" {
+		t.Fatalf("msg 2 = %#v", out[2].Content[0])
+	}
+}
+
 func TestConverseSystem(t *testing.T) {
 	t.Parallel()
 	if converseSystem("", "us.amazon.nova-pro-v1:0") != nil {


### PR DESCRIPTION
## Summary
- Bedrock's Converse API rejects a turn where multiple tool calls' results arrive as separate consecutive user turns — it requires every result for one assistant turn's tool calls in a single following user turn
- Hit live: a research session asking for a cost comparison triggered two parallel `calculate` calls, and the second turn failed with "Expected toolResult blocks ... for the following Ids"
- `converseMessages` now merges consecutive tool-result messages into one user turn instead of one turn per result

## Test plan
- [x] `go build`, `go vet` clean
- [x] New regression tests: parallel tool results merge into one turn; a real user-text turn is never merged into a tool-result turn
- [x] Full `internal/gateway/provider` suite green with `-race`
- [x] `golangci-lint` — 0 issues