### PR TITLE
docs: reflect shipped features and dev workflow in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,15 @@
 
 Self-hosted personal AI assistant: chat, cost tracking, tasks, and agents — running on your own hardware, talking to whichever LLM providers you configure.
 
-**Status: early development.** Not ready for use.
+**Status: early development.** The core works — chat, tools, memory, dashboard — but the agent harness and deployment story are still being built. Not ready for anyone else's use.
+
+## What works today
+
+- **Multi-provider chat** — Anthropic, Amazon Bedrock, and any OpenAI-compatible API behind one gateway; providers, models, and per-task routing are database configuration, editable at runtime from the settings panel with hot reload.
+- **Sessions that survive** — every conversation is an append-only event log; kill a container mid-stream and the session resumes and replays exactly.
+- **Tools, permissions, skills** — the agent loop executes tools behind a constraint/permission chain (destructive actions require explicit approval in the UI); skill packs load lazily by task.
+- **Long-term memory** — staged fact extraction with a confirmation queue, hybrid pgvector retrieval (vector + text + entity, RRF-fused) under a strict token budget.
+- **Cost accounting** — every request lands in a ledger with honest pricing (unknown price is recorded as null, never guessed); usage dashboard, spend budgets with alerts, Prometheus metrics on every service.
 
 ## Architecture
 
@@ -31,13 +39,16 @@ cp deploy/env.example deploy/.env   # fill in provider keys
 make up
 ```
 
-Web UI on `:3300`, API on `:8300`.
+Web UI on `:3300`, API on `:8300`. For frontend work, `docker compose -f deploy/docker-compose.yml --profile dev up web-dev` serves a hot-reloading Vite dev server on `:3301`.
 
 ## Development
 
+The Go toolchain runs containerized — no host Go install required.
+
 ```sh
-make test    # unit tests (containerized)
-make lint    # golangci-lint
+make test               # unit tests
+make test-integration   # against the running compose stack
+make lint               # golangci-lint
 ```
 
 Design decisions are documented as `D-0XX` markers in code comments next to the code they explain.


### PR DESCRIPTION
The readme still described the project as bare scaffolding. This documents what actually works today and how to develop against it.

- Add a "What works today" section: multi-provider chat, event-sourced sessions, tools/permissions/skills, long-term memory, cost accounting with budgets and Prometheus metrics
- Document the `web-dev` compose profile (hot-reloading Vite on :3301) alongside the production web image
- Note the containerized Go toolchain and `make test-integration`
- Soften the status line: core works, harness/deploy still ahead