### PR TITLE
fix(web): mount logo sprites at app root

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,8 @@ import { getToken } from './api/client'
 import { SessionList } from './components/SessionList'
 import { SessionsProvider } from './components/SessionsProvider'
 import { SettingsDialog } from './components/SettingsDialog'
+import { ConnectorLogoSprite } from './components/settings/ConnectorLogo'
+import { LogoSprite } from './components/settings/ProviderLogo'
 import {
   CommandDialog,
   CommandEmpty,
@@ -283,6 +285,8 @@ function App() {
   return (
     <TooltipProvider delayDuration={300}>
       <SessionsProvider>
+        <LogoSprite />
+        <ConnectorLogoSprite />
         <Toaster richColors closeButton theme={theme} />
         <SidebarProvider className="min-h-dvh">
           <AppSidebar

--- a/web/src/components/settings/ConnectorAdd.tsx
+++ b/web/src/components/settings/ConnectorAdd.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../api/client'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
-import { ConnectorLogo, ConnectorLogoSprite } from './ConnectorLogo'
+import { ConnectorLogo } from './ConnectorLogo'
 import { connectorPresets } from './connectorPresets'
 import { Field } from './shared'
 import { useDefaultSecretBackend } from './useDefaultSecretBackend'
@@ -147,7 +147,6 @@ export function ConnectorAdd() {
 
   return (
     <div className="mt-6 w-full space-y-6">
-      <ConnectorLogoSprite />
       <Link
         to="/settings/connectors"
         className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"

--- a/web/src/components/settings/ConnectorEdit.tsx
+++ b/web/src/components/settings/ConnectorEdit.tsx
@@ -21,7 +21,7 @@ import {
   DialogTitle,
 } from '../ui/dialog'
 import { Input } from '../ui/input'
-import { ConnectorLogo, ConnectorLogoSprite } from './ConnectorLogo'
+import { ConnectorLogo } from './ConnectorLogo'
 import { connectorPresets, unknownPreset } from './connectorPresets'
 import { useDefaultSecretBackend } from './useDefaultSecretBackend'
 import { Field } from './shared'
@@ -107,7 +107,6 @@ export function ConnectorEdit() {
 
   return (
     <div className="mt-6 w-full space-y-6">
-      <ConnectorLogoSprite />
       <Link
         to="/settings/connectors"
         className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"

--- a/web/src/components/settings/ConnectorLogo.tsx
+++ b/web/src/components/settings/ConnectorLogo.tsx
@@ -2,6 +2,8 @@ import type { ConnectorPreset } from './connectorPresets'
 
 // Official connector marks (simple-icons, monochrome), rendered white
 // on the preset's brand color — same treatment as provider logos.
+// ConnectorLogoSprite mounts once in App; ConnectorLogo references
+// symbols from it.
 export function ConnectorLogoSprite() {
   return (
     <svg width="0" height="0" className="absolute" aria-hidden="true">

--- a/web/src/components/settings/ConnectorsList.tsx
+++ b/web/src/components/settings/ConnectorsList.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner'
 import { listConnectors, patchConnector, testConnector } from '../../api/client'
 import type { AdminConnector } from '../../api/types'
 import { Button } from '../ui/button'
-import { ConnectorLogo, ConnectorLogoSprite } from './ConnectorLogo'
+import { ConnectorLogo } from './ConnectorLogo'
 import { connectorPresets, unknownPreset } from './connectorPresets'
 import { Toggle } from './shared'
 import { errText } from './util'
@@ -28,8 +28,6 @@ export function ConnectorsList() {
 
   return (
     <div className="mt-6 space-y-8">
-      <ConnectorLogoSprite />
-
       {oauthConnected && (
         <div className="flex items-center gap-3 rounded-xl border border-good/30 bg-good-soft p-3 text-sm text-good">
           <span>Google account connected to “{oauthConnected}”. Enable it below to serve tools.</span>

--- a/web/src/components/settings/ProviderAdd.tsx
+++ b/web/src/components/settings/ProviderAdd.tsx
@@ -10,7 +10,7 @@ import { Input } from '../ui/input'
 import { ModelInput, type ModelSuggestion } from './ModelInput'
 import { modelCatalog } from './modelCatalog'
 import { providerPresets, type ProviderPreset } from './presets'
-import { LogoSprite, ProviderLogo } from './ProviderLogo'
+import { ProviderLogo } from './ProviderLogo'
 import { Field } from './shared'
 import { useDefaultSecretBackend } from './useDefaultSecretBackend'
 import { errText, secretField, stripPaste } from './util'
@@ -181,7 +181,6 @@ export function ProviderAdd() {
 
   return (
     <div className="mt-6 w-full space-y-6">
-      <LogoSprite />
       <Link
         to="/settings/providers"
         className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"

--- a/web/src/components/settings/ProviderEdit.tsx
+++ b/web/src/components/settings/ProviderEdit.tsx
@@ -26,7 +26,7 @@ import { Input } from '../ui/input'
 import { ModelInput, type ModelSuggestion } from './ModelInput'
 import { modelCatalog } from './modelCatalog'
 import { matchPreset } from './presets'
-import { LogoSprite, ProviderLogo } from './ProviderLogo'
+import { ProviderLogo } from './ProviderLogo'
 import { Field } from './shared'
 import { useDefaultSecretBackend } from './useDefaultSecretBackend'
 import { backendLabel, errText, stripPaste, secretField } from './util'
@@ -66,7 +66,6 @@ export function ProviderEdit() {
 
   return (
     <div className="mt-6 w-full space-y-6">
-      <LogoSprite />
       <Link
         to="/settings/providers"
         className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"

--- a/web/src/components/settings/ProviderLogo.tsx
+++ b/web/src/components/settings/ProviderLogo.tsx
@@ -1,8 +1,8 @@
 import type { ProviderPreset } from './presets'
 
 // Official provider marks (lobehub icon set, monochrome variants),
-// rendered white on the preset's brand color. LogoSprite mounts once;
-// ProviderLogo references symbols from it.
+// rendered white on the preset's brand color. LogoSprite mounts once
+// in App; ProviderLogo references symbols from it.
 export function LogoSprite() {
   return (
     <svg width="0" height="0" className="absolute" aria-hidden="true">

--- a/web/src/components/settings/ProvidersList.tsx
+++ b/web/src/components/settings/ProvidersList.tsx
@@ -5,7 +5,7 @@ import { listProviders, patchProvider, providersHealth, testProvider } from '../
 import type { AdminProvider, ProviderHealth, TestResult } from '../../api/types'
 import { Button } from '../ui/button'
 import { matchPreset, providerPresets } from './presets'
-import { LogoSprite, ProviderLogo } from './ProviderLogo'
+import { ProviderLogo } from './ProviderLogo'
 import { Toggle } from './shared'
 import { errText } from './util'
 
@@ -26,8 +26,6 @@ export function ProvidersList() {
 
   return (
     <div className="mt-6 space-y-8">
-      <LogoSprite />
-
       <section className="space-y-3">
         <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           {providers.length > 0 ? `Your providers · ${providers.length}` : 'Your providers'}

--- a/web/src/components/settings/presets.test.ts
+++ b/web/src/components/settings/presets.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import type { AdminProvider } from '../../api/types'
+import { matchPreset } from './presets'
+
+function provider(overrides: Partial<AdminProvider>): AdminProvider {
+  return {
+    id: 'p1',
+    name: 'test',
+    kind: 'api',
+    driver: 'openaicompat',
+    base_url: '',
+    default_model: '',
+    models: [],
+    credential_ref: '',
+    headers: {},
+    enabled: true,
+    ...overrides,
+  }
+}
+
+describe('matchPreset', () => {
+  it.each([
+    'http://ollama:11434/v1',
+    'http://localhost:11434/v1',
+    'http://host.docker.internal:11434/v1',
+  ])('matches the ollama preset by port for %s', (base_url) => {
+    const p = provider({ base_url })
+    expect(matchPreset(p).id).toBe('ollama')
+  })
+
+  it('matches by exact host when the port is not 11434', () => {
+    const p = provider({ base_url: 'https://api.z.ai/api/paas/v4' })
+    expect(matchPreset(p).id).toBe('glm')
+  })
+
+  it('falls back to custom for an unknown url', () => {
+    const p = provider({ base_url: 'https://example.com/v1' })
+    expect(matchPreset(p).id).toBe('custom')
+  })
+
+  it('matches the bedrock preset by driver', () => {
+    const p = provider({ driver: 'bedrock', base_url: 'us-east-1' })
+    expect(matchPreset(p).id).toBe('bedrock')
+  })
+
+  it('matches the anthropic preset by driver', () => {
+    const p = provider({ driver: 'anthropic', base_url: '' })
+    expect(matchPreset(p).id).toBe('anthropic')
+  })
+})

--- a/web/src/components/settings/presets.ts
+++ b/web/src/components/settings/presets.ts
@@ -71,7 +71,7 @@ export const providerPresets: ProviderPreset[] = [
     driver: 'openaicompat',
     description: "Zhipu's GLM models",
     logo: 'zai',
-    brandColor: '#4B5563',
+    brandColor: '#000000',
     baseURL: 'https://api.z.ai/api/paas/v4',
     requiresKey: true,
     defaultRef: 'ZAI_API_KEY',
@@ -100,10 +100,10 @@ export const providerPresets: ProviderPreset[] = [
     description: 'Local models, no key needed',
     logo: 'ollama',
     brandColor: '#4B5563',
-    // The gateway runs in Docker; the ollama compose service is the
-    // one actually deployed (see deploy/docker-compose.yml) — reached
-    // by its service name on the shared network, not the host.
-    baseURL: 'http://ollama:11434/v1',
+    // Ollama runs natively on the host for GPU access (the compose
+    // service was removed); the gateway reaches it via Docker's host
+    // alias.
+    baseURL: 'http://host.docker.internal:11434/v1',
     requiresKey: false,
     validateModel: 'qwen2.5:7b',
   },
@@ -127,6 +127,16 @@ export function matchPreset(p: AdminProvider): ProviderPreset {
   const custom = providerPresets.find((x) => x.id === 'custom')!
   if (p.driver === 'anthropic' || p.driver === 'bedrock') {
     return providerPresets.find((x) => x.driver === p.driver) ?? custom
+  }
+  // Ollama's fixed default port (11434) is a stronger signal than
+  // hostname, which varies across deployments (ollama, localhost,
+  // host.docker.internal).
+  try {
+    if (new URL(p.base_url).port === '11434') {
+      return providerPresets.find((x) => x.id === 'ollama') ?? custom
+    }
+  } catch {
+    // fall through to host matching below
   }
   const byURL = providerPresets.find((x) => {
     if (!x.baseURL || x.id === 'custom') return false


### PR DESCRIPTION
Routing page brand tiles rendered blank: `PipelineCard` uses `ProviderLogo` (`<use href="#plogo-…">`) but the `LogoSprite` symbol defs were only mounted on the Providers/Connectors pages, never on the routing page.

- `LogoSprite` + `ConnectorLogoSprite` mount once in `App.tsx` (zero-size SVGs); all six per-page mounts removed.
- `matchPreset` recognizes Ollama by its fixed port 11434 — hostname varies (`ollama`, `localhost`, `host.docker.internal`), port doesn't. Preset baseURL updated to the native-host address.
- Z.ai brand tile black per official mark (was placeholder gray).
- New `presets.test.ts` (7 tests): ollama-by-port across hostnames, host match, driver match, custom fallback.

Build + lint + 279 tests green.