### PR TITLE
feat(web): group tool activity into collapsed line with detail panel

### DIFF
--- a/web/src/components/Activity.test.tsx
+++ b/web/src/components/Activity.test.tsx
@@ -1,0 +1,269 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { applyEvent, emptyAssistant, type AssistantState } from '../lib/chat'
+import type { ChatEvent } from '../api/types'
+import {
+  ActivityLine,
+  ActivityPanel,
+  formatDuration,
+  prettyArgs,
+  summarizeTools,
+  totalDuration,
+} from './Activity'
+import { Sheet } from './ui/sheet'
+
+afterEach(cleanup)
+
+function play(events: ChatEvent[]): AssistantState {
+  return events.reduce(applyEvent, emptyAssistant())
+}
+
+describe('formatDuration', () => {
+  it('renders sub-second durations in milliseconds', () => {
+    expect(formatDuration(42)).toBe('42ms')
+  })
+
+  it('renders durations of a second or more in seconds', () => {
+    expect(formatDuration(1500)).toBe('1.5s')
+  })
+})
+
+describe('prettyArgs', () => {
+  it('pretty-prints valid JSON', () => {
+    expect(prettyArgs('{"a":1}')).toBe('{\n  "a": 1\n}')
+  })
+
+  it('falls back to the raw string for invalid JSON', () => {
+    expect(prettyArgs('not json')).toBe('not json')
+  })
+})
+
+describe('totalDuration', () => {
+  it('sums the duration of every tool that reported one', () => {
+    expect(
+      totalDuration([
+        { id: 'c1', name: 'a', status: 'ok', durationMs: 10 },
+        { id: 'c2', name: 'b', status: 'ok', durationMs: 20 },
+      ]),
+    ).toBe(30)
+  })
+
+  it('treats a still-running call (no durationMs) as contributing nothing', () => {
+    expect(
+      totalDuration([
+        { id: 'c1', name: 'a', status: 'ok', durationMs: 10 },
+        { id: 'c2', name: 'b', status: 'running' },
+      ]),
+    ).toBe(10)
+  })
+})
+
+describe('summarizeTools', () => {
+  it('dedupes by first appearance and counts repeats', () => {
+    expect(
+      summarizeTools([
+        { id: 'c1', name: 'web_search', status: 'ok' },
+        { id: 'c2', name: 'web_search', status: 'ok' },
+        { id: 'c3', name: 'web_fetch', status: 'ok' },
+      ]),
+    ).toBe('2× web_search, web_fetch')
+  })
+
+  it('caps at three names and folds the rest into a "+N more"', () => {
+    expect(
+      summarizeTools([
+        { id: 'c1', name: 'a', status: 'ok' },
+        { id: 'c2', name: 'b', status: 'ok' },
+        { id: 'c3', name: 'c', status: 'ok' },
+        { id: 'c4', name: 'd', status: 'ok' },
+        { id: 'c5', name: 'e', status: 'ok' },
+      ]),
+    ).toBe('a, b, c, +2 more')
+  })
+})
+
+describe('ActivityLine', () => {
+  it('renders nothing for a turn with no tools and no reasoning', () => {
+    const msg = play([{ type: 'chunk', text: 'hi' }, { type: 'meta', session_id: 's' }])
+    render(<ActivityLine msg={msg} onOpen={vi.fn()} />)
+    expect(screen.queryByTestId('activity-line')).not.toBeInTheDocument()
+  })
+
+  it('shows "Running <name>…" while a tool is in flight mid-stream', () => {
+    const msg = play([{ type: 'tool_start', tool_call: { id: 'c1', name: 'shell' } }])
+    render(<ActivityLine msg={msg} onOpen={vi.fn()} />)
+    expect(screen.getByTestId('activity-line')).toHaveTextContent('Running shell…')
+  })
+
+  it('shows "Thinking…" while streaming with only reasoning so far', () => {
+    const msg = play([{ type: 'reasoning_chunk', text: 'hmm' }])
+    render(<ActivityLine msg={msg} onOpen={vi.fn()} />)
+    expect(screen.getByTestId('activity-line')).toHaveTextContent('Thinking…')
+  })
+
+  it('shows "Worked for <duration> · <summary>" once done', () => {
+    const msg = play([
+      { type: 'tool_start', tool_call: { id: 'c1', name: 'shell' } },
+      { type: 'tool_result', tool_result: { id: 'c1', name: 'shell', status: 'ok', duration_ms: 42 } },
+      { type: 'meta', session_id: 's' },
+    ])
+    render(<ActivityLine msg={msg} onOpen={vi.fn()} />)
+    expect(screen.getByTestId('activity-line')).toHaveTextContent('Worked for 42ms · shell')
+  })
+
+  it('falls back to "Ran <n> tools" when the total duration is zero', () => {
+    const msg = play([
+      { type: 'tool_start', tool_call: { id: 'c1', name: 'shell' } },
+      { type: 'tool_result', tool_result: { id: 'c1', name: 'shell', status: 'ok', duration_ms: 0 } },
+      { type: 'meta', session_id: 's' },
+    ])
+    render(<ActivityLine msg={msg} onOpen={vi.fn()} />)
+    expect(screen.getByTestId('activity-line')).toHaveTextContent('Ran 1 tools · shell')
+  })
+
+  it('shows "Reasoning" once done with reasoning but no tools', () => {
+    const msg = play([
+      { type: 'reasoning_chunk', text: 'hmm' },
+      { type: 'chunk', text: 'answer' },
+      { type: 'meta', session_id: 's' },
+    ])
+    render(<ActivityLine msg={msg} onOpen={vi.fn()} />)
+    expect(screen.getByTestId('activity-line')).toHaveTextContent('Reasoning')
+  })
+
+  it('shows a red dot when any tool errored', () => {
+    const msg = play([
+      { type: 'tool_start', tool_call: { id: 'c1', name: 'shell' } },
+      { type: 'tool_result', tool_result: { id: 'c1', name: 'shell', status: 'error', duration_ms: 5 } },
+      { type: 'meta', session_id: 's' },
+    ])
+    const { container } = render(<ActivityLine msg={msg} onOpen={vi.fn()} />)
+    expect(container.querySelector('.bg-red-500')).not.toBeNull()
+  })
+
+  it('shows an amber dot when any tool was denied', () => {
+    const msg = play([
+      { type: 'tool_start', tool_call: { id: 'c1', name: 'shell' } },
+      { type: 'tool_result', tool_result: { id: 'c1', name: 'shell', status: 'denied', duration_ms: 5 } },
+      { type: 'meta', session_id: 's' },
+    ])
+    const { container } = render(<ActivityLine msg={msg} onOpen={vi.fn()} />)
+    expect(container.querySelector('.bg-amber-500')).not.toBeNull()
+  })
+
+  it('calls onOpen when clicked', () => {
+    const msg = play([
+      { type: 'tool_start', tool_call: { id: 'c1', name: 'shell' } },
+      { type: 'tool_result', tool_result: { id: 'c1', name: 'shell', status: 'ok', duration_ms: 5 } },
+      { type: 'meta', session_id: 's' },
+    ])
+    const onOpen = vi.fn()
+    render(<ActivityLine msg={msg} onOpen={onOpen} />)
+    fireEvent.click(screen.getByTestId('activity-line'))
+    expect(onOpen).toHaveBeenCalledOnce()
+  })
+})
+
+describe('ActivityPanel', () => {
+  it('renders reasoning and every tool call with status, duration, args, and digest', () => {
+    const msg = play([
+      { type: 'reasoning_chunk', text: 'thinking it through' },
+      { type: 'tool_start', tool_call: { id: 'c1', name: 'shell' } },
+      { type: 'tool_end', tool_call: { id: 'c1', name: 'shell', input: { command: 'ls' } } },
+      {
+        type: 'tool_result',
+        tool_result: { id: 'c1', name: 'shell', status: 'ok', digest: 'notes.md', duration_ms: 42 },
+      },
+      { type: 'meta', session_id: 's' },
+    ])
+    render(
+      <Sheet open>
+        <ActivityPanel msg={msg} />
+      </Sheet>,
+    )
+    expect(screen.getByText('Activity')).toBeInTheDocument()
+    expect(screen.getByText('thinking it through')).toBeInTheDocument()
+    expect(screen.getByTestId('tool-status')).toHaveTextContent('ok')
+    expect(screen.getByText('notes.md')).toBeInTheDocument()
+    expect(screen.getByText('42ms')).toBeInTheDocument()
+  })
+
+  it('pretty-prints args as JSON', () => {
+    const msg = play([
+      { type: 'tool_start', tool_call: { id: 'c1', name: 'shell' } },
+      { type: 'tool_end', tool_call: { id: 'c1', name: 'shell', input: { command: 'ls' } } },
+      { type: 'tool_result', tool_result: { id: 'c1', name: 'shell', status: 'ok', duration_ms: 1 } },
+    ])
+    render(
+      <Sheet open>
+        <ActivityPanel msg={msg} />
+      </Sheet>,
+    )
+    expect(screen.getByText(/"command": "ls"/)).toBeInTheDocument()
+  })
+
+  it('shows a running badge for a tool honestly left running (e.g. an aborted turn)', () => {
+    const msg = play([{ type: 'tool_start', tool_call: { id: 'c1', name: 'shell' } }])
+    render(
+      <Sheet open>
+        <ActivityPanel msg={msg} />
+      </Sheet>,
+    )
+    expect(screen.getByTestId('tool-status')).toHaveTextContent('running…')
+  })
+
+  it('copies the reasoning text', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+
+    const msg = play([{ type: 'reasoning_chunk', text: 'the reasoning' }])
+    render(
+      <Sheet open>
+        <ActivityPanel msg={msg} />
+      </Sheet>,
+    )
+    fireEvent.click(screen.getByLabelText('Copy reasoning'))
+    expect(writeText).toHaveBeenCalledWith('the reasoning')
+    vi.unstubAllGlobals()
+  })
+
+  it('copies a tool result digest', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+
+    const msg = play([
+      { type: 'tool_start', tool_call: { id: 'c1', name: 'shell' } },
+      {
+        type: 'tool_result',
+        tool_result: { id: 'c1', name: 'shell', status: 'ok', digest: 'the digest', duration_ms: 1 },
+      },
+    ])
+    render(
+      <Sheet open>
+        <ActivityPanel msg={msg} />
+      </Sheet>,
+    )
+    fireEvent.click(screen.getByLabelText('Copy tool response'))
+    expect(writeText).toHaveBeenCalledWith('the digest')
+    vi.unstubAllGlobals()
+  })
+
+  it('shows the tool count and total duration in the header', () => {
+    const msg = play([
+      { type: 'tool_start', tool_call: { id: 'c1', name: 'shell' } },
+      { type: 'tool_result', tool_result: { id: 'c1', name: 'shell', status: 'ok', duration_ms: 42 } },
+      { type: 'tool_start', tool_call: { id: 'c2', name: 'web_search' } },
+      {
+        type: 'tool_result',
+        tool_result: { id: 'c2', name: 'web_search', status: 'ok', duration_ms: 58 },
+      },
+      { type: 'meta', session_id: 's' },
+    ])
+    render(
+      <Sheet open>
+        <ActivityPanel msg={msg} />
+      </Sheet>,
+    )
+    expect(screen.getByText('2 tools · 100ms')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/Activity.tsx
+++ b/web/src/components/Activity.tsx
@@ -1,0 +1,169 @@
+import { WrenchIcon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { Badge } from './ui/badge'
+import { SheetContent, SheetHeader, SheetTitle } from './ui/sheet'
+import { CopyButton } from './Message'
+import type { AssistantState, ToolRun } from '../lib/chat'
+
+// formatDuration renders a tool call's wall time compactly: sub-second
+// as milliseconds, otherwise one decimal of seconds.
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+// prettyArgs pretty-prints a tool call's JSON args; malformed or
+// non-JSON input renders raw rather than throwing.
+export function prettyArgs(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2)
+  } catch {
+    return raw
+  }
+}
+
+// totalDuration sums the wall time of every tool call that reported
+// one. Calls still running (no durationMs yet) contribute nothing —
+// an honest "0" rather than a guess is the caller's job to phrase.
+export function totalDuration(tools: ToolRun[]): number {
+  return tools.reduce((sum, t) => sum + (t.durationMs ?? 0), 0)
+}
+
+// summarizeTools names what a turn did, deduped by first appearance
+// and capped so a turn with a dozen tool calls still reads as one
+// line: "web_search, 2× web_fetch, +2 more".
+export function summarizeTools(tools: ToolRun[]): string {
+  const order: string[] = []
+  const counts = new Map<string, number>()
+  for (const t of tools) {
+    if (!counts.has(t.name)) order.push(t.name)
+    counts.set(t.name, (counts.get(t.name) ?? 0) + 1)
+  }
+  const names = order.map((name) => {
+    const n = counts.get(name) ?? 1
+    return n > 1 ? `${n}× ${name}` : name
+  })
+  if (names.length <= 3) return names.join(', ')
+  return `${names.slice(0, 3).join(', ')}, +${names.length - 3} more`
+}
+
+const statusStyles: Record<ToolRun['status'], string> = {
+  running: 'border-blue-500/40 bg-blue-500/10 text-blue-600 dark:text-blue-400',
+  ok: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  error: 'border-red-500/40 bg-red-500/10 text-red-600 dark:text-red-400',
+  denied: 'border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400',
+}
+
+// ActivityLine is the collapsed, inline summary of a turn's reasoning
+// and tool calls — a thin button, not a card, that opens the detail
+// panel. It renders only when there is something to summarize.
+export function ActivityLine({ msg, onOpen }: { msg: AssistantState; onOpen: () => void }) {
+  if (msg.tools.length === 0 && msg.reasoning === '') return null
+
+  const hasError = msg.tools.some((t) => t.status === 'error')
+  const hasDenied = msg.tools.some((t) => t.status === 'denied')
+  const running = msg.tools.find((t) => t.status === 'running')
+
+  let label: string
+  if (msg.streaming && running) label = `Running ${running.name}…`
+  else if (msg.streaming) label = 'Thinking…'
+  else if (msg.tools.length > 0) {
+    const sum = totalDuration(msg.tools)
+    const prefix =
+      sum > 0 ? `Worked for ${formatDuration(sum)}` : `Ran ${msg.tools.length} tools`
+    label = `${prefix} · ${summarizeTools(msg.tools)}`
+  } else label = 'Reasoning'
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      data-testid="activity-line"
+      className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+    >
+      {msg.streaming && (
+        <span className="size-1.5 animate-pulse rounded-full bg-blue-500" aria-hidden />
+      )}
+      {hasError && <span className="size-1.5 rounded-full bg-red-500" aria-hidden />}
+      {!hasError && hasDenied && <span className="size-1.5 rounded-full bg-amber-500" aria-hidden />}
+      {label}
+    </button>
+  )
+}
+
+// ToolCallRow renders one call's full detail: name, status, duration,
+// pretty-printed args, and the result digest — each copyable. Raw
+// tool results never reach the browser; the digest is all there is.
+function ToolCallRow({ tool }: { tool: ToolRun }) {
+  return (
+    <div className="space-y-2 rounded-lg border border-zinc-200 p-3 text-xs dark:border-zinc-700">
+      <div className="flex items-center gap-2">
+        <HugeiconsIcon icon={WrenchIcon} className="size-3.5 text-zinc-400" />
+        <span className="font-mono text-zinc-600 dark:text-zinc-300">{tool.name}</span>
+        <Badge variant="outline" className={statusStyles[tool.status]} data-testid="tool-status">
+          {tool.status === 'running' ? 'running…' : tool.status}
+        </Badge>
+        {tool.durationMs !== undefined && (
+          <span className="text-zinc-400">{formatDuration(tool.durationMs)}</span>
+        )}
+      </div>
+      {tool.args && (
+        <div className="relative">
+          <pre className="overflow-x-auto rounded bg-zinc-100 p-2 pr-8 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+            {prettyArgs(tool.args)}
+          </pre>
+          <div className="absolute top-1 right-1">
+            <CopyButton text={tool.args} label="Copy tool args" alwaysVisible />
+          </div>
+        </div>
+      )}
+      {tool.digest && (
+        <div className="relative">
+          <pre className="max-h-64 overflow-auto rounded bg-zinc-100 p-2 pr-8 whitespace-pre-wrap text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
+            {tool.digest}
+          </pre>
+          <div className="absolute top-1 right-1">
+            <CopyButton text={tool.digest} label="Copy tool response" alwaysVisible />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ActivityPanel is the full detail behind an ActivityLine: reasoning
+// text plus every tool call, args and digest included. Chat.tsx hosts
+// one Sheet instance and re-derives the item from live state each
+// render, so the panel updates in real time while a turn streams.
+export function ActivityPanel({ msg }: { msg: AssistantState }) {
+  const sum = totalDuration(msg.tools)
+  return (
+    <SheetContent side="right" className="data-[side=right]:sm:max-w-lg">
+      <SheetHeader>
+        <SheetTitle>Activity</SheetTitle>
+        {msg.tools.length > 0 && (
+          <p className="text-sm text-muted-foreground">
+            {msg.tools.length} tool{msg.tools.length === 1 ? '' : 's'}
+            {sum > 0 && ` · ${formatDuration(sum)}`}
+          </p>
+        )}
+      </SheetHeader>
+      <div className="flex-1 space-y-3 overflow-y-auto px-4 pb-4">
+        {msg.reasoning !== '' && (
+          <div className="relative space-y-1">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-muted-foreground">Reasoning</span>
+              <CopyButton text={msg.reasoning} label="Copy reasoning" alwaysVisible />
+            </div>
+            <div className="rounded-lg border border-zinc-200 p-3 text-xs whitespace-pre-wrap text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">
+              {msg.reasoning}
+            </div>
+          </div>
+        )}
+        {msg.tools.map((t) => (
+          <ToolCallRow key={t.id} tool={t} />
+        ))}
+      </div>
+    </SheetContent>
+  )
+}

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -2,13 +2,7 @@ import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ChatEvent } from '../api/types'
 import { applyEvent, emptyAssistant, type AssistantState } from '../lib/chat'
-import {
-  AssistantMessage,
-  CompactionDivider,
-  InterruptedMessage,
-  ToolBlock,
-  UserMessage,
-} from './Message'
+import { AssistantMessage, CompactionDivider, InterruptedMessage, UserMessage } from './Message'
 
 afterEach(cleanup)
 
@@ -29,18 +23,29 @@ describe('AssistantMessage', () => {
     expect(screen.getByText('world').tagName).toBe('STRONG')
   })
 
-  it('collapses reasoning behind a toggle', () => {
+  it('shows a reasoning-only activity line that opens the detail panel', () => {
+    const msg = play([
+      { type: 'reasoning_chunk', text: 'thinking…' },
+      { type: 'chunk', text: 'answer' },
+      { type: 'meta', session_id: 's' },
+    ])
+    const onShowActivity = vi.fn()
+    render(<AssistantMessage msg={msg} onShowActivity={onShowActivity} />)
+
+    const line = screen.getByTestId('activity-line')
+    expect(line).toHaveTextContent('Reasoning')
+    fireEvent.click(line)
+    expect(onShowActivity).toHaveBeenCalledOnce()
+  })
+
+  it('omits the activity line entirely when there is no onShowActivity handler', () => {
     const msg = play([
       { type: 'reasoning_chunk', text: 'thinking…' },
       { type: 'chunk', text: 'answer' },
       { type: 'meta', session_id: 's' },
     ])
     render(<AssistantMessage msg={msg} />)
-
-    const details = screen.getByText('Reasoning').closest('details')
-    expect(details).not.toBeNull()
-    expect(details).not.toHaveAttribute('open')
-    expect(screen.getByText('thinking…')).toBeInTheDocument()
+    expect(screen.queryByTestId('activity-line')).not.toBeInTheDocument()
   })
 
   it('renders retry and incomplete honestly', () => {
@@ -166,23 +171,6 @@ describe('copy buttons', () => {
     vi.unstubAllGlobals()
   })
 
-  it('copies a tool response digest', () => {
-    const writeText = vi.fn().mockResolvedValue(undefined)
-    vi.stubGlobal('navigator', { clipboard: { writeText } })
-
-    render(
-      <ToolBlock tool={{ id: 'c9', name: 'calculate', status: 'ok', digest: 'the answer is 42' }} />,
-    )
-    fireEvent.click(screen.getByTestId('copy-button'))
-    expect(writeText).toHaveBeenCalledWith('the answer is 42')
-    vi.unstubAllGlobals()
-  })
-
-  it('omits the copy button when a tool has no digest yet', () => {
-    render(<ToolBlock tool={{ id: 'c9', name: 'shell', status: 'running' }} />)
-    expect(screen.queryByTestId('copy-button')).toBeNull()
-  })
-
   it('confirms the copy then reverts after two seconds', async () => {
     vi.useFakeTimers()
     const writeText = vi.fn().mockResolvedValue(undefined)
@@ -243,27 +231,15 @@ describe('tool calls', () => {
     expect(msg.tools).toHaveLength(1)
     expect(msg.tools[0]).toMatchObject({ id: 'c1', status: 'ok', digest: 'notes.md' })
 
-    render(<AssistantMessage msg={msg} />)
-    expect(screen.getByTestId('tool-block')).toHaveTextContent('shell')
-    expect(screen.getByTestId('tool-status')).toHaveTextContent('ok')
-    expect(screen.getByTestId('tool-block')).toHaveTextContent('42ms')
+    render(<AssistantMessage msg={msg} onShowActivity={vi.fn()} />)
+    expect(screen.getByTestId('activity-line')).toHaveTextContent('Worked for 42ms · shell')
   })
 
-  it('shows a running tool before its result arrives', () => {
+  it('shows a running tool while streaming', () => {
     const msg = play([{ type: 'tool_start', tool_call: { id: 'c1', name: 'web_fetch' } }])
-    render(<AssistantMessage msg={msg} />)
-    expect(screen.getByTestId('tool-status')).toHaveTextContent('running…')
+    render(<AssistantMessage msg={msg} onShowActivity={vi.fn()} />)
+    expect(screen.getByTestId('activity-line')).toHaveTextContent('Running web_fetch…')
   })
-
-  it('renders a standalone replayed tool block', () => {
-    render(
-      <ToolBlock
-        tool={{ id: 'c9', name: 'calculate', status: 'error', digest: 'division by zero' }}
-      />,
-    )
-    expect(screen.getByTestId('tool-status')).toHaveTextContent('error')
-  })
-
 
   it('parks visibly while a permission request is pending', () => {
     const msg = play([

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -1,12 +1,13 @@
-import { Copy01Icon, Link04Icon, Tick02Icon, WrenchIcon } from '@hugeicons-pro/core-stroke-rounded'
+import { Copy01Icon, Link04Icon, Tick02Icon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import rehypeHighlight from 'rehype-highlight'
 import remarkGfm from 'remark-gfm'
+import { ActivityLine } from './Activity'
 import { Badge } from './ui/badge'
 import { collapseRepeatedTail, splitSources } from '../lib/citations'
-import type { AssistantState, ToolRun } from '../lib/chat'
+import type { AssistantState } from '../lib/chat'
 import { cn } from '../lib/utils'
 import 'highlight.js/styles/github-dark.css'
 
@@ -44,7 +45,7 @@ function SourcesPanel({ citations }: { citations: { title: string; url: string }
 // (AssistantMessage's wrapper); alwaysVisible drops that dependency
 // for contexts with no such group (e.g. inside a collapsible details
 // block, already hidden until expanded).
-function CopyButton({
+export function CopyButton({
   text,
   label,
   alwaysVisible = false,
@@ -129,66 +130,20 @@ export function InterruptedMessage({ text }: { text: string }) {
   )
 }
 
-// ToolBlock renders one tool call: name, status, duration, and a
-// collapsible result digest. Raw results never reach the browser —
-// the digest is all there is.
-export function ToolBlock({ tool }: { tool: ToolRun }) {
-  const statusStyles: Record<ToolRun['status'], string> = {
-    running: 'border-blue-500/40 bg-blue-500/10 text-blue-600 dark:text-blue-400',
-    ok: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
-    error: 'border-red-500/40 bg-red-500/10 text-red-600 dark:text-red-400',
-    denied: 'border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400',
-  }
-  return (
-    <details
-      className="w-full max-w-3xl rounded-lg border border-zinc-200 px-3 py-2 text-xs dark:border-zinc-700"
-      data-testid="tool-block"
-    >
-      <summary className="flex cursor-pointer items-center gap-2 select-none">
-        <HugeiconsIcon icon={WrenchIcon} className="size-3.5 text-zinc-400" />
-        <span className="font-mono text-zinc-600 dark:text-zinc-300">{tool.name}</span>
-        <Badge variant="outline" className={statusStyles[tool.status]} data-testid="tool-status">
-          {tool.status === 'running' ? 'running…' : tool.status}
-        </Badge>
-        {tool.durationMs !== undefined && (
-          <span className="text-zinc-400">{formatDuration(tool.durationMs)}</span>
-        )}
-      </summary>
-      <div className="mt-2 space-y-2">
-        {tool.args && (
-          <pre className="overflow-x-auto rounded bg-zinc-100 p-2 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
-            {tool.args}
-          </pre>
-        )}
-        {tool.digest && (
-          <div className="relative">
-            <pre className="max-h-64 overflow-auto rounded bg-zinc-100 p-2 pr-8 whitespace-pre-wrap text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
-              {tool.digest}
-            </pre>
-            <div className="absolute top-1 right-1">
-              <CopyButton text={tool.digest} label="Copy tool response" alwaysVisible />
-            </div>
-          </div>
-        )}
-      </div>
-    </details>
-  )
-}
-
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`
-  return `${(ms / 1000).toFixed(1)}s`
-}
-
 export function AssistantMessage({
   msg,
   onRetry,
+  onShowActivity,
 }: {
   msg: AssistantState
   // Present only for the trailing item when it's safe to retry (an
   // error and not mid-stream) — Chat.tsx decides that, this component
   // just renders whatever it's handed.
   onRetry?: () => void
+  // Opens the Activity detail panel for this turn — Chat.tsx owns the
+  // Sheet and passes this through. Omitted, the activity line simply
+  // doesn't render (there's nowhere for it to open).
+  onShowActivity?: () => void
 }) {
   const tokens = msg.meta?.usage
     ? `${msg.meta.usage.input_tokens}→${msg.meta.usage.output_tokens} tok`
@@ -201,16 +156,7 @@ export function AssistantMessage({
     : splitSources(collapseRepeatedTail(msg.text))
   return (
     <div className="group/message flex flex-col items-start gap-2">
-      {msg.reasoning !== '' && (
-        <details className="w-full max-w-3xl rounded-lg border border-zinc-200 px-3 py-2 text-xs text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">
-          <summary className="cursor-pointer select-none">Reasoning</summary>
-          <div className="mt-2 whitespace-pre-wrap">{msg.reasoning}</div>
-        </details>
-      )}
-
-      {msg.tools.map((t) => (
-        <ToolBlock key={t.id} tool={t} />
-      ))}
+      {onShowActivity && <ActivityLine msg={msg} onOpen={onShowActivity} />}
 
       {msg.permissions.length > 0 && (
         <Badge

--- a/web/src/lib/transcript.test.ts
+++ b/web/src/lib/transcript.test.ts
@@ -39,6 +39,7 @@ describe('fromTranscript', () => {
       role: 'assistant',
       text: 'hi **there**',
       reasoning: 'thinking about it',
+      tools: [],
       streaming: false,
       meta: { provider: 'zai-glm', model: 'glm-4.7', usage: { input_tokens: 81, output_tokens: 396 } },
     })
@@ -70,7 +71,104 @@ describe('fromTranscript', () => {
     expect(items[0]).toMatchObject({ role: 'assistant', meta: undefined })
   })
 
-  it('skips tool items until the tool loop lands', () => {
+  it('groups tool items into the following assistant turn', () => {
+    const items = fromTranscript([
+      { seq: 1, kind: 'user', text: 'q', created_at: at },
+      {
+        seq: 2,
+        kind: 'tool',
+        tool: { call_id: 'c1', name: 'shell', status: 'ok', result_digest: 'notes.md', duration_ms: 42 },
+        created_at: at,
+      },
+      { seq: 3, kind: 'assistant', blocks: [{ type: 'text', text: 'a' }], created_at: at },
+    ])
+    expect(items.map((i) => i.role)).toEqual(['user', 'assistant'])
+    expect(items[1]).toMatchObject({
+      role: 'assistant',
+      text: 'a',
+      tools: [{ id: 'c1', name: 'shell', status: 'ok', digest: 'notes.md', durationMs: 42 }],
+    })
+  })
+
+  it('groups a run of several tool calls onto one following assistant turn', () => {
+    const items = fromTranscript([
+      {
+        seq: 1,
+        kind: 'tool',
+        tool: { call_id: 'c1', name: 'web_search', status: 'ok', duration_ms: 10 },
+        created_at: at,
+      },
+      {
+        seq: 2,
+        kind: 'tool',
+        tool: { call_id: 'c2', name: 'web_fetch', status: 'ok', duration_ms: 20 },
+        created_at: at,
+      },
+      { seq: 3, kind: 'assistant', blocks: [{ type: 'text', text: 'done' }], created_at: at },
+    ])
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({ role: 'assistant', text: 'done' })
+    if (items[0].role === 'assistant') {
+      expect(items[0].tools.map((t) => t.id)).toEqual(['c1', 'c2'])
+    }
+  })
+
+  it('flushes trailing tool calls with no following assistant turn as a bare activity item', () => {
+    const items = fromTranscript([
+      { seq: 1, kind: 'user', text: 'q', created_at: at },
+      {
+        seq: 2,
+        kind: 'tool',
+        tool: { call_id: 'c1', name: 'shell', status: 'error', duration_ms: 5 },
+        created_at: at,
+      },
+    ])
+    expect(items.map((i) => i.role)).toEqual(['user', 'assistant'])
+    expect(items[1]).toMatchObject({
+      id: 'replay-2',
+      role: 'assistant',
+      text: '',
+      tools: [{ id: 'c1', status: 'error' }],
+    })
+  })
+
+  it('flushes pending tools before a compaction or interrupted item, never leaking across them', () => {
+    const items = fromTranscript([
+      {
+        seq: 1,
+        kind: 'tool',
+        tool: { call_id: 'c1', name: 'shell', status: 'ok' },
+        created_at: at,
+      },
+      { seq: 2, kind: 'compaction', text: 'summarized', created_at: at },
+      {
+        seq: 3,
+        kind: 'tool',
+        tool: { call_id: 'c2', name: 'shell', status: 'ok' },
+        created_at: at,
+      },
+      { seq: 4, kind: 'interrupted', text: 'partial', created_at: at },
+    ])
+    expect(items.map((i) => i.role)).toEqual(['assistant', 'compaction', 'assistant', 'interrupted'])
+    expect(items[0]).toMatchObject({ tools: [{ id: 'c1' }] })
+    expect(items[2]).toMatchObject({ tools: [{ id: 'c2' }] })
+  })
+
+  it('falls back to ok status for an unrecognized tool status', () => {
+    const items = fromTranscript([
+      {
+        seq: 1,
+        kind: 'tool',
+        tool: { call_id: 'c1', name: 'shell', status: 'unknown' },
+        created_at: at,
+      },
+    ])
+    if (items[0].role === 'assistant') {
+      expect(items[0].tools[0].status).toBe('ok')
+    }
+  })
+
+  it('drops tool items with no tool payload', () => {
     const items = fromTranscript([
       { seq: 1, kind: 'user', text: 'q', created_at: at },
       { seq: 2, kind: 'tool', created_at: at },

--- a/web/src/lib/transcript.ts
+++ b/web/src/lib/transcript.ts
@@ -7,40 +7,62 @@ import type { AssistantState, ToolRun } from './chat'
 export type ChatItem = { id: string } & (
   | { role: 'user'; text: string }
   | ({ role: 'assistant' } & AssistantState)
-  | { role: 'tool'; tool: ToolRun }
   | { role: 'compaction'; text: string }
   | { role: 'interrupted'; text: string }
 )
 
+function toToolRun(tool: NonNullable<TranscriptItem['tool']>): ToolRun {
+  const status = tool.status
+  return {
+    id: tool.call_id,
+    name: tool.name,
+    args: tool.args,
+    status: status === 'ok' || status === 'error' || status === 'denied' ? status : 'ok',
+    digest: tool.result_digest,
+    durationMs: tool.duration_ms,
+  }
+}
+
 // fromTranscript maps the server's UI replay projection into chat
 // items. The transcript hides nothing: compaction dividers and
-// interrupted turns, and executed tool calls render alongside the
-// conversation.
+// interrupted turns render alongside the conversation. Tool calls no
+// longer get their own item — a flush-based pass folds each run of
+// `kind: 'tool'` items into the assistant item that follows, matching
+// the live `AssistantState` shape (`tools[]` on the turn). A run of
+// tool items with no following assistant turn (trailing tool loop, or
+// one cut short by a user/compaction/interrupted item) still flushes,
+// as a tools-only assistant item so replay never drops executed calls.
 export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
   const out: ChatItem[] = []
+  let pending: { seq: number; tool: NonNullable<TranscriptItem['tool']> }[] = []
+
+  const flush = () => {
+    if (pending.length === 0) return
+    const tools = pending.map((p) => toToolRun(p.tool))
+    out.push({
+      id: `replay-${pending[0].seq}`,
+      role: 'assistant',
+      text: '',
+      reasoning: '',
+      notices: [],
+      tools,
+      permissions: [],
+      streaming: false,
+      meta: undefined,
+    })
+    pending = []
+  }
+
   for (const item of items) {
     const id = `replay-${item.seq}`
     switch (item.kind) {
       case 'user':
+        flush()
         out.push({ id, role: 'user', text: item.text ?? '' })
         break
-      case 'tool': {
-        if (!item.tool) break
-        const status = item.tool.status
-        out.push({
-          id,
-          role: 'tool',
-          tool: {
-            id: item.tool.call_id,
-            name: item.tool.name,
-            args: item.tool.args,
-            status: status === 'ok' || status === 'error' || status === 'denied' ? status : 'ok',
-            digest: item.tool.result_digest,
-            durationMs: item.tool.duration_ms,
-          },
-        })
+      case 'tool':
+        if (item.tool) pending.push({ seq: item.seq, tool: item.tool })
         break
-      }
       case 'assistant': {
         let text = ''
         let reasoning = ''
@@ -50,13 +72,15 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
           if (b.type === 'text') text += b.text ?? ''
           else if (b.type === 'reasoning') reasoning += b.text ?? ''
         }
+        const tools = pending.map((p) => toToolRun(p.tool))
+        pending = []
         out.push({
           id,
           role: 'assistant',
           text,
           reasoning,
           notices: [],
-          tools: [],
+          tools,
           permissions: [],
           streaming: false,
           meta: item.provider
@@ -66,12 +90,15 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
         break
       }
       case 'compaction':
+        flush()
         out.push({ id, role: 'compaction', text: item.text ?? '' })
         break
       case 'interrupted':
+        flush()
         out.push({ id, role: 'interrupted', text: item.text ?? '' })
         break
     }
   }
+  flush()
   return out
 }

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -2,15 +2,11 @@ import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router'
 import { answerPermission, ChatError, chatStream, getTranscript, retryStream } from '../api/client'
 import type { ChatEvent } from '../api/types'
+import { ActivityPanel } from '../components/Activity'
 import { Composer } from '../components/Composer'
-import {
-  AssistantMessage,
-  CompactionDivider,
-  InterruptedMessage,
-  ToolBlock,
-  UserMessage,
-} from '../components/Message'
+import { AssistantMessage, CompactionDivider, InterruptedMessage, UserMessage } from '../components/Message'
 import { PermissionModal } from '../components/PermissionModal'
+import { Sheet } from '../components/ui/sheet'
 import {
   answerPermission as clearPermission,
   applyEvent,
@@ -63,6 +59,10 @@ export function Chat({
   const [skillHint, setSkillHint] = useState<string | undefined>(lockedSkillHint)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [streaming, setStreaming] = useState(false)
+  // Id of the assistant item whose Activity panel is open, if any. The
+  // panel content is derived from `items` below rather than captured
+  // once, so it keeps updating live while that turn is still streaming.
+  const [activityId, setActivityId] = useState<string | null>(null)
   const sessionRef = useRef<string | undefined>(routeSession)
   // Session ids this page itself adopted mid-stream (via navigate):
   // the resume effect must not clobber the live stream with a replay.
@@ -268,9 +268,17 @@ export function Chat({
     })
   }
 
+  // Re-derived from `items` every render (not captured on open) so the
+  // panel keeps showing live tool/reasoning state while its turn streams.
+  const activityItem = items.find((i) => i.id === activityId)
+  const activityMsg = activityItem?.role === 'assistant' ? activityItem : undefined
+
   return (
     <div className="flex h-full flex-col">
       {pendingPermission && <PermissionModal request={pendingPermission} onDecision={decide} />}
+      <Sheet open={activityMsg !== undefined} onOpenChange={(open) => !open && setActivityId(null)}>
+        {activityMsg && <ActivityPanel msg={activityMsg} />}
+      </Sheet>
       <div ref={listRef} onScroll={trackPin} className="flex-1 space-y-6 overflow-y-auto py-6">
         {items.length === 0 && !loadError && (
           <div className="mt-24 text-center">
@@ -289,8 +297,6 @@ export function Chat({
           switch (item.role) {
             case 'user':
               return <UserMessage key={item.id} text={item.text} />
-            case 'tool':
-              return <ToolBlock key={item.id} tool={item.tool} />
             case 'compaction':
               return <CompactionDivider key={item.id} text={item.text} />
             case 'interrupted':
@@ -304,6 +310,7 @@ export function Chat({
                   // (the session's last event server-side) — never a
                   // mid-transcript message.
                   onRetry={i === items.length - 1 && !streaming ? retryLast : undefined}
+                  onShowActivity={() => setActivityId(item.id)}
                 />
               )
           }


### PR DESCRIPTION
Chat tool calls no longer render as stacked inline cards. Each assistant turn gets one compact activity line — pulsing "Running <tool>…" while streaming, "Worked for <duration> · <tools>" when done — that opens a right-side sheet with per-call args, result digests, status badges, and reasoning.

The transcript rebuild path now groups tool events into their owning assistant turn (the flat `role:'tool'` item is gone), so live streaming and session replay render through one code path.

## Verification

- Web build/lint green; new Activity component suite plus rewritten Message/transcript tests (grouping, flush boundaries, trailing tool-only turns, aborted-turn status fallback).
- Live: gmail-tool session shows a single activity line while streaming; panel updates in real time; reload replays identically.

## Out of scope

- Richer tool output in the browser — the server still sends digests only.