### PR TITLE
feat: current date in chat system prompt + email-research skill

### DIFF
--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -382,7 +382,7 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 	// (D-011 poisoning defense); the skill body is instructions the
 	// user explicitly selected, deterministically loaded rather than
 	// left to the model's load_skill judgment.
-	system := assembleSystem(skills.Index(s.allowedPacks(ctx, profile)))
+	system := assembleSystem(skills.Index(s.allowedPacks(ctx, profile)), time.Now())
 	// The agent overlay is stable for a given agent, so it sits ahead
 	// of the per-turn tail and stays inside the cacheable prefix.
 	if profile.PromptOverlay != "" {

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -711,9 +711,11 @@ func TestMemoryRetrieveInjectsIntoSystemTail(t *testing.T) {
 	if !strings.HasSuffix(sent.System, block) {
 		t.Fatalf("memory block not at system tail:\n%s", sent.System)
 	}
-	// The stable prefix stays byte-identical (D-018).
+	// The stable prefix (identity + skills index) stays byte-identical
+	// (D-018); only the per-turn tail (date line, then memory) varies.
 	base := newService(gw, log)
-	if !strings.HasPrefix(sent.System, assembleSystem(skills.Index(base.allowedPacks(t.Context(), agents.Agent{Memory: true})))) {
+	stablePrefix := systemPrompt + "\n\n" + skills.Index(base.allowedPacks(t.Context(), agents.Agent{Memory: true}))
+	if !strings.HasPrefix(sent.System, stablePrefix) {
 		t.Fatal("system prefix changed by memory injection")
 	}
 }
@@ -747,7 +749,7 @@ func TestMemoryRetrieveEmptyLeavesSystemUntouched(t *testing.T) {
 	drain(t, ch)
 
 	got := chatRequest(t, gw).System
-	want := assembleSystem(skills.Index(svc.allowedPacks(t.Context(), agents.Agent{Memory: true})))
+	want := assembleSystem(skills.Index(svc.allowedPacks(t.Context(), agents.Agent{Memory: true})), time.Now())
 	if got != want {
 		t.Fatalf("system modified on empty recall:\n%q\nvs\n%q", got, want)
 	}

--- a/internal/brain/chat/systemprompt.go
+++ b/internal/brain/chat/systemprompt.go
@@ -1,7 +1,9 @@
 package chat
 
+import "time"
+
 // systemPromptVersion increments with any change to the prompt text.
-const systemPromptVersion = 3
+const systemPromptVersion = 4
 
 // systemPrompt is Timothy's identity. Additions APPEND after the
 // existing text and the terseness steer stays the LAST line: the
@@ -21,10 +23,18 @@ Before a tool call, write at most one short line saying what you are checking �
 const systemPromptClose = `Be concise; do not restate context or repeat the question.`
 
 // assembleSystem builds the full system prompt: identity, then the
-// optional per-deploy skills index, then the closing steer.
-func assembleSystem(skillsIndex string) string {
+// optional per-deploy skills index, then a current-date line, then the
+// closing steer. now must be evaluated at request time (never cached
+// at construction) so the date line is fresh every turn — a model
+// with no other way to know "today" otherwise anchors on training
+// data and mangles date-bounded tool calls (e.g. Gmail after:/before:
+// operators). Date only, no clock time: a timestamp would bust the
+// provider prompt cache's tail every single request, where a date
+// busts it once per day (D-018) — acceptable.
+func assembleSystem(skillsIndex string, now time.Time) string {
+	dateLine := "Today is " + now.UTC().Format("Monday, 2006-01-02") + " (UTC)."
 	if skillsIndex == "" {
-		return systemPrompt + "\n\n" + systemPromptClose
+		return systemPrompt + "\n\n" + dateLine + "\n\n" + systemPromptClose
 	}
-	return systemPrompt + "\n\n" + skillsIndex + "\n" + systemPromptClose
+	return systemPrompt + "\n\n" + skillsIndex + "\n\n" + dateLine + "\n\n" + systemPromptClose
 }

--- a/internal/brain/chat/systemprompt_test.go
+++ b/internal/brain/chat/systemprompt_test.go
@@ -1,0 +1,60 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAssembleSystemDateLine(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.July, 28, 15, 4, 5, 0, time.UTC)
+	got := assembleSystem("", now)
+
+	want := "Today is Tuesday, 2026-07-28 (UTC)."
+	if !strings.Contains(got, want) {
+		t.Fatalf("date line missing or wrong:\n%s\nwant substring:\n%s", got, want)
+	}
+	if strings.Contains(got, "15:04") || strings.Contains(got, "15:04:05") {
+		t.Fatalf("date line must not carry a clock time:\n%s", got)
+	}
+}
+
+func TestAssembleSystemDateLineNonUTCInputNormalized(t *testing.T) {
+	t.Parallel()
+	loc := time.FixedZone("UTC-5", -5*60*60)
+	// 2026-07-28 23:30 UTC-5 == 2026-07-29 04:30 UTC.
+	now := time.Date(2026, time.July, 28, 23, 30, 0, 0, loc)
+	got := assembleSystem("", now)
+
+	if !strings.Contains(got, "Today is Wednesday, 2026-07-29 (UTC).") {
+		t.Fatalf("date line not normalized to UTC:\n%s", got)
+	}
+}
+
+func TestAssembleSystemCloseStaysLast(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.July, 28, 0, 0, 0, 0, time.UTC)
+
+	for _, skillsIndex := range []string{"", "# Skills\n\n- foo: does foo"} {
+		got := assembleSystem(skillsIndex, now)
+		if !strings.HasSuffix(got, systemPromptClose) {
+			t.Fatalf("close steer not last line (skillsIndex=%q):\n%s", skillsIndex, got)
+		}
+	}
+}
+
+func TestAssembleSystemStablePrefixUnchangedByDate(t *testing.T) {
+	t.Parallel()
+	skillsIndex := "# Skills\n\n- foo: does foo"
+	day1 := assembleSystem(skillsIndex, time.Date(2026, time.July, 28, 0, 0, 0, 0, time.UTC))
+	day2 := assembleSystem(skillsIndex, time.Date(2026, time.July, 29, 0, 0, 0, 0, time.UTC))
+
+	prefix := systemPrompt + "\n\n" + skillsIndex
+	if !strings.HasPrefix(day1, prefix) || !strings.HasPrefix(day2, prefix) {
+		t.Fatalf("identity + skills index prefix changed across days")
+	}
+	if day1 == day2 {
+		t.Fatalf("expected date line to differ across days, got identical output")
+	}
+}

--- a/skills/email-research/SKILL.md
+++ b/skills/email-research/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: email-research
+description: Searches, reads, and aggregates Gmail content — finding bookings, costs, topics, or senders, and summarizing or digesting threads. Use when the ask involves email in any way: finding a message, extracting amounts or dates from mail, summarizing a thread, or digesting what a sender or label contains.
+---
+
+# Email research discipline
+
+## Rules
+
+- Gmail query operators, used correctly:
+  - Quote multi-word phrases: `subject:"booking confirmation"`, not `subject:booking confirmation` (the latter only matches the first word as the operator's argument).
+  - `from:`/`to:` take an address or domain: `from:noreply@airline.com`, `from:airline.com`.
+  - OR grouping: `{from:a@x.com from:b@x.com}` or `(from:a@x.com OR from:b@x.com)` — bare `OR` between terms with no parens/braces is parsed unreliably, always group it explicitly.
+  - Date bounds: `after:YYYY/MM/DD`, `before:YYYY/MM/DD`, `newer_than:Nd` (or `Nm`/`Ny`), `older_than:Nd`.
+  - `has:attachment`, `label:`, `category:`, `is:unread`, `is:read`.
+- Date bounds MUST be derived from the current date in the system prompt — never a guessed or recalled year. If a search built from a "today" you assumed returns nothing, re-derive the bound from the actual system-prompt date before concluding the mail isn't there.
+- Pipeline discipline: start broad (wide date range, no subject/keyword narrowing), then narrow iteratively — a `from:` combined with subject/keyword terms narrows twice and a near-miss becomes a zero-result search.
+- A `gmail_search` result (subjects, senders, snippets) is a digest, not content. Before citing or aggregating what is "in" any message, `gmail_read` it — snippets truncate and routinely omit the amount, date, or detail you need.
+- Extract every amount together with its currency (`$42.50`, `€19`, `12.00 USD`) — a bare number is not usable in a total.
+- All arithmetic (sums, counts, averages) goes through the `calculate` tool — never add or estimate in your head. Show the expression you evaluated.
+- Any total or aggregate figure shows its per-item breakdown (each item's amount and source email) alongside the total, not the total alone.
+- Distinguish confirmations/receipts from marketing and reminders, even from the same sender domain: a confirmation states a completed transaction with an amount and reference number; marketing and reminders promise, upsell, or nudge. Label which is which rather than lumping every message from a domain together.
+
+## Multi-currency
+
+- Report one subtotal PER currency present — never silently convert or combine different currencies into one number.
+- If a conversion is explicitly requested, state the rate and its date/source; otherwise leave amounts in their original currency.
+
+## Anti-rationalization
+
+| Excuse | Rebuttal |
+|---|---|
+| "The snippet already shows the amount" | Snippets truncate; gmail_read the message before citing a figure from it. |
+| "I can add these three numbers myself" | Mental arithmetic on amounts you'll report as fact goes through calculate — no exceptions. |
+| "Combining $40 and €40 into one total is close enough" | Different currencies are different totals; report each separately. |
+| "It's from the same sender as the confirmation, so it counts" | Marketing and reminders from that domain are not the transaction; label them separately. |
+| "The user's message implies this year" | Never guess a year — read it from the system prompt's current date. |
+| "No Gmail tool is available, but I probably know the answer" | Say "email not connected" — never answer from assumption when the tool is simply missing. |
+
+## Red flags — stop and re-check
+
+- An amount is being reported without its currency.
+- A total appears with no per-item breakdown, or was computed without calculate.
+- A date bound (`after:`/`before:`) was written without checking the system prompt's current date first.
+- A claim about a message's content is being made from a search snippet alone, with no gmail_read call this turn.
+- Two different currencies are being added into a single total.
+- A privacy refusal ("I can't access your email") is about to be given while gmail tools are present in this turn's tool list.
+
+## Evidence required
+
+- Every cited message actually opened with gmail_read this turn (or gmail_read_attachment, for attachment content).
+- Every amount paired with its currency and its source message.
+- Every total accompanied by the calculate expression used and the per-item breakdown it was built from.
+- Confirmations distinguished from marketing/reminders explicitly, not merged by sender domain alone.


### PR DESCRIPTION
Two fixes from a failed real session (find accommodation bookings + costs from email): the model guessed "July 2024" as today and improvised Gmail search syntax.

## Commits

1. **feat(chat)** — system prompt gets a `Today is <weekday>, <date> (UTC).` line appended per request, placed after the skills index so the stable cache prefix (D-018) only busts once per day.
2. **feat(skills)** — `email-research` skill pack: exact Gmail operators, read-before-cite, calculator-only arithmetic with per-currency subtotals, no fabricated privacy refusals. General-purpose: search, summarization, and cost tasks over email.

## Verification

- Go gates green; new systemprompt tests; `make skills-validate` passes (6 skills).
- Live: the originally failing booking-cost question now completes — 5/5 bookings found, PDF receipts read, correct multi-currency total.