### PR TITLE
fix(brain): route sensitive-turn side-calls through pinned route

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -46,6 +46,13 @@ import (
 // driven budgets arrive when model rows carry context windows.
 const defaultTokenBudget = 60_000
 
+// sensitiveToolSuffixes is the single source of truth for which tools'
+// output must never leave the sensitive route floor once called: the
+// in-turn pin (loop.Agent.SetForceRoute) and the side-call route
+// (session.SensitiveTools, chat/memoryd/compactor) both key off this
+// same list, so a tool added here is covered everywhere at once.
+var sensitiveToolSuffixes = []string{"gmail_read", "gmail_read_attachment"}
+
 const (
 	serviceName = "brain"
 	defaultPort = 8080
@@ -205,21 +212,34 @@ func main() {
 		})
 	}
 
+	// Single source of truth for "this turn/session executed a sensitive
+	// tool": the loop's in-turn SetForceRoute pin above and this
+	// SensitiveTools value share sensitiveToolSuffixes, so side-calls
+	// (extraction, compaction summarize) honor the same route floor the
+	// tool loop already pinned the turn to. Nil when SENSITIVE_TOOL_ROUTE
+	// is unset — every side-call keeps today's behavior.
+	var sensitiveTools *session.SensitiveTools
+	if sensitiveRoute := os.Getenv("SENSITIVE_TOOL_ROUTE"); sensitiveRoute != "" {
+		sensitiveTools = &session.SensitiveTools{Suffixes: sensitiveToolSuffixes, Route: sensitiveRoute}
+	}
+
 	svc := chat.New(turnRouter{agent: agent, gw: gwc, flags: flags}, store, distill,
 		gatedCompactor{inner: compactor, flags: flags}, budgetFn, packs, flags.SkillAllowed,
 		agentReg.Resolve, app.Log)
 	svc.SetAutoDispatch(agentReg.Enabled, chat.ClassifyOverGateway(gwc))
-	svc.SetMemoryExtract(func(ctx context.Context, sessionID string, seq int64, text string) {
+	svc.SetSensitiveTools(sensitiveTools)
+	compactor.SetSensitiveTools(sensitiveTools)
+	svc.SetMemoryExtract(func(ctx context.Context, sessionID string, seq int64, text, route string) {
 		if !flags.Enabled(ctx, settings.KeyMemoryExtraction) {
 			return
 		}
 		ectx, cancel := context.WithTimeout(context.WithoutCancel(ctx), extractBudget)
 		defer cancel()
-		if _, err := mc.Extract(ectx, sessionID, seq, text); err != nil {
+		if _, err := mc.Extract(ectx, sessionID, seq, text, route); err != nil {
 			app.Log.Warn("turn memory extraction failed", "session_id", sessionID, "error", err)
 		}
 	})
-	compactor.SetMemoryExtract(func(ctx context.Context, sessionID string, seq int64, text string) []string {
+	compactor.SetMemoryExtract(func(ctx context.Context, sessionID string, seq int64, text, route string) []string {
 		if !flags.Enabled(ctx, settings.KeyMemoryExtraction) {
 			return nil
 		}
@@ -227,7 +247,7 @@ func main() {
 		// never starve the summarize that follows it.
 		ectx, cancel := context.WithTimeout(ctx, preCompactExtractBudget)
 		defer cancel()
-		ids, err := mc.Extract(ectx, sessionID, seq, text)
+		ids, err := mc.Extract(ectx, sessionID, seq, text, route)
 		if err != nil {
 			app.Log.Warn("pre-compaction extraction failed", "session_id", sessionID, "error", err)
 			return nil
@@ -519,8 +539,9 @@ func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, wor
 	// route the turn started on — optional, since not everyone runs a
 	// local model.
 	if sensitiveRoute := os.Getenv("SENSITIVE_TOOL_ROUTE"); sensitiveRoute != "" {
-		agent.SetForceRoute("gmail_read", sensitiveRoute)
-		agent.SetForceRoute("gmail_read_attachment", sensitiveRoute)
+		for _, suffix := range sensitiveToolSuffixes {
+			agent.SetForceRoute(suffix, sensitiveRoute)
+		}
 	} else {
 		log.Warn("SENSITIVE_TOOL_ROUTE not set; gmail_read/gmail_read_attachment output is processed on the turn's normal route, same as everything else")
 	}

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -82,8 +82,10 @@ type Compactor interface {
 // MemoryExtract posts one turn's text to memoryd for long-term memory
 // extraction. Fire-and-forget from chat's view: chat invokes it on a
 // goroutine, the wrapper owns timeout and error logging, and no
-// failure may touch the user-facing turn.
-type MemoryExtract func(ctx context.Context, sessionID string, seq int64, text string)
+// failure may touch the user-facing turn. route is "" for the normal
+// side-call route, or the sensitive route pin when the turn executed a
+// sensitive tool (see Service.sensitive).
+type MemoryExtract func(ctx context.Context, sessionID string, seq int64, text string, route string)
 
 // MemoryRetrieve returns the rendered long-term memory block for a
 // user message, or "" for nothing relevant. The wrapper owns timeout
@@ -107,6 +109,7 @@ type Service struct {
 	skillAllow  func(context.Context, string) bool // nil: all packs allowed
 	skillBodies map[string]string                  // name -> full pack body, for skill_hint
 	flushEvery  time.Duration                      // pending-state flush cadence mid-stream
+	sensitive   *session.SensitiveTools            // nil: no sensitive-tool route pin for side-calls
 	logger      *slog.Logger
 }
 
@@ -116,6 +119,12 @@ func (s *Service) SetMemoryExtract(fn MemoryExtract) { s.memory = fn }
 
 // SetMemoryRetrieve wires per-turn memory recall. Optional.
 func (s *Service) SetMemoryRetrieve(fn MemoryRetrieve) { s.recall = fn }
+
+// SetSensitiveTools wires the sensitive-tool route pin for side-calls
+// (memory extraction): a turn that executed a matching tool sends its
+// extraction on t.Route instead of memoryd's own default. Optional —
+// nil leaves every turn's side-calls on today's behavior.
+func (s *Service) SetSensitiveTools(t *session.SensitiveTools) { s.sensitive = t }
 
 // SetAutoDispatch wires auto agent dispatch (D-034 follow-up): a
 // request naming the autoAgentName sentinel resolves through candidates
@@ -426,6 +435,15 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 	var usage *stream.Usage
 	sawDone := false
 	flushed := 0
+	// turnSensitive flips once any tool this turn executed matches
+	// s.sensitive — memory extraction then rides the sensitive route
+	// pin instead of its own default (see persistTurn).
+	turnSensitive := false
+	noteToolResult := func(ev stream.StreamEvent) {
+		if ev.Type == stream.EventToolResult && ev.ToolResult != nil && s.sensitive.Matches(ev.ToolResult.Name) {
+			turnSensitive = true
+		}
+	}
 
 	// flushPending checkpoints the partial answer DURING the stream so
 	// even a SIGKILL mid-turn loses at most one flush interval — the
@@ -458,9 +476,10 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 				sawDone = true
 				meta = ev.Meta
 			}
+			noteToolResult(ev)
 		}
 		close(out)
-		s.persistTurn(sessionID, userText, route, profile, needsTitle, text.String(), reasoning.String(), meta, usage, sawDone, flushed)
+		s.persistTurn(sessionID, userText, route, profile, needsTitle, text.String(), reasoning.String(), meta, usage, sawDone, flushed, turnSensitive)
 	}
 
 	ticker := time.NewTicker(s.flushEvery)
@@ -484,6 +503,7 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 				sawDone = true
 				meta = ev.Meta
 			}
+			noteToolResult(ev)
 			select {
 			case out <- ev:
 			case <-ctx.Done():
@@ -501,7 +521,7 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 	}
 }
 
-func (s *Service) persistTurn(sessionID, userText, route string, profile agents.Agent, needsTitle bool, text, reasoning string, meta *stream.Meta, usage *stream.Usage, sawDone bool, flushed int) {
+func (s *Service) persistTurn(sessionID, userText, route string, profile agents.Agent, needsTitle bool, text, reasoning string, meta *stream.Meta, usage *stream.Usage, sawDone bool, flushed int, turnSensitive bool) {
 	if !sawDone {
 		// Abnormal end: keep the partial durable; the projection
 		// splices it into the next request. Skip when the periodic
@@ -586,7 +606,16 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 		} else if text != "" {
 			mtext += "\n\nassistant: " + text
 		}
-		go s.memory(context.Background(), sessionID, turnSeq, mtext)
+		// A turn that executed a sensitive tool pins its extraction to
+		// the same route the loop already forced the turn onto — the
+		// text extraction sees can quote raw sensitive output (e.g.
+		// email), so it must never fall back to memoryd's own default
+		// side-call route.
+		extractRoute := ""
+		if turnSensitive && s.sensitive != nil {
+			extractRoute = s.sensitive.Route
+		}
+		go s.memory(context.Background(), sessionID, turnSeq, mtext, extractRoute)
 	}
 
 	if s.compactor != nil {

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -635,7 +635,7 @@ func TestMemoryExtractGetsUserTextAndResidue(t *testing.T) {
 		text      string
 	}
 	got := make(chan call, 1)
-	svc.SetMemoryExtract(func(_ context.Context, sessionID string, seq int64, text string) {
+	svc.SetMemoryExtract(func(_ context.Context, sessionID string, seq int64, text, _ string) {
 		got <- call{sessionID, seq, text}
 	})
 
@@ -668,7 +668,7 @@ func TestMemoryExtractWithoutDistillSendsAssistantText(t *testing.T) {
 	svc := newService(gw, log) // no distiller
 
 	got := make(chan string, 1)
-	svc.SetMemoryExtract(func(_ context.Context, _ string, _ int64, text string) {
+	svc.SetMemoryExtract(func(_ context.Context, _ string, _ int64, text, _ string) {
 		got <- text
 	})
 
@@ -765,7 +765,7 @@ func TestMemoryExtractFiresOnTextlessTurn(t *testing.T) {
 	}}
 	svc := newService(gw, log)
 	got := make(chan string, 1)
-	svc.SetMemoryExtract(func(_ context.Context, _ string, _ int64, text string) {
+	svc.SetMemoryExtract(func(_ context.Context, _ string, _ int64, text, _ string) {
 		got <- text
 	})
 
@@ -1056,4 +1056,76 @@ func TestAutoTitleUsesDefaultRouteNotClassifyRoute(t *testing.T) {
 		}
 	}
 	t.Fatal("no title request recorded")
+}
+
+// TestMemoryExtractUsesSensitiveRouteWhenTurnRanSensitiveTool pins the
+// side-call route pin: a turn that executed a tool matching the wired
+// SensitiveTools sends its extraction on the sensitive route instead of
+// memoryd's own default, mirroring the in-turn SetForceRoute pin.
+func TestMemoryExtractUsesSensitiveRouteWhenTurnRanSensitiveTool(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: []stream.StreamEvent{
+		{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{ID: "c1", Name: "personal_gmail_read", Status: "ok"}},
+		{Type: stream.EventChunk, Text: "the answer"},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
+	}}
+	svc := newService(gw, log)
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: "local"})
+
+	got := make(chan string, 1)
+	svc.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) {
+		got <- route
+	})
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize my inbox"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	select {
+	case route := <-got:
+		if route != "local" {
+			t.Fatalf("route = %q, want local (sensitive tool ran this turn)", route)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("memory extract never invoked")
+	}
+}
+
+// TestMemoryExtractUsesEmptyRouteWhenTurnDidNotRunSensitiveTool proves
+// the pin is per-turn, not global: a turn with no matching tool call
+// leaves the route empty (memoryd's own default) even with
+// SensitiveTools wired.
+func TestMemoryExtractUsesEmptyRouteWhenTurnDidNotRunSensitiveTool(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: []stream.StreamEvent{
+		{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{ID: "c1", Name: "shell", Status: "ok"}},
+		{Type: stream.EventChunk, Text: "the answer"},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
+	}}
+	svc := newService(gw, log)
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: "local"})
+
+	got := make(chan string, 1)
+	svc.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) {
+		got <- route
+	})
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "run a shell command"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	select {
+	case route := <-got:
+		if route != "" {
+			t.Fatalf("route = %q, want empty (no sensitive tool ran)", route)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("memory extract never invoked")
+	}
 }

--- a/internal/brain/memclient/memclient.go
+++ b/internal/brain/memclient/memclient.go
@@ -30,10 +30,12 @@ func New(baseURL string) *Client {
 }
 
 // Extract posts one extraction job and returns the inserted memory
-// ids.
-func (c *Client) Extract(ctx context.Context, sessionID string, sourceSeq int64, text string) ([]string, error) {
+// ids. route overrides memoryd's own side-call route when non-empty —
+// set when the turn/session being extracted executed a sensitive tool
+// and must not fall back to the default side-call route.
+func (c *Client) Extract(ctx context.Context, sessionID string, sourceSeq int64, text, route string) ([]string, error) {
 	body, err := json.Marshal(map[string]any{
-		"session_id": sessionID, "source_seq": sourceSeq, "text": text,
+		"session_id": sessionID, "source_seq": sourceSeq, "text": text, "route": route,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("memclient: marshal: %w", err)

--- a/internal/brain/memclient/memclient_test.go
+++ b/internal/brain/memclient/memclient_test.go
@@ -23,7 +23,7 @@ func TestExtractRoundTrip(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ids, err := New(srv.URL).Extract(t.Context(), "s1", 42, "turn text")
+	ids, err := New(srv.URL).Extract(t.Context(), "s1", 42, "turn text", "")
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
@@ -35,6 +35,26 @@ func TestExtractRoundTrip(t *testing.T) {
 	}
 }
 
+// TestExtractSendsRouteOverride pins the sensitive-route pass-through:
+// a non-empty route reaches the wire so memoryd's extraction honors the
+// same floor the tool loop already pinned a sensitive turn to.
+func TestExtractSendsRouteOverride(t *testing.T) {
+	t.Parallel()
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		_ = json.NewEncoder(w).Encode(map[string]any{"memory_ids": []string{}})
+	}))
+	defer srv.Close()
+
+	if _, err := New(srv.URL).Extract(t.Context(), "s1", 1, "x", "local"); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if got["route"] != "local" {
+		t.Fatalf("request body = %v, want route=local", got)
+	}
+}
+
 func TestExtractSurfacesHTTPError(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -42,7 +62,7 @@ func TestExtractSurfacesHTTPError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := New(srv.URL).Extract(t.Context(), "s1", 1, "x"); err == nil {
+	if _, err := New(srv.URL).Extract(t.Context(), "s1", 1, "x", ""); err == nil {
 		t.Fatal("Extract succeeded on 502, want error")
 	}
 }

--- a/internal/brain/session/compactor.go
+++ b/internal/brain/session/compactor.go
@@ -56,17 +56,21 @@ type Compactor struct {
 	// budget resolves the fallback cap when no model window is
 	// resolvable — a func because it is a runtime setting, editable
 	// without a restart.
-	budget   func(context.Context) int
-	extract  MemoryExtract
-	logger   *slog.Logger
-	compacts prometheus.Counter // nil-safe: may be unset in tests
+	budget    func(context.Context) int
+	extract   MemoryExtract
+	sensitive *SensitiveTools // nil: no sensitive-tool route pin for summarize
+	logger    *slog.Logger
+	compacts  prometheus.Counter // nil-safe: may be unset in tests
 }
 
 // MemoryExtract sends turns about to be summarized to memoryd and
 // returns the extracted memory ids. Runs BEFORE summarization so
 // names, dates, and commitments survive the summary (D-011). Failures
-// return nil — extraction must never block compaction.
-type MemoryExtract func(ctx context.Context, sessionID string, seq int64, text string) []string
+// return nil — extraction must never block compaction. route carries
+// the sensitive-tool route pin (see SetSensitiveTools) when the
+// session being extracted from is sensitive, "" otherwise — matches
+// chat.MemoryExtract's param order.
+type MemoryExtract func(ctx context.Context, sessionID string, seq int64, text string, route string) []string
 
 func NewCompactor(log Log, gw Gateway, windows Windows, budget func(context.Context) int, logger *slog.Logger, compacts prometheus.Counter) *Compactor {
 	return &Compactor{log: log, gw: gw, windows: windows, budget: budget, logger: logger, compacts: compacts}
@@ -75,6 +79,12 @@ func NewCompactor(log Log, gw Gateway, windows Windows, budget func(context.Cont
 // SetMemoryExtract wires the memoryd hook. Optional — nil skips
 // pre-compaction extraction.
 func (c *Compactor) SetMemoryExtract(fn MemoryExtract) { c.extract = fn }
+
+// SetSensitiveTools wires the sensitive-tool route pin for the
+// summarize call: a session where any tool_execution event matches
+// summarizes on t.Route instead of the compactor's own default route.
+// Optional — nil leaves every session's summarize on today's behavior.
+func (c *Compactor) SetSensitiveTools(t *SensitiveTools) { c.sensitive = t }
 
 // budgetFor sizes the token budget to the model that served the
 // session's last turn: 60% of its context window per the gateway's
@@ -95,6 +105,31 @@ func (c *Compactor) budgetFor(ctx context.Context, sessionID string, events []Ev
 		return w * 60 / 100
 	}
 	return c.budget(ctx)
+}
+
+// sessionIsSensitive reports whether any tool_execution event anywhere
+// in the session matches sensitive — scoped to the whole session, not
+// just the span about to be summarized, since a later compaction pass
+// can summarize a span that never itself ran the sensitive tool but
+// still sits downstream of a turn that did (D-007 residue can carry
+// content forward). nil sensitive (feature off) always reports false.
+func sessionIsSensitive(events []Event, sensitive *SensitiveTools) bool {
+	if sensitive == nil {
+		return false
+	}
+	for _, ev := range events {
+		if ev.Kind != KindToolExecution {
+			continue
+		}
+		var te ToolExecution
+		if decode(ev, &te) != nil {
+			continue
+		}
+		if sensitive.Matches(te.Name) {
+			return true
+		}
+	}
+	return false
 }
 
 // lastModel returns the model of the newest assistant_turn, or "".
@@ -140,20 +175,35 @@ func (c *Compactor) MaybeCompact(ctx context.Context, sessionID string) error {
 		return nil // nothing safely summarizable (e.g. one giant turn)
 	}
 
+	// Sensitive if ANY tool_execution event in the WHOLE session matches
+	// — compaction can summarize any span of the session's history, not
+	// just the newest turns, so a sensitive tool call anywhere in it
+	// taints both the extract and summarize calls for the same reason
+	// the loop pins the rest of a sensitive TURN's route (the content
+	// downstream of it may quote raw sensitive output). Computed once so
+	// extract and summarize agree on the same verdict.
+	sensitive := sessionIsSensitive(events, c.sensitive)
+
 	// Extract BEFORE summarizing: once the summary replaces these
-	// turns, whatever it dropped is gone for good (D-011).
+	// turns, whatever it dropped is gone for good (D-011). The turns
+	// being extracted are exactly the ones that may carry sensitive
+	// content, so extraction rides the same route pin as summarize.
 	facts := []string{}
 	if c.extract != nil {
 		var b strings.Builder
 		for _, m := range toSummarize {
 			b.WriteString(m.Role + ": " + m.Content + "\n\n")
 		}
-		if ids := c.extract(ctx, sessionID, boundary, b.String()); ids != nil {
+		extractRoute := ""
+		if sensitive && c.sensitive != nil {
+			extractRoute = c.sensitive.Route
+		}
+		if ids := c.extract(ctx, sessionID, boundary, b.String(), extractRoute); ids != nil {
 			facts = ids
 		}
 	}
 
-	summary, err := c.summarize(ctx, sessionID, toSummarize)
+	summary, err := c.summarize(ctx, sessionID, toSummarize, sensitive)
 	if err != nil {
 		return fmt.Errorf("session: compact %s: %w", sessionID, err)
 	}
@@ -258,16 +308,20 @@ func planCompaction(events []Event) (boundary int64, toSummarize []provider.Mess
 	return 0, nil, false // projection/event mismatch: refuse to guess
 }
 
-func (c *Compactor) summarize(ctx context.Context, sessionID string, msgs []provider.Message) (string, error) {
+func (c *Compactor) summarize(ctx context.Context, sessionID string, msgs []provider.Message, sensitive bool) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, compactTimeout)
 	defer cancel()
 
+	route := "summarize"
+	if sensitive && c.sensitive != nil && c.sensitive.Route != "" {
+		route = c.sensitive.Route
+	}
 	var b strings.Builder
 	for _, m := range msgs {
 		b.WriteString(m.Role + ": " + m.Content + "\n\n")
 	}
 	events, err := c.gw.Stream(ctx, gwclient.StreamRequest{
-		Route: "summarize",
+		Route: route,
 		Purpose:      "compaction",
 		System:       summarizeSystem,
 		Messages:     []provider.Message{{Role: "user", Content: b.String()}},

--- a/internal/brain/session/compactor_test.go
+++ b/internal/brain/session/compactor_test.go
@@ -41,6 +41,7 @@ type summarizerGW struct {
 	summary   string
 	sawText   string
 	sawSystem string
+	sawRoute  string
 	calls     int
 }
 
@@ -48,6 +49,7 @@ func (g *summarizerGW) Stream(_ context.Context, req gwclient.StreamRequest) (<-
 	g.calls++
 	g.sawText = req.Messages[0].Content
 	g.sawSystem = req.System
+	g.sawRoute = req.Route
 	ch := make(chan stream.StreamEvent, 2)
 	ch <- stream.StreamEvent{Type: stream.EventChunk, Text: g.summary}
 	ch <- stream.StreamEvent{Type: stream.EventDone}
@@ -446,7 +448,7 @@ func TestCompactionExtractsBeforeSummarizing(t *testing.T) {
 
 	var sawText string
 	var extractedAtCall int
-	c.SetMemoryExtract(func(_ context.Context, sessionID string, seq int64, text string) []string {
+	c.SetMemoryExtract(func(_ context.Context, sessionID string, seq int64, text, _ string) []string {
 		sawText = text
 		extractedAtCall = gw.calls // 0 = before the summarizer ran
 		if sessionID != "s1" || seq == 0 {
@@ -479,13 +481,123 @@ func TestCompactionExtractsBeforeSummarizing(t *testing.T) {
 	}
 }
 
+// TestCompactionUsesSensitiveRouteWhenSessionRanSensitiveTool pins the
+// summarize route pin: a session carrying ANY tool_execution event that
+// matches the wired SensitiveTools summarizes on the sensitive route
+// instead of the compactor's own default, mirroring the in-turn
+// SetForceRoute pin the loop already applies within a turn.
+func TestCompactionUsesSensitiveRouteWhenSessionRanSensitiveTool(t *testing.T) {
+	t.Parallel()
+	log := newMemLog()
+	gw := &summarizerGW{summary: "short summary"}
+	seedConversation(t, log, "s1", 10)
+	if _, err := log.Append(context.Background(), "s1", KindToolExecution, ToolExecution{
+		CallID: "c1", Name: "personal_gmail_read", Status: "ok",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
+	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: "local"})
+
+	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
+		t.Fatalf("MaybeCompact: %v", err)
+	}
+	if gw.calls != 1 {
+		t.Fatalf("summarizer calls = %d, want 1", gw.calls)
+	}
+	if gw.sawRoute != "local" {
+		t.Fatalf("summarize route = %q, want local (session ran a sensitive tool)", gw.sawRoute)
+	}
+}
+
+// TestCompactionUsesDefaultRouteWithoutSensitiveTool proves the pin is
+// per-session, not global: a session with no matching tool_execution
+// event summarizes on the compactor's own default route even with
+// SensitiveTools wired.
+func TestCompactionUsesDefaultRouteWithoutSensitiveTool(t *testing.T) {
+	t.Parallel()
+	log := newMemLog()
+	gw := &summarizerGW{summary: "short summary"}
+	seedConversation(t, log, "s1", 10)
+	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
+	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: "local"})
+
+	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
+		t.Fatalf("MaybeCompact: %v", err)
+	}
+	if gw.calls != 1 {
+		t.Fatalf("summarizer calls = %d, want 1", gw.calls)
+	}
+	if gw.sawRoute != "summarize" {
+		t.Fatalf("summarize route = %q, want summarize (no sensitive tool ran)", gw.sawRoute)
+	}
+}
+
+// TestCompactionExtractUsesSensitiveRouteWhenSessionRanSensitiveTool
+// proves the pre-compaction extract hook honors the same route pin as
+// summarize: the turns handed to extract are exactly the ones that may
+// carry sensitive content, so a sensitive tool call anywhere in the
+// session must pin the extract call's route too.
+func TestCompactionExtractUsesSensitiveRouteWhenSessionRanSensitiveTool(t *testing.T) {
+	t.Parallel()
+	log := newMemLog()
+	gw := &summarizerGW{summary: "short summary"}
+	seedConversation(t, log, "s1", 10)
+	if _, err := log.Append(context.Background(), "s1", KindToolExecution, ToolExecution{
+		CallID: "c1", Name: "personal_gmail_read", Status: "ok",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
+	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: "local"})
+
+	var sawRoute string
+	c.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) []string {
+		sawRoute = route
+		return nil
+	})
+
+	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
+		t.Fatalf("MaybeCompact: %v", err)
+	}
+	if sawRoute != "local" {
+		t.Fatalf("extract route = %q, want local (session ran a sensitive tool)", sawRoute)
+	}
+}
+
+// TestCompactionExtractUsesEmptyRouteWithoutSensitiveTool proves the
+// extract route pin is per-session, not global: a session with no
+// matching tool_execution event extracts on "" even with
+// SensitiveTools wired.
+func TestCompactionExtractUsesEmptyRouteWithoutSensitiveTool(t *testing.T) {
+	t.Parallel()
+	log := newMemLog()
+	gw := &summarizerGW{summary: "short summary"}
+	seedConversation(t, log, "s1", 10)
+	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
+	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: "local"})
+
+	sawRoute := "unset"
+	c.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) []string {
+		sawRoute = route
+		return nil
+	})
+
+	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
+		t.Fatalf("MaybeCompact: %v", err)
+	}
+	if sawRoute != "" {
+		t.Fatalf("extract route = %q, want empty (no sensitive tool ran)", sawRoute)
+	}
+}
+
 func TestCompactionSurvivesExtractionFailure(t *testing.T) {
 	t.Parallel()
 	log := newMemLog()
 	gw := &summarizerGW{summary: "short summary"}
 	seedConversation(t, log, "s1", 10)
 	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
-	c.SetMemoryExtract(func(context.Context, string, int64, string) []string {
+	c.SetMemoryExtract(func(context.Context, string, int64, string, string) []string {
 		return nil // extraction failed upstream; hook contract returns nil
 	})
 

--- a/internal/brain/session/sensitive.go
+++ b/internal/brain/session/sensitive.go
@@ -1,0 +1,32 @@
+package session
+
+import "strings"
+
+// SensitiveTools names the tools whose execution marks a turn/session
+// sensitive, and the route side-calls must fall back to when they are.
+// The loop pins the TURN's own route once a matching tool runs
+// (Agent.SetForceRoute), but side-calls — memory extraction, session
+// compaction — re-send turn/conversation content to their own routes
+// LATER, on their own schedule; without this they'd bypass the same
+// floor the in-turn steps already honor and ship raw sensitive content
+// (e.g. email text) to a cloud model. Suffix, not exact name: connector
+// tools are namespaced "<connector-name>_<tool-name>" with a user-chosen
+// connector name (same rule as Agent.SetForceRoute/matchGrant, D-036).
+type SensitiveTools struct {
+	Suffixes []string
+	Route    string
+}
+
+// Matches reports whether toolName ends a sensitive suffix: exact
+// match, or toolName ends with "_"+suffix.
+func (s *SensitiveTools) Matches(toolName string) bool {
+	if s == nil {
+		return false
+	}
+	for _, suffix := range s.Suffixes {
+		if toolName == suffix || strings.HasSuffix(toolName, "_"+suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/brain/session/sensitive_test.go
+++ b/internal/brain/session/sensitive_test.go
@@ -1,0 +1,39 @@
+package session
+
+import "testing"
+
+// TestSensitiveToolsMatches pins the suffix semantics: exact name, or
+// name ending "_"+suffix (connector namespacing), same rule as
+// loop.Agent.SetForceRoute/matchGrant (D-036).
+func TestSensitiveToolsMatches(t *testing.T) {
+	t.Parallel()
+	s := &SensitiveTools{Suffixes: []string{"gmail_read", "gmail_read_attachment"}, Route: "local"}
+	tests := []struct {
+		name string
+		tool string
+		want bool
+	}{
+		{name: "exact match", tool: "gmail_read", want: true},
+		{name: "connector-namespaced match", tool: "personal_gmail_read", want: true},
+		{name: "other suffix connector-namespaced", tool: "work_gmail_read_attachment", want: true},
+		{name: "unrelated tool", tool: "shell", want: false},
+		{name: "prefix only, not suffix", tool: "gmail_read_something_else", want: false},
+		{name: "partial suffix without underscore boundary", tool: "xgmail_read", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := s.Matches(tc.tool); got != tc.want {
+				t.Fatalf("Matches(%q) = %v, want %v", tc.tool, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSensitiveToolsMatchesNilReceiver(t *testing.T) {
+	t.Parallel()
+	var s *SensitiveTools
+	if s.Matches("gmail_read") {
+		t.Fatal("nil SensitiveTools matched a tool, want false (feature off)")
+	}
+}

--- a/internal/memory/extract/consolidate.go
+++ b/internal/memory/extract/consolidate.go
@@ -329,6 +329,11 @@ func mergeGuard(members []string, merged string) string {
 func (c *Consolidator) mergedContent(ctx context.Context, lines []string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, llmTimeout)
 	defer cancel()
+	// Always sideRoute, never a sensitive-tool route override: this
+	// merges lines from already-active memories across an unbounded,
+	// cross-session batch, not one turn/session whose sensitivity is
+	// known — there is no single caller-side sensitivity flag that
+	// would even apply here.
 	events, err := c.gw.Stream(ctx, gwclient.StreamRequest{
 		Route: sideRoute,
 		Purpose:      "memory-consolidate",

--- a/internal/memory/extract/extract.go
+++ b/internal/memory/extract/extract.go
@@ -73,6 +73,12 @@ type Request struct {
 	SessionID string `json:"session_id"`
 	SourceSeq int64  `json:"source_seq"`
 	Text      string `json:"text"`
+	// Route overrides sideRoute for this job's LLM call — set by the
+	// caller when the source turn/session executed a sensitive tool, so
+	// extraction honors the same route floor the tool loop already
+	// pinned the turn to instead of falling back to sideRoute's cloud
+	// model.
+	Route string `json:"route,omitempty"`
 }
 
 // Extractor runs the pipeline.
@@ -192,8 +198,12 @@ func (e *Extractor) proposeOnce(ctx context.Context, req Request) (string, error
 	ctx, cancel := context.WithTimeout(ctx, llmTimeout)
 	defer cancel()
 
+	route := sideRoute
+	if req.Route != "" {
+		route = req.Route
+	}
 	events, err := e.gw.Stream(ctx, gwclient.StreamRequest{
-		Route: sideRoute,
+		Route: route,
 		Purpose:      "memory-extract",
 		System:       system,
 		Messages:     []provider.Message{{Role: "user", Content: req.Text}},

--- a/internal/memory/extract/extract_test.go
+++ b/internal/memory/extract/extract_test.go
@@ -210,6 +210,23 @@ func TestExtractInsertsAndPromotes(t *testing.T) {
 	}
 }
 
+// TestExtractUsesRequestRouteOverride pins the sensitive-route
+// override: a non-empty Request.Route rides the LLM call instead of
+// sideRoute, so extraction honors the same floor the tool loop already
+// pinned a sensitive turn/session to.
+func TestExtractUsesRequestRouteOverride(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGateway{replies: []string{`[{"type":"semantic","content":"User lives in Porto.","entities":[],"confidence":0.9}]`}}
+	st := &fakeStore{}
+	_, err := New(gw, st, testLog()).Extract(t.Context(), Request{Text: "x", Route: "local"})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if len(gw.routes) != 1 || gw.routes[0] != "local" {
+		t.Fatalf("routes = %v, want [local] (Request.Route overrides sideRoute)", gw.routes)
+	}
+}
+
 func TestExtractDropsExactDuplicate(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGateway{replies: []string{`[{"type":"semantic","content":"User lives in Porto.","entities":[],"confidence":0.9}]`}}


### PR DESCRIPTION
The in-turn pin (`SetForceRoute`) protects the turn itself, but memory extraction and compaction re-send turn/session content — assistant text can quote raw email — on the summarize route's cloud model. Now:

- `session.SensitiveTools` — suffix set + route, same D-036 suffix semantics as `SetForceRoute`/`matchGrant`; built once in main.go from `SENSITIVE_TOOL_ROUTE`, shared with the `SetForceRoute` wiring (one source of truth).
- Chat tracks whether the turn executed a sensitive tool → memory extraction request carries the pinned route (`memclient.Extract` + memoryd `extract.Request.Route`, falls back to `summarize`).
- Compactor scans the session's `tool_execution` events → both the pre-compaction extract hook and the summarize call run on the pinned route for sensitive sessions.
- Turn distillation already ran on `local` — untouched. Consolidation stays on `sideRoute` (cross-session batch, no single sensitivity flag) with a comment.
- Env unset → nil everywhere → behavior identical to before.

Companion to #89 (hint-drop): closes the remaining paths where sensitive tool output could reach a non-pinned route.