### PR TITLE
fix(memoryd): unbreak memory extraction pipeline

### DIFF
--- a/internal/memory/extract/consolidate.go
+++ b/internal/memory/extract/consolidate.go
@@ -24,7 +24,10 @@ const (
 	decayFactor        = 0.8
 	decayBatch         = 10 // stalest per run; a queue, not a flood
 
-	mergeMaxTokens = 300
+	// Reasoning models spend thinking tokens from the same budget
+	// before emitting content — 300 would starve the one-sentence
+	// reply the same way extraction's old 1000 cap did.
+	mergeMaxTokens = 2000
 )
 
 const mergeSystem = `You merge near-duplicate memory entries into ONE canonical fact. Reply with ONLY the merged fact as a single self-contained sentence (absolute dates, full names). Keep every distinct detail; drop only repetition.`
@@ -181,7 +184,7 @@ func (c *Consolidator) mergedContent(ctx context.Context, lines []string) (strin
 	ctx, cancel := context.WithTimeout(ctx, llmTimeout)
 	defer cancel()
 	events, err := c.gw.Stream(ctx, gwclient.StreamRequest{
-		Route: "mini",
+		Route: sideRoute,
 		Purpose:      "memory-consolidate",
 		System:       mergeSystem,
 		Messages:     []provider.Message{{Role: "user", Content: strings.Join(lines, "\n")}},

--- a/internal/memory/extract/extract.go
+++ b/internal/memory/extract/extract.go
@@ -40,6 +40,14 @@ const (
 	maxAttempts = 2
 	maxFacts    = 20
 
+	// sideRoute serves extraction and consolidation side-calls. The
+	// "mini" route these calls used before was never seeded by any
+	// migration, so every one failed with no_route (same bug brain's
+	// classifyRoute already fixed). "summarize" is a real fixed route
+	// and these calls need its model quality: small local models fail
+	// the strict JSON contract more often than they meet it.
+	sideRoute = "summarize"
+
 	// nearDupSimilarity marks a candidate as restating known
 	// knowledge; exactDupSimilarity (or byte-equal content) drops it
 	// outright. Near-dups still insert — the consolidation job merges
@@ -178,11 +186,14 @@ func (e *Extractor) proposeOnce(ctx context.Context, req Request) (string, error
 	defer cancel()
 
 	events, err := e.gw.Stream(ctx, gwclient.StreamRequest{
-		Route: "mini",
+		Route: sideRoute,
 		Purpose:      "memory-extract",
 		System:       system,
 		Messages:     []provider.Message{{Role: "user", Content: req.Text}},
-		MaxTokens:    1000,
+		// Reasoning models spend thinking tokens from the same budget
+		// before emitting content; 1000 starved the JSON reply entirely
+		// (stream ended incomplete with zero content chunks).
+		MaxTokens:    4000,
 		SessionID:    req.SessionID,
 	})
 	if err != nil {

--- a/internal/memory/extract/extract_test.go
+++ b/internal/memory/extract/extract_test.go
@@ -102,9 +102,11 @@ type fakeGateway struct {
 	replies []string
 	calls   int
 	embeds  [][]float32
+	routes  []string
 }
 
 func (g *fakeGateway) Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+	g.routes = append(g.routes, req.Route)
 	ch := make(chan stream.StreamEvent, 2)
 	reply := g.replies[min(g.calls, len(g.replies)-1)]
 	g.calls++
@@ -194,6 +196,11 @@ func TestExtractInsertsAndPromotes(t *testing.T) {
 	}
 	if len(first.Embedding) == 0 {
 		t.Fatal("embedding not attached")
+	}
+	// The side-call must ride a route migrations actually seed —
+	// "mini" never existed and every call on it failed with no_route.
+	if len(gw.routes) != 1 || gw.routes[0] != "summarize" {
+		t.Fatalf("routes = %v, want [summarize]", gw.routes)
 	}
 }
 

--- a/internal/memory/retrieval/golden_integration_test.go
+++ b/internal/memory/retrieval/golden_integration_test.go
@@ -22,11 +22,11 @@ import (
 
 const goldenMarker = "itest-golden:"
 
-// basis returns a 1536-dim unit vector along one dimension — a
+// basis returns a 1024-dim unit vector along one dimension — a
 // deterministic stand-in for real embeddings that gives the vector
 // leg perfect discrimination between fixtures.
 func basis(dim int) store.Vector {
-	v := make(store.Vector, 1536)
+	v := make(store.Vector, 1024)
 	v[dim] = 1
 	return v
 }

--- a/internal/memory/store/store_integration_test.go
+++ b/internal/memory/store/store_integration_test.go
@@ -201,7 +201,7 @@ func TestInsertStoresEmbedding(t *testing.T) {
 	ctx := t.Context()
 
 	m := mem("embedded fact")
-	m.Embedding = make(Vector, 1536)
+	m.Embedding = make(Vector, 1024)
 	m.Embedding[0] = 0.5
 	id, err := s.Insert(ctx, m)
 	if err != nil {
@@ -218,7 +218,7 @@ func TestInsertStoresEmbedding(t *testing.T) {
 		t.Fatal("embedding not stored")
 	}
 
-	// Wrong dimension must be refused by the vector(1536) column.
+	// Wrong dimension must be refused by the vector(1024) column.
 	bad := mem("bad dimension")
 	bad.Embedding = Vector{0.1, 0.2}
 	if _, err := s.Insert(ctx, bad); err == nil {
@@ -395,7 +395,7 @@ func TestNearestActive(t *testing.T) {
 
 	// No active embedded rows that match closely → still returns the
 	// nearest, so assert with a known-identical vector instead.
-	base := make(Vector, 1536)
+	base := make(Vector, 1024)
 	base[0], base[1] = 0.6, 0.8
 
 	m := mem("nearest target fact")
@@ -464,7 +464,7 @@ func TestNearDupPairs(t *testing.T) {
 	ctx := t.Context()
 
 	near := func(dim int, delta float32) Vector {
-		v := make(Vector, 1536)
+		v := make(Vector, 1024)
 		v[dim] = 1
 		v[dim+1] = delta // small off-axis component
 		return v

--- a/migrations/0033_memory_embedding_dim.sql
+++ b/migrations/0033_memory_embedding_dim.sql
@@ -1,0 +1,13 @@
+-- memories.embedding was sized for 1536-dim vectors, but the embedding
+-- route serves amazon.titan-embed-text-v2:0 whose widest output is
+-- 1024 -- every insert with a vector failed and extraction degraded to
+-- embedding-less rows. All stored embeddings are NULL (nothing ever
+-- fit), so the narrowing cast is trivial; the hnsw index is rebuilt by
+-- the type change.
+DO $$
+BEGIN
+    IF (SELECT atttypmod FROM pg_attribute
+        WHERE attrelid = 'memories'::regclass AND attname = 'embedding') <> 1024 THEN
+        ALTER TABLE memories ALTER COLUMN embedding TYPE vector(1024);
+    END IF;
+END $$;


### PR DESCRIPTION
## What

Memory extraction never worked in a running stack — no chat turn ever produced a queue entry. Three independent faults stacked:

1. **Phantom route.** `extract.go`/`consolidate.go` called route `"mini"`, which no migration seeds; every call failed with `no_route`. Brain's side had the identical bug fixed in #58 (`classifyRoute = "local"`), memoryd was missed. Pinned to `"summarize"` — extraction needs its chain's strict-JSON discipline (qwen2.5:7b on `local` failed the entity-type contract on every attempt tried).
2. **Reasoning-starved budgets.** Thinking tokens draw from `MaxTokens`; 1000 (extract) / 300 (merge) ended streams `incomplete` with zero content chunks. Raised to 4000 / 2000.
3. **Embedding dimension mismatch.** `memories.embedding` was `vector(1536)` but the embedding route serves `titan-embed-v2` (1024 max) — every vector insert failed since 0010; extraction degraded to embedding-less rows. All stored embeddings were NULL, so 0033's narrowing cast is trivial.

## Verification

- `make build test vet lint` — 0 issues
- New route pin in `TestExtractInsertsAndPromotes` (fake gateway now records requested routes)
- Live end-to-end on the stack: POST `/v1/extract` → 3 facts pending, 6 entities created, 3/3 embeddings stored at 1024 dims, `/v1/entities/graph` returns nodes

## Notes

- Ledger evidence for each fault: `no_route` 502s (16:54Z), GLM `incomplete` at exactly 1000 output tokens, then `expected 1536 dimensions, not 1024` on insert.
- This unblocks the Memory Graph tab (#72) — it was rendering the empty state because extraction had never populated `entities`.
