### PR TITLE
feat(connectors): MCP-backed integration framework for agent tools

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/SumonMSelim/timothy/internal/brain/api"
 	"github.com/SumonMSelim/timothy/internal/brain/chat"
+	"github.com/SumonMSelim/timothy/internal/brain/connectors"
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
 	"github.com/SumonMSelim/timothy/internal/brain/loop"
 	"github.com/SumonMSelim/timothy/internal/brain/memclient"
@@ -29,6 +30,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/tools/builtin"
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+	"github.com/SumonMSelim/timothy/internal/secretstore"
 	"github.com/SumonMSelim/timothy/internal/platform/httpserver"
 	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
 	"github.com/SumonMSelim/timothy/internal/platform/service"
@@ -146,12 +148,21 @@ func main() {
 
 	searxngURL := os.Getenv("SEARXNG_URL")
 
-	agent, broker, outputs, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, packs, mc.Add, app.Log)
+	agent, broker, outputs, builtinSet, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, packs, mc.Add, app.Log)
 	if buildErr != nil {
 		fmt.Fprintln(os.Stderr, buildErr)
 		os.Exit(1)
 	}
 	go runOutputGC(ctx, outputs, app.Log)
+
+	conns := buildConnectors(app.DB, app.Log)
+	if conns != nil {
+		conns.RegisterBuilder("mcp", connectors.MCPBuilder(nil))
+		conns.SetOnReload(func(context.Context) {
+			swapAgentTools(agent, builtinSet, conns, app.Log)
+		})
+		go runConnectorReload(ctx, conns, app.Log)
+	}
 
 	svc := chat.New(turnRouter{agent: agent, gw: gwc, flags: flags}, store, distill,
 		gatedCompactor{inner: compactor, flags: flags}, budget, packs, app.Log)
@@ -192,12 +203,36 @@ func main() {
 	})
 
 	api.Register(app.Server, svc, store, broker,
-		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, app.Log), flags, token, app.Log)
+		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, app.Log), flags,
+		conns, token, app.Log)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)
 		os.Exit(1)
 	}
+}
+
+// buildConnectors wires the integration control plane. Brain resolves
+// connector credentials through its own secret-store handle (same DB,
+// same master key as the gateway); without a valid master key the
+// connector surface stays unmounted and the rest of brain runs.
+func buildConnectors(db *pgpool.Pool, log *slog.Logger) *connectors.Manager {
+	masterKey, err := secretstore.DecodeMasterKey(os.Getenv(secretstore.MasterKeyEnv))
+	if err != nil {
+		log.Warn("connectors disabled: no usable master key", "error", err)
+		return nil
+	}
+	secrets, err := secretstore.New(db, masterKey)
+	if err != nil {
+		log.Warn("connectors disabled: secret store init failed", "error", err)
+		return nil
+	}
+	resolve := func(ctx context.Context, ref string) (string, error) {
+		return secrets.Resolve(ctx, ref)
+	}
+	mgr := connectors.NewManager(connectors.NewStore(db, log), resolve, log)
+	// Kind builders (mcp, google) register here as they land.
+	return mgr
 }
 
 // memoryProxy forwards the web's memory-management routes to memoryd
@@ -286,10 +321,10 @@ func (r turnRouter) Stream(ctx context.Context, req gwclient.StreamRequest) (<-c
 }
 
 // buildAgent assembles the compiled-in tool registry and its guard
-// rails (D-009, D-010).
-func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, workspace, searxngURL string, packs []skills.Skill, remember builtin.RememberFunc, log *slog.Logger) (*loop.Agent, *loop.PermBroker, *tools.Outputs, error) {
+// rails (D-009, D-010). The returned builtin set is the fixed half of
+// the tool surface; connector tools join it via swapAgentTools.
+func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, workspace, searxngURL string, packs []skills.Skill, remember builtin.RememberFunc, log *slog.Logger) (*loop.Agent, *loop.PermBroker, *tools.Outputs, []*tools.Tool, error) {
 	outputs := tools.NewOutputs(db)
-	reg := tools.NewRegistry()
 	set := []*tools.Tool{
 		builtin.CurrentTime(time.Now),
 		builtin.ConvertTime(),
@@ -307,20 +342,9 @@ func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, wor
 	if len(packs) > 0 {
 		set = append(set, skills.LoadSkillTool(packs))
 	}
-	for _, t := range set {
-		if err := reg.Register(t); err != nil {
-			return nil, nil, nil, fmt.Errorf("register tools: %w", err)
-		}
-	}
-	constrained, err := tools.NewConstrained(reg)
+	constrained, defs, err := compileToolset(set, nil, log)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("compile tool schemas: %w", err)
-	}
-	constrained.SetClamp("shell", builtin.ShellTimeoutClamp())
-
-	defs := make([]provider.ToolDef, 0, len(reg.List()))
-	for _, t := range reg.List() {
-		defs = append(defs, provider.ToolDef{Name: t.Name, Description: t.Description, InputSchema: t.InputSchema})
+		return nil, nil, nil, nil, err
 	}
 
 	perms := tools.NewPermissions(db, workspace)
@@ -329,7 +353,71 @@ func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, wor
 	// Shell dumps grow fast; offload them sooner than the default so a
 	// long command output never bloats the context (D-019).
 	agent.SetOffloadThreshold("shell", 4<<10)
-	return agent, broker, outputs, nil
+	return agent, broker, outputs, set, nil
+}
+
+// compileToolset registers builtin + connector tools into a fresh
+// constrained registry. A connector tool whose name collides with an
+// existing tool is skipped with a log — a remote server must never
+// shadow a builtin.
+func compileToolset(builtins, connectorTools []*tools.Tool, log *slog.Logger) (*tools.Constrained, []provider.ToolDef, error) {
+	reg := tools.NewRegistry()
+	for _, t := range builtins {
+		if err := reg.Register(t); err != nil {
+			return nil, nil, fmt.Errorf("register tools: %w", err)
+		}
+	}
+	for _, t := range connectorTools {
+		if err := reg.Register(t); err != nil {
+			log.Warn("connector tool skipped", "tool", t.Name, "error", err)
+		}
+	}
+	constrained, err := tools.NewConstrained(reg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("compile tool schemas: %w", err)
+	}
+	constrained.SetClamp("shell", builtin.ShellTimeoutClamp())
+
+	defs := make([]provider.ToolDef, 0, len(reg.List()))
+	for _, t := range reg.List() {
+		defs = append(defs, provider.ToolDef{Name: t.Name, Description: t.Description, InputSchema: t.InputSchema})
+	}
+	return constrained, defs, nil
+}
+
+// swapAgentTools recompiles builtin + connector tools and swaps them
+// into the agent. A compile failure keeps the previous surface — a
+// broken connector schema must not take down the builtins.
+func swapAgentTools(agent *loop.Agent, builtins []*tools.Tool, conns *connectors.Manager, log *slog.Logger) {
+	constrained, defs, err := compileToolset(builtins, conns.Tools(), log)
+	if err != nil {
+		log.Warn("connector toolset compile failed; keeping previous tools", "error", err)
+		return
+	}
+	agent.SwapTools(constrained, defs)
+	log.Info("agent tool surface updated", "tools", len(defs))
+}
+
+// runConnectorReload loads connector sources at startup and keeps
+// retrying/refreshing on a slow tick, mirroring the gateway's snapshot
+// poll: a DB that wasn't ready at boot, or a row edited outside the
+// admin API, converges within a minute.
+func runConnectorReload(ctx context.Context, conns *connectors.Manager, log *slog.Logger) {
+	if err := conns.Reload(ctx); err != nil {
+		log.Warn("initial connector load failed; will retry", "error", err)
+	}
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := conns.Reload(ctx); err != nil {
+				log.Warn("connector reload failed; keeping previous sources", "error", err)
+			}
+		}
+	}
 }
 
 // runOutputGC sweeps expired offloaded outputs (D-019 retention).

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -67,6 +67,9 @@ services:
       SESSION_TOKEN_BUDGET: ${SESSION_TOKEN_BUDGET:-}
       # Brain-only secret: the public API bearer token.
       TIMOTHY_API_TOKEN: ${TIMOTHY_API_TOKEN:-}
+      # Connector credentials resolve through brain's own secret-store
+      # handle — same key the gateway uses.
+      TIMOTHY_MASTER_KEY: ${TIMOTHY_MASTER_KEY:?set TIMOTHY_MASTER_KEY in deploy/.env}
       # Where the shell tool runs; the only tree tools may touch.
       WORKSPACE_ROOT: /workspace
       # Compose-internal only: the model never sees this address.

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -15,8 +15,9 @@ LOG_LEVEL=info
 
 # --- Secrets ---
 # Root of trust for the encrypted secret store (generate: openssl rand
-# -base64 32). Provider keys entered in Settings are encrypted with
-# this; losing it makes stored secrets unrecoverable.
+# -base64 32). Provider keys and connector credentials entered in
+# Settings are encrypted with this; losing it makes stored secrets
+# unrecoverable. Shared by gateway and brain.
 TIMOTHY_MASTER_KEY=
 
 # Bearer token for brain's public API (generate: openssl rand -hex 32)

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/SumonMSelim/timothy/internal/brain/chat"
+	"github.com/SumonMSelim/timothy/internal/brain/connectors"
 	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/brain/settings"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
@@ -61,9 +62,9 @@ var memoryRoutePatterns = []string{
 
 // Register mounts the routes, each wrapped in bearer auth. memories
 // is the reverse proxy to memoryd's management routes, admin the
-// proxy to the gateway's internal control plane (nil leaves either
-// unmounted).
-func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, token string, log *slog.Logger) {
+// proxy to the gateway's internal control plane, conns the local
+// connector control plane (nil leaves any of them unmounted).
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, conns *connectors.Manager, token string, log *slog.Logger) {
 	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log}
 	if memories != nil {
 		for _, pattern := range memoryRoutePatterns {
@@ -72,6 +73,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	}
 	a.registerAdmin(srv.Handle, admin)
 	a.registerSettings(srv.Handle, flags)
+	a.registerConnectors(srv.Handle, conns)
 	srv.Handle("GET /v1/sessions", a.auth(http.HandlerFunc(a.handleList)))
 	srv.Handle("POST /v1/sessions", a.auth(http.HandlerFunc(a.handleCreate)))
 	srv.Handle("GET /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleTranscript)))

--- a/internal/brain/api/connectors.go
+++ b/internal/brain/api/connectors.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/SumonMSelim/timothy/internal/brain/connectors"
+)
+
+// registerConnectors mounts brain's own integration control plane —
+// served locally like the settings routes, not proxied: connectors
+// are brain's domain (their tools execute in the agent loop). nil
+// leaves the surface unmounted (no master key, connectors disabled).
+func (a *API) registerConnectors(handle func(pattern string, h http.Handler), mgr *connectors.Manager) {
+	if mgr == nil {
+		return
+	}
+	h := &connectorAPI{mgr: mgr}
+	handle("GET /v1/admin/connectors", a.auth(http.HandlerFunc(h.list)))
+	handle("POST /v1/admin/connectors", a.auth(http.HandlerFunc(h.create)))
+	handle("PATCH /v1/admin/connectors/{id}", a.auth(http.HandlerFunc(h.patch)))
+	handle("DELETE /v1/admin/connectors/{id}", a.auth(http.HandlerFunc(h.delete)))
+	handle("POST /v1/admin/connectors/{id}/test", a.auth(http.HandlerFunc(h.test)))
+}
+
+type connectorAPI struct {
+	mgr *connectors.Manager
+}
+
+// failConnector maps the package's sentinel errors onto HTTP statuses;
+// everything else is the caller's input.
+func failConnector(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, connectors.ErrNotFound):
+		jsonError(w, http.StatusNotFound, "not_found", err.Error())
+	case errors.Is(err, connectors.ErrUnsupported):
+		jsonError(w, http.StatusUnprocessableEntity, "unsupported", err.Error())
+	default:
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+	}
+}
+
+func (h *connectorAPI) list(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.mgr.Store().List(r.Context())
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "connectors_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"connectors": rows})
+}
+
+func (h *connectorAPI) create(w http.ResponseWriter, r *http.Request) {
+	var c connectors.Connector
+	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	id, err := h.mgr.Store().Create(r.Context(), c)
+	if err != nil {
+		failConnector(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"id": id})
+}
+
+func (h *connectorAPI) patch(w http.ResponseWriter, r *http.Request) {
+	var patch connectors.Patch
+	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if err := h.mgr.Store().Patch(r.Context(), r.PathValue("id"), patch); err != nil {
+		failConnector(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *connectorAPI) delete(w http.ResponseWriter, r *http.Request) {
+	if err := h.mgr.Store().Delete(r.Context(), r.PathValue("id")); err != nil {
+		failConnector(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// test mirrors the provider test endpoint's shape: 200 with {ok,
+// error} for probe outcomes so the UI renders failures inline; HTTP
+// errors only for unknown ids and unbuildable kinds.
+func (h *connectorAPI) test(w http.ResponseWriter, r *http.Request) {
+	err := h.mgr.Test(r.Context(), r.PathValue("id"))
+	switch {
+	case err == nil:
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	case errors.Is(err, connectors.ErrNotFound), errors.Is(err, connectors.ErrUnsupported):
+		failConnector(w, err)
+	default:
+		writeJSON(w, http.StatusOK, map[string]any{"ok": false, "error": err.Error()})
+	}
+}

--- a/internal/brain/connectors/connectors.go
+++ b/internal/brain/connectors/connectors.go
@@ -1,0 +1,250 @@
+// Package connectors is brain's integration control plane: third-party
+// services (MCP servers, Google Workspace, ...) the agent can call as
+// tools. Connectors are data — admin CRUD writes rows, the manager
+// reloads and rebuilds tool sources without restarts — mirroring how
+// the gateway treats providers (D-004). credential_ref names a secret
+// in the shared secret store; a value is never stored or returned here.
+package connectors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"regexp"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+// kinds whitelists what the manager can actually build. google
+// arrives with the OAuth phase; the panel shows it once a builder
+// registers.
+var kinds = map[string]bool{"mcp": true, "google": true}
+
+// credentialRefPattern matches the gateway's: names and paths only,
+// never anything that could be a pasted secret.
+var credentialRefPattern = regexp.MustCompile(`^[A-Za-z0-9_./-]{0,128}$`)
+
+// Connector is the API shape of one connectors row.
+type Connector struct {
+	ID            string          `json:"id"`
+	Name          string          `json:"name"`
+	Kind          string          `json:"kind"`
+	Config        json.RawMessage `json:"config"`
+	CredentialRef string          `json:"credential_ref"`
+	Enabled       bool            `json:"enabled"`
+}
+
+// namePattern keeps connector names usable as tool-name prefixes
+// (tools surface as "<name>_<tool>"): lowercase slug, no spaces.
+var namePattern = regexp.MustCompile(`^[a-z0-9]+(?:[-_][a-z0-9]+)*$`)
+
+func validate(c Connector) error {
+	if !namePattern.MatchString(c.Name) {
+		return fmt.Errorf("name must be a lowercase slug (a-z, 0-9, - or _), it prefixes the connector's tool names")
+	}
+	if !kinds[c.Kind] {
+		return fmt.Errorf("unknown kind %q", c.Kind)
+	}
+	if !credentialRefPattern.MatchString(c.CredentialRef) {
+		return fmt.Errorf("credential_ref must be a name or path, never a secret value")
+	}
+	if len(c.Config) > 0 && !json.Valid(c.Config) {
+		return fmt.Errorf("config must be a JSON object")
+	}
+	return nil
+}
+
+// Sentinel errors the HTTP layer maps onto status codes.
+var (
+	ErrNotFound    = fmt.Errorf("not found")
+	ErrUnsupported = fmt.Errorf("unsupported")
+)
+
+// Store is the connectors table's CRUD, audited like the gateway's
+// admin mutations. onChange fires after every successful write so the
+// manager can rebuild its sources.
+type Store struct {
+	db       *pgpool.Pool
+	log      *slog.Logger
+	onChange func(context.Context)
+}
+
+func NewStore(db *pgpool.Pool, log *slog.Logger) *Store {
+	return &Store{db: db, log: log, onChange: func(context.Context) {}}
+}
+
+// SetOnChange registers the post-write hook. Call before serving.
+func (s *Store) SetOnChange(fn func(context.Context)) {
+	if fn != nil {
+		s.onChange = fn
+	}
+}
+
+// List returns every connector row, config order by name.
+func (s *Store) List(ctx context.Context) ([]Connector, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("connectors list: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT id, name, kind, config, credential_ref, enabled
+		FROM connectors ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("connectors list: %w", err)
+	}
+	defer rows.Close()
+
+	out := []Connector{}
+	for rows.Next() {
+		var c Connector
+		if err := rows.Scan(&c.ID, &c.Name, &c.Kind, &c.Config, &c.CredentialRef, &c.Enabled); err != nil {
+			return nil, fmt.Errorf("connectors list: %w", err)
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// Get returns one connector row by id.
+func (s *Store) Get(ctx context.Context, id string) (Connector, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return Connector{}, fmt.Errorf("connectors get: %w", err)
+	}
+	return scanConnector(ctx, db, id, "")
+}
+
+// Create inserts a connector, audits, and fires the change hook.
+func (s *Store) Create(ctx context.Context, c Connector) (string, error) {
+	if err := validate(c); err != nil {
+		return "", err
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		return "", fmt.Errorf("connectors create: %w", err)
+	}
+	cfg := c.Config
+	if len(cfg) == 0 {
+		cfg = json.RawMessage("{}")
+	}
+	var id string
+	err = db.QueryRow(ctx, `INSERT INTO connectors (name, kind, config, credential_ref, enabled)
+		VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+		c.Name, c.Kind, cfg, c.CredentialRef, c.Enabled).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("connectors create: %w", err)
+	}
+	s.audit(ctx, "create", id, nil, c)
+	s.onChange(ctx)
+	return id, nil
+}
+
+// Patch applies a partial update. Name and kind are immutable: the
+// name prefixes served tool names and the kind picks the builder —
+// changing either mid-flight would silently re-identify every tool.
+type Patch struct {
+	Config        *json.RawMessage `json:"config"`
+	CredentialRef *string          `json:"credential_ref"`
+	Enabled       *bool            `json:"enabled"`
+}
+
+func (s *Store) Patch(ctx context.Context, id string, patch Patch) error {
+	if patch.CredentialRef != nil && !credentialRefPattern.MatchString(*patch.CredentialRef) {
+		return fmt.Errorf("credential_ref must be a name or path, never a secret value")
+	}
+	if patch.Config != nil && len(*patch.Config) > 0 && !json.Valid(*patch.Config) {
+		return fmt.Errorf("config must be a JSON object")
+	}
+
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("connectors patch: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("connectors patch: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// FOR UPDATE holds the row across the read-modify-write, same as
+	// the gateway's provider patch.
+	before, err := scanConnector(ctx, tx, id, "FOR UPDATE")
+	if err != nil {
+		return err
+	}
+	after := before
+	if patch.Config != nil {
+		after.Config = *patch.Config
+	}
+	if patch.CredentialRef != nil {
+		after.CredentialRef = *patch.CredentialRef
+	}
+	if patch.Enabled != nil {
+		after.Enabled = *patch.Enabled
+	}
+
+	if _, err := tx.Exec(ctx, `UPDATE connectors SET config = $2, credential_ref = $3,
+			enabled = $4, updated_at = now() WHERE id = $1`,
+		id, after.Config, after.CredentialRef, after.Enabled); err != nil {
+		return fmt.Errorf("connectors patch: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("connectors patch: %w", err)
+	}
+	s.audit(ctx, "update", id, before, after)
+	s.onChange(ctx)
+	return nil
+}
+
+// Delete removes a connector; its tools vanish on the next reload.
+func (s *Store) Delete(ctx context.Context, id string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("connectors delete: %w", err)
+	}
+	before, err := scanConnector(ctx, db, id, "")
+	if err != nil {
+		return err
+	}
+	if _, err := db.Exec(ctx, `DELETE FROM connectors WHERE id = $1`, id); err != nil {
+		return fmt.Errorf("connectors delete: %w", err)
+	}
+	s.audit(ctx, "delete", id, before, nil)
+	s.onChange(ctx)
+	return nil
+}
+
+// pgxQuerier is satisfied by both *pgxpool.Pool and pgx.Tx.
+type pgxQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+func scanConnector(ctx context.Context, q pgxQuerier, id, lock string) (Connector, error) {
+	var c Connector
+	err := q.QueryRow(ctx, `SELECT id, name, kind, config, credential_ref, enabled
+		FROM connectors WHERE id = $1 `+lock, id).
+		Scan(&c.ID, &c.Name, &c.Kind, &c.Config, &c.CredentialRef, &c.Enabled)
+	if err != nil {
+		return Connector{}, fmt.Errorf("connector %s: %w", id, ErrNotFound)
+	}
+	return c, nil
+}
+
+// audit records who-did-what in the shared admin_audit table; failures
+// log — an audit hiccup must not roll back a successful mutation, but
+// it must never be silent.
+func (s *Store) audit(ctx context.Context, action, entityID string, before, after any) {
+	db, err := s.db.Get()
+	if err != nil {
+		s.log.Warn("connector audit skipped", "action", action, "error", err)
+		return
+	}
+	b, _ := json.Marshal(before)
+	aft, _ := json.Marshal(after)
+	if _, err := db.Exec(ctx, `INSERT INTO admin_audit (action, entity, entity_id, before, after)
+		VALUES ($1, 'connector', $2, $3, $4)`, action, entityID, b, aft); err != nil {
+		s.log.Warn("connector audit failed", "action", action, "error", err)
+	}
+}

--- a/internal/brain/connectors/connectors_integration_test.go
+++ b/internal/brain/connectors/connectors_integration_test.go
@@ -1,0 +1,153 @@
+//go:build integration
+
+package connectors
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+	"github.com/SumonMSelim/timothy/internal/platform/migrate"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+	"github.com/SumonMSelim/timothy/migrations"
+)
+
+const marker = "itest-conn-"
+
+func testStore(t *testing.T) (*Store, *pgpool.Pool) {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	sweep := func(ctx context.Context) {
+		_, _ = db.Exec(ctx, "DELETE FROM connectors WHERE name LIKE $1 || '%'", marker)
+		_, _ = db.Exec(ctx, `DELETE FROM admin_audit WHERE entity = 'connector'
+			AND (after::text LIKE '%' || $1 || '%' OR before::text LIKE '%' || $1 || '%')`, marker)
+	}
+	sweep(ctx)
+	t.Cleanup(func() { sweep(context.Background()) })
+	return NewStore(pool, log), pool
+}
+
+func TestConnectorCRUDAuditsAndNotifies(t *testing.T) {
+	store, pool := testStore(t)
+	ctx := t.Context()
+	name := marker + "github"
+
+	changes := 0
+	store.SetOnChange(func(context.Context) { changes++ })
+
+	id, err := store.Create(ctx, Connector{
+		Name: name, Kind: "mcp",
+		Config:        json.RawMessage(`{"endpoint":"https://api.example/mcp"}`),
+		CredentialRef: "GITHUB_MCP_TOKEN",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if changes != 1 {
+		t.Fatalf("changes after create = %d, want 1", changes)
+	}
+
+	// Duplicate name refused by the unique constraint.
+	if _, err := store.Create(ctx, Connector{Name: name, Kind: "mcp"}); err == nil {
+		t.Fatal("duplicate name accepted")
+	}
+
+	enabled := true
+	if err := store.Patch(ctx, id, Patch{Enabled: &enabled}); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	list, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var got *Connector
+	for i := range list {
+		if list[i].ID == id {
+			got = &list[i]
+		}
+	}
+	if got == nil || !got.Enabled || got.Kind != "mcp" {
+		t.Fatalf("patched connector = %+v, want enabled mcp", got)
+	}
+
+	// Ref validation holds on patch too.
+	bad := "has a space"
+	if err := store.Patch(ctx, id, Patch{CredentialRef: &bad}); err == nil {
+		t.Fatal("secret-looking credential_ref accepted on patch")
+	}
+
+	if err := store.Delete(ctx, id); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := store.Get(ctx, id); err == nil {
+		t.Fatal("Get after delete: want ErrNotFound")
+	}
+	if changes != 3 { // create + patch + delete; rejected patch must not fire
+		t.Fatalf("changes = %d, want 3", changes)
+	}
+
+	// Every mutation audited under entity='connector'.
+	db, _ := pool.Get()
+	var audits int
+	if err := db.QueryRow(ctx, `SELECT count(*) FROM admin_audit
+		WHERE entity = 'connector' AND entity_id = $1`, id).Scan(&audits); err != nil {
+		t.Fatalf("audit query: %v", err)
+	}
+	if audits != 3 {
+		t.Fatalf("audit rows = %d, want 3 (create, update, delete)", audits)
+	}
+}
+
+func TestManagerReloadFromDB(t *testing.T) {
+	store, _ := testStore(t)
+	ctx := t.Context()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	mgr := NewManager(store, func(context.Context, string) (string, error) { return "resolved", nil }, log)
+	mgr.RegisterBuilder("mcp", func(_ context.Context, c Connector, _ Resolve) (Source, error) {
+		return nopSource{}, nil
+	})
+
+	// Create-enabled fires the change hook, which reloads the manager.
+	name := marker + "live"
+	if _, err := store.Create(ctx, Connector{Name: name, Kind: "mcp", Enabled: true}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	found := false
+	for _, n := range mgr.Names() {
+		if n == name {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("Names = %v, want %s present after create", mgr.Names(), name)
+	}
+}
+
+type nopSource struct{}
+
+func (nopSource) Tools() []*tools.Tool        { return nil }
+func (nopSource) Test(context.Context) error  { return nil }
+func (nopSource) Close() error                { return nil }

--- a/internal/brain/connectors/manager.go
+++ b/internal/brain/connectors/manager.go
@@ -1,0 +1,194 @@
+package connectors
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// Resolve turns a credential_ref into its secret value at build time.
+// Wired to the secret store in production, a fake in tests.
+type Resolve func(ctx context.Context, ref string) (string, error)
+
+// Source is one built connector: a live handle on the third-party
+// service.
+type Source interface {
+	// Tools returns the source's tools, un-namespaced; fetched at
+	// build time and immutable for the source's lifetime (reloads
+	// rebuild sources).
+	Tools() []*tools.Tool
+	// Test checks connectivity and auth without side effects.
+	Test(ctx context.Context) error
+	Close() error
+}
+
+// Builder constructs a Source for one connector kind ("mcp",
+// "google"). Builders are registered at startup; a kind without a
+// builder is configured but dormant.
+type Builder func(ctx context.Context, c Connector, resolve Resolve) (Source, error)
+
+const testTimeout = 20 * time.Second
+
+// rowSource is the slice of Store the manager reads; a fake satisfies
+// it in unit tests.
+type rowSource interface {
+	List(ctx context.Context) ([]Connector, error)
+	Get(ctx context.Context, id string) (Connector, error)
+}
+
+// Manager owns the built sources: Reload loads enabled rows, builds
+// each through its kind's builder, and swaps the set atomically —
+// admin writes serve without restarts, mirroring the gateway's
+// snapshot store.
+type Manager struct {
+	store    *Store
+	rows     rowSource
+	resolve  Resolve
+	builders map[string]Builder
+	log      *slog.Logger
+
+	onReload func(context.Context)
+
+	mu      sync.RWMutex
+	sources map[string]Source // by connector name
+}
+
+func NewManager(store *Store, resolve Resolve, log *slog.Logger) *Manager {
+	m := &Manager{
+		store:    store,
+		rows:     store,
+		resolve:  resolve,
+		builders: map[string]Builder{},
+		log:      log,
+		sources:  map[string]Source{},
+	}
+	store.SetOnChange(func(ctx context.Context) {
+		if err := m.Reload(ctx); err != nil {
+			log.Warn("connector reload failed; keeping previous sources", "error", err)
+		}
+	})
+	return m
+}
+
+// Store exposes the CRUD layer for the HTTP handlers.
+func (m *Manager) Store() *Store { return m.store }
+
+// RegisterBuilder wires one kind's builder. Startup-time only.
+func (m *Manager) RegisterBuilder(kind string, b Builder) {
+	m.builders[kind] = b
+}
+
+// Reload builds sources for every enabled connector and swaps the set.
+// A connector whose build fails is skipped with a log — one bad row
+// must not take down the others — and the previous set is closed only
+// after the swap.
+func (m *Manager) Reload(ctx context.Context) error {
+	rows, err := m.rows.List(ctx)
+	if err != nil {
+		return err
+	}
+	fresh := map[string]Source{}
+	for _, c := range rows {
+		if !c.Enabled {
+			continue
+		}
+		b, ok := m.builders[c.Kind]
+		if !ok {
+			m.log.Warn("connector kind has no builder; skipping", "connector", c.Name, "kind", c.Kind)
+			continue
+		}
+		src, err := b(ctx, c, m.resolve)
+		if err != nil {
+			m.log.Warn("connector build failed; skipping", "connector", c.Name, "error", err)
+			continue
+		}
+		fresh[c.Name] = src
+	}
+
+	m.mu.Lock()
+	old := m.sources
+	m.sources = fresh
+	m.mu.Unlock()
+
+	for name, src := range old {
+		if err := src.Close(); err != nil {
+			m.log.Warn("connector close failed", "connector", name, "error", err)
+		}
+	}
+	if m.onReload != nil {
+		m.onReload(ctx)
+	}
+	return nil
+}
+
+// toolNameSanitizer strips characters providers reject in tool names.
+var toolNameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
+
+// Tools returns every built connector's tools, each renamed to
+// "<connector>_<tool>" so names never collide across connectors or
+// with the builtin set. The clones share the source's Execute.
+func (m *Manager) Tools() []*tools.Tool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var out []*tools.Tool
+	for name, src := range m.sources {
+		for _, t := range src.Tools() {
+			full := toolNameSanitizer.ReplaceAllString(name+"_"+t.Name, "_")
+			if len(full) > 128 {
+				full = full[:128]
+			}
+			clone := *t
+			clone.Name = full
+			out = append(out, &clone)
+		}
+	}
+	return out
+}
+
+// SetOnReload registers a hook that fires after every successful
+// Reload — the agent's tool set rebuilds from it. Startup-time only.
+func (m *Manager) SetOnReload(fn func(context.Context)) {
+	m.onReload = fn
+}
+
+// Names returns the currently-built connector names (unordered).
+func (m *Manager) Names() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	names := make([]string, 0, len(m.sources))
+	for n := range m.sources {
+		names = append(names, n)
+	}
+	return names
+}
+
+// Test builds the connector fresh — enabled or not — and runs its
+// connectivity check, so a connector can be verified before it is
+// switched on. The ephemeral source is closed either way.
+func (m *Manager) Test(ctx context.Context, id string) error {
+	c, err := m.rows.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	b, ok := m.builders[c.Kind]
+	if !ok {
+		return fmt.Errorf("connector kind %s has no builder yet: %w", c.Kind, ErrUnsupported)
+	}
+	tctx, cancel := context.WithTimeout(ctx, testTimeout)
+	defer cancel()
+	src, err := b(tctx, c, m.resolve)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := src.Close(); err != nil {
+			m.log.Warn("connector close failed", "connector", c.Name, "error", err)
+		}
+	}()
+	return src.Test(tctx)
+}

--- a/internal/brain/connectors/manager_test.go
+++ b/internal/brain/connectors/manager_test.go
@@ -1,0 +1,176 @@
+package connectors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"slices"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+type fakeRows struct {
+	rows []Connector
+	err  error
+}
+
+func (f fakeRows) List(context.Context) ([]Connector, error) { return f.rows, f.err }
+func (f fakeRows) Get(_ context.Context, id string) (Connector, error) {
+	for _, c := range f.rows {
+		if c.ID == id {
+			return c, nil
+		}
+	}
+	return Connector{}, fmt.Errorf("connector %s: %w", id, ErrNotFound)
+}
+
+type fakeSource struct {
+	tools   []*tools.Tool
+	testErr error
+	closed  bool
+	tested  bool
+}
+
+func (f *fakeSource) Tools() []*tools.Tool        { return f.tools }
+func (f *fakeSource) Test(context.Context) error  { f.tested = true; return f.testErr }
+func (f *fakeSource) Close() error                { f.closed = true; return nil }
+
+func testManager(rows rowSource) *Manager {
+	return &Manager{
+		rows:     rows,
+		resolve:  func(context.Context, string) (string, error) { return "resolved", nil },
+		builders: map[string]Builder{},
+		log:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		sources:  map[string]Source{},
+	}
+}
+
+func TestReloadBuildsEnabledOnly(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{rows: []Connector{
+		{ID: "1", Name: "github", Kind: "mcp", Enabled: true},
+		{ID: "2", Name: "grafana", Kind: "mcp", Enabled: false},
+		{ID: "3", Name: "gmail", Kind: "google", Enabled: true}, // no builder → skipped
+	}})
+	m.RegisterBuilder("mcp", func(context.Context, Connector, Resolve) (Source, error) {
+		return &fakeSource{}, nil
+	})
+
+	if err := m.Reload(t.Context()); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	got := m.Names()
+	slices.Sort(got)
+	if !slices.Equal(got, []string{"github"}) {
+		t.Fatalf("Names = %v, want [github]", got)
+	}
+}
+
+func TestReloadSkipsFailedBuildAndClosesOld(t *testing.T) {
+	t.Parallel()
+	old := &fakeSource{}
+	m := testManager(fakeRows{rows: []Connector{
+		{ID: "1", Name: "good", Kind: "mcp", Enabled: true},
+		{ID: "2", Name: "bad", Kind: "mcp", Enabled: true},
+	}})
+	m.sources = map[string]Source{"stale": old}
+	m.RegisterBuilder("mcp", func(_ context.Context, c Connector, _ Resolve) (Source, error) {
+		if c.Name == "bad" {
+			return nil, errors.New("boom")
+		}
+		return &fakeSource{}, nil
+	})
+
+	if err := m.Reload(t.Context()); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if got := m.Names(); !slices.Equal(got, []string{"good"}) {
+		t.Fatalf("Names = %v, want [good]", got)
+	}
+	if !old.closed {
+		t.Fatal("previous source not closed after swap")
+	}
+}
+
+func TestReloadKeepsSetOnListError(t *testing.T) {
+	t.Parallel()
+	keep := &fakeSource{}
+	m := testManager(fakeRows{err: errors.New("db down")})
+	m.sources = map[string]Source{"keep": keep}
+
+	if err := m.Reload(t.Context()); err == nil {
+		t.Fatal("Reload with failing list: want error")
+	}
+	if got := m.Names(); !slices.Equal(got, []string{"keep"}) {
+		t.Fatalf("Names after failed reload = %v, want [keep]", got)
+	}
+	if keep.closed {
+		t.Fatal("kept source must not be closed on failed reload")
+	}
+}
+
+func TestTestBuildsEphemeralSource(t *testing.T) {
+	t.Parallel()
+	src := &fakeSource{testErr: errors.New("401 unauthorized")}
+	m := testManager(fakeRows{rows: []Connector{
+		{ID: "1", Name: "github", Kind: "mcp", Enabled: false}, // disabled still testable
+	}})
+	m.RegisterBuilder("mcp", func(context.Context, Connector, Resolve) (Source, error) {
+		return src, nil
+	})
+
+	err := m.Test(t.Context(), "1")
+	if err == nil || err.Error() != "401 unauthorized" {
+		t.Fatalf("Test = %v, want the probe error", err)
+	}
+	if !src.tested || !src.closed {
+		t.Fatalf("ephemeral source tested=%v closed=%v, want both", src.tested, src.closed)
+	}
+}
+
+func TestTestUnknownKindAndID(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{rows: []Connector{
+		{ID: "1", Name: "gmail", Kind: "google", Enabled: true},
+	}})
+
+	if err := m.Test(t.Context(), "1"); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("Test without builder = %v, want ErrUnsupported", err)
+	}
+	if err := m.Test(t.Context(), "nope"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Test unknown id = %v, want ErrNotFound", err)
+	}
+}
+
+func TestValidateRejectsBadInput(t *testing.T) {
+	t.Parallel()
+	base := Connector{Name: "github", Kind: "mcp"}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*Connector)
+	}{
+		{"uppercase name", func(c *Connector) { c.Name = "GitHub" }},
+		{"empty name", func(c *Connector) { c.Name = "" }},
+		{"space in name", func(c *Connector) { c.Name = "git hub" }},
+		{"unknown kind", func(c *Connector) { c.Kind = "smtp" }},
+		{"secret-looking ref", func(c *Connector) { c.CredentialRef = "sk-abc def" }},
+		{"invalid config", func(c *Connector) { c.Config = []byte("{not json") }},
+	} {
+		c := base
+		tc.mutate(&c)
+		if err := validate(c); err == nil {
+			t.Errorf("%s: accepted", tc.name)
+		}
+	}
+
+	ok := base
+	ok.Config = []byte(`{"endpoint":"https://api.example/mcp"}`)
+	ok.CredentialRef = "GITHUB_MCP_TOKEN"
+	if err := validate(ok); err != nil {
+		t.Fatalf("valid connector rejected: %v", err)
+	}
+}

--- a/internal/brain/connectors/mcp.go
+++ b/internal/brain/connectors/mcp.go
@@ -1,0 +1,291 @@
+package connectors
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+	"github.com/SumonMSelim/timothy/internal/platform/sse"
+)
+
+// mcpProtocolVersion is the streamable-HTTP MCP revision this client
+// speaks. Servers negotiate down; we accept whatever they answer.
+const mcpProtocolVersion = "2025-06-18"
+
+// mcpCallTimeout bounds one JSON-RPC round trip, including a tool
+// call's remote work.
+const mcpCallTimeout = 60 * time.Second
+
+// mcpConfig is the connectors.config shape for kind='mcp'. Only
+// streamable HTTP is supported: stdio would mean running arbitrary
+// admin-configured subprocesses inside brain's container.
+type mcpConfig struct {
+	Endpoint string            `json:"endpoint"`
+	Headers  map[string]string `json:"headers"`
+}
+
+// MCPBuilder returns the Builder for kind='mcp'. The credential ref
+// resolves to a bearer token; an empty or unresolvable ref builds
+// without auth and lets the server's 401 surface at initialize.
+func MCPBuilder(client *http.Client) Builder {
+	if client == nil {
+		client = &http.Client{}
+	}
+	return func(ctx context.Context, c Connector, resolve Resolve) (Source, error) {
+		var cfg mcpConfig
+		if err := json.Unmarshal(c.Config, &cfg); err != nil {
+			return nil, fmt.Errorf("mcp %s: config: %w", c.Name, err)
+		}
+		if cfg.Endpoint == "" {
+			return nil, fmt.Errorf("mcp %s: config.endpoint is required", c.Name)
+		}
+		token := ""
+		if c.CredentialRef != "" {
+			if v, err := resolve(ctx, c.CredentialRef); err == nil {
+				token = v
+			}
+		}
+		src := &mcpSource{name: c.Name, cfg: cfg, token: token, client: client}
+		if err := src.connect(ctx); err != nil {
+			return nil, fmt.Errorf("mcp %s: %w", c.Name, err)
+		}
+		return src, nil
+	}
+}
+
+// mcpSource is one connected MCP server: initialized session plus the
+// tool list fetched at build time. Reloads rebuild sources, so the
+// tool list is immutable for a source's lifetime.
+type mcpSource struct {
+	name   string
+	cfg    mcpConfig
+	token  string
+	client *http.Client
+
+	sessionID string // Mcp-Session-Id, captured at initialize
+	nextID    atomic.Int64
+	toolList  []*tools.Tool
+}
+
+// connect runs the MCP handshake and caches the tool list.
+func (s *mcpSource) connect(ctx context.Context) error {
+	var initRes struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	err := s.rpc(ctx, "initialize", map[string]any{
+		"protocolVersion": mcpProtocolVersion,
+		"capabilities":    map[string]any{},
+		"clientInfo":      map[string]any{"name": "timothy", "version": "1"},
+	}, &initRes)
+	if err != nil {
+		return fmt.Errorf("initialize: %w", err)
+	}
+	if err := s.notify(ctx, "notifications/initialized"); err != nil {
+		return fmt.Errorf("initialized notification: %w", err)
+	}
+
+	var listRes struct {
+		Tools []struct {
+			Name        string          `json:"name"`
+			Description string          `json:"description"`
+			InputSchema json.RawMessage `json:"inputSchema"`
+		} `json:"tools"`
+	}
+	if err := s.rpc(ctx, "tools/list", map[string]any{}, &listRes); err != nil {
+		return fmt.Errorf("tools/list: %w", err)
+	}
+	for _, t := range listRes.Tools {
+		remote := t.Name
+		schema := t.InputSchema
+		if len(schema) == 0 {
+			schema = json.RawMessage(`{"type":"object"}`)
+		}
+		s.toolList = append(s.toolList, &tools.Tool{
+			Name:        remote,
+			Description: t.Description,
+			InputSchema: schema,
+			Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
+				return s.call(ctx, remote, args)
+			},
+		})
+	}
+	return nil
+}
+
+// Tools returns the server's tools, un-namespaced — the manager
+// prefixes connector names when it aggregates.
+func (s *mcpSource) Tools() []*tools.Tool { return s.toolList }
+
+// Test re-lists tools: proves the session, auth, and endpoint are
+// still good without side effects.
+func (s *mcpSource) Test(ctx context.Context) error {
+	var res json.RawMessage
+	return s.rpc(ctx, "tools/list", map[string]any{}, &res)
+}
+
+// Close is a no-op: streamable HTTP holds no persistent connection.
+// Kept on the interface for transports that will (stdio, websocket).
+func (s *mcpSource) Close() error { return nil }
+
+// call invokes one remote tool and flattens its content to text. An
+// isError result comes back as a Go error so the loop reports it as
+// tool feedback.
+func (s *mcpSource) call(ctx context.Context, tool string, args json.RawMessage) (string, error) {
+	if len(args) == 0 {
+		args = json.RawMessage(`{}`)
+	}
+	var res struct {
+		IsError bool `json:"isError"`
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	err := s.rpc(ctx, "tools/call", map[string]any{"name": tool, "arguments": args}, &res)
+	if err != nil {
+		return "", fmt.Errorf("mcp %s: %s: %w", s.name, tool, err)
+	}
+	var b strings.Builder
+	for _, c := range res.Content {
+		if c.Type == "text" {
+			b.WriteString(c.Text)
+		}
+	}
+	if res.IsError {
+		return "", fmt.Errorf("mcp %s: %s: %s", s.name, tool, b.String())
+	}
+	return b.String(), nil
+}
+
+// jsonrpcEnvelope is the response shape for both plain-JSON and SSE
+// replies.
+type jsonrpcEnvelope struct {
+	ID     json.Number     `json:"id"`
+	Result json.RawMessage `json:"result"`
+	Error  *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// rpc posts one JSON-RPC request and decodes the response, which a
+// streamable-HTTP server may deliver as plain JSON or as an SSE
+// stream carrying the response message.
+func (s *mcpSource) rpc(ctx context.Context, method string, params, result any) error {
+	id := s.nextID.Add(1)
+	resp, err := s.post(ctx, map[string]any{
+		"jsonrpc": "2.0", "id": id, "method": method, "params": params,
+	})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return fmt.Errorf("%s: status %d: %s", method, resp.StatusCode, snippet)
+	}
+	if sid := resp.Header.Get("Mcp-Session-Id"); sid != "" {
+		s.sessionID = sid
+	}
+
+	var envelope jsonrpcEnvelope
+	if strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream") {
+		found := false
+		err := sse.Read(resp.Body, func(ev sse.Event) bool {
+			var e jsonrpcEnvelope
+			if json.Unmarshal([]byte(ev.Data), &e) != nil {
+				return true // notification or noise; keep scanning
+			}
+			if e.ID.String() != fmt.Sprint(id) {
+				return true
+			}
+			envelope, found = e, true
+			return false
+		})
+		if err != nil && !found {
+			return fmt.Errorf("%s: read sse: %w", method, err)
+		}
+		if !found {
+			return fmt.Errorf("%s: stream ended without a response", method)
+		}
+	} else {
+		if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+			return fmt.Errorf("%s: decode: %w", method, err)
+		}
+	}
+
+	if envelope.Error != nil {
+		return fmt.Errorf("%s: rpc error %d: %s", method, envelope.Error.Code, envelope.Error.Message)
+	}
+	if result != nil {
+		if err := json.Unmarshal(envelope.Result, result); err != nil {
+			return fmt.Errorf("%s: result: %w", method, err)
+		}
+	}
+	return nil
+}
+
+// notify posts a JSON-RPC notification (no id, no response body
+// expected beyond the status).
+func (s *mcpSource) notify(ctx context.Context, method string) error {
+	resp, err := s.post(ctx, map[string]any{"jsonrpc": "2.0", "method": method})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s: status %d", method, resp.StatusCode)
+	}
+	return nil
+}
+
+func (s *mcpSource) post(ctx context.Context, body any) (*http.Response, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	cctx, cancel := context.WithTimeout(ctx, mcpCallTimeout)
+	req, err := http.NewRequestWithContext(cctx, http.MethodPost, s.cfg.Endpoint, bytes.NewReader(payload))
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if s.token != "" {
+		req.Header.Set("Authorization", "Bearer "+s.token)
+	}
+	if s.sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", s.sessionID)
+	}
+	for k, v := range s.cfg.Headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	// The cancel rides the body: rpc/notify close it promptly.
+	resp.Body = &cancelBody{ReadCloser: resp.Body, cancel: cancel}
+	return resp, nil
+}
+
+// cancelBody ties a request's timeout context to its body's lifetime.
+type cancelBody struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (c *cancelBody) Close() error {
+	c.cancel()
+	return c.ReadCloser.Close()
+}

--- a/internal/brain/connectors/mcp_test.go
+++ b/internal/brain/connectors/mcp_test.go
@@ -1,0 +1,212 @@
+package connectors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// fakeMCP is a minimal streamable-HTTP MCP server: initialize,
+// initialized notification, tools/list, tools/call. sseMode answers
+// RPCs as one-event SSE streams instead of plain JSON.
+type fakeMCP struct {
+	token     string
+	sseMode   bool
+	callErr   bool
+	gotAuth   string
+	gotProto  string
+	gotCalls  []string
+	sessionID string
+}
+
+func (f *fakeMCP) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		f.gotAuth = r.Header.Get("Authorization")
+		if f.token != "" && f.gotAuth != "Bearer "+f.token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		var req struct {
+			ID     json.Number     `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		respond := func(result string) {
+			body := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":%s}`, req.ID, result)
+			if f.sseMode {
+				w.Header().Set("Content-Type", "text/event-stream")
+				// A notification frame first: the client must skip
+				// non-response frames while scanning for its id.
+				_, _ = fmt.Fprint(w, "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/ping\"}\n\n")
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", body)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+		}
+
+		switch req.Method {
+		case "initialize":
+			var p struct {
+				ProtocolVersion string `json:"protocolVersion"`
+			}
+			_ = json.Unmarshal(req.Params, &p)
+			f.gotProto = p.ProtocolVersion
+			f.sessionID = "sess-1"
+			w.Header().Set("Mcp-Session-Id", f.sessionID)
+			respond(`{"protocolVersion":"2025-06-18","capabilities":{},"serverInfo":{"name":"fake"}}`)
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			if f.sessionID != "" && r.Header.Get("Mcp-Session-Id") != f.sessionID {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			// One line: SSE data frames must not contain raw newlines.
+			respond(`{"tools":[{"name":"create_issue","description":"Create a GitHub issue","inputSchema":{"type":"object","properties":{"title":{"type":"string"}}}},{"name":"search code","description":"Search"}]}`)
+		case "tools/call":
+			var p struct {
+				Name      string          `json:"name"`
+				Arguments json.RawMessage `json:"arguments"`
+			}
+			_ = json.Unmarshal(req.Params, &p)
+			f.gotCalls = append(f.gotCalls, p.Name+" "+string(p.Arguments))
+			if f.callErr {
+				respond(`{"isError":true,"content":[{"type":"text","text":"boom: rate limited"}]}`)
+				return
+			}
+			respond(`{"content":[{"type":"text","text":"issue "},{"type":"text","text":"#42 created"}]}`)
+		default:
+			respond(`{}`)
+		}
+	}
+}
+
+func buildMCP(t *testing.T, f *fakeMCP, token string) Source {
+	t.Helper()
+	srv := httptest.NewServer(f.handler())
+	t.Cleanup(srv.Close)
+	//nolint:gosec // G101: CredentialRef is a ref NAME, not a credential value.
+	src, err := MCPBuilder(srv.Client())(t.Context(), Connector{
+		Name: "github", Kind: "mcp",
+		Config:        json.RawMessage(`{"endpoint":"` + srv.URL + `"}`),
+		CredentialRef: "GITHUB_MCP_TOKEN",
+	}, func(context.Context, string) (string, error) { return token, nil })
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	return src
+}
+
+func TestMCPHandshakeAndToolList(t *testing.T) {
+	t.Parallel()
+	f := &fakeMCP{token: "tok-1"}
+	src := buildMCP(t, f, "tok-1")
+
+	if f.gotAuth != "Bearer tok-1" || f.gotProto != mcpProtocolVersion {
+		t.Fatalf("handshake auth=%q proto=%q", f.gotAuth, f.gotProto)
+	}
+	list := src.Tools()
+	if len(list) != 2 || list[0].Name != "create_issue" || list[0].Description == "" {
+		t.Fatalf("tools = %+v", list)
+	}
+	// Missing schema gets the permissive object default.
+	if string(list[1].InputSchema) != `{"type":"object"}` {
+		t.Fatalf("default schema = %s", list[1].InputSchema)
+	}
+	if err := src.Test(t.Context()); err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+}
+
+func TestMCPCallRoundTrip(t *testing.T) {
+	t.Parallel()
+	f := &fakeMCP{}
+	src := buildMCP(t, f, "")
+
+	out, err := src.Tools()[0].Execute(t.Context(), json.RawMessage(`{"title":"bug"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out != "issue #42 created" {
+		t.Fatalf("Execute = %q", out)
+	}
+	if len(f.gotCalls) != 1 || f.gotCalls[0] != `create_issue {"title":"bug"}` {
+		t.Fatalf("server saw %v", f.gotCalls)
+	}
+}
+
+func TestMCPCallErrorSurfacesAsToolError(t *testing.T) {
+	t.Parallel()
+	f := &fakeMCP{callErr: true}
+	src := buildMCP(t, f, "")
+
+	_, err := src.Tools()[0].Execute(t.Context(), json.RawMessage(`{}`))
+	if err == nil || !strings.Contains(err.Error(), "rate limited") {
+		t.Fatalf("Execute err = %v, want the isError content", err)
+	}
+}
+
+func TestMCPSSEResponses(t *testing.T) {
+	t.Parallel()
+	f := &fakeMCP{sseMode: true}
+	src := buildMCP(t, f, "")
+
+	if got := len(src.Tools()); got != 2 {
+		t.Fatalf("tools over sse = %d, want 2", got)
+	}
+	out, err := src.Tools()[0].Execute(t.Context(), nil)
+	if err != nil || out != "issue #42 created" {
+		t.Fatalf("Execute over sse = (%q, %v)", out, err)
+	}
+}
+
+func TestMCPBuildFailures(t *testing.T) {
+	t.Parallel()
+	builder := MCPBuilder(nil)
+	resolve := func(context.Context, string) (string, error) { return "", nil }
+
+	// Endpoint is required.
+	if _, err := builder(t.Context(), Connector{Name: "x", Config: json.RawMessage(`{}`)}, resolve); err == nil {
+		t.Fatal("missing endpoint accepted")
+	}
+	// A 401 at initialize fails the build (bad token → skipped, logged).
+	f := &fakeMCP{token: "right"}
+	srv := httptest.NewServer(f.handler())
+	t.Cleanup(srv.Close)
+	_, err := MCPBuilder(srv.Client())(t.Context(), Connector{
+		Name: "x", Config: json.RawMessage(`{"endpoint":"` + srv.URL + `"}`),
+	}, func(context.Context, string) (string, error) { return "wrong", nil })
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Fatalf("bad token build = %v, want 401", err)
+	}
+}
+
+func TestManagerNamespacesTools(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{})
+	m.sources = map[string]Source{
+		"github": &fakeSource{tools: []*tools.Tool{
+			{Name: "create_issue"},
+			{Name: "search code"}, // space sanitized
+		}},
+	}
+	names := map[string]bool{}
+	for _, tl := range m.Tools() {
+		names[tl.Name] = true
+	}
+	if !names["github_create_issue"] || !names["github_search_code"] {
+		t.Fatalf("namespaced tools = %v", names)
+	}
+}

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -67,17 +67,22 @@ const coercionMessage = "[system] This task category requires consulting your to
 // the step ceiling.
 type Agent struct {
 	gw             Gateway
-	exec           Executor
 	perms          Permissioner
 	outputs        OutputSink
 	audit          AuditSink
 	events         EventAppender
 	broker         *PermBroker
-	defs           []provider.ToolDef
 	maxSteps       int
 	offloadAt      int
 	offloadPerTool map[string]int
 	logger         *slog.Logger
+
+	// The tool surface swaps at runtime when connectors reload; a turn
+	// snapshots both under one lock at its start, so defs and executor
+	// always agree within a turn.
+	toolMu sync.RWMutex
+	exec   Executor
+	defs   []provider.ToolDef
 }
 
 func NewAgent(gw Gateway, exec Executor, perms Permissioner, outputs OutputSink, audit AuditSink, events EventAppender, broker *PermBroker, defs []provider.ToolDef, logger *slog.Logger) *Agent {
@@ -89,6 +94,20 @@ func NewAgent(gw Gateway, exec Executor, perms Permissioner, outputs OutputSink,
 		offloadPerTool: map[string]int{},
 		logger:         logger,
 	}
+}
+
+// SwapTools atomically replaces the tool surface for future turns;
+// in-flight turns keep the snapshot they started with.
+func (a *Agent) SwapTools(exec Executor, defs []provider.ToolDef) {
+	a.toolMu.Lock()
+	defer a.toolMu.Unlock()
+	a.exec, a.defs = exec, defs
+}
+
+func (a *Agent) toolset() (Executor, []provider.ToolDef) {
+	a.toolMu.RLock()
+	defer a.toolMu.RUnlock()
+	return a.exec, a.defs
 }
 
 // SetOffloadThreshold overrides the offload size for one tool (D-019
@@ -131,6 +150,7 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 		}
 	}
 
+	exec, defs := a.toolset()
 	msgs := append([]provider.Message(nil), req.Messages...)
 	total := stream.Usage{}
 	var lastMeta *stream.Meta
@@ -154,7 +174,7 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			ModelHint:    req.ModelHint,
 			System:       req.System,
 			Messages:     msgs,
-			Tools:        a.defs,
+			Tools:        defs,
 			Effort:       effort,
 			SessionID:    req.SessionID,
 		}
@@ -252,7 +272,7 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 
 		toolCallCount += len(calls)
 		stuck = repeats.Record(calls)
-		results := a.executeAll(ctx, req.SessionID, calls, emit)
+		results := a.executeAll(ctx, exec, req.SessionID, calls, emit)
 
 		msgs = append(msgs, provider.Message{
 			Role: "assistant", Content: text.String(), ToolCalls: calls,
@@ -281,13 +301,13 @@ func EffortFor(results []provider.ToolResult) string {
 
 // executeAll runs a step's tool calls concurrently (bounded) and
 // returns results in call order.
-func (a *Agent) executeAll(ctx context.Context, sessionID string, calls []provider.ToolCall, emit func(stream.StreamEvent)) []provider.ToolResult {
+func (a *Agent) executeAll(ctx context.Context, exec Executor, sessionID string, calls []provider.ToolCall, emit func(stream.StreamEvent)) []provider.ToolResult {
 	results := make([]provider.ToolResult, len(calls))
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(maxParallelTools)
 	for i, call := range calls {
 		g.Go(func() error {
-			results[i] = a.executeOne(gctx, sessionID, call, emit)
+			results[i] = a.executeOne(gctx, exec, sessionID, call, emit)
 			return nil
 		})
 	}
@@ -295,9 +315,9 @@ func (a *Agent) executeAll(ctx context.Context, sessionID string, calls []provid
 	return results
 }
 
-func (a *Agent) executeOne(ctx context.Context, sessionID string, call provider.ToolCall, emit func(stream.StreamEvent)) provider.ToolResult {
+func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, emit func(stream.StreamEvent)) provider.ToolResult {
 	start := time.Now()
-	content, status := a.resolveAndRun(ctx, sessionID, call, emit)
+	content, status := a.resolveAndRun(ctx, exec, sessionID, call, emit)
 	isError := status != "ok"
 
 	if status == "ok" {
@@ -360,7 +380,7 @@ func (a *Agent) executeOne(ctx context.Context, sessionID string, call provider.
 // on allow. It returns the content the model sees plus a status of
 // ok, denied, or error — denials and failures come back as feedback
 // text, never as a broken turn (D-009).
-func (a *Agent) resolveAndRun(ctx context.Context, sessionID string, call provider.ToolCall, emit func(stream.StreamEvent)) (content, status string) {
+func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, emit func(stream.StreamEvent)) (content, status string) {
 	res, err := a.perms.Resolve(ctx, sessionID, call.Name, call.Input)
 	if err != nil {
 		return "permission check failed: " + err.Error(), "error"
@@ -383,7 +403,7 @@ func (a *Agent) resolveAndRun(ctx context.Context, sessionID string, call provid
 		}
 	}
 
-	out, err := a.exec.Execute(ctx, call.Name, call.Input)
+	out, err := exec.Execute(ctx, call.Name, call.Input)
 	if err != nil {
 		if tools.IsViolation(err) {
 			return err.Error(), "error"

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -774,3 +774,51 @@ func TestAgentResearchCoercion(t *testing.T) {
 		t.Fatal("must still end with exactly one done")
 	}
 }
+
+func TestSwapToolsChangesSurfaceForNewTurns(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"github_create_issue", `{"title":"bug"}`}),
+		finalStep("filed"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	// Swap in a connector tool alongside the builtin echo.
+	reg := tools.NewRegistry()
+	connector := &tools.Tool{
+		Name:        "github_create_issue",
+		Description: "Create a GitHub issue",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+		Execute: func(context.Context, json.RawMessage) (string, error) {
+			return "issue #7", nil
+		},
+	}
+	if err := reg.Register(connector); err != nil {
+		t.Fatal(err)
+	}
+	c, err := tools.NewConstrained(reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.SwapTools(registryExec{c}, []provider.ToolDef{
+		{Name: connector.Name, Description: connector.Description, InputSchema: connector.InputSchema},
+	})
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", TaskCategory: "coding",
+		Messages: []provider.Message{{Role: "user", Content: "file it"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	results := ofType(evs, stream.EventToolResult)
+	if len(results) != 1 || results[0].ToolResult.Status != "ok" || results[0].ToolResult.Digest != "issue #7" {
+		t.Fatalf("tool result = %+v, want ok issue #7", results)
+	}
+	// The gateway saw the swapped defs, not the original echo set.
+	gw.mu.Lock()
+	defer gw.mu.Unlock()
+	if len(gw.requests) == 0 || len(gw.requests[0].Tools) != 1 || gw.requests[0].Tools[0].Name != "github_create_issue" {
+		t.Fatalf("first request tools = %+v, want only github_create_issue", gw.requests[0].Tools)
+	}
+}

--- a/migrations/0020_connectors.sql
+++ b/migrations/0020_connectors.sql
@@ -1,0 +1,18 @@
+-- Connectors are third-party integrations the agent can call as tools
+-- (MCP servers, Google Workspace, ...). Like providers they are data:
+-- admin CRUD writes rows, brain reloads and surfaces each connector's
+-- tools into the registry namespaced by connector name. credential_ref
+-- names a secret in the secrets table — never a value.
+CREATE TABLE IF NOT EXISTS connectors (
+    id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    name           text UNIQUE NOT NULL,
+    kind           text NOT NULL CHECK (kind IN ('mcp', 'google')),
+    -- kind-specific settings: mcp → {transport, endpoint, headers},
+    -- google → {scopes}. OAuth tokens NEVER live here; they go to the
+    -- secrets table under credential_ref.
+    config         jsonb NOT NULL DEFAULT '{}',
+    credential_ref text NOT NULL DEFAULT '',
+    enabled        boolean NOT NULL DEFAULT false,
+    created_at     timestamptz NOT NULL DEFAULT now(),
+    updated_at     timestamptz NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
## Why

Agents need third-party integrations — GitHub, Grafana, email/calendar, arbitrary MCP servers — surfaced as tools. This is phases 1+2 of the connectors plan: the data/control plane and the MCP substrate. Google OAuth (Gmail/Calendar) follows in the next PR; the kind whitelist and builder registry already carry the `google` kind.

## What

**Connector core**
- `connectors` table (migration 0020): name (unique slug — prefixes tool names), kind (`mcp` | `google`), config jsonb, `credential_ref`, enabled. Tokens never in config.
- `internal/brain/connectors`: audited CRUD (shared `admin_audit`, entity `connector`), FOR UPDATE patches, name/kind immutable post-create, credential-ref pattern guard (names only, never values).
- Manager: builder-per-kind registry, `Reload` builds enabled rows and swaps the source set atomically (bad row skipped with log, old sources closed post-swap, failed list keeps previous set), `Test` builds an ephemeral source so connectors verify before enabling.
- Brain-local admin API `/v1/admin/connectors` CRUD + `/test` behind bearer — connectors are brain's domain (their tools run in the agent loop), so no gateway proxy.
- Brain gets its own secret-store handle (same DB + `TIMOTHY_MASTER_KEY`, now in brain's compose env). Rationale: proxying secret values from the gateway over the compose network would expose them to anything on it. No key → connector surface unmounted, brain runs as before.

**MCP client (streamable HTTP)**
- Handshake (`initialize` → `notifications/initialized` → `tools/list`), `Mcp-Session-Id` capture, JSON-RPC responses parsed from plain JSON **and** SSE frames (reuses `platform/sse`), bearer from secretstore ref, 60s per-call timeout, `isError` results surfaced as tool feedback.
- stdio transport deliberately excluded: it would mean running arbitrary admin-configured subprocesses inside brain's container.

**Agent loop**
- Tools namespaced `<connector>_<tool>` (sanitized, ≤128 chars); registry collisions skipped with a log — a remote server can never shadow a builtin.
- `Agent.SwapTools` atomic swap; each turn snapshots executor + defs together, so a mid-turn reload can't desync what the model sees from what executes.
- Permission chain unchanged: connector tools are non-exempt — writes prompt the user, session grants apply.
- Startup loader + 1-minute refresh tick, mirroring the gateway's snapshot poll.

## Testing

- 12 unit tests: manager reload/test/validate semantics, fake MCP server (JSON + SSE modes, auth, session id, isError, build failures), namespacing, loop-level swap test proving the gateway sees swapped defs and the connector tool executes.
- 2 integration tests against live postgres: CRUD/audit/notify, manager reload from DB.
- Full `make test`, `make test-integration`, `make lint` (0 issues) green.
