### PR TITLE
fix: provider stream resilience (reasoning_effort retry, nova tool use, loop step retry)

### DIFF
--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -57,6 +57,17 @@ const (
 	retrieveInlineCap = 32 << 10
 )
 
+// maxStepRetries bounds automatic retry of one step's stream (D-038):
+// a 3rd consecutive failure surfaces as today rather than retrying
+// forever.
+const maxStepRetries = 2
+
+// stepRetryBackoff scales the wait before each step retry (attempt *
+// this duration); a package-level var so tests can shrink it instead
+// of plumbing a config knob through Request/NewAgent for one knob
+// only tests need.
+var stepRetryBackoff = time.Second
+
 const finalizeWarning = "[system] You have one tool step left before the limit. Finish gathering and produce your final answer on the next step."
 
 const coercionMessage = "[system] This task category requires consulting your tools before answering. Make the relevant tool call(s), then answer."
@@ -256,50 +267,83 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			sreq.Tools = nil
 		}
 
-		upstream, err := a.gw.Stream(ctx, sreq)
-		if err != nil {
-			// Flush usage accumulated by earlier steps before the
-			// terminal error, matching the in-stream error path — a
-			// mid-loop gateway failure must not undercount the turn.
-			emit(stream.StreamEvent{Type: stream.EventUsage, Usage: &total})
-			emit(stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
-				Code: "gateway_unavailable", Message: err.Error(), Retryable: true,
-			}})
-			return
-		}
-
+		// Inner attempt loop: a stream that dies before anything
+		// user-visible went out for THIS step can be re-tried transparently
+		// — the web "retry" handler appends a notice but never resets
+		// partial text, so re-streaming after any emission would duplicate
+		// content in the saved turn. Retrying never advances step/directive:
+		// same sreq, same msgs.
 		var text strings.Builder
 		var calls []provider.ToolCall
 		terminal := stream.StreamEvent{}
-		for ev := range upstream {
-			switch ev.Type {
-			case stream.EventChunk:
-				text.WriteString(ev.Text)
-				emit(ev)
-			case stream.EventReasoningChunk, stream.EventRetry, stream.EventToolStart:
-				emit(ev)
-			case stream.EventToolEnd:
-				if ev.ToolCall != nil {
-					calls = append(calls, provider.ToolCall{
-						ID: ev.ToolCall.ID, Name: ev.ToolCall.Name, Input: ev.ToolCall.Input,
-					})
+		emittedThisAttempt := false
+
+		for attempt := 0; ; attempt++ {
+			upstream, err := a.gw.Stream(ctx, sreq)
+			if err != nil {
+				if attempt < maxStepRetries && retryStep(ctx, emit, attempt+1, err.Error()) {
+					continue
 				}
-				emit(ev)
-			case stream.EventUsage:
-				if ev.Usage != nil {
-					total.InputTokens += ev.Usage.InputTokens
-					total.OutputTokens += ev.Usage.OutputTokens
-					total.CacheReadTokens += ev.Usage.CacheReadTokens
-					total.CacheWriteTokens += ev.Usage.CacheWriteTokens
-				}
-			case stream.EventDone:
-				terminal = ev
-				if ev.Meta != nil {
-					lastMeta = ev.Meta
-				}
-			case stream.EventIncomplete, stream.EventError:
-				terminal = ev
+				// Flush usage accumulated by earlier steps before the
+				// terminal error, matching the in-stream error path — a
+				// mid-loop gateway failure must not undercount the turn.
+				emit(stream.StreamEvent{Type: stream.EventUsage, Usage: &total})
+				emit(stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
+					Code: "gateway_unavailable", Message: err.Error(), Retryable: true,
+				}})
+				return
 			}
+
+			text.Reset()
+			calls = nil
+			terminal = stream.StreamEvent{}
+			emittedThisAttempt = false
+			for ev := range upstream {
+				switch ev.Type {
+				case stream.EventChunk:
+					text.WriteString(ev.Text)
+					emittedThisAttempt = true
+					emit(ev)
+				case stream.EventReasoningChunk, stream.EventRetry, stream.EventToolStart:
+					if ev.Type != stream.EventRetry {
+						emittedThisAttempt = true
+					}
+					emit(ev)
+				case stream.EventToolEnd:
+					if ev.ToolCall != nil {
+						calls = append(calls, provider.ToolCall{
+							ID: ev.ToolCall.ID, Name: ev.ToolCall.Name, Input: ev.ToolCall.Input,
+						})
+					}
+					emittedThisAttempt = true
+					emit(ev)
+				case stream.EventUsage:
+					if ev.Usage != nil {
+						total.InputTokens += ev.Usage.InputTokens
+						total.OutputTokens += ev.Usage.OutputTokens
+						total.CacheReadTokens += ev.Usage.CacheReadTokens
+						total.CacheWriteTokens += ev.Usage.CacheWriteTokens
+					}
+				case stream.EventDone:
+					terminal = ev
+					if ev.Meta != nil {
+						lastMeta = ev.Meta
+					}
+				case stream.EventIncomplete, stream.EventError:
+					terminal = ev
+				}
+			}
+
+			// EventIncomplete is a cut-off stream, not a retryable failure
+			// signal on its own — only a terminal EventError with
+			// Retryable set qualifies, and only before anything emitted.
+			if terminal.Type == stream.EventError && terminal.Err != nil && terminal.Err.Retryable &&
+				!emittedThisAttempt && attempt < maxStepRetries {
+				if retryStep(ctx, emit, attempt+1, terminal.Err.Message) {
+					continue
+				}
+			}
+			break
 		}
 
 		// Abnormal step end: surface it and stop — the relay persists
@@ -357,6 +401,25 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			msgs = append(msgs, provider.Message{Role: "tool", ToolResult: &results[i]})
 		}
 		effort = EffortFor(results)
+	}
+}
+
+// retryStep emits a stream.EventRetry for the upcoming attempt and
+// waits the scaled backoff, aborting early if ctx is done. It reports
+// whether the caller should retry; false means ctx ended mid-wait, in
+// which case the caller falls through to its normal failure path.
+func retryStep(ctx context.Context, emit func(stream.StreamEvent), attempt int, reason string) bool {
+	backoff := time.Duration(attempt) * stepRetryBackoff
+	emit(stream.StreamEvent{Type: stream.EventRetry, Retry: &stream.RetryInfo{
+		Attempt: attempt, BackoffMs: backoff.Milliseconds(), Reason: reason,
+	}})
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
 	}
 }
 

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -414,9 +414,11 @@ func TestAgentCeilingTerminatesEvenIfModelKeepsCalling(t *testing.T) {
 
 func TestAgentFlushesUsageOnGatewayError(t *testing.T) {
 	t.Parallel()
+	withShortRetryBackoff(t)
 	// First step succeeds with a tool call and usage; the second
-	// Stream call errors synchronously (exhausted script). Accumulated
-	// usage must still reach the client before the error.
+	// Stream call errors synchronously (exhausted script) on every
+	// attempt, exhausting the step retry budget. Accumulated usage
+	// must still reach the client before the error.
 	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
 		toolCallStep([2]string{"echo", `{"text":"hi"}`}),
 	}}

--- a/internal/brain/loop/retry_test.go
+++ b/internal/brain/loop/retry_test.go
@@ -1,0 +1,201 @@
+package loop
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// errThenScripts is a Gateway test double that returns a hard error
+// from Stream a fixed number of times before falling back to
+// scriptedGateway's normal script playback — for exercising the
+// gw.Stream-returns-err retry path (as opposed to a terminal
+// EventError arriving inside the stream).
+type errThenScripts struct {
+	scriptedGateway
+	failsLeft int
+	err       error
+}
+
+func (g *errThenScripts) Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+	if g.failsLeft > 0 {
+		g.failsLeft--
+		g.requests = append(g.requests, req)
+		return nil, g.err
+	}
+	return g.scriptedGateway.Stream(ctx, req)
+}
+
+// retryableErrorStep is a one-event script: a terminal EventError
+// with Retryable set, nothing emitted before it.
+func retryableErrorStep() []stream.StreamEvent {
+	return []stream.StreamEvent{
+		{Type: stream.EventError, Err: &stream.StreamError{Code: "gateway_stream_cut", Message: "stream cut", Retryable: true}},
+	}
+}
+
+func nonRetryableErrorStep() []stream.StreamEvent {
+	return []stream.StreamEvent{
+		{Type: stream.EventError, Err: &stream.StreamError{Code: "bad_request", Message: "bad request", Retryable: false}},
+	}
+}
+
+// errorAfterChunkStep emits visible content before the terminal error
+// — the case that must NOT retry, since the partial text already went
+// to the client.
+func errorAfterChunkStep() []stream.StreamEvent {
+	return []stream.StreamEvent{
+		{Type: stream.EventChunk, Text: "partial"},
+		{Type: stream.EventError, Err: &stream.StreamError{Code: "gateway_stream_cut", Message: "stream cut", Retryable: true}},
+	}
+}
+
+func withShortRetryBackoff(t *testing.T) {
+	t.Helper()
+	orig := stepRetryBackoff
+	stepRetryBackoff = time.Millisecond
+	t.Cleanup(func() { stepRetryBackoff = orig })
+}
+
+func TestAgentRetriesStreamErrorBeforeContentThenSucceeds(t *testing.T) {
+	withShortRetryBackoff(t)
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		retryableErrorStep(),
+		finalStep("the answer"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	if got := ofType(evs, stream.EventRetry); len(got) != 1 {
+		t.Fatalf("retry events = %d, want exactly 1: %+v", len(got), evs)
+	}
+	if got := ofType(evs, stream.EventError); len(got) != 0 {
+		t.Fatalf("error events = %d, want 0: %+v", len(got), evs)
+	}
+	done := ofType(evs, stream.EventDone)
+	if len(done) != 1 {
+		t.Fatalf("done events = %d, want exactly 1", len(done))
+	}
+	chunks := ofType(evs, stream.EventChunk)
+	if len(chunks) != 1 || chunks[0].Text != "the answer" {
+		t.Fatalf("chunks = %+v, want exactly one 'the answer' (no duplication)", chunks)
+	}
+	if len(gw.requests) != 2 {
+		t.Fatalf("gw.Stream calls = %d, want 2 (failed attempt + retry)", len(gw.requests))
+	}
+}
+
+func TestAgentDoesNotRetryErrorAfterContentEmitted(t *testing.T) {
+	withShortRetryBackoff(t)
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		errorAfterChunkStep(),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	if got := ofType(evs, stream.EventRetry); len(got) != 0 {
+		t.Fatalf("retry events = %d, want 0 once content emitted: %+v", len(got), evs)
+	}
+	if got := ofType(evs, stream.EventError); len(got) != 1 {
+		t.Fatalf("error events = %d, want exactly 1", len(got))
+	}
+	if len(gw.requests) != 1 {
+		t.Fatalf("gw.Stream calls = %d, want 1 (no retry)", len(gw.requests))
+	}
+}
+
+func TestAgentDoesNotRetryNonRetryableError(t *testing.T) {
+	withShortRetryBackoff(t)
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		nonRetryableErrorStep(),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	if got := ofType(evs, stream.EventRetry); len(got) != 0 {
+		t.Fatalf("retry events = %d, want 0 for a non-retryable error: %+v", len(got), evs)
+	}
+	if got := ofType(evs, stream.EventError); len(got) != 1 {
+		t.Fatalf("error events = %d, want exactly 1", len(got))
+	}
+	if len(gw.requests) != 1 {
+		t.Fatalf("gw.Stream calls = %d, want 1 (no retry)", len(gw.requests))
+	}
+}
+
+func TestAgentGivesUpAfterMaxStepRetries(t *testing.T) {
+	withShortRetryBackoff(t)
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		retryableErrorStep(),
+		retryableErrorStep(),
+		retryableErrorStep(),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	if got := ofType(evs, stream.EventRetry); len(got) != maxStepRetries {
+		t.Fatalf("retry events = %d, want %d (max retries, 3rd failure surfaces)", len(got), maxStepRetries)
+	}
+	if got := ofType(evs, stream.EventError); len(got) != 1 {
+		t.Fatalf("error events = %d, want exactly 1 after budget exhausted", len(got))
+	}
+	if len(gw.requests) != maxStepRetries+1 {
+		t.Fatalf("gw.Stream calls = %d, want %d (initial + %d retries)", len(gw.requests), maxStepRetries+1, maxStepRetries)
+	}
+}
+
+func TestAgentRetriesGatewayStreamErrThenSucceeds(t *testing.T) {
+	withShortRetryBackoff(t)
+	gw := &errThenScripts{
+		scriptedGateway: scriptedGateway{scripts: [][]stream.StreamEvent{
+			finalStep("recovered"),
+		}},
+		failsLeft: 1,
+		err:       errors.New("gateway_unavailable"),
+	}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	if got := ofType(evs, stream.EventRetry); len(got) != 1 {
+		t.Fatalf("retry events = %d, want exactly 1: %+v", len(got), evs)
+	}
+	if got := ofType(evs, stream.EventError); len(got) != 0 {
+		t.Fatalf("error events = %d, want 0: %+v", len(got), evs)
+	}
+	if got := ofType(evs, stream.EventDone); len(got) != 1 {
+		t.Fatalf("done events = %d, want exactly 1", len(got))
+	}
+	chunks := ofType(evs, stream.EventChunk)
+	if len(chunks) != 1 || chunks[0].Text != "recovered" {
+		t.Fatalf("chunks = %+v, want exactly one 'recovered'", chunks)
+	}
+}

--- a/internal/gateway/provider/bedrock.go
+++ b/internal/gateway/provider/bedrock.go
@@ -101,20 +101,7 @@ func (b *Bedrock) Stream(ctx context.Context, req CompletionRequest) (<-chan str
 		return nil, err
 	}
 
-	// Nova models are served through inference profiles, so ModelId is
-	// e.g. "us.amazon.nova-pro-v1:0" — the bare model ID rejects
-	// on-demand invocation.
-	input := &bedrockruntime.ConverseStreamInput{
-		ModelId:    aws.String(req.Model),
-		Messages:   converseMessages(req.Messages),
-		ToolConfig: converseTools(req.Tools),
-		System:     converseSystem(req.System, req.Model),
-	}
-	if req.MaxTokens > 0 {
-		input.InferenceConfig = &types.InferenceConfiguration{
-			MaxTokens: aws.Int32(int32(req.MaxTokens)), //nolint:gosec // token caps are far below int32 max
-		}
-	}
+	input := buildConverseStreamInput(req)
 
 	outCh := make(chan stream.StreamEvent, 64)
 
@@ -247,6 +234,43 @@ func (b *Bedrock) Stream(ctx context.Context, req CompletionRequest) (<-chan str
 	return outCh, nil
 }
 
+// buildConverseStreamInput assembles the ConverseStream request.
+// Nova models are served through inference profiles, so ModelId is
+// e.g. "us.amazon.nova-pro-v1:0" — the bare model ID rejects
+// on-demand invocation.
+//
+// D-037: Nova tool-calling streams intermittently abort mid-stream
+// with "ModelStreamErrorException: Model produced invalid sequence as
+// part of ToolUse". AWS's Nova tool-troubleshooting guide prescribes
+// greedy decoding (temperature 0, topK 1) for any request that offers
+// tools — sampling variance is what produces the malformed ToolUse
+// sequence. topK has no field on InferenceConfiguration; Nova reads it
+// from AdditionalModelRequestFields instead. Titan has no such
+// failure mode and no topK field, so the workaround is gated to Nova.
+func buildConverseStreamInput(req CompletionRequest) *bedrockruntime.ConverseStreamInput {
+	input := &bedrockruntime.ConverseStreamInput{
+		ModelId:    aws.String(req.Model),
+		Messages:   converseMessages(req.Messages),
+		ToolConfig: converseTools(req.Tools),
+		System:     converseSystem(req.System, req.Model),
+	}
+	if req.MaxTokens > 0 {
+		input.InferenceConfig = &types.InferenceConfiguration{
+			MaxTokens: aws.Int32(int32(req.MaxTokens)), //nolint:gosec // token caps are far below int32 max
+		}
+	}
+	if len(req.Tools) > 0 && strings.Contains(req.Model, "amazon.nova") {
+		if input.InferenceConfig == nil {
+			input.InferenceConfig = &types.InferenceConfiguration{}
+		}
+		input.InferenceConfig.Temperature = aws.Float32(0)
+		input.AdditionalModelRequestFields = document.NewLazyDocument(map[string]any{
+			"inferenceConfig": map[string]any{"topK": 1},
+		})
+	}
+	return input
+}
+
 // converseMessages maps normalized messages onto Bedrock Converse
 // messages. Tool results ride as user-role toolResult blocks;
 // assistant messages that carry neither text nor tool calls are
@@ -365,12 +389,49 @@ func converseTools(defs []ToolDef) *types.ToolConfiguration {
 				Name:        aws.String(t.Name),
 				Description: aws.String(t.Description),
 				InputSchema: &types.ToolInputSchemaMemberJson{
-					Value: documentFromJSON(t.InputSchema),
+					Value: documentFromJSON(sanitizeNovaSchema(t.InputSchema)),
 				},
 			},
 		})
 	}
 	return &types.ToolConfiguration{Tools: tools}
+}
+
+// sanitizeNovaSchema strips top-level schema keys AWS's Nova
+// tool-troubleshooting guide identifies as contributors to invalid
+// ToolUse sequences: the top-level tool input schema object supports
+// only "type", "properties", and "required" — fields like $schema,
+// additionalProperties, and title are rejected mid-stream instead of
+// at request time. This adapter serves only Amazon first-party models
+// (Bedrock, D-037), so the sanitize runs unconditionally rather than
+// gating on model family. Nested schema keys (e.g. additionalProperties
+// inside a property's own subschema) are untouched — only the
+// top-level object is filtered. Unparseable or empty input is returned
+// as-is; documentFromJSON already handles that case.
+func sanitizeNovaSchema(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return raw
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return raw
+	}
+	const (
+		keyType       = "type"
+		keyProperties = "properties"
+		keyRequired   = "required"
+	)
+	clean := make(map[string]any, 3)
+	for _, k := range []string{keyType, keyProperties, keyRequired} {
+		if v, ok := m[k]; ok {
+			clean[k] = v
+		}
+	}
+	out, err := json.Marshal(clean)
+	if err != nil {
+		return raw
+	}
+	return out
 }
 
 // documentFromJSON converts a raw JSON schema into the

--- a/internal/gateway/provider/bedrock_test.go
+++ b/internal/gateway/provider/bedrock_test.go
@@ -147,6 +147,131 @@ func TestConverseTools(t *testing.T) {
 	}
 }
 
+// TestSanitizeNovaSchema covers the AWS-documented Nova constraint
+// (D-037): only "type"/"properties"/"required" survive at the schema's
+// top level, while nested keys inside a property's own subschema
+// (including additionalProperties there) are left untouched.
+func TestSanitizeNovaSchema(t *testing.T) {
+	t.Parallel()
+	in := json.RawMessage(`{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"title": "calc input",
+		"description": "arguments for calc",
+		"additionalProperties": false,
+		"type": "object",
+		"required": ["a"],
+		"properties": {
+			"a": {
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {"b": {"type": "string"}}
+			}
+		}
+	}`)
+
+	out := sanitizeNovaSchema(in)
+
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("output not valid JSON: %v", err)
+	}
+	for _, forbidden := range []string{"$schema", "title", "description", "additionalProperties"} {
+		if _, ok := got[forbidden]; ok {
+			t.Fatalf("top-level key %q must be stripped, got %#v", forbidden, got)
+		}
+	}
+	if got["type"] != "object" {
+		t.Fatalf("type = %#v, want object", got["type"])
+	}
+	required, ok := got["required"].([]any)
+	if !ok || len(required) != 1 || required[0] != "a" {
+		t.Fatalf("required = %#v", got["required"])
+	}
+	props, ok := got["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties = %#v", got["properties"])
+	}
+	a, ok := props["a"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties.a = %#v", props["a"])
+	}
+	// Nested additionalProperties (inside a property subschema) must survive.
+	if v, ok := a["additionalProperties"]; !ok || v != false {
+		t.Fatalf("nested additionalProperties stripped or wrong: %#v", a["additionalProperties"])
+	}
+}
+
+// TestSanitizeNovaSchemaEmptyOrInvalid proves the sanitize step never
+// panics and leaves empty/unparseable input alone so documentFromJSON's
+// existing nil-on-empty, nil-on-invalid behavior is unaffected.
+func TestSanitizeNovaSchemaEmptyOrInvalid(t *testing.T) {
+	t.Parallel()
+	if out := sanitizeNovaSchema(nil); out != nil {
+		t.Fatalf("nil input must stay nil, got %#v", out)
+	}
+	if out := sanitizeNovaSchema(json.RawMessage{}); len(out) != 0 {
+		t.Fatalf("empty input must stay empty, got %#v", out)
+	}
+	broken := json.RawMessage(`{broken`)
+	if out := sanitizeNovaSchema(broken); string(out) != string(broken) {
+		t.Fatalf("invalid JSON must pass through unchanged, got %#v", out)
+	}
+	if documentFromJSON(sanitizeNovaSchema(nil)) != nil {
+		t.Fatal("nil schema through the full pipeline must still yield a nil document")
+	}
+}
+
+// TestBuildConverseStreamInput covers the D-037 Nova greedy-decoding
+// workaround: only requests that are both Nova and tool-bearing get
+// temperature 0 + topK 1, and MaxTokens mapping is unaffected.
+func TestBuildConverseStreamInput(t *testing.T) {
+	t.Parallel()
+
+	novaTools := CompletionRequest{
+		Model:     "us.amazon.nova-pro-v1:0",
+		Tools:     []ToolDef{{Name: "calc", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+		MaxTokens: 512,
+	}
+	input := buildConverseStreamInput(novaTools)
+	if input.InferenceConfig == nil || input.InferenceConfig.Temperature == nil || *input.InferenceConfig.Temperature != 0 {
+		t.Fatalf("nova+tools: InferenceConfig = %#v, want Temperature 0", input.InferenceConfig)
+	}
+	if input.InferenceConfig.MaxTokens == nil || *input.InferenceConfig.MaxTokens != 512 {
+		t.Fatalf("nova+tools: MaxTokens = %#v, want 512", input.InferenceConfig.MaxTokens)
+	}
+	if input.AdditionalModelRequestFields == nil {
+		t.Fatal("nova+tools: AdditionalModelRequestFields must be set")
+	}
+
+	novaNoTools := CompletionRequest{Model: "us.amazon.nova-pro-v1:0", MaxTokens: 512}
+	input = buildConverseStreamInput(novaNoTools)
+	if input.InferenceConfig == nil || input.InferenceConfig.Temperature != nil {
+		t.Fatalf("nova without tools: Temperature must stay unset, got %#v", input.InferenceConfig)
+	}
+	if input.AdditionalModelRequestFields != nil {
+		t.Fatal("nova without tools: AdditionalModelRequestFields must stay nil")
+	}
+	if input.InferenceConfig.MaxTokens == nil || *input.InferenceConfig.MaxTokens != 512 {
+		t.Fatalf("nova without tools: MaxTokens = %#v, want 512", input.InferenceConfig.MaxTokens)
+	}
+
+	titanTools := CompletionRequest{
+		Model:     "amazon.titan-text-premier-v1:0",
+		Tools:     []ToolDef{{Name: "calc", InputSchema: json.RawMessage(`{"type":"object"}`)}},
+		MaxTokens: 256,
+	}
+	input = buildConverseStreamInput(titanTools)
+	if input.InferenceConfig == nil || input.InferenceConfig.Temperature != nil {
+		t.Fatalf("titan+tools: Temperature must stay unset, got %#v", input.InferenceConfig)
+	}
+	if input.AdditionalModelRequestFields != nil {
+		t.Fatal("titan+tools: AdditionalModelRequestFields must stay nil")
+	}
+	if input.InferenceConfig.MaxTokens == nil || *input.InferenceConfig.MaxTokens != 256 {
+		t.Fatalf("titan+tools: MaxTokens = %#v, want 256", input.InferenceConfig.MaxTokens)
+	}
+}
+
 func TestDocumentFromJSON(t *testing.T) {
 	t.Parallel()
 	if documentFromJSON(nil) != nil {

--- a/internal/gateway/provider/openaicompat.go
+++ b/internal/gateway/provider/openaicompat.go
@@ -154,8 +154,10 @@ type oaiRequest struct {
 	} `json:"stream_options"`
 	Tools     []oaiTool `json:"tools,omitempty"`
 	MaxTokens int       `json:"max_tokens,omitempty"`
-	// ReasoningEffort is the D-020 dial; providers that don't know
-	// the field ignore it.
+	// ReasoningEffort is the D-020 dial. Not every OpenAI-compatible
+	// backend tolerates the field: Ollama returns HTTP 400 for models
+	// that don't recognize it. Stream retries once without it on that
+	// exact failure (see stripReasoningEffortAndRetry).
 	ReasoningEffort string `json:"reasoning_effort,omitempty"`
 }
 
@@ -196,12 +198,29 @@ func (o *OpenAICompat) Stream(ctx context.Context, req CompletionRequest) (<-cha
 	if req.Model == "" {
 		return nil, fmt.Errorf("openaicompat: model is required")
 	}
-	body, err := json.Marshal(o.buildRequest(req))
+	wire := o.buildRequest(req)
+	body, err := json.Marshal(wire)
 	if err != nil {
 		return nil, fmt.Errorf("openaicompat: marshal request: %w", err)
 	}
 
-	build := func(ctx context.Context) (*http.Request, error) {
+	ch := runStream(ctx, o.client, o.cfg.Timeout, retriesFor(req.FinalAttempt), o.buildFor(body), o.relay)
+	if wire.ReasoningEffort == "" {
+		return ch, nil
+	}
+
+	// Some OpenAI-compatible backends (Ollama, for qwen2.5 family
+	// models) reject an unrecognized reasoning_effort field with HTTP
+	// 400 instead of ignoring it. That surfaces as a single permanent
+	// error event with no prior stream activity — retry once with the
+	// field stripped rather than failing the whole turn over a hint.
+	return stripReasoningEffortAndRetry(ctx, o, req, wire, ch), nil
+}
+
+// buildFor returns the request builder for a fixed, already-marshaled
+// body.
+func (o *OpenAICompat) buildFor(body []byte) func(ctx context.Context) (*http.Request, error) {
+	return func(ctx context.Context) (*http.Request, error) {
 		r, err := http.NewRequestWithContext(ctx, http.MethodPost, o.cfg.BaseURL+"/chat/completions", bytes.NewReader(body))
 		if err != nil {
 			return nil, err
@@ -213,7 +232,62 @@ func (o *OpenAICompat) Stream(ctx context.Context, req CompletionRequest) (<-cha
 		}
 		return r, nil
 	}
-	return runStream(ctx, o.client, o.cfg.Timeout, retriesFor(req.FinalAttempt), build, o.relay), nil
+}
+
+// stripReasoningEffortAndRetry peeks the first event off first. Per
+// the runStream contract, a request-level failure (doWithRetry
+// returning a permanent error) emits exactly one error event and
+// closes the channel — nothing can follow it. So a bare http_400 as
+// that first event is unambiguously "rejected before any stream
+// activity"; retry once with reasoning_effort cleared. Any other first
+// event means relay already ran, so pass everything through
+// unchanged, event by event, keeping the success path streaming live
+// rather than buffering.
+func stripReasoningEffortAndRetry(ctx context.Context, o *OpenAICompat, req CompletionRequest, wire oaiRequest, first <-chan stream.StreamEvent) <-chan stream.StreamEvent {
+	out := make(chan stream.StreamEvent)
+	go func() {
+		defer close(out)
+		ev, ok := <-first
+		if !ok {
+			return
+		}
+		if isHTTP400(ev) {
+			retryReasoningEffortStripped(ctx, o, req, wire, out)
+			return
+		}
+		if !emit(ctx, out, ev) {
+			return
+		}
+		for ev := range first {
+			if !emit(ctx, out, ev) {
+				return
+			}
+		}
+	}()
+	return out
+}
+
+// retryReasoningEffortStripped rebuilds the request without
+// ReasoningEffort and relays the retried stream to out.
+func retryReasoningEffortStripped(ctx context.Context, o *OpenAICompat, req CompletionRequest, wire oaiRequest, out chan<- stream.StreamEvent) {
+	wire.ReasoningEffort = ""
+	body, err := json.Marshal(wire)
+	if err != nil {
+		emit(ctx, out, errEvent(fmt.Errorf("openaicompat: marshal retry request: %w", err)))
+		return
+	}
+	retry := runStream(ctx, o.client, o.cfg.Timeout, retriesFor(req.FinalAttempt), o.buildFor(body), o.relay)
+	for ev := range retry {
+		if !emit(ctx, out, ev) {
+			return
+		}
+	}
+}
+
+// isHTTP400 reports whether ev is the terminal error event for an
+// HTTP 400 response.
+func isHTTP400(ev stream.StreamEvent) bool {
+	return ev.Type == stream.EventError && ev.Err != nil && ev.Err.Code == "http_400"
 }
 
 func (o *OpenAICompat) buildRequest(req CompletionRequest) oaiRequest {

--- a/internal/gateway/provider/openaicompat_test.go
+++ b/internal/gateway/provider/openaicompat_test.go
@@ -1,10 +1,13 @@
 package provider
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -259,5 +262,123 @@ func TestOpenAICompatMalformed(t *testing.T) {
 	errs := eventsOfType(events, stream.EventError)
 	if len(errs) != 1 || errs[0].Err.Code != "malformed_stream" {
 		t.Fatalf("want malformed_stream error: %+v", events)
+	}
+}
+
+func readReasoningEffort(t *testing.T, r *http.Request) string {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	var wire oaiRequest
+	if err := json.Unmarshal(body, &wire); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	return wire.ReasoningEffort
+}
+
+func TestOpenAICompat400ReasoningEffortStripAndRetry(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	var efforts []string
+	var mu sync.Mutex
+	p := oaiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		efforts = append(efforts, readReasoningEffort(t, r))
+		mu.Unlock()
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		oaiWrite(w, `{"choices":[{"delta":{"content":"ok"}}]}`)
+		oaiWrite(w, "[DONE]")
+	})
+
+	ch, err := p.Stream(t.Context(), CompletionRequest{Model: "m", Effort: "low"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	if calls.Load() != 2 {
+		t.Fatalf("calls = %d, want 2 (retry after 400)", calls.Load())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(efforts) != 2 || efforts[0] != "low" || efforts[1] != "" {
+		t.Fatalf("efforts across attempts = %v, want [low, \"\"]", efforts)
+	}
+	if got := textOf(events, stream.EventChunk); got != "ok" {
+		t.Fatalf("chunks = %q, want ok", got)
+	}
+	if len(eventsOfType(events, stream.EventError)) != 0 {
+		t.Fatalf("want no error event surfaced after successful retry: %+v", events)
+	}
+	if lastType(t, events) != stream.EventDone {
+		t.Fatalf("last = %v, want done", lastType(t, events))
+	}
+}
+
+func TestOpenAICompat400TwiceSurfacesError(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	p := oaiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+	})
+
+	ch, err := p.Stream(t.Context(), CompletionRequest{Model: "m", Effort: "low"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	if calls.Load() != 2 {
+		t.Fatalf("calls = %d, want 2 (one retry, then surface)", calls.Load())
+	}
+	errs := eventsOfType(events, stream.EventError)
+	if len(errs) != 1 || errs[0].Err.Code != "http_400" {
+		t.Fatalf("want one http_400 error event: %+v", events)
+	}
+}
+
+func TestOpenAICompat400WithoutReasoningEffortNoRetry(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	p := oaiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+	})
+
+	ch, err := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	if calls.Load() != 1 {
+		t.Fatalf("calls = %d, want 1 (no retry without reasoning_effort)", calls.Load())
+	}
+	errs := eventsOfType(events, stream.EventError)
+	if len(errs) != 1 || errs[0].Err.Code != "http_400" {
+		t.Fatalf("want one http_400 error event: %+v", events)
+	}
+}
+
+func TestOpenAICompatNoEffortNeverSendsReasoningEffort(t *testing.T) {
+	t.Parallel()
+	var gotEffort string
+	p := oaiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotEffort = readReasoningEffort(t, r)
+		oaiWrite(w, `{"choices":[{"delta":{"content":"ok"}}]}`)
+		oaiWrite(w, "[DONE]")
+	})
+
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	collect(t, ch)
+
+	if gotEffort != "" {
+		t.Fatalf("reasoning_effort = %q, want empty when Effort unset", gotEffort)
 	}
 }


### PR DESCRIPTION
Three independent fixes for provider streams that died mid-turn and surfaced as interrupted chats or failed missions.

## Changes

- **gateway/openaicompat**: providers that 400 on `reasoning_effort` get one retry without the field instead of failing the attempt.
- **gateway/bedrock (D-037)**: Amazon Nova tool-calling requests now use greedy decoding (temperature 0, topK 1) and top-level tool schemas sanitized to `type`/`properties`/`required` — both straight from the AWS Nova tool-use troubleshooting guide. Fixes repeated `ModelStreamErrorException: Model produced invalid sequence as part of ToolUse`.
- **brain/loop (D-038)**: a step whose stream dies retryably *before emitting anything user-visible* is retried up to twice with backoff, emitting a `retry` notice. Errors after content still surface honestly — the web retry handler never resets partial text, so retrying after emission would duplicate content.

## Verification

- `make build test vet lint` green; new table tests for schema sanitizing, converse input construction, and all retry paths (before/after content, retryable/non-retryable, budget exhaustion, gateway hard error).
- Live: nova-pro completed three consecutive tool-call steps that previously failed instantly; a subsequent throttle failed over silently mid-chain with no user-visible error.

## Out of scope

- Nova models stay fallback-only in route chains: they throttle quickly at agent-loop call rates.
- Verify the sensitive-route pin survives mid-turn retries (possible routing gap, tracked separately).
- Claude on Bedrock as an additional provider.