### PR TITLE
feat(api): push mission and notification updates over SSE

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -186,7 +186,7 @@ func main() {
 	// over the same registry.
 	agentReg := agents.NewStore(app.DB, app.Log)
 
-	missionStore, missionDriver, missionNotifier, missionWorkspace := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, app.Log)
+	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, app.Log)
 	if missionDriver != nil {
 		var sandboxSweeper interface {
 			Sweep(ctx context.Context, isTerminal func(missionID string) bool) error
@@ -248,7 +248,7 @@ func main() {
 	api.Register(app.Server, svc, store, broker,
 		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, app.Log), flags,
 		agentReg, conns, goog, agent, missionStore, missionDriver, missionNotifier,
-		missionWorkspace, resolveSecret, token, app.Log)
+		missionWorkspace, resolveSecret, missionHub, token, app.Log)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)
@@ -329,19 +329,23 @@ func missionAgentResolver(agentReg *agents.Store) missions.AgentResolver {
 }
 
 // buildMissions wires the mission engine (Store, Driver, Notifier,
-// Scheduler). Gated on WORKSPACES: no workspace root configured means
-// missions stay entirely inert — no goroutines started, nothing
+// Scheduler, Hub). Gated on WORKSPACES: no workspace root configured
+// means missions stay entirely inert — no goroutines started, nothing
 // scheduled, the API surface unmounted (registerMissions 404s on a nil
 // store). agentReg is D-034's agent registry, resolved at scheduler
 // fire time and mission provisioning time (never schedule-create
-// time) so an agent edited after the fact still applies.
-func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, agentReg *agents.Store, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace) {
+// time) so an agent edited after the fact still applies. The hub
+// lives inside the same gate as everything else here — no missions,
+// no push events either.
+func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, agentReg *agents.Store, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace, *missions.Hub) {
 	root := os.Getenv("WORKSPACES")
 	if root == "" {
 		log.Info("WORKSPACES not set; missions disabled")
-		return nil, nil, nil, nil
+		return nil, nil, nil, nil, nil
 	}
+	hub := missions.NewHub()
 	store := missions.NewStore(db, log)
+	store.SetHub(hub)
 	identity := func(ctx context.Context) (string, string) {
 		return flags.Value(ctx, settings.ValueGitAuthorName), flags.Value(ctx, settings.ValueGitAuthorEmail)
 	}
@@ -369,6 +373,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	runner := missions.NewNativeRunnerWithFloor(agent, parker, floorDeny, sandboxExec, log)
 	webhookURL := os.Getenv("NOTIFY_WEBHOOK_URL")
 	notifier := missions.NewNotifier(db, webhookURL, log)
+	notifier.SetHub(hub)
 	// A second tools.Permissions instance, not the one buildAgent built —
 	// it's stateless besides the shared db/root (Grant/Resolve hit
 	// Postgres directly), so a fresh instance behaves identically. Used
@@ -384,7 +389,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	schedulerEnabled := func(ctx context.Context) bool { return flags.Enabled(ctx, settings.KeyScheduler) }
 	scheduler := missions.NewScheduler(db, store, resolveAgent, schedulerEnabled, log)
 	go scheduler.Run(ctx)
-	return store, driver, notifier, workspace
+	return store, driver, notifier, workspace, hub
 }
 
 // memoryProxy forwards the web's memory-management routes to memoryd

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -77,7 +77,7 @@ var memoryRoutePatterns = []string{
 // is the reverse proxy to memoryd's management routes, admin the
 // proxy to the gateway's internal control plane, conns the local
 // connector control plane (nil leaves any of them unmounted).
-func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, toolset Toolset, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), token string, log *slog.Logger) {
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, toolset Toolset, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), hub *missions.Hub, token string, log *slog.Logger) {
 	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log}
 	if memories != nil {
 		for _, pattern := range memoryRoutePatterns {
@@ -91,6 +91,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	a.registerTools(srv.Handle, toolset)
 	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret)
 	a.registerSchedules(srv.Handle, missionStore)
+	a.registerEvents(srv.Handle, hub)
 	srv.Handle("GET /v1/sessions", a.auth(http.HandlerFunc(a.handleList)))
 	srv.Handle("POST /v1/sessions", a.auth(http.HandlerFunc(a.handleCreate)))
 	srv.Handle("GET /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleTranscript)))

--- a/internal/brain/api/events.go
+++ b/internal/brain/api/events.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+// eventsHeartbeat keeps the SSE connection alive through proxies that
+// kill an idle connection — a comment line carries no event, so it
+// never triggers a client refetch.
+const eventsHeartbeat = 30 * time.Second
+
+// registerEvents mounts GET /v1/events, the push replacement for the
+// web's old 5s mission/notification poll: nil hub (missions disabled,
+// see cmd/brain/main.go's WORKSPACES gate) leaves it unmounted (404),
+// matching every other nil-gated optional surface in this package.
+func (a *API) registerEvents(handle func(pattern string, h http.Handler), hub *missions.Hub) {
+	if hub == nil {
+		return
+	}
+	h := &eventsAPI{hub: hub}
+	handle("GET /v1/events", a.auth(http.HandlerFunc(h.stream)))
+}
+
+type eventsAPI struct {
+	hub *missions.Hub
+}
+
+// stream relays hub signals to the client as SSE, same headers/flush
+// discipline as streamTurn: an initial "ready" event lets the client
+// know the stream is live (and refetch anything it might have missed
+// while connecting), then one "signal" event per hub push, plus a
+// heartbeat comment so idle connections survive proxies. Signals
+// carry only kind/id — no payload — so the client always refetches
+// the real state over the normal REST endpoints. The JSON payload
+// also carries "type" (same convention as chat's terminal meta event)
+// so a client parsing only "data:" lines — the web's createSSEParser
+// never looks at the "event:" line — can still tell ready from signal.
+func (h *eventsAPI) stream(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		jsonError(w, http.StatusInternalServerError, "streaming_unsupported", "response writer cannot flush")
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+
+	_, _ = fmt.Fprintf(w, "event: ready\ndata: {\"type\":\"ready\"}\n\n")
+	flusher.Flush()
+
+	ctx := r.Context()
+	sigs := h.hub.Subscribe(ctx)
+	ticker := time.NewTicker(eventsHeartbeat)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case sig, ok := <-sigs:
+			if !ok {
+				return
+			}
+			_, _ = fmt.Fprintf(w, "event: signal\ndata: {\"type\":\"signal\",\"kind\":%q,\"id\":%q}\n\n", sig.Kind, sig.ID)
+			flusher.Flush()
+		case <-ticker.C:
+			_, _ = fmt.Fprintf(w, ": ping\n\n")
+			flusher.Flush()
+		}
+	}
+}

--- a/internal/brain/api/events_test.go
+++ b/internal/brain/api/events_test.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+// syncRecorder wraps httptest.ResponseRecorder with a mutex so a test
+// can read the body from one goroutine while the handler under test
+// (running in its own goroutine, as the events stream must) writes to
+// it from another — plain ResponseRecorder isn't safe for that.
+type syncRecorder struct {
+	mu sync.Mutex
+	*httptest.ResponseRecorder
+}
+
+func newSyncRecorder() *syncRecorder {
+	return &syncRecorder{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func (r *syncRecorder) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.ResponseRecorder.Write(p)
+}
+
+func (r *syncRecorder) WriteHeader(code int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ResponseRecorder.WriteHeader(code)
+}
+
+func (r *syncRecorder) Flush() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ResponseRecorder.Flush()
+}
+
+func (r *syncRecorder) body() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.Body.String()
+}
+
+var _ http.Flusher = (*syncRecorder)(nil)
+
+func TestEventsEndpointUnmountedWhenHubNil(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	m := http.NewServeMux()
+	a.registerEvents(m.Handle, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/events", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	rec := httptest.NewRecorder()
+	m.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("GET /v1/events with a nil hub = %d, want 404 (unmounted)", rec.Code)
+	}
+}
+
+// TestEventsEndpointStreamsSignals confirms a connected client sees
+// the initial ready event, then a signal event for a hub publish that
+// happens after it connected — the exact contract the web's
+// subscribeEvents relies on to know when to refetch.
+func TestEventsEndpointStreamsSignals(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	hub := missions.NewHub()
+	m := http.NewServeMux()
+	a.registerEvents(m.Handle, hub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/v1/events", nil).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer tok")
+	rec := newSyncRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		m.ServeHTTP(rec, req)
+		close(done)
+	}()
+
+	// Give the handler a moment to subscribe before publishing — a
+	// publish before Subscribe registers would simply miss this
+	// subscriber (benign per the hub's own contract), so this waits on
+	// the ready event as proof the subscription is live.
+	deadline := time.Now().Add(2 * time.Second)
+	for !strings.Contains(rec.body(), "event: ready") {
+		if time.Now().After(deadline) {
+			t.Fatal("never saw the initial ready event")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	hub.Publish(missions.Signal{Kind: "mission", ID: "m1"})
+
+	deadline = time.Now().Add(2 * time.Second)
+	for !strings.Contains(rec.body(), "event: signal") {
+		if time.Now().After(deadline) {
+			t.Fatal("never saw the published signal")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler never returned after context cancel")
+	}
+
+	body := rec.body()
+	if !strings.Contains(body, `data: {"type":"signal","kind":"mission","id":"m1"}`) {
+		t.Fatalf("body missing expected signal payload: %s", body)
+	}
+	if rec.Header().Get("Content-Type") != "text/event-stream" {
+		t.Fatalf("Content-Type = %q, want text/event-stream", rec.Header().Get("Content-Type"))
+	}
+}
+
+func TestEventsEndpointRequiresAuth(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	hub := missions.NewHub()
+	m := http.NewServeMux()
+	a.registerEvents(m.Handle, hub)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/events", nil)
+	rec := httptest.NewRecorder()
+	m.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("code = %d, want 401 without a bearer token", rec.Code)
+	}
+}

--- a/internal/brain/missions/hub.go
+++ b/internal/brain/missions/hub.go
@@ -1,0 +1,72 @@
+package missions
+
+import (
+	"context"
+	"sync"
+)
+
+// Signal is a change hint pushed to subscribers — never a payload.
+// Kind is "mission" (ID = mission id) or "notification" (ID =
+// notification id). The client refetches the actual state over the
+// normal REST endpoints; the hub only tells it something changed, so
+// there's nothing here that can leak or go stale.
+type Signal struct {
+	Kind string `json:"kind"`
+	ID   string `json:"id"`
+}
+
+// Hub is an in-process pub/sub fan-out from mission/notification
+// writes to live SSE connections. It replaces the web's 5s poll: the
+// web used to re-fetch missions/notifications on a timer regardless
+// of whether anything changed; the hub instead pushes a hint the
+// instant a write commits, and the client refetches only then.
+type Hub struct {
+	mu   sync.Mutex
+	subs map[chan Signal]struct{}
+}
+
+func NewHub() *Hub {
+	return &Hub{subs: map[chan Signal]struct{}{}}
+}
+
+// subSignalBuf caps a subscriber's backlog — signals carry no payload,
+// so a client that misses one just refetches on the next signal or on
+// reconnect; there is nothing to replay.
+const subSignalBuf = 16
+
+// Subscribe registers a new subscriber and returns its channel. The
+// channel is closed and unregistered once ctx ends (e.g. the SSE
+// request disconnects) — callers range over it until closed.
+func (h *Hub) Subscribe(ctx context.Context) <-chan Signal {
+	ch := make(chan Signal, subSignalBuf)
+	h.mu.Lock()
+	h.subs[ch] = struct{}{}
+	h.mu.Unlock()
+
+	go func() {
+		<-ctx.Done()
+		h.mu.Lock()
+		if _, ok := h.subs[ch]; ok {
+			delete(h.subs, ch)
+			close(ch)
+		}
+		h.mu.Unlock()
+	}()
+	return ch
+}
+
+// Publish fans a signal out to every live subscriber. Non-blocking: a
+// full (slow) subscriber has this signal dropped rather than stalling
+// the writer that just committed a mission/notification change —
+// losing a signal is benign since the client's own state always lives
+// in Postgres, not in the hub.
+func (h *Hub) Publish(sig Signal) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for ch := range h.subs {
+		select {
+		case ch <- sig:
+		default:
+		}
+	}
+}

--- a/internal/brain/missions/hub_test.go
+++ b/internal/brain/missions/hub_test.go
@@ -1,0 +1,89 @@
+package missions
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestHubPublishReachesSubscriber(t *testing.T) {
+	t.Parallel()
+	h := NewHub()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := h.Subscribe(ctx)
+
+	h.Publish(Signal{Kind: "mission", ID: "m1"})
+
+	select {
+	case sig := <-ch:
+		if sig.Kind != "mission" || sig.ID != "m1" {
+			t.Fatalf("got signal %+v, want {mission m1}", sig)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("subscriber never received the published signal")
+	}
+}
+
+func TestHubSlowSubscriberDroppedNotBlocked(t *testing.T) {
+	t.Parallel()
+	h := NewHub()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := h.Subscribe(ctx)
+
+	// Fill the buffer, then publish once more: Publish must return
+	// immediately (never block on a full subscriber) and the extra
+	// signal is simply dropped for that subscriber.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < subSignalBuf+5; i++ {
+			h.Publish(Signal{Kind: "mission", ID: "m1"})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Publish blocked on a full subscriber instead of dropping the signal")
+	}
+
+	// Drain: at most subSignalBuf signals should be queued, not
+	// subSignalBuf+5 — proving the overflow was dropped, not buffered.
+	drained := 0
+	for {
+		select {
+		case <-ch:
+			drained++
+		default:
+			if drained > subSignalBuf {
+				t.Fatalf("drained %d signals, want at most %d (buffer cap)", drained, subSignalBuf)
+			}
+			return
+		}
+	}
+}
+
+func TestHubCtxCancelUnsubscribes(t *testing.T) {
+	t.Parallel()
+	h := NewHub()
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := h.Subscribe(ctx)
+	cancel()
+
+	// The channel must close once ctx ends — ranging over it (as the
+	// SSE handler does) exits instead of hanging forever.
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("channel delivered a value instead of closing on ctx cancel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("channel never closed after ctx cancel")
+	}
+
+	// A publish after unsubscribe must not panic (send on closed
+	// channel) and must not reach this subscriber.
+	h.Publish(Signal{Kind: "mission", ID: "m2"})
+}

--- a/internal/brain/missions/notify.go
+++ b/internal/brain/missions/notify.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
 )
 
@@ -22,10 +24,18 @@ type Notifier struct {
 	webhookURL string // NOTIFY_WEBHOOK_URL; empty disables fan-out, inbox row still always written
 	log        *slog.Logger
 	http       *http.Client
+	hub        *Hub
 }
 
 func NewNotifier(db *pgpool.Pool, webhookURL string, log *slog.Logger) *Notifier {
 	return &Notifier{db: db, webhookURL: webhookURL, log: log, http: &http.Client{Timeout: webhookTimeout}}
+}
+
+// SetHub wires the push-notification hub; nil (the default) makes
+// OnTransition's publish a no-op, same nil-safe convention as
+// Store.SetHub.
+func (n *Notifier) SetHub(hub *Hub) {
+	n.hub = hub
 }
 
 // isActionableTransition is the pure classification Driver's
@@ -66,19 +76,29 @@ func (n *Notifier) OnTransition(ctx context.Context, missionID string, before, a
 // sendOncePerMission dedupes by "already has an unread notification of
 // this kind" — checked inside the same insert (via a NOT EXISTS
 // subquery), not a separate pre-check, to avoid a TOCTOU race between
-// two concurrent Advance calls for the same mission.
+// two concurrent Advance calls for the same mission. RETURNING id
+// yields pgx.ErrNoRows exactly when the NOT EXISTS guard suppressed
+// the insert (already an unread row of this kind) — not a failure,
+// just "nothing to publish."
 func (n *Notifier) sendOncePerMission(ctx context.Context, missionID, kind, message string) error {
 	db, err := n.db.Get()
 	if err != nil {
 		return fmt.Errorf("get pool: %w", err)
 	}
-	_, err = db.Exec(ctx, `INSERT INTO notifications (mission_id, kind, message)
+	var id string
+	err = db.QueryRow(ctx, `INSERT INTO notifications (mission_id, kind, message)
 		SELECT $1, $2, $3
 		WHERE NOT EXISTS (
 			SELECT 1 FROM notifications WHERE mission_id = $1 AND kind = $2 AND NOT read
-		)`, missionID, kind, message)
+		) RETURNING id`, missionID, kind, message).Scan(&id)
 	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil
+		}
 		return fmt.Errorf("insert: %w", err)
+	}
+	if n.hub != nil {
+		n.hub.Publish(Signal{Kind: "notification", ID: id})
 	}
 	return nil
 }

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -27,10 +27,19 @@ const workSlotLockKey = 0x54494D53 // "TIMS"
 type Store struct {
 	db  *pgpool.Pool
 	log *slog.Logger
+	hub *Hub
 }
 
 func NewStore(db *pgpool.Pool, log *slog.Logger) *Store {
 	return &Store{db: db, log: log}
+}
+
+// SetHub wires the push-notification hub: a nil hub (the default,
+// before this is called) makes every publish below a no-op, so a
+// mission API test or a build without SSE wired up behaves exactly as
+// it did before this feature existed.
+func (s *Store) SetHub(hub *Hub) {
+	s.hub = hub
 }
 
 const missionColumns = `id, goal, kind, agent_id, phase, status, pause_reason, pause_message,
@@ -378,6 +387,9 @@ func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) er
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("missions apply transition commit: %w", err)
 	}
+	if s.hub != nil {
+		s.hub.Publish(Signal{Kind: "mission", ID: id})
+	}
 	return nil
 }
 
@@ -398,7 +410,13 @@ func (s *Store) AppendEvent(ctx context.Context, id, kind string, payload map[st
 	if err := appendEventTx(ctx, tx, id, kind, payload, "live"); err != nil {
 		return fmt.Errorf("missions append event: %w", err)
 	}
-	return tx.Commit(ctx)
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	if s.hub != nil {
+		s.hub.Publish(Signal{Kind: "mission", ID: id})
+	}
+	return nil
 }
 
 // appendEventTx does the actual locked-seq insert within an

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -43,7 +43,9 @@ export function setToken(token: string) {
 // createSSEParser incrementally parses an SSE byte stream that may be
 // chunked at arbitrary boundaries. Each complete "data:" block is
 // JSON-decoded and passed to onEvent; malformed blocks are skipped.
-export function createSSEParser(onEvent: (ev: ChatEvent) => void) {
+// Generic so events.ts's /v1/events stream (frames shaped differently
+// than ChatEvent) can reuse the same parsing without a cast.
+export function createSSEParser<T = ChatEvent>(onEvent: (ev: T) => void) {
   let buf = ''
 
   const emit = (block: string) => {
@@ -54,7 +56,7 @@ export function createSSEParser(onEvent: (ev: ChatEvent) => void) {
       .join('\n')
     if (!data) return
     try {
-      onEvent(JSON.parse(data) as ChatEvent)
+      onEvent(JSON.parse(data) as T)
     } catch {
       // Malformed frame: skip rather than kill the stream.
     }

--- a/web/src/lib/events.test.ts
+++ b/web/src/lib/events.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { subscribeEvents } from './events'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('subscribeEvents', () => {
+  it('fires onReady for the ready event and onSignal for a signal event', async () => {
+    vi.stubGlobal('localStorage', { getItem: () => 'tok', setItem: () => {} })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          'event: ready\ndata: {"type":"ready"}\n\n' +
+            'event: signal\ndata: {"type":"signal","kind":"mission","id":"m1"}\n\n',
+        ),
+      ),
+    )
+
+    const onSignal = vi.fn()
+    const onReady = vi.fn()
+    const unsubscribe = subscribeEvents(onSignal, onReady)
+
+    await vi.waitFor(() => expect(onReady).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(onSignal).toHaveBeenCalledWith({ kind: 'mission', id: 'm1' }))
+
+    unsubscribe()
+  })
+
+  it('sends the bearer token from localStorage', async () => {
+    vi.stubGlobal('localStorage', { getItem: () => 'tok', setItem: () => {} })
+    const fetchMock = vi.fn().mockResolvedValue(new Response('event: ready\ndata: {"type":"ready"}\n\n'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const unsubscribe = subscribeEvents(vi.fn())
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled())
+
+    expect(fetchMock.mock.calls[0][0]).toBe('/v1/events')
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer tok')
+
+    unsubscribe()
+  })
+
+  it('stops reconnecting once unsubscribed', async () => {
+    vi.stubGlobal('localStorage', { getItem: () => 'tok', setItem: () => {} })
+    const fetchMock = vi.fn().mockResolvedValue(new Response('event: ready\ndata: {"type":"ready"}\n\n'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const unsubscribe = subscribeEvents(vi.fn())
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    unsubscribe()
+
+    const callsAtUnsubscribe = fetchMock.mock.calls.length
+    await new Promise((r) => setTimeout(r, 1100))
+    expect(fetchMock.mock.calls.length).toBe(callsAtUnsubscribe)
+  })
+})

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -1,0 +1,79 @@
+import { createSSEParser, getToken } from '../api/client'
+
+export interface Signal {
+  kind: string
+  id: string
+}
+
+// EventFrame is the raw JSON payload of one /v1/events "data:" line —
+// createSSEParser only sees "data:" lines (it ignores the SSE
+// "event:" line), so "type" rides inside the JSON itself, same
+// convention as chat's terminal meta event.
+interface EventFrame {
+  type: 'ready' | 'signal'
+  kind?: string
+  id?: string
+}
+
+const initialBackoffMs = 1000
+const maxBackoffMs = 15000
+
+// subscribeEvents replaces the old 5s poll: it opens GET /v1/events
+// (fetch, not EventSource — EventSource can't send a Bearer header)
+// and reads it the same way chatStream/postSSE already does, via
+// createSSEParser over the response body's reader. onSignal fires for
+// every mission/notification change hint; onReady fires once per
+// (re)connect (initial connect and every reconnect after a drop), so
+// callers refetch anything they might have missed while disconnected.
+// Returns an unsubscribe function: aborts the in-flight request and
+// stops any pending reconnect.
+export function subscribeEvents(onSignal: (s: Signal) => void, onReady?: () => void): () => void {
+  const controller = new AbortController()
+  let stopped = false
+  let backoffMs = initialBackoffMs
+  let retryTimer: ReturnType<typeof setTimeout> | undefined
+
+  async function connect() {
+    if (stopped) return
+    try {
+      const res = await fetch('/v1/events', {
+        headers: { Authorization: `Bearer ${getToken()}` },
+        signal: controller.signal,
+      })
+      if (!res.ok || !res.body) throw new Error(`events stream failed (${res.status})`)
+
+      backoffMs = initialBackoffMs
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      const parser = createSSEParser<EventFrame>((e) => {
+        if (e.type === 'ready') {
+          onReady?.()
+        } else if (e.type === 'signal' && e.kind && e.id) {
+          onSignal({ kind: e.kind, id: e.id })
+        }
+      })
+      for (;;) {
+        const { done, value } = await reader.read()
+        if (done) break
+        parser.feed(decoder.decode(value, { stream: true }))
+      }
+      parser.end()
+    } catch {
+      // Aborted (unsubscribe called) or a transport error — either
+      // way, fall through to reconnect-with-backoff unless stopped.
+    }
+    if (stopped) return
+    retryTimer = setTimeout(() => {
+      void connect()
+    }, backoffMs)
+    backoffMs = Math.min(backoffMs * 2, maxBackoffMs)
+  }
+
+  void connect()
+
+  return () => {
+    stopped = true
+    controller.abort()
+    if (retryTimer) clearTimeout(retryTimer)
+  }
+}

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -2,9 +2,11 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Mission, MissionEvent } from '../api/types'
+import type { Signal } from '../lib/events'
 import { MissionDetail } from './MissionDetail'
 
 vi.mock('../lib/alertSound', () => ({ playAlertSound: vi.fn() }))
+vi.mock('../lib/events', () => ({ subscribeEvents: vi.fn() }))
 
 vi.mock('../api/client', () => ({
   getMission: vi.fn(),
@@ -35,6 +37,20 @@ import {
   secretStatus,
 } from '../api/client'
 import { playAlertSound } from '../lib/alertSound'
+import { subscribeEvents } from '../lib/events'
+
+// captureSubscribe grabs the onSignal/onReady callbacks subscribeEvents
+// was last called with, so a test can fire them directly instead of
+// waiting on a real SSE stream.
+function captureSubscribe() {
+  const unsubscribe = vi.fn()
+  vi.mocked(subscribeEvents).mockReturnValue(unsubscribe)
+  return {
+    fireSignal: (sig: Signal) => vi.mocked(subscribeEvents).mock.calls.at(-1)?.[0](sig),
+    fireReady: () => vi.mocked(subscribeEvents).mock.calls.at(-1)?.[1]?.(),
+    unsubscribe,
+  }
+}
 
 const baseMission: Mission = {
   id: 'm1',
@@ -106,6 +122,7 @@ function renderPage(id = 'm1') {
 afterEach(cleanup)
 beforeEach(() => {
   vi.clearAllMocks()
+  vi.mocked(subscribeEvents).mockReturnValue(vi.fn())
   vi.mocked(getMission).mockResolvedValue(baseMission)
   vi.mocked(missionEvents).mockResolvedValue(events)
   vi.mocked(missionUsage).mockResolvedValue({
@@ -184,28 +201,25 @@ describe('MissionDetail', () => {
     await waitFor(() => expect(answerMissionPermission).toHaveBeenCalledWith('m1', 'once'))
   })
 
-  it('plays an alert sound only on the transition into a permission block, not on later polls', async () => {
-    vi.useFakeTimers()
-    try {
-      vi.mocked(getMission).mockResolvedValue(baseMission)
-      renderPage()
-      await vi.waitFor(() => expect(getMission).toHaveBeenCalled())
-      expect(playAlertSound).not.toHaveBeenCalled()
+  it('plays an alert sound only on the transition into a permission block, not on later refetches', async () => {
+    const sub = captureSubscribe()
+    vi.mocked(getMission).mockResolvedValue(baseMission)
+    renderPage()
+    await vi.waitFor(() => expect(getMission).toHaveBeenCalled())
+    expect(playAlertSound).not.toHaveBeenCalled()
 
-      vi.mocked(getMission).mockResolvedValue({
-        ...baseMission,
-        pending_permission: 'perm-1',
-        pending_permission_tool: 'shell',
-      })
-      await vi.advanceTimersByTimeAsync(5000)
-      await vi.waitFor(() => expect(playAlertSound).toHaveBeenCalledTimes(1))
+    vi.mocked(getMission).mockResolvedValue({
+      ...baseMission,
+      pending_permission: 'perm-1',
+      pending_permission_tool: 'shell',
+    })
+    sub.fireSignal({ kind: 'mission', id: 'm1' })
+    await vi.waitFor(() => expect(playAlertSound).toHaveBeenCalledTimes(1))
 
-      // Still pending on the next poll — must not chime again.
-      await vi.advanceTimersByTimeAsync(1500 * 2)
-      expect(playAlertSound).toHaveBeenCalledTimes(1)
-    } finally {
-      vi.useRealTimers()
-    }
+    // Still pending on the next refetch — must not chime again.
+    sub.fireSignal({ kind: 'mission', id: 'm1' })
+    await vi.waitFor(() => expect(getMission).toHaveBeenCalledTimes(3))
+    expect(playAlertSound).toHaveBeenCalledTimes(1)
   })
 
   it('renders known event kinds with their specific text and unknown kinds with the fallback', async () => {
@@ -316,23 +330,39 @@ describe('MissionDetail', () => {
     expect(screen.queryByRole('button', { name: 'Push branch' })).toBeNull()
   })
 
-  it('stops polling once the mission reaches a terminal phase with no pending permission', async () => {
-    vi.useFakeTimers()
-    try {
-      vi.mocked(getMission).mockResolvedValue({ ...baseMission, phase: 'done', status: 'done' })
-      renderPage()
-      // One call on initial mount, one more when the effect re-runs after
-      // `mission` resolves (phase dep flips from undefined to 'done') —
-      // then the terminal branch stops scheduling any further interval.
-      await vi.waitFor(() => expect(getMission).toHaveBeenCalledTimes(2))
-      const callsAtTerminal = vi.mocked(getMission).mock.calls.length
+  it('ignores a signal for a different mission id', async () => {
+    const sub = captureSubscribe()
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    vi.mocked(getMission).mockClear()
 
-      await vi.advanceTimersByTimeAsync(5000 * 3)
+    sub.fireSignal({ kind: 'mission', id: 'some-other-mission' })
 
-      expect(getMission).toHaveBeenCalledTimes(callsAtTerminal)
-    } finally {
-      vi.useRealTimers()
-    }
+    // Nothing to await on directly (a no-op produces no event), so
+    // give any errant refetch a turn to happen, then assert it didn't.
+    await Promise.resolve()
+    expect(getMission).not.toHaveBeenCalled()
+  })
+
+  it('refetches on a signal naming this mission, and on ready', async () => {
+    const sub = captureSubscribe()
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    vi.mocked(getMission).mockClear()
+
+    sub.fireSignal({ kind: 'mission', id: 'm1' })
+    await vi.waitFor(() => expect(getMission).toHaveBeenCalledTimes(1))
+
+    sub.fireReady()
+    await vi.waitFor(() => expect(getMission).toHaveBeenCalledTimes(2))
+  })
+
+  it('unsubscribes on unmount', async () => {
+    const sub = captureSubscribe()
+    const { unmount } = renderPage()
+    await screen.findByText('Fix the login bug')
+    unmount()
+    expect(sub.unsubscribe).toHaveBeenCalled()
   })
 
   it('renders a Result section for a terminal mission with worker-reported evidence', async () => {

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -24,14 +24,12 @@ import { Button } from '../components/ui/button'
 import { errText } from '../components/settings/util'
 import { describeCron } from '../lib/schedules'
 import { playAlertSound } from '../lib/alertSound'
+import { subscribeEvents } from '../lib/events'
 
 function formatDate(v?: string): string {
   if (!v) return '—'
   return new Date(v).toLocaleString()
 }
-
-const pollIntervalIdle = 5000
-const pollIntervalPending = 1500
 
 const resumableStatuses = new Set(['paused', 'waiting_for_input'])
 const terminalPhases = new Set(['done', 'failed'])
@@ -52,17 +50,22 @@ export function MissionDetail() {
     missionUsage(id).then(setUsage, () => undefined)
   }, [id])
 
-  const phase = mission?.phase
   const pendingPermission = mission?.pending_permission
   const wasPendingRef = useRef(false)
 
   useEffect(() => {
     refresh()
-    if (phase && terminalPhases.has(phase) && !pendingPermission) return
-    const interval = pendingPermission ? pollIntervalPending : pollIntervalIdle
-    const timer = setInterval(refresh, interval)
-    return () => clearInterval(timer)
-  }, [refresh, pendingPermission, phase])
+    // Only refetch for a signal naming THIS mission — other missions'
+    // signals don't concern this page. onReady covers the initial
+    // connect and every reconnect, catching anything missed while
+    // disconnected.
+    return subscribeEvents(
+      (sig) => {
+        if (sig.kind === 'mission' && sig.id === id) refresh()
+      },
+      () => refresh(),
+    )
+  }, [refresh, id])
 
   // No GET-by-id for schedules; the list is small, so find the one
   // this mission fired from rather than adding a single-row endpoint.

--- a/web/src/pages/Missions.test.tsx
+++ b/web/src/pages/Missions.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { createMemoryRouter, RouterProvider } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Mission, Notification } from '../api/types'
+import type { Signal } from '../lib/events'
 import { Missions } from './Missions'
 
 vi.mock('../api/client', () => ({
@@ -12,7 +13,23 @@ vi.mock('../api/client', () => ({
   listAgents: vi.fn(),
 }))
 
+vi.mock('../lib/events', () => ({ subscribeEvents: vi.fn() }))
+
 import { listAgents, listMissions, listNotifications, listSchedules } from '../api/client'
+import { subscribeEvents } from '../lib/events'
+
+// captureSubscribe grabs the onSignal/onReady callbacks subscribeEvents
+// was last called with, so a test can fire them directly instead of
+// waiting on a real SSE stream.
+function captureSubscribe() {
+  const unsubscribe = vi.fn()
+  vi.mocked(subscribeEvents).mockReturnValue(unsubscribe)
+  return {
+    fireSignal: (sig: Signal) => vi.mocked(subscribeEvents).mock.calls.at(-1)?.[0](sig),
+    fireReady: () => vi.mocked(subscribeEvents).mock.calls.at(-1)?.[1]?.(),
+    unsubscribe,
+  }
+}
 
 const mission: Mission = {
   id: 'm1',
@@ -48,6 +65,7 @@ function renderPage() {
 afterEach(cleanup)
 beforeEach(() => {
   vi.clearAllMocks()
+  vi.mocked(subscribeEvents).mockReturnValue(vi.fn())
   vi.mocked(listMissions).mockResolvedValue([mission])
   vi.mocked(listNotifications).mockResolvedValue([])
   vi.mocked(listAgents).mockResolvedValue([])
@@ -98,5 +116,44 @@ describe('Missions board', () => {
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/missions/new'))
     expect(await screen.findByText('new mission page')).toBeTruthy()
+  })
+
+  it('refetches missions and notifications on any signal', async () => {
+    const sub = captureSubscribe()
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    vi.mocked(listMissions).mockClear()
+    vi.mocked(listNotifications).mockClear()
+
+    sub.fireSignal({ kind: 'mission', id: 'm1' })
+
+    await waitFor(() => expect(listMissions).toHaveBeenCalledTimes(1))
+    expect(listNotifications).toHaveBeenCalledTimes(1)
+  })
+
+  it('refetches on the ready event (initial connect and reconnects)', async () => {
+    const sub = captureSubscribe()
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    vi.mocked(listMissions).mockClear()
+
+    sub.fireReady()
+
+    await waitFor(() => expect(listMissions).toHaveBeenCalledTimes(1))
+  })
+
+  it('unsubscribes on unmount', async () => {
+    const sub = captureSubscribe()
+    const { unmount } = render(
+      <RouterProvider
+        router={createMemoryRouter(
+          [{ path: '/missions', element: <Missions /> }],
+          { initialEntries: ['/missions'] },
+        )}
+      />,
+    )
+    await screen.findByText('Fix the login bug')
+    unmount()
+    expect(sub.unsubscribe).toHaveBeenCalled()
   })
 })

--- a/web/src/pages/Missions.tsx
+++ b/web/src/pages/Missions.tsx
@@ -7,8 +7,7 @@ import type { Mission, Notification } from '../api/types'
 import { MissionCard } from '../components/missions/MissionCard'
 import { RecurringSchedules } from '../components/missions/RecurringSchedules'
 import { Button } from '../components/ui/button'
-
-const pollInterval = 5000
+import { subscribeEvents } from '../lib/events'
 
 export function Missions() {
   const navigate = useNavigate()
@@ -22,8 +21,14 @@ export function Missions() {
 
   useEffect(() => {
     refresh()
-    const id = setInterval(refresh, pollInterval)
-    return () => clearInterval(id)
+    // Any mission or notification signal means this board is stale —
+    // refetch both lists rather than trying to patch just the one
+    // that changed. onReady covers the initial connect and every
+    // reconnect, catching anything missed while disconnected.
+    return subscribeEvents(
+      () => refresh(),
+      () => refresh(),
+    )
   }, [refresh])
 
   const unread = notifications.filter((n) => !n.read)


### PR DESCRIPTION
The web polled missions every 5s (1.5s while a permission was pending). Replaced with push:

- `missions.Hub`: in-process pub/sub — buffered per-subscriber channels, non-blocking publish (slow subscriber drops the hint; state lives in the DB, next signal or reconnect refetches).
- `Store.ApplyTransition` / `Store.AppendEvent` / notification insert publish `{kind, id}` hints after successful commit. Notification insert now uses `RETURNING id` to publish only on genuine insert (NOT EXISTS dedupe suppression → no signal).
- `GET /v1/events`: SSE relay, nil-gated on the hub (missions disabled → 404). Initial `ready` event, 30s heartbeat comment.
- Web `lib/events.ts`: fetch-based SSE reader (Bearer — EventSource can't), 1s→15s backoff reconnect, refetch on ready. Missions + MissionDetail pages drop setInterval polling.

Live-verified: 10 mission signals captured on /v1/events during a canary run; canary PASS.