### PR TITLE
feat(brain): make sensitive tool route a runtime setting

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -145,7 +145,15 @@ func main() {
 
 	toolCalls := app.Metrics.NewCounterVec("tool_calls_total",
 		"Tool executions by tool name and outcome.", "tool", "outcome")
-	agent, broker, outputs, builtinSet, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, markitdownURL, packs, flags.SkillAllowed, mc.Add, app.Log, toolCalls)
+	// sensitiveRoute resolves the route sensitive-tool turns and their
+	// side-calls (extraction, compaction summarize) pin to: the runtime
+	// setting, else "" (feature off). A func, not a value snapshotted at
+	// startup, so a settings change from the web UI applies to the next
+	// turn without a restart.
+	sensitiveRoute := func(ctx context.Context) string {
+		return flags.Value(ctx, settings.ValueSensitiveToolRoute)
+	}
+	agent, broker, outputs, builtinSet, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, markitdownURL, packs, flags.SkillAllowed, mc.Add, app.Log, toolCalls, sensitiveRoute)
 	if buildErr != nil {
 		fmt.Fprintln(os.Stderr, buildErr)
 		os.Exit(1)
@@ -214,14 +222,13 @@ func main() {
 
 	// Single source of truth for "this turn/session executed a sensitive
 	// tool": the loop's in-turn SetForceRoute pin above and this
-	// SensitiveTools value share sensitiveToolSuffixes, so side-calls
-	// (extraction, compaction summarize) honor the same route floor the
-	// tool loop already pinned the turn to. Nil when SENSITIVE_TOOL_ROUTE
-	// is unset — every side-call keeps today's behavior.
-	var sensitiveTools *session.SensitiveTools
-	if sensitiveRoute := os.Getenv("SENSITIVE_TOOL_ROUTE"); sensitiveRoute != "" {
-		sensitiveTools = &session.SensitiveTools{Suffixes: sensitiveToolSuffixes, Route: sensitiveRoute}
-	}
+	// SensitiveTools value share sensitiveToolSuffixes and the same
+	// sensitiveRoute resolver, so side-calls (extraction, compaction
+	// summarize) honor the same route floor the tool loop already
+	// pinned the turn to. Wired unconditionally — sensitiveRoute
+	// resolving to "" at call time means the feature is currently off,
+	// same as before, but now editable at runtime from the settings UI.
+	sensitiveTools := &session.SensitiveTools{Suffixes: sensitiveToolSuffixes, Route: sensitiveRoute}
 
 	svc := chat.New(turnRouter{agent: agent, gw: gwc, flags: flags}, store, distill,
 		gatedCompactor{inner: compactor, flags: flags}, budgetFn, packs, flags.SkillAllowed,
@@ -502,7 +509,7 @@ func (r turnRouter) Stream(ctx context.Context, req gwclient.StreamRequest) (<-c
 // buildAgent assembles the compiled-in tool registry and its guard
 // rails (D-009, D-010). The returned builtin set is the fixed half of
 // the tool surface; connector tools join it via swapAgentTools.
-func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, workspace, searxngURL, markitdownURL string, packs []skills.Skill, skillAllow func(context.Context, string) bool, remember builtin.RememberFunc, log *slog.Logger, toolCalls *prometheus.CounterVec) (*loop.Agent, *loop.PermBroker, *tools.Outputs, []*tools.Tool, error) {
+func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, workspace, searxngURL, markitdownURL string, packs []skills.Skill, skillAllow func(context.Context, string) bool, remember builtin.RememberFunc, log *slog.Logger, toolCalls *prometheus.CounterVec, sensitiveRoute func(context.Context) string) (*loop.Agent, *loop.PermBroker, *tools.Outputs, []*tools.Tool, error) {
 	outputs := tools.NewOutputs(db)
 	set := []*tools.Tool{
 		builtin.CurrentTime(time.Now),
@@ -537,13 +544,12 @@ func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, wor
 	// fires, pin the rest of the turn to a trusted route (e.g. one
 	// chained only to a local Ollama provider) instead of whatever
 	// route the turn started on — optional, since not everyone runs a
-	// local model.
-	if sensitiveRoute := os.Getenv("SENSITIVE_TOOL_ROUTE"); sensitiveRoute != "" {
-		for _, suffix := range sensitiveToolSuffixes {
-			agent.SetForceRoute(suffix, sensitiveRoute)
-		}
-	} else {
-		log.Warn("SENSITIVE_TOOL_ROUTE not set; gmail_read/gmail_read_attachment output is processed on the turn's normal route, same as everything else")
+	// local model. sensitiveRoute resolving to "" at flip time means
+	// the feature is currently off; wired unconditionally since the
+	// route is now runtime-configurable from the settings UI, not just
+	// boot-time env.
+	for _, suffix := range sensitiveToolSuffixes {
+		agent.SetForceRoute(suffix, sensitiveRoute)
 	}
 	return agent, broker, outputs, set, nil
 }

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -107,12 +107,6 @@ services:
       # Converts Gmail attachments (PDFs) and HTML-only email bodies to
       # markdown/text; compose-internal only.
       MARKITDOWN_URL: http://markitdown:8000
-      # Optional: a route name (configured in Settings → Routing,
-      # normally chained only to a local Ollama provider) that gmail_read
-      # and gmail_read_attachment force the rest of their turn onto —
-      # keeps real email content off third-party providers. Empty: those
-      # tools' output is processed on whatever route the turn started on.
-      SENSITIVE_TOOL_ROUTE: ${SENSITIVE_TOOL_ROUTE:-}
       # sandboxd's internal address — set only when MISSION_SANDBOX_IMAGE
       # is configured (sandboxd itself always runs; without an image it
       # just idles degraded). Empty keeps the original in-process exec

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -27,19 +27,11 @@ TIMOTHY_API_TOKEN=
 # http://localhost:3300 — used for connector OAuth redirects (Google).
 # The same URL + /v1/connectors/oauth/callback goes in the OAuth
 # client's authorized redirect URIs.
-TIMOTHY_PUBLIC_URL=
+TIMOTHY_PUBLIC_URL=http://localhost:3300
 
 # --- Third-party services ---
 # npm auth token for HugeIcons Pro packages (from your hugeicons.com account)
 HUGEICONS_TOKEN=
-
-# --- Sensitive-data routing ---
-# Route name (create it in Settings → Routing, chained to a local
-# Ollama provider) that gmail_read / gmail_read_attachment force the
-# rest of their turn onto, keeping real email content off third-party
-# LLM providers. Leave empty to skip this — those tools' output is
-# processed on the turn's normal route like everything else.
-SENSITIVE_TOOL_ROUTE=
 
 # --- Mission sandbox ---
 # Image tag for per-mission sandbox containers that run model-authored
@@ -48,7 +40,8 @@ SENSITIVE_TOOL_ROUTE=
 # `make sandbox-image`, then set this to timothy-sandbox:latest). Leave
 # empty to keep the original in-process exec behavior; sandboxd itself
 # still runs, just idling degraded with nothing to do.
-MISSION_SANDBOX_IMAGE=
+MISSION_SANDBOX_IMAGE=timothy-sandbox:latest
+
 # Group ID of the docker.sock on your host, needed so sandboxd (running
 # as a non-root user) can use it. Docker Desktop: 0 (the default)
 # works. Linux hosts: run `stat -c '%g' /var/run/docker.sock` and set

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -612,8 +612,8 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 		// email), so it must never fall back to memoryd's own default
 		// side-call route.
 		extractRoute := ""
-		if turnSensitive && s.sensitive != nil {
-			extractRoute = s.sensitive.Route
+		if turnSensitive && s.sensitive != nil && s.sensitive.Route != nil {
+			extractRoute = s.sensitive.Route(context.Background())
 		}
 		go s.memory(context.Background(), sessionID, turnSeq, mtext, extractRoute)
 	}

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -1071,7 +1071,7 @@ func TestMemoryExtractUsesSensitiveRouteWhenTurnRanSensitiveTool(t *testing.T) {
 		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
 	}}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: "local"})
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
 
 	got := make(chan string, 1)
 	svc.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) {
@@ -1107,7 +1107,7 @@ func TestMemoryExtractUsesEmptyRouteWhenTurnDidNotRunSensitiveTool(t *testing.T)
 		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
 	}}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: "local"})
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
 
 	got := make(chan string, 1)
 	svc.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) {

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -102,14 +102,18 @@ type Agent struct {
 	exec   Executor
 	defs   []provider.ToolDef
 
-	// forceRouteBySuffix maps a tool name SUFFIX to a route its output
-	// must be processed under — e.g. a route chained only to a
-	// local/trusted provider, for tools whose results carry sensitive
-	// data (raw email content) that should never reach a third-party
-	// model. Suffix, not exact name: connector tools are namespaced
-	// "<connector-name>_<tool-name>" and the connector name is user-
-	// chosen, so "gmail_read" must match regardless of prefix.
-	forceRouteBySuffix map[string]string
+	// forceRouteBySuffix maps a tool name SUFFIX to a resolver for the
+	// route its output must be processed under — e.g. a route chained
+	// only to a local/trusted provider, for tools whose results carry
+	// sensitive data (raw email content) that should never reach a
+	// third-party model. Suffix, not exact name: connector tools are
+	// namespaced "<connector-name>_<tool-name>" and the connector name
+	// is user-chosen, so "gmail_read" must match regardless of prefix.
+	// A func, not a static string: the route is resolved at flip time
+	// (settings-backed), so a runtime settings change applies to the
+	// next turn without a restart; an empty result means the feature is
+	// currently off and no flip happens.
+	forceRouteBySuffix map[string]func(context.Context) string
 }
 
 func NewAgent(gw Gateway, exec Executor, perms Permissioner, outputs OutputSink, audit AuditSink, events EventAppender, broker *PermBroker, defs []provider.ToolDef, logger *slog.Logger) *Agent {
@@ -119,7 +123,7 @@ func NewAgent(gw Gateway, exec Executor, perms Permissioner, outputs OutputSink,
 		maxSteps:           tools.DefaultMaxSteps,
 		offloadAt:          tools.DefaultOffloadThreshold,
 		offloadPerTool:     map[string]int{},
-		forceRouteBySuffix: map[string]string{},
+		forceRouteBySuffix: map[string]func(context.Context) string{},
 		logger:             logger,
 	}
 }
@@ -154,18 +158,22 @@ func (a *Agent) SetOffloadThreshold(tool string, bytes int) {
 	a.offloadPerTool[tool] = bytes
 }
 
-// SetForceRoute pins a tool's output to route for the rest of the
+// SetForceRoute pins a tool's output to route(ctx) for the rest of the
 // turn: once a tool whose name ENDS WITH suffix is called, every
-// subsequent LLM step in the SAME turn uses route instead of the
-// turn's normal route — sticky, never un-forced mid-turn, since the
-// sensitive content is already in context by then. The turn's FIRST
-// step (before any tool has run) still uses the turn's own route; this
-// only takes effect after. suffix, not the exact registered name:
-// connector tools are namespaced "<connector-name>_<tool-name>" with a
-// user-chosen connector name, so "gmail_read" matches regardless of
-// which connector name serves it. Forcing also clears the turn's model
-// hint from then on, since a hint outranks the route at the gateway.
-func (a *Agent) SetForceRoute(suffix, route string) {
+// subsequent LLM step in the SAME turn uses the resolved route instead
+// of the turn's normal route — sticky, never un-forced mid-turn, since
+// the sensitive content is already in context by then. The turn's
+// FIRST step (before any tool has run) still uses the turn's own
+// route; this only takes effect after. suffix, not the exact
+// registered name: connector tools are namespaced
+// "<connector-name>_<tool-name>" with a user-chosen connector name, so
+// "gmail_read" matches regardless of which connector name serves it.
+// Forcing also clears the turn's model hint from then on, since a hint
+// outranks the route at the gateway. route is resolved at flip time
+// (not when SetForceRoute is called), so a settings change takes
+// effect on the next turn without a restart; an empty result means the
+// feature is currently off and the turn's route is left alone.
+func (a *Agent) SetForceRoute(suffix string, route func(context.Context) string) {
 	a.forceRouteBySuffix[suffix] = route
 }
 
@@ -414,10 +422,12 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 		toolCallCount += len(calls)
 		stuck = repeats.Record(calls)
 		for _, c := range calls {
-			for suffix, forced := range a.forceRouteBySuffix {
+			for suffix, fn := range a.forceRouteBySuffix {
 				if strings.HasSuffix(c.Name, suffix) {
-					route = forced
-					hint = ""
+					if forced := fn(ctx); forced != "" {
+						route = forced
+						hint = ""
+					}
 				}
 			}
 		}

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -862,7 +862,7 @@ func TestForceRouteSwitchesRouteAfterMatchingToolAndStaysSticky(t *testing.T) {
 		},
 	}
 	a, _, _, _ := testAgent(t, gw, sensitive)
-	a.SetForceRoute("gmail_read", "local")
+	a.SetForceRoute("gmail_read", func(context.Context) string { return "local" })
 
 	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "default",
 		Messages: []provider.Message{{Role: "user", Content: "check my email"}}})
@@ -895,7 +895,7 @@ func TestForceRouteIgnoresNonMatchingTools(t *testing.T) {
 		finalStep("done"),
 	}}
 	a, _, _, _ := testAgent(t, gw)
-	a.SetForceRoute("gmail_read", "local")
+	a.SetForceRoute("gmail_read", func(context.Context) string { return "local" })
 
 	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "default",
 		Messages: []provider.Message{{Role: "user", Content: "go"}}})
@@ -931,7 +931,7 @@ func TestForceRouteDropsModelHint(t *testing.T) {
 		},
 	}
 	a, _, _, _ := testAgent(t, gw, sensitive)
-	a.SetForceRoute("gmail_read", "local")
+	a.SetForceRoute("gmail_read", func(context.Context) string { return "local" })
 
 	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "default", ModelHint: "glm-4.7-flash",
 		Messages: []provider.Message{{Role: "user", Content: "check my email"}}})
@@ -974,7 +974,7 @@ func TestForceRoutePinSurvivesStepRetry(t *testing.T) {
 		},
 	}
 	a, _, _, _ := testAgent(t, gw, sensitive)
-	a.SetForceRoute("gmail_read", "local")
+	a.SetForceRoute("gmail_read", func(context.Context) string { return "local" })
 
 	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "default", ModelHint: "glm-4.7-flash",
 		Messages: []provider.Message{{Role: "user", Content: "check my email"}}})

--- a/internal/brain/session/compactor.go
+++ b/internal/brain/session/compactor.go
@@ -195,8 +195,8 @@ func (c *Compactor) MaybeCompact(ctx context.Context, sessionID string) error {
 			b.WriteString(m.Role + ": " + m.Content + "\n\n")
 		}
 		extractRoute := ""
-		if sensitive && c.sensitive != nil {
-			extractRoute = c.sensitive.Route
+		if sensitive && c.sensitive != nil && c.sensitive.Route != nil {
+			extractRoute = c.sensitive.Route(ctx)
 		}
 		if ids := c.extract(ctx, sessionID, boundary, b.String(), extractRoute); ids != nil {
 			facts = ids
@@ -313,8 +313,10 @@ func (c *Compactor) summarize(ctx context.Context, sessionID string, msgs []prov
 	defer cancel()
 
 	route := "summarize"
-	if sensitive && c.sensitive != nil && c.sensitive.Route != "" {
-		route = c.sensitive.Route
+	if sensitive && c.sensitive != nil && c.sensitive.Route != nil {
+		if forced := c.sensitive.Route(ctx); forced != "" {
+			route = forced
+		}
 	}
 	var b strings.Builder
 	for _, m := range msgs {

--- a/internal/brain/session/compactor_test.go
+++ b/internal/brain/session/compactor_test.go
@@ -497,7 +497,7 @@ func TestCompactionUsesSensitiveRouteWhenSessionRanSensitiveTool(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
-	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: "local"})
+	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
 
 	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
 		t.Fatalf("MaybeCompact: %v", err)
@@ -520,7 +520,7 @@ func TestCompactionUsesDefaultRouteWithoutSensitiveTool(t *testing.T) {
 	gw := &summarizerGW{summary: "short summary"}
 	seedConversation(t, log, "s1", 10)
 	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
-	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: "local"})
+	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
 
 	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
 		t.Fatalf("MaybeCompact: %v", err)
@@ -549,7 +549,7 @@ func TestCompactionExtractUsesSensitiveRouteWhenSessionRanSensitiveTool(t *testi
 		t.Fatal(err)
 	}
 	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
-	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: "local"})
+	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
 
 	var sawRoute string
 	c.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) []string {
@@ -575,7 +575,7 @@ func TestCompactionExtractUsesEmptyRouteWithoutSensitiveTool(t *testing.T) {
 	gw := &summarizerGW{summary: "short summary"}
 	seedConversation(t, log, "s1", 10)
 	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
-	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: "local"})
+	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
 
 	sawRoute := "unset"
 	c.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) []string {

--- a/internal/brain/session/sensitive.go
+++ b/internal/brain/session/sensitive.go
@@ -1,6 +1,9 @@
 package session
 
-import "strings"
+import (
+	"context"
+	"strings"
+)
 
 // SensitiveTools names the tools whose execution marks a turn/session
 // sensitive, and the route side-calls must fall back to when they are.
@@ -12,9 +15,12 @@ import "strings"
 // (e.g. email text) to a cloud model. Suffix, not exact name: connector
 // tools are namespaced "<connector-name>_<tool-name>" with a user-chosen
 // connector name (same rule as Agent.SetForceRoute/matchGrant, D-036).
+// Route is a func, not a static string, so a settings change applies to
+// the next side-call without a restart; an empty result means the
+// feature is currently off (callers keep their own default route).
 type SensitiveTools struct {
 	Suffixes []string
-	Route    string
+	Route    func(context.Context) string
 }
 
 // Matches reports whether toolName ends a sensitive suffix: exact

--- a/internal/brain/session/sensitive_test.go
+++ b/internal/brain/session/sensitive_test.go
@@ -1,13 +1,16 @@
 package session
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 // TestSensitiveToolsMatches pins the suffix semantics: exact name, or
 // name ending "_"+suffix (connector namespacing), same rule as
 // loop.Agent.SetForceRoute/matchGrant (D-036).
 func TestSensitiveToolsMatches(t *testing.T) {
 	t.Parallel()
-	s := &SensitiveTools{Suffixes: []string{"gmail_read", "gmail_read_attachment"}, Route: "local"}
+	s := &SensitiveTools{Suffixes: []string{"gmail_read", "gmail_read_attachment"}, Route: func(context.Context) string { return "local" }}
 	tests := []struct {
 		name string
 		tool string

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -44,11 +44,17 @@ const (
 	// timothy/timothy@localhost identity.
 	ValueGitAuthorName  = "git_author_name"
 	ValueGitAuthorEmail = "git_author_email"
+	// ValueSensitiveToolRoute names the route that sensitive-tool turns
+	// (e.g. gmail_read) and their side-calls (memory extraction,
+	// compaction) pin to; empty means the feature is off. Set from the
+	// web settings panel.
+	ValueSensitiveToolRoute = "sensitive_tool_route"
 )
 
 var knownValueKeys = map[string]bool{
 	ValueTokenBudget: true, ValueSkillsAllowlist: true,
 	ValueGitAuthorName: true, ValueGitAuthorEmail: true,
+	ValueSensitiveToolRoute: true,
 }
 
 const cacheTTL = 10 * time.Second

--- a/migrations/0022_local_route.sql
+++ b/migrations/0022_local_route.sql
@@ -1,6 +1,7 @@
 -- Seeds a 5th fixed route name: 'local' — the sensitive-tool-routing
 -- floor (gmail_read / gmail_read_attachment force the rest of their
--- turn onto this route, keyed by SENSITIVE_TOOL_ROUTE) needs a real
+-- turn onto this route, keyed by the sensitive_tool_route setting)
+-- needs a real
 -- route name to target; the fixed set from 0002_gateway.sql has none
 -- meant for it. No chain, no opinions — the user chains it to a
 -- trusted/local provider in Settings.

--- a/web/src/components/settings/FeaturesTab.tsx
+++ b/web/src/components/settings/FeaturesTab.tsx
@@ -1,13 +1,16 @@
 import { useCallback, useEffect, useState } from 'react'
 import {
   getSettings,
+  listRoutes,
   patchBudget,
   patchSettings,
   patchSettingValues,
   usageBudget,
 } from '../../api/client'
+import type { AdminRoute } from '../../api/types'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { ErrorBanner, Toggle } from './shared'
 import { errText } from './util'
 
@@ -71,6 +74,7 @@ export function FeaturesTab() {
         </div>
       ))}
       {values && <AgentCard values={values} onError={setError} onSaved={refresh} />}
+      {values && <SensitiveRouteCard values={values} onError={setError} onSaved={refresh} />}
       <BudgetsCard />
     </div>
   )
@@ -169,6 +173,87 @@ function AgentCard({
       <p className="mt-2 text-xs text-muted-foreground">
         Git author name/email are used for mission commits; set them to your GitHub identity so
         pushed commits link to your account.
+      </p>
+    </div>
+  )
+}
+
+const SENSITIVE_ROUTE_OFF = '__off__'
+
+// SensitiveRouteCard picks the route sensitive-tool turns (e.g. reading
+// email content) and their memory extraction/compaction side-calls pin
+// to. Fetches the route list on mount like AgentAdd/AgentEdit; if that
+// fetch fails (or the admin proxy is nil-gated), falls back to a plain
+// text input so the setting stays editable without the picker.
+function SensitiveRouteCard({
+  values,
+  onError,
+  onSaved,
+}: {
+  values: Record<string, string>
+  onError: (msg: string) => void
+  onSaved: () => void
+}) {
+  const [route, setRoute] = useState(values.sensitive_tool_route ?? '')
+  const [routes, setRoutes] = useState<AdminRoute[] | null>(null)
+  const [saved, setSaved] = useState(false)
+
+  useEffect(() => {
+    listRoutes().then(setRoutes, () => setRoutes(null))
+  }, [])
+
+  const save = () => {
+    setSaved(false)
+    patchSettingValues({ sensitive_tool_route: route.trim() })
+      .then(() => {
+        setSaved(true)
+        onSaved()
+      })
+      .catch((err: unknown) => onError(errText(err)))
+  }
+
+  return (
+    <div className="rounded-xl border border-border p-4">
+      <div className="text-sm font-medium">Sensitive tool route</div>
+      <div className="mt-3 flex flex-wrap items-end gap-3">
+        {routes ? (
+          <div className="grid gap-1 text-xs text-muted-foreground">
+            <span>Route</span>
+            <Select
+              value={route || SENSITIVE_ROUTE_OFF}
+              onValueChange={(v) => setRoute(v === SENSITIVE_ROUTE_OFF ? '' : v)}
+            >
+              <SelectTrigger className="h-10 w-56" aria-label="Sensitive tool route">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={SENSITIVE_ROUTE_OFF}>Off (default)</SelectItem>
+                {routes.map((r) => (
+                  <SelectItem key={r.name} value={r.name}>
+                    {r.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ) : (
+          <label className="grid gap-1 text-xs text-muted-foreground">
+            Route
+            <Input
+              value={route}
+              onChange={(e) => setRoute(e.target.value)}
+              placeholder="empty = off"
+              className="w-56"
+              aria-label="Sensitive tool route"
+            />
+          </label>
+        )}
+        <Button onClick={save}>Save</Button>
+        {saved && <span className="text-xs text-muted-foreground">Saved.</span>}
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Turns that read email content switch to this route, and their memory extraction and
+        compaction follow. Chain it to a local provider for a privacy floor.
       </p>
     </div>
   )

--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChatError } from '../api/client'
@@ -138,7 +138,8 @@ describe('Features tab agent settings', () => {
     fireEvent.change(screen.getByLabelText('Skills allowlist'), {
       target: { value: 'coding-task, research' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    const card = budget.closest('div.rounded-xl') as HTMLElement
+    fireEvent.click(within(card).getByRole('button', { name: 'Save' }))
 
     await waitFor(() =>
       expect(patchSettingValues).toHaveBeenCalledWith({
@@ -147,6 +148,55 @@ describe('Features tab agent settings', () => {
         git_author_name: '',
         git_author_email: '',
       }),
+    )
+  })
+})
+
+describe('Features tab sensitive tool route', () => {
+  beforeEach(() => {
+    vi.mocked(getSettings).mockResolvedValue({
+      settings: { tools_enabled: true },
+      values: { sensitive_tool_route: '' },
+    })
+    vi.mocked(usageBudget).mockResolvedValue({
+      day: { limit_usd: null, spend_usd: 0, over: false },
+      month: { limit_usd: null, spend_usd: 0, over: false },
+    })
+    vi.mocked(patchSettingValues).mockResolvedValue()
+  })
+
+  it('offers every route plus Off, and patches the chosen one', async () => {
+    vi.mocked(listRoutes).mockResolvedValue([
+      { name: 'default', chain: [], strategy: 'ordered', enabled: true },
+      { name: 'local', chain: [], strategy: 'ordered', enabled: true },
+    ])
+
+    renderPage('/settings/features')
+    const trigger = await screen.findByRole('combobox', { name: 'Sensitive tool route' })
+    fireEvent.click(trigger)
+    fireEvent.click(await screen.findByText('local'))
+
+    const card = trigger.closest('div.rounded-xl') as HTMLElement
+    fireEvent.click(within(card).getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(patchSettingValues).toHaveBeenCalledWith({ sensitive_tool_route: 'local' }),
+    )
+  })
+
+  it('falls back to a text input when the route list fails to load', async () => {
+    vi.mocked(listRoutes).mockRejectedValue(new Error('admin proxy unavailable'))
+
+    renderPage('/settings/features')
+    const input = await screen.findByLabelText('Sensitive tool route')
+    expect((input as HTMLInputElement).tagName).toBe('INPUT')
+
+    fireEvent.change(input, { target: { value: 'local' } })
+    const card = input.closest('div.rounded-xl') as HTMLElement
+    fireEvent.click(within(card).getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(patchSettingValues).toHaveBeenCalledWith({ sensitive_tool_route: 'local' }),
     )
   })
 })


### PR DESCRIPTION
SENSITIVE_TOOL_ROUTE was boot-time env only — changing the privacy floor meant editing deploy config and restarting.

- New typed setting `sensitive_tool_route` (settings store, knownValueKeys). Empty = pin off.
- Route resolves **per call** via `func(ctx) string`: loop's `SetForceRoute` now takes a resolver (flip + hint-drop only when it returns non-empty); `session.SensitiveTools.Route` is a resolver too — chat extraction, compactor extract hook, and summarize all read the live value. Settings change applies next turn, no restart.
- Web Settings→Features: "Sensitive tool route" dropdown fed by the routes list (Off + one per route), plain-input fallback when the admin proxy is unavailable.
- `SENSITIVE_TOOL_ROUTE` env removed everywhere (main.go, env.example, compose); stale 0022 comment updated (comment-only, runner tracks by filename).

Wired live: setting=`local`, `local` route chained to Ollama qwen3:32b only — sensitive turns and their side-calls now stay on-host.