### PR TITLE
feat(sandboxd): move docker socket out of brain into socket-proxy sidecar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        service: [brain, gateway, memoryd, web]
+        service: [brain, gateway, memoryd, sandboxd, web]
     steps:
       - uses: actions/checkout@v7
       - name: Build image

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GO_RUN := docker run --rm -v $(CURDIR):/src -w /src \
 	-e GOFLAGS=-buildvcs=false $(GO_IMAGE)
 
 .PHONY: build test test-integration test-live vet lint tidy skills-validate up down logs \
-	brain gateway memoryd web markitdown ollama dev canary canary-coding sandbox-image
+	brain gateway memoryd web markitdown ollama sandboxd dev canary canary-coding sandbox-image
 
 build:
 	$(GO_RUN) go build ./...
@@ -61,8 +61,13 @@ up:
 	$(COMPOSE) up -d --build
 
 # Per-service rebuild+restart for when only one service changed:
-#   make brain / make gateway / make memoryd / make web / make markitdown / make ollama
-brain gateway memoryd web markitdown ollama:
+#   make brain / make gateway / make memoryd / make web / make markitdown / make ollama / make sandboxd
+# Rolling brain and sandboxd separately: restart sandboxd first — the
+# API between them is additive-only, so an older brain against a newer
+# sandboxd (or vice versa, briefly) stays compatible either order, but
+# sandboxd-first avoids brain's own restart racing against sandboxd's
+# health check on its way up.
+brain gateway memoryd web markitdown ollama sandboxd:
 	$(COMPOSE) up -d --build $@
 
 # Vite dev server with hot reload on :3301 (proxies /v1 to brain).

--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/loop"
 	"github.com/SumonMSelim/timothy/internal/brain/memclient"
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
-	"github.com/SumonMSelim/timothy/internal/brain/sandbox"
+	"github.com/SumonMSelim/timothy/internal/brain/sandboxclient"
 	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/brain/settings"
 	"github.com/SumonMSelim/timothy/internal/brain/skills"
@@ -166,17 +166,18 @@ func main() {
 		go runConnectorReload(ctx, conns, app.Log)
 	}
 
-	// Fail closed: an operator who set MISSION_SANDBOX_IMAGE opted into
-	// sandboxed execution, so a manager that cannot initialize (daemon
-	// unreachable, workspace mount unresolvable) must stop the service
-	// loudly — silently falling back to executing model-authored
-	// commands inside brain's own process would defeat the whole point.
-	// A missing image is deliberately NOT fatal: the health check below
-	// reports it, and building it needs no brain restart.
-	missionSandbox, sberr := sandbox.NewManager(ctx, os.Getenv("MISSION_SANDBOX_IMAGE"), app.Log)
-	if sberr != nil {
-		fmt.Fprintln(os.Stderr, sberr)
-		os.Exit(1)
+	// SANDBOXD_URL empty (MISSION_SANDBOX_IMAGE unset in compose) keeps a
+	// nil client and the original in-process exec fallback — same
+	// nil-able-dependency convention as every other optional brain
+	// dependency. Unlike the old direct-socket path, brain itself can no
+	// longer fail closed on a Docker problem: that fail-closed behavior
+	// moved to sandboxd's own boot (it holds the socket now), and a
+	// sandboxd that's unreachable or degraded surfaces here as a
+	// degraded health check, with missions failing as infra at exec
+	// time instead of brain refusing to start.
+	var missionSandbox *sandboxclient.Client
+	if sandboxdURL := os.Getenv("SANDBOXD_URL"); sandboxdURL != "" {
+		missionSandbox = sandboxclient.New(sandboxdURL)
 	}
 
 	missionStore, missionDriver, missionNotifier, missionWorkspace := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, app.Log)
@@ -191,11 +192,8 @@ func main() {
 	}
 	if missionSandbox != nil {
 		app.AddCheck("sandbox", func() httpserver.Check {
-			if err := missionSandbox.Ping(ctx); err != nil {
-				return httpserver.Check{Status: "degraded", Detail: "docker daemon unreachable: " + err.Error()}
-			}
-			if err := missionSandbox.CheckImage(ctx); err != nil {
-				return httpserver.Check{Status: "degraded", Detail: "sandbox image not found: " + err.Error()}
+			if err := missionSandbox.Health(ctx); err != nil {
+				return httpserver.Check{Status: "degraded", Detail: err.Error()}
 			}
 			return httpserver.Check{Status: "ok"}
 		})
@@ -311,7 +309,7 @@ const missionWorkSlotMax = 4
 // missions stay entirely inert — no goroutines started, nothing
 // scheduled, the API surface unmounted (registerMissions 404s on a nil
 // store).
-func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandbox.Manager, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace) {
+func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace) {
 	root := os.Getenv("WORKSPACES")
 	if root == "" {
 		log.Info("WORKSPACES not set; missions disabled")
@@ -334,9 +332,10 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 		}
 	}
 	// sandboxMgr non-nil routes model-authored command execution (the
-	// worker/reviewer shell, verify_cmd) OUT of brain's own process into
-	// a per-mission Docker container; nil (MISSION_SANDBOX_IMAGE unset)
-	// keeps the original in-process exec.CommandContext behavior.
+	// worker/reviewer shell, verify_cmd) OUT of brain's own process,
+	// through sandboxd, into a per-mission Docker container; nil
+	// (SANDBOXD_URL unset) keeps the original in-process
+	// exec.CommandContext behavior.
 	var sandboxExec func(context.Context, string, string, string, time.Duration, io.Writer) (int, error)
 	if sandboxMgr != nil {
 		sandboxExec = sandboxMgr.Exec

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -1,0 +1,125 @@
+// Command sandboxd holds the Docker socket on brain's behalf: it is
+// the only service that talks to the Docker daemon, exposing a narrow,
+// mission-scoped HTTP API (missionID in — never container names,
+// images, mounts, env) that brain's sandboxclient calls instead of
+// mounting docker.sock itself. Unlike every other Timothy service this
+// has no database — there is nothing here to persist.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	"github.com/SumonMSelim/timothy/internal/platform/config"
+	"github.com/SumonMSelim/timothy/internal/platform/httpserver"
+	"github.com/SumonMSelim/timothy/internal/platform/logging"
+	"github.com/SumonMSelim/timothy/internal/platform/metrics"
+	"github.com/SumonMSelim/timothy/internal/platform/service"
+	"github.com/SumonMSelim/timothy/internal/sandboxd"
+)
+
+const (
+	serviceName = "sandboxd"
+	defaultPort = 8083
+)
+
+func main() {
+	healthcheck := flag.Bool("healthcheck", false,
+		"probe /health and exit; used as the container health check")
+	flag.Parse()
+	if *healthcheck {
+		os.Exit(service.ProbeHealth(defaultPort))
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	cfg, err := config.Load(serviceName, defaultPort)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	log := logging.New(cfg.Name, cfg.LogLevel)
+	m := metrics.New()
+
+	// Fail closed: an operator who set MISSION_SANDBOX_IMAGE opted into
+	// sandboxed execution, so a manager that cannot initialize (daemon
+	// unreachable, workspace mount unresolvable) must stop this service
+	// loudly rather than come up in a state where every exec fails
+	// opaquely. A missing image is deliberately NOT fatal: the health
+	// check below reports it, and building the image needs no restart.
+	mgr, err := sandboxd.NewManager(ctx, os.Getenv("MISSION_SANDBOX_IMAGE"), log)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	srv := httpserver.New(cfg.Port, log, m, func() httpserver.Health {
+		return health(ctx, mgr)
+	})
+	sandboxd.Register(srv, mgr, execConfig(), log)
+
+	log.Info("starting", "port", cfg.Port)
+	if err := srv.Run(ctx); err != nil {
+		log.Error("server exited", "error", err)
+		os.Exit(1)
+	}
+}
+
+// health assembles /health's checks from the Manager: a nil manager
+// (MISSION_SANDBOX_IMAGE unset) reports one degraded check rather than
+// the usual docker+image pair, since there is nothing to Ping or
+// CheckImage yet.
+func health(ctx context.Context, mgr *sandboxd.Manager) httpserver.Health {
+	if mgr == nil {
+		return httpserver.Health{
+			Status: "degraded",
+			Checks: map[string]httpserver.Check{
+				"sandbox": {Status: "degraded", Detail: "MISSION_SANDBOX_IMAGE not set"},
+			},
+		}
+	}
+	checks := map[string]httpserver.Check{}
+	status := "ok"
+	if err := mgr.Ping(ctx); err != nil {
+		checks["docker"] = httpserver.Check{Status: "degraded", Detail: "docker daemon unreachable: " + err.Error()}
+		status = "degraded"
+	} else {
+		checks["docker"] = httpserver.Check{Status: "ok"}
+	}
+	if err := mgr.CheckImage(ctx); err != nil {
+		checks["image"] = httpserver.Check{Status: "degraded", Detail: "sandbox image not found: " + err.Error()}
+		status = "degraded"
+	} else {
+		checks["image"] = httpserver.Check{Status: "ok"}
+	}
+	return httpserver.Health{Status: status, Checks: checks}
+}
+
+// execConfig reads the concurrency caps from the environment — bare
+// os.Getenv + strconv, matching the rest of this repo's env parsing in
+// main, not a config framework. Invalid or unset values fall back to
+// sandboxd's package defaults (Register zero-checks them).
+func execConfig() sandboxd.Config {
+	return sandboxd.Config{
+		MaxExecs:      envInt("SANDBOXD_MAX_EXECS"),
+		MaxContainers: envInt("SANDBOXD_MAX_CONTAINERS"),
+	}
+}
+
+func envInt(name string) int {
+	v := os.Getenv(name)
+	if v == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -113,23 +113,13 @@ services:
       # keeps real email content off third-party providers. Empty: those
       # tools' output is processed on whatever route the turn started on.
       SENSITIVE_TOOL_ROUTE: ${SENSITIVE_TOOL_ROUTE:-}
-      # Image tag for per-mission sandbox containers (`make
-      # sandbox-image`) — model-authored shell/verify_cmd execution
-      # moves out of brain's own process into one of these instead of
-      # brain's process, so it never inherits brain's secrets. Empty
-      # (the default) keeps the original in-process exec behavior.
-      MISSION_SANDBOX_IMAGE: ${MISSION_SANDBOX_IMAGE:-}
+      # sandboxd's internal address — set only when MISSION_SANDBOX_IMAGE
+      # is configured (sandboxd itself always runs; without an image it
+      # just idles degraded). Empty keeps the original in-process exec
+      # behavior; brain never touches the Docker socket directly.
+      SANDBOXD_URL: ${MISSION_SANDBOX_IMAGE:+http://sandboxd:8083}
     volumes:
       - workspace:/workspace
-      # Lets brain create/exec/remove per-mission sandbox containers via
-      # the Docker Go SDK — a no-op mount when MISSION_SANDBOX_IMAGE is
-      # unset. group_add grants the socket's group inside the container;
-      # Docker Desktop's socket is group 0 (root), Linux hosts typically
-      # use a "docker" group with an arbitrary gid — override via
-      # DOCKER_SOCK_GID in deploy/.env if 0 doesn't work on your host.
-      - /var/run/docker.sock:/var/run/docker.sock
-    group_add:
-      - "${DOCKER_SOCK_GID:-0}"
     ports:
       - "${BRAIN_PORT:-8300}:8080"
     depends_on:
@@ -139,6 +129,67 @@ services:
         condition: service_started
       markitdown:
         condition: service_started
+      sandboxd:
+        condition: service_started
+    networks: [timothy, timothy-sandbox]
+
+  # Holds the Docker socket on brain's behalf: the only service that
+  # talks to the Docker daemon, exposing a narrow mission-scoped API
+  # (missionID in — never container names, images, mounts, env) that
+  # brain's sandboxclient calls instead. Not a *go-service: no postgres
+  # dependency, no database at all.
+  sandboxd:
+    <<: *service
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+      args: {SERVICE: sandboxd}
+      # Default (distroless) target — sandboxd's own shell tool never
+      # runs here; commands execute inside the sandbox containers it
+      # creates, not in this one.
+    environment:
+      PORT: "8083"
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      # The one operator knob: empty keeps sandboxd up but degraded
+      # (nothing to Ping/CheckImage), same parity as brain's old
+      # in-process behavior when this was unset.
+      MISSION_SANDBOX_IMAGE: ${MISSION_SANDBOX_IMAGE:-}
+    volumes:
+      # Metadata-only read: resolveWorkspaceMount inspects this mount to
+      # learn the exact volume/bind spec, then replicates it (rw) into
+      # each sandbox container it creates — sandboxd itself never reads
+      # or writes mission files through this mount. A container's own
+      # replicated mount is unaffected by the ro flag here.
+      - workspace:/workspace:ro
+      # The socket this service exists to hold instead of brain.
+      # group_add grants its group inside the container; Docker
+      # Desktop's socket is group 0 (root), Linux hosts typically use a
+      # "docker" group with an arbitrary gid — override via
+      # DOCKER_SOCK_GID in deploy/.env if 0 doesn't work on your host.
+      - /var/run/docker.sock:/var/run/docker.sock
+    group_add:
+      - "${DOCKER_SOCK_GID:-0}"
+    # Hardening against non-socket bugs in this service — it cannot stop
+    # the socket itself being root-equivalent, but everything else about
+    # the container is locked down.
+    read_only: true
+    cap_drop: [ALL]
+    security_opt: ["no-new-privileges:true"]
+    healthcheck:
+      test: ["CMD", "/app", "-healthcheck"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    # internal-only: no published ports; brain is the sole caller.
+    # Second network (not just `timothy`): sandboxd is strictly more
+    # privileged than any other internal service (it holds the socket),
+    # so it reaches only brain, not searxng/markitdown/ollama/web. No
+    # auth header on the API — a shared secret would have to live in
+    # brain's own env, the exact thing this split assumes may be
+    # compromised (same reasoning as memoryd's unauthenticated internal
+    # API).
+    networks: [timothy-sandbox]
 
   gateway:
     <<: *go-service
@@ -238,3 +289,5 @@ volumes:
 
 networks:
   timothy:
+  # brain + sandboxd only — see the sandboxd service comment.
+  timothy-sandbox:

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -43,12 +43,14 @@ SENSITIVE_TOOL_ROUTE=
 
 # --- Mission sandbox ---
 # Image tag for per-mission sandbox containers that run model-authored
-# shell/verify_cmd commands OUTSIDE brain's own process (build with
+# shell/verify_cmd commands OUTSIDE brain's own process, via sandboxd
+# (the only service holding the Docker socket — build the image with
 # `make sandbox-image`, then set this to timothy-sandbox:latest). Leave
-# empty to keep the original in-process exec behavior.
+# empty to keep the original in-process exec behavior; sandboxd itself
+# still runs, just idling degraded with nothing to do.
 MISSION_SANDBOX_IMAGE=
-# Group ID of the docker.sock on your host, needed so brain (running as
-# a non-root user) can use it. Docker Desktop: 0 (the default) works.
-# Linux hosts: run `stat -c '%g' /var/run/docker.sock` and set it here
-# if it isn't 0.
+# Group ID of the docker.sock on your host, needed so sandboxd (running
+# as a non-root user) can use it. Docker Desktop: 0 (the default)
+# works. Linux hosts: run `stat -c '%g' /var/run/docker.sock` and set
+# it here if it isn't 0.
 DOCKER_SOCK_GID=0

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -498,12 +498,18 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, researchNotes
 		user += "\n\nResearch findings:\n" + NeutralizeSlot(researchNotes)
 	}
 	req := loop.Request{
-		SessionID:  m.SessionID,
-		Route:      m.Route,
-		Agent:      "mission-planner",
-		MissionID:  m.ID,
-		System:     system,
-		Messages:   []provider.Message{{Role: "user", Content: user}},
+		SessionID: m.SessionID,
+		Route:     m.Route,
+		Agent:     "mission-planner",
+		MissionID: m.ID,
+		System:    system,
+		Messages:  []provider.Message{{Role: "user", Content: user}},
+		// The planner plans; it must not act. No base tool matches this
+		// allowlist (submit_plan arrives via ExtraTools, which bypass
+		// it), so the turn's only tool is submit_plan — a planner that
+		// reaches for shell parked a live canary on the permission gate
+		// for ten minutes trying to do the worker's job in plan phase.
+		ToolAllow:  []string{planToolName},
 		ExtraTools: []*tools.Tool{PlanTool()},
 	}
 	text, args, err := r.runTurn(ctx, req, planToolName)

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -275,6 +275,11 @@ func TestPlanSessionParsesSpec(t *testing.T) {
 	if agent.call != 1 {
 		t.Fatalf("expected exactly one turn (no recovery needed), got %d", agent.call)
 	}
+	// The planner must not act: its only tool is submit_plan, so the
+	// base surface (shell, write_file, ...) is filtered out entirely.
+	if allow := agent.requests[0].ToolAllow; len(allow) != 1 || allow[0] != planToolName {
+		t.Fatalf("planner ToolAllow = %v, want [%s]", allow, planToolName)
+	}
 }
 
 func TestPlanSessionRejectsEmptyPlan(t *testing.T) {

--- a/internal/brain/missions/sentinel.go
+++ b/internal/brain/missions/sentinel.go
@@ -81,7 +81,7 @@ func PlanTool() *tools.Tool {
 							"artifacts": {
 								"type": "array",
 								"items": {"type": "string"},
-								"description": "Workspace-relative file path(s) this unit must produce."
+								"description": "Workspace-relative file path(s) this unit must produce. Files only — the harness rejects directories."
 							},
 							"verify_cmd": {
 								"type": "string",

--- a/internal/brain/missions/sweep.go
+++ b/internal/brain/missions/sweep.go
@@ -21,32 +21,34 @@ const (
 	recoverWorkingRetryDelay = 2 * time.Second
 )
 
-// sandboxSweeper is the narrow slice of *sandbox.Manager the boot-time
-// orphan pass needs — kept as an interface (not an import of the
-// sandbox package) for the same reason as Driver's sandboxRemover: no
-// compile-time dependency on Docker from this package.
+// sandboxSweeper is the narrow slice of the sandbox backend the
+// periodic orphan pass needs — kept as an interface (not an import of
+// sandboxd or sandboxclient) for the same reason as Driver's
+// sandboxRemover: no compile-time dependency on Docker from this
+// package.
 type sandboxSweeper interface {
 	Sweep(ctx context.Context, isTerminal func(missionID string) bool) error
 }
 
 // RecoverAndSweep runs the boot-time recovery pass once (re-Drives any
-// mission left status='working' from a prior process's crash), sweeps
-// any sandbox container whose mission is terminal or unknown (the
-// day-to-day path is Driver removing its own mission's container at
-// its terminal transition; this is the backstop for missions that
-// terminated, or were deleted, while brain was down), then runs the
-// periodic work-slot sweep until ctx is done. This is the one entry
-// point cmd/brain/main.go needs — it owns the Driver, which carries
-// its own Store reference. sandbox may be nil (MISSION_SANDBOX_IMAGE
-// unset), in which case the container sweep is skipped entirely.
+// mission left status='working' from a prior process's crash), then
+// runs the periodic work-slot sweep until ctx is done — which now also
+// sweeps orphaned sandbox containers on the same tick (see
+// runWorkSlotSweep). This is the one entry point cmd/brain/main.go
+// needs — it owns the Driver, which carries its own Store reference.
+// sandbox may be nil (SANDBOXD_URL unset), in which case the container
+// sweep is skipped entirely.
 func RecoverAndSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, log *slog.Logger) {
 	recoverWorking(ctx, d, store, log)
-	sweepOrphanSandboxes(ctx, store, sandbox, log)
-	runWorkSlotSweep(ctx, d, store, maxConcurrent, log)
+	runWorkSlotSweep(ctx, d, store, maxConcurrent, sandbox, log)
 }
 
-// sweepOrphanSandboxes runs once at boot. A mission is terminal (safe
-// to remove its container) if it doesn't exist at all (deleted) or its
+// sweepOrphanSandboxes runs on every runWorkSlotSweep tick (previously
+// boot-only — fixes a pre-existing race where a straggler exec racing
+// a mission's own terminal-transition Remove could recreate a
+// container that then lived until the next brain restart; a 30s-later
+// retry now cleans it up instead). A mission is terminal (safe to
+// remove its container) if it doesn't exist at all (deleted) or its
 // Phase reports Terminal(); everything else — including phases this
 // process doesn't recognize — is left alone, since removing a live
 // mission's container out from under it is far worse than leaving an
@@ -104,9 +106,10 @@ func recoverWorking(ctx context.Context, d *Driver, store *Store, log *slog.Logg
 
 // runWorkSlotSweep retries missions parked idle over the work-slot cap
 // every workSlotSweepInterval via ClaimWorkSlot, kicking off a Drive
-// for whichever gets claimed. Runs until ctx is done — this call
-// blocks, so RecoverAndSweep's caller runs it in its own goroutine.
-func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, log *slog.Logger) {
+// for whichever gets claimed, and sweeps orphaned sandbox containers on
+// the same tick. Runs until ctx is done — this call blocks, so
+// RecoverAndSweep's caller runs it in its own goroutine.
+func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, log *slog.Logger) {
 	ticker := time.NewTicker(workSlotSweepInterval)
 	defer ticker.Stop()
 	for {
@@ -114,6 +117,7 @@ func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurren
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			sweepOrphanSandboxes(ctx, store, sandbox, log)
 			id, ok, err := store.ClaimWorkSlot(ctx, maxConcurrent)
 			if err != nil {
 				log.Error("work slot sweep: claim failed", "error", err)

--- a/internal/brain/sandboxclient/sandboxclient.go
+++ b/internal/brain/sandboxclient/sandboxclient.go
@@ -1,0 +1,225 @@
+// Package sandboxclient is brain's client for sandboxd's internal API
+// — the only way brain reaches per-mission sandbox containers now that
+// the Docker socket lives in sandboxd, not brain. Exec matches the
+// missions package's sandboxExec function type exactly, so
+// cmd/brain/main.go wires *Client.Exec in wherever *sandbox.Manager.Exec
+// used to go.
+package sandboxclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/platform/sse"
+)
+
+// Client talks to one sandboxd base URL.
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+func New(baseURL string) *Client {
+	return &Client{baseURL: baseURL, http: &http.Client{
+		// No overall timeout: Exec streams for as long as the mission's
+		// own timeout_seconds allows. Bound only the phase that can hang
+		// before any byte arrives — sandboxd writes headers and flushes
+		// before starting the exec, so a quiet command never trips this.
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			ResponseHeaderTimeout: 30 * time.Second,
+		},
+	}}
+}
+
+type execRequest struct {
+	Workdir        string `json:"workdir"`
+	Command        string `json:"command"`
+	TimeoutSeconds int    `json:"timeout_seconds"`
+}
+
+// Exec matches the missions package's sandboxExec function type: runs
+// command in missionID's sandbox container via sandboxd, streaming
+// decoded output to out, and returns the exit code. err is non-nil only
+// for infrastructure failures or a timeout — mirroring
+// sandboxd.Manager.Exec's own contract (a command that ran and exited
+// non-zero is reported via exitCode, not err).
+func (c *Client) Exec(ctx context.Context, missionID, workdir, command string, timeout time.Duration, out io.Writer) (int, error) {
+	body, err := json.Marshal(execRequest{
+		Workdir: workdir, Command: command, TimeoutSeconds: int(timeout / time.Second),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("sandboxclient: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/v1/sandboxes/"+missionID+"/exec", bytes.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("sandboxclient: request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("sandboxclient: sandboxd unreachable: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return 0, fmt.Errorf("sandboxclient: sandboxd http %d: %s", resp.StatusCode, string(msg))
+	}
+
+	var (
+		exitCode    int
+		execErr     error
+		sawTerminal bool
+	)
+	readErr := sse.Read(resp.Body, func(ev sse.Event) bool {
+		switch ev.Name {
+		case "output":
+			decoded, err := base64.StdEncoding.DecodeString(ev.Data)
+			if err != nil {
+				execErr = fmt.Errorf("sandboxclient: decode output chunk: %w", err)
+				sawTerminal = true
+				return false
+			}
+			if _, err := out.Write(decoded); err != nil {
+				execErr = fmt.Errorf("sandboxclient: write output: %w", err)
+				sawTerminal = true
+				return false
+			}
+			return true
+		case "exit":
+			var payload struct {
+				ExitCode int `json:"exit_code"`
+			}
+			if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+				execErr = fmt.Errorf("sandboxclient: decode exit event: %w", err)
+			} else {
+				exitCode = payload.ExitCode
+			}
+			sawTerminal = true
+			return false
+		case "error":
+			var payload struct {
+				Code     string `json:"code"`
+				ExitCode int    `json:"exit_code"`
+				Message  string `json:"message"`
+			}
+			if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+				execErr = fmt.Errorf("sandboxclient: decode error event: %w", err)
+			} else if payload.Code == "timeout" {
+				exitCode = payload.ExitCode
+				execErr = fmt.Errorf("%s", payload.Message)
+			} else {
+				execErr = fmt.Errorf("sandboxclient: %s", payload.Message)
+			}
+			sawTerminal = true
+			return false
+		default:
+			return true
+		}
+	})
+	if readErr != nil && !sawTerminal {
+		return 0, fmt.Errorf("sandboxclient: stream read: %w", readErr)
+	}
+	if !sawTerminal {
+		return 0, fmt.Errorf("sandboxclient: stream ended without a terminal event")
+	}
+	return exitCode, execErr
+}
+
+// Remove force-removes missionID's sandbox container via sandboxd.
+// Idempotent — a mission with no container reports success the same as
+// an actual removal.
+func (c *Client) Remove(ctx context.Context, missionID string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/v1/sandboxes/"+missionID, nil)
+	if err != nil {
+		return fmt.Errorf("sandboxclient: request: %w", err)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("sandboxclient: sandboxd unreachable: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return fmt.Errorf("sandboxclient: sandboxd http %d: %s", resp.StatusCode, string(msg))
+	}
+	return nil
+}
+
+// Sweep lists every sandbox container sandboxd knows about and removes
+// each one isTerminal reports true for — the inversion of
+// sandboxd.Manager.Sweep now that sandboxd holds no Postgres state to
+// make that call itself. Continues past a single mission's removal
+// failure so one bad container never blocks the rest; all failures
+// join into the returned error.
+func (c *Client) Sweep(ctx context.Context, isTerminal func(missionID string) bool) error {
+	ids, err := c.list(ctx)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, missionID := range ids {
+		if !isTerminal(missionID) {
+			continue
+		}
+		if err := c.Remove(ctx, missionID); err != nil {
+			errs = append(errs, fmt.Errorf("mission %s: %w", missionID, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (c *Client) list(ctx context.Context) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/sandboxes", nil)
+	if err != nil {
+		return nil, fmt.Errorf("sandboxclient: request: %w", err)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sandboxclient: sandboxd unreachable: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("sandboxclient: sandboxd http %d: %s", resp.StatusCode, string(msg))
+	}
+	var out struct {
+		MissionIDs []string `json:"mission_ids"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("sandboxclient: decode: %w", err)
+	}
+	return out.MissionIDs, nil
+}
+
+// Health reports whether sandboxd itself is reachable — the sandbox
+// health check surfaced through brain's own /health.
+func (c *Client) Health(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/health", nil)
+	if err != nil {
+		return fmt.Errorf("sandboxclient: request: %w", err)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("sandboxclient: sandboxd unreachable: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var body struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return fmt.Errorf("sandboxclient: decode health: %w", err)
+	}
+	if body.Status != "ok" {
+		return fmt.Errorf("sandboxclient: sandboxd degraded")
+	}
+	return nil
+}

--- a/internal/brain/sandboxclient/sandboxclient_test.go
+++ b/internal/brain/sandboxclient/sandboxclient_test.go
@@ -1,0 +1,168 @@
+package sandboxclient
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func sandboxdStub(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return New(srv.URL)
+}
+
+func TestExecDecodesOutputChunksInOrder(t *testing.T) {
+	t.Parallel()
+	c := sandboxdStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		for _, chunk := range []string{"hello ", "world"} {
+			_, _ = fmt.Fprintf(w, "event: output\ndata: %s\n\n", base64.StdEncoding.EncodeToString([]byte(chunk)))
+			flusher.Flush()
+		}
+		_, _ = fmt.Fprint(w, "event: exit\ndata: {\"exit_code\":0}\n\n")
+		flusher.Flush()
+	})
+
+	var out bytes.Buffer
+	code, err := c.Exec(t.Context(), "m1", "/workspace", "echo hi", 0, &out)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	if out.String() != "hello world" {
+		t.Errorf("output = %q, want %q", out.String(), "hello world")
+	}
+}
+
+func TestExecNonZeroExitIsNotAnError(t *testing.T) {
+	t.Parallel()
+	c := sandboxdStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "event: exit\ndata: {\"exit_code\":7}\n\n")
+		w.(http.Flusher).Flush()
+	})
+
+	var out bytes.Buffer
+	code, err := c.Exec(t.Context(), "m1", "/workspace", "exit 7", 0, &out)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if code != 7 {
+		t.Errorf("exit code = %d, want 7", code)
+	}
+}
+
+func TestExecTimeoutErrorMessage(t *testing.T) {
+	t.Parallel()
+	c := sandboxdStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "event: error\ndata: {\"code\":\"timeout\",\"exit_code\":124,\"message\":\"command timed out after 5s\"}\n\n")
+		w.(http.Flusher).Flush()
+	})
+
+	var out bytes.Buffer
+	code, err := c.Exec(t.Context(), "m1", "/workspace", "sleep 5", 0, &out)
+	if err == nil {
+		t.Fatal("Exec: want a timeout error, got nil")
+	}
+	if code != 124 {
+		t.Errorf("exit code = %d, want 124", code)
+	}
+	const want = "command timed out after"
+	if got := err.Error(); !strings.Contains(got, want) {
+		t.Errorf("error = %q, want it to contain %q", got, want)
+	}
+}
+
+func TestExecStreamCutWithoutTerminalIsInfraError(t *testing.T) {
+	t.Parallel()
+	c := sandboxdStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, "event: output\ndata: %s\n\n", base64.StdEncoding.EncodeToString([]byte("partial")))
+		w.(http.Flusher).Flush()
+		panic(http.ErrAbortHandler)
+	})
+
+	var out bytes.Buffer
+	if _, err := c.Exec(t.Context(), "m1", "/workspace", "cmd", 0, &out); err == nil {
+		t.Fatal("Exec: want an error when the stream ends without a terminal event, got nil")
+	}
+}
+
+func TestExecNon200IsInfraError(t *testing.T) {
+	t.Parallel()
+	c := sandboxdStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"bad_request","message":"invalid mission id"}`, http.StatusBadRequest)
+	})
+
+	var out bytes.Buffer
+	if _, err := c.Exec(t.Context(), "not-a-uuid", "/workspace", "cmd", 0, &out); err == nil {
+		t.Fatal("Exec: want an error for a non-200 sandboxd response, got nil")
+	}
+}
+
+func TestSweepDeletesExactlyTerminalMissions(t *testing.T) {
+	t.Parallel()
+	var deleted []string
+	c := sandboxdStub(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/sandboxes":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"mission_ids":["m1","m2","m3"]}`))
+		case r.Method == http.MethodDelete:
+			deleted = append(deleted, r.URL.Path)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected call: %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	terminal := map[string]bool{"m1": true, "m2": false, "m3": true}
+	if err := c.Sweep(t.Context(), func(id string) bool { return terminal[id] }); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(deleted) != 2 || deleted[0] != "/v1/sandboxes/m1" || deleted[1] != "/v1/sandboxes/m3" {
+		t.Fatalf("deleted = %v, want exactly [/v1/sandboxes/m1 /v1/sandboxes/m3]", deleted)
+	}
+}
+
+func TestHealthPassthrough(t *testing.T) {
+	t.Parallel()
+	c := sandboxdStub(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"degraded"}`))
+	})
+
+	if err := c.Health(t.Context()); err == nil {
+		t.Fatal("Health: want an error for a degraded status, got nil")
+	}
+}
+
+func TestHealthOK(t *testing.T) {
+	t.Parallel()
+	c := sandboxdStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	if err := c.Health(t.Context()); err != nil {
+		t.Fatalf("Health: %v", err)
+	}
+}

--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -82,6 +82,7 @@ func NewPermissions(db *pgpool.Pool, workspaceRoot string) *Permissions {
 			// protocol parked every mission's first turn for nothing.
 			"mission_status": true,
 			"review_verdict": true,
+			"submit_plan":    true,
 			// write_file is root-confined by construction (relative
 			// paths only, .. rejected, root fixed at registration) —
 			// there is nothing for a prompt to guard that the tool

--- a/internal/brain/tools/permissions_test.go
+++ b/internal/brain/tools/permissions_test.go
@@ -142,6 +142,19 @@ func TestResolveShortCircuits(t *testing.T) {
 		}
 	})
 
+	t.Run("mission sentinel tools exempt", func(t *testing.T) {
+		t.Parallel()
+		for _, tool := range []string{"mission_status", "review_verdict", "submit_plan"} {
+			res, err := p.Resolve(ctx, "s1", tool, json.RawMessage(`{}`))
+			if err != nil {
+				t.Fatalf("Resolve(%s): %v", tool, err)
+			}
+			if res.Decision != DecisionAllow {
+				t.Fatalf("Resolve(%s) = %+v, want allow", tool, res)
+			}
+		}
+	})
+
 	t.Run("destructive forces ask", func(t *testing.T) {
 		t.Parallel()
 		res, err := p.Resolve(ctx, "s1", "shell", json.RawMessage(`{"command":"rm -rf build/"}`))

--- a/internal/sandboxd/api.go
+++ b/internal/sandboxd/api.go
@@ -1,0 +1,298 @@
+// Package sandboxd (this file) is the HTTP surface: brain's only way
+// to reach the Docker daemon this service holds the socket for. Every
+// route validates its mission id/workdir in Go code before touching
+// Docker — never pass an unvalidated value through, no allowlist
+// fallthrough (a remote server must reject the unrecognized, not
+// silently let it pass).
+package sandboxd
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"path"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/platform/httpserver"
+)
+
+const (
+	// execMinTimeout / execMaxTimeout clamp a client-supplied
+	// timeout_seconds server-side — never trust the caller's number
+	// unbounded, even though brain is the only caller today. 15m covers
+	// verify_cmd's own ceiling (10m) with room to spare.
+	execMinTimeout = 1 * time.Second
+	execMaxTimeout = 15 * time.Minute
+
+	// execBodyLimit bounds the exec request body; the request has
+	// exactly three small fields, so 1 MiB is already generous.
+	execBodyLimit = 1 << 20
+
+	// defaultMaxExecs / defaultMaxContainers are the concurrency caps
+	// applied when the operator sets neither SANDBOXD_MAX_EXECS nor
+	// SANDBOXD_MAX_CONTAINERS — generous relative to today's realistic
+	// worst case (4 concurrently-working missions × 4 parallel tool
+	// calls each = 16) while still bounding the blast radius of a
+	// runaway caller.
+	defaultMaxExecs      = 32
+	defaultMaxContainers = 32
+)
+
+// missionIDPattern matches exactly the UUID gen_random_uuid() produces
+// (migrations/0025_missions.sql) — checked before any Docker call, so
+// no mission-id-shaped input ever reaches a container name.
+var missionIDPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// Config bounds the two things this service must cap regardless of
+// what a caller asks for: concurrent execs (a slow/hung command must
+// not let an unbounded number pile up) and live containers (a runaway
+// caller must not be able to exhaust the host). Zero fields fall back
+// to the package defaults.
+type Config struct {
+	MaxExecs      int
+	MaxContainers int
+}
+
+// API serves sandboxd's routes.
+type API struct {
+	mgr *Manager
+	log *slog.Logger
+
+	execSem       chan struct{}
+	maxContainers int
+}
+
+// Register mounts sandboxd's routes on the shared server. mgr may be
+// nil (MISSION_SANDBOX_IMAGE unset) — every route reports 503 rather
+// than panicking.
+func Register(s *httpserver.Server, mgr *Manager, cfg Config, log *slog.Logger) {
+	maxExecs := cfg.MaxExecs
+	if maxExecs <= 0 {
+		maxExecs = defaultMaxExecs
+	}
+	maxContainers := cfg.MaxContainers
+	if maxContainers <= 0 {
+		maxContainers = defaultMaxContainers
+	}
+	a := &API{
+		mgr:           mgr,
+		log:           log,
+		execSem:       make(chan struct{}, maxExecs),
+		maxContainers: maxContainers,
+	}
+	s.Handle("POST /v1/sandboxes/{missionID}/exec", http.HandlerFunc(a.handleExec))
+	s.Handle("DELETE /v1/sandboxes/{missionID}", http.HandlerFunc(a.handleRemove))
+	s.Handle("GET /v1/sandboxes", http.HandlerFunc(a.handleList))
+}
+
+func jsonError(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": code, "message": msg})
+}
+
+// validMissionID rejects anything that is not exactly a gen_random_uuid()
+// shape — including image-name-shaped or path-traversal-shaped input —
+// before it ever reaches containerName/Docker.
+func validMissionID(id string) bool {
+	return missionIDPattern.MatchString(id)
+}
+
+// validWorkdir is hygiene, not a security boundary: the sandbox mounts
+// the whole workspace volume, so the boundary actually being defended
+// is the host/daemon (missionID validation, container naming), not
+// mission-vs-mission file access. Still, an absolute, clean path under
+// /workspace is the only shape a legitimate caller ever sends.
+func validWorkdir(w string) bool {
+	if w != "/workspace" && !strings.HasPrefix(w, "/workspace/") {
+		return false
+	}
+	return path.Clean(w) == w
+}
+
+type execRequest struct {
+	Workdir        string `json:"workdir"`
+	Command        string `json:"command"`
+	TimeoutSeconds int    `json:"timeout_seconds"`
+}
+
+// handleExec streams command's combined stdout+stderr as SSE. Pre-stream
+// failures (bad request, at-capacity, ensure failure) are plain JSON
+// errors; once headers are written the response commits to the SSE
+// contract and every subsequent failure becomes a terminal `event:
+// error`.
+func (a *API) handleExec(w http.ResponseWriter, r *http.Request) {
+	missionID := r.PathValue("missionID")
+	if !validMissionID(missionID) {
+		jsonError(w, http.StatusBadRequest, "bad_request", "invalid mission id")
+		return
+	}
+	if a.mgr == nil {
+		jsonError(w, http.StatusServiceUnavailable, "not_configured", ErrDisabled.Error())
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, execBodyLimit)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	var req execRequest
+	if err := dec.Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if !validWorkdir(req.Workdir) {
+		jsonError(w, http.StatusBadRequest, "bad_request", "workdir must be an absolute, clean path under /workspace")
+		return
+	}
+	if strings.TrimSpace(req.Command) == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "command is required")
+		return
+	}
+	timeout := time.Duration(req.TimeoutSeconds) * time.Second
+	if timeout < execMinTimeout {
+		timeout = execMinTimeout
+	}
+	if timeout > execMaxTimeout {
+		timeout = execMaxTimeout
+	}
+
+	select {
+	case a.execSem <- struct{}{}:
+		defer func() { <-a.execSem }()
+	default:
+		jsonError(w, http.StatusTooManyRequests, "at_capacity", "too many concurrent execs")
+		return
+	}
+
+	if n, err := a.liveContainers(r.Context()); err != nil {
+		jsonError(w, http.StatusServiceUnavailable, "infra", err.Error())
+		return
+	} else if n >= a.maxContainers {
+		jsonError(w, http.StatusServiceUnavailable, "at_capacity", "too many live sandbox containers")
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		jsonError(w, http.StatusInternalServerError, "streaming_unsupported", "response writer cannot flush")
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	ctrl := http.NewResponseController(w)
+	out := &sseOutputWriter{w: w, flusher: flusher, ctrl: ctrl}
+
+	exitCode, err := a.mgr.Exec(r.Context(), missionID, req.Workdir, req.Command, timeout, out)
+	switch {
+	case err != nil && errors.Is(err, ErrTimeout):
+		writeEvent(w, flusher, "error", map[string]any{
+			"code": "timeout", "exit_code": 124, "message": err.Error(),
+		})
+	case err != nil:
+		writeEvent(w, flusher, "error", map[string]any{
+			"code": "infra", "message": err.Error(),
+		})
+	default:
+		writeEvent(w, flusher, "exit", map[string]any{"exit_code": exitCode})
+	}
+}
+
+// liveContainers counts sandbox containers currently known to Docker —
+// the ensure-time cap that keeps a runaway caller from exhausting the
+// host, distinct from execSem's cap on concurrent Exec calls.
+func (a *API) liveContainers(ctx context.Context) (int, error) {
+	ids, err := a.mgr.List(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return len(ids), nil
+}
+
+// sseOutputWriter adapts Manager.Exec's io.Writer contract (arbitrary
+// binary chunks) onto the SSE wire format: one `event: output` /
+// `data: <base64>` per Write, flushed immediately so the client sees
+// output as it happens, refreshing the write deadline each time so a
+// stalled client (not a stalled command) is what times this out.
+type sseOutputWriter struct {
+	w       http.ResponseWriter
+	flusher http.Flusher
+	ctrl    *http.ResponseController
+}
+
+func (o *sseOutputWriter) Write(p []byte) (int, error) {
+	_ = o.ctrl.SetWriteDeadline(time.Now().Add(30 * time.Second))
+	encoded := base64.StdEncoding.EncodeToString(p)
+	if _, err := fmt.Fprintf(o.w, "event: output\ndata: %s\n\n", encoded); err != nil {
+		return 0, err
+	}
+	o.flusher.Flush()
+	return len(p), nil
+}
+
+// writeEvent emits one terminal SSE event (exit or error) as a single
+// JSON data line.
+func writeEvent(w http.ResponseWriter, flusher http.Flusher, event string, payload map[string]any) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data)
+	flusher.Flush()
+}
+
+// handleRemove force-removes missionID's sandbox container. Idempotent:
+// a mission with no container (already removed, or never created)
+// reports 204 the same as a successful removal — matching Manager.Remove's
+// own not-found-is-fine contract.
+func (a *API) handleRemove(w http.ResponseWriter, r *http.Request) {
+	missionID := r.PathValue("missionID")
+	if !validMissionID(missionID) {
+		jsonError(w, http.StatusBadRequest, "bad_request", "invalid mission id")
+		return
+	}
+	if a.mgr == nil {
+		jsonError(w, http.StatusServiceUnavailable, "not_configured", ErrDisabled.Error())
+		return
+	}
+	if err := a.mgr.Remove(r.Context(), missionID); err != nil {
+		a.log.Warn("sandbox remove failed", "mission_id", missionID, "error", err)
+		jsonError(w, http.StatusBadGateway, "infra", err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type listResponse struct {
+	MissionIDs []string `json:"mission_ids"`
+}
+
+// handleList reports the mission id of every sandbox container that
+// currently exists — brain's sweep uses this to decide what is safe to
+// remove; this service holds no Postgres state to make that decision
+// itself.
+func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
+	if a.mgr == nil {
+		jsonError(w, http.StatusServiceUnavailable, "not_configured", ErrDisabled.Error())
+		return
+	}
+	ids, err := a.mgr.List(r.Context())
+	if err != nil {
+		a.log.Warn("sandbox list failed", "error", err)
+		jsonError(w, http.StatusBadGateway, "infra", err.Error())
+		return
+	}
+	if ids == nil {
+		ids = []string{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(listResponse{MissionIDs: ids})
+}

--- a/internal/sandboxd/api_test.go
+++ b/internal/sandboxd/api_test.go
@@ -1,0 +1,256 @@
+package sandboxd
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/moby/moby/api/types/common"
+	"github.com/moby/moby/api/types/container"
+)
+
+func testLog() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func testAPI(mgr *Manager) *API {
+	return &API{mgr: mgr, log: testLog(), execSem: make(chan struct{}, defaultMaxExecs), maxContainers: defaultMaxContainers}
+}
+
+// validUUID is a mission id shaped exactly like gen_random_uuid()'s
+// output — every "valid missionID" test uses this so a failure clearly
+// means the handler rejected a well-formed id, not a coincidentally
+// malformed fixture.
+const validUUID = "a1b2c3d4-e5f6-4789-a012-b34c56d78e9f"
+
+func execReq(missionID, body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/v1/sandboxes/"+missionID+"/exec", strings.NewReader(body))
+	req.SetPathValue("missionID", missionID)
+	return req
+}
+
+func removeReq(missionID string) *http.Request {
+	req := httptest.NewRequest(http.MethodDelete, "/v1/sandboxes/"+missionID, nil)
+	req.SetPathValue("missionID", missionID)
+	return req
+}
+
+func TestHandleExecInvalidMissionID(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"not-a-uuid",
+		"../../etc/passwd",
+		"alpine:latest",
+		"a1b2c3d4-e5f6-4789-a012-b34c56d78e9", // one char short
+		"A1B2C3D4-E5F6-4789-A012-B34C56D78E9F", // uppercase not accepted
+	}
+	for _, id := range cases {
+		rec := httptest.NewRecorder()
+		testAPI(nil).handleExec(rec, execReq(id, `{}`))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("id=%q: status = %d, want 400", id, rec.Code)
+		}
+	}
+}
+
+func TestHandleRemoveInvalidMissionID(t *testing.T) {
+	t.Parallel()
+	rec := httptest.NewRecorder()
+	testAPI(nil).handleRemove(rec, removeReq("../escape"))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleExecNilManagerReturns503(t *testing.T) {
+	t.Parallel()
+	rec := httptest.NewRecorder()
+	testAPI(nil).handleExec(rec, execReq(validUUID, `{"workdir":"/workspace","command":"true","timeout_seconds":5}`))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}
+
+func TestHandleRemoveNilManagerReturns503(t *testing.T) {
+	t.Parallel()
+	rec := httptest.NewRecorder()
+	testAPI(nil).handleRemove(rec, removeReq(validUUID))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}
+
+func TestHandleListNilManagerReturns503(t *testing.T) {
+	t.Parallel()
+	rec := httptest.NewRecorder()
+	testAPI(nil).handleList(rec, httptest.NewRequest(http.MethodGet, "/v1/sandboxes", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}
+
+func TestHandleExecWorkdirEscape(t *testing.T) {
+	t.Parallel()
+	cli := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected daemon call for a workdir that should 400 before ensureContainer: %s %s", r.Method, r.URL.Path)
+	})
+	mgr := newTestManager(cli)
+
+	cases := []string{
+		"/workspace/../etc",
+		"workspace",
+		"/workspace/",
+		"/other",
+	}
+	for _, wd := range cases {
+		body, _ := json.Marshal(map[string]any{"workdir": wd, "command": "true", "timeout_seconds": 5})
+		rec := httptest.NewRecorder()
+		testAPI(mgr).handleExec(rec, execReq(validUUID, string(body)))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("workdir=%q: status = %d, want 400", wd, rec.Code)
+		}
+	}
+}
+
+func TestHandleExecUnknownFieldRejected(t *testing.T) {
+	t.Parallel()
+	cli := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected daemon call: %s %s", r.Method, r.URL.Path)
+	})
+	mgr := newTestManager(cli)
+
+	body := `{"workdir":"/workspace","command":"true","timeout_seconds":5,"image":"escape:latest"}`
+	rec := httptest.NewRecorder()
+	testAPI(mgr).handleExec(rec, execReq(validUUID, body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestHandleExecTimeoutClampVisibleInArgv confirms an out-of-range
+// timeout_seconds is clamped server-side before ever reaching the
+// daemon: the fake records ExecCreate's Cmd argv (the "timeout N ..."
+// wrapper) and asserts the clamped value, not the caller's raw input.
+// ExecAttach is left to fail (this fake speaks plain JSON-over-HTTP,
+// not the raw hijacked upgrade ExecAttach needs — that path is
+// exercised by the integration test against a real daemon); what
+// matters here is what argv the daemon received before that point.
+func TestHandleExecTimeoutClampVisibleInArgv(t *testing.T) {
+	t.Parallel()
+	var mu sync.Mutex
+	var gotCmd []string
+	cli := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/containers/json"):
+			// liveContainers' List call, ahead of ensureContainer: no
+			// sandboxes running yet, so the container cap never trips.
+			writeJSON(t, w, http.StatusOK, []container.Summary{})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "timothy-sandbox-") && strings.HasSuffix(r.URL.Path, "/json"):
+			writeJSON(t, w, http.StatusOK, container.InspectResponse{
+				ID: "c1", State: &container.State{Running: true},
+			})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/exec"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read exec create body: %v", err)
+			}
+			var req container.ExecCreateRequest
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Fatalf("unmarshal exec create body: %v", err)
+			}
+			mu.Lock()
+			gotCmd = req.Cmd
+			mu.Unlock()
+			writeJSON(t, w, http.StatusCreated, common.IDResponse{ID: "exec1"})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/start"):
+			// No hijack support: report a plain error status so ExecAttach
+			// fails cleanly instead of hanging on a protocol upgrade this
+			// fake doesn't implement.
+			http.Error(w, "attach not supported by fake daemon", http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected call: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	mgr := newTestManager(cli)
+
+	// 999999 seconds is far past execMaxTimeout (15m); the handler must
+	// clamp it before it ever reaches the daemon.
+	body := `{"workdir":"/workspace","command":"true","timeout_seconds":999999}`
+	rec := httptest.NewRecorder()
+	testAPI(mgr).handleExec(rec, execReq(validUUID, body))
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(gotCmd) < 4 {
+		t.Fatalf("ExecCreate argv = %v, want at least [timeout -k N secs ...]", gotCmd)
+	}
+	if gotCmd[0] != "timeout" {
+		t.Fatalf("ExecCreate argv[0] = %q, want %q", gotCmd[0], "timeout")
+	}
+	secs := gotCmd[3]
+	if secs != "900" {
+		t.Errorf("clamped timeout seconds = %q, want 900 (execMaxTimeout)", secs)
+	}
+}
+
+func TestHandleRemoveIdempotent(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	cli := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			calls++
+			http.Error(w, "no such container", http.StatusNotFound)
+			return
+		}
+		t.Fatalf("unexpected call: %s %s", r.Method, r.URL.Path)
+	})
+	mgr := newTestManager(cli)
+	api := testAPI(mgr)
+
+	for i := 0; i < 2; i++ {
+		rec := httptest.NewRecorder()
+		api.handleRemove(rec, removeReq(validUUID))
+		if rec.Code != http.StatusNoContent {
+			t.Errorf("call %d: status = %d, want 204", i, rec.Code)
+		}
+	}
+	if calls != 2 {
+		t.Fatalf("daemon remove calls = %d, want 2", calls)
+	}
+}
+
+func TestHandleListLabelFiltering(t *testing.T) {
+	t.Parallel()
+	cli := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/containers/json") {
+			writeJSON(t, w, http.StatusOK, []container.Summary{
+				{ID: "c1", Labels: map[string]string{missionLabel: validUUID}},
+				{ID: "c2", Labels: map[string]string{missionLabel: ""}},
+				{ID: "c3", Labels: map[string]string{}},
+			})
+			return
+		}
+		t.Fatalf("unexpected call: %s %s", r.Method, r.URL.Path)
+	})
+	mgr := newTestManager(cli)
+
+	rec := httptest.NewRecorder()
+	testAPI(mgr).handleList(rec, httptest.NewRequest(http.MethodGet, "/v1/sandboxes", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var out struct {
+		MissionIDs []string `json:"mission_ids"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.MissionIDs) != 1 || out.MissionIDs[0] != validUUID {
+		t.Fatalf("mission_ids = %v, want [%s] (empty/missing labels skipped)", out.MissionIDs, validUUID)
+	}
+}

--- a/internal/sandboxd/manager.go
+++ b/internal/sandboxd/manager.go
@@ -1,11 +1,12 @@
-// Package sandbox drives per-mission Docker containers that execute
+// Package sandboxd drives per-mission Docker containers that execute
 // model-authored shell commands (mission worker/reviewer shell calls,
 // verify_cmd) OUTSIDE brain's own process — so a command never inherits
 // brain's environment (DATABASE_URL, TIMOTHY_MASTER_KEY, API tokens)
 // or reaches brain's filesystem/binaries. Harness-authored git
 // operations stay in brain; only model/plan-authored commands route
-// here.
-package sandbox
+// here. The Docker socket lives only in this service — brain reaches
+// it exclusively through sandboxclient's narrow HTTP API.
+package sandboxd
 
 import (
 	"context"
@@ -73,6 +74,12 @@ const (
 // ErrDisabled is returned by every Manager method when no image was
 // configured — callers check this to fall back to in-process exec.
 var ErrDisabled = errors.New("sandbox: not configured")
+
+// ErrTimeout wraps Exec's two timeout-return paths so the HTTP handler
+// can classify a timeout (SSE event: error, code "timeout") separately
+// from every other infrastructure failure via errors.Is, without
+// string-matching the error text.
+var ErrTimeout = errors.New("sandbox: command timed out")
 
 // Manager creates, reuses, and tears down one Docker container per
 // mission on the same Docker daemon brain itself runs under (driven via
@@ -370,7 +377,7 @@ func (m *Manager) Exec(ctx context.Context, missionID, workdir, command string, 
 			if ctx.Err() != nil {
 				return 0, ctx.Err()
 			}
-			return 0, fmt.Errorf("command timed out after %s", timeout)
+			return 0, fmt.Errorf("command timed out after %s: %w", timeout, ErrTimeout)
 		case now := <-poll.C:
 			if !execDone {
 				cur, ierr := m.cli.ExecInspect(cctx, created.ID, client.ExecInspectOptions{})
@@ -394,7 +401,7 @@ func (m *Manager) Exec(ctx context.Context, missionID, workdir, command string, 
 		}
 	}
 	if insp.ExitCode == timeoutExitCode {
-		return timeoutExitCode, fmt.Errorf("command timed out after %s", timeout)
+		return timeoutExitCode, fmt.Errorf("command timed out after %s: %w", timeout, ErrTimeout)
 	}
 	return insp.ExitCode, nil
 }
@@ -417,36 +424,28 @@ func (m *Manager) Remove(ctx context.Context, missionID string) error {
 	return nil
 }
 
-// Sweep force-removes every sandbox container whose mission is
-// terminal (or no longer known) according to isTerminal, given the
-// mission id encoded in the timothy.mission label. Meant to run once
-// at boot and on the existing periodic sweep tick — the day-to-day path
-// is Remove at each mission's own terminal transition; this is the
-// backstop for missions that terminated (or were deleted) while brain
-// was down.
-func (m *Manager) Sweep(ctx context.Context, isTerminal func(missionID string) bool) error {
+// List returns the mission id (the timothy.mission label's value) of
+// every sandbox container that exists, running or not. The caller
+// (brain's sandboxclient.Sweep) filters this against its own
+// terminal-mission knowledge and deletes what it decides is safe to
+// remove — this package holds no Postgres state to make that call
+// itself.
+func (m *Manager) List(ctx context.Context) ([]string, error) {
 	if m == nil {
-		return ErrDisabled
+		return nil, ErrDisabled
 	}
 	result, err := m.cli.ContainerList(ctx, client.ContainerListOptions{
 		All:     true,
 		Filters: make(client.Filters).Add("label", missionLabel),
 	})
 	if err != nil {
-		return fmt.Errorf("sandbox: sweep: list: %w", err)
+		return nil, fmt.Errorf("sandbox: list: %w", err)
 	}
+	ids := make([]string, 0, len(result.Items))
 	for _, c := range result.Items {
-		missionID := c.Labels[missionLabel]
-		if missionID == "" || !isTerminal(missionID) {
-			continue
+		if missionID := c.Labels[missionLabel]; missionID != "" {
+			ids = append(ids, missionID)
 		}
-		if _, err := m.cli.ContainerRemove(ctx, c.ID, client.ContainerRemoveOptions{Force: true}); err != nil && !errdefs.IsNotFound(err) {
-			m.log.Warn("sandbox: sweep remove failed", "mission_id", missionID, "container_id", c.ID, "error", err)
-			continue
-		}
-		m.mu.Lock()
-		delete(m.locks, missionID)
-		m.mu.Unlock()
 	}
-	return nil
+	return ids, nil
 }

--- a/internal/sandboxd/manager_integration_test.go
+++ b/internal/sandboxd/manager_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package sandbox
+package sandboxd
 
 import (
 	"bytes"

--- a/internal/sandboxd/manager_test.go
+++ b/internal/sandboxd/manager_test.go
@@ -1,4 +1,4 @@
-package sandbox
+package sandboxd
 
 import (
 	"bytes"
@@ -256,8 +256,8 @@ func TestManagerDisabledReturnsErrDisabled(t *testing.T) {
 	if err := mgr.Remove(ctx, "m1"); err != ErrDisabled {
 		t.Errorf("Remove on nil manager = %v, want ErrDisabled", err)
 	}
-	if err := mgr.Sweep(ctx, func(string) bool { return true }); err != ErrDisabled {
-		t.Errorf("Sweep on nil manager = %v, want ErrDisabled", err)
+	if _, err := mgr.List(ctx); err != ErrDisabled {
+		t.Errorf("List on nil manager = %v, want ErrDisabled", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **sandboxd**: new compose-internal service, the only container mounting `/var/run/docker.sock`. Four-route mission-scoped API (exec with SSE-streamed output, remove, list, health). Strict UUID validation on mission IDs; image/user/limits/mounts/network all fixed server-side. Runs read-only, cap-drop ALL, no-new-privileges, on a dedicated `timothy-sandbox` network shared only with brain.
- **brain**: loses the socket mount, `group_add`, and direct moby dependency entirely (`go list -deps ./cmd/brain` is clean). Talks to sandboxd via the new `sandboxclient` package. Missions package types untouched — same `sandboxExec` signature, only the backend changed.
- **Sweep**: orphan-sandbox sweep moves from boot-only onto the existing 30s tick (fixes recreate-after-remove race).
- **Gating**: `MISSION_SANDBOX_IMAGE` stays the single operator knob; compose derives brain's `SANDBOXD_URL` from it. Unset = legacy in-process exec, unchanged.
- **fix(missions)**: three canary-exposed planner parks — `submit_plan` permission exemption, planner tool surface locked to `submit_plan`, plan schema now says artifacts are files.

## Test plan

- [x] `make build` / `vet` / `test` (race) / `lint` — 0 issues
- [x] `make test-integration` — green
- [x] Live: brain inspect shows no socket mount; sandboxd healthy with docker+image checks
- [x] `make canary-coding` — PASS unattended (35s); sandbox container created via sandboxd, removed at terminal
- [x] `make canary` — PASS (26s)