### PR TITLE
feat(settings): default secret backend and UI-managed runtime knobs

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -88,17 +87,13 @@ func main() {
 	if gatewayURL == "" {
 		gatewayURL = "http://gateway:8081"
 	}
-	budget := defaultTokenBudget
-	if v := os.Getenv("SESSION_TOKEN_BUDGET"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			budget = n
-		}
-	}
-
 	gwc := gwclient.New(gatewayURL)
 	store := session.NewStore(app.DB)
 	flags := settings.New(app.DB, app.Log)
-	compactor := session.NewCompactor(store, gwc, gwc, budget, app.Log,
+	// Runtime settings, editable in the UI without a restart: the
+	// projected-context budget fallback and the skill-pack allowlist.
+	budgetFn := func(ctx context.Context) int { return flags.TokenBudget(ctx, defaultTokenBudget) }
+	compactor := session.NewCompactor(store, gwc, gwc, budgetFn, app.Log,
 		app.Metrics.NewCounter("session_compactions_total", "Sessions compacted to stay under the context budget."))
 	distill := func(ctx context.Context, sessionID, turnText string) *session.TurnMemory {
 		return loop.DistillTurn(ctx, gwc, sessionID, turnText)
@@ -113,25 +108,11 @@ func main() {
 		skillsDir = "/skills"
 	}
 	// Broken packs degrade health rather than crash the service.
+	// All loaded packs stay in memory; the skills_allowlist runtime
+	// setting gates which ones the agent may reach per turn.
 	packs, err := skills.Load(skillsDir)
 	if err != nil {
 		app.Log.Error("skills failed to load; continuing without them", "error", err)
-	}
-	// SKILLS_ALLOWLIST restricts which loaded packs the agent may reach
-	// for, without deleting the others from disk — comma-separated
-	// names, empty means no restriction.
-	if allow := os.Getenv("SKILLS_ALLOWLIST"); allow != "" {
-		allowed := make(map[string]bool)
-		for _, name := range strings.Split(allow, ",") {
-			allowed[strings.TrimSpace(name)] = true
-		}
-		filtered := packs[:0]
-		for _, p := range packs {
-			if allowed[p.Name] {
-				filtered = append(filtered, p)
-			}
-		}
-		packs = filtered
 	}
 	app.AddCheck("skills", func() httpserver.Check {
 		if err != nil {
@@ -148,7 +129,7 @@ func main() {
 
 	searxngURL := os.Getenv("SEARXNG_URL")
 
-	agent, broker, outputs, builtinSet, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, packs, mc.Add, app.Log)
+	agent, broker, outputs, builtinSet, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, packs, flags.SkillAllowed, mc.Add, app.Log)
 	if buildErr != nil {
 		fmt.Fprintln(os.Stderr, buildErr)
 		os.Exit(1)
@@ -168,7 +149,7 @@ func main() {
 	}
 
 	svc := chat.New(turnRouter{agent: agent, gw: gwc, flags: flags}, store, distill,
-		gatedCompactor{inner: compactor, flags: flags}, budget, packs, app.Log)
+		gatedCompactor{inner: compactor, flags: flags}, budgetFn, packs, flags.SkillAllowed, app.Log)
 	svc.SetMemoryExtract(func(ctx context.Context, sessionID string, seq int64, text string) {
 		if !flags.Enabled(ctx, settings.KeyMemoryExtraction) {
 			return
@@ -335,7 +316,7 @@ func (r turnRouter) Stream(ctx context.Context, req gwclient.StreamRequest) (<-c
 // buildAgent assembles the compiled-in tool registry and its guard
 // rails (D-009, D-010). The returned builtin set is the fixed half of
 // the tool surface; connector tools join it via swapAgentTools.
-func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, workspace, searxngURL string, packs []skills.Skill, remember builtin.RememberFunc, log *slog.Logger) (*loop.Agent, *loop.PermBroker, *tools.Outputs, []*tools.Tool, error) {
+func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, workspace, searxngURL string, packs []skills.Skill, skillAllow func(context.Context, string) bool, remember builtin.RememberFunc, log *slog.Logger) (*loop.Agent, *loop.PermBroker, *tools.Outputs, []*tools.Tool, error) {
 	outputs := tools.NewOutputs(db)
 	set := []*tools.Tool{
 		builtin.CurrentTime(time.Now),
@@ -352,7 +333,7 @@ func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, wor
 		set = append(set, builtin.WebSearch(searxngURL))
 	}
 	if len(packs) > 0 {
-		set = append(set, skills.LoadSkillTool(packs))
+		set = append(set, skills.LoadSkillTool(packs, skillAllow))
 	}
 	constrained, defs, err := compileToolset(set, nil, log)
 	if err != nil {

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -62,9 +62,6 @@ services:
       PORT: "8080"
       GATEWAY_URL: http://gateway:8081
       MEMORYD_URL: http://memoryd:8082
-      # Optional projected-context budget override (tokens); empty
-      # uses the built-in default. Handy for compaction testing.
-      SESSION_TOKEN_BUDGET: ${SESSION_TOKEN_BUDGET:-}
       # Brain-only secret: the public API bearer token.
       TIMOTHY_API_TOKEN: ${TIMOTHY_API_TOKEN:-}
       # Connector credentials resolve through brain's own secret-store
@@ -77,9 +74,6 @@ services:
       WORKSPACE_ROOT: /workspace
       # Compose-internal only: the model never sees this address.
       SEARXNG_URL: http://searxng:8080
-      # Restricts the agent to this skill pack only; empty allows all
-      # loaded packs. Comma-separated names.
-      SKILLS_ALLOWLIST: ${SKILLS_ALLOWLIST:-}
     volumes:
       - workspace:/workspace
     ports:

--- a/internal/brain/api/admin.go
+++ b/internal/brain/api/admin.go
@@ -26,6 +26,8 @@ var adminRoutePatterns = []string{
 	"PUT /v1/admin/secrets/{ref_name}",
 	"DELETE /v1/admin/secrets/{ref_name}",
 	"GET /v1/admin/secrets/{ref_name}",
+	"GET /v1/admin/secret-backends",
+	"PUT /v1/admin/secret-backends/default",
 	"GET /v1/admin/secret-backends/{backend}",
 	"PUT /v1/admin/secret-backends/{backend}",
 	"DELETE /v1/admin/secret-backends/{backend}",
@@ -51,7 +53,10 @@ func (a *API) registerSettings(handle func(pattern string, h http.Handler), flag
 	}
 	handle("GET /v1/admin/settings", a.auth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"settings": flags.All(r.Context())})
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"settings": flags.All(r.Context()),
+			"values":   flags.AllValues(r.Context()),
+		})
 	})))
 	handle("PATCH /v1/admin/settings", a.auth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body map[string]bool
@@ -61,6 +66,23 @@ func (a *API) registerSettings(handle func(pattern string, h http.Handler), flag
 		}
 		for key, value := range body {
 			if err := flags.Set(r.Context(), key, value); err != nil {
+				jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})))
+	// Typed runtime settings (strings; empty resets to the built-in
+	// default) — separate from the boolean switches above so both
+	// bodies stay flat maps.
+	handle("PATCH /v1/admin/settings/values", a.auth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || len(body) == 0 {
+			jsonError(w, http.StatusBadRequest, "bad_request", "body must be a JSON object of setting keys to string values")
+			return
+		}
+		for key, value := range body {
+			if err := flags.SetValue(r.Context(), key, value); err != nil {
 				jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 				return
 			}

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -24,6 +24,11 @@ import (
 
 func discard() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
 
+func staticBudget(n int) func(context.Context) int {
+	return func(context.Context) int { return n }
+}
+
+
 // memDir is an in-memory Directory + chat.SessionLog.
 type memDir struct {
 	mu     sync.Mutex
@@ -147,7 +152,7 @@ func testAPI(t *testing.T, token string, events []stream.StreamEvent) (*API, *me
 	t.Helper()
 	dir := newMemDir()
 	gw := &fakeGateway{events: events}
-	svc := chat.New(gw, dir, nil, nil, 60_000, nil, discard())
+	svc := chat.New(gw, dir, nil, nil, staticBudget(60_000), nil, nil, discard())
 	return &API{svc: svc, dir: dir, token: token, log: discard()}, dir, gw
 }
 
@@ -504,7 +509,7 @@ func TestChatErrorCarriesSessionID(t *testing.T) {
 	id, _ := dir.Create(t.Context(), "t")
 	// gateway with error
 	gw := &fakeGateway{err: context.DeadlineExceeded}
-	a.svc = chat.New(gw, dir, nil, nil, 60_000, nil, discard())
+	a.svc = chat.New(gw, dir, nil, nil, staticBudget(60_000), nil, nil, discard())
 
 	w := doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages", `{"message":"hi"}`)
 	if w.Code != http.StatusBadGateway {

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -85,10 +85,11 @@ type Service struct {
 	compactor   Compactor
 	memory      MemoryExtract  // nil: long-term memory off
 	recall      MemoryRetrieve // nil: no memory injection
-	budget      int
-	system      string
-	skillBodies map[string]string // name -> full pack body, for skill_hint
-	flushEvery  time.Duration     // pending-state flush cadence mid-stream
+	budget      func(context.Context) int
+	packs       []skills.Skill
+	skillAllow  func(context.Context, string) bool // nil: all packs allowed
+	skillBodies map[string]string                  // name -> full pack body, for skill_hint
+	flushEvery  time.Duration                      // pending-state flush cadence mid-stream
 	logger      *slog.Logger
 }
 
@@ -101,19 +102,38 @@ func (s *Service) SetMemoryRetrieve(fn MemoryRetrieve) { s.recall = fn }
 
 // New builds the service. packs are the loaded skill definitions: their
 // one-line index goes into the system prompt, and their bodies back
-// skill_hint (nil/empty = no skills).
-func New(gw Gateway, log SessionLog, distill Distill, compactor Compactor, budget int, packs []skills.Skill, logger *slog.Logger) *Service {
-	logger.Info("chat service ready", "system_prompt_version", systemPromptVersion, "token_budget", budget)
+// skill_hint (nil/empty = no skills). budget resolves the projected
+// context cap per turn (a runtime setting, not a constant); skillAllow
+// gates packs per turn, nil allows all. The assembled system prompt
+// only changes when a setting does, so provider prompt caches (D-018)
+// stay warm in the steady state.
+func New(gw Gateway, log SessionLog, distill Distill, compactor Compactor, budget func(context.Context) int, packs []skills.Skill, skillAllow func(context.Context, string) bool, logger *slog.Logger) *Service {
+	logger.Info("chat service ready", "system_prompt_version", systemPromptVersion)
 	bodies := make(map[string]string, len(packs))
 	for _, p := range packs {
 		bodies[p.Name] = p.Body
 	}
 	return &Service{
 		gw: gw, log: log, distill: distill, compactor: compactor, budget: budget,
-		system:      assembleSystem(skills.Index(packs)),
+		packs:       packs,
+		skillAllow:  skillAllow,
 		skillBodies: bodies,
 		flushEvery:  2 * time.Second, logger: logger,
 	}
+}
+
+// allowedPacks filters the loaded packs through the runtime allowlist.
+func (s *Service) allowedPacks(ctx context.Context) []skills.Skill {
+	if s.skillAllow == nil {
+		return s.packs
+	}
+	out := make([]skills.Skill, 0, len(s.packs))
+	for _, p := range s.packs {
+		if s.skillAllow(ctx, p.Name) {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // Request is one chat turn.
@@ -141,7 +161,7 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	var skillBody string
 	if req.SkillHint != "" {
 		body, ok := s.skillBodies[req.SkillHint]
-		if !ok {
+		if !ok || (s.skillAllow != nil && !s.skillAllow(ctx, req.SkillHint)) {
 			return "", nil, fmt.Errorf("chat: %w: unknown skill %q", ErrBadRequest, req.SkillHint)
 		}
 		skillBody = body
@@ -187,7 +207,7 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	if err != nil {
 		return sessionID, nil, err
 	}
-	msgs, err := session.LLMContext(events, s.budget)
+	msgs, err := session.LLMContext(events, s.budget(ctx))
 	if err != nil {
 		return sessionID, nil, err
 	}
@@ -199,7 +219,7 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	// (D-011 poisoning defense); the skill body is instructions the
 	// user explicitly selected, deterministically loaded rather than
 	// left to the model's load_skill judgment.
-	system := s.system
+	system := assembleSystem(skills.Index(s.allowedPacks(ctx)))
 	if skillBody != "" {
 		system += "\n\n# Skill: " + req.SkillHint + "\n\n" + skillBody
 	}

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -19,6 +19,11 @@ import (
 
 func discard() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
 
+func staticBudget(n int) func(context.Context) int {
+	return func(context.Context) int { return n }
+}
+
+
 // fakeLog is an in-memory SessionLog.
 type fakeLog struct {
 	mu       sync.Mutex
@@ -141,7 +146,7 @@ func okEvents(text string) []stream.StreamEvent {
 }
 
 func newService(gw Gateway, log SessionLog) *Service {
-	return New(gw, log, nil, nil, 60_000, nil, discard())
+	return New(gw, log, nil, nil, staticBudget(60_000), nil, nil, discard())
 }
 
 func drain(t *testing.T, ch <-chan stream.StreamEvent) []stream.StreamEvent {
@@ -336,9 +341,9 @@ func TestChatValidatesMessage(t *testing.T) {
 func TestChatSkillHintInjectsBodyDeterministically(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGW{events: okEvents("planned")}
-	s := New(gw, newFakeLog(), nil, nil, 60_000, []skills.Skill{
+	s := New(gw, newFakeLog(), nil, nil, staticBudget(60_000), []skills.Skill{
 		{Name: "travel-planning", Description: "Use when planning a trip", Body: "Ask about dates, budget, destination."},
-	}, discard())
+	}, nil, discard())
 
 	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "Tokyo, 5 days", SkillHint: "travel-planning"})
 	if err != nil {
@@ -354,6 +359,33 @@ func TestChatSkillHintInjectsBodyDeterministically(t *testing.T) {
 	gw.mu.Unlock()
 	if !strings.Contains(sys, "travel-planning") || !strings.Contains(sys, "Ask about dates, budget, destination.") {
 		t.Fatalf("system prompt missing the hinted skill body:\n%s", sys)
+	}
+}
+
+// The runtime allowlist gates both the system-prompt skill index and
+// skill_hint, per turn — no restart, no rebuild.
+func TestChatSkillAllowlistGatesIndexAndHint(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGW{events: okEvents("ok")}
+	packs := []skills.Skill{
+		{Name: "allowed-skill", Description: "Use when allowed", Body: "rules-a"},
+		{Name: "blocked-skill", Description: "Use when blocked", Body: "rules-b"},
+	}
+	allow := func(_ context.Context, name string) bool { return name == "allowed-skill" }
+	s := New(gw, newFakeLog(), nil, nil, staticBudget(60_000), packs, allow, discard())
+
+	if _, _, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "hi", SkillHint: "blocked-skill"}); err == nil {
+		t.Fatal("skill_hint for a disallowed pack accepted")
+	}
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "hi"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	sys := chatRequest(t, gw).System
+	if !strings.Contains(sys, "allowed-skill") || strings.Contains(sys, "blocked-skill") {
+		t.Fatalf("skill index not gated by allowlist:\n%s", sys)
 	}
 }
 
@@ -402,7 +434,7 @@ func TestChatCompactsBeforeSend(t *testing.T) {
 	log := newFakeLog()
 	order := &orderCompactor{}
 	gw := &gwAfterCompact{fakeGW: &fakeGW{events: okEvents("hi")}, order: order}
-	svc := New(gw, log, nil, order, 60_000, nil, discard())
+	svc := New(gw, log, nil, order, staticBudget(60_000), nil, nil, discard())
 
 	_, ch, err := svc.Chat(t.Context(), Request{Message: "hello"})
 	if err != nil {
@@ -451,7 +483,7 @@ func TestChatSendsCompactedContext(t *testing.T) {
 	}
 
 	gw := &fakeGW{events: okEvents("fresh reply")}
-	svc := New(gw, log, nil, &compactingLog{log: log}, 60_000, nil, discard())
+	svc := New(gw, log, nil, &compactingLog{log: log}, staticBudget(60_000), nil, nil, discard())
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "new question"})
 	if err != nil {
@@ -494,7 +526,7 @@ func TestFollowUpSeesCompletedTurnWhileDistillRuns(t *testing.T) {
 		return &session.TurnMemory{KeyFindings: []string{"late residue"}}
 	}
 	defer close(distillRelease)
-	svc := New(gw, log, distill, nil, 60_000, nil, discard())
+	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, discard())
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "first question"})
 	if err != nil {
@@ -544,7 +576,7 @@ func TestMemoryExtractGetsUserTextAndResidue(t *testing.T) {
 	distill := func(context.Context, string, string) *session.TurnMemory {
 		return &session.TurnMemory{KeyFindings: []string{"user moved to Porto"}}
 	}
-	svc := New(gw, log, distill, nil, 60_000, nil, discard())
+	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, discard())
 
 	type call struct {
 		sessionID string
@@ -630,7 +662,7 @@ func TestMemoryRetrieveInjectsIntoSystemTail(t *testing.T) {
 	}
 	// The stable prefix stays byte-identical (D-018).
 	base := newService(gw, log)
-	if !strings.HasPrefix(sent.System, base.system) {
+	if !strings.HasPrefix(sent.System, assembleSystem(skills.Index(base.allowedPacks(t.Context())))) {
 		t.Fatal("system prefix changed by memory injection")
 	}
 }
@@ -664,8 +696,9 @@ func TestMemoryRetrieveEmptyLeavesSystemUntouched(t *testing.T) {
 	drain(t, ch)
 
 	got := chatRequest(t, gw).System
-	if got != svc.system {
-		t.Fatalf("system modified on empty recall:\n%q\nvs\n%q", got, svc.system)
+	want := assembleSystem(skills.Index(svc.allowedPacks(t.Context())))
+	if got != want {
+		t.Fatalf("system modified on empty recall:\n%q\nvs\n%q", got, want)
 	}
 }
 

--- a/internal/brain/session/compactor.go
+++ b/internal/brain/session/compactor.go
@@ -50,10 +50,13 @@ const summarizeSystem = `Summarize this conversation excerpt for an AI assistant
 // compaction_applied event. Automatic and incremental — never a
 // destructive one-shot (D-006).
 type Compactor struct {
-	log      Log
-	gw       Gateway
-	windows  Windows // nil-safe: static budget only
-	budget   int     // fallback when no model window is resolvable
+	log     Log
+	gw      Gateway
+	windows Windows // nil-safe: static budget only
+	// budget resolves the fallback cap when no model window is
+	// resolvable — a func because it is a runtime setting, editable
+	// without a restart.
+	budget   func(context.Context) int
 	extract  MemoryExtract
 	logger   *slog.Logger
 	compacts prometheus.Counter // nil-safe: may be unset in tests
@@ -65,7 +68,7 @@ type Compactor struct {
 // return nil — extraction must never block compaction.
 type MemoryExtract func(ctx context.Context, sessionID string, seq int64, text string) []string
 
-func NewCompactor(log Log, gw Gateway, windows Windows, budget int, logger *slog.Logger, compacts prometheus.Counter) *Compactor {
+func NewCompactor(log Log, gw Gateway, windows Windows, budget func(context.Context) int, logger *slog.Logger, compacts prometheus.Counter) *Compactor {
 	return &Compactor{log: log, gw: gw, windows: windows, budget: budget, logger: logger, compacts: compacts}
 }
 
@@ -81,17 +84,17 @@ func (c *Compactor) SetMemoryExtract(fn MemoryExtract) { c.extract = fn }
 func (c *Compactor) budgetFor(ctx context.Context, sessionID string, events []Event) int {
 	model := lastModel(events)
 	if c.windows == nil || model == "" {
-		return c.budget
+		return c.budget(ctx)
 	}
 	ws, err := c.windows.ModelWindows(ctx)
 	if err != nil {
 		c.logger.Warn("model windows lookup, using static budget", "session_id", sessionID, "error", err)
-		return c.budget
+		return c.budget(ctx)
 	}
 	if w := ws[model]; w > 0 {
 		return w * 60 / 100
 	}
-	return c.budget
+	return c.budget(ctx)
 }
 
 // lastModel returns the model of the newest assistant_turn, or "".

--- a/internal/brain/session/compactor_test.go
+++ b/internal/brain/session/compactor_test.go
@@ -55,6 +55,10 @@ func (g *summarizerGW) Stream(_ context.Context, req gwclient.StreamRequest) (<-
 	return ch, nil
 }
 
+func staticBudget(n int) func(context.Context) int {
+	return func(context.Context) int { return n }
+}
+
 func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
 
 // seedConversation appends n user/assistant turn pairs with padded
@@ -79,7 +83,7 @@ func TestMaybeCompactUnderBudgetIsNoop(t *testing.T) {
 	t.Parallel()
 	log, gw := newMemLog(), &summarizerGW{summary: "s"}
 	seedConversation(t, log, "s1", 3)
-	c := NewCompactor(log, gw, nil, 1_000_000, discardLogger(), nil)
+	c := NewCompactor(log, gw, nil, staticBudget(1_000_000), discardLogger(), nil)
 
 	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
 		t.Fatalf("MaybeCompact: %v", err)
@@ -94,7 +98,7 @@ func TestMaybeCompactSummarizesOldestHalf(t *testing.T) {
 	log := newMemLog()
 	gw := &summarizerGW{summary: "compact summary: topics 0 through N discussed"}
 	seedConversation(t, log, "s1", 10)
-	c := NewCompactor(log, gw, nil, 500, discardLogger(), nil) // force compaction
+	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil) // force compaction
 
 	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
 		t.Fatalf("MaybeCompact: %v", err)
@@ -136,7 +140,7 @@ func TestCompactionConverges(t *testing.T) {
 			id := fmt.Sprintf("s-%d", turns)
 			seedConversation(t, log, id, turns)
 			budget := 800
-			c := NewCompactor(log, gw, nil, budget, discardLogger(), nil)
+			c := NewCompactor(log, gw, nil, staticBudget(budget), discardLogger(), nil)
 
 			for i := 0; i < 12; i++ { // bounded iterations must suffice
 				events, _ := log.Events(t.Context(), id)
@@ -230,7 +234,7 @@ func TestBudgetFollowsModelWindow(t *testing.T) {
 		log, gw := newMemLog(), &summarizerGW{summary: "s"}
 		seed(t, log)
 		windows := &fakeWindows{windows: map[string]int{"narrow-model": 1000}} // budget 600
-		c := NewCompactor(log, gw, windows, 1_000_000, discardLogger(), nil)
+		c := NewCompactor(log, gw, windows, staticBudget(1_000_000), discardLogger(), nil)
 		if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
 			t.Fatalf("MaybeCompact: %v", err)
 		}
@@ -244,7 +248,7 @@ func TestBudgetFollowsModelWindow(t *testing.T) {
 		log, gw := newMemLog(), &summarizerGW{summary: "s"}
 		seed(t, log)
 		windows := &fakeWindows{err: fmt.Errorf("gateway down")}
-		c := NewCompactor(log, gw, windows, 1_000_000, discardLogger(), nil)
+		c := NewCompactor(log, gw, windows, staticBudget(1_000_000), discardLogger(), nil)
 		if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
 			t.Fatalf("MaybeCompact: %v", err)
 		}
@@ -258,7 +262,7 @@ func TestBudgetFollowsModelWindow(t *testing.T) {
 		log, gw := newMemLog(), &summarizerGW{summary: "s"}
 		seed(t, log)
 		windows := &fakeWindows{windows: map[string]int{"other-model": 1000}}
-		c := NewCompactor(log, gw, windows, 1_000_000, discardLogger(), nil)
+		c := NewCompactor(log, gw, windows, staticBudget(1_000_000), discardLogger(), nil)
 		if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
 			t.Fatalf("MaybeCompact: %v", err)
 		}
@@ -345,7 +349,7 @@ func TestSummarizeInputPreservesFacts(t *testing.T) {
 	}
 	seedConversation(t, log, "s1", 6) // push the facts into the oldest half
 
-	c := NewCompactor(log, gw, nil, 500, discardLogger(), nil)
+	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
 	if err := c.MaybeCompact(ctx, "s1"); err != nil {
 		t.Fatalf("MaybeCompact: %v", err)
 	}
@@ -380,7 +384,7 @@ func TestHundredTurnSessionPreservesReference(t *testing.T) {
 	pad := strings.Repeat("lorem ipsum dolor sit amet ", 10)
 
 	budget := 2000
-	c := NewCompactor(log, gw, nil, budget, discardLogger(), nil)
+	c := NewCompactor(log, gw, nil, staticBudget(budget), discardLogger(), nil)
 	for i := 0; i < 100; i++ {
 		text := fmt.Sprintf("question %d %s", i, pad)
 		if i == 2 {
@@ -438,7 +442,7 @@ func TestCompactionExtractsBeforeSummarizing(t *testing.T) {
 	log := newMemLog()
 	gw := &summarizerGW{summary: "short summary"}
 	seedConversation(t, log, "s1", 10)
-	c := NewCompactor(log, gw, nil, 500, discardLogger(), nil)
+	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
 
 	var sawText string
 	var extractedAtCall int
@@ -480,7 +484,7 @@ func TestCompactionSurvivesExtractionFailure(t *testing.T) {
 	log := newMemLog()
 	gw := &summarizerGW{summary: "short summary"}
 	seedConversation(t, log, "s1", 10)
-	c := NewCompactor(log, gw, nil, 500, discardLogger(), nil)
+	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
 	c.SetMemoryExtract(func(context.Context, string, int64, string) []string {
 		return nil // extraction failed upstream; hook contract returns nil
 	})

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -27,6 +29,22 @@ var knownKeys = map[string]bool{
 	KeyTools: true, KeyMemoryExtraction: true, KeyCompaction: true, KeyScheduler: true,
 }
 
+// Typed value settings (runtime_settings table): strings where empty
+// means the built-in default. These replaced the SESSION_TOKEN_BUDGET
+// and SKILLS_ALLOWLIST env vars.
+const (
+	// ValueTokenBudget caps the projected context in tokens; empty
+	// defers to the model window / built-in default.
+	ValueTokenBudget = "session_token_budget"
+	// ValueSkillsAllowlist restricts the agent to these skill packs
+	// (comma-separated names); empty allows all loaded packs.
+	ValueSkillsAllowlist = "skills_allowlist"
+)
+
+var knownValueKeys = map[string]bool{
+	ValueTokenBudget: true, ValueSkillsAllowlist: true,
+}
+
 const cacheTTL = 10 * time.Second
 
 // Store reads and writes switches. Reads serve from a short cache;
@@ -39,6 +57,10 @@ type Store struct {
 	mu      sync.Mutex
 	cached  map[string]bool
 	fetched time.Time
+
+	valMu      sync.Mutex
+	valCached  map[string]string
+	valFetched time.Time
 }
 
 func New(db *pgpool.Pool, log *slog.Logger) *Store {
@@ -89,6 +111,106 @@ func (s *Store) All(ctx context.Context) map[string]bool {
 	}
 	s.cached, s.fetched = out, time.Now()
 	return out
+}
+
+// Value returns one typed setting; empty string means "use the
+// built-in default" (absent row, unknown key, or database outage).
+func (s *Store) Value(ctx context.Context, key string) string {
+	return s.AllValues(ctx)[key]
+}
+
+// TokenBudget parses the session token budget, falling back to def
+// when unset or unparsable.
+func (s *Store) TokenBudget(ctx context.Context, def int) int {
+	if v := s.Value(ctx, ValueTokenBudget); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+// SkillAllowed reports whether the allowlist admits a pack name;
+// an empty allowlist admits everything.
+func (s *Store) SkillAllowed(ctx context.Context, name string) bool {
+	allow := s.Value(ctx, ValueSkillsAllowlist)
+	if allow == "" {
+		return true
+	}
+	for _, n := range strings.Split(allow, ",") {
+		if strings.TrimSpace(n) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// AllValues returns every known value setting; missing rows come back
+// as empty strings so callers apply their own defaults.
+func (s *Store) AllValues(ctx context.Context) map[string]string {
+	s.valMu.Lock()
+	defer s.valMu.Unlock()
+	if s.valCached != nil && time.Since(s.valFetched) < cacheTTL {
+		return s.valCached
+	}
+
+	out := map[string]string{}
+	for k := range knownValueKeys {
+		out[k] = ""
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		s.log.Warn("runtime settings read degraded to defaults", "error", err)
+		return out
+	}
+	rows, err := db.Query(ctx, `SELECT key, value FROM runtime_settings`)
+	if err != nil {
+		s.log.Warn("runtime settings read degraded to defaults", "error", err)
+		return out
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var k, v string
+		if err := rows.Scan(&k, &v); err == nil && knownValueKeys[k] {
+			out[k] = v
+		}
+	}
+	s.valCached, s.valFetched = out, time.Now()
+	return out
+}
+
+// SetValue stores one typed setting (empty clears back to default),
+// audits the change, and invalidates the cache.
+func (s *Store) SetValue(ctx context.Context, key, value string) error {
+	if !knownValueKeys[key] {
+		return fmt.Errorf("unknown setting %q", key)
+	}
+	value = strings.TrimSpace(value)
+	if key == ValueTokenBudget && value != "" {
+		if n, err := strconv.Atoi(value); err != nil || n <= 0 {
+			return fmt.Errorf("%s must be a positive integer or empty", key)
+		}
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("settings: %w", err)
+	}
+	before := s.Value(ctx, key)
+	if _, err := db.Exec(ctx, `INSERT INTO runtime_settings (key, value) VALUES ($1, $2)
+		ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()`, key, value); err != nil {
+		return fmt.Errorf("settings: %w", err)
+	}
+	b, _ := json.Marshal(before)
+	a, _ := json.Marshal(value)
+	if _, err := db.Exec(ctx, `INSERT INTO admin_audit (action, entity, entity_id, before, after)
+		VALUES ('update', 'setting', $1, $2, $3)`, key, b, a); err != nil {
+		s.log.Warn("settings audit failed", "key", key, "error", err)
+	}
+
+	s.valMu.Lock()
+	s.valCached = nil // next read refetches
+	s.valMu.Unlock()
+	return nil
 }
 
 // Set flips one switch, audits the change, and invalidates the cache.

--- a/internal/brain/settings/settings_integration_test.go
+++ b/internal/brain/settings/settings_integration_test.go
@@ -35,10 +35,16 @@ func testStore(t *testing.T) *Store {
 	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	t.Cleanup(func() {
-		_, _ = db.Exec(context.Background(), "DELETE FROM settings")
-		_, _ = db.Exec(context.Background(), "DELETE FROM admin_audit WHERE entity = 'setting'")
-	})
+	// Sweep at setup AND teardown: the teardown runs after t.Context()
+	// is canceled (dead pool → silent failure), so the next run's setup
+	// must clean leftovers itself.
+	sweep := func(ctx context.Context) {
+		_, _ = db.Exec(ctx, "DELETE FROM settings")
+		_, _ = db.Exec(ctx, "DELETE FROM runtime_settings")
+		_, _ = db.Exec(ctx, "DELETE FROM admin_audit WHERE entity = 'setting'")
+	}
+	sweep(ctx)
+	t.Cleanup(func() { sweep(context.Background()) })
 	return New(pool, log)
 }
 
@@ -75,5 +81,57 @@ func TestSettingsDefaultsFlipAndAudit(t *testing.T) {
 	}
 	if n == 0 {
 		t.Fatal("no audit row for the settings flip")
+	}
+}
+
+// Typed value settings: empty by default, validated on write, cache
+// invalidated, helpers apply defaults and parse the allowlist.
+func TestRuntimeValueSettings(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	if v := s.Value(ctx, ValueTokenBudget); v != "" {
+		t.Fatalf("default budget value = %q, want empty", v)
+	}
+	if got := s.TokenBudget(ctx, 60_000); got != 60_000 {
+		t.Fatalf("TokenBudget default = %d, want 60000", got)
+	}
+	if !s.SkillAllowed(ctx, "anything") {
+		t.Fatal("empty allowlist must admit everything")
+	}
+
+	if err := s.SetValue(ctx, ValueTokenBudget, "not-a-number"); err == nil {
+		t.Fatal("non-numeric budget accepted")
+	}
+	if err := s.SetValue(ctx, ValueTokenBudget, "-5"); err == nil {
+		t.Fatal("negative budget accepted")
+	}
+	if err := s.SetValue(ctx, "nope", "x"); err == nil {
+		t.Fatal("unknown value key accepted")
+	}
+
+	if err := s.SetValue(ctx, ValueTokenBudget, "120000"); err != nil {
+		t.Fatalf("SetValue budget: %v", err)
+	}
+	if got := s.TokenBudget(ctx, 60_000); got != 120_000 {
+		t.Fatalf("TokenBudget = %d, want 120000 (cache must invalidate on write)", got)
+	}
+
+	if err := s.SetValue(ctx, ValueSkillsAllowlist, "coding-task, research"); err != nil {
+		t.Fatalf("SetValue allowlist: %v", err)
+	}
+	if !s.SkillAllowed(ctx, "coding-task") || !s.SkillAllowed(ctx, "research") {
+		t.Fatal("listed packs must be allowed")
+	}
+	if s.SkillAllowed(ctx, "other") {
+		t.Fatal("unlisted pack admitted")
+	}
+
+	// Empty clears back to default.
+	if err := s.SetValue(ctx, ValueSkillsAllowlist, ""); err != nil {
+		t.Fatalf("SetValue clear: %v", err)
+	}
+	if !s.SkillAllowed(ctx, "other") {
+		t.Fatal("cleared allowlist must admit everything")
 	}
 }

--- a/internal/brain/skills/skills_test.go
+++ b/internal/brain/skills/skills_test.go
@@ -108,7 +108,7 @@ func TestLoadSkillTool(t *testing.T) {
 	t.Parallel()
 	tool := LoadSkillTool([]Skill{
 		{Name: "coding-task", Description: "d", Body: "- plan first\n- test first"},
-	})
+	}, nil)
 
 	args, _ := json.Marshal(map[string]string{"name": "coding-task"})
 	got, err := tool.Execute(context.Background(), args)
@@ -123,6 +123,30 @@ func TestLoadSkillTool(t *testing.T) {
 	if _, err := tool.Execute(context.Background(), args); err == nil ||
 		!strings.Contains(err.Error(), "unknown skill") {
 		t.Fatalf("err = %v", err)
+	}
+}
+
+// A disallowed pack loads exactly like an unknown one, and the
+// "available" list never leaks disallowed names.
+func TestLoadSkillToolHonorsAllowlist(t *testing.T) {
+	t.Parallel()
+	tool := LoadSkillTool([]Skill{
+		{Name: "allowed", Description: "d", Body: "a"},
+		{Name: "blocked", Description: "d", Body: "b"},
+	}, func(_ context.Context, name string) bool { return name == "allowed" })
+
+	args, _ := json.Marshal(map[string]string{"name": "blocked"})
+	_, err := tool.Execute(context.Background(), args)
+	if err == nil || !strings.Contains(err.Error(), "unknown skill") {
+		t.Fatalf("err = %v, want unknown-skill refusal", err)
+	}
+	if strings.Contains(err.Error(), "blocked") && strings.Contains(err.Error(), "available: allowed, blocked") {
+		t.Fatalf("available list leaks disallowed pack: %v", err)
+	}
+
+	args, _ = json.Marshal(map[string]string{"name": "allowed"})
+	if _, err := tool.Execute(context.Background(), args); err != nil {
+		t.Fatalf("allowed pack refused: %v", err)
 	}
 }
 

--- a/internal/brain/skills/tool.go
+++ b/internal/brain/skills/tool.go
@@ -15,8 +15,10 @@ type loadArgs struct {
 
 // LoadSkillTool returns the load_skill tool over an already-loaded
 // pack set. The body comes back as a transient tool result — it is
-// never copied into the system prompt.
-func LoadSkillTool(packs []Skill) *tools.Tool {
+// never copied into the system prompt. allow gates packs against the
+// runtime allowlist at load time (nil allows all); a disallowed pack
+// is indistinguishable from an unknown one.
+func LoadSkillTool(packs []Skill, allow func(context.Context, string) bool) *tools.Tool {
 	byName := make(map[string]Skill, len(packs))
 	names := make([]string, 0, len(packs))
 	for _, s := range packs {
@@ -51,14 +53,23 @@ Example: {"name": "` + names[0] + `"} → the pack's rules.`,
 			"required": ["name"],
 			"additionalProperties": false
 		}`),
-		Execute: func(_ context.Context, raw json.RawMessage) (string, error) {
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
 			var args loadArgs
 			if err := json.Unmarshal(raw, &args); err != nil {
 				return "", fmt.Errorf("invalid arguments: %w", err)
 			}
 			s, ok := byName[args.Name]
-			if !ok {
-				return "", fmt.Errorf("unknown skill %q — available: %s", args.Name, strings.Join(names, ", "))
+			if !ok || (allow != nil && !allow(ctx, args.Name)) {
+				available := names
+				if allow != nil {
+					available = available[:0:0]
+					for _, n := range names {
+						if allow(ctx, n) {
+							available = append(available, n)
+						}
+					}
+				}
+				return "", fmt.Errorf("unknown skill %q — available: %s", args.Name, strings.Join(available, ", "))
 			}
 			return fmt.Sprintf("# Skill: %s\n\n%s", s.Name, s.Body), nil
 		},

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -99,6 +99,37 @@ func (a *Admin) SetSecretExternal(ctx context.Context, refName, backend, backend
 	return nil
 }
 
+// SetSecretValue stores value under refName through the store-wide
+// default backend: built-in storage encrypts the value itself, while
+// vault/asm treat it as the reference (path or name) of a secret that
+// already lives there — Timothy never writes into external systems.
+func (a *Admin) SetSecretValue(ctx context.Context, refName, value string) error {
+	backend, err := a.secrets.DefaultBackend(ctx)
+	if err != nil {
+		return err
+	}
+	if backend == "db" {
+		return a.SetSecret(ctx, refName, value)
+	}
+	return a.SetSecretExternal(ctx, refName, backend, value)
+}
+
+// SecretBackends lists every secret backend with configured/default
+// state for the settings UI.
+func (a *Admin) SecretBackends(ctx context.Context) ([]secretstore.BackendStatus, error) {
+	return a.secrets.Backends(ctx)
+}
+
+// SetDefaultSecretBackend moves the single store-wide default that
+// SetSecretValue routes through.
+func (a *Admin) SetDefaultSecretBackend(ctx context.Context, backend string) error {
+	if err := a.secrets.SetDefaultBackend(ctx, backend); err != nil {
+		return err
+	}
+	a.audit(ctx, "set", "secret_backend_default", backend, nil, map[string]string{"default": backend})
+	return nil
+}
+
 // SecretStatus reports whether refName has a stored secret and which
 // backend serves it, without exposing the value — used to render the
 // "configured" badge in the UI.
@@ -244,6 +275,7 @@ func (a *Admin) List(ctx context.Context) ([]Provider, error) {
 		if err := json.Unmarshal(hdrs, &p.Headers); err != nil {
 			return nil, fmt.Errorf("admin providers: headers: %w", err)
 		}
+		normalizeProvider(&p)
 		out = append(out, p)
 	}
 	return out, rows.Err()
@@ -702,7 +734,19 @@ func scanProvider(ctx context.Context, q pgxQuerier, id, lock string) (Provider,
 	}
 	_ = json.Unmarshal(models, &p.Models)
 	_ = json.Unmarshal(hdrs, &p.Headers)
+	normalizeProvider(&p)
 	return p, nil
+}
+
+// normalizeProvider papers over jsonb null in rows written before
+// jsonOr guarded against typed nils: clients get [] / {}, never null.
+func normalizeProvider(p *Provider) {
+	if p.Models == nil {
+		p.Models = []router.ModelInfo{}
+	}
+	if p.Headers == nil {
+		p.Headers = map[string]string{}
+	}
 }
 
 // audit records who-did-what; failures log — an audit hiccup must not
@@ -730,9 +774,12 @@ func (a *Admin) reload(ctx context.Context) {
 	}
 }
 
+// jsonOr never returns "null": a nil slice or map inside v marshals to
+// JSON null (v == nil is false for typed nils), which would land in a
+// jsonb column and come back as null to API clients that expect [] / {}.
 func jsonOr(v any, empty string) []byte {
 	b, err := json.Marshal(v)
-	if err != nil || v == nil {
+	if err != nil || string(b) == "null" {
 		return []byte(empty)
 	}
 	return b

--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -12,6 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
 	"github.com/SumonMSelim/timothy/internal/gateway/ledger"
 	"github.com/SumonMSelim/timothy/internal/gateway/router"
 	"github.com/SumonMSelim/timothy/internal/platform/migrate"
@@ -44,8 +47,12 @@ func testAdmin(t *testing.T) (*Admin, *router.Store, *pgpool.Pool) {
 	}
 	// Sweep runs at setup AND teardown: a killed run never executes
 	// cleanups, and its leftovers would fail every later run (unique
-	// name collisions, accumulated audit rows).
-	sweep := func(ctx context.Context) {
+	// name collisions, accumulated audit rows) — and pollute a shared
+	// dev database with fixture rows.
+	type execer interface {
+		Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	}
+	sweep := func(ctx context.Context, db execer) {
 		_, _ = db.Exec(ctx,
 			"DELETE FROM task_routes WHERE task_category LIKE $1 || '%'", adminMarker)
 		_, _ = db.Exec(ctx,
@@ -57,8 +64,21 @@ func testAdmin(t *testing.T) (*Admin, *router.Store, *pgpool.Pool) {
 		_, _ = db.Exec(ctx, "DELETE FROM spend_budgets")
 		_, _ = db.Exec(ctx, "DELETE FROM secrets WHERE ref_name LIKE $1 || '%'", adminMarker)
 	}
-	sweep(ctx)
-	t.Cleanup(func() { sweep(context.Background()) })
+	sweep(ctx, db)
+	t.Cleanup(func() {
+		// The pool dies with t.Context(), which is canceled before
+		// cleanups run — a sweep through it fails silently and leaves
+		// fixture rows behind. Sweep over a fresh one-shot connection.
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		conn, err := pgx.Connect(ctx, dsn)
+		if err != nil {
+			t.Logf("teardown sweep skipped: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close(ctx) }()
+		sweep(ctx, conn)
+	})
 
 	store := router.NewStore(pool, func(string) string { return "resolved" }, log)
 	if err := store.Load(ctx); err != nil {
@@ -142,6 +162,99 @@ func TestProviderCRUDAuditsAndReloads(t *testing.T) {
 	if len(actions) < 3 || actions[0] != "create" || actions[len(actions)-1] != "delete" {
 		t.Fatalf("audit actions = %v, want create…delete", actions)
 	}
+}
+
+// SetSecretValue routes through the store-wide default backend: the
+// built-in store encrypts the value itself, an external default
+// records the value as that backend's reference.
+func TestSetSecretValueFollowsDefaultBackend(t *testing.T) {
+	adm, _, _ := testAdmin(t)
+	ctx := t.Context()
+
+	ref := adminMarker + "SECRET_DB"
+	if err := adm.SetSecretValue(ctx, ref, "sk-plain"); err != nil {
+		t.Fatalf("SetSecretValue: %v", err)
+	}
+	if configured, backend, err := adm.SecretStatus(ctx, ref); err != nil || !configured || backend != "db" {
+		t.Fatalf("Status = %v %q %v, want configured via db", configured, backend, err)
+	}
+
+	// Shared table: restore the pre-test vault config and default flag.
+	// Defers run while t.Context() is still alive; t.Cleanup would not.
+	origCfg, err := adm.SecretBackendConfig(ctx, "vault")
+	if err != nil {
+		t.Fatalf("SecretBackendConfig: %v", err)
+	}
+	defer func() {
+		if string(origCfg) != "{}" {
+			if err := adm.SetSecretBackendConfig(ctx, "vault", origCfg); err != nil {
+				t.Errorf("restore vault config: %v", err)
+			}
+		} else if err := adm.DeleteSecretBackendConfig(ctx, "vault"); err != nil {
+			t.Errorf("remove test vault config: %v", err)
+		}
+		if err := adm.SetDefaultSecretBackend(ctx, "db"); err != nil {
+			t.Errorf("restore default backend: %v", err)
+		}
+	}()
+
+	if err := adm.SetSecretBackendConfig(ctx, "vault", []byte(`{"address":"http://127.0.0.1:1"}`)); err != nil {
+		t.Fatalf("SetSecretBackendConfig: %v", err)
+	}
+	if err := adm.SetDefaultSecretBackend(ctx, "vault"); err != nil {
+		t.Fatalf("SetDefaultSecretBackend: %v", err)
+	}
+	extRef := adminMarker + "SECRET_VAULT"
+	if err := adm.SetSecretValue(ctx, extRef, "timothy/key#api_key"); err != nil {
+		t.Fatalf("SetSecretValue external: %v", err)
+	}
+	if configured, backend, err := adm.SecretStatus(ctx, extRef); err != nil || !configured || backend != "vault" {
+		t.Fatalf("Status = %v %q %v, want configured via vault", configured, backend, err)
+	}
+}
+
+// A provider created without models/headers, and rows that already
+// hold jsonb null (written before jsonOr guarded typed nils), must
+// come back as [] / {} — a null models array crashes the settings UI.
+func TestProviderNilModelsRoundTripsAsEmpty(t *testing.T) {
+	adm, _, pool := testAdmin(t)
+	ctx := t.Context()
+
+	id, err := adm.Create(ctx, Provider{
+		Name: adminMarker + "nilmodels", Kind: "api", Driver: "bedrock",
+		BaseURL: "us-east-1", CredentialRef: "SOME_ENV_NAME",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	db, _ := pool.Get()
+	var raw string
+	if err := db.QueryRow(ctx, `SELECT models::text FROM providers WHERE id = $1`, id).Scan(&raw); err != nil {
+		t.Fatalf("models query: %v", err)
+	}
+	if raw != "[]" {
+		t.Fatalf("stored models = %s, want []", raw)
+	}
+
+	// Simulate a pre-fix row: jsonb null in both columns.
+	if _, err := db.Exec(ctx, `UPDATE providers SET models = 'null', headers = 'null' WHERE id = $1`, id); err != nil {
+		t.Fatalf("force null: %v", err)
+	}
+	list, err := adm.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, p := range list {
+		if p.ID != id {
+			continue
+		}
+		if p.Models == nil || p.Headers == nil {
+			t.Fatalf("List returned nil models/headers: %+v", p)
+		}
+		return
+	}
+	t.Fatal("created provider missing from List")
 }
 
 // seedRoute inserts an enabled route whose chain references the

--- a/internal/gateway/api/admin.go
+++ b/internal/gateway/api/admin.go
@@ -27,6 +27,8 @@ func RegisterAdmin(srv *httpserver.Server, adm *admin.Admin) {
 	srv.Handle("PUT /internal/admin/secrets/{ref_name}", http.HandlerFunc(h.setSecret))
 	srv.Handle("DELETE /internal/admin/secrets/{ref_name}", http.HandlerFunc(h.deleteSecret))
 	srv.Handle("GET /internal/admin/secrets/{ref_name}", http.HandlerFunc(h.getSecretStatus))
+	srv.Handle("GET /internal/admin/secret-backends", http.HandlerFunc(h.listSecretBackends))
+	srv.Handle("PUT /internal/admin/secret-backends/default", http.HandlerFunc(h.putDefaultSecretBackend))
 	srv.Handle("GET /internal/admin/secret-backends/{backend}", http.HandlerFunc(h.getSecretBackend))
 	srv.Handle("PUT /internal/admin/secret-backends/{backend}", http.HandlerFunc(h.putSecretBackend))
 	srv.Handle("DELETE /internal/admin/secret-backends/{backend}", http.HandlerFunc(h.deleteSecretBackend))
@@ -185,24 +187,32 @@ func (h *adminAPI) patchBudget(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// setSecret stores a secret two ways: {"value": ...} encrypts the
-// value into the db backend; {"backend": "vault"|"asm",
-// "backend_ref": ...} points the ref at an external system instead.
+// setSecret stores {"value": ...} through the store-wide default
+// backend: built-in storage encrypts the value, an external default
+// (vault/asm) treats it as the reference of a secret already there.
+// The client no longer picks a backend per key — the one exception is
+// {"backend": "db"}, which pins built-in storage for bootstrap
+// credentials (the vault token, ASM secret key): the credential that
+// unlocks an external backend cannot live behind that backend.
 func (h *adminAPI) setSecret(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Value      string `json:"value"`
-		Backend    string `json:"backend"`
-		BackendRef string `json:"backend_ref"`
+		Value   string `json:"value"`
+		Backend string `json:"backend"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
 	var err error
-	if body.Backend != "" && body.Backend != "db" {
-		err = h.adm.SetSecretExternal(r.Context(), r.PathValue("ref_name"), body.Backend, body.BackendRef)
-	} else {
+	switch body.Backend {
+	case "":
+		err = h.adm.SetSecretValue(r.Context(), r.PathValue("ref_name"), body.Value)
+	case "db":
 		err = h.adm.SetSecret(r.Context(), r.PathValue("ref_name"), body.Value)
+	default:
+		jsonError(w, http.StatusUnprocessableEntity, "bad_backend",
+			"per-key backend selection was removed; set the default backend in the Secrets tab")
+		return
 	}
 	if err != nil {
 		fail(w, err)
@@ -226,6 +236,32 @@ func (h *adminAPI) getSecretStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, map[string]any{"configured": configured, "backend": backend})
+}
+
+func (h *adminAPI) listSecretBackends(w http.ResponseWriter, r *http.Request) {
+	backends, err := h.adm.SecretBackends(r.Context())
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "admin_failed", err.Error())
+		return
+	}
+	writeJSON(w, map[string]any{"backends": backends})
+}
+
+// putDefaultSecretBackend is registered as a literal path, so it wins
+// over the {backend} wildcard routes on the same prefix.
+func (h *adminAPI) putDefaultSecretBackend(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Backend string `json:"backend"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if err := h.adm.SetDefaultSecretBackend(r.Context(), body.Backend); err != nil {
+		fail(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *adminAPI) getSecretBackend(w http.ResponseWriter, r *http.Request) {

--- a/internal/secretstore/backends.go
+++ b/internal/secretstore/backends.go
@@ -137,7 +137,8 @@ func (s *Store) SetBackendConfig(ctx context.Context, backend string, cfg json.R
 // DeleteBackendConfig removes a backend's connection config. Secrets
 // already pointed at that backend stay stored and simply fail to
 // resolve (provider unhealthy) until the backend is reconfigured or
-// the refs are repointed.
+// the refs are repointed. Removing the default backend hands the flag
+// back to built-in storage so credential writes always have a home.
 func (s *Store) DeleteBackendConfig(ctx context.Context, backend string) error {
 	if err := validExternalBackend(backend); err != nil {
 		return err
@@ -146,14 +147,139 @@ func (s *Store) DeleteBackendConfig(ctx context.Context, backend string) error {
 	if err != nil {
 		return fmt.Errorf("secretstore: %w", err)
 	}
-	if _, err := db.Exec(ctx,
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("secretstore: delete backend config %s: %w", backend, err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx,
 		`DELETE FROM secret_backend_config WHERE backend = $1`, backend); err != nil {
+		return fmt.Errorf("secretstore: delete backend config %s: %w", backend, err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO secret_backend_config (backend, is_default)
+		SELECT 'db', true
+		WHERE NOT EXISTS (SELECT 1 FROM secret_backend_config WHERE is_default)
+		ON CONFLICT (backend) DO UPDATE SET is_default = true, updated_at = now()`); err != nil {
+		return fmt.Errorf("secretstore: delete backend config %s: %w", backend, err)
+	}
+	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("secretstore: delete backend config %s: %w", backend, err)
 	}
 	if backend == "asm" {
 		s.asmMu.Lock()
 		s.asm = nil
 		s.asmMu.Unlock()
+	}
+	return nil
+}
+
+// BackendStatus is one row of the backends listing: whether a backend
+// has connection config and whether it is the store-wide default.
+type BackendStatus struct {
+	Backend    string `json:"backend"`
+	Configured bool   `json:"configured"`
+	Default    bool   `json:"default"`
+}
+
+// Backends lists every known backend with its configured/default
+// state. Built-in storage ("db") is always configured — it needs
+// nothing beyond the master key the store was constructed with.
+func (s *Store) Backends(ctx context.Context) ([]BackendStatus, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("secretstore: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT backend, is_default FROM secret_backend_config`)
+	if err != nil {
+		return nil, fmt.Errorf("secretstore: list backends: %w", err)
+	}
+	defer rows.Close()
+	state := map[string]bool{}
+	anyDefault := false
+	for rows.Next() {
+		var backend string
+		var isDefault bool
+		if err := rows.Scan(&backend, &isDefault); err != nil {
+			return nil, fmt.Errorf("secretstore: list backends: %w", err)
+		}
+		state[backend] = isDefault
+		anyDefault = anyDefault || isDefault
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("secretstore: list backends: %w", err)
+	}
+	out := []BackendStatus{{Backend: "db", Configured: true}}
+	for _, b := range []string{"vault", "asm"} {
+		if isDefault, ok := state[b]; ok {
+			out = append(out, BackendStatus{Backend: b, Configured: true, Default: isDefault})
+		} else {
+			out = append(out, BackendStatus{Backend: b})
+		}
+	}
+	// No flagged row anywhere means built-in storage is the default.
+	out[0].Default = state["db"] || !anyDefault
+	return out, nil
+}
+
+// DefaultBackend returns the backend every newly entered credential is
+// stored through. No flagged row means built-in storage.
+func (s *Store) DefaultBackend(ctx context.Context) (string, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return "", fmt.Errorf("secretstore: %w", err)
+	}
+	var backend string
+	err = db.QueryRow(ctx,
+		`SELECT backend FROM secret_backend_config WHERE is_default`).Scan(&backend)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "db", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("secretstore: read default backend: %w", err)
+	}
+	return backend, nil
+}
+
+// SetDefaultBackend moves the single default flag. An external backend
+// must have connection config first — a default that cannot resolve
+// would break every subsequent credential write.
+func (s *Store) SetDefaultBackend(ctx context.Context, backend string) error {
+	if backend != "db" {
+		if err := validExternalBackend(backend); err != nil {
+			return err
+		}
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("secretstore: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("secretstore: set default backend: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if backend != "db" {
+		var configured bool
+		if err := tx.QueryRow(ctx, `SELECT EXISTS (
+				SELECT 1 FROM secret_backend_config WHERE backend = $1)`, backend).Scan(&configured); err != nil {
+			return fmt.Errorf("secretstore: set default backend: %w", err)
+		}
+		if !configured {
+			return fmt.Errorf("secretstore: backend %s must be configured before it can be the default", backend)
+		}
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE secret_backend_config SET is_default = false WHERE is_default`); err != nil {
+		return fmt.Errorf("secretstore: set default backend: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO secret_backend_config (backend, is_default) VALUES ($1, true)
+		ON CONFLICT (backend) DO UPDATE SET is_default = true, updated_at = now()`, backend); err != nil {
+		return fmt.Errorf("secretstore: set default backend: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("secretstore: set default backend: %w", err)
 	}
 	return nil
 }

--- a/internal/secretstore/secretstore_integration_test.go
+++ b/internal/secretstore/secretstore_integration_test.go
@@ -158,3 +158,72 @@ func TestVaultResolve(t *testing.T) {
 		t.Fatalf("Status: configured=%v backend=%q err=%v", configured, backend, err)
 	}
 }
+
+// Default backend: single flag, external backends must be configured
+// before they can take it, and removing the default's config hands the
+// flag back to built-in storage.
+func TestDefaultBackendLifecycle(t *testing.T) {
+	s := integrationStore(t)
+	ctx := t.Context()
+
+	origCfg, err := s.GetBackendConfig(ctx, "vault")
+	if err != nil {
+		t.Fatalf("GetBackendConfig: %v", err)
+	}
+	origDefault, err := s.DefaultBackend(ctx)
+	if err != nil {
+		t.Fatalf("DefaultBackend: %v", err)
+	}
+	// The backend config table is shared state (a dev database may hold
+	// a real vault config): restore what was there. A defer, not
+	// t.Cleanup — it runs while t.Context() is still alive.
+	defer func() {
+		if string(origCfg) != "{}" {
+			if _, err := s.SetBackendConfig(ctx, "vault", origCfg); err != nil {
+				t.Errorf("restore vault config: %v", err)
+			}
+		} else {
+			_ = s.DeleteBackendConfig(ctx, "vault")
+		}
+		if err := s.SetDefaultBackend(ctx, origDefault); err != nil {
+			t.Errorf("restore default backend: %v", err)
+		}
+	}()
+
+	if err := s.SetDefaultBackend(ctx, "nope"); err == nil {
+		t.Fatal("unknown backend accepted as default")
+	}
+	if err := s.DeleteBackendConfig(ctx, "vault"); err != nil {
+		t.Fatalf("DeleteBackendConfig: %v", err)
+	}
+	if err := s.SetDefaultBackend(ctx, "vault"); err == nil {
+		t.Fatal("unconfigured vault accepted as default")
+	}
+
+	if _, err := s.SetBackendConfig(ctx, "vault", []byte(`{"address":"http://127.0.0.1:1"}`)); err != nil {
+		t.Fatalf("SetBackendConfig: %v", err)
+	}
+	if err := s.SetDefaultBackend(ctx, "vault"); err != nil {
+		t.Fatalf("SetDefaultBackend vault: %v", err)
+	}
+	if got, err := s.DefaultBackend(ctx); err != nil || got != "vault" {
+		t.Fatalf("DefaultBackend = %q, %v; want vault", got, err)
+	}
+	backends, err := s.Backends(ctx)
+	if err != nil {
+		t.Fatalf("Backends: %v", err)
+	}
+	for _, b := range backends {
+		if b.Default != (b.Backend == "vault") {
+			t.Fatalf("Backends = %+v, want only vault default", backends)
+		}
+	}
+
+	// Deleting the default's config falls back to built-in storage.
+	if err := s.DeleteBackendConfig(ctx, "vault"); err != nil {
+		t.Fatalf("DeleteBackendConfig: %v", err)
+	}
+	if got, err := s.DefaultBackend(ctx); err != nil || got != "db" {
+		t.Fatalf("DefaultBackend after delete = %q, %v; want db", got, err)
+	}
+}

--- a/migrations/0021_secret_default_backend.sql
+++ b/migrations/0021_secret_default_backend.sql
@@ -1,0 +1,18 @@
+-- One secret backend is the default: every credential entered in the
+-- UI (provider keys, connector tokens) is stored through it, instead
+-- of a per-key source choice. 'db' (Timothy's own encrypted storage)
+-- joins the table so it can carry the flag; its config stays empty.
+ALTER TABLE secret_backend_config DROP CONSTRAINT secret_backend_config_check;
+ALTER TABLE secret_backend_config
+    ADD CONSTRAINT secret_backend_config_check CHECK (backend IN ('db', 'vault', 'asm'));
+ALTER TABLE secret_backend_config
+    ADD COLUMN IF NOT EXISTS is_default boolean NOT NULL DEFAULT false;
+
+-- At most one default, enforced by the database not the application.
+CREATE UNIQUE INDEX IF NOT EXISTS secret_backend_config_one_default
+    ON secret_backend_config ((true)) WHERE is_default;
+
+-- Built-in storage starts as the default unless one is already set.
+INSERT INTO secret_backend_config (backend, config, is_default)
+SELECT 'db', '{}'::jsonb, NOT EXISTS (SELECT 1 FROM secret_backend_config WHERE is_default)
+ON CONFLICT (backend) DO NOTHING;

--- a/migrations/0022_runtime_settings.sql
+++ b/migrations/0022_runtime_settings.sql
@@ -1,0 +1,9 @@
+-- Typed runtime settings alongside the boolean feature switches:
+-- string values editable from the Settings UI, replacing env knobs
+-- (SESSION_TOKEN_BUDGET, SKILLS_ALLOWLIST). Empty/absent value means
+-- the built-in default.
+CREATE TABLE IF NOT EXISTS runtime_settings (
+    key        text PRIMARY KEY,
+    value      text NOT NULL DEFAULT '',
+    updated_at timestamptz NOT NULL DEFAULT now()
+);

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -3,6 +3,7 @@ import {
   ChatError,
   chatStream,
   createSSEParser,
+  listProviders,
   listSessions,
   patchBudget,
   usageBudget,
@@ -171,5 +172,25 @@ describe('spend budgets', () => {
     expect(url).toBe('/v1/admin/usage/budget')
     expect(init.method).toBe('PATCH')
     expect(JSON.parse(init.body as string)).toEqual({ day: 5, month: null })
+  })
+})
+
+describe('listProviders', () => {
+  it('normalizes null models/headers so the settings page never maps over null', async () => {
+    vi.stubGlobal('localStorage', { getItem: () => 'tok', setItem: () => {} })
+    const body = {
+      providers: [
+        { id: 'p1', name: 'legacy', kind: 'api', driver: 'bedrock', models: null, headers: null },
+      ],
+    }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(JSON.stringify(body), { status: 200 })),
+    )
+
+    const [p] = await listProviders()
+
+    expect(p.models).toEqual([])
+    expect(p.headers).toEqual({})
   })
 })

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -328,7 +328,10 @@ export async function patchBudget(changes: {
 
 export async function listProviders(): Promise<AdminProvider[]> {
   const { providers } = await request<{ providers: AdminProvider[] }>('/v1/admin/providers')
-  return providers ?? []
+  // Rows written before the backend guarded typed nils can carry
+  // models/headers as JSON null; a null models array would crash every
+  // component that maps over it, blanking the whole settings page.
+  return (providers ?? []).map((p) => ({ ...p, models: p.models ?? [], headers: p.headers ?? {} }))
 }
 
 export async function createProvider(p: Partial<AdminProvider>): Promise<string> {
@@ -387,10 +390,12 @@ export async function providersHealth(): Promise<ProviderHealth[]> {
   return providers ?? []
 }
 
-// setSecret stores a credential value under refName (write-only: it is
-// never returned by any endpoint). deleteSecret removes it; the
-// provider then builds without a key and shows unhealthy until a new
-// value is set.
+// setSecret stores a credential under refName through the store-wide
+// default backend (write-only: it is never returned by any endpoint).
+// Built-in storage encrypts the value; a Vault/ASM default records it
+// as the reference of a secret already held there. deleteSecret
+// removes it; the provider then builds without a key and shows
+// unhealthy until a new value is set.
 export async function setSecret(refName: string, value: string): Promise<void> {
   await request<void>(`/v1/admin/secrets/${encodeURIComponent(refName)}`, {
     method: 'PUT',
@@ -398,16 +403,14 @@ export async function setSecret(refName: string, value: string): Promise<void> {
   })
 }
 
-// setSecretExternal points refName at a secret held in Vault or AWS
-// Secrets Manager instead of storing a value here.
-export async function setSecretExternal(
-  refName: string,
-  backend: 'vault' | 'asm',
-  backendRef: string,
-): Promise<void> {
+// setSecretStorage pins built-in storage regardless of the default
+// backend. Only for backend bootstrap credentials (the vault token,
+// ASM secret key): the credential that unlocks an external backend
+// cannot live behind that backend.
+export async function setSecretStorage(refName: string, value: string): Promise<void> {
   await request<void>(`/v1/admin/secrets/${encodeURIComponent(refName)}`, {
     method: 'PUT',
-    body: JSON.stringify({ backend, backend_ref: backendRef }),
+    body: JSON.stringify({ value, backend: 'db' }),
   })
 }
 
@@ -423,6 +426,28 @@ export interface SecretStatus {
 export async function secretStatus(refName: string): Promise<SecretStatus> {
   if (!refName) return { configured: false, backend: '' }
   return request<SecretStatus>(`/v1/admin/secrets/${encodeURIComponent(refName)}`)
+}
+
+export interface SecretBackendStatus {
+  backend: string
+  configured: boolean
+  default: boolean
+}
+
+// listSecretBackends reports each backend's configured/default state;
+// exactly one is the default all credential writes route through.
+export async function listSecretBackends(): Promise<SecretBackendStatus[]> {
+  const { backends } = await request<{ backends: SecretBackendStatus[] }>(
+    '/v1/admin/secret-backends',
+  )
+  return backends ?? []
+}
+
+export async function setDefaultSecretBackend(backend: string): Promise<void> {
+  await request<void>('/v1/admin/secret-backends/default', {
+    method: 'PUT',
+    body: JSON.stringify({ backend }),
+  })
 }
 
 export async function getSecretBackendConfig(
@@ -515,13 +540,28 @@ export async function patchRoute(
   })
 }
 
-export async function getSettings(): Promise<Record<string, boolean>> {
-  const { settings } = await request<{ settings: Record<string, boolean> }>('/v1/admin/settings')
-  return settings ?? {}
+export interface AdminSettings {
+  settings: Record<string, boolean>
+  // Typed runtime settings; empty string means the built-in default.
+  values: Record<string, string>
+}
+
+export async function getSettings(): Promise<AdminSettings> {
+  const s = await request<AdminSettings>('/v1/admin/settings')
+  return { settings: s.settings ?? {}, values: s.values ?? {} }
 }
 
 export async function patchSettings(changes: Record<string, boolean>): Promise<void> {
   await request<void>('/v1/admin/settings', {
+    method: 'PATCH',
+    body: JSON.stringify(changes),
+  })
+}
+
+// patchSettingValues updates typed runtime settings (strings; empty
+// resets a key to its built-in default).
+export async function patchSettingValues(changes: Record<string, string>): Promise<void> {
+  await request<void>('/v1/admin/settings/values', {
     method: 'PATCH',
     body: JSON.stringify(changes),
   })

--- a/web/src/components/settings/ConnectorsTab.test.tsx
+++ b/web/src/components/settings/ConnectorsTab.test.tsx
@@ -9,6 +9,7 @@ vi.mock('../../api/client', () => ({
   createConnector: vi.fn(),
   deleteConnector: vi.fn(),
   listConnectors: vi.fn(),
+  listSecretBackends: vi.fn(),
   patchConnector: vi.fn(),
   setSecret: vi.fn(),
   testConnector: vi.fn(),
@@ -18,6 +19,7 @@ import {
   connectorOAuthStart,
   createConnector,
   listConnectors,
+  listSecretBackends,
   patchConnector,
   setSecret,
   testConnector,
@@ -46,6 +48,11 @@ afterEach(cleanup)
 beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+  vi.mocked(listSecretBackends).mockResolvedValue([
+    { backend: 'db', configured: true, default: true },
+    { backend: 'vault', configured: false, default: false },
+    { backend: 'asm', configured: false, default: false },
+  ])
   vi.stubGlobal('location', { ...window.location, assign, origin: 'http://localhost:3300' })
 })
 

--- a/web/src/components/settings/ConnectorsTab.tsx
+++ b/web/src/components/settings/ConnectorsTab.tsx
@@ -24,7 +24,8 @@ import { Input } from '../ui/input'
 import { ConnectorLogo, ConnectorLogoSprite } from './ConnectorLogo'
 import { connectorPresets, type ConnectorPreset } from './connectorPresets'
 import { ErrorBanner, Field, Toggle } from './shared'
-import { errText } from './util'
+import { useDefaultSecretBackend } from './useDefaultSecretBackend'
+import { errText, secretField } from './util'
 
 // slugify turns a display name into a connector name (tool-name
 // prefix): lowercase slug, the backend rejects anything else.
@@ -307,6 +308,7 @@ function AddConnectorDialog({
   const [clientSecret, setClientSecret] = useState('')
   const [busy, setBusy] = useState(false)
   const [status, setStatus] = useState<string | null>(null)
+  const defaultBackend = useDefaultSecretBackend()
 
   useEffect(() => {
     if (!preset) return
@@ -419,10 +421,10 @@ function AddConnectorDialog({
                 </Field>
                 <Field label="OAuth client secret">
                   <Input
-                    type="password"
+                    type={secretField(defaultBackend, '').type}
                     value={clientSecret}
                     onChange={(e) => setClientSecret(e.target.value)}
-                    placeholder="GOCSPX-…"
+                    placeholder={secretField(defaultBackend, 'GOCSPX-…').placeholder}
                     className="mt-1 h-8"
                     autoComplete="off"
                   />
@@ -450,15 +452,19 @@ function AddConnectorDialog({
               )}
               <Field label={preset.id === 'custom-mcp' ? 'Bearer token (optional)' : 'Bearer token'}>
                 <Input
-                  type="password"
+                  type={secretField(defaultBackend, '').type}
                   value={token}
                   onChange={(e) => setToken(e.target.value)}
-                  placeholder={preset.tokenPlaceholder ?? 'token'}
+                  placeholder={secretField(defaultBackend, preset.tokenPlaceholder ?? 'token').placeholder}
                   className="mt-1 h-8"
                   autoComplete="off"
                 />
               </Field>
-              {preset.tokenHint && <p className="text-xs text-muted-foreground">{preset.tokenHint}</p>}
+              {(secretField(defaultBackend, '').hint || preset.tokenHint) && (
+                <p className="text-xs text-muted-foreground">
+                  {secretField(defaultBackend, '').hint || preset.tokenHint}
+                </p>
+              )}
             </>
           )}
 

--- a/web/src/components/settings/FeaturesTab.tsx
+++ b/web/src/components/settings/FeaturesTab.tsx
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useState } from 'react'
-import { getSettings, patchBudget, patchSettings, usageBudget } from '../../api/client'
+import {
+  getSettings,
+  patchBudget,
+  patchSettings,
+  patchSettingValues,
+  usageBudget,
+} from '../../api/client'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { ErrorBanner, Toggle } from './shared'
@@ -26,12 +32,14 @@ const featureCopy: Record<string, { label: string; description: string }> = {
 
 export function FeaturesTab() {
   const [flags, setFlags] = useState<Record<string, boolean> | null>(null)
+  const [values, setValues] = useState<Record<string, string> | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const refresh = useCallback(() => {
     getSettings()
       .then((s) => {
-        setFlags(s)
+        setFlags(s.settings)
+        setValues(s.values)
         setError(null)
       })
       .catch((err: unknown) => setError(errText(err)))
@@ -62,7 +70,78 @@ export function FeaturesTab() {
           />
         </div>
       ))}
+      {values && <AgentCard values={values} onError={setError} onSaved={refresh} />}
       <BudgetsCard />
+    </div>
+  )
+}
+
+// AgentCard edits the typed runtime settings that used to be env vars:
+// the context-budget fallback and the skill-pack allowlist. Empty
+// resets a key to its built-in default; changes apply within seconds,
+// no restart.
+function AgentCard({
+  values,
+  onError,
+  onSaved,
+}: {
+  values: Record<string, string>
+  onError: (msg: string) => void
+  onSaved: () => void
+}) {
+  const [budget, setBudget] = useState(values.session_token_budget ?? '')
+  const [allowlist, setAllowlist] = useState(values.skills_allowlist ?? '')
+  const [saved, setSaved] = useState(false)
+
+  const save = () => {
+    setSaved(false)
+    patchSettingValues({
+      session_token_budget: budget.trim(),
+      skills_allowlist: allowlist.trim(),
+    })
+      .then(() => {
+        setSaved(true)
+        onSaved()
+      })
+      .catch((err: unknown) => onError(errText(err)))
+  }
+
+  return (
+    <div className="rounded-xl border border-border p-4">
+      <div className="text-sm font-medium">Agent</div>
+      <p className="mt-0.5 text-xs text-muted-foreground">
+        Runtime knobs, applied within seconds — no restart.
+      </p>
+      <div className="mt-3 flex flex-wrap items-end gap-3">
+        <label className="grid gap-1 text-xs text-muted-foreground">
+          Context budget (tokens)
+          <Input
+            value={budget}
+            onChange={(e) => setBudget(e.target.value)}
+            placeholder="60000"
+            inputMode="numeric"
+            className="w-36"
+            aria-label="Session token budget"
+          />
+        </label>
+        <label className="grid gap-1 text-xs text-muted-foreground">
+          Skill allowlist (comma-separated)
+          <Input
+            value={allowlist}
+            onChange={(e) => setAllowlist(e.target.value)}
+            placeholder="empty = all packs"
+            className="w-72"
+            aria-label="Skills allowlist"
+          />
+        </label>
+        <Button onClick={save}>Save</Button>
+        {saved && <span className="text-xs text-muted-foreground">Saved.</span>}
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Budget caps the projected context when the serving model&apos;s window is unknown (a
+        known window still wins at 60%). Allowlist restricts which skill packs the agent may
+        load; empty allows all.
+      </p>
     </div>
   )
 }

--- a/web/src/components/settings/ProvidersTab.tsx
+++ b/web/src/components/settings/ProvidersTab.tsx
@@ -11,7 +11,6 @@ import {
   providersHealth,
   secretStatus,
   setSecret,
-  setSecretExternal,
   testProvider,
   validateProvider,
 } from '../../api/client'
@@ -40,9 +39,8 @@ import {
 import { matchPreset, providerPresets, type ProviderPreset } from './presets'
 import { LogoSprite, ProviderLogo } from './ProviderLogo'
 import { ErrorBanner, Field, Toggle } from './shared'
-import { backendLabel, errText } from './util'
-
-type KeySource = 'db' | 'vault' | 'asm'
+import { useDefaultSecretBackend } from './useDefaultSecretBackend'
+import { backendLabel, errText, secretField } from './util'
 
 // stripPaste removes whitespace and zero-width characters that ride
 // along when a key is copied out of wrapped text.
@@ -64,6 +62,7 @@ export function ProvidersTab() {
   const [error, setError] = useState<string | null>(null)
   const [confirmDelete, setConfirmDelete] = useState<AdminProvider | null>(null)
   const [connecting, setConnecting] = useState<ProviderPreset | null>(null)
+  const defaultBackend = useDefaultSecretBackend()
 
   const refresh = useCallback(() => {
     Promise.all([listProviders(), providersHealth()])
@@ -103,6 +102,7 @@ export function ProvidersTab() {
           key={p.id}
           provider={p}
           health={health[p.name]}
+          defaultBackend={defaultBackend}
           onChanged={refresh}
           onDelete={() => setConfirmDelete(p)}
           onError={setError}
@@ -141,6 +141,7 @@ export function ProvidersTab() {
 
       <ConnectDialog
         preset={connecting}
+        defaultBackend={defaultBackend}
         onClose={() => setConnecting(null)}
         onAdded={() => {
           setConnecting(null)
@@ -178,10 +179,12 @@ export function ProvidersTab() {
 // all.
 function ConnectDialog({
   preset,
+  defaultBackend,
   onClose,
   onAdded,
 }: {
   preset: ProviderPreset | null
+  defaultBackend: string
   onClose: () => void
   onAdded: () => void
 }) {
@@ -190,7 +193,6 @@ function ConnectDialog({
   const [region, setRegion] = useState('')
   const [profile, setProfile] = useState('')
   const [key, setKey] = useState('')
-  const [source, setSource] = useState<KeySource>('db')
   const [ref, setRef] = useState('')
   const [refEdited, setRefEdited] = useState(false)
   const [model, setModel] = useState('')
@@ -206,7 +208,6 @@ function ConnectDialog({
     setRegion(preset.region ?? '')
     setProfile('')
     setKey('')
-    setSource('db')
     setRef(preset.id === 'custom' ? '' : refFor(preset, preset.name))
     setRefEdited(false)
     setModel(preset.validateModel)
@@ -239,8 +240,7 @@ function ConnectDialog({
     try {
       if (wantsKey && key) {
         if (!ref.trim()) throw new Error('a credential reference name is required to store the key')
-        if (source === 'db') await setSecret(ref.trim(), stripPaste(key))
-        else await setSecretExternal(ref.trim(), source, key.trim())
+        await setSecret(ref.trim(), stripPaste(key))
       }
       const res = await validateProvider(config, model.trim())
       setStatus(res)
@@ -324,41 +324,29 @@ function ConnectDialog({
                   />
                 </Field>
               )}
-              {wantsKey && (
-                <div>
-                  <Field label={preset.id === 'custom' ? 'API key (optional)' : 'API key'}>
-                    <div className="mt-1 flex gap-2">
-                      <Select value={source} onValueChange={(v) => setSource(v as KeySource)}>
-                        <SelectTrigger className="h-8 w-40 shrink-0 text-xs" aria-label="key source">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="db">Encrypted here</SelectItem>
-                          <SelectItem value="vault">Vault</SelectItem>
-                          <SelectItem value="asm">AWS Secrets Manager</SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <Input
-                        type={source === 'db' ? 'password' : 'text'}
-                        value={key}
-                        onChange={(e) => setKey(e.target.value)}
-                        placeholder={
-                          source === 'db'
-                            ? (preset.keyPlaceholder ?? 'paste key')
-                            : source === 'vault'
-                              ? 'path, e.g. timothy/anthropic#api_key'
-                              : 'name or ARN, optional #json_key'
-                        }
-                        className="h-8"
-                        autoComplete="off"
-                      />
+              {wantsKey &&
+                (() => {
+                  const field = secretField(defaultBackend, preset.keyPlaceholder ?? 'paste key')
+                  return (
+                    <div>
+                      <Field label={preset.id === 'custom' ? 'API key (optional)' : 'API key'}>
+                        <Input
+                          type={field.type}
+                          value={key}
+                          onChange={(e) => setKey(e.target.value)}
+                          placeholder={field.placeholder}
+                          className="mt-1 h-8"
+                          autoComplete="off"
+                        />
+                      </Field>
+                      {(field.hint || preset.keyHint) && (
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {field.hint || preset.keyHint}
+                        </p>
+                      )}
                     </div>
-                  </Field>
-                  {preset.keyHint && (
-                    <p className="mt-1 text-xs text-muted-foreground">{preset.keyHint}</p>
-                  )}
-                </div>
-              )}
+                  )
+                })()}
             </>
           )}
 
@@ -427,12 +415,14 @@ function ConnectDialog({
 function ProviderCard({
   provider,
   health,
+  defaultBackend,
   onChanged,
   onDelete,
   onError,
 }: {
   provider: AdminProvider
   health?: ProviderHealth
+  defaultBackend: string
   onChanged: () => void
   onDelete: () => void
   onError: (msg: string) => void
@@ -443,7 +433,6 @@ function ProviderCard({
   const [test, setTest] = useState<TestResult | null>(null)
   const [configured, setConfigured] = useState(false)
   const [storedBackend, setStoredBackend] = useState('')
-  const [source, setSource] = useState<KeySource>('db')
   const [secretValue, setSecretValue] = useState('')
   const [savingSecret, setSavingSecret] = useState(false)
 
@@ -486,8 +475,7 @@ function ProviderCard({
     if (!ref || !secretValue) return
     setSavingSecret(true)
     try {
-      if (source === 'db') await setSecret(ref, stripPaste(secretValue))
-      else await setSecretExternal(ref, source, secretValue)
+      await setSecret(ref, stripPaste(secretValue))
       setSecretValue('')
       refreshSecretStatus()
       onChanged()
@@ -607,28 +595,13 @@ function ProviderCard({
               )}
             </div>
             <div className="mt-1.5 flex gap-2">
-              <Select value={source} onValueChange={(v) => setSource(v as KeySource)}>
-                <SelectTrigger className="h-8 w-40 shrink-0 text-xs" aria-label="key source">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="db">Encrypted here</SelectItem>
-                  <SelectItem value="vault">Vault</SelectItem>
-                  <SelectItem value="asm">AWS Secrets Manager</SelectItem>
-                </SelectContent>
-              </Select>
               <Input
-                type={source === 'db' ? 'password' : 'text'}
+                type={secretField(defaultBackend, '').type}
                 value={secretValue}
                 onChange={(e) => setSecretValue(e.target.value)}
                 placeholder={
-                  source === 'db'
-                    ? configured
-                      ? 'paste new key to rotate'
-                      : 'paste key'
-                    : source === 'vault'
-                      ? 'path, e.g. timothy/anthropic#api_key'
-                      : 'name or ARN, optional #json_key'
+                  secretField(defaultBackend, configured ? 'paste new key to rotate' : 'paste key')
+                    .placeholder
                 }
                 className="h-8"
                 autoComplete="off"
@@ -643,11 +616,11 @@ function ProviderCard({
               </Button>
             </div>
             <p className="mt-1.5 text-xs text-muted-foreground">
-              {source === 'db'
-                ? 'Encrypted with the master key and kept in Timothy’s database.'
-                : source === 'vault'
-                  ? 'The key stays in Vault; only its path is saved. Connect Vault in the Secrets tab.'
-                  : 'The key stays in AWS Secrets Manager; only its name is saved. Connect AWS in the Secrets tab.'}
+              {defaultBackend === 'vault'
+                ? 'The key stays in Vault; only its path is saved. The default backend is set in the Secrets tab.'
+                : defaultBackend === 'asm'
+                  ? 'The key stays in AWS Secrets Manager; only its name is saved. The default backend is set in the Secrets tab.'
+                  : 'Encrypted with the master key and kept in Timothy’s database.'}
             </p>
             <details className="mt-2">
               <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground">

--- a/web/src/components/settings/SecretsTab.tsx
+++ b/web/src/components/settings/SecretsTab.tsx
@@ -1,12 +1,15 @@
 import { Delete02Icon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   deleteSecretBackendConfig,
   getSecretBackendConfig,
+  listSecretBackends,
   putSecretBackendConfig,
-  setSecret,
+  setDefaultSecretBackend,
+  setSecretStorage,
   testSecretBackend,
+  type SecretBackendStatus,
 } from '../../api/client'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
@@ -22,17 +25,94 @@ import { errText } from './util'
 
 export function SecretsTab() {
   const [error, setError] = useState<string | null>(null)
+  const [backends, setBackends] = useState<SecretBackendStatus[]>([])
+
+  const refresh = useCallback(() => {
+    listSecretBackends().then(setBackends, (err: unknown) => setError(errText(err)))
+  }, [])
+  useEffect(refresh, [refresh])
+
+  const state = (b: string) => backends.find((x) => x.backend === b)
+  const makeDefault = (b: string) => {
+    setDefaultSecretBackend(b).then(refresh, (err: unknown) => setError(errText(err)))
+  }
+
   return (
     <div className="mt-6 space-y-4">
       <p className="text-sm text-muted-foreground">
-        Where provider keys live. By default each key is encrypted with the master key and kept
-        in Timothy&apos;s own database — nothing to configure. Connect Vault or AWS Secrets
-        Manager to resolve keys from existing secret infrastructure instead; pick the source
-        per key on its provider card. OAuth-based connections arrive with connectors.
+        Where credentials live. Exactly one backend is the default: every key or token entered
+        anywhere (providers, connectors) is stored through it. Timothy storage keeps values
+        encrypted in its own database; with Vault or AWS Secrets Manager as default you enter
+        the reference of a secret already held there — Timothy only reads, never writes,
+        external systems.
       </p>
       <ErrorBanner message={error} />
-      <VaultCard onError={setError} />
-      <ASMCard onError={setError} />
+      <StorageCard isDefault={state('db')?.default ?? true} onMakeDefault={() => makeDefault('db')} />
+      <VaultCard
+        isDefault={state('vault')?.default ?? false}
+        onMakeDefault={() => makeDefault('vault')}
+        onBackendsChanged={refresh}
+        onError={setError}
+      />
+      <ASMCard
+        isDefault={state('asm')?.default ?? false}
+        onMakeDefault={() => makeDefault('asm')}
+        onBackendsChanged={refresh}
+        onError={setError}
+      />
+    </div>
+  )
+}
+
+// DefaultControl is the per-card default marker: a badge when the card
+// is the default, a button to claim it otherwise.
+function DefaultControl({
+  isDefault,
+  disabled,
+  onMakeDefault,
+}: {
+  isDefault: boolean
+  disabled?: boolean
+  onMakeDefault: () => void
+}) {
+  if (isDefault) {
+    return (
+      <span className="rounded bg-sky-500/15 px-1.5 py-px text-[10px] font-medium uppercase text-sky-600 dark:text-sky-400">
+        default
+      </span>
+    )
+  }
+  return (
+    <Button size="sm" variant="outline" disabled={disabled} onClick={onMakeDefault}>
+      Make default
+    </Button>
+  )
+}
+
+// StorageCard is the built-in backend: nothing to configure, always
+// available, keys envelope-encrypted with the master key.
+function StorageCard({
+  isDefault,
+  onMakeDefault,
+}: {
+  isDefault: boolean
+  onMakeDefault: () => void
+}) {
+  return (
+    <div className="rounded-xl border border-border p-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="font-medium">Timothy storage</span>
+        <span className="rounded bg-emerald-500/15 px-1.5 py-px text-[10px] font-medium uppercase text-emerald-600 dark:text-emerald-400">
+          built-in
+        </span>
+        <div className="ml-auto flex items-center gap-3">
+          <DefaultControl isDefault={isDefault} onMakeDefault={onMakeDefault} />
+        </div>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Keys are envelope-encrypted with the master key and kept in Timothy&apos;s own database.
+        Nothing to configure.
+      </p>
     </div>
   )
 }
@@ -43,6 +123,7 @@ function useBackendCard(
   backend: 'vault' | 'asm',
   onLoaded: (cfg: Record<string, string>) => void,
   onError: (msg: string) => void,
+  onChanged: () => void,
 ) {
   const [configured, setConfigured] = useState(false)
   const [busy, setBusy] = useState(false)
@@ -77,6 +158,9 @@ function useBackendCard(
     run(async () => {
       await deleteSecretBackendConfig(backend)
       setConfigured(false)
+      // Removing the default backend hands the flag back to storage;
+      // the parent re-fetches so badges follow.
+      onChanged()
       return 'removed'
     })
 
@@ -90,6 +174,8 @@ function BackendCardHeader({
   status,
   busy,
   canSave,
+  isDefault,
+  onMakeDefault,
   onSave,
   onTest,
   onRemove,
@@ -100,6 +186,8 @@ function BackendCardHeader({
   status: string
   busy: boolean
   canSave: boolean
+  isDefault: boolean
+  onMakeDefault: () => void
   onSave: () => void
   onTest: () => void
   onRemove: () => void
@@ -125,6 +213,11 @@ function BackendCardHeader({
           </span>
         )}
         <div className="ml-auto flex items-center gap-3">
+          <DefaultControl
+            isDefault={isDefault}
+            disabled={busy || !configured}
+            onMakeDefault={onMakeDefault}
+          />
           <Button size="sm" variant="outline" disabled={busy || !configured} onClick={onTest}>
             Test
           </Button>
@@ -149,7 +242,14 @@ function BackendCardHeader({
   )
 }
 
-function VaultCard({ onError }: { onError: (msg: string) => void }) {
+type BackendCardProps = {
+  isDefault: boolean
+  onMakeDefault: () => void
+  onBackendsChanged: () => void
+  onError: (msg: string) => void
+}
+
+function VaultCard({ isDefault, onMakeDefault, onBackendsChanged, onError }: BackendCardProps) {
   const [cfg, setCfg] = useState({
     address: '',
     mount: '',
@@ -164,20 +264,22 @@ function VaultCard({ onError }: { onError: (msg: string) => void }) {
     'vault',
     (c) => setCfg((v) => ({ ...v, ...c, auth: c.auth || 'token' })),
     onError,
+    onBackendsChanged,
   )
 
   const save = () =>
     card.run(async () => {
       await putSecretBackendConfig('vault', cfg)
       if (cfg.auth === 'token' && tokenPaste) {
-        await setSecret(cfg.token_ref || 'VAULT_TOKEN', tokenPaste)
+        await setSecretStorage(cfg.token_ref || 'VAULT_TOKEN', tokenPaste)
         setTokenPaste('')
       }
       if (cfg.auth === 'approle' && secretIDPaste) {
-        await setSecret(cfg.secret_id_ref || 'VAULT_SECRET_ID', secretIDPaste)
+        await setSecretStorage(cfg.secret_id_ref || 'VAULT_SECRET_ID', secretIDPaste)
         setSecretIDPaste('')
       }
       card.setConfigured(true)
+      onBackendsChanged()
       return 'saved'
     })
 
@@ -190,6 +292,8 @@ function VaultCard({ onError }: { onError: (msg: string) => void }) {
         status={card.status}
         busy={card.busy}
         canSave={!!cfg.address}
+        isDefault={isDefault}
+        onMakeDefault={onMakeDefault}
         onSave={save}
         onTest={card.test}
         onRemove={card.remove}
@@ -263,7 +367,7 @@ function VaultCard({ onError }: { onError: (msg: string) => void }) {
   )
 }
 
-function ASMCard({ onError }: { onError: (msg: string) => void }) {
+function ASMCard({ isDefault, onMakeDefault, onBackendsChanged, onError }: BackendCardProps) {
   const [cfg, setCfg] = useState({
     region: '',
     auth: 'chain',
@@ -276,16 +380,18 @@ function ASMCard({ onError }: { onError: (msg: string) => void }) {
     'asm',
     (c) => setCfg((v) => ({ ...v, ...c, auth: c.auth || 'chain' })),
     onError,
+    onBackendsChanged,
   )
 
   const save = () =>
     card.run(async () => {
       await putSecretBackendConfig('asm', cfg)
       if (cfg.auth === 'keys' && secretKeyPaste) {
-        await setSecret(cfg.secret_key_ref || 'AWS_SECRET_ACCESS_KEY', secretKeyPaste)
+        await setSecretStorage(cfg.secret_key_ref || 'AWS_SECRET_ACCESS_KEY', secretKeyPaste)
         setSecretKeyPaste('')
       }
       card.setConfigured(true)
+      onBackendsChanged()
       return 'saved'
     })
 
@@ -298,6 +404,8 @@ function ASMCard({ onError }: { onError: (msg: string) => void }) {
         status={card.status}
         busy={card.busy}
         canSave
+        isDefault={isDefault}
+        onMakeDefault={onMakeDefault}
         onSave={save}
         onTest={card.test}
         onRemove={card.remove}

--- a/web/src/components/settings/useDefaultSecretBackend.ts
+++ b/web/src/components/settings/useDefaultSecretBackend.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react'
+import { listSecretBackends } from '../../api/client'
+
+// useDefaultSecretBackend resolves which backend credential writes
+// route through, so key inputs can ask for a value or a reference.
+// Falls back to built-in storage while loading or on error.
+export function useDefaultSecretBackend(): string {
+  const [backend, setBackend] = useState('db')
+  useEffect(() => {
+    listSecretBackends().then(
+      (bs) => setBackend(bs.find((b) => b.default)?.backend ?? 'db'),
+      () => undefined,
+    )
+  }, [])
+  return backend
+}

--- a/web/src/components/settings/util.ts
+++ b/web/src/components/settings/util.ts
@@ -7,3 +7,28 @@ export function backendLabel(b: string): string {
 export function errText(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
+
+// secretField shapes a credential input for the store-wide default
+// backend: built-in storage takes the value itself (masked), an
+// external backend takes the reference of a secret already there.
+export function secretField(
+  backend: string,
+  dbPlaceholder: string,
+): { type: 'password' | 'text'; placeholder: string; hint: string } {
+  switch (backend) {
+    case 'vault':
+      return {
+        type: 'text',
+        placeholder: 'Vault path, e.g. timothy/anthropic#api_key',
+        hint: 'Default backend is Vault — paste the path of the secret, not the secret itself.',
+      }
+    case 'asm':
+      return {
+        type: 'text',
+        placeholder: 'ASM name or ARN, optional #json_key',
+        hint: 'Default backend is AWS Secrets Manager — paste the secret name, not the secret itself.',
+      }
+    default:
+      return { type: 'password', placeholder: dbPlaceholder, hint: '' }
+  }
+}

--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -16,8 +16,11 @@ vi.mock('../api/client', async (importOriginal) => {
     deleteSecretBackendConfig: vi.fn(),
     getSecretBackendConfig: vi.fn(),
     getSettings: vi.fn(),
+    patchSettingValues: vi.fn(),
     listProviders: vi.fn(),
     listRoutes: vi.fn(),
+    listSecretBackends: vi.fn(),
+    setDefaultSecretBackend: vi.fn(),
     patchBudget: vi.fn(),
     patchProvider: vi.fn(),
     patchRoute: vi.fn(),
@@ -26,7 +29,6 @@ vi.mock('../api/client', async (importOriginal) => {
     putSecretBackendConfig: vi.fn(),
     secretStatus: vi.fn(),
     setSecret: vi.fn(),
-    setSecretExternal: vi.fn(),
     testProvider: vi.fn(),
     testSecretBackend: vi.fn(),
     usageBudget: vi.fn(),
@@ -38,11 +40,16 @@ import {
   availableModels,
   createProvider,
   getSecretBackendConfig,
+  getSettings,
   listProviders,
+  listSecretBackends,
   patchProvider,
+  patchSettingValues,
   providersHealth,
   secretStatus,
+  setDefaultSecretBackend,
   setSecret,
+  usageBudget,
   validateProvider,
 } from '../api/client'
 
@@ -78,6 +85,11 @@ beforeEach(() => {
   ])
   vi.mocked(secretStatus).mockResolvedValue({ configured: true, backend: 'db' })
   vi.mocked(getSecretBackendConfig).mockResolvedValue({})
+  vi.mocked(listSecretBackends).mockResolvedValue([
+    { backend: 'db', configured: true, default: true },
+    { backend: 'vault', configured: false, default: false },
+    { backend: 'asm', configured: false, default: false },
+  ])
 })
 
 describe('Settings tabs', () => {
@@ -90,6 +102,65 @@ describe('Settings tabs', () => {
   it('defaults to Providers', async () => {
     renderPage()
     expect(await screen.findByText('Connect a provider')).toBeTruthy()
+  })
+})
+
+describe('Features tab agent settings', () => {
+  it('renders stored runtime values and patches them on save', async () => {
+    vi.mocked(getSettings).mockResolvedValue({
+      settings: { tools_enabled: true },
+      values: { session_token_budget: '120000', skills_allowlist: '' },
+    })
+    vi.mocked(usageBudget).mockResolvedValue({
+      day: { limit_usd: null, spend_usd: 0, over: false },
+      month: { limit_usd: null, spend_usd: 0, over: false },
+    })
+    vi.mocked(patchSettingValues).mockResolvedValue()
+
+    renderPage('/settings?tab=features')
+    const budget = await screen.findByLabelText('Session token budget')
+    expect((budget as HTMLInputElement).value).toBe('120000')
+
+    fireEvent.change(screen.getByLabelText('Skills allowlist'), {
+      target: { value: 'coding-task, research' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(patchSettingValues).toHaveBeenCalledWith({
+        session_token_budget: '120000',
+        skills_allowlist: 'coding-task, research',
+      }),
+    )
+  })
+})
+
+describe('Secrets tab default backend', () => {
+  it('shows the built-in storage card carrying the default badge', async () => {
+    renderPage('/settings?tab=secrets')
+    expect(await screen.findByText('Timothy storage')).toBeTruthy()
+    expect(screen.getByText('default')).toBeTruthy()
+    // Unconfigured backends cannot claim the default.
+    const buttons = screen.getAllByRole('button', { name: 'Make default' })
+    expect(buttons.length).toBe(2)
+    for (const b of buttons) expect((b as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('claims the default for a configured backend', async () => {
+    vi.mocked(getSecretBackendConfig).mockResolvedValue({ address: 'http://vault:8200' })
+    vi.mocked(listSecretBackends).mockResolvedValue([
+      { backend: 'db', configured: true, default: true },
+      { backend: 'vault', configured: true, default: false },
+      { backend: 'asm', configured: false, default: false },
+    ])
+    vi.mocked(setDefaultSecretBackend).mockResolvedValue()
+
+    renderPage('/settings?tab=secrets')
+    const enabled = (await screen.findAllByRole('button', { name: 'Make default' })).find(
+      (b) => !(b as HTMLButtonElement).disabled,
+    )
+    fireEvent.click(enabled!)
+    await waitFor(() => expect(setDefaultSecretBackend).toHaveBeenCalledWith('vault'))
   })
 })
 
@@ -139,6 +210,22 @@ describe('Providers tab', () => {
         models: [{ id: 'llama-3.3-70b-versatile' }],
       }),
     )
+  })
+
+  it('asks for a reference, not a key, when the default backend is external', async () => {
+    vi.mocked(listSecretBackends).mockResolvedValue([
+      { backend: 'db', configured: true, default: false },
+      { backend: 'vault', configured: true, default: true },
+      { backend: 'asm', configured: false, default: false },
+    ])
+
+    renderPage()
+    fireEvent.click(await screen.findByRole('button', { name: /Groq/ }))
+    const dialog = within(await screen.findByRole('dialog'))
+    const input = await dialog.findByPlaceholderText(/Vault path/)
+    // A reference is not a secret: no password masking.
+    expect((input as HTMLInputElement).type).toBe('text')
+    expect(dialog.getByText(/paste the path of the secret/)).toBeTruthy()
   })
 
   it('keeps the dialog open and skips create when validation fails', async () => {


### PR DESCRIPTION
## What

- **Single default secret backend**: storage (built-in, encrypted Postgres), Vault, or ASM — exactly one is the default, DB-enforced (partial unique index). Every credential entered on providers/connectors routes through it; the per-key source dropdown is gone. Unconfigured backends can't take the flag; removing the default's config hands the flag back to storage.
- **Bootstrap credential pinning**: Vault token / AppRole secret-id / ASM secret key always store in built-in storage (`backend: "db"`) — the credential that unlocks an external backend cannot live behind that backend. Any other explicit backend in the body is rejected 422.
- **Runtime settings replace env knobs**: `SESSION_TOKEN_BUDGET` and `SKILLS_ALLOWLIST` removed from env/compose; now `runtime_settings` rows edited in Features → Agent card, applied per turn (~10s cache). Skill allowlist gates the system-prompt index, `skill_hint`, and `load_skill` uniformly; disallowed packs are indistinguishable from unknown ones.
- **Fix**: blank settings page — typed-nil models slice marshaled to jsonb `null`; UI crashed mapping over it. Guarded at write (jsonOr), read (normalize), and fetch boundary.
- **Fix**: integration-test fixture leaks — teardown sweeps ran on a pool killed by `t.Context()` cancel and failed silently; sweeps now use a fresh one-shot connection plus a setup sweep.

## Migrations

- 0021: `secret_backend_config` + `is_default` (single-default index), allows `db` row, seeds storage as default
- 0022: `runtime_settings` key/value table

## Tests

Go unit + integration (run twice for idempotence), golangci-lint 0 issues, 90 web tests, tsc, oxlint.