### PR TITLE
Fix mini route, admin probe cost, ollama preset

### DIFF
--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -29,8 +29,10 @@ const (
 	autoAgentName = "auto"
 	// classifyRoute serves the auto-dispatch classification call —
 	// same cheap side-call route as auto-title, distillation, and
-	// extraction.
-	classifyRoute = "mini"
+	// extraction. "local" is a real, always-provisioned fixed route
+	// (migrations/0022_local_route.sql); "mini" was never seeded by
+	// any migration and every call on it failed with no_route.
+	classifyRoute = "local"
 	// defaultRoute serves plain chat turns when the caller picks
 	// nothing; the web UI exposes a per-message picker.
 	defaultRoute = "default"
@@ -606,7 +608,7 @@ func (s *Service) autoTitle(sessionID, userText, reply string) {
 	input := userText + "\n\n" + truncateRunes(reply, 200)
 
 	events, err := s.gw.Stream(ctx, gwclient.StreamRequest{
-		Route: "mini",
+		Route: classifyRoute,
 		Purpose:      "title",
 		System:       titleSystem,
 		Messages:     []provider.Message{{Role: "user", Content: input}},

--- a/internal/brain/loop/turnmemory.go
+++ b/internal/brain/loop/turnmemory.go
@@ -55,8 +55,11 @@ func distillOnce(ctx context.Context, gw Gateway, sessionID, turnText string) (*
 	ctx, cancel := context.WithTimeout(ctx, distillTimeout)
 	defer cancel()
 
+	// "local" is the real, always-provisioned fixed route
+	// (migrations/0022_local_route.sql); "mini" was never seeded by
+	// any migration and every call on it failed with no_route.
 	events, err := gw.Stream(ctx, gwclient.StreamRequest{
-		Route: "mini",
+		Route: "local",
 		Purpose:      "distill",
 		System:       distillSystem,
 		Messages:     []provider.Message{{Role: "user", Content: turnText}},

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -644,7 +644,7 @@ func (a *Admin) Test(ctx context.Context, id, model string) (TestResult, error) 
 		return TestResult{}, fmt.Errorf("provider %s has no default model; pass one", p.Name)
 	}
 
-	res := a.probe(ctx, drv, p.Name, model)
+	res := a.probe(ctx, drv, p.Name, model, snap.Prices(p.Name, model))
 	a.audit(ctx, "test", "provider", id, nil, res)
 	return res, nil
 }
@@ -678,7 +678,7 @@ func (a *Admin) Validate(ctx context.Context, p Provider, model string) (TestRes
 	}
 	drv, _ := reg.Get(p.Name)
 
-	res := a.probe(ctx, drv, p.Name, model)
+	res := a.probe(ctx, drv, p.Name, model, nil)
 	a.audit(ctx, "validate", "provider", p.Name, nil, res)
 	return res, nil
 }
@@ -726,7 +726,7 @@ func (a *Admin) credentialLookup() func(string) string {
 // probe runs one one-token completion against drv and books it under
 // purpose='test'. Shared by Test (persisted provider) and Validate
 // (unsaved config).
-func (a *Admin) probe(ctx context.Context, drv provider.Provider, providerName, model string) TestResult {
+func (a *Admin) probe(ctx context.Context, drv provider.Provider, providerName, model string, prices *router.ModelPrices) TestResult {
 	tctx, cancel := context.WithTimeout(ctx, testTimeout)
 	defer cancel()
 	start := time.Now()
@@ -753,6 +753,7 @@ func (a *Admin) probe(ctx context.Context, drv provider.Provider, providerName, 
 		}
 		if res.OK {
 			entry.Status = "ok"
+			entry.CostUSD = ledger.Cost(prices, entry.Usage)
 		} else {
 			entry.Status, entry.ErrorCode = "error", "provider_error"
 		}

--- a/internal/gateway/admin/admin_validate_integration_test.go
+++ b/internal/gateway/admin/admin_validate_integration_test.go
@@ -3,11 +3,16 @@
 package admin
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/router"
 )
@@ -87,6 +92,58 @@ func TestValidateProbesWithoutPersisting(t *testing.T) {
 	}
 	if _, err := adm.Validate(ctx, Provider{Name: name, Kind: "api", Driver: "openaicompat", BaseURL: srv.URL}, ""); err == nil {
 		t.Fatal("missing model accepted")
+	}
+}
+
+func TestConnectionProbePricesACostedModel(t *testing.T) {
+	adm, _, pool := testAdmin(t)
+	ctx := t.Context()
+	srv := stubOpenAI(t)
+	name := adminMarker + "priced-probe"
+
+	id, err := adm.Create(ctx, Provider{
+		Name: name, Kind: "api", Driver: "openaicompat", BaseURL: srv.URL,
+		DefaultModel: "m-alpha",
+		Models: []router.ModelInfo{
+			{ID: "m-alpha", Prices: &router.ModelPrices{InputPerMTok: 1, OutputPerMTok: 2}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer ccancel()
+		conn, err := pgx.Connect(cctx, os.Getenv("DATABASE_URL"))
+		if err != nil {
+			t.Errorf("cleanup connect: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close(cctx) }()
+		if _, err := conn.Exec(cctx, "DELETE FROM admin_audit WHERE entity_id = $1", id); err != nil {
+			t.Errorf("cleanup probe audit rows: %v", err)
+		}
+	})
+
+	res, err := adm.Test(ctx, id, "m-alpha")
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("Test = %+v, want ok", res)
+	}
+
+	// stubOpenAI reports 2 prompt + 1 completion token; at $1/$2 per
+	// million that's (2*1 + 1*2) / 1e6.
+	const want = (2*1.0 + 1*2.0) / 1_000_000.0
+	db, _ := pool.Get()
+	var got float64
+	if err := db.QueryRow(ctx, `SELECT cost_usd FROM cost_ledger
+		WHERE provider = $1 ORDER BY ts DESC LIMIT 1`, name).Scan(&got); err != nil {
+		t.Fatalf("ledger row: %v", err)
+	}
+	if got != want {
+		t.Fatalf("cost_usd = %v, want %v", got, want)
 	}
 }
 

--- a/web/src/components/settings/ProviderAdd.tsx
+++ b/web/src/components/settings/ProviderAdd.tsx
@@ -157,6 +157,8 @@ export function ProviderAdd() {
     if (!tested) return
     setBusy(true)
     try {
+      const trimmedModel = model.trim()
+      const prices = (modelCatalog[preset.id] ?? []).find((m) => m.id === trimmedModel)?.prices
       await createProvider({
         name: name.trim(),
         kind: 'api',
@@ -164,8 +166,8 @@ export function ProviderAdd() {
         base_url: isBedrock ? region.trim() : baseURL.trim(),
         credential_ref: effectiveRef.trim(),
         headers: {},
-        default_model: model.trim(),
-        models: [{ id: model.trim() }],
+        default_model: trimmedModel,
+        models: [{ id: trimmedModel, ...(prices ? { prices } : {}) }],
         enabled: true,
       })
       toast.success('Provider added', { description: `${name.trim()} is connected and ready to route to.` })

--- a/web/src/components/settings/ProviderEdit.test.tsx
+++ b/web/src/components/settings/ProviderEdit.test.tsx
@@ -75,6 +75,27 @@ describe('ProviderEdit models section', () => {
     )
   })
 
+  it('carries catalog pricing onto a model that matches a priced catalog entry', async () => {
+    vi.mocked(patchProvider).mockResolvedValue()
+    renderPage()
+
+    const input = await screen.findByPlaceholderText('model id')
+    fireEvent.change(input, { target: { value: 'amazon.nova-lite-v1:0' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() =>
+      expect(patchProvider).toHaveBeenCalledWith('p1', {
+        models: [
+          {
+            id: 'amazon.nova-lite-v1:0',
+            prices: { input_per_mtok: 0.06, output_per_mtok: 0.24 },
+          },
+        ],
+        default_model: 'amazon.nova-lite-v1:0',
+      }),
+    )
+  })
+
   it('adds an embeddings model with the capability flag and leaves default_model untouched', async () => {
     vi.mocked(patchProvider).mockResolvedValue()
     renderPage()

--- a/web/src/components/settings/ProviderEdit.tsx
+++ b/web/src/components/settings/ProviderEdit.tsx
@@ -372,7 +372,12 @@ function ModelsSection({ provider, onChanged }: { provider: AdminProvider; onCha
   const add = async () => {
     const trimmed = entry.trim()
     if (!trimmed || declared.has(trimmed)) return
-    const model: AdminModel = embeddings ? { id: trimmed, capabilities: ['embeddings'] } : { id: trimmed }
+    const prices = (modelCatalog[preset.id] ?? []).find((m) => m.id === trimmed)?.prices
+    const model: AdminModel = {
+      id: trimmed,
+      ...(embeddings ? { capabilities: ['embeddings'] } : {}),
+      ...(prices ? { prices } : {}),
+    }
     const models = [...provider.models, model]
     await patchModels(models, embeddings ? undefined : provider.default_model || trimmed)
     setEntry('')

--- a/web/src/components/settings/modelCatalog.ts
+++ b/web/src/components/settings/modelCatalog.ts
@@ -85,6 +85,7 @@ export const modelCatalog: Record<string, CatalogModel[]> = {
     { id: 'llama3.2', name: 'Llama 3.2', prices: { input_per_mtok: 0, output_per_mtok: 0 } },
     { id: 'llama3.1', name: 'Llama 3.1', prices: { input_per_mtok: 0, output_per_mtok: 0 } },
     { id: 'qwen2.5', name: 'Qwen 2.5', prices: { input_per_mtok: 0, output_per_mtok: 0 } },
+    { id: 'qwen2.5:7b', name: 'Qwen 2.5 7B', prices: { input_per_mtok: 0, output_per_mtok: 0 } },
     { id: 'mistral', name: 'Mistral', prices: { input_per_mtok: 0, output_per_mtok: 0 } },
     { id: 'deepseek-r1', name: 'DeepSeek R1', prices: { input_per_mtok: 0, output_per_mtok: 0 } },
     { id: 'gemma2', name: 'Gemma 2', prices: { input_per_mtok: 0, output_per_mtok: 0 } },

--- a/web/src/components/settings/presets.ts
+++ b/web/src/components/settings/presets.ts
@@ -104,11 +104,12 @@ export const providerPresets: ProviderPreset[] = [
     description: 'Local models, no key needed',
     logo: 'ollama',
     brandColor: '#4B5563',
-    // The gateway runs in Docker; host.docker.internal reaches an
-    // Ollama serving on the host machine.
-    baseURL: 'http://host.docker.internal:11434/v1',
+    // The gateway runs in Docker; the ollama compose service is the
+    // one actually deployed (see deploy/docker-compose.yml) — reached
+    // by its service name on the shared network, not the host.
+    baseURL: 'http://ollama:11434/v1',
     requiresKey: false,
-    validateModel: 'llama3.2',
+    validateModel: 'qwen2.5:7b',
   },
   {
     id: 'custom',

--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -230,7 +230,7 @@ describe('Providers tab', () => {
       expect.objectContaining({
         enabled: true,
         default_model: 'glm-5.2',
-        models: [{ id: 'glm-5.2' }],
+        models: [{ id: 'glm-5.2', prices: { input_per_mtok: 1.4, output_per_mtok: 4.4 } }],
       }),
     )
   })


### PR DESCRIPTION
## Summary
- `classifyRoute` pointed at a "mini" route that no migration ever seeded — every auto-title and memory-distillation call failed silently since the route system was introduced. Repointed to "local" (real, seeded, already chained to a working model).
- `Admin.probe()` never called `ledger.Cost()`, so Test/Validate connection pings always showed null cost regardless of pricing. `Test()` now prices against the snapshot; `Validate()` stays unpriced (unpersisted config, no snapshot entry).
- ProviderAdd/ProviderEdit's "add a model" flows now carry a matching `modelCatalog.ts` price onto newly added models automatically.
- Ollama preset was still pointed at `host.docker.internal:11434/v1` + `llama3.2`, stale since Ollama became its own compose service — fixed to `http://ollama:11434/v1` + `qwen2.5:7b` (what's actually deployed/pulled).

## Test plan
- [x] `make build` / `make vet` — clean
- [x] `go test -race` for chat/loop/gwclient packages — pass
- [x] Admin integration tests incl. new `TestConnectionProbePricesACostedModel` — pass against live DB
- [x] `npm run test -- --run` (web) — 110/110 pass
- [x] `npm run build` (web) — clean
- [x] Verified live: fresh chat message now auto-titles ("Capital of France?"); GLM chat message showed correct non-null cost_usd