### PR TITLE
Tools picker, retry-message, and two routing fixes

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -192,7 +192,7 @@ func main() {
 
 	api.Register(app.Server, svc, store, broker,
 		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, app.Log), flags,
-		agentReg, conns, goog, token, app.Log)
+		agentReg, conns, goog, agent, token, app.Log)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -21,6 +21,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/connectors"
 	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/brain/settings"
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 	"github.com/SumonMSelim/timothy/internal/platform/httpserver"
 )
@@ -39,6 +40,13 @@ type Directory interface {
 // broker satisfies it. Nil disables the endpoint (404).
 type PermissionResolver interface {
 	Resolve(id, decision string) bool
+}
+
+// Toolset lists the live tool surface (builtins + connector tools);
+// loop.Agent satisfies it. Nil disables the endpoint (404) — an agent
+// tools-allowlist picker degrades to free text.
+type Toolset interface {
+	Tools() []provider.ToolDef
 }
 
 // API serves brain's public routes.
@@ -65,7 +73,7 @@ var memoryRoutePatterns = []string{
 // is the reverse proxy to memoryd's management routes, admin the
 // proxy to the gateway's internal control plane, conns the local
 // connector control plane (nil leaves any of them unmounted).
-func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, token string, log *slog.Logger) {
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, toolset Toolset, token string, log *slog.Logger) {
 	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log}
 	if memories != nil {
 		for _, pattern := range memoryRoutePatterns {
@@ -76,6 +84,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	a.registerSettings(srv.Handle, flags)
 	a.registerAgents(srv.Handle, agentReg)
 	a.registerConnectors(srv.Handle, conns, goog)
+	a.registerTools(srv.Handle, toolset)
 	srv.Handle("GET /v1/sessions", a.auth(http.HandlerFunc(a.handleList)))
 	srv.Handle("POST /v1/sessions", a.auth(http.HandlerFunc(a.handleCreate)))
 	srv.Handle("GET /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleTranscript)))

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -90,6 +90,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	srv.Handle("GET /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleTranscript)))
 	srv.Handle("PATCH /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleUpdate)))
 	srv.Handle("POST /v1/sessions/{id}/messages", a.auth(http.HandlerFunc(a.handleMessages)))
+	srv.Handle("POST /v1/sessions/{id}/messages/retry", a.auth(http.HandlerFunc(a.handleRetry)))
 	srv.Handle("POST /v1/permissions/{id}", a.auth(http.HandlerFunc(a.handlePermission)))
 	// Deprecated shim: same behavior, session_id in the body.
 	srv.Handle("POST /v1/chat", a.auth(http.HandlerFunc(a.handleChatShim)))
@@ -312,7 +313,9 @@ func (a *API) handleMessages(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusInternalServerError, "get_failed", err.Error())
 		return
 	}
-	a.streamTurn(w, r, req)
+	a.streamTurn(w, r, func(ctx context.Context) (string, <-chan stream.StreamEvent, error) {
+		return a.svc.Chat(ctx, req)
+	})
 }
 
 // handleChatShim keeps the original /v1/chat contract alive for one
@@ -326,7 +329,32 @@ func (a *API) handleChatShim(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Deprecation", "true")
 	w.Header().Set("Link", `</v1/sessions/{id}/messages>; rel="successor-version"`)
-	a.streamTurn(w, r, req)
+	a.streamTurn(w, r, func(ctx context.Context) (string, <-chan stream.StreamEvent, error) {
+		return a.svc.Chat(ctx, req)
+	})
+}
+
+// handleRetry re-runs the session's last turn without re-persisting
+// the user message: Chat already leaves it durable even on failure
+// (chat.Service.Retry's doc explains why), so a naive resend of
+// /messages would double it. Same terminal SSE contract as /messages.
+func (a *API) handleRetry(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	if !validSessionID(sessionID) {
+		jsonError(w, http.StatusNotFound, "not_found", "no such session")
+		return
+	}
+	if _, err := a.dir.Get(r.Context(), sessionID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			jsonError(w, http.StatusNotFound, "not_found", "no such session")
+			return
+		}
+		jsonError(w, http.StatusInternalServerError, "get_failed", err.Error())
+		return
+	}
+	a.streamTurn(w, r, func(ctx context.Context) (string, <-chan stream.StreamEvent, error) {
+		return a.svc.Retry(ctx, sessionID)
+	})
 }
 
 // meta is brain's terminal SSE event: session identity plus whatever
@@ -347,11 +375,18 @@ type meta struct {
 	LedgerID  string        `json:"ledger_id,omitempty"`
 }
 
-func (a *API) streamTurn(w http.ResponseWriter, r *http.Request, req chat.Request) {
-	sessionID, events, err := a.svc.Chat(r.Context(), req)
+// streamTurn runs run (chat.Service.Chat or Retry) and relays its
+// terminal-contract channel to the client as SSE; both callers only
+// differ in how the turn starts, not in how it streams or ends.
+func (a *API) streamTurn(w http.ResponseWriter, r *http.Request, run func(context.Context) (string, <-chan stream.StreamEvent, error)) {
+	sessionID, events, err := run(r.Context())
 	if err != nil {
 		if errors.Is(err, chat.ErrBadRequest) {
 			jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+		if errors.Is(err, chat.ErrNoRetryableTurn) {
+			jsonError(w, http.StatusConflict, "no_retryable_turn", err.Error())
 			return
 		}
 		// session_id rides the error when a row was already created so

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -174,6 +174,7 @@ func mux(a *API) *http.ServeMux {
 	m.Handle("GET /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleTranscript)))
 	m.Handle("PATCH /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleUpdate)))
 	m.Handle("POST /v1/sessions/{id}/messages", a.auth(http.HandlerFunc(a.handleMessages)))
+	m.Handle("POST /v1/sessions/{id}/messages/retry", a.auth(http.HandlerFunc(a.handleRetry)))
 	m.Handle("POST /v1/permissions/{id}", a.auth(http.HandlerFunc(a.handlePermission)))
 	m.Handle("POST /v1/chat", a.auth(http.HandlerFunc(a.handleChatShim)))
 	return m
@@ -484,6 +485,70 @@ func TestMessagesEndpointStreamsAndPersists(t *testing.T) {
 
 	if w = doMux(a, http.MethodPost, "/v1/sessions/missing/messages", `{"message":"x"}`); w.Code != http.StatusNotFound {
 		t.Fatalf("missing session message: %d", w.Code)
+	}
+}
+
+// TestRetryEndpoint covers the surface the tools-picker-adjacent retry
+// feature adds: a failed /messages call leaves a dangling user_message
+// (chat.Service never appends the assistant turn without EventDone),
+// and /messages/retry must reuse it — no request body, no duplicate.
+func TestRetryEndpoint(t *testing.T) {
+	t.Parallel()
+	a, dir, gw := testAPI(t, "tok", []stream.StreamEvent{
+		{Type: stream.EventError, Err: &stream.StreamError{Code: "chain_exhausted", Message: "boom"}},
+	})
+	id, _ := dir.Create(t.Context(), "t")
+
+	w := doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages", `{"message":"hello","route":"mini"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("initial send code = %d body=%s", w.Code, w.Body.String())
+	}
+
+	// A session with no dangling turn (never messaged, or already
+	// completed) has nothing to retry.
+	if w := doMux(a, http.MethodPost, "/v1/sessions/missing/messages/retry", ``); w.Code != http.StatusNotFound {
+		t.Fatalf("retry on missing session: code = %d", w.Code)
+	}
+
+	gw.events = okEvents()
+	w = doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages/retry", ``)
+	if w.Code != http.StatusOK {
+		t.Fatalf("retry code = %d body=%s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("X-Session-Id"); got != id {
+		t.Fatalf("X-Session-Id = %q, want %s", got, id)
+	}
+	if gw.got.Route != "mini" {
+		t.Fatalf("retried route = %q, want mini (the original message's persisted route)", gw.got.Route)
+	}
+
+	// persistTurn runs after the SSE body closes (close(out) unblocks
+	// the client write, persistence follows), so the assistant_turn
+	// isn't guaranteed durable the instant doMux returns.
+	want := []string{session.KindSessionStarted, session.KindUserMessage, session.KindAssistantTurn}
+	deadline := time.Now().Add(5 * time.Second)
+	var kinds []string
+	for {
+		events, err := dir.Events(t.Context(), id)
+		if err != nil {
+			t.Fatalf("Events: %v", err)
+		}
+		kinds = nil
+		for _, ev := range events {
+			kinds = append(kinds, ev.Kind)
+		}
+		if strings.Join(kinds, ",") == strings.Join(want, ",") || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if strings.Join(kinds, ",") != strings.Join(want, ",") {
+		t.Fatalf("kinds after retry = %v, want %v (no duplicated user_message)", kinds, want)
+	}
+
+	// The turn just completed — nothing left dangling to retry again.
+	if w := doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages/retry", ``); w.Code != http.StatusConflict {
+		t.Fatalf("retry after completion: code = %d, want 409", w.Code)
 	}
 }
 

--- a/internal/brain/api/connectors.go
+++ b/internal/brain/api/connectors.go
@@ -54,15 +54,15 @@ func (h *connectorAPI) oauthStart(w http.ResponseWriter, r *http.Request) {
 func (h *connectorAPI) oauthCallback(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	if errCode := q.Get("error"); errCode != "" {
-		http.Redirect(w, r, "/settings?tab=connectors&oauth_error="+url.QueryEscape(errCode), http.StatusFound)
+		http.Redirect(w, r, "/settings/connectors?oauth_error="+url.QueryEscape(errCode), http.StatusFound)
 		return
 	}
 	name, err := h.goog.HandleCallback(r.Context(), q.Get("state"), q.Get("code"))
 	if err != nil {
-		http.Redirect(w, r, "/settings?tab=connectors&oauth_error="+url.QueryEscape(err.Error()), http.StatusFound)
+		http.Redirect(w, r, "/settings/connectors?oauth_error="+url.QueryEscape(err.Error()), http.StatusFound)
 		return
 	}
-	http.Redirect(w, r, "/settings?tab=connectors&oauth_connected="+url.QueryEscape(name), http.StatusFound)
+	http.Redirect(w, r, "/settings/connectors?oauth_connected="+url.QueryEscape(name), http.StatusFound)
 }
 
 // failConnector maps the package's sentinel errors onto HTTP statuses;

--- a/internal/brain/api/tools.go
+++ b/internal/brain/api/tools.go
@@ -1,0 +1,26 @@
+package api
+
+import "net/http"
+
+// registerTools mounts a read-only listing of the live tool surface
+// (builtins + connector tools) — feeds the agent editor's tools
+// allowlist picker so a name is chosen from what actually exists,
+// never typed blind. nil toolset leaves the surface unmounted.
+func (a *API) registerTools(handle func(pattern string, h http.Handler), toolset Toolset) {
+	if toolset == nil {
+		return
+	}
+	handle("GET /v1/admin/tools", a.auth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defs := toolset.Tools()
+		out := make([]toolSummary, len(defs))
+		for i, d := range defs {
+			out[i] = toolSummary{Name: d.Name, Description: d.Description}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"tools": out})
+	})))
+}
+
+type toolSummary struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}

--- a/internal/brain/api/tools_test.go
+++ b/internal/brain/api/tools_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
+)
+
+type stubToolset struct{ defs []provider.ToolDef }
+
+func (s stubToolset) Tools() []provider.ToolDef { return s.defs }
+
+func TestToolsEndpointListsLiveSurface(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	m := mux(a)
+	a.registerTools(m.Handle, stubToolset{defs: []provider.ToolDef{
+		{Name: "web_search", Description: "Search the web", InputSchema: []byte(`{}`)},
+		{Name: "github_create_issue", Description: "Create a GitHub issue", InputSchema: []byte(`{}`)},
+	}})
+
+	req := httptest.NewRequest("GET", "/v1/admin/tools", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	body := decodeToolsBody(t, w.Body.Bytes())
+	if len(body.Tools) != 2 || body.Tools[0].Name != "web_search" || body.Tools[1].Name != "github_create_issue" {
+		t.Fatalf("tools = %+v", body.Tools)
+	}
+	// Only name/description are exposed — never the input schema
+	// (an implementation detail an allowlist picker doesn't need).
+	if body.Tools[0].Description != "Search the web" {
+		t.Fatalf("description = %q, want Search the web", body.Tools[0].Description)
+	}
+}
+
+func TestToolsEndpointRequiresAuth(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	m := mux(a)
+	a.registerTools(m.Handle, stubToolset{})
+
+	req := httptest.NewRequest("GET", "/v1/admin/tools", nil)
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	if w.Code != 401 {
+		t.Fatalf("unauthenticated status = %d, want 401", w.Code)
+	}
+}
+
+func TestToolsEndpointUnmountedWhenToolsetNil(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	m := mux(a)
+	a.registerTools(m.Handle, nil)
+
+	req := httptest.NewRequest("GET", "/v1/admin/tools", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	if w.Code == 200 {
+		t.Fatal("nil toolset must leave /v1/admin/tools unmounted, got 200")
+	}
+}
+
+type toolsBody struct {
+	Tools []struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	} `json:"tools"`
+}
+
+func decodeToolsBody(t *testing.T, raw []byte) toolsBody {
+	t.Helper()
+	var body toolsBody
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body
+}

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -296,6 +296,53 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	}); err != nil {
 		return sessionID, nil, err
 	}
+	return s.runTurn(ctx, sessionID, req.Message, req.ModelHint, req.SkillHint, skillBody, route, profile, firstExchange)
+}
+
+// ErrNoRetryableTurn marks a Retry call whose session isn't in a
+// retryable state — its last event isn't a user message left dangling
+// by a failed attempt (persistTurn only completes a turn on sawDone).
+var ErrNoRetryableTurn = errors.New("no retryable turn")
+
+// Retry re-runs generation for a session's last turn WITHOUT persisting
+// a second user_message: Chat unconditionally appends before streaming
+// (line above), so a failed attempt already leaves that message durable
+// with no assistant_turn after it. Retry reuses it verbatim — same
+// route/agent/model_hint the original request resolved to, since those
+// live on the persisted UserMessage, not the transient Request. A
+// skill_hint is NOT persisted (it's a rare, deliberate one-off pick),
+// so a retried turn never re-loads one.
+func (s *Service) Retry(ctx context.Context, sessionID string) (string, <-chan stream.StreamEvent, error) {
+	events, err := s.log.Events(ctx, sessionID)
+	if err != nil {
+		return sessionID, nil, err
+	}
+	last, ok := lastUserMessage(events)
+	if !ok {
+		return sessionID, nil, fmt.Errorf("chat: %w: session has no retryable turn", ErrNoRetryableTurn)
+	}
+	firstExchange := isOnlyUserMessage(events)
+
+	profile := agents.Agent{Memory: true}
+	if s.agents != nil {
+		var known bool
+		profile, known = s.agents(ctx, last.Agent)
+		if !known {
+			return sessionID, nil, fmt.Errorf("chat: %w: unknown agent %q", ErrBadRequest, last.Agent)
+		}
+	}
+	route := last.Route
+	if route == "" {
+		route = defaultRoute
+	}
+	return s.runTurn(ctx, sessionID, last.Text, last.ModelHint, "", "", route, profile, firstExchange)
+}
+
+// runTurn is the shared tail of Chat and Retry: compact, project
+// context, assemble the system prompt, stream, and relay. The caller
+// has already ensured exactly the right user_message sits durable at
+// the end of the log — this never appends one itself.
+func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, skillHint, skillBody, route string, profile agents.Agent, firstExchange bool) (string, <-chan stream.StreamEvent, error) {
 	// Pre-send guarantee: the context actually sent to the provider
 	// stays under budget even on the turn that crosses it. The
 	// post-turn pass below keeps sessions compacted ahead of time, so
@@ -308,7 +355,7 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 		}
 		cancel()
 	}
-	events, err = s.log.Events(ctx, sessionID)
+	events, err := s.log.Events(ctx, sessionID)
 	if err != nil {
 		return sessionID, nil, err
 	}
@@ -331,10 +378,10 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 		system += "\n\n# Agent: " + profile.Name + "\n\n" + profile.PromptOverlay
 	}
 	if skillBody != "" {
-		system += "\n\n# Skill: " + req.SkillHint + "\n\n" + skillBody
+		system += "\n\n# Skill: " + skillHint + "\n\n" + skillBody
 	}
 	if s.recall != nil && profile.Memory {
-		if block := s.recall(ctx, sessionID, req.Message); block != "" {
+		if block := s.recall(ctx, sessionID, userText); block != "" {
 			system += "\n\n" + block
 		}
 	}
@@ -344,7 +391,7 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 		Agent:     profile.Name,
 		ToolAllow: profile.Tools,
 		Purpose:   "chat",
-		ModelHint: req.ModelHint,
+		ModelHint: modelHint,
 		System:    system,
 		Messages:  msgs,
 		SessionID: sessionID,
@@ -354,7 +401,7 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	}
 
 	out := make(chan stream.StreamEvent)
-	go s.relay(ctx, sessionID, req.Message, route, profile, firstExchange, upstream, out)
+	go s.relay(ctx, sessionID, userText, route, profile, firstExchange, upstream, out)
 	return sessionID, out, nil
 }
 
@@ -627,4 +674,33 @@ func hasUserMessage(events []session.Event) bool {
 		}
 	}
 	return false
+}
+
+// lastUserMessage returns the log's last event when — and only when —
+// it is a user_message: the signature of a turn that never completed
+// (persistTurn only appends assistant_turn on sawDone). Any other
+// trailing kind means there's nothing dangling to retry.
+func lastUserMessage(events []session.Event) (session.UserMessage, bool) {
+	if len(events) == 0 || events[len(events)-1].Kind != session.KindUserMessage {
+		return session.UserMessage{}, false
+	}
+	var msg session.UserMessage
+	if err := json.Unmarshal(events[len(events)-1].Payload, &msg); err != nil {
+		return session.UserMessage{}, false
+	}
+	return msg, true
+}
+
+// isOnlyUserMessage reports whether events carries exactly one
+// user_message — the auto-title condition Chat computes as
+// firstExchange BEFORE appending its own; Retry checks the same thing
+// against the message already sitting in the log.
+func isOnlyUserMessage(events []session.Event) bool {
+	n := 0
+	for _, ev := range events {
+		if ev.Kind == session.KindUserMessage {
+			n++
+		}
+	}
+	return n == 1
 }

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -892,5 +893,82 @@ func TestAgentProfileShapesTurn(t *testing.T) {
 	}
 	if recalled || strings.Contains(sent.System, "MEMORY BLOCK") {
 		t.Fatal("memory recall ran for a memory-off agent")
+	}
+}
+
+// A failed attempt (no EventDone) leaves the user_message durable with
+// nothing after it — persistTurn only appends assistant_turn on
+// sawDone. Retry must reuse that message, not append a second one.
+func TestRetryReusesLastUserMessageWithoutDuplicating(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: []stream.StreamEvent{{Type: stream.EventError, Err: &stream.StreamError{Code: "boom", Message: "boom"}}}}
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "the question", Route: "mini"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 2 })
+	if kinds := log.kinds("s1"); strings.Join(kinds, ",") != strings.Join([]string{session.KindSessionStarted, session.KindUserMessage}, ",") {
+		t.Fatalf("kinds after failed attempt = %v, want a dangling user_message", kinds)
+	}
+
+	gw.mu.Lock()
+	gw.events = okEvents("the answer")
+	gw.mu.Unlock()
+
+	_, ch, err = s.Retry(t.Context(), "s1")
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+
+	kinds := log.kinds("s1")
+	want := []string{session.KindSessionStarted, session.KindUserMessage, session.KindAssistantTurn}
+	if strings.Join(kinds, ",") != strings.Join(want, ",") {
+		t.Fatalf("kinds after retry = %v, want %v (no duplicated user_message)", kinds, want)
+	}
+
+	sent := chatRequest(t, gw)
+	if sent.Route != "mini" {
+		t.Fatalf("retried route = %q, want mini (the original message's persisted route)", sent.Route)
+	}
+
+	events, _ := log.Events(t.Context(), "s1")
+	var turn session.AssistantTurn
+	if err := json.Unmarshal(events[2].Payload, &turn); err != nil {
+		t.Fatalf("decode turn: %v", err)
+	}
+	if turn.LLM.Message != "the answer" {
+		t.Fatalf("turn = %+v", turn)
+	}
+}
+
+// Retry on a session whose last event isn't a dangling user_message —
+// no messages at all, or a turn that already completed — has nothing
+// to retry and must reject rather than silently no-op or duplicate.
+func TestRetryRejectsWhenNothingToRetry(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	s := newService(&fakeGW{}, log)
+
+	if _, _, err := s.Retry(t.Context(), "s1"); !errors.Is(err, ErrNoRetryableTurn) {
+		t.Fatalf("Retry on empty session: err = %v, want ErrNoRetryableTurn", err)
+	}
+
+	gw := &fakeGW{events: okEvents("answer")}
+	s2 := newService(gw, log)
+	_, ch, err := s2.Chat(t.Context(), Request{SessionID: "s2", Message: "q", Route: "mini"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s2")) == 3 })
+
+	if _, _, err := s2.Retry(t.Context(), "s2"); !errors.Is(err, ErrNoRetryableTurn) {
+		t.Fatalf("Retry on a completed turn: err = %v, want ErrNoRetryableTurn", err)
 	}
 }

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -110,6 +110,15 @@ func (a *Agent) toolset() (Executor, []provider.ToolDef) {
 	return a.exec, a.defs
 }
 
+// Tools returns the live tool surface (builtins + connector tools,
+// SwapTools keeps it current) — for surfaces that need to list what's
+// available, like an agent's tools-allowlist picker, without executing
+// anything.
+func (a *Agent) Tools() []provider.ToolDef {
+	_, defs := a.toolset()
+	return defs
+}
+
 // SetOffloadThreshold overrides the offload size for one tool (D-019
 // "per-tool overridable"). A tool whose results are always small can
 // raise it; a chatty tool can lower it.

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -821,4 +821,11 @@ func TestSwapToolsChangesSurfaceForNewTurns(t *testing.T) {
 	if len(gw.requests) == 0 || len(gw.requests[0].Tools) != 1 || gw.requests[0].Tools[0].Name != "github_create_issue" {
 		t.Fatalf("first request tools = %+v, want only github_create_issue", gw.requests[0].Tools)
 	}
+
+	// Tools() reflects the same live swap — the surface a tools-
+	// allowlist picker would list.
+	got := a.Tools()
+	if len(got) != 1 || got[0].Name != "github_create_issue" || got[0].Description != "Create a GitHub issue" {
+		t.Fatalf("Tools() = %+v, want only github_create_issue", got)
+	}
 }

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -335,12 +335,27 @@ func (a *Admin) bootstrapRoutes(ctx context.Context, p router.ProviderRow) {
 	}
 	updates := router.BootstrapChain(p, existing)
 	for name, chain := range updates {
-		if _, err := db.Exec(ctx, `UPDATE routes SET chain = $2, updated_at = now() WHERE name = $1`,
-			name, jsonOr(chain, "[]")); err != nil {
+		// A route seeded from empty was unusable before (disabled by
+		// default, D-033) — bootstrap must flip it on, or the whole
+		// point of auto-fill (a freshly connected provider "just
+		// works") silently fails with a permanent no_route error.
+		// Appending a fallback to an already-configured route leaves
+		// enabled untouched: that route's on/off state is an
+		// operator decision bootstrap has no business overriding.
+		seeded := len(existing[name]) == 0
+		var err error
+		if seeded {
+			_, err = db.Exec(ctx, `UPDATE routes SET chain = $2, enabled = true, updated_at = now() WHERE name = $1`,
+				name, jsonOr(chain, "[]"))
+		} else {
+			_, err = db.Exec(ctx, `UPDATE routes SET chain = $2, updated_at = now() WHERE name = $1`,
+				name, jsonOr(chain, "[]"))
+		}
+		if err != nil {
 			a.log.Warn("route bootstrap: write chain", "route", name, "error", err)
 			continue
 		}
-		a.audit(ctx, "bootstrap", "route", name, nil, map[string]any{"chain": chain, "provider": p.ID})
+		a.audit(ctx, "bootstrap", "route", name, nil, map[string]any{"chain": chain, "provider": p.ID, "enabled": seeded})
 	}
 }
 

--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -523,21 +523,34 @@ func TestCreateBootstrapsFixedRoutes(t *testing.T) {
 	ctx := t.Context()
 	db, _ := pool.Get()
 
-	saved := map[string][]byte{}
+	type saved struct {
+		chain   []byte
+		enabled bool
+	}
+	origs := map[string]saved{}
 	for _, name := range []string{"default", "summarize", "embedding"} {
-		var chain []byte
-		if err := db.QueryRow(ctx, `SELECT chain FROM routes WHERE name = $1`, name).Scan(&chain); err != nil {
-			t.Fatalf("read %s chain: %v", name, err)
+		var s saved
+		if err := db.QueryRow(ctx, `SELECT chain, enabled FROM routes WHERE name = $1`, name).Scan(&s.chain, &s.enabled); err != nil {
+			t.Fatalf("read %s route: %v", name, err)
 		}
-		saved[name] = chain
+		origs[name] = s
 	}
 	defer func() {
-		for name, chain := range saved {
-			if _, err := db.Exec(ctx, `UPDATE routes SET chain = $2 WHERE name = $1`, name, chain); err != nil {
-				t.Errorf("restore %s chain: %v", name, err)
+		for name, s := range origs {
+			if _, err := db.Exec(ctx, `UPDATE routes SET chain = $2, enabled = $3 WHERE name = $1`, name, s.chain, s.enabled); err != nil {
+				t.Errorf("restore %s route: %v", name, err)
 			}
 		}
 	}()
+
+	// Force every fixed route disabled first — a seeded (was-empty)
+	// chain must flip enabled on; an appended (already-had-a-chain)
+	// fallback must leave it exactly as found.
+	for _, name := range []string{"default", "summarize", "embedding"} {
+		if _, err := db.Exec(ctx, `UPDATE routes SET chain = '[]', enabled = false WHERE name = $1`, name); err != nil {
+			t.Fatalf("reset %s route: %v", name, err)
+		}
+	}
 
 	id, err := adm.Create(ctx, Provider{
 		Name: adminMarker + "bootstrap", Kind: "api", Driver: "openaicompat",
@@ -570,6 +583,16 @@ func TestCreateBootstrapsFixedRoutes(t *testing.T) {
 		if last.ProviderID != id || last.Model != tc.wantModel {
 			t.Fatalf("%s chain tail = %+v, want provider %s model %s", tc.route, last, id, tc.wantModel)
 		}
+		if !byName[tc.route].Enabled {
+			t.Fatalf("%s enabled = false, want true: seeding an empty chain must make the route usable", tc.route)
+		}
+	}
+
+	// Disable default again (chain now non-empty) to prove the next
+	// bootstrap — a fallback append, not a seed — leaves enabled alone
+	// instead of silently re-enabling a route an operator turned off.
+	if _, err := db.Exec(ctx, `UPDATE routes SET enabled = false WHERE name = 'default'`); err != nil {
+		t.Fatalf("disable default: %v", err)
 	}
 
 	// A second, distinct provider appends as a further fallback —
@@ -598,6 +621,9 @@ func TestCreateBootstrapsFixedRoutes(t *testing.T) {
 		last := r.Chain[len(r.Chain)-1]
 		if last.ProviderID != secondID || last.Model != "chat-cheap" {
 			t.Fatalf("default chain tail = %+v, want second provider's chat-cheap appended last", last)
+		}
+		if r.Enabled {
+			t.Fatalf("default enabled = true, want false: appending a fallback must not override an operator's disable")
 		}
 	}
 }

--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -166,11 +166,27 @@ func TestProviderCRUDAuditsAndReloads(t *testing.T) {
 	if err := adm.PatchRoute(ctx, adminMarker+"cat", RoutePatch{Enabled: &off}); err != nil {
 		t.Fatalf("disable route: %v", err)
 	}
+	// This provider declares a chat-capable model, so Create also
+	// bootstrapped it into the shared default/summarize routes and
+	// (D-033 follow-up) enabled them — a second, unrelated enabled
+	// reference Delete's guard sees just as validly as the scoped one
+	// above. Strip it the same way the shared sweep does for
+	// leftovers, but inline: this test's own Delete call needs it gone
+	// NOW, not at teardown.
+	db, _ := pool.Get()
+	if _, err := db.Exec(ctx, `
+		UPDATE routes SET chain = (
+			SELECT COALESCE(jsonb_agg(e), '[]'::jsonb)
+			FROM jsonb_array_elements(chain) e
+			WHERE e->>'provider_id' <> $1
+		)
+		WHERE name IN ('default', 'summarize', 'embedding')`, id); err != nil {
+		t.Fatalf("strip bootstrapped chain refs: %v", err)
+	}
 	if err := adm.Delete(ctx, id); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
 
-	db, _ := pool.Get()
 	var actions []string
 	rows, err := db.Query(ctx, `SELECT action FROM admin_audit WHERE entity_id = $1 ORDER BY ts`, id)
 	if err != nil {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -103,28 +103,51 @@ export interface ChatStreamOptions {
 export async function chatStream(
   req: ChatRequest,
   onEvent: (ev: ChatEvent) => void,
-  { signal, onSession }: ChatStreamOptions = {},
+  opts: ChatStreamOptions = {},
 ): Promise<void> {
   const { session_id, ...body } = req
   const url = session_id ? `/v1/sessions/${session_id}/messages` : '/v1/chat'
+  return postSSE(url, session_id ? body : req, onEvent, opts)
+}
+
+// retryStream re-runs a session's last (failed) turn: the session
+// already carries the dangling user message server-side, so this
+// posts no body — retry has nothing new to say, just "try again".
+export async function retryStream(
+  sessionId: string,
+  onEvent: (ev: ChatEvent) => void,
+  opts: ChatStreamOptions = {},
+): Promise<void> {
+  return postSSE(`/v1/sessions/${sessionId}/messages/retry`, undefined, onEvent, opts)
+}
+
+// postSSE is chatStream and retryStream's shared body: POST, surface a
+// structured ChatError on failure, then relay the SSE stream until the
+// terminal meta event.
+async function postSSE(
+  url: string,
+  body: unknown,
+  onEvent: (ev: ChatEvent) => void,
+  { signal, onSession }: ChatStreamOptions,
+): Promise<void> {
   const res = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${getToken()}`,
     },
-    body: JSON.stringify(session_id ? body : req),
+    body: body !== undefined ? JSON.stringify(body) : undefined,
     signal,
   })
   if (!res.ok || !res.body) {
-    const body = await res.text().catch(() => '')
+    const text = await res.text().catch(() => '')
     let code: string | undefined
-    let message = body
+    let message = text
     let sessionId: string | undefined
     try {
-      const parsed = JSON.parse(body) as { error?: string; message?: string; session_id?: string }
+      const parsed = JSON.parse(text) as { error?: string; message?: string; session_id?: string }
       code = parsed.error
-      message = parsed.message ?? body
+      message = parsed.message ?? text
       sessionId = parsed.session_id || undefined
     } catch {
       // Non-JSON error body: keep the raw text.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3,6 +3,7 @@ import type {
   AdminConnector,
   AdminProvider,
   AdminRoute,
+  AdminTool,
   AvailableModel,
   BudgetStatus,
   CacheRow,
@@ -487,6 +488,13 @@ export async function testSecretBackend(
 export async function listAgents(): Promise<AdminAgent[]> {
   const { agents } = await request<{ agents: AdminAgent[] }>('/v1/admin/agents')
   return agents ?? []
+}
+
+// listTools lists the live tool surface (builtins + connector tools),
+// feeding the agent editor's tools allowlist picker.
+export async function listTools(): Promise<AdminTool[]> {
+  const { tools } = await request<{ tools: AdminTool[] }>('/v1/admin/tools')
+  return tools ?? []
 }
 
 export async function createAgent(a: Partial<AdminAgent>): Promise<string> {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -277,6 +277,14 @@ export interface AdminAgent {
   enabled: boolean
 }
 
+// AdminTool is one entry of the live tool surface (builtins +
+// connector tools) — feeds the agent editor's tools allowlist picker
+// so a name is chosen from what actually exists, never typed blind.
+export interface AdminTool {
+  name: string
+  description: string
+}
+
 // AdminConnector is one third-party integration the agent can call as
 // tools (MCP server or Google account). config is kind-specific; the
 // credential_ref names where its secret/tokens live.

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -86,6 +86,26 @@ describe('AssistantMessage', () => {
 
     expect(screen.getByTestId('error')).toHaveTextContent('chain_exhausted: all failed')
   })
+
+  it('shows a retry button only when onRetry is given, and calls it on click', () => {
+    const msg = play([
+      { type: 'error', error: { code: 'chain_exhausted', message: 'all failed', retryable: false } },
+      { type: 'meta', session_id: 's' },
+    ])
+    const { rerender } = render(<AssistantMessage msg={msg} />)
+    expect(screen.queryByTestId('retry-button')).not.toBeInTheDocument()
+
+    const onRetry = vi.fn()
+    rerender(<AssistantMessage msg={msg} onRetry={onRetry} />)
+    fireEvent.click(screen.getByTestId('retry-button'))
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+
+  it('omits the retry button when there is no error, even with onRetry given', () => {
+    const msg = play([{ type: 'chunk', text: 'all good' }, { type: 'meta', session_id: 's' }])
+    render(<AssistantMessage msg={msg} onRetry={vi.fn()} />)
+    expect(screen.queryByTestId('retry-button')).not.toBeInTheDocument()
+  })
 })
 
 describe('replay-only components', () => {

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -159,7 +159,16 @@ function formatDuration(ms: number): string {
   return `${(ms / 1000).toFixed(1)}s`
 }
 
-export function AssistantMessage({ msg }: { msg: AssistantState }) {
+export function AssistantMessage({
+  msg,
+  onRetry,
+}: {
+  msg: AssistantState
+  // Present only for the trailing item when it's safe to retry (an
+  // error and not mid-stream) — Chat.tsx decides that, this component
+  // just renders whatever it's handed.
+  onRetry?: () => void
+}) {
   const tokens = msg.meta?.usage
     ? `${msg.meta.usage.input_tokens}→${msg.meta.usage.output_tokens} tok`
     : null
@@ -210,9 +219,21 @@ export function AssistantMessage({ msg }: { msg: AssistantState }) {
         </Badge>
       ))}
       {msg.error && (
-        <Badge variant="destructive" data-testid="error">
-          {msg.error}
-        </Badge>
+        <div className="flex items-center gap-2">
+          <Badge variant="destructive" data-testid="error">
+            {msg.error}
+          </Badge>
+          {onRetry && (
+            <button
+              type="button"
+              data-testid="retry-button"
+              onClick={onRetry}
+              className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+            >
+              retry
+            </button>
+          )}
+        </div>
       )}
       {!msg.streaming && (Boolean(msg.meta?.provider) || msg.text !== '') && (
         <div className="flex items-center gap-1.5">

--- a/web/src/components/settings/AgentForm.tsx
+++ b/web/src/components/settings/AgentForm.tsx
@@ -8,6 +8,7 @@ import {
   SelectValue,
 } from '../ui/select'
 import { Field, Toggle } from './shared'
+import { ToolsPicker } from './ToolsPicker'
 import type { AdminAgent, AdminRoute } from '../../api/types'
 
 // slugify mirrors the backend's name rule: lowercase slug.
@@ -42,7 +43,7 @@ export function useAgentForm(agent?: AdminAgent) {
   const [overlay, setOverlay] = useState(agent?.prompt_overlay ?? '')
   const [route, setRoute] = useState(agent?.route ?? '')
   const [skillsText, setSkillsText] = useState(agent?.skills.join(', ') ?? '')
-  const [toolsText, setToolsText] = useState(agent?.tools.join(', ') ?? '')
+  const [tools, setTools] = useState<string[]>(agent?.tools ?? [])
   const [memory, setMemory] = useState(agent?.memory ?? true)
 
   const value: AgentFormValue = {
@@ -51,14 +52,14 @@ export function useAgentForm(agent?: AdminAgent) {
     overlay,
     route,
     skills: splitList(skillsText),
-    tools: splitList(toolsText),
+    tools,
     memory,
   }
 
   return {
     value,
     canSubmit: agent ? true : slugify(name) !== '',
-    fields: { name, setName, description, setDescription, overlay, setOverlay, route, setRoute, skillsText, setSkillsText, toolsText, setToolsText, memory, setMemory },
+    fields: { name, setName, description, setDescription, overlay, setOverlay, route, setRoute, skillsText, setSkillsText, tools, setTools, memory, setMemory },
   }
 }
 
@@ -140,13 +141,8 @@ export function AgentForm({
           className="mt-1.5 h-10"
         />
       </Field>
-      <Field label="Tools allowlist" hint="comma-separated; empty = all">
-        <Input
-          value={fields.toolsText}
-          onChange={(e) => fields.setToolsText(e.target.value)}
-          placeholder="web_search, web_fetch, shell"
-          className="mt-1.5 h-10"
-        />
+      <Field label="Tools allowlist" hint="pick from the live tool surface; empty = all">
+        <ToolsPicker value={fields.tools} onChange={fields.setTools} />
       </Field>
     </div>
   )

--- a/web/src/components/settings/ToolsPicker.tsx
+++ b/web/src/components/settings/ToolsPicker.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from 'react'
+import { ChevronDownIcon } from 'lucide-react'
+import { listTools } from '../../api/client'
+import type { AdminTool } from '../../api/types'
+import { Button } from '../ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '../ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
+
+// Module-level cache: the picker can render in every agent form; the
+// tool surface changes rarely (a connector enable/disable) and a
+// stale list self-heals on the next mount.
+let cachedTools: AdminTool[] | null = null
+
+function useTools(): AdminTool[] {
+  const [tools, setTools] = useState<AdminTool[]>(cachedTools ?? [])
+  useEffect(() => {
+    listTools().then(
+      (list) => {
+        cachedTools = list
+        setTools(list)
+      },
+      () => undefined,
+    )
+  }, [])
+  return tools
+}
+
+// ToolsPicker lets an agent's tools allowlist be built from the actual
+// live tool surface (builtins + connector tools, e.g. a GitHub
+// connector's "github_search_issues") instead of typed blind — the
+// exact composed name a connector tool gets is otherwise undiscoverable.
+// Falls back to comma-separated free text when the list is empty (the
+// admin endpoint failed to load, or a fresh install with no tools
+// wired yet), so the allowlist stays usable either way.
+export function ToolsPicker({
+  value,
+  onChange,
+}: {
+  value: string[]
+  onChange: (v: string[]) => void
+}) {
+  const tools = useTools()
+  const [open, setOpen] = useState(false)
+
+  const toggle = (name: string) => {
+    onChange(value.includes(name) ? value.filter((v) => v !== name) : [...value, name])
+  }
+
+  if (tools.length === 0) {
+    return (
+      <input
+        value={value.join(', ')}
+        onChange={(e) =>
+          onChange(
+            e.target.value
+              .split(',')
+              .map((s) => s.trim())
+              .filter(Boolean),
+          )
+        }
+        placeholder="web_search, web_fetch, shell"
+        className="mt-1.5 flex h-10 w-full rounded-lg border border-input bg-transparent px-3 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+      />
+    )
+  }
+
+  return (
+    <div className="mt-1.5">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="h-10 w-full justify-between font-normal"
+          >
+            <span className="truncate text-left">
+              {value.length === 0 ? 'All tools' : `${value.length} selected`}
+            </span>
+            <ChevronDownIcon className="size-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[min(92vw,24rem)] p-0" align="start">
+          <Command>
+            <CommandInput placeholder="Search tools…" />
+            <CommandList>
+              <CommandEmpty>No tool matches.</CommandEmpty>
+              <CommandGroup>
+                {tools.map((t) => (
+                  <CommandItem
+                    key={t.name}
+                    value={t.name}
+                    data-checked={value.includes(t.name) || undefined}
+                    onSelect={() => toggle(t.name)}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="font-mono text-xs">{t.name}</div>
+                      {t.description && (
+                        <div className="truncate text-xs text-muted-foreground">
+                          {t.description}
+                        </div>
+                      )}
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      {value.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {value.map((name) => (
+            <button
+              key={name}
+              type="button"
+              onClick={() => toggle(name)}
+              className="rounded-full bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground transition hover:bg-destructive/10 hover:text-destructive"
+              aria-label={`Remove ${name}`}
+            >
+              {name} ×
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router'
-import { answerPermission, ChatError, chatStream, getTranscript } from '../api/client'
+import { answerPermission, ChatError, chatStream, getTranscript, retryStream } from '../api/client'
 import type { ChatEvent } from '../api/types'
 import { Composer } from '../components/Composer'
 import {
@@ -198,6 +198,43 @@ export function Chat({
 
   const send = () => void sendMessage(draft, agent)
 
+  // retryLast re-runs the last (failed) turn: the session already
+  // carries the dangling user message server-side (chat.Service.Retry),
+  // so this resets the existing assistant item in place rather than
+  // appending a new user+assistant pair like sendMessage does.
+  const retryLast = async () => {
+    const sessionId = sessionRef.current
+    if (!sessionId || streaming) return
+    setStreaming(true)
+    pinnedRef.current = true
+    updateLast(() => emptyAssistant())
+
+    const controller = new AbortController()
+    abortRef.current = controller
+    try {
+      await retryStream(
+        sessionId,
+        (ev: ChatEvent) => updateLast((m) => applyEvent(m, ev)),
+        { signal: controller.signal },
+      )
+      refresh()
+    } catch (err) {
+      if (controller.signal.aborted) return
+      if (err instanceof ChatError) {
+        if (err.status === 401 || err.status === 503) onNeedToken()
+        updateLast((m) => ({ ...m, streaming: false, error: err.message }))
+      } else {
+        updateLast((m) => ({ ...m, streaming: false, error: String(err) }))
+      }
+    } finally {
+      abortRef.current = null
+      if (!controller.signal.aborted) {
+        setStreaming(false)
+        updateLast((m) => ({ ...m, streaming: false }))
+      }
+    }
+  }
+
   // Consume a home-screen intent exactly once: `send` fires the
   // message immediately, `draft` prefills the composer, `skillHint`
   // pins the chip. sendMessage takes hint explicitly here rather than
@@ -248,7 +285,7 @@ export function Chat({
             Could not load this session: {loadError}
           </div>
         )}
-        {items.map((item) => {
+        {items.map((item, i) => {
           switch (item.role) {
             case 'user':
               return <UserMessage key={item.id} text={item.text} />
@@ -259,7 +296,16 @@ export function Chat({
             case 'interrupted':
               return <InterruptedMessage key={item.id} text={item.text} />
             default:
-              return <AssistantMessage key={item.id} msg={item} />
+              return (
+                <AssistantMessage
+                  key={item.id}
+                  msg={item}
+                  // Retry only ever targets the trailing dangling turn
+                  // (the session's last event server-side) — never a
+                  // mid-transcript message.
+                  onRetry={i === items.length - 1 && !streaming ? retryLast : undefined}
+                />
+              )
           }
         })}
         <div ref={bottomRef} />


### PR DESCRIPTION
## Summary
- Agent editor's tools allowlist is now a real picker over the live tool surface (builtins + connector tools), not blind free-text.
- Fix: Google OAuth callback now redirects to `/settings/connectors` (path-based routing), not the old `?tab=` query param — fixes landing on the wrong tab and a success banner that never showed.
- Fix: route auto-bootstrap now enables a fixed route (`default`/`summarize`/`embedding`) the first time it seeds an empty chain — previously it wrote the chain but left `enabled=false`, so a freshly connected provider still hit `no_route`.
- New: retry a failed chat message without duplicating history — reuses the already-persisted user message instead of resending it.

## Test plan
- [x] Go unit + integration tests (`internal/brain/...`, `internal/gateway/admin/...`)
- [x] Frontend unit tests (`Message.test.tsx`, full suite) + `tsc -b` + prod build
- [x] Manually verified against the live stack: Gmail OAuth connect → correct tab + banner; GLM provider chat turn after bootstrap fix; tools picker rendering real tool names