### PR TITLE
feat(costs): per-mission spend, unpriced-usage visibility, mission session filtering

### DIFF
--- a/internal/brain/session/store.go
+++ b/internal/brain/session/store.go
@@ -154,11 +154,17 @@ func (s *Store) List(ctx context.Context, query string, before time.Time, before
 		beforeID = "ffffffff-ffff-ffff-ffff-ffffffffffff"
 	}
 
+	// Mission bookkeeping sessions (missions.session_id) are not chat:
+	// they exist so tool audit rows have a session FK (migration 0028)
+	// and would otherwise litter the list as untitled sessions.
+	const notMission = `NOT EXISTS (SELECT 1 FROM missions m WHERE m.session_id = %s.id)`
+
 	var sql string
 	var args []any
 	if query == "" {
 		sql = `SELECT id, COALESCE(title, ''), archived, last_route, created_at, updated_at
 		       FROM sessions WHERE NOT archived AND (updated_at, id) < ($1, $2::uuid)
+		         AND ` + fmt.Sprintf(notMission, "sessions") + `
 		       ORDER BY updated_at DESC, id DESC LIMIT $3`
 		args = []any{before, beforeID, listLimit}
 	} else {
@@ -168,6 +174,7 @@ func (s *Store) List(ctx context.Context, query string, before time.Time, before
 		       FROM sessions s
 		       LEFT JOIN session_events e ON e.session_id = s.id AND e.kind = 'user_message'
 		       WHERE (s.updated_at, s.id) < ($2, $3::uuid)
+		         AND ` + fmt.Sprintf(notMission, "s") + `
 		         AND (s.title ILIKE '%' || $4 || '%'
 		          OR (e.payload IS NOT NULL
 		              AND to_tsvector('english', e.payload->>'text') @@ plainto_tsquery('english', $1)))

--- a/internal/brain/session/store_integration_test.go
+++ b/internal/brain/session/store_integration_test.go
@@ -219,6 +219,85 @@ func TestListCursorStableOnTiedTimestamps(t *testing.T) {
 	}
 }
 
+// TestListExcludesMissionSessions: mission bookkeeping sessions
+// (missions.session_id) exist only so tool audit has a session FK.
+// They are not chat and must never appear in the list — with or
+// without a search query.
+func TestListExcludesMissionSessions(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	s := NewStore(pool)
+
+	const marker = "mission-session-list-test"
+	chatID, err := s.Create(ctx, marker)
+	if err != nil {
+		t.Fatalf("Create chat: %v", err)
+	}
+	missionSessionID, err := s.Create(ctx, marker)
+	if err != nil {
+		t.Fatalf("Create mission session: %v", err)
+	}
+	var missionID string
+	if err := db.QueryRow(ctx,
+		"INSERT INTO missions (goal, kind, session_id) VALUES ($1, 'research', $2) RETURNING id",
+		marker, missionSessionID).Scan(&missionID); err != nil {
+		t.Fatalf("insert mission: %v", err)
+	}
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer ccancel()
+		conn, err := pgx.Connect(cctx, dsn)
+		if err != nil {
+			t.Errorf("cleanup connect: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close(cctx) }()
+		_, _ = conn.Exec(cctx, "DELETE FROM missions WHERE id = $1", missionID)
+		for _, id := range []string{chatID, missionSessionID} {
+			_, _ = conn.Exec(cctx, "DELETE FROM session_events WHERE session_id = $1", id)
+			_, _ = conn.Exec(cctx, "DELETE FROM sessions WHERE id = $1", id)
+		}
+	})
+
+	for _, query := range []string{"", marker} {
+		got, err := s.List(ctx, query, time.Time{}, "")
+		if err != nil {
+			t.Fatalf("List(%q): %v", query, err)
+		}
+		var sawChat, sawMission bool
+		for _, m := range got {
+			switch m.ID {
+			case chatID:
+				sawChat = true
+			case missionSessionID:
+				sawMission = true
+			}
+		}
+		if sawMission {
+			t.Fatalf("List(%q) returned the mission bookkeeping session", query)
+		}
+		if !sawChat && query != "" {
+			t.Fatalf("List(%q) lost the ordinary chat session", query)
+		}
+	}
+}
+
 // TestListQueryMatchesTitleOnlySession pins the NULL guard in the
 // search SQL: a session that has never emitted a user_message (its
 // joined payload is NULL) must still be findable by title.

--- a/internal/gateway/api/usage.go
+++ b/internal/gateway/api/usage.go
@@ -21,6 +21,7 @@ func RegisterUsage(srv *httpserver.Server, agg *ledger.Aggregator, budgets *ledg
 	srv.Handle("GET /internal/admin/usage/latency", http.HandlerFunc(u.handleLatency))
 	srv.Handle("GET /internal/admin/usage/cache", http.HandlerFunc(u.handleCache))
 	srv.Handle("GET /internal/admin/usage/budget", http.HandlerFunc(u.handleBudget))
+	srv.Handle("GET /internal/admin/usage/mission", http.HandlerFunc(u.handleMission))
 }
 
 type usageAPI struct {
@@ -123,6 +124,20 @@ func (u *usageAPI) handleCache(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, map[string]any{"providers": rows})
+}
+
+func (u *usageAPI) handleMission(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "id is required")
+		return
+	}
+	m, err := u.agg.Mission(r.Context(), id)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "usage_failed", err.Error())
+		return
+	}
+	writeJSON(w, m)
 }
 
 func (u *usageAPI) handleBudget(w http.ResponseWriter, r *http.Request) {

--- a/internal/gateway/ledger/aggregate.go
+++ b/internal/gateway/ledger/aggregate.go
@@ -33,15 +33,21 @@ var groups = map[string]string{
 
 const notTest = `purpose IS DISTINCT FROM 'test'`
 
-// Summary is the header-tile answer: totals for a range.
+// Summary is the header-tile answer: totals for a range. Unpriced
+// fields count rows where cost_usd is NULL (D-013: unknown price is
+// recorded as NULL, never guessed) — without them, unpriced usage is
+// invisible because SUM(cost_usd) silently treats NULL as free.
 type Summary struct {
-	CostUSD          float64 `json:"cost_usd"`
-	InputTokens      int64   `json:"input_tokens"`
-	OutputTokens     int64   `json:"output_tokens"`
-	CacheReadTokens  int64   `json:"cache_read_tokens"`
-	CacheWriteTokens int64   `json:"cache_write_tokens"`
-	Requests         int64   `json:"requests"`
-	Errors           int64   `json:"errors"`
+	CostUSD              float64 `json:"cost_usd"`
+	InputTokens          int64   `json:"input_tokens"`
+	OutputTokens         int64   `json:"output_tokens"`
+	CacheReadTokens      int64   `json:"cache_read_tokens"`
+	CacheWriteTokens     int64   `json:"cache_write_tokens"`
+	Requests             int64   `json:"requests"`
+	Errors               int64   `json:"errors"`
+	UnpricedRequests     int64   `json:"unpriced_requests"`
+	UnpricedInputTokens  int64   `json:"unpriced_input_tokens"`
+	UnpricedOutputTokens int64   `json:"unpriced_output_tokens"`
 }
 
 func (a *Aggregator) Summary(ctx context.Context, from, to time.Time) (Summary, error) {
@@ -54,11 +60,15 @@ func (a *Aggregator) Summary(ctx context.Context, from, to time.Time) (Summary, 
 			COALESCE(SUM(cost_usd), 0),
 			COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0),
 			COALESCE(SUM(cache_read_tokens), 0), COALESCE(SUM(cache_write_tokens), 0),
-			COUNT(*), COUNT(*) FILTER (WHERE status = 'error')
+			COUNT(*), COUNT(*) FILTER (WHERE status = 'error'),
+			COUNT(*) FILTER (WHERE cost_usd IS NULL),
+			COALESCE(SUM(input_tokens) FILTER (WHERE cost_usd IS NULL), 0),
+			COALESCE(SUM(output_tokens) FILTER (WHERE cost_usd IS NULL), 0)
 		FROM cost_ledger
 		WHERE ts >= $1 AND ts < $2 AND `+notTest,
 		from, to).Scan(&s.CostUSD, &s.InputTokens, &s.OutputTokens,
-		&s.CacheReadTokens, &s.CacheWriteTokens, &s.Requests, &s.Errors)
+		&s.CacheReadTokens, &s.CacheWriteTokens, &s.Requests, &s.Errors,
+		&s.UnpricedRequests, &s.UnpricedInputTokens, &s.UnpricedOutputTokens)
 	if err != nil {
 		return Summary{}, fmt.Errorf("usage summary: %w", err)
 	}
@@ -66,14 +76,19 @@ func (a *Aggregator) Summary(ctx context.Context, from, to time.Time) (Summary, 
 }
 
 // SeriesPoint is one (time bucket, group) cell of a stacked chart.
+// Unpriced token sums (rows where cost_usd is NULL) let the dashboard
+// estimate what unpriced usage would cost from its advisory catalog —
+// the estimate stays client-side, the server never guesses (D-013).
 type SeriesPoint struct {
-	Bucket       time.Time `json:"bucket"`
-	Group        string    `json:"group"`
-	CostUSD      float64   `json:"cost_usd"`
-	InputTokens  int64     `json:"input_tokens"`
-	OutputTokens int64     `json:"output_tokens"`
-	Requests     int64     `json:"requests"`
-	Errors       int64     `json:"errors"`
+	Bucket               time.Time `json:"bucket"`
+	Group                string    `json:"group"`
+	CostUSD              float64   `json:"cost_usd"`
+	InputTokens          int64     `json:"input_tokens"`
+	OutputTokens         int64     `json:"output_tokens"`
+	Requests             int64     `json:"requests"`
+	Errors               int64     `json:"errors"`
+	UnpricedInputTokens  int64     `json:"unpriced_input_tokens"`
+	UnpricedOutputTokens int64     `json:"unpriced_output_tokens"`
 }
 
 // Series returns bucketed usage grouped by provider, model, or
@@ -95,7 +110,9 @@ func (a *Aggregator) Series(ctx context.Context, from, to time.Time, bucket, gro
 			date_trunc('`+b+`', ts) AS bucket, `+col+`,
 			COALESCE(SUM(cost_usd), 0),
 			COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0),
-			COUNT(*), COUNT(*) FILTER (WHERE status = 'error')
+			COUNT(*), COUNT(*) FILTER (WHERE status = 'error'),
+			COALESCE(SUM(input_tokens) FILTER (WHERE cost_usd IS NULL), 0),
+			COALESCE(SUM(output_tokens) FILTER (WHERE cost_usd IS NULL), 0)
 		FROM cost_ledger
 		WHERE ts >= $1 AND ts < $2 AND `+notTest+`
 		GROUP BY 1, 2 ORDER BY 1, 2`, from, to)
@@ -108,12 +125,43 @@ func (a *Aggregator) Series(ctx context.Context, from, to time.Time, bucket, gro
 	for rows.Next() {
 		var p SeriesPoint
 		if err := rows.Scan(&p.Bucket, &p.Group, &p.CostUSD,
-			&p.InputTokens, &p.OutputTokens, &p.Requests, &p.Errors); err != nil {
+			&p.InputTokens, &p.OutputTokens, &p.Requests, &p.Errors,
+			&p.UnpricedInputTokens, &p.UnpricedOutputTokens); err != nil {
 			return nil, fmt.Errorf("usage series: %w", err)
 		}
 		out = append(out, p)
 	}
 	return out, rows.Err()
+}
+
+// MissionUsage totals one mission's ledger footprint — every turn the
+// missions engine ran for it, across all its sessions.
+type MissionUsage struct {
+	MissionID        string  `json:"mission_id"`
+	CostUSD          float64 `json:"cost_usd"`
+	InputTokens      int64   `json:"input_tokens"`
+	OutputTokens     int64   `json:"output_tokens"`
+	Requests         int64   `json:"requests"`
+	UnpricedRequests int64   `json:"unpriced_requests"`
+}
+
+func (a *Aggregator) Mission(ctx context.Context, missionID string) (MissionUsage, error) {
+	db, err := a.db.Get()
+	if err != nil {
+		return MissionUsage{}, fmt.Errorf("usage mission: %w", err)
+	}
+	m := MissionUsage{MissionID: missionID}
+	err = db.QueryRow(ctx, `SELECT
+			COALESCE(SUM(cost_usd), 0),
+			COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0),
+			COUNT(*), COUNT(*) FILTER (WHERE cost_usd IS NULL)
+		FROM cost_ledger
+		WHERE mission_id = $1 AND `+notTest, missionID).
+		Scan(&m.CostUSD, &m.InputTokens, &m.OutputTokens, &m.Requests, &m.UnpricedRequests)
+	if err != nil {
+		return MissionUsage{}, fmt.Errorf("usage mission: %w", err)
+	}
+	return m, nil
 }
 
 // SessionUsage ranks sessions by spend for the top-N table.

--- a/internal/gateway/ledger/aggregate_integration_test.go
+++ b/internal/gateway/ledger/aggregate_integration_test.go
@@ -137,6 +137,54 @@ func TestAggregateSummaryExcludesTestTraffic(t *testing.T) {
 	}
 }
 
+func TestAggregateMissionUsage(t *testing.T) {
+	agg, led := testAggregator(t)
+	ctx := t.Context()
+	mission := aggMarker + "mission-1"
+
+	rows := []Entry{
+		{Provider: aggMarker + "a", Model: "m1", Route: "coding", MissionID: mission,
+			Usage:     &stream.Usage{InputTokens: 100, OutputTokens: 50},
+			LatencyMS: 100, Status: "ok", CostUSD: usd(0.10)},
+		{Provider: aggMarker + "a", Model: "m1", Route: "coding", MissionID: mission,
+			Usage:     &stream.Usage{InputTokens: 200, OutputTokens: 100},
+			LatencyMS: 100, Status: "ok", CostUSD: usd(0.20)},
+		// Unpriced turn: cost NULL by design, must count as unpriced.
+		{Provider: aggMarker + "a", Model: "m-local", Route: "coding", MissionID: mission,
+			Usage:     &stream.Usage{InputTokens: 40, OutputTokens: 20},
+			LatencyMS: 100, Status: "ok"},
+		// Another mission and a test probe: both excluded.
+		{Provider: aggMarker + "a", Model: "m1", Route: "coding", MissionID: aggMarker + "other",
+			Usage:     &stream.Usage{InputTokens: 1000, OutputTokens: 1000},
+			LatencyMS: 100, Status: "ok", CostUSD: usd(9.0)},
+		{Provider: aggMarker + "a", Model: "m1", Route: "coding", MissionID: mission, Purpose: "test",
+			Usage:     &stream.Usage{InputTokens: 999999, OutputTokens: 999999},
+			LatencyMS: 100, Status: "ok", CostUSD: usd(99.0)},
+	}
+	for _, e := range rows {
+		led.Record(ctx, e)
+	}
+
+	got, err := agg.Mission(ctx, mission)
+	if err != nil {
+		t.Fatalf("Mission: %v", err)
+	}
+	want := MissionUsage{MissionID: mission, CostUSD: 0.30,
+		InputTokens: 340, OutputTokens: 170, Requests: 3, UnpricedRequests: 1}
+	if got != want {
+		t.Fatalf("Mission = %+v, want %+v", got, want)
+	}
+
+	// A mission with no ledger rows is all zeros, not an error.
+	empty, err := agg.Mission(ctx, aggMarker+"never-ran")
+	if err != nil {
+		t.Fatalf("Mission(empty): %v", err)
+	}
+	if empty.Requests != 0 || empty.CostUSD != 0 {
+		t.Fatalf("empty mission = %+v, want zeros", empty)
+	}
+}
+
 func TestAggregateLatencyPercentiles(t *testing.T) {
 	agg, led := testAggregator(t)
 	from, to := seedAgg(t, led)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -14,6 +14,7 @@ import type {
   MemoryItem,
   Mission,
   MissionEvent,
+  MissionUsage,
   Notification,
   ProviderHealth,
   RetrievedMemory,
@@ -665,6 +666,10 @@ export async function getMission(id: string): Promise<Mission> {
 export async function missionEvents(id: string): Promise<MissionEvent[]> {
   const { events } = await request<{ events: MissionEvent[] }>(`/v1/missions/${id}/events`)
   return events ?? []
+}
+
+export async function missionUsage(id: string): Promise<MissionUsage> {
+  return request<MissionUsage>(`/v1/admin/usage/mission?id=${encodeURIComponent(id)}`)
 }
 
 export async function resumeMission(id: string): Promise<void> {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -151,6 +151,9 @@ export interface UsageSummary {
   cache_write_tokens: number
   requests: number
   errors: number
+  unpriced_requests: number
+  unpriced_input_tokens: number
+  unpriced_output_tokens: number
 }
 
 export interface UsagePoint {
@@ -161,6 +164,20 @@ export interface UsagePoint {
   output_tokens: number
   requests: number
   errors: number
+  unpriced_input_tokens: number
+  unpriced_output_tokens: number
+}
+
+// One mission's total ledger footprint. unpriced_requests counts turns
+// whose cost is unknown (NULL in the ledger) — cost_usd is then a
+// floor, not the whole bill.
+export interface MissionUsage {
+  mission_id: string
+  cost_usd: number
+  input_tokens: number
+  output_tokens: number
+  requests: number
+  unpriced_requests: number
 }
 
 export interface SessionUsage {

--- a/web/src/lib/costEstimate.test.ts
+++ b/web/src/lib/costEstimate.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import type { UsagePoint } from '../api/types'
+import { estimateUnpriced, totalEstimate } from './costEstimate'
+
+function point(overrides: Partial<UsagePoint>): UsagePoint {
+  return {
+    bucket: '2026-07-24T00:00:00Z',
+    group: 'gpt-5.6-sol',
+    cost_usd: 0,
+    input_tokens: 0,
+    output_tokens: 0,
+    requests: 1,
+    errors: 0,
+    unpriced_input_tokens: 0,
+    unpriced_output_tokens: 0,
+    ...overrides,
+  }
+}
+
+describe('estimateUnpriced', () => {
+  it('prices unpriced tokens from the catalog per model', () => {
+    // gpt-5.6-sol: $5/mtok in, $30/mtok out in the catalog.
+    const est = estimateUnpriced([
+      point({ unpriced_input_tokens: 1_000_000, unpriced_output_tokens: 100_000 }),
+      point({ unpriced_input_tokens: 1_000_000 }),
+    ])
+    expect(est.get('gpt-5.6-sol')).toBeCloseTo(5 + 3 + 5, 6)
+  })
+
+  it('skips models absent from the catalog and priced usage', () => {
+    const est = estimateUnpriced([
+      point({ group: 'my-local-finetune', unpriced_input_tokens: 5_000_000 }),
+      point({ cost_usd: 1.23, input_tokens: 100_000 }), // priced: no unpriced tokens
+    ])
+    expect(est.size).toBe(0)
+    expect(totalEstimate(est)).toBe(0)
+  })
+
+  it('totals across models', () => {
+    const est = estimateUnpriced([
+      point({ unpriced_output_tokens: 1_000_000 }), // $30
+      point({ group: 'gpt-5.6-sol-pro', unpriced_input_tokens: 2_000_000 }), // $10
+    ])
+    expect(totalEstimate(est)).toBeCloseTo(40, 6)
+  })
+})

--- a/web/src/lib/costEstimate.ts
+++ b/web/src/lib/costEstimate.ts
@@ -1,0 +1,44 @@
+import { modelCatalog } from '../components/settings/modelCatalog'
+import type { UsagePoint } from '../api/types'
+
+// catalogPrices flattens the advisory model catalog into one id→price
+// lookup. When the same model id appears under several providers the
+// first entry wins — the catalog keeps duplicates price-identical.
+const catalogPrices = (() => {
+  const m = new Map<string, { input: number; output: number }>()
+  for (const models of Object.values(modelCatalog)) {
+    for (const model of models) {
+      if (model.prices && !m.has(model.id)) {
+        m.set(model.id, {
+          input: model.prices.input_per_mtok,
+          output: model.prices.output_per_mtok,
+        })
+      }
+    }
+  }
+  return m
+})()
+
+// estimateUnpriced prices a model-grouped series' unpriced tokens from
+// the advisory catalog. The ledger's cost_usd stays the honest record
+// (unknown price = NULL, never guessed server-side); this is a display
+// hint for what the unpriced calls would roughly cost. Models absent
+// from the catalog contribute nothing — the estimate is itself a floor.
+export function estimateUnpriced(byModel: UsagePoint[]): Map<string, number> {
+  const out = new Map<string, number>()
+  for (const p of byModel) {
+    const price = catalogPrices.get(p.group)
+    if (!price) continue
+    const est =
+      (p.unpriced_input_tokens * price.input + p.unpriced_output_tokens * price.output) / 1_000_000
+    if (est <= 0) continue
+    out.set(p.group, (out.get(p.group) ?? 0) + est)
+  }
+  return out
+}
+
+export function totalEstimate(estimates: Map<string, number>): number {
+  let sum = 0
+  for (const v of estimates.values()) sum += v
+  return sum
+}

--- a/web/src/pages/Analytics.test.tsx
+++ b/web/src/pages/Analytics.test.tsx
@@ -30,6 +30,9 @@ const summary: UsageSummary = {
   cache_write_tokens: 0,
   requests: 10,
   errors: 0,
+  unpriced_requests: 0,
+  unpriced_input_tokens: 0,
+  unpriced_output_tokens: 0,
 }
 
 const calmBudget: BudgetStatus = {
@@ -99,5 +102,34 @@ describe('Analytics token tiles', () => {
     expect(screen.getByText('Output tokens')).toBeTruthy()
     expect(screen.getByText('84.0k')).toBeTruthy()
     expect(screen.getByText('400.0k cached reads')).toBeTruthy()
+  })
+})
+
+describe('Analytics unpriced usage', () => {
+  it('notes unpriced calls with a catalog estimate', async () => {
+    vi.mocked(usageSummary).mockResolvedValue({ ...summary, unpriced_requests: 4 })
+    // gpt-5.6-sol prices in the catalog: $5/mtok in, $30/mtok out.
+    vi.mocked(usageSeries).mockResolvedValue([
+      {
+        bucket: '2026-07-24T00:00:00Z',
+        group: 'gpt-5.6-sol',
+        cost_usd: 0,
+        input_tokens: 1_000_000,
+        output_tokens: 100_000,
+        requests: 4,
+        errors: 0,
+        unpriced_input_tokens: 1_000_000,
+        unpriced_output_tokens: 100_000,
+      },
+    ])
+    renderPage()
+    const note = await screen.findByText(/had no configured price/)
+    expect(note).toHaveTextContent('≈$8.00 at catalog prices')
+  })
+
+  it('stays silent when every call is priced', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getAllByText('$2.50').length).toBeGreaterThan(0))
+    expect(screen.queryByText(/had no configured price/)).toBeNull()
   })
 })

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -28,6 +28,7 @@ import type {
   UsagePoint,
   UsageSummary,
 } from '../api/types'
+import { estimateUnpriced, totalEstimate } from '../lib/costEstimate'
 
 // Accessible categorical palette that reads on light and dark.
 const palette = ['#3b82f6', '#8b5cf6', '#10b981', '#f59e0b', '#f43f5e', '#06b6d4', '#a3a3a3']
@@ -126,6 +127,9 @@ export function Analytics() {
       cache_write_tokens: 0,
       requests: 0,
       errors: 0,
+      unpriced_requests: 0,
+      unpriced_input_tokens: 0,
+      unpriced_output_tokens: 0,
     }
 
     let live = true
@@ -182,6 +186,15 @@ export function Analytics() {
     }
     return [...byBucket.values()]
   }, [data])
+
+  // Advisory estimates for calls the ledger recorded without a price
+  // (cost_usd NULL). Computed client-side from the model catalog and
+  // always shown with a ≈ so they never masquerade as accounting.
+  const estimates = useMemo(
+    () => (data ? estimateUnpriced(data.byModel) : new Map<string, number>()),
+    [data],
+  )
+  const estimatedTotal = totalEstimate(estimates)
 
   const cacheHit = useMemo(() => {
     if (!data) return 0
@@ -293,6 +306,14 @@ export function Analytics() {
           ))}
         </div>
 
+        {s && s.unpriced_requests > 0 && (
+          <p className="mt-3 text-xs text-muted-foreground">
+            {compact(s.unpriced_requests)} call{s.unpriced_requests === 1 ? '' : 's'} in range
+            {' '}had no configured price and are excluded from spend
+            {estimatedTotal > 0 && <> — roughly ≈{money(estimatedTotal)} at catalog prices</>}.
+          </p>
+        )}
+
         <div className="mt-6 grid gap-6 lg:grid-cols-2">
           <section className="rounded-xl border border-border p-4">
             <h2 className="text-sm font-medium">Cost by provider</h2>
@@ -347,7 +368,7 @@ export function Analytics() {
         </div>
 
         <div className="mt-6 grid gap-6 lg:grid-cols-3">
-          <BreakdownTable title="By model" rows={data ? totals(data.byModel) : []} />
+          <BreakdownTable title="By model" rows={data ? totals(data.byModel) : []} estimates={estimates} />
           <BreakdownTable title="By route" rows={data ? totals(data.byRoute) : []} />
           <section className="rounded-xl border border-border p-4">
             <h2 className="text-sm font-medium">Top sessions by cost</h2>
@@ -421,9 +442,11 @@ export function Analytics() {
 function BreakdownTable({
   title,
   rows,
+  estimates,
 }: {
   title: string
   rows: [string, { cost: number; requests: number; errors: number; tokens: number }][]
+  estimates?: Map<string, number>
 }) {
   return (
     <section className="rounded-xl border border-border p-4">
@@ -434,7 +457,17 @@ function BreakdownTable({
             <tr key={group} className="border-t border-border/60">
               <td className="max-w-36 truncate py-2 pr-2">{group}</td>
               <td className="py-2 text-right text-muted-foreground">{compact(t.tokens)} tok</td>
-              <td className="py-2 text-right font-medium">{money(t.cost)}</td>
+              <td className="py-2 text-right font-medium">
+                {money(t.cost)}
+                {(estimates?.get(group) ?? 0) > 0 && (
+                  <span
+                    className="ml-1 text-xs font-normal text-muted-foreground"
+                    title="Estimated from catalog prices for calls with no configured price."
+                  >
+                    +≈{money(estimates?.get(group) ?? 0)}
+                  </span>
+                )}
+              </td>
             </tr>
           ))}
           {rows.length === 0 && (

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -7,6 +7,7 @@ import { MissionDetail } from './MissionDetail'
 vi.mock('../api/client', () => ({
   getMission: vi.fn(),
   missionEvents: vi.fn(),
+  missionUsage: vi.fn(),
   resumeMission: vi.fn(),
   cancelMission: vi.fn(),
   answerMissionPermission: vi.fn(),
@@ -17,6 +18,7 @@ import {
   cancelMission,
   getMission,
   missionEvents,
+  missionUsage,
   resumeMission,
 } from '../api/client'
 
@@ -91,6 +93,41 @@ beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(getMission).mockResolvedValue(baseMission)
   vi.mocked(missionEvents).mockResolvedValue(events)
+  vi.mocked(missionUsage).mockResolvedValue({
+    mission_id: 'm1',
+    cost_usd: 0,
+    input_tokens: 0,
+    output_tokens: 0,
+    requests: 0,
+    unpriced_requests: 0,
+  })
+})
+
+describe('MissionDetail spend', () => {
+  it('shows cost, calls, tokens, and budget share once usage exists', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, budget_usd: 2 })
+    vi.mocked(missionUsage).mockResolvedValue({
+      mission_id: 'm1',
+      cost_usd: 0.5,
+      input_tokens: 120_000,
+      output_tokens: 8_000,
+      requests: 7,
+      unpriced_requests: 2,
+    })
+    renderPage()
+    expect(await screen.findByText('Spend')).toBeTruthy()
+    expect(screen.getByText('$0.5000')).toBeTruthy()
+    expect(screen.getByText('7 model calls')).toBeTruthy()
+    expect(screen.getByText('120,000 in / 8,000 out')).toBeTruthy()
+    expect(screen.getByText('25% of budget')).toBeTruthy()
+    expect(screen.getByText('2 unpriced calls')).toBeTruthy()
+  })
+
+  it('hides the section while the mission has no ledger rows', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(screen.queryByText('Spend')).toBeNull()
+  })
 })
 
 describe('MissionDetail', () => {

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -8,9 +8,10 @@ import {
   cancelMission,
   getMission,
   missionEvents,
+  missionUsage,
   resumeMission,
 } from '../api/client'
-import type { Mission, MissionEvent } from '../api/types'
+import type { Mission, MissionEvent, MissionUsage } from '../api/types'
 import { PermissionBanner } from '../components/missions/PermissionBanner'
 import { PlanSection } from '../components/missions/PlanSection'
 import { ProgressSection } from '../components/missions/ProgressSection'
@@ -28,12 +29,14 @@ export function MissionDetail() {
   const { id } = useParams<{ id: string }>()
   const [mission, setMission] = useState<Mission | null>(null)
   const [events, setEvents] = useState<MissionEvent[]>([])
+  const [usage, setUsage] = useState<MissionUsage | null>(null)
   const [busy, setBusy] = useState(false)
 
   const refresh = useCallback(() => {
     if (!id) return
     getMission(id).then(setMission, () => undefined)
     missionEvents(id).then(setEvents, () => undefined)
+    missionUsage(id).then(setUsage, () => undefined)
   }, [id])
 
   useEffect(() => {
@@ -146,6 +149,27 @@ export function MissionDetail() {
           </div>
         </div>
       </div>
+
+      {usage && usage.requests > 0 && (
+        <section>
+          <h2 className="mb-2 text-sm font-semibold tracking-tight">Spend</h2>
+          <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm text-muted-foreground">
+            <span className="text-foreground">${usage.cost_usd.toFixed(4)}</span>
+            <span>{usage.requests} model calls</span>
+            <span>
+              {usage.input_tokens.toLocaleString()} in / {usage.output_tokens.toLocaleString()} out
+            </span>
+            {mission.budget_usd != null && mission.budget_usd > 0 && (
+              <span>{Math.round((usage.cost_usd / mission.budget_usd) * 100)}% of budget</span>
+            )}
+            {usage.unpriced_requests > 0 && (
+              <span title="Some calls have no configured price; their cost is not included.">
+                {usage.unpriced_requests} unpriced call{usage.unpriced_requests === 1 ? '' : 's'}
+              </span>
+            )}
+          </div>
+        </section>
+      )}
 
       <section>
         <h2 className="mb-2 text-sm font-semibold tracking-tight">Plan</h2>


### PR DESCRIPTION
## What

- **Per-mission spend.** `cost_ledger.mission_id` was written on every mission turn but aggregated nowhere. New gateway aggregate + `GET /internal/admin/usage/mission?id=` (rides the existing brain proxy), and a Spend section on MissionDetail: cost, model calls, tokens in/out, % of budget, unpriced-call count.
- **Unpriced usage is visible.** Rows with `cost_usd IS NULL` (unknown price is recorded as NULL, never guessed — D-013) were silently `COALESCE`d to zero in every dashboard figure. Summary and series now return `unpriced_*` splits; Analytics shows a note ("N calls had no configured price… roughly ≈$X at catalog prices") and per-model `+≈$` hints estimated client-side from the advisory model catalog. Estimates are always ≈-marked and never mixed into recorded spend.
- **Mission bookkeeping sessions no longer pollute the chat list.** Migration 0028's comment promised a join filter that was never written; `session.Store.List` now excludes sessions referenced by `missions.session_id` in both plain and search listings.

## Testing

- Integration: `TestAggregateMissionUsage` (priced + unpriced + cross-mission + test-probe exclusion), `TestListExcludesMissionSessions` (both query modes); full `-tags integration ./internal/...` green.
- Web: `costEstimate` unit tests, Analytics unpriced-note tests, MissionDetail Spend tests — 132 tests green, build + lint clean.
- Go: `go test -race ./...` green, golangci-lint 0 issues.
- Live: research canary PASS (20s, 3 turns), coding canary PASS (26s, 4 turns) after brain+gateway rebuild.
