### PR TITLE
feat(memory): entity knowledge graph from entity_refs co-occurrence

### DIFF
--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -68,6 +68,8 @@ var memoryRoutePatterns = []string{
 	"POST /v1/memories/{id}",
 	"GET /v1/memories/{id}/chain",
 	"POST /v1/memories/search",
+	"GET /v1/entities/graph",
+	"GET /v1/entities/{id}/memories",
 }
 
 // Register mounts the routes, each wrapped in bearer auth. memories

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -212,13 +212,15 @@ func TestMemoryProxyScopedToDocumentedRoutes(t *testing.T) {
 		{http.MethodPost, "/v1/memories/abc"},
 		{http.MethodGet, "/v1/memories/abc/chain"},
 		{http.MethodPost, "/v1/memories/search"},
+		{http.MethodGet, "/v1/entities/graph"},
+		{http.MethodGet, "/v1/entities/abc/memories"},
 	} {
 		if code := call(c.method, c.path, "Bearer tok"); code != http.StatusOK {
 			t.Fatalf("%s %s = %d, want 200", c.method, c.path, code)
 		}
 	}
-	if proxied != 5 {
-		t.Fatalf("proxied = %d, want 5", proxied)
+	if proxied != 7 {
+		t.Fatalf("proxied = %d, want 7", proxied)
 	}
 
 	// memoryd-internal routes must never be reachable through brain —

--- a/internal/memory/api/api.go
+++ b/internal/memory/api/api.go
@@ -52,6 +52,8 @@ func Register(srv *httpserver.Server, ext Extractor, search Searcher, embed Embe
 	srv.Handle("POST /v1/memories", http.HandlerFunc(a.handleAdd))
 	srv.Handle("POST /v1/memories/{id}", http.HandlerFunc(a.handleResolve))
 	srv.Handle("GET /v1/memories/{id}/chain", http.HandlerFunc(a.handleChain))
+	srv.Handle("GET /v1/entities/graph", http.HandlerFunc(a.handleEntityGraph))
+	srv.Handle("GET /v1/entities/{id}/memories", http.HandlerFunc(a.handleEntityMemories))
 }
 
 // handleExtract runs extraction synchronously and returns the inserted

--- a/internal/memory/api/entities.go
+++ b/internal/memory/api/entities.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"regexp"
+)
+
+// uuidPattern gates path ids before they reach a ::uuid comparison —
+// an invalid literal is a client error, not a query failure.
+var uuidPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+type entityJSON struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	Name        string `json:"name"`
+	MemoryCount int    `json:"memory_count"`
+}
+
+type edgeJSON struct {
+	Src    string `json:"src"`
+	Dst    string `json:"dst"`
+	Weight int    `json:"weight"`
+}
+
+// handleEntityGraph returns the whole entity graph in one payload:
+// nodes with active-memory counts plus co-occurrence edges. One
+// atomic view — nodes and edges can never skew across requests.
+func (a *API) handleEntityGraph(w http.ResponseWriter, r *http.Request) {
+	entities, err := a.store.ListEntities(r.Context())
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "graph_failed", err.Error())
+		return
+	}
+	edges, err := a.store.EntityEdges(r.Context())
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "graph_failed", err.Error())
+		return
+	}
+	outEntities := make([]entityJSON, len(entities))
+	for i, e := range entities {
+		outEntities[i] = entityJSON{ID: e.ID, Type: e.Type, Name: e.Name, MemoryCount: e.MemoryCount}
+	}
+	outEdges := make([]edgeJSON, len(edges))
+	for i, e := range edges {
+		outEdges[i] = edgeJSON{Src: e.Src, Dst: e.Dst, Weight: e.Weight}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"entities": outEntities, "edges": outEdges})
+}
+
+// handleEntityMemories returns the active memories referencing one
+// entity, newest first — the graph's detail panel.
+func (a *API) handleEntityMemories(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !uuidPattern.MatchString(id) {
+		jsonError(w, http.StatusBadRequest, "bad_request", "id must be a uuid")
+		return
+	}
+	memories, err := a.store.ListByEntity(r.Context(), id)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "entity_memories_failed", err.Error())
+		return
+	}
+	out := make([]memoryJSON, len(memories))
+	for i, m := range memories {
+		out[i] = toJSON(m)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"memories": out})
+}

--- a/internal/memory/api/entities_test.go
+++ b/internal/memory/api/entities_test.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/memory/store"
+)
+
+func (f *fakeManager) ListEntities(_ context.Context) ([]store.Entity, error) {
+	return f.entities, nil
+}
+
+func (f *fakeManager) EntityEdges(_ context.Context) ([]store.EntityEdge, error) {
+	return f.edges, nil
+}
+
+func (f *fakeManager) ListByEntity(_ context.Context, entityID string) ([]store.Memory, error) {
+	return f.entityMems[entityID], nil
+}
+
+const entityID = "11111111-1111-4111-8111-111111111111"
+
+func TestEntityGraphShape(t *testing.T) {
+	t.Parallel()
+	fm := newFakeManager()
+	fm.entities = []store.Entity{{ID: entityID, Type: "project", Name: "timothy", MemoryCount: 3}}
+	fm.edges = []store.EntityEdge{{Src: entityID, Dst: "22222222-2222-4222-8222-222222222222", Weight: 2}}
+
+	rec := httptest.NewRecorder()
+	manageAPI(fm).handleEntityGraph(rec, httptest.NewRequest(http.MethodGet, "/v1/entities/graph", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body %s", rec.Code, rec.Body)
+	}
+	var out struct {
+		Entities []entityJSON `json:"entities"`
+		Edges    []edgeJSON   `json:"edges"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Entities) != 1 || out.Entities[0].Name != "timothy" || out.Entities[0].MemoryCount != 3 {
+		t.Fatalf("entities = %+v", out.Entities)
+	}
+	if len(out.Edges) != 1 || out.Edges[0].Weight != 2 {
+		t.Fatalf("edges = %+v", out.Edges)
+	}
+}
+
+func TestEntityGraphEmptyIsArrays(t *testing.T) {
+	t.Parallel()
+	rec := httptest.NewRecorder()
+	manageAPI(newFakeManager()).handleEntityGraph(rec, httptest.NewRequest(http.MethodGet, "/v1/entities/graph", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"entities":[]`) || !strings.Contains(body, `"edges":[]`) {
+		t.Fatalf("empty graph must encode arrays, got %s", body)
+	}
+}
+
+func TestEntityMemories(t *testing.T) {
+	t.Parallel()
+	fm := newFakeManager()
+	fm.entityMems = map[string][]store.Memory{
+		entityID: {{ID: "m1", Type: store.TypeSemantic, Content: "fact", Status: store.StatusActive, CreatedAt: time.Now()}},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/v1/entities/"+entityID+"/memories", nil)
+	req.SetPathValue("id", entityID)
+	rec := httptest.NewRecorder()
+	manageAPI(fm).handleEntityMemories(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body %s", rec.Code, rec.Body)
+	}
+	var out struct {
+		Memories []memoryJSON `json:"memories"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Memories) != 1 || out.Memories[0].ID != "m1" {
+		t.Fatalf("memories = %+v", out.Memories)
+	}
+}
+
+func TestEntityMemoriesRejectsBadID(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest(http.MethodGet, "/v1/entities/not-a-uuid/memories", nil)
+	req.SetPathValue("id", "not-a-uuid")
+	rec := httptest.NewRecorder()
+	manageAPI(newFakeManager()).handleEntityMemories(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}

--- a/internal/memory/api/manage.go
+++ b/internal/memory/api/manage.go
@@ -10,7 +10,8 @@ import (
 	"github.com/SumonMSelim/timothy/internal/memory/store"
 )
 
-// Manager is the store slice behind the queue and browser endpoints.
+// Manager is the store slice behind the queue, browser, and entity
+// graph endpoints.
 type Manager interface {
 	ListByStatus(ctx context.Context, status store.Status, types ...store.MemoryType) ([]store.Memory, error)
 	Insert(ctx context.Context, m store.Memory) (string, error)
@@ -18,6 +19,9 @@ type Manager interface {
 	Reject(ctx context.Context, id string) error
 	Supersede(ctx context.Context, oldID, newID string) error
 	Chain(ctx context.Context, id string) ([]store.Memory, error)
+	ListEntities(ctx context.Context) ([]store.Entity, error)
+	EntityEdges(ctx context.Context) ([]store.EntityEdge, error)
+	ListByEntity(ctx context.Context, entityID string) ([]store.Memory, error)
 }
 
 type memoryJSON struct {

--- a/internal/memory/api/manage_test.go
+++ b/internal/memory/api/manage_test.go
@@ -22,6 +22,9 @@ type fakeManager struct {
 	inserted   []store.Memory
 	superseded map[string]string
 	nextID     int
+	entities   []store.Entity
+	edges      []store.EntityEdge
+	entityMems map[string][]store.Memory
 }
 
 func newFakeManager() *fakeManager {

--- a/internal/memory/store/entities.go
+++ b/internal/memory/store/entities.go
@@ -1,0 +1,94 @@
+package store
+
+import (
+	"context"
+	"fmt"
+)
+
+// ListEntities returns every entity with its active-memory count,
+// busiest first. Zero-count entities are included — the graph shows
+// them at minimum size rather than hiding them.
+func (s *Store) ListEntities(ctx context.Context) ([]Entity, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("list entities: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT e.id, e.type, e.name, count(m.id)::int
+		FROM entities e
+		LEFT JOIN memories m ON e.id = ANY(m.entity_refs) AND m.status = $1
+		GROUP BY e.id
+		ORDER BY count(m.id) DESC, e.name`, StatusActive)
+	if err != nil {
+		return nil, fmt.Errorf("list entities: %w", err)
+	}
+	defer rows.Close()
+	var out []Entity
+	for rows.Next() {
+		var e Entity
+		if err := rows.Scan(&e.ID, &e.Type, &e.Name, &e.MemoryCount); err != nil {
+			return nil, fmt.Errorf("list entities: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// EntityEdges derives the co-occurrence graph from entity_refs: one
+// edge per entity pair that shares at least one active memory,
+// weighted by how many. entity_refs has no FK, so refs whose entity
+// was deleted are filtered out here rather than surfacing as ghost
+// nodes. Volumes are tiny (an entity per named thing, a handful of
+// refs per memory) — the pairwise unnest is fine without indexes.
+func (s *Store) EntityEdges(ctx context.Context) ([]EntityEdge, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("entity edges: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT a.eid, b.eid, count(*)::int AS weight
+		FROM memories m
+		CROSS JOIN LATERAL unnest(m.entity_refs) AS a(eid)
+		CROSS JOIN LATERAL unnest(m.entity_refs) AS b(eid)
+		WHERE m.status = $1 AND a.eid < b.eid
+		  AND EXISTS (SELECT 1 FROM entities WHERE id = a.eid)
+		  AND EXISTS (SELECT 1 FROM entities WHERE id = b.eid)
+		GROUP BY a.eid, b.eid
+		ORDER BY weight DESC, a.eid, b.eid`, StatusActive)
+	if err != nil {
+		return nil, fmt.Errorf("entity edges: %w", err)
+	}
+	defer rows.Close()
+	var out []EntityEdge
+	for rows.Next() {
+		var e EntityEdge
+		if err := rows.Scan(&e.Src, &e.Dst, &e.Weight); err != nil {
+			return nil, fmt.Errorf("entity edges: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// ListByEntity returns the active memories referencing one entity,
+// newest first (detail-panel order).
+func (s *Store) ListByEntity(ctx context.Context, entityID string) ([]Memory, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("list by entity: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT `+memoryColumns+` FROM memories
+		WHERE $1 = ANY(entity_refs) AND status = $2
+		ORDER BY created_at DESC`, entityID, StatusActive)
+	if err != nil {
+		return nil, fmt.Errorf("list by entity: %w", err)
+	}
+	defer rows.Close()
+	var out []Memory
+	for rows.Next() {
+		m, err := scanMemory(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list by entity: %w", err)
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}

--- a/internal/memory/store/models.go
+++ b/internal/memory/store/models.go
@@ -51,11 +51,22 @@ type Memory struct {
 	Confidence      float32
 }
 
-// Entity is a named thing memories can reference.
+// Entity is a named thing memories can reference. MemoryCount is the
+// number of active memories referencing it (graph listings only; zero
+// for entities no active memory cites).
 type Entity struct {
-	ID   string
-	Type string
-	Name string
+	ID          string
+	Type        string
+	Name        string
+	MemoryCount int
+}
+
+// EntityEdge is one co-occurrence edge of the entity graph: Weight
+// active memories reference both Src and Dst. Src < Dst (deduped).
+type EntityEdge struct {
+	Src    string
+	Dst    string
+	Weight int
 }
 
 // Vector is a pgvector embedding, encoded as the extension's text

--- a/internal/memory/store/store_integration_test.go
+++ b/internal/memory/store/store_integration_test.go
@@ -77,6 +77,91 @@ func mem(content string) Memory {
 	}
 }
 
+// TestEntityGraphQueries exercises the graph trio end-to-end: node
+// counts, co-occurrence edges (active-only, dangling refs filtered),
+// and the per-entity memory listing.
+func TestEntityGraphQueries(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	upsert := func(name string) string {
+		id, err := s.UpsertEntity(ctx, "topic", "itest-entity-"+t.Name()+"-"+name)
+		if err != nil {
+			t.Fatalf("UpsertEntity(%s): %v", name, err)
+		}
+		return id
+	}
+	a, b, c := upsert("a"), upsert("b"), upsert("c")
+	const ghost = "99999999-9999-4999-8999-999999999999"
+
+	insert := func(refs []string, active bool) string {
+		m := mem("graph fixture")
+		m.EntityRefs = refs
+		if active {
+			m.Actor = ActorUser // user-explicit memories activate directly
+		}
+		id, err := s.Insert(ctx, m)
+		if err != nil {
+			t.Fatalf("Insert: %v", err)
+		}
+		return id
+	}
+	insert([]string{a, b}, true)
+	insert([]string{a, b}, true)
+	insert([]string{a, c}, true)
+	insert([]string{b, c}, false)     // pending: excluded everywhere
+	insert([]string{a, ghost}, true)  // dangling ref: counted for a, no edge
+
+	entities, err := s.ListEntities(ctx)
+	if err != nil {
+		t.Fatalf("ListEntities: %v", err)
+	}
+	counts := map[string]int{}
+	for _, e := range entities {
+		counts[e.ID] = e.MemoryCount
+	}
+	if counts[a] != 4 || counts[b] != 2 || counts[c] != 1 {
+		t.Fatalf("counts a=%d b=%d c=%d, want 4/2/1", counts[a], counts[b], counts[c])
+	}
+
+	edges, err := s.EntityEdges(ctx)
+	if err != nil {
+		t.Fatalf("EntityEdges: %v", err)
+	}
+	mine := map[string]int{}
+	ours := map[string]bool{a: true, b: true, c: true}
+	for _, e := range edges {
+		if e.Src == ghost || e.Dst == ghost {
+			t.Fatalf("dangling ref produced an edge: %+v", e)
+		}
+		if ours[e.Src] && ours[e.Dst] {
+			mine[e.Src+"|"+e.Dst] = e.Weight
+		}
+	}
+	key := func(x, y string) string {
+		if x < y {
+			return x + "|" + y
+		}
+		return y + "|" + x
+	}
+	if len(mine) != 2 || mine[key(a, b)] != 2 || mine[key(a, c)] != 1 {
+		t.Fatalf("edges = %v, want a-b:2 a-c:1 only", mine)
+	}
+
+	byA, err := s.ListByEntity(ctx, a)
+	if err != nil {
+		t.Fatalf("ListByEntity: %v", err)
+	}
+	if len(byA) != 4 {
+		t.Fatalf("ListByEntity(a) = %d memories, want 4 (active only)", len(byA))
+	}
+	for i := 1; i < len(byA); i++ {
+		if byA[i-1].CreatedAt.Before(byA[i].CreatedAt) {
+			t.Fatalf("ListByEntity not newest-first at %d", i)
+		}
+	}
+}
+
 func TestInsertStagesAgentWrites(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -10,6 +10,7 @@ import type {
   ChainEntry,
   ChatEvent,
   ChatRequest,
+  EntityGraphData,
   LatencyRow,
   MemoryItem,
   Mission,
@@ -286,6 +287,16 @@ export async function searchMemories(query: string): Promise<RetrievedMemory[]> 
     method: 'POST',
     body: JSON.stringify({ query }),
   })
+  return memories ?? []
+}
+
+export async function entityGraph(): Promise<EntityGraphData> {
+  const data = await request<EntityGraphData>('/v1/entities/graph')
+  return { entities: data.entities ?? [], edges: data.edges ?? [] }
+}
+
+export async function entityMemories(id: string): Promise<MemoryItem[]> {
+  const { memories } = await request<{ memories: MemoryItem[] }>(`/v1/entities/${id}/memories`)
   return memories ?? []
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -141,6 +141,27 @@ export interface RetrievedMemory {
   score: number
 }
 
+// Entity graph (GET /v1/entities/graph): nodes are extracted entities
+// with their active-memory counts; edges are co-occurrences (weight =
+// shared active memories).
+export interface EntityNode {
+  id: string
+  type: string
+  name: string
+  memory_count: number
+}
+
+export interface EntityEdge {
+  src: string
+  dst: string
+  weight: number
+}
+
+export interface EntityGraphData {
+  entities: EntityNode[]
+  edges: EntityEdge[]
+}
+
 // Usage aggregates served by /v1/admin/usage/* — chart-ready, never
 // raw ledger rows.
 export interface UsageSummary {

--- a/web/src/components/memory/ChainDialog.tsx
+++ b/web/src/components/memory/ChainDialog.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+import { memoryChain } from '../../api/client'
+import type { MemoryItem } from '../../api/types'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+import { TypeBadge } from './TypeBadge'
+
+// ChainDialog shows a memory's supersede history, oldest first.
+export function ChainDialog({ id, onClose }: { id: string; onClose: () => void }) {
+  const [chain, setChain] = useState<MemoryItem[]>([])
+  useEffect(() => {
+    memoryChain(id).then(setChain).catch(() => setChain([]))
+  }, [id])
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Supersede history</DialogTitle>
+        </DialogHeader>
+        <ol className="space-y-2" data-testid="chain-list">
+          {chain.map((m, i) => (
+            <li key={m.id} className="rounded border p-3 text-sm">
+              <div className="mb-1 flex items-center gap-2">
+                <span className="text-xs text-muted-foreground">v{i + 1}</span>
+                <TypeBadge type={m.type} />
+                <span className="text-xs text-muted-foreground">{m.status}</span>
+              </div>
+              {m.content}
+            </li>
+          ))}
+        </ol>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/src/components/memory/EntityDetailPanel.tsx
+++ b/web/src/components/memory/EntityDetailPanel.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { entityMemories } from '../../api/client'
+import type { EntityNode, MemoryItem } from '../../api/types'
+import { ChainDialog } from './ChainDialog'
+import { TypeBadge } from './TypeBadge'
+
+// Confidence thresholds map to the semantic tokens: solid ≥ 0.7,
+// shaky in between, doubtful below 0.4.
+function confidenceClass(c: number): string {
+  if (c >= 0.7) return 'bg-good'
+  if (c >= 0.4) return 'bg-warning'
+  return 'bg-destructive'
+}
+
+// EntityDetailPanel lists the active memories behind one graph node.
+export function EntityDetailPanel({ entity }: { entity: EntityNode }) {
+  const [memories, setMemories] = useState<MemoryItem[] | null>(null)
+  const [chainFor, setChainFor] = useState<string | null>(null)
+
+  useEffect(() => {
+    setMemories(null)
+    entityMemories(entity.id)
+      .then(setMemories)
+      .catch(() => {
+        toast.error('Could not load entity memories')
+        setMemories([])
+      })
+  }, [entity.id])
+
+  return (
+    <div className="space-y-3" data-testid="entity-detail">
+      <div className="flex items-center gap-2">
+        <h3 className="min-w-0 flex-1 truncate text-sm font-semibold">{entity.name}</h3>
+        <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+          {entity.type}
+        </span>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {entity.memory_count} active {entity.memory_count === 1 ? 'memory' : 'memories'}
+      </p>
+      {memories === null ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : memories.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No active memories reference this entity.</p>
+      ) : (
+        <div className="space-y-2">
+          {memories.map((m) => (
+            <div key={m.id} className="space-y-2 rounded-lg border p-3 text-sm" data-testid="entity-memory">
+              <div className="flex items-center gap-2">
+                <TypeBadge type={m.type} />
+                <span className="text-xs text-muted-foreground">
+                  {new Date(m.created_at).toLocaleDateString()}
+                </span>
+                <button
+                  type="button"
+                  className="ml-auto text-xs text-muted-foreground underline-offset-2 hover:underline"
+                  onClick={() => setChainFor(m.id)}
+                >
+                  history
+                </button>
+              </div>
+              <p className="leading-relaxed">{m.content}</p>
+              <div
+                className="h-1 overflow-hidden rounded-full bg-muted"
+                title={`confidence ${Math.round(m.confidence * 100)}%`}
+              >
+                <div
+                  className={`h-full rounded-full ${confidenceClass(m.confidence)}`}
+                  style={{ width: `${Math.round(m.confidence * 100)}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      {chainFor && <ChainDialog id={chainFor} onClose={() => setChainFor(null)} />}
+    </div>
+  )
+}

--- a/web/src/components/memory/EntityGraph.tsx
+++ b/web/src/components/memory/EntityGraph.tsx
@@ -1,0 +1,158 @@
+import { useMemo, useState } from 'react'
+import type { EntityGraphData } from '../../api/types'
+import { layoutGraph } from './graphLayout'
+
+// Node fill per entity kind — mid hues that read on both themes,
+// consistent with the page's raw-palette convention (TypeBadge).
+const kindFill: Record<string, string> = {
+  person: 'fill-blue-500/70',
+  project: 'fill-violet-500/70',
+  service: 'fill-cyan-500/70',
+  preference: 'fill-emerald-500/70',
+  decision: 'fill-amber-500/70',
+  topic: 'fill-rose-500/70',
+  place: 'fill-lime-500/70',
+}
+
+const W = 720
+const H = 520
+
+// EntityGraph is the presentational SVG: type-clustered nodes sized
+// by memory count, co-occurrence edges weighted by shared memories.
+// Click a node to inspect it; click the background to clear.
+export function EntityGraph({
+  data,
+  selectedId,
+  onSelect,
+}: {
+  data: EntityGraphData
+  selectedId: string | null
+  onSelect: (id: string | null) => void
+}) {
+  const [hoverId, setHoverId] = useState<string | null>(null)
+
+  const { positions, edges } = useMemo(
+    () => layoutGraph(data.entities, data.edges, W, H),
+    [data],
+  )
+  const neighbors = useMemo(() => {
+    const map = new Map<string, Set<string>>()
+    for (const e of edges) {
+      if (!map.has(e.src)) map.set(e.src, new Set())
+      if (!map.has(e.dst)) map.set(e.dst, new Set())
+      map.get(e.src)!.add(e.dst)
+      map.get(e.dst)!.add(e.src)
+    }
+    return map
+  }, [edges])
+
+  if (data.entities.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No entities yet — the graph builds as Timothy extracts memories.
+      </p>
+    )
+  }
+
+  const focus = hoverId ?? selectedId
+  const maxWeight = Math.max(1, ...edges.map((e) => e.weight))
+  const present = [...new Set(data.entities.map((n) => n.type))]
+
+  return (
+    <div className="space-y-2">
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        className="h-auto w-full rounded-xl border border-border bg-card"
+        data-testid="entity-graph"
+        role="img"
+        aria-label="Entity knowledge graph"
+        onClick={() => onSelect(null)}
+      >
+        {edges.map((e) => {
+          const a = positions.get(e.src)
+          const b = positions.get(e.dst)
+          if (!a || !b) return null
+          const incident = focus !== null && (e.src === focus || e.dst === focus)
+          return (
+            <line
+              key={`${e.src}-${e.dst}`}
+              x1={a.x}
+              y1={a.y}
+              x2={b.x}
+              y2={b.y}
+              strokeWidth={1 + 3 * (e.weight / maxWeight)}
+              className={
+                incident
+                  ? 'stroke-brand'
+                  : focus !== null
+                    ? 'stroke-border opacity-30'
+                    : 'stroke-border'
+              }
+            />
+          )
+        })}
+        {data.entities.map((n) => {
+          const p = positions.get(n.id)
+          if (!p) return null
+          const dimmed =
+            focus !== null && focus !== n.id && !(neighbors.get(focus)?.has(n.id) ?? false)
+          return (
+            <g
+              key={n.id}
+              data-testid="entity-node"
+              role="button"
+              tabIndex={0}
+              aria-label={n.name}
+              className={`cursor-pointer outline-none ${dimmed ? 'opacity-40' : ''}`}
+              onClick={(e) => {
+                e.stopPropagation()
+                onSelect(n.id === selectedId ? null : n.id)
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  onSelect(n.id === selectedId ? null : n.id)
+                }
+              }}
+              onMouseEnter={() => setHoverId(n.id)}
+              onMouseLeave={() => setHoverId(null)}
+            >
+              {n.id === selectedId && (
+                <circle cx={p.x} cy={p.y} r={p.r + 4} className="fill-none stroke-brand" strokeWidth={2} />
+              )}
+              <circle cx={p.x} cy={p.y} r={p.r} className={kindFill[n.type] ?? 'fill-muted-foreground/60'} />
+              <text
+                x={p.x}
+                y={p.y + p.r + 12}
+                textAnchor="middle"
+                className="fill-foreground text-[10px]"
+              >
+                {n.name.length > 18 ? `${n.name.slice(0, 17)}…` : n.name}
+              </text>
+              {n.memory_count > 0 && (
+                <text
+                  x={p.x}
+                  y={p.y + p.r + 23}
+                  textAnchor="middle"
+                  className="fill-muted-foreground text-[9px]"
+                >
+                  {n.memory_count}
+                </text>
+              )}
+            </g>
+          )
+        })}
+      </svg>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        {present.map((t) => (
+          <span key={t} className="inline-flex items-center gap-1.5">
+            <svg viewBox="0 0 8 8" className="size-2" aria-hidden="true">
+              <circle cx="4" cy="4" r="4" className={kindFill[t] ?? 'fill-muted-foreground/60'} />
+            </svg>
+            {t}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/memory/GraphTab.test.tsx
+++ b/web/src/components/memory/GraphTab.test.tsx
@@ -1,0 +1,83 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EntityGraphData, MemoryItem } from '../../api/types'
+import { GraphTab } from './GraphTab'
+
+vi.mock('../../api/client', () => ({
+  entityGraph: vi.fn(),
+  entityMemories: vi.fn(),
+  memoryChain: vi.fn(),
+}))
+
+import { entityGraph, entityMemories } from '../../api/client'
+
+const graph: EntityGraphData = {
+  entities: [
+    { id: 'e1', type: 'project', name: 'timothy', memory_count: 2 },
+    { id: 'e2', type: 'person', name: 'sumon', memory_count: 1 },
+  ],
+  edges: [{ src: 'e1', dst: 'e2', weight: 1 }],
+}
+
+const memory: MemoryItem = {
+  id: 'm1',
+  type: 'semantic',
+  content: 'Timothy is a self-hosted assistant.',
+  status: 'active',
+  confidence: 0.9,
+  actor: 'agent',
+  created_at: '2026-07-11T10:00:00Z',
+}
+
+function renderTab() {
+  return render(
+    <MemoryRouter>
+      <GraphTab />
+    </MemoryRouter>,
+  )
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(entityGraph).mockResolvedValue(graph)
+  vi.mocked(entityMemories).mockResolvedValue([memory])
+})
+
+describe('GraphTab', () => {
+  it('renders one node per entity with a legend', async () => {
+    renderTab()
+    const nodes = await screen.findAllByTestId('entity-node')
+    expect(nodes).toHaveLength(2)
+    expect(screen.getByText('project')).toBeInTheDocument()
+    expect(screen.getByText('person')).toBeInTheDocument()
+  })
+
+  it('clicking a node opens the detail panel with its memories', async () => {
+    renderTab()
+    const nodes = await screen.findAllByTestId('entity-node')
+    fireEvent.click(nodes[0])
+    const panel = await screen.findByTestId('entity-detail')
+    expect(panel).toHaveTextContent('timothy')
+    expect(await screen.findByTestId('entity-memory')).toHaveTextContent(
+      'Timothy is a self-hosted assistant.',
+    )
+    expect(entityMemories).toHaveBeenCalledWith('e1')
+  })
+
+  it('shows the empty state when no entities exist', async () => {
+    vi.mocked(entityGraph).mockResolvedValue({ entities: [], edges: [] })
+    renderTab()
+    expect(await screen.findByText(/No entities yet/)).toBeInTheDocument()
+  })
+
+  it('survives an edge pointing at an unknown entity', async () => {
+    vi.mocked(entityGraph).mockResolvedValue({
+      entities: graph.entities,
+      edges: [{ src: 'e1', dst: 'nope', weight: 3 }],
+    })
+    renderTab()
+    expect(await screen.findAllByTestId('entity-node')).toHaveLength(2)
+  })
+})

--- a/web/src/components/memory/GraphTab.tsx
+++ b/web/src/components/memory/GraphTab.tsx
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { entityGraph } from '../../api/client'
+import type { EntityGraphData } from '../../api/types'
+import { memoryChangedEvent } from '../../lib/memory'
+import { EntityDetailPanel } from './EntityDetailPanel'
+import { EntityGraph } from './EntityGraph'
+
+// GraphTab is the Memory page's knowledge-graph view: the entity map
+// on the left, the selected entity's memories on the right. Refreshes
+// whenever memories change elsewhere (confirm/reject/add).
+export function GraphTab() {
+  const [data, setData] = useState<EntityGraphData>({ entities: [], edges: [] })
+  const [loaded, setLoaded] = useState(false)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+
+  const refresh = useCallback(() => {
+    entityGraph()
+      .then(setData)
+      .catch(() => {
+        toast.error('Could not load entity graph')
+        setData({ entities: [], edges: [] })
+      })
+      .finally(() => setLoaded(true))
+  }, [])
+  useEffect(() => {
+    refresh()
+    window.addEventListener(memoryChangedEvent, refresh)
+    return () => window.removeEventListener(memoryChangedEvent, refresh)
+  }, [refresh])
+
+  if (!loaded) return <p className="text-sm text-muted-foreground">Loading…</p>
+
+  const selected = data.entities.find((e) => e.id === selectedId) ?? null
+
+  return (
+    <div className="flex flex-col gap-6 lg:flex-row">
+      <div className="min-w-0 flex-1">
+        <EntityGraph data={data} selectedId={selectedId} onSelect={setSelectedId} />
+      </div>
+      {selected ? (
+        <div className="lg:w-80 lg:shrink-0">
+          <EntityDetailPanel entity={selected} />
+        </div>
+      ) : (
+        data.entities.length > 0 && (
+          <p className="text-sm text-muted-foreground lg:w-80 lg:shrink-0">
+            Select an entity to see the memories behind it.
+          </p>
+        )
+      )}
+    </div>
+  )
+}

--- a/web/src/components/memory/TypeBadge.tsx
+++ b/web/src/components/memory/TypeBadge.tsx
@@ -1,0 +1,15 @@
+import { Badge } from '../ui/badge'
+
+const typeTone: Record<string, string> = {
+  semantic: 'bg-blue-500/15 text-blue-600 dark:text-blue-400',
+  episodic: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
+  procedural: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+}
+
+export function TypeBadge({ type }: { type: string }) {
+  return (
+    <Badge variant="outline" className={`border-0 ${typeTone[type] ?? ''}`}>
+      {type}
+    </Badge>
+  )
+}

--- a/web/src/components/memory/graphLayout.test.ts
+++ b/web/src/components/memory/graphLayout.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import type { EntityEdge, EntityNode } from '../../api/types'
+import { layoutGraph } from './graphLayout'
+
+const node = (id: string, type: string, count: number): EntityNode => ({
+  id,
+  type,
+  name: `entity-${id}`,
+  memory_count: count,
+})
+
+const nodes: EntityNode[] = [
+  node('a', 'person', 5),
+  node('b', 'project', 3),
+  node('c', 'project', 1),
+  node('d', 'topic', 0),
+]
+const edges: EntityEdge[] = [
+  { src: 'a', dst: 'b', weight: 2 },
+  { src: 'a', dst: 'ghost', weight: 1 }, // dangling ref
+]
+
+describe('layoutGraph', () => {
+  it('is deterministic', () => {
+    const one = layoutGraph(nodes, edges, 720, 520)
+    const two = layoutGraph(nodes, edges, 720, 520)
+    expect([...one.positions.entries()]).toEqual([...two.positions.entries()])
+    expect(one.edges).toEqual(two.edges)
+  })
+
+  it('positions every node inside the canvas', () => {
+    const { positions } = layoutGraph(nodes, edges, 720, 520)
+    expect(positions.size).toBe(nodes.length)
+    for (const p of positions.values()) {
+      expect(p.x - p.r).toBeGreaterThanOrEqual(0)
+      expect(p.x + p.r).toBeLessThanOrEqual(720)
+      expect(p.y - p.r).toBeGreaterThanOrEqual(0)
+      expect(p.y + p.r).toBeLessThanOrEqual(520)
+    }
+  })
+
+  it('sizes radius monotonically with memory count', () => {
+    const { positions } = layoutGraph(nodes, edges, 720, 520)
+    const r = (id: string) => positions.get(id)!.r
+    expect(r('a')).toBeGreaterThan(r('b'))
+    expect(r('b')).toBeGreaterThan(r('c'))
+    expect(r('c')).toBeGreaterThan(r('d'))
+    expect(r('d')).toBe(6) // zero-count floor
+  })
+
+  it('drops edges with unknown endpoints', () => {
+    const { edges: kept } = layoutGraph(nodes, edges, 720, 520)
+    expect(kept).toEqual([{ src: 'a', dst: 'b', weight: 2 }])
+  })
+
+  it('centers a single-type graph', () => {
+    const { positions } = layoutGraph([node('solo', 'person', 1)], [], 720, 520)
+    const p = positions.get('solo')!
+    expect(p.x).toBe(360)
+    expect(p.y).toBe(260)
+  })
+})

--- a/web/src/components/memory/graphLayout.ts
+++ b/web/src/components/memory/graphLayout.ts
@@ -1,0 +1,83 @@
+import type { EntityEdge, EntityNode } from '../../api/types'
+
+// Fixed cluster order so the same kinds always land in the same
+// region of the canvas across reloads.
+export const ENTITY_TYPE_ORDER = [
+  'person',
+  'project',
+  'service',
+  'preference',
+  'decision',
+  'topic',
+  'place',
+] as const
+
+export interface NodePos {
+  x: number
+  y: number
+  r: number
+}
+
+// Golden angle in radians: successive nodes on a sunflower spiral
+// pack near-uniformly without overlap checks.
+const goldenAngle = 2.399963229728653
+
+// layoutGraph places nodes deterministically: one cluster per entity
+// type arranged on a circle around the canvas center, nodes within a
+// cluster on a sunflower spiral, busiest first. Edges referencing
+// unknown nodes (dangling entity_refs) are dropped. Pure function —
+// identical input yields identical output, no randomness.
+export function layoutGraph(
+  nodes: EntityNode[],
+  edges: EntityEdge[],
+  width: number,
+  height: number,
+): { positions: Map<string, NodePos>; edges: EntityEdge[] } {
+  const known = new Set(nodes.map((n) => n.id))
+  const keptEdges = edges.filter((e) => known.has(e.src) && known.has(e.dst))
+
+  const byType = new Map<string, EntityNode[]>()
+  for (const n of nodes) {
+    const list = byType.get(n.type) ?? []
+    list.push(n)
+    byType.set(n.type, list)
+  }
+  const knownOrder = ENTITY_TYPE_ORDER as readonly string[]
+  const presentTypes = knownOrder
+    .filter((t) => byType.has(t))
+    .concat([...byType.keys()].filter((t) => !knownOrder.includes(t)).sort())
+
+  const maxCount = Math.max(1, ...nodes.map((n) => n.memory_count))
+  const radiusOf = (count: number) => 6 + 12 * Math.sqrt(count / maxCount)
+
+  const cx = width / 2
+  const cy = height / 2
+  const clusterRing = 0.32 * Math.min(width, height)
+  const spread = 2.4 * radiusOf(maxCount)
+
+  const positions = new Map<string, NodePos>()
+  presentTypes.forEach((type, ti) => {
+    const members = [...(byType.get(type) ?? [])].sort(
+      (a, b) => b.memory_count - a.memory_count || a.name.localeCompare(b.name),
+    )
+    const angle = -Math.PI / 2 + (ti * 2 * Math.PI) / presentTypes.length
+    const ccx = presentTypes.length === 1 ? cx : cx + clusterRing * Math.cos(angle)
+    const ccy = presentTypes.length === 1 ? cy : cy + clusterRing * Math.sin(angle)
+    members.forEach((n, k) => {
+      const theta = k * goldenAngle
+      const dist = spread * Math.sqrt(k)
+      const r = radiusOf(n.memory_count)
+      positions.set(n.id, {
+        x: clamp(ccx + dist * Math.cos(theta), r, width - r),
+        y: clamp(ccy + dist * Math.sin(theta), r, height - r),
+        r,
+      })
+    })
+  })
+
+  return { positions, edges: keptEdges }
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.min(Math.max(v, lo), hi)
+}

--- a/web/src/pages/Memory.test.tsx
+++ b/web/src/pages/Memory.test.tsx
@@ -10,9 +10,12 @@ vi.mock('../api/client', () => ({
   resolveMemory: vi.fn(),
   memoryChain: vi.fn(),
   searchMemories: vi.fn(),
+  entityGraph: vi.fn(),
+  entityMemories: vi.fn(),
 }))
 
 import {
+  entityGraph,
   listMemories,
   resolveMemory,
   searchMemories,
@@ -100,6 +103,19 @@ describe('Memory queue', () => {
     vi.mocked(listMemories).mockResolvedValue([])
     renderPage()
     expect(await screen.findByText(/Queue is empty/)).toBeInTheDocument()
+  })
+})
+
+describe('Memory graph tab', () => {
+  it('renders the entity graph', async () => {
+    vi.mocked(entityGraph).mockResolvedValue({
+      entities: [{ id: 'e1', type: 'project', name: 'timothy', memory_count: 1 }],
+      edges: [],
+    })
+    renderPage()
+    fireEvent.click(await screen.findByTestId('tab-graph'))
+    expect(await screen.findByTestId('entity-graph')).toBeInTheDocument()
+    expect(screen.getAllByTestId('entity-node')).toHaveLength(1)
   })
 })
 

--- a/web/src/pages/Memory.tsx
+++ b/web/src/pages/Memory.tsx
@@ -1,21 +1,17 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router'
+import { toast } from 'sonner'
 import {
   addMemory,
   listMemories,
-  memoryChain,
   resolveMemory,
   searchMemories,
 } from '../api/client'
 import type { MemoryItem, RetrievedMemory } from '../api/types'
-import { Badge } from '../components/ui/badge'
+import { ChainDialog } from '../components/memory/ChainDialog'
+import { GraphTab } from '../components/memory/GraphTab'
+import { TypeBadge } from '../components/memory/TypeBadge'
 import { Button } from '../components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '../components/ui/dialog'
 import { Input } from '../components/ui/input'
 import {
   Select,
@@ -26,20 +22,6 @@ import {
 } from '../components/ui/select'
 import { Textarea } from '../components/ui/textarea'
 import { notifyMemoryChanged } from '../lib/memory'
-
-const typeTone: Record<string, string> = {
-  semantic: 'bg-blue-500/15 text-blue-600 dark:text-blue-400',
-  episodic: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
-  procedural: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
-}
-
-function TypeBadge({ type }: { type: string }) {
-  return (
-    <Badge variant="outline" className={`border-0 ${typeTone[type] ?? ''}`}>
-      {type}
-    </Badge>
-  )
-}
 
 // QueueCard is one pending memory awaiting the user's verdict.
 function QueueCard({
@@ -126,7 +108,10 @@ function Queue() {
   const refresh = useCallback(() => {
     listMemories('pending')
       .then(setPending)
-      .catch(() => setPending([]))
+      .catch(() => {
+        toast.error('Could not load the memory queue')
+        setPending([])
+      })
       .finally(() => setLoaded(true))
   }, [])
   useEffect(refresh, [refresh])
@@ -164,35 +149,6 @@ function Queue() {
   )
 }
 
-// ChainDialog shows a memory's supersede history, oldest first.
-function ChainDialog({ id, onClose }: { id: string; onClose: () => void }) {
-  const [chain, setChain] = useState<MemoryItem[]>([])
-  useEffect(() => {
-    memoryChain(id).then(setChain).catch(() => setChain([]))
-  }, [id])
-  return (
-    <Dialog open onOpenChange={(open) => !open && onClose()}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Supersede history</DialogTitle>
-        </DialogHeader>
-        <ol className="space-y-2" data-testid="chain-list">
-          {chain.map((m, i) => (
-            <li key={m.id} className="rounded border p-3 text-sm">
-              <div className="mb-1 flex items-center gap-2">
-                <span className="text-xs text-muted-foreground">v{i + 1}</span>
-                <TypeBadge type={m.type} />
-                <span className="text-xs text-muted-foreground">{m.status}</span>
-              </div>
-              {m.content}
-            </li>
-          ))}
-        </ol>
-      </DialogContent>
-    </Dialog>
-  )
-}
-
 function Browser() {
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<RetrievedMemory[] | null>(null)
@@ -206,7 +162,10 @@ function Browser() {
   const loadBrowse = useCallback(() => {
     listMemories(status)
       .then(setBrowse)
-      .catch(() => setBrowse([]))
+      .catch(() => {
+        toast.error('Could not load memories')
+        setBrowse([])
+      })
   }, [status])
   useEffect(loadBrowse, [loadBrowse])
 
@@ -219,6 +178,7 @@ function Browser() {
     try {
       setResults(await searchMemories(query.trim()))
     } catch {
+      toast.error('Search failed')
       setResults([])
     } finally {
       setBusy(false)
@@ -233,6 +193,8 @@ function Browser() {
       setNewFact('')
       notifyMemoryChanged()
       if (status === 'active') loadBrowse()
+    } catch {
+      toast.error('Could not save the memory')
     } finally {
       setBusy(false)
     }
@@ -342,28 +304,36 @@ function Browser() {
   )
 }
 
+const tabs = [
+  { id: 'queue', label: 'Queue' },
+  { id: 'browser', label: 'Browser' },
+  { id: 'graph', label: 'Graph' },
+] as const
+
 export function Memory() {
-  const [tab, setTab] = useState<'queue' | 'browser'>('queue')
+  const [tab, setTab] = useState<(typeof tabs)[number]['id']>('queue')
   return (
     <div className="h-full overflow-y-auto">
-      <div className="mx-auto w-full max-w-3xl p-6 space-y-6">
+      <div
+        className={`mx-auto w-full p-6 space-y-6 ${tab === 'graph' ? 'max-w-5xl' : 'max-w-3xl'}`}
+      >
         <div className="flex items-center gap-2">
           <h1 className="text-lg font-semibold">Memory</h1>
           <div className="ml-auto flex gap-1 rounded-lg border p-0.5">
-            {(['queue', 'browser'] as const).map((t) => (
+            {tabs.map((t) => (
               <Button
-                key={t}
+                key={t.id}
                 size="sm"
-                variant={tab === t ? 'secondary' : 'ghost'}
-                onClick={() => setTab(t)}
-                data-testid={`tab-${t}`}
+                variant={tab === t.id ? 'secondary' : 'ghost'}
+                onClick={() => setTab(t.id)}
+                data-testid={`tab-${t.id}`}
               >
-                {t === 'queue' ? 'Queue' : 'Browser'}
+                {t.label}
               </Button>
             ))}
           </div>
         </div>
-        {tab === 'queue' ? <Queue /> : <Browser />}
+        {tab === 'queue' ? <Queue /> : tab === 'browser' ? <Browser /> : <GraphTab />}
       </div>
     </div>
   )


### PR DESCRIPTION
## What

Adds a knowledge-graph view to the Memory page, built entirely from data that already exists.

**memoryd:** extraction has populated `entities` since `0010`, but nothing read them back — and `relations` has no writers. The graph is derivable without any extraction work: nodes from `entities` with active-memory counts, edges from entity pairs co-occurring in a memory's `entity_refs` (active memories only, weight = shared count). Two read-only endpoints — `GET /v1/entities/graph`, `GET /v1/entities/{id}/memories` — proxied through brain's deny-by-default allowlist. No migrations, no schema changes; dangling refs (`entity_refs` has no FK) are filtered in the queries.

**Web:** third "Graph" tab — hand-rolled SVG, deterministic layout (one cluster per entity kind, golden-angle spiral within, node size tracks memory count, edge width tracks weight), hover/select neighbor highlighting, legend, and a detail panel with each entity's memories, confidence bars, and supersede history. `TypeBadge`/`ChainDialog` extracted to `components/memory/`; the page's silent fetch failures now surface as toasts. No graph library added.

## Verification

- `make build test vet lint` — 0 issues
- Integration: `TestEntityGraphQueries` (counts, edge weights, pending excluded, dangling refs produce no edges, per-entity ordering) run green against a live stack DB
- Web: build, lint, 142 tests (10 new: layout determinism/bounds/radius/dangling-edge filtering, node→panel flow, empty state)
- brain allowlist-pinning test updated (5 → 7 proxied patterns)

## Notes

- `relations` table intentionally untouched — typed relation extraction is a separate, larger piece of work; co-occurrence gives a useful graph today.
- Empty graph renders an explanatory state (extraction off / fresh DB).
