### PR TITLE
feat(missions): mission delete endpoint and canary self-cleanup

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -32,10 +32,11 @@ func (a *API) registerMissions(handle func(pattern string, h http.Handler), stor
 	if store == nil {
 		return
 	}
-	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, workspace: workspace, resolveSecret: resolveSecret, perms: a.perms, log: a.log}
+	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, workspace: workspace, resolveSecret: resolveSecret, perms: a.perms, dir: a.dir, log: a.log}
 	handle("GET /v1/missions", a.auth(http.HandlerFunc(h.list)))
 	handle("POST /v1/missions", a.auth(http.HandlerFunc(h.create)))
 	handle("GET /v1/missions/{id}", a.auth(http.HandlerFunc(h.get)))
+	handle("DELETE /v1/missions/{id}", a.auth(http.HandlerFunc(h.delete)))
 	handle("GET /v1/missions/{id}/events", a.auth(http.HandlerFunc(h.events)))
 	handle("POST /v1/missions/{id}/resume", a.auth(http.HandlerFunc(h.resume)))
 	handle("POST /v1/missions/{id}/cancel", a.auth(http.HandlerFunc(h.cancel)))
@@ -53,8 +54,8 @@ type missionAPI struct {
 	driver   *missions.Driver
 	notifier *missions.Notifier
 	agentReg *agents.Store
-	// workspace performs mission-directory git operations (currently
-	// just Push) outside the normal Drive loop.
+	// workspace performs mission-directory git operations (Push,
+	// Teardown for delete) outside the normal Drive loop.
 	workspace *missions.Workspace
 	// resolveSecret resolves a credential_ref to its plaintext value for
 	// push; nil means no secret store is configured.
@@ -63,7 +64,11 @@ type missionAPI struct {
 	// PermissionResolver chat sessions use (A.perms), never a
 	// mission-specific broker.
 	perms PermissionResolver
-	log   *slog.Logger
+	// dir deletes a mission's hidden session on mission delete — the
+	// same Directory the top-level session routes use (a.dir), not a
+	// mission-specific store.
+	dir Directory
+	log *slog.Logger
 }
 
 func failMission(w http.ResponseWriter, err error) {
@@ -74,6 +79,8 @@ func failMission(w http.ResponseWriter, err error) {
 		jsonError(w, http.StatusConflict, "branch_conflict", err.Error())
 	case errors.Is(err, missions.ErrTerminal):
 		jsonError(w, http.StatusConflict, "already_finished", err.Error())
+	case errors.Is(err, missions.ErrNotTerminal):
+		jsonError(w, http.StatusConflict, "not_terminal", err.Error())
 	default:
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 	}
@@ -211,6 +218,33 @@ func (h *missionAPI) get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, m)
+}
+
+// delete permanently removes a terminal mission: its row (Store.Delete
+// cascades mission_events/notifications), its hidden session, and its
+// on-disk workspace. Only a terminal mission (done/error, which
+// includes cancelled) may be deleted — 409 not_terminal otherwise — so
+// a live mission's row can never vanish out from under a running
+// Driver.Advance. Session and workspace cleanup are best-effort past
+// that point: the mission row is already gone, so a failure here is
+// logged, never turned into an error response.
+func (h *missionAPI) delete(w http.ResponseWriter, r *http.Request) {
+	m, err := h.store.Delete(r.Context(), r.PathValue("id"))
+	if err != nil {
+		failMission(w, err)
+		return
+	}
+	if m.SessionID != "" && h.dir != nil {
+		if err := h.dir.Delete(r.Context(), m.SessionID); err != nil {
+			h.log.Warn("mission delete: hidden session cleanup failed", "mission_id", m.ID, "session_id", m.SessionID, "error", err)
+		}
+	}
+	if m.Workspace != "" && h.workspace != nil {
+		if err := h.workspace.Teardown(r.Context(), m.Workspace, m.Worktree, m.Kind); err != nil {
+			h.log.Warn("mission delete: workspace cleanup failed", "mission_id", m.ID, "workspace", m.Workspace, "error", err)
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *missionAPI) events(w http.ResponseWriter, r *http.Request) {

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -19,6 +19,7 @@ func TestMissionsEndpointsUnmountedWhenStoreNil(t *testing.T) {
 		{"GET", "/v1/missions"},
 		{"POST", "/v1/missions"},
 		{"GET", "/v1/missions/abc"},
+		{"DELETE", "/v1/missions/abc"},
 		{"GET", "/v1/missions/abc/events"},
 		{"POST", "/v1/missions/abc/resume"},
 		{"POST", "/v1/missions/abc/cancel"},
@@ -79,5 +80,32 @@ func TestMissionsListFilterValidation(t *testing.T) {
 	}
 	if code := call("/v1/missions?limit=10"); code != 500 {
 		t.Fatalf("valid limit against a degraded store = %d, want 500 (passed validation)", code)
+	}
+}
+
+// TestMissionsDeleteReachesStore confirms DELETE /v1/missions/{id} is
+// wired to Store.Delete: against a never-connecting pool the request
+// still passes routing/auth and reaches the store call, which fails
+// closed as failMission's default 400 (the same generic-error mapping
+// every other mission handler falls back to for an unrecognized
+// error) — never a 404/409, which would mean the id path or the
+// not-terminal check short-circuited before the store was even called.
+// The actual not_found/not_terminal/success semantics need a real
+// Postgres connection and are covered by the Store.Delete integration
+// tests in internal/brain/missions.
+func TestMissionsDeleteReachesStore(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	m := mux(a)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("DELETE", "/v1/missions/abc", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Fatalf("DELETE against a degraded store = %d, want 400 (reached the store, generic failure)", w.Code)
 	}
 }

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -146,4 +146,10 @@ var (
 	ErrNotFound       = errors.New("not found")
 	ErrBranchConflict = errors.New("workspace or branch already claimed by an active mission")
 	ErrTerminal       = errors.New("mission already finished")
+	// ErrNotTerminal guards Store.Delete: only a mission whose Phase has
+	// reached done or failed (which includes cancelled — cancel ends as
+	// mission.failed, there is no separate terminal status) may be
+	// deleted, so a live mission's row/events/workspace can never vanish
+	// out from under a running Driver.Advance.
+	ErrNotTerminal = errors.New("mission is not terminal")
 )

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -147,6 +147,47 @@ func (s *Store) Get(ctx context.Context, id string) (Mission, error) {
 	return m, nil
 }
 
+// Delete permanently removes a terminal mission: its row (mission_events
+// and notifications cascade via FK, migrations 0025/0027) plus every
+// other trace this package owns. This is NOT a violation of the
+// append-only discipline that governs mission_events within a mission's
+// life — that rule protects a LIVE mission's history from being
+// rewritten mid-flight; deleting the whole aggregate once it has
+// finished (test-fixture cleanup, an operator purging old runs) is
+// removal of the aggregate, not mutation of it. Refuses with
+// ErrNotTerminal if the mission's Phase hasn't reached done/failed
+// (covers cancelled too — cancel ends as mission.failed) and
+// ErrNotFound for an unknown id. Returns the deleted mission so the
+// caller (the API layer, which also owns the session store and
+// Workspace) can tear down the hidden session and the on-disk
+// workspace — both outside this package's remit.
+func (s *Store) Delete(ctx context.Context, id string) (Mission, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return Mission{}, fmt.Errorf("missions delete: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return Mission{}, fmt.Errorf("missions delete begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+
+	m, err := scanMission(tx.QueryRow(ctx, `SELECT `+missionColumns+` FROM missions WHERE id = $1 FOR UPDATE`, id))
+	if err != nil {
+		return Mission{}, fmt.Errorf("mission %s: %w", id, ErrNotFound)
+	}
+	if !m.Phase.Terminal() {
+		return Mission{}, fmt.Errorf("mission %s: %w", id, ErrNotTerminal)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM missions WHERE id = $1`, id); err != nil {
+		return Mission{}, fmt.Errorf("missions delete: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Mission{}, fmt.Errorf("missions delete commit: %w", err)
+	}
+	return m, nil
+}
+
 // ListFilter narrows List's result set — the zero value (no filter,
 // no limit) is the original "every mission" behavior. Added for a
 // recurring schedule's fire history view (?schedule_id=) and any

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -5,6 +5,7 @@ package missions
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -116,6 +117,56 @@ func TestMissionCRUD(t *testing.T) {
 
 	if _, err := s.Get(ctx, "00000000-0000-0000-0000-000000000000"); err == nil {
 		t.Fatal("Get of a nonexistent id succeeded")
+	}
+}
+
+// TestMissionDelete covers Store.Delete's three outcomes: unknown id
+// (ErrNotFound), a live (non-terminal) mission (ErrNotTerminal), and a
+// terminal mission — which must actually remove the row, and its
+// mission_events via the ON DELETE CASCADE migrations 0025/0027 rely
+// on.
+func TestMissionDelete(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	if _, err := s.Delete(ctx, "00000000-0000-0000-0000-000000000000"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Delete of a nonexistent id = %v, want ErrNotFound", err)
+	}
+
+	id, err := s.Create(ctx, Mission{Goal: marker + "delete-live", Kind: "research"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := s.Delete(ctx, id); !errors.Is(err, ErrNotTerminal) {
+		t.Fatalf("Delete of a live (research/idle) mission = %v, want ErrNotTerminal", err)
+	}
+
+	if err := s.AppendEvent(ctx, id, "mission.progress", map[string]any{"note": "hi"}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	if err := s.ApplyTransition(ctx, id, Transition{
+		Next: StepState{Phase: PhaseDone, Status: StatusDone},
+	}); err != nil {
+		t.Fatalf("ApplyTransition to terminal: %v", err)
+	}
+
+	deleted, err := s.Delete(ctx, id)
+	if err != nil {
+		t.Fatalf("Delete of a terminal mission: %v", err)
+	}
+	if deleted.ID != id {
+		t.Fatalf("Delete returned mission %q, want %q", deleted.ID, id)
+	}
+
+	if _, err := s.Get(ctx, id); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get after Delete = %v, want ErrNotFound (row gone)", err)
+	}
+	events, err := s.Events(ctx, id)
+	if err != nil {
+		t.Fatalf("Events after Delete: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("Events after Delete = %+v, want none (mission_events cascades on mission delete)", events)
 	}
 }
 

--- a/scripts/canary-coding.sh
+++ b/scripts/canary-coding.sh
@@ -141,3 +141,13 @@ fi
 }
 
 echo "canary-coding: PASS"
+
+# Cleanup only runs once every check above has passed (set -e would
+# have already aborted the script on any failure) — a failed mission is
+# left in place for debugging. Tolerated as best-effort: a cleanup
+# failure must never flip this PASS to a FAIL.
+if curl -sf -X DELETE "${auth[@]}" "${BASE_URL}/v1/missions/${id}"; then
+  echo "canary-coding: cleaned up mission ${id}"
+else
+  echo "canary-coding: WARNING — cleanup of mission ${id} failed (non-fatal)" >&2
+fi

--- a/scripts/canary-mission.sh
+++ b/scripts/canary-mission.sh
@@ -106,3 +106,13 @@ if failures:
     sys.exit(1)
 print("canary: PASS")
 PY
+
+# Cleanup only runs once every check above has passed (set -e would
+# have already aborted the script on any failure) — a failed mission is
+# left in place for debugging. Tolerated as best-effort: a cleanup
+# failure must never flip this PASS to a FAIL.
+if curl -sf -X DELETE "${auth[@]}" "${BASE_URL}/v1/missions/${id}"; then
+  echo "canary: cleaned up mission ${id}"
+else
+  echo "canary: WARNING — cleanup of mission ${id} failed (non-fatal)" >&2
+fi


### PR DESCRIPTION
Canary runs left mission rows, hidden sessions, and workspace dirs behind (63 piled up before a manual purge).

- `DELETE /v1/missions/{id}` — 204 on success; 404 unknown; 409 `not_terminal` unless phase is done/failed. Deletes the missions row (`mission_events`/`notifications` cascade via FK), then best-effort tears down the hidden session (`Directory.Delete`) and the workspace dir (`Workspace.Teardown` — worktree-aware). Order matters: mission row first so the session store's `ErrMissionReferenced` guard doesn't block.
- `Store.Delete`: FOR UPDATE + terminal check in one tx; doc comment explains why aggregate removal doesn't violate the append-only discipline (that rule protects a live mission's history from mutation).
- `canary-mission.sh` / `canary-coding.sh`: DELETE after PASS only — failed missions stay for debugging; cleanup failure warns, never flips a PASS.

Live-verified: canary PASS → mission, hidden session, and workspace dir all gone. Integration test `TestMissionDelete` green against the stack.