### PR TITLE
feat(missions): opt-in escalation route + fail-fast chain retries

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -96,6 +96,12 @@ services:
       # Root for mission workspaces/worktrees; unset disables the
       # missions feature entirely (API surface stays unmounted).
       WORKSPACES: /workspace/missions
+      # Models too weak to drive tool-using mission work (substring
+      # match on the served model id). A turn served by one pauses the
+      # mission as infra instead of burning iterations on a model that
+      # cannot do the job — the small local fallback exists for chat
+      # resilience, not for missions.
+      MISSION_MODEL_FLOOR: ${MISSION_MODEL_FLOOR:-qwen2.5:7b}
       # Compose-internal only: the model never sees this address.
       SEARXNG_URL: http://searxng:8080
       # Converts Gmail attachments (PDFs) and HTML-only email bodies to

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -77,9 +77,13 @@ type createMissionRequest struct {
 	AgentID       string   `json:"agent_id"`
 	Route         string   `json:"route"`
 	ReviewRoute   string   `json:"review_route"`
-	MaxIterations int      `json:"max_iterations"`
-	BudgetUSD     *float64 `json:"budget_usd"`
-	RepoPath      string   `json:"repo_path"`
+	// EscalationRoute, when set, is where worker turns move after a
+	// failure or rework. Empty keeps escalation off — never defaulted,
+	// so a route change is always an explicit choice.
+	EscalationRoute string   `json:"escalation_route"`
+	MaxIterations   int      `json:"max_iterations"`
+	BudgetUSD       *float64 `json:"budget_usd"`
+	RepoPath        string   `json:"repo_path"`
 	// AutoApproveSafe defaults true (a pointer so an omitted field is
 	// distinguishable from an explicit false) — missions run for hours
 	// unattended, so auto-approving DangerSafe shell calls is the
@@ -146,7 +150,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 	}
 	m := missions.Mission{
 		Goal: req.Goal, Kind: req.Kind, AgentID: req.AgentID,
-		Route: req.Route, ReviewRoute: req.ReviewRoute,
+		Route: req.Route, ReviewRoute: req.ReviewRoute, EscalationRoute: req.EscalationRoute,
 		MaxIterations: req.MaxIterations, BudgetUSD: req.BudgetUSD,
 		AutoApproveSafe: autoApproveSafe,
 	}

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -215,10 +215,14 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 	// Turn telemetry: one event per phase run, so a mission's cost in
 	// wall-clock and outcomes is readable from its event log alone
 	// (token/model cost is in cost_ledger, keyed by mission_id).
-	if evErr := d.store.AppendEvent(ctx, id, "mission.turn", map[string]any{
+	payload := map[string]any{
 		"phase": string(m.Phase), "duration_ms": turnMs,
 		"ok": err == nil, "input": string(in.Input), "reason": in.Reason,
-	}); evErr != nil {
+	}
+	if m.Phase == PhaseExecute && workerRoute(m) != m.Route {
+		payload["escalated_route"] = workerRoute(m)
+	}
+	if evErr := d.store.AppendEvent(ctx, id, "mission.turn", payload); evErr != nil {
 		d.log.Warn("driver: record turn failed", "mission_id", id, "error", evErr)
 	}
 

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -42,6 +42,11 @@ type Mission struct {
 	BudgetUSD           *float64 `json:"budget_usd,omitempty"`
 	Route               string   `json:"route"`
 	ReviewRoute         string   `json:"review_route"`
+	// EscalationRoute, when non-empty, is the route worker turns switch
+	// to after a worker failure or review rework — instead of burning
+	// iterations on a model that already proved too weak for the unit.
+	// Empty disables escalation.
+	EscalationRoute string `json:"escalation_route,omitempty"`
 	PendingPermission   string   `json:"pending_permission,omitempty"`
 	// PendingPermissionTool/Args/Danger/Rationale describe the parked
 	// tool call for the UI — set alongside PendingPermission whenever a

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -214,6 +214,19 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 	return b.String(), sentinelArgs, nil
 }
 
+// workerRoute picks the route a worker turn runs on. With an
+// escalation route configured, any evidence the current model is not
+// cutting it — a worker failure or a review rework already on the
+// books — switches subsequent worker turns to it. Empty escalation
+// route means the ladder is off and the mission's own route always
+// wins.
+func workerRoute(m Mission) string {
+	if m.EscalationRoute != "" && (m.ConsecutiveFailures > 0 || m.StallCount > 0) {
+		return m.EscalationRoute
+	}
+	return m.Route
+}
+
 // RunWorker seeds a fresh session (packet only, no prior transcript)
 // and enforces the sentinel ladder: a present, well-formed
 // mission_status call is trusted directly; a missing or invalid one
@@ -225,7 +238,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 	extra := append([]*tools.Tool{MissionStatusTool()}, missionTools(m)...)
 	req := loop.Request{
 		SessionID:  m.SessionID,
-		Route:      m.Route,
+		Route:      workerRoute(m),
 		Agent:      "mission-worker",
 		MissionID:  m.ID,
 		System:     system,

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -382,6 +382,41 @@ func TestRunWorkerModelFloorDisabledByDefault(t *testing.T) {
 // root cause of the workspace-split failure family was workers running
 // shell in the shared global root while verification looked in the
 // per-mission directory.
+func TestWorkerRoute(t *testing.T) {
+	tests := []struct {
+		name string
+		m    Mission
+		want string
+	}{
+		{"no escalation route configured", Mission{Route: "mini", ConsecutiveFailures: 2, StallCount: 1}, "mini"},
+		{"clean run stays on its route", Mission{Route: "mini", EscalationRoute: "coding"}, "mini"},
+		{"worker failure escalates", Mission{Route: "mini", EscalationRoute: "coding", ConsecutiveFailures: 1}, "coding"},
+		{"review rework escalates", Mission{Route: "mini", EscalationRoute: "coding", StallCount: 1}, "coding"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := workerRoute(tc.m); got != tc.want {
+				t.Fatalf("workerRoute = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunWorkerUsesEscalatedRoute(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ok"}`)},
+	}}
+	r := newTestRunner(agent)
+	m := Mission{ID: "m1", Route: "mini", EscalationRoute: "coding",
+		ConsecutiveFailures: 1, Workspace: "/workspace/missions/m1"}
+	if _, _, err := r.RunWorker(context.Background(), m, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if got := agent.requests[0].Route; got != "coding" {
+		t.Fatalf("worker request route = %q, want the escalation route", got)
+	}
+}
+
 func TestRunWorkerGetsMissionScopedShell(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ok"}`)},

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -36,6 +36,7 @@ func NewStore(db *pgpool.Pool, log *slog.Logger) *Store {
 const missionColumns = `id, goal, kind, agent_id, phase, status, pause_reason, pause_message,
 	workspace, worktree, branch, base_commit, spec, progress, iteration, max_iterations,
 	consecutive_failures, last_gap_fingerprint, stall_count, budget_usd, route, review_route,
+	escalation_route,
 	pending_permission, pending_permission_tool, pending_permission_args,
 	pending_permission_danger, pending_permission_rationale, auto_approve_safe, last_evidence,
 	schedule_id, session_id, created_at, updated_at`
@@ -51,6 +52,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 	if err := row.Scan(&m.ID, &m.Goal, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
 		&m.ConsecutiveFailures, &m.LastGapFingerprint, &m.StallCount, &m.BudgetUSD, &m.Route, &m.ReviewRoute,
+		&m.EscalationRoute,
 		&pendingPermission, &m.PendingPermissionTool, &m.PendingPermissionArgs,
 		&m.PendingPermissionDanger, &m.PendingPermissionRationale, &m.AutoApproveSafe, &m.LastEvidence,
 		&scheduleID, &sessionID, &m.CreatedAt, &m.UpdatedAt); err != nil {
@@ -106,9 +108,9 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	}
 	var id string
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, kind, agent_id, max_iterations, budget_usd, route, review_route, spec, session_id, auto_approve_safe)
-		VALUES ($1, $2, NULLIF($3, '')::uuid, $4, $5, $6, $7, $8, NULLIF($9, '')::uuid, $10) RETURNING id`,
-		m.Goal, m.Kind, m.AgentID, orDefault(m.MaxIterations, 8), m.BudgetUSD, m.Route, m.ReviewRoute, spec, m.SessionID, m.AutoApproveSafe,
+			(goal, kind, agent_id, max_iterations, budget_usd, route, review_route, escalation_route, spec, session_id, auto_approve_safe)
+		VALUES ($1, $2, NULLIF($3, '')::uuid, $4, $5, $6, $7, $8, $9, NULLIF($10, '')::uuid, $11) RETURNING id`,
+		m.Goal, m.Kind, m.AgentID, orDefault(m.MaxIterations, 8), m.BudgetUSD, m.Route, m.ReviewRoute, m.EscalationRoute, spec, m.SessionID, m.AutoApproveSafe,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)

--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -130,8 +130,11 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var failed []string
-	for _, att := range attempts {
+	for i, att := range attempts {
 		completion.Model = att.Model
+		// Last chain entry gets the full in-provider retry budget;
+		// earlier entries fail fast so the chain can advance.
+		completion.FinalAttempt = i == len(attempts)-1
 		res := streamAttempt(r.Context(), att, completion, ledger.Entry{
 			ID:       ledger.NewID(),
 			Provider: att.ProviderName, Model: att.Model,

--- a/internal/gateway/provider/anthropic.go
+++ b/internal/gateway/provider/anthropic.go
@@ -197,7 +197,7 @@ func (a *Anthropic) Stream(ctx context.Context, req CompletionRequest) (<-chan s
 		}
 		return r, nil
 	}
-	return runStream(ctx, a.client, a.cfg.Timeout, build, a.relay), nil
+	return runStream(ctx, a.client, a.cfg.Timeout, retriesFor(req.FinalAttempt), build, a.relay), nil
 }
 
 func (a *Anthropic) buildRequest(req CompletionRequest) anthropicRequest {

--- a/internal/gateway/provider/httpx.go
+++ b/internal/gateway/provider/httpx.go
@@ -33,12 +33,22 @@ func backoffFor(attempt int) time.Duration {
 	return d + time.Duration(rand.Int64N(int64(d)/2+1)) // #nosec G404 -- jitter, not a secret
 }
 
+// retriesFor sizes the in-provider retry budget: the full maxRetries
+// when this is the chain's final attempt, one quick retry otherwise —
+// failover to the next provider beats backing off against a limiter.
+func retriesFor(finalAttempt bool) int {
+	if finalAttempt {
+		return maxRetries
+	}
+	return 1
+}
+
 // doWithRetry issues the request built by build, retrying 429/5xx
-// responses and network errors up to maxRetries with jittered backoff.
-// Each retry is reported through notify (return false to abort); pass
-// nil to retry silently. On success the response body is open and the
-// caller owns closing it.
-func doWithRetry(ctx context.Context, client *http.Client, build func() (*http.Request, error), notify func(stream.RetryInfo) bool) (*http.Response, error) {
+// responses and network errors up to retries times with jittered
+// backoff. Each retry is reported through notify (return false to
+// abort); pass nil to retry silently. On success the response body is
+// open and the caller owns closing it.
+func doWithRetry(ctx context.Context, client *http.Client, retries int, build func() (*http.Request, error), notify func(stream.RetryInfo) bool) (*http.Response, error) {
 	var lastErr error
 	for attempt := 0; ; attempt++ {
 		if attempt > 0 {
@@ -64,7 +74,7 @@ func doWithRetry(ctx context.Context, client *http.Client, build func() (*http.R
 		resp, err := client.Do(req)
 		if err != nil {
 			lastErr = err
-			if attempt < maxRetries && ctx.Err() == nil {
+			if attempt < retries && ctx.Err() == nil {
 				continue
 			}
 			return nil, lastErr
@@ -73,7 +83,7 @@ func doWithRetry(ctx context.Context, client *http.Client, build func() (*http.R
 			body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
 			_ = resp.Body.Close()
 			lastErr = fmt.Errorf("http %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
-			if attempt < maxRetries && ctx.Err() == nil {
+			if attempt < retries && ctx.Err() == nil {
 				continue
 			}
 			return nil, lastErr
@@ -140,14 +150,14 @@ type relayFunc func(ctx context.Context, body io.Reader, ch chan<- stream.Stream
 // lifecycle, terminal error emission, and the incomplete+done tail
 // when a stream cuts off mid-flight. Drivers own only request building
 // and delta parsing.
-func runStream(ctx context.Context, client *http.Client, timeout time.Duration, build func(ctx context.Context) (*http.Request, error), relay relayFunc) <-chan stream.StreamEvent {
+func runStream(ctx context.Context, client *http.Client, timeout time.Duration, retries int, build func(ctx context.Context) (*http.Request, error), relay relayFunc) <-chan stream.StreamEvent {
 	ch := make(chan stream.StreamEvent)
 	go func() {
 		defer close(ch)
 		callCtx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 
-		resp, err := doWithRetry(callCtx, client, func() (*http.Request, error) {
+		resp, err := doWithRetry(callCtx, client, retries, func() (*http.Request, error) {
 			return build(callCtx)
 		}, func(ri stream.RetryInfo) bool {
 			return emit(callCtx, ch, stream.StreamEvent{Type: stream.EventRetry, Retry: &ri})

--- a/internal/gateway/provider/httpx_test.go
+++ b/internal/gateway/provider/httpx_test.go
@@ -1,6 +1,9 @@
 package provider
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -15,6 +18,39 @@ func TestBackoffGrowsWithJitter(t *testing.T) {
 				t.Fatalf("attempt %d: backoff %v outside [%v, %v]", attempt, got, base, base+base/2)
 			}
 		}
+	}
+}
+
+func TestRetriesFor(t *testing.T) {
+	t.Parallel()
+	if got := retriesFor(true); got != maxRetries {
+		t.Fatalf("final attempt retries = %d, want the full budget %d", got, maxRetries)
+	}
+	if got := retriesFor(false); got != 1 {
+		t.Fatalf("non-final attempt retries = %d, want 1 — the chain is the retry", got)
+	}
+}
+
+// TestDoWithRetryHonorsBudget pins the failover-latency contract: a
+// rate-limited provider mid-chain is retried once (2 requests total),
+// not maxRetries times — re-hammering a limiter only delays failover.
+func TestDoWithRetryHonorsBudget(t *testing.T) {
+	t.Parallel()
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	build := func() (*http.Request, error) {
+		return http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	}
+	if _, err := doWithRetry(context.Background(), srv.Client(), 1, build, nil); err == nil {
+		t.Fatal("persistent 429 reported no error")
+	}
+	if hits != 2 {
+		t.Fatalf("provider hit %d times with budget 1, want 2 (initial + one retry)", hits)
 	}
 }
 

--- a/internal/gateway/provider/listmodels.go
+++ b/internal/gateway/provider/listmodels.go
@@ -23,7 +23,7 @@ type ModelLister interface {
 // listModels GETs url and decodes the OpenAI-style {"data": [{"id"}]}
 // envelope, which the Anthropic models endpoint shares.
 func listModels(ctx context.Context, client *http.Client, url string, header func(*http.Request)) ([]AvailableModel, error) {
-	resp, err := doWithRetry(ctx, client, func() (*http.Request, error) {
+	resp, err := doWithRetry(ctx, client, maxRetries, func() (*http.Request, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return nil, err

--- a/internal/gateway/provider/openaicompat.go
+++ b/internal/gateway/provider/openaicompat.go
@@ -62,7 +62,7 @@ func (o *OpenAICompat) Embed(ctx context.Context, model string, texts []string) 
 
 	callCtx, cancel := context.WithTimeout(ctx, o.cfg.Timeout)
 	defer cancel()
-	resp, err := doWithRetry(callCtx, o.client, func() (*http.Request, error) {
+	resp, err := doWithRetry(callCtx, o.client, maxRetries, func() (*http.Request, error) {
 		req, err := http.NewRequestWithContext(callCtx, http.MethodPost, o.cfg.BaseURL+"/embeddings", bytes.NewReader(body))
 		if err != nil {
 			return nil, fmt.Errorf("openaicompat: embed request: %w", err)
@@ -213,7 +213,7 @@ func (o *OpenAICompat) Stream(ctx context.Context, req CompletionRequest) (<-cha
 		}
 		return r, nil
 	}
-	return runStream(ctx, o.client, o.cfg.Timeout, build, o.relay), nil
+	return runStream(ctx, o.client, o.cfg.Timeout, retriesFor(req.FinalAttempt), build, o.relay), nil
 }
 
 func (o *OpenAICompat) buildRequest(req CompletionRequest) oaiRequest {

--- a/internal/gateway/provider/provider.go
+++ b/internal/gateway/provider/provider.go
@@ -73,6 +73,12 @@ type CompletionRequest struct {
 	// their provider's reasoning-effort control where one exists and
 	// ignore it otherwise.
 	Effort string
+	// FinalAttempt tells the driver no other chain entry follows this
+	// one: spend the full in-provider retry budget. When false (more
+	// providers remain), transient failures get one quick retry and
+	// then surface — the chain is the retry, and re-hammering a
+	// rate-limited provider only delays failover.
+	FinalAttempt bool
 }
 
 // Provider is one configured LLM provider. Stream returns quickly; all

--- a/internal/gateway/provider/runstream_test.go
+++ b/internal/gateway/provider/runstream_test.go
@@ -33,7 +33,7 @@ func TestRunStreamTimeoutErrorDeliversOnParentCtx(t *testing.T) {
 	t.Cleanup(func() { close(blocked); srv.Close() })
 
 	relayCalled := false
-	ch := runStream(t.Context(), &http.Client{}, 100*time.Millisecond, buildFor(srv.URL),
+	ch := runStream(t.Context(), &http.Client{}, 100*time.Millisecond, maxRetries, buildFor(srv.URL),
 		func(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (bool, error) {
 			relayCalled = true
 			return true, nil
@@ -67,7 +67,7 @@ func TestRunStreamIncompleteTail(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			ch := runStream(t.Context(), &http.Client{}, time.Second, buildFor(srv.URL),
+			ch := runStream(t.Context(), &http.Client{}, time.Second, maxRetries, buildFor(srv.URL),
 				func(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (bool, error) {
 					return false, tt.relayErr
 				})
@@ -89,7 +89,7 @@ func TestRunStreamFinishedRelayGetsNoTail(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	t.Cleanup(srv.Close)
 
-	ch := runStream(t.Context(), &http.Client{}, time.Second, buildFor(srv.URL),
+	ch := runStream(t.Context(), &http.Client{}, time.Second, maxRetries, buildFor(srv.URL),
 		func(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (bool, error) {
 			emit(ctx, ch, stream.StreamEvent{Type: stream.EventDone})
 			return true, nil
@@ -113,7 +113,7 @@ func TestRunStreamRetryEventsPrecedeSuccess(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	ch := runStream(t.Context(), &http.Client{}, 5*time.Second, buildFor(srv.URL),
+	ch := runStream(t.Context(), &http.Client{}, 5*time.Second, maxRetries, buildFor(srv.URL),
 		func(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (bool, error) {
 			b, _ := io.ReadAll(body)
 			emit(ctx, ch, stream.StreamEvent{Type: stream.EventChunk, Text: string(b)})

--- a/migrations/0032_mission_escalation_route.sql
+++ b/migrations/0032_mission_escalation_route.sql
@@ -1,0 +1,6 @@
+-- Opt-in escalation ladder: when set, worker turns switch to this
+-- route after a worker failure or review rework instead of burning
+-- more iterations on a model that already proved too weak for the
+-- unit. Empty (the default) disables escalation entirely -- route
+-- changes must never be a surprise cost jump.
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS escalation_route text NOT NULL DEFAULT '';

--- a/scripts/canary-coding.sh
+++ b/scripts/canary-coding.sh
@@ -13,7 +13,22 @@ COMPOSE=(docker compose -f "${REPO_ROOT}/deploy/docker-compose.yml")
 BASE_URL="${CANARY_BASE_URL:-http://localhost:${BRAIN_PORT:-8300}}"
 TIMEOUT_SECS="${CANARY_TIMEOUT:-900}"
 FIXTURE=/workspace/canary-fixture
-GOAL="Add a CHANGELOG.md file at the repository root with a '## 0.1.0' heading and one bullet point describing the initial release."
+
+# A different goal every run: repeating one fixed goal would let
+# prompt caches and prior runs' artifacts flatter the result. Each
+# case pins the exact artifact path so the script can independently
+# assert it exists in the worktree afterward.
+CASES=(
+  "CHANGELOG.md|Add a CHANGELOG.md file at the repository root with a version heading and one bullet point describing the initial release."
+  "CONTRIBUTING.md|Add a CONTRIBUTING.md file at the repository root with a short section on how to propose a change."
+  "docs/USAGE.md|Add a docs/USAGE.md file with a short Usage section explaining what this fixture repo is for."
+  "SECURITY.md|Add a SECURITY.md file at the repository root describing how to report a vulnerability."
+  ".editorconfig|Add an .editorconfig file at the repository root with root=true and basic UTF-8/LF settings."
+  "docs/FAQ.md|Add a docs/FAQ.md file with two short frequently-asked questions and answers about this repo."
+)
+CASE="${CASES[$((RANDOM % ${#CASES[@]}))]}"
+ARTIFACT="${CASE%%|*}"
+GOAL="${CASE#*|}"
 
 # The API token stays in the shell environment only — sourced here,
 # never printed.
@@ -119,9 +134,9 @@ if [[ -z "${worktree}" || -z "${branch}" ]]; then
 fi
 "${COMPOSE[@]}" exec -T brain sh -c "
   git -C ${FIXTURE} rev-parse --verify --quiet '${branch}' >/dev/null &&
-  test -s '${worktree}/CHANGELOG.md'
+  test -s '${worktree}/${ARTIFACT}'
 " || {
-  echo "canary-coding: FAIL — branch ${branch} or ${worktree}/CHANGELOG.md missing in container" >&2
+  echo "canary-coding: FAIL — branch ${branch} or ${worktree}/${ARTIFACT} missing in container" >&2
   exit 1
 }
 

--- a/scripts/canary-mission.sh
+++ b/scripts/canary-mission.sh
@@ -9,7 +9,24 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BASE_URL="${CANARY_BASE_URL:-http://localhost:${BRAIN_PORT:-8300}}"
 TIMEOUT_SECS="${CANARY_TIMEOUT:-900}"
-GOAL="Summarize what HTTP status code 429 means and when a client should retry, in a markdown file."
+
+# A different goal every run: repeating one fixed goal would let
+# provider prompt caches, model memorization, and leftover artifacts
+# from prior runs flatter the result — a pass must mean the harness
+# worked NOW, on work it hasn't seen before.
+GOALS=(
+  "Summarize what HTTP status code 429 means and when a client should retry, in a markdown file."
+  "Explain how the Retry-After header works with 503 responses, in a markdown file."
+  "Describe HTTP ETag headers and conditional requests, in a markdown file."
+  "Explain CORS preflight requests and when browsers send them, in a markdown file."
+  "Compare HTTP 301 and 308 redirects and when to use each, in a markdown file."
+  "Describe the robots.txt format and how crawlers use it, in a markdown file."
+  "Explain HTTP chunked transfer encoding and when it applies, in a markdown file."
+  "Compare HTTP HEAD and GET requests and typical uses of HEAD, in a markdown file."
+  "Summarize what DNS TTL means and how it affects record changes, in a markdown file."
+  "Explain what an idempotent HTTP method is with examples, in a markdown file."
+)
+GOAL="${GOALS[$((RANDOM % ${#GOALS[@]}))]}"
 
 # The API token stays in the shell environment only — sourced here,
 # never printed.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -641,6 +641,7 @@ export interface CreateMissionInput {
   agent_id?: string
   route?: string
   review_route?: string
+  escalation_route?: string
   max_iterations?: number
   budget_usd?: number
   repo_path?: string

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -349,6 +349,7 @@ export interface Mission {
   budget_usd?: number
   route: string
   review_route: string
+  escalation_route?: string
   pending_permission?: string
   pending_permission_tool?: string
   pending_permission_args?: string

--- a/web/src/components/PermissionModal.tsx
+++ b/web/src/components/PermissionModal.tsx
@@ -38,10 +38,14 @@ export function PermissionModal({
     <Dialog open onOpenChange={(open) => !open && onDecision(request.id, 'deny')}>
       <DialogContent data-testid="permission-modal">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            Allow <span className="font-mono">{request.tool}</span>?
+          {/* Inline flow, not flex: a long connector tool name
+              (google-calendar_calendar_list_events) must wrap inside
+              the title without orphaning the "?" or colliding with
+              the close button. */}
+          <DialogTitle className="pr-8 leading-snug">
+            Allow <span className="font-mono text-[0.9em] break-all">{request.tool}</span>?
             {request.danger_level === 'destructive' && (
-              <Badge variant="destructive" data-testid="danger-badge">
+              <Badge variant="destructive" data-testid="danger-badge" className="ml-2 align-middle">
                 destructive
               </Badge>
             )}

--- a/web/src/components/missions/NewMissionDialog.tsx
+++ b/web/src/components/missions/NewMissionDialog.tsx
@@ -41,6 +41,7 @@ export function NewMissionDialog({
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [route, setRoute] = useState('')
   const [reviewRoute, setReviewRoute] = useState('')
+  const [escalationRoute, setEscalationRoute] = useState('')
   const [budget, setBudget] = useState('')
   const [autoApproveSafe, setAutoApproveSafe] = useState(true)
   const [busy, setBusy] = useState(false)
@@ -64,6 +65,7 @@ export function NewMissionDialog({
     setShowAdvanced(false)
     setRoute('')
     setReviewRoute('')
+    setEscalationRoute('')
     setBudget('')
     setAutoApproveSafe(true)
   }
@@ -77,6 +79,7 @@ export function NewMissionDialog({
         agent_id: agentID || undefined,
         route: route || undefined,
         review_route: reviewRoute || undefined,
+        escalation_route: escalationRoute || undefined,
         budget_usd: budget ? Number(budget) : undefined,
         repo_path: kind === 'coding' ? repoPath.trim() : undefined,
         auto_approve_safe: autoApproveSafe,
@@ -186,6 +189,15 @@ export function NewMissionDialog({
                   value={reviewRoute}
                   onChange={(e) => setReviewRoute(e.target.value)}
                   placeholder="default"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="mission-escalation-route">Escalation route</Label>
+                <Input
+                  id="mission-escalation-route"
+                  value={escalationRoute}
+                  onChange={(e) => setEscalationRoute(e.target.value)}
+                  placeholder="Off — set to switch route after a failed or reworked turn"
                 />
               </div>
               <div className="space-y-1.5">


### PR DESCRIPTION
## What

Four changes that make missions recover from weak models and flaky providers instead of burning iterations:

- **Escalation route (opt-in):** `escalation_route` on a mission switches worker turns to a stronger route after the first worker failure or review rework. Empty by default — a route (and cost) change is always an explicit choice. Escalated turns are recorded in `mission.turn` events (`escalated_route`) so the ladder is auditable. Exposed in the New Mission dialog under Advanced.
- **Fail-fast chain retries:** mid-chain providers get one quick in-provider retry instead of the full budget — the chain is the retry; re-hammering a rate-limited provider only delays failover. Only the final chain entry spends the full budget. One-off calls (embed, model listing) keep the full budget.
- **Canary goal randomization:** both canaries draw a fresh goal per run so prompt caches, memorization, and leftover artifacts can't flatter a broken harness; coding cases pin the artifact path for independent assertion.
- **Permission modal fix:** long connector tool ids wrap inside the dialog title instead of colliding with the close button.

Also pins the `MISSION_MODEL_FLOOR` compose default (`qwen2.5:7b`) so the local fallback never silently drives mission work.

## Verification

- `make build test vet lint` — 0 issues
- Web: build, lint, 132 tests green
- `make canary` — PASS (3 model turns, unit verified). One earlier run parked `infra` when Bedrock and GLM both erred and the chain fell to the local model — the floor doing its job; rerun on healthy providers passed.

## Notes

- Migration `0032` follows the existing iterative-ALTER pattern (`0029`–`0031`).
- New unit tests: `workerRoute` ladder table, escalated-route wiring in `RunWorker`, retry-budget contract (`TestDoWithRetryHonorsBudget` pins 429 → 2 requests mid-chain).
