### PR TITLE
feat(observability): log every HTTP request, add tool/provider metrics

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -29,6 +29,8 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/skills"
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
 	"github.com/SumonMSelim/timothy/internal/brain/tools/builtin"
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 	"github.com/SumonMSelim/timothy/internal/platform/httpserver"
@@ -132,7 +134,9 @@ func main() {
 	searxngURL := os.Getenv("SEARXNG_URL")
 	markitdownURL := os.Getenv("MARKITDOWN_URL")
 
-	agent, broker, outputs, builtinSet, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, markitdownURL, packs, flags.SkillAllowed, mc.Add, app.Log)
+	toolCalls := app.Metrics.NewCounterVec("tool_calls_total",
+		"Tool executions by tool name and outcome.", "tool", "outcome")
+	agent, broker, outputs, builtinSet, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, markitdownURL, packs, flags.SkillAllowed, mc.Add, app.Log, toolCalls)
 	if buildErr != nil {
 		fmt.Fprintln(os.Stderr, buildErr)
 		os.Exit(1)
@@ -146,7 +150,7 @@ func main() {
 			conns.RegisterBuilder("google", goog.Builder())
 		}
 		conns.SetOnReload(func(context.Context) {
-			swapAgentTools(agent, builtinSet, conns, app.Log)
+			swapAgentTools(agent, builtinSet, conns, app.Log, toolCalls)
 		})
 		go runConnectorReload(ctx, conns, app.Log)
 	}
@@ -378,7 +382,7 @@ func (r turnRouter) Stream(ctx context.Context, req gwclient.StreamRequest) (<-c
 // buildAgent assembles the compiled-in tool registry and its guard
 // rails (D-009, D-010). The returned builtin set is the fixed half of
 // the tool surface; connector tools join it via swapAgentTools.
-func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, workspace, searxngURL, markitdownURL string, packs []skills.Skill, skillAllow func(context.Context, string) bool, remember builtin.RememberFunc, log *slog.Logger) (*loop.Agent, *loop.PermBroker, *tools.Outputs, []*tools.Tool, error) {
+func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, workspace, searxngURL, markitdownURL string, packs []skills.Skill, skillAllow func(context.Context, string) bool, remember builtin.RememberFunc, log *slog.Logger, toolCalls *prometheus.CounterVec) (*loop.Agent, *loop.PermBroker, *tools.Outputs, []*tools.Tool, error) {
 	outputs := tools.NewOutputs(db)
 	set := []*tools.Tool{
 		builtin.CurrentTime(time.Now),
@@ -398,7 +402,7 @@ func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, wor
 	if len(packs) > 0 {
 		set = append(set, skills.LoadSkillTool(packs, skillAllow))
 	}
-	constrained, defs, err := compileToolset(set, nil, log)
+	constrained, defs, err := compileToolset(set, nil, log, toolCalls)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -427,7 +431,7 @@ func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, wor
 // constrained registry. A connector tool whose name collides with an
 // existing tool is skipped with a log — a remote server must never
 // shadow a builtin.
-func compileToolset(builtins, connectorTools []*tools.Tool, log *slog.Logger) (*tools.Constrained, []provider.ToolDef, error) {
+func compileToolset(builtins, connectorTools []*tools.Tool, log *slog.Logger, toolCalls *prometheus.CounterVec) (*tools.Constrained, []provider.ToolDef, error) {
 	reg := tools.NewRegistry()
 	for _, t := range builtins {
 		if err := reg.Register(t); err != nil {
@@ -439,7 +443,7 @@ func compileToolset(builtins, connectorTools []*tools.Tool, log *slog.Logger) (*
 			log.Warn("connector tool skipped", "tool", t.Name, "error", err)
 		}
 	}
-	constrained, err := tools.NewConstrained(reg)
+	constrained, err := tools.NewConstrained(reg, toolCalls)
 	if err != nil {
 		return nil, nil, fmt.Errorf("compile tool schemas: %w", err)
 	}
@@ -455,8 +459,8 @@ func compileToolset(builtins, connectorTools []*tools.Tool, log *slog.Logger) (*
 // swapAgentTools recompiles builtin + connector tools and swaps them
 // into the agent. A compile failure keeps the previous surface — a
 // broken connector schema must not take down the builtins.
-func swapAgentTools(agent *loop.Agent, builtins []*tools.Tool, conns *connectors.Manager, log *slog.Logger) {
-	constrained, defs, err := compileToolset(builtins, conns.Tools(), log)
+func swapAgentTools(agent *loop.Agent, builtins []*tools.Tool, conns *connectors.Manager, log *slog.Logger, toolCalls *prometheus.CounterVec) {
+	constrained, defs, err := compileToolset(builtins, conns.Tools(), log, toolCalls)
 	if err != nil {
 		log.Warn("connector toolset compile failed; keeping previous tools", "error", err)
 		return

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -60,7 +60,7 @@ func main() {
 	led := ledger.New(app.DB, app.Log)
 	agg := ledger.NewAggregator(app.DB)
 	budgets := ledger.NewBudgetStore(app.DB)
-	api.Register(app.Server, store, led, app.Log)
+	api.Register(app.Server, store, led, app.Log, app.Metrics)
 	api.RegisterUsage(app.Server, agg, budgets)
 	api.RegisterAdmin(app.Server, admin.New(app.DB, store, led, budgets, secrets, app.Log))
 

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -11,11 +11,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 )
+
+func testToolCalls() *prometheus.CounterVec {
+	return prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_tool_calls_total"}, []string{"tool", "outcome"})
+}
 
 // scriptedGateway plays one canned event script per Stream call and
 // records every request it saw.
@@ -155,7 +161,7 @@ func testAgent(t *testing.T, gw Gateway, extra ...*tools.Tool) (*Agent, *memAudi
 			t.Fatal(err)
 		}
 	}
-	c, err := tools.NewConstrained(reg)
+	c, err := tools.NewConstrained(reg, testToolCalls())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -796,7 +802,7 @@ func TestSwapToolsChangesSurfaceForNewTurns(t *testing.T) {
 	if err := reg.Register(connector); err != nil {
 		t.Fatal(err)
 	}
-	c, err := tools.NewConstrained(reg)
+	c, err := tools.NewConstrained(reg, testToolCalls())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/brain/tools/constraints.go
+++ b/internal/brain/tools/constraints.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
@@ -42,15 +43,21 @@ type Constrained struct {
 	reg     *Registry
 	schemas map[string]*jsonschema.Schema
 	clamps  map[string]Clamp
+	calls   *prometheus.CounterVec
 }
 
 // NewConstrained compiles every registered tool's input schema up
 // front; a malformed schema is a programming error caught at startup.
-func NewConstrained(reg *Registry) (*Constrained, error) {
+// calls counts tool executions by name and outcome — the caller
+// creates it once and passes it in, since a connector reload rebuilds
+// the registry (and would otherwise re-register the same metric name
+// on the shared Prometheus registry and panic).
+func NewConstrained(reg *Registry, calls *prometheus.CounterVec) (*Constrained, error) {
 	c := &Constrained{
 		reg:     reg,
 		schemas: make(map[string]*jsonschema.Schema),
 		clamps:  make(map[string]Clamp),
+		calls:   calls,
 	}
 	for _, t := range reg.List() {
 		if len(t.InputSchema) == 0 {
@@ -81,7 +88,9 @@ func (c *Constrained) SetClamp(tool string, clamp Clamp) {
 // Execute runs one tool call through the constraint chain. A
 // *Violation error is model feedback; any other error is an
 // infrastructure fault.
-func (c *Constrained) Execute(ctx context.Context, name string, args json.RawMessage) (string, error) {
+func (c *Constrained) Execute(ctx context.Context, name string, args json.RawMessage) (out string, err error) {
+	defer func() { c.calls.WithLabelValues(name, outcomeFor(err)).Inc() }()
+
 	tool, ok := c.reg.Get(name)
 	if !ok {
 		return "", &Violation{Msg: fmt.Sprintf(
@@ -90,23 +99,38 @@ func (c *Constrained) Execute(ctx context.Context, name string, args json.RawMes
 	if len(args) == 0 {
 		args = json.RawMessage(`{}`)
 	}
-	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(args))
-	if err != nil {
+	doc, uerr := jsonschema.UnmarshalJSON(bytes.NewReader(args))
+	if uerr != nil {
 		return "", &Violation{Msg: fmt.Sprintf(
-			"arguments for %s are not valid JSON: %v — resend the call with corrected arguments", name, err)}
+			"arguments for %s are not valid JSON: %v — resend the call with corrected arguments", name, uerr)}
 	}
-	if err := c.schemas[name].Validate(doc); err != nil {
+	if verr := c.schemas[name].Validate(doc); verr != nil {
 		return "", &Violation{Msg: fmt.Sprintf(
-			"arguments for %s failed validation: %v — check the tool description for the expected format and resend", name, err)}
+			"arguments for %s failed validation: %v — check the tool description for the expected format and resend", name, verr)}
 	}
 	if clamp, ok := c.clamps[name]; ok {
-		clamped, err := clamp(args)
-		if err != nil {
-			return "", fmt.Errorf("tools: clamp %s: %w", name, err)
+		clamped, cerr := clamp(args)
+		if cerr != nil {
+			return "", fmt.Errorf("tools: clamp %s: %w", name, cerr)
 		}
 		args = clamped
 	}
 	return tool.Execute(ctx, args)
+}
+
+// outcomeFor labels a tool call's result for the tool_calls_total
+// counter: "ok" on success, "violation" for model-correctable feedback
+// (bad arguments, unknown tool), "error" for everything else — an
+// infrastructure fault the model can't fix by retrying differently.
+func outcomeFor(err error) string {
+	switch {
+	case err == nil:
+		return "ok"
+	case IsViolation(err):
+		return "violation"
+	default:
+		return "error"
+	}
 }
 
 // WithinRoot resolves path (which must be absolute) against symlinks

--- a/internal/brain/tools/constraints_test.go
+++ b/internal/brain/tools/constraints_test.go
@@ -8,8 +8,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 )
+
+func testToolCalls() *prometheus.CounterVec {
+	return prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_tool_calls_total"}, []string{"tool", "outcome"})
+}
 
 func constrainedEcho(t *testing.T) *Constrained {
 	t.Helper()
@@ -33,7 +40,7 @@ func constrainedEcho(t *testing.T) *Constrained {
 	if err != nil {
 		t.Fatalf("register: %v", err)
 	}
-	c, err := NewConstrained(r)
+	c, err := NewConstrained(r, testToolCalls())
 	if err != nil {
 		t.Fatalf("NewConstrained: %v", err)
 	}
@@ -81,8 +88,48 @@ func TestConstrainedRequiresSchemas(t *testing.T) {
 	t.Parallel()
 	r := NewRegistry()
 	_ = r.Register(&Tool{Name: "bare", Description: "no schema"})
-	if _, err := NewConstrained(r); err == nil {
+	if _, err := NewConstrained(r, testToolCalls()); err == nil {
 		t.Fatal("tool without schema accepted")
+	}
+}
+
+func TestConstrainedRecordsToolCallOutcomes(t *testing.T) {
+	t.Parallel()
+	r := NewRegistry()
+	if err := r.Register(&Tool{
+		Name:        "echo",
+		Description: "echoes text",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"text":{"type":"string"}},"required":["text"],"additionalProperties":false}`),
+		Execute: func(_ context.Context, args json.RawMessage) (string, error) {
+			return string(args), nil
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	calls := testToolCalls()
+	c, err := NewConstrained(r, calls)
+	if err != nil {
+		t.Fatalf("NewConstrained: %v", err)
+	}
+
+	if _, err := c.Execute(context.Background(), "echo", json.RawMessage(`{"text":"hi"}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if _, err := c.Execute(context.Background(), "echo", json.RawMessage(`{}`)); err == nil {
+		t.Fatal("want validation violation")
+	}
+	if _, err := c.Execute(context.Background(), "nope", json.RawMessage(`{}`)); err == nil {
+		t.Fatal("want unknown-tool violation")
+	}
+
+	if got := testutil.ToFloat64(calls.WithLabelValues("echo", "ok")); got != 1 {
+		t.Fatalf("echo/ok = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(calls.WithLabelValues("echo", "violation")); got != 1 {
+		t.Fatalf("echo/violation = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(calls.WithLabelValues("nope", "violation")); got != 1 {
+		t.Fatalf("nope/violation = %v, want 1", got)
 	}
 }
 

--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -13,11 +13,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/SumonMSelim/timothy/internal/gateway/ledger"
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/router"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 	"github.com/SumonMSelim/timothy/internal/platform/httpserver"
+	"github.com/SumonMSelim/timothy/internal/platform/metrics"
 )
 
 // ConfigSource supplies routing snapshots and reloads; router.Store
@@ -29,18 +32,32 @@ type ConfigSource interface {
 
 // API serves the gateway routes.
 type API struct {
-	store  ConfigSource
-	ledger ledger.Recorder
-	log    *slog.Logger
+	store         ConfigSource
+	ledger        ledger.Recorder
+	log           *slog.Logger
+	providerCalls *prometheus.CounterVec
 }
 
 // Register mounts the gateway API on the shared server.
-func Register(srv *httpserver.Server, store ConfigSource, rec ledger.Recorder, log *slog.Logger) {
-	a := &API{store: store, ledger: rec, log: log}
+func Register(srv *httpserver.Server, store ConfigSource, rec ledger.Recorder, log *slog.Logger, m *metrics.Metrics) {
+	a := &API{
+		store:  store,
+		ledger: rec,
+		log:    log,
+		providerCalls: m.NewCounterVec("provider_calls_total",
+			"Provider attempts by provider, route, and outcome.", "provider", "route", "status"),
+	}
 	srv.Handle("POST /v1/stream", http.HandlerFunc(a.handleStream))
 	srv.Handle("POST /v1/embed", http.HandlerFunc(a.handleEmbed))
 	srv.Handle("GET /v1/providers", http.HandlerFunc(a.handleProviders))
 	srv.Handle("POST /internal/reload", http.HandlerFunc(a.handleReload))
+}
+
+// recordAttempt writes the ledger row and the matching provider-call
+// counter in one place so the two accountings never drift apart.
+func (a *API) recordAttempt(ctx context.Context, entry ledger.Entry) {
+	a.ledger.Record(ctx, entry)
+	a.providerCalls.WithLabelValues(entry.Provider, entry.Route, entry.Status).Inc()
 }
 
 type streamRequest struct {
@@ -144,12 +161,12 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 
 		if res.failedOver() {
 			failed = append(failed, fmt.Sprintf("%s/%s: %s", att.ProviderName, att.Model, res.reason))
-			a.ledger.Record(r.Context(), res.entry)
+			a.recordAttempt(r.Context(), res.entry)
 			continue
 		}
 
 		res.entry.CostUSD = ledger.Cost(snap.Prices(att.ProviderName, att.Model), res.entry.Usage)
-		a.ledger.Record(r.Context(), res.entry)
+		a.recordAttempt(r.Context(), res.entry)
 		return
 	}
 
@@ -316,14 +333,14 @@ func (a *API) handleEmbed(w http.ResponseWriter, r *http.Request) {
 		entry.Usage = usage
 		if err != nil {
 			entry.Status, entry.ErrorCode = "error", "provider_error"
-			a.ledger.Record(r.Context(), entry)
+			a.recordAttempt(r.Context(), entry)
 			failed = append(failed, fmt.Sprintf("%s/%s: %v", att.ProviderName, att.Model, err))
 			continue
 		}
 
 		entry.Status = "ok"
 		entry.CostUSD = ledger.Cost(snap.Prices(att.ProviderName, att.Model), usage)
-		a.ledger.Record(r.Context(), entry)
+		a.recordAttempt(r.Context(), entry)
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{

--- a/internal/gateway/api/api_test.go
+++ b/internal/gateway/api/api_test.go
@@ -14,9 +14,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"github.com/SumonMSelim/timothy/internal/gateway/ledger"
 	"github.com/SumonMSelim/timothy/internal/gateway/router"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+	"github.com/SumonMSelim/timothy/internal/platform/metrics"
 )
 
 type fakeSource struct {
@@ -107,7 +110,9 @@ func snapshotFor(t *testing.T, firstURL, secondURL string) *router.Snapshot {
 
 func newAPI(snap *router.Snapshot) (*API, *memRecorder) {
 	rec := &memRecorder{}
-	return &API{store: &fakeSource{snap: snap}, ledger: rec, log: discard()}, rec
+	a := &API{store: &fakeSource{snap: snap}, ledger: rec, log: discard()}
+	a.providerCalls = metrics.New().NewCounterVec("provider_calls_total", "test", "provider", "route", "status")
+	return a, rec
 }
 
 func postJSON(t *testing.T, h http.HandlerFunc, body string) *httptest.ResponseRecorder {
@@ -174,6 +179,9 @@ func TestStreamHappyPathWithLedger(t *testing.T) {
 	if e.LatencyMS <= 0 {
 		t.Fatalf("latency_ms = %d, want > 0", e.LatencyMS)
 	}
+	if got := testutil.ToFloat64(a.providerCalls.WithLabelValues("one", "coding", "ok")); got != 1 {
+		t.Fatalf("provider_calls_total{one,coding,ok} = %v, want 1", got)
+	}
 }
 
 func TestStreamFailoverToSecondProvider(t *testing.T) {
@@ -205,6 +213,12 @@ func TestStreamFailoverToSecondProvider(t *testing.T) {
 	}
 	if entries[1].Status != "ok" || entries[1].Provider != "two" {
 		t.Fatalf("second entry = %+v", entries[1])
+	}
+	if got := testutil.ToFloat64(a.providerCalls.WithLabelValues("one", "coding", "error")); got != 1 {
+		t.Fatalf("provider_calls_total{one,coding,error} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(a.providerCalls.WithLabelValues("two", "coding", "ok")); got != 1 {
+		t.Fatalf("provider_calls_total{two,coding,ok} = %v, want 1", got)
 	}
 }
 

--- a/internal/platform/httpserver/server.go
+++ b/internal/platform/httpserver/server.go
@@ -72,9 +72,57 @@ func New(port int, log *slog.Logger, m *metrics.Metrics, health HealthFunc) *Ser
 }
 
 // Handle registers a handler under a method-qualified ServeMux pattern
-// ("GET /health"), instrumented with the pattern as the route label.
+// ("GET /health"), instrumented with the pattern as the route label and
+// logged on completion.
 func (s *Server) Handle(pattern string, h http.Handler) {
-	s.mux.Handle(pattern, s.m.Instrument(pattern, h))
+	s.mux.Handle(pattern, s.m.Instrument(pattern, s.logAccess(pattern, h)))
+}
+
+// noAccessLog are polled every few seconds by compose healthchecks and
+// the Prometheus scraper — logging them would just recreate the
+// wall-of-noise this is meant to fix.
+var noAccessLog = map[string]bool{
+	"GET /health":  true,
+	"GET /metrics": true,
+}
+
+// logAccess emits one structured line per request: method, route,
+// status, and duration, with the trace id withTrace already put on the
+// context. This is the only place any service logs a request — no
+// handler needs to log its own access line.
+func (s *Server) logAccess(pattern string, next http.Handler) http.Handler {
+	if noAccessLog[pattern] {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+		start := time.Now()
+		next.ServeHTTP(sw, r)
+		s.log.InfoContext(r.Context(), "request",
+			"method", r.Method,
+			"route", pattern,
+			"status", sw.status,
+			"duration_ms", time.Since(start).Milliseconds(),
+		)
+	})
+}
+
+// statusWriter records the response status and keeps http.Flusher
+// visible for streaming handlers.
+type statusWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *statusWriter) WriteHeader(code int) {
+	w.status = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *statusWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
 }
 
 // withTrace gives every request a trace id (accepting an inbound

--- a/internal/platform/httpserver/server_test.go
+++ b/internal/platform/httpserver/server_test.go
@@ -1,6 +1,7 @@
 package httpserver
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -8,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,6 +23,14 @@ func discard() *slog.Logger {
 
 func newTestServer(health HealthFunc) *Server {
 	return New(0, discard(), metrics.New(), health)
+}
+
+// newLoggingTestServer is newTestServer with its log output captured
+// instead of discarded, for tests that assert on emitted lines.
+func newLoggingTestServer(health HealthFunc) (*Server, *bytes.Buffer) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, nil))
+	return New(0, log, metrics.New(), health), &buf
 }
 
 func TestHealthEndpoint(t *testing.T) {
@@ -93,6 +103,38 @@ func TestInboundTraceIDPreserved(t *testing.T) {
 
 	if got != "upstream-1" {
 		t.Fatalf("trace id = %q, want upstream-1", got)
+	}
+}
+
+func TestAccessLogged(t *testing.T) {
+	t.Parallel()
+	s, buf := newLoggingTestServer(func() Health { return Health{Status: "ok"} })
+	s.Handle("GET /echo", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	s.srv.Handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/echo", nil))
+
+	line := buf.String()
+	for _, want := range []string{`"msg":"request"`, `"method":"GET"`, `"route":"GET /echo"`, `"status":418`} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("log = %s, want containing %q", line, want)
+		}
+	}
+}
+
+// TestHealthAndMetricsNotAccessLogged: both are polled every few
+// seconds by compose healthchecks and the Prometheus scraper — logging
+// them would recreate the exact noise this access log is meant to fix.
+func TestHealthAndMetricsNotAccessLogged(t *testing.T) {
+	t.Parallel()
+	s, buf := newLoggingTestServer(func() Health { return Health{Status: "ok"} })
+
+	s.srv.Handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/health", nil))
+	s.srv.Handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if buf.Len() != 0 {
+		t.Fatalf("log = %s, want no access lines for /health or /metrics", buf.String())
 	}
 }
 

--- a/internal/platform/metrics/metrics.go
+++ b/internal/platform/metrics/metrics.go
@@ -63,6 +63,14 @@ func (m *Metrics) NewGaugeVec(name, help string, labels ...string) *prometheus.G
 	return g
 }
 
+// NewCounterVec registers a service-specific labeled counter on this
+// registry.
+func (m *Metrics) NewCounterVec(name, help string, labels ...string) *prometheus.CounterVec {
+	c := prometheus.NewCounterVec(prometheus.CounterOpts{Namespace: "timothy", Name: name, Help: help}, labels)
+	m.registry.MustRegister(c)
+	return c
+}
+
 // Handler serves the registry in Prometheus exposition format.
 func (m *Metrics) Handler() http.Handler {
 	return promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{})

--- a/internal/platform/metrics/metrics_test.go
+++ b/internal/platform/metrics/metrics_test.go
@@ -42,6 +42,22 @@ func TestInstrumentDefaultsTo200(t *testing.T) {
 	}
 }
 
+func TestNewCounterVec(t *testing.T) {
+	t.Parallel()
+	m := New()
+	c := m.NewCounterVec("widgets_total", "Widgets processed.", "kind")
+	c.WithLabelValues("blue").Inc()
+	c.WithLabelValues("blue").Inc()
+	c.WithLabelValues("red").Inc()
+
+	if got := testutil.ToFloat64(c.WithLabelValues("blue")); got != 2 {
+		t.Fatalf("blue = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(c.WithLabelValues("red")); got != 1 {
+		t.Fatalf("red = %v, want 1", got)
+	}
+}
+
 func TestHandlerServesExposition(t *testing.T) {
 	t.Parallel()
 	m := New()


### PR DESCRIPTION
## Summary
- brain and gateway logs carried nothing but a background poller line every 30-60s ("agent tool surface updated", "routing config loaded") — no signal on requests in, how they resolved, or what tools/providers actually ran
- Add one structured access-log line per HTTP request (method, route, status, duration, trace_id) at the shared `httpserver.Handle` chokepoint, so every service gets it automatically; `/health` and `/metrics` are skipped since compose healthchecks and the Prometheus scraper poll them every few seconds and would just recreate the noise
- Add `tool_calls_total{tool,outcome}` on the brain agent loop and `provider_calls_total{provider,route,status}` on the gateway's stream/embed dispatch — the same status values already written to the cost ledger, now queryable without ad-hoc SQL

## Test plan
- [x] `go build ./... && go vet ./... && go test -race ./...` (full repo, all green)
- [x] `golangci-lint run ./...` (0 issues)
- [x] New tests: `TestAccessLogged`, `TestHealthAndMetricsNotAccessLogged`, `TestNewCounterVec`, `TestConstrainedRecordsToolCallOutcomes`, plus provider-call assertions added to the existing gateway stream tests
- [x] Verified live against the running stack: rebuilt brain+gateway, confirmed `"msg":"request"` lines appear for real traffic and `/health` stays silent
