### PR TITLE
feat(sessions): permanent session deletion

### DIFF
--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -35,6 +35,7 @@ type Directory interface {
 	Get(ctx context.Context, id string) (session.Meta, error)
 	Events(ctx context.Context, id string) ([]session.Event, error)
 	Update(ctx context.Context, id string, title *string, archived *bool) error
+	Delete(ctx context.Context, id string) error
 }
 
 // PermissionResolver answers parked permission prompts; the loop's
@@ -93,6 +94,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	srv.Handle("POST /v1/sessions", a.auth(http.HandlerFunc(a.handleCreate)))
 	srv.Handle("GET /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleTranscript)))
 	srv.Handle("PATCH /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleUpdate)))
+	srv.Handle("DELETE /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleDelete)))
 	srv.Handle("POST /v1/sessions/{id}/messages", a.auth(http.HandlerFunc(a.handleMessages)))
 	srv.Handle("POST /v1/sessions/{id}/messages/retry", a.auth(http.HandlerFunc(a.handleRetry)))
 	srv.Handle("POST /v1/permissions/{id}", a.auth(http.HandlerFunc(a.handlePermission)))
@@ -291,6 +293,30 @@ func (a *API) handleUpdate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		jsonError(w, http.StatusInternalServerError, "update_failed", err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleDelete permanently removes a session and all its
+// session-scoped records. Irreversible; the web UI gates it behind an
+// explicit confirmation.
+func (a *API) handleDelete(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !validSessionID(id) {
+		jsonError(w, http.StatusNotFound, "not_found", "no such session")
+		return
+	}
+	if err := a.dir.Delete(r.Context(), id); err != nil {
+		switch {
+		case errors.Is(err, session.ErrMissionReferenced):
+			jsonError(w, http.StatusConflict, "mission_referenced",
+				"a mission references this session; its transcript must stay")
+		case strings.Contains(err.Error(), "not found"):
+			jsonError(w, http.StatusNotFound, "not_found", "no such session")
+		default:
+			jsonError(w, http.StatusInternalServerError, "delete_failed", err.Error())
+		}
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -31,10 +31,11 @@ func staticBudget(n int) func(context.Context) int {
 
 // memDir is an in-memory Directory + chat.SessionLog.
 type memDir struct {
-	mu     sync.Mutex
-	metas  map[string]session.Meta
-	events map[string][]session.Event
-	nextID int
+	mu         sync.Mutex
+	metas      map[string]session.Meta
+	events     map[string][]session.Event
+	missionRef map[string]bool
+	nextID     int
 }
 
 func newMemDir() *memDir {
@@ -109,6 +110,20 @@ func (d *memDir) Update(_ context.Context, id string, title *string, archived *b
 	return nil
 }
 
+func (d *memDir) Delete(_ context.Context, id string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.missionRef[id] {
+		return fmt.Errorf("session: delete %s: %w", id, session.ErrMissionReferenced)
+	}
+	if _, ok := d.metas[id]; !ok {
+		return fmt.Errorf("session: delete %s: not found", id)
+	}
+	delete(d.metas, id)
+	delete(d.events, id)
+	return nil
+}
+
 func (d *memDir) Append(_ context.Context, id, kind string, payload any) (int64, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -173,6 +188,7 @@ func mux(a *API) *http.ServeMux {
 	m.Handle("POST /v1/sessions", a.auth(http.HandlerFunc(a.handleCreate)))
 	m.Handle("GET /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleTranscript)))
 	m.Handle("PATCH /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleUpdate)))
+	m.Handle("DELETE /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleDelete)))
 	m.Handle("POST /v1/sessions/{id}/messages", a.auth(http.HandlerFunc(a.handleMessages)))
 	m.Handle("POST /v1/sessions/{id}/messages/retry", a.auth(http.HandlerFunc(a.handleRetry)))
 	m.Handle("POST /v1/permissions/{id}", a.auth(http.HandlerFunc(a.handlePermission)))
@@ -428,6 +444,37 @@ func TestSessionCRUD(t *testing.T) {
 	// patch missing
 	if w = doMux(a, http.MethodPatch, "/v1/sessions/nope", `{"archived":true}`); w.Code != http.StatusNotFound {
 		t.Fatalf("patch missing: %d", w.Code)
+	}
+}
+
+func TestSessionDelete(t *testing.T) {
+	t.Parallel()
+	a, dir, _ := testAPI(t, "tok", nil)
+	id, _ := dir.Create(t.Context(), "doomed")
+
+	if w := doMux(a, http.MethodDelete, "/v1/sessions/"+id, ""); w.Code != http.StatusNoContent {
+		t.Fatalf("delete: %d %s", w.Code, w.Body.String())
+	}
+	if _, err := dir.Get(t.Context(), id); err == nil {
+		t.Fatal("session still present after delete")
+	}
+	// delete again: gone means 404
+	if w := doMux(a, http.MethodDelete, "/v1/sessions/"+id, ""); w.Code != http.StatusNotFound {
+		t.Fatalf("re-delete: %d", w.Code)
+	}
+	// invalid id shape
+	if w := doMux(a, http.MethodDelete, "/v1/sessions/nope", ""); w.Code != http.StatusNotFound {
+		t.Fatalf("delete bad id: %d", w.Code)
+	}
+	// mission-referenced sessions refuse with 409
+	held, _ := dir.Create(t.Context(), "mission transcript")
+	dir.missionRef = map[string]bool{held: true}
+	w := doMux(a, http.MethodDelete, "/v1/sessions/"+held, "")
+	if w.Code != http.StatusConflict || !strings.Contains(w.Body.String(), "mission_referenced") {
+		t.Fatalf("mission-referenced delete: %d %s", w.Code, w.Body.String())
+	}
+	if _, err := dir.Get(t.Context(), held); err != nil {
+		t.Fatal("mission-referenced session must survive")
 	}
 }
 

--- a/internal/brain/session/store.go
+++ b/internal/brain/session/store.go
@@ -3,12 +3,17 @@ package session
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
 )
+
+// ErrMissionReferenced refuses deletion of a session a mission points
+// at — mission history must keep its transcript.
+var ErrMissionReferenced = errors.New("session referenced by a mission")
 
 // Store persists session rows and their append-only event logs.
 type Store struct {
@@ -233,6 +238,58 @@ func (s *Store) Update(ctx context.Context, id string, title *string, archived *
 	}
 	if tag.RowsAffected() == 0 {
 		return fmt.Errorf("session: update %s: not found", id)
+	}
+	return nil
+}
+
+// Delete permanently removes a session and every session-scoped
+// record: events, permission grants, tool audit rows, and stored tool
+// outputs (D-035). This is user-initiated data control, not an edit of
+// history — the append-only rule forbids mutating events in place, not
+// discarding a whole session. Cost-ledger rows and extracted memories
+// survive on purpose: spend history stays honest and the supersede-only
+// memory store keeps its facts (their source_session link dangles).
+// A session referenced by a mission refuses with ErrMissionReferenced.
+func (s *Store) Delete(ctx context.Context, id string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("session: delete: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("session: delete begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+
+	var referenced bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM missions WHERE session_id = $1)`, id,
+	).Scan(&referenced); err != nil {
+		return fmt.Errorf("session: delete mission check: %w", err)
+	}
+	if referenced {
+		return fmt.Errorf("session: delete %s: %w", id, ErrMissionReferenced)
+	}
+
+	for _, stmt := range []string{
+		`DELETE FROM session_grants WHERE session_id = $1`,
+		`DELETE FROM tool_audit WHERE session_id = $1`,
+		`DELETE FROM tool_outputs WHERE session_id = $1`,
+		`DELETE FROM session_events WHERE session_id = $1`,
+	} {
+		if _, err := tx.Exec(ctx, stmt, id); err != nil {
+			return fmt.Errorf("session: delete %s: %w", id, err)
+		}
+	}
+	tag, err := tx.Exec(ctx, `DELETE FROM sessions WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("session: delete %s: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("session: delete %s: not found", id)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("session: delete commit: %w", err)
 	}
 	return nil
 }

--- a/internal/brain/session/store_integration_test.go
+++ b/internal/brain/session/store_integration_test.go
@@ -4,9 +4,11 @@ package session
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -66,6 +68,87 @@ func integrationStore(t *testing.T) (*Store, string) {
 		}
 	})
 	return s, id
+}
+
+func TestDeleteRemovesSessionScopedRecords(t *testing.T) {
+	s, id := integrationStore(t)
+	ctx := t.Context()
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	// Populate every session-scoped table Delete must clear.
+	if _, err := s.Append(ctx, id, KindUserMessage, UserMessage{Text: "doomed turn"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	for _, stmt := range []string{
+		`INSERT INTO session_grants (session_id, tool, pattern, expires) VALUES ($1, 'shell', '*', now() + interval '1 hour')`,
+		`INSERT INTO tool_audit (session_id, tool, args_digest, status, duration_ms) VALUES ($1, 'shell', 'x', 'ok', 1)`,
+		`INSERT INTO tool_outputs (session_id, tool, content, bytes) VALUES ($1, 'shell', 'out', 3)`,
+	} {
+		if _, err := db.Exec(ctx, stmt, id); err != nil {
+			t.Fatalf("seed %q: %v", stmt, err)
+		}
+	}
+
+	if err := s.Delete(ctx, id); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	for _, q := range []string{
+		`SELECT count(*) FROM sessions WHERE id = $1`,
+		`SELECT count(*) FROM session_events WHERE session_id = $1`,
+		`SELECT count(*) FROM session_grants WHERE session_id = $1`,
+		`SELECT count(*) FROM tool_audit WHERE session_id = $1`,
+		`SELECT count(*) FROM tool_outputs WHERE session_id = $1`,
+	} {
+		var n int
+		if err := db.QueryRow(ctx, q, id).Scan(&n); err != nil {
+			t.Fatalf("%q: %v", q, err)
+		}
+		if n != 0 {
+			t.Fatalf("%q = %d rows after delete, want 0", q, n)
+		}
+	}
+
+	// Second delete: the session is gone.
+	if err := s.Delete(ctx, id); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("re-delete err = %v, want not found", err)
+	}
+}
+
+func TestDeleteRefusesMissionSession(t *testing.T) {
+	s, id := integrationStore(t)
+	ctx := t.Context()
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	var missionID string
+	if err := db.QueryRow(ctx, `INSERT INTO missions (goal, kind, session_id)
+		VALUES ('itest-delete-guard', 'research', $1) RETURNING id`, id).Scan(&missionID); err != nil {
+		t.Fatalf("seed mission: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		conn, err := pgx.Connect(ctx, os.Getenv("DATABASE_URL"))
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close(ctx) }()
+		_, _ = conn.Exec(ctx, `DELETE FROM mission_events WHERE mission_id = $1`, missionID)
+		_, _ = conn.Exec(ctx, `DELETE FROM missions WHERE id = $1`, missionID)
+	})
+
+	if err := s.Delete(ctx, id); !errors.Is(err, ErrMissionReferenced) {
+		t.Fatalf("Delete err = %v, want ErrMissionReferenced", err)
+	}
+	var n int
+	if err := db.QueryRow(ctx, `SELECT count(*) FROM sessions WHERE id = $1`, id).Scan(&n); err != nil || n != 1 {
+		t.Fatalf("session rows = %d (%v), want 1 — refusal must not delete", n, err)
+	}
 }
 
 func TestAppendAssignsGaplessOrderedSeqs(t *testing.T) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -245,6 +245,10 @@ export async function updateSession(
   await request<void>(`/v1/sessions/${id}`, { method: 'PATCH', body: JSON.stringify(patch) })
 }
 
+export async function deleteSession(id: string): Promise<void> {
+  await request<void>(`/v1/sessions/${id}`, { method: 'DELETE' })
+}
+
 // --- Long-term memory (queue + browser) ---
 
 export async function listMemories(

--- a/web/src/components/SessionList.test.tsx
+++ b/web/src/components/SessionList.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SessionMeta } from '../api/types'
+import { SessionsContext } from '../lib/sessions'
+import { SessionList } from './SessionList'
+import { SidebarProvider } from './ui/sidebar'
+
+vi.mock('../api/client', () => ({
+  deleteSession: vi.fn(),
+  updateSession: vi.fn(),
+}))
+
+// SidebarProvider's useIsMobile needs matchMedia, which jsdom lacks.
+window.matchMedia = (query: string) =>
+  ({
+    matches: false,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    onchange: null,
+    dispatchEvent: () => false,
+  }) as MediaQueryList
+
+import { deleteSession } from '../api/client'
+
+const meta: SessionMeta = {
+  id: '11111111-1111-1111-1111-111111111111',
+  title: 'doomed chat',
+  archived: false,
+  created_at: '2026-07-25T10:00:00Z',
+  updated_at: '2026-07-25T10:00:00Z',
+}
+
+const refresh = vi.fn()
+
+function renderList() {
+  return render(
+    <MemoryRouter>
+      <SidebarProvider>
+        <SessionsContext.Provider
+          value={{
+            sessions: [meta],
+            query: '',
+            setQuery: () => {},
+            refresh,
+            hasMore: false,
+            loadMore: () => {},
+          }}
+        >
+          <SessionList />
+        </SessionsContext.Provider>
+      </SidebarProvider>
+    </MemoryRouter>,
+  )
+}
+
+// Radix opens dropdowns on pointerdown, not click.
+function openMenu() {
+  const trigger = screen.getByRole('button', { name: /Actions for doomed chat/ })
+  fireEvent.pointerDown(trigger, { button: 0, pointerId: 1 })
+  fireEvent.click(trigger)
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(deleteSession).mockResolvedValue(undefined)
+})
+
+describe('SessionList delete', () => {
+  it('confirms before deleting, then refreshes', async () => {
+    renderList()
+    openMenu()
+    fireEvent.click(await screen.findByText('Delete'))
+    expect(await screen.findByText(/permanently removes the conversation/)).toBeInTheDocument()
+    expect(deleteSession).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(deleteSession).toHaveBeenCalledWith(meta.id))
+    expect(refresh).toHaveBeenCalled()
+  })
+
+  it('cancel closes the dialog without deleting', async () => {
+    renderList()
+    openMenu()
+    fireEvent.click(await screen.findByText('Delete'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+    await waitFor(() =>
+      expect(screen.queryByText(/permanently removes the conversation/)).not.toBeInTheDocument(),
+    )
+    expect(deleteSession).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -2,6 +2,7 @@ import {
   Add01Icon,
   Archive02Icon,
   BubbleChatIcon,
+  Delete02Icon,
   MoreHorizontalIcon,
   PencilEdit01Icon,
   Search01Icon,
@@ -11,10 +12,19 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useRef, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router'
 import { toast } from 'sonner'
-import { updateSession } from '../api/client'
+import { deleteSession, updateSession } from '../api/client'
 import type { SessionMeta } from '../api/types'
 import { groupByDay, useSessions } from '../lib/sessions'
+import { errText } from './settings/util'
 import { Badge } from './ui/badge'
+import { Button } from './ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -37,6 +47,7 @@ export function SessionList() {
   const navigate = useNavigate()
   const [editingId, setEditingId] = useState<string | null>(null)
   const [title, setTitle] = useState('')
+  const [confirmDelete, setConfirmDelete] = useState<SessionMeta | null>(null)
   const sentinelRef = useRef<HTMLDivElement>(null)
 
   // Infinite scroll: fetch the next page when the sentinel below the
@@ -76,6 +87,22 @@ export function SessionList() {
     refresh()
     // Archiving the open session sends you back to a fresh chat.
     if (!s.archived && pathname === `/chat/${s.id}`) navigate('/chat')
+  }
+
+  const remove = async () => {
+    if (!confirmDelete) return
+    const s = confirmDelete
+    setConfirmDelete(null)
+    try {
+      await deleteSession(s.id)
+      toast.success('Session deleted', {
+        description: `“${s.title || 'New session'}” and its history are gone.`,
+      })
+      refresh()
+      if (pathname === `/chat/${s.id}`) navigate('/chat')
+    } catch (err) {
+      toast.error('Could not delete session', { description: errText(err) })
+    }
   }
 
   // Flat, dated rows (not day-sectioned): each session carries its own
@@ -161,6 +188,13 @@ export function SessionList() {
                       <HugeiconsIcon icon={s.archived ? Unarchive03Icon : Archive02Icon} />
                       {s.archived ? 'Unarchive' : 'Archive'}
                     </DropdownMenuItem>
+                    <DropdownMenuItem
+                      variant="destructive"
+                      onClick={() => setConfirmDelete(s)}
+                    >
+                      <HugeiconsIcon icon={Delete02Icon} />
+                      Delete
+                    </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
               </SidebarMenuItem>
@@ -173,6 +207,26 @@ export function SessionList() {
         <p className="px-4 py-1 text-xs text-muted-foreground">No sessions match.</p>
       )}
       {hasMore && <div ref={sentinelRef} className="h-px" data-testid="sessions-sentinel" />}
+
+      <Dialog open={confirmDelete !== null} onOpenChange={(o) => !o && setConfirmDelete(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete “{confirmDelete?.title || 'New session'}”?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            This permanently removes the conversation, its tool activity, and its permission
+            grants. It cannot be undone. Confirmed memories and cost history are kept.
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmDelete(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={() => void remove()}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }


### PR DESCRIPTION
## What

Adds permanent session deletion — archive was the only lifecycle action, so sessions and their scoped records lived forever.

- **API**: `DELETE /v1/sessions/{id}` (bearer-gated like the rest). One transaction removes the session row plus `session_events`, `session_grants`, `tool_audit`, and `tool_outputs` (D-035).
- **Deliberately kept**: `cost_ledger` rows (spend history stays honest) and extracted memories (supersede-only store; `source_session` links dangle by design).
- **Guard**: a session referenced by a mission refuses with 409 `mission_referenced` — mission history keeps its transcript.
- **Web**: destructive "Delete" item in the session dropdown behind a confirmation dialog that states exactly what is removed and what survives; deleting the open session navigates back to a fresh chat.

On append-only: the invariant forbids mutating events in place, not user-initiated disposal of a whole session — deletion is data control, documented on `Store.Delete`.

## Verification

- `make build test vet lint` — 0 issues
- Web: build, lint, full suite (2 new `SessionList` tests: confirm-then-delete flow, cancel keeps the session)
- Unit: `TestSessionDelete` (204 + gone, 404 re-delete, 404 bad id, 409 mission-referenced survives)
- Integration against live stack DB: `TestDeleteRemovesSessionScopedRecords` (every scoped table verified empty), `TestDeleteRefusesMissionSession`
