### PR TITLE
fix(web): offer retry on a turn that died before any reply

### DIFF
--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -155,6 +155,18 @@ describe('copy buttons', () => {
     vi.unstubAllGlobals()
   })
 
+  it('renders no retry button on a user message without onRetry', () => {
+    render(<UserMessage text="my question" />)
+    expect(screen.queryByTestId('retry-button')).not.toBeInTheDocument()
+  })
+
+  it('shows a retry button on a user message when onRetry is given, and calls it on click', () => {
+    const onRetry = vi.fn()
+    render(<UserMessage text="my question" onRetry={onRetry} />)
+    fireEvent.click(screen.getByTestId('retry-button'))
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+
   it('hides the copy button while streaming', () => {
     const msg = play([{ type: 'chunk', text: 'partial' }])
     render(<AssistantMessage msg={msg} />)

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -85,13 +85,37 @@ export function CopyButton({
   )
 }
 
-export function UserMessage({ text }: { text: string }) {
+export function UserMessage({
+  text,
+  onRetry,
+}: {
+  text: string
+  // Present only for a trailing dangling user message (the turn died
+  // before any assistant event landed) — Chat.tsx decides that, this
+  // component just renders whatever it's handed.
+  onRetry?: () => void
+}) {
   return (
-    <div className="group/message flex items-end justify-end gap-1">
-      <CopyButton text={text} label="Copy message" />
-      <div className="max-w-2xl rounded-2xl bg-blue-600 px-4 py-2.5 text-sm/6 whitespace-pre-wrap text-white">
-        {text}
+    <div className="flex flex-col items-end gap-1">
+      <div className="group/message flex items-end justify-end gap-1">
+        <CopyButton text={text} label="Copy message" />
+        <div className="max-w-2xl rounded-2xl bg-blue-600 px-4 py-2.5 text-sm/6 whitespace-pre-wrap text-white">
+          {text}
+        </div>
       </div>
+      {onRetry && (
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <span className="text-xs">No reply — the turn failed.</span>
+          <button
+            type="button"
+            data-testid="retry-button"
+            onClick={onRetry}
+            className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          >
+            retry
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -200,14 +200,24 @@ export function Chat({
 
   // retryLast re-runs the last (failed) turn: the session already
   // carries the dangling user message server-side (chat.Service.Retry),
-  // so this resets the existing assistant item in place rather than
-  // appending a new user+assistant pair like sendMessage does.
+  // so this never sends a new user message like sendMessage does. Two
+  // shapes reach here: an in-session failure, where the trailing item
+  // is still the assistant one from the failed attempt and gets reset
+  // in place; and a reload after a failure, where the transcript ends
+  // at the dangling user message (no assistant item survived), so one
+  // is appended for the stream to render into.
   const retryLast = async () => {
     const sessionId = sessionRef.current
     if (!sessionId || streaming) return
     setStreaming(true)
     pinnedRef.current = true
-    updateLast(() => emptyAssistant())
+    setItems((prev) => {
+      const next = [...prev]
+      const last = next[next.length - 1]
+      if (last?.role === 'assistant') next[next.length - 1] = { ...emptyAssistant(), id: last.id, role: 'assistant' }
+      else next.push({ id: crypto.randomUUID(), role: 'assistant', ...emptyAssistant() })
+      return next
+    })
 
     const controller = new AbortController()
     abortRef.current = controller
@@ -296,7 +306,16 @@ export function Chat({
         {items.map((item, i) => {
           switch (item.role) {
             case 'user':
-              return <UserMessage key={item.id} text={item.text} />
+              return (
+                <UserMessage
+                  key={item.id}
+                  text={item.text}
+                  // A trailing user message means the turn died before any
+                  // assistant event reached the transcript — retry re-runs
+                  // it server-side, same trailing-only condition as above.
+                  onRetry={i === items.length - 1 && !streaming ? retryLast : undefined}
+                />
+              )
             case 'compaction':
               return <CompactionDivider key={item.id} text={item.text} />
             case 'interrupted':


### PR DESCRIPTION
A failed turn leaves a dangling user message server-side. After a page reload the transcript projects no assistant item, so the existing retry affordance (an error badge on the assistant message, client-side state only) never rendered — and `retryLast` reset the last assistant item, which no-ops when the transcript ends at a user message, so stream events would have rendered nowhere.

Changes:
- Trailing user message (not streaming) now renders a retry row ("No reply — the turn failed." + retry button, same style as the assistant-side button).
- `retryLast` appends a fresh assistant item when the transcript ends at a dangling user message; resets in place otherwise.
- Two new `UserMessage` tests.

Backend is untouched — `POST /v1/sessions/{id}/messages/retry` already handled this state.