### PR TITLE
fix(missions,gateway,tools): planner JSON, Ollama fallback, digest hint

### DIFF
--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -485,26 +485,67 @@ func renderReviewContent(p ReviewPacket) string {
 }
 
 // PlanSession runs the planning turn that produces a Spec from the
-// mission's goal and research-phase findings.
+// mission's goal and research-phase findings. The plan is forced
+// through the submit_plan tool call (mirroring RunWorker/RunReview's
+// sentinel ladder) rather than asked for as bare JSON prose — a model
+// free to preface its reply with prose was the root cause of a real
+// stuck mission (5 straight "invalid plan JSON" failures, identical
+// each retry since nothing told the model what went wrong).
 func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, researchNotes string) (Spec, error) {
-	system := "You are planning one mission. Break the goal into the SMALLEST ordered list of verifiable units that achieves it — one unit is correct for a simple goal; never pad the plan. Reply with ONLY a JSON object: {\"units\":[{\"title\":\"...\",\"artifacts\":[\"relative/path.md\"],\"verify_cmd\":\"...\"}]}. artifacts lists the workspace-relative file(s) the unit must produce — the harness itself checks each exists and is non-empty, so name the real deliverables. verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory — it must be a real POSIX shell command (using binaries like grep, test, wc — NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace." + r.execEnvironmentNote()
+	system := "You are planning one mission. Break the goal into the SMALLEST ordered list of verifiable units that achieves it — one unit is correct for a simple goal; never pad the plan. artifacts lists the workspace-relative file(s) the unit must produce — the harness itself checks each exists and is non-empty, so name the real deliverables. verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory — it must be a real POSIX shell command (using binaries like grep, test, wc — NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. End your turn with exactly one submit_plan tool call." + r.execEnvironmentNote()
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if researchNotes != "" {
 		user += "\n\nResearch findings:\n" + NeutralizeSlot(researchNotes)
 	}
 	req := loop.Request{
-		SessionID: m.SessionID,
-		Route:     m.Route,
-		Agent:     "mission-planner",
-		MissionID: m.ID,
-		System:    system,
-		Messages:  []provider.Message{{Role: "user", Content: user}},
+		SessionID:  m.SessionID,
+		Route:      m.Route,
+		Agent:      "mission-planner",
+		MissionID:  m.ID,
+		System:     system,
+		Messages:   []provider.Message{{Role: "user", Content: user}},
+		ExtraTools: []*tools.Tool{PlanTool()},
 	}
-	text, _, err := r.runTurn(ctx, req, "")
+	text, args, err := r.runTurn(ctx, req, planToolName)
 	if err != nil {
 		return Spec{}, err
 	}
-	return parseSpec(text)
+	if len(args) > 0 {
+		if spec, specErr := parseSpec(string(args)); specErr == nil {
+			return spec, nil
+		}
+	}
+
+	// Recovery re-run: either the tool call was missing entirely, or its
+	// arguments didn't decode as a valid Spec — either way, tell the
+	// model exactly what was wrong instead of silently repeating the
+	// identical prompt (which previously produced the identical failure
+	// on every retry).
+	var recoverReason string
+	if len(args) == 0 {
+		recoverReason = "you did not call submit_plan"
+	} else if _, specErr := parseSpec(string(args)); specErr != nil {
+		recoverReason = specErr.Error()
+	}
+	recoverReq := req
+	recoverReq.Messages = append(append([]provider.Message{}, req.Messages...),
+		provider.Message{Role: "assistant", Content: text},
+		provider.Message{Role: "user", Content: "[system] Your last turn did not produce a usable plan: " + recoverReason + ". You must end this turn with exactly one submit_plan tool call."},
+	)
+	recoverText, recoverArgs, err := r.runTurn(ctx, recoverReq, planToolName)
+	if err != nil {
+		return Spec{}, err
+	}
+	if len(recoverArgs) == 0 {
+		r.log.Warn("mission planner ended without a submit_plan call", "mission_id", m.ID, "text", text, "recover_text", recoverText)
+		return Spec{}, fmt.Errorf("mission runner: planner ended without a submit_plan call")
+	}
+	spec, err := parseSpec(string(recoverArgs))
+	if err != nil {
+		r.log.Warn("mission planner submitted an invalid plan twice", "mission_id", m.ID, "text", text, "recover_text", recoverText, "error", err)
+		return Spec{}, err
+	}
+	return spec, nil
 }
 
 // execEnvironmentNote tells the planner what execution environment

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -259,7 +259,7 @@ func TestRunReviewRecoversWhenVerdictMissingThenPresent(t *testing.T) {
 
 func TestPlanSessionParsesSpec(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{textEvent(`{"units":[{"title":"Add validation","verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","verify_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
@@ -272,11 +272,15 @@ func TestPlanSessionParsesSpec(t *testing.T) {
 	if spec.Units[0].Passes {
 		t.Fatal("PlanSession must never trust a planner-claimed passes=true — only RunVerify may set it")
 	}
+	if agent.call != 1 {
+		t.Fatalf("expected exactly one turn (no recovery needed), got %d", agent.call)
+	}
 }
 
 func TestPlanSessionRejectsEmptyPlan(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{textEvent(`{"units":[]}`)},
+		{toolEndEvent(planToolName, `{"units":[]}`)},
+		{toolEndEvent(planToolName, `{"units":[]}`)},
 	}}
 	r := newTestRunner(agent)
 	if _, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, ""); err == nil {
@@ -287,10 +291,42 @@ func TestPlanSessionRejectsEmptyPlan(t *testing.T) {
 func TestPlanSessionRejectsMalformedJSON(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{textEvent("I think the plan should have a few steps but I won't format it as JSON")},
+		{textEvent("still no tool call")},
 	}}
 	r := newTestRunner(agent)
 	if _, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, ""); err == nil {
 		t.Fatal("PlanSession accepted non-JSON output")
+	}
+	if agent.call != 2 {
+		t.Fatalf("expected exactly two turns (original + one recovery), got %d", agent.call)
+	}
+}
+
+// TestPlanSessionRecoversWithFeedback confirms a missing/invalid
+// submit_plan call on the first turn gets ONE recovery re-run whose
+// injected message names what was wrong — not a byte-identical retry
+// of the original prompt, which previously produced the same failure
+// every time against a nondeterministic model.
+func TestPlanSessionRecoversWithFeedback(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{textEvent("here's my plan in prose, no tool call")},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Fix it","verify_cmd":"true"}]}`)},
+	}}
+	r := newTestRunner(agent)
+	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if len(spec.Units) != 1 || spec.Units[0].Title != "Fix it" {
+		t.Fatalf("PlanSession spec = %+v", spec)
+	}
+	if agent.call != 2 {
+		t.Fatalf("expected exactly two turns (original + one recovery), got %d", agent.call)
+	}
+	recoverReq := agent.requests[1]
+	last := recoverReq.Messages[len(recoverReq.Messages)-1]
+	if !strings.Contains(last.Content, "did not call submit_plan") {
+		t.Fatalf("recovery message = %q, want it to name the failure", last.Content)
 	}
 }
 

--- a/internal/brain/missions/sentinel.go
+++ b/internal/brain/missions/sentinel.go
@@ -54,6 +54,52 @@ func MissionStatusTool() *tools.Tool {
 	}
 }
 
+// planToolName is the planner's end-of-turn sentinel call — forcing
+// the plan through a tool call (like mission_status and review_verdict
+// already do) instead of asking the model to reply with bare JSON
+// prose eliminates the fence-stripping fragility that caused plans to
+// fail on stray prose or wrapping the model's provider doesn't emit
+// consistently.
+const planToolName = "submit_plan"
+
+// PlanTool defines the planner's one tool call — registered per-turn
+// via loop.Request.ExtraTools, never in the shared agent tool surface.
+func PlanTool() *tools.Tool {
+	return &tools.Tool{
+		Name:        planToolName,
+		Description: "Submit the mission plan. Call this exactly once, as your final action.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"units": {
+					"type": "array",
+					"description": "The smallest ordered list of verifiable units that achieves the goal.",
+					"items": {
+						"type": "object",
+						"properties": {
+							"title": {"type": "string", "description": "One-line summary of the unit."},
+							"artifacts": {
+								"type": "array",
+								"items": {"type": "string"},
+								"description": "Workspace-relative file path(s) this unit must produce."
+							},
+							"verify_cmd": {
+								"type": "string",
+								"description": "A real POSIX shell command, run as /bin/sh -c \"<verify_cmd>\" in the mission's workspace, that checks the CONTENT of the artifacts."
+							}
+						},
+						"required": ["title", "verify_cmd"]
+					}
+				}
+			},
+			"required": ["units"]
+		}`),
+		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
+			return "plan recorded", nil
+		},
+	}
+}
+
 // WorkerVerdict is the parsed mission_status call.
 type WorkerVerdict struct {
 	Outcome  string // done | retry | blocked

--- a/internal/brain/tools/digest.go
+++ b/internal/brain/tools/digest.go
@@ -25,7 +25,7 @@ var errorLineRe = regexp.MustCompile(`(?i)\b(error|fail|failed|failure|panic|fat
 func Digest(content, tool, ref string) string {
 	lines := strings.Split(content, "\n")
 	var b strings.Builder
-	fmt.Fprintf(&b, "[%s output offloaded: %d bytes, %d lines. Full content: retrieve_output {\"ref\": %q}]\n",
+	fmt.Fprintf(&b, "[%s output offloaded: %d bytes, %d lines. To see the full content, call the retrieve_output TOOL (not a shell command) with argument ref=%q.]\n",
 		tool, len(content), len(lines), ref)
 
 	head := lines

--- a/internal/brain/tools/digest_test.go
+++ b/internal/brain/tools/digest_test.go
@@ -19,7 +19,8 @@ func TestDigest(t *testing.T) {
 
 	for _, want := range []string{
 		"500 lines",
-		`retrieve_output {"ref": "9be4c1d2-04a7-47a1-a1a9-3f6d2c9f1e10"}`,
+		"retrieve_output TOOL",
+		`ref="9be4c1d2-04a7-47a1-a1a9-3f6d2c9f1e10"`,
 		"line 1 ok",   // head
 		"line 500 ok", // tail
 		"460 lines omitted",

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -225,6 +225,11 @@ type Provider struct {
 	CredentialRef string             `json:"credential_ref"`
 	Headers       map[string]string  `json:"headers"`
 	Enabled       bool               `json:"enabled"`
+	// ExcludeFromBootstrap opts this provider out of auto-fallback fill
+	// on the shared default/summarize/embedding routes — for local/dev
+	// providers (e.g. Ollama) that should never silently serve
+	// production traffic as a fallback.
+	ExcludeFromBootstrap bool `json:"exclude_from_bootstrap"`
 }
 
 func validateProvider(p Provider) error {
@@ -253,7 +258,7 @@ func (a *Admin) List(ctx context.Context) ([]Provider, error) {
 		return nil, fmt.Errorf("admin providers: %w", err)
 	}
 	rows, err := db.Query(ctx, `SELECT id, name, kind, driver, base_url, default_model,
-		models, credential_ref, headers, enabled FROM providers ORDER BY name`)
+		models, credential_ref, headers, enabled, exclude_from_bootstrap FROM providers ORDER BY name`)
 	if err != nil {
 		return nil, fmt.Errorf("admin providers: %w", err)
 	}
@@ -266,7 +271,7 @@ func (a *Admin) List(ctx context.Context) ([]Provider, error) {
 			models, hdrs []byte
 		)
 		if err := rows.Scan(&p.ID, &p.Name, &p.Kind, &p.Driver, &p.BaseURL,
-			&p.DefaultModel, &models, &p.CredentialRef, &hdrs, &p.Enabled); err != nil {
+			&p.DefaultModel, &models, &p.CredentialRef, &hdrs, &p.Enabled, &p.ExcludeFromBootstrap); err != nil {
 			return nil, fmt.Errorf("admin providers: %w", err)
 		}
 		if err := json.Unmarshal(models, &p.Models); err != nil {
@@ -295,14 +300,14 @@ func (a *Admin) Create(ctx context.Context, p Provider) (string, error) {
 	models, hdrs := jsonOr(p.Models, "[]"), jsonOr(p.Headers, "{}")
 	var id string
 	err = db.QueryRow(ctx, `INSERT INTO providers
-			(name, kind, driver, base_url, default_model, models, credential_ref, headers, enabled)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id`,
-		p.Name, p.Kind, p.Driver, p.BaseURL, p.DefaultModel, models, p.CredentialRef, hdrs, p.Enabled).Scan(&id)
+			(name, kind, driver, base_url, default_model, models, credential_ref, headers, enabled, exclude_from_bootstrap)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING id`,
+		p.Name, p.Kind, p.Driver, p.BaseURL, p.DefaultModel, models, p.CredentialRef, hdrs, p.Enabled, p.ExcludeFromBootstrap).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("admin create: %w", err)
 	}
 	a.audit(ctx, "create", "provider", id, nil, p)
-	a.bootstrapRoutes(ctx, router.ProviderRow{ID: id, Models: p.Models})
+	a.bootstrapRoutes(ctx, router.ProviderRow{ID: id, Models: p.Models, ExcludeFromBootstrap: p.ExcludeFromBootstrap})
 	a.reload(ctx)
 	return id, nil
 }
@@ -362,12 +367,13 @@ func (a *Admin) bootstrapRoutes(ctx context.Context, p router.ProviderRow) {
 // Patch applies a partial update. Only fields present in the request
 // change; before/after land in the audit row.
 type ProviderPatch struct {
-	BaseURL       *string             `json:"base_url"`
-	DefaultModel  *string             `json:"default_model"`
-	Models        *[]router.ModelInfo `json:"models"`
-	CredentialRef *string             `json:"credential_ref"`
-	Headers       *map[string]string  `json:"headers"`
-	Enabled       *bool               `json:"enabled"`
+	BaseURL              *string             `json:"base_url"`
+	DefaultModel         *string             `json:"default_model"`
+	Models               *[]router.ModelInfo `json:"models"`
+	CredentialRef        *string             `json:"credential_ref"`
+	Headers              *map[string]string  `json:"headers"`
+	Enabled              *bool               `json:"enabled"`
+	ExcludeFromBootstrap *bool               `json:"exclude_from_bootstrap"`
 }
 
 func (a *Admin) Patch(ctx context.Context, id string, patch ProviderPatch) error {
@@ -411,12 +417,15 @@ func (a *Admin) Patch(ctx context.Context, id string, patch ProviderPatch) error
 	if patch.Enabled != nil {
 		after.Enabled = *patch.Enabled
 	}
+	if patch.ExcludeFromBootstrap != nil {
+		after.ExcludeFromBootstrap = *patch.ExcludeFromBootstrap
+	}
 
 	tag, err := tx.Exec(ctx, `UPDATE providers SET base_url = $2, default_model = $3,
-			models = $4, credential_ref = $5, headers = $6, enabled = $7, updated_at = now()
+			models = $4, credential_ref = $5, headers = $6, enabled = $7, exclude_from_bootstrap = $8, updated_at = now()
 		WHERE id = $1`,
 		id, after.BaseURL, after.DefaultModel, jsonOr(after.Models, "[]"),
-		after.CredentialRef, jsonOr(after.Headers, "{}"), after.Enabled)
+		after.CredentialRef, jsonOr(after.Headers, "{}"), after.Enabled, after.ExcludeFromBootstrap)
 	if err != nil {
 		return fmt.Errorf("admin patch: %w", err)
 	}
@@ -868,9 +877,9 @@ func scanProvider(ctx context.Context, q pgxQuerier, id, lock string) (Provider,
 		models, hdrs []byte
 	)
 	err := q.QueryRow(ctx, `SELECT id, name, kind, driver, base_url, default_model,
-			models, credential_ref, headers, enabled FROM providers WHERE id = $1 `+lock, id).
+			models, credential_ref, headers, enabled, exclude_from_bootstrap FROM providers WHERE id = $1 `+lock, id).
 		Scan(&p.ID, &p.Name, &p.Kind, &p.Driver, &p.BaseURL, &p.DefaultModel,
-			&models, &p.CredentialRef, &hdrs, &p.Enabled)
+			&models, &p.CredentialRef, &hdrs, &p.Enabled, &p.ExcludeFromBootstrap)
 	if err != nil {
 		return Provider{}, fmt.Errorf("provider %s: %w", id, ErrNotFound)
 	}

--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -653,6 +653,70 @@ func TestCreateBootstrapsFixedRoutes(t *testing.T) {
 	}
 }
 
+// TestCreateExcludeFromBootstrapSkipsFixedRoutes covers the fix for a
+// real incident: a local Ollama provider auto-bootstrapped onto the
+// shared "default" route, and a cloud-outage failover silently served
+// a mission turn with a below-floor local model. A provider created
+// with exclude_from_bootstrap=true must never touch default/summarize/
+// embedding's chains, however cheap or capable its models are.
+func TestCreateExcludeFromBootstrapSkipsFixedRoutes(t *testing.T) {
+	adm, _, pool := testAdmin(t)
+	ctx := t.Context()
+	db, _ := pool.Get()
+
+	type saved struct {
+		chain   []byte
+		enabled bool
+	}
+	origs := map[string]saved{}
+	for _, name := range []string{"default", "summarize", "embedding"} {
+		var s saved
+		if err := db.QueryRow(ctx, `SELECT chain, enabled FROM routes WHERE name = $1`, name).Scan(&s.chain, &s.enabled); err != nil {
+			t.Fatalf("read %s route: %v", name, err)
+		}
+		origs[name] = s
+	}
+	defer func() {
+		for name, s := range origs {
+			if _, err := db.Exec(ctx, `UPDATE routes SET chain = $2, enabled = $3 WHERE name = $1`, name, s.chain, s.enabled); err != nil {
+				t.Errorf("restore %s route: %v", name, err)
+			}
+		}
+	}()
+
+	id, err := adm.Create(ctx, Provider{
+		Name: adminMarker + "excluded", Kind: "api", Driver: "openaicompat",
+		BaseURL: "http://ollama.invalid:11434", DefaultModel: "qwen2.5:7b",
+		ExcludeFromBootstrap: true,
+		Models: []router.ModelInfo{
+			{ID: "qwen2.5:7b", Capabilities: []string{"chat"}, Prices: &router.ModelPrices{InputPerMTok: 0}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	routes, err := adm.Routes(ctx)
+	if err != nil {
+		t.Fatalf("Routes: %v", err)
+	}
+	for _, r := range routes {
+		for _, entry := range r.Chain {
+			if entry.ProviderID == id {
+				t.Fatalf("route %s chain = %+v, want excluded provider %s absent from every fixed route", r.Name, r.Chain, id)
+			}
+		}
+	}
+
+	got, err := adm.get(ctx, id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !got.ExcludeFromBootstrap {
+		t.Fatal("ExcludeFromBootstrap round-tripped as false, want true")
+	}
+}
+
 func TestSecretExternalBackendConfig(t *testing.T) {
 	adm, _, _ := testAdmin(t)
 	ctx := t.Context()

--- a/internal/gateway/router/bootstrap.go
+++ b/internal/gateway/router/bootstrap.go
@@ -25,6 +25,9 @@ var bootstrapRoutes = map[string]string{
 // as the LAST entry — existing priority order is never reordered or
 // removed, so hand-tuned chains only ever gain a fallback.
 func BootstrapChain(p ProviderRow, existing map[string][]ChainEntry) map[string][]ChainEntry {
+	if p.ExcludeFromBootstrap {
+		return nil
+	}
 	out := map[string][]ChainEntry{}
 	for route, needed := range bootstrapRoutes {
 		model, ok := cheapestCapable(p.Models, needed)

--- a/internal/gateway/router/bootstrap_test.go
+++ b/internal/gateway/router/bootstrap_test.go
@@ -123,6 +123,18 @@ func TestBootstrapChainNeverMutatesExistingSlice(t *testing.T) {
 	}
 }
 
+func TestBootstrapChainExcludedProviderYieldsNoUpdates(t *testing.T) {
+	p := ProviderRow{ID: "ollama", ExcludeFromBootstrap: true, Models: []ModelInfo{
+		priced("qwen2.5:7b", 0, "chat"),
+	}}
+
+	got := BootstrapChain(p, map[string][]ChainEntry{})
+
+	if got != nil {
+		t.Fatalf("BootstrapChain(excluded) = %+v, want nil (no route touched)", got)
+	}
+}
+
 func TestBootstrapChainIgnoresResearchRoute(t *testing.T) {
 	p := ProviderRow{ID: "p1", Models: []ModelInfo{priced("m", 1, "chat")}}
 

--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -41,6 +41,11 @@ type ProviderRow struct {
 	CredentialRef string
 	Headers       map[string]string
 	Enabled       bool
+	// ExcludeFromBootstrap opts this provider out of BootstrapChain's
+	// auto-fallback fill — for a local/dev provider (e.g. Ollama) that
+	// should never be silently appended as a fallback on the shared
+	// default/summarize/embedding routes production mission traffic runs on.
+	ExcludeFromBootstrap bool
 }
 
 // ChainEntry is one step of a route chain.

--- a/migrations/0036_provider_exclude_bootstrap.sql
+++ b/migrations/0036_provider_exclude_bootstrap.sql
@@ -1,0 +1,7 @@
+-- exclude_from_bootstrap opts a provider out of BootstrapChain's
+-- auto-fallback fill (D-033 follow-up): a local/dev provider (e.g.
+-- Ollama) otherwise gets silently appended as a fallback on the
+-- shared default/summarize/embedding routes the moment it's
+-- connected, which let a below-floor local model serve production
+-- mission traffic during a cloud-provider outage.
+ALTER TABLE providers ADD COLUMN IF NOT EXISTS exclude_from_bootstrap boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
Three bugs found while verifying the sandbox-container migration against live test missions:

- **Planner invalid JSON**: the planner asked for bare JSON prose with no tool-forcing, so a model free to preface its reply with text produced unparseable output — one mission hit 5 identical "invalid plan JSON" failures in a row, since retries repeated the exact same prompt. Fixed by forcing the plan through a `submit_plan` tool call (mirrors `mission_status`/`review_verdict`'s existing pattern), with one recovery re-run that names the specific parse failure instead of blindly retrying.

- **Below-floor Ollama routing**: a local Ollama provider auto-bootstrapped onto the shared `default` route. During a brain restart, a cloud-provider timeout storm walked the fallback chain down to it, serving a mission turn with `qwen2.5:7b` — the below-floor pause caught it correctly, but nothing stopped the model being in the chain. Adds `providers.exclude_from_bootstrap` so a provider can opt out of route auto-fill while staying usable via its own dedicated route; flipped on for the existing Ollama provider and removed it from `default`/`research`/`summarize`'s chains.

- **Digest retrieval hint misread as shell syntax**: the offloaded-output digest read as `retrieve_output {"ref": "..."}`, phrased exactly like an inline function call. A worker mistook it for shell syntax and pasted it into `cat $(retrieve_output {...})`, which fails every time, then retried with a fresh ref indefinitely. Reworded to say plainly it's a tool to call, not text to embed.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test -race ./...` — all packages pass, including new/updated tests in `missions`, `gateway/router`, `gateway/admin`, `brain/tools`
- [x] `make test-integration` — full integration suite against live Postgres, including a new `TestCreateExcludeFromBootstrapSkipsFixedRoutes`
- [x] `golangci-lint run ./...` — 0 issues
- [x] Live-verified against two real test missions: a coding mission (sandbox exec) reached `done` after surviving an AWS SSO expiry + GLM rate-limiting, and a research mission reached `done` with clean `submit_plan` tool calls throughout (no more invalid-JSON failures)