### PR TITLE
fix(loop): drop model hint once sensitive route pin fires

### DIFF
--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -156,7 +156,8 @@ func (a *Agent) SetOffloadThreshold(tool string, bytes int) {
 // only takes effect after. suffix, not the exact registered name:
 // connector tools are namespaced "<connector-name>_<tool-name>" with a
 // user-chosen connector name, so "gmail_read" matches regardless of
-// which connector name serves it.
+// which connector name serves it. Forcing also clears the turn's model
+// hint from then on, since a hint outranks the route at the gateway.
 func (a *Agent) SetForceRoute(suffix, route string) {
 	a.forceRouteBySuffix[suffix] = route
 }
@@ -251,7 +252,12 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 	stuck := false
 	// route is req.Route until a tool with a forced route runs; from
 	// then on it's sticky for the rest of the turn (see SetForceRoute).
+	// hint follows the same lifecycle: it's dropped alongside the flip
+	// because gateway hint resolution is not chain-constrained — a
+	// surviving hint would let the model pick a provider outside the
+	// forced route's chain and bypass it entirely.
 	route := req.Route
+	hint := req.ModelHint
 
 	for step := 1; ; step++ {
 		directive := tools.CeilingFor(step, a.maxSteps)
@@ -265,7 +271,7 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			Route:     route,
 			Agent:     req.Agent,
 			Purpose:   "chat",
-			ModelHint: req.ModelHint,
+			ModelHint: hint,
 			System:    req.System,
 			Messages:  msgs,
 			Tools:     defs,
@@ -404,6 +410,7 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			for suffix, forced := range a.forceRouteBySuffix {
 				if strings.HasSuffix(c.Name, suffix) {
 					route = forced
+					hint = ""
 				}
 			}
 		}

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -911,6 +911,92 @@ func TestForceRouteIgnoresNonMatchingTools(t *testing.T) {
 	}
 }
 
+// TestForceRouteDropsModelHint closes the gateway-hint privacy hole: a
+// ModelHint outranks Route in the gateway's Resolve order, so a hint
+// surviving the flip would let a turn escape the forced route entirely
+// after a sensitive tool ran. The hint must be dropped the moment the
+// route is forced, not just the route switched.
+func TestForceRouteDropsModelHint(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"personal_gmail_read", `{}`}),
+		finalStep("done"),
+	}}
+	sensitive := &tools.Tool{
+		Name:        "personal_gmail_read",
+		Description: "reads a fake email",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`),
+		Execute: func(context.Context, json.RawMessage) (string, error) {
+			return "email body", nil
+		},
+	}
+	a, _, _, _ := testAgent(t, gw, sensitive)
+	a.SetForceRoute("gmail_read", "local")
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "default", ModelHint: "glm-4.7-flash",
+		Messages: []provider.Message{{Role: "user", Content: "check my email"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	if len(gw.requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(gw.requests))
+	}
+	if gw.requests[0].ModelHint != "glm-4.7-flash" {
+		t.Fatalf("step 1 hint = %q, want glm-4.7-flash (before the sensitive tool ran)", gw.requests[0].ModelHint)
+	}
+	if gw.requests[1].Route != "local" {
+		t.Fatalf("step 2 route = %q, want local (forced after gmail_read ran)", gw.requests[1].Route)
+	}
+	if gw.requests[1].ModelHint != "" {
+		t.Fatalf("step 2 hint = %q, want empty — a surviving hint bypasses the forced route at the gateway", gw.requests[1].ModelHint)
+	}
+}
+
+// TestForceRoutePinSurvivesStepRetry confirms the forced route and
+// dropped hint hold even when a step's stream dies and is retried
+// (D-038): the retry re-sends the same sreq built after the flip, so
+// it must never revert to the turn's original route or hint.
+func TestForceRoutePinSurvivesStepRetry(t *testing.T) {
+	withShortRetryBackoff(t)
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"personal_gmail_read", `{}`}),
+		retryableErrorStep(),
+		finalStep("done"),
+	}}
+	sensitive := &tools.Tool{
+		Name:        "personal_gmail_read",
+		Description: "reads a fake email",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`),
+		Execute: func(context.Context, json.RawMessage) (string, error) {
+			return "email body", nil
+		},
+	}
+	a, _, _, _ := testAgent(t, gw, sensitive)
+	a.SetForceRoute("gmail_read", "local")
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "default", ModelHint: "glm-4.7-flash",
+		Messages: []provider.Message{{Role: "user", Content: "check my email"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	// step 1 (unforced), step 2 attempt 1 (retryable error), step 2
+	// attempt 2 (the retry) — three gw.Stream calls.
+	if len(gw.requests) != 3 {
+		t.Fatalf("requests = %d, want 3", len(gw.requests))
+	}
+	retried := gw.requests[2]
+	if retried.Route != "local" {
+		t.Fatalf("retried request route = %q, want local (pin must survive the step retry)", retried.Route)
+	}
+	if retried.ModelHint != "" {
+		t.Fatalf("retried request hint = %q, want empty (dropped hint must survive the step retry)", retried.ModelHint)
+	}
+}
+
 // TestRequestExtraToolsCallableAndExecutable reproduces the missions
 // bug: a sentinel-style tool defined outside the shared agent registry
 // must still be (a) offered to the model as callable and (b)


### PR DESCRIPTION
A model hint outranks the route in the gateway's resolve order and is not constrained to the route's chain, so a hint surviving the `SetForceRoute` flip let a turn send sensitive tool output (raw email content) to the hinted provider, bypassing the forced route entirely.

- Clear the hint alongside the route flip; sticky for the rest of the turn.
- `TestForceRouteDropsModelHint`: step after `gmail_read` runs on forced route with empty hint.
- `TestForceRoutePinSurvivesStepRetry`: forced route + dropped hint hold across a D-038 step retry (regression gap — nothing covered retry+pin interplay before).

Out of scope: gateway-side hint validation against route chains (option B, bigger blast radius); `local` route chain currently points at cloud providers by owner's choice.