### PR TITLE
fix(missions): fail fast on permission asks when nobody is watching

### DIFF
--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -178,6 +178,11 @@ type Request struct {
 	// must never see. Executed via extraExecutor, never merged into the
 	// shared registry other callers read.
 	ExtraTools []*tools.Tool
+
+	// Unattended marks a turn nobody is watching (schedule-fired
+	// missions): a permission ask resolves as immediate denial instead
+	// of parking on a human prompt for the full timeout (D-039).
+	Unattended bool
 }
 
 // Start launches the loop and returns its event stream. The channel
@@ -225,6 +230,16 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			}
 		}
 		defs = append(kept, extraDefs...)
+	}
+	// toolNames is the turn's actual offered surface (post ToolAllow
+	// filter, post ExtraTools override) — built once per turn so a
+	// hallucinated tool name can be rejected before it ever reaches the
+	// permission chain (D-039). tools.Constrained.Execute already checks
+	// this, but only after askUser has parked; an unattended mission
+	// can't afford the wait to find out.
+	toolNames := make(map[string]bool, len(defs))
+	for _, d := range defs {
+		toolNames[d.Name] = true
 	}
 	msgs := append([]provider.Message(nil), req.Messages...)
 	total := stream.Usage{}
@@ -392,7 +407,7 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 				}
 			}
 		}
-		results := a.executeAll(ctx, exec, req.SessionID, calls, emit)
+		results := a.executeAll(ctx, exec, req.SessionID, calls, toolNames, req.Unattended, emit)
 
 		msgs = append(msgs, provider.Message{
 			Role: "assistant", Content: text.String(), ToolCalls: calls,
@@ -439,14 +454,16 @@ func EffortFor(results []provider.ToolResult) string {
 }
 
 // executeAll runs a step's tool calls concurrently (bounded) and
-// returns results in call order.
-func (a *Agent) executeAll(ctx context.Context, exec Executor, sessionID string, calls []provider.ToolCall, emit func(stream.StreamEvent)) []provider.ToolResult {
+// returns results in call order. toolNames is the turn's offered
+// surface (see run's toolNames comment); unattended is req.Unattended,
+// threaded down to resolveAndRun's DecisionAsk handling (D-039).
+func (a *Agent) executeAll(ctx context.Context, exec Executor, sessionID string, calls []provider.ToolCall, toolNames map[string]bool, unattended bool, emit func(stream.StreamEvent)) []provider.ToolResult {
 	results := make([]provider.ToolResult, len(calls))
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(maxParallelTools)
 	for i, call := range calls {
 		g.Go(func() error {
-			results[i] = a.executeOne(gctx, exec, sessionID, call, emit)
+			results[i] = a.executeOne(gctx, exec, sessionID, call, toolNames, unattended, emit)
 			return nil
 		})
 	}
@@ -454,9 +471,9 @@ func (a *Agent) executeAll(ctx context.Context, exec Executor, sessionID string,
 	return results
 }
 
-func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, emit func(stream.StreamEvent)) provider.ToolResult {
+func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, toolNames map[string]bool, unattended bool, emit func(stream.StreamEvent)) provider.ToolResult {
 	start := time.Now()
-	content, status := a.resolveAndRun(ctx, exec, sessionID, call, emit)
+	content, status := a.resolveAndRun(ctx, exec, sessionID, call, toolNames, unattended, emit)
 	isError := status != "ok"
 
 	if status == "ok" {
@@ -519,7 +536,18 @@ func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string,
 // on allow. It returns the content the model sees plus a status of
 // ok, denied, or error — denials and failures come back as feedback
 // text, never as a broken turn (D-009).
-func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, emit func(stream.StreamEvent)) (content, status string) {
+//
+// A call whose name is absent from toolNames (a hallucinated tool)
+// never reaches a.perms.Resolve at all — it is rejected here, before
+// the permission chain and before any askUser park, with the same
+// feedback tools.Constrained.Execute would eventually give (D-039):
+// an unattended mission can't afford to wait out a 10-minute prompt
+// timeout just to learn the name never existed.
+func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, toolNames map[string]bool, unattended bool, emit func(stream.StreamEvent)) (content, status string) {
+	if !toolNames[call.Name] {
+		return fmt.Sprintf("unknown tool %q — use one of the tools you were given", call.Name), "error"
+	}
+
 	res, err := a.perms.Resolve(ctx, sessionID, call.Name, call.Input)
 	if err != nil {
 		return "permission check failed: " + err.Error(), "error"
@@ -529,6 +557,13 @@ func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID stri
 	case tools.DecisionDeny:
 		return "denied: " + res.Rationale + ". This is a hard policy; do not retry the same call.", "denied"
 	case tools.DecisionAsk:
+		if unattended {
+			// No human is watching a schedule-fired mission's turn — parking
+			// on askUser would strand it for the full permissionTimeout with
+			// nobody to answer (D-039). Fail fast with feedback that steers
+			// the model toward calls the allowlist actually grants.
+			return fmt.Sprintf("permission denied automatically (unattended mission): %s. No human is available to approve. Rewrite the call to avoid the flagged pattern — create files with write_file instead of shell redirects, avoid command substitution — or use only tools the agent's allowlist grants.", res.Rationale), "denied"
+		}
 		decision := a.askUser(ctx, call, res, emit)
 		switch decision {
 		case DecideSession:

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -1041,3 +1041,134 @@ func TestRequestExtraToolsOverrideBaseTool(t *testing.T) {
 		t.Fatal("base echo executed instead of the turn-scoped override")
 	}
 }
+
+// countingAskPerms behaves like askPerms (always DecisionAsk) but
+// counts Resolve calls — tests use it to assert the permission chain
+// was never reached at all (the unknown-tool precheck short-circuits
+// before it).
+type countingAskPerms struct {
+	resolveCalls int
+}
+
+func (p *countingAskPerms) Resolve(_ context.Context, _, tool string, _ json.RawMessage) (tools.Resolution, error) {
+	p.resolveCalls++
+	return tools.Resolution{Decision: tools.DecisionAsk, Subject: tool, Rationale: "no standing grant"}, nil
+}
+func (p *countingAskPerms) Grant(context.Context, string, string, string, time.Duration) error { return nil }
+
+// TestAgentUnknownToolRejectedBeforePermissionChain is D-039's first
+// failure mode: a hallucinated tool name must never reach the
+// permission chain (and so never park on askUser) — it's rejected with
+// the same feedback tools.Constrained.Execute gives, just earlier.
+func TestAgentUnknownToolRejectedBeforePermissionChain(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"does_not_exist", `{}`}),
+		finalStep("adapted"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+	perms := &countingAskPerms{}
+	a.perms = perms
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	results := ofType(evs, stream.EventToolResult)
+	if len(results) != 1 || results[0].ToolResult.Status != "error" {
+		t.Fatalf("tool result = %+v, want one error result", results)
+	}
+	if !strings.Contains(results[0].ToolResult.Digest, `unknown tool "does_not_exist"`) {
+		t.Fatalf("digest = %q, want the unknown-tool feedback", results[0].ToolResult.Digest)
+	}
+	if len(ofType(evs, stream.EventPermissionRequest)) != 0 {
+		t.Fatal("unknown tool must never trigger a permission request")
+	}
+	if perms.resolveCalls != 0 {
+		t.Fatalf("perms.Resolve called %d times, want 0 — unknown tool must short-circuit before it", perms.resolveCalls)
+	}
+}
+
+// TestAgentUnattendedAskDeniesImmediately is D-039's second failure
+// mode: an unattended (schedule-fired) turn hitting DecisionAsk must
+// deny immediately with feedback naming the rationale, never call
+// askUser (so no EventPermissionRequest, no 10-minute wait). The test
+// itself finishing well under that timeout is part of the assertion.
+func TestAgentUnattendedAskDeniesImmediately(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"echo", `{"text":"hi"}`}),
+		finalStep("adapted"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+	a.perms = askPerms{}
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding", Unattended: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	results := ofType(evs, stream.EventToolResult)
+	if len(results) != 1 || results[0].ToolResult.Status != "denied" {
+		t.Fatalf("tool result = %+v, want denied", results)
+	}
+	if len(ofType(evs, stream.EventPermissionRequest)) != 0 {
+		t.Fatal("unattended turn must never emit a permission request")
+	}
+	var content string
+	for _, m := range gw.requests[1].Messages {
+		if m.ToolResult != nil {
+			content = m.ToolResult.Content
+		}
+	}
+	if !strings.Contains(content, "no standing grant") {
+		t.Fatalf("feedback = %q, want it to contain the resolution's rationale", content)
+	}
+	if !strings.Contains(content, "unattended mission") {
+		t.Fatalf("feedback = %q, want it to explain no human is available", content)
+	}
+}
+
+// TestAgentAttendedAskStillParks is the control for the above: with
+// Unattended left false (the default), DecisionAsk must still emit
+// EventPermissionRequest and be answerable through the broker exactly
+// as before D-039.
+func TestAgentAttendedAskStillParks(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"echo", `{"text":"hi"}`}),
+		finalStep("after decision"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+	a.perms = askPerms{}
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var evs []stream.StreamEvent
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				results := ofType(evs, stream.EventToolResult)
+				if len(results) != 1 || results[0].ToolResult.Status != "ok" {
+					t.Fatalf("results = %+v, want ok after DecideOnce", results)
+				}
+				return
+			}
+			evs = append(evs, ev)
+			if ev.Type == stream.EventPermissionRequest {
+				if !a.broker.Resolve(ev.Permission.ID, DecideOnce) {
+					t.Fatal("broker did not know the prompt id")
+				}
+			}
+		case <-deadline:
+			t.Fatal("loop never finished")
+		}
+	}
+}

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -92,6 +92,18 @@ func (p *StorePermissionParker) OnPermissionCleared(ctx context.Context, mission
 	}
 }
 
+// OnPermissionDenied records that a tool call was denied (D-039: most
+// often the automatic unattended-turn denial, but any denied result
+// qualifies) — best-effort, same stance as OnPermissionParked/Cleared:
+// a failed append logs and never aborts the turn it's reporting on.
+func (p *StorePermissionParker) OnPermissionDenied(ctx context.Context, missionID, tool, digest string) {
+	if err := p.Store.AppendEvent(ctx, missionID, "mission.permission_denied", map[string]any{
+		"tool": tool, "digest": digest,
+	}); err != nil {
+		p.Log.Error("mission: record permission denied failed", "mission_id", missionID, "error", err)
+	}
+}
+
 // parkNotifier reports a mission turn parking on (and later clearing)
 // a tool-call permission prompt — without this, the same interactive
 // broker chat sessions use silently strands a mission worker turn for
@@ -101,6 +113,10 @@ func (p *StorePermissionParker) OnPermissionCleared(ctx context.Context, mission
 type parkNotifier interface {
 	OnPermissionParked(ctx context.Context, missionID, permissionID, tool, args, danger, rationale string)
 	OnPermissionCleared(ctx context.Context, missionID string)
+	// OnPermissionDenied reports a tool result that came back denied —
+	// most often the unattended-turn automatic denial (D-039), but any
+	// denial qualifies. Best-effort like the two methods above.
+	OnPermissionDenied(ctx context.Context, missionID, tool, digest string)
 }
 
 // sandboxExec is the narrow slice of *sandbox.Manager nativeRunner
@@ -284,6 +300,13 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 					r.parker.OnPermissionCleared(ctx, req.MissionID)
 				}
 			}
+			// A denied result — most often the unattended-turn automatic
+			// denial (D-039), which never emits EventPermissionRequest at
+			// all — is otherwise invisible to anything watching the
+			// mission; record it as an event.
+			if ev.ToolResult != nil && ev.ToolResult.Status == "denied" && r.parker != nil {
+				r.parker.OnPermissionDenied(ctx, req.MissionID, ev.ToolResult.Name, ev.ToolResult.Digest)
+			}
 		case stream.EventDone:
 			if ev.Meta != nil {
 				servedModel = ev.Meta.Model
@@ -331,6 +354,10 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		System:     system,
 		Messages:   []provider.Message{{Role: "user", Content: user}},
 		ExtraTools: extra,
+		// Schedule-fired missions have nobody watching: asks fail fast
+		// with feedback instead of parking (D-039). UI-created missions
+		// (ScheduleID empty) keep the park-and-answer flow.
+		Unattended: m.ScheduleID != "",
 	}
 
 	text, args, err := r.runTurn(ctx, req, missionStatusToolName)
@@ -402,6 +429,7 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 		System:     system,
 		Messages:   messages,
 		ExtraTools: extra,
+		Unattended: m.ScheduleID != "",
 	}
 	text, args, err := r.runTurn(ctx, req, reviewVerdictToolName)
 	if err != nil {
@@ -511,6 +539,7 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, researchNotes
 		// for ten minutes trying to do the worker's job in plan phase.
 		ToolAllow:  []string{planToolName},
 		ExtraTools: []*tools.Tool{PlanTool()},
+		Unattended: m.ScheduleID != "",
 	}
 	text, args, err := r.runTurn(ctx, req, planToolName)
 	if err != nil {

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -65,6 +65,7 @@ func newTestRunnerWithParker(agent agentStream, parker parkNotifier) *nativeRunn
 type fakeParker struct {
 	parked  []string // "missionID:tool:danger"
 	cleared []string // missionID
+	denied  []string // "missionID:tool:digest"
 }
 
 func (f *fakeParker) OnPermissionParked(_ context.Context, missionID, _, tool, _, danger, _ string) {
@@ -75,6 +76,10 @@ func (f *fakeParker) OnPermissionCleared(_ context.Context, missionID string) {
 	f.cleared = append(f.cleared, missionID)
 }
 
+func (f *fakeParker) OnPermissionDenied(_ context.Context, missionID, tool, digest string) {
+	f.denied = append(f.denied, missionID+":"+tool+":"+digest)
+}
+
 func permissionRequestEvent(id, callID, tool, danger string) stream.StreamEvent {
 	return stream.StreamEvent{Type: stream.EventPermissionRequest, Permission: &stream.PermissionRequestEvent{
 		ID: id, CallID: callID, Tool: tool, Danger: danger,
@@ -83,6 +88,12 @@ func permissionRequestEvent(id, callID, tool, danger string) stream.StreamEvent 
 
 func toolResultEvent(id string) stream.StreamEvent {
 	return stream.StreamEvent{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{ID: id}}
+}
+
+func deniedToolResultEvent(id, name, digest string) stream.StreamEvent {
+	return stream.StreamEvent{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{
+		ID: id, Name: name, Status: "denied", Digest: digest,
+	}}
 }
 
 func TestRunWorkerSentinelPresent(t *testing.T) {
@@ -668,5 +679,60 @@ func TestMissionToolsSandboxCapsOutput(t *testing.T) {
 	}
 	if len(out) > shellOutputCap+len("\n[output capped]") {
 		t.Fatalf("output length %d exceeds cap plus marker", len(out))
+	}
+}
+
+// TestRunWorkerUnattendedFollowsScheduleID is the D-039 wiring check:
+// a schedule-fired mission (ScheduleID set) has nobody watching its
+// turns, so the loop.Request it hands to the agent must say so.
+func TestRunWorkerUnattendedFollowsScheduleID(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ok"}`)},
+	}}
+	r := newTestRunner(agent)
+	m := Mission{ID: "m1", Route: "default", ScheduleID: "sched-1"}
+	if _, _, err := r.RunWorker(context.Background(), m, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if !agent.requests[0].Unattended {
+		t.Fatal("worker request Unattended = false, want true for a schedule-fired mission")
+	}
+}
+
+// TestRunWorkerAttendedWithoutScheduleID is the other half: a
+// UI-created mission (no ScheduleID) keeps the park-and-answer flow.
+func TestRunWorkerAttendedWithoutScheduleID(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ok"}`)},
+	}}
+	r := newTestRunner(agent)
+	m := Mission{ID: "m1", Route: "default"}
+	if _, _, err := r.RunWorker(context.Background(), m, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if agent.requests[0].Unattended {
+		t.Fatal("worker request Unattended = true, want false without a ScheduleID")
+	}
+}
+
+// TestRunWorkerReportsPermissionDenied confirms a denied tool result
+// (the D-039 automatic unattended denial, or any other denial) reaches
+// the mission via parkNotifier as a mission.permission_denied event —
+// without this, an unattended turn's fast-fail denials would be
+// invisible to anything watching the mission (no park event is ever
+// emitted for them, unlike the ask-and-timeout path).
+func TestRunWorkerReportsPermissionDenied(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{{
+		textEvent("tried a risky call"),
+		deniedToolResultEvent("call1", "shell", "permission denied automatically (unattended mission): ..."),
+		toolEndEvent(missionStatusToolName, `{"outcome":"retry","analysis":"denied"}`),
+	}}}
+	parker := &fakeParker{}
+	r := newTestRunnerWithParker(agent, parker)
+	if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if len(parker.denied) != 1 || !strings.HasPrefix(parker.denied[0], "m1:shell:") {
+		t.Fatalf("parker.denied = %v, want exactly one m1:shell:... entry", parker.denied)
 	}
 }


### PR DESCRIPTION
Schedule-fired missions parked on the interactive permission prompt for the full 10-minute deny timeout — any opaque shell command (`$(...)` substitution) or hallucinated tool name stalled an unattended run with nobody there to answer.

Changes (D-039):
- `loop.Request.Unattended`: permission asks resolve as an immediate denial with steering feedback ("rewrite without the flagged pattern / use write_file / rely on allowlisted tools") instead of parking on a human prompt.
- Unknown-tool precheck: tool calls are validated against the turn's offered tool surface (base defs after ToolAllow filtering + ExtraTools) before the permission chain runs — a hallucinated tool gets instant "unknown tool" feedback and never parks anything. Chat turns benefit too.
- Runner sets `Unattended: m.ScheduleID != ""` on worker/reviewer/planner turns — UI-created missions keep today's park-and-answer flow (`POST /v1/missions/{id}/permission` unchanged).
- New `mission.permission_denied` event records each auto-denial (tool + digest) so silent denials stay observable and allowlist gaps are visible.

Verification: `make build test vet lint` clean; canary PASS; 6 new unit tests (loop: unknown tool short-circuits before `perms.Resolve`, unattended ask denies instantly, attended ask still parks; runner: Unattended mirrors ScheduleID, denied results append the event). Live e2e: schedule-fired mission baited into command substitution was auto-denied twice with feedback, adapted, and completed in ~4 min instead of stalling 20+ min in parks.

Out of scope: ToolAllow enforcement at execution time (allowlist currently filters offered defs only); parallel-call permission race in chat (N prompts for one burst).