### PR TITLE
feat(web): unify agent and route pickers into one dropdown

### DIFF
--- a/web/src/components/AgentPicker.tsx
+++ b/web/src/components/AgentPicker.tsx
@@ -1,20 +1,6 @@
-import {
-  AiBrain01Icon,
-  ArrowDown01Icon,
-  SparklesIcon,
-  Tick02Icon,
-} from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useState } from 'react'
 import { listAgents } from '../api/client'
 import type { AdminAgent } from '../api/types'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuTrigger,
-} from './ui/dropdown-menu'
 
 // Sentinel value meaning "let the system pick" (D-034 follow-up) —
 // matches the backend's autoAgentName. Not a real agent row: the
@@ -38,81 +24,4 @@ export function useAgents(): AdminAgent[] {
     )
   }, [])
   return agents
-}
-
-// AgentPicker chooses WHO serves the next message (D-034). The agent
-// carries its own routing, skills, tools, and memory behavior — the
-// picker needs to explain none of that, just name and description.
-export function AgentPicker({
-  value,
-  onChange,
-}: {
-  value: string
-  onChange: (v: string) => void
-}) {
-  const agents = useAgents()
-  const isAuto = value === AUTO_AGENT
-  const current = isAuto
-    ? null
-    : (agents.find((a) => a.name === value) ?? agents.find((a) => a.is_default) ?? null)
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        aria-label="Agent"
-        className="flex h-8 items-center gap-1.5 rounded-full border border-zinc-950/10 px-3 text-sm text-zinc-700 transition hover:bg-zinc-100 dark:border-white/10 dark:text-zinc-200 dark:hover:bg-zinc-700/50"
-      >
-        <HugeiconsIcon icon={isAuto ? SparklesIcon : AiBrain01Icon} className="size-4" />
-        <span className="capitalize">{isAuto ? 'Auto' : (current?.name ?? 'Agent')}</span>
-        <HugeiconsIcon icon={ArrowDown01Icon} className="size-3.5 opacity-60" />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-[min(92vw,22rem)] p-1.5">
-        <DropdownMenuLabel className="px-2.5 pt-1.5">
-          <div className="text-sm font-semibold">Agent</div>
-          <p className="mt-0.5 text-xs font-normal text-muted-foreground">
-            Who serves your next message. Agents are configured in Settings.
-          </p>
-        </DropdownMenuLabel>
-        <DropdownMenuItem
-          onSelect={() => onChange(AUTO_AGENT)}
-          data-selected={isAuto || undefined}
-          className="items-start gap-3 rounded-lg px-2.5 py-2 data-selected:bg-zinc-100 dark:data-selected:bg-zinc-800"
-        >
-          <div className="min-w-0 flex-1">
-            <span className="text-sm font-medium">Auto</span>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              Picks the best-fit agent for each message.
-            </p>
-          </div>
-          {isAuto && <HugeiconsIcon icon={Tick02Icon} className="mt-1 size-4 shrink-0" />}
-        </DropdownMenuItem>
-        {agents.map((a) => {
-          const selected = a.name === (current?.name ?? '')
-          return (
-            <DropdownMenuItem
-              key={a.id}
-              onSelect={() => onChange(a.name)}
-              data-selected={selected || undefined}
-              className="items-start gap-3 rounded-lg px-2.5 py-2 data-selected:bg-zinc-100 dark:data-selected:bg-zinc-800"
-            >
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium capitalize">{a.name}</span>
-                  {a.is_default && (
-                    <span className="rounded bg-blue-500/10 px-1.5 py-px text-[10px] font-medium text-blue-600 dark:text-blue-400">
-                      Default
-                    </span>
-                  )}
-                </div>
-                {a.description && (
-                  <p className="mt-0.5 text-xs text-muted-foreground">{a.description}</p>
-                )}
-              </div>
-              {selected && <HugeiconsIcon icon={Tick02Icon} className="mt-1 size-4 shrink-0" />}
-            </DropdownMenuItem>
-          )
-        })}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  )
 }

--- a/web/src/components/AgentRoutePicker.test.tsx
+++ b/web/src/components/AgentRoutePicker.test.tsx
@@ -1,0 +1,174 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AdminAgent, AdminRoute } from '../api/types'
+
+vi.mock('../api/client', () => ({
+  listAgents: vi.fn(),
+  listRoutes: vi.fn(),
+}))
+
+const agents: AdminAgent[] = [
+  {
+    id: '1',
+    name: 'general',
+    description: '',
+    prompt_overlay: '',
+    route: '',
+    skills: [],
+    tools: [],
+    memory: false,
+    is_default: true,
+    enabled: true,
+    review_route: '',
+  },
+  {
+    id: '2',
+    name: 'researcher',
+    description: '',
+    prompt_overlay: '',
+    route: '',
+    skills: [],
+    tools: [],
+    memory: false,
+    is_default: false,
+    enabled: true,
+    review_route: '',
+  },
+]
+
+const routes: AdminRoute[] = [
+  {
+    name: 'default',
+    strategy: 'ordered',
+    enabled: true,
+    chain: [
+      { provider_id: 'p1', model: 'glm-5.2' },
+      { provider_id: 'p2', model: 'nova-pro' },
+    ],
+  },
+  { name: 'local', strategy: 'price', enabled: true, chain: [] },
+]
+
+// Radix opens dropdowns on pointerdown, not click.
+function openMenu(name: string) {
+  const trigger = screen.getByRole('button', { name })
+  fireEvent.pointerDown(trigger, { button: 0, pointerId: 1 })
+  fireEvent.click(trigger)
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// AgentRoutePicker composes AgentPicker's useAgents and its own
+// useRoutes, both module-level caches — each test resets modules and
+// re-imports fresh to avoid one test's fetch leaking into the next.
+async function freshPicker() {
+  vi.resetModules()
+  const client = await import('../api/client')
+  const { AgentRoutePicker } = await import('./AgentRoutePicker')
+  return { AgentRoutePicker, listAgents: client.listAgents, listRoutes: client.listRoutes }
+}
+
+describe('AgentRoutePicker', () => {
+  it("shows 'Auto' when agent is auto and no route is selected", async () => {
+    const { AgentRoutePicker, listAgents, listRoutes } = await freshPicker()
+    vi.mocked(listAgents).mockResolvedValue(agents)
+    vi.mocked(listRoutes).mockResolvedValue(routes)
+    render(<AgentRoutePicker agent="auto" onAgent={vi.fn()} route="" onRoute={vi.fn()} />)
+
+    expect(await screen.findByRole('button', { name: 'Agent and route' })).toHaveTextContent(
+      'Auto',
+    )
+  })
+
+  it("shows a combined 'agent · route' label when both are set", async () => {
+    const { AgentRoutePicker, listAgents, listRoutes } = await freshPicker()
+    vi.mocked(listAgents).mockResolvedValue(agents)
+    vi.mocked(listRoutes).mockResolvedValue(routes)
+    render(<AgentRoutePicker agent="general" onAgent={vi.fn()} route="local" onRoute={vi.fn()} />)
+
+    const trigger = await screen.findByRole('button', { name: 'Agent and route' })
+    await waitFor(() => expect(trigger).toHaveTextContent('general · local'))
+  })
+
+  it('shows both Agent and Route sections when onRoute is given', async () => {
+    const { AgentRoutePicker, listAgents, listRoutes } = await freshPicker()
+    vi.mocked(listAgents).mockResolvedValue(agents)
+    vi.mocked(listRoutes).mockResolvedValue(routes)
+    render(<AgentRoutePicker agent="auto" onAgent={vi.fn()} route="" onRoute={vi.fn()} />)
+
+    await screen.findByRole('button', { name: 'Agent and route' })
+    openMenu('Agent and route')
+    expect(await screen.findByText('Agent')).toBeTruthy()
+    expect(await screen.findByText('Route')).toBeTruthy()
+    expect(screen.getByText('researcher')).toBeTruthy()
+    expect(screen.getByText('default')).toBeTruthy()
+    expect(screen.getByText('local')).toBeTruthy()
+  })
+
+  it('omits the Route section when onRoute is not passed', async () => {
+    const { AgentRoutePicker, listAgents, listRoutes } = await freshPicker()
+    vi.mocked(listAgents).mockResolvedValue(agents)
+    vi.mocked(listRoutes).mockResolvedValue(routes)
+    render(<AgentRoutePicker agent="auto" onAgent={vi.fn()} />)
+
+    await screen.findByRole('button', { name: 'Agent and route' })
+    openMenu('Agent and route')
+    expect(await screen.findByText('Agent')).toBeTruthy()
+    expect(screen.queryByText('Route')).toBeNull()
+  })
+
+  it('omits the Route section when listRoutes rejects, Agent section still works', async () => {
+    const { AgentRoutePicker, listAgents, listRoutes } = await freshPicker()
+    vi.mocked(listAgents).mockResolvedValue(agents)
+    vi.mocked(listRoutes).mockRejectedValue(new Error('forbidden'))
+    render(<AgentRoutePicker agent="auto" onAgent={vi.fn()} route="" onRoute={vi.fn()} />)
+
+    await screen.findByRole('button', { name: 'Agent and route' })
+    await waitFor(() => expect(listRoutes).toHaveBeenCalled())
+    openMenu('Agent and route')
+    expect(await screen.findByText('Agent')).toBeTruthy()
+    expect(screen.getByText('researcher')).toBeTruthy()
+    expect(screen.queryByText('Route')).toBeNull()
+  })
+
+  it('shows the chain models on a route item, or a placeholder when empty', async () => {
+    const { AgentRoutePicker, listAgents, listRoutes } = await freshPicker()
+    vi.mocked(listAgents).mockResolvedValue(agents)
+    vi.mocked(listRoutes).mockResolvedValue(routes)
+    render(<AgentRoutePicker agent="auto" onAgent={vi.fn()} route="" onRoute={vi.fn()} />)
+
+    await screen.findByRole('button', { name: 'Agent and route' })
+    openMenu('Agent and route')
+    expect(await screen.findByText('glm-5.2 → nova-pro')).toBeTruthy()
+    expect(screen.getByText('No models configured')).toBeTruthy()
+  })
+
+  it('clicking a route item calls onRoute', async () => {
+    const { AgentRoutePicker, listAgents, listRoutes } = await freshPicker()
+    vi.mocked(listAgents).mockResolvedValue(agents)
+    vi.mocked(listRoutes).mockResolvedValue(routes)
+    const onRoute = vi.fn()
+    render(<AgentRoutePicker agent="auto" onAgent={vi.fn()} route="" onRoute={onRoute} />)
+
+    await screen.findByRole('button', { name: 'Agent and route' })
+    openMenu('Agent and route')
+    fireEvent.click(await screen.findByText('local'))
+    expect(onRoute).toHaveBeenCalledWith('local')
+  })
+
+  it('clicking an agent item calls onAgent', async () => {
+    const { AgentRoutePicker, listAgents, listRoutes } = await freshPicker()
+    vi.mocked(listAgents).mockResolvedValue(agents)
+    vi.mocked(listRoutes).mockResolvedValue(routes)
+    const onAgent = vi.fn()
+    render(<AgentRoutePicker agent="auto" onAgent={onAgent} route="" onRoute={vi.fn()} />)
+
+    await screen.findByRole('button', { name: 'Agent and route' })
+    openMenu('Agent and route')
+    fireEvent.click(await screen.findByText('researcher'))
+    expect(onAgent).toHaveBeenCalledWith('researcher')
+  })
+})

--- a/web/src/components/AgentRoutePicker.tsx
+++ b/web/src/components/AgentRoutePicker.tsx
@@ -1,0 +1,174 @@
+import {
+  AiBrain01Icon,
+  ArrowDown01Icon,
+  SparklesIcon,
+  Tick02Icon,
+} from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useEffect, useState } from 'react'
+import { listRoutes } from '../api/client'
+import type { AdminRoute } from '../api/types'
+import { AUTO_AGENT, useAgents } from './AgentPicker'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from './ui/dropdown-menu'
+
+// Module-level cache: the picker renders in every composer; the route
+// list changes rarely and a stale list self-heals on the next mount.
+let cachedRoutes: AdminRoute[] | null = null
+
+function useRoutes(): AdminRoute[] | null {
+  const [routes, setRoutes] = useState<AdminRoute[] | null>(cachedRoutes)
+  useEffect(() => {
+    listRoutes().then(
+      (list) => {
+        cachedRoutes = list
+        setRoutes(cachedRoutes)
+      },
+      () => undefined, // admin proxy may be unreachable — picker hides itself
+    )
+  }, [])
+  return routes
+}
+
+// AgentRoutePicker combines who serves the next message with which
+// model chain serves it (D-034) into one control: the agent carries
+// its own routing, skills, tools, and memory behavior, while the route
+// section lets a route override that per turn. The route section only
+// renders once routes are fetched successfully — on failure it stays
+// hidden rather than showing a broken picker.
+export function AgentRoutePicker({
+  agent,
+  onAgent,
+  route,
+  onRoute,
+}: {
+  agent: string
+  onAgent: (a: string) => void
+  route?: string
+  onRoute?: (r: string) => void
+}) {
+  const agents = useAgents()
+  const routes = useRoutes()
+  const isAuto = agent === AUTO_AGENT
+  const current = isAuto
+    ? null
+    : (agents.find((a) => a.name === agent) ?? agents.find((a) => a.is_default) ?? null)
+  const showRoutes = Boolean(onRoute) && routes !== null
+  const isRouteAuto = !route
+  const currentRoute = isRouteAuto ? null : (routes?.find((r) => r.name === route) ?? null)
+
+  const agentLabel = isAuto ? 'Auto' : (current?.name ?? 'Agent')
+  const label = currentRoute ? `${agentLabel} · ${currentRoute.name}` : agentLabel
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label="Agent and route"
+        className="flex h-8 items-center gap-1.5 rounded-full border border-zinc-950/10 px-3 text-sm text-zinc-700 transition hover:bg-zinc-100 dark:border-white/10 dark:text-zinc-200 dark:hover:bg-zinc-700/50"
+      >
+        <HugeiconsIcon
+          icon={isAuto && !currentRoute ? SparklesIcon : AiBrain01Icon}
+          className="size-4"
+        />
+        <span className="capitalize">{label}</span>
+        <HugeiconsIcon icon={ArrowDown01Icon} className="size-3.5 opacity-60" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-[min(92vw,22rem)] p-1.5">
+        <DropdownMenuLabel className="px-2.5 pt-1.5">
+          <div className="text-sm font-semibold">Agent</div>
+          <p className="mt-0.5 text-xs font-normal text-muted-foreground">
+            Who serves your next message. Agents are configured in Settings.
+          </p>
+        </DropdownMenuLabel>
+        <DropdownMenuItem
+          onSelect={() => onAgent(AUTO_AGENT)}
+          data-selected={isAuto || undefined}
+          className="items-start gap-3 rounded-lg px-2.5 py-2 data-selected:bg-zinc-100 dark:data-selected:bg-zinc-800"
+        >
+          <div className="min-w-0 flex-1">
+            <span className="text-sm font-medium">Auto</span>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Picks the best-fit agent for each message.
+            </p>
+          </div>
+          {isAuto && <HugeiconsIcon icon={Tick02Icon} className="mt-1 size-4 shrink-0" />}
+        </DropdownMenuItem>
+        {agents.map((a) => {
+          const selected = a.name === (current?.name ?? '')
+          return (
+            <DropdownMenuItem
+              key={a.id}
+              onSelect={() => onAgent(a.name)}
+              data-selected={selected || undefined}
+              className="items-start gap-3 rounded-lg px-2.5 py-2 data-selected:bg-zinc-100 dark:data-selected:bg-zinc-800"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium capitalize">{a.name}</span>
+                  {a.is_default && (
+                    <span className="rounded bg-blue-500/10 px-1.5 py-px text-[10px] font-medium text-blue-600 dark:text-blue-400">
+                      Default
+                    </span>
+                  )}
+                </div>
+                {a.description && (
+                  <p className="mt-0.5 text-xs text-muted-foreground">{a.description}</p>
+                )}
+              </div>
+              {selected && <HugeiconsIcon icon={Tick02Icon} className="mt-1 size-4 shrink-0" />}
+            </DropdownMenuItem>
+          )
+        })}
+        {showRoutes && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="px-2.5 pt-1.5">
+              <div className="text-sm font-semibold">Route</div>
+              <p className="mt-0.5 text-xs font-normal text-muted-foreground">
+                Which model chain serves your next message. Routes are configured in Settings.
+              </p>
+            </DropdownMenuLabel>
+            <DropdownMenuItem
+              onSelect={() => onRoute?.('')}
+              data-selected={isRouteAuto || undefined}
+              className="items-start gap-3 rounded-lg px-2.5 py-2 data-selected:bg-zinc-100 dark:data-selected:bg-zinc-800"
+            >
+              <div className="min-w-0 flex-1">
+                <span className="text-sm font-medium">Auto</span>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Uses the agent's own route, or the server default.
+                </p>
+              </div>
+              {isRouteAuto && <HugeiconsIcon icon={Tick02Icon} className="mt-1 size-4 shrink-0" />}
+            </DropdownMenuItem>
+            {routes?.map((r) => {
+              const selected = r.name === route
+              const chainLabel =
+                r.chain.length > 0 ? r.chain.map((c) => c.model).join(' → ') : 'No models configured'
+              return (
+                <DropdownMenuItem
+                  key={r.name}
+                  onSelect={() => onRoute?.(r.name)}
+                  data-selected={selected || undefined}
+                  className="items-start gap-3 rounded-lg px-2.5 py-2 data-selected:bg-zinc-100 dark:data-selected:bg-zinc-800"
+                >
+                  <div className="min-w-0 flex-1">
+                    <span className="text-sm font-medium capitalize">{r.name}</span>
+                    <p className="mt-0.5 text-xs text-muted-foreground">{chainLabel}</p>
+                  </div>
+                  {selected && <HugeiconsIcon icon={Tick02Icon} className="mt-1 size-4 shrink-0" />}
+                </DropdownMenuItem>
+              )
+            })}
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -2,7 +2,7 @@ import { ArrowUp01Icon, Cancel01Icon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useRef } from 'react'
 import { skillLabels } from '../lib/skills'
-import { AgentPicker } from './AgentPicker'
+import { AgentRoutePicker } from './AgentRoutePicker'
 
 // Composer is the one message box: the chat page's docked input and
 // the home page's hero input are the same component so behavior
@@ -13,7 +13,9 @@ export function Composer({
   onSend,
   agent,
   onAgent,
-  hideAgentPicker = false,
+  route,
+  onRoute,
+  hidePicker = false,
   skillHint,
   onRemoveSkillHint,
   disabled = false,
@@ -25,7 +27,9 @@ export function Composer({
   onSend: () => void
   agent: string
   onAgent: (a: string) => void
-  hideAgentPicker?: boolean
+  route?: string
+  onRoute?: (r: string) => void
+  hidePicker?: boolean
   skillHint?: string
   onRemoveSkillHint?: () => void
   disabled?: boolean
@@ -79,7 +83,11 @@ export function Composer({
         }}
       />
       <div className="flex items-center justify-between gap-2 px-2.5 pb-2.5">
-        {hideAgentPicker ? <span /> : <AgentPicker value={agent} onChange={onAgent} />}
+        <div className="flex items-center gap-2">
+          {!hidePicker && (
+            <AgentRoutePicker agent={agent} onAgent={onAgent} route={route} onRoute={onRoute} />
+          )}
+        </div>
         <button
           type="button"
           onClick={onSend}

--- a/web/src/pages/Chat.test.tsx
+++ b/web/src/pages/Chat.test.tsx
@@ -1,0 +1,92 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ChatStreamOptions } from '../api/client'
+import type { ChatEvent, ChatRequest } from '../api/types'
+import { Chat } from './Chat'
+
+vi.mock('../api/client', () => ({
+  ChatError: class ChatError extends Error {},
+  chatStream: vi.fn(),
+  retryStream: vi.fn(),
+  getTranscript: vi.fn(),
+  answerPermission: vi.fn(),
+  listRoutes: vi.fn(),
+  listAgents: vi.fn(),
+}))
+
+import { chatStream, getTranscript, listAgents, listRoutes } from '../api/client'
+
+function renderChat() {
+  return render(
+    <MemoryRouter initialEntries={['/chat']}>
+      <Routes>
+        <Route path="/chat" element={<Chat onNeedToken={vi.fn()} />} />
+        <Route path="/chat/:id" element={<Chat onNeedToken={vi.fn()} />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+const routes = [
+  { name: 'default', strategy: 'ordered', enabled: true, chain: [] },
+  { name: 'summarize', strategy: 'price', enabled: true, chain: [] },
+]
+
+// Radix opens dropdowns on pointerdown, not click.
+function openMenu(name: string) {
+  const trigger = screen.getByRole('button', { name })
+  fireEvent.pointerDown(trigger, { button: 0, pointerId: 1 })
+  fireEvent.click(trigger)
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  // jsdom lacks scrollIntoView; the message list calls it on update.
+  Element.prototype.scrollIntoView = vi.fn()
+  vi.mocked(listAgents).mockResolvedValue([])
+  vi.mocked(listRoutes).mockResolvedValue(routes)
+  vi.mocked(getTranscript).mockResolvedValue({
+    session: { id: 's1', title: '', archived: false, created_at: '', updated_at: '' },
+    items: [],
+  })
+  vi.mocked(chatStream).mockImplementation(
+    async (_req: ChatRequest, onEvent: (ev: ChatEvent) => void, opts: ChatStreamOptions = {}) => {
+      opts.onSession?.('s1')
+      onEvent({ type: 'meta', session_id: 's1' })
+    },
+  )
+})
+
+describe('Chat route picker', () => {
+  it('omits route from the request body when Auto is selected', async () => {
+    renderChat()
+    const input = screen.getByLabelText('Message')
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(chatStream).toHaveBeenCalled())
+    const [req] = vi.mocked(chatStream).mock.calls[0]
+    expect(req.message).toBe('hello')
+    expect(req.route).toBeUndefined()
+  })
+
+  it('includes the chosen route in the request body', async () => {
+    renderChat()
+
+    await screen.findByRole('button', { name: 'Agent and route' })
+    openMenu('Agent and route')
+    fireEvent.click(await screen.findByText('summarize'))
+
+    const input = screen.getByLabelText('Message')
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(chatStream).toHaveBeenCalled())
+    const [req] = vi.mocked(chatStream).mock.calls[0]
+    expect(req.route).toBe('summarize')
+    expect(localStorage.getItem('timothy.route')).toBe('summarize')
+  })
+})

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -18,6 +18,7 @@ import { fromTranscript, type ChatItem } from '../lib/transcript'
 import type { ChatIntent } from './Home'
 
 const agentKey = 'timothy.agent'
+const routeKey = 'timothy.route'
 
 export function Chat({
   onNeedToken,
@@ -52,6 +53,13 @@ export function Chat({
   // direction. Empty string = the server-side default agent.
   const [agent, setAgent] = useState(
     () => (lockedSkillHint ? 'researcher' : (localStorage.getItem(agentKey) ?? '')),
+  )
+  // Same locked-page carve-out as agent: a dedicated page fixes its
+  // own route (or leaves it Auto) and never touches the shared
+  // preference. Empty string = Auto (the agent's own route, or the
+  // server default).
+  const [route, setRoute] = useState(
+    () => (lockedSkillHint ? '' : (localStorage.getItem(routeKey) ?? '')),
   )
   // A skill picked from the home screen: pinned, not text the user
   // can accidentally mangle. Rides every turn until removed. Locked
@@ -107,6 +115,7 @@ export function Chat({
         if (stale) return
         setItems(fromTranscript(items))
         if (session.agent) setAgent(session.agent)
+        setRoute(session.last_route ?? '')
       })
       .catch((err: unknown) => {
         if (stale) return
@@ -133,6 +142,11 @@ export function Chat({
     localStorage.setItem(agentKey, a)
   }
 
+  const pickRoute = (r: string) => {
+    setRoute(r)
+    localStorage.setItem(routeKey, r)
+  }
+
   const updateLast = (fn: (m: AssistantState) => AssistantState) =>
     setItems((prev) => {
       const next = [...prev]
@@ -142,7 +156,12 @@ export function Chat({
       return next
     })
 
-  const sendMessage = async (text: string, agentName: string, hint = skillHint) => {
+  const sendMessage = async (
+    text: string,
+    agentName: string,
+    hint = skillHint,
+    routeName = route,
+  ) => {
     const message = text.trim()
     if (!message || streaming) return
     setDraft('')
@@ -166,7 +185,13 @@ export function Chat({
     }
     try {
       await chatStream(
-        { session_id: sessionRef.current, message, agent: agentName, skill_hint: hint },
+        {
+          session_id: sessionRef.current,
+          message,
+          agent: agentName,
+          route: routeName || undefined,
+          skill_hint: hint,
+        },
         (ev: ChatEvent) => {
           if (ev.type === 'meta') adoptSession(ev.session_id)
           updateLast((m) => applyEvent(m, ev))
@@ -253,13 +278,16 @@ export function Chat({
   useEffect(() => {
     if (lockedSkillHint || intentConsumedRef.current) return
     const intent = location.state as ChatIntent | null
-    if (!intent || (!intent.send && !intent.draft && !intent.agent && !intent.skillHint)) return
+    if (!intent || (!intent.send && !intent.draft && !intent.agent && !intent.route && !intent.skillHint))
+      return
     intentConsumedRef.current = true
     window.history.replaceState(null, '') // don't refire on back/refresh
     const who = intent.agent ?? agent
+    const whichRoute = intent.route ?? route
     if (intent.agent) pickAgent(intent.agent)
+    if (intent.route) pickRoute(intent.route)
     if (intent.skillHint) setSkillHint(intent.skillHint)
-    if (intent.send) void sendMessage(intent.send, who, intent.skillHint)
+    if (intent.send) void sendMessage(intent.send, who, intent.skillHint, whichRoute)
     else if (intent.draft) setDraft(intent.draft)
     // Mount-time only by design: the intent rides the navigation that
     // created this page instance; the ref guards strict-mode replays.
@@ -350,7 +378,9 @@ export function Chat({
           onSend={send}
           agent={agent}
           onAgent={pickAgent}
-          hideAgentPicker={Boolean(lockedSkillHint)}
+          route={route}
+          onRoute={pickRoute}
+          hidePicker={Boolean(lockedSkillHint)}
           skillHint={skillHint}
           onRemoveSkillHint={lockedSkillHint ? undefined : () => setSkillHint(undefined)}
           disabled={streaming}

--- a/web/src/pages/Home.test.tsx
+++ b/web/src/pages/Home.test.tsx
@@ -7,9 +7,11 @@ import { Home } from './Home'
 vi.mock('../api/client', () => ({
   listAgents: vi.fn(),
   listMemories: vi.fn(),
+  listRoutes: vi.fn(),
 }))
 
-import { listAgents, listMemories } from '../api/client'
+import type { AdminRoute } from '../api/types'
+import { listAgents, listMemories, listRoutes } from '../api/client'
 
 let landed: { pathname: string; state: ChatIntent | null } | null = null
 
@@ -57,6 +59,14 @@ const researchAgent = {
   is_default: false,
   enabled: true,
 }
+const routes: AdminRoute[] = [{ name: 'summarize', strategy: 'ordered', enabled: true, chain: [] }]
+
+// Radix opens dropdowns on pointerdown, not click.
+function openMenu(name: string) {
+  const trigger = screen.getByRole('button', { name })
+  fireEvent.pointerDown(trigger, { button: 0, pointerId: 1 })
+  fireEvent.click(trigger)
+}
 
 afterEach(cleanup)
 beforeEach(() => {
@@ -64,6 +74,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(listAgents).mockResolvedValue([generalAgent, researchAgent])
   vi.mocked(listMemories).mockResolvedValue([])
+  vi.mocked(listRoutes).mockRejectedValue(new Error('not used on this page'))
   localStorage.clear()
 })
 
@@ -85,6 +96,21 @@ describe('Home', () => {
     expect(landed?.state?.send).toBe('hello there')
     // Agent may be '' (server default) — the intent just carries it.
     expect(landed?.state).toHaveProperty('agent')
+  })
+
+  it('submitting with a picked route includes it in the navigate state', async () => {
+    vi.mocked(listRoutes).mockResolvedValue(routes)
+    renderHome()
+
+    await screen.findByRole('button', { name: 'Agent and route' })
+    openMenu('Agent and route')
+    fireEvent.click(await screen.findByText('summarize'))
+
+    const input = screen.getByLabelText('Message')
+    fireEvent.change(input, { target: { value: 'hello there' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(landed?.state?.route).toBe('summarize')
+    expect(localStorage.getItem('timothy.route')).toBe('summarize')
   })
 
   it('an empty composer does not navigate', () => {

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -11,6 +11,7 @@ import { Composer } from '../components/Composer'
 import { usePendingMemories } from '../lib/memory'
 
 const agentKey = 'timothy.agent'
+const routeKey = 'timothy.route'
 
 // ChatIntent carries a home-screen action into the chat page: `send`
 // fires immediately, `draft` only prefills the composer, `skillHint`
@@ -19,6 +20,7 @@ export interface ChatIntent {
   send?: string
   draft?: string
   agent?: string
+  route?: string
   skillHint?: string
 }
 
@@ -32,16 +34,22 @@ export function Home() {
   const agents = useAgents()
   const [draft, setDraft] = useState('')
   const [agent, setAgent] = useState(() => localStorage.getItem(agentKey) ?? '')
+  const [route, setRoute] = useState(() => localStorage.getItem(routeKey) ?? '')
 
   const pickAgent = (a: string) => {
     setAgent(a)
     localStorage.setItem(agentKey, a)
   }
 
+  const pickRoute = (r: string) => {
+    setRoute(r)
+    localStorage.setItem(routeKey, r)
+  }
+
   const send = () => {
     const message = draft.trim()
     if (!message) return
-    navigate('/chat', { state: { send: message, agent } satisfies ChatIntent })
+    navigate('/chat', { state: { send: message, agent, route: route || undefined } satisfies ChatIntent })
   }
 
   const openAgent = (name: string) => {
@@ -63,6 +71,8 @@ export function Home() {
             onSend={send}
             agent={agent}
             onAgent={pickAgent}
+            route={route}
+            onRoute={pickRoute}
             autoFocus
             placeholder="Ask anything…"
           />


### PR DESCRIPTION
Route choice is a per-message knob (D-034) but lived in a second pill next to the agent picker, and only on the chat page.

- One combined dropdown (Agent section, Route section) in the composer, replacing the two pills; `hideAgentPicker`/`hideRoutePicker` collapse to `hidePicker`.
- Home landing composer gains the same picker; `ChatIntent` carries the picked route into the first message of a new chat.
- Route items preview their chain (models in try order, second line), empty chain shows "No models configured".
- `AgentPicker.tsx` slims to `AUTO_AGENT` + `useAgents` exports; standalone `RoutePicker` never shipped.

Tests: new `AgentRoutePicker.test.tsx` (8), `Chat.test.tsx` (2), Home route-intent test; 283 total green (build + lint + vitest in Docker).