### PR TITLE
Production web image, spend budgets with alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,14 +88,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        service: [brain, gateway, memoryd]
+        service: [brain, gateway, memoryd, web]
     steps:
       - uses: actions/checkout@v7
       - name: Build image
-        run: >-
-          docker build -f deploy/Dockerfile
-          --build-arg SERVICE=${{ matrix.service }}
-          -t timothy-${{ matrix.service }}:ci .
+        env:
+          # Web only: HugeIcons Pro registry auth, passed as a BuildKit
+          # secret so it never lands in an image layer.
+          HUGEICONS_TOKEN: ${{ secrets.HUGEICONS_TOKEN }}
+        run: |
+          if [ "${{ matrix.service }}" = "web" ]; then
+            docker build -f web/Dockerfile \
+              --secret id=hugeicons_token,env=HUGEICONS_TOKEN \
+              -t timothy-web:ci web
+          else
+            docker build -f deploy/Dockerfile \
+              --build-arg SERVICE=${{ matrix.service }} \
+              -t timothy-${{ matrix.service }}:ci .
+          fi
       - name: Scan image
         uses: aquasecurity/trivy-action@v0.36.0
         with:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ make test    # unit tests (containerized)
 make lint    # golangci-lint
 ```
 
-Design decisions live in [docs/architecture.md](docs/architecture.md).
+Design decisions are documented as `D-0XX` markers in code comments next to the code they explain.
 
 ## License
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/admin"
 	"github.com/SumonMSelim/timothy/internal/gateway/api"
@@ -44,9 +45,17 @@ func main() {
 	store := router.NewStore(app.DB, os.Getenv, app.Log)
 	go store.Run(ctx)
 	led := ledger.New(app.DB, app.Log)
+	agg := ledger.NewAggregator(app.DB)
+	budgets := ledger.NewBudgetStore(app.DB)
 	api.Register(app.Server, store, led, app.Log)
-	api.RegisterUsage(app.Server, ledger.NewAggregator(app.DB))
-	api.RegisterAdmin(app.Server, admin.New(app.DB, store, led, app.Log))
+	api.RegisterUsage(app.Server, agg, budgets)
+	api.RegisterAdmin(app.Server, admin.New(app.DB, store, led, budgets, app.Log))
+
+	spendGauge := app.Metrics.NewGaugeVec("spend_usd",
+		"USD spent in the current UTC calendar window.", "window")
+	budgetGauge := app.Metrics.NewGaugeVec("spend_budget_usd",
+		"Configured USD budget per window; 0 when unset.", "window")
+	go ledger.RunSpendGauges(ctx, time.Minute, agg, budgets, spendGauge, budgetGauge, app.Log)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -123,6 +123,29 @@ services:
 
   web:
     <<: *service
+    build:
+      context: ../web
+      # HugeIcons Pro registry auth for npm ci, passed as a BuildKit
+      # secret (name-only ref; the value lives in deploy/.env, never in
+      # the repo or an image layer).
+      secrets: [hugeicons_token]
+    environment:
+      # nginx proxy target for /v1 (browser stays same-origin)
+      BRAIN_URL: http://brain:8080
+    ports:
+      - "${WEB_PORT:-3300}:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/ >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  # Vite dev server with hot reload; opt in with --profile dev. Uses
+  # its own port so it can run alongside the production web service.
+  web-dev:
+    <<: *service
+    profiles: [dev]
     image: node:24.18.0-alpine
     working_dir: /app
     environment:
@@ -139,13 +162,17 @@ services:
       - ../web:/app
       - web_node_modules:/app/node_modules
     ports:
-      - "${WEB_PORT:-3300}:3000"
+      - "${WEB_DEV_PORT:-3301}:3000"
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/ >/dev/null"]
       interval: 10s
       timeout: 5s
       retries: 3
       start_period: 60s
+
+secrets:
+  hugeicons_token:
+    environment: HUGEICONS_TOKEN
 
 volumes:
   pgdata:

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -4,6 +4,8 @@ LOG_LEVEL=info
 # Host ports (containers keep their internal ports)
 WEB_PORT=3300
 BRAIN_PORT=8300
+# Vite dev server (docker compose --profile dev up web-dev)
+WEB_DEV_PORT=3301
 
 # Provider API keys (referenced by credential_ref in the providers
 # table; leave empty to keep a provider unhealthy/skipped)

--- a/internal/brain/api/admin.go
+++ b/internal/brain/api/admin.go
@@ -12,6 +12,7 @@ import (
 // from outside. Tests pin this scope like the memory proxy's.
 var adminRoutePatterns = []string{
 	"GET /v1/admin/usage/{rest...}",
+	"PATCH /v1/admin/usage/budget",
 	"GET /v1/admin/providers",
 	"POST /v1/admin/providers",
 	"PATCH /v1/admin/providers/{id}",

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -267,8 +267,11 @@ func TestAdminProxyScopedToUsageRoutes(t *testing.T) {
 			t.Fatalf("GET %s = %d, want 200", path, code)
 		}
 	}
-	if proxied != 3 {
-		t.Fatalf("proxied = %d, want 3", proxied)
+	if code := call(http.MethodPatch, "/v1/admin/usage/budget", "Bearer tok"); code != http.StatusOK {
+		t.Fatalf("PATCH /v1/admin/usage/budget = %d, want 200", code)
+	}
+	if proxied != 4 {
+		t.Fatalf("proxied = %d, want 4", proxied)
 	}
 
 	// Only the admin usage surface is mounted; the gateway's other

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -42,14 +42,46 @@ const testTimeout = 20 * time.Second
 // snapshot after every write; rec books test-connection probes under
 // purpose='test' so they never pollute usage.
 type Admin struct {
-	db    *pgpool.Pool
-	store *router.Store
-	rec   ledger.Recorder
-	log   *slog.Logger
+	db      *pgpool.Pool
+	store   *router.Store
+	rec     ledger.Recorder
+	budgets *ledger.BudgetStore
+	log     *slog.Logger
 }
 
-func New(db *pgpool.Pool, store *router.Store, rec ledger.Recorder, log *slog.Logger) *Admin {
-	return &Admin{db: db, store: store, rec: rec, log: log}
+func New(db *pgpool.Pool, store *router.Store, rec ledger.Recorder, budgets *ledger.BudgetStore, log *slog.Logger) *Admin {
+	return &Admin{db: db, store: store, rec: rec, budgets: budgets, log: log}
+}
+
+// PatchBudget applies per-window budget changes: a key maps a window
+// scope to its new USD limit, nil clears it, absent keys stay
+// untouched. All keys are validated before any write so a bad entry
+// cannot leave a partial update. No snapshot reload: budgets never
+// affect routing.
+func (a *Admin) PatchBudget(ctx context.Context, patch map[string]*float64) error {
+	for scope, limit := range patch {
+		if scope != "day" && scope != "month" {
+			return fmt.Errorf("unknown budget scope %q", scope)
+		}
+		if limit != nil && *limit <= 0 {
+			return fmt.Errorf("budget limit for %s must be positive", scope)
+		}
+	}
+	before, err := a.budgets.Limits(ctx)
+	if err != nil {
+		return err
+	}
+	for scope, limit := range patch {
+		if err := a.budgets.Set(ctx, scope, limit); err != nil {
+			return err
+		}
+	}
+	after, err := a.budgets.Limits(ctx)
+	if err != nil {
+		return err
+	}
+	a.audit(ctx, "update", "budget", "spend", before, after)
+	return nil
 }
 
 // Provider is the API shape of one providers row. credential_ref is a

--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -55,7 +55,7 @@ func testAdmin(t *testing.T) (*Admin, *router.Store, *pgpool.Pool) {
 	if err := store.Load(ctx); err != nil {
 		t.Fatalf("store load: %v", err)
 	}
-	return New(pool, store, ledger.New(pool, log), log), store, pool
+	return New(pool, store, ledger.New(pool, log), ledger.NewBudgetStore(pool), log), store, pool
 }
 
 func TestProviderCRUDAuditsAndReloads(t *testing.T) {
@@ -243,5 +243,47 @@ func TestConnectionProbeBooksAsTestOnly(t *testing.T) {
 		if p.Group == adminMarker+"probe" {
 			t.Fatalf("test probe leaked into usage series: %+v", p)
 		}
+	}
+}
+
+func TestPatchBudgetValidatesAndAudits(t *testing.T) {
+	adm, _, pool := testAdmin(t)
+	ctx := t.Context()
+	db, _ := pool.Get()
+	t.Cleanup(func() {
+		_, _ = db.Exec(context.Background(), "DELETE FROM spend_budgets")
+		_, _ = db.Exec(context.Background(), "DELETE FROM admin_audit WHERE entity = 'budget'")
+	})
+
+	// Any invalid key rejects the whole patch before writes.
+	limit := 5.0
+	if err := adm.PatchBudget(ctx, map[string]*float64{"day": &limit, "week": &limit}); err == nil {
+		t.Fatal("unknown scope accepted")
+	}
+	var count int
+	_ = db.QueryRow(ctx, `SELECT count(*) FROM spend_budgets`).Scan(&count)
+	if count != 0 {
+		t.Fatalf("partial write: %d rows after rejected patch", count)
+	}
+
+	// Valid patch writes both windows and audits once.
+	month := 100.0
+	if err := adm.PatchBudget(ctx, map[string]*float64{"day": &limit, "month": &month}); err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	limits, err := ledger.NewBudgetStore(pool).Limits(ctx)
+	if err != nil {
+		t.Fatalf("limits: %v", err)
+	}
+	if limits.Day == nil || *limits.Day != limit || limits.Month == nil || *limits.Month != month {
+		t.Fatalf("limits = %+v, want day=%v month=%v", limits, limit, month)
+	}
+	var audits int
+	if err := db.QueryRow(ctx, `SELECT count(*) FROM admin_audit
+		WHERE entity = 'budget' AND action = 'update'`).Scan(&audits); err != nil {
+		t.Fatalf("audit query: %v", err)
+	}
+	if audits != 1 {
+		t.Fatalf("audit rows = %d, want 1", audits)
 	}
 }

--- a/internal/gateway/api/admin.go
+++ b/internal/gateway/api/admin.go
@@ -21,6 +21,7 @@ func RegisterAdmin(srv *httpserver.Server, adm *admin.Admin) {
 	srv.Handle("GET /internal/admin/providers/health", http.HandlerFunc(h.health))
 	srv.Handle("GET /internal/admin/routes", http.HandlerFunc(h.routes))
 	srv.Handle("PATCH /internal/admin/routes/{category}", http.HandlerFunc(h.patchRoute))
+	srv.Handle("PATCH /internal/admin/usage/budget", http.HandlerFunc(h.patchBudget))
 }
 
 type adminAPI struct {
@@ -122,6 +123,20 @@ func (h *adminAPI) patchRoute(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.adm.PatchRoute(r.Context(), r.PathValue("category"), patch); err != nil {
+		fail(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *adminAPI) patchBudget(w http.ResponseWriter, r *http.Request) {
+	var patch map[string]*float64
+	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil || len(patch) == 0 {
+		jsonError(w, http.StatusBadRequest, "bad_request",
+			"body must map budget scopes (day, month) to USD limits or null")
+		return
+	}
+	if err := h.adm.PatchBudget(r.Context(), patch); err != nil {
 		fail(w, err)
 		return
 	}

--- a/internal/gateway/api/usage.go
+++ b/internal/gateway/api/usage.go
@@ -13,17 +13,19 @@ import (
 // RegisterUsage mounts the internal usage-aggregation routes. Like the
 // rest of the gateway surface they carry no auth — brain proxies them
 // behind its bearer as /v1/admin/usage/*.
-func RegisterUsage(srv *httpserver.Server, agg *ledger.Aggregator) {
-	u := &usageAPI{agg: agg}
+func RegisterUsage(srv *httpserver.Server, agg *ledger.Aggregator, budgets *ledger.BudgetStore) {
+	u := &usageAPI{agg: agg, budgets: budgets}
 	srv.Handle("GET /internal/admin/usage/summary", http.HandlerFunc(u.handleSummary))
 	srv.Handle("GET /internal/admin/usage/series", http.HandlerFunc(u.handleSeries))
 	srv.Handle("GET /internal/admin/usage/sessions", http.HandlerFunc(u.handleSessions))
 	srv.Handle("GET /internal/admin/usage/latency", http.HandlerFunc(u.handleLatency))
 	srv.Handle("GET /internal/admin/usage/cache", http.HandlerFunc(u.handleCache))
+	srv.Handle("GET /internal/admin/usage/budget", http.HandlerFunc(u.handleBudget))
 }
 
 type usageAPI struct {
-	agg *ledger.Aggregator
+	agg     *ledger.Aggregator
+	budgets *ledger.BudgetStore
 }
 
 // timeRange parses from/to with sane defaults: the last 30 days, and
@@ -121,6 +123,20 @@ func (u *usageAPI) handleCache(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, map[string]any{"providers": rows})
+}
+
+func (u *usageAPI) handleBudget(w http.ResponseWriter, r *http.Request) {
+	limits, err := u.budgets.Limits(r.Context())
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "usage_failed", err.Error())
+		return
+	}
+	status, err := u.agg.BudgetStatus(r.Context(), limits, time.Now())
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "usage_failed", err.Error())
+		return
+	}
+	writeJSON(w, status)
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/internal/gateway/ledger/budget.go
+++ b/internal/gateway/ledger/budget.go
@@ -1,0 +1,125 @@
+package ledger
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+// BudgetLimits are the configured USD spend limits; nil means no
+// budget set for that window.
+type BudgetLimits struct {
+	Day   *float64 `json:"day"`
+	Month *float64 `json:"month"`
+}
+
+// BudgetStore reads and writes the spend_budgets table.
+type BudgetStore struct {
+	db *pgpool.Pool
+}
+
+func NewBudgetStore(db *pgpool.Pool) *BudgetStore {
+	return &BudgetStore{db: db}
+}
+
+// Limits returns the configured budgets. Missing rows come back nil.
+func (s *BudgetStore) Limits(ctx context.Context) (BudgetLimits, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return BudgetLimits{}, fmt.Errorf("budget limits: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT scope, limit_usd FROM spend_budgets`)
+	if err != nil {
+		return BudgetLimits{}, fmt.Errorf("budget limits: %w", err)
+	}
+	defer rows.Close()
+
+	var limits BudgetLimits
+	for rows.Next() {
+		var (
+			scope string
+			limit float64
+		)
+		if err := rows.Scan(&scope, &limit); err != nil {
+			return BudgetLimits{}, fmt.Errorf("budget limits: %w", err)
+		}
+		switch scope {
+		case "day":
+			limits.Day = &limit
+		case "month":
+			limits.Month = &limit
+		}
+	}
+	return limits, rows.Err()
+}
+
+// Set upserts one window's limit; nil clears it.
+func (s *BudgetStore) Set(ctx context.Context, scope string, limitUSD *float64) error {
+	if scope != "day" && scope != "month" {
+		return fmt.Errorf("unknown budget scope %q", scope)
+	}
+	if limitUSD != nil && *limitUSD <= 0 {
+		return fmt.Errorf("budget limit for %s must be positive", scope)
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("budget set: %w", err)
+	}
+	if limitUSD == nil {
+		_, err = db.Exec(ctx, `DELETE FROM spend_budgets WHERE scope = $1`, scope)
+	} else {
+		_, err = db.Exec(ctx, `INSERT INTO spend_budgets (scope, limit_usd) VALUES ($1, $2)
+			ON CONFLICT (scope) DO UPDATE SET limit_usd = $2, updated_at = now()`, scope, *limitUSD)
+	}
+	if err != nil {
+		return fmt.Errorf("budget set: %w", err)
+	}
+	return nil
+}
+
+// BudgetWindow is one window's budget position: what is configured,
+// what was spent, and whether the limit is reached.
+type BudgetWindow struct {
+	LimitUSD *float64 `json:"limit_usd"`
+	SpendUSD float64  `json:"spend_usd"`
+	Over     bool     `json:"over"`
+}
+
+// BudgetStatus pairs both windows for the alert surface.
+type BudgetStatus struct {
+	Day   BudgetWindow `json:"day"`
+	Month BudgetWindow `json:"month"`
+}
+
+// BudgetStatus computes spend against the given limits. Windows are
+// UTC calendar boundaries: the dashboard's local-midnight tiles may
+// differ slightly; the alert stays timezone-independent.
+func (a *Aggregator) BudgetStatus(ctx context.Context, limits BudgetLimits, now time.Time) (BudgetStatus, error) {
+	now = now.UTC()
+	dayFrom := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	monthFrom := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+
+	window := func(from time.Time, limit *float64) (BudgetWindow, error) {
+		s, err := a.Summary(ctx, from, now)
+		if err != nil {
+			return BudgetWindow{}, err
+		}
+		return BudgetWindow{
+			LimitUSD: limit,
+			SpendUSD: s.CostUSD,
+			Over:     limit != nil && s.CostUSD >= *limit,
+		}, nil
+	}
+
+	day, err := window(dayFrom, limits.Day)
+	if err != nil {
+		return BudgetStatus{}, fmt.Errorf("budget status: %w", err)
+	}
+	month, err := window(monthFrom, limits.Month)
+	if err != nil {
+		return BudgetStatus{}, fmt.Errorf("budget status: %w", err)
+	}
+	return BudgetStatus{Day: day, Month: month}, nil
+}

--- a/internal/gateway/ledger/budget_integration_test.go
+++ b/internal/gateway/ledger/budget_integration_test.go
@@ -1,0 +1,117 @@
+//go:build integration
+
+package ledger
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+	"github.com/SumonMSelim/timothy/internal/platform/migrate"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+	"github.com/SumonMSelim/timothy/migrations"
+)
+
+func TestBudgetRoundTripAndStatus(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.Exec(context.Background(), "DELETE FROM spend_budgets")
+		_, _ = db.Exec(context.Background(), "DELETE FROM cost_ledger WHERE provider = 'itest-budget'")
+	})
+
+	s := NewBudgetStore(pool)
+
+	// Round-trip: set both, read back, clear one.
+	day, month := 0.9, 1e9
+	if err := s.Set(ctx, "day", &day); err != nil {
+		t.Fatalf("set day: %v", err)
+	}
+	if err := s.Set(ctx, "month", &month); err != nil {
+		t.Fatalf("set month: %v", err)
+	}
+	limits, err := s.Limits(ctx)
+	if err != nil {
+		t.Fatalf("limits: %v", err)
+	}
+	if limits.Day == nil || *limits.Day != day || limits.Month == nil || *limits.Month != month {
+		t.Fatalf("limits = %+v, want day=%v month=%v", limits, day, month)
+	}
+
+	// Upsert overwrites.
+	day2 := 0.8
+	if err := s.Set(ctx, "day", &day2); err != nil {
+		t.Fatalf("set day again: %v", err)
+	}
+
+	// Status: spend today crosses the day limit but not the huge
+	// month limit. Other tests' rows can only add spend, which keeps
+	// both assertions stable.
+	l := New(pool, log)
+	cost := 0.5
+	for range 2 {
+		l.Record(ctx, Entry{
+			Provider: "itest-budget", Model: "m1", TaskCategory: "coding",
+			Usage:     &stream.Usage{InputTokens: 1, OutputTokens: 1},
+			LatencyMS: 1, Status: "ok", CostUSD: &cost,
+		})
+	}
+	limits, err = s.Limits(ctx)
+	if err != nil {
+		t.Fatalf("limits: %v", err)
+	}
+	agg := NewAggregator(pool)
+	status, err := agg.BudgetStatus(ctx, limits, time.Now())
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.Day.SpendUSD < 1.0 || !status.Day.Over {
+		t.Fatalf("day = %+v, want spend >= 1.0 and over", status.Day)
+	}
+	if status.Month.Over {
+		t.Fatalf("month = %+v, want not over under limit %v", status.Month, month)
+	}
+	if status.Month.LimitUSD == nil || *status.Month.LimitUSD != month {
+		t.Fatalf("month limit = %v, want %v", status.Month.LimitUSD, month)
+	}
+
+	// Clear: nil deletes the row.
+	if err := s.Set(ctx, "day", nil); err != nil {
+		t.Fatalf("clear day: %v", err)
+	}
+	limits, err = s.Limits(ctx)
+	if err != nil {
+		t.Fatalf("limits after clear: %v", err)
+	}
+	if limits.Day != nil {
+		t.Fatalf("day limit after clear = %v, want nil", *limits.Day)
+	}
+	// No limit set: never over, spend still reported.
+	status, err = agg.BudgetStatus(ctx, limits, time.Now())
+	if err != nil {
+		t.Fatalf("status after clear: %v", err)
+	}
+	if status.Day.Over || status.Day.LimitUSD != nil {
+		t.Fatalf("day after clear = %+v, want no limit and not over", status.Day)
+	}
+}

--- a/internal/gateway/ledger/budget_test.go
+++ b/internal/gateway/ledger/budget_test.go
@@ -1,0 +1,25 @@
+package ledger
+
+import (
+	"strings"
+	"testing"
+)
+
+// Validation rejects bad input before any database access, so a
+// zero-value store is enough here.
+func TestBudgetSetValidation(t *testing.T) {
+	t.Parallel()
+	s := &BudgetStore{}
+	neg := -5.0
+	zero := 0.0
+
+	if err := s.Set(t.Context(), "week", nil); err == nil || !strings.Contains(err.Error(), "unknown budget scope") {
+		t.Fatalf("unknown scope: err = %v", err)
+	}
+	if err := s.Set(t.Context(), "day", &neg); err == nil || !strings.Contains(err.Error(), "must be positive") {
+		t.Fatalf("negative limit: err = %v", err)
+	}
+	if err := s.Set(t.Context(), "month", &zero); err == nil || !strings.Contains(err.Error(), "must be positive") {
+		t.Fatalf("zero limit: err = %v", err)
+	}
+}

--- a/internal/gateway/ledger/spendmetrics.go
+++ b/internal/gateway/ledger/spendmetrics.go
@@ -1,0 +1,52 @@
+package ledger
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// UpdateSpendGauges refreshes the spend/budget gauges from the ledger.
+// The budget gauge reports 0 for an unset window so the pair stays
+// usable in alert expressions (spend >= budget and budget > 0).
+func UpdateSpendGauges(ctx context.Context, agg *Aggregator, budgets *BudgetStore, spend, budget *prometheus.GaugeVec) error {
+	limits, err := budgets.Limits(ctx)
+	if err != nil {
+		return err
+	}
+	status, err := agg.BudgetStatus(ctx, limits, time.Now())
+	if err != nil {
+		return err
+	}
+	set := func(window string, w BudgetWindow) {
+		spend.WithLabelValues(window).Set(w.SpendUSD)
+		var limit float64
+		if w.LimitUSD != nil {
+			limit = *w.LimitUSD
+		}
+		budget.WithLabelValues(window).Set(limit)
+	}
+	set("day", status.Day)
+	set("month", status.Month)
+	return nil
+}
+
+// RunSpendGauges updates the gauges immediately and then on every
+// tick until ctx ends. Failures log and the next tick retries —
+// metrics must never take serving down.
+func RunSpendGauges(ctx context.Context, interval time.Duration, agg *Aggregator, budgets *BudgetStore, spend, budget *prometheus.GaugeVec, log *slog.Logger) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		if err := UpdateSpendGauges(ctx, agg, budgets, spend, budget); err != nil {
+			log.Warn("spend gauge update failed", "error", err)
+		}
+		select {
+		case <-t.C:
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/internal/platform/metrics/metrics.go
+++ b/internal/platform/metrics/metrics.go
@@ -55,6 +55,14 @@ func (m *Metrics) NewCounter(name, help string) prometheus.Counter {
 	return c
 }
 
+// NewGaugeVec registers a service-specific labeled gauge on this
+// registry.
+func (m *Metrics) NewGaugeVec(name, help string, labels ...string) *prometheus.GaugeVec {
+	g := prometheus.NewGaugeVec(prometheus.GaugeOpts{Namespace: "timothy", Name: name, Help: help}, labels)
+	m.registry.MustRegister(g)
+	return g
+}
+
 // Handler serves the registry in Prometheus exposition format.
 func (m *Metrics) Handler() http.Handler {
 	return promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{})

--- a/migrations/0016_spend_budgets.sql
+++ b/migrations/0016_spend_budgets.sql
@@ -1,0 +1,7 @@
+-- Spend budgets for the alert surface: at most one USD limit per
+-- window. Absent row = no budget set, nothing to alert on.
+CREATE TABLE IF NOT EXISTS spend_budgets (
+    scope      text PRIMARY KEY CHECK (scope IN ('day', 'month')),
+    limit_usd  numeric(12, 2) NOT NULL CHECK (limit_usd > 0),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+coverage
+Dockerfile
+.dockerignore

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+# Production web image: Vite build served by unprivileged nginx.
+# The HugeIcons Pro registry token is consumed as a BuildKit secret so
+# it never lands in an image layer or the build history.
+FROM node:24.18.0-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json .npmrc ./
+RUN --mount=type=secret,id=hugeicons_token \
+    HUGEICONS_TOKEN="$(cat /run/secrets/hugeicons_token)" npm ci
+COPY . .
+RUN npm run build
+
+FROM nginxinc/nginx-unprivileged:1.29-alpine
+# Same-origin /v1 in the browser; nginx forwards to brain (the image
+# entrypoint envsubsts ${BRAIN_URL} into the template at startup).
+ENV BRAIN_URL=http://brain:8080
+COPY nginx/default.conf.template /etc/nginx/templates/default.conf.template
+COPY --from=build /app/dist /usr/share/nginx/html

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -11,6 +11,11 @@ COPY . .
 RUN npm run build
 
 FROM nginxinc/nginx-unprivileged:1.29-alpine
+# The base image's OS packages lag their alpine repo fixes; upgrade so
+# the Trivy CI gate (CRITICAL/HIGH, fixed-only) stays green.
+USER root
+RUN apk upgrade --no-cache
+USER 101
 # Same-origin /v1 in the browser; nginx forwards to brain (the image
 # entrypoint envsubsts ${BRAIN_URL} into the template at startup).
 ENV BRAIN_URL=http://brain:8080

--- a/web/nginx/default.conf.template
+++ b/web/nginx/default.conf.template
@@ -1,0 +1,33 @@
+# Serves the built SPA and proxies /v1 to brain. Only ${BRAIN_URL} is
+# substituted at container start (set env vars stay, nginx runtime
+# variables like $uri pass through untouched).
+server {
+    listen 8080;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA: unknown paths fall back to the app shell.
+    location / {
+        try_files $uri /index.html;
+    }
+
+    # API, including SSE chat streams: no buffering, long read timeout
+    # so a slow turn is not cut mid-stream. proxy_pass through a
+    # variable + Docker's embedded DNS defers name resolution to
+    # request time: nginx boots before brain and survives brain
+    # getting a new address on restart.
+    resolver 127.0.0.11 valid=30s ipv6=off;
+    location /v1/ {
+        set $brain ${BRAIN_URL};
+        proxy_pass $brain;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 1h;
+    }
+}

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { ChatError, chatStream, createSSEParser, listSessions } from './client'
+import {
+  ChatError,
+  chatStream,
+  createSSEParser,
+  listSessions,
+  patchBudget,
+  usageBudget,
+} from './client'
 import type { ChatEvent } from './types'
 
 afterEach(() => vi.unstubAllGlobals())
@@ -132,5 +139,37 @@ describe('chatStream errors', () => {
     expect(err.status).toBe(500)
     expect(err.message).toBe('plain failure')
     expect(err.sessionId).toBeUndefined()
+  })
+})
+
+describe('spend budgets', () => {
+  it('fetches budget status from the usage surface', async () => {
+    vi.stubGlobal('localStorage', { getItem: () => 'tok', setItem: () => {} })
+    const status = {
+      day: { limit_usd: 1, spend_usd: 1.5, over: true },
+      month: { limit_usd: null, spend_usd: 8, over: false },
+    }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify(status), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const b = await usageBudget()
+
+    expect(fetchMock.mock.calls[0][0]).toBe('/v1/admin/usage/budget')
+    expect(b).toEqual(status)
+  })
+
+  it('patches budgets keeping explicit nulls so clearing works', async () => {
+    vi.stubGlobal('localStorage', { getItem: () => 'tok', setItem: () => {} })
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await patchBudget({ day: 5, month: null })
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/v1/admin/usage/budget')
+    expect(init.method).toBe('PATCH')
+    expect(JSON.parse(init.body as string)).toEqual({ day: 5, month: null })
   })
 })

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,6 +1,7 @@
 import type {
   AdminProvider,
   AdminRoute,
+  BudgetStatus,
   CacheRow,
   ChainEntry,
   ChatEvent,
@@ -303,6 +304,22 @@ export async function usageCache(from: Date, to: Date): Promise<CacheRow[]> {
     `/v1/admin/usage/cache?${rangeParams(from, to)}`,
   )
   return providers ?? []
+}
+
+export async function usageBudget(): Promise<BudgetStatus> {
+  return request<BudgetStatus>('/v1/admin/usage/budget')
+}
+
+// patchBudget updates spend limits per window: a number sets, null
+// clears, an absent key stays untouched.
+export async function patchBudget(changes: {
+  day?: number | null
+  month?: number | null
+}): Promise<void> {
+  await request<void>('/v1/admin/usage/budget', {
+    method: 'PATCH',
+    body: JSON.stringify(changes),
+  })
 }
 
 // --- admin control plane (settings panel) ---

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -184,6 +184,19 @@ export interface CacheRow {
   hit_ratio: number
 }
 
+// Budget position per UTC calendar window; limit_usd is null when no
+// budget is configured.
+export interface BudgetWindow {
+  limit_usd: number | null
+  spend_usd: number
+  over: boolean
+}
+
+export interface BudgetStatus {
+  day: BudgetWindow
+  month: BudgetWindow
+}
+
 // Control-plane shapes (/v1/admin/*). credential_ref is a NAME (env
 // var / Vault path / AWS profile) — secret values never travel.
 export interface AdminModel {

--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -1,0 +1,86 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { BudgetStatus, UsageSummary } from '../api/types'
+import { Dashboard } from './Dashboard'
+
+vi.mock('../api/client', () => ({
+  usageBudget: vi.fn(),
+  usageCache: vi.fn(),
+  usageLatency: vi.fn(),
+  usageSeries: vi.fn(),
+  usageSessions: vi.fn(),
+  usageSummary: vi.fn(),
+}))
+
+import {
+  usageBudget,
+  usageCache,
+  usageLatency,
+  usageSeries,
+  usageSessions,
+  usageSummary,
+} from '../api/client'
+
+const summary: UsageSummary = {
+  cost_usd: 2.5,
+  input_tokens: 1000,
+  output_tokens: 500,
+  cache_read_tokens: 0,
+  cache_write_tokens: 0,
+  requests: 10,
+  errors: 0,
+}
+
+const calmBudget: BudgetStatus = {
+  day: { limit_usd: 10, spend_usd: 2.5, over: false },
+  month: { limit_usd: null, spend_usd: 2.5, over: false },
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <Dashboard />
+    </MemoryRouter>,
+  )
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(usageSummary).mockResolvedValue(summary)
+  vi.mocked(usageSeries).mockResolvedValue([])
+  vi.mocked(usageSessions).mockResolvedValue([])
+  vi.mocked(usageLatency).mockResolvedValue([])
+  vi.mocked(usageCache).mockResolvedValue([])
+  vi.mocked(usageBudget).mockResolvedValue(calmBudget)
+})
+
+describe('Dashboard budget alert', () => {
+  it('shows no banner while spend stays under budget', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getAllByText('$2.50').length).toBeGreaterThan(0))
+    expect(screen.queryByRole('alert')).toBeNull()
+    // A configured limit still surfaces as a tile hint.
+    expect(screen.getByText('of $10.00 budget')).toBeInTheDocument()
+  })
+
+  it('shows a banner naming every window over budget', async () => {
+    vi.mocked(usageBudget).mockResolvedValue({
+      day: { limit_usd: 1, spend_usd: 1.5, over: true },
+      month: { limit_usd: 100, spend_usd: 120, over: true },
+    })
+    renderPage()
+    const banner = await screen.findByRole('alert')
+    expect(banner).toHaveTextContent('Daily budget reached: $1.50 spent of $1.00.')
+    expect(banner).toHaveTextContent('Monthly budget reached: $120.00 spent of $100.00.')
+  })
+
+  it('stays silent when the budget endpoint fails', async () => {
+    vi.mocked(usageBudget).mockRejectedValue(new Error('gateway down'))
+    renderPage()
+    // The shared widget-failure note appears; no budget banner.
+    await screen.findByText(/widgets failed to load/)
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -13,13 +13,21 @@ import {
   YAxis,
 } from 'recharts'
 import {
+  usageBudget,
   usageCache,
   usageLatency,
   usageSeries,
   usageSessions,
   usageSummary,
 } from '../api/client'
-import type { CacheRow, LatencyRow, SessionUsage, UsagePoint, UsageSummary } from '../api/types'
+import type {
+  BudgetStatus,
+  CacheRow,
+  LatencyRow,
+  SessionUsage,
+  UsagePoint,
+  UsageSummary,
+} from '../api/types'
 
 // Accessible categorical palette that reads on light and dark.
 const palette = ['#3b82f6', '#8b5cf6', '#10b981', '#f59e0b', '#f43f5e', '#06b6d4', '#a3a3a3']
@@ -59,6 +67,7 @@ interface Loaded {
   sessions: SessionUsage[]
   latency: LatencyRow[]
   cache: CacheRow[]
+  budget: BudgetStatus | null
 }
 
 // pivot turns (bucket, group) points into recharts rows keyed by
@@ -131,6 +140,7 @@ export function Dashboard() {
       usageSessions(from, to, 10),
       usageLatency(from, to),
       usageCache(from, to),
+      usageBudget(),
     ]).then((results) => {
       if (!live) return
       const failed = results.filter((r) => r.status === 'rejected').length
@@ -148,6 +158,7 @@ export function Dashboard() {
         sessions: val(results[6], []),
         latency: val(results[7], []),
         cache: val(results[8], []),
+        budget: val<BudgetStatus | null>(results[9], null),
       })
     })
     return () => {
@@ -180,9 +191,16 @@ export function Dashboard() {
   }, [data])
 
   const s = data?.summary
+  const budget = data?.budget
+  const budgetHint = (w?: { limit_usd: number | null }) =>
+    w?.limit_usd != null ? `of ${money(w.limit_usd)} budget` : undefined
   const tiles = [
-    { label: 'Spend today', value: data ? money(data.today.cost_usd) : '—' },
-    { label: 'Spend this month', value: data ? money(data.month.cost_usd) : '—' },
+    { label: 'Spend today', value: data ? money(data.today.cost_usd) : '—', hint: budgetHint(budget?.day) },
+    {
+      label: 'Spend this month',
+      value: data ? money(data.month.cost_usd) : '—',
+      hint: budgetHint(budget?.month),
+    },
     {
       label: 'Requests',
       value: s ? compact(s.requests) : '—',
@@ -235,6 +253,24 @@ export function Dashboard() {
         {error && (
           <div className="mt-6 rounded-xl border border-red-500/30 bg-red-500/5 p-4 text-sm text-red-600 dark:text-red-400">
             Could not load usage: {error}
+          </div>
+        )}
+
+        {budget && (budget.day.over || budget.month.over) && (
+          <div
+            role="alert"
+            className="mt-6 rounded-xl border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-700 dark:text-amber-400"
+          >
+            {[
+              budget.day.over && budget.day.limit_usd != null
+                ? `Daily budget reached: ${money(budget.day.spend_usd)} spent of ${money(budget.day.limit_usd)}.`
+                : null,
+              budget.month.over && budget.month.limit_usd != null
+                ? `Monthly budget reached: ${money(budget.month.spend_usd)} spent of ${money(budget.month.limit_usd)}.`
+                : null,
+            ]
+              .filter(Boolean)
+              .join(' ')}
           </div>
         )}
 

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -7,11 +7,13 @@ import {
   getSettings,
   listProviders,
   listRoutes,
+  patchBudget,
   patchProvider,
   patchRoute,
   patchSettings,
   providersHealth,
   testProvider,
+  usageBudget,
 } from '../api/client'
 import type { AdminProvider, AdminRoute, ChainEntry, ProviderHealth, TestResult } from '../api/types'
 import { Button } from '../components/ui/button'
@@ -599,6 +601,90 @@ function FeaturesTab() {
           />
         </div>
       ))}
+      <BudgetsCard />
+    </div>
+  )
+}
+
+// BudgetsCard edits the gateway's spend budgets. Empty field = no
+// budget for that window; both keys always travel so clearing works.
+function BudgetsCard() {
+  const [day, setDay] = useState('')
+  const [month, setMonth] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+
+  useEffect(() => {
+    usageBudget()
+      .then((b) => {
+        setDay(b.day.limit_usd != null ? String(b.day.limit_usd) : '')
+        setMonth(b.month.limit_usd != null ? String(b.month.limit_usd) : '')
+      })
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : String(err)))
+  }, [])
+
+  // '' → null (clear), positive number → set, anything else → invalid.
+  const parse = (v: string): number | null | undefined => {
+    if (v.trim() === '') return null
+    const n = Number(v)
+    return Number.isFinite(n) && n > 0 ? n : undefined
+  }
+
+  const save = () => {
+    setSaved(false)
+    const d = parse(day)
+    const m = parse(month)
+    if (d === undefined || m === undefined) {
+      setError('Budgets must be positive USD amounts (or empty for no budget).')
+      return
+    }
+    patchBudget({ day: d, month: m })
+      .then(() => {
+        setError(null)
+        setSaved(true)
+      })
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : String(err)))
+  }
+
+  return (
+    <div className="rounded-xl border border-border p-4">
+      <div className="text-sm font-medium">Spend budgets</div>
+      <p className="mt-0.5 text-xs text-muted-foreground">
+        USD limits per UTC day and month. When spend reaches a limit the dashboard shows a
+        banner; Prometheus gauges carry the same signal for external alerting. Requests are
+        never blocked.
+      </p>
+      {error && (
+        <div className="mt-3 rounded-lg border border-red-500/30 bg-red-500/5 p-2 text-xs text-red-600 dark:text-red-400">
+          {error}
+        </div>
+      )}
+      <div className="mt-3 flex flex-wrap items-end gap-3">
+        <label className="grid gap-1 text-xs text-muted-foreground">
+          Daily (USD)
+          <Input
+            value={day}
+            onChange={(e) => setDay(e.target.value)}
+            placeholder="none"
+            inputMode="decimal"
+            className="w-32"
+            aria-label="Daily budget in USD"
+          />
+        </label>
+        <label className="grid gap-1 text-xs text-muted-foreground">
+          Monthly (USD)
+          <Input
+            value={month}
+            onChange={(e) => setMonth(e.target.value)}
+            placeholder="none"
+            inputMode="decimal"
+            className="w-32"
+            aria-label="Monthly budget in USD"
+          />
+        </label>
+        <Button onClick={save}>Save budgets</Button>
+        {saved && <span className="text-xs text-muted-foreground">Saved.</span>}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## What

- **README**: replace dead `docs/architecture.md` link with a pointer to the `D-0XX` markers in code.
- **Production web**: multi-stage `web/Dockerfile` (Vite build → unprivileged nginx). SPA fallback; `/v1` proxied to brain unbuffered with a 1h read timeout so SSE turns stream and never cut. Request-time DNS: nginx boots before brain and survives brain restarts. HugeIcons registry token passes as a BuildKit secret — never in an image layer. Vite dev server stays available as `web-dev` behind `--profile dev`. CI image matrix + Trivy now cover the web image.
- **Spend budgets** (the alerts the ledger docstring promised): USD limits per UTC day/month in `spend_budgets` (migration 0016), edited from Settings → Features, served as `GET/PATCH /internal/admin/usage/budget` (PATCH audited, proxied by brain behind its bearer). Dashboard shows an amber banner when a window is over budget plus budget hints on the spend tiles. Gateway exports `timothy_spend_usd{window}` and `timothy_spend_budget_usd{window}` gauges (60s poll) for external alerting. Alerting only — requests are never blocked.

## Verification

- `go vet` + golangci-lint clean; unit + integration tests pass (new: budget store round-trip/status, PatchBudget validate+audit, brain proxy scope).
- Web: build + oxlint clean, 70 vitest tests pass (new: Dashboard banner/silence cases, budget client calls).
- Live smoke on compose: budget GET/PATCH round-trip, gauges report patched values, prod web image serves SPA and proxies `/v1`.