### PR TITLE
feat(tools): route web_fetch html and pdf through markitdown sidecar

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -130,8 +130,9 @@ func main() {
 	mc := memclient.New(memorydURL)
 
 	searxngURL := os.Getenv("SEARXNG_URL")
+	markitdownURL := os.Getenv("MARKITDOWN_URL")
 
-	agent, broker, outputs, builtinSet, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, packs, flags.SkillAllowed, mc.Add, app.Log)
+	agent, broker, outputs, builtinSet, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, markitdownURL, packs, flags.SkillAllowed, mc.Add, app.Log)
 	if buildErr != nil {
 		fmt.Fprintln(os.Stderr, buildErr)
 		os.Exit(1)
@@ -377,13 +378,13 @@ func (r turnRouter) Stream(ctx context.Context, req gwclient.StreamRequest) (<-c
 // buildAgent assembles the compiled-in tool registry and its guard
 // rails (D-009, D-010). The returned builtin set is the fixed half of
 // the tool surface; connector tools join it via swapAgentTools.
-func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, workspace, searxngURL string, packs []skills.Skill, skillAllow func(context.Context, string) bool, remember builtin.RememberFunc, log *slog.Logger) (*loop.Agent, *loop.PermBroker, *tools.Outputs, []*tools.Tool, error) {
+func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, workspace, searxngURL, markitdownURL string, packs []skills.Skill, skillAllow func(context.Context, string) bool, remember builtin.RememberFunc, log *slog.Logger) (*loop.Agent, *loop.PermBroker, *tools.Outputs, []*tools.Tool, error) {
 	outputs := tools.NewOutputs(db)
 	set := []*tools.Tool{
 		builtin.CurrentTime(time.Now),
 		builtin.ConvertTime(),
 		builtin.Calculator(),
-		builtin.WebFetch(),
+		builtin.WebFetch(builtin.WebFetchConfig{MarkitdownURL: markitdownURL}),
 		builtin.Shell(builtin.ShellConfig{WorkspaceRoot: workspace}),
 		builtin.RetrieveOutput(outputs),
 		builtin.Remember(remember),

--- a/internal/brain/connectors/google_tools.go
+++ b/internal/brain/connectors/google_tools.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
+	"github.com/SumonMSelim/timothy/internal/platform/markitdown"
 )
 
 // Builder returns the Builder for kind='google'. The tool surface is
@@ -309,7 +310,7 @@ func (s *googleSource) gmailRead() *tools.Tool {
 			body := plainText(allParts)
 			if body == "" {
 				if raw := htmlPart(allParts); raw != nil {
-					if text, err := convertToMarkdown(ctx, s.g.Client, s.g.MarkItDownURL, "body.html", "text/html", raw); err == nil {
+					if text, err := markitdown.Convert(ctx, s.g.Client, s.g.MarkItDownURL, "body.html", "text/html", raw); err == nil {
 						body = text
 					}
 				}
@@ -371,7 +372,7 @@ func (s *googleSource) gmailReadAttachment() *tools.Tool {
 			if err != nil {
 				return "", fmt.Errorf("decode attachment: %w", err)
 			}
-			return convertToMarkdown(ctx, s.g.Client, s.g.MarkItDownURL, in.Filename, "", raw)
+			return markitdown.Convert(ctx, s.g.Client, s.g.MarkItDownURL, in.Filename, "", raw)
 		},
 	}
 }

--- a/internal/brain/tools/builtin/webfetch.go
+++ b/internal/brain/tools/builtin/webfetch.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/net/html"
 
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
+	"github.com/SumonMSelim/timothy/internal/platform/markitdown"
 )
 
 const (
@@ -26,13 +27,25 @@ type webFetchArgs struct {
 	URL string `json:"url"`
 }
 
+// WebFetchConfig carries optional infrastructure for the tool.
+type WebFetchConfig struct {
+	// MarkitdownURL is the markitdown sidecar's base address (compose-
+	// internal). When set, HTML pages convert to structured markdown
+	// (headings, tables, links survive) and PDF responses become
+	// readable; empty falls back to the built-in DOM text extractor
+	// and PDFs stay unsupported.
+	MarkitdownURL string
+}
+
 // WebFetch fetches a public URL and returns a readable text extract.
 // Every connection — including redirect hops — dials only vetted
 // public IPs: the guard resolves the host itself and refuses private,
 // loopback, link-local (cloud metadata), CGNAT, and unspecified
 // ranges, then dials the vetted address directly so a DNS answer
-// can't change between check and connect.
-func WebFetch() *tools.Tool {
+// can't change between check and connect. The markitdown sidecar is
+// deliberately NOT behind that guard: its address is operator config
+// (compose-internal), never model input.
+func WebFetch(cfg WebFetchConfig) *tools.Tool {
 	client := &http.Client{
 		Timeout: webFetchTimeout,
 		Transport: &http.Transport{
@@ -52,10 +65,11 @@ Arguments:
 - url (string, required): full http:// or https:// URL including
   scheme, e.g. "https://example.com/pricing".
 
-Returns the page title and extracted text for HTML, or the raw body
-for plain-text responses. Long pages are truncated (a note marks the
-cut). Errors state the reason: blocked address, non-text content,
-HTTP status, timeout.
+Returns readable markdown for HTML and PDF responses when the
+converter is available (falling back to a plain-text extract), or the
+raw body for plain-text responses. Long pages are truncated (a note
+marks the cut). Errors state the reason: blocked address, unsupported
+content, HTTP status, timeout.
 
 Example: {"url": "https://go.dev/doc/devel/release"} → "Release
 History — Go 1.26 (released 2026-02-10) ..."`,
@@ -75,12 +89,12 @@ History — Go 1.26 (released 2026-02-10) ..."`,
 			if err := json.Unmarshal(raw, &args); err != nil {
 				return "", fmt.Errorf("invalid arguments: %w", err)
 			}
-			return fetchReadable(ctx, client, args.URL)
+			return fetchReadable(ctx, client, cfg.MarkitdownURL, args.URL)
 		},
 	}
 }
 
-func fetchReadable(ctx context.Context, client *http.Client, rawURL string) (string, error) {
+func fetchReadable(ctx context.Context, client *http.Client, markitdownURL, rawURL string) (string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return "", fmt.Errorf("invalid url: %w", err)
@@ -97,7 +111,11 @@ func fetchReadable(ctx context.Context, client *http.Client, rawURL string) (str
 		return "", fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("User-Agent", "timothy/1.0 (+self-hosted assistant)")
-	req.Header.Set("Accept", "text/html, text/plain;q=0.9, application/json;q=0.8, */*;q=0.1")
+	accept := "text/html, text/plain;q=0.9, application/json;q=0.8, */*;q=0.1"
+	if markitdownURL != "" {
+		accept = "text/html, application/pdf;q=0.9, text/plain;q=0.9, application/json;q=0.8, */*;q=0.1"
+	}
+	req.Header.Set("Accept", accept)
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -122,7 +140,25 @@ func fetchReadable(ctx context.Context, client *http.Client, rawURL string) (str
 	var text string
 	switch {
 	case strings.Contains(ct, "text/html"):
-		text = extractHTMLText(body)
+		// Markitdown keeps structure (headings, tables, links) the DOM
+		// text walk flattens away; any sidecar failure degrades to the
+		// walk rather than failing the fetch.
+		text = ""
+		if markitdownURL != "" {
+			text, _ = markitdown.Convert(ctx, nil, markitdownURL, "page.html", "text/html", body)
+		}
+		if strings.TrimSpace(text) == "" {
+			text = extractHTMLText(body)
+		}
+	case strings.Contains(ct, "application/pdf"):
+		if markitdownURL == "" {
+			return "", fmt.Errorf("unsupported content type %q: PDF conversion needs the markitdown sidecar, which is not configured", ct)
+		}
+		md, err := markitdown.Convert(ctx, nil, markitdownURL, "page.pdf", "application/pdf", body)
+		if err != nil {
+			return "", fmt.Errorf("pdf conversion failed: %w", err)
+		}
+		text = md
 	case strings.HasPrefix(ct, "text/"),
 		strings.Contains(ct, "json"),
 		strings.Contains(ct, "xml"):

--- a/internal/brain/tools/builtin/webfetch_test.go
+++ b/internal/brain/tools/builtin/webfetch_test.go
@@ -50,7 +50,7 @@ func TestWebFetchRefusesLocalAddresses(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	tool := WebFetch()
+	tool := WebFetch(WebFetchConfig{})
 	args, _ := json.Marshal(map[string]string{"url": srv.URL})
 	_, err := tool.Execute(context.Background(), args)
 	if err == nil || !strings.Contains(err.Error(), "blocked address") {
@@ -60,7 +60,7 @@ func TestWebFetchRefusesLocalAddresses(t *testing.T) {
 
 func TestWebFetchRejectsBadSchemes(t *testing.T) {
 	t.Parallel()
-	tool := WebFetch()
+	tool := WebFetch(WebFetchConfig{})
 	for _, u := range []string{"file:///etc/passwd", "ftp://example.com", "gopher://x"} {
 		args, _ := json.Marshal(map[string]string{"url": u})
 		_, err := tool.Execute(context.Background(), args)
@@ -106,7 +106,7 @@ func TestFetchReadableTruncatesLongText(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	got, err := fetchReadable(context.Background(), srv.Client(), srv.URL)
+	got, err := fetchReadable(context.Background(), srv.Client(), "", srv.URL)
 	if err != nil {
 		t.Fatalf("fetchReadable: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestFetchReadableStripsUserinfo(t *testing.T) {
 	// Inject credentials into the URL; they must not become a header.
 	u, _ := url.Parse(srv.URL)
 	authed := u.Scheme + "://user:secret@" + u.Host + "/"
-	if _, err := fetchReadable(context.Background(), srv.Client(), authed); err != nil {
+	if _, err := fetchReadable(context.Background(), srv.Client(), "", authed); err != nil {
 		t.Fatalf("fetchReadable: %v", err)
 	}
 	if gotAuth != "" {
@@ -152,12 +152,99 @@ func TestFetchReadableRejectsNonTextAndErrors(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := fetchReadable(context.Background(), srv.Client(), srv.URL+"/bin"); err == nil ||
+	if _, err := fetchReadable(context.Background(), srv.Client(), "", srv.URL+"/bin"); err == nil ||
 		!strings.Contains(err.Error(), "unsupported content type") {
 		t.Fatalf("binary fetch err = %v", err)
 	}
-	if _, err := fetchReadable(context.Background(), srv.Client(), srv.URL+"/missing"); err == nil ||
+	if _, err := fetchReadable(context.Background(), srv.Client(), "", srv.URL+"/missing"); err == nil ||
 		!strings.Contains(err.Error(), "http 404") {
 		t.Fatalf("404 fetch err = %v", err)
+	}
+}
+
+// fakeMarkitdown returns a sidecar stub whose /convert response is
+// controlled by the handler.
+func fakeMarkitdown(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestFetchReadableHTMLPrefersMarkitdown(t *testing.T) {
+	t.Parallel()
+	md := fakeMarkitdown(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Mimetype"); got != "text/html" {
+			t.Errorf("X-Mimetype = %q", got)
+		}
+		_, _ = w.Write([]byte(`{"markdown": "# Plans\n\n| tier | price |\n|---|---|\n| basic | $5 |"}`))
+	})
+	page := fakeMarkitdown(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body><h1>Plans</h1><table><tr><td>basic</td><td>$5</td></tr></table></body></html>`))
+	})
+
+	got, err := fetchReadable(context.Background(), page.Client(), md.URL, page.URL)
+	if err != nil {
+		t.Fatalf("fetchReadable: %v", err)
+	}
+	if !strings.Contains(got, "| tier | price |") {
+		t.Fatalf("got %q, want markitdown table structure", got)
+	}
+}
+
+func TestFetchReadableHTMLFallsBackWhenSidecarFails(t *testing.T) {
+	t.Parallel()
+	md := fakeMarkitdown(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "conversion failed", http.StatusUnprocessableEntity)
+	})
+	page := fakeMarkitdown(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><head><title>Pricing</title></head><body><p>Basic costs $5.</p></body></html>`))
+	})
+
+	got, err := fetchReadable(context.Background(), page.Client(), md.URL, page.URL)
+	if err != nil {
+		t.Fatalf("fetchReadable: %v", err)
+	}
+	if !strings.Contains(got, "Basic costs") {
+		t.Fatalf("got %q, want DOM-extractor fallback content", got)
+	}
+}
+
+func TestFetchReadablePDF(t *testing.T) {
+	t.Parallel()
+	md := fakeMarkitdown(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Mimetype"); got != "application/pdf" {
+			t.Errorf("X-Mimetype = %q", got)
+		}
+		_, _ = w.Write([]byte(`{"markdown": "# Q3 Report\n\nRevenue grew."}`))
+	})
+	pdf := fakeMarkitdown(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		_, _ = w.Write([]byte("%PDF-1.7 fake"))
+	})
+
+	got, err := fetchReadable(context.Background(), pdf.Client(), md.URL, pdf.URL)
+	if err != nil {
+		t.Fatalf("fetchReadable: %v", err)
+	}
+	if !strings.Contains(got, "Q3 Report") {
+		t.Fatalf("got %q, want converted PDF markdown", got)
+	}
+
+	// Without the sidecar, PDFs stay unsupported with a clear reason.
+	if _, err := fetchReadable(context.Background(), pdf.Client(), "", pdf.URL); err == nil ||
+		!strings.Contains(err.Error(), "markitdown sidecar") {
+		t.Fatalf("unconfigured pdf fetch err = %v", err)
+	}
+
+	// A sidecar failure on PDF is an error, not silent garbage.
+	broken := fakeMarkitdown(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "conversion failed", http.StatusUnprocessableEntity)
+	})
+	if _, err := fetchReadable(context.Background(), pdf.Client(), broken.URL, pdf.URL); err == nil ||
+		!strings.Contains(err.Error(), "pdf conversion failed") {
+		t.Fatalf("broken sidecar pdf fetch err = %v", err)
 	}
 }

--- a/internal/platform/markitdown/markitdown.go
+++ b/internal/platform/markitdown/markitdown.go
@@ -1,4 +1,8 @@
-package connectors
+// Package markitdown is the client for the markitdown sidecar
+// (markitdown-svc/): one POST /convert per file, raw bytes in,
+// markdown out. Compose-internal, no auth — the sidecar is only
+// reachable inside the compose network.
+package markitdown
 
 import (
 	"bytes"
@@ -10,13 +14,14 @@ import (
 	"time"
 )
 
-const markItDownTimeout = 60 * time.Second
+const convertTimeout = 60 * time.Second
 
-// convertToMarkdown posts raw file bytes to the markitdown sidecar and
-// returns the converted markdown. baseURL empty means the sidecar
-// isn't configured — callers fall back to whatever they'd otherwise
-// do (the snippet, in gmail_read's case).
-func convertToMarkdown(ctx context.Context, client *http.Client, baseURL, filename, mimeType string, raw []byte) (string, error) {
+// Convert posts raw file bytes to the markitdown sidecar and returns
+// the converted markdown. baseURL empty means the sidecar isn't
+// configured — callers fall back to whatever they'd otherwise do.
+// filename and mimeType are hints for the converter; either may be
+// empty when unknown.
+func Convert(ctx context.Context, client *http.Client, baseURL, filename, mimeType string, raw []byte) (string, error) {
 	if baseURL == "" {
 		return "", fmt.Errorf("markitdown is not configured")
 	}
@@ -32,7 +37,7 @@ func convertToMarkdown(ctx context.Context, client *http.Client, baseURL, filena
 	if c == nil {
 		c = http.DefaultClient
 	}
-	cctx, cancel := context.WithTimeout(ctx, markItDownTimeout)
+	cctx, cancel := context.WithTimeout(ctx, convertTimeout)
 	defer cancel()
 	req = req.WithContext(cctx)
 

--- a/internal/platform/markitdown/markitdown_test.go
+++ b/internal/platform/markitdown/markitdown_test.go
@@ -1,0 +1,54 @@
+package markitdown
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestConvert(t *testing.T) {
+	t.Run("posts bytes with filename and mimetype headers", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/convert" {
+				t.Errorf("path = %q, want /convert", r.URL.Path)
+			}
+			if got := r.Header.Get("X-Filename"); got != "doc.pdf" {
+				t.Errorf("X-Filename = %q", got)
+			}
+			if got := r.Header.Get("X-Mimetype"); got != "application/pdf" {
+				t.Errorf("X-Mimetype = %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"markdown": "# converted"}`))
+		}))
+		defer srv.Close()
+
+		out, err := Convert(context.Background(), srv.Client(), srv.URL, "doc.pdf", "application/pdf", []byte("%PDF-1.7"))
+		if err != nil {
+			t.Fatalf("Convert: %v", err)
+		}
+		if out != "# converted" {
+			t.Fatalf("out = %q", out)
+		}
+	})
+
+	t.Run("unconfigured base URL errors without a request", func(t *testing.T) {
+		if _, err := Convert(context.Background(), nil, "", "a.html", "text/html", []byte("x")); err == nil {
+			t.Fatal("empty baseURL accepted")
+		}
+	})
+
+	t.Run("non-2xx surfaces status and body snippet", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "conversion failed: broken file", http.StatusUnprocessableEntity)
+		}))
+		defer srv.Close()
+
+		_, err := Convert(context.Background(), srv.Client(), srv.URL, "a.html", "text/html", []byte("x"))
+		if err == nil || !strings.Contains(err.Error(), "422") {
+			t.Fatalf("err = %v, want http 422 surfaced", err)
+		}
+	})
+}


### PR DESCRIPTION
## What

- Extracts the markitdown sidecar client from `internal/brain/connectors` into a shared `internal/platform/markitdown` package (two consumers now: gmail connectors and web_fetch).
- `web_fetch` gains `WebFetchConfig{MarkitdownURL}`: HTML responses convert to structured markdown (headings, tables, links survive); any sidecar failure silently degrades to the existing DOM text extractor. PDF responses become fetchable when the sidecar is configured, with a clear error otherwise.
- Wired via the existing `MARKITDOWN_URL` env in `cmd/brain/main.go`. The sidecar call deliberately bypasses the SSRF dial guard — its address is operator config (compose-internal), never model input.

## Why

Research missions fetch pages to extract facts, and the DOM text walk flattened away exactly the structure they need (tables, headings). PDFs were rejected outright. The sidecar was already in the stack for gmail_read; this reuses it.

## Testing

- New unit tests: markitdown client (headers, unconfigured, non-2xx), web_fetch markitdown-preferred / fallback-on-failure / PDF happy + unconfigured + broken-sidecar paths.
- Full suite `go test -race ./...` green; golangci-lint 0 issues.
- Live canary (`make canary`) after brain rebuild: PASS in 51s, 3 turns, 0 parks, harness-verified artifact.
