### PR TITLE
fix(loop): serialize parallel same-tool permission asks

### DIFF
--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -83,6 +83,7 @@ type Agent struct {
 	audit          AuditSink
 	events         EventAppender
 	broker         *PermBroker
+	askGate        *askGate
 	maxSteps       int
 	offloadAt      int
 	offloadPerTool map[string]int
@@ -108,7 +109,7 @@ type Agent struct {
 func NewAgent(gw Gateway, exec Executor, perms Permissioner, outputs OutputSink, audit AuditSink, events EventAppender, broker *PermBroker, defs []provider.ToolDef, logger *slog.Logger) *Agent {
 	return &Agent{
 		gw: gw, exec: exec, perms: perms, outputs: outputs, audit: audit,
-		events: events, broker: broker, defs: defs,
+		events: events, broker: broker, askGate: newAskGate(), defs: defs,
 		maxSteps:           tools.DefaultMaxSteps,
 		offloadAt:          tools.DefaultOffloadThreshold,
 		offloadPerTool:     map[string]int{},
@@ -571,17 +572,51 @@ func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID stri
 			// the model toward calls the allowlist actually grants.
 			return fmt.Sprintf("permission denied automatically (unattended mission): %s. No human is available to approve. Rewrite the call to avoid the flagged pattern — create files with write_file instead of shell redirects, avoid command substitution — or use only tools the agent's allowlist grants.", res.Rationale), "denied"
 		}
-		decision := a.askUser(ctx, call, res, emit)
-		switch decision {
-		case DecideSession:
-			if err := a.perms.Grant(ctx, sessionID, call.Name, res.Subject, sessionGrantTTL); err != nil {
-				a.logger.Warn("record session grant", "session_id", sessionID, "error", err)
-			}
-		case DecideOnce:
-			// proceed
-		default: // deny or timeout
+
+		// A step's parallel same-tool calls (executeAll) all land here
+		// before any of them has been answered — without the gate, each
+		// would independently park on askUser and the user would see N
+		// identical prompts for what is really one decision. The gate
+		// serializes them per (session, tool, subject): only the first
+		// caller through asks; the rest wait, then re-resolve below to
+		// pick up whatever grant the first one just recorded.
+		key := sessionID + "\x00" + call.Name + "\x00" + res.Subject
+		release, ok := a.askGate.lock(ctx, key)
+		if !ok {
 			return "the user denied permission for this call. Adapt your approach or ask the user what they want.", "denied"
 		}
+
+		// Re-resolve under the gate: a parallel sibling's session grant
+		// may have landed while we waited — Allow means zero prompt.
+		res, err = a.perms.Resolve(ctx, sessionID, call.Name, call.Input)
+		if err != nil {
+			release()
+			return "permission check failed: " + err.Error(), "error"
+		}
+		switch res.Decision {
+		case tools.DecisionAllow:
+			// fall through to execution below.
+		case tools.DecisionDeny:
+			release()
+			return "denied: " + res.Rationale + ". This is a hard policy; do not retry the same call.", "denied"
+		default: // still DecisionAsk
+			decision := a.askUser(ctx, call, res, emit)
+			switch decision {
+			case DecideSession:
+				if err := a.perms.Grant(ctx, sessionID, call.Name, res.Subject, sessionGrantTTL); err != nil {
+					a.logger.Warn("record session grant", "session_id", sessionID, "error", err)
+				}
+			case DecideOnce:
+				// proceed
+			default: // deny or timeout
+				release()
+				return "the user denied permission for this call. Adapt your approach or ask the user what they want.", "denied"
+			}
+		}
+		// Execution runs outside the gate: only the ask/re-resolve/grant
+		// needs serializing, not the tool call itself — parallel same-tool
+		// calls must still execute concurrently once permission is settled.
+		release()
 	}
 
 	out, err := exec.Execute(ctx, call.Name, call.Input)

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -1279,6 +1279,150 @@ func TestAgentUnattendedAskDeniesImmediately(t *testing.T) {
 	}
 }
 
+// sessionGrantPerms mimics the real Permissions chain's behavior for
+// the single-flight ask gate tests: Resolve returns Ask for a tool
+// until a Grant has been recorded for it, after which it returns
+// Allow — matching how a real session grant, once written, makes a
+// later Resolve on the same (session, tool, subject) succeed without
+// asking again.
+type sessionGrantPerms struct {
+	mu      sync.Mutex
+	granted map[string]bool
+}
+
+func (p *sessionGrantPerms) Resolve(_ context.Context, sessionID, tool string, _ json.RawMessage) (tools.Resolution, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.granted[sessionID+"\x00"+tool] {
+		return tools.Resolution{Decision: tools.DecisionAllow, Subject: tool}, nil
+	}
+	return tools.Resolution{Decision: tools.DecisionAsk, Subject: tool, Rationale: "no standing grant"}, nil
+}
+
+func (p *sessionGrantPerms) Grant(_ context.Context, sessionID, tool, _ string, _ time.Duration) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.granted == nil {
+		p.granted = map[string]bool{}
+	}
+	p.granted[sessionID+"\x00"+tool] = true
+	return nil
+}
+
+// TestParallelSameToolAsksOnce reproduces the race this change fixes:
+// a step firing 3 parallel calls to the same tool with the same
+// arguments (same subject) must produce exactly one permission
+// prompt. Answering that prompt with "session" records a grant that
+// the other two calls — parked behind the gate — pick up on
+// re-resolve, so they never prompt at all.
+func TestParallelSameToolAsksOnce(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep(
+			[2]string{"echo", `{"text":"hi"}`},
+			[2]string{"echo", `{"text":"hi"}`},
+			[2]string{"echo", `{"text":"hi"}`},
+		),
+		finalStep("done"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+	a.perms = &sessionGrantPerms{}
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var evs []stream.StreamEvent
+	var prompts int
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				results := ofType(evs, stream.EventToolResult)
+				if len(results) != 3 {
+					t.Fatalf("tool results = %d, want 3", len(results))
+				}
+				for _, r := range results {
+					if r.ToolResult.Status != "ok" {
+						t.Fatalf("result = %+v, want ok", r.ToolResult)
+					}
+				}
+				if prompts != 1 {
+					t.Fatalf("permission prompts = %d, want exactly 1", prompts)
+				}
+				return
+			}
+			evs = append(evs, ev)
+			if ev.Type == stream.EventPermissionRequest {
+				prompts++
+				if !a.broker.Resolve(ev.Permission.ID, DecideSession) {
+					t.Fatal("broker did not know the prompt id")
+				}
+			}
+		case <-deadline:
+			t.Fatal("loop never finished")
+		}
+	}
+}
+
+// TestParallelSameToolOnceAnswerReAsks confirms "once" (not "session")
+// answers do NOT suppress a sibling call's prompt: with only 2
+// parallel same-tool calls, answering the first prompt with
+// DecideOnce records no grant, so the second call — released from the
+// gate after the first's execution — must still hit its own prompt.
+func TestParallelSameToolOnceAnswerReAsks(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep(
+			[2]string{"echo", `{"text":"hi"}`},
+			[2]string{"echo", `{"text":"hi"}`},
+		),
+		finalStep("done"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+	a.perms = &sessionGrantPerms{}
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var evs []stream.StreamEvent
+	var prompts int
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				results := ofType(evs, stream.EventToolResult)
+				if len(results) != 2 {
+					t.Fatalf("tool results = %d, want 2", len(results))
+				}
+				for _, r := range results {
+					if r.ToolResult.Status != "ok" {
+						t.Fatalf("result = %+v, want ok", r.ToolResult)
+					}
+				}
+				if prompts != 2 {
+					t.Fatalf("permission prompts = %d, want exactly 2 (once must not suppress the sibling's ask)", prompts)
+				}
+				return
+			}
+			evs = append(evs, ev)
+			if ev.Type == stream.EventPermissionRequest {
+				prompts++
+				if !a.broker.Resolve(ev.Permission.ID, DecideOnce) {
+					t.Fatal("broker did not know the prompt id")
+				}
+			}
+		case <-deadline:
+			t.Fatal("loop never finished")
+		}
+	}
+}
+
 // TestAgentAttendedAskStillParks is the control for the above: with
 // Unattended left false (the default), DecisionAsk must still emit
 // EventPermissionRequest and be answerable through the broker exactly

--- a/internal/brain/loop/askgate.go
+++ b/internal/brain/loop/askgate.go
@@ -1,0 +1,79 @@
+package loop
+
+import (
+	"context"
+	"sync"
+)
+
+// askGate serializes DecisionAsk handling per (session, tool, subject)
+// key: a step's parallel same-tool calls (executeAll, bounded by
+// errgroup) each hit a.perms.Resolve before any of them has answered
+// the prompt, so all N would independently park on askUser — the
+// first "session" answer grants a standing permission that covers the
+// rest, but by then they're already waiting on their own prompts. The
+// gate makes callers queue on the same key instead: only the first one
+// through actually asks: the rest re-resolve once they get the lock,
+// see the grant the first caller just recorded, and skip the prompt
+// entirely.
+type askGate struct {
+	mu      sync.Mutex
+	entries map[string]*gateEntry
+}
+
+// gateEntry is one key's lock: ch is a size-1 buffered channel used as
+// a mutex token (send to acquire, receive to release), refs counts
+// callers currently holding or waiting for it so the entry can be
+// removed once nobody needs it — otherwise the map would grow for
+// every distinct (session, tool, subject) ever seen and never shrink.
+type gateEntry struct {
+	ch   chan struct{}
+	refs int
+}
+
+func newAskGate() *askGate {
+	return &askGate{entries: map[string]*gateEntry{}}
+}
+
+// lock acquires the gate for key, blocking until it's free or ctx is
+// done. release must be called exactly once to hand the lock to the
+// next waiter (or, if there is none, to drop the entry). ok is false
+// only when ctx ended before the lock was acquired; the caller must
+// not call release in that case.
+func (g *askGate) lock(ctx context.Context, key string) (release func(), ok bool) {
+	g.mu.Lock()
+	e, exists := g.entries[key]
+	if !exists {
+		e = &gateEntry{ch: make(chan struct{}, 1)}
+		e.ch <- struct{}{}
+		g.entries[key] = e
+	}
+	e.refs++
+	g.mu.Unlock()
+
+	select {
+	case <-e.ch:
+		return func() { g.release(key, e) }, true
+	case <-ctx.Done():
+		g.mu.Lock()
+		e.refs--
+		if e.refs == 0 {
+			delete(g.entries, key)
+		}
+		g.mu.Unlock()
+		return nil, false
+	}
+}
+
+// release returns e's token and drops the entry once nobody else
+// holds or awaits it.
+func (g *askGate) release(key string, e *gateEntry) {
+	g.mu.Lock()
+	e.refs--
+	if e.refs == 0 {
+		delete(g.entries, key)
+		g.mu.Unlock()
+		return
+	}
+	g.mu.Unlock()
+	e.ch <- struct{}{}
+}

--- a/internal/brain/loop/askgate_test.go
+++ b/internal/brain/loop/askgate_test.go
@@ -1,0 +1,97 @@
+package loop
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestAskGateCtxCancelDeniesWaiter pins the gate's ctx-aware wait: a
+// waiter whose context ends before the lock is free must return
+// ok=false promptly, not block for the holder's full lifetime — and
+// the entry's refcount bookkeeping must not leak once everyone
+// involved has finished with the key.
+func TestAskGateCtxCancelDeniesWaiter(t *testing.T) {
+	t.Parallel()
+	g := newAskGate()
+	const key = "s1\x00shell\x00ls"
+
+	holderRelease, ok := g.lock(t.Context(), key)
+	if !ok {
+		t.Fatal("holder failed to acquire the uncontended lock")
+	}
+
+	waitCtx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		cancel() // cancel promptly so the waiter never gets the lock
+		if _, ok := g.lock(waitCtx, key); ok {
+			t.Error("waiter with a cancelled context acquired the lock")
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled waiter did not return promptly")
+	}
+
+	holderRelease()
+
+	g.mu.Lock()
+	n := len(g.entries)
+	g.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("askGate.entries = %d after all parties finished, want 0 (leaked entry)", n)
+	}
+}
+
+// TestAskGateSerializesConcurrentWaiters confirms the gate actually
+// forces waiters to take turns rather than letting them proceed
+// concurrently — the property the loop's DecisionAsk handling relies
+// on to make only the first caller ask.
+func TestAskGateSerializesConcurrentWaiters(t *testing.T) {
+	t.Parallel()
+	g := newAskGate()
+	const key = "s1\x00shell\x00ls"
+	const n = 5
+
+	var order []int
+	orderCh := make(chan int, n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			<-start
+			release, ok := g.lock(t.Context(), key)
+			if !ok {
+				t.Errorf("goroutine %d failed to acquire the lock", i)
+				orderCh <- -1
+				return
+			}
+			time.Sleep(2 * time.Millisecond)
+			orderCh <- i
+			release()
+		}(i)
+	}
+	close(start)
+
+	for i := 0; i < n; i++ {
+		select {
+		case v := <-orderCh:
+			order = append(order, v)
+		case <-time.After(5 * time.Second):
+			t.Fatal("goroutine did not complete in time — gate may be deadlocked")
+		}
+	}
+	if len(order) != n {
+		t.Fatalf("completed = %d, want %d", len(order), n)
+	}
+
+	g.mu.Lock()
+	left := len(g.entries)
+	g.mu.Unlock()
+	if left != 0 {
+		t.Fatalf("askGate.entries = %d after all released, want 0", left)
+	}
+}


### PR DESCRIPTION
A step's parallel same-tool calls each parked on `askUser` before the first "session" answer recorded its grant — N identical prompts for one decision (observed live: 9 prompts for 3 gmail tools in one burst).

- New `askGate`: refcounted per-key (session, tool, subject) ctx-aware mutex.
- `resolveAndRun` DecisionAsk path acquires the gate, then **re-resolves**: a sibling's session grant landed while waiting → Allow → zero prompt.
- "once" and deny answers re-ask sequentially (semantics preserved, no parallel spam); distinct shell commands keep distinct prompts (subject differs).
- Execution runs outside the gate — settled calls still execute concurrently.
- Unattended (D-039) fast-fail path untouched, runs before the gate.

Tests: 3-call burst → 1 prompt + 3 ok; once-answer re-asks; ctx-cancel waiter denied promptly, no entry leak; 5-way contention drains clean. Canary PASS.