### PR TITLE
feat: recurring missions — schedules fire mission templates on cron

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -180,7 +180,13 @@ func main() {
 		missionSandbox = sandboxclient.New(sandboxdURL)
 	}
 
-	missionStore, missionDriver, missionNotifier, missionWorkspace := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, app.Log)
+	// Built here, above buildMissions, so both the scheduler (fire-time
+	// route/review_route/budget/prompt_overlay resolution) and the
+	// driver (ApprovalAllowlist grants at provisioning time) can close
+	// over the same registry.
+	agentReg := agents.NewStore(app.DB, app.Log)
+
+	missionStore, missionDriver, missionNotifier, missionWorkspace := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, app.Log)
 	if missionDriver != nil {
 		var sandboxSweeper interface {
 			Sweep(ctx context.Context, isTerminal func(missionID string) bool) error
@@ -199,7 +205,6 @@ func main() {
 		})
 	}
 
-	agentReg := agents.NewStore(app.DB, app.Log)
 	svc := chat.New(turnRouter{agent: agent, gw: gwc, flags: flags}, store, distill,
 		gatedCompactor{inner: compactor, flags: flags}, budgetFn, packs, flags.SkillAllowed,
 		agentReg.Resolve, app.Log)
@@ -304,12 +309,33 @@ func buildConnectors(db *pgpool.Pool, secrets *secretstore.Store, log *slog.Logg
 // setting.
 const missionWorkSlotMax = 4
 
+// missionAgentResolver adapts agentReg.ResolveByID to scheduler.go's
+// AgentResolver / driver.go's SetAgentResolver shape — both need the
+// SAME resolution (route/review_route/budget/prompt_overlay/
+// approval_allowlist from an agents row), just at different moments
+// (schedule fire time vs mission provisioning time), so one adapter
+// serves both call sites.
+func missionAgentResolver(agentReg *agents.Store) missions.AgentResolver {
+	return func(ctx context.Context, agentID string) (missions.AgentDefaults, bool) {
+		a, ok := agentReg.ResolveByID(ctx, agentID)
+		if !ok {
+			return missions.AgentDefaults{}, false
+		}
+		return missions.AgentDefaults{
+			Route: a.Route, ReviewRoute: a.ReviewRoute, PromptOverlay: a.PromptOverlay,
+			BudgetUSD: a.BudgetUSD, ApprovalAllowlist: a.ApprovalAllowlist,
+		}, true
+	}
+}
+
 // buildMissions wires the mission engine (Store, Driver, Notifier,
 // Scheduler). Gated on WORKSPACES: no workspace root configured means
 // missions stay entirely inert — no goroutines started, nothing
 // scheduled, the API surface unmounted (registerMissions 404s on a nil
-// store).
-func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace) {
+// store). agentReg is D-034's agent registry, resolved at scheduler
+// fire time and mission provisioning time (never schedule-create
+// time) so an agent edited after the fact still applies.
+func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, agentReg *agents.Store, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace) {
 	root := os.Getenv("WORKSPACES")
 	if root == "" {
 		log.Info("WORKSPACES not set; missions disabled")
@@ -352,8 +378,11 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	if sandboxMgr != nil {
 		driver.SetSandbox(sandboxExec, sandboxMgr)
 	}
+	resolveAgent := missionAgentResolver(agentReg)
+	driver.SetAgentResolver(resolveAgent)
 
-	scheduler := missions.NewScheduler(db, store, log)
+	schedulerEnabled := func(ctx context.Context) bool { return flags.Enabled(ctx, settings.KeyScheduler) }
+	scheduler := missions.NewScheduler(db, store, resolveAgent, schedulerEnabled, log)
 	go scheduler.Run(ctx)
 	return store, driver, notifier, workspace
 }

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -90,6 +90,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	a.registerConnectors(srv.Handle, conns, goog)
 	a.registerTools(srv.Handle, toolset)
 	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret)
+	a.registerSchedules(srv.Handle, missionStore)
 	srv.Handle("GET /v1/sessions", a.auth(http.HandlerFunc(a.handleList)))
 	srv.Handle("POST /v1/sessions", a.auth(http.HandlerFunc(a.handleCreate)))
 	srv.Handle("GET /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleTranscript)))

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 
 	"github.com/SumonMSelim/timothy/internal/brain/agents"
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
@@ -78,8 +79,29 @@ func failMission(w http.ResponseWriter, err error) {
 	}
 }
 
+// list serves GET /v1/missions, optionally narrowed by ?schedule_id=
+// (a recurring schedule's fire history: every mission it spawned)
+// and/or ?limit= (a positive result cap). Both are ignored when
+// empty/absent — the original "every mission" behavior — and a
+// malformed value is a 400 rather than a silently-empty filter.
 func (h *missionAPI) list(w http.ResponseWriter, r *http.Request) {
-	rows, err := h.store.List(r.Context())
+	var filter missions.ListFilter
+	if v := r.URL.Query().Get("schedule_id"); v != "" {
+		if !validSessionID(v) {
+			jsonError(w, http.StatusBadRequest, "bad_request", "schedule_id must be a UUID")
+			return
+		}
+		filter.ScheduleID = v
+	}
+	if v := r.URL.Query().Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			jsonError(w, http.StatusBadRequest, "bad_request", "limit must be a positive integer")
+			return
+		}
+		filter.Limit = n
+	}
+	rows, err := h.store.List(r.Context(), filter)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "missions_failed", err.Error())
 		return

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -1,8 +1,12 @@
 package api
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
 )
 
 func TestMissionsEndpointsUnmountedWhenStoreNil(t *testing.T) {
@@ -33,5 +37,47 @@ func TestMissionsEndpointsUnmountedWhenStoreNil(t *testing.T) {
 		if w.Code != 404 {
 			t.Fatalf("%s %s with a nil mission store = %d, want 404 (unmounted)", req.method, req.path, w.Code)
 		}
+	}
+}
+
+// TestMissionsListFilterValidation confirms bad ?schedule_id=/?limit=
+// values 400 before ever reaching the store — a never-connecting pool
+// (bad DSN, degraded) is enough to prove this, since a request that
+// got past validation would instead surface a 500 from the store call.
+func TestMissionsListFilterValidation(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	m := mux(a)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil)
+
+	call := func(path string) int {
+		req := httptest.NewRequest("GET", path, nil)
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := call("/v1/missions?schedule_id=not-a-uuid"); code != 400 {
+		t.Fatalf("bad schedule_id = %d, want 400", code)
+	}
+	if code := call("/v1/missions?limit=0"); code != 400 {
+		t.Fatalf("limit=0 = %d, want 400", code)
+	}
+	if code := call("/v1/missions?limit=-5"); code != 400 {
+		t.Fatalf("negative limit = %d, want 400", code)
+	}
+	if code := call("/v1/missions?limit=nope"); code != 400 {
+		t.Fatalf("non-numeric limit = %d, want 400", code)
+	}
+	// Valid shapes pass validation and reach the (degraded) store,
+	// which then 500s — proving they were NOT rejected as bad input.
+	if code := call("/v1/missions"); code != 500 {
+		t.Fatalf("no filter against a degraded store = %d, want 500 (passed validation)", code)
+	}
+	if code := call("/v1/missions?limit=10"); code != 500 {
+		t.Fatalf("valid limit against a degraded store = %d, want 500 (passed validation)", code)
 	}
 }

--- a/internal/brain/api/schedules.go
+++ b/internal/brain/api/schedules.go
@@ -1,0 +1,157 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+// registerSchedules mounts the schedules surface: served locally,
+// schedules is missions' domain (the table lives in
+// internal/brain/missions), same nil-gating pattern as agents/
+// connectors. store is *missions.Store — schedules and missions share
+// one store since schedules is this package's own table.
+func (a *API) registerSchedules(handle func(pattern string, h http.Handler), store *missions.Store) {
+	if store == nil {
+		return
+	}
+	h := &scheduleAPI{store: store}
+	handle("GET /v1/schedules", a.auth(http.HandlerFunc(h.list)))
+	handle("POST /v1/schedules", a.auth(http.HandlerFunc(h.create)))
+	handle("PATCH /v1/schedules/{id}", a.auth(http.HandlerFunc(h.patch)))
+	handle("DELETE /v1/schedules/{id}", a.auth(http.HandlerFunc(h.delete)))
+}
+
+type scheduleAPI struct {
+	store *missions.Store
+}
+
+func failSchedule(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, missions.ErrNotFound):
+		jsonError(w, http.StatusNotFound, "not_found", err.Error())
+	case errors.Is(err, missions.ErrScheduleNameConflict):
+		jsonError(w, http.StatusConflict, "name_conflict", err.Error())
+	case errors.Is(err, missions.ErrScheduleInUse):
+		jsonError(w, http.StatusConflict, "in_use", err.Error())
+	case errors.Is(err, missions.ErrBadCron):
+		jsonError(w, http.StatusBadRequest, "bad_cron", err.Error())
+	default:
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+	}
+}
+
+// scheduleView is a Schedule decorated with the computed next_run the
+// web UI needs but the row itself doesn't store.
+type scheduleView struct {
+	missions.Schedule
+	NextRun *time.Time `json:"next_run,omitempty"`
+}
+
+// decorate computes next_run from the schedule's own cron and last_run
+// (or created_at, mirroring scheduler.go's fireOne anchor rule) — a
+// disabled schedule still gets a next_run so re-enabling it shows
+// where it will pick back up.
+func decorate(sc missions.Schedule) scheduleView {
+	anchor := sc.CreatedAt
+	if sc.LastRun != nil {
+		anchor = *sc.LastRun
+	}
+	next := missions.NextRun(sc.Cron, anchor)
+	view := scheduleView{Schedule: sc}
+	if !next.IsZero() {
+		view.NextRun = &next
+	}
+	return view
+}
+
+func (h *scheduleAPI) list(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.store.ListSchedules(r.Context())
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "schedules_failed", err.Error())
+		return
+	}
+	views := make([]scheduleView, 0, len(rows))
+	for _, sc := range rows {
+		views = append(views, decorate(sc))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"schedules": views})
+}
+
+type createScheduleRequest struct {
+	Name            string                   `json:"name"`
+	Cron            string                   `json:"cron"`
+	MissionTemplate missions.MissionTemplate `json:"mission_template"`
+	Enabled         *bool                    `json:"enabled"`
+	ExpiresAt       *time.Time               `json:"expires_at"`
+}
+
+func (h *scheduleAPI) create(w http.ResponseWriter, r *http.Request) {
+	var req createScheduleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	id, err := h.store.CreateSchedule(r.Context(), missions.Schedule{
+		Name: req.Name, Cron: req.Cron,
+		MissionTemplate: req.MissionTemplate, Enabled: enabled, ExpiresAt: req.ExpiresAt,
+	})
+	if err != nil {
+		failSchedule(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]string{"id": id})
+}
+
+type patchScheduleRequest struct {
+	Name            *string                   `json:"name"`
+	Cron            *string                   `json:"cron"`
+	MissionTemplate *missions.MissionTemplate `json:"mission_template"`
+	Enabled         *bool                     `json:"enabled"`
+	// ExpiresAt: nil (omitted OR explicit null — encoding/json can't
+	// tell those apart through a single pointer) means "leave
+	// unchanged," same convention as agents.Patch.BudgetUSD. Clearing an
+	// expiry entirely is not reachable through this endpoint in v1 —
+	// delete and recreate the schedule instead.
+	ExpiresAt *time.Time `json:"expires_at"`
+}
+
+func (h *scheduleAPI) patch(w http.ResponseWriter, r *http.Request) {
+	var req patchScheduleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	p := missions.SchedulePatch{
+		Name: req.Name, Cron: req.Cron,
+		MissionTemplate: req.MissionTemplate, Enabled: req.Enabled,
+	}
+	if req.ExpiresAt != nil {
+		p.ExpiresAt = &req.ExpiresAt
+	}
+	if err := h.store.PatchSchedule(r.Context(), r.PathValue("id"), p); err != nil {
+		failSchedule(w, err)
+		return
+	}
+	sc, err := h.store.GetSchedule(r.Context(), r.PathValue("id"))
+	if err != nil {
+		failSchedule(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, decorate(sc))
+}
+
+func (h *scheduleAPI) delete(w http.ResponseWriter, r *http.Request) {
+	if err := h.store.DeleteSchedule(r.Context(), r.PathValue("id")); err != nil {
+		failSchedule(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/brain/api/schedules_test.go
+++ b/internal/brain/api/schedules_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+func TestSchedulesEndpointsUnmountedWhenStoreNil(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	m := mux(a)
+	a.registerSchedules(m.Handle, nil)
+
+	for _, req := range []struct{ method, path string }{
+		{"GET", "/v1/schedules"},
+		{"POST", "/v1/schedules"},
+		{"PATCH", "/v1/schedules/abc"},
+		{"DELETE", "/v1/schedules/abc"},
+	} {
+		httpReq := httptest.NewRequest(req.method, req.path, nil)
+		httpReq.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, httpReq)
+		if w.Code != 404 {
+			t.Fatalf("%s %s with a nil schedules store = %d, want 404 (unmounted)", req.method, req.path, w.Code)
+		}
+	}
+}
+
+// TestDecorateNextRun is a pure test of the GET-decoration helper: no
+// store, no HTTP round trip, just the anchor/cron math.
+func TestDecorateNextRun(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	sc := missions.Schedule{Cron: "0 9 * * *", CreatedAt: created}
+	view := decorate(sc)
+	if view.NextRun == nil {
+		t.Fatal("decorate did not compute a next_run")
+	}
+	want := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	if !view.NextRun.Equal(want) {
+		t.Fatalf("NextRun = %v, want %v", *view.NextRun, want)
+	}
+
+	// last_run anchors ahead of created_at once the schedule has fired.
+	lastRun := time.Date(2026, 1, 2, 9, 0, 0, 0, time.UTC)
+	sc.LastRun = &lastRun
+	view = decorate(sc)
+	want = time.Date(2026, 1, 3, 9, 0, 0, 0, time.UTC)
+	if view.NextRun == nil || !view.NextRun.Equal(want) {
+		t.Fatalf("NextRun with last_run set = %v, want %v", view.NextRun, want)
+	}
+
+	// An invalid cron (shouldn't happen past CreateSchedule's own
+	// validation, but decorate must degrade gracefully) omits next_run
+	// rather than panicking or reporting a fabricated zero time.
+	sc = missions.Schedule{Cron: "garbage", CreatedAt: created}
+	view = decorate(sc)
+	if view.NextRun != nil {
+		t.Fatalf("NextRun for invalid cron = %v, want nil", view.NextRun)
+	}
+}

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -69,6 +69,7 @@ type driverStore interface {
 	ApplyTransition(ctx context.Context, id string, t Transition) error
 	AppendEvent(ctx context.Context, id, kind string, payload map[string]any) error
 	SetSpec(ctx context.Context, id string, spec Spec) error
+	SetSession(ctx context.Context, id, sessionID string) error
 	SetProvisioned(ctx context.Context, id, workspace, worktree, branch, baseCommit string) error
 	SetLastEvidence(ctx context.Context, id, evidence string) error
 	AppendProgress(ctx context.Context, id, note string) error
@@ -106,6 +107,12 @@ type Driver struct {
 	// in-process fallback (MISSION_SANDBOX_IMAGE unset).
 	sandboxExec   sandboxExec
 	sandboxRemove sandboxRemover
+
+	// resolveAgent resolves a mission's agent_id to its
+	// ApprovalAllowlist at provisioning time (see SetAgentResolver) —
+	// nil-safe: unset means no allowlist grants, same as before this
+	// existed.
+	resolveAgent AgentResolver
 
 	// gatekeepers holds each mission's in-progress reviewer session
 	// state, keyed by mission id, for the "delta recheck" resume on
@@ -146,6 +153,15 @@ func (d *Driver) SetSandbox(exec sandboxExec, remove sandboxRemover) {
 	d.sandboxExec, d.sandboxRemove = exec, remove
 }
 
+// SetAgentResolver wires the resolver ensureProvisioned uses to grant
+// each of a mission's agent's ApprovalAllowlist tools at provisioning
+// time — a setter (not a NewDriver parameter) because cmd/brain/main.go
+// builds the Driver before it builds the agents.Store the resolver
+// closes over.
+func (d *Driver) SetAgentResolver(resolve AgentResolver) {
+	d.resolveAgent = resolve
+}
+
 // removeSandbox best-effort tears down a mission's sandbox container in
 // the background — a slow or unreachable daemon must never block the
 // terminal state transition (or the notify that follows it), only log
@@ -167,54 +183,21 @@ func (d *Driver) removeSandbox(id string) {
 	}()
 }
 
-// Create opens the mission's hidden bookkeeping session, inserts the
-// mission row, provisions its workspace (a git worktree for coding
-// missions, a plain directory otherwise), and kicks off the first
-// Drive in a background goroutine — callers (the API's create handler)
-// get the new id back immediately without waiting on the mission to
-// actually run.
+// Create inserts the mission row bare (no session, no workspace yet),
+// then calls ensureProvisioned to give it both — the exact same
+// provisioning step Advance calls lazily for a mission that reached
+// the store some other way (scheduler.go's createFromTemplate). Kicks
+// off the first Drive in a background goroutine — callers (the API's
+// create handler) get the new id back immediately without waiting on
+// the mission to actually run.
 func (d *Driver) Create(ctx context.Context, m Mission, repoPath string) (string, error) {
-	if d.sessions != nil {
-		sessionID, err := d.sessions.Create(ctx, "")
-		if err != nil {
-			return "", fmt.Errorf("driver: create: session: %w", err)
-		}
-		m.SessionID = sessionID
-		if m.AutoApproveSafe && d.perms != nil {
-			// Best-effort: a failed grant just means the mission asks on
-			// its first safe shell call instead of running unattended —
-			// degraded autonomy, not a broken mission.
-			if err := d.perms.Grant(ctx, sessionID, "shell", "*", missionGrantTTL); err != nil {
-				d.log.Warn("driver: create: auto-approve grant failed", "mission_id", m.ID, "error", err)
-			}
-		}
-	}
 	id, err := d.store.Create(ctx, m)
 	if err != nil {
 		return "", fmt.Errorf("driver: create: %w", err)
 	}
-	if d.workspace != nil {
-		workspace, worktree, branch, baseCommit, err := d.workspace.Provision(ctx, id, m.Goal, m.Kind, repoPath)
-		if err != nil {
-			return "", fmt.Errorf("driver: create: provision: %w", err)
-		}
-		if err := d.store.SetProvisioned(ctx, id, workspace, worktree, branch, baseCommit); err != nil {
-			return "", fmt.Errorf("driver: create: %w", err)
-		}
-		if m.AutoApproveSafe && d.perms != nil && m.SessionID != "" {
-			// Register the mission's own directory as the session's
-			// sandbox: destructive-classified commands provably confined
-			// to it (writing the mission's own artifacts, cleaning its
-			// own files) stop parking on a human prompt. Best-effort,
-			// same as the shell grant above.
-			root := worktree
-			if root == "" {
-				root = workspace
-			}
-			if err := d.perms.Grant(ctx, m.SessionID, tools.SandboxGrantTool, root, missionGrantTTL); err != nil {
-				d.log.Warn("driver: create: sandbox grant failed", "mission_id", id, "error", err)
-			}
-		}
+	m.ID = id
+	if _, err := d.ensureProvisioned(ctx, m, repoPath); err != nil {
+		return "", fmt.Errorf("driver: create: %w", err)
 	}
 	go func() { //nolint:gosec // G118: deliberate — the mission must outlive the HTTP request that created it, driveTimeBound is Drive's own cap
 		if err := d.Drive(context.Background(), id); err != nil {
@@ -222,6 +205,102 @@ func (d *Driver) Create(ctx context.Context, m Mission, repoPath string) (string
 		}
 	}()
 	return id, nil
+}
+
+// ensureProvisioned gives a mission everything Create used to set up
+// inline — a hidden session, its standing grants, and a workspace —
+// but callable a second time for a mission that reached the store some
+// OTHER way (scheduler.go's createFromTemplate inserts a bare row
+// directly, bypassing Create entirely: no session, no workspace, no
+// grants). Advance calls this at the top of every turn so a
+// scheduler-born mission gets provisioned the first time anything
+// actually drives it, not at fire time. Idempotent: a mission that
+// already has both a session and a workspace/worktree is a no-op,
+// and SetSession's own WHERE session_id IS NULL guard makes a second
+// concurrent attempt safe even without that check.
+//
+// Grants happen in BOTH the session-creation and the workspace-
+// provisioning halves below — same shape as Create always had, plus
+// the new ApprovalAllowlist grants (via resolveAgent) once a session
+// exists, whichever half of ensureProvisioned actually created it.
+func (d *Driver) ensureProvisioned(ctx context.Context, m Mission, repoPath string) (Mission, error) {
+	if m.SessionID == "" && d.sessions != nil {
+		sessionID, err := d.sessions.Create(ctx, "")
+		if err != nil {
+			return m, fmt.Errorf("session: %w", err)
+		}
+		if err := d.store.SetSession(ctx, m.ID, sessionID); err != nil {
+			return m, fmt.Errorf("set session: %w", err)
+		}
+		m.SessionID = sessionID
+		d.grantSessionDefaults(ctx, m)
+	}
+	if d.workspace != nil && m.Workspace == "" && m.Worktree == "" {
+		workspace, worktree, branch, baseCommit, err := d.workspace.Provision(ctx, m.ID, m.Goal, m.Kind, repoPath)
+		if err != nil {
+			return m, fmt.Errorf("provision: %w", err)
+		}
+		if err := d.store.SetProvisioned(ctx, m.ID, workspace, worktree, branch, baseCommit); err != nil {
+			return m, err
+		}
+		m.Workspace, m.Worktree, m.Branch, m.BaseCommit = workspace, worktree, branch, baseCommit
+		if m.AutoApproveSafe && d.perms != nil && m.SessionID != "" {
+			// Register the mission's own directory as the session's
+			// sandbox: destructive-classified commands provably confined
+			// to it (writing the mission's own artifacts, cleaning its
+			// own files) stop parking on a human prompt. Best-effort, same
+			// as the grants in grantSessionDefaults.
+			root := worktree
+			if root == "" {
+				root = workspace
+			}
+			if err := d.perms.Grant(ctx, m.SessionID, tools.SandboxGrantTool, root, missionGrantTTL); err != nil {
+				d.log.Warn("driver: sandbox grant failed", "mission_id", m.ID, "error", err)
+			}
+		}
+	}
+	return m, nil
+}
+
+// grantSessionDefaults pre-authorizes a freshly created hidden session:
+// standing "safe shell" approval when the mission opted in, plus every
+// tool in the mission's agent's ApprovalAllowlist (resolved at
+// provisioning time via resolveAgent, same fire-time-not-create-time
+// principle as scheduler.go's createFromTemplate — an agent's allowlist
+// edited after the mission started still applies to a not-yet-
+// provisioned mission). All best-effort: a failed grant just means the
+// mission asks on its first call instead of running unattended —
+// degraded autonomy, never a broken mission.
+//
+// AutoApproveSafe is deliberately shell-scoped only ("shell" + sandbox
+// root) — it does not widen to connector tools, which default
+// danger=safe unclassified; doing so would silently unlock every
+// connector write (send an email, delete a calendar event) for an
+// unattended mission with no per-tool review. Autonomy over connector
+// tools comes only from the agent's ApprovalAllowlist grants below,
+// matched against the connector-namespaced tool name via matchGrant's
+// suffix rule (D-036).
+func (d *Driver) grantSessionDefaults(ctx context.Context, m Mission) {
+	if d.perms == nil {
+		return
+	}
+	if m.AutoApproveSafe {
+		if err := d.perms.Grant(ctx, m.SessionID, "shell", "*", missionGrantTTL); err != nil {
+			d.log.Warn("driver: auto-approve grant failed", "mission_id", m.ID, "error", err)
+		}
+	}
+	if d.resolveAgent == nil {
+		return
+	}
+	defaults, ok := d.resolveAgent(ctx, m.AgentID)
+	if !ok {
+		return
+	}
+	for _, tool := range defaults.ApprovalAllowlist {
+		if err := d.perms.Grant(ctx, m.SessionID, tool, "*", missionGrantTTL); err != nil {
+			d.log.Warn("driver: approval allowlist grant failed", "mission_id", m.ID, "tool", tool, "error", err)
+		}
+	}
 }
 
 // Advance performs exactly one worker turn, review round, or planning
@@ -236,6 +315,18 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 	}
 	if m.Phase.Terminal() || m.Status == StatusPaused || m.Status == StatusWaitingForInput {
 		return false, nil
+	}
+	// A mission that reached the store without going through Create
+	// (scheduler.go's createFromTemplate inserts a bare row directly) has
+	// no session and no workspace yet — provision it now, on the first
+	// turn that actually drives it, rather than leaving the worker with
+	// no shell/write_file tools (runner.go's missionTools returns nil for
+	// an empty WorkRoot).
+	if m.SessionID == "" || (m.Workspace == "" && m.Worktree == "") {
+		m, err = d.ensureProvisioned(ctx, m, "")
+		if err != nil {
+			return false, fmt.Errorf("driver advance: ensure provisioned: %w", err)
+		}
 	}
 
 	before := m.Status

--- a/internal/brain/missions/driver_integration_test.go
+++ b/internal/brain/missions/driver_integration_test.go
@@ -9,6 +9,9 @@ import (
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/session"
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
 )
 
 // TestDriverEndToEndCodingMission is M2's exit criterion: one mission
@@ -107,5 +110,69 @@ func TestDriverEndToEndCodingMission(t *testing.T) {
 
 	if err := workspace.Teardown(ctx, ws, wt, "coding"); err != nil {
 		t.Fatalf("Teardown: %v", err)
+	}
+}
+
+// TestDriverLazilyProvisionsBareSchedulerStyleMission reproduces the
+// plan's defect #1 against a real Postgres store: a mission inserted
+// directly (bypassing Driver.Create — exactly what scheduler.go's
+// createFromTemplate does) has no session, no workspace, no grants.
+// One Advance call must provision all three before running the phase,
+// or the worker gets no shell/write_file tools at all.
+func TestDriverLazilyProvisionsBareSchedulerStyleMission(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	id, err := store.Create(ctx, Mission{
+		Goal: marker + "lazy provisioning", Kind: "research", Route: "default", ReviewRoute: "default",
+		AutoApproveSafe: true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Bare row, exactly as createFromTemplate leaves it: no session_id,
+	// no workspace/worktree — confirmed before Advance runs.
+	m, err := store.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.SessionID != "" || m.Workspace != "" {
+		t.Fatalf("mission before Advance = %+v, want no session and no workspace", m)
+	}
+
+	wsRoot := t.TempDir()
+	workspace := NewWorkspace(wsRoot, nil, log)
+	sessions := session.NewStore(store.db)
+	perms := tools.NewPermissions(store.db, wsRoot)
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
+	d := NewDriver(store, runner, workspace, nil, sessions, perms, log)
+
+	if _, err := d.Advance(ctx, id); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+
+	m, err = store.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get after Advance: %v", err)
+	}
+	if m.SessionID == "" {
+		t.Fatal("Advance did not provision a hidden session")
+	}
+	if m.Workspace == "" {
+		t.Fatal("Advance did not provision a workspace")
+	}
+
+	db, err := store.db.Get()
+	if err != nil {
+		t.Fatalf("Get pool: %v", err)
+	}
+	var grantCount int
+	if err := db.QueryRow(ctx, `SELECT count(*) FROM session_grants WHERE session_id = $1 AND tool = 'shell'`,
+		m.SessionID).Scan(&grantCount); err != nil {
+		t.Fatalf("count session_grants: %v", err)
+	}
+	if grantCount == 0 {
+		t.Fatal("Advance's lazy provisioning did not grant the auto-approve-safe shell allowance")
 	}
 }

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -52,6 +52,20 @@ func (f *fakeStore) SetProvisioned(ctx context.Context, id, workspace, worktree,
 	return nil
 }
 
+// SetSession mirrors the real Store's WHERE session_id IS NULL guard —
+// a second call for a mission that already has one is a no-op, not an
+// overwrite.
+func (f *fakeStore) SetSession(ctx context.Context, id, sessionID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	m := f.missions[id]
+	if m.SessionID == "" {
+		m.SessionID = sessionID
+		f.missions[id] = m
+	}
+	return nil
+}
+
 func (f *fakeStore) Get(ctx context.Context, id string) (Mission, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -504,6 +518,137 @@ func TestDriverCreateSkipsGrantWhenAutoApproveDisabled(t *testing.T) {
 	}
 	if len(granter.calls) != 0 {
 		t.Fatalf("Grant calls = %d, want 0 when AutoApproveSafe is false", len(granter.calls))
+	}
+}
+
+// TestDriverCreateGrantsApprovalAllowlist confirms Create grants every
+// tool in the resolved agent's ApprovalAllowlist — the fix that makes
+// api/missions.go:28's stale "ApprovalAllowlist is resolved" comment
+// actually true.
+func TestDriverCreateGrantsApprovalAllowlist(t *testing.T) {
+	store := newFakeStore()
+	granter := &fakeGranter{}
+	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, slog.Default())
+	d.SetAgentResolver(func(ctx context.Context, agentID string) (AgentDefaults, bool) {
+		if agentID != "briefing-agent" {
+			return AgentDefaults{}, false
+		}
+		return AgentDefaults{ApprovalAllowlist: []string{"gmail_search", "gmail_send"}}, true
+	})
+
+	id, err := d.Create(context.Background(), Mission{
+		Goal: "test", Kind: "research", AgentID: "briefing-agent",
+		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: false,
+	}, "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	m, _ := store.Get(context.Background(), id)
+
+	gotTools := map[string]bool{}
+	for _, call := range granter.calls {
+		if call.sessionID != m.SessionID {
+			t.Fatalf("Grant call sessionID = %q, want the mission's own hidden session %q", call.sessionID, m.SessionID)
+		}
+		gotTools[call.tool] = true
+	}
+	for _, want := range []string{"gmail_search", "gmail_send"} {
+		if !gotTools[want] {
+			t.Fatalf("Grant calls = %+v, want a grant for %q", granter.calls, want)
+		}
+	}
+}
+
+// TestDriverCreateSkipsAllowlistGrantWhenAgentUnresolved: an
+// AgentID that doesn't resolve (deleted agent, or none set) grants
+// nothing beyond whatever AutoApproveSafe itself produces — no
+// allowlist to apply.
+func TestDriverCreateSkipsAllowlistGrantWhenAgentUnresolved(t *testing.T) {
+	store := newFakeStore()
+	granter := &fakeGranter{}
+	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, slog.Default())
+	d.SetAgentResolver(func(ctx context.Context, agentID string) (AgentDefaults, bool) {
+		return AgentDefaults{}, false
+	})
+
+	if _, err := d.Create(context.Background(), Mission{
+		Goal: "test", Kind: "research", AutoApproveSafe: false,
+		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8,
+	}, ""); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(granter.calls) != 0 {
+		t.Fatalf("Grant calls = %d, want 0 for an unresolved agent", len(granter.calls))
+	}
+}
+
+// TestDriverAdvanceLazilyProvisionsBareMission reproduces the fix for
+// the plan's defect #1: a mission inserted directly (bypassing
+// Create — exactly what scheduler.go's createFromTemplate does) has no
+// session and no workspace. The first Advance call must provision both
+// before running the phase, or the worker gets no shell/write_file
+// tools (runner.go's missionTools returns nil for an empty WorkRoot).
+func TestDriverAdvanceLazilyProvisionsBareMission(t *testing.T) {
+	store := newFakeStore()
+	// A bare row, exactly as createFromTemplate leaves it: no
+	// SessionID, no Workspace/Worktree.
+	store.put("m1", Mission{
+		ID: "m1", Goal: "scheduled run", Kind: "research",
+		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: true,
+	})
+	granter := &fakeGranter{}
+	sessions := &fakeSessionCreator{}
+	wsRoot := t.TempDir()
+	workspace := NewWorkspace(wsRoot, nil, slog.Default())
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
+	d := NewDriver(store, runner, workspace, nil, sessions, granter, slog.Default())
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.SessionID == "" {
+		t.Fatal("Advance did not provision a hidden session for a bare mission")
+	}
+	if m.Workspace == "" {
+		t.Fatal("Advance did not provision a workspace for a bare mission")
+	}
+	found := false
+	for _, call := range granter.calls {
+		if call.tool == "shell" && call.pattern == "*" && call.sessionID == m.SessionID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("Advance's lazy provisioning did not grant the auto-approve-safe shell allowance")
+	}
+}
+
+// TestDriverAdvanceSkipsProvisioningWhenAlreadyProvisioned confirms
+// ensureProvisioned is a no-op (no new session, no re-grant) once a
+// mission already has both — the ordinary case for every mission
+// created via Create, which must not re-provision on every single
+// Advance call.
+func TestDriverAdvanceSkipsProvisioningWhenAlreadyProvisioned(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking,
+		MaxIterations: 8, SessionID: "already-provisioned-session", Workspace: "/already/provisioned",
+	})
+	granter := &fakeGranter{}
+	sessions := &fakeSessionCreator{}
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
+	d := NewDriver(store, runner, nil, nil, sessions, granter, slog.Default())
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if len(granter.calls) != 0 {
+		t.Fatalf("Grant calls = %d, want 0 for an already-provisioned mission", len(granter.calls))
+	}
+	if sessions.n != 0 {
+		t.Fatalf("sessions.Create was called %d times, want 0 for an already-provisioned mission", sessions.n)
 	}
 }
 

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -27,16 +27,22 @@ const schedulerLockKey = 0x4D495353
 // anyway — at most one backfilled run after downtime, never a burst.
 const misfireGrace = 1 * time.Hour
 
+// defaultMissionRoute mirrors api.defaultMissionRoute: an agent's empty
+// route means "the default chain," but the gateway's /v1/stream
+// requires a real, non-empty route name.
+const defaultMissionRoute = "default"
+
 // Schedule is one schedules row.
 type Schedule struct {
-	ID              string
-	Name            string
-	Cron            string
-	MissionTemplate MissionTemplate
-	Enabled         bool
-	ExpiresAt       *time.Time
-	LastRun         *time.Time
-	CreatedAt       time.Time
+	ID              string          `json:"id"`
+	Name            string          `json:"name"`
+	Cron            string          `json:"cron"`
+	MissionTemplate MissionTemplate `json:"mission_template"`
+	Enabled         bool            `json:"enabled"`
+	ExpiresAt       *time.Time      `json:"expires_at,omitempty"`
+	LastRun         *time.Time      `json:"last_run,omitempty"`
+	CreatedAt       time.Time       `json:"created_at"`
+	UpdatedAt       time.Time       `json:"updated_at"`
 }
 
 // MissionTemplate is applied verbatim as a new mission's initial
@@ -49,7 +55,31 @@ type MissionTemplate struct {
 	ReviewRoute   string   `json:"review_route"`
 	MaxIterations int      `json:"max_iterations"`
 	BudgetUSD     *float64 `json:"budget_usd,omitempty"`
+	// AutoApproveSafe defaults true for a scheduled mission, same as
+	// api/missions.go's create handler — a mission fired unattended
+	// needs the same standing shell approval a UI-created one gets by
+	// default, or its very first shell call parks with nobody watching.
+	AutoApproveSafe bool `json:"auto_approve_safe"`
 }
+
+// AgentDefaults is the slice of an agents row a fired mission borrows
+// when its template leaves the corresponding field empty — mirrors
+// api/missions.go's create-handler resolution so a scheduler-fired
+// mission gets the same defaults a UI-created one would.
+type AgentDefaults struct {
+	Route             string
+	ReviewRoute       string
+	PromptOverlay     string
+	BudgetUSD         *float64
+	ApprovalAllowlist []string
+}
+
+// AgentResolver resolves an agent id to its defaults at FIRE time, not
+// schedule-create time — an agent edited after the schedule was made
+// (a new prompt overlay, a changed allowlist) must apply the moment it
+// next fires, not freeze at whatever it was when the schedule was
+// created. ok reports whether the id resolved to a real agent.
+type AgentResolver func(ctx context.Context, agentID string) (AgentDefaults, bool)
 
 // Scheduler ticks every schedulerTick, evaluating schedules rows
 // against their cron expression (5-field, parsed via robfig/cron/v3's
@@ -60,11 +90,21 @@ type MissionTemplate struct {
 type Scheduler struct {
 	db       *pgpool.Pool
 	missions *Store
+	resolve  AgentResolver
+	enabled  func(ctx context.Context) bool
 	log      *slog.Logger
 }
 
-func NewScheduler(db *pgpool.Pool, missions *Store, log *slog.Logger) *Scheduler {
-	return &Scheduler{db: db, missions: missions, log: log}
+// NewScheduler wires the scheduler with the agent resolver
+// createFromTemplate uses to fill in missing route/review_route/
+// budget/prompt_overlay at fire time, and the scheduler_enabled
+// feature switch (D-032) that tick checks first — nil-safe on both:
+// a nil resolve leaves an unresolved AgentID's fields at whatever the
+// template already specified, and a nil enabled defaults every tick to
+// enabled (degrade open, since a config-read hiccup pausing every
+// schedule silently would be worse than one that keeps firing).
+func NewScheduler(db *pgpool.Pool, missions *Store, resolve AgentResolver, enabled func(ctx context.Context) bool, log *slog.Logger) *Scheduler {
+	return &Scheduler{db: db, missions: missions, resolve: resolve, enabled: enabled, log: log}
 }
 
 // Run ticks forever until ctx is done. Double-fire protection across
@@ -116,8 +156,15 @@ func dueDecision(cronExpr string, anchor, now time.Time, grace time.Duration) (d
 	return decisionFire, nil
 }
 
-// tick evaluates every enabled, unexpired schedule once.
+// tick evaluates every enabled, unexpired schedule once — but only
+// when the scheduler_enabled feature switch is on: this is the toggle
+// wire-up that was previously a no-op UI switch (see settings.KeyScheduler),
+// checked before anything else in the tick so a disabled scheduler
+// does no work at all, not even the advisory-lock attempt.
 func (s *Scheduler) tick(ctx context.Context, now time.Time) error {
+	if s.enabled != nil && !s.enabled(ctx) {
+		return nil
+	}
 	db, err := s.db.Get()
 	if err != nil {
 		return fmt.Errorf("scheduler: %w", err)
@@ -136,7 +183,7 @@ func (s *Scheduler) tick(ctx context.Context, now time.Time) error {
 		return tx.Commit(ctx) // another instance already owns this tick
 	}
 
-	rows, err := tx.Query(ctx, `SELECT id, name, cron, mission_template, enabled, expires_at, last_run, created_at
+	rows, err := tx.Query(ctx, `SELECT id, name, cron, mission_template, enabled, expires_at, last_run, created_at, updated_at
 		FROM schedules WHERE enabled AND (expires_at IS NULL OR expires_at > now())`)
 	if err != nil {
 		return fmt.Errorf("scheduler: query schedules: %w", err)
@@ -145,7 +192,7 @@ func (s *Scheduler) tick(ctx context.Context, now time.Time) error {
 	for rows.Next() {
 		var sc Schedule
 		var templateJSON []byte
-		if err := rows.Scan(&sc.ID, &sc.Name, &sc.Cron, &templateJSON, &sc.Enabled, &sc.ExpiresAt, &sc.LastRun, &sc.CreatedAt); err != nil {
+		if err := rows.Scan(&sc.ID, &sc.Name, &sc.Cron, &templateJSON, &sc.Enabled, &sc.ExpiresAt, &sc.LastRun, &sc.CreatedAt, &sc.UpdatedAt); err != nil {
 			rows.Close()
 			return fmt.Errorf("scheduler: scan schedule: %w", err)
 		}
@@ -211,13 +258,56 @@ func (s *Scheduler) fireOne(ctx context.Context, tx pgx.Tx, sc Schedule, now tim
 }
 
 // createFromTemplate inserts a new mission from the schedule's
-// template, tagged with the schedule that spawned it.
+// template, tagged with the schedule that spawned it. It resolves the
+// template's agent_id AT FIRE TIME (mirroring api/missions.go's create
+// handler): an empty route/review_route/budget/prompt_overlay is
+// filled from the agent's current defaults, and an agent's own empty
+// route (its "use the default chain" shorthand) still falls back to
+// defaultMissionRoute since the gateway requires a real route name.
+// This inserted row bypasses Driver.Create entirely — it has no
+// session, no workspace, no grants yet — so it is provisioned lazily
+// the first time Advance/Drive touches it (see driver.go's
+// ensureProvisioned).
 func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedule) error {
-	t := sc.MissionTemplate
+	t, promptOverlay := resolveTemplateDefaults(ctx, sc.MissionTemplate, s.resolve)
 	spec, _ := json.Marshal(Spec{})
 	_, err := tx.Exec(ctx, `INSERT INTO missions
-			(goal, kind, agent_id, max_iterations, budget_usd, route, review_route, spec, schedule_id)
-		VALUES ($1, $2, NULLIF($3, '')::uuid, $4, $5, $6, $7, $8, $9)`,
-		t.Goal, t.Kind, t.AgentID, orDefault(t.MaxIterations, 8), t.BudgetUSD, t.Route, t.ReviewRoute, spec, sc.ID)
+			(goal, kind, agent_id, max_iterations, budget_usd, route, review_route, prompt_overlay, auto_approve_safe, spec, schedule_id)
+		VALUES ($1, $2, NULLIF($3, '')::uuid, $4, $5, $6, $7, $8, $9, $10, $11)`,
+		t.Goal, t.Kind, t.AgentID, orDefault(t.MaxIterations, 8), t.BudgetUSD, t.Route, t.ReviewRoute,
+		promptOverlay, t.AutoApproveSafe, spec, sc.ID)
 	return err
+}
+
+// resolveTemplateDefaults is the pure fire-time resolution step
+// createFromTemplate performs, split out so it's unit-testable without
+// a real pgx.Tx: an empty route/review_route/budget is filled from the
+// resolved agent's current defaults (nil-safe — a nil resolve, or one
+// that reports ok=false, leaves the template exactly as given except
+// for the final defaultMissionRoute fallback), and the resolved
+// agent's prompt overlay is returned separately since MissionTemplate
+// itself carries no such field.
+func resolveTemplateDefaults(ctx context.Context, t MissionTemplate, resolve AgentResolver) (MissionTemplate, string) {
+	promptOverlay := ""
+	if resolve != nil {
+		if defaults, ok := resolve(ctx, t.AgentID); ok {
+			if t.Route == "" {
+				t.Route = defaults.Route
+			}
+			if t.ReviewRoute == "" {
+				t.ReviewRoute = defaults.ReviewRoute
+			}
+			if t.BudgetUSD == nil {
+				t.BudgetUSD = defaults.BudgetUSD
+			}
+			promptOverlay = defaults.PromptOverlay
+		}
+	}
+	if t.Route == "" {
+		t.Route = defaultMissionRoute
+	}
+	if t.ReviewRoute == "" {
+		t.ReviewRoute = defaultMissionRoute
+	}
+	return t, promptOverlay
 }

--- a/internal/brain/missions/scheduler_integration_test.go
+++ b/internal/brain/missions/scheduler_integration_test.go
@@ -45,8 +45,8 @@ func TestSchedulerNoDoubleFireAcrossInstances(t *testing.T) {
 		t.Fatalf("backdate schedule: %v", err)
 	}
 
-	sched1 := NewScheduler(store.db, store, store.log)
-	sched2 := NewScheduler(store.db, store, store.log)
+	sched1 := NewScheduler(store.db, store, nil, nil, store.log)
+	sched2 := NewScheduler(store.db, store, nil, nil, store.log)
 
 	now := time.Now()
 	var wg sync.WaitGroup
@@ -93,7 +93,7 @@ func TestSchedulerLiveQueueDedup(t *testing.T) {
 		t.Fatalf("attach schedule: %v", err)
 	}
 
-	sched := NewScheduler(store.db, store, store.log)
+	sched := NewScheduler(store.db, store, nil, nil, store.log)
 	now := time.Now()
 	if err := sched.tick(ctx, now); err != nil {
 		t.Fatalf("tick: %v", err)

--- a/internal/brain/missions/scheduler_test.go
+++ b/internal/brain/missions/scheduler_test.go
@@ -1,6 +1,7 @@
 package missions
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -83,4 +84,110 @@ func TestDueDecision(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveTemplateDefaults(t *testing.T) {
+	t.Parallel()
+	budget := 5.0
+
+	cases := []struct {
+		name        string
+		template    MissionTemplate
+		resolve     AgentResolver
+		wantRoute   string
+		wantReview  string
+		wantBudget  *float64
+		wantOverlay string
+	}{
+		{
+			name:       "nil resolver falls back to defaultMissionRoute",
+			template:   MissionTemplate{Goal: "g", AgentID: "a1"},
+			resolve:    nil,
+			wantRoute:  defaultMissionRoute,
+			wantReview: defaultMissionRoute,
+		},
+		{
+			name:     "unresolved agent id falls back to defaultMissionRoute",
+			template: MissionTemplate{Goal: "g", AgentID: "missing"},
+			resolve: func(ctx context.Context, agentID string) (AgentDefaults, bool) {
+				return AgentDefaults{}, false
+			},
+			wantRoute:  defaultMissionRoute,
+			wantReview: defaultMissionRoute,
+		},
+		{
+			name:     "empty template fields fill from resolved agent",
+			template: MissionTemplate{Goal: "g", AgentID: "briefing"},
+			resolve: func(ctx context.Context, agentID string) (AgentDefaults, bool) {
+				return AgentDefaults{Route: "fast", ReviewRoute: "careful", BudgetUSD: &budget, PromptOverlay: "overlay text"}, true
+			},
+			wantRoute:   "fast",
+			wantReview:  "careful",
+			wantBudget:  &budget,
+			wantOverlay: "overlay text",
+		},
+		{
+			name:     "template's own non-empty fields are never overwritten",
+			template: MissionTemplate{Goal: "g", AgentID: "briefing", Route: "explicit", ReviewRoute: "explicit-review"},
+			resolve: func(ctx context.Context, agentID string) (AgentDefaults, bool) {
+				return AgentDefaults{Route: "fast", ReviewRoute: "careful", PromptOverlay: "overlay text"}, true
+			},
+			wantRoute:   "explicit",
+			wantReview:  "explicit-review",
+			wantOverlay: "overlay text",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, overlay := resolveTemplateDefaults(context.Background(), tc.template, tc.resolve)
+			if got.Route != tc.wantRoute {
+				t.Errorf("Route = %q, want %q", got.Route, tc.wantRoute)
+			}
+			if got.ReviewRoute != tc.wantReview {
+				t.Errorf("ReviewRoute = %q, want %q", got.ReviewRoute, tc.wantReview)
+			}
+			if (got.BudgetUSD == nil) != (tc.wantBudget == nil) {
+				t.Errorf("BudgetUSD = %v, want %v", got.BudgetUSD, tc.wantBudget)
+			} else if got.BudgetUSD != nil && *got.BudgetUSD != *tc.wantBudget {
+				t.Errorf("BudgetUSD = %v, want %v", *got.BudgetUSD, *tc.wantBudget)
+			}
+			if overlay != tc.wantOverlay {
+				t.Errorf("overlay = %q, want %q", overlay, tc.wantOverlay)
+			}
+		})
+	}
+}
+
+func TestTickSkipsAllWorkWhenDisabled(t *testing.T) {
+	t.Parallel()
+	called := false
+	s := &Scheduler{enabled: func(ctx context.Context) bool {
+		called = true
+		return false
+	}}
+	// db is nil: if tick proceeded past the enabled check it would
+	// panic dereferencing s.db.Get, not merely fail — the disabled
+	// short-circuit must return before any of that.
+	if err := s.tick(context.Background(), time.Now()); err != nil {
+		t.Fatalf("tick with scheduler disabled: %v", err)
+	}
+	if !called {
+		t.Fatal("tick never consulted the enabled func")
+	}
+}
+
+func TestTickNilEnabledDegradesOpen(t *testing.T) {
+	t.Parallel()
+	// A nil enabled func must NOT short-circuit tick (degrade open) —
+	// this only checks the guard itself doesn't panic or skip; db is
+	// nil, so a real proceed would panic on s.db.Get, proving the nil
+	// check alone can't be mistaken for "disabled".
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("tick with nil enabled and nil db: want it to proceed past the guard and panic on the nil db, proving degrade-open")
+		}
+	}()
+	s := &Scheduler{enabled: nil}
+	_ = s.tick(context.Background(), time.Now())
 }

--- a/internal/brain/missions/schedules.go
+++ b/internal/brain/missions/schedules.go
@@ -1,0 +1,240 @@
+package missions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/robfig/cron/v3"
+)
+
+// scheduleNamePattern mirrors agents.namePattern: a lowercase slug that
+// survives in URLs, ledger rows, and event payloads. Kept as its own
+// copy rather than an exported symbol from the agents package — the
+// two name spaces (agent names, schedule names) are independent and
+// have no reason to import each other over one regexp.
+var scheduleNamePattern = regexp.MustCompile(`^[a-z0-9]+(?:[-_][a-z0-9]+)*$`)
+
+// ErrBadCron and ErrScheduleNameConflict are the sentinel errors the
+// HTTP layer maps onto 400/409, mirroring ErrNotFound.
+var (
+	ErrBadCron              = errors.New("invalid cron expression")
+	ErrScheduleNameConflict = errors.New("a schedule with this name already exists")
+	ErrScheduleInUse        = errors.New("missions still reference this schedule")
+)
+
+// ValidateCron reports whether cronExpr parses as a standard 5-field
+// cron expression (robfig/cron/v3's parser — the same one dueDecision
+// already uses at fire time, so a schedule that validates here is
+// guaranteed to actually fire later).
+func ValidateCron(cronExpr string) error {
+	if _, err := cron.ParseStandard(cronExpr); err != nil {
+		return fmt.Errorf("%w: %s", ErrBadCron, err)
+	}
+	return nil
+}
+
+// NextRun computes the next fire time after now for cronExpr — the
+// GET schedules API decorates each row with this so the UI can show
+// "next run" without duplicating cron math client-side. Returns the
+// zero time on an invalid expression (ValidateCron should already have
+// caught that at create/patch time; this is a defensive fallback, not
+// the primary guard).
+func NextRun(cronExpr string, now time.Time) time.Time {
+	schedule, err := cron.ParseStandard(cronExpr)
+	if err != nil {
+		return time.Time{}
+	}
+	return schedule.Next(now)
+}
+
+const scheduleColumns = `id, name, cron, mission_template, enabled, expires_at, last_run, created_at, updated_at`
+
+func scanSchedule(row pgx.Row) (Schedule, error) {
+	var sc Schedule
+	var templateJSON []byte
+	if err := row.Scan(&sc.ID, &sc.Name, &sc.Cron, &templateJSON, &sc.Enabled, &sc.ExpiresAt, &sc.LastRun, &sc.CreatedAt, &sc.UpdatedAt); err != nil {
+		return Schedule{}, err
+	}
+	_ = json.Unmarshal(templateJSON, &sc.MissionTemplate)
+	return sc, nil
+}
+
+// ListSchedules returns every schedule, newest first.
+func (s *Store) ListSchedules(ctx context.Context) ([]Schedule, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("schedules list: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT `+scheduleColumns+` FROM schedules ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("schedules list: %w", err)
+	}
+	defer rows.Close()
+	out := []Schedule{}
+	for rows.Next() {
+		sc, err := scanSchedule(rows)
+		if err != nil {
+			return nil, fmt.Errorf("schedules list: %w", err)
+		}
+		out = append(out, sc)
+	}
+	return out, rows.Err()
+}
+
+// GetSchedule returns one schedule by id.
+func (s *Store) GetSchedule(ctx context.Context, id string) (Schedule, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return Schedule{}, fmt.Errorf("schedules get: %w", err)
+	}
+	sc, err := scanSchedule(db.QueryRow(ctx, `SELECT `+scheduleColumns+` FROM schedules WHERE id = $1`, id))
+	if err != nil {
+		return Schedule{}, fmt.Errorf("schedule %s: %w", id, ErrNotFound)
+	}
+	return sc, nil
+}
+
+// CreateSchedule validates name and cron, and inserts. A duplicate name
+// (schedules.name is UNIQUE) reports ErrScheduleNameConflict rather
+// than a raw pg error.
+func (s *Store) CreateSchedule(ctx context.Context, sc Schedule) (string, error) {
+	if !scheduleNamePattern.MatchString(sc.Name) {
+		return "", fmt.Errorf("name must be a lowercase slug (a-z, 0-9, - or _)")
+	}
+	if err := ValidateCron(sc.Cron); err != nil {
+		return "", err
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		return "", fmt.Errorf("schedules create: %w", err)
+	}
+	template, err := json.Marshal(sc.MissionTemplate)
+	if err != nil {
+		return "", fmt.Errorf("schedules create: %w", err)
+	}
+	var id string
+	err = db.QueryRow(ctx, `INSERT INTO schedules (name, cron, mission_template, enabled, expires_at)
+		VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+		sc.Name, sc.Cron, template, sc.Enabled, sc.ExpiresAt).Scan(&id)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return "", ErrScheduleNameConflict
+		}
+		return "", fmt.Errorf("schedules create: %w", err)
+	}
+	return id, nil
+}
+
+// SchedulePatch is a partial update; nil fields are left unchanged.
+// Name is patchable (unlike agents.Patch, where name is immutable) —
+// a schedule's name is a display label with no ledger/event
+// attribution riding on it.
+type SchedulePatch struct {
+	Name            *string
+	Cron            *string
+	MissionTemplate *MissionTemplate
+	Enabled         *bool
+	ExpiresAt       **time.Time
+}
+
+// PatchSchedule applies a partial update, re-validating name/cron the
+// same way CreateSchedule does when they're set.
+func (s *Store) PatchSchedule(ctx context.Context, id string, p SchedulePatch) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("schedules patch: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("schedules patch: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	before, err := scanSchedule(tx.QueryRow(ctx, `SELECT `+scheduleColumns+` FROM schedules WHERE id = $1 FOR UPDATE`, id))
+	if err != nil {
+		return fmt.Errorf("schedule %s: %w", id, ErrNotFound)
+	}
+	after := before
+	if p.Name != nil {
+		if !scheduleNamePattern.MatchString(*p.Name) {
+			return fmt.Errorf("name must be a lowercase slug (a-z, 0-9, - or _)")
+		}
+		after.Name = *p.Name
+	}
+	if p.Cron != nil {
+		if err := ValidateCron(*p.Cron); err != nil {
+			return err
+		}
+		after.Cron = *p.Cron
+	}
+	if p.MissionTemplate != nil {
+		after.MissionTemplate = *p.MissionTemplate
+	}
+	if p.Enabled != nil {
+		after.Enabled = *p.Enabled
+	}
+	if p.ExpiresAt != nil {
+		after.ExpiresAt = *p.ExpiresAt
+	}
+	template, err := json.Marshal(after.MissionTemplate)
+	if err != nil {
+		return fmt.Errorf("schedules patch: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `UPDATE schedules SET name = $2, cron = $3, mission_template = $4,
+			enabled = $5, expires_at = $6, updated_at = now()
+		WHERE id = $1`,
+		id, after.Name, after.Cron, template, after.Enabled, after.ExpiresAt); err != nil {
+		if isUniqueViolation(err) {
+			return ErrScheduleNameConflict
+		}
+		return fmt.Errorf("schedules patch: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("schedules patch: %w", err)
+	}
+	return nil
+}
+
+// DeleteSchedule removes a schedule. missions_schedule_id_fkey (0026)
+// has no ON DELETE clause, so Postgres refuses this with a foreign-key
+// violation while any mission still references the schedule — a
+// schedule's fire history stays attributable rather than silently
+// orphaned or cascaded away.
+func (s *Store) DeleteSchedule(ctx context.Context, id string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("schedules delete: %w", err)
+	}
+	tag, err := db.Exec(ctx, `DELETE FROM schedules WHERE id = $1`, id)
+	if err != nil {
+		if isForeignKeyViolation(err) {
+			return fmt.Errorf("schedule %s: %w", id, ErrScheduleInUse)
+		}
+		return fmt.Errorf("schedules delete: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("schedule %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+// isForeignKeyViolation reports whether err is Postgres's
+// foreign_key_violation (23503) — a schedule delete blocked by
+// missions still referencing it.
+func isForeignKeyViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23503"
+}
+
+// isUniqueViolation reports whether err is Postgres's unique_violation
+// (23505) — schedules.name's UNIQUE constraint.
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}

--- a/internal/brain/missions/schedules_integration_test.go
+++ b/internal/brain/missions/schedules_integration_test.go
@@ -1,0 +1,123 @@
+//go:build integration
+
+package missions
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// slugMarker adapts the package's own marker (which has a trailing
+// space — fine for a mission goal's LIKE-prefix sweep, not fine for a
+// schedule name's namePattern slug) into something CreateSchedule's
+// validation actually accepts.
+var slugMarker = strings.TrimSpace(marker)
+
+func TestScheduleCRUD(t *testing.T) {
+	store := testStore(t)
+	ctx := t.Context()
+	name := slugMarker + "-daily-brief"
+
+	id, err := store.CreateSchedule(ctx, Schedule{
+		Name: name, Cron: "0 7 * * *",
+		MissionTemplate: MissionTemplate{Goal: marker + "check topics", Kind: "research"},
+		Enabled:         true,
+	})
+	if err != nil {
+		t.Fatalf("CreateSchedule: %v", err)
+	}
+
+	sc, err := store.GetSchedule(ctx, id)
+	if err != nil {
+		t.Fatalf("GetSchedule: %v", err)
+	}
+	if sc.Name != name || !sc.Enabled {
+		t.Fatalf("GetSchedule = %+v", sc)
+	}
+
+	// Duplicate name conflicts.
+	_, err = store.CreateSchedule(ctx, Schedule{Name: name, Cron: "0 8 * * *"})
+	if !errors.Is(err, ErrScheduleNameConflict) {
+		t.Fatalf("CreateSchedule duplicate name = %v, want ErrScheduleNameConflict", err)
+	}
+
+	// Bad cron rejected.
+	_, err = store.CreateSchedule(ctx, Schedule{Name: slugMarker + "-bad-cron", Cron: "nonsense"})
+	if !errors.Is(err, ErrBadCron) {
+		t.Fatalf("CreateSchedule bad cron = %v, want ErrBadCron", err)
+	}
+
+	all, err := store.ListSchedules(ctx)
+	if err != nil {
+		t.Fatalf("ListSchedules: %v", err)
+	}
+	found := false
+	for _, row := range all {
+		if row.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("ListSchedules did not include the created schedule")
+	}
+
+	disabled := false
+	if err := store.PatchSchedule(ctx, id, SchedulePatch{Enabled: &disabled}); err != nil {
+		t.Fatalf("PatchSchedule: %v", err)
+	}
+	sc, err = store.GetSchedule(ctx, id)
+	if err != nil {
+		t.Fatalf("GetSchedule after patch: %v", err)
+	}
+	if sc.Enabled {
+		t.Fatalf("GetSchedule after patch = %+v", sc)
+	}
+
+	badCron := "nonsense"
+	if err := store.PatchSchedule(ctx, id, SchedulePatch{Cron: &badCron}); !errors.Is(err, ErrBadCron) {
+		t.Fatalf("PatchSchedule bad cron = %v, want ErrBadCron", err)
+	}
+
+	if err := store.DeleteSchedule(ctx, id); err != nil {
+		t.Fatalf("DeleteSchedule: %v", err)
+	}
+	if _, err := store.GetSchedule(ctx, id); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetSchedule after delete = %v, want ErrNotFound", err)
+	}
+	if err := store.DeleteSchedule(ctx, id); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("second DeleteSchedule = %v, want ErrNotFound", err)
+	}
+}
+
+// TestScheduleDeleteBlockedByReferencingMission confirms the FK
+// (missions_schedule_id_fkey, no ON DELETE) really does block deleting
+// a schedule some mission still references, surfaced as
+// ErrScheduleInUse rather than a raw pg error.
+func TestScheduleDeleteBlockedByReferencingMission(t *testing.T) {
+	store := testStore(t)
+	ctx := t.Context()
+
+	id, err := store.CreateSchedule(ctx, Schedule{
+		Name: slugMarker + "-in-use", Cron: "0 7 * * *",
+		MissionTemplate: MissionTemplate{Goal: marker + "referenced", Kind: "research"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSchedule: %v", err)
+	}
+	missionID, err := store.Create(ctx, Mission{Goal: marker + "referencing mission", Kind: "research"})
+	if err != nil {
+		t.Fatalf("Create mission: %v", err)
+	}
+	db, err := store.db.Get()
+	if err != nil {
+		t.Fatalf("Get pool: %v", err)
+	}
+	if _, err := db.Exec(ctx, "UPDATE missions SET schedule_id = $2 WHERE id = $1", missionID, id); err != nil {
+		t.Fatalf("attach schedule: %v", err)
+	}
+
+	if err := store.DeleteSchedule(ctx, id); !errors.Is(err, ErrScheduleInUse) {
+		t.Fatalf("DeleteSchedule with a referencing mission = %v, want ErrScheduleInUse", err)
+	}
+}

--- a/internal/brain/missions/schedules_test.go
+++ b/internal/brain/missions/schedules_test.go
@@ -1,0 +1,53 @@
+package missions
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestValidateCron(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		cron    string
+		wantErr bool
+	}{
+		{name: "daily at 9", cron: "0 9 * * *"},
+		{name: "every 5 minutes", cron: "*/5 * * * *"},
+		{name: "weekdays at 8", cron: "0 8 * * 1-5"},
+		{name: "empty string", cron: "", wantErr: true},
+		{name: "garbage", cron: "not a cron expression", wantErr: true},
+		{name: "too few fields", cron: "* * *", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateCron(tc.cron)
+			if tc.wantErr {
+				if err == nil || !errors.Is(err, ErrBadCron) {
+					t.Fatalf("ValidateCron(%q) = %v, want ErrBadCron", tc.cron, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateCron(%q): %v", tc.cron, err)
+			}
+		})
+	}
+}
+
+func TestNextRun(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 8, 0, 0, 0, time.UTC)
+
+	next := NextRun("0 9 * * *", now)
+	want := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	if !next.Equal(want) {
+		t.Fatalf("NextRun = %v, want %v", next, want)
+	}
+
+	if got := NextRun("garbage", now); !got.IsZero() {
+		t.Fatalf("NextRun with invalid cron = %v, want zero time", got)
+	}
+}

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -138,13 +138,36 @@ func (s *Store) Get(ctx context.Context, id string) (Mission, error) {
 	return m, nil
 }
 
-// List returns every mission, newest first.
-func (s *Store) List(ctx context.Context) ([]Mission, error) {
+// ListFilter narrows List's result set — the zero value (no filter,
+// no limit) is the original "every mission" behavior. Added for a
+// recurring schedule's fire history view (?schedule_id=) and any
+// future paginated list (?limit=), both optional.
+type ListFilter struct {
+	ScheduleID string
+	// Limit caps the result count; 0 means unlimited.
+	Limit int
+}
+
+// List returns missions matching filter, newest first. The zero
+// ListFilter{} returns every mission, matching the pre-filter
+// behavior exactly.
+func (s *Store) List(ctx context.Context, filter ListFilter) ([]Mission, error) {
 	db, err := s.db.Get()
 	if err != nil {
 		return nil, fmt.Errorf("missions list: %w", err)
 	}
-	rows, err := db.Query(ctx, `SELECT `+missionColumns+` FROM missions ORDER BY created_at DESC`)
+	query := `SELECT ` + missionColumns + ` FROM missions`
+	var args []any
+	if filter.ScheduleID != "" {
+		args = append(args, filter.ScheduleID)
+		query += fmt.Sprintf(" WHERE schedule_id = $%d", len(args))
+	}
+	query += " ORDER BY created_at DESC"
+	if filter.Limit > 0 {
+		args = append(args, filter.Limit)
+		query += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
+	rows, err := db.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("missions list: %w", err)
 	}
@@ -458,6 +481,29 @@ func (s *Store) ReconcileTerminal(ctx context.Context, id string, proposed Phase
 		return fmt.Errorf("missions reconcile event: %w", err)
 	}
 	return tx.Commit(ctx)
+}
+
+// SetSession attaches the mission's hidden bookkeeping session id —
+// used by lazy provisioning (driver.go's ensureProvisioned) for a
+// mission that reached the store without going through Driver.Create
+// (a scheduler-fired row, see scheduler.go's createFromTemplate).
+// Race-idempotent by construction: the WHERE clause only ever matches
+// a mission that doesn't already have one, so two concurrent
+// ensureProvisioned calls for the same never-provisioned mission (a
+// Drive loop racing the work-slot sweep's own re-Drive) can't each
+// create their own session and stomp the other's — the loser's write
+// silently affects zero rows instead of overwriting a session id a
+// worker turn may already be running under.
+func (s *Store) SetSession(ctx context.Context, id, sessionID string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("missions set session: %w", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE missions SET session_id = $2, updated_at = now()
+		WHERE id = $1 AND session_id IS NULL`, id, sessionID); err != nil {
+		return fmt.Errorf("missions set session: %w", err)
+	}
+	return nil
 }
 
 // SetProvisioned checks-and-writes workspace/worktree/branch/base_commit

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -70,12 +71,16 @@ type execer interface {
 // goal verbatim, not the marker prefix — delete them via the schedule
 // join FIRST, before deleting schedules (whose FK would otherwise
 // orphan them under ON DELETE CASCADE at an unpredictable order
-// relative to a concurrently running test).
+// relative to a concurrently running test). Schedule NAMES can't carry
+// marker verbatim (it has a trailing space; schedule names must be a
+// slug — see schedules_integration_test.go's slugMarker), so schedule
+// rows are also swept by the slug form.
 func sweep(ctx context.Context, db execer) {
+	slug := strings.TrimSpace(marker)
 	_, _ = db.Exec(ctx, `DELETE FROM missions WHERE schedule_id IN (
-		SELECT id FROM schedules WHERE name LIKE $1 || '%'
-	)`, marker)
-	_, _ = db.Exec(ctx, "DELETE FROM schedules WHERE name LIKE $1 || '%'", marker)
+		SELECT id FROM schedules WHERE name LIKE $1 || '%' OR name LIKE $2 || '%'
+	)`, marker, slug)
+	_, _ = db.Exec(ctx, "DELETE FROM schedules WHERE name LIKE $1 || '%' OR name LIKE $2 || '%'", marker, slug)
 	_, _ = db.Exec(ctx, "DELETE FROM missions WHERE goal LIKE $1 || '%'", marker)
 }
 
@@ -95,7 +100,7 @@ func TestMissionCRUD(t *testing.T) {
 		t.Fatalf("Get = %+v, want default research/idle/8", m)
 	}
 
-	list, err := s.List(ctx)
+	list, err := s.List(ctx, ListFilter{})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}

--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -233,31 +233,61 @@ func (p *Permissions) Grant(ctx context.Context, sessionID, tool, pattern string
 
 // matchGrant checks the project allowlist, then unexpired session
 // grants, glob-matching each pattern against the subject.
+//
+// D-036: a grant row's tool also matches when the call's tool name
+// ENDS WITH "_"+rowTool — connector tools are namespaced
+// "<connector-name>_<tool-name>" (connectors.Manager.Tools), so an
+// allowlist entry like "calendar_list_events" (agent-authored, before
+// any connector name is known) still hits
+// "google-calendar_calendar_list_events" at call time. Same suffix
+// semantics as loop.Agent.SetForceRoute, for the same reason. The
+// SandboxGrantTool sentinel ("__sandbox__") is excluded — it is never
+// a real tool call, only a stored sandbox root, and its leading "__"
+// can never be a legitimate "_"-boundary suffix match target anyway
+// since no call tool ends with "__sandbox__".
 func (p *Permissions) matchGrant(ctx context.Context, sessionID, tool, subject string) (bool, string, error) {
 	db, err := p.db.Get()
 	if err != nil {
 		return false, "", fmt.Errorf("tools: match grant: %w", err)
 	}
 	rows, err := db.Query(ctx, `
-		SELECT pattern, 'project allowlist' FROM project_allowlist WHERE tool = $2
+		SELECT tool, pattern, 'project allowlist' FROM project_allowlist
 		UNION ALL
-		SELECT pattern, 'session grant' FROM session_grants
-		WHERE session_id = $1 AND tool = $2 AND expires > now()`,
-		sessionID, tool)
+		SELECT tool, pattern, 'session grant' FROM session_grants
+		WHERE session_id = $1 AND expires > now()`,
+		sessionID)
 	if err != nil {
 		return false, "", fmt.Errorf("tools: match grant: %w", err)
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var pattern, source string
-		if err := rows.Scan(&pattern, &source); err != nil {
+		var rowTool, pattern, source string
+		if err := rows.Scan(&rowTool, &pattern, &source); err != nil {
 			return false, "", fmt.Errorf("tools: match grant: %w", err)
+		}
+		if !toolMatches(tool, rowTool) {
+			continue
 		}
 		if globMatch(pattern, subject) {
 			return true, source + " " + pattern, nil
 		}
 	}
 	return false, "", rows.Err()
+}
+
+// toolMatches reports whether a grant/allowlist row named rowTool
+// covers a call to tool: exact match, or tool ends with "_"+rowTool
+// (connector namespacing — see matchGrant's D-036 note). rowTool ==
+// SandboxGrantTool never suffix-matches; it is a stored sandbox root,
+// not a grantable tool name.
+func toolMatches(tool, rowTool string) bool {
+	if tool == rowTool {
+		return true
+	}
+	if rowTool == SandboxGrantTool {
+		return false
+	}
+	return strings.HasSuffix(tool, "_"+rowTool)
 }
 
 // globMatch matches shell-style patterns. A trailing "*" also matches

--- a/internal/brain/tools/permissions_test.go
+++ b/internal/brain/tools/permissions_test.go
@@ -112,6 +112,32 @@ func TestGlobMatch(t *testing.T) {
 	}
 }
 
+func TestToolMatches(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		tool, rowTool string
+		want          bool
+	}{
+		{name: "exact match", tool: "gmail_search", rowTool: "gmail_search", want: true},
+		{name: "connector suffix match", tool: "google-calendar_calendar_list_events", rowTool: "calendar_list_events", want: true},
+		{name: "connector suffix match gmail", tool: "gmail_gmail_search", rowTool: "gmail_search", want: true},
+		{name: "sandbox sentinel never suffix-matches", tool: "foo___sandbox__", rowTool: SandboxGrantTool, want: false},
+		{name: "sandbox sentinel exact still matches", tool: SandboxGrantTool, rowTool: SandboxGrantTool, want: true},
+		{name: "no underscore boundary rejected", tool: "notcalendar_list_events", rowTool: "calendar_list_events", want: false},
+		{name: "trailing extra text rejected", tool: "calendar_list_events_extra", rowTool: "calendar_list_events", want: false},
+		{name: "unrelated tool", tool: "shell", rowTool: "calendar_list_events", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := toolMatches(tc.tool, tc.rowTool); got != tc.want {
+				t.Errorf("toolMatches(%q, %q) = %v, want %v", tc.tool, tc.rowTool, got, tc.want)
+			}
+		})
+	}
+}
+
 // The chain short-circuits before any DB access for policy-guard
 // denials, exempt tools, and danger-classified commands — so these
 // paths are testable without Postgres (nil pool).

--- a/migrations/0037_briefing_agent.sql
+++ b/migrations/0037_briefing_agent.sql
@@ -1,0 +1,27 @@
+-- Briefing agent seed (roadmap item 3): the daily-briefing skill's
+-- prompt overlay and approval allowlist, seeded once so recurring
+-- "briefing" missions have an agent to run against. Goal-driven: the
+-- topics to cover come from the mission goal text itself, resolved at
+-- mission-run time — no separate topics table. Pre-release: fold into
+-- 0021_agents.sql at next DB reset — kept as its own numbered file for
+-- now per the iterative-migration rule while the schema is still
+-- moving.
+--
+-- approval_allowlist names tools by their bare, connector-unprefixed
+-- name ("calendar_list_events", not "google-calendar_calendar_list_
+-- events") — matchGrant's suffix rule (D-036, internal/brain/tools/
+-- permissions.go) matches these against the runtime-namespaced tool
+-- name a connector actually registers, so this works regardless of
+-- which connector name serves gmail/calendar for a given user.
+INSERT INTO agents (name, description, prompt_overlay, skills, tools, approval_allowlist, memory, route)
+VALUES (
+    'briefing',
+    'Goal-driven briefing: covers every topic named in the mission goal, adds calendar/email highlights when connected, writes briefing.md.',
+    'Load the daily-briefing skill first and follow its rules for the rest of this mission. Cover every topic named in the mission goal, using web_search to check each one for anything from roughly the last 24 hours. When calendar and email tools are available, add short highlight sections for today''s events and unread mail; when they are not available, say so plainly instead of inventing content. Write the full briefing as briefing.md at the workspace root. Only send it by email via gmail_send if the goal explicitly names a recipient.',
+    '["daily-briefing"]',
+    '["web_search", "calendar_list_events", "gmail_search", "gmail_read", "gmail_send"]',
+    '["gmail_search", "gmail_read", "calendar_list_events", "gmail_send"]',
+    false,
+    'research'
+)
+ON CONFLICT (name) DO NOTHING;

--- a/skills/daily-briefing/SKILL.md
+++ b/skills/daily-briefing/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: daily-briefing
+description: Writes a structured briefing covering every topic named in the mission goal, plus calendar/email highlights when connected. Use when running a scheduled/recurring briefing mission — never for one-off research or chat answers.
+---
+
+# Daily briefing discipline
+
+## Rules
+
+- Cover EVERY topic named in the mission goal — check each one with web_search. A topic with nothing new still gets a line saying so; never silently drop it.
+- Last ~24 hours only: this is a daily brief, not a history lesson. Older context only if a topic literally has nothing from the last day.
+- Every claim carries a source URL and a date/time — a briefing fact with no citation is not a fact, it's a guess.
+- Calendar section only when a calendar tool is actually available. If it's not, write "calendar not connected" — never invent events or imply a schedule you cannot see.
+- Email section only when a gmail tool is available: use `gmail_search is:unread newer_than:1d`, summarize senders and subjects, never long quotes from message bodies. No tool available → "email not connected".
+- Write the full briefing as `briefing.md` at the workspace root via write_file — this is the mission's artifact contract; nothing else counts as the deliverable.
+- Structure every briefing the same way: Topics (one subsection per goal topic), Calendar, Email, Sources — consistency is what makes a recurring brief scannable at a glance.
+- Only call gmail_send if the mission goal explicitly names a recipient. Subject line: "Daily briefing — <date>". No goal-named recipient → never send, the artifact alone is the deliverable.
+
+## Anti-rationalization
+
+| Excuse | Rebuttal |
+|---|---|
+| "This topic had nothing, skip it" | The reader expects every goal topic accounted for; "nothing new" is itself the answer. |
+| "I remember calendar tools were connected last time" | Check THIS turn's tool list; connectivity can change between runs. |
+| "Paraphrasing the email preview is basically quoting it" | Keep it to sender + subject + one-line gist — the reader can open their own inbox for more. |
+| "The goal didn't say NOT to email it" | Silence is not permission; only an explicit recipient in the goal authorizes gmail_send. |
+
+## Red flags — stop and re-check
+
+- A topic named in the mission goal is missing from the briefing entirely.
+- A claim has no source URL or no date.
+- The calendar or email section contains content but no tool was actually called this turn.
+- gmail_send was called without an explicit recipient named in the goal.
+
+## Evidence required
+
+- Source and timestamp on every topic claim.
+- Every topic named in the mission goal present, including "nothing new" topics.
+- briefing.md actually written via write_file at the workspace root before ending the turn.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -17,9 +17,11 @@ import type {
   MissionEvent,
   MissionFile,
   MissionUsage,
+  MissionTemplate,
   Notification,
   ProviderHealth,
   RetrievedMemory,
+  Schedule,
   SessionMeta,
   SessionUsage,
   TestResult,
@@ -653,7 +655,7 @@ export async function patchSettingValues(changes: Record<string, string>): Promi
 
 export interface CreateMissionInput {
   goal: string
-  kind: 'coding' | 'research' | 'scheduled'
+  kind: 'coding' | 'research'
   agent_id?: string
   route?: string
   review_route?: string
@@ -664,8 +666,18 @@ export interface CreateMissionInput {
   auto_approve_safe?: boolean
 }
 
-export async function listMissions(): Promise<Mission[]> {
-  const { missions } = await request<{ missions: Mission[] }>('/v1/missions')
+// listMissions returns every mission by default; opts narrows to one
+// schedule's fire history (scheduleId) and/or caps the result count
+// (limit) — both map directly to the server's optional query params.
+export async function listMissions(opts?: {
+  scheduleId?: string
+  limit?: number
+}): Promise<Mission[]> {
+  const params = new URLSearchParams()
+  if (opts?.scheduleId) params.set('schedule_id', opts.scheduleId)
+  if (opts?.limit) params.set('limit', String(opts.limit))
+  const qs = params.size > 0 ? `?${params.toString()}` : ''
+  const { missions } = await request<{ missions: Mission[] }>(`/v1/missions${qs}`)
   return missions ?? []
 }
 
@@ -813,4 +825,46 @@ export async function pushMission(
     method: 'POST',
     body: JSON.stringify({ credential_ref: credentialRef }),
   })
+}
+
+// --- schedules (recurring cron triggers that fire mission templates) ---
+
+export interface CreateScheduleInput {
+  name: string
+  cron: string
+  mission_template: MissionTemplate
+  enabled?: boolean
+  expires_at?: string
+}
+
+export async function listSchedules(): Promise<Schedule[]> {
+  const { schedules } = await request<{ schedules: Schedule[] }>('/v1/schedules')
+  return schedules ?? []
+}
+
+export async function createSchedule(input: CreateScheduleInput): Promise<{ id: string }> {
+  return request<{ id: string }>('/v1/schedules', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  })
+}
+
+export async function patchSchedule(
+  id: string,
+  patch: {
+    name?: string
+    cron?: string
+    mission_template?: MissionTemplate
+    enabled?: boolean
+    expires_at?: string | null
+  },
+): Promise<Schedule> {
+  return request<Schedule>(`/v1/schedules/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(patch),
+  })
+}
+
+export async function deleteSchedule(id: string): Promise<void> {
+  await request<void>(`/v1/schedules/${id}`, { method: 'DELETE' })
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -382,7 +382,7 @@ export interface ProgressNote {
 export interface Mission {
   id: string
   goal: string
-  kind: 'coding' | 'research' | 'scheduled'
+  kind: 'coding' | 'research'
   agent_id?: string
   phase: 'research' | 'plan' | 'execute' | 'review' | 'done' | 'failed'
   status: 'idle' | 'working' | 'waiting_for_input' | 'paused' | 'done' | 'error'
@@ -454,4 +454,36 @@ export interface AdminConnector {
   config: Record<string, unknown>
   credential_ref: string
   enabled: boolean
+}
+
+// MissionTemplate is the frozen mission-creation payload a schedule
+// fires at each tick (internal/brain/missions.MissionTemplate) — same
+// shape as CreateMissionInput, minus repo_path (out of scope for
+// scheduled missions in v1).
+export interface MissionTemplate {
+  goal: string
+  kind: 'coding' | 'research'
+  agent_id?: string
+  route?: string
+  review_route?: string
+  max_iterations?: number
+  budget_usd?: number
+  auto_approve_safe?: boolean
+}
+
+// Schedule is a recurring cron trigger that fires mission_template
+// (internal/brain/missions.Schedule), managed from the Missions page's
+// recurring schedules section. next_run is server-computed, present
+// whenever the cron parses.
+export interface Schedule {
+  id: string
+  name: string
+  cron: string
+  mission_template: MissionTemplate
+  enabled: boolean
+  expires_at?: string
+  last_run?: string
+  next_run?: string
+  created_at: string
+  updated_at: string
 }

--- a/web/src/components/missions/MissionCard.tsx
+++ b/web/src/components/missions/MissionCard.tsx
@@ -35,6 +35,11 @@ export function MissionCard({ mission }: { mission: Mission }) {
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
         <span className="capitalize">{mission.kind}</span>
         <span>{mission.phase}</span>
+        {mission.schedule_id && (
+          <span className="rounded bg-brand-soft px-1.5 py-0.5 text-xs font-semibold text-brand-soft-foreground">
+            recurring
+          </span>
+        )}
         <span>
           iteration {mission.iteration}/{mission.max_iterations}
         </span>

--- a/web/src/components/missions/NewMissionDialog.tsx
+++ b/web/src/components/missions/NewMissionDialog.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react'
 import { toast } from 'sonner'
-import { createMission } from '../../api/client'
+import { createMission, createSchedule } from '../../api/client'
 import type { AdminAgent } from '../../api/types'
 import { useAgents } from '../AgentPicker'
+import { slugify } from '../settings/AgentForm'
+import { cronPresets, type CronPresetValue } from '../../lib/schedules'
 import { Button } from '../ui/button'
 import {
   Dialog,
@@ -21,17 +23,21 @@ import { errText } from '../settings/util'
 const kinds = [
   { value: 'research', label: 'Research' },
   { value: 'coding', label: 'Coding' },
-  { value: 'scheduled', label: 'Scheduled' },
 ] as const
 
 export function NewMissionDialog({
   open,
   onOpenChange,
   onCreated,
+  onScheduled,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   onCreated: (id: string) => void
+  // Fires after a recurring schedule is created instead of a one-off
+  // mission — the caller refreshes its schedule list; unlike onCreated
+  // this never navigates, there is no mission yet to open.
+  onScheduled?: () => void
 }) {
   const agents = useAgents()
   const [goal, setGoal] = useState('')
@@ -46,6 +52,15 @@ export function NewMissionDialog({
   const [autoApproveSafe, setAutoApproveSafe] = useState(true)
   const [busy, setBusy] = useState(false)
 
+  // Repeat-on-schedule fields — only read/submitted while repeat is on.
+  const [repeat, setRepeat] = useState(false)
+  const [scheduleName, setScheduleName] = useState('')
+  const [preset, setPreset] = useState<CronPresetValue>('daily-7am')
+  const [cron, setCron] = useState<string>(cronPresets[0].cron ?? '0 7 * * *')
+  const [cronError, setCronError] = useState<string | null>(null)
+  const [maxIterations, setMaxIterations] = useState('')
+  const [expiresAt, setExpiresAt] = useState('')
+
   const pickAgent = (id: string) => {
     setAgentID(id)
     const agent = agents.find((a) => a.id === id)
@@ -55,7 +70,26 @@ export function NewMissionDialog({
     }
   }
 
-  const canSubmit = goal.trim() !== '' && (kind !== 'coding' || repoPath.trim() !== '')
+  const pickPreset = (v: CronPresetValue) => {
+    setPreset(v)
+    const found = cronPresets.find((p) => p.value === v)
+    if (found?.cron) setCron(found.cron)
+  }
+
+  // A client-side 5-field shape check only — the server is the
+  // authoritative cron validator (robfig/cron), this just catches
+  // obvious typos before a round trip.
+  const validCronShape = (v: string) => v.trim().split(/\s+/).length === 5
+
+  const onCronChange = (v: string) => {
+    setCron(v)
+    setCronError(null)
+  }
+
+  const canSubmit =
+    goal.trim() !== '' &&
+    (kind !== 'coding' || repoPath.trim() !== '') &&
+    (!repeat || validCronShape(cron))
 
   const reset = () => {
     setGoal('')
@@ -68,28 +102,69 @@ export function NewMissionDialog({
     setEscalationRoute('')
     setBudget('')
     setAutoApproveSafe(true)
+    setRepeat(false)
+    setScheduleName('')
+    setPreset('daily-7am')
+    setCron(cronPresets[0].cron ?? '0 7 * * *')
+    setCronError(null)
+    setMaxIterations('')
+    setExpiresAt('')
   }
 
-  const submit = async () => {
-    setBusy(true)
-    try {
-      const { id } = await createMission({
+  const submitMission = async () => {
+    const { id } = await createMission({
+      goal: goal.trim(),
+      kind,
+      agent_id: agentID || undefined,
+      route: route || undefined,
+      review_route: reviewRoute || undefined,
+      escalation_route: escalationRoute || undefined,
+      budget_usd: budget ? Number(budget) : undefined,
+      repo_path: kind === 'coding' ? repoPath.trim() : undefined,
+      auto_approve_safe: autoApproveSafe,
+    })
+    toast.success('Mission created')
+    onCreated(id)
+  }
+
+  const submitSchedule = async () => {
+    await createSchedule({
+      name: slugify(scheduleName || goal),
+      cron,
+      mission_template: {
         goal: goal.trim(),
         kind,
         agent_id: agentID || undefined,
         route: route || undefined,
         review_route: reviewRoute || undefined,
-        escalation_route: escalationRoute || undefined,
+        max_iterations: maxIterations ? Number(maxIterations) : undefined,
         budget_usd: budget ? Number(budget) : undefined,
-        repo_path: kind === 'coding' ? repoPath.trim() : undefined,
         auto_approve_safe: autoApproveSafe,
-      })
-      toast.success('Mission created')
+      },
+      expires_at: expiresAt ? new Date(expiresAt).toISOString() : undefined,
+    })
+    toast.success('Schedule created')
+    onScheduled?.()
+  }
+
+  const submit = async () => {
+    if (repeat && !validCronShape(cron)) {
+      setCronError('Cron must have 5 space-separated fields (minute hour day month weekday).')
+      return
+    }
+    setBusy(true)
+    try {
+      if (repeat) {
+        await submitSchedule()
+      } else {
+        await submitMission()
+      }
       reset()
       onOpenChange(false)
-      onCreated(id)
     } catch (err) {
-      toast.error('Could not create mission', { description: errText(err) })
+      toast.error(repeat ? 'Could not create schedule' : 'Could not create mission', {
+        description: errText(err),
+      })
     } finally {
       setBusy(false)
     }
@@ -125,15 +200,21 @@ export function NewMissionDialog({
               </SelectTrigger>
               <SelectContent>
                 {kinds.map((k) => (
-                  <SelectItem key={k.value} value={k.value}>
+                  <SelectItem key={k.value} value={k.value} disabled={repeat && k.value === 'coding'}>
                     {k.label}
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
+            {repeat && (
+              <p className="text-xs text-muted-foreground">
+                Coding missions aren't supported on a recurring schedule yet — each fire has no
+                repository to work in.
+              </p>
+            )}
           </div>
 
-          {kind === 'coding' && (
+          {kind === 'coding' && !repeat && (
             <div className="space-y-1.5">
               <Label htmlFor="mission-repo">Repository path</Label>
               <Input
@@ -160,6 +241,90 @@ export function NewMissionDialog({
                   ))}
                 </SelectContent>
               </Select>
+            </div>
+          )}
+
+          <label htmlFor="mission-repeat" className="flex items-start gap-2 text-sm">
+            <input
+              id="mission-repeat"
+              type="checkbox"
+              checked={repeat}
+              onChange={(e) => {
+                setRepeat(e.target.checked)
+                if (e.target.checked && kind === 'coding') setKind('research')
+              }}
+              className="mt-0.5"
+            />
+            <span>
+              Repeat on schedule
+              <span className="block text-xs text-muted-foreground">
+                Fires this mission on a cron schedule instead of running it once.
+              </span>
+            </span>
+          </label>
+
+          {repeat && (
+            <div className="space-y-3 rounded-lg border border-border p-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="mission-schedule-name">Schedule name</Label>
+                <Input
+                  id="mission-schedule-name"
+                  value={scheduleName}
+                  onChange={(e) => setScheduleName(e.target.value)}
+                  placeholder={slugify(goal) || 'schedule name'}
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label>Runs</Label>
+                <Select value={preset} onValueChange={(v) => pickPreset(v as CronPresetValue)}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {cronPresets.map((p) => (
+                      <SelectItem key={p.value} value={p.value}>
+                        {p.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {preset === 'custom' && (
+                  <Input
+                    aria-label="Cron expression"
+                    value={cron}
+                    onChange={(e) => onCronChange(e.target.value)}
+                    placeholder="0 7 * * *"
+                    className="font-mono"
+                  />
+                )}
+                {cronError && <p className="text-xs text-destructive">{cronError}</p>}
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="mission-max-iterations">Max iterations</Label>
+                <Input
+                  id="mission-max-iterations"
+                  type="number"
+                  value={maxIterations}
+                  onChange={(e) => setMaxIterations(e.target.value)}
+                  placeholder="Default"
+                />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="mission-expires">Expires</Label>
+                <Input
+                  id="mission-expires"
+                  type="datetime-local"
+                  value={expiresAt}
+                  onChange={(e) => setExpiresAt(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Server time — the schedule stops firing after this moment. Empty means it never
+                  expires.
+                </p>
+              </div>
             </div>
           )}
 
@@ -191,15 +356,17 @@ export function NewMissionDialog({
                   placeholder="default"
                 />
               </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="mission-escalation-route">Escalation route</Label>
-                <Input
-                  id="mission-escalation-route"
-                  value={escalationRoute}
-                  onChange={(e) => setEscalationRoute(e.target.value)}
-                  placeholder="Off — set to switch route after a failed or reworked turn"
-                />
-              </div>
+              {!repeat && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="mission-escalation-route">Escalation route</Label>
+                  <Input
+                    id="mission-escalation-route"
+                    value={escalationRoute}
+                    onChange={(e) => setEscalationRoute(e.target.value)}
+                    placeholder="Off — set to switch route after a failed or reworked turn"
+                  />
+                </div>
+              )}
               <div className="space-y-1.5">
                 <Label htmlFor="mission-budget">Budget (USD)</Label>
                 <Input
@@ -235,7 +402,7 @@ export function NewMissionDialog({
             Cancel
           </Button>
           <Button disabled={!canSubmit || busy} onClick={() => void submit()}>
-            Create mission
+            {repeat ? 'Create schedule' : 'Create mission'}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/web/src/components/missions/RecurringSchedules.test.tsx
+++ b/web/src/components/missions/RecurringSchedules.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Schedule } from '../../api/types'
+import { RecurringSchedules } from './RecurringSchedules'
+
+vi.mock('../../api/client', () => ({
+  listSchedules: vi.fn(),
+  createSchedule: vi.fn(),
+  patchSchedule: vi.fn(),
+  deleteSchedule: vi.fn(),
+  listAgents: vi.fn(),
+}))
+
+import { deleteSchedule, listAgents, listSchedules, patchSchedule } from '../../api/client'
+
+const schedule: Schedule = {
+  id: 's1',
+  name: 'weekly-digest',
+  cron: '0 8 * * 1-5',
+  mission_template: { goal: 'Summarize the week', kind: 'research', auto_approve_safe: true },
+  enabled: true,
+  next_run: '2026-07-27T08:00:00Z',
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+}
+
+function renderList() {
+  return render(
+    <MemoryRouter>
+      <RecurringSchedules />
+    </MemoryRouter>,
+  )
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  vi.clearAllMocks()
+  vi.mocked(listSchedules).mockResolvedValue([])
+  vi.mocked(listAgents).mockResolvedValue([])
+})
+
+describe('RecurringSchedules', () => {
+  it('renders nothing when there are no schedules', async () => {
+    const { container } = renderList()
+    await waitFor(() => expect(listSchedules).toHaveBeenCalled())
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('lists schedules with cron description and next run', async () => {
+    vi.mocked(listSchedules).mockResolvedValue([schedule])
+    renderList()
+    expect(await screen.findByText('weekly-digest')).toBeTruthy()
+    expect(screen.getByText('Weekdays, 8:00 AM')).toBeTruthy()
+  })
+
+  it('toggles enabled optimistically', async () => {
+    vi.mocked(listSchedules).mockResolvedValue([schedule])
+    vi.mocked(patchSchedule).mockResolvedValue({ ...schedule, enabled: false })
+    renderList()
+    await screen.findByText('weekly-digest')
+
+    fireEvent.click(screen.getByRole('switch', { name: 'weekly-digest enabled' }))
+    await waitFor(() => expect(patchSchedule).toHaveBeenCalledWith('s1', { enabled: false }))
+  })
+
+  it('deletes a schedule after confirming', async () => {
+    vi.mocked(listSchedules).mockResolvedValue([schedule])
+    vi.mocked(deleteSchedule).mockResolvedValue()
+    renderList()
+    await screen.findByText('weekly-digest')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete weekly-digest' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(deleteSchedule).toHaveBeenCalledWith('s1'))
+  })
+})

--- a/web/src/components/missions/RecurringSchedules.tsx
+++ b/web/src/components/missions/RecurringSchedules.tsx
@@ -1,0 +1,135 @@
+import { Delete02Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { deleteSchedule, patchSchedule, listSchedules } from '../../api/client'
+import type { Schedule } from '../../api/types'
+import { describeCron } from '../../lib/schedules'
+import { ScheduleDialog } from '../schedules/ScheduleDialog'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+import { Toggle } from '../settings/shared'
+import { errText } from '../settings/util'
+
+function formatDate(v?: string): string {
+  if (!v) return '—'
+  return new Date(v).toLocaleString()
+}
+
+// RecurringSchedules lists the recurring missions created via
+// NewMissionDialog's "Repeat on schedule" toggle — rendered on the
+// Missions page between the notifications strip and the mission grid,
+// only when at least one schedule exists.
+export function RecurringSchedules() {
+  const [schedules, setSchedules] = useState<Schedule[]>([])
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editing, setEditing] = useState<Schedule | undefined>(undefined)
+  const [confirmDelete, setConfirmDelete] = useState<Schedule | null>(null)
+
+  const refresh = useCallback(() => {
+    listSchedules()
+      .then(setSchedules)
+      .catch((err: unknown) => toast.error('Could not load schedules', { description: errText(err) }))
+  }, [])
+  useEffect(refresh, [refresh])
+
+  const toggle = (sc: Schedule, enabled: boolean) => {
+    setSchedules((prev) => prev.map((s) => (s.id === sc.id ? { ...s, enabled } : s))) // optimistic
+    patchSchedule(sc.id, { enabled }).then(refresh, (err: unknown) => {
+      toast.error('Could not update schedule', { description: errText(err) })
+      refresh()
+    })
+  }
+
+  const openEdit = (sc: Schedule) => {
+    setEditing(sc)
+    setDialogOpen(true)
+  }
+
+  const remove = async () => {
+    if (!confirmDelete) return
+    try {
+      await deleteSchedule(confirmDelete.id)
+      toast.success('Schedule removed')
+      setConfirmDelete(null)
+      refresh()
+    } catch (err) {
+      toast.error('Could not remove schedule', { description: errText(err) })
+      setConfirmDelete(null)
+    }
+  }
+
+  if (schedules.length === 0) return null
+
+  return (
+    <div className="mt-4 space-y-3">
+      <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Recurring · {schedules.length}
+      </h2>
+      <div className="space-y-3">
+        {schedules.map((sc) => (
+          <div
+            key={sc.id}
+            className="flex items-center gap-4 rounded-xl border border-border bg-card p-4"
+          >
+            <div className="min-w-0 flex-1">
+              <span className="truncate text-sm font-semibold">{sc.name}</span>
+              <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
+                {sc.mission_template.goal}
+              </p>
+              <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+                <span>{describeCron(sc.cron)}</span>
+                <span>next run {formatDate(sc.next_run)}</span>
+                {sc.last_run && <span>last run {formatDate(sc.last_run)}</span>}
+              </div>
+            </div>
+            <Toggle on={sc.enabled} onChange={(v) => toggle(sc, v)} label={`${sc.name} enabled`} />
+            <Button size="sm" variant="outline" onClick={() => openEdit(sc)}>
+              Edit
+            </Button>
+            <button
+              type="button"
+              aria-label={`Delete ${sc.name}`}
+              onClick={() => setConfirmDelete(sc)}
+              className="text-muted-foreground hover:text-destructive"
+            >
+              <HugeiconsIcon icon={Delete02Icon} className="size-4" />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <ScheduleDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        schedule={editing}
+        onSaved={refresh}
+      />
+
+      <Dialog open={confirmDelete !== null} onOpenChange={(o) => !o && setConfirmDelete(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete {confirmDelete?.name}?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            This schedule stops firing. Missions it already created keep their history.
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmDelete(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={() => void remove()}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/web/src/components/schedules/ScheduleDialog.tsx
+++ b/web/src/components/schedules/ScheduleDialog.tsx
@@ -1,0 +1,310 @@
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { patchSchedule } from '../../api/client'
+import type { AdminAgent, Schedule } from '../../api/types'
+import { slugify } from '../settings/AgentForm'
+import { errText } from '../settings/util'
+import { useAgents } from '../AgentPicker'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { Textarea } from '../ui/textarea'
+import { cronPresets, type CronPresetValue, presetFor } from '../../lib/schedules'
+
+// ScheduleDialog edits an existing recurring schedule — creation now
+// happens from NewMissionDialog's "Repeat on schedule" toggle, so this
+// dialog no longer has a create path or a kind field of its own: it
+// preserves whatever kind the schedule's mission_template already
+// carries.
+export function ScheduleDialog({
+  open,
+  onOpenChange,
+  schedule,
+  onSaved,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  schedule?: Schedule
+  onSaved: (sc: { id: string }) => void
+}) {
+  const agents = useAgents()
+
+  const [name, setName] = useState('')
+  const [cron, setCron] = useState('')
+  const [preset, setPreset] = useState<CronPresetValue>('daily-7am')
+  const [goal, setGoal] = useState('')
+  const [agentID, setAgentID] = useState('')
+  const [autoApproveSafe, setAutoApproveSafe] = useState(true)
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [route, setRoute] = useState('')
+  const [reviewRoute, setReviewRoute] = useState('')
+  const [maxIterations, setMaxIterations] = useState('')
+  const [budget, setBudget] = useState('')
+  const [expiresAt, setExpiresAt] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [cronError, setCronError] = useState<string | null>(null)
+
+  // Re-seed the form every time the dialog opens fresh from the
+  // schedule being edited.
+  useEffect(() => {
+    if (!open || !schedule) return
+    setName(schedule.name)
+    setCron(schedule.cron)
+    setPreset(presetFor(schedule.cron))
+    setGoal(schedule.mission_template.goal)
+    setAgentID(schedule.mission_template.agent_id ?? '')
+    setAutoApproveSafe(schedule.mission_template.auto_approve_safe ?? true)
+    setShowAdvanced(false)
+    setRoute(schedule.mission_template.route ?? '')
+    setReviewRoute(schedule.mission_template.review_route ?? '')
+    setMaxIterations(
+      schedule.mission_template.max_iterations != null
+        ? String(schedule.mission_template.max_iterations)
+        : '',
+    )
+    setBudget(
+      schedule.mission_template.budget_usd != null ? String(schedule.mission_template.budget_usd) : '',
+    )
+    setExpiresAt(schedule.expires_at ? schedule.expires_at.slice(0, 16) : '')
+    setCronError(null)
+  }, [open, schedule])
+
+  const pickAgent = (id: string) => {
+    setAgentID(id)
+    const agent = agents.find((a) => a.id === id)
+    if (agent) {
+      setReviewRoute(agent.review_route ?? '')
+      if (agent.budget_usd != null) setBudget(String(agent.budget_usd))
+    }
+  }
+
+  const pickPreset = (v: CronPresetValue) => {
+    setPreset(v)
+    const found = cronPresets.find((p) => p.value === v)
+    if (found?.cron) setCron(found.cron)
+  }
+
+  // A client-side 5-field shape check only — the server is the
+  // authoritative cron validator (robfig/cron), this just catches
+  // obvious typos before a round trip.
+  const validCronShape = (v: string) => v.trim().split(/\s+/).length === 5
+
+  const onCronChange = (v: string) => {
+    setCron(v)
+    setCronError(null)
+  }
+
+  const canSubmit = name.trim() !== '' && goal.trim() !== '' && validCronShape(cron)
+
+  const submit = async () => {
+    if (!schedule) return
+    if (!validCronShape(cron)) {
+      setCronError('Cron must have 5 space-separated fields (minute hour day month weekday).')
+      return
+    }
+    setBusy(true)
+    try {
+      const missionTemplate = {
+        goal: goal.trim(),
+        kind: schedule.mission_template.kind,
+        agent_id: agentID || undefined,
+        route: route || undefined,
+        review_route: reviewRoute || undefined,
+        max_iterations: maxIterations ? Number(maxIterations) : undefined,
+        budget_usd: budget ? Number(budget) : undefined,
+        auto_approve_safe: autoApproveSafe,
+      }
+      const sc = await patchSchedule(schedule.id, {
+        name: slugify(name),
+        cron,
+        mission_template: missionTemplate,
+        expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
+      })
+      toast.success('Schedule updated')
+      onOpenChange(false)
+      onSaved({ id: sc.id })
+    } catch (err) {
+      toast.error('Could not update schedule', { description: errText(err) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit schedule</DialogTitle>
+          <DialogDescription>
+            A recurring mission that fires on the cron below.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="schedule-name">Name</Label>
+            <Input
+              id="schedule-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="daily-briefing"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Runs</Label>
+            <Select value={preset} onValueChange={(v) => pickPreset(v as CronPresetValue)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {cronPresets.map((p) => (
+                  <SelectItem key={p.value} value={p.value}>
+                    {p.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {preset === 'custom' && (
+              <Input
+                aria-label="Cron expression"
+                value={cron}
+                onChange={(e) => onCronChange(e.target.value)}
+                placeholder="0 7 * * *"
+                className="font-mono"
+              />
+            )}
+            {cronError && <p className="text-xs text-destructive">{cronError}</p>}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="schedule-goal">Goal</Label>
+            <Textarea
+              id="schedule-goal"
+              value={goal}
+              onChange={(e) => setGoal(e.target.value)}
+              placeholder="What should this mission accomplish each time it fires?"
+              rows={3}
+            />
+          </div>
+
+          {agents.length > 0 && (
+            <div className="space-y-1.5">
+              <Label>Agent</Label>
+              <Select value={agentID} onValueChange={pickAgent}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Default" />
+                </SelectTrigger>
+                <SelectContent>
+                  {agents.map((a: AdminAgent) => (
+                    <SelectItem key={a.id} value={a.id}>
+                      {a.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={() => setShowAdvanced((v) => !v)}
+            className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+          >
+            {showAdvanced ? 'Hide advanced options' : 'Show advanced options'}
+          </button>
+
+          {showAdvanced && (
+            <div className="space-y-3 rounded-lg border border-border p-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="schedule-route">Route</Label>
+                <Input
+                  id="schedule-route"
+                  value={route}
+                  onChange={(e) => setRoute(e.target.value)}
+                  placeholder="default"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="schedule-review-route">Review route</Label>
+                <Input
+                  id="schedule-review-route"
+                  value={reviewRoute}
+                  onChange={(e) => setReviewRoute(e.target.value)}
+                  placeholder="default"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="schedule-max-iterations">Max iterations</Label>
+                <Input
+                  id="schedule-max-iterations"
+                  type="number"
+                  value={maxIterations}
+                  onChange={(e) => setMaxIterations(e.target.value)}
+                  placeholder="Default"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="schedule-budget">Budget (USD)</Label>
+                <Input
+                  id="schedule-budget"
+                  type="number"
+                  value={budget}
+                  onChange={(e) => setBudget(e.target.value)}
+                  placeholder="No limit"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="schedule-expires">Expires</Label>
+                <Input
+                  id="schedule-expires"
+                  type="datetime-local"
+                  value={expiresAt}
+                  onChange={(e) => setExpiresAt(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Server time — the schedule stops firing after this moment. Empty means it never
+                  expires.
+                </p>
+              </div>
+              <label htmlFor="schedule-auto-approve" className="flex items-start gap-2 text-sm">
+                <input
+                  id="schedule-auto-approve"
+                  type="checkbox"
+                  checked={autoApproveSafe}
+                  onChange={(e) => setAutoApproveSafe(e.target.checked)}
+                  className="mt-0.5"
+                />
+                <span>
+                  Auto-approve safe tool calls
+                  <span className="block text-xs text-muted-foreground">
+                    Runs unattended without pausing for approval on routine commands. Destructive
+                    or unrecognized commands still always ask.
+                  </span>
+                </span>
+              </label>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" disabled={busy} onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button disabled={!canSubmit || busy} onClick={() => void submit()}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/src/components/settings/FeaturesTab.tsx
+++ b/web/src/components/settings/FeaturesTab.tsx
@@ -26,7 +26,7 @@ const featureCopy: Record<string, { label: string; description: string }> = {
   },
   scheduler_enabled: {
     label: 'Scheduler',
-    description: 'Stored now; gains a consumer when the agent harness lands.',
+    description: 'Off: recurring schedules stop firing missions.',
   },
 }
 

--- a/web/src/lib/schedules.test.ts
+++ b/web/src/lib/schedules.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { cronPresets, describeCron, presetFor } from './schedules'
+
+describe('presetFor', () => {
+  it('round-trips every non-custom preset cron back to its preset value', () => {
+    for (const preset of cronPresets) {
+      if (preset.cron === null) continue
+      expect(presetFor(preset.cron)).toBe(preset.value)
+    }
+  })
+
+  it('falls back to custom for an unrecognized cron', () => {
+    expect(presetFor('*/5 * * * *')).toBe('custom')
+  })
+})
+
+describe('describeCron', () => {
+  it('describes a known preset in plain English', () => {
+    expect(describeCron('0 7 * * *')).toBe('Daily, 7:00 AM')
+  })
+
+  it('shows an unrecognized cron verbatim', () => {
+    expect(describeCron('*/5 * * * *')).toBe('*/5 * * * *')
+  })
+})

--- a/web/src/lib/schedules.ts
+++ b/web/src/lib/schedules.ts
@@ -1,0 +1,28 @@
+// cronPresets covers the common recurring shapes the schedule dialog
+// offers directly; 'custom' has no cron value of its own — it means
+// "let the user type one," matched last by presetFor.
+export const cronPresets = [
+  { value: 'daily-7am', label: 'Daily, 7:00 AM', cron: '0 7 * * *' },
+  { value: 'weekdays-8am', label: 'Weekdays, 8:00 AM', cron: '0 8 * * 1-5' },
+  { value: 'hourly', label: 'Hourly', cron: '0 * * * *' },
+  { value: 'custom', label: 'Custom', cron: null },
+] as const
+
+export type CronPresetValue = (typeof cronPresets)[number]['value']
+
+// presetFor maps a stored cron expression back to the preset that
+// produced it, so editing a schedule reopens the same preset it was
+// created with rather than always falling back to "Custom".
+export function presetFor(cron: string): CronPresetValue {
+  const match = cronPresets.find((p) => p.cron === cron)
+  return match?.value ?? 'custom'
+}
+
+// describeCron renders a cron expression as plain English for the
+// handful of shapes this UI ever produces; anything else is shown
+// verbatim (still valid cron, just not one of our presets).
+export function describeCron(cron: string): string {
+  const preset = cronPresets.find((p) => p.cron === cron)
+  if (preset) return preset.label
+  return cron
+}

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../api/client', () => ({
   cancelMission: vi.fn(),
   answerMissionPermission: vi.fn(),
   listMissionFiles: vi.fn(),
+  listSchedules: vi.fn(),
   pushMission: vi.fn(),
   downloadMissionFile: vi.fn(),
   downloadMissionArchive: vi.fn(),
@@ -27,6 +28,7 @@ import {
   getMission,
   listConnectors,
   listMissionFiles,
+  listSchedules,
   missionEvents,
   missionUsage,
   resumeMission,
@@ -116,6 +118,7 @@ beforeEach(() => {
     models: [],
   })
   vi.mocked(listMissionFiles).mockResolvedValue({ files: [], truncated: false })
+  vi.mocked(listSchedules).mockResolvedValue([])
   vi.mocked(secretStatus).mockResolvedValue({ configured: false, backend: '' })
   vi.mocked(listConnectors).mockResolvedValue([])
 })
@@ -349,5 +352,29 @@ describe('MissionDetail', () => {
     renderPage()
     await screen.findByText('Fix the login bug')
     expect(screen.queryByText('Result')).toBeNull()
+  })
+
+  it('shows a recurring schedule strip when the mission fired from a schedule', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, schedule_id: 'sc1' })
+    vi.mocked(listSchedules).mockResolvedValue([
+      {
+        id: 'sc1',
+        name: 'daily-brief',
+        cron: '0 7 * * *',
+        mission_template: { goal: 'brief', kind: 'research' },
+        enabled: true,
+        next_run: '2026-01-02T07:00:00Z',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ])
+    renderPage()
+    expect(await screen.findByText(/Recurring · Daily, 7:00 AM · next run/)).toBeTruthy()
+  })
+
+  it('omits the recurring strip for a one-off mission', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(screen.queryByText(/Recurring ·/)).toBeNull()
   })
 })

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -7,11 +7,12 @@ import {
   answerMissionPermission,
   cancelMission,
   getMission,
+  listSchedules,
   missionEvents,
   missionUsage,
   resumeMission,
 } from '../api/client'
-import type { Mission, MissionEvent, MissionUsage } from '../api/types'
+import type { Mission, MissionEvent, MissionUsage, Schedule } from '../api/types'
 import { ArtifactsSection } from '../components/missions/ArtifactsSection'
 import { PermissionBanner } from '../components/missions/PermissionBanner'
 import { PlanSection } from '../components/missions/PlanSection'
@@ -21,7 +22,13 @@ import { TimelineSection } from '../components/missions/TimelineSection'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
 import { errText } from '../components/settings/util'
+import { describeCron } from '../lib/schedules'
 import { playAlertSound } from '../lib/alertSound'
+
+function formatDate(v?: string): string {
+  if (!v) return '—'
+  return new Date(v).toLocaleString()
+}
 
 const pollIntervalIdle = 5000
 const pollIntervalPending = 1500
@@ -34,6 +41,7 @@ export function MissionDetail() {
   const [mission, setMission] = useState<Mission | null>(null)
   const [events, setEvents] = useState<MissionEvent[]>([])
   const [usage, setUsage] = useState<MissionUsage | null>(null)
+  const [schedule, setSchedule] = useState<Schedule | null>(null)
   const [busy, setBusy] = useState(false)
   const [pushOpen, setPushOpen] = useState(false)
 
@@ -55,6 +63,20 @@ export function MissionDetail() {
     const timer = setInterval(refresh, interval)
     return () => clearInterval(timer)
   }, [refresh, pendingPermission, phase])
+
+  // No GET-by-id for schedules; the list is small, so find the one
+  // this mission fired from rather than adding a single-row endpoint.
+  const scheduleID = mission?.schedule_id
+  useEffect(() => {
+    if (!scheduleID) {
+      setSchedule(null)
+      return
+    }
+    listSchedules().then(
+      (rows) => setSchedule(rows.find((s) => s.id === scheduleID) ?? null),
+      () => undefined,
+    )
+  }, [scheduleID])
 
   // Chime only on the transition into a permission block, not on every
   // poll while it stays pending — the banner itself is the persistent
@@ -168,6 +190,11 @@ export function MissionDetail() {
             {mission.branch && (
               <p className="mt-1 text-xs text-muted-foreground">
                 {mission.branch} @ {mission.base_commit?.slice(0, 8)}
+              </p>
+            )}
+            {schedule && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                Recurring · {describeCron(schedule.cron)} · next run {formatDate(schedule.next_run)}
               </p>
             )}
             {pauseDetail && (

--- a/web/src/pages/Missions.test.tsx
+++ b/web/src/pages/Missions.test.tsx
@@ -9,10 +9,19 @@ vi.mock('../api/client', () => ({
   listNotifications: vi.fn(),
   markNotificationRead: vi.fn(),
   createMission: vi.fn(),
+  createSchedule: vi.fn(),
+  listSchedules: vi.fn(),
   listAgents: vi.fn(),
 }))
 
-import { createMission, listAgents, listMissions, listNotifications } from '../api/client'
+import {
+  createMission,
+  createSchedule,
+  listAgents,
+  listMissions,
+  listNotifications,
+  listSchedules,
+} from '../api/client'
 
 const mission: Mission = {
   id: 'm1',
@@ -47,6 +56,7 @@ beforeEach(() => {
   vi.mocked(listMissions).mockResolvedValue([mission])
   vi.mocked(listNotifications).mockResolvedValue([])
   vi.mocked(listAgents).mockResolvedValue([])
+  vi.mocked(listSchedules).mockResolvedValue([])
 })
 
 describe('Missions board', () => {
@@ -155,5 +165,84 @@ describe('Missions board', () => {
 
     fireEvent.change(screen.getByLabelText('Repository path'), { target: { value: '/workspace/repo' } })
     expect(createButton.disabled).toBe(false)
+  })
+})
+
+describe('Missions board — repeat on schedule', () => {
+  it('submits a schedule with the slugified default name, preset cron, and research kind', async () => {
+    vi.mocked(createSchedule).mockResolvedValue({ id: 'sc1' })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+
+    fireEvent.click(screen.getByRole('button', { name: 'New mission' }))
+    fireEvent.change(await screen.findByLabelText('Goal'), {
+      target: { value: 'Check the news every morning' },
+    })
+    fireEvent.click(screen.getByLabelText(/Repeat on schedule/))
+    fireEvent.click(screen.getByRole('button', { name: 'Create schedule' }))
+
+    await waitFor(() =>
+      expect(createSchedule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'check-the-news-every-morning',
+          cron: '0 7 * * *',
+          mission_template: expect.objectContaining({
+            goal: 'Check the news every morning',
+            kind: 'research',
+            auto_approve_safe: true,
+          }),
+        }),
+      ),
+    )
+    expect(createMission).not.toHaveBeenCalled()
+  })
+
+  it('disables the Coding kind while repeating', async () => {
+    Element.prototype.scrollIntoView = vi.fn()
+    renderPage()
+    await screen.findByText('Fix the login bug')
+
+    fireEvent.click(screen.getByRole('button', { name: 'New mission' }))
+    await screen.findByLabelText('Goal')
+    fireEvent.click(screen.getByLabelText(/Repeat on schedule/))
+    fireEvent.click(screen.getAllByRole('combobox')[0])
+
+    expect((await screen.findByText('Coding')).closest('[role="option"]')).toHaveAttribute(
+      'data-disabled',
+    )
+  })
+
+  it('cascades the picked agent onto review route the same as a one-off mission', async () => {
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.mocked(listAgents).mockResolvedValue([
+      {
+        id: 'a1',
+        name: 'briefing',
+        description: '',
+        prompt_overlay: '',
+        route: '',
+        skills: [],
+        tools: [],
+        memory: false,
+        is_default: false,
+        enabled: true,
+        review_route: 'careful',
+      },
+    ])
+    vi.mocked(createSchedule).mockResolvedValue({ id: 'sc1' })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+
+    fireEvent.click(screen.getByRole('button', { name: 'New mission' }))
+    fireEvent.change(await screen.findByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(screen.getByLabelText(/Repeat on schedule/))
+
+    // Combobox order: Kind, Agent, Runs (cron preset) — the agent
+    // picker is the second one once repeat is on.
+    fireEvent.click(screen.getAllByRole('combobox')[1])
+    fireEvent.click(await screen.findByText('briefing'))
+    fireEvent.click(screen.getByText('Show advanced options'))
+
+    expect((screen.getByLabelText('Review route') as HTMLInputElement).value).toBe('careful')
   })
 })

--- a/web/src/pages/Missions.tsx
+++ b/web/src/pages/Missions.tsx
@@ -6,6 +6,7 @@ import { listMissions, listNotifications, markNotificationRead } from '../api/cl
 import type { Mission, Notification } from '../api/types'
 import { MissionCard } from '../components/missions/MissionCard'
 import { NewMissionDialog } from '../components/missions/NewMissionDialog'
+import { RecurringSchedules } from '../components/missions/RecurringSchedules'
 import { Button } from '../components/ui/button'
 
 const pollInterval = 5000
@@ -15,6 +16,9 @@ export function Missions() {
   const [missions, setMissions] = useState<Mission[]>([])
   const [notifications, setNotifications] = useState<Notification[]>([])
   const [dialogOpen, setDialogOpen] = useState(false)
+  // Bumped to force RecurringSchedules to refetch after a new schedule
+  // is created from the dialog — it manages its own list internally.
+  const [schedulesVersion, setSchedulesVersion] = useState(0)
 
   const refresh = useCallback(() => {
     listMissions().then(setMissions, () => undefined)
@@ -73,6 +77,8 @@ export function Missions() {
         </div>
       )}
 
+      <RecurringSchedules key={schedulesVersion} />
+
       <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {missions.map((m) => (
           <MissionCard key={m.id} mission={m} />
@@ -88,6 +94,7 @@ export function Missions() {
         open={dialogOpen}
         onOpenChange={setDialogOpen}
         onCreated={(id) => navigate(`/missions/${id}`)}
+        onScheduled={() => setSchedulesVersion((v) => v + 1)}
       />
     </div>
   )


### PR DESCRIPTION
Missions now recur natively instead of needing a bespoke watchlist/briefing feature. A schedule row holds a cron expression plus a mission template; the scheduler resolves agent defaults at fire time, inserts a schedule-tagged mission, and the driver provisions it lazily on first touch (workspace, session, approval-allowlist grants). A schedule skips firing while one of its missions is still active, so a stuck run cannot pile up duplicates.

## Commits

1. **feat(missions)** — schedules CRUD + scheduler + lazy provisioning + seeded goal-driven briefing agent/skill (topics come from the mission goal text).
2. **fix(tools)** — approval grants now match connector-namespaced tool names by `_<name>` suffix (D-036). Found live: a scheduler-fired mission parked on `google-calendar_calendar_list_events` despite a standing `calendar_list_events` grant. `auto_approve_safe` deliberately stays shell-scoped.
3. **feat(web)** — repeat toggle in mission creation, recurring-schedules management on the Missions page, recurring indicators on cards/detail.

## Verification

- `make build test vet lint`, web build/lint/tests, `make test-integration`, `make canary`, `make canary-coding` all green.
- Live e2e: schedule fired → lazy provisioning → calendar connector tool executed with no permission park → briefing.md written → review skipped on harness evidence → mission done.

## Out of scope

- ToolAllow enforcement for mission workers.
- `repo_path`/`escalation_route` in mission templates (coding kind disabled while repeating).
- Unknown/hallucinated tool names park missions as permission asks; should fast-fail instead.
- SSE notifications for fired missions.