### PR TITLE
chore(deploy): drop containerized ollama for native host runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GO_RUN := docker run --rm -v $(CURDIR):/src -w /src \
 	-e GOFLAGS=-buildvcs=false $(GO_IMAGE)
 
 .PHONY: build test test-integration test-live vet lint tidy skills-validate up down logs \
-	brain gateway memoryd web markitdown ollama sandboxd dev canary canary-coding sandbox-image
+	brain gateway memoryd web markitdown sandboxd dev canary canary-coding sandbox-image
 
 build:
 	$(GO_RUN) go build ./...
@@ -61,13 +61,13 @@ up:
 	$(COMPOSE) up -d --build
 
 # Per-service rebuild+restart for when only one service changed:
-#   make brain / make gateway / make memoryd / make web / make markitdown / make ollama / make sandboxd
+#   make brain / make gateway / make memoryd / make web / make markitdown / make sandboxd
 # Rolling brain and sandboxd separately: restart sandboxd first — the
 # API between them is additive-only, so an older brain against a newer
 # sandboxd (or vice versa, briefly) stays compatible either order, but
 # sandboxd-first avoids brain's own restart racing against sandboxd's
 # health check on its way up.
-brain gateway memoryd web markitdown ollama sandboxd:
+brain gateway memoryd web markitdown sandboxd:
 	$(COMPOSE) up -d --build $@
 
 # Vite dev server with hot reload on :3301 (proxies /v1 to brain).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Go microservices behind a single public API, one PostgreSQL database, React web 
 | `web`        | React + Tailwind interface — chat, missions, usage, settings            |
 | `searxng`    | Internal metasearch backend for the web_search tool                     |
 | `markitdown` | Internal Python sidecar — file→markdown conversion                      |
-| `ollama`     | Optional local model runner (OpenAI-compatible)                         |
 
 Sessions are an append-only event log: every turn, tool run, and compaction is an immutable event, so conversations survive crashes mid-stream and replay exactly as they happened.
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -56,19 +56,10 @@ services:
     # internal-only: no published ports, no auth; brain is the sole
     # caller, same trust boundary as searxng.
 
-  # Local model runner: an OpenAI-compatible endpoint at /v1, registered
-  # in Settings as a regular "openaicompat" provider — no gateway code
-  # needed. Pull a model once with:
-  #   docker compose exec ollama ollama pull qwen2.5:14b
-  ollama:
-    <<: *service
-    image: ollama/ollama@sha256:c3886c198155aa7d45a29851100cc16f5d6ea6777d635ddd0597fe95874161af
-    volumes:
-      - ollama-models:/root/.ollama
-    # internal-only by default; uncomment to reach it from the host
-    # (e.g. `ollama pull` from your Mac instead of via compose exec):
-    # ports:
-    #   - "${OLLAMA_PORT:-11434}:11434"
+  # Local models: run Ollama natively on the host (Metal/CUDA — a
+  # containerized runner gets CPU only and can't serve big models) and
+  # register http://host.docker.internal:11434/v1 in Settings as a
+  # regular "openaicompat" provider — no gateway code needed.
 
   brain:
     <<: *go-service
@@ -178,7 +169,7 @@ services:
     # internal-only: no published ports; brain is the sole caller.
     # Second network (not just `timothy`): sandboxd is strictly more
     # privileged than any other internal service (it holds the socket),
-    # so it reaches only brain, not searxng/markitdown/ollama/web. No
+    # so it reaches only brain, not searxng/markitdown/web. No
     # auth header on the API — a shared secret would have to live in
     # brain's own env, the exact thing this split assumes may be
     # compromised (same reasoning as memoryd's unauthenticated internal
@@ -279,7 +270,6 @@ volumes:
   pgdata:
   web_node_modules:
   workspace:
-  ollama-models:
 
 networks:
   timothy:


### PR DESCRIPTION
Containerized Ollama on macOS is CPU-only (no Metal) — qwen3:32b never produced tokens before the gateway header timeout. Native brew-installed Ollama serves the same model fully GPU-accelerated (~12 tok/s eval, 32k ctx).

- compose: ollama service + `ollama-models` volume removed; comment documents the native pattern (register `http://host.docker.internal:11434/v1` as an openaicompat provider)
- Makefile: ollama target and .PHONY entry removed
- README: service table row removed