### PR TITLE
fix: chat rendering and answer repetition

### DIFF
--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -338,7 +338,12 @@ func (s *Service) persistTurn(sessionID, userText, category string, firstExchang
 	if reasoning != "" {
 		turn.UI.Blocks = append(turn.UI.Blocks, session.UIBlock{Type: "reasoning", Text: reasoning})
 	}
-	turn.UI.Blocks = append(turn.UI.Blocks, session.UIBlock{Type: "text", Text: text})
+	// A turn whose answer landed entirely in reasoning has no text;
+	// an empty text block serializes without its text key (omitempty)
+	// and renders as a literal "undefined" in older clients.
+	if text != "" {
+		turn.UI.Blocks = append(turn.UI.Blocks, session.UIBlock{Type: "text", Text: text})
+	}
 	if meta != nil {
 		turn.Provider, turn.Model, turn.LedgerID = meta.Provider, meta.Model, meta.LedgerID
 	}

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -326,6 +326,13 @@ func (s *Service) persistTurn(sessionID, userText, category string, firstExchang
 		return
 	}
 
+	// Models occasionally restate their entire answer after a late
+	// tool call; the loop concatenates every step's text, so the
+	// restatement lands as a verbatim duplicate tail. Collapse it
+	// before the turn becomes durable.
+	text = collapseRepeatedTail(text)
+	reasoning = collapseRepeatedTail(reasoning)
+
 	var turn session.AssistantTurn
 	turn.LLM.Message = text
 	if reasoning != "" {
@@ -451,6 +458,29 @@ func truncateRunes(s string, n int) string {
 		return s
 	}
 	return string(runes[:n])
+}
+
+// collapseRepeatedTail strips a verbatim duplicated tail: when the
+// text ends with a block that is an exact copy of what immediately
+// precedes it (whitespace between copies aside), one copy is dropped.
+// The 40-char floor keeps legitimately repeated short phrases intact;
+// scanning longest-first collapses the whole restated answer, not a
+// fragment of it.
+func collapseRepeatedTail(s string) string {
+	const minRepeat = 40
+	t := strings.TrimRight(s, " \t\n")
+	n := len(t)
+	for l := n / 2; l >= minRepeat; l-- {
+		tail := t[n-l:]
+		head := strings.TrimRight(t[:n-l], " \t\n")
+		if strings.HasSuffix(head, tail) {
+			return collapseRepeatedTail(head)
+		}
+	}
+	if n == len(s) {
+		return s
+	}
+	return t
 }
 
 func hasUserMessage(events []session.Event) bool {

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -698,3 +698,30 @@ func TestMemoryExtractFiresOnTextlessTurn(t *testing.T) {
 		t.Fatal("memory extract skipped on textless turn")
 	}
 }
+
+// TestCollapseRepeatedTail covers the duplicate-answer collapse: a
+// model that restates its whole reply after a late tool call must not
+// leave two copies in the persisted turn.
+func TestCollapseRepeatedTail(t *testing.T) {
+	t.Parallel()
+	answer := "The monthly bill would be $29.85 based on 30 million requests and 1,843,200 GB-seconds.\n\n## Sources\n1. [AWS Lambda Pricing](https://aws.amazon.com/lambda/pricing)"
+	cases := []struct {
+		name, in, want string
+	}{
+		{"exact double", answer + answer, answer},
+		{"double with newline between", answer + "\n" + answer, answer},
+		{"triple", answer + "\n" + answer + "\n" + answer, answer},
+		{"prefix kept", "Let me check the pricing page.\n" + answer + "\n" + answer, "Let me check the pricing page.\n" + answer},
+		{"no repeat unchanged", answer, answer},
+		{"short repeats kept", "very good, very good, very good", "very good, very good, very good"},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := collapseRepeatedTail(tc.in); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/brain/chat/systemprompt.go
+++ b/internal/brain/chat/systemprompt.go
@@ -1,7 +1,7 @@
 package chat
 
 // systemPromptVersion increments with any change to the prompt text.
-const systemPromptVersion = 2
+const systemPromptVersion = 3
 
 // systemPrompt is Timothy's identity. Additions APPEND after the
 // existing text and the terseness steer stays the LAST line: the
@@ -12,7 +12,9 @@ const systemPrompt = `You are Timothy, a self-hosted personal AI assistant servi
 
 You have tools: use them whenever the answer depends on the current time, arithmetic, a web page's content, files in your workspace, or a stored output — never guess what a tool can tell you. Some tool calls need the owner's approval; a denial is an answer, adapt rather than retry. You have no memory of prior sessions.
 
-Answer from knowledge when confident; say plainly when you are unsure or lack access to current information.`
+Answer from knowledge when confident; say plainly when you are unsure or lack access to current information.
+
+Before a tool call, write at most one short line saying what you are checking — never the answer itself; the answer comes only after the tool results are in. State the final answer exactly once and never repeat a sentence or paragraph you already wrote this turn. Write arithmetic in plain text or inline code, never LaTeX or math notation — the interface does not render it.`
 
 // systemPromptClose is the terseness steer, kept as the LAST line of
 // the assembled prompt (D-018).

--- a/skills/research-brief/SKILL.md
+++ b/skills/research-brief/SKILL.md
@@ -21,6 +21,19 @@ description: Source-grounded research with verification and citations. Use when 
   `1. [Title](URL)`. Nothing else on that line — no dates, no notes,
   no extra prose. Every URL listed must be one you actually fetched or
   searched this turn.
+- Write arithmetic in plain text or inline code — never LaTeX or math
+  notation (`\frac`, `\times`, `\text`, `$...$`); the interface does
+  not render it.
+- Before a tool call, write at most one short line saying what you are
+  checking — never the answer itself. The answer comes only after all
+  tool results are in.
+- State the final answer exactly once. Never repeat a sentence or
+  paragraph you already wrote this turn, and do not add an `## Answer`
+  heading.
+- When comparing a number against a limit or allowance, write the
+  comparison out explicitly (`184,320 < 400,000: under the limit`)
+  before concluding. When pricing usage that has a free allowance,
+  subtract the allowance first and price only the remainder.
 
 ## Anti-rationalization
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24,6 +24,7 @@
         "react-router": "^8.2.0",
         "recharts": "^3.9.2",
         "rehype-highlight": "^7.0.2",
+        "remark-gfm": "^4.0.1",
         "shadcn": "^4.13.0",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.2",
@@ -5553,6 +5554,18 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -7051,6 +7064,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7058,6 +7081,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -7078,6 +7117,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7323,6 +7463,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -8826,6 +9087,24 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -8853,6 +9132,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,7 @@
     "react-router": "^8.2.0",
     "recharts": "^3.9.2",
     "rehype-highlight": "^7.0.2",
+    "remark-gfm": "^4.0.1",
     "shadcn": "^4.13.0",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.2",

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import rehypeHighlight from 'rehype-highlight'
 import { Badge } from './ui/badge'
-import { splitSources } from '../lib/citations'
+import { collapseRepeatedTail, splitSources } from '../lib/citations'
 import type { AssistantState, ToolRun } from '../lib/chat'
 import 'highlight.js/styles/github-dark.css'
 
@@ -165,7 +165,9 @@ export function AssistantMessage({ msg }: { msg: AssistantState }) {
   // Citations only split out once the answer is done streaming: a
   // partial "## Sources" heading mid-stream would otherwise flicker
   // the body text as more of it arrives.
-  const { body, citations } = msg.streaming ? { body: msg.text, citations: [] } : splitSources(msg.text)
+  const { body, citations } = msg.streaming
+    ? { body: msg.text, citations: [] }
+    : splitSources(collapseRepeatedTail(msg.text))
   return (
     <div className="group/message flex flex-col items-start gap-2">
       {msg.reasoning !== '' && (

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -3,6 +3,7 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import rehypeHighlight from 'rehype-highlight'
+import remarkGfm from 'remark-gfm'
 import { Badge } from './ui/badge'
 import { collapseRepeatedTail, splitSources } from '../lib/citations'
 import type { AssistantState, ToolRun } from '../lib/chat'
@@ -97,7 +98,7 @@ export function InterruptedMessage({ text }: { text: string }) {
   return (
     <div className="group/message flex flex-col items-start gap-2" data-testid="interrupted">
       <div className="prose prose-sm max-w-3xl dark:prose-invert prose-pre:bg-zinc-900">
-        <ReactMarkdown rehypePlugins={[rehypeHighlight]}>{text}</ReactMarkdown>
+        <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>{text}</ReactMarkdown>
       </div>
       <div className="flex items-center gap-1.5">
         <Badge
@@ -192,7 +193,7 @@ export function AssistantMessage({ msg }: { msg: AssistantState }) {
       )}
 
       <div className="prose prose-sm max-w-3xl dark:prose-invert prose-pre:bg-zinc-900">
-        <ReactMarkdown rehypePlugins={[rehypeHighlight]}>{body}</ReactMarkdown>
+        <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>{body}</ReactMarkdown>
         {msg.streaming && msg.permissions.length === 0 && <span className="animate-pulse">▍</span>}
       </div>
 

--- a/web/src/lib/citations.test.ts
+++ b/web/src/lib/citations.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { splitSources } from './citations'
+import { collapseRepeatedTail, splitSources } from './citations'
 
 describe('splitSources', () => {
   it('splits a trailing Sources section into structured citations', () => {
@@ -48,5 +48,46 @@ describe('splitSources', () => {
     ].join('\n')
     const { citations } = splitSources(text)
     expect(citations).toEqual([{ title: 'Ref', url: 'https://example.com' }])
+  })
+})
+
+describe('collapseRepeatedTail', () => {
+  const answer = [
+    'The monthly bill would be $29.85 based on 30 million requests.',
+    '',
+    '## Sources',
+    '1. [AWS Lambda Pricing](https://aws.amazon.com/lambda/pricing)',
+  ].join('\n')
+
+  it('collapses an exact duplicated answer', () => {
+    expect(collapseRepeatedTail(answer + answer)).toBe(answer)
+  })
+
+  it('collapses a duplicate separated by a newline', () => {
+    expect(collapseRepeatedTail(answer + '\n' + answer)).toBe(answer)
+  })
+
+  it('collapses a triple restatement', () => {
+    expect(collapseRepeatedTail(answer + '\n' + answer + '\n' + answer)).toBe(answer)
+  })
+
+  it('keeps a distinct prefix before the duplicate', () => {
+    const prefixed = 'Let me check the pricing page.\n' + answer + '\n' + answer
+    expect(collapseRepeatedTail(prefixed)).toBe('Let me check the pricing page.\n' + answer)
+  })
+
+  it('leaves text without a repeat unchanged', () => {
+    expect(collapseRepeatedTail(answer)).toBe(answer)
+  })
+
+  it('leaves short legitimate repeats intact', () => {
+    const text = 'very good, very good, very good'
+    expect(collapseRepeatedTail(text)).toBe(text)
+  })
+
+  it('feeds splitSources a single Sources section after collapse', () => {
+    const { citations, body } = splitSources(collapseRepeatedTail(answer + '\n' + answer))
+    expect(citations).toHaveLength(1)
+    expect(body).toBe('The monthly bill would be $29.85 based on 30 million requests.')
   })
 })

--- a/web/src/lib/citations.ts
+++ b/web/src/lib/citations.ts
@@ -12,6 +12,24 @@ export interface SplitAnswer {
   citations: Citation[]
 }
 
+// collapseRepeatedTail strips a verbatim duplicated tail: models
+// occasionally restate their entire answer (Sources section included)
+// after a late tool call, and the stream concatenates both copies.
+// Mirrors the server-side collapse so the live view matches what the
+// brain persists. The 40-char floor keeps legitimately repeated short
+// phrases intact.
+export function collapseRepeatedTail(s: string): string {
+  const minRepeat = 40
+  const t = s.replace(/[ \t\n]+$/, '')
+  const n = t.length
+  for (let l = Math.floor(n / 2); l >= minRepeat; l--) {
+    const tail = t.slice(n - l)
+    const head = t.slice(0, n - l).replace(/[ \t\n]+$/, '')
+    if (head.endsWith(tail)) return collapseRepeatedTail(head)
+  }
+  return n === s.length ? s : t
+}
+
 const sourcesHeading = /\n##\s*Sources\s*\n/gi
 const citationLine = /^\s*\d+\.\s*\[([^\]]+)\]\(([^)]+)\)\s*$/
 

--- a/web/src/lib/transcript.ts
+++ b/web/src/lib/transcript.ts
@@ -45,8 +45,10 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
         let text = ''
         let reasoning = ''
         for (const b of item.blocks ?? []) {
-          if (b.type === 'text') text += b.text
-          else if (b.type === 'reasoning') reasoning += b.text
+          // An empty block serializes without its text key (omitempty);
+          // naive concat would render a literal "undefined".
+          if (b.type === 'text') text += b.text ?? ''
+          else if (b.type === 'reasoning') reasoning += b.text ?? ''
         }
         out.push({
           id,

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -70,6 +70,11 @@ export function Chat({
   const adoptedRef = useRef<string | null>(null)
   const intentConsumedRef = useRef(false)
   const bottomRef = useRef<HTMLDivElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+  // Whether the view is pinned to the bottom. Scrolling up releases
+  // the pin so a streaming answer stops yanking the view back down;
+  // scrolling back near the bottom re-engages it.
+  const pinnedRef = useRef(true)
   const abortRef = useRef<AbortController | null>(null)
 
   // Cancel any in-flight stream when the page unmounts (route change).
@@ -115,8 +120,14 @@ export function Chat({
   }, [routeSession, onNeedToken])
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+    if (pinnedRef.current) bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [items])
+
+  const trackPin = () => {
+    const el = listRef.current
+    if (!el) return
+    pinnedRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80
+  }
 
   const pickCategory = (c: string) => {
     setCategory(c)
@@ -137,6 +148,7 @@ export function Chat({
     if (!message || streaming) return
     setDraft('')
     setStreaming(true)
+    pinnedRef.current = true // sending always re-follows the answer
     setItems((prev) => [
       ...prev,
       { id: crypto.randomUUID(), role: 'user', text: message },
@@ -223,7 +235,7 @@ export function Chat({
   return (
     <div className="flex h-full flex-col">
       {pendingPermission && <PermissionModal request={pendingPermission} onDecision={decide} />}
-      <div className="flex-1 space-y-6 overflow-y-auto py-6">
+      <div ref={listRef} onScroll={trackPin} className="flex-1 space-y-6 overflow-y-auto py-6">
         {items.length === 0 && !loadError && (
           <div className="mt-24 text-center">
             <h2 className="text-xl font-semibold text-zinc-700 dark:text-zinc-200">

--- a/web/src/pages/Memory.tsx
+++ b/web/src/pages/Memory.tsx
@@ -345,24 +345,26 @@ function Browser() {
 export function Memory() {
   const [tab, setTab] = useState<'queue' | 'browser'>('queue')
   return (
-    <div className="mx-auto w-full max-w-3xl p-6 space-y-6">
-      <div className="flex items-center gap-2">
-        <h1 className="text-lg font-semibold">Memory</h1>
-        <div className="ml-auto flex gap-1 rounded-lg border p-0.5">
-          {(['queue', 'browser'] as const).map((t) => (
-            <Button
-              key={t}
-              size="sm"
-              variant={tab === t ? 'secondary' : 'ghost'}
-              onClick={() => setTab(t)}
-              data-testid={`tab-${t}`}
-            >
-              {t === 'queue' ? 'Queue' : 'Browser'}
-            </Button>
-          ))}
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto w-full max-w-3xl p-6 space-y-6">
+        <div className="flex items-center gap-2">
+          <h1 className="text-lg font-semibold">Memory</h1>
+          <div className="ml-auto flex gap-1 rounded-lg border p-0.5">
+            {(['queue', 'browser'] as const).map((t) => (
+              <Button
+                key={t}
+                size="sm"
+                variant={tab === t ? 'secondary' : 'ghost'}
+                onClick={() => setTab(t)}
+                data-testid={`tab-${t}`}
+              >
+                {t === 'queue' ? 'Queue' : 'Browser'}
+              </Button>
+            ))}
+          </div>
         </div>
+        {tab === 'queue' ? <Queue /> : <Browser />}
       </div>
-      {tab === 'queue' ? <Queue /> : <Browser />}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Fixes a batch of chat-output and UI defects found while preparing the research-assistant demo:

- **Duplicate answers**: models occasionally restate their entire answer after a late tool call; the agent loop concatenates every step's text, so the restatement persisted verbatim. `collapseRepeatedTail` now strips the duplicated tail on both sides — in the brain before the turn becomes durable, and in the web client before sources split out — so live view matches storage. Anti-repetition and no-LaTeX rules also move into the base system prompt (duplication reproduced in plain chat where the research skill never loads).
- **Literal "undefined" in transcripts**: a turn whose text landed entirely in the reasoning stream persisted an empty text block; `omitempty` dropped the `text` key and the transcript mapper concatenated `undefined`. Empty blocks are now skipped at persist and missing text defaults to `''` on read.
- **GFM tables rendered as collapsed pipe soup**: react-markdown needs `remark-gfm` for table syntax.
- **Chat autoscroll**: the message list yanked to the bottom on every streamed chunk, making scroll-up impossible mid-stream. Auto-scroll now only fires while the view is pinned near the bottom; sending re-pins.
- **Memory page unscrollable**: no scroll container of its own inside the overflow-hidden route wrapper.
- **research-brief skill**: output rules for plain-text arithmetic, no answer text before tool results, single final answer, and explicit limit comparisons before pricing against a free allowance.

## Testing

- Go: full suite with `-race`, vet, golangci-lint 0 issues; 7 new table-driven cases for `collapseRepeatedTail`
- Web: tsc clean; vitest 65 tests incl. 7 new collapse cases (one pre-existing flaky timeout under container load, passes isolated)
- Live: brain rebuilt and healthy

https://claude.ai/code/session_015xJFNRxUULMez4KkUgi3q7