### PR TITLE
feat(routes): visual pipeline editor with router-resolved order and scores

### DIFF
--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -476,12 +476,78 @@ func (a *Admin) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-// Route is the API shape of one routes row.
+// Route is the API shape of one routes row. Chain/Strategy/Enabled are
+// DB truth (what PATCH edits); Resolved and Serving are derived from
+// the live snapshot — the router's actual try order with the stats and
+// scores behind it. Both are empty for disabled routes (the snapshot
+// holds enabled routes only) or when no snapshot is loaded yet.
 type Route struct {
 	Name     string              `json:"name"`
 	Chain    []router.ChainEntry `json:"chain"`
 	Strategy string              `json:"strategy"`
 	Enabled  bool                `json:"enabled"`
+	Resolved []RouteEntryStatus  `json:"resolved,omitempty"`
+	Serving  *router.ChainEntry  `json:"serving,omitempty"`
+}
+
+// RouteEntryStatus is one resolved chain entry with the router's gate
+// verdict and scoring factors. Nullable numerics are nil when the
+// ledger has no data (or the model is unpriced) — never a guessed 0.
+type RouteEntryStatus struct {
+	ProviderID    string   `json:"provider_id"`
+	ProviderName  string   `json:"provider_name,omitempty"`
+	Model         string   `json:"model"`
+	Usable        bool     `json:"usable"`
+	SkipReason    string   `json:"skip_reason,omitempty"`
+	Score         *float64 `json:"score,omitempty"`
+	NormPrice     *float64 `json:"norm_price,omitempty"`
+	NormLatency   *float64 `json:"norm_latency,omitempty"`
+	NormTPS       *float64 `json:"norm_tps,omitempty"`
+	Uptime        *float64 `json:"uptime,omitempty"`
+	LatencyMS     *float64 `json:"latency_ms,omitempty"`
+	TokensPerS    *float64 `json:"tokens_per_s,omitempty"`
+	OutputPerMTok *float64 `json:"output_per_mtok,omitempty"`
+}
+
+// resolvedForRoute maps the router's annotated try order to wire
+// shape and picks the first usable entry as the serving one.
+func resolvedForRoute(snap *router.Snapshot, name string) ([]RouteEntryStatus, *router.ChainEntry) {
+	detail := snap.ResolveDetail(name)
+	if len(detail) == 0 {
+		return nil, nil
+	}
+	opt := func(v, none float64) *float64 {
+		if v == none {
+			return nil
+		}
+		return &v
+	}
+	out := make([]RouteEntryStatus, len(detail))
+	var serving *router.ChainEntry
+	for i, d := range detail {
+		out[i] = RouteEntryStatus{
+			ProviderID:    d.Entry.ProviderID,
+			ProviderName:  d.ProviderName,
+			Model:         d.Model,
+			Usable:        d.Usable,
+			SkipReason:    d.SkipReason,
+			Uptime:        opt(d.Uptime, -1),
+			LatencyMS:     opt(d.LatencyMS, 0),
+			TokensPerS:    opt(d.TokensPerS, 0),
+			OutputPerMTok: opt(d.OutputPerMTok, 0),
+		}
+		if d.Scored {
+			out[i].Score = &detail[i].Score
+			out[i].NormPrice = opt(d.NormPrice, -1)
+			out[i].NormLatency = opt(d.NormLatency, -1)
+			out[i].NormTPS = opt(d.NormTPS, -1)
+		}
+		if serving == nil && d.Usable {
+			entry := d.Entry
+			serving = &entry
+		}
+	}
+	return out, serving
 }
 
 func (a *Admin) Routes(ctx context.Context) ([]Route, error) {
@@ -509,7 +575,17 @@ func (a *Admin) Routes(ctx context.Context) ([]Route, error) {
 		}
 		out = append(out, r)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if snap := a.store.Snapshot(); snap != nil {
+		for i := range out {
+			if out[i].Enabled {
+				out[i].Resolved, out[i].Serving = resolvedForRoute(snap, out[i].Name)
+			}
+		}
+	}
+	return out, nil
 }
 
 // RoutePatch reorders/replaces a route's chain, changes its strategy,

--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -363,6 +363,14 @@ func TestRoutePatchValidatesProviderRefs(t *testing.T) {
 			if len(r.Chain) != 2 || r.Chain[0].Model != "m2" {
 				t.Fatalf("chain = %+v, want reordered [m2 m1]", r.Chain)
 			}
+			// PatchRoute reloaded the snapshot, so the enabled route
+			// carries the router's resolved view.
+			if len(r.Resolved) != 2 || !r.Resolved[0].Usable {
+				t.Fatalf("resolved = %+v, want 2 usable entries", r.Resolved)
+			}
+			if r.Serving == nil || r.Serving.Model != "m2" {
+				t.Fatalf("serving = %+v, want m2", r.Serving)
+			}
 			return
 		}
 	}

--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -339,6 +339,7 @@ func TestRoutePatchValidatesProviderRefs(t *testing.T) {
 	id, err := adm.Create(ctx, Provider{
 		Name: adminMarker + "route", Kind: "api", Driver: "openaicompat",
 		BaseURL: "https://example.invalid/v1", DefaultModel: "m1",
+		Enabled: true,
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)

--- a/internal/gateway/admin/admin_routes_test.go
+++ b/internal/gateway/admin/admin_routes_test.go
@@ -1,0 +1,124 @@
+package admin
+
+import (
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/router"
+)
+
+func routesSnapshot(t *testing.T, strategy string) *router.Snapshot {
+	t.Helper()
+	provRows := []router.ProviderRow{
+		{ID: "p1", Name: "pricey", Kind: "api", Driver: "openaicompat",
+			BaseURL: "https://a.example/v1", DefaultModel: "big", CredentialRef: "K1", Enabled: true,
+			Models: []router.ModelInfo{{ID: "big", Prices: &router.ModelPrices{OutputPerMTok: 25}}}},
+		{ID: "p2", Name: "cheap", Kind: "api", Driver: "openaicompat",
+			BaseURL: "https://b.example/v1", DefaultModel: "small", CredentialRef: "K2", Enabled: true,
+			Models: []router.ModelInfo{{ID: "small", Prices: &router.ModelPrices{OutputPerMTok: 1}}}},
+		{ID: "p3", Name: "off", Kind: "api", Driver: "openaicompat",
+			BaseURL: "https://c.example/v1", DefaultModel: "m", CredentialRef: "K3", Enabled: false},
+	}
+	routeRows := []router.RouteRow{{Name: "r", Strategy: strategy, Enabled: true, Chain: []router.ChainEntry{
+		{ProviderID: "p1", Model: "big"},
+		{ProviderID: "p3", Model: "m"},
+		{ProviderID: "p2", Model: "small"},
+	}}}
+	snap, err := router.BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
+	if err != nil {
+		t.Fatalf("BuildSnapshot: %v", err)
+	}
+	return snap
+}
+
+func TestResolvedForRouteOrdered(t *testing.T) {
+	t.Parallel()
+	snap := routesSnapshot(t, "ordered")
+	snap.SetStats(map[string]router.ModelStats{
+		"pricey/big": {Uptime: 0.9, LatencyMS: 800, TokensPerS: 40},
+	})
+
+	resolved, serving := resolvedForRoute(snap, "r")
+	if len(resolved) != 3 {
+		t.Fatalf("resolved len = %d, want 3", len(resolved))
+	}
+	first := resolved[0]
+	if first.ProviderName != "pricey" || first.Model != "big" || !first.Usable {
+		t.Fatalf("first entry = %+v", first)
+	}
+	if first.Score != nil || first.NormPrice != nil {
+		t.Fatalf("ordered route carries scores: %+v", first)
+	}
+	if first.Uptime == nil || *first.Uptime != 0.9 || *first.LatencyMS != 800 || *first.TokensPerS != 40 {
+		t.Fatalf("raw stats not mapped: %+v", first)
+	}
+	if *first.OutputPerMTok != 25 {
+		t.Fatalf("price not mapped: %+v", first)
+	}
+	if resolved[1].Usable || resolved[1].SkipReason != "disabled" {
+		t.Fatalf("disabled entry = %+v", resolved[1])
+	}
+	// No ledger data and no data sentinels leak as zeros.
+	if third := resolved[2]; third.Uptime != nil || third.LatencyMS != nil || third.TokensPerS != nil {
+		t.Fatalf("no-data entry carries values: %+v", third)
+	}
+	if serving == nil || serving.ProviderID != "p1" || serving.Model != "big" {
+		t.Fatalf("serving = %+v, want p1/big", serving)
+	}
+}
+
+func TestResolvedForRouteScored(t *testing.T) {
+	t.Parallel()
+	snap := routesSnapshot(t, "price")
+
+	resolved, serving := resolvedForRoute(snap, "r")
+	if resolved[0].ProviderName != "cheap" {
+		t.Fatalf("price strategy did not sort cheap first: %+v", resolved)
+	}
+	first := resolved[0]
+	if first.Score == nil || first.NormPrice == nil || *first.NormPrice != 1 {
+		t.Fatalf("scored fields missing: %+v", first)
+	}
+	// No ledger data: latency/tps norms are nil, scored neutrally.
+	if first.NormLatency != nil || first.NormTPS != nil {
+		t.Fatalf("no-data norms leaked: %+v", first)
+	}
+	if serving == nil || serving.ProviderID != "p2" {
+		t.Fatalf("serving = %+v, want cheap (p2)", serving)
+	}
+}
+
+func TestResolvedForRouteSkipsAllUnusable(t *testing.T) {
+	t.Parallel()
+	// No credential resolves: every entry is unhealthy, nothing serves.
+	provRows := []router.ProviderRow{
+		{ID: "p1", Name: "dark", Kind: "api", Driver: "openaicompat",
+			BaseURL: "https://a.example/v1", DefaultModel: "m", CredentialRef: "MISSING", Enabled: true},
+	}
+	routeRows := []router.RouteRow{{Name: "r", Enabled: true, Chain: []router.ChainEntry{
+		{ProviderID: "p1", Model: "m"},
+	}}}
+	snap, err := router.BuildSnapshot(provRows, routeRows, func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("BuildSnapshot: %v", err)
+	}
+
+	resolved, serving := resolvedForRoute(snap, "r")
+	if len(resolved) != 1 || resolved[0].Usable {
+		t.Fatalf("resolved = %+v", resolved)
+	}
+	if resolved[0].SkipReason != "unhealthy: credential MISSING unresolved" {
+		t.Fatalf("skip reason = %q", resolved[0].SkipReason)
+	}
+	if serving != nil {
+		t.Fatalf("serving = %+v, want nil", serving)
+	}
+}
+
+func TestResolvedForRouteUnknownRoute(t *testing.T) {
+	t.Parallel()
+	snap := routesSnapshot(t, "ordered")
+	resolved, serving := resolvedForRoute(snap, "no-such-route")
+	if resolved != nil || serving != nil {
+		t.Fatalf("unknown route = %+v, %+v", resolved, serving)
+	}
+}

--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -193,22 +193,15 @@ func (s *Snapshot) Resolve(route, hint string, sticky Sticky) ([]Attempt, error)
 	seen := map[string]bool{} // "name/model" dedupe across hint + sticky + chain
 
 	add := func(row ProviderRow, model, source string) {
-		p, inRegistry := s.registry.Get(row.Name)
-		switch {
-		case !row.Enabled:
-			skipped = append(skipped, fmt.Sprintf("%s (disabled, %s)", row.Name, source))
-		case !s.healthy[row.Name]:
-			skipped = append(skipped, fmt.Sprintf("%s (unhealthy: credential %s unresolved, %s)", row.Name, row.CredentialRef, source))
-		case !inRegistry:
-			skipped = append(skipped, fmt.Sprintf("%s (not in registry, %s)", row.Name, source))
-		case !attemptCapable(p, row, model, required):
-			skipped = append(skipped, fmt.Sprintf("%s/%s (lacks %s capability, %s)", row.Name, model, required, source))
-		default:
-			key := row.Name + "/" + model
-			if !seen[key] {
-				seen[key] = true
-				attempts = append(attempts, Attempt{Provider: p, ProviderName: row.Name, Model: model})
-			}
+		p, subject, reason := s.entryGate(row, model, required)
+		if reason != "" {
+			skipped = append(skipped, fmt.Sprintf("%s (%s, %s)", subject, reason, source))
+			return
+		}
+		key := row.Name + "/" + model
+		if !seen[key] {
+			seen[key] = true
+			attempts = append(attempts, Attempt{Provider: p, ProviderName: row.Name, Model: model})
 		}
 	}
 
@@ -254,6 +247,25 @@ func (s *Snapshot) Resolve(route, hint string, sticky Sticky) ([]Attempt, error)
 	return attempts, nil
 }
 
+// entryGate applies the usability checks Resolve runs on every
+// candidate. It returns the built driver plus empty subject/reason when
+// usable, or a skip subject ("name", or "name/model" for capability
+// misses) and reason matching the NoRouteError wording.
+func (s *Snapshot) entryGate(row ProviderRow, model string, required provider.Capability) (provider.Provider, string, string) {
+	p, inRegistry := s.registry.Get(row.Name)
+	switch {
+	case !row.Enabled:
+		return nil, row.Name, "disabled"
+	case !s.healthy[row.Name]:
+		return nil, row.Name, fmt.Sprintf("unhealthy: credential %s unresolved", row.CredentialRef)
+	case !inRegistry:
+		return nil, row.Name, "not in registry"
+	case !attemptCapable(p, row, model, required):
+		return nil, row.Name + "/" + model, fmt.Sprintf("lacks %s capability", required)
+	}
+	return p, "", ""
+}
+
 // Strategy weights: relative importance of each additive factor,
 // normalized against the best candidate in the chain (the llmgateway
 // scheme). price dominates "price", latency dominates "latency",
@@ -267,80 +279,131 @@ var strategyWeights = map[string]struct{ price, latency, tps float64 }{
 	"latency": {price: 0.1, latency: 0.6, tps: 0.1},
 }
 
-// orderedChain returns a route's chain in try order: written order for
-// "ordered" (or unknown) strategies, descending score otherwise.
-func (s *Snapshot) orderedChain(route string) []ChainEntry {
+// ResolvedEntry is one chain candidate in router try order, annotated
+// with the usability gate Resolve applies and the factors the scored
+// strategies use. Sentinels: Uptime and the Norm* fields are -1 when
+// the ledger has no data (scoring treats the factor as neutral); raw
+// LatencyMS, TokensPerS, and OutputPerMTok are 0 when unknown — an
+// absent price stays absent, never guessed.
+type ResolvedEntry struct {
+	Entry         ChainEntry
+	ProviderName  string // empty when the provider id is unknown
+	Model         string // entry model, defaulted to the provider's default when empty
+	Usable        bool
+	SkipReason    string  // empty when usable; NoRouteError wording without the source suffix
+	Scored        bool    // false for "ordered" (or unknown) strategies
+	Score         float64 // uptime-multiplied total; 0 when not scored
+	NormPrice     float64 // best-in-chain normalized, 0..1
+	NormLatency   float64
+	NormTPS       float64
+	Uptime        float64 // raw weighted success rate, 0..1
+	LatencyMS     float64 // raw weighted mean latency
+	TokensPerS    float64 // raw weighted output tokens per second
+	OutputPerMTok float64 // declared output price used for scoring
+}
+
+// ResolveDetail returns a route's chain in the exact try order
+// orderedChain produces, annotated for observability. It is the single
+// scoring path: written order for "ordered" (or unknown) strategies,
+// descending score otherwise. Only enabled routes exist in the
+// snapshot; unknown routes return an empty slice.
+func (s *Snapshot) ResolveDetail(route string) []ResolvedEntry {
 	chain := s.routes[route]
 	w, scoredStrategy := strategyWeights[s.strategy[route]]
-	if !scoredStrategy || len(chain) < 2 {
-		return chain
-	}
+	required := requiredCapability(route)
 
 	// Gather each entry's raw factors first: normalization needs the
 	// best value across the candidate set.
-	type cand struct {
-		entry   ChainEntry
-		price   float64 // declared output price; 0 = unknown
-		uptime  float64 // -1 = unknown
-		latency float64 // 0 = unknown
-		tps     float64 // 0 = unknown
-	}
-	cands := make([]cand, 0, len(chain))
+	out := make([]ResolvedEntry, 0, len(chain))
 	minPrice, minLatency, maxTPS := 0.0, 0.0, 0.0
 	for _, e := range chain {
-		c := cand{entry: e, uptime: -1}
-		if row, ok := s.rows[e.ProviderID]; ok {
-			if p := s.Prices(row.Name, e.Model); p != nil && p.OutputPerMTok > 0 {
-				c.price = p.OutputPerMTok
-				if minPrice == 0 || c.price < minPrice {
-					minPrice = c.price
-				}
-			}
-			if st, ok := s.stats[row.Name+"/"+e.Model]; ok {
-				c.uptime = st.Uptime
-				c.latency = st.LatencyMS
-				c.tps = st.TokensPerS
-				if c.latency > 0 && (minLatency == 0 || c.latency < minLatency) {
-					minLatency = c.latency
-				}
-				if c.tps > maxTPS {
-					maxTPS = c.tps
-				}
+		d := ResolvedEntry{
+			Entry: e, Model: e.Model, Scored: scoredStrategy,
+			Uptime: -1, NormPrice: -1, NormLatency: -1, NormTPS: -1,
+		}
+		row, ok := s.rows[e.ProviderID]
+		if !ok {
+			d.SkipReason = "unknown provider id"
+			out = append(out, d)
+			continue
+		}
+		d.ProviderName = row.Name
+		if d.Model == "" {
+			d.Model = row.DefaultModel
+		}
+		// Stats and prices are keyed by the raw entry model — same
+		// lookup Resolve's scoring has always used.
+		if p := s.Prices(row.Name, e.Model); p != nil && p.OutputPerMTok > 0 {
+			d.OutputPerMTok = p.OutputPerMTok
+			if minPrice == 0 || d.OutputPerMTok < minPrice {
+				minPrice = d.OutputPerMTok
 			}
 		}
-		cands = append(cands, c)
+		if st, ok := s.stats[row.Name+"/"+e.Model]; ok {
+			d.Uptime = st.Uptime
+			d.LatencyMS = st.LatencyMS
+			d.TokensPerS = st.TokensPerS
+			if d.LatencyMS > 0 && (minLatency == 0 || d.LatencyMS < minLatency) {
+				minLatency = d.LatencyMS
+			}
+			if d.TokensPerS > maxTPS {
+				maxTPS = d.TokensPerS
+			}
+		}
+		if _, _, reason := s.entryGate(row, d.Model, required); reason != "" {
+			d.SkipReason = reason
+		} else {
+			d.Usable = true
+		}
+		out = append(out, d)
+	}
+
+	if !scoredStrategy {
+		return out
 	}
 
 	const neutral = 0.5
-	score := func(c cand) float64 {
+	for i := range out {
+		d := &out[i]
 		total := 0.0
-		if c.price > 0 && minPrice > 0 {
-			total += w.price * (minPrice / c.price)
+		if d.OutputPerMTok > 0 && minPrice > 0 {
+			d.NormPrice = minPrice / d.OutputPerMTok
+			total += w.price * d.NormPrice
 		} else {
 			total += w.price * neutral
 		}
-		if c.latency > 0 && minLatency > 0 {
-			total += w.latency * (minLatency / c.latency)
+		if d.LatencyMS > 0 && minLatency > 0 {
+			d.NormLatency = minLatency / d.LatencyMS
+			total += w.latency * d.NormLatency
 		} else {
 			total += w.latency * neutral
 		}
-		if c.tps > 0 && maxTPS > 0 {
-			total += w.tps * (c.tps / maxTPS)
+		if d.TokensPerS > 0 && maxTPS > 0 {
+			d.NormTPS = d.TokensPerS / maxTPS
+			total += w.tps * d.NormTPS
 		} else {
 			total += w.tps * neutral
 		}
-		if c.uptime >= 0 {
+		if d.Uptime >= 0 {
 			// Multiplicative, floored so one bad minute can't zero a
 			// candidate out of consideration entirely.
-			total *= max(c.uptime, 0.05)
+			total *= max(d.Uptime, 0.05)
 		}
-		return total
+		d.Score = total
 	}
+	if len(chain) >= 2 {
+		sort.SliceStable(out, func(i, j int) bool { return out[i].Score > out[j].Score })
+	}
+	return out
+}
 
-	sort.SliceStable(cands, func(i, j int) bool { return score(cands[i]) > score(cands[j]) })
-	out := make([]ChainEntry, len(cands))
-	for i, c := range cands {
-		out[i] = c.entry
+// orderedChain returns a route's chain in try order: written order for
+// "ordered" (or unknown) strategies, descending score otherwise.
+func (s *Snapshot) orderedChain(route string) []ChainEntry {
+	detail := s.ResolveDetail(route)
+	out := make([]ChainEntry, len(detail))
+	for i, d := range detail {
+		out[i] = d.Entry
 	}
 	return out
 }

--- a/internal/gateway/router/router_test.go
+++ b/internal/gateway/router/router_test.go
@@ -394,6 +394,191 @@ func TestOrderedStrategyIgnoresStats(t *testing.T) {
 	}
 }
 
+func almostEqual(a, b float64) bool {
+	d := a - b
+	return d < 1e-9 && d > -1e-9
+}
+
+// An ordered route's detail keeps written order, is unscored, and
+// still carries the raw ledger stats for observability.
+func TestResolveDetailOrdered(t *testing.T) {
+	t.Parallel()
+	snap := testSnapshot(t, allKeys())
+	snap.SetStats(map[string]ModelStats{
+		"anthropic/sonnet": {Uptime: 0.9, LatencyMS: 800, TokensPerS: 40},
+	})
+
+	detail := snap.ResolveDetail("coding")
+	if len(detail) != 2 {
+		t.Fatalf("detail len = %d, want 2", len(detail))
+	}
+	if detail[0].ProviderName != "anthropic" || detail[1].ProviderName != "grok" {
+		t.Fatalf("order = %s,%s, want written order", detail[0].ProviderName, detail[1].ProviderName)
+	}
+	first := detail[0]
+	if first.Scored || first.Score != 0 {
+		t.Fatalf("ordered route scored: %+v", first)
+	}
+	if !first.Usable || first.SkipReason != "" {
+		t.Fatalf("healthy entry not usable: %+v", first)
+	}
+	if first.Uptime != 0.9 || first.LatencyMS != 800 || first.TokensPerS != 40 {
+		t.Fatalf("raw stats not carried: %+v", first)
+	}
+	if second := detail[1]; second.Uptime != -1 || second.LatencyMS != 0 {
+		t.Fatalf("no-data sentinels wrong: %+v", second)
+	}
+}
+
+// A scored route's detail matches Resolve's try order exactly and
+// exposes the normalized factors behind it.
+func TestResolveDetailScoredMatchesResolve(t *testing.T) {
+	provRows := []ProviderRow{
+		{ID: "p1", Name: "pricey", Kind: "api", Driver: "openaicompat",
+			BaseURL: "https://a.example/v1", DefaultModel: "big", CredentialRef: "K1", Enabled: true,
+			Models: []ModelInfo{{ID: "big", Prices: &ModelPrices{OutputPerMTok: 25}}}},
+		{ID: "p2", Name: "cheap", Kind: "api", Driver: "openaicompat",
+			BaseURL: "https://b.example/v1", DefaultModel: "small", CredentialRef: "K2", Enabled: true,
+			Models: []ModelInfo{{ID: "small", Prices: &ModelPrices{OutputPerMTok: 1}}}},
+	}
+	routeRows := []RouteRow{{Name: "r", Strategy: "price", Enabled: true, Chain: []ChainEntry{
+		{ProviderID: "p1", Model: "big"},
+		{ProviderID: "p2", Model: "small"},
+	}}}
+	snap, err := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
+	if err != nil {
+		t.Fatalf("BuildSnapshot: %v", err)
+	}
+
+	detail := snap.ResolveDetail("r")
+	attempts, err := snap.Resolve("r", "", Sticky{})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	for i := range detail {
+		if detail[i].ProviderName != attempts[i].ProviderName {
+			t.Fatalf("detail order diverges from Resolve at %d: %s vs %s",
+				i, detail[i].ProviderName, attempts[i].ProviderName)
+		}
+	}
+
+	cheap, pricey := detail[0], detail[1]
+	if cheap.ProviderName != "cheap" {
+		t.Fatalf("cheapest not first: %+v", detail)
+	}
+	if !cheap.Scored || !almostEqual(cheap.NormPrice, 1) || !almostEqual(pricey.NormPrice, 1.0/25) {
+		t.Fatalf("norm prices wrong: cheap=%+v pricey=%+v", cheap, pricey)
+	}
+	// price weights: 0.9 price + 0.02 latency + 0.02 tps, latency/tps
+	// neutral (0.5) with no ledger data, no uptime multiplier.
+	if !almostEqual(cheap.Score, 0.9+0.02) {
+		t.Fatalf("cheap score = %v", cheap.Score)
+	}
+	if !almostEqual(pricey.Score, 0.9/25+0.02) {
+		t.Fatalf("pricey score = %v", pricey.Score)
+	}
+}
+
+// Missing factors stay sentinel -1 and score neutrally; a near-dead
+// uptime is floored at 0.05 rather than zeroing the candidate.
+func TestResolveDetailNeutralAndFloor(t *testing.T) {
+	provRows := []ProviderRow{
+		{ID: "p1", Name: "quiet", Kind: "api", Driver: "openaicompat",
+			BaseURL: "https://a.example/v1", DefaultModel: "m1", CredentialRef: "K", Enabled: true,
+			Models: []ModelInfo{{ID: "m1"}}},
+		{ID: "p2", Name: "flaky", Kind: "api", Driver: "openaicompat",
+			BaseURL: "https://b.example/v1", DefaultModel: "m2", CredentialRef: "K", Enabled: true,
+			Models: []ModelInfo{{ID: "m2"}}},
+	}
+	routeRows := []RouteRow{{Name: "r", Strategy: "auto", Enabled: true, Chain: []ChainEntry{
+		{ProviderID: "p1", Model: "m1"},
+		{ProviderID: "p2", Model: "m2"},
+	}}}
+	snap, err := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
+	if err != nil {
+		t.Fatalf("BuildSnapshot: %v", err)
+	}
+	snap.SetStats(map[string]ModelStats{
+		"flaky/m2": {Uptime: 0.01, LatencyMS: 100, TokensPerS: 10},
+	})
+
+	detail := snap.ResolveDetail("r")
+	if detail[0].ProviderName != "quiet" {
+		t.Fatalf("floored candidate outranked neutral one: %+v", detail)
+	}
+	quiet, flaky := detail[0], detail[1]
+	if quiet.NormPrice != -1 || quiet.NormLatency != -1 || quiet.NormTPS != -1 || quiet.Uptime != -1 {
+		t.Fatalf("no-data sentinels wrong: %+v", quiet)
+	}
+	// auto weights: all factors neutral, no uptime multiplier.
+	if !almostEqual(quiet.Score, (0.6+0.1+0.05)*0.5) {
+		t.Fatalf("quiet score = %v", quiet.Score)
+	}
+	// flaky is best (only) latency and tps candidate, price neutral,
+	// then multiplied by the 0.05 uptime floor.
+	if !almostEqual(flaky.Score, (0.6*0.5+0.1+0.05)*0.05) {
+		t.Fatalf("flaky score = %v", flaky.Score)
+	}
+	if !almostEqual(flaky.NormLatency, 1) || !almostEqual(flaky.NormTPS, 1) {
+		t.Fatalf("flaky norms wrong: %+v", flaky)
+	}
+}
+
+// Unusable entries stay in the detail with the gate's reason: the UI
+// shows why an entry is skipped instead of hiding it.
+func TestResolveDetailUsability(t *testing.T) {
+	t.Parallel()
+	snap := testSnapshot(t, allKeys())
+
+	if d := snap.ResolveDetail("mini"); len(d) != 1 || d[0].Usable || d[0].SkipReason != "disabled" {
+		t.Fatalf("disabled provider detail = %+v", d)
+	}
+	if d := snap.ResolveDetail("ghost"); len(d) != 1 || d[0].Usable || d[0].SkipReason != "unknown provider id" || d[0].ProviderName != "" {
+		t.Fatalf("unknown provider detail = %+v", d)
+	}
+	if d := snap.ResolveDetail("embedding"); len(d) != 2 || d[0].Usable || d[0].SkipReason != "lacks embeddings capability" {
+		t.Fatalf("capability detail = %+v", d)
+	}
+	if d := snap.ResolveDetail("no-such-route"); len(d) != 0 {
+		t.Fatalf("unknown route detail = %+v", d)
+	}
+
+	unhealthy := testSnapshot(t, map[string]string{"X_KEY": "sk-x"}) // A_KEY unresolved
+	d := unhealthy.ResolveDetail("coding")
+	if d[0].Usable || d[0].SkipReason != "unhealthy: credential A_KEY unresolved" {
+		t.Fatalf("unhealthy detail = %+v", d[0])
+	}
+	if !d[1].Usable {
+		t.Fatalf("healthy entry marked unusable: %+v", d[1])
+	}
+}
+
+// A single-entry scored chain keeps written order (nothing to sort)
+// but still reports its score and factors.
+func TestResolveDetailSingleEntryScored(t *testing.T) {
+	provRows := []ProviderRow{
+		{ID: "p1", Name: "solo", Kind: "api", Driver: "openaicompat",
+			BaseURL: "https://a.example/v1", DefaultModel: "m", CredentialRef: "K", Enabled: true,
+			Models: []ModelInfo{{ID: "m", Prices: &ModelPrices{OutputPerMTok: 2}}}},
+	}
+	routeRows := []RouteRow{{Name: "r", Strategy: "price", Enabled: true, Chain: []ChainEntry{
+		{ProviderID: "p1", Model: "m"},
+	}}}
+	snap, err := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
+	if err != nil {
+		t.Fatalf("BuildSnapshot: %v", err)
+	}
+
+	d := snap.ResolveDetail("r")
+	if len(d) != 1 || !d[0].Scored {
+		t.Fatalf("detail = %+v", d)
+	}
+	// Sole candidate is its own best price; latency/tps neutral.
+	if !almostEqual(d[0].Score, 0.9+0.02) || !almostEqual(d[0].NormPrice, 1) {
+		t.Fatalf("solo score = %+v", d[0])
+	}
+}
+
 // Sticky moves a chain member to the front, but never smuggles in a
 // provider+model outside the chain.
 func TestStickyPrefersChainMemberOnly(t *testing.T) {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -248,6 +248,26 @@ export interface ChainEntry {
   model: string
 }
 
+// RouteEntryStatus is the router's live view of one chain entry: the
+// usability gate verdict plus the ledger stats and normalized factors
+// behind scored strategies. Numeric fields are absent when the ledger
+// has no data (or the model is unpriced) — never a guessed 0.
+export interface RouteEntryStatus {
+  provider_id: string
+  provider_name?: string
+  model: string
+  usable: boolean
+  skip_reason?: string
+  score?: number
+  norm_price?: number
+  norm_latency?: number
+  norm_tps?: number
+  uptime?: number
+  latency_ms?: number
+  tokens_per_s?: number
+  output_per_mtok?: number
+}
+
 export interface AdminRoute {
   name: string
   chain: ChainEntry[]
@@ -255,6 +275,10 @@ export interface AdminRoute {
   // score entries from recent ledger stats and declared prices.
   strategy: string
   enabled: boolean
+  // Router try order with live stats — present for enabled routes once
+  // a snapshot is loaded. serving is the first usable resolved entry.
+  resolved?: RouteEntryStatus[]
+  serving?: ChainEntry
 }
 
 export interface ProviderHealth {

--- a/web/src/components/settings/RouteEdit.test.tsx
+++ b/web/src/components/settings/RouteEdit.test.tsx
@@ -1,0 +1,192 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AdminProvider, AdminRoute } from '../../api/types'
+import { RouteEdit } from './RouteEdit'
+
+vi.mock('../../api/client', () => ({
+  listRoutes: vi.fn(),
+  listProviders: vi.fn(),
+  patchRoute: vi.fn(),
+}))
+
+import { listProviders, listRoutes, patchRoute } from '../../api/client'
+
+const providers: AdminProvider[] = [
+  {
+    id: 'p1', name: 'anthropic', kind: 'api', driver: 'anthropic', base_url: '',
+    default_model: 'sonnet', models: [{ id: 'sonnet' }], credential_ref: 'A_KEY',
+    headers: {}, enabled: true,
+  },
+  {
+    id: 'p2', name: 'grok', kind: 'api', driver: 'openaicompat', base_url: 'https://x.example/v1',
+    default_model: 'grok-4', models: [{ id: 'grok-4' }], credential_ref: 'X_KEY',
+    headers: {}, enabled: true,
+  },
+]
+
+const orderedRoute: AdminRoute = {
+  name: 'default',
+  strategy: 'ordered',
+  enabled: true,
+  chain: [
+    { provider_id: 'p1', model: 'sonnet' },
+    { provider_id: 'p2', model: 'grok-4' },
+  ],
+  resolved: [
+    {
+      provider_id: 'p1', provider_name: 'anthropic', model: 'sonnet', usable: true,
+      latency_ms: 812, uptime: 0.98, output_per_mtok: 15,
+    },
+    {
+      provider_id: 'p2', provider_name: 'grok', model: 'grok-4', usable: false,
+      skip_reason: 'unhealthy: credential X_KEY unresolved',
+    },
+  ],
+  serving: { provider_id: 'p1', model: 'sonnet' },
+}
+
+const scoredRoute: AdminRoute = {
+  ...orderedRoute,
+  name: 'summarize',
+  strategy: 'price',
+  // Router order: grok (cheaper) first, opposite of the written chain.
+  resolved: [
+    {
+      provider_id: 'p2', provider_name: 'grok', model: 'grok-4', usable: true,
+      score: 0.92, norm_price: 1, output_per_mtok: 1,
+    },
+    {
+      provider_id: 'p1', provider_name: 'anthropic', model: 'sonnet', usable: true,
+      score: 0.056, norm_price: 0.04, output_per_mtok: 25,
+    },
+  ],
+  serving: { provider_id: 'p2', model: 'grok-4' },
+}
+
+function renderRoute(name: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/settings/routes/${name}`]}>
+      <Routes>
+        <Route path="/settings/routes/:name" element={<RouteEdit />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(listRoutes).mockResolvedValue([orderedRoute, scoredRoute])
+  vi.mocked(listProviders).mockResolvedValue(providers)
+  vi.mocked(patchRoute).mockResolvedValue(undefined)
+})
+
+describe('RouteEdit ordered pipeline', () => {
+  it('shows the serving entry from the router, not a guess', async () => {
+    renderRoute('default')
+    await screen.findByTestId('pipeline')
+    expect(screen.getByText('serving').closest('[data-testid="pipeline-card"]')).toHaveTextContent(
+      'anthropic',
+    )
+  })
+
+  it('surfaces the skip reason on an unusable entry', async () => {
+    renderRoute('default')
+    await screen.findByTestId('pipeline')
+    expect(screen.getAllByText('unhealthy: credential X_KEY unresolved').length).toBeGreaterThan(0)
+  })
+
+  it('renders stats, and unpriced instead of $0', async () => {
+    renderRoute('default')
+    const cards = await screen.findAllByTestId('pipeline-card')
+    expect(cards[0]).toHaveTextContent('812 ms')
+    expect(cards[0]).toHaveTextContent('$15/MTok')
+    expect(cards[0]).toHaveTextContent('98%')
+    expect(cards[1]).toHaveTextContent('unpriced')
+  })
+
+  it('arrow button reorders via a single PATCH', async () => {
+    renderRoute('default')
+    await screen.findByTestId('pipeline')
+    fireEvent.click(screen.getByRole('button', { name: 'Move sonnet right' }))
+    await waitFor(() =>
+      expect(patchRoute).toHaveBeenCalledWith('default', {
+        chain: [
+          { provider_id: 'p2', model: 'grok-4' },
+          { provider_id: 'p1', model: 'sonnet' },
+        ],
+      }),
+    )
+    expect(patchRoute).toHaveBeenCalledTimes(1)
+  })
+
+  it('pointer drag commits one PATCH with the new order', async () => {
+    renderRoute('default')
+    const cards = await screen.findAllByTestId('pipeline-card')
+    cards.forEach((card, i) => {
+      const wrapper = card.parentElement as HTMLElement
+      wrapper.getBoundingClientRect = () =>
+        ({ left: i * 100, width: 100, right: i * 100 + 100, top: 0, bottom: 50, height: 50, x: i * 100, y: 0 }) as DOMRect
+    })
+    fireEvent.pointerDown(cards[0], { clientX: 10, button: 0 })
+    fireEvent.pointerMove(window, { clientX: 180 })
+    fireEvent.pointerUp(window)
+    await waitFor(() =>
+      expect(patchRoute).toHaveBeenCalledWith('default', {
+        chain: [
+          { provider_id: 'p2', model: 'grok-4' },
+          { provider_id: 'p1', model: 'sonnet' },
+        ],
+      }),
+    )
+    expect(patchRoute).toHaveBeenCalledTimes(1)
+  })
+
+  it('Escape cancels a drag without a PATCH', async () => {
+    renderRoute('default')
+    const cards = await screen.findAllByTestId('pipeline-card')
+    cards.forEach((card, i) => {
+      const wrapper = card.parentElement as HTMLElement
+      wrapper.getBoundingClientRect = () =>
+        ({ left: i * 100, width: 100, right: i * 100 + 100, top: 0, bottom: 50, height: 50, x: i * 100, y: 0 }) as DOMRect
+    })
+    fireEvent.pointerDown(cards[0], { clientX: 10, button: 0 })
+    fireEvent.pointerMove(window, { clientX: 180 })
+    fireEvent.keyDown(window, { key: 'Escape' })
+    fireEvent.pointerUp(window)
+    expect(patchRoute).not.toHaveBeenCalled()
+  })
+
+  it('removes an entry', async () => {
+    renderRoute('default')
+    await screen.findByTestId('pipeline')
+    fireEvent.click(screen.getByRole('button', { name: 'Remove grok-4' }))
+    await waitFor(() =>
+      expect(patchRoute).toHaveBeenCalledWith('default', {
+        chain: [{ provider_id: 'p1', model: 'sonnet' }],
+      }),
+    )
+  })
+})
+
+describe('RouteEdit scored pipeline', () => {
+  it('renders the resolved order with score bars and no reorder controls', async () => {
+    renderRoute('summarize')
+    const cards = await screen.findAllByTestId('pipeline-card')
+    // Router order (cheap grok first), not written chain order.
+    expect(cards[0]).toHaveTextContent('grok')
+    expect(cards[1]).toHaveTextContent('anthropic')
+    expect(screen.getAllByTestId('score-fill')).toHaveLength(2)
+    expect(screen.queryByRole('button', { name: /Move .* (left|right)/ })).toBeNull()
+    expect(screen.getByText('auto-sorted by score')).toBeInTheDocument()
+  })
+
+  it('serving chip follows the router order', async () => {
+    renderRoute('summarize')
+    await screen.findByTestId('pipeline')
+    expect(screen.getByText('serving').closest('[data-testid="pipeline-card"]')).toHaveTextContent(
+      'grok',
+    )
+  })
+})

--- a/web/src/components/settings/RouteEdit.tsx
+++ b/web/src/components/settings/RouteEdit.tsx
@@ -1,15 +1,10 @@
-import {
-  ArrowDown01Icon,
-  ArrowLeft01Icon,
-  ArrowUp01Icon,
-  Delete02Icon,
-} from '@hugeicons-pro/core-stroke-rounded'
+import { ArrowLeft01Icon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useCallback, useEffect, useState } from 'react'
 import { Link, Navigate, useParams } from 'react-router'
 import { toast } from 'sonner'
-import { listProviders, listRoutes, patchRoute, providersHealth } from '../../api/client'
-import type { AdminProvider, AdminRoute, ChainEntry, ProviderHealth } from '../../api/types'
+import { listProviders, listRoutes, patchRoute } from '../../api/client'
+import type { AdminProvider, AdminRoute, ChainEntry } from '../../api/types'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import {
@@ -19,21 +14,23 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../ui/select'
+import { Pipeline, type PipelineEntry } from './pipeline/Pipeline'
+import { reorder } from './pipeline/useReorderDrag'
 import { Field, Toggle } from './shared'
 import { errText } from './util'
+
+const scoredStrategies = ['auto', 'price', 'latency']
 
 export function RouteEdit() {
   const { name } = useParams()
   const [route, setRoute] = useState<AdminRoute | null | undefined>(undefined)
   const [providers, setProviders] = useState<AdminProvider[]>([])
-  const [health, setHealth] = useState<Record<string, ProviderHealth>>({})
 
   const refresh = useCallback(() => {
-    Promise.all([listRoutes(), listProviders(), providersHealth()])
-      .then(([routes, p, h]) => {
+    Promise.all([listRoutes(), listProviders()])
+      .then(([routes, p]) => {
         setRoute(routes.find((r) => r.name === name) ?? null)
         setProviders(p)
-        setHealth(Object.fromEntries(h.map((x) => [x.name, x])))
       })
       .catch((err: unknown) => toast.error('Could not load route', { description: errText(err) }))
   }, [name])
@@ -43,17 +40,47 @@ export function RouteEdit() {
   if (route === undefined) return null
 
   const nameOf = (id: string) => providers.find((p) => p.id === id)?.name ?? id.slice(0, 8)
-  const serving = route.enabled
-    ? route.chain.find((e) => {
-        const p = providers.find((x) => x.id === e.provider_id)
-        return p?.enabled && health[p.name]?.healthy
-      })
-    : undefined
+  const scored = scoredStrategies.includes(route.strategy)
+  const serving = route.serving
 
   const save = (patch: { chain?: ChainEntry[]; strategy?: string; enabled?: boolean }) => {
     patchRoute(route.name, patch).then(refresh, (err: unknown) =>
       toast.error('Could not update route', { description: errText(err) }),
     )
+  }
+
+  // Display order: the router's resolved order for scored strategies
+  // (what actually gets tried), written chain order otherwise — where
+  // resolved lines up index-for-index because ordered routes never
+  // re-sort. Chain entry references are preserved so edits map back.
+  const displayEntries: PipelineEntry[] = (() => {
+    if (scored && route.resolved) {
+      const pool = [...route.chain]
+      return route.resolved.map((s) => {
+        const i = pool.findIndex(
+          (c) => c.provider_id === s.provider_id && (c.model === s.model || c.model === ''),
+        )
+        const entry = i >= 0 ? pool.splice(i, 1)[0] : { provider_id: s.provider_id, model: s.model }
+        return { entry, status: s }
+      })
+    }
+    return route.chain.map((e, i) => ({ entry: e, status: route.resolved?.[i] }))
+  })()
+
+  // Reorder positions are display positions; drag and arrows are only
+  // live for ordered routes, where display order IS chain order.
+  const moveEntry = (from: number, to: number) => {
+    if (to < 0 || to >= route.chain.length || from === to) return
+    save({ chain: reorder(route.chain, from, to) })
+  }
+  const removeEntry = (displayIndex: number) => {
+    const target = displayEntries[displayIndex].entry
+    const i = route.chain.indexOf(target)
+    const chain =
+      i >= 0
+        ? route.chain.filter((_, j) => j !== i)
+        : route.chain.filter((c) => !(c.provider_id === target.provider_id && c.model === target.model))
+    save({ chain })
   }
 
   return (
@@ -94,60 +121,25 @@ export function RouteEdit() {
         <Toggle on={route.enabled} onChange={(v) => save({ enabled: v })} label={`${route.name} route enabled`} />
       </div>
 
-      <div className="max-w-2xl space-y-4">
-        <h2 className="text-sm font-semibold">Chain</h2>
-        <ol className="space-y-2">
-          {route.chain.map((e, i) => (
-            <li
-              key={`${e.provider_id}-${e.model}-${i}`}
-              className="flex items-center gap-3 rounded-lg border border-border px-3 py-2.5 text-sm"
-            >
-              <span className="w-5 text-xs text-muted-foreground">{i + 1}.</span>
-              <span className="min-w-0 flex-1 truncate">
-                {nameOf(e.provider_id)} / <span className="font-mono">{e.model}</span>
-              </span>
-              <span className="flex items-center gap-1">
-                <button
-                  type="button"
-                  aria-label={`Move ${e.model} up`}
-                  disabled={i === 0}
-                  onClick={() => {
-                    const chain = [...route.chain]
-                    ;[chain[i - 1], chain[i]] = [chain[i], chain[i - 1]]
-                    save({ chain })
-                  }}
-                  className="text-muted-foreground hover:text-foreground disabled:opacity-30"
-                >
-                  <HugeiconsIcon icon={ArrowUp01Icon} className="size-4" />
-                </button>
-                <button
-                  type="button"
-                  aria-label={`Move ${e.model} down`}
-                  disabled={i === route.chain.length - 1}
-                  onClick={() => {
-                    const chain = [...route.chain]
-                    ;[chain[i], chain[i + 1]] = [chain[i + 1], chain[i]]
-                    save({ chain })
-                  }}
-                  className="text-muted-foreground hover:text-foreground disabled:opacity-30"
-                >
-                  <HugeiconsIcon icon={ArrowDown01Icon} className="size-4" />
-                </button>
-                <button
-                  type="button"
-                  aria-label={`Remove ${e.model}`}
-                  onClick={() => save({ chain: route.chain.filter((_, j) => j !== i) })}
-                  className="text-muted-foreground hover:text-destructive"
-                >
-                  <HugeiconsIcon icon={Delete02Icon} className="size-4" />
-                </button>
-              </span>
-            </li>
-          ))}
-          {route.chain.length === 0 && (
-            <li className="text-sm text-muted-foreground">No providers in this chain yet.</li>
+      <div className="space-y-4">
+        <div className="flex items-center gap-3">
+          <h2 className="text-sm font-semibold">Chain</h2>
+          {scored ? (
+            <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+              auto-sorted by score
+            </span>
+          ) : (
+            <span className="text-xs text-muted-foreground">drag cards to set priority</span>
           )}
-        </ol>
+        </div>
+        <Pipeline
+          entries={displayEntries}
+          scored={scored}
+          serving={serving}
+          providers={providers}
+          onReorder={moveEntry}
+          onRemove={removeEntry}
+        />
         <AddChainEntry providers={providers} onAdd={(entry) => save({ chain: [...route.chain, entry] })} />
       </div>
     </div>

--- a/web/src/components/settings/RoutesList.test.tsx
+++ b/web/src/components/settings/RoutesList.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AdminProvider, AdminRoute } from '../../api/types'
+import { RoutesList } from './RoutesList'
+
+vi.mock('../../api/client', () => ({
+  listRoutes: vi.fn(),
+  listProviders: vi.fn(),
+  patchRoute: vi.fn(),
+}))
+
+import { listProviders, listRoutes } from '../../api/client'
+
+const providers: AdminProvider[] = [
+  {
+    id: 'p1', name: 'anthropic', kind: 'api', driver: 'anthropic', base_url: '',
+    default_model: 'sonnet', models: [], credential_ref: 'A_KEY', headers: {}, enabled: true,
+  },
+]
+
+const base: AdminRoute = {
+  name: 'default',
+  strategy: 'ordered',
+  enabled: true,
+  chain: [{ provider_id: 'p1', model: 'sonnet' }],
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(listProviders).mockResolvedValue(providers)
+})
+
+function renderList() {
+  return render(
+    <MemoryRouter>
+      <RoutesList />
+    </MemoryRouter>,
+  )
+}
+
+describe('RoutesList serving states', () => {
+  it('shows the router-resolved serving entry', async () => {
+    vi.mocked(listRoutes).mockResolvedValue([
+      {
+        ...base,
+        resolved: [{ provider_id: 'p1', provider_name: 'anthropic', model: 'sonnet', usable: true }],
+        serving: { provider_id: 'p1', model: 'sonnet' },
+      },
+    ])
+    renderList()
+    expect(await screen.findByText('sonnet')).toBeInTheDocument()
+    expect(screen.getByText(/serving/)).toBeInTheDocument()
+  })
+
+  it('warns when nothing is usable', async () => {
+    vi.mocked(listRoutes).mockResolvedValue([
+      {
+        ...base,
+        resolved: [{ provider_id: 'p1', model: 'sonnet', usable: false, skip_reason: 'disabled' }],
+      },
+    ])
+    renderList()
+    expect(await screen.findByText('no usable provider')).toBeInTheDocument()
+  })
+
+  it('marks a disabled route', async () => {
+    vi.mocked(listRoutes).mockResolvedValue([{ ...base, enabled: false }])
+    renderList()
+    expect(await screen.findByText('disabled')).toBeInTheDocument()
+  })
+
+  it('shows a loading state before the snapshot has stats', async () => {
+    vi.mocked(listRoutes).mockResolvedValue([base])
+    renderList()
+    expect(await screen.findByText('stats loading…')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/settings/RoutesList.tsx
+++ b/web/src/components/settings/RoutesList.tsx
@@ -1,39 +1,27 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
-import { listProviders, listRoutes, patchRoute, providersHealth } from '../../api/client'
-import type { AdminProvider, AdminRoute, ChainEntry, ProviderHealth } from '../../api/types'
+import { listProviders, listRoutes, patchRoute } from '../../api/client'
+import type { AdminProvider, AdminRoute } from '../../api/types'
 import { Toggle } from './shared'
 import { errText } from './util'
 
 export function RoutesList() {
   const [routes, setRoutes] = useState<AdminRoute[]>([])
   const [providers, setProviders] = useState<AdminProvider[]>([])
-  const [health, setHealth] = useState<Record<string, ProviderHealth>>({})
   const navigate = useNavigate()
 
   const refresh = useCallback(() => {
-    Promise.all([listRoutes(), listProviders(), providersHealth()])
-      .then(([r, p, h]) => {
+    Promise.all([listRoutes(), listProviders()])
+      .then(([r, p]) => {
         setRoutes(r)
         setProviders(p)
-        setHealth(Object.fromEntries(h.map((x) => [x.name, x])))
       })
       .catch((err: unknown) => toast.error('Could not load routes', { description: errText(err) }))
   }, [])
   useEffect(refresh, [refresh])
 
   const nameOf = (id: string) => providers.find((p) => p.id === id)?.name ?? id.slice(0, 8)
-
-  // servingEntry mirrors the router: first chain entry whose provider
-  // is enabled and credential-healthy serves the request.
-  const servingEntry = (r: AdminRoute): ChainEntry | undefined =>
-    r.enabled
-      ? r.chain.find((e) => {
-          const p = providers.find((x) => x.id === e.provider_id)
-          return p?.enabled && health[p.name]?.healthy
-        })
-      : undefined
 
   const toggle = (r: AdminRoute, enabled: boolean) => {
     patchRoute(r.name, { enabled }).then(refresh, (err: unknown) =>
@@ -50,7 +38,8 @@ export function RoutesList() {
 
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {routes.map((r) => {
-          const serving = servingEntry(r)
+          // The router's own verdict: first usable entry in try order.
+          const serving = r.serving
           return (
             <button
               key={r.name}
@@ -72,10 +61,12 @@ export function RoutesList() {
                   serving <span className="text-foreground">{nameOf(serving.provider_id)}</span> /{' '}
                   <span className="font-mono text-foreground">{serving.model}</span>
                 </p>
+              ) : !r.enabled ? (
+                <p className="text-xs font-medium text-warning">disabled</p>
+              ) : r.resolved ? (
+                <p className="text-xs font-medium text-warning">no usable provider</p>
               ) : (
-                <p className="text-xs font-medium text-warning">
-                  {r.enabled ? 'no usable provider' : 'disabled'}
-                </p>
+                <p className="text-xs text-muted-foreground">stats loading…</p>
               )}
               <p className="text-xs text-muted-foreground">{r.chain.length} provider(s) in chain</p>
             </button>

--- a/web/src/components/settings/pipeline/Pipeline.tsx
+++ b/web/src/components/settings/pipeline/Pipeline.tsx
@@ -1,0 +1,91 @@
+import { ArrowRight02Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { Fragment } from 'react'
+import type { AdminProvider, ChainEntry, RouteEntryStatus } from '../../../api/types'
+import { PipelineCard } from './PipelineCard'
+import { reorder, useReorderDrag } from './useReorderDrag'
+
+// One card of the pipeline: the raw chain entry plus the router's
+// live status for it, when known.
+export interface PipelineEntry {
+  entry: ChainEntry
+  status?: RouteEntryStatus
+}
+
+export function Pipeline({
+  entries,
+  scored,
+  serving,
+  providers,
+  onReorder,
+  onRemove,
+}: {
+  entries: PipelineEntry[]
+  scored: boolean
+  serving?: ChainEntry
+  providers: AdminProvider[]
+  // from/to are positions in the DISPLAYED order; the parent maps them
+  // back to chain indices (identical for ordered routes).
+  onReorder: (from: number, to: number) => void
+  onRemove: (displayIndex: number) => void
+}) {
+  const { dragIndex, overIndex, handleProps, setItemRef } = useReorderDrag({
+    disabled: scored,
+    onCommit: onReorder,
+  })
+
+  // Live preview: show the list as it would land if dropped here.
+  const display =
+    dragIndex !== null && overIndex !== null && overIndex !== dragIndex
+      ? reorder(entries, dragIndex, overIndex)
+      : entries
+  const previewing = display !== entries
+
+  const maxScore = Math.max(0, ...entries.map((e) => e.status?.score ?? 0))
+  const providerOf = (id: string) => providers.find((p) => p.id === id)
+
+  if (entries.length === 0) {
+    return <p className="text-sm text-muted-foreground">No providers in this chain yet.</p>
+  }
+
+  return (
+    <div className="flex items-center gap-2 overflow-x-auto pb-2" data-testid="pipeline">
+      {display.map((e, i) => {
+        const original = entries.indexOf(e)
+        const provider = providerOf(e.entry.provider_id)
+        const isServing =
+          !previewing &&
+          serving !== undefined &&
+          serving.provider_id === e.entry.provider_id &&
+          serving.model === e.entry.model
+        return (
+          <Fragment key={`${e.entry.provider_id}-${e.entry.model}-${original}`}>
+            {i > 0 && (
+              <HugeiconsIcon
+                icon={ArrowRight02Icon}
+                className="size-4 shrink-0 text-muted-foreground/60"
+                aria-hidden="true"
+              />
+            )}
+            <div ref={setItemRef(i)} {...handleProps(original)}>
+              <PipelineCard
+                provider={provider}
+                name={e.status?.provider_name ?? provider?.name ?? e.entry.provider_id.slice(0, 8)}
+                model={e.status?.model ?? e.entry.model}
+                status={e.status}
+                serving={isServing}
+                scored={scored}
+                maxScore={maxScore}
+                index={original}
+                count={entries.length}
+                onMove={onReorder}
+                onRemove={() => onRemove(original)}
+                dragging={dragIndex === original}
+              />
+            </div>
+          </Fragment>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/src/components/settings/pipeline/PipelineCard.tsx
+++ b/web/src/components/settings/pipeline/PipelineCard.tsx
@@ -1,0 +1,124 @@
+import {
+  ArrowLeft01Icon,
+  ArrowRight01Icon,
+  Delete02Icon,
+} from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import type { AdminProvider, RouteEntryStatus } from '../../../api/types'
+import { matchPreset } from '../presets'
+import { ProviderLogo } from '../ProviderLogo'
+import { ScoreBar } from './ScoreBar'
+
+const fmtLatency = (v?: number) => (v === undefined ? '—' : `${Math.round(v)} ms`)
+const fmtPrice = (v?: number) => (v === undefined ? 'unpriced' : `$${v}/MTok`)
+const fmtUptime = (v?: number) => (v === undefined ? '—' : `${Math.round(v * 100)}%`)
+
+export function PipelineCard({
+  provider,
+  name,
+  model,
+  status,
+  serving,
+  scored,
+  maxScore,
+  index,
+  count,
+  onMove,
+  onRemove,
+  dragging,
+}: {
+  provider?: AdminProvider
+  name: string
+  model: string
+  status?: RouteEntryStatus
+  serving: boolean
+  scored: boolean
+  maxScore: number
+  index: number
+  count: number
+  onMove: (from: number, to: number) => void
+  onRemove: () => void
+  dragging?: boolean
+}) {
+  const usable = status ? status.usable : true
+  return (
+    <div
+      data-testid="pipeline-card"
+      className={`w-56 shrink-0 select-none space-y-2.5 rounded-xl border border-border bg-card p-4 shadow-sm transition ${
+        dragging ? 'opacity-60 ring-2 ring-brand' : ''
+      } ${scored ? '' : 'cursor-grab'}`}
+    >
+      <div className="flex items-center gap-2.5">
+        {provider && <ProviderLogo preset={matchPreset(provider)} className="size-7" />}
+        <span className="min-w-0 flex-1 truncate text-sm font-semibold">{name}</span>
+        <span
+          data-testid="health-dot"
+          title={status?.skip_reason}
+          className={`size-1.5 shrink-0 rounded-full ${usable ? 'bg-good' : 'bg-warning'}`}
+        />
+      </div>
+      <p className="truncate font-mono text-xs text-muted-foreground" title={model}>
+        {model || '(default model)'}
+      </p>
+      <dl className="grid grid-cols-3 gap-1 text-[10px] text-muted-foreground">
+        <div>
+          <dt>latency</dt>
+          <dd className="font-mono text-foreground">{fmtLatency(status?.latency_ms)}</dd>
+        </div>
+        <div>
+          <dt>price</dt>
+          <dd className="font-mono text-foreground">{fmtPrice(status?.output_per_mtok)}</dd>
+        </div>
+        <div>
+          <dt>uptime</dt>
+          <dd className="font-mono text-foreground">{fmtUptime(status?.uptime)}</dd>
+        </div>
+      </dl>
+      {scored && <ScoreBar score={status?.score} max={maxScore} />}
+      <div className="flex items-center gap-1">
+        {serving && (
+          <span className="rounded-4xl bg-good-soft px-2 py-0.5 text-[10px] font-medium text-good">
+            serving
+          </span>
+        )}
+        {!usable && status?.skip_reason && (
+          <span className="truncate text-[10px] text-warning" title={status.skip_reason}>
+            {status.skip_reason}
+          </span>
+        )}
+        <span className="ml-auto flex items-center gap-1">
+          {!scored && (
+            <>
+              <button
+                type="button"
+                aria-label={`Move ${model} left`}
+                disabled={index === 0}
+                onClick={() => onMove(index, index - 1)}
+                className="text-muted-foreground hover:text-foreground disabled:opacity-30"
+              >
+                <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+              </button>
+              <button
+                type="button"
+                aria-label={`Move ${model} right`}
+                disabled={index === count - 1}
+                onClick={() => onMove(index, index + 1)}
+                className="text-muted-foreground hover:text-foreground disabled:opacity-30"
+              >
+                <HugeiconsIcon icon={ArrowRight01Icon} className="size-4" />
+              </button>
+            </>
+          )}
+          <button
+            type="button"
+            aria-label={`Remove ${model}`}
+            onClick={onRemove}
+            className="text-muted-foreground hover:text-destructive"
+          >
+            <HugeiconsIcon icon={Delete02Icon} className="size-4" />
+          </button>
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/settings/pipeline/ScoreBar.tsx
+++ b/web/src/components/settings/pipeline/ScoreBar.tsx
@@ -1,0 +1,20 @@
+// ScoreBar renders a route entry's score against the best score in
+// its chain: the leader fills the track, everything else is relative.
+export function ScoreBar({ score, max }: { score?: number; max: number }) {
+  if (score === undefined) return null
+  const pct = max > 0 ? Math.max(2, Math.round((score / max) * 100)) : 0
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-1.5 min-w-0 flex-1 overflow-hidden rounded-full bg-muted">
+        <div
+          data-testid="score-fill"
+          className="h-full rounded-full bg-brand"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
+        {score.toFixed(2)}
+      </span>
+    </div>
+  )
+}

--- a/web/src/components/settings/pipeline/useReorderDrag.test.ts
+++ b/web/src/components/settings/pipeline/useReorderDrag.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { reorder, targetIndex } from './useReorderDrag'
+
+describe('targetIndex', () => {
+  const midpoints = [50, 150, 250]
+
+  it.each([
+    [0, 0], // left of everything
+    [49, 0],
+    [51, 1], // past the first midpoint
+    [151, 2],
+    [400, 2], // clamped to the last index
+  ])('pointer at %d → index %d', (x, want) => {
+    expect(targetIndex(midpoints, x)).toBe(want)
+  })
+
+  it('returns 0 for an empty list', () => {
+    expect(targetIndex([], 100)).toBe(0)
+  })
+})
+
+describe('reorder', () => {
+  it('moves an element forward', () => {
+    expect(reorder(['a', 'b', 'c'], 0, 2)).toEqual(['b', 'c', 'a'])
+  })
+  it('moves an element backward', () => {
+    expect(reorder(['a', 'b', 'c'], 2, 0)).toEqual(['c', 'a', 'b'])
+  })
+  it('does not mutate the input', () => {
+    const input = ['a', 'b']
+    reorder(input, 0, 1)
+    expect(input).toEqual(['a', 'b'])
+  })
+})

--- a/web/src/components/settings/pipeline/useReorderDrag.ts
+++ b/web/src/components/settings/pipeline/useReorderDrag.ts
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+// targetIndex maps a pointer x to a destination position among the
+// cards whose horizontal midpoints are given in display order: the
+// number of midpoints left of the pointer, clamped to a valid index.
+export function targetIndex(midpoints: number[], x: number): number {
+  if (midpoints.length === 0) return 0
+  let idx = 0
+  for (const m of midpoints) {
+    if (x > m) idx++
+  }
+  return Math.min(idx, midpoints.length - 1)
+}
+
+// reorder moves one element of a list, returning a new array.
+export function reorder<T>(list: T[], from: number, to: number): T[] {
+  const next = [...list]
+  const [item] = next.splice(from, 1)
+  next.splice(to, 0, item)
+  return next
+}
+
+const activationPx = 5
+
+// useReorderDrag is a dependency-free pointer-event drag for
+// horizontally laid-out cards. The caller registers each card element
+// via setItemRef and spreads handleProps(i) on its drag surface;
+// dragIndex/overIndex drive the live preview and onCommit fires once
+// on drop. Escape or pointercancel aborts.
+export function useReorderDrag({
+  disabled,
+  onCommit,
+}: {
+  disabled?: boolean
+  onCommit: (from: number, to: number) => void
+}) {
+  const [dragIndex, setDragIndex] = useState<number | null>(null)
+  const [overIndex, setOverIndex] = useState<number | null>(null)
+  const items = useRef<(HTMLElement | null)[]>([])
+  const gesture = useRef<{ from: number; startX: number; active: boolean } | null>(null)
+
+  const setItemRef = useCallback(
+    (i: number) => (el: HTMLElement | null) => {
+      items.current[i] = el
+    },
+    [],
+  )
+
+  const stop = useCallback(() => {
+    gesture.current = null
+    setDragIndex(null)
+    setOverIndex(null)
+  }, [])
+
+  useEffect(() => {
+    const onMove = (e: PointerEvent) => {
+      const g = gesture.current
+      if (!g) return
+      if (!g.active) {
+        if (Math.abs(e.clientX - g.startX) < activationPx) return
+        g.active = true
+        setDragIndex(g.from)
+      }
+      const midpoints = items.current
+        .filter((el): el is HTMLElement => el !== null)
+        .map((el) => {
+          const r = el.getBoundingClientRect()
+          return r.left + r.width / 2
+        })
+      setOverIndex(targetIndex(midpoints, e.clientX))
+    }
+    const onUp = () => {
+      const g = gesture.current
+      if (!g) return
+      if (g.active) {
+        // Read the latest preview position from state via the setter to
+        // avoid a stale closure over overIndex.
+        setOverIndex((over) => {
+          if (over !== null && over !== g.from) onCommit(g.from, over)
+          return null
+        })
+      }
+      gesture.current = null
+      setDragIndex(null)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') stop()
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+    window.addEventListener('pointercancel', stop)
+    window.addEventListener('keydown', onKey)
+    return () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      window.removeEventListener('pointercancel', stop)
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [onCommit, stop])
+
+  const handleProps = (i: number) => ({
+    onPointerDown: (e: React.PointerEvent<HTMLElement>) => {
+      if (disabled || e.button !== 0) return
+      // Buttons inside the card keep their own click behavior.
+      if ((e.target as HTMLElement).closest('button')) return
+      gesture.current = { from: i, startX: e.clientX, active: false }
+    },
+  })
+
+  return { dragIndex, overIndex, handleProps, setItemRef }
+}


### PR DESCRIPTION
## What

Replaces the text-based route editor with a visual pipeline and stops the UI guessing what serves.

**Gateway:** `orderedChain` now delegates to exported `Snapshot.ResolveDetail` — one scoring path, try order unchanged by construction. `GET /internal/admin/routes` gains `resolved` (per-entry gate verdict, skip reason, latency/uptime/tps, declared price, normalized factors + score for scored strategies) and `serving` (first usable entry in try order). Missing data serializes as `null`, never a guessed zero. No new endpoint, no brain allowlist change — the route was already proxied.

**Web:** route chains render as a horizontal pipeline of provider cards (logo, mono model, health dot with skip-reason tooltip, latency/price/uptime, serving chip). Ordered routes reorder by pointer drag — one PATCH per drop, arrow buttons kept as the keyboard path. Scored routes display the router's resolved order with score bars and an "auto-sorted by score" badge. Fixes the `servingEntry` heuristic (first-enabled-healthy), which was wrong for every scored strategy. Dependency-free drag — no dnd library added.

## Verification

- `make build test vet lint` — 0 issues
- Web: build, lint, 154 tests (13 new: pointer-drag commit/cancel, arrow reorder payloads, resolved-order rendering, score bars, unpriced rendering, serving states)
- New Go tests: `ResolveDetail` ordered/scored/neutral-and-floor/usability tables, Resolve↔ResolveDetail order parity, `resolvedForRoute` wire mapping, integration assertion on `Routes()`

## Notes

- Router scoring behavior is structurally unchanged (thin-wrapper refactor); parity test pins it.
- Skip strings preserved exactly — `NoRouteError` wording is user-visible.
- Disabled routes carry no `resolved`/`serving` (snapshot holds enabled routes only); UI falls back to the written chain.
