### PR TITLE
feat(missions): scheduler, notifications, web UI, and hardened harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,3 +74,9 @@ down:
 
 logs:
 	$(COMPOSE) logs -f
+
+# Golden-mission regression gate: runs one research mission end-to-end
+# against the live stack and asserts it completes unattended (no parks,
+# harness-verified artifacts, bounded turns). Needs the stack up.
+canary:
+	./scripts/canary-mission.sh

--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
 	"github.com/SumonMSelim/timothy/internal/brain/loop"
 	"github.com/SumonMSelim/timothy/internal/brain/memclient"
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
 	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/brain/settings"
 	"github.com/SumonMSelim/timothy/internal/brain/skills"
@@ -30,10 +31,10 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/tools/builtin"
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
-	"github.com/SumonMSelim/timothy/internal/secretstore"
 	"github.com/SumonMSelim/timothy/internal/platform/httpserver"
 	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
 	"github.com/SumonMSelim/timothy/internal/platform/service"
+	"github.com/SumonMSelim/timothy/internal/secretstore"
 	"github.com/SumonMSelim/timothy/migrations"
 )
 
@@ -149,6 +150,11 @@ func main() {
 		go runConnectorReload(ctx, conns, app.Log)
 	}
 
+	missionStore, missionDriver, missionNotifier := buildMissions(app.DB, agent, store, workspace, app.Log)
+	if missionDriver != nil {
+		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, app.Log)
+	}
+
 	agentReg := agents.NewStore(app.DB, app.Log)
 	svc := chat.New(turnRouter{agent: agent, gw: gwc, flags: flags}, store, distill,
 		gatedCompactor{inner: compactor, flags: flags}, budgetFn, packs, flags.SkillAllowed,
@@ -192,7 +198,7 @@ func main() {
 
 	api.Register(app.Server, svc, store, broker,
 		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, app.Log), flags,
-		agentReg, conns, goog, agent, token, app.Log)
+		agentReg, conns, goog, agent, missionStore, missionDriver, missionNotifier, token, app.Log)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)
@@ -235,6 +241,50 @@ func buildConnectors(db *pgpool.Pool, log *slog.Logger) (*connectors.Manager, *c
 		log.Warn("MARKITDOWN_URL not set; gmail_read falls back to a snippet for HTML-only mail, and gmail_read_attachment is unavailable")
 	}
 	return mgr, goog
+}
+
+// missionWorkSlotMax bounds how many missions may be status='working'
+// at once — a conservative default until this needs to be a runtime
+// setting.
+const missionWorkSlotMax = 4
+
+// buildMissions wires the mission engine (Store, Driver, Notifier,
+// Scheduler). Gated on WORKSPACES: no workspace root configured means
+// missions stay entirely inert — no goroutines started, nothing
+// scheduled, the API surface unmounted (registerMissions 404s on a nil
+// store).
+func buildMissions(db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier) {
+	root := os.Getenv("WORKSPACES")
+	if root == "" {
+		log.Info("WORKSPACES not set; missions disabled")
+		return nil, nil, nil
+	}
+	store := missions.NewStore(db, log)
+	workspace := missions.NewWorkspace(root, log)
+	parker := missions.NewStorePermissionParker(store, log)
+	// MISSION_MODEL_FLOOR lists model-name substrings (comma-separated)
+	// too weak to drive tool-using mission turns; a turn served by one
+	// pauses the mission immediately instead of burning its iteration
+	// budget. Unset = floor disabled.
+	var floorDeny []string
+	for _, s := range strings.Split(os.Getenv("MISSION_MODEL_FLOOR"), ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			floorDeny = append(floorDeny, s)
+		}
+	}
+	runner := missions.NewNativeRunnerWithFloor(agent, parker, floorDeny, log)
+	webhookURL := os.Getenv("NOTIFY_WEBHOOK_URL")
+	notifier := missions.NewNotifier(db, webhookURL, log)
+	// A second tools.Permissions instance, not the one buildAgent built —
+	// it's stateless besides the shared db/root (Grant/Resolve hit
+	// Postgres directly), so a fresh instance behaves identically. Used
+	// only to pre-authorize a mission's hidden session at creation.
+	perms := tools.NewPermissions(db, toolWorkspaceRoot)
+	driver := missions.NewDriver(store, runner, workspace, notifier, sessions, perms, log)
+
+	scheduler := missions.NewScheduler(db, store, log)
+	go scheduler.Run(context.Background())
+	return store, driver, notifier
 }
 
 // memoryProxy forwards the web's memory-management routes to memoryd

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -17,8 +17,13 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 # Brain's shell tool needs /bin/sh; alpine provides busybox sh while
 # staying minimal. Select with build target runtime-shell. Everything
-# else keeps the distroless default (last stage).
+# else keeps the distroless default (last stage). curl is installed
+# explicitly: busybox wget is present by default, but plan/verify_cmd
+# content (model-authored) reaches for curl as the more common default,
+# and a missing binary fails a verify_cmd with a misleading exit code
+# instead of a clear "not found".
 FROM alpine:3.22.2 AS runtime-shell
+RUN apk add --no-cache curl
 COPY --from=build /out/app /app
 COPY skills/ /skills/
 RUN mkdir -p /workspace && chown nobody:nobody /workspace

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -93,6 +93,9 @@ services:
       TIMOTHY_PUBLIC_URL: ${TIMOTHY_PUBLIC_URL:-}
       # Where the shell tool runs; the only tree tools may touch.
       WORKSPACE_ROOT: /workspace
+      # Root for mission workspaces/worktrees; unset disables the
+      # missions feature entirely (API surface stays unmounted).
+      WORKSPACES: /workspace/missions
       # Compose-internal only: the model never sees this address.
       SEARXNG_URL: http://searxng:8080
       # Converts Gmail attachments (PDFs) and HTML-only email bodies to

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/pkoukk/tiktoken-go-loader v0.0.2
 	github.com/prometheus/client_golang v1.23.2
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	golang.org/x/net v0.57.0
 	golang.org/x/sync v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/agents"
 	"github.com/SumonMSelim/timothy/internal/brain/chat"
 	"github.com/SumonMSelim/timothy/internal/brain/connectors"
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
 	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/brain/settings"
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
@@ -73,7 +74,7 @@ var memoryRoutePatterns = []string{
 // is the reverse proxy to memoryd's management routes, admin the
 // proxy to the gateway's internal control plane, conns the local
 // connector control plane (nil leaves any of them unmounted).
-func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, toolset Toolset, token string, log *slog.Logger) {
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, toolset Toolset, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, token string, log *slog.Logger) {
 	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log}
 	if memories != nil {
 		for _, pattern := range memoryRoutePatterns {
@@ -85,6 +86,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	a.registerAgents(srv.Handle, agentReg)
 	a.registerConnectors(srv.Handle, conns, goog)
 	a.registerTools(srv.Handle, toolset)
+	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg)
 	srv.Handle("GET /v1/sessions", a.auth(http.HandlerFunc(a.handleList)))
 	srv.Handle("POST /v1/sessions", a.auth(http.HandlerFunc(a.handleCreate)))
 	srv.Handle("GET /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleTranscript)))

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -1,0 +1,265 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/SumonMSelim/timothy/internal/brain/agents"
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+// defaultMissionRoute mirrors chat.defaultRoute: an agent's empty
+// route means "the default chain," but the gateway's /v1/stream
+// requires a real, non-empty route name.
+const defaultMissionRoute = "default"
+
+// registerMissions mounts the mission surface: served locally,
+// missions are brain's domain like agents and connectors. nil store
+// leaves the surface unmounted (404s), matching the memories/admin/
+// agents gating pattern. agentReg resolves a mission's route/
+// review_route/budget/approval_allowlist defaults from the chosen
+// agent when the create request omits them.
+func (a *API) registerMissions(handle func(pattern string, h http.Handler), store *missions.Store, driver *missions.Driver, notifier *missions.Notifier, agentReg *agents.Store) {
+	if store == nil {
+		return
+	}
+	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, perms: a.perms, log: a.log}
+	handle("GET /v1/missions", a.auth(http.HandlerFunc(h.list)))
+	handle("POST /v1/missions", a.auth(http.HandlerFunc(h.create)))
+	handle("GET /v1/missions/{id}", a.auth(http.HandlerFunc(h.get)))
+	handle("GET /v1/missions/{id}/events", a.auth(http.HandlerFunc(h.events)))
+	handle("POST /v1/missions/{id}/resume", a.auth(http.HandlerFunc(h.resume)))
+	handle("POST /v1/missions/{id}/cancel", a.auth(http.HandlerFunc(h.cancel)))
+	handle("POST /v1/missions/{id}/permission", a.auth(http.HandlerFunc(h.permission)))
+	handle("GET /v1/notifications", a.auth(http.HandlerFunc(h.notifications)))
+	handle("POST /v1/notifications/{id}/read", a.auth(http.HandlerFunc(h.markRead)))
+}
+
+type missionAPI struct {
+	store    *missions.Store
+	driver   *missions.Driver
+	notifier *missions.Notifier
+	agentReg *agents.Store
+	// perms answers a mission's pending_permission — the same
+	// PermissionResolver chat sessions use (A.perms), never a
+	// mission-specific broker.
+	perms PermissionResolver
+	log   *slog.Logger
+}
+
+func failMission(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, missions.ErrNotFound):
+		jsonError(w, http.StatusNotFound, "not_found", err.Error())
+	case errors.Is(err, missions.ErrBranchConflict):
+		jsonError(w, http.StatusConflict, "branch_conflict", err.Error())
+	case errors.Is(err, missions.ErrTerminal):
+		jsonError(w, http.StatusConflict, "already_finished", err.Error())
+	default:
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+	}
+}
+
+func (h *missionAPI) list(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.store.List(r.Context())
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "missions_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"missions": rows})
+}
+
+type createMissionRequest struct {
+	Goal          string   `json:"goal"`
+	Kind          string   `json:"kind"`
+	AgentID       string   `json:"agent_id"`
+	Route         string   `json:"route"`
+	ReviewRoute   string   `json:"review_route"`
+	MaxIterations int      `json:"max_iterations"`
+	BudgetUSD     *float64 `json:"budget_usd"`
+	RepoPath      string   `json:"repo_path"`
+	// AutoApproveSafe defaults true (a pointer so an omitted field is
+	// distinguishable from an explicit false) — missions run for hours
+	// unattended, so auto-approving DangerSafe shell calls is the
+	// sensible default; destructive commands always ask regardless.
+	AutoApproveSafe *bool `json:"auto_approve_safe"`
+}
+
+// create validates the request, resolves route/review_route/budget
+// defaults from the chosen agent when the request omits them, and
+// hands off to Driver.Create — provisioning and the mission's first
+// turn happen in the background; this returns {id} immediately.
+func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
+	var req createMissionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if req.Goal == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "goal is required")
+		return
+	}
+	switch req.Kind {
+	case "coding", "research", "scheduled":
+	default:
+		jsonError(w, http.StatusBadRequest, "bad_request", `kind must be "coding", "research", or "scheduled"`)
+		return
+	}
+	if req.Kind == "coding" && req.RepoPath == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "repo_path is required for coding missions")
+		return
+	}
+
+	// Resolve even with an empty AgentID: agents.Resolve("") falls back
+	// to the default agent, same as chat sessions that don't pick one —
+	// a mission created without an explicit agent still needs a real
+	// route, not an empty string the gateway will reject.
+	if h.agentReg != nil {
+		if a, ok := h.agentReg.Resolve(r.Context(), req.AgentID); ok {
+			if req.Route == "" {
+				req.Route = a.Route
+			}
+			if req.ReviewRoute == "" {
+				req.ReviewRoute = a.ReviewRoute
+			}
+			if req.BudgetUSD == nil {
+				req.BudgetUSD = a.BudgetUSD
+			}
+		}
+	}
+	// An agent's route (and this handler's own fallback) can still be
+	// "" — that's each agent's shorthand for "the default chain," same
+	// as chat.defaultRoute — but the gateway requires a real route
+	// name, so the substitution has to happen somewhere concrete.
+	if req.Route == "" {
+		req.Route = defaultMissionRoute
+	}
+	if req.ReviewRoute == "" {
+		req.ReviewRoute = defaultMissionRoute
+	}
+
+	autoApproveSafe := true
+	if req.AutoApproveSafe != nil {
+		autoApproveSafe = *req.AutoApproveSafe
+	}
+	m := missions.Mission{
+		Goal: req.Goal, Kind: req.Kind, AgentID: req.AgentID,
+		Route: req.Route, ReviewRoute: req.ReviewRoute,
+		MaxIterations: req.MaxIterations, BudgetUSD: req.BudgetUSD,
+		AutoApproveSafe: autoApproveSafe,
+	}
+	id, err := h.driver.Create(r.Context(), m, req.RepoPath)
+	if err != nil {
+		failMission(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]string{"id": id})
+}
+
+func (h *missionAPI) get(w http.ResponseWriter, r *http.Request) {
+	m, err := h.store.Get(r.Context(), r.PathValue("id"))
+	if err != nil {
+		failMission(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, m)
+}
+
+func (h *missionAPI) events(w http.ResponseWriter, r *http.Request) {
+	events, err := h.store.Events(r.Context(), r.PathValue("id"))
+	if err != nil {
+		failMission(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"events": events})
+}
+
+func (h *missionAPI) resume(w http.ResponseWriter, r *http.Request) {
+	if err := h.driver.Signal(r.Context(), r.PathValue("id"), missions.InputResume); err != nil {
+		failMission(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *missionAPI) cancel(w http.ResponseWriter, r *http.Request) {
+	if err := h.driver.Signal(r.Context(), r.PathValue("id"), missions.InputCancel); err != nil {
+		failMission(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// permission answers a mission's pending_permission — the SAME
+// permission broker chat sessions use (a.perms), keyed by the
+// broker-issued id stored on the mission row rather than a session id.
+// No mission-specific broker exists; a mission's pending_permission is
+// only ever set by the same interactive-prompt code path chat already
+// goes through.
+func (h *missionAPI) permission(w http.ResponseWriter, r *http.Request) {
+	if h.perms == nil {
+		jsonError(w, http.StatusNotFound, "not_found", "permissions are not enabled")
+		return
+	}
+	m, err := h.store.Get(r.Context(), r.PathValue("id"))
+	if err != nil {
+		failMission(w, err)
+		return
+	}
+	if m.PendingPermission == "" {
+		jsonError(w, http.StatusNotFound, "not_found", "this mission has no pending permission request")
+		return
+	}
+	var body struct {
+		Decision string `json:"decision"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", "body must be JSON with a decision field")
+		return
+	}
+	switch body.Decision {
+	case "once", "session", "deny":
+	default:
+		jsonError(w, http.StatusBadRequest, "bad_request", `decision must be "once", "session", or "deny"`)
+		return
+	}
+	if !h.perms.Resolve(m.PendingPermission, body.Decision) {
+		jsonError(w, http.StatusNotFound, "not_found", "unknown or already-answered permission request")
+		return
+	}
+	// Best-effort: the decision already took effect (Resolve above
+	// unparked the turn); a failure to log it is a missing Timeline
+	// entry, not a wrong mission state, so it must not fail this request.
+	if err := h.store.AppendEvent(r.Context(), m.ID, "mission.permission_answered",
+		map[string]any{"tool": m.PendingPermissionTool, "decision": body.Decision}); err != nil {
+		h.log.Warn("mission: record permission_answered event failed", "mission_id", m.ID, "error", err)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *missionAPI) notifications(w http.ResponseWriter, r *http.Request) {
+	if h.notifier == nil {
+		jsonError(w, http.StatusNotFound, "not_found", "notifications are not enabled")
+		return
+	}
+	rows, err := h.notifier.List(r.Context())
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "notifications_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"notifications": rows})
+}
+
+func (h *missionAPI) markRead(w http.ResponseWriter, r *http.Request) {
+	if h.notifier == nil {
+		jsonError(w, http.StatusNotFound, "not_found", "notifications are not enabled")
+		return
+	}
+	if err := h.notifier.MarkRead(r.Context(), r.PathValue("id")); err != nil {
+		jsonError(w, http.StatusInternalServerError, "mark_read_failed", err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMissionsEndpointsUnmountedWhenStoreNil(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	m := mux(a)
+	a.registerMissions(m.Handle, nil, nil, nil, nil)
+
+	for _, req := range []struct{ method, path string }{
+		{"GET", "/v1/missions"},
+		{"POST", "/v1/missions"},
+		{"GET", "/v1/missions/abc"},
+		{"GET", "/v1/missions/abc/events"},
+		{"POST", "/v1/missions/abc/resume"},
+		{"POST", "/v1/missions/abc/cancel"},
+		{"POST", "/v1/missions/abc/permission"},
+		{"GET", "/v1/notifications"},
+		{"POST", "/v1/notifications/abc/read"},
+	} {
+		httpReq := httptest.NewRequest(req.method, req.path, nil)
+		httpReq.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, httpReq)
+		if w.Code != 404 {
+			t.Fatalf("%s %s with a nil mission store = %d, want 404 (unmounted)", req.method, req.path, w.Code)
+		}
+	}
+}

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -28,10 +28,13 @@ const (
 	// through candidates+classify before the normal agent lookup.
 	autoAgentName = "auto"
 	// classifyRoute serves the auto-dispatch classification call —
-	// same cheap side-call route as auto-title, distillation, and
-	// extraction. "local" is a real, always-provisioned fixed route
+	// same cheap side-call route distillation and extraction still use.
+	// "local" is a real, always-provisioned fixed route
 	// (migrations/0022_local_route.sql); "mini" was never seeded by
-	// any migration and every call on it failed with no_route.
+	// any migration and every call on it failed with no_route. autoTitle
+	// uses defaultRoute instead — a session's name deserves the same
+	// model quality as the conversation it's naming, not the cheapest
+	// available one.
 	classifyRoute = "local"
 	// defaultRoute serves plain chat turns when the caller picks
 	// nothing; the web UI exposes a per-message picker.
@@ -608,10 +611,10 @@ func (s *Service) autoTitle(sessionID, userText, reply string) {
 	input := userText + "\n\n" + truncateRunes(reply, 200)
 
 	events, err := s.gw.Stream(ctx, gwclient.StreamRequest{
-		Route: classifyRoute,
-		Purpose:      "title",
-		System:       titleSystem,
-		Messages:     []provider.Message{{Role: "user", Content: input}},
+		Route:    defaultRoute,
+		Purpose:  "title",
+		System:   titleSystem,
+		Messages: []provider.Message{{Role: "user", Content: input}},
 		// Reasoning models spend hundreds of tokens thinking before
 		// the first answer token; a tight cap truncates the stream
 		// mid-reasoning and yields an empty title.

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -1021,3 +1021,37 @@ func TestRetryRejectsWhenNothingToRetry(t *testing.T) {
 		t.Fatalf("Retry on a completed turn: err = %v, want ErrNoRetryableTurn", err)
 	}
 }
+
+// TestAutoTitleUsesDefaultRouteNotClassifyRoute pins a real behavior
+// change: a session's name deserves the same model quality as the
+// conversation it's naming, not the cheapest classification route
+// (which resolves to a small local model unfit for the job).
+func TestAutoTitleUsesDefaultRouteNotClassifyRoute(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("a good title")}
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "hi"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool {
+		log.mu.Lock()
+		defer log.mu.Unlock()
+		return log.titles["s1"] != ""
+	})
+
+	gw.mu.Lock()
+	defer gw.mu.Unlock()
+	for _, r := range gw.requests {
+		if r.Purpose == "title" {
+			if r.Route != defaultRoute {
+				t.Fatalf("auto-title route = %q, want %q", r.Route, defaultRoute)
+			}
+			return
+		}
+	}
+	t.Fatal("no title request recorded")
+}

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -160,6 +160,13 @@ type Request struct {
 	System    string
 	Messages  []provider.Message
 	MissionID string // ledger tag: set when this turn serves a mission, not chat
+
+	// ExtraTools are tool defs available ONLY for this turn, on top of
+	// the agent's shared base set — e.g. the missions package's
+	// mission_status/review_verdict sentinel calls, which chat sessions
+	// must never see. Executed via extraExecutor, never merged into the
+	// shared registry other callers read.
+	ExtraTools []*tools.Tool
 }
 
 // Start launches the loop and returns its event stream. The channel
@@ -188,6 +195,26 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 
 	exec, defs := a.toolset()
 	defs = filterDefs(defs, req.ToolAllow)
+	if len(req.ExtraTools) > 0 {
+		var extraDefs []provider.ToolDef
+		exec, extraDefs = withExtraTools(exec, req.ExtraTools)
+		// An extra tool that shares a base tool's name REPLACES it for
+		// this turn (extraExecutor already resolves extras first): the
+		// model must see exactly one def per name, and it must be the
+		// turn-scoped one — e.g. a mission's workspace-rooted shell
+		// shadowing the global shell.
+		override := make(map[string]bool, len(extraDefs))
+		for _, d := range extraDefs {
+			override[d.Name] = true
+		}
+		kept := make([]provider.ToolDef, 0, len(defs))
+		for _, d := range defs {
+			if !override[d.Name] {
+				kept = append(kept, d)
+			}
+		}
+		defs = append(kept, extraDefs...)
+	}
 	msgs := append([]provider.Message(nil), req.Messages...)
 	total := stream.Usage{}
 	var lastMeta *stream.Meta
@@ -546,4 +573,36 @@ func filterDefs(defs []provider.ToolDef, allow []string) []provider.ToolDef {
 		}
 	}
 	return out
+}
+
+// extraExecutor tries a turn's ExtraTools before falling back to the
+// shared base executor — extras are never merged into the shared
+// registry, so no other caller (chat, another turn) ever sees them.
+type extraExecutor struct {
+	base  Executor
+	extra map[string]*tools.Tool
+}
+
+func (e *extraExecutor) Execute(ctx context.Context, name string, args json.RawMessage) (string, error) {
+	if t, ok := e.extra[name]; ok {
+		return t.Execute(ctx, args)
+	}
+	return e.base.Execute(ctx, name, args)
+}
+
+// withExtraTools wraps base so calls to req.ExtraTools resolve without
+// touching the agent's shared registry, and derives the matching
+// []provider.ToolDef the model needs to see them as callable. Unlike
+// tools.Constrained, this does not schema-validate the call args
+// before Execute runs — ExtraTools come from this package's own
+// trusted callers (missions), whose Execute already parses/rejects
+// malformed args itself, not from arbitrary registered tools.
+func withExtraTools(base Executor, extra []*tools.Tool) (Executor, []provider.ToolDef) {
+	byName := make(map[string]*tools.Tool, len(extra))
+	defs := make([]provider.ToolDef, 0, len(extra))
+	for _, t := range extra {
+		byName[t.Name] = t
+		defs = append(defs, provider.ToolDef{Name: t.Name, Description: t.Description, InputSchema: t.InputSchema})
+	}
+	return &extraExecutor{base: base, extra: byName}, defs
 }

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -902,3 +902,134 @@ func TestForceRouteIgnoresNonMatchingTools(t *testing.T) {
 		}
 	}
 }
+
+// TestRequestExtraToolsCallableAndExecutable reproduces the missions
+// bug: a sentinel-style tool defined outside the shared agent registry
+// must still be (a) offered to the model as callable and (b)
+// executable, via Request.ExtraTools — without ever touching the
+// shared base registry other turns read.
+func TestRequestExtraToolsCallableAndExecutable(t *testing.T) {
+	t.Parallel()
+	var gotArgs json.RawMessage
+	sentinel := &tools.Tool{
+		Name:        "mission_status",
+		Description: "reports turn outcome",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"outcome":{"type":"string"}},"required":["outcome"]}`),
+		Execute: func(_ context.Context, args json.RawMessage) (string, error) {
+			gotArgs = args
+			return "status recorded", nil
+		},
+	}
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"mission_status", `{"outcome":"done"}`}),
+		finalStep("finished"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{
+		SessionID:  "s1",
+		Route:      "default",
+		Messages:   []provider.Message{{Role: "user", Content: "go"}},
+		ExtraTools: []*tools.Tool{sentinel},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	if got := ofType(evs, stream.EventToolResult); len(got) != 1 || got[0].ToolResult.Status != "ok" {
+		t.Fatalf("tool results = %+v, want one ok result for mission_status", got)
+	}
+	if string(gotArgs) != `{"outcome":"done"}` {
+		t.Fatalf("sentinel Execute args = %s, want the model's call forwarded through", gotArgs)
+	}
+
+	// The first request sent to the gateway must have listed
+	// mission_status as callable — this is the exact gap that let the
+	// model silently never call it.
+	var sawDef bool
+	for _, d := range gw.requests[0].Tools {
+		if d.Name == "mission_status" {
+			sawDef = true
+		}
+	}
+	if !sawDef {
+		t.Fatalf("mission_status not offered in first request's tool defs: %+v", gw.requests[0].Tools)
+	}
+}
+
+// TestRequestExtraToolsNotVisibleWithoutOptIn confirms a turn that
+// doesn't set ExtraTools never sees another turn's extra tool — the
+// isolation the missions package relies on to keep mission_status out
+// of chat sessions.
+func TestRequestExtraToolsNotVisibleWithoutOptIn(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		finalStep("done, no tools needed"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "default",
+		Messages: []provider.Message{{Role: "user", Content: "go"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	for _, d := range gw.requests[0].Tools {
+		if d.Name == "mission_status" {
+			t.Fatalf("mission_status leaked into a plain request's tool defs: %+v", gw.requests[0].Tools)
+		}
+	}
+}
+
+// TestRequestExtraToolsOverrideBaseTool: an extra tool sharing a base
+// tool's name must REPLACE it for the turn — one def offered to the
+// model, and execution resolving to the turn-scoped implementation.
+// This is how a mission's workspace-rooted shell shadows the global
+// shell without touching the shared registry.
+func TestRequestExtraToolsOverrideBaseTool(t *testing.T) {
+	t.Parallel()
+	executed := false
+	override := &tools.Tool{
+		Name:        "echo",
+		Description: "turn-scoped echo",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}`),
+		Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+			executed = true
+			return "override ran", nil
+		},
+	}
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"echo", `{"text":"hi"}`}),
+		finalStep("done"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{
+		SessionID:  "s1",
+		Route:      "default",
+		Messages:   []provider.Message{{Role: "user", Content: "go"}},
+		ExtraTools: []*tools.Tool{override},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	count := 0
+	for _, d := range gw.requests[0].Tools {
+		if d.Name == "echo" {
+			count++
+			if d.Description != "turn-scoped echo" {
+				t.Fatalf("echo def = %q, want the override's def, not the base one", d.Description)
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("model saw %d echo defs, want exactly 1", count)
+	}
+	if !executed {
+		t.Fatal("base echo executed instead of the turn-scoped override")
+	}
+}

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -2,9 +2,14 @@ package missions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
+	"sync"
 	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
 )
 
 // driveTimeBound bounds one Drive call: long enough for a real
@@ -25,14 +30,47 @@ type notifier interface {
 	OnTransition(ctx context.Context, missionID string, before, after Status) error
 }
 
+// sessionCreator opens the hidden, non-chat-facing session every
+// mission runs its worker/reviewer/planner turns under —
+// *session.Store satisfies it. loop.Agent's tool-call bookkeeping
+// (session_events, audit) hard-requires a real session id; a mission
+// has no chat session of its own to supply one.
+type sessionCreator interface {
+	Create(ctx context.Context, title string) (string, error)
+}
+
+// sessionGranter is the narrow slice of *tools.Permissions Driver
+// needs to pre-authorize a mission's hidden session — a mission runs
+// for hours unattended, and per-command-shape approval (built for a
+// human watching a chat) would otherwise park it on every novel shell
+// invocation. Granting "*" for "shell" only ever reaches
+// DangerSafe calls: tools.Permissions.Resolve hard-forces
+// DangerDestructive to DecisionAsk before any grant is even
+// consulted, so this cannot auto-approve a destructive command no
+// matter what pattern is granted.
+type sessionGranter interface {
+	Grant(ctx context.Context, sessionID, tool, pattern string, ttl time.Duration) error
+}
+
+// missionGrantTTL matches loop.sessionGrantTTL (12h) — comfortably
+// covers driveTimeBound (4h) and any recovery re-drive reusing the
+// same hidden session across restarts. A mission genuinely spanning
+// longer just resumes asking once the grant expires — a degrade, not
+// a break.
+const missionGrantTTL = 12 * time.Hour
+
 // driverStore is the narrow slice of *Store the Driver actually calls
 // — kept as an interface so tests can fake it without a real Postgres
 // pool.
 type driverStore interface {
+	Create(ctx context.Context, m Mission) (string, error)
 	Get(ctx context.Context, id string) (Mission, error)
 	ApplyTransition(ctx context.Context, id string, t Transition) error
 	AppendEvent(ctx context.Context, id, kind string, payload map[string]any) error
 	SetSpec(ctx context.Context, id string, spec Spec) error
+	SetProvisioned(ctx context.Context, id, workspace, worktree, branch, baseCommit string) error
+	SetLastEvidence(ctx context.Context, id, evidence string) error
+	AppendProgress(ctx context.Context, id, note string) error
 }
 
 // Driver walks the state machine for one mission: calls Runner for the
@@ -45,6 +83,8 @@ type Driver struct {
 	runner    Runner
 	workspace *Workspace
 	notify    notifier
+	sessions  sessionCreator
+	perms     sessionGranter
 	log       *slog.Logger
 	cfg       Config
 
@@ -53,14 +93,87 @@ type Driver struct {
 	// rework. Process-local by design: lost on restart is acceptable —
 	// a cold reviewer just re-checks everything from scratch.
 	gatekeepers map[string]*GatekeeperState
+
+	// driving guards against two Drive loops racing the same mission:
+	// Advance's own state transitions pass through status='idle'
+	// transiently between steps (e.g. stepReviewApprove moving to the
+	// next unit) while the owning Drive loop is about to call Advance
+	// again — if the work-slot sweep's ClaimWorkSlot claims that same
+	// transient idle row, a second Drive spawns and both goroutines
+	// read-then-write the mission concurrently, silently clobbering
+	// each other's transitions (observed: a mission.done transition
+	// overwritten moments later by a stale rework transition). Drive
+	// claims the mission's slot here for its own lifetime; a second
+	// caller (sweep or a resume racing an already-running Drive)
+	// no-ops instead of starting a competing loop.
+	drivingMu sync.Mutex
+	driving   map[string]bool
 }
 
-func NewDriver(store driverStore, runner Runner, workspace *Workspace, notify notifier, log *slog.Logger) *Driver {
+func NewDriver(store driverStore, runner Runner, workspace *Workspace, notify notifier, sessions sessionCreator, perms sessionGranter, log *slog.Logger) *Driver {
 	return &Driver{
-		store: store, runner: runner, workspace: workspace, notify: notify, log: log,
+		store: store, runner: runner, workspace: workspace, notify: notify, sessions: sessions, perms: perms, log: log,
 		cfg:         DefaultConfig,
 		gatekeepers: map[string]*GatekeeperState{},
+		driving:     map[string]bool{},
 	}
+}
+
+// Create opens the mission's hidden bookkeeping session, inserts the
+// mission row, provisions its workspace (a git worktree for coding
+// missions, a plain directory otherwise), and kicks off the first
+// Drive in a background goroutine — callers (the API's create handler)
+// get the new id back immediately without waiting on the mission to
+// actually run.
+func (d *Driver) Create(ctx context.Context, m Mission, repoPath string) (string, error) {
+	if d.sessions != nil {
+		sessionID, err := d.sessions.Create(ctx, "")
+		if err != nil {
+			return "", fmt.Errorf("driver: create: session: %w", err)
+		}
+		m.SessionID = sessionID
+		if m.AutoApproveSafe && d.perms != nil {
+			// Best-effort: a failed grant just means the mission asks on
+			// its first safe shell call instead of running unattended —
+			// degraded autonomy, not a broken mission.
+			if err := d.perms.Grant(ctx, sessionID, "shell", "*", missionGrantTTL); err != nil {
+				d.log.Warn("driver: create: auto-approve grant failed", "mission_id", m.ID, "error", err)
+			}
+		}
+	}
+	id, err := d.store.Create(ctx, m)
+	if err != nil {
+		return "", fmt.Errorf("driver: create: %w", err)
+	}
+	if d.workspace != nil {
+		workspace, worktree, branch, baseCommit, err := d.workspace.Provision(ctx, id, m.Goal, m.Kind, repoPath)
+		if err != nil {
+			return "", fmt.Errorf("driver: create: provision: %w", err)
+		}
+		if err := d.store.SetProvisioned(ctx, id, workspace, worktree, branch, baseCommit); err != nil {
+			return "", fmt.Errorf("driver: create: %w", err)
+		}
+		if m.AutoApproveSafe && d.perms != nil && m.SessionID != "" {
+			// Register the mission's own directory as the session's
+			// sandbox: destructive-classified commands provably confined
+			// to it (writing the mission's own artifacts, cleaning its
+			// own files) stop parking on a human prompt. Best-effort,
+			// same as the shell grant above.
+			root := worktree
+			if root == "" {
+				root = workspace
+			}
+			if err := d.perms.Grant(ctx, m.SessionID, tools.SandboxGrantTool, root, missionGrantTTL); err != nil {
+				d.log.Warn("driver: create: sandbox grant failed", "mission_id", id, "error", err)
+			}
+		}
+	}
+	go func() { //nolint:gosec // G118: deliberate — the mission must outlive the HTTP request that created it, driveTimeBound is Drive's own cap
+		if err := d.Drive(context.Background(), id); err != nil {
+			d.log.Error("driver: initial drive failed", "mission_id", id, "error", err)
+		}
+	}()
+	return id, nil
 }
 
 // Advance performs exactly one worker turn, review round, or planning
@@ -78,17 +191,35 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 	}
 
 	before := m.Status
+	turnStart := time.Now()
 	in, err := d.runPhase(ctx, m)
+	turnMs := time.Since(turnStart).Milliseconds()
 	if err != nil {
 		d.log.Error("driver: phase run failed", "mission_id", id, "phase", m.Phase, "error", err)
-		in = StepInput{Input: InputReviewInfraFailure}
-		if m.Phase != PhaseReview {
+		switch {
+		case errors.Is(err, ErrModelFloor):
+			// A below-floor fallback model served this turn: it cannot
+			// drive tool-using work, so retrying just burns iterations.
+			// Pause immediately as infra with the model named.
+			in = StepInput{Input: InputReviewInfraFailure, Reason: err.Error()}
+		case m.Phase == PhaseReview:
+			in = StepInput{Input: InputReviewInfraFailure, Reason: err.Error()}
+		default:
 			// review_infra_failure is review's error input; other phases
 			// report the equivalent-shaped worker_failed so the same
 			// backoff/pause machinery applies uniformly regardless of
 			// which phase actually failed.
-			in = StepInput{Input: InputWorkerFailed}
+			in = StepInput{Input: InputWorkerFailed, Reason: err.Error()}
 		}
+	}
+	// Turn telemetry: one event per phase run, so a mission's cost in
+	// wall-clock and outcomes is readable from its event log alone
+	// (token/model cost is in cost_ledger, keyed by mission_id).
+	if evErr := d.store.AppendEvent(ctx, id, "mission.turn", map[string]any{
+		"phase": string(m.Phase), "duration_ms": turnMs,
+		"ok": err == nil, "input": string(in.Input), "reason": in.Reason,
+	}); evErr != nil {
+		d.log.Warn("driver: record turn failed", "mission_id", id, "error", evErr)
 	}
 
 	state := toStepState(m)
@@ -113,6 +244,11 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 // next begins, so a process death mid-Drive leaves the mission in a
 // valid, resumable state rather than a torn one.
 func (d *Driver) Drive(ctx context.Context, id string) error {
+	if !d.claimDriving(id) {
+		return nil // another Drive loop already owns this mission
+	}
+	defer d.releaseDriving(id)
+
 	dctx, cancel := context.WithTimeout(ctx, driveTimeBound)
 	defer cancel()
 	for {
@@ -127,6 +263,60 @@ func (d *Driver) Drive(ctx context.Context, id string) error {
 			return nil
 		}
 	}
+}
+
+func (d *Driver) claimDriving(id string) bool {
+	d.drivingMu.Lock()
+	defer d.drivingMu.Unlock()
+	if d.driving[id] {
+		return false
+	}
+	d.driving[id] = true
+	return true
+}
+
+func (d *Driver) releaseDriving(id string) {
+	d.drivingMu.Lock()
+	defer d.drivingMu.Unlock()
+	delete(d.driving, id)
+}
+
+// Signal applies an externally-triggered input (resume or cancel) to a
+// mission outside the normal Advance loop — the API layer's
+// resume/cancel endpoints call this. On resume, it re-kicks Drive in a
+// background goroutine since the mission may have work to do again.
+func (d *Driver) Signal(ctx context.Context, id string, input Input) error {
+	if input != InputResume && input != InputCancel {
+		return fmt.Errorf("driver: signal: %q is not an externally-triggerable input", input)
+	}
+	m, err := d.store.Get(ctx, id)
+	if err != nil {
+		return fmt.Errorf("driver: signal: %w", err)
+	}
+	if m.Phase.Terminal() {
+		return ErrTerminal
+	}
+	before := m.Status
+	t := Step(toStepState(m), StepInput{Input: input}, d.cfg)
+	if err := d.store.ApplyTransition(ctx, id, t); err != nil {
+		return fmt.Errorf("driver: signal: apply transition: %w", err)
+	}
+	if t.Next.Phase.Terminal() {
+		delete(d.gatekeepers, id)
+	}
+	if d.notify != nil {
+		if err := d.notify.OnTransition(ctx, id, before, t.Next.Status); err != nil {
+			d.log.Warn("driver: notify failed", "mission_id", id, "error", err)
+		}
+	}
+	if input == InputResume {
+		go func() { //nolint:gosec // G118: deliberate — the mission must outlive the HTTP request that resumed it, driveTimeBound is Drive's own cap
+			if err := d.Drive(context.Background(), id); err != nil {
+				d.log.Error("driver: post-resume drive failed", "mission_id", id, "error", err)
+			}
+		}()
+	}
+	return nil
 }
 
 // toStepState projects a Mission onto the state machine's input shape.
@@ -211,6 +401,12 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 				d.log.Warn("driver: commit unit failed", "mission_id", m.ID, "error", err)
 			}
 		}
+		if err := d.store.SetLastEvidence(ctx, m.ID, verdict.Evidence); err != nil {
+			d.log.Warn("driver: record evidence failed", "mission_id", m.ID, "error", err)
+		}
+		if in, ok := d.trySkipReview(ctx, m); ok {
+			return in, nil
+		}
 		return StepInput{Input: InputPhaseComplete}, nil
 	case "blocked":
 		return StepInput{Input: InputWorkerBlocked, Message: verdict.Question}, nil
@@ -220,8 +416,56 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 				d.log.Warn("driver: rollback failed", "mission_id", m.ID, "error", err)
 			}
 		}
-		return StepInput{Input: InputWorkerRetry}, nil
+		return StepInput{Input: InputWorkerRetry, Reason: truncate(verdict.Analysis, 500)}, nil
 	}
+}
+
+// trySkipReview short-circuits the review round for a non-coding
+// mission's unit when the harness's own deterministic evidence
+// (declared artifacts present and non-empty, verify_cmd passing)
+// already establishes the unit holds up — an LLM review round on top
+// of passing harness checks adds tokens, latency, and (with the
+// reviewer being the least reliable link) failure modes, not safety.
+// Coding missions always review: a diff can be wrong in ways
+// existence checks can't see. Units with no declared artifacts always
+// review too — there is no harness evidence to stand on.
+func (d *Driver) trySkipReview(ctx context.Context, m Mission) (StepInput, bool) {
+	if m.Kind == "coding" {
+		return StepInput{}, false
+	}
+	unit, idx := currentUnit(m.Spec)
+	if unit == nil || len(unit.Artifacts) == 0 {
+		return StepInput{}, false
+	}
+	if err := d.verifyCurrentUnit(ctx, m); err != nil {
+		var vf *verifyFailure
+		if errors.As(err, &vf) {
+			note := fmt.Sprintf("Verification failed for unit %d before review: %s", vf.unit, vf.excerpt)
+			if perr := d.recordProgress(ctx, m.ID, note); perr != nil {
+				d.log.Warn("driver: record verify-failure note failed", "mission_id", m.ID, "error", perr)
+			}
+			return StepInput{Input: InputWorkerRetry, Reason: truncate(note, 500)}, true
+		}
+		d.log.Warn("driver: pre-review verify errored; falling back to review", "mission_id", m.ID, "error", err)
+		return StepInput{}, false
+	}
+	if err := d.store.AppendEvent(ctx, m.ID, "mission.review_skipped", map[string]any{
+		"unit": idx, "reason": "artifacts and verify_cmd passed harness checks",
+	}); err != nil {
+		d.log.Warn("driver: record review skip failed", "mission_id", m.ID, "error", err)
+	}
+	return StepInput{Input: InputReviewApprove}, true
+}
+
+// currentUnit returns the plan's first unverified unit and its index,
+// or nil when every unit already passed.
+func currentUnit(spec Spec) (*PlanUnit, int) {
+	for i := range spec.Units {
+		if !spec.Units[i].Passes {
+			return &spec.Units[i], i
+		}
+	}
+	return nil, -1
 }
 
 func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
@@ -233,8 +477,20 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 			return StepInput{}, err
 		}
 	}
+	workRoot := m.Worktree
+	if workRoot == "" {
+		workRoot = m.Workspace
+	}
+	packet := ReviewPacket{
+		Goal: m.Goal, Plan: m.Spec, Diff: diff, Evidence: m.LastEvidence,
+		Listing: ListWorkspace(workRoot),
+	}
+	if unit, _ := currentUnit(m.Spec); unit != nil {
+		packet.UnitTitle = unit.Title
+		packet.Artifacts = ReadArtifacts(workRoot, unit.Artifacts)
+	}
 	gk := d.gatekeepers[m.ID]
-	verdict, nextGK, err := d.runner.RunReview(ctx, m, diff, gk)
+	verdict, nextGK, err := d.runner.RunReview(ctx, m, packet, gk)
 	if err != nil {
 		return StepInput{}, err
 	}
@@ -248,7 +504,26 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 	}
 
 	if verdict.Approved {
+		var vf *verifyFailure
 		if err := d.verifyCurrentUnit(ctx, m); err != nil {
+			if errors.As(err, &vf) {
+				// The reviewer approved, but the harness's own verify_cmd
+				// disagrees — real evidence the approval didn't hold up
+				// (e.g. a claimed file was never actually written), not an
+				// infra fault. Route through the SAME rework path a
+				// reviewer's own rejection takes: back to execute, costs an
+				// iteration, and (via GapFingerprint) stall-pauses if the
+				// exact same verify keeps failing round after round instead
+				// of looping forever. Tell the worker exactly what
+				// verification found, so the next turn doesn't just repeat
+				// the same false claim.
+				note := fmt.Sprintf("Verification failed for unit %d: the harness ran verify_cmd and it did NOT pass. Output:\n%s", vf.unit, vf.excerpt)
+				if err := d.recordProgress(ctx, m.ID, note); err != nil {
+					d.log.Warn("driver: record verify-failure note failed", "mission_id", m.ID, "error", err)
+				}
+				fp := fmt.Sprintf("verify_failed:unit_%d", vf.unit)
+				return StepInput{Input: InputReviewRework, GapFingerprint: fp}, nil
+			}
 			return StepInput{Input: InputReviewInfraFailure}, err
 		}
 		return StepInput{Input: InputReviewApprove}, nil
@@ -259,35 +534,86 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 	}); err != nil {
 		d.log.Warn("driver: record review verdict failed", "mission_id", m.ID, "error", err)
 	}
-	return StepInput{Input: InputReviewRework, GapFingerprint: fp}, nil
+	if fp != "" && fp == m.LastGapFingerprint {
+		// Same gap rejected twice: the resumed reviewer session is
+		// anchored to its earlier judgment. Drop it so the next round
+		// (if the stall brake doesn't pause first) re-reads everything
+		// with fresh eyes instead of re-asserting its previous verdict.
+		delete(d.gatekeepers, m.ID)
+	}
+	return StepInput{Input: InputReviewRework, GapFingerprint: fp, Reason: truncate(reviewReason(verdict.Findings), 500)}, nil
 }
 
-// verifyCurrentUnit runs RunVerify for the plan's current (first
-// unverified) unit and marks it passed — only this harness-run
-// evidence may flip a unit's Passes flag, never model output.
+// reviewReason flattens findings into one line for event payloads.
+func reviewReason(findings []Finding) string {
+	titles := make([]string, 0, len(findings))
+	for _, f := range findings {
+		titles = append(titles, f.Title)
+	}
+	return strings.Join(titles, "; ")
+}
+
+// verifyFailure is a unit's verify_cmd genuinely running and reporting
+// failure — real evidence the reviewer's approval didn't hold up, not
+// an infrastructure fault. Kept distinct from a plain error (RunVerify
+// itself erroring: timeout, exec failure) so the caller can route each
+// to a different StepInput instead of conflating both as infra.
+type verifyFailure struct {
+	unit    int
+	excerpt string
+}
+
+func (e *verifyFailure) Error() string {
+	return fmt.Sprintf("driver: unit %d verify_cmd failed", e.unit)
+}
+
+// verifyCurrentUnit runs the harness's own checks for the plan's
+// current (first unverified) unit and marks it passed — only this
+// harness-run evidence may flip a unit's Passes flag, never model
+// output. Declared artifacts are checked first (exists, non-empty):
+// a tautological verify_cmd cannot pass a unit whose artifact was
+// never written.
 func (d *Driver) verifyCurrentUnit(ctx context.Context, m Mission) error {
 	for i, u := range m.Spec.Units {
 		if u.Passes {
 			continue
 		}
-		if u.VerifyCmd == "" {
-			return d.markUnitPassed(ctx, m, i)
-		}
 		workRoot := m.Worktree
 		if workRoot == "" {
 			workRoot = m.Workspace
+		}
+		if problems := CheckArtifacts(workRoot, u.Artifacts); len(problems) > 0 {
+			excerpt := "declared artifacts failed the harness check:\n" + strings.Join(problems, "\n")
+			// Show what DOES exist: the dominant failure here is a
+			// worker writing a real file under a slightly different
+			// name and never spotting the mismatch from "not found"
+			// alone.
+			if listing := ListWorkspace(workRoot); listing != "" {
+				excerpt += "\nfiles currently in the workspace:\n" + listing
+			} else {
+				excerpt += "\nthe workspace is currently empty"
+			}
+			if err := d.store.AppendEvent(ctx, m.ID, "mission.unit_verified", map[string]any{
+				"unit": i, "passed": false, "check": "artifacts", "problems": problems,
+			}); err != nil {
+				d.log.Warn("driver: record verify failed", "mission_id", m.ID, "error", err)
+			}
+			return &verifyFailure{unit: i, excerpt: excerpt}
+		}
+		if u.VerifyCmd == "" {
+			return d.markUnitPassed(ctx, m, i)
 		}
 		res, err := RunVerify(ctx, workRoot, u.VerifyCmd)
 		if err != nil {
 			return fmt.Errorf("driver: verify unit %d: %w", i, err)
 		}
 		if err := d.store.AppendEvent(ctx, m.ID, "mission.unit_verified", map[string]any{
-			"unit": i, "passed": res.Passed, "exit_code": res.ExitCode, "output_sha256": res.OutputSHA256,
+			"unit": i, "passed": res.Passed, "check": "verify_cmd", "exit_code": res.ExitCode, "output_sha256": res.OutputSHA256,
 		}); err != nil {
 			d.log.Warn("driver: record verify failed", "mission_id", m.ID, "error", err)
 		}
 		if !res.Passed {
-			return fmt.Errorf("driver: unit %d verify_cmd failed with exit %d", i, res.ExitCode)
+			return &verifyFailure{unit: i, excerpt: res.Excerpt}
 		}
 		return d.markUnitPassed(ctx, m, i)
 	}
@@ -316,7 +642,7 @@ func (d *Driver) recordProgress(ctx context.Context, id, text string) error {
 	if text == "" {
 		return nil
 	}
-	return d.store.AppendEvent(ctx, id, "mission.progress", map[string]any{"note": NeutralizeSlot(truncate(text, 2000))})
+	return d.store.AppendProgress(ctx, id, NeutralizeSlot(truncate(text, 2000)))
 }
 
 func truncate(s string, n int) string {

--- a/internal/brain/missions/driver_integration_test.go
+++ b/internal/brain/missions/driver_integration_test.go
@@ -45,7 +45,7 @@ func TestDriverEndToEndCodingMission(t *testing.T) {
 		},
 		reviewVerdicts: []ReviewVerdict{{Approved: true}},
 	}
-	d := NewDriver(store, runner, workspace, nil, log)
+	d := NewDriver(store, runner, workspace, nil, nil, nil, log)
 
 	// The scripted worker "does the work" by actually creating the file
 	// the verify_cmd checks for — RunVerify runs for real against the

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -4,8 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // fakeStore is an in-memory driverStore for scripting Driver scenarios
@@ -25,6 +30,25 @@ func (f *fakeStore) put(id string, m Mission) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.missions[id] = m
+}
+
+func (f *fakeStore) Create(ctx context.Context, m Mission) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if m.ID == "" {
+		m.ID = fmt.Sprintf("fake-%d", len(f.missions)+1)
+	}
+	f.missions[m.ID] = m
+	return m.ID, nil
+}
+
+func (f *fakeStore) SetProvisioned(ctx context.Context, id, workspace, worktree, branch, baseCommit string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	m := f.missions[id]
+	m.Workspace, m.Worktree, m.Branch, m.BaseCommit = workspace, worktree, branch, baseCommit
+	f.missions[id] = m
+	return nil
 }
 
 func (f *fakeStore) Get(ctx context.Context, id string) (Mission, error) {
@@ -69,6 +93,26 @@ func (f *fakeStore) SetSpec(ctx context.Context, id string, spec Spec) error {
 	return nil
 }
 
+func (f *fakeStore) SetLastEvidence(ctx context.Context, id, evidence string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	m := f.missions[id]
+	m.LastEvidence = evidence
+	f.missions[id] = m
+	return nil
+}
+
+func (f *fakeStore) AppendProgress(ctx context.Context, id, note string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	m := f.missions[id]
+	m.Progress = append(m.Progress, ProgressNote{Note: note})
+	f.missions[id] = m
+	f.seq[id]++
+	f.events[id] = append(f.events[id], Event{MissionID: id, Seq: f.seq[id], Kind: "mission.progress"})
+	return nil
+}
+
 // scriptedRunner replays fixed responses for RunWorker/RunReview/
 // PlanSession, one entry consumed per call — lets a test script an
 // exact sequence of outcomes across several Advance calls. workerErr,
@@ -98,7 +142,7 @@ func (r *scriptedRunner) RunWorker(ctx context.Context, m Mission, packet WorkPa
 	return v, "worker output", nil
 }
 
-func (r *scriptedRunner) RunReview(ctx context.Context, m Mission, diff string, gk *GatekeeperState) (ReviewVerdict, *GatekeeperState, error) {
+func (r *scriptedRunner) RunReview(ctx context.Context, m Mission, packet ReviewPacket, gk *GatekeeperState) (ReviewVerdict, *GatekeeperState, error) {
 	v := r.reviewVerdicts[r.reviewIdx]
 	if r.reviewIdx < len(r.reviewVerdicts)-1 {
 		r.reviewIdx++
@@ -115,7 +159,7 @@ func (r *scriptedRunner) PlanSession(ctx context.Context, m Mission, researchNot
 }
 
 func testDriver(store driverStore, runner Runner) *Driver {
-	return NewDriver(store, runner, nil, nil, slog.Default())
+	return NewDriver(store, runner, nil, nil, nil, nil, slog.Default())
 }
 
 // driveN calls Advance up to n times, stopping early if it returns
@@ -149,6 +193,9 @@ func TestDriverHappyPathToDone(t *testing.T) {
 	m, _ := store.Get(context.Background(), "m1")
 	if m.Phase != PhaseDone || m.Status != StatusDone {
 		t.Fatalf("mission after happy path = %+v, want done/done", m)
+	}
+	if m.LastEvidence != "did it" {
+		t.Fatalf("mission.LastEvidence = %q, want the worker's evidence persisted for the reviewer", m.LastEvidence)
 	}
 }
 
@@ -270,6 +317,120 @@ func TestDriverGatekeeperCleanupOnTerminal(t *testing.T) {
 	}
 }
 
+// blockingRunner's RunWorker blocks on a channel until released,
+// letting a test force two concurrent Drive calls to overlap on the
+// same mission — reproducing the race where the work-slot sweep
+// claims a mission that a still-running Drive loop already owns.
+type blockingRunner struct {
+	release  chan struct{}
+	started  chan struct{}
+	starts   int32
+	verdict  WorkerVerdict
+	reviewV  ReviewVerdict
+	planSpec Spec
+}
+
+func (r *blockingRunner) RunWorker(ctx context.Context, m Mission, packet WorkPacket) (WorkerVerdict, string, error) {
+	atomic.AddInt32(&r.starts, 1)
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+	<-r.release
+	return r.verdict, "worker output", nil
+}
+
+func (r *blockingRunner) RunReview(ctx context.Context, m Mission, packet ReviewPacket, gk *GatekeeperState) (ReviewVerdict, *GatekeeperState, error) {
+	return r.reviewV, &GatekeeperState{}, nil
+}
+
+func (r *blockingRunner) PlanSession(ctx context.Context, m Mission, researchNotes string) (Spec, error) {
+	return r.planSpec, nil
+}
+
+// TestDriverDriveIsSerializedPerMission reproduces a real bug: the
+// work-slot sweep's ClaimWorkSlot can claim a mission that is still
+// actively owned by an earlier Drive goroutine (Advance's own
+// transitions pass through status='idle' transiently between steps),
+// spawning a second concurrent Drive loop that races the first's
+// read-then-write Advance calls. A second Drive call for a mission
+// already being driven must no-op instead of starting a competing
+// loop.
+func TestDriverDriveIsSerializedPerMission(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8,
+		Spec: Spec{Units: []PlanUnit{{Title: "only unit"}}},
+	})
+	runner := &blockingRunner{
+		release: make(chan struct{}),
+		started: make(chan struct{}, 1),
+		verdict: WorkerVerdict{Outcome: "done", Evidence: "did it"},
+		reviewV: ReviewVerdict{Approved: true},
+	}
+	d := testDriver(store, runner)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_ = d.Drive(context.Background(), "m1")
+	}()
+	<-runner.started // first Drive is now blocked inside RunWorker
+	go func() {
+		defer wg.Done()
+		_ = d.Drive(context.Background(), "m1") // must no-op, not race the first
+	}()
+	time.Sleep(20 * time.Millisecond) // give the second call a chance to (wrongly) start a competing Advance
+	close(runner.release)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&runner.starts); got != 1 {
+		t.Fatalf("RunWorker started %d times for one mission, want exactly 1 (second Drive must no-op while the first owns the mission)", got)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseDone || m.Status != StatusDone {
+		t.Fatalf("mission after single-owner drive = %+v, want done/done", m)
+	}
+}
+
+// TestDriverReviewApprovalContradictedByVerifyRoutesToRework
+// reproduces a real bug: the reviewer approves a unit whose evidence
+// doesn't hold up (e.g. a worker claiming a file exists when it never
+// wrote one) — the harness's own verify_cmd then fails. This must NOT
+// be treated as an infra fault (which just parks the mission for a
+// human to blindly resume forever); it must route through rework,
+// back to execute, so the worker gets another attempt with the actual
+// failure recorded as a progress note.
+func TestDriverReviewApprovalContradictedByVerifyRoutesToRework(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "research", Phase: PhaseReview, Status: StatusWorking, MaxIterations: 8,
+		Spec: Spec{Units: []PlanUnit{{Title: "write summary.md", VerifyCmd: "test -f /nonexistent-verify-target"}}},
+	})
+	d := testDriver(store, &scriptedRunner{reviewVerdicts: []ReviewVerdict{{Approved: true}}})
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseExecute {
+		t.Fatalf("mission phase = %q, want execute (rework path), not stuck on an infra pause", m.Phase)
+	}
+	if m.PauseReason == PauseInfra {
+		t.Fatal("a failed verify_cmd after approval must not be classified as an infra fault")
+	}
+	if m.Iteration != 1 {
+		t.Fatalf("iteration = %d, want 1 (rework costs an iteration like any other rework)", m.Iteration)
+	}
+	if len(m.Progress) == 0 {
+		t.Fatal("expected a progress note explaining the verify failure to the next worker turn")
+	}
+	if !strings.Contains(m.Progress[len(m.Progress)-1].Note, "Verification failed") {
+		t.Fatalf("progress note = %q, want it to explain the verify failure", m.Progress[len(m.Progress)-1].Note)
+	}
+}
+
 func TestDriverBlockedParksForInput(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
@@ -286,5 +447,200 @@ func TestDriverBlockedParksForInput(t *testing.T) {
 	m, _ := store.Get(context.Background(), "m1")
 	if m.Status != StatusWaitingForInput {
 		t.Fatalf("mission status = %q, want waiting_for_input", m.Status)
+	}
+}
+
+// fakeSessionCreator hands out sequential ids without a real
+// session.Store — Driver.Create only needs a non-empty string back.
+type fakeSessionCreator struct{ n int }
+
+func (f *fakeSessionCreator) Create(ctx context.Context, title string) (string, error) {
+	f.n++
+	return fmt.Sprintf("session-%d", f.n), nil
+}
+
+// fakeGranter records every Grant call for assertion — a real
+// sessionGranter for tests, not a mock of one.
+type fakeGranter struct {
+	calls []struct{ sessionID, tool, pattern string }
+}
+
+func (f *fakeGranter) Grant(ctx context.Context, sessionID, tool, pattern string, ttl time.Duration) error {
+	f.calls = append(f.calls, struct{ sessionID, tool, pattern string }{sessionID, tool, pattern})
+	return nil
+}
+
+func TestDriverCreateGrantsShellAutoApproveWhenEnabled(t *testing.T) {
+	store := newFakeStore()
+	granter := &fakeGranter{}
+	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, slog.Default())
+
+	id, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: true}, "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(granter.calls) != 1 {
+		t.Fatalf("Grant calls = %d, want exactly 1", len(granter.calls))
+	}
+	call := granter.calls[0]
+	if call.tool != "shell" || call.pattern != "*" {
+		t.Fatalf("Grant call = %+v, want tool=shell pattern=*", call)
+	}
+	m, _ := store.Get(context.Background(), id)
+	if call.sessionID != m.SessionID {
+		t.Fatalf("Grant sessionID = %q, want the mission's own hidden session %q", call.sessionID, m.SessionID)
+	}
+}
+
+func TestDriverCreateSkipsGrantWhenAutoApproveDisabled(t *testing.T) {
+	store := newFakeStore()
+	granter := &fakeGranter{}
+	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, slog.Default())
+
+	if _, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: false}, ""); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(granter.calls) != 0 {
+		t.Fatalf("Grant calls = %d, want 0 when AutoApproveSafe is false", len(granter.calls))
+	}
+}
+
+// TestDriverSkipsReviewWhenHarnessChecksPass: a non-coding mission
+// whose unit declares artifacts that pass the harness's own checks
+// completes WITHOUT an LLM review round — the reviewer is the least
+// reliable and most expensive link, and passing deterministic checks
+// already establish the unit holds up. The scriptedRunner has no
+// review verdicts scripted: any RunReview call would panic the test.
+func TestDriverSkipsReviewWhenHarnessChecksPass(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "summary.md"), []byte("real content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking,
+		MaxIterations: 8, Workspace: root,
+		Spec: Spec{Units: []PlanUnit{{Title: "write summary", Artifacts: []string{"summary.md"}}}},
+	})
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote it"}}}
+	d := testDriver(store, runner)
+
+	driveN(t, d, "m1", 2)
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseDone || m.Status != StatusDone {
+		t.Fatalf("mission = %+v, want done/done without a review round", m)
+	}
+}
+
+// TestDriverArtifactCheckBlocksTautologicalDone: the worker claims
+// done but never wrote the declared artifact — the harness check must
+// send it back to execute (self-retry), never let the claim stand.
+func TestDriverArtifactCheckBlocksTautologicalDone(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking,
+		MaxIterations: 8, Workspace: t.TempDir(),
+		Spec: Spec{Units: []PlanUnit{{Title: "write summary", Artifacts: []string{"summary.md"}, VerifyCmd: "echo done"}}},
+	})
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote it (no it didn't)"}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseExecute || m.Spec.Units[0].Passes {
+		t.Fatalf("mission = phase %s passes %v, want back in execute with the unit NOT passed", m.Phase, m.Spec.Units[0].Passes)
+	}
+	if m.Iteration == 0 {
+		t.Fatal("a failed artifact check must cost an iteration")
+	}
+}
+
+// TestDriverCodingMissionsAlwaysReview: the skip gate must never apply
+// to coding missions — a diff can be wrong in ways existence checks
+// cannot see.
+func TestDriverCodingMissionsAlwaysReview(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "coding", Phase: PhaseExecute, Status: StatusWorking,
+		MaxIterations: 8, Workspace: root,
+		Spec: Spec{Units: []PlanUnit{{Title: "write code", Artifacts: []string{"main.go"}}}},
+	})
+	runner := &scriptedRunner{
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner)
+
+	driveN(t, d, "m1", 3)
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseDone {
+		t.Fatalf("mission = %+v, want done via a real review round", m)
+	}
+	if m.Phase == PhaseDone && runner.reviewIdx == 0 && len(runner.reviewVerdicts) == 1 {
+		// reviewIdx stays 0 when only one verdict exists and it was
+		// consumed; assert the review actually ran via phase history:
+		// a skipped review would have finished in 2 Advance calls with
+		// no review phase. The phase_started events record it.
+		found := false
+		for _, ev := range store.events["m1"] {
+			if ev.Kind == "mission.review_skipped" {
+				found = true
+			}
+		}
+		if found {
+			t.Fatal("coding mission skipped review — the gate must not apply to coding kind")
+		}
+	}
+}
+
+// TestDriverEscalatesRepeatedRework: a second review rejection with
+// the IDENTICAL gap fingerprint drops the resumed gatekeeper session,
+// so any subsequent round starts with fresh eyes instead of the same
+// session re-asserting its anchored verdict.
+func TestDriverEscalatesRepeatedRework(t *testing.T) {
+	findings := []Finding{{Title: "missing depth", File: "summary.md"}}
+	fp := GapFingerprint(findings)
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "research", Phase: PhaseReview, Status: StatusWorking,
+		MaxIterations: 8, Workspace: t.TempDir(), LastGapFingerprint: fp, StallCount: 1,
+		Spec: Spec{Units: []PlanUnit{{Title: "write summary"}}},
+	})
+	runner := &scriptedRunner{reviewVerdicts: []ReviewVerdict{{Approved: false, Findings: findings}}}
+	d := testDriver(store, runner)
+	d.gatekeepers["m1"] = &GatekeeperState{}
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if _, ok := d.gatekeepers["m1"]; ok {
+		t.Fatal("gatekeeper state survived a repeated identical rework — must be dropped for fresh-eyes review")
+	}
+}
+
+// TestDriverModelFloorPausesImmediately: ErrModelFloor from the runner
+// must pause the mission as infra on the FIRST turn — not accrue
+// worker_failed rounds toward backoff.
+func TestDriverModelFloorPausesImmediately(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
+	runner := &scriptedRunner{workerErr: fmt.Errorf("%w: amazon.nova-lite-v1:0", ErrModelFloor)}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Status != StatusPaused || m.PauseReason != PauseInfra {
+		t.Fatalf("mission after below-floor turn = %s/%s, want paused/infra immediately", m.Status, m.PauseReason)
 	}
 }

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -14,32 +14,63 @@ import (
 
 // Mission is the API/DB shape of one missions row.
 type Mission struct {
-	ID                  string         `json:"id"`
-	Goal                string         `json:"goal"`
-	Kind                string         `json:"kind"` // coding | research | scheduled
-	AgentID             string         `json:"agent_id,omitempty"`
-	Phase               Phase          `json:"phase"`
-	Status              Status         `json:"status"`
-	PauseReason         PauseReason    `json:"pause_reason,omitempty"`
-	PauseMessage        string         `json:"pause_message,omitempty"`
-	Workspace           string         `json:"workspace,omitempty"`
-	Worktree            string         `json:"worktree,omitempty"`
-	Branch              string         `json:"branch,omitempty"`
-	BaseCommit          string         `json:"base_commit,omitempty"`
-	Spec                Spec           `json:"spec"`
-	Progress            []ProgressNote `json:"progress"`
-	Iteration           int            `json:"iteration"`
-	MaxIterations       int            `json:"max_iterations"`
-	ConsecutiveFailures int            `json:"consecutive_failures"`
-	LastGapFingerprint  string         `json:"last_gap_fingerprint,omitempty"`
-	StallCount          int            `json:"stall_count"`
-	BudgetUSD           *float64       `json:"budget_usd,omitempty"`
-	Route               string         `json:"route"`
-	ReviewRoute         string         `json:"review_route"`
-	PendingPermission   string         `json:"pending_permission,omitempty"`
-	ScheduleID          string         `json:"schedule_id,omitempty"`
-	CreatedAt           time.Time      `json:"created_at"`
-	UpdatedAt           time.Time      `json:"updated_at"`
+	ID           string         `json:"id"`
+	Goal         string         `json:"goal"`
+	Kind         string         `json:"kind"` // coding | research | scheduled
+	AgentID      string         `json:"agent_id,omitempty"`
+	Phase        Phase          `json:"phase"`
+	Status       Status         `json:"status"`
+	PauseReason  PauseReason    `json:"pause_reason,omitempty"`
+	PauseMessage string         `json:"pause_message,omitempty"`
+	Workspace    string         `json:"workspace,omitempty"`
+	Worktree     string         `json:"worktree,omitempty"`
+	Branch       string         `json:"branch,omitempty"`
+	BaseCommit   string         `json:"base_commit,omitempty"`
+	Spec         Spec           `json:"spec"`
+	Progress     []ProgressNote `json:"progress"`
+	// LastEvidence is the most recent worker mission_status call's
+	// evidence text — carried from execute into review so a
+	// research/scheduled mission (whose baseline diff is always empty,
+	// having touched no tracked files) still gives the reviewer
+	// something real to judge instead of nothing.
+	LastEvidence        string   `json:"last_evidence,omitempty"`
+	Iteration           int      `json:"iteration"`
+	MaxIterations       int      `json:"max_iterations"`
+	ConsecutiveFailures int      `json:"consecutive_failures"`
+	LastGapFingerprint  string   `json:"last_gap_fingerprint,omitempty"`
+	StallCount          int      `json:"stall_count"`
+	BudgetUSD           *float64 `json:"budget_usd,omitempty"`
+	Route               string   `json:"route"`
+	ReviewRoute         string   `json:"review_route"`
+	PendingPermission   string   `json:"pending_permission,omitempty"`
+	// PendingPermissionTool/Args/Danger/Rationale describe the parked
+	// tool call for the UI — set alongside PendingPermission whenever a
+	// worker/reviewer/planner turn parks on stream.EventPermissionRequest,
+	// cleared together once the broker resolves it. Bypasses the state
+	// machine entirely (SetPendingPermission/ClearPendingPermission),
+	// same as SetSpec/SetProvisioned: parking happens mid-turn, not at
+	// an Advance boundary.
+	PendingPermissionTool      string `json:"pending_permission_tool,omitempty"`
+	PendingPermissionArgs      string `json:"pending_permission_args,omitempty"`
+	PendingPermissionDanger    string `json:"pending_permission_danger,omitempty"`
+	PendingPermissionRationale string `json:"pending_permission_rationale,omitempty"`
+	// AutoApproveSafe, when true (the default for new missions), grants
+	// the hidden session standing approval for any shell call the
+	// danger classifier rates safe — a mission runs for hours
+	// unattended, and per-command-shape approval built for a human
+	// watching a chat session would otherwise park it on every novel
+	// (but harmless) shell invocation. Destructive-classified commands
+	// still always ask: tools.Permissions.Resolve forces that
+	// regardless of any grant, so this cannot weaken that guarantee.
+	AutoApproveSafe bool   `json:"auto_approve_safe"`
+	ScheduleID      string `json:"schedule_id,omitempty"`
+	// SessionID is a hidden, non-chat-facing session row this mission's
+	// worker/reviewer/planner turns run under — loop.Agent's tool-call
+	// bookkeeping (session_events, audit) hard-requires a real session
+	// id, which a mission otherwise has no reason to have.
+	SessionID string    `json:"-"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // Spec is the mission's plan: an ordered list of units, each verified
@@ -49,12 +80,17 @@ type Spec struct {
 }
 
 // PlanUnit is one item of the plan. Passes is flipped only by the
-// harness (RunVerify), never by model output, and only on verify_cmd's
-// exit-code evidence.
+// harness (RunVerify + CheckArtifacts), never by model output, and
+// only on that harness-run evidence.
 type PlanUnit struct {
 	Title     string `json:"title"`
 	VerifyCmd string `json:"verify_cmd"`
-	Passes    bool   `json:"passes"`
+	// Artifacts are workspace-relative paths this unit must produce.
+	// The harness checks each exists and is non-empty BEFORE running
+	// verify_cmd — a tautological verify_cmd (echo 'done') can no
+	// longer fake completion when the declared artifact is missing.
+	Artifacts []string `json:"artifacts,omitempty"`
+	Passes    bool     `json:"passes"`
 }
 
 // ProgressNote is one append-only entry in the mission's progress log
@@ -74,6 +110,16 @@ type Event struct {
 	Provenance  string          `json:"provenance"`
 	Fingerprint string          `json:"fingerprint,omitempty"`
 	CreatedAt   time.Time       `json:"created_at"`
+}
+
+// Notification is one row from the notifications inbox.
+type Notification struct {
+	ID        string    `json:"id"`
+	MissionID string    `json:"mission_id"`
+	Kind      string    `json:"kind"`
+	Message   string    `json:"message"`
+	Read      bool      `json:"read"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // Sentinel errors the HTTP layer maps onto status codes, mirroring

--- a/internal/brain/missions/notify.go
+++ b/internal/brain/missions/notify.go
@@ -1,0 +1,164 @@
+package missions
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+const webhookTimeout = 10 * time.Second
+
+// Notifier fires ONLY on actionable transitions (waiting_for_input,
+// paused, done, error) and only exactly on the transition INTO that
+// state — re-kicking an already-paused mission stays silent.
+type Notifier struct {
+	db         *pgpool.Pool
+	webhookURL string // NOTIFY_WEBHOOK_URL; empty disables fan-out, inbox row still always written
+	log        *slog.Logger
+	http       *http.Client
+}
+
+func NewNotifier(db *pgpool.Pool, webhookURL string, log *slog.Logger) *Notifier {
+	return &Notifier{db: db, webhookURL: webhookURL, log: log, http: &http.Client{Timeout: webhookTimeout}}
+}
+
+// isActionableTransition is the pure classification Driver's
+// before/after Status pair goes through: only these four destination
+// states are actionable, and only when the mission just arrived there
+// this call (a repeat Advance on an already-paused mission reports the
+// SAME before/after, so it's silent by construction).
+func isActionableTransition(before, after Status) (kind string, ok bool) {
+	if before == after {
+		return "", false
+	}
+	switch after {
+	case StatusWaitingForInput, StatusPaused, StatusDone, StatusError:
+		return string(after), true
+	default:
+		return "", false
+	}
+}
+
+// OnTransition is called by Driver after ApplyTransition succeeds, with
+// the before/after Status. Durable channel: a notifications row is
+// always written for a qualifying transition. Best-effort fan-out:
+// webhook POST of a generic JSON payload; failure only logs, never
+// blocks or loses the notification.
+func (n *Notifier) OnTransition(ctx context.Context, missionID string, before, after Status) error {
+	kind, ok := isActionableTransition(before, after)
+	if !ok {
+		return nil
+	}
+	message := fmt.Sprintf("mission %s is now %s", missionID, kind)
+	if err := n.sendOncePerMission(ctx, missionID, kind, message); err != nil {
+		return fmt.Errorf("notify: %w", err)
+	}
+	n.fanOut(ctx, missionID, kind, message)
+	return nil
+}
+
+// sendOncePerMission dedupes by "already has an unread notification of
+// this kind" — checked inside the same insert (via a NOT EXISTS
+// subquery), not a separate pre-check, to avoid a TOCTOU race between
+// two concurrent Advance calls for the same mission.
+func (n *Notifier) sendOncePerMission(ctx context.Context, missionID, kind, message string) error {
+	db, err := n.db.Get()
+	if err != nil {
+		return fmt.Errorf("get pool: %w", err)
+	}
+	_, err = db.Exec(ctx, `INSERT INTO notifications (mission_id, kind, message)
+		SELECT $1, $2, $3
+		WHERE NOT EXISTS (
+			SELECT 1 FROM notifications WHERE mission_id = $1 AND kind = $2 AND NOT read
+		)`, missionID, kind, message)
+	if err != nil {
+		return fmt.Errorf("insert: %w", err)
+	}
+	return nil
+}
+
+// fanOut posts a generic JSON payload to webhookURL for ntfy/Slack/
+// Telegram-style receivers. Best-effort: a failure only logs, it never
+// blocks the caller or drops the durable inbox row already written.
+func (n *Notifier) fanOut(ctx context.Context, missionID, kind, message string) {
+	if n.webhookURL == "" {
+		return
+	}
+	body, err := json.Marshal(map[string]string{
+		"mission_id": missionID, "kind": kind, "message": message,
+	})
+	if err != nil {
+		n.log.Warn("notify: webhook marshal failed", "error", err)
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.webhookURL, bytes.NewReader(body))
+	if err != nil {
+		n.log.Warn("notify: webhook request build failed", "error", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := n.http.Do(req)
+	if err != nil {
+		n.log.Warn("notify: webhook post failed", "error", err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		n.log.Warn("notify: webhook returned non-2xx", "status", resp.StatusCode)
+	}
+}
+
+// ClearMission marks unread rows read once the mission advances past
+// waiting_for_input/paused — stale "waiting for input" rows don't
+// linger once the situation's resolved.
+func (n *Notifier) ClearMission(ctx context.Context, missionID string) error {
+	db, err := n.db.Get()
+	if err != nil {
+		return fmt.Errorf("notify: clear: %w", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE notifications SET read = true WHERE mission_id = $1 AND NOT read`, missionID); err != nil {
+		return fmt.Errorf("notify: clear: %w", err)
+	}
+	return nil
+}
+
+// List returns unread-first notifications across all missions.
+func (n *Notifier) List(ctx context.Context) ([]Notification, error) {
+	db, err := n.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("notify: list: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT id, mission_id, kind, message, read, created_at
+		FROM notifications ORDER BY read, created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("notify: list: %w", err)
+	}
+	defer rows.Close()
+	out := []Notification{}
+	for rows.Next() {
+		var note Notification
+		if err := rows.Scan(&note.ID, &note.MissionID, &note.Kind, &note.Message, &note.Read, &note.CreatedAt); err != nil {
+			return nil, fmt.Errorf("notify: list: %w", err)
+		}
+		out = append(out, note)
+	}
+	return out, rows.Err()
+}
+
+// MarkRead marks one notification read (idempotent).
+func (n *Notifier) MarkRead(ctx context.Context, id string) error {
+	db, err := n.db.Get()
+	if err != nil {
+		return fmt.Errorf("notify: mark read: %w", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE notifications SET read = true WHERE id = $1`, id); err != nil {
+		return fmt.Errorf("notify: mark read: %w", err)
+	}
+	return nil
+}

--- a/internal/brain/missions/notify_integration_test.go
+++ b/internal/brain/missions/notify_integration_test.go
@@ -1,0 +1,184 @@
+//go:build integration
+
+package missions
+
+import (
+	"context"
+	"testing"
+)
+
+func testNotifier(t *testing.T, store *Store) *Notifier {
+	t.Helper()
+	return NewNotifier(store.db, "", store.log)
+}
+
+func TestOnTransitionWritesNotificationOnActionableTransition(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	n := testNotifier(t, store)
+
+	id, err := store.Create(ctx, Mission{Goal: marker + "notify-1", Kind: "research"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := n.OnTransition(ctx, id, StatusWorking, StatusPaused); err != nil {
+		t.Fatalf("OnTransition: %v", err)
+	}
+	notes, err := n.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	found := false
+	for _, note := range notes {
+		if note.MissionID == id {
+			found = true
+			if note.Kind != "paused" || note.Read {
+				t.Fatalf("notification = %+v, want kind=paused unread", note)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("OnTransition on an actionable transition did not write a notification")
+	}
+}
+
+func TestOnTransitionSilentOnNonActionable(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	n := testNotifier(t, store)
+
+	id, err := store.Create(ctx, Mission{Goal: marker + "notify-2", Kind: "research"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := n.OnTransition(ctx, id, StatusIdle, StatusWorking); err != nil {
+		t.Fatalf("OnTransition: %v", err)
+	}
+	notes, err := n.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, note := range notes {
+		if note.MissionID == id {
+			t.Fatalf("non-actionable transition wrote a notification: %+v", note)
+		}
+	}
+}
+
+func TestSendOncePerMissionDedupes(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	n := testNotifier(t, store)
+
+	id, err := store.Create(ctx, Mission{Goal: marker + "notify-3", Kind: "research"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// A worker re-asking permission every command still produces
+	// exactly ONE inbox row, not one per re-ask.
+	for i := 0; i < 3; i++ {
+		if err := n.OnTransition(ctx, id, StatusWorking, StatusWaitingForInput); err != nil {
+			t.Fatalf("OnTransition[%d]: %v", i, err)
+		}
+	}
+	notes, err := n.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	count := 0
+	for _, note := range notes {
+		if note.MissionID == id {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("notification count for repeated identical transitions = %d, want 1", count)
+	}
+}
+
+func TestClearMissionMarksUnreadRowsRead(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	n := testNotifier(t, store)
+
+	id, err := store.Create(ctx, Mission{Goal: marker + "notify-4", Kind: "research"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := n.OnTransition(ctx, id, StatusWorking, StatusPaused); err != nil {
+		t.Fatalf("OnTransition: %v", err)
+	}
+	if err := n.ClearMission(ctx, id); err != nil {
+		t.Fatalf("ClearMission: %v", err)
+	}
+	notes, err := n.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, note := range notes {
+		if note.MissionID == id && !note.Read {
+			t.Fatalf("ClearMission did not mark the notification read: %+v", note)
+		}
+	}
+
+	// A NEW notification for the same mission after clearing is not
+	// suppressed by the dedup logic (the prior one is read, so the
+	// NOT EXISTS ... AND NOT read guard doesn't see it).
+	if err := n.OnTransition(ctx, id, StatusWorking, StatusDone); err != nil {
+		t.Fatalf("OnTransition after clear: %v", err)
+	}
+	notes, err = n.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	unreadDone := false
+	for _, note := range notes {
+		if note.MissionID == id && note.Kind == "done" && !note.Read {
+			unreadDone = true
+		}
+	}
+	if !unreadDone {
+		t.Fatal("a fresh actionable transition after ClearMission did not write a new unread notification")
+	}
+}
+
+func TestMarkRead(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	n := testNotifier(t, store)
+
+	id, err := store.Create(ctx, Mission{Goal: marker + "notify-5", Kind: "research"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := n.OnTransition(ctx, id, StatusWorking, StatusError); err != nil {
+		t.Fatalf("OnTransition: %v", err)
+	}
+	notes, err := n.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var noteID string
+	for _, note := range notes {
+		if note.MissionID == id {
+			noteID = note.ID
+		}
+	}
+	if noteID == "" {
+		t.Fatal("could not find the notification just created")
+	}
+	if err := n.MarkRead(ctx, noteID); err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+	notes, err = n.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, note := range notes {
+		if note.ID == noteID && !note.Read {
+			t.Fatal("MarkRead did not mark the notification read")
+		}
+	}
+}

--- a/internal/brain/missions/notify_test.go
+++ b/internal/brain/missions/notify_test.go
@@ -1,0 +1,30 @@
+package missions
+
+import "testing"
+
+func TestIsActionableTransition(t *testing.T) {
+	cases := []struct {
+		name          string
+		before, after Status
+		wantOK        bool
+		wantKind      string
+	}{
+		{"idle to working is not actionable", StatusIdle, StatusWorking, false, ""},
+		{"working to idle is not actionable", StatusWorking, StatusIdle, false, ""},
+		{"working to waiting_for_input is actionable", StatusWorking, StatusWaitingForInput, true, "waiting_for_input"},
+		{"working to paused is actionable", StatusWorking, StatusPaused, true, "paused"},
+		{"working to done is actionable", StatusWorking, StatusDone, true, "done"},
+		{"working to error is actionable", StatusWorking, StatusError, true, "error"},
+		{"paused to paused (repeat Advance) is NOT actionable", StatusPaused, StatusPaused, false, ""},
+		{"waiting_for_input to waiting_for_input (repeat) is NOT actionable", StatusWaitingForInput, StatusWaitingForInput, false, ""},
+		{"paused to idle (resume) is not itself actionable", StatusPaused, StatusIdle, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kind, ok := isActionableTransition(tc.before, tc.after)
+			if ok != tc.wantOK || kind != tc.wantKind {
+				t.Fatalf("isActionableTransition(%q, %q) = (%q, %v), want (%q, %v)", tc.before, tc.after, kind, ok, tc.wantKind, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/brain/missions/packet.go
+++ b/internal/brain/missions/packet.go
@@ -28,7 +28,7 @@ type WorkPacket struct {
 // messages, an earlier note); both pass through NeutralizeSlot before
 // insertion — self-injection hardening.
 func (p WorkPacket) Render() (system, user string) {
-	system = "You are executing one unit of a plan. Work toward the goal, then end your turn with exactly one mission_status tool call: done (with evidence), retry (with analysis), or blocked (with a question)."
+	system = "You are executing one unit of a plan. Work toward the goal, then end your turn with exactly one mission_status tool call: done (with evidence), retry (with analysis), or blocked (with a question). Create or update files ONLY with the write_file tool using workspace-relative paths — never shell redirects (>, >>) or heredocs, which require interactive approval and will stall you. Use shell for reading and checking, not writing. The harness verifies your declared artifacts exist on disk; describing a file is not producing it."
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "Goal: %s\n", NeutralizeSlot(p.Goal))
@@ -42,6 +42,15 @@ func (p WorkPacket) Render() (system, user string) {
 				status = "verified"
 			}
 			fmt.Fprintf(&b, "- [%s] %s\n", status, NeutralizeSlot(u.Title))
+			// The EXACT artifact paths the harness will check — a worker
+			// that invents its own filename (http-429 vs http429) fails
+			// verification without ever seeing why.
+			for _, a := range u.Artifacts {
+				fmt.Fprintf(&b, "  must produce (exact path): %s\n", NeutralizeSlot(a))
+			}
+			if u.VerifyCmd != "" {
+				fmt.Fprintf(&b, "  verified by: %s\n", NeutralizeSlot(u.VerifyCmd))
+			}
 		}
 		b.WriteString("\n")
 	}

--- a/internal/brain/missions/review.go
+++ b/internal/brain/missions/review.go
@@ -6,26 +6,125 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io/fs"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
-	"github.com/SumonMSelim/timothy/internal/gateway/provider"
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
 )
 
 const (
 	reviewVerdictToolName = "review_verdict"
 	baselineDiffCap       = 256 << 10
 	baselineDiffTimeout   = 30 * time.Second
+
+	// reviewArtifactsCap bounds the total artifact bytes a reviewer
+	// sees — enough for real research/config artifacts, small enough
+	// to never balloon the review turn.
+	reviewArtifactsCap = 32 << 10
+	// reviewListingCap bounds the workspace file listing.
+	reviewListingCap = 2 << 10
 )
 
-// ReviewVerdictTool defines the reviewer's one tool call. The
-// reviewer's system prompt instructs it to REFUTE — approval is the
-// fallthrough the driver takes only on an explicit approve, never the
-// default read of an ambiguous response.
-func ReviewVerdictTool() provider.ToolDef {
-	return provider.ToolDef{
+// ReviewPacket is everything a reviewer turn judges: the mission's
+// goal and plan (an earlier failure mode was reviewers rejecting with
+// "missing original mission goal"), the ACTUAL artifact contents read
+// by the harness from the workspace (never the worker's description
+// of them), the baseline diff when a worktree exists, and the
+// worker's evidence text last.
+type ReviewPacket struct {
+	Goal      string
+	UnitTitle string
+	Plan      Spec
+	Diff      string
+	// Artifacts maps workspace-relative path -> file contents, read by
+	// the harness (ReadArtifacts), capped at reviewArtifactsCap total.
+	Artifacts map[string]string
+	// Listing is a flat file listing of the workspace (name + size) so
+	// the reviewer can see what exists even when a unit declares no
+	// artifacts.
+	Listing  string
+	Evidence string
+}
+
+// ReadArtifacts reads each declared artifact from workRoot, capped at
+// reviewArtifactsCap TOTAL across files; a file that would blow the
+// remaining budget is truncated with an honest marker. Missing or
+// unreadable files map to an error note rather than being dropped —
+// the reviewer must see the gap, not silently less material.
+func ReadArtifacts(workRoot string, artifacts []string) map[string]string {
+	if len(artifacts) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(artifacts))
+	remaining := reviewArtifactsCap
+	for _, a := range artifacts {
+		rel := strings.TrimSpace(a)
+		if rel == "" {
+			continue
+		}
+		cleaned := filepath.Clean(rel)
+		if filepath.IsAbs(cleaned) || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+			out[rel] = "[not readable: path escapes the workspace]"
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(workRoot, cleaned)) //nolint:gosec // path is workspace-relative, cleaned, and .. / absolute forms are rejected above
+		if err != nil {
+			out[rel] = "[not readable: " + err.Error() + "]"
+			continue
+		}
+		if len(b) > remaining {
+			out[rel] = string(b[:remaining]) + fmt.Sprintf("\n[truncated: file is %d bytes, review cap reached]", len(b))
+			remaining = 0
+			continue
+		}
+		out[rel] = string(b)
+		remaining -= len(b)
+	}
+	return out
+}
+
+// ListWorkspace returns a flat "path (size)" listing of regular files
+// under workRoot, capped — the reviewer's map of what actually exists
+// on disk, independent of what anyone claims.
+func ListWorkspace(workRoot string) string {
+	var b strings.Builder
+	_ = filepath.WalkDir(workRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || b.Len() >= reviewListingCap {
+			return filepath.SkipAll
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, relErr := filepath.Rel(workRoot, path)
+		if relErr != nil {
+			return nil
+		}
+		info, infoErr := d.Info()
+		size := int64(0)
+		if infoErr == nil {
+			size = info.Size()
+		}
+		fmt.Fprintf(&b, "%s (%d bytes)\n", rel, size)
+		return nil
+	})
+	return b.String()
+}
+
+// ReviewVerdictTool defines the reviewer's one tool call — registered
+// per-turn via loop.Request.ExtraTools, never in the shared agent tool
+// surface. The reviewer's system prompt instructs it to REFUTE —
+// approval is the fallthrough the driver takes only on an explicit
+// approve, never the default read of an ambiguous response.
+func ReviewVerdictTool() *tools.Tool {
+	return &tools.Tool{
 		Name:        reviewVerdictToolName,
 		Description: "Report your review verdict. Call this exactly once. Look for reasons to reject before approving — approve only when you cannot find a real gap.",
 		InputSchema: json.RawMessage(`{
@@ -52,6 +151,9 @@ func ReviewVerdictTool() provider.ToolDef {
 			},
 			"required": ["decision"]
 		}`),
+		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
+			return "verdict recorded", nil
+		},
 	}
 }
 

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -3,14 +3,25 @@ package missions
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 
 	"github.com/SumonMSelim/timothy/internal/brain/loop"
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+	"github.com/SumonMSelim/timothy/internal/brain/tools/builtin"
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 )
+
+// ErrModelFloor reports that a mission turn was served by a model on
+// the runner's deny list — a fallback too weak to drive tool-using
+// agentic turns. The driver pauses the mission immediately (infra)
+// instead of burning its iteration budget on a model that cannot
+// succeed.
+var ErrModelFloor = errors.New("mission turn served by a below-floor model")
 
 // GatekeeperState is whatever a reviewer session needs to resume
 // in-memory for a delta recheck on rework, instead of cold-reanalyzing
@@ -35,9 +46,9 @@ type Runner interface {
 	RunWorker(ctx context.Context, m Mission, packet WorkPacket) (WorkerVerdict, string, error)
 
 	// RunReview resumes (or starts, on the first round) the gatekeeper
-	// session, judging diff plus the worker's evidence, and returns the
-	// verdict.
-	RunReview(ctx context.Context, m Mission, diff string, gatekeeper *GatekeeperState) (ReviewVerdict, *GatekeeperState, error)
+	// session, judging the packet — goal, plan, harness-read artifact
+	// contents, diff, evidence — and returns the verdict.
+	RunReview(ctx context.Context, m Mission, packet ReviewPacket, gatekeeper *GatekeeperState) (ReviewVerdict, *GatekeeperState, error)
 
 	// PlanSession runs the planning turn that produces a Spec (the list
 	// of PlanUnits) from the mission's goal and research-phase findings.
@@ -52,20 +63,102 @@ type agentStream interface {
 	Start(ctx context.Context, req loop.Request) (<-chan stream.StreamEvent, error)
 }
 
+// StorePermissionParker adapts *Store to parkNotifier — the production
+// implementation NewNativeRunner is constructed with. Errors are
+// logged, never returned: a failed park/clear write must not abort the
+// turn it's reporting on.
+type StorePermissionParker struct {
+	Store *Store
+	Log   *slog.Logger
+}
+
+// NewStorePermissionParker builds the parkNotifier cmd/brain/main.go
+// wires into NewNativeRunner.
+func NewStorePermissionParker(store *Store, log *slog.Logger) *StorePermissionParker {
+	return &StorePermissionParker{Store: store, Log: log}
+}
+
+func (p *StorePermissionParker) OnPermissionParked(ctx context.Context, missionID, permissionID, tool, args, danger, rationale string) {
+	if err := p.Store.SetPendingPermission(ctx, missionID, permissionID, tool, args, danger, rationale); err != nil {
+		p.Log.Error("mission: record pending permission failed", "mission_id", missionID, "error", err)
+	}
+}
+
+func (p *StorePermissionParker) OnPermissionCleared(ctx context.Context, missionID string) {
+	if err := p.Store.ClearPendingPermission(ctx, missionID); err != nil {
+		p.Log.Error("mission: clear pending permission failed", "mission_id", missionID, "error", err)
+	}
+}
+
+// parkNotifier reports a mission turn parking on (and later clearing)
+// a tool-call permission prompt — without this, the same interactive
+// broker chat sessions use silently strands a mission worker turn for
+// the full 10-minute timeout with nothing telling the UI a decision is
+// needed. Backed by *Store in production (SetPendingPermission /
+// ClearPendingPermission), faked in tests.
+type parkNotifier interface {
+	OnPermissionParked(ctx context.Context, missionID, permissionID, tool, args, danger, rationale string)
+	OnPermissionCleared(ctx context.Context, missionID string)
+}
+
 // nativeRunner is Phase 1's only Runner: every call is one loop.Agent
 // turn over the gateway, tagged with the mission's route/review_route
 // and MissionID (for ledger attribution).
 type nativeRunner struct {
-	agent agentStream
-	log   *slog.Logger
+	agent  agentStream
+	parker parkNotifier
+	log    *slog.Logger
+	// modelFloorDeny lists model-name substrings too weak to drive a
+	// tool-using mission turn (e.g. "nova-lite", "qwen2.5:7b"); a turn
+	// served by one returns ErrModelFloor so the driver pauses fast
+	// instead of burning iterations. Empty = floor disabled.
+	modelFloorDeny []string
 }
 
 // NewNativeRunner wraps a production *loop.Agent as a Runner. The
 // agent instance is expected to be brain's existing chat agent — a
 // mission worker turn is just another loop.Agent caller, not a
-// separate permission/audit/tool-execution stack.
-func NewNativeRunner(agent *loop.Agent, log *slog.Logger) Runner {
-	return &nativeRunner{agent: agent, log: log}
+// separate permission/audit/tool-execution stack. parker may be nil
+// (park events are then silently ignored, same as before this existed).
+func NewNativeRunner(agent *loop.Agent, parker parkNotifier, log *slog.Logger) Runner {
+	return &nativeRunner{agent: agent, parker: parker, log: log}
+}
+
+// NewNativeRunnerWithFloor is NewNativeRunner plus a model floor deny
+// list (see nativeRunner.modelFloorDeny).
+func NewNativeRunnerWithFloor(agent *loop.Agent, parker parkNotifier, floorDeny []string, log *slog.Logger) Runner {
+	return &nativeRunner{agent: agent, parker: parker, modelFloorDeny: floorDeny, log: log}
+}
+
+// missionTools builds the turn-scoped file tools rooted in the
+// mission's OWN directory (worktree for coding, workspace otherwise):
+// a shell that replaces the global workspace-rooted one for the turn —
+// the root cause of a whole failure family was workers writing into
+// the shared root while verify_cmd and the reviewer looked in the
+// per-mission directory — and write_file, so artifact writes never go
+// through destructive-classified shell redirects.
+func missionTools(m Mission) []*tools.Tool {
+	root := m.Worktree
+	if root == "" {
+		root = m.Workspace
+	}
+	if root == "" {
+		return nil
+	}
+	return []*tools.Tool{
+		builtin.Shell(builtin.ShellConfig{WorkspaceRoot: root}),
+		builtin.WriteFile(builtin.WriteFileConfig{Root: root}),
+	}
+}
+
+// belowFloor reports whether model matches the deny list.
+func (r *nativeRunner) belowFloor(model string) bool {
+	for _, deny := range r.modelFloorDeny {
+		if deny != "" && strings.Contains(strings.ToLower(model), strings.ToLower(deny)) {
+			return true
+		}
+	}
+	return false
 }
 
 // runTurn drives one loop.Agent session to completion, capturing the
@@ -79,6 +172,8 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 		return "", nil, err
 	}
 	var b strings.Builder
+	parked := false
+	servedModel := ""
 	for ev := range events {
 		switch ev.Type {
 		case stream.EventChunk:
@@ -87,9 +182,34 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if ev.ToolCall != nil && ev.ToolCall.Name == sentinelTool {
 				sentinelArgs = ev.ToolCall.Input
 			}
+		case stream.EventPermissionRequest:
+			if r.parker != nil && ev.Permission != nil {
+				parked = true
+				r.parker.OnPermissionParked(ctx, req.MissionID, ev.Permission.ID, ev.Permission.Tool,
+					ev.Permission.Args, ev.Permission.Danger, ev.Permission.Rationale)
+			}
+		case stream.EventToolResult:
+			// Any tool result clears a park — resolving the very call
+			// that parked ends it; a parallel call finishing first would
+			// clear early, but Phase 1's worker/reviewer/planner turns
+			// never issue overlapping tool calls, so this stays exact.
+			if parked && r.parker != nil {
+				parked = false
+				r.parker.OnPermissionCleared(ctx, req.MissionID)
+			}
+		case stream.EventDone:
+			if ev.Meta != nil {
+				servedModel = ev.Meta.Model
+			}
 		case stream.EventError:
+			if parked && r.parker != nil {
+				r.parker.OnPermissionCleared(ctx, req.MissionID)
+			}
 			return b.String(), sentinelArgs, fmt.Errorf("mission runner: %s", ev.Err.Message)
 		}
+	}
+	if servedModel != "" && r.belowFloor(servedModel) {
+		return b.String(), sentinelArgs, fmt.Errorf("%w: %s", ErrModelFloor, servedModel)
 	}
 	return b.String(), sentinelArgs, nil
 }
@@ -102,12 +222,15 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 // retry, never a silent accept.
 func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPacket) (WorkerVerdict, string, error) {
 	system, user := packet.Render()
+	extra := append([]*tools.Tool{MissionStatusTool()}, missionTools(m)...)
 	req := loop.Request{
-		Route:     m.Route,
-		Agent:     "mission-worker",
-		MissionID: m.ID,
-		System:    system,
-		Messages:  []provider.Message{{Role: "user", Content: user}},
+		SessionID:  m.SessionID,
+		Route:      m.Route,
+		Agent:      "mission-worker",
+		MissionID:  m.ID,
+		System:     system,
+		Messages:   []provider.Message{{Role: "user", Content: user}},
+		ExtraTools: extra,
 	}
 
 	text, args, err := r.runTurn(ctx, req, missionStatusToolName)
@@ -154,32 +277,54 @@ func (r *nativeRunner) tryParseVerdict(args json.RawMessage) (WorkerVerdict, boo
 	return v, true
 }
 
-// RunReview judges the worker's evidence against the baseline diff.
-// gatekeeper carries prior messages to resume the same reviewer
+// RunReview judges the packet: the mission's goal and plan, the
+// harness-read artifact contents (never the worker's description of
+// them), the baseline diff when one exists, and the worker's evidence
+// last. gatekeeper carries prior messages to resume the same reviewer
 // session on rework (a "delta recheck" instead of cold-reanalyzing);
 // nil starts fresh.
-func (r *nativeRunner) RunReview(ctx context.Context, m Mission, diff string, gatekeeper *GatekeeperState) (ReviewVerdict, *GatekeeperState, error) {
-	system := "You are reviewing one unit of a mission's work. Look for reasons to reject before approving. Judge the actual diff, not the worker's description of it. End your turn with exactly one review_verdict tool call."
+func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPacket, gatekeeper *GatekeeperState) (ReviewVerdict, *GatekeeperState, error) {
+	system := "You are reviewing one unit of a mission's work. The mission goal, the plan, and the actual artifact contents (read from disk by the harness, not reported by the worker) are all below — judge against THEM. Look for real reasons to reject before approving: the artifact not satisfying the goal, unsupported claims, missing substance. Do NOT reject for material you were not given (the harness supplies everything there is). End your turn with exactly one review_verdict tool call."
+	content := renderReviewContent(packet)
 
 	var messages []provider.Message
 	if gatekeeper != nil {
 		messages = append(messages, gatekeeper.Messages...)
 	}
-	messages = append(messages, provider.Message{Role: "user", Content: "Diff to review:\n" + diff})
+	messages = append(messages, provider.Message{Role: "user", Content: content})
 
+	extra := append([]*tools.Tool{ReviewVerdictTool()}, missionTools(m)...)
 	req := loop.Request{
-		Route:     m.ReviewRoute,
-		Agent:     "mission-reviewer",
-		MissionID: m.ID,
-		System:    system,
-		Messages:  messages,
+		SessionID:  m.SessionID,
+		Route:      m.ReviewRoute,
+		Agent:      "mission-reviewer",
+		MissionID:  m.ID,
+		System:     system,
+		Messages:   messages,
+		ExtraTools: extra,
 	}
 	text, args, err := r.runTurn(ctx, req, reviewVerdictToolName)
 	if err != nil {
 		return ReviewVerdict{}, nil, err
 	}
 	if len(args) == 0 {
-		return ReviewVerdict{}, nil, fmt.Errorf("mission runner: reviewer ended without a review_verdict call")
+		// Recovery re-run: same one-shot ladder RunWorker uses — a
+		// reviewer that ran long on analysis and didn't reach its tool
+		// call gets one more turn demanding it, instead of failing the
+		// whole review round outright.
+		recoverReq := req
+		recoverReq.Messages = append(append([]provider.Message{}, req.Messages...),
+			provider.Message{Role: "assistant", Content: text},
+			provider.Message{Role: "user", Content: "[system] You must end your turn with exactly one review_verdict tool call: approve or rework."},
+		)
+		recoverText, recoverArgs, err := r.runTurn(ctx, recoverReq, reviewVerdictToolName)
+		if err != nil {
+			return ReviewVerdict{}, nil, err
+		}
+		if len(recoverArgs) == 0 {
+			return ReviewVerdict{}, nil, fmt.Errorf("mission runner: reviewer ended without a review_verdict call")
+		}
+		text, args = text+"\n"+recoverText, recoverArgs
 	}
 	verdict, err := parseReviewVerdict(args)
 	if err != nil {
@@ -190,15 +335,65 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, diff string, ga
 	return verdict, nextState, nil
 }
 
+// renderReviewContent lays the packet out for the reviewer: goal and
+// plan first (context), harness-read artifacts and diff in the middle
+// (the evidence that counts), the worker's own account last (the
+// least trustworthy part). All model-produced text passes through
+// NeutralizeSlot.
+func renderReviewContent(p ReviewPacket) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Mission goal: %s\n", NeutralizeSlot(p.Goal))
+	if p.UnitTitle != "" {
+		fmt.Fprintf(&b, "Unit under review: %s\n", NeutralizeSlot(p.UnitTitle))
+	}
+	if len(p.Plan.Units) > 0 {
+		b.WriteString("\nPlan:\n")
+		for _, u := range p.Plan.Units {
+			status := "pending"
+			if u.Passes {
+				status = "verified"
+			}
+			fmt.Fprintf(&b, "- [%s] %s\n", status, NeutralizeSlot(u.Title))
+		}
+	}
+	if p.Listing != "" {
+		b.WriteString("\nWorkspace files:\n")
+		b.WriteString(p.Listing)
+	}
+	if len(p.Artifacts) > 0 {
+		paths := make([]string, 0, len(p.Artifacts))
+		for path := range p.Artifacts {
+			paths = append(paths, path)
+		}
+		sort.Strings(paths)
+		b.WriteString("\nArtifact contents (read from disk by the harness):\n")
+		for _, path := range paths {
+			fmt.Fprintf(&b, "\n--- %s ---\n%s\n", path, NeutralizeSlot(p.Artifacts[path]))
+		}
+	}
+	if p.Diff != "" {
+		b.WriteString("\nDiff to review:\n")
+		b.WriteString(p.Diff)
+		b.WriteString("\n")
+	}
+	if p.Evidence != "" {
+		b.WriteString("\nWorker's own report (verify against the artifacts above, do not take at face value):\n")
+		b.WriteString(NeutralizeSlot(p.Evidence))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
 // PlanSession runs the planning turn that produces a Spec from the
 // mission's goal and research-phase findings.
 func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, researchNotes string) (Spec, error) {
-	system := "You are planning one mission. Break the goal into an ordered list of verifiable units. Reply with ONLY a JSON object: {\"units\":[{\"title\":\"...\",\"verify_cmd\":\"...\"}]}"
+	system := "You are planning one mission. Break the goal into the SMALLEST ordered list of verifiable units that achieves it — one unit is correct for a simple goal; never pad the plan. Reply with ONLY a JSON object: {\"units\":[{\"title\":\"...\",\"artifacts\":[\"relative/path.md\"],\"verify_cmd\":\"...\"}]}. artifacts lists the workspace-relative file(s) the unit must produce — the harness itself checks each exists and is non-empty, so name the real deliverables. verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory — it must be a real POSIX shell command (using binaries like grep, test, wc — NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace."
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if researchNotes != "" {
 		user += "\n\nResearch findings:\n" + NeutralizeSlot(researchNotes)
 	}
 	req := loop.Request{
+		SessionID: m.SessionID,
 		Route:     m.Route,
 		Agent:     "mission-planner",
 		MissionID: m.ID,

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -3,7 +3,10 @@ package missions
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/SumonMSelim/timothy/internal/brain/loop"
@@ -15,11 +18,13 @@ import (
 // batch N. Lets a test script "first turn has no sentinel, recovery
 // turn does" without a real gateway.
 type scriptedAgent struct {
-	batches [][]stream.StreamEvent
-	call    int
+	batches  [][]stream.StreamEvent
+	call     int
+	requests []loop.Request
 }
 
 func (f *scriptedAgent) Start(ctx context.Context, req loop.Request) (<-chan stream.StreamEvent, error) {
+	f.requests = append(f.requests, req)
 	i := f.call
 	f.call++
 	if i >= len(f.batches) {
@@ -45,6 +50,35 @@ func toolEndEvent(name string, args string) stream.StreamEvent {
 
 func newTestRunner(agent agentStream) *nativeRunner {
 	return &nativeRunner{agent: agent, log: slog.Default()}
+}
+
+func newTestRunnerWithParker(agent agentStream, parker parkNotifier) *nativeRunner {
+	return &nativeRunner{agent: agent, parker: parker, log: slog.Default()}
+}
+
+// fakeParker records park/clear calls in order for assertion, keyed by
+// mission id — a real parkNotifier for tests, not a mock of one.
+type fakeParker struct {
+	parked  []string // "missionID:tool:danger"
+	cleared []string // missionID
+}
+
+func (f *fakeParker) OnPermissionParked(_ context.Context, missionID, _, tool, _, danger, _ string) {
+	f.parked = append(f.parked, missionID+":"+tool+":"+danger)
+}
+
+func (f *fakeParker) OnPermissionCleared(_ context.Context, missionID string) {
+	f.cleared = append(f.cleared, missionID)
+}
+
+func permissionRequestEvent(id, callID, tool, danger string) stream.StreamEvent {
+	return stream.StreamEvent{Type: stream.EventPermissionRequest, Permission: &stream.PermissionRequestEvent{
+		ID: id, CallID: callID, Tool: tool, Danger: danger,
+	}}
+}
+
+func toolResultEvent(id string) stream.StreamEvent {
+	return stream.StreamEvent{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{ID: id}}
 }
 
 func TestRunWorkerSentinelPresent(t *testing.T) {
@@ -130,7 +164,7 @@ func TestRunReviewParsesVerdictAndCarriesGatekeeperState(t *testing.T) {
 		{textEvent("looks fine"), toolEndEvent(reviewVerdictToolName, `{"decision":"approve"}`)},
 	}}
 	r := newTestRunner(agent)
-	v, state, err := r.RunReview(context.Background(), Mission{ID: "m1", ReviewRoute: "default"}, "diff content", nil)
+	v, state, err := r.RunReview(context.Background(), Mission{ID: "m1", ReviewRoute: "default"}, ReviewPacket{Goal: "goal", Diff: "diff content"}, nil)
 	if err != nil {
 		t.Fatalf("RunReview: %v", err)
 	}
@@ -142,14 +176,80 @@ func TestRunReviewParsesVerdictAndCarriesGatekeeperState(t *testing.T) {
 	}
 }
 
+// TestRunReviewPacketRendersArtifactsGoalAndEvidence covers the
+// research-mission review gap: reviewers used to reject every round
+// for "missing goal" / "missing artifact" because neither was in
+// their context. The packet's goal, harness-read artifact contents,
+// and the worker's evidence must all reach the reviewer — and no
+// empty "Diff to review" section may appear when there is no diff.
+func TestRunReviewPacketRendersArtifactsGoalAndEvidence(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{textEvent("looks solid"), toolEndEvent(reviewVerdictToolName, `{"decision":"approve"}`)},
+	}}
+	r := newTestRunner(agent)
+	packet := ReviewPacket{
+		Goal:      "Summarize HTTP 429",
+		UnitTitle: "write summary",
+		Artifacts: map[string]string{"summary.md": "429 means Too Many Requests, per RFC 6585."},
+		Evidence:  "Summary written to summary.md, sourced from RFC 6585.",
+	}
+	v, _, err := r.RunReview(context.Background(), Mission{ID: "m1", ReviewRoute: "default"}, packet, nil)
+	if err != nil {
+		t.Fatalf("RunReview: %v", err)
+	}
+	if !v.Approved {
+		t.Fatalf("RunReview verdict = %+v, want approved", v)
+	}
+	if len(agent.requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(agent.requests))
+	}
+	msgs := agent.requests[0].Messages
+	content := msgs[len(msgs)-1].Content
+	for _, want := range []string{packet.Goal, "RFC 6585", packet.Evidence, "summary.md"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("reviewer message missing %q:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, "Diff to review") {
+		t.Fatalf("reviewer message must not claim there's a diff when there is none:\n%s", content)
+	}
+}
+
 func TestRunReviewErrorsWhenVerdictMissing(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{textEvent("I'm not sure about this one")},
+		{textEvent("Still not calling it.")}, // recovery turn also missing
 	}}
 	r := newTestRunner(agent)
-	_, _, err := r.RunReview(context.Background(), Mission{ID: "m1", ReviewRoute: "default"}, "diff", nil)
+	_, _, err := r.RunReview(context.Background(), Mission{ID: "m1", ReviewRoute: "default"}, ReviewPacket{Diff: "diff"}, nil)
 	if err == nil {
 		t.Fatal("RunReview did not error when the reviewer never called review_verdict")
+	}
+	if agent.call != 2 {
+		t.Fatalf("expected exactly two turns (original + one recovery, then give up), got %d", agent.call)
+	}
+}
+
+// TestRunReviewRecoversWhenVerdictMissingThenPresent mirrors
+// RunWorker's recovery ladder: a reviewer that doesn't call
+// review_verdict on its first turn (e.g. it ran long on analysis) gets
+// one recovery turn demanding the call before the round is treated as
+// a failure.
+func TestRunReviewRecoversWhenVerdictMissingThenPresent(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{textEvent("Still analyzing the evidence in depth...")}, // no verdict
+		{textEvent("Approved."), toolEndEvent(reviewVerdictToolName, `{"decision":"approve"}`)},
+	}}
+	r := newTestRunner(agent)
+	v, _, err := r.RunReview(context.Background(), Mission{ID: "m1", ReviewRoute: "default"}, ReviewPacket{Diff: "diff"}, nil)
+	if err != nil {
+		t.Fatalf("RunReview: %v", err)
+	}
+	if !v.Approved {
+		t.Fatalf("RunReview verdict after recovery = %+v, want approved", v)
+	}
+	if agent.call != 2 {
+		t.Fatalf("expected exactly two turns (original + one recovery), got %d", agent.call)
 	}
 }
 
@@ -187,5 +287,118 @@ func TestPlanSessionRejectsMalformedJSON(t *testing.T) {
 	r := newTestRunner(agent)
 	if _, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, ""); err == nil {
 		t.Fatal("PlanSession accepted non-JSON output")
+	}
+}
+
+// TestRunWorkerReportsPermissionParkAndClear is the M4.1 exit
+// criterion: a tool call that parks on an interactive permission
+// prompt must reach the mission row (via parkNotifier), not vanish
+// into runTurn's event drain the way it silently did before this
+// existed — that gap is what stranded a real mission for its full
+// 10-minute timeout with the UI showing nothing.
+func TestRunWorkerReportsPermissionParkAndClear(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{{
+		textEvent("about to run a risky command"),
+		permissionRequestEvent("perm1", "call1", "shell", "destructive"),
+		toolResultEvent("call1"),
+		toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ran it"}`),
+	}}}
+	parker := &fakeParker{}
+	r := newTestRunnerWithParker(agent, parker)
+	v, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if v.Outcome != "done" {
+		t.Fatalf("RunWorker verdict = %+v, want done (the turn continues normally after the park clears)", v)
+	}
+	if len(parker.parked) != 1 || parker.parked[0] != "m1:shell:destructive" {
+		t.Fatalf("parker.parked = %v, want exactly one m1:shell:destructive", parker.parked)
+	}
+	if len(parker.cleared) != 1 || parker.cleared[0] != "m1" {
+		t.Fatalf("parker.cleared = %v, want exactly one clear for m1", parker.cleared)
+	}
+}
+
+// TestRunWorkerClearsPermissionParkOnStreamError covers the other exit
+// path: if the turn errors out while still parked (e.g. the gateway
+// connection drops), the mission row must not be left showing a
+// pending_permission nothing will ever resolve.
+func TestRunWorkerClearsPermissionParkOnStreamError(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{{
+		permissionRequestEvent("perm1", "call1", "shell", "moderate"),
+		{Type: stream.EventError, Err: &stream.StreamError{Message: "connection lost"}},
+	}}}
+	parker := &fakeParker{}
+	r := newTestRunnerWithParker(agent, parker)
+	if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"}); err == nil {
+		t.Fatal("RunWorker: expected the stream error to propagate")
+	}
+	if len(parker.parked) != 1 {
+		t.Fatalf("parker.parked = %v, want exactly one park", parker.parked)
+	}
+	if len(parker.cleared) != 1 || parker.cleared[0] != "m1" {
+		t.Fatalf("parker.cleared = %v, want exactly one clear for m1 even on error", parker.cleared)
+	}
+}
+
+func doneEvent(model string) stream.StreamEvent {
+	return stream.StreamEvent{Type: stream.EventDone, Meta: &stream.Meta{Model: model}}
+}
+
+// TestRunWorkerModelFloor: a turn served by a deny-listed fallback
+// model must surface ErrModelFloor so the driver pauses the mission
+// immediately instead of burning iterations on a model that cannot
+// drive tool-using work.
+func TestRunWorkerModelFloor(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{textEvent("uh"), doneEvent("amazon.nova-lite-v1:0")},
+	}}
+	r := &nativeRunner{agent: agent, modelFloorDeny: []string{"nova-lite", "qwen2.5:7b"}, log: slog.Default()}
+	_, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"})
+	if !errors.Is(err, ErrModelFloor) {
+		t.Fatalf("RunWorker err = %v, want ErrModelFloor", err)
+	}
+}
+
+// TestRunWorkerModelFloorDisabledByDefault: no deny list, any model is
+// fine — the sentinel outcome decides.
+func TestRunWorkerModelFloorDisabledByDefault(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ok"}`), doneEvent("amazon.nova-lite-v1:0")},
+	}}
+	r := newTestRunner(agent)
+	v, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if v.Outcome != "done" {
+		t.Fatalf("verdict = %+v", v)
+	}
+}
+
+// TestRunWorkerGetsMissionScopedShell: the worker turn must carry a
+// turn-scoped shell tool rooted in the mission's own workspace — the
+// root cause of the workspace-split failure family was workers running
+// shell in the shared global root while verification looked in the
+// per-mission directory.
+func TestRunWorkerGetsMissionScopedShell(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ok"}`)},
+	}}
+	r := newTestRunner(agent)
+	m := Mission{ID: "m1", Route: "default", Workspace: "/workspace/missions/m1"}
+	if _, _, err := r.RunWorker(context.Background(), m, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	var names []string
+	for _, tool := range agent.requests[0].ExtraTools {
+		names = append(names, tool.Name)
+	}
+	if !slices.Contains(names, "shell") {
+		t.Fatalf("worker ExtraTools = %v, want a mission-scoped shell", names)
+	}
+	if !slices.Contains(names, missionStatusToolName) {
+		t.Fatalf("worker ExtraTools = %v, want the mission_status sentinel", names)
 	}
 }

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -1,0 +1,223 @@
+package missions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/robfig/cron/v3"
+
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+// schedulerTick is how often the scheduler evaluates every schedule.
+const schedulerTick = time.Minute
+
+// schedulerLockKey is this package's own advisory lock key ("MISS"),
+// distinct from migrate.go's 0x54494D4F and store.go's
+// workSlotLockKey ("TIMS") — schema migrations, work-slot claims, and
+// schedule firing must never contend for the same lock.
+const schedulerLockKey = 0x4D495353
+
+// misfireGrace bounds how late a scheduled fire can run and still fire
+// at all: beyond it, the tick skips silently and advances last_run
+// anyway — at most one backfilled run after downtime, never a burst.
+const misfireGrace = 1 * time.Hour
+
+// Schedule is one schedules row.
+type Schedule struct {
+	ID              string
+	Name            string
+	Cron            string
+	MissionTemplate MissionTemplate
+	Enabled         bool
+	ExpiresAt       *time.Time
+	LastRun         *time.Time
+	CreatedAt       time.Time
+}
+
+// MissionTemplate is applied verbatim as a new mission's initial
+// columns each time its schedule fires.
+type MissionTemplate struct {
+	Goal          string   `json:"goal"`
+	Kind          string   `json:"kind"`
+	AgentID       string   `json:"agent_id"`
+	Route         string   `json:"route"`
+	ReviewRoute   string   `json:"review_route"`
+	MaxIterations int      `json:"max_iterations"`
+	BudgetUSD     *float64 `json:"budget_usd,omitempty"`
+}
+
+// Scheduler ticks every schedulerTick, evaluating schedules rows
+// against their cron expression (5-field, parsed via robfig/cron/v3's
+// standard parser — parsing only, not its own goroutine scheduler: the
+// tick+advisory-lock loop here matches the existing
+// platform/migrate.go idiom rather than introducing a second
+// scheduling paradigm).
+type Scheduler struct {
+	db       *pgpool.Pool
+	missions *Store
+	log      *slog.Logger
+}
+
+func NewScheduler(db *pgpool.Pool, missions *Store, log *slog.Logger) *Scheduler {
+	return &Scheduler{db: db, missions: missions, log: log}
+}
+
+// Run ticks forever until ctx is done. Double-fire protection across
+// scaled instances: pg_try_advisory_xact_lock(schedulerLockKey) — a
+// tick that doesn't get the lock skips silently, another instance
+// already has it this minute.
+func (s *Scheduler) Run(ctx context.Context) {
+	ticker := time.NewTicker(schedulerTick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.tick(ctx, time.Now()); err != nil {
+				s.log.Error("scheduler: tick failed", "error", err)
+			}
+		}
+	}
+}
+
+// decision is the pure classification dueDecision produces for one
+// schedule at a given moment.
+type decision int
+
+const (
+	decisionSkip decision = iota
+	decisionFire
+	decisionBackfillSkip // due, but past misfireGrace: skip firing, still advance last_run
+)
+
+// dueDecision is the pure part of scheduling: given (cron expression,
+// last run, now, grace), decide fire/skip/backfill-skip. Kept separate
+// from tick's I/O so it's unit-testable without a Store. anchor is
+// lastRun if set, else the schedule's created-at equivalent — callers
+// pass whichever applies.
+func dueDecision(cronExpr string, anchor, now time.Time, grace time.Duration) (decision, error) {
+	schedule, err := cron.ParseStandard(cronExpr)
+	if err != nil {
+		return decisionSkip, fmt.Errorf("parse cron %q: %w", cronExpr, err)
+	}
+	next := schedule.Next(anchor)
+	if next.After(now) {
+		return decisionSkip, nil
+	}
+	if now.Sub(next) > grace {
+		return decisionBackfillSkip, nil
+	}
+	return decisionFire, nil
+}
+
+// tick evaluates every enabled, unexpired schedule once.
+func (s *Scheduler) tick(ctx context.Context, now time.Time) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("scheduler: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("scheduler: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+
+	var acquired bool
+	if err := tx.QueryRow(ctx, `SELECT pg_try_advisory_xact_lock($1)`, int64(schedulerLockKey)).Scan(&acquired); err != nil {
+		return fmt.Errorf("scheduler: advisory lock: %w", err)
+	}
+	if !acquired {
+		return tx.Commit(ctx) // another instance already owns this tick
+	}
+
+	rows, err := tx.Query(ctx, `SELECT id, name, cron, mission_template, enabled, expires_at, last_run, created_at
+		FROM schedules WHERE enabled AND (expires_at IS NULL OR expires_at > now())`)
+	if err != nil {
+		return fmt.Errorf("scheduler: query schedules: %w", err)
+	}
+	var schedules []Schedule
+	for rows.Next() {
+		var sc Schedule
+		var templateJSON []byte
+		if err := rows.Scan(&sc.ID, &sc.Name, &sc.Cron, &templateJSON, &sc.Enabled, &sc.ExpiresAt, &sc.LastRun, &sc.CreatedAt); err != nil {
+			rows.Close()
+			return fmt.Errorf("scheduler: scan schedule: %w", err)
+		}
+		_ = json.Unmarshal(templateJSON, &sc.MissionTemplate)
+		schedules = append(schedules, sc)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("scheduler: schedules rows: %w", err)
+	}
+
+	for _, sc := range schedules {
+		if err := s.fireOne(ctx, tx, sc, now); err != nil {
+			s.log.Error("scheduler: schedule firing failed", "schedule_id", sc.ID, "name", sc.Name, "error", err)
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+// fireOne evaluates and, if due, fires one schedule — inside the same
+// transaction tick holds, so last_run and any created mission commit
+// atomically together.
+func (s *Scheduler) fireOne(ctx context.Context, tx pgx.Tx, sc Schedule, now time.Time) error {
+	// A never-run schedule anchors on its own creation, not "now" —
+	// otherwise Next(now) is always in the future and it could never
+	// fire on its very first eligible boundary.
+	anchor := sc.CreatedAt
+	if sc.LastRun != nil {
+		anchor = *sc.LastRun
+	}
+
+	dec, err := dueDecision(sc.Cron, anchor, now, misfireGrace)
+	if err != nil {
+		return err
+	}
+	if dec == decisionSkip {
+		return nil
+	}
+
+	// Live-queue dedup: a mission from THIS schedule still active means
+	// firing again would pile up parallel runs of the same job — skip
+	// firing, but still advance last_run so the next boundary computes
+	// from now, not from the stale anchor.
+	if dec == decisionFire {
+		var activeCount int
+		if err := tx.QueryRow(ctx, `SELECT count(*) FROM missions
+			WHERE schedule_id = $1 AND phase NOT IN ('done', 'failed')`, sc.ID).Scan(&activeCount); err != nil {
+			return fmt.Errorf("check active missions: %w", err)
+		}
+		if activeCount == 0 {
+			if err := s.createFromTemplate(ctx, tx, sc); err != nil {
+				return fmt.Errorf("create mission: %w", err)
+			}
+		} else {
+			s.log.Info("scheduler: skipped firing, a mission from this schedule is still active", "schedule_id", sc.ID)
+		}
+	}
+
+	if _, err := tx.Exec(ctx, `UPDATE schedules SET last_run = $2, updated_at = now() WHERE id = $1`, sc.ID, now); err != nil {
+		return fmt.Errorf("advance last_run: %w", err)
+	}
+	return nil
+}
+
+// createFromTemplate inserts a new mission from the schedule's
+// template, tagged with the schedule that spawned it.
+func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedule) error {
+	t := sc.MissionTemplate
+	spec, _ := json.Marshal(Spec{})
+	_, err := tx.Exec(ctx, `INSERT INTO missions
+			(goal, kind, agent_id, max_iterations, budget_usd, route, review_route, spec, schedule_id)
+		VALUES ($1, $2, NULLIF($3, '')::uuid, $4, $5, $6, $7, $8, $9)`,
+		t.Goal, t.Kind, t.AgentID, orDefault(t.MaxIterations, 8), t.BudgetUSD, t.Route, t.ReviewRoute, spec, sc.ID)
+	return err
+}

--- a/internal/brain/missions/scheduler_integration_test.go
+++ b/internal/brain/missions/scheduler_integration_test.go
@@ -1,0 +1,117 @@
+//go:build integration
+
+package missions
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func createTestSchedule(t *testing.T, store *Store, name, cronExpr string) string {
+	t.Helper()
+	db, err := store.db.Get()
+	if err != nil {
+		t.Fatalf("Get pool: %v", err)
+	}
+	var id string
+	err = db.QueryRow(context.Background(), `INSERT INTO schedules (name, cron, mission_template)
+		VALUES ($1, $2, $3) RETURNING id`, name, cronExpr, `{"goal":"`+marker+`scheduled run","kind":"research"}`).Scan(&id)
+	if err != nil {
+		t.Fatalf("create schedule: %v", err)
+	}
+	t.Cleanup(func() {
+		cctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_, _ = db.Exec(cctx, "DELETE FROM schedules WHERE id = $1", id)
+	})
+	return id
+}
+
+// TestSchedulerNoDoubleFireAcrossInstances simulates two service
+// replicas racing the same tick against a shared Postgres: only one
+// may fire per due boundary, enforced by the advisory lock.
+func TestSchedulerNoDoubleFireAcrossInstances(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	// A cron expression due right now: every minute, anchored a minute
+	// in the past so dueDecision reports fire.
+	id := createTestSchedule(t, store, marker+"race", "* * * * *")
+	db, _ := store.db.Get()
+	past := time.Now().Add(-2 * time.Minute)
+	if _, err := db.Exec(ctx, "UPDATE schedules SET created_at = $2 WHERE id = $1", id, past); err != nil {
+		t.Fatalf("backdate schedule: %v", err)
+	}
+
+	sched1 := NewScheduler(store.db, store, store.log)
+	sched2 := NewScheduler(store.db, store, store.log)
+
+	now := time.Now()
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	wg.Add(2)
+	go func() { defer wg.Done(); errs[0] = sched1.tick(ctx, now) }()
+	go func() { defer wg.Done(); errs[1] = sched2.tick(ctx, now) }()
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("tick[%d]: %v", i, err)
+		}
+	}
+
+	var missionCount int
+	if err := db.QueryRow(ctx, `SELECT count(*) FROM missions WHERE schedule_id = $1`, id).Scan(&missionCount); err != nil {
+		t.Fatalf("count missions: %v", err)
+	}
+	if missionCount != 1 {
+		t.Fatalf("mission count after two racing ticks = %d, want exactly 1", missionCount)
+	}
+}
+
+// TestSchedulerLiveQueueDedup confirms a schedule whose prior mission
+// is still active does not fire a second one, but last_run still
+// advances so the next boundary computes correctly.
+func TestSchedulerLiveQueueDedup(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	id := createTestSchedule(t, store, marker+"dedup", "* * * * *")
+	db, _ := store.db.Get()
+	past := time.Now().Add(-2 * time.Minute)
+	if _, err := db.Exec(ctx, "UPDATE schedules SET created_at = $2 WHERE id = $1", id, past); err != nil {
+		t.Fatalf("backdate schedule: %v", err)
+	}
+
+	// Pre-seed an ACTIVE mission already tied to this schedule.
+	missionID, err := store.Create(ctx, Mission{Goal: marker + "already active", Kind: "research"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := db.Exec(ctx, "UPDATE missions SET schedule_id = $2 WHERE id = $1", missionID, id); err != nil {
+		t.Fatalf("attach schedule: %v", err)
+	}
+
+	sched := NewScheduler(store.db, store, store.log)
+	now := time.Now()
+	if err := sched.tick(ctx, now); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	var missionCount int
+	if err := db.QueryRow(ctx, `SELECT count(*) FROM missions WHERE schedule_id = $1`, id).Scan(&missionCount); err != nil {
+		t.Fatalf("count missions: %v", err)
+	}
+	if missionCount != 1 {
+		t.Fatalf("mission count = %d, want still 1 (no new mission fired while one is active)", missionCount)
+	}
+
+	var lastRun *time.Time
+	if err := db.QueryRow(ctx, `SELECT last_run FROM schedules WHERE id = $1`, id).Scan(&lastRun); err != nil {
+		t.Fatalf("read last_run: %v", err)
+	}
+	if lastRun == nil {
+		t.Fatal("last_run was not advanced despite the dedup skip")
+	}
+}

--- a/internal/brain/missions/scheduler_test.go
+++ b/internal/brain/missions/scheduler_test.go
@@ -1,0 +1,86 @@
+package missions
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDueDecision(t *testing.T) {
+	// "0 9 * * *" = every day at 09:00.
+	const dailyAt9 = "0 9 * * *"
+
+	cases := []struct {
+		name   string
+		cron   string
+		anchor time.Time
+		now    time.Time
+		grace  time.Duration
+		want   decision
+	}{
+		{
+			name:   "on-time fire: now is exactly at the next boundary",
+			cron:   dailyAt9,
+			anchor: time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC),
+			now:    time.Date(2026, 1, 2, 9, 0, 0, 0, time.UTC),
+			grace:  time.Hour,
+			want:   decisionFire,
+		},
+		{
+			name:   "not yet due",
+			cron:   dailyAt9,
+			anchor: time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC),
+			now:    time.Date(2026, 1, 2, 8, 0, 0, 0, time.UTC),
+			grace:  time.Hour,
+			want:   decisionSkip,
+		},
+		{
+			name:   "misfire within grace still fires",
+			cron:   dailyAt9,
+			anchor: time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC),
+			now:    time.Date(2026, 1, 2, 9, 30, 0, 0, time.UTC), // 30 min late
+			grace:  time.Hour,
+			want:   decisionFire,
+		},
+		{
+			name:   "misfire beyond grace skips but caller still advances last_run",
+			cron:   dailyAt9,
+			anchor: time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC),
+			now:    time.Date(2026, 1, 3, 12, 0, 0, 0, time.UTC), // over a day late
+			grace:  time.Hour,
+			want:   decisionBackfillSkip,
+		},
+		{
+			name:   "never-run schedule fires on its first eligible boundary",
+			cron:   dailyAt9,
+			anchor: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), // e.g. schedule created at midnight
+			now:    time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC),
+			grace:  time.Hour,
+			want:   decisionFire,
+		},
+		{
+			name:   "invalid cron expression errors",
+			cron:   "not a cron expression",
+			anchor: time.Now(),
+			now:    time.Now(),
+			grace:  time.Hour,
+			want:   decisionSkip,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := dueDecision(tc.cron, tc.anchor, tc.now, tc.grace)
+			if tc.name == "invalid cron expression errors" {
+				if err == nil {
+					t.Fatal("dueDecision accepted an invalid cron expression")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("dueDecision: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("dueDecision = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/brain/missions/sentinel.go
+++ b/internal/brain/missions/sentinel.go
@@ -1,11 +1,12 @@
 package missions
 
 import (
+	"context"
 	"encoding/json"
 	"regexp"
 	"strings"
 
-	"github.com/SumonMSelim/timothy/internal/gateway/provider"
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
 )
 
 // missionStatusToolName is the one tool call a worker turn must end
@@ -14,9 +15,14 @@ import (
 // question.
 const missionStatusToolName = "mission_status"
 
-// MissionStatusTool defines the worker's end-of-turn sentinel call.
-func MissionStatusTool() provider.ToolDef {
-	return provider.ToolDef{
+// MissionStatusTool defines the worker's end-of-turn sentinel call —
+// registered per-turn via loop.Request.ExtraTools, never in the shared
+// agent tool surface, so chat sessions never see it. Execute itself
+// does nothing but acknowledge the call; the driver reads the actual
+// verdict from the tool call's captured arguments (runner.go), not
+// from this return value.
+func MissionStatusTool() *tools.Tool {
+	return &tools.Tool{
 		Name:        missionStatusToolName,
 		Description: "Report this turn's outcome. Call this exactly once, as your final action. DONE means you believe the current unit is complete and ready for the harness to verify and review — it is a request for verification, not a claim that the work is accepted. RETRY means you hit a problem and are explaining what you learned before the next attempt. BLOCKED means you need a specific answer from the user before you can continue.",
 		InputSchema: json.RawMessage(`{
@@ -42,6 +48,9 @@ func MissionStatusTool() provider.ToolDef {
 			},
 			"required": ["outcome"]
 		}`),
+		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
+			return "status recorded", nil
+		},
 	}
 }
 

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -119,6 +119,11 @@ type StepInput struct {
 	Input          Input
 	GapFingerprint string // set on InputReviewRework
 	Message        string // set on InputWorkerBlocked / pause explanations
+	// Reason is WHY this input happened (a worker's retry analysis, an
+	// error string, flattened review findings) — carried into the
+	// transition's event payloads so a mission's failure cause is
+	// readable from its event log alone, never only from process logs.
+	Reason string
 }
 
 // EventDraft is one event Step decided must be appended; the Store
@@ -180,14 +185,14 @@ func Step(s StepState, in StepInput, cfg Config) Transition {
 	case InputPhaseComplete:
 		return stepPhaseComplete(s)
 	case InputWorkerRetry:
-		return stepWorkerRetry(s)
+		return stepWorkerRetry(s, in)
 	case InputWorkerBlocked:
 		return Transition{
 			Next:   withStatus(s, StatusWaitingForInput),
 			Events: []EventDraft{{Kind: "mission.blocked", Payload: map[string]any{"question": in.Message}}},
 		}
 	case InputWorkerFailed:
-		return stepWorkerFailed(s, cfg)
+		return stepWorkerFailed(s, in, cfg)
 	case InputReviewApprove:
 		return stepReviewApprove(s)
 	case InputReviewRework:
@@ -195,7 +200,7 @@ func Step(s StepState, in StepInput, cfg Config) Transition {
 	case InputReviewInfraFailure:
 		return Transition{
 			Next:   withPause(s, PauseInfra),
-			Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseInfra)}}},
+			Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseInfra), "detail": in.Reason}}},
 		}
 	default:
 		// Unrecognized input: no-op rather than a panic or a silent
@@ -255,38 +260,38 @@ func stepPhaseComplete(s StepState) Transition {
 // stepWorkerFailed counts consecutive failures toward the backoff
 // brake; a fresh success (any non-failed input) resets the counter
 // elsewhere (the driver clears ConsecutiveFailures on progress).
-func stepWorkerFailed(s StepState, cfg Config) Transition {
+func stepWorkerFailed(s StepState, in StepInput, cfg Config) Transition {
 	s.ConsecutiveFailures++
 	s.Iteration++
 	if s.ConsecutiveFailures >= cfg.BackoffFailures {
 		return Transition{
 			Next:   withPause(s, PauseBackoff),
-			Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseBackoff)}}},
+			Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseBackoff), "detail": in.Reason}}},
 		}
 	}
 	if s.Iteration >= s.MaxIterations {
 		return Transition{
 			Next:   withPhaseFailed(s),
-			Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "max_iterations"}}},
+			Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "max_iterations", "detail": in.Reason}}},
 		}
 	}
-	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.retry"}}}
+	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.retry", Payload: map[string]any{"cause": "worker_failed", "reason": in.Reason}}}}
 }
 
 // stepWorkerRetry is a worker's own self-reported RETRY (failure
 // analysis, distinct from a harness-detected WorkerFailed): it costs
 // an iteration but does not count toward the backoff brake — the
 // worker is still making an attempt, not silently failing.
-func stepWorkerRetry(s StepState) Transition {
+func stepWorkerRetry(s StepState, in StepInput) Transition {
 	s.Iteration++
 	s.ConsecutiveFailures = 0
 	if s.Iteration >= s.MaxIterations {
 		return Transition{
 			Next:   withPhaseFailed(s),
-			Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "max_iterations"}}},
+			Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "max_iterations", "detail": in.Reason}}},
 		}
 	}
-	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.retry"}}}
+	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.retry", Payload: map[string]any{"cause": "worker_retry", "reason": in.Reason}}}}
 }
 
 // stepReviewApprove clears the stall counter (progress was made) and
@@ -321,7 +326,7 @@ func stepReviewRework(s StepState, in StepInput, cfg Config) Transition {
 	if s.StallCount >= cfg.StallRounds {
 		return Transition{
 			Next:   withPause(s, PauseNoProgress),
-			Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseNoProgress)}}},
+			Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseNoProgress), "detail": in.Reason}}},
 		}
 	}
 	s.Phase = PhaseExecute
@@ -330,8 +335,8 @@ func stepReviewRework(s StepState, in StepInput, cfg Config) Transition {
 	if s.Iteration >= s.MaxIterations {
 		return Transition{
 			Next:   withPhaseFailed(s),
-			Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "max_iterations"}}},
+			Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "max_iterations", "detail": in.Reason}}},
 		}
 	}
-	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.review_verdict", Payload: map[string]any{"decision": "rework"}}}}
+	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.review_verdict", Payload: map[string]any{"decision": "rework", "reason": in.Reason}}}}
 }

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -35,20 +36,24 @@ func NewStore(db *pgpool.Pool, log *slog.Logger) *Store {
 const missionColumns = `id, goal, kind, agent_id, phase, status, pause_reason, pause_message,
 	workspace, worktree, branch, base_commit, spec, progress, iteration, max_iterations,
 	consecutive_failures, last_gap_fingerprint, stall_count, budget_usd, route, review_route,
-	pending_permission, schedule_id, created_at, updated_at`
+	pending_permission, pending_permission_tool, pending_permission_args,
+	pending_permission_danger, pending_permission_rationale, auto_approve_safe, last_evidence,
+	schedule_id, session_id, created_at, updated_at`
 
 func scanMission(row pgx.Row) (Mission, error) {
 	var (
-		m                   Mission
-		agentID, scheduleID *string
-		phase, status       string
-		pendingPermission   *string
-		spec, progress      []byte
+		m                              Mission
+		agentID, scheduleID, sessionID *string
+		phase, status                  string
+		pendingPermission              *string
+		spec, progress                 []byte
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
 		&m.ConsecutiveFailures, &m.LastGapFingerprint, &m.StallCount, &m.BudgetUSD, &m.Route, &m.ReviewRoute,
-		&pendingPermission, &scheduleID, &m.CreatedAt, &m.UpdatedAt); err != nil {
+		&pendingPermission, &m.PendingPermissionTool, &m.PendingPermissionArgs,
+		&m.PendingPermissionDanger, &m.PendingPermissionRationale, &m.AutoApproveSafe, &m.LastEvidence,
+		&scheduleID, &sessionID, &m.CreatedAt, &m.UpdatedAt); err != nil {
 		return Mission{}, err
 	}
 	if agentID != nil {
@@ -56,6 +61,9 @@ func scanMission(row pgx.Row) (Mission, error) {
 	}
 	if scheduleID != nil {
 		m.ScheduleID = *scheduleID
+	}
+	if sessionID != nil {
+		m.SessionID = *sessionID
 	}
 	if pendingPermission != nil {
 		m.PendingPermission = *pendingPermission
@@ -98,9 +106,9 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	}
 	var id string
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, kind, agent_id, max_iterations, budget_usd, route, review_route, spec)
-		VALUES ($1, $2, NULLIF($3, '')::uuid, $4, $5, $6, $7, $8) RETURNING id`,
-		m.Goal, m.Kind, m.AgentID, orDefault(m.MaxIterations, 8), m.BudgetUSD, m.Route, m.ReviewRoute, spec,
+			(goal, kind, agent_id, max_iterations, budget_usd, route, review_route, spec, session_id, auto_approve_safe)
+		VALUES ($1, $2, NULLIF($3, '')::uuid, $4, $5, $6, $7, $8, NULLIF($9, '')::uuid, $10) RETURNING id`,
+		m.Goal, m.Kind, m.AgentID, orDefault(m.MaxIterations, 8), m.BudgetUSD, m.Route, m.ReviewRoute, spec, m.SessionID, m.AutoApproveSafe,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)
@@ -169,6 +177,105 @@ func (s *Store) SetSpec(ctx context.Context, id string, spec Spec) error {
 	return nil
 }
 
+// AppendProgress adds one note to the mission's durable progress log
+// (read back by WorkPacket.Render so the NEXT fresh worker turn has
+// real memory of what happened, since workers carry no transcript of
+// their own) and appends the matching mission.progress event in the
+// same transaction, so the Timeline and the worker's own memory never
+// diverge.
+func (s *Store) AppendProgress(ctx context.Context, id, note string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("missions append progress: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("missions append progress begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+	entry, err := json.Marshal(ProgressNote{At: time.Now().UTC(), Note: note})
+	if err != nil {
+		return fmt.Errorf("missions append progress: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `UPDATE missions SET
+			progress = progress || jsonb_build_array($2::jsonb), updated_at = now()
+		WHERE id = $1`, id, entry); err != nil {
+		return fmt.Errorf("missions append progress: %w", err)
+	}
+	if err := appendEventTx(ctx, tx, id, "mission.progress", map[string]any{"note": note}, "live"); err != nil {
+		return fmt.Errorf("missions append progress: %w", err)
+	}
+	return tx.Commit(ctx)
+}
+
+// SetPendingPermission records a mission's turn parking on a tool-call
+// permission prompt (loop.PermBroker id plus the detail the UI needs
+// to render a real decision, not a bare "waiting" banner). Independent
+// of ApplyTransition — parking happens mid-turn, inside a single
+// Runner call, not at an Advance boundary. Also appends a
+// mission.permission_requested event in the same transaction — without
+// this, the Timeline shows nothing while a mission is parked, and the
+// tool/command detail is lost once ClearPendingPermission runs (the
+// pending_permission_* columns are live-only state, not history). Args
+// are truncated the same way progress notes are — a shell command can
+// be arbitrarily large, and the log only needs enough to identify what
+// was approved, not a byte-for-byte replay.
+func (s *Store) SetPendingPermission(ctx context.Context, id, permissionID, tool, args, danger, rationale string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("missions set pending permission: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("missions set pending permission begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+	if _, err := tx.Exec(ctx, `UPDATE missions SET
+			pending_permission = $2, pending_permission_tool = $3, pending_permission_args = $4,
+			pending_permission_danger = $5, pending_permission_rationale = $6, updated_at = now()
+		WHERE id = $1`, id, permissionID, tool, args, danger, rationale); err != nil {
+		return fmt.Errorf("missions set pending permission: %w", err)
+	}
+	payload := map[string]any{"tool": tool, "args": truncate(args, 2000), "danger": danger, "rationale": rationale}
+	if err := appendEventTx(ctx, tx, id, "mission.permission_requested", payload, "live"); err != nil {
+		return fmt.Errorf("missions set pending permission: %w", err)
+	}
+	return tx.Commit(ctx)
+}
+
+// ClearPendingPermission drops a mission's parked-permission state
+// once the broker resolves it (decision or timeout-deny) — the same
+// Runner call that parked continues past this point on its own.
+func (s *Store) ClearPendingPermission(ctx context.Context, id string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("missions clear pending permission: %w", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE missions SET
+			pending_permission = '', pending_permission_tool = '', pending_permission_args = '',
+			pending_permission_danger = '', pending_permission_rationale = '', updated_at = now()
+		WHERE id = $1`, id); err != nil {
+		return fmt.Errorf("missions clear pending permission: %w", err)
+	}
+	return nil
+}
+
+// SetLastEvidence records the worker's most recent mission_status
+// evidence text, read back by the next review round — durable (not
+// process-local like gatekeepers) since losing it on restart would
+// silently degrade a research mission's review back to diff-only.
+func (s *Store) SetLastEvidence(ctx context.Context, id, evidence string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("missions set last evidence: %w", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE missions SET last_evidence = $2, updated_at = now() WHERE id = $1`,
+		id, evidence); err != nil {
+		return fmt.Errorf("missions set last evidence: %w", err)
+	}
+	return nil
+}
+
 // Events returns a mission's full event log in seq order.
 func (s *Store) Events(ctx context.Context, id string) ([]Event, error) {
 	db, err := s.db.Get()
@@ -207,13 +314,34 @@ func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) er
 	}
 	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
 
+	// pause_message is cleared unconditionally: the state machine's
+	// Transition never carries a message string (only scanMission's
+	// read-time degrade-on-corruption path ever produces one, in
+	// memory only), so any value sitting in the column is leftover from
+	// an out-of-band write (e.g. manual DB surgery during an incident)
+	// and must not survive the mission's next legitimate transition —
+	// otherwise a stale message keeps showing in the UI long after the
+	// mission has moved on.
+	//
+	// A transition landing on a terminal phase (cancel, or the state
+	// machine's own done/failed) also clears any pending_permission*
+	// detail — a dead mission can never resolve a park (the API's
+	// answer-permission handler checks phase first and would already
+	// reject it), so leaving the columns populated only stales the
+	// Timeline's "Allow" banner for a mission that's no longer running.
+	clearPending := t.Next.Phase.Terminal()
 	if _, err := tx.Exec(ctx, `UPDATE missions SET
-			phase = $2, status = $3, pause_reason = $4, iteration = $5, max_iterations = $6,
-			consecutive_failures = $7, last_gap_fingerprint = $8, stall_count = $9, updated_at = now()
+			phase = $2, status = $3, pause_reason = $4, pause_message = '', iteration = $5, max_iterations = $6,
+			consecutive_failures = $7, last_gap_fingerprint = $8, stall_count = $9, updated_at = now(),
+			pending_permission = CASE WHEN $10 THEN '' ELSE pending_permission END,
+			pending_permission_tool = CASE WHEN $10 THEN '' ELSE pending_permission_tool END,
+			pending_permission_args = CASE WHEN $10 THEN '' ELSE pending_permission_args END,
+			pending_permission_danger = CASE WHEN $10 THEN '' ELSE pending_permission_danger END,
+			pending_permission_rationale = CASE WHEN $10 THEN '' ELSE pending_permission_rationale END
 		WHERE id = $1`,
 		id, string(t.Next.Phase), string(t.Next.Status), string(t.Next.PauseReason),
 		t.Next.Iteration, t.Next.MaxIterations, t.Next.ConsecutiveFailures,
-		t.Next.LastGapFingerprint, t.Next.StallCount,
+		t.Next.LastGapFingerprint, t.Next.StallCount, clearPending,
 	); err != nil {
 		return fmt.Errorf("missions apply transition update: %w", err)
 	}

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -4,6 +4,7 @@ package missions
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/SumonMSelim/timothy/internal/platform/migrate"
 	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
@@ -40,10 +42,7 @@ func testStore(t *testing.T) *Store {
 	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	sweep := func(ctx context.Context) {
-		_, _ = db.Exec(ctx, "DELETE FROM missions WHERE goal LIKE $1 || '%'", marker)
-	}
-	sweep(ctx)
+	sweep(ctx, db)
 	t.Cleanup(func() {
 		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer ccancel()
@@ -53,9 +52,31 @@ func testStore(t *testing.T) *Store {
 			return
 		}
 		defer func() { _ = conn.Close(cctx) }()
-		_, _ = conn.Exec(cctx, "DELETE FROM missions WHERE goal LIKE $1 || '%'", marker)
+		sweep(cctx, conn)
 	})
 	return NewStore(pool, log)
+}
+
+// execer is the shared Exec surface between a pool connection and a
+// one-shot pgx.Conn — lets sweep run identically at setup (via the
+// pool) and teardown (via a fresh connection, since the pool dies with
+// t.Context()).
+type execer interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+// sweep clears every fixture row this package's tests create. Missions
+// spawned by a test schedule carry the schedule's mission_template
+// goal verbatim, not the marker prefix — delete them via the schedule
+// join FIRST, before deleting schedules (whose FK would otherwise
+// orphan them under ON DELETE CASCADE at an unpredictable order
+// relative to a concurrently running test).
+func sweep(ctx context.Context, db execer) {
+	_, _ = db.Exec(ctx, `DELETE FROM missions WHERE schedule_id IN (
+		SELECT id FROM schedules WHERE name LIKE $1 || '%'
+	)`, marker)
+	_, _ = db.Exec(ctx, "DELETE FROM schedules WHERE name LIKE $1 || '%'", marker)
+	_, _ = db.Exec(ctx, "DELETE FROM missions WHERE goal LIKE $1 || '%'", marker)
 }
 
 func TestMissionCRUD(t *testing.T) {
@@ -93,6 +114,95 @@ func TestMissionCRUD(t *testing.T) {
 	}
 }
 
+func TestSetAndClearPendingPermission(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{Goal: marker + "permission", Kind: "research", Route: "default"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := s.SetPendingPermission(ctx, id, "perm-1", "shell", `{"command":"rm -rf x"}`, "destructive", "deletes files"); err != nil {
+		t.Fatalf("SetPendingPermission: %v", err)
+	}
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.PendingPermission != "perm-1" || m.PendingPermissionTool != "shell" ||
+		m.PendingPermissionDanger != "destructive" || m.PendingPermissionRationale != "deletes files" {
+		t.Fatalf("Get after SetPendingPermission = %+v, want the parked detail persisted", m)
+	}
+
+	events, err := s.Events(ctx, id)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	last := events[len(events)-1]
+	if last.Kind != "mission.permission_requested" {
+		t.Fatalf("last event kind = %q, want mission.permission_requested", last.Kind)
+	}
+	var payload struct {
+		Tool, Args, Danger, Rationale string
+	}
+	if err := json.Unmarshal(last.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal event payload: %v", err)
+	}
+	if payload.Tool != "shell" || payload.Args != `{"command":"rm -rf x"}` || payload.Danger != "destructive" {
+		t.Fatalf("event payload = %+v, want the tool/args/danger the mission parked on", payload)
+	}
+
+	if err := s.ClearPendingPermission(ctx, id); err != nil {
+		t.Fatalf("ClearPendingPermission: %v", err)
+	}
+	m, err = s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.PendingPermission != "" || m.PendingPermissionTool != "" || m.PendingPermissionDanger != "" || m.PendingPermissionRationale != "" {
+		t.Fatalf("Get after ClearPendingPermission = %+v, want all permission fields empty", m)
+	}
+}
+
+func TestAppendProgress(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{Goal: marker + "progress", Kind: "research", Route: "default"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := s.AppendProgress(ctx, id, "first note"); err != nil {
+		t.Fatalf("AppendProgress: %v", err)
+	}
+	if err := s.AppendProgress(ctx, id, "second note"); err != nil {
+		t.Fatalf("AppendProgress: %v", err)
+	}
+
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(m.Progress) != 2 || m.Progress[0].Note != "first note" || m.Progress[1].Note != "second note" {
+		t.Fatalf("Get.Progress = %+v, want both notes in order — this is what WorkPacket.Render reads for the next worker turn's memory", m.Progress)
+	}
+
+	events, err := s.Events(ctx, id)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2 mission.progress events alongside the column writes", len(events))
+	}
+	for _, e := range events {
+		if e.Kind != "mission.progress" {
+			t.Fatalf("event kind = %q, want mission.progress", e.Kind)
+		}
+	}
+}
+
 func TestApplyTransitionAndEvents(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
@@ -124,6 +234,51 @@ func TestApplyTransitionAndEvents(t *testing.T) {
 	}
 	if len(events) != 1 || events[0].Kind != "mission.phase_started" || events[0].Seq != 1 {
 		t.Fatalf("Events = %+v, want one mission.phase_started at seq 1", events)
+	}
+}
+
+// TestApplyTransitionClearsPendingPermissionOnTerminal reproduces a
+// real bug: cancelling (or otherwise terminating) a mission parked on
+// a permission left the pending_permission_* columns populated —
+// the mission was dead, but its "Allow" banner kept showing in the
+// UI since nothing ever cleared them on the terminal transition.
+func TestApplyTransitionClearsPendingPermissionOnTerminal(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{Goal: marker + "cancel-parked", Kind: "research"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := s.SetPendingPermission(ctx, id, "perm-1", "shell", `{"command":"echo hi"}`, "safe", "no standing grant"); err != nil {
+		t.Fatalf("SetPendingPermission: %v", err)
+	}
+
+	// Non-terminal transition must NOT clear it — only a terminal one.
+	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8}}); err != nil {
+		t.Fatalf("ApplyTransition (non-terminal): %v", err)
+	}
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.PendingPermissionTool != "shell" {
+		t.Fatalf("PendingPermissionTool after non-terminal transition = %q, want unchanged (shell)", m.PendingPermissionTool)
+	}
+
+	if err := s.ApplyTransition(ctx, id, Transition{
+		Next:   StepState{Phase: PhaseFailed, Status: StatusError, MaxIterations: 8},
+		Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "cancelled"}}},
+	}); err != nil {
+		t.Fatalf("ApplyTransition (terminal): %v", err)
+	}
+	m, err = s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.PendingPermission != "" || m.PendingPermissionTool != "" || m.PendingPermissionArgs != "" ||
+		m.PendingPermissionDanger != "" || m.PendingPermissionRationale != "" {
+		t.Fatalf("Get after terminal transition = %+v, want all pending_permission fields cleared", m)
 	}
 }
 
@@ -227,6 +382,22 @@ func TestClaimWorkSlotConcurrencyCap(t *testing.T) {
 	ctx := t.Context()
 
 	const total, max = 10, 3
+	// The cap is global across the shared database: any real mission
+	// already 'working' (the suite runs against a live stack) consumes
+	// a slot, so the expected claim count is max minus that baseline —
+	// asserting a bare max flakes whenever a live mission is running.
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	baseline := 0
+	if err := db.QueryRow(ctx, "SELECT count(*) FROM missions WHERE status = 'working'").Scan(&baseline); err != nil {
+		t.Fatalf("count working baseline: %v", err)
+	}
+	want := max - baseline
+	if want < 0 {
+		want = 0
+	}
 	ids := make([]string, total)
 	for i := range ids {
 		id, err := s.Create(ctx, Mission{Goal: marker + "slot", Kind: "research"})
@@ -259,17 +430,16 @@ func TestClaimWorkSlotConcurrencyCap(t *testing.T) {
 	for id := range claimed {
 		got = append(got, id)
 	}
-	if len(got) != max {
-		t.Fatalf("claimed %d slots, want exactly %d (cap)", len(got), max)
+	if len(got) != want {
+		t.Fatalf("claimed %d slots, want exactly %d (cap %d minus %d already working)", len(got), want, max, baseline)
 	}
 
-	db, _ := s.db.Get()
 	var working int
 	if err := db.QueryRow(ctx, `SELECT count(*) FROM missions WHERE status = 'working' AND goal LIKE $1 || '%'`, marker).Scan(&working); err != nil {
 		t.Fatalf("count working: %v", err)
 	}
-	if working != max {
-		t.Fatalf("working count = %d, want %d", working, max)
+	if working != want {
+		t.Fatalf("working count = %d, want %d", working, want)
 	}
 }
 

--- a/internal/brain/missions/sweep.go
+++ b/internal/brain/missions/sweep.go
@@ -9,20 +9,51 @@ import (
 // workSlotSweepInterval is how often the idle-over-cap sweep retries
 // claiming a work slot for missions parked idle because the
 // concurrency cap was full when they last tried.
-//
-//nolint:unused // wired into cmd/brain/main.go in M3 alongside the scheduler
 const workSlotSweepInterval = 30 * time.Second
+
+// recoverWorkingRetries and recoverWorkingRetryDelay bound the boot
+// recovery pass's tolerance for Postgres not yet accepting connections
+// (brain can start before its DB dependency is ready) — without a
+// retry here, a single transient connect failure strands every
+// mission left status='working' with no other path back to Drive.
+const (
+	recoverWorkingRetries    = 5
+	recoverWorkingRetryDelay = 2 * time.Second
+)
+
+// RecoverAndSweep runs the boot-time recovery pass once (re-Drives any
+// mission left status='working' from a prior process's crash), then
+// runs the periodic work-slot sweep until ctx is done. This is the one
+// entry point cmd/brain/main.go needs — it owns the Driver, which
+// carries its own Store reference.
+func RecoverAndSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, log *slog.Logger) {
+	recoverWorking(ctx, d, store, log)
+	runWorkSlotSweep(ctx, d, store, maxConcurrent, log)
+}
 
 // recoverWorking runs once at service boot: every mission Store
 // reports via RecoverWorking (status='working' at process start,
 // meaning the prior process died mid-Advance) gets re-Driven — this is
 // what makes driveTimeBound and any hard crash NOT a dead end.
-//
-//nolint:unused // wired into cmd/brain/main.go in M3 alongside the scheduler
 func recoverWorking(ctx context.Context, d *Driver, store *Store, log *slog.Logger) {
-	missions, err := store.RecoverWorking(ctx)
+	var missions []Mission
+	var err error
+	for attempt := 1; attempt <= recoverWorkingRetries; attempt++ {
+		missions, err = store.RecoverWorking(ctx)
+		if err == nil {
+			break
+		}
+		log.Error("mission recovery sweep: list working missions", "attempt", attempt, "error", err)
+		if attempt < recoverWorkingRetries {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(recoverWorkingRetryDelay):
+			}
+		}
+	}
 	if err != nil {
-		log.Error("mission recovery sweep: list working missions", "error", err)
+		log.Error("mission recovery sweep: giving up after retries", "attempts", recoverWorkingRetries, "error", err)
 		return
 	}
 	for _, m := range missions {
@@ -37,9 +68,8 @@ func recoverWorking(ctx context.Context, d *Driver, store *Store, log *slog.Logg
 
 // runWorkSlotSweep retries missions parked idle over the work-slot cap
 // every workSlotSweepInterval via ClaimWorkSlot, kicking off a Drive
-// for whichever gets claimed. Runs until ctx is done.
-//
-//nolint:unused // wired into cmd/brain/main.go in M3 alongside the scheduler
+// for whichever gets claimed. Runs until ctx is done — this call
+// blocks, so RecoverAndSweep's caller runs it in its own goroutine.
 func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, log *slog.Logger) {
 	ticker := time.NewTicker(workSlotSweepInterval)
 	defer ticker.Stop()

--- a/internal/brain/missions/verify.go
+++ b/internal/brain/missions/verify.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -56,4 +60,40 @@ func RunVerify(ctx context.Context, workRoot, verifyCmd string) (VerifyResult, e
 		Excerpt:      string(excerpt),
 		Passed:       exitCode == 0,
 	}, nil
+}
+
+// CheckArtifacts verifies each declared workspace-relative artifact
+// path exists under workRoot and is non-empty, returning a
+// human-readable problem per failing path. This deterministic check
+// runs BEFORE verify_cmd and is the harness's own evidence — a plan
+// whose verify_cmd is a tautology still cannot pass a unit whose
+// artifact was never written. A path that escapes workRoot (absolute,
+// or climbing out via ..) is reported as a problem, never resolved.
+func CheckArtifacts(workRoot string, artifacts []string) []string {
+	var problems []string
+	for _, a := range artifacts {
+		rel := strings.TrimSpace(a)
+		if rel == "" {
+			continue
+		}
+		if filepath.IsAbs(rel) {
+			problems = append(problems, fmt.Sprintf("%s: artifact paths must be relative to the workspace", rel))
+			continue
+		}
+		cleaned := filepath.Clean(rel)
+		if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+			problems = append(problems, fmt.Sprintf("%s: artifact path escapes the workspace", rel))
+			continue
+		}
+		info, err := os.Stat(filepath.Join(workRoot, cleaned))
+		switch {
+		case err != nil:
+			problems = append(problems, fmt.Sprintf("%s: not found in the workspace", rel))
+		case info.IsDir():
+			problems = append(problems, fmt.Sprintf("%s: is a directory, expected a file", rel))
+		case info.Size() == 0:
+			problems = append(problems, fmt.Sprintf("%s: exists but is empty", rel))
+		}
+	}
+	return problems
 }

--- a/internal/brain/missions/verify_test.go
+++ b/internal/brain/missions/verify_test.go
@@ -2,6 +2,8 @@ package missions
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -63,5 +65,41 @@ func TestRunVerifyExcerptTruncatesFromEnd(t *testing.T) {
 	}
 	if strings.Contains(res.Excerpt, "line 1\n") {
 		t.Fatal("excerpt contains the first line — truncation kept the head instead of the tail")
+	}
+}
+
+func TestCheckArtifacts(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "summary.md"), []byte("429 means Too Many Requests"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "empty.md"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "adir"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name      string
+		artifacts []string
+		problems  int
+	}{
+		{"present and non-empty passes", []string{"summary.md"}, 0},
+		{"missing file fails", []string{"nope.md"}, 1},
+		{"empty file fails", []string{"empty.md"}, 1},
+		{"directory fails", []string{"adir"}, 1},
+		{"absolute path fails", []string{"/etc/passwd"}, 1},
+		{"escape via .. fails", []string{"../outside.md"}, 1},
+		{"blank entries skipped", []string{"", "  ", "summary.md"}, 0},
+		{"one good one bad reports only the bad", []string{"summary.md", "nope.md"}, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			problems := CheckArtifacts(root, tc.artifacts)
+			if len(problems) != tc.problems {
+				t.Fatalf("CheckArtifacts(%v) = %v, want %d problem(s)", tc.artifacts, problems, tc.problems)
+			}
+		})
 	}
 }

--- a/internal/brain/tools/builtin/writefile.go
+++ b/internal/brain/tools/builtin/writefile.go
@@ -1,0 +1,101 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// writeFileMaxBytes bounds one write_file call — an artifact, not a
+// datastore dump.
+const writeFileMaxBytes = 1 << 20
+
+// WriteFileConfig fixes the directory writes are confined to.
+type WriteFileConfig struct {
+	Root string
+}
+
+type writeFileArgs struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+// WriteFile is the purpose-built alternative to writing files through
+// shell redirects: `echo ... > f` and heredocs classify as destructive
+// (or opaque, when the CONTENT happens to contain $() or backticks)
+// and park the turn on a human prompt — while this tool is confined to
+// its root by construction, so there is nothing to classify. Fewer
+// escaping games for the model, no false-positive prompts, cheaper
+// turns.
+func WriteFile(cfg WriteFileConfig) *tools.Tool {
+	return &tools.Tool{
+		Name: "write_file",
+		Description: `Writes a file in the workspace, creating parent directories as needed and replacing any existing content.
+
+This is the ONLY correct way to create or update a file — do not use
+shell redirects (>, >>) or heredocs, which require interactive
+approval and often fail.
+
+Arguments:
+- path (string, required): workspace-relative file path, e.g.
+  "summary.md" or "reports/http-429.md". Absolute paths and paths
+  containing ".." are rejected.
+- content (string, required): the complete file content to write.
+
+Returns a confirmation with the byte count written.
+
+Example: {"path": "summary.md", "content": "# Title\n\nBody."}`,
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"path": {
+					"type": "string",
+					"description": "Workspace-relative file path to write"
+				},
+				"content": {
+					"type": "string",
+					"description": "Complete file content"
+				}
+			},
+			"required": ["path", "content"],
+			"additionalProperties": false
+		}`),
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
+			var args writeFileArgs
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return "", fmt.Errorf("invalid arguments: %w", err)
+			}
+			if cfg.Root == "" {
+				return "", fmt.Errorf("write_file is not configured with a workspace")
+			}
+			if args.Path == "" {
+				return "", fmt.Errorf("path is empty")
+			}
+			if len(args.Content) > writeFileMaxBytes {
+				return "", fmt.Errorf("content is %d bytes, the limit is %d", len(args.Content), writeFileMaxBytes)
+			}
+			if filepath.IsAbs(args.Path) {
+				return "", fmt.Errorf("path must be workspace-relative, got an absolute path")
+			}
+			cleaned := filepath.Clean(args.Path)
+			if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+				return "", fmt.Errorf("path escapes the workspace")
+			}
+			target := filepath.Join(cfg.Root, cleaned)
+			if dir := filepath.Dir(target); dir != cfg.Root {
+				if err := os.MkdirAll(dir, 0o750); err != nil {
+					return "", fmt.Errorf("create parent directories: %w", err)
+				}
+			}
+			if err := os.WriteFile(target, []byte(args.Content), 0o644); err != nil { //nolint:gosec // artifact files are meant to be readable; path is root-confined above
+				return "", fmt.Errorf("write file: %w", err)
+			}
+			return fmt.Sprintf("wrote %d bytes to %s", len(args.Content), cleaned), nil
+		},
+	}
+}

--- a/internal/brain/tools/builtin/writefile_test.go
+++ b/internal/brain/tools/builtin/writefile_test.go
@@ -1,0 +1,102 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteFile(t *testing.T) {
+	root := t.TempDir()
+	tool := WriteFile(WriteFileConfig{Root: root})
+	call := func(path, content string) (string, error) {
+		args, _ := json.Marshal(map[string]string{"path": path, "content": content})
+		return tool.Execute(context.Background(), args)
+	}
+
+	t.Run("writes workspace-relative file", func(t *testing.T) {
+		out, err := call("summary.md", "# 429\n\nToo Many Requests.")
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if !strings.Contains(out, "summary.md") {
+			t.Fatalf("out = %q", out)
+		}
+		b, err := os.ReadFile(filepath.Join(root, "summary.md")) //nolint:gosec // test reads from its own TempDir
+		if err != nil || string(b) != "# 429\n\nToo Many Requests." {
+			t.Fatalf("file = %q, err %v", b, err)
+		}
+	})
+
+	t.Run("creates parent directories", func(t *testing.T) {
+		if _, err := call("reports/deep/note.md", "hi"); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(root, "reports", "deep", "note.md")); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("overwrites existing content", func(t *testing.T) {
+		if _, err := call("summary.md", "v2"); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		b, _ := os.ReadFile(filepath.Join(root, "summary.md")) //nolint:gosec // test reads from its own TempDir
+		if string(b) != "v2" {
+			t.Fatalf("file = %q, want overwritten", b)
+		}
+	})
+
+	t.Run("rejects absolute path", func(t *testing.T) {
+		if _, err := call("/etc/evil", "x"); err == nil {
+			t.Fatal("absolute path accepted")
+		}
+	})
+
+	t.Run("rejects escape via ..", func(t *testing.T) {
+		if _, err := call("../outside.md", "x"); err == nil {
+			t.Fatal(".. escape accepted")
+		}
+		if _, err := call("a/../../outside.md", "x"); err == nil {
+			t.Fatal("nested .. escape accepted")
+		}
+	})
+
+	t.Run("rejects oversized content", func(t *testing.T) {
+		if _, err := call("big.md", strings.Repeat("x", writeFileMaxBytes+1)); err == nil {
+			t.Fatal("oversized content accepted")
+		}
+	})
+
+	t.Run("rejects empty path and unconfigured root", func(t *testing.T) {
+		if _, err := call("", "x"); err == nil {
+			t.Fatal("empty path accepted")
+		}
+		bare := WriteFile(WriteFileConfig{})
+		args, _ := json.Marshal(map[string]string{"path": "a.md", "content": "x"})
+		if _, err := bare.Execute(context.Background(), args); err == nil {
+			t.Fatal("unconfigured root accepted")
+		}
+	})
+}
+
+// TestWriteFileContentWithShellMetacharacters is the reason this tool
+// exists: content full of $(), backticks, and redirects — which would
+// classify a shell heredoc as opaque/destructive and park the turn —
+// writes cleanly with no classification at all.
+func TestWriteFileContentWithShellMetacharacters(t *testing.T) {
+	root := t.TempDir()
+	tool := WriteFile(WriteFileConfig{Root: root})
+	content := "run `date` or $(curl -s example.com) > out.txt 2>&1"
+	args, _ := json.Marshal(map[string]string{"path": "tricky.md", "content": content})
+	if _, err := tool.Execute(context.Background(), args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	b, _ := os.ReadFile(filepath.Join(root, "tricky.md")) //nolint:gosec // test reads from its own TempDir
+	if string(b) != content {
+		t.Fatalf("file = %q, want metacharacters preserved verbatim", b)
+	}
+}

--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -76,6 +76,17 @@ func NewPermissions(db *pgpool.Pool, workspaceRoot string) *Permissions {
 			// prompt would demand consent for consent. The write is
 			// visible and reversible in the memory browser.
 			"remember": true,
+			// Mission protocol sentinels: pure argument parsing, zero
+			// side effects — their Execute just records a verdict for
+			// the harness. Asking a human to approve the harness's own
+			// protocol parked every mission's first turn for nothing.
+			"mission_status": true,
+			"review_verdict": true,
+			// write_file is root-confined by construction (relative
+			// paths only, .. rejected, root fixed at registration) —
+			// there is nothing for a prompt to guard that the tool
+			// doesn't already enforce harder.
+			"write_file": true,
 		},
 	}
 }
@@ -100,9 +111,11 @@ func (p *Permissions) Resolve(ctx context.Context, sessionID, tool string, args 
 	var matchedRules []string
 	if tool == "shell" {
 		danger, matchedRules = ClassifyCommand(subject)
-		if danger == DangerDestructive {
-			// Destructive commands are never auto-approved, no
-			// matter what the allowlists say.
+		if danger == DangerDestructive && !p.sandboxAllows(ctx, sessionID, subject, matchedRules) {
+			// Destructive commands are never auto-approved, no matter
+			// what the allowlists say — UNLESS the session has a
+			// registered sandbox and the command's destruction is
+			// provably confined to it (see sandboxAllows).
 			return Resolution{
 				Decision:  DecisionAsk,
 				Subject:   subject,
@@ -126,6 +139,80 @@ func (p *Permissions) Resolve(ctx context.Context, sessionID, tool string, args 
 		Danger:    danger,
 		Rationale: "no standing grant",
 	}, nil
+}
+
+// SandboxGrantTool is the reserved session_grants tool name whose
+// pattern column carries a session's sandbox root directory instead
+// of a command pattern. A mission's hidden session registers its own
+// workspace here (Grant(sessionID, SandboxGrantTool, root, ttl)):
+// destructive shell commands whose blast radius is provably confined
+// to that root skip the interactive prompt and fall through to normal
+// grant matching. Reusing session_grants keeps the mapping shared
+// across Permissions instances and process restarts with no schema
+// change; the "__" prefix keeps it from ever colliding with a real
+// tool name.
+const SandboxGrantTool = "__sandbox__"
+
+// sandboxDowngradeable names the danger rules whose destruction is
+// file-scoped — confined to whatever paths the command names. Rules
+// NOT here (sudo, docker, git-push, pipe-to-shell, pkg-install, dd,
+// mkfs, opaque forms...) always keep the prompt: their blast radius
+// is not a path inside the sandbox.
+var sandboxDowngradeable = map[string]bool{
+	"redirect-overwrite": true,
+	"append-redirect":    true,
+	"rm":                 true,
+	"rmdir":              true,
+	"mv":                 true,
+	"truncate":           true,
+	"shred":              true,
+	"find-exec":          true,
+	"chmod-recursive":    true,
+}
+
+// sandboxAllows reports whether a destructive-classified shell
+// command may skip the interactive prompt because (1) the session has
+// a registered sandbox root, (2) every matched danger rule is
+// file-scoped, and (3) every absolute path the command names sits
+// inside that root — relative paths resolve against the sandbox
+// itself, since a sandboxed session's shell runs rooted there. The
+// policy guard (.. rejection, off-limits paths) already ran before
+// this is consulted.
+func (p *Permissions) sandboxAllows(ctx context.Context, sessionID, subject string, matchedRules []string) bool {
+	for _, r := range matchedRules {
+		if !sandboxDowngradeable[r] {
+			return false
+		}
+	}
+	root := p.sandboxFor(ctx, sessionID)
+	if root == "" {
+		return false
+	}
+	for _, tok := range commandTokens(subject) {
+		if strings.HasPrefix(tok, "/") && !pathWithin(root, tok) {
+			return false
+		}
+	}
+	return true
+}
+
+// sandboxFor returns the session's registered sandbox root, or "".
+func (p *Permissions) sandboxFor(ctx context.Context, sessionID string) string {
+	if p.db == nil {
+		return ""
+	}
+	db, err := p.db.Get()
+	if err != nil {
+		return ""
+	}
+	var root string
+	err = db.QueryRow(ctx,
+		"SELECT pattern FROM session_grants WHERE session_id = $1 AND tool = $2 AND expires > now() ORDER BY expires DESC LIMIT 1",
+		sessionID, SandboxGrantTool).Scan(&root)
+	if err != nil {
+		return ""
+	}
+	return root
 }
 
 // Grant records an "allow for this session" answer.
@@ -279,7 +366,11 @@ func commandTokens(command string) []string {
 	fields := strings.Fields(strings.ReplaceAll(command, "=", " "))
 	out := make([]string, 0, len(fields))
 	for _, f := range fields {
-		f = strings.Trim(f, `'";|&()<>0123456789`)
+		// Redirect/fd syntax (>, <, 2>) only ever prefixes a path, never
+		// trails it — trimming from both ends would also strip a
+		// literal "<tag>" down to "/tag", a false absolute-path hit.
+		f = strings.TrimLeft(f, "<>0123456789")
+		f = strings.Trim(f, `'";|&()`)
 		if f != "" {
 			out = append(out, f)
 		}

--- a/internal/brain/tools/permissions_test.go
+++ b/internal/brain/tools/permissions_test.go
@@ -36,6 +36,9 @@ func TestGuardSubject(t *testing.T) {
 		{name: "relative path", command: "grep -rn TODO src/"},
 		{name: "dev null", command: "grep x file > /dev/null"},
 		{name: "environment word", command: "grep environment docs/config.md"},
+		{name: "html closing tag", command: `echo "</head>" >> summary.md`},
+		{name: "html tag no quotes", command: "printf '<html>\\n</html>'"},
+		{name: "redirect outside workspace", command: "cat file 2>&1 >/etc/passwd", blocked: "outside the workspace"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -150,6 +153,38 @@ func TestResolveShortCircuits(t *testing.T) {
 		}
 		if !strings.Contains(res.Rationale, "rm") {
 			t.Fatalf("rationale %q does not name the rule", res.Rationale)
+		}
+	})
+}
+
+// TestSandboxAllowsGating covers the pieces of the sandbox downgrade
+// that need no database: rules that are not file-scoped must never
+// downgrade, and without a registered sandbox (nil db here) nothing
+// downgrades at all.
+func TestSandboxAllowsGating(t *testing.T) {
+	t.Parallel()
+	p := NewPermissions(nil, "/workspace")
+	ctx := context.Background()
+
+	t.Run("no sandbox registered keeps the ask", func(t *testing.T) {
+		t.Parallel()
+		if p.sandboxAllows(ctx, "s1", "rm -rf ./build", []string{"rm"}) {
+			t.Fatal("sandboxAllows = true with no sandbox registered")
+		}
+	})
+
+	t.Run("non-file-scoped rule keeps the ask before any lookup", func(t *testing.T) {
+		t.Parallel()
+		if p.sandboxAllows(ctx, "s1", "git push origin main", []string{"git-push"}) {
+			t.Fatal("sandboxAllows = true for git-push — not a file-scoped rule")
+		}
+	})
+
+	t.Run("opaque classification keeps the ask", func(t *testing.T) {
+		t.Parallel()
+		_, rules := ClassifyCommand("eval $CMD")
+		if p.sandboxAllows(ctx, "s1", "eval $CMD", rules) {
+			t.Fatal("sandboxAllows = true for an opaque command")
 		}
 	})
 }

--- a/migrations/0028_mission_session.sql
+++ b/migrations/0028_mission_session.sql
@@ -1,0 +1,7 @@
+-- Mission worker turns run through loop.Agent same as chat, but tool-
+-- call bookkeeping (session_events, tools audit) hard-requires a real
+-- session_id uuid FK -- a mission has no chat session of its own. Give
+-- every mission a hidden session row purely so that bookkeeping has
+-- something real to attach to; nothing about it is chat-facing (no
+-- title shown, sessions list can filter it out by join).
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS session_id uuid REFERENCES sessions(id);

--- a/migrations/0029_mission_permission_detail.sql
+++ b/migrations/0029_mission_permission_detail.sql
@@ -1,0 +1,8 @@
+-- pending_permission already holds the broker-issued id a mission is
+-- parked on; these columns carry what the UI needs to render a real
+-- decision prompt (tool name, args, danger level, rationale) instead
+-- of a bare "waiting" banner -- mirrors chat's PermissionRequestEvent.
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS pending_permission_tool text NOT NULL DEFAULT '';
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS pending_permission_args text NOT NULL DEFAULT '';
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS pending_permission_danger text NOT NULL DEFAULT '';
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS pending_permission_rationale text NOT NULL DEFAULT '';

--- a/migrations/0030_mission_auto_approve.sql
+++ b/migrations/0030_mission_auto_approve.sql
@@ -1,0 +1,7 @@
+-- Missions run for hours unattended; per-command-shape approval (built
+-- for a human watching a chat session) would otherwise park a mission
+-- on every novel-but-harmless shell call. Default true: new missions
+-- auto-approve DangerSafe shell calls via a standing session grant set
+-- at creation (Driver.Create) -- destructive-classified commands still
+-- always ask, unaffected by this column or any grant.
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS auto_approve_safe boolean NOT NULL DEFAULT true;

--- a/migrations/0031_mission_last_evidence.sql
+++ b/migrations/0031_mission_last_evidence.sql
@@ -1,0 +1,7 @@
+-- The reviewer judges the baseline git diff, but a research/scheduled
+-- mission never touches tracked files -- its diff is always empty, so
+-- the reviewer previously had zero evidence to judge and rejected
+-- every round. This carries the worker's own mission_status evidence
+-- text forward from execute to review, alongside (not instead of) the
+-- diff for coding missions.
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS last_evidence text NOT NULL DEFAULT '';

--- a/scripts/canary-mission.sh
+++ b/scripts/canary-mission.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Canary mission: runs one golden research mission end-to-end against
+# the live stack and asserts the harness contract holds — done within
+# the iteration budget, zero human permission parks, artifacts verified
+# by the harness. Run after every harness change (make canary) so
+# regressions surface here, not in production missions.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASE_URL="${CANARY_BASE_URL:-http://localhost:${BRAIN_PORT:-8300}}"
+TIMEOUT_SECS="${CANARY_TIMEOUT:-900}"
+GOAL="Summarize what HTTP status code 429 means and when a client should retry, in a markdown file."
+
+# The API token stays in the shell environment only — sourced here,
+# never printed.
+if [[ -z "${TIMOTHY_API_TOKEN:-}" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${REPO_ROOT}/deploy/.env"
+  set +a
+fi
+if [[ -z "${TIMOTHY_API_TOKEN:-}" ]]; then
+  echo "canary: TIMOTHY_API_TOKEN not set and deploy/.env did not provide it" >&2
+  exit 2
+fi
+
+auth=(-H "Authorization: Bearer ${TIMOTHY_API_TOKEN}" -H "Content-Type: application/json")
+
+echo "canary: creating mission against ${BASE_URL}"
+create_resp="$(curl -sf "${auth[@]}" -X POST "${BASE_URL}/v1/missions" \
+  -d "{\"goal\": \"${GOAL}\", \"kind\": \"research\"}")"
+id="$(echo "${create_resp}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+echo "canary: mission ${id}"
+
+start=$(date +%s)
+phase=""
+status=""
+while :; do
+  now=$(date +%s)
+  if (( now - start > TIMEOUT_SECS )); then
+    echo "canary: FAIL — timed out after ${TIMEOUT_SECS}s (phase=${phase} status=${status})" >&2
+    exit 1
+  fi
+  m="$(curl -sf "${auth[@]}" "${BASE_URL}/v1/missions/${id}")"
+  phase="$(echo "${m}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["phase"])')"
+  status="$(echo "${m}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])')"
+  pending="$(echo "${m}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("pending_permission_tool") or "")')"
+  echo "canary: ${phase}/${status} (t+$((now - start))s)${pending:+ [PARKED on ${pending}]}"
+  case "${phase}/${status}" in
+    done/*) break ;;
+    failed/*)
+      echo "canary: FAIL — mission failed" >&2
+      curl -sf "${auth[@]}" "${BASE_URL}/v1/missions/${id}/events" | python3 -m json.tool | tail -40 >&2
+      exit 1 ;;
+  esac
+  if [[ "${status}" == "paused" || "${status}" == "waiting_for_input" ]]; then
+    echo "canary: FAIL — mission parked (${status}); a canary must run unattended" >&2
+    exit 1
+  fi
+  sleep 5
+done
+
+events="$(curl -sf "${auth[@]}" "${BASE_URL}/v1/missions/${id}/events")"
+CANARY_EVENTS="${events}" python3 <<'PY'
+import json, os, sys
+events = json.loads(os.environ["CANARY_EVENTS"])["events"]
+kinds = {}
+for e in events:
+    kinds[e["kind"]] = kinds.get(e["kind"], 0) + 1
+
+parks = kinds.get("mission.permission_requested", 0)
+turns = [e for e in events if e["kind"] == "mission.turn"]
+total_ms = sum((e.get("payload") or {}).get("duration_ms", 0) for e in turns)
+verified = [e for e in events if e["kind"] == "mission.unit_verified"
+            and (e.get("payload") or {}).get("passed") is True]
+
+print(f"canary: event counts: {json.dumps(kinds, sort_keys=True)}")
+print(f"canary: {len(turns)} model turns, {total_ms/1000:.0f}s total model time")
+
+failures = []
+if parks > 0:
+    failures.append(f"{parks} permission park(s) — canary must run unattended")
+if not verified:
+    failures.append("no harness-verified unit — done was claimed, never proven")
+if len(turns) > 8:
+    failures.append(f"{len(turns)} turns for a trivial mission — loop is not right-sized")
+if failures:
+    print("canary: FAIL — " + "; ".join(failures), file=sys.stderr)
+    sys.exit(1)
+print("canary: PASS")
+PY

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import {
   Home01Icon,
   Key01Icon,
   Moon02Icon,
+  RocketIcon,
   Search01Icon,
   Settings02Icon,
   Sun03Icon,
@@ -48,12 +49,15 @@ import { Chat } from './pages/Chat'
 import { Analytics } from './pages/Analytics'
 import { Home } from './pages/Home'
 import { Memory } from './pages/Memory'
+import { MissionDetail } from './pages/MissionDetail'
+import { Missions } from './pages/Missions'
 import { Research } from './pages/Research'
 import { Settings } from './pages/Settings'
 
 const nav = [
   { label: 'Home', href: '/', icon: Home01Icon },
   { label: 'Chat', href: '/chat', icon: BubbleChatIcon },
+  { label: 'Missions', href: '/missions', icon: RocketIcon },
   { label: 'Memory', href: '/memory', icon: Brain02Icon },
   { label: 'Analytics', href: '/analytics', icon: Analytics01Icon },
   { label: 'Settings', href: '/settings', icon: Settings02Icon },
@@ -65,6 +69,7 @@ const themeLabel = { system: 'System theme', light: 'Light theme', dark: 'Dark t
 function isActive(pathname: string, href: string): boolean {
   if (href === '/') return pathname === '/'
   if (href === '/chat') return pathname === '/chat' || pathname.startsWith('/chat/')
+  if (href === '/missions') return pathname === '/missions' || pathname.startsWith('/missions/')
   if (href === '/settings') return pathname.startsWith('/settings')
   return pathname === href
 }
@@ -313,6 +318,8 @@ function App() {
                 <Route path="/analytics" element={<Analytics />} />
                 {/* Old bookmarks: the page lived at /dashboard before the rename. */}
                 <Route path="/dashboard" element={<Navigate to="/analytics" replace />} />
+                <Route path="/missions" element={<Missions />} />
+                <Route path="/missions/:id" element={<MissionDetail />} />
                 <Route path="/memory" element={<Memory />} />
                 <Route path="/settings/*" element={<Settings />} />
                 {/* Old bookmark: Settings lived at one page with ?tab= before sub-routes. */}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -12,6 +12,9 @@ import type {
   ChatRequest,
   LatencyRow,
   MemoryItem,
+  Mission,
+  MissionEvent,
+  Notification,
   ProviderHealth,
   RetrievedMemory,
   SessionMeta,
@@ -627,4 +630,66 @@ export async function patchSettingValues(changes: Record<string, string>): Promi
     method: 'PATCH',
     body: JSON.stringify(changes),
   })
+}
+
+// --- missions (long-running, agent-driven units of work) ---
+
+export interface CreateMissionInput {
+  goal: string
+  kind: 'coding' | 'research' | 'scheduled'
+  agent_id?: string
+  route?: string
+  review_route?: string
+  max_iterations?: number
+  budget_usd?: number
+  repo_path?: string
+  auto_approve_safe?: boolean
+}
+
+export async function listMissions(): Promise<Mission[]> {
+  const { missions } = await request<{ missions: Mission[] }>('/v1/missions')
+  return missions ?? []
+}
+
+export async function createMission(input: CreateMissionInput): Promise<{ id: string }> {
+  return request<{ id: string }>('/v1/missions', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  })
+}
+
+export async function getMission(id: string): Promise<Mission> {
+  return request<Mission>(`/v1/missions/${id}`)
+}
+
+export async function missionEvents(id: string): Promise<MissionEvent[]> {
+  const { events } = await request<{ events: MissionEvent[] }>(`/v1/missions/${id}/events`)
+  return events ?? []
+}
+
+export async function resumeMission(id: string): Promise<void> {
+  await request<void>(`/v1/missions/${id}/resume`, { method: 'POST' })
+}
+
+export async function cancelMission(id: string): Promise<void> {
+  await request<void>(`/v1/missions/${id}/cancel`, { method: 'POST' })
+}
+
+export async function answerMissionPermission(
+  id: string,
+  decision: 'once' | 'session' | 'deny',
+): Promise<void> {
+  await request<void>(`/v1/missions/${id}/permission`, {
+    method: 'POST',
+    body: JSON.stringify({ decision }),
+  })
+}
+
+export async function listNotifications(): Promise<Notification[]> {
+  const { notifications } = await request<{ notifications: Notification[] }>('/v1/notifications')
+  return notifications ?? []
+}
+
+export async function markNotificationRead(id: string): Promise<void> {
+  await request<void>(`/v1/notifications/${id}/read`, { method: 'POST' })
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -275,6 +275,13 @@ export interface AdminAgent {
   memory: boolean
   is_default: boolean
   enabled: boolean
+  // Mission-only fields (internal/brain/missions) — meaningless to a
+  // chat-only agent, absent or at zero values for one. Optional here
+  // since most call sites (chat agent picker etc.) never populate
+  // them.
+  review_route?: string
+  budget_usd?: number
+  approval_allowlist?: string[]
 }
 
 // AdminTool is one entry of the live tool surface (builtins +
@@ -283,6 +290,76 @@ export interface AdminAgent {
 export interface AdminTool {
   name: string
   description: string
+}
+
+// PlanUnit is one item of a mission's plan. passes is flipped only by
+// the harness (RunVerify), never claimed by the model.
+export interface PlanUnit {
+  title: string
+  verify_cmd: string
+  artifacts?: string[]
+  passes: boolean
+}
+
+export interface ProgressNote {
+  at: string
+  note: string
+}
+
+// Mission is one long-running, agent-driven unit of work
+// (internal/brain/missions): research -> plan -> execute -> review
+// under a state machine.
+export interface Mission {
+  id: string
+  goal: string
+  kind: 'coding' | 'research' | 'scheduled'
+  agent_id?: string
+  phase: 'research' | 'plan' | 'execute' | 'review' | 'done' | 'failed'
+  status: 'idle' | 'working' | 'waiting_for_input' | 'paused' | 'done' | 'error'
+  pause_reason?: 'backoff' | 'no_progress' | 'infra' | 'budget' | ''
+  pause_message?: string
+  workspace?: string
+  worktree?: string
+  branch?: string
+  base_commit?: string
+  spec: { units: PlanUnit[] }
+  progress: ProgressNote[]
+  iteration: number
+  max_iterations: number
+  consecutive_failures: number
+  last_gap_fingerprint?: string
+  stall_count: number
+  budget_usd?: number
+  route: string
+  review_route: string
+  pending_permission?: string
+  pending_permission_tool?: string
+  pending_permission_args?: string
+  pending_permission_danger?: string
+  pending_permission_rationale?: string
+  auto_approve_safe: boolean
+  schedule_id?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface MissionEvent {
+  mission_id: string
+  seq: number
+  kind: string
+  payload: unknown
+  provenance: string
+  fingerprint?: string
+  created_at: string
+}
+
+export interface Notification {
+  id: string
+  mission_id: string
+  kind: string
+  message: string
+  read: boolean
+  created_at: string
 }
 
 // AdminConnector is one third-party integration the agent can call as

--- a/web/src/components/missions/MissionCard.tsx
+++ b/web/src/components/missions/MissionCard.tsx
@@ -1,0 +1,48 @@
+import { Link } from 'react-router'
+import type { Mission } from '../../api/types'
+
+const statusColor: Record<Mission['status'], string> = {
+  idle: 'bg-muted text-muted-foreground',
+  working: 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300',
+  waiting_for_input: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300',
+  paused: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300',
+  done: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300',
+  error: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300',
+}
+
+function unitProgress(mission: Mission): string | null {
+  const units = mission.spec?.units
+  if (!units || units.length === 0) return null
+  const done = units.filter((u) => u.passes).length
+  return `${done}/${units.length} units`
+}
+
+export function MissionCard({ mission }: { mission: Mission }) {
+  const progress = unitProgress(mission)
+  return (
+    <Link
+      to={`/missions/${mission.id}`}
+      className="flex flex-col gap-2 rounded-xl border border-border bg-card p-4 text-left shadow-sm transition hover:border-brand hover:shadow-md"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="line-clamp-2 text-sm font-semibold">{mission.goal}</span>
+        <span
+          className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium whitespace-nowrap ${statusColor[mission.status]}`}
+        >
+          {mission.status.replace(/_/g, ' ')}
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+        <span className="capitalize">{mission.kind}</span>
+        <span>{mission.phase}</span>
+        <span>
+          iteration {mission.iteration}/{mission.max_iterations}
+        </span>
+        {progress && <span>{progress}</span>}
+      </div>
+      {mission.pause_message && (
+        <p className="line-clamp-2 text-xs text-amber-700 dark:text-amber-400">{mission.pause_message}</p>
+      )}
+    </Link>
+  )
+}

--- a/web/src/components/missions/NewMissionDialog.tsx
+++ b/web/src/components/missions/NewMissionDialog.tsx
@@ -1,0 +1,232 @@
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { createMission } from '../../api/client'
+import type { AdminAgent } from '../../api/types'
+import { useAgents } from '../AgentPicker'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { Textarea } from '../ui/textarea'
+import { errText } from '../settings/util'
+
+const kinds = [
+  { value: 'research', label: 'Research' },
+  { value: 'coding', label: 'Coding' },
+  { value: 'scheduled', label: 'Scheduled' },
+] as const
+
+export function NewMissionDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onCreated: (id: string) => void
+}) {
+  const agents = useAgents()
+  const [goal, setGoal] = useState('')
+  const [kind, setKind] = useState<(typeof kinds)[number]['value']>('research')
+  const [agentID, setAgentID] = useState('')
+  const [repoPath, setRepoPath] = useState('')
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [route, setRoute] = useState('')
+  const [reviewRoute, setReviewRoute] = useState('')
+  const [budget, setBudget] = useState('')
+  const [autoApproveSafe, setAutoApproveSafe] = useState(true)
+  const [busy, setBusy] = useState(false)
+
+  const pickAgent = (id: string) => {
+    setAgentID(id)
+    const agent = agents.find((a) => a.id === id)
+    if (agent) {
+      setReviewRoute(agent.review_route ?? '')
+      if (agent.budget_usd != null) setBudget(String(agent.budget_usd))
+    }
+  }
+
+  const canSubmit = goal.trim() !== '' && (kind !== 'coding' || repoPath.trim() !== '')
+
+  const reset = () => {
+    setGoal('')
+    setKind('research')
+    setAgentID('')
+    setRepoPath('')
+    setShowAdvanced(false)
+    setRoute('')
+    setReviewRoute('')
+    setBudget('')
+    setAutoApproveSafe(true)
+  }
+
+  const submit = async () => {
+    setBusy(true)
+    try {
+      const { id } = await createMission({
+        goal: goal.trim(),
+        kind,
+        agent_id: agentID || undefined,
+        route: route || undefined,
+        review_route: reviewRoute || undefined,
+        budget_usd: budget ? Number(budget) : undefined,
+        repo_path: kind === 'coding' ? repoPath.trim() : undefined,
+        auto_approve_safe: autoApproveSafe,
+      })
+      toast.success('Mission created')
+      reset()
+      onOpenChange(false)
+      onCreated(id)
+    } catch (err) {
+      toast.error('Could not create mission', { description: errText(err) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>New mission</DialogTitle>
+          <DialogDescription>
+            A long-running task that plans, executes, and reviews its own work.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="mission-goal">Goal</Label>
+            <Textarea
+              id="mission-goal"
+              value={goal}
+              onChange={(e) => setGoal(e.target.value)}
+              placeholder="What should this mission accomplish?"
+              rows={3}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Kind</Label>
+            <Select value={kind} onValueChange={(v) => setKind(v as typeof kind)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {kinds.map((k) => (
+                  <SelectItem key={k.value} value={k.value}>
+                    {k.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {kind === 'coding' && (
+            <div className="space-y-1.5">
+              <Label htmlFor="mission-repo">Repository path</Label>
+              <Input
+                id="mission-repo"
+                value={repoPath}
+                onChange={(e) => setRepoPath(e.target.value)}
+                placeholder="/workspace/my-repo"
+              />
+            </div>
+          )}
+
+          {agents.length > 0 && (
+            <div className="space-y-1.5">
+              <Label>Agent</Label>
+              <Select value={agentID} onValueChange={pickAgent}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Default" />
+                </SelectTrigger>
+                <SelectContent>
+                  {agents.map((a: AdminAgent) => (
+                    <SelectItem key={a.id} value={a.id}>
+                      {a.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={() => setShowAdvanced((v) => !v)}
+            className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+          >
+            {showAdvanced ? 'Hide advanced options' : 'Show advanced options'}
+          </button>
+
+          {showAdvanced && (
+            <div className="space-y-3 rounded-lg border border-border p-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="mission-route">Route</Label>
+                <Input
+                  id="mission-route"
+                  value={route}
+                  onChange={(e) => setRoute(e.target.value)}
+                  placeholder="default"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="mission-review-route">Review route</Label>
+                <Input
+                  id="mission-review-route"
+                  value={reviewRoute}
+                  onChange={(e) => setReviewRoute(e.target.value)}
+                  placeholder="default"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="mission-budget">Budget (USD)</Label>
+                <Input
+                  id="mission-budget"
+                  type="number"
+                  value={budget}
+                  onChange={(e) => setBudget(e.target.value)}
+                  placeholder="No limit"
+                />
+              </div>
+              <label htmlFor="mission-auto-approve" className="flex items-start gap-2 text-sm">
+                <input
+                  id="mission-auto-approve"
+                  type="checkbox"
+                  checked={autoApproveSafe}
+                  onChange={(e) => setAutoApproveSafe(e.target.checked)}
+                  className="mt-0.5"
+                />
+                <span>
+                  Auto-approve safe tool calls
+                  <span className="block text-xs text-muted-foreground">
+                    Runs unattended without pausing for approval on routine commands. Destructive
+                    or unrecognized commands still always ask.
+                  </span>
+                </span>
+              </label>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" disabled={busy} onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button disabled={!canSubmit || busy} onClick={() => void submit()}>
+            Create mission
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/src/components/missions/PermissionBanner.tsx
+++ b/web/src/components/missions/PermissionBanner.tsx
@@ -1,0 +1,58 @@
+import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
+
+function prettyArgs(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2)
+  } catch {
+    return raw
+  }
+}
+
+// PermissionBanner renders only when a mission has a live
+// pending_permission — the same once|session|deny vocabulary and tool
+// detail chat's PermissionModal shows, just inline rather than modal
+// since a mission isn't a focused single-turn interaction.
+export function PermissionBanner({
+  tool,
+  args,
+  danger,
+  rationale,
+  onDecide,
+}: {
+  tool?: string
+  args?: string
+  danger?: string
+  rationale?: string
+  onDecide: (decision: 'once' | 'session' | 'deny') => void
+}) {
+  return (
+    <div className="space-y-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900 dark:bg-amber-950">
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <p className="flex items-center gap-2 text-sm font-medium text-amber-900 dark:text-amber-200">
+            Allow <span className="font-mono">{tool || 'this tool call'}</span>?
+            {danger === 'destructive' && <Badge variant="destructive">destructive</Badge>}
+          </p>
+          {rationale && <p className="text-sm text-amber-800 dark:text-amber-300">{rationale}</p>}
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <Button variant="ghost" size="sm" onClick={() => onDecide('deny')}>
+            Deny
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => onDecide('session')}>
+            Allow for session
+          </Button>
+          <Button size="sm" onClick={() => onDecide('once')}>
+            Allow once
+          </Button>
+        </div>
+      </div>
+      {args && (
+        <pre className="max-h-48 overflow-auto rounded bg-white/60 p-3 text-xs whitespace-pre-wrap text-amber-950 dark:bg-black/20 dark:text-amber-100">
+          {prettyArgs(args)}
+        </pre>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/missions/PlanSection.tsx
+++ b/web/src/components/missions/PlanSection.tsx
@@ -1,0 +1,25 @@
+import type { PlanUnit } from '../../api/types'
+
+export function PlanSection({ units }: { units: PlanUnit[] }) {
+  if (units.length === 0) {
+    return <p className="text-sm text-muted-foreground">No plan yet.</p>
+  }
+  return (
+    <ul className="space-y-1.5">
+      {units.map((u, i) => (
+        <li key={i} className="flex items-center gap-2 text-sm">
+          <span
+            className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium ${
+              u.passes
+                ? 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300'
+                : 'bg-muted text-muted-foreground'
+            }`}
+          >
+            {u.passes ? 'verified' : 'pending'}
+          </span>
+          <span>{u.title}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/web/src/components/missions/ProgressSection.tsx
+++ b/web/src/components/missions/ProgressSection.tsx
@@ -1,0 +1,17 @@
+import type { ProgressNote } from '../../api/types'
+
+export function ProgressSection({ notes }: { notes: ProgressNote[] }) {
+  if (notes.length === 0) {
+    return <p className="text-sm text-muted-foreground">No progress notes yet.</p>
+  }
+  return (
+    <ul className="space-y-2">
+      {notes.map((n, i) => (
+        <li key={i} className="text-sm">
+          <span className="mr-2 text-xs text-muted-foreground">{new Date(n.at).toLocaleString()}</span>
+          {n.note}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/web/src/components/missions/TimelineSection.tsx
+++ b/web/src/components/missions/TimelineSection.tsx
@@ -1,0 +1,80 @@
+import { ArrowDown01Icon, ArrowUp01Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useEffect, useRef } from 'react'
+import type { MissionEvent } from '../../api/types'
+import { Button } from '../ui/button'
+import { renderEvent } from './eventRenderers'
+
+// How close to the bottom (px) counts as "already following the tail"
+// — auto-scroll only kicks in within this margin, so a reader who has
+// scrolled up to read history never gets yanked back down by new
+// events arriving from the poll loop.
+const followThresholdPx = 48
+
+export function TimelineSection({ events }: { events: MissionEvent[] }) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const wasAtBottomRef = useRef(true)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (el && wasAtBottomRef.current) {
+      el.scrollTop = el.scrollHeight
+    }
+  }, [events])
+
+  const handleScroll = () => {
+    const el = containerRef.current
+    if (!el) return
+    wasAtBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight <= followThresholdPx
+  }
+
+  const scrollToTop = () => {
+    containerRef.current?.scrollTo({ top: 0, behavior: 'smooth' })
+    wasAtBottomRef.current = false
+  }
+
+  const scrollToBottom = () => {
+    const el = containerRef.current
+    if (!el) return
+    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
+    wasAtBottomRef.current = true
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      <div className="flex items-center justify-between border-b border-border bg-muted/50 px-3 py-1.5">
+        <span className="text-xs text-muted-foreground">
+          {events.length} event{events.length === 1 ? '' : 's'}
+        </span>
+        <div className="flex gap-1">
+          <Button variant="ghost" size="icon-xs" title="Scroll to top" onClick={scrollToTop}>
+            <HugeiconsIcon icon={ArrowUp01Icon} />
+          </Button>
+          <Button variant="ghost" size="icon-xs" title="Scroll to bottom" onClick={scrollToBottom}>
+            <HugeiconsIcon icon={ArrowDown01Icon} />
+          </Button>
+        </div>
+      </div>
+      <div
+        ref={containerRef}
+        onScroll={handleScroll}
+        className="h-80 overflow-y-auto bg-zinc-950 px-3 py-2 font-mono text-xs dark:bg-black"
+      >
+        {events.length === 0 ? (
+          <p className="text-zinc-500">No events yet.</p>
+        ) : (
+          <ol className="space-y-1">
+            {events.map((e) => (
+              <li key={e.seq} className="flex gap-3 text-zinc-300">
+                <span className="w-24 shrink-0 whitespace-nowrap text-zinc-500">
+                  {new Date(e.created_at).toLocaleTimeString()}
+                </span>
+                <span className="flex-1 break-words">{renderEvent(e)}</span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode } from 'react'
+import type { MissionEvent } from '../../api/types'
+
+// eventRenderers maps a mission_events kind to a short, human-readable
+// summary of its payload. Unrecognized kinds fall back to the generic
+// renderer below — forward-compatible with new event kinds the web
+// hasn't been updated to render specifically, rather than rendering
+// blank.
+const renderers: Record<string, (payload: unknown) => ReactNode> = {
+  'mission.created': () => 'Mission created',
+  'mission.provisioned': (p) => {
+    const { branch } = asRecord(p)
+    return branch ? `Workspace provisioned on branch ${String(branch)}` : 'Workspace provisioned'
+  },
+  'mission.phase_started': (p) => {
+    const { phase } = asRecord(p)
+    return `Phase started: ${String(phase ?? '?')}`
+  },
+  'mission.plan_created': (p) => {
+    const { units } = asRecord(p)
+    return `Plan created with ${String(units ?? '?')} unit(s)`
+  },
+  'mission.worker_started': () => 'Worker turn started',
+  'mission.worker_finished': () => 'Worker turn finished',
+  'mission.progress': (p) => {
+    const { note } = asRecord(p)
+    return String(note ?? '')
+  },
+  'mission.unit_verified': (p) => {
+    const { unit, passed } = asRecord(p)
+    return `Unit ${String(unit ?? '?')} verification: ${passed ? 'passed' : 'failed'}`
+  },
+  'mission.review_verdict': (p) => {
+    const { decision } = asRecord(p)
+    return `Review verdict: ${String(decision ?? '?')}`
+  },
+  'mission.retry': () => 'Retrying',
+  'mission.blocked': (p) => {
+    const { question } = asRecord(p)
+    return `Blocked: ${String(question ?? 'waiting on the user')}`
+  },
+  'mission.permission_requested': (p) => {
+    const { tool, args, danger } = asRecord(p)
+    const dangerSuffix = danger && danger !== 'safe' ? ` (${String(danger)})` : ''
+    return (
+      <span>
+        Permission requested: {String(tool ?? 'a tool call')}
+        {dangerSuffix}
+        {args ? (
+          <code className="ml-1 rounded bg-muted px-1 py-0.5 text-xs whitespace-pre-wrap">
+            {truncateForDisplay(String(args))}
+          </code>
+        ) : null}
+      </span>
+    )
+  },
+  'mission.permission_answered': (p) => {
+    const { tool, decision } = asRecord(p)
+    return `Permission ${String(decision ?? '?')}: ${String(tool ?? 'a tool call')}`
+  },
+  'mission.paused': (p) => {
+    const { reason } = asRecord(p)
+    return `Paused (${String(reason ?? 'unknown reason')})`
+  },
+  'mission.resumed': () => 'Resumed',
+  'mission.recovery': () => 'Recovered after a restart',
+  'mission.violation': () => 'Policy violation detected',
+  'mission.done': () => 'Mission completed',
+  'mission.failed': (p) => {
+    const { reason } = asRecord(p)
+    return `Mission failed${reason ? `: ${String(reason)}` : ''}`
+  },
+  'mission.reconciled': (p) => {
+    const { canonical_phase } = asRecord(p)
+    return `Conflicting outcome reconciled (canonical: ${String(canonical_phase ?? '?')})`
+  },
+}
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return typeof v === 'object' && v !== null ? (v as Record<string, unknown>) : {}
+}
+
+// truncateForDisplay caps an inline Timeline snippet well below the
+// backend's own 2000-char event cap — a full shell command belongs in
+// the (already truncated) event payload, not a single Timeline row.
+function truncateForDisplay(s: string, n = 200): string {
+  return s.length <= n ? s : s.slice(0, n) + '…'
+}
+
+export function renderEvent(event: MissionEvent): ReactNode {
+  const render = renderers[event.kind]
+  if (render) return render(event.payload)
+  return event.kind
+}

--- a/web/src/components/settings/ProviderAdd.test.tsx
+++ b/web/src/components/settings/ProviderAdd.test.tsx
@@ -63,6 +63,6 @@ describe('ProviderAdd model suggestions', () => {
     const input = await screen.findByPlaceholderText('model id')
     fireEvent.focus(input)
 
-    expect(await screen.findByText('glm-5.2')).toBeInTheDocument()
+    expect(await screen.findByText('glm-4.7-flash')).toBeInTheDocument()
   })
 })

--- a/web/src/components/settings/modelCatalog.ts
+++ b/web/src/components/settings/modelCatalog.ts
@@ -64,6 +64,9 @@ export const modelCatalog: Record<string, CatalogModel[]> = {
     // docs.z.ai direct pricing (verified earlier, cross-checked
     // against 2 sources) — OpenRouter re-sells this at a different
     // rate, not the number that matters for a direct GLM provider.
+    // glm-4.7-flash is Z.ai's free tier — distinct from the paid
+    // glm-4.7-flashx SKU, do not conflate the two.
+    { id: 'glm-4.7-flash', name: 'GLM-4.7 Flash', prices: { input_per_mtok: 0, output_per_mtok: 0 } },
     { id: 'glm-5.2', name: 'GLM-5.2', prices: { input_per_mtok: 1.4, output_per_mtok: 4.4 } },
     { id: 'glm-4.6', name: 'GLM-4.6', prices: { input_per_mtok: 0.6, output_per_mtok: 2.2 } },
     { id: 'glm-4.5', name: 'GLM-4.5', prices: { input_per_mtok: 0.6, output_per_mtok: 2.2 } },

--- a/web/src/components/settings/presets.ts
+++ b/web/src/components/settings/presets.ts
@@ -79,7 +79,7 @@ export const providerPresets: ProviderPreset[] = [
     defaultRef: 'ZAI_API_KEY',
     keyPlaceholder: 'paste key',
     keyHint: 'Create one at z.ai.',
-    validateModel: 'glm-5.2',
+    validateModel: 'glm-4.7-flash',
   },
   {
     id: 'grok',

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -1,0 +1,172 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mission, MissionEvent } from '../api/types'
+import { MissionDetail } from './MissionDetail'
+
+vi.mock('../api/client', () => ({
+  getMission: vi.fn(),
+  missionEvents: vi.fn(),
+  resumeMission: vi.fn(),
+  cancelMission: vi.fn(),
+  answerMissionPermission: vi.fn(),
+}))
+
+import {
+  answerMissionPermission,
+  cancelMission,
+  getMission,
+  missionEvents,
+  resumeMission,
+} from '../api/client'
+
+const baseMission: Mission = {
+  id: 'm1',
+  goal: 'Fix the login bug',
+  kind: 'coding',
+  phase: 'execute',
+  status: 'working',
+  branch: 'mission/fix-login',
+  base_commit: 'abc123def456',
+  spec: { units: [{ title: 'Add validation', verify_cmd: 'go test', passes: true }] },
+  progress: [{ at: '2026-01-01T00:00:00Z', note: 'found the root cause' }],
+  iteration: 2,
+  max_iterations: 8,
+  consecutive_failures: 0,
+  stall_count: 0,
+  route: 'default',
+  review_route: 'default',
+  auto_approve_safe: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const events: MissionEvent[] = [
+  {
+    mission_id: 'm1',
+    seq: 1,
+    kind: 'mission.created',
+    payload: {},
+    provenance: 'live',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    mission_id: 'm1',
+    seq: 2,
+    kind: 'mission.some_future_kind',
+    payload: { detail: 'x' },
+    provenance: 'live',
+    created_at: '2026-01-01T00:01:00Z',
+  },
+  {
+    mission_id: 'm1',
+    seq: 3,
+    kind: 'mission.permission_requested',
+    payload: { tool: 'shell', args: '{"command":"rm -rf /tmp/x"}', danger: 'destructive' },
+    provenance: 'live',
+    created_at: '2026-01-01T00:02:00Z',
+  },
+  {
+    mission_id: 'm1',
+    seq: 4,
+    kind: 'mission.permission_answered',
+    payload: { tool: 'shell', decision: 'once' },
+    provenance: 'live',
+    created_at: '2026-01-01T00:03:00Z',
+  },
+]
+
+function renderPage(id = 'm1') {
+  return render(
+    <MemoryRouter initialEntries={[`/missions/${id}`]}>
+      <Routes>
+        <Route path="/missions/:id" element={<MissionDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(getMission).mockResolvedValue(baseMission)
+  vi.mocked(missionEvents).mockResolvedValue(events)
+})
+
+describe('MissionDetail', () => {
+  it('renders mission header, plan, and progress', async () => {
+    renderPage()
+    expect(await screen.findByText('Fix the login bug')).toBeTruthy()
+    expect(screen.getByText('Add validation')).toBeTruthy()
+    expect(screen.getByText('found the root cause')).toBeTruthy()
+  })
+
+  it('does not show a permission banner when none is pending', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(screen.queryByText(/Allow/)).toBeNull()
+  })
+
+  it('shows the permission banner with tool detail when pending_permission is set', async () => {
+    vi.mocked(getMission).mockResolvedValue({
+      ...baseMission,
+      pending_permission: 'perm-1',
+      pending_permission_tool: 'shell',
+      pending_permission_args: '{"command":"rm -rf /tmp/x"}',
+      pending_permission_danger: 'destructive',
+      pending_permission_rationale: 'deletes files',
+    })
+    renderPage()
+    expect(await screen.findByText('shell')).toBeTruthy()
+    expect(screen.getByText('destructive')).toBeTruthy()
+    expect(screen.getByText('deletes files')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Allow once' }))
+    await waitFor(() => expect(answerMissionPermission).toHaveBeenCalledWith('m1', 'once'))
+  })
+
+  it('renders known event kinds with their specific text and unknown kinds with the fallback', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(await screen.findByText('Mission created')).toBeTruthy()
+    // Unknown kind falls back to rendering the raw kind string.
+    expect(screen.getByText('mission.some_future_kind')).toBeTruthy()
+    expect(screen.getByText(/Permission requested: shell \(destructive\)/)).toBeTruthy()
+    expect(screen.getByText('{"command":"rm -rf /tmp/x"}')).toBeTruthy()
+    expect(screen.getByText('Permission once: shell')).toBeTruthy()
+  })
+
+  it('renders the timeline as a scrollable container with scroll-to-top/bottom controls', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(screen.getByTitle('Scroll to top')).toBeTruthy()
+    expect(screen.getByTitle('Scroll to bottom')).toBeTruthy()
+    expect(screen.getByText(`${events.length} events`)).toBeTruthy()
+  })
+
+  it('shows resume for a paused mission and cancel for a non-terminal one', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, status: 'paused', pause_reason: 'backoff' })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(screen.getByRole('button', { name: 'Resume' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resume' }))
+    await waitFor(() => expect(resumeMission).toHaveBeenCalledWith('m1'))
+  })
+
+  it('hides resume and cancel for a done mission', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, phase: 'done', status: 'done' })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(screen.queryByRole('button', { name: 'Resume' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull()
+  })
+
+  it('cancels a mission', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(cancelMission).toHaveBeenCalledWith('m1'))
+  })
+})

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -1,0 +1,166 @@
+import { ArrowLeft01Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useCallback, useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router'
+import { toast } from 'sonner'
+import {
+  answerMissionPermission,
+  cancelMission,
+  getMission,
+  missionEvents,
+  resumeMission,
+} from '../api/client'
+import type { Mission, MissionEvent } from '../api/types'
+import { PermissionBanner } from '../components/missions/PermissionBanner'
+import { PlanSection } from '../components/missions/PlanSection'
+import { ProgressSection } from '../components/missions/ProgressSection'
+import { TimelineSection } from '../components/missions/TimelineSection'
+import { Button } from '../components/ui/button'
+import { errText } from '../components/settings/util'
+
+const pollIntervalIdle = 5000
+const pollIntervalPending = 1500
+
+const resumableStatuses = new Set(['paused', 'waiting_for_input'])
+const terminalPhases = new Set(['done', 'failed'])
+
+export function MissionDetail() {
+  const { id } = useParams<{ id: string }>()
+  const [mission, setMission] = useState<Mission | null>(null)
+  const [events, setEvents] = useState<MissionEvent[]>([])
+  const [busy, setBusy] = useState(false)
+
+  const refresh = useCallback(() => {
+    if (!id) return
+    getMission(id).then(setMission, () => undefined)
+    missionEvents(id).then(setEvents, () => undefined)
+  }, [id])
+
+  useEffect(() => {
+    refresh()
+    const interval = mission?.pending_permission ? pollIntervalPending : pollIntervalIdle
+    const timer = setInterval(refresh, interval)
+    return () => clearInterval(timer)
+  }, [refresh, mission?.pending_permission])
+
+  if (!id) return null
+  if (!mission) {
+    return (
+      <div className="mx-auto w-full max-w-3xl px-4 py-6">
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      </div>
+    )
+  }
+
+  const canResume = resumableStatuses.has(mission.status)
+  const canCancel = !terminalPhases.has(mission.phase)
+
+  const resume = async () => {
+    setBusy(true)
+    try {
+      await resumeMission(id)
+      toast.success('Mission resumed')
+      refresh()
+    } catch (err) {
+      toast.error('Could not resume mission', { description: errText(err) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const cancel = async () => {
+    setBusy(true)
+    try {
+      await cancelMission(id)
+      toast.success('Mission cancelled')
+      refresh()
+    } catch (err) {
+      toast.error('Could not cancel mission', { description: errText(err) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const decidePermission = async (decision: 'once' | 'session' | 'deny') => {
+    try {
+      await answerMissionPermission(id, decision)
+      refresh()
+    } catch (err) {
+      toast.error('Could not answer permission request', { description: errText(err) })
+    }
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6 px-4 py-6">
+      <Link
+        to="/missions"
+        className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+      >
+        <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+        Missions
+      </Link>
+
+      {mission.pending_permission && (
+        <PermissionBanner
+          tool={mission.pending_permission_tool}
+          args={mission.pending_permission_args}
+          danger={mission.pending_permission_danger}
+          rationale={mission.pending_permission_rationale}
+          onDecide={(d) => void decidePermission(d)}
+        />
+      )}
+
+      <div className="border-b border-border pb-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-xl font-semibold tracking-tight">{mission.goal}</h1>
+            <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-sm text-muted-foreground">
+              <span className="capitalize">{mission.kind}</span>
+              <span>{mission.phase}</span>
+              <span>{mission.status.replace(/_/g, ' ')}</span>
+              <span>
+                iteration {mission.iteration}/{mission.max_iterations}
+              </span>
+              {mission.budget_usd != null && <span>budget ${mission.budget_usd}</span>}
+            </div>
+            {mission.branch && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                {mission.branch} @ {mission.base_commit?.slice(0, 8)}
+              </p>
+            )}
+            {mission.pause_message && (
+              <p className="mt-2 text-sm text-amber-700 dark:text-amber-400">{mission.pause_message}</p>
+            )}
+          </div>
+          <div className="flex shrink-0 gap-2">
+            {canResume && (
+              <Button variant="outline" disabled={busy} onClick={() => void resume()}>
+                Resume
+              </Button>
+            )}
+            {canCancel && (
+              <Button variant="destructive" disabled={busy} onClick={() => void cancel()}>
+                Cancel
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold tracking-tight">Plan</h2>
+        <PlanSection units={mission.spec?.units ?? []} />
+      </section>
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold tracking-tight">Progress</h2>
+        <ProgressSection notes={mission.progress} />
+      </section>
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold tracking-tight">Timeline</h2>
+        <TimelineSection events={events} />
+      </section>
+    </div>
+  )
+}

--- a/web/src/pages/Missions.test.tsx
+++ b/web/src/pages/Missions.test.tsx
@@ -1,0 +1,159 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mission, Notification } from '../api/types'
+import { Missions } from './Missions'
+
+vi.mock('../api/client', () => ({
+  listMissions: vi.fn(),
+  listNotifications: vi.fn(),
+  markNotificationRead: vi.fn(),
+  createMission: vi.fn(),
+  listAgents: vi.fn(),
+}))
+
+import { createMission, listAgents, listMissions, listNotifications } from '../api/client'
+
+const mission: Mission = {
+  id: 'm1',
+  goal: 'Fix the login bug',
+  kind: 'research',
+  phase: 'execute',
+  status: 'working',
+  spec: { units: [] },
+  progress: [],
+  iteration: 1,
+  max_iterations: 8,
+  consecutive_failures: 0,
+  stall_count: 0,
+  route: 'default',
+  review_route: 'default',
+  auto_approve_safe: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <Missions />
+    </MemoryRouter>,
+  )
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(listMissions).mockResolvedValue([mission])
+  vi.mocked(listNotifications).mockResolvedValue([])
+  vi.mocked(listAgents).mockResolvedValue([])
+})
+
+describe('Missions board', () => {
+  it('renders the mission card list', async () => {
+    renderPage()
+    expect(await screen.findByText('Fix the login bug')).toBeTruthy()
+    expect(screen.getByText('working')).toBeTruthy()
+  })
+
+  it('shows an unread notification strip', async () => {
+    const note: Notification = {
+      id: 'n1',
+      mission_id: 'm1',
+      kind: 'paused',
+      message: 'mission m1 is now paused',
+      read: false,
+      created_at: '2026-01-01T00:00:00Z',
+    }
+    vi.mocked(listNotifications).mockResolvedValue([note])
+    renderPage()
+    expect(await screen.findByText('mission m1 is now paused')).toBeTruthy()
+  })
+
+  it('does not show read notifications', async () => {
+    const note: Notification = {
+      id: 'n1',
+      mission_id: 'm1',
+      kind: 'done',
+      message: 'mission m1 is now done',
+      read: true,
+      created_at: '2026-01-01T00:00:00Z',
+    }
+    vi.mocked(listNotifications).mockResolvedValue([note])
+    renderPage()
+    await waitFor(() => expect(listNotifications).toHaveBeenCalled())
+    expect(screen.queryByText('mission m1 is now done')).toBeNull()
+  })
+
+  it('opens the new mission dialog and submits a research mission', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm2' })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+
+    fireEvent.click(screen.getByRole('button', { name: 'New mission' }))
+    const goalField = await screen.findByLabelText('Goal')
+    fireEvent.change(goalField, { target: { value: 'Research something new' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          goal: 'Research something new',
+          kind: 'research',
+          auto_approve_safe: true,
+        }),
+      ),
+    )
+  })
+
+  it('sends auto_approve_safe: false when the toggle is unchecked', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm2' })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+
+    fireEvent.click(screen.getByRole('button', { name: 'New mission' }))
+    const goalField = await screen.findByLabelText('Goal')
+    fireEvent.change(goalField, { target: { value: 'Research something new' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Show advanced options' }))
+    fireEvent.click(screen.getByLabelText(/Auto-approve safe tool calls/))
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(
+        expect.objectContaining({ auto_approve_safe: false }),
+      ),
+    )
+  })
+
+  it('disables submit until a goal is entered', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    fireEvent.click(screen.getByRole('button', { name: 'New mission' }))
+    await screen.findByLabelText('Goal')
+
+    const createButton = screen.getByRole('button', { name: 'Create mission' }) as HTMLButtonElement
+    expect(createButton.disabled).toBe(true)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Fix a bug' } })
+    expect(createButton.disabled).toBe(false)
+  })
+
+  it('requires a repo path before submitting a coding mission', async () => {
+    // jsdom lacks scrollIntoView; Radix Select calls it on open.
+    Element.prototype.scrollIntoView = vi.fn()
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    fireEvent.click(screen.getByRole('button', { name: 'New mission' }))
+    await screen.findByLabelText('Goal')
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Fix a bug' } })
+    fireEvent.click(screen.getByRole('combobox'))
+    fireEvent.click(await screen.findByText('Coding'))
+
+    const createButton = screen.getByRole('button', { name: 'Create mission' }) as HTMLButtonElement
+    expect(createButton.disabled).toBe(true)
+
+    fireEvent.change(screen.getByLabelText('Repository path'), { target: { value: '/workspace/repo' } })
+    expect(createButton.disabled).toBe(false)
+  })
+})

--- a/web/src/pages/Missions.tsx
+++ b/web/src/pages/Missions.tsx
@@ -1,0 +1,94 @@
+import { BellIcon, CancelCircleIcon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router'
+import { listMissions, listNotifications, markNotificationRead } from '../api/client'
+import type { Mission, Notification } from '../api/types'
+import { MissionCard } from '../components/missions/MissionCard'
+import { NewMissionDialog } from '../components/missions/NewMissionDialog'
+import { Button } from '../components/ui/button'
+
+const pollInterval = 5000
+
+export function Missions() {
+  const navigate = useNavigate()
+  const [missions, setMissions] = useState<Mission[]>([])
+  const [notifications, setNotifications] = useState<Notification[]>([])
+  const [dialogOpen, setDialogOpen] = useState(false)
+
+  const refresh = useCallback(() => {
+    listMissions().then(setMissions, () => undefined)
+    listNotifications().then(setNotifications, () => undefined)
+  }, [])
+
+  useEffect(() => {
+    refresh()
+    const id = setInterval(refresh, pollInterval)
+    return () => clearInterval(id)
+  }, [refresh])
+
+  const unread = notifications.filter((n) => !n.read)
+
+  const dismiss = (id: string) => {
+    markNotificationRead(id).then(refresh, () => undefined)
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-6">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight">Missions</h1>
+          <p className="text-sm text-muted-foreground">
+            Long-running tasks that plan, execute, and review their own work.
+          </p>
+        </div>
+        <Button onClick={() => setDialogOpen(true)}>New mission</Button>
+      </div>
+
+      {unread.length > 0 && (
+        <div className="mt-4 space-y-2">
+          {unread.map((n) => (
+            <div
+              key={n.id}
+              className="flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200"
+            >
+              <button
+                type="button"
+                onClick={() => navigate(`/missions/${n.mission_id}`)}
+                className="flex items-center gap-2 text-left hover:underline"
+              >
+                <HugeiconsIcon icon={BellIcon} className="size-4 shrink-0" />
+                {n.message}
+              </button>
+              <button
+                type="button"
+                onClick={() => dismiss(n.id)}
+                className="shrink-0 text-amber-700 hover:text-amber-900 dark:text-amber-400 dark:hover:text-amber-200"
+                aria-label="Dismiss"
+              >
+                <HugeiconsIcon icon={CancelCircleIcon} className="size-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {missions.map((m) => (
+          <MissionCard key={m.id} mission={m} />
+        ))}
+        {missions.length === 0 && (
+          <div className="col-span-full rounded-xl border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+            No missions yet — create one to get started.
+          </div>
+        )}
+      </div>
+
+      <NewMissionDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onCreated={(id) => navigate(`/missions/${id}`)}
+      />
+    </div>
+  )
+}

--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -205,7 +205,7 @@ describe('Providers tab', () => {
 
   it('disables Add until a test passes, then stores the key and creates enabled', async () => {
     vi.mocked(setSecret).mockResolvedValue()
-    vi.mocked(validateProvider).mockResolvedValue({ ok: true, latency_ms: 187, model: 'glm-5.2' })
+    vi.mocked(validateProvider).mockResolvedValue({ ok: true, latency_ms: 187, model: 'glm-4.7-flash' })
     vi.mocked(createProvider).mockResolvedValue('p2')
 
     renderPage('/settings/providers')
@@ -224,13 +224,13 @@ describe('Providers tab', () => {
     expect(setSecret).toHaveBeenCalledWith('ZAI_API_KEY', 'gsk_abc')
     expect(validateProvider).toHaveBeenCalledWith(
       expect.objectContaining({ driver: 'openaicompat', base_url: 'https://api.z.ai/api/paas/v4' }),
-      'glm-5.2',
+      'glm-4.7-flash',
     )
     expect(createProvider).toHaveBeenCalledWith(
       expect.objectContaining({
         enabled: true,
-        default_model: 'glm-5.2',
-        models: [{ id: 'glm-5.2', prices: { input_per_mtok: 1.4, output_per_mtok: 4.4 } }],
+        default_model: 'glm-4.7-flash',
+        models: [{ id: 'glm-4.7-flash', prices: { input_per_mtok: 0, output_per_mtok: 0 } }],
       }),
     )
   })
@@ -245,7 +245,7 @@ describe('Providers tab', () => {
 
   it('re-locks Add after editing a field past a passing test', async () => {
     vi.mocked(setSecret).mockResolvedValue()
-    vi.mocked(validateProvider).mockResolvedValue({ ok: true, latency_ms: 187, model: 'glm-5.2' })
+    vi.mocked(validateProvider).mockResolvedValue({ ok: true, latency_ms: 187, model: 'glm-4.7-flash' })
 
     renderPage('/settings/providers')
     fireEvent.click(await screen.findByRole('button', { name: /GLM/ }))
@@ -283,7 +283,7 @@ describe('Providers tab', () => {
     vi.mocked(validateProvider).mockResolvedValue({
       ok: false,
       latency_ms: 5000,
-      model: 'glm-5.2',
+      model: 'glm-4.7-flash',
       detail: 'upstream status 401',
     })
 


### PR DESCRIPTION
## Summary

Completes M3 (cron scheduler, transition notifications) and M4 (HTTP API, missions board + detail pages) of the missions engine, then hardens the harness against the failure families observed across the first twelve live missions — ten of which failed on a trivial research goal.

## Root causes fixed

- **Workspace split**: worker shell ran in the shared global root while verify_cmd and the reviewer looked in the per-mission directory — every honest verification failed. Worker turns now get a turn-scoped shell and a new `write_file` tool rooted in the mission's own workspace (ExtraTools shadow base tools by name for the turn).
- **Unverifiable done**: plan units now declare `artifacts` the harness checks deterministically (exists, non-empty) before verify_cmd — a tautological `echo done` can no longer fake completion. Exact artifact paths render in the worker packet; failure feedback lists what actually exists on disk.
- **Blind reviewer**: the review packet now carries the goal, plan, and harness-read artifact contents. Previously reviewers rejected every round for material they were never given ("missing goal", "no diff").
- **Self-blocking permissions**: protocol sentinels and `write_file` are exempt; a session sandbox (`__sandbox__` grant) downgrades file-scoped destructive commands confined to the mission's own directory. Missions ran ~9 human approvals each; now zero.
- **Zero observability**: retry/pause/fail events carry reasons, and `mission.turn` records per-phase duration and outcome — failure cause readable from the event log alone.
- **Oversized loop**: review rounds are skipped for non-coding units that pass harness checks; `MISSION_MODEL_FLOOR` pauses fast on too-weak fallback models; a repeated identical rejection resets the reviewer session for fresh eyes.

## Eval gate

`make canary` runs a golden research mission end-to-end and asserts done within budget, zero parks, and harness-verified artifacts.

| Metric | Before | After |
|---|---|---|
| Success | 1/12 (artifact missing) | PASS, artifact on disk |
| Wall clock | 7 min – 2.5 hrs | 41 s |
| Model turns | 15–25+ | 3 |
| Permission parks | ~9 | 0 |

## Testing

- `go test -race ./...`, `go vet` (incl. `-tags integration`), `golangci-lint`: clean
- Integration suite green (fixed pre-existing isolation flake in `TestClaimWorkSlotConcurrencyCap`)
- Three live canary runs; the second exposed a weak-model filename mismatch, fixed deterministically and validated by the third