### PR TITLE
fix(tools): resolve symlinks before shell/write_file paths execute

### DIFF
--- a/internal/brain/tools/builtin/shell.go
+++ b/internal/brain/tools/builtin/shell.go
@@ -114,6 +114,14 @@ Example: {"command": "wc -l notes.md"} → "42 notes.md"`,
 			if args.TimeoutSeconds > 0 {
 				runTimeout = time.Duration(args.TimeoutSeconds) * time.Second
 			}
+			// The permission chain's sandbox check on absolute path
+			// tokens is lexical only, so a symlink planted inside the
+			// workspace pointing outside it would otherwise reach the
+			// shell unchecked. Re-check with symlinks resolved here,
+			// right before the command actually runs.
+			if err := tools.CheckCommandPaths(cfg.WorkspaceRoot, args.Command); err != nil {
+				return "", err
+			}
 			return runShell(ctx, cfg.WorkspaceRoot, runTimeout, args.Command)
 		},
 	}

--- a/internal/brain/tools/builtin/shell_test.go
+++ b/internal/brain/tools/builtin/shell_test.go
@@ -3,6 +3,7 @@ package builtin
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -88,6 +89,35 @@ func TestShellCapsOutput(t *testing.T) {
 	}
 	if !strings.Contains(got, "[output capped]") {
 		t.Fatal("capped output missing marker")
+	}
+}
+
+// TestShellRejectsSymlinkEscape is the sandbox-bypass this tool must
+// close on its own: a symlink already sitting inside the workspace
+// (e.g. brought in by a repo checkout) pointing outside it lets a
+// purely workspace-relative command like "rm -rf vendor/lib/file"
+// destroy something elsewhere. Nothing in the permission chain's
+// lexical containment check catches this — pathWithin only inspects
+// absolute tokens, and a relative token never trips it. The tool
+// itself re-checks with symlinks resolved right before it execs.
+func TestShellRejectsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+	tool, dir := shellTool(t, 0)
+	outside := t.TempDir()
+	targetPath := outside + "/target"
+	if err := os.WriteFile(targetPath, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	if err := os.Symlink(outside, dir+"/escape"); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	_, err := runTool(t, tool, "rm -rf escape/target")
+	if err == nil || !strings.Contains(err.Error(), "outside the workspace") {
+		t.Fatalf("err = %v, want symlink escape rejected", err)
+	}
+	if _, statErr := os.Stat(targetPath); statErr != nil {
+		t.Fatalf("target was deleted through the symlink: %v", statErr)
 	}
 }
 

--- a/internal/brain/tools/builtin/writefile.go
+++ b/internal/brain/tools/builtin/writefile.go
@@ -92,6 +92,12 @@ Example: {"path": "summary.md", "content": "# Title\n\nBody."}`,
 					return "", fmt.Errorf("create parent directories: %w", err)
 				}
 			}
+			// The lexical join above can't see a symlinked ancestor
+			// inside the workspace pointing outside it; WithinRoot
+			// resolves symlinks before the write lands.
+			if err := tools.WithinRoot(cfg.Root, target); err != nil {
+				return "", err
+			}
 			if err := os.WriteFile(target, []byte(args.Content), 0o644); err != nil { //nolint:gosec // artifact files are meant to be readable; path is root-confined above
 				return "", fmt.Errorf("write file: %w", err)
 			}

--- a/internal/brain/tools/builtin/writefile_test.go
+++ b/internal/brain/tools/builtin/writefile_test.go
@@ -83,6 +83,26 @@ func TestWriteFile(t *testing.T) {
 	})
 }
 
+// TestWriteFileRejectsSymlinkEscape covers the gap the lexical ".."
+// check above can't see: a workspace-relative path that resolves
+// cleanly on paper but walks through a symlinked ancestor pointing
+// outside the root.
+func TestWriteFileRejectsSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	tool := WriteFile(WriteFileConfig{Root: root})
+	args, _ := json.Marshal(map[string]string{"path": "escape/evil.txt", "content": "x"})
+	if _, err := tool.Execute(context.Background(), args); err == nil {
+		t.Fatal("symlink escape accepted")
+	}
+	if _, err := os.Stat(filepath.Join(outside, "evil.txt")); err == nil {
+		t.Fatal("file was written outside the workspace")
+	}
+}
+
 // TestWriteFileContentWithShellMetacharacters is the reason this tool
 // exists: content full of $(), backticks, and redirects — which would
 // classify a shell heredoc as opaque/destructive and park the turn —

--- a/internal/brain/tools/constraints.go
+++ b/internal/brain/tools/constraints.go
@@ -134,6 +134,41 @@ func WithinRoot(root, path string) error {
 	return nil
 }
 
+// CheckCommandPaths re-validates every path-like token a shell command
+// names, with symlinks resolved, right before the command execs. The
+// permission chain's containment check (guardSubject/pathWithin) is
+// lexical only and only inspects absolute tokens — it can't see a
+// symlink inside the workspace pointing outside it, and it never
+// checks relative tokens at all, even though the shell resolves them
+// against the workspace root same as an absolute path underneath it.
+// A destructive command confined "on paper" to the sandbox would still
+// land through either gap.
+func CheckCommandPaths(root, command string) error {
+	if root == "" {
+		return nil
+	}
+	for _, tok := range CommandTokens(command) {
+		abs := tok
+		if !filepath.IsAbs(tok) {
+			abs = filepath.Join(root, tok)
+		}
+		exempt := false
+		for _, p := range AllowedAbsPrefixes {
+			if abs == p || strings.HasPrefix(abs, p+"/") {
+				exempt = true
+				break
+			}
+		}
+		if exempt {
+			continue
+		}
+		if err := WithinRoot(root, abs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // resolveExisting walks up from path to the deepest existing ancestor,
 // resolves that through symlinks, and rejoins the nonexistent tail.
 func resolveExisting(path string) (string, error) {

--- a/internal/brain/tools/constraints_test.go
+++ b/internal/brain/tools/constraints_test.go
@@ -155,6 +155,59 @@ func TestWithinRoot(t *testing.T) {
 	}
 }
 
+func TestCheckCommandPaths(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "target"), []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A symlink inside the workspace pointing out of it — what
+	// guardSubject's lexical check on its own cannot see through.
+	link := filepath.Join(root, "escape")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		command string
+		wantErr string
+	}{
+		{name: "no root configured", command: "rm -rf /etc/passwd"},
+		{name: "relative path ok", command: "rm -rf reports/"},
+		{name: "plain absolute path within root ok", command: "rm -rf " + filepath.Join(root, "sub")},
+		{name: "dev null exempt", command: "echo hi > /dev/null"},
+		{
+			name:    "symlink escape rejected",
+			command: "rm -rf " + filepath.Join(link, "target"),
+			wantErr: "outside the workspace",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r := root
+			if tc.name == "no root configured" {
+				r = ""
+			}
+			err := CheckCommandPaths(r, tc.command)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("CheckCommandPaths: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+			}
+			if !IsViolation(err) {
+				t.Fatalf("err %v is not a Violation", err)
+			}
+		})
+	}
+}
+
 func TestCeilingFor(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -188,7 +188,7 @@ func (p *Permissions) sandboxAllows(ctx context.Context, sessionID, subject stri
 	if root == "" {
 		return false
 	}
-	for _, tok := range commandTokens(subject) {
+	for _, tok := range CommandTokens(subject) {
 		if strings.HasPrefix(tok, "/") && !pathWithin(root, tok) {
 			return false
 		}
@@ -306,9 +306,9 @@ var guardPatterns = []struct {
 	{name: "system dirs", pattern: regexp.MustCompile(`(^|[\s'"=])/(etc|root|proc|sys|dev|boot|var/(run|lib))(/|\s|$)`)},
 }
 
-// allowedAbsPrefixes are absolute paths a shell command may name even
+// AllowedAbsPrefixes are absolute paths a shell command may name even
 // though they sit outside the workspace: stream plumbing only.
-var allowedAbsPrefixes = []string{"/dev/null", "/dev/stdin", "/dev/stdout", "/dev/stderr"}
+var AllowedAbsPrefixes = []string{"/dev/null", "/dev/stdin", "/dev/stdout", "/dev/stderr"}
 
 // guardSubject applies the policy guard to shell commands. Other
 // tools have no path-bearing arguments yet; web_fetch has its own
@@ -319,7 +319,7 @@ func guardSubject(root, tool, subject string) string {
 	}
 	// Blank the allowed stream-plumbing paths first so /dev/null
 	// doesn't trip the system-dirs rule.
-	for _, p := range allowedAbsPrefixes {
+	for _, p := range AllowedAbsPrefixes {
 		subject = strings.ReplaceAll(subject, p, " ")
 	}
 	for _, g := range guardPatterns {
@@ -328,7 +328,7 @@ func guardSubject(root, tool, subject string) string {
 		}
 	}
 	if root != "" {
-		for _, tok := range commandTokens(subject) {
+		for _, tok := range CommandTokens(subject) {
 			// A parent-directory reference in any path-like token can
 			// climb out of the workspace once the shell resolves it —
 			// the lexical check below can't see where it lands, so a
@@ -357,11 +357,11 @@ func pathWithin(root, p string) bool {
 	return cleaned == root || strings.HasPrefix(cleaned, root+"/")
 }
 
-// commandTokens splits a command line the cheap way — whitespace,
+// CommandTokens splits a command line the cheap way — whitespace,
 // with quotes and redirect prefixes stripped — enough to spot
 // absolute paths. It intentionally over-matches: a false hit returns
 // corrective feedback, and the model retries with workspace paths.
-func commandTokens(command string) []string {
+func CommandTokens(command string) []string {
 	// '=' splits too, so --output=/abs/path exposes its path part.
 	fields := strings.Fields(strings.ReplaceAll(command, "=", " "))
 	out := make([]string, 0, len(fields))


### PR DESCRIPTION
## Summary
- `pathWithin` (the permission chain's containment check for shell paths) is lexical only and only inspects absolute tokens — it never checks relative tokens at all, and can't see a symlink already sitting inside the workspace pointing outside it
- A symlink brought in by e.g. a repo checkout, plus a purely workspace-relative destructive command (`rm -rf vendor/lib/file`), would sail past the permission chain's sandbox auto-approval and land outside the workspace through the symlink
- `write_file`'s own confinement is the same kind of lexical join with no symlink resolution
- `WithinRoot` already existed and resolves symlinks correctly, but had zero callers outside its own test — wire it into both `shell`'s execution path (`CheckCommandPaths`, checking every path-like token right before exec) and `write_file`'s write path

## Test plan
- [x] `go build ./... && go vet ./... && go test -race ./...` (full repo, all green)
- [x] `golangci-lint run ./...` (0 issues)
- [x] New tests reproduce the exploit and confirm it's blocked: `TestShellRejectsSymlinkEscape`, `TestWriteFileRejectsSymlinkEscape`, `TestCheckCommandPaths`
