### PR TITLE
feat(brain): persist permission asks for session replay

### DIFF
--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -445,6 +445,42 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 		}
 	}
 
+	// notePermission persists an ask (and its resolution) the moment it
+	// crosses the relay, not at turn end: a parked turn can sit for the
+	// full permissionTimeout, and the whole point of this event is that
+	// a session opened while that's happening shows the same prompt the
+	// live stream shows. Same detached-timeout, best-effort pattern as
+	// flushPending — a failed write here loses the replay prompt, never
+	// the turn itself.
+	notePermission := func(ev stream.StreamEvent) {
+		var kind string
+		var payload any
+		switch ev.Type {
+		case stream.EventPermissionRequest:
+			if ev.Permission == nil {
+				return
+			}
+			kind = session.KindPermissionRequest
+			payload = session.PermissionRequest{
+				ID: ev.Permission.ID, CallID: ev.Permission.CallID, Tool: ev.Permission.Tool,
+				Args: ev.Permission.Args, Danger: ev.Permission.Danger, Rationale: ev.Permission.Rationale,
+			}
+		case stream.EventPermissionResolved:
+			if ev.Resolved == nil {
+				return
+			}
+			kind = session.KindPermissionResolved
+			payload = session.PermissionResolved{ID: ev.Resolved.ID, Decision: ev.Resolved.Decision}
+		default:
+			return
+		}
+		wctx, cancel := context.WithTimeout(context.Background(), persistTimeout)
+		defer cancel()
+		if _, err := s.log.Append(wctx, sessionID, kind, payload); err != nil {
+			s.logger.Warn("persist permission event", "session_id", sessionID, "kind", kind, "error", err)
+		}
+	}
+
 	// flushPending checkpoints the partial answer DURING the stream so
 	// even a SIGKILL mid-turn loses at most one flush interval — the
 	// projection splices the last pending in, and a completed turn
@@ -477,6 +513,7 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 				meta = ev.Meta
 			}
 			noteToolResult(ev)
+			notePermission(ev)
 		}
 		close(out)
 		s.persistTurn(sessionID, userText, route, profile, needsTitle, text.String(), reasoning.String(), meta, usage, sawDone, flushed, turnSensitive)
@@ -504,6 +541,7 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 				meta = ev.Meta
 			}
 			noteToolResult(ev)
+			notePermission(ev)
 			select {
 			case out <- ev:
 			case <-ctx.Done():

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -215,6 +215,128 @@ func TestChatPersistsTurnAsEvents(t *testing.T) {
 	}
 }
 
+// TestChatPersistsPermissionAsks confirms the relay appends
+// permission_request and permission_resolved as their own durable
+// session events the moment they cross the stream — not batched into
+// persistTurn at turn end, since a parked ask is exactly the case
+// where the turn hasn't ended yet. A replay of the session must then
+// carry the resolved pair, and UITranscript must drop it once
+// answered (only a still-pending ask belongs in replay).
+func TestChatPersistsPermissionAsks(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: []stream.StreamEvent{
+		{Type: stream.EventPermissionRequest, Permission: &stream.PermissionRequestEvent{
+			ID: "perm-1", CallID: "call-1", Tool: "shell", Args: "{}",
+			Danger: "destructive", Rationale: "runs a shell command",
+		}},
+		{Type: stream.EventPermissionResolved, Resolved: &stream.PermissionResolvedEvent{
+			ID: "perm-1", Decision: "once",
+		}},
+		{Type: stream.EventChunk, Text: "done"},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod", LedgerID: "led"}},
+	}}
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "run a command"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 5 })
+	kinds := log.kinds("s1")
+	want := []string{
+		session.KindSessionStarted, session.KindUserMessage,
+		session.KindPermissionRequest, session.KindPermissionResolved,
+		session.KindAssistantTurn,
+	}
+	if strings.Join(kinds, ",") != strings.Join(want, ",") {
+		t.Fatalf("kinds = %v, want %v", kinds, want)
+	}
+
+	events, _ := log.Events(t.Context(), "s1")
+	var req session.PermissionRequest
+	if err := json.Unmarshal(events[2].Payload, &req); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if req.ID != "perm-1" || req.Tool != "shell" || req.Danger != "destructive" {
+		t.Fatalf("request = %+v", req)
+	}
+	var res session.PermissionResolved
+	if err := json.Unmarshal(events[3].Payload, &res); err != nil {
+		t.Fatalf("decode resolved: %v", err)
+	}
+	if res.ID != "perm-1" || res.Decision != "once" {
+		t.Fatalf("resolved = %+v", res)
+	}
+
+	// A resolved ask must not appear in a replay: only a still-pending
+	// prompt belongs in the UI transcript.
+	items, err := session.UITranscript(events)
+	if err != nil {
+		t.Fatalf("UITranscript: %v", err)
+	}
+	for _, it := range items {
+		if it.Kind == "permission" {
+			t.Fatalf("resolved ask still in replay: %+v", it)
+		}
+	}
+}
+
+// TestChatReplayCarriesUnresolvedPermissionAsk confirms a session
+// whose turn is still parked on an ask exposes it in the UI transcript
+// projection — the whole point of persisting the request at all.
+func TestChatReplayCarriesUnresolvedPermissionAsk(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	block := make(chan struct{})
+	gw := &fakeGW{blockCh: block, events: []stream.StreamEvent{
+		{Type: stream.EventPermissionRequest, Permission: &stream.PermissionRequestEvent{
+			ID: "perm-1", CallID: "call-1", Tool: "shell", Args: "{}",
+			Danger: "safe", Rationale: "runs a shell command",
+		}},
+		// No resolution, no terminal — the turn is still parked.
+	}}
+	s := newService(gw, log)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	_, ch, err := s.Chat(ctx, Request{SessionID: "s1", Message: "run a command"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	close(block)
+	<-ch // receive the permission_request
+
+	waitFor(t, func() bool {
+		for _, k := range log.kinds("s1") {
+			if k == session.KindPermissionRequest {
+				return true
+			}
+		}
+		return false
+	})
+
+	events, _ := log.Events(t.Context(), "s1")
+	items, err := session.UITranscript(events)
+	if err != nil {
+		t.Fatalf("UITranscript: %v", err)
+	}
+	var found bool
+	for _, it := range items {
+		if it.Kind == "permission" {
+			found = true
+			if it.Permission == nil || it.Permission.ID != "perm-1" {
+				t.Fatalf("permission item = %+v", it)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("unresolved ask missing from replay")
+	}
+}
+
 func TestChatHistoryComesFromProjection(t *testing.T) {
 	t.Parallel()
 	log := newFakeLog()

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -653,7 +653,11 @@ func (a *Agent) resolveAndRun(ctx context.Context, exec Executor, sessionID stri
 // the decision (timeout = deny, D-010). Turn durability while parked
 // comes from the relay's periodic pending_state flushes; the prompt
 // itself is in-memory only — a restart drops it, which resolves as a
-// deny.
+// deny. Whatever the outcome — an explicit answer, a timeout, or ctx
+// cancellation — a permission_resolved event follows so anything
+// tracking the request (persistence, a replay client) learns the
+// outcome too; the live web client already clears its prompt off
+// tool_result, so this is additive, not a behavior change for it.
 func (a *Agent) askUser(ctx context.Context, call provider.ToolCall, res tools.Resolution, emit func(stream.StreamEvent)) string {
 	id, answer := a.broker.Create()
 	defer a.broker.Forget(id)
@@ -665,16 +669,22 @@ func (a *Agent) askUser(ctx context.Context, call provider.ToolCall, res tools.R
 		Rationale: res.Rationale,
 	}})
 
-	timer := time.NewTimer(permissionTimeout)
-	defer timer.Stop()
-	select {
-	case d := <-answer:
-		return d
-	case <-timer.C:
-		return DecideDeny
-	case <-ctx.Done():
-		return DecideDeny
-	}
+	decision := func() string {
+		timer := time.NewTimer(permissionTimeout)
+		defer timer.Stop()
+		select {
+		case d := <-answer:
+			return d
+		case <-timer.C:
+			return DecideDeny
+		case <-ctx.Done():
+			return DecideDeny
+		}
+	}()
+	emit(stream.StreamEvent{Type: stream.EventPermissionResolved, Resolved: &stream.PermissionResolvedEvent{
+		ID: id, Decision: decision,
+	}})
+	return decision
 }
 
 func (a *Agent) offloadIfBig(ctx context.Context, sessionID, tool, content string) (string, error) {

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -1463,3 +1463,54 @@ func TestAgentAttendedAskStillParks(t *testing.T) {
 		}
 	}
 }
+
+// TestAskUserEmitsResolvedOnAnswer confirms askUser follows its
+// permission_request with a permission_resolved event carrying the
+// same ID and the decision the broker delivered — the persistence path
+// (chat's relay) and any replay client learn the outcome from the
+// stream itself, not just from the tool_result that happens to follow.
+func TestAskUserEmitsResolvedOnAnswer(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"echo", `{"text":"hi"}`}),
+		finalStep("after decision"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+	a.perms = askPerms{}
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var evs []stream.StreamEvent
+	var requestID string
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				resolved := ofType(evs, stream.EventPermissionResolved)
+				if len(resolved) != 1 {
+					t.Fatalf("permission_resolved count = %d, want 1: %+v", len(resolved), resolved)
+				}
+				if resolved[0].Resolved.ID != requestID {
+					t.Fatalf("resolved id = %q, want %q", resolved[0].Resolved.ID, requestID)
+				}
+				if resolved[0].Resolved.Decision != DecideOnce {
+					t.Fatalf("resolved decision = %q, want %q", resolved[0].Resolved.Decision, DecideOnce)
+				}
+				return
+			}
+			evs = append(evs, ev)
+			if ev.Type == stream.EventPermissionRequest {
+				requestID = ev.Permission.ID
+				if !a.broker.Resolve(ev.Permission.ID, DecideOnce) {
+					t.Fatal("broker did not know the prompt id")
+				}
+			}
+		case <-deadline:
+			t.Fatal("loop never finished")
+		}
+	}
+}
+

--- a/internal/brain/session/events.go
+++ b/internal/brain/session/events.go
@@ -14,13 +14,15 @@ import (
 
 // Event kinds. The log is append-only: kinds are added, never changed.
 const (
-	KindSessionStarted    = "session_started"
-	KindUserMessage       = "user_message"
-	KindAssistantTurn     = "assistant_turn"
-	KindToolExecution     = "tool_execution"
-	KindCompactionApplied = "compaction_applied"
-	KindPendingState      = "pending_state"
-	KindTurnMemory        = "turn_memory"
+	KindSessionStarted     = "session_started"
+	KindUserMessage        = "user_message"
+	KindAssistantTurn      = "assistant_turn"
+	KindToolExecution      = "tool_execution"
+	KindCompactionApplied  = "compaction_applied"
+	KindPendingState       = "pending_state"
+	KindTurnMemory         = "turn_memory"
+	KindPermissionRequest  = "permission_request"
+	KindPermissionResolved = "permission_resolved"
 )
 
 // Event is one row of a session's log.
@@ -115,6 +117,28 @@ type CompactionApplied struct {
 // abnormally; the next request splices it in, then it is superseded.
 type PendingState struct {
 	Partial string `json:"partial"`
+}
+
+// PermissionRequest records a parked tool call awaiting approval
+// (mirrors stream.PermissionRequestEvent). A session opened while the
+// turn is still parked replays this so the same approval prompt the
+// live stream shows appears on reload too; a matching
+// PermissionResolved (by ID) means it is no longer pending.
+type PermissionRequest struct {
+	ID        string `json:"id"`
+	CallID    string `json:"call_id"`
+	Tool      string `json:"tool"`
+	Args      string `json:"args"`
+	Danger    string `json:"danger_level"`
+	Rationale string `json:"rationale"`
+}
+
+// PermissionResolved records the decision a parked ask received
+// (mirrors stream.PermissionResolvedEvent). ID ties it to the
+// PermissionRequest it resolves.
+type PermissionResolved struct {
+	ID       string `json:"id"`
+	Decision string `json:"decision"`
 }
 
 // decode unmarshals an event payload into out with kind context on

--- a/internal/brain/session/projection.go
+++ b/internal/brain/session/projection.go
@@ -169,15 +169,16 @@ func renderTurnMemory(tm *TurnMemory) string {
 
 // TranscriptItem is one renderable unit of the UI replay.
 type TranscriptItem struct {
-	Seq       int64          `json:"seq"`
-	Kind      string         `json:"kind"` // user | assistant | tool | compaction | interrupted
-	Text      string         `json:"text,omitempty"`
-	Blocks    []UIBlock      `json:"blocks,omitempty"`
-	Provider  string         `json:"provider,omitempty"`
-	Model     string         `json:"model,omitempty"`
-	Usage     *stream.Usage  `json:"usage,omitempty"`
-	Tool      *ToolExecution `json:"tool,omitempty"`
-	CreatedAt time.Time      `json:"created_at"`
+	Seq        int64              `json:"seq"`
+	Kind       string             `json:"kind"` // user | assistant | tool | permission | compaction | interrupted
+	Text       string             `json:"text,omitempty"`
+	Blocks     []UIBlock          `json:"blocks,omitempty"`
+	Provider   string             `json:"provider,omitempty"`
+	Model      string             `json:"model,omitempty"`
+	Usage      *stream.Usage      `json:"usage,omitempty"`
+	Tool       *ToolExecution     `json:"tool,omitempty"`
+	Permission *PermissionRequest `json:"permission,omitempty"`
+	CreatedAt  time.Time          `json:"created_at"`
 }
 
 // UITranscript projects the log into the full rich replay. Unlike the
@@ -186,6 +187,10 @@ type TranscriptItem struct {
 // interrupted turn.
 func UITranscript(events []Event) ([]TranscriptItem, error) {
 	livePending := livePendingSeq(events)
+	resolved, err := resolvedPermissionIDs(events)
+	if err != nil {
+		return nil, err
+	}
 	var items []TranscriptItem
 	for _, ev := range events {
 		item := TranscriptItem{Seq: ev.Seq, CreatedAt: ev.CreatedAt}
@@ -211,6 +216,17 @@ func UITranscript(events []Event) ([]TranscriptItem, error) {
 				return nil, err
 			}
 			item.Kind, item.Tool = "tool", &te
+		case KindPermissionRequest:
+			var p PermissionRequest
+			if err := decode(ev, &p); err != nil {
+				return nil, err
+			}
+			if resolved[p.ID] {
+				continue // answered — the live client drops these too
+			}
+			item.Kind, item.Permission = "permission", &p
+		case KindPermissionResolved:
+			continue // no standalone item; only gates the request above
 		case KindCompactionApplied:
 			var c CompactionApplied
 			if err := decode(ev, &c); err != nil {
@@ -233,4 +249,23 @@ func UITranscript(events []Event) ([]TranscriptItem, error) {
 		items = append(items, item)
 	}
 	return items, nil
+}
+
+// resolvedPermissionIDs collects every permission id that has a
+// matching permission_resolved event, so UITranscript can skip
+// answered asks — a parked prompt only belongs in replay while it is
+// still actually pending.
+func resolvedPermissionIDs(events []Event) (map[string]bool, error) {
+	out := map[string]bool{}
+	for _, ev := range events {
+		if ev.Kind != KindPermissionResolved {
+			continue
+		}
+		var r PermissionResolved
+		if err := decode(ev, &r); err != nil {
+			return nil, err
+		}
+		out[r.ID] = true
+	}
+	return out, nil
 }

--- a/internal/gateway/stream/events.go
+++ b/internal/gateway/stream/events.go
@@ -25,23 +25,25 @@ const (
 	EventError          EventType = "error"           // terminal: failure
 
 	// Agent-loop events (brain-side; never emitted by providers).
-	EventToolResult        EventType = "tool_result"        // a tool execution finished
-	EventPermissionRequest EventType = "permission_request" // the turn parked awaiting approval
+	EventToolResult         EventType = "tool_result"         // a tool execution finished
+	EventPermissionRequest  EventType = "permission_request"  // the turn parked awaiting approval
+	EventPermissionResolved EventType = "permission_resolved" // the parked ask got a decision
 )
 
 // StreamEvent is one normalized event. Exactly the field matching Type
 // is populated; Meta additionally rides the terminal done event when
 // the gateway API attributes the serving provider.
 type StreamEvent struct {
-	Type       EventType               `json:"type"`
-	Text       string                  `json:"text,omitempty"`
-	ToolCall   *ToolCallEvent          `json:"tool_call,omitempty"`
-	ToolResult *ToolResultEvent        `json:"tool_result,omitempty"`
-	Permission *PermissionRequestEvent `json:"permission,omitempty"`
-	Usage      *Usage                  `json:"usage,omitempty"`
-	Err        *StreamError            `json:"error,omitempty"`
-	Retry      *RetryInfo              `json:"retry,omitempty"`
-	Meta       *Meta                   `json:"meta,omitempty"`
+	Type       EventType                `json:"type"`
+	Text       string                   `json:"text,omitempty"`
+	ToolCall   *ToolCallEvent           `json:"tool_call,omitempty"`
+	ToolResult *ToolResultEvent         `json:"tool_result,omitempty"`
+	Permission *PermissionRequestEvent  `json:"permission,omitempty"`
+	Resolved   *PermissionResolvedEvent `json:"resolved,omitempty"`
+	Usage      *Usage                   `json:"usage,omitempty"`
+	Err        *StreamError             `json:"error,omitempty"`
+	Retry      *RetryInfo               `json:"retry,omitempty"`
+	Meta       *Meta                    `json:"meta,omitempty"`
 }
 
 // ToolResultEvent reports a finished tool execution to the client:
@@ -65,6 +67,16 @@ type PermissionRequestEvent struct {
 	Args      string `json:"args"`
 	Danger    string `json:"danger_level"`
 	Rationale string `json:"rationale"`
+}
+
+// PermissionResolvedEvent tells the client (and the persistence path)
+// a parked ask got a decision, however it arrived: an explicit
+// once/session/deny answer, or the permissionTimeout/ctx-cancellation
+// deny askUser falls back to. ID ties it to the PermissionRequestEvent
+// it resolves.
+type PermissionResolvedEvent struct {
+	ID       string `json:"id"`
+	Decision string `json:"decision"`
 }
 
 // Meta identifies who served a request — attached to the done event by

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -31,6 +31,11 @@ export interface PermissionRequestEvent {
   rationale: string
 }
 
+export interface PermissionResolvedEvent {
+  id: string
+  decision: string
+}
+
 export interface StreamEvent {
   type:
     | 'chunk'
@@ -39,6 +44,7 @@ export interface StreamEvent {
     | 'tool_end'
     | 'tool_result'
     | 'permission_request'
+    | 'permission_resolved'
     | 'usage'
     | 'retry'
     | 'incomplete'
@@ -48,6 +54,7 @@ export interface StreamEvent {
   tool_call?: ToolCallEvent
   tool_result?: ToolResultEvent
   permission?: PermissionRequestEvent
+  resolved?: PermissionResolvedEvent
   usage?: Usage
   error?: { code: string; message: string; retryable: boolean }
   retry?: { attempt: number; backoff_ms: number; reason: string }
@@ -103,12 +110,15 @@ export interface ToolExecution {
 
 // One renderable unit of the UI replay projection. The transcript
 // hides nothing: compactions and interrupted turns are items too.
+// A 'permission' item is a still-unresolved ask (an answered one is
+// dropped by the server projection, same as the live client drops it).
 export interface TranscriptItem {
   seq: number
-  kind: 'user' | 'assistant' | 'tool' | 'compaction' | 'interrupted'
+  kind: 'user' | 'assistant' | 'tool' | 'permission' | 'compaction' | 'interrupted'
   text?: string
   blocks?: UIBlock[]
   tool?: ToolExecution
+  permission?: PermissionRequestEvent
   provider?: string
   model?: string
   usage?: Usage

--- a/web/src/lib/transcript.test.ts
+++ b/web/src/lib/transcript.test.ts
@@ -180,4 +180,74 @@ describe('fromTranscript', () => {
   it('handles the empty transcript of a fresh session', () => {
     expect(fromTranscript([])).toEqual([])
   })
+
+  it('exposes a still-unresolved replayed ask in permissions[]', () => {
+    const items = fromTranscript([
+      { seq: 1, kind: 'user', text: 'q', created_at: at },
+      {
+        seq: 2,
+        kind: 'permission',
+        permission: {
+          id: 'perm-1',
+          call_id: 'c1',
+          tool: 'shell',
+          args: '{}',
+          danger_level: 'destructive',
+          rationale: 'runs a shell command',
+        },
+        created_at: at,
+      },
+    ])
+    expect(items.map((i) => i.role)).toEqual(['user', 'assistant'])
+    if (items[1].role === 'assistant') {
+      expect(items[1].permissions).toEqual([
+        {
+          id: 'perm-1',
+          call_id: 'c1',
+          tool: 'shell',
+          args: '{}',
+          danger_level: 'destructive',
+          rationale: 'runs a shell command',
+        },
+      ])
+    }
+  })
+
+  it('folds a replayed ask into the assistant turn that follows it', () => {
+    const items = fromTranscript([
+      {
+        seq: 1,
+        kind: 'permission',
+        permission: {
+          id: 'perm-1',
+          call_id: 'c1',
+          tool: 'shell',
+          args: '{}',
+          danger_level: 'safe',
+          rationale: 'runs a shell command',
+        },
+        created_at: at,
+      },
+      { seq: 2, kind: 'assistant', blocks: [{ type: 'text', text: 'done' }], created_at: at },
+    ])
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({ role: 'assistant', text: 'done' })
+    if (items[0].role === 'assistant') {
+      expect(items[0].permissions.map((p) => p.id)).toEqual(['perm-1'])
+    }
+  })
+
+  it('never surfaces a resolved ask — the server projection already drops it', () => {
+    // The server never emits a `permission` item for an id that has a
+    // matching permission_resolved event, so replay has nothing to
+    // reconstruct here; this only guards that an empty transcript of
+    // asks renders no stray permissions.
+    const items = fromTranscript([
+      { seq: 1, kind: 'user', text: 'q', created_at: at },
+      { seq: 2, kind: 'assistant', blocks: [{ type: 'text', text: 'a' }], created_at: at },
+    ])
+    if (items[1].role === 'assistant') {
+      expect(items[1].permissions).toEqual([])
+    }
+  })
 })

--- a/web/src/lib/transcript.ts
+++ b/web/src/lib/transcript.ts
@@ -32,25 +32,36 @@ function toToolRun(tool: NonNullable<TranscriptItem['tool']>): ToolRun {
 // tool items with no following assistant turn (trailing tool loop, or
 // one cut short by a user/compaction/interrupted item) still flushes,
 // as a tools-only assistant item so replay never drops executed calls.
+// `kind: 'permission'` items (a still-unresolved ask — the projection
+// already dropped answered ones) fold the same way, landing in
+// `permissions[]` so the existing PermissionModal renders on reload
+// exactly as it does live.
 export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
   const out: ChatItem[] = []
-  let pending: { seq: number; tool: NonNullable<TranscriptItem['tool']> }[] = []
+  let pendingTools: { seq: number; tool: NonNullable<TranscriptItem['tool']> }[] = []
+  let pendingPermissions: { seq: number; permission: NonNullable<TranscriptItem['permission']> }[] = []
 
   const flush = () => {
-    if (pending.length === 0) return
-    const tools = pending.map((p) => toToolRun(p.tool))
+    if (pendingTools.length === 0 && pendingPermissions.length === 0) return
+    const tools = pendingTools.map((p) => toToolRun(p.tool))
+    const permissions = pendingPermissions.map((p) => p.permission)
+    const seq = Math.min(
+      ...pendingTools.map((p) => p.seq),
+      ...pendingPermissions.map((p) => p.seq),
+    )
     out.push({
-      id: `replay-${pending[0].seq}`,
+      id: `replay-${seq}`,
       role: 'assistant',
       text: '',
       reasoning: '',
       notices: [],
       tools,
-      permissions: [],
+      permissions,
       streaming: false,
       meta: undefined,
     })
-    pending = []
+    pendingTools = []
+    pendingPermissions = []
   }
 
   for (const item of items) {
@@ -61,7 +72,10 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
         out.push({ id, role: 'user', text: item.text ?? '' })
         break
       case 'tool':
-        if (item.tool) pending.push({ seq: item.seq, tool: item.tool })
+        if (item.tool) pendingTools.push({ seq: item.seq, tool: item.tool })
+        break
+      case 'permission':
+        if (item.permission) pendingPermissions.push({ seq: item.seq, permission: item.permission })
         break
       case 'assistant': {
         let text = ''
@@ -72,8 +86,10 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
           if (b.type === 'text') text += b.text ?? ''
           else if (b.type === 'reasoning') reasoning += b.text ?? ''
         }
-        const tools = pending.map((p) => toToolRun(p.tool))
-        pending = []
+        const tools = pendingTools.map((p) => toToolRun(p.tool))
+        const permissions = pendingPermissions.map((p) => p.permission)
+        pendingTools = []
+        pendingPermissions = []
         out.push({
           id,
           role: 'assistant',
@@ -81,7 +97,7 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
           reasoning,
           notices: [],
           tools,
-          permissions: [],
+          permissions,
           streaming: false,
           meta: item.provider
             ? { provider: item.provider, model: item.model, usage: item.usage }

--- a/web/src/pages/Chat.test.tsx
+++ b/web/src/pages/Chat.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ChatStreamOptions } from '../api/client'
@@ -6,7 +6,13 @@ import type { ChatEvent, ChatRequest } from '../api/types'
 import { Chat } from './Chat'
 
 vi.mock('../api/client', () => ({
-  ChatError: class ChatError extends Error {},
+  ChatError: class ChatError extends Error {
+    status: number
+    constructor(status: number, message: string) {
+      super(message)
+      this.status = status
+    }
+  },
   chatStream: vi.fn(),
   retryStream: vi.fn(),
   getTranscript: vi.fn(),
@@ -15,7 +21,10 @@ vi.mock('../api/client', () => ({
   listAgents: vi.fn(),
 }))
 
-import { chatStream, getTranscript, listAgents, listRoutes } from '../api/client'
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+import { answerPermission, ChatError, chatStream, getTranscript, listAgents, listRoutes } from '../api/client'
+import { toast } from 'sonner'
 
 function renderChat() {
   return render(
@@ -88,5 +97,93 @@ describe('Chat route picker', () => {
     const [req] = vi.mocked(chatStream).mock.calls[0]
     expect(req.route).toBe('summarize')
     expect(localStorage.getItem('timothy.route')).toBe('summarize')
+  })
+})
+
+describe('replayed permission asks', () => {
+  it('shows the approval modal for a still-unresolved replayed ask', async () => {
+    vi.mocked(getTranscript).mockResolvedValue({
+      session: { id: 's1', title: '', archived: false, created_at: '', updated_at: '' },
+      items: [
+        { seq: 1, kind: 'user', text: 'do the thing', created_at: '' },
+        {
+          seq: 2,
+          kind: 'permission',
+          permission: {
+            id: 'perm-1',
+            call_id: 'call-1',
+            tool: 'shell',
+            args: '{}',
+            danger_level: 'destructive',
+            rationale: 'runs a shell command',
+          },
+          created_at: '',
+        },
+      ],
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/chat/s1']}>
+        <Routes>
+          <Route path="/chat/:id" element={<Chat onNeedToken={vi.fn()} />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByTestId('permission-modal')).toBeInTheDocument()
+  })
+
+  it('does not show a modal for a resolved replayed ask (server already dropped it)', async () => {
+    vi.mocked(getTranscript).mockResolvedValue({
+      session: { id: 's1', title: '', archived: false, created_at: '', updated_at: '' },
+      items: [{ seq: 1, kind: 'user', text: 'do the thing', created_at: '' }],
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/chat/s1']}>
+        <Routes>
+          <Route path="/chat/:id" element={<Chat onNeedToken={vi.fn()} />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await screen.findByText('do the thing')
+    expect(screen.queryByTestId('permission-modal')).not.toBeInTheDocument()
+  })
+
+  it('toasts and clears the prompt when approving a stale (404) replayed ask', async () => {
+    vi.mocked(getTranscript).mockResolvedValue({
+      session: { id: 's1', title: '', archived: false, created_at: '', updated_at: '' },
+      items: [
+        {
+          seq: 1,
+          kind: 'permission',
+          permission: {
+            id: 'perm-1',
+            call_id: 'call-1',
+            tool: 'shell',
+            args: '{}',
+            danger_level: 'safe',
+            rationale: 'runs a shell command',
+          },
+          created_at: '',
+        },
+      ],
+    })
+    vi.mocked(answerPermission).mockRejectedValue(new ChatError(404, 'unknown or already-answered'))
+
+    render(
+      <MemoryRouter initialEntries={['/chat/s1']}>
+        <Routes>
+          <Route path="/chat/:id" element={<Chat onNeedToken={vi.fn()} />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    const modal = await screen.findByTestId('permission-modal')
+    fireEvent.click(within(modal).getByRole('button', { name: /Allow once/ }))
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    expect(screen.queryByTestId('permission-modal')).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router'
+import { toast } from 'sonner'
 import { answerPermission, ChatError, chatStream, getTranscript, retryStream } from '../api/client'
 import type { ChatEvent } from '../api/types'
 import { ActivityPanel } from '../components/Activity'
@@ -300,9 +301,15 @@ export function Chat({
   const pendingPermission = last?.role === 'assistant' ? last.permissions[0] : undefined
   const decide = (id: string, decision: 'once' | 'session' | 'deny') => {
     updateLast((m) => clearPermission(m, id))
-    answerPermission(id, decision).catch(() => {
-      // The 10-minute server timeout resolves an undeliverable
-      // decision as deny; nothing useful to render here.
+    answerPermission(id, decision).catch((err: unknown) => {
+      // A replayed ask whose turn died (brain restart) answers 404
+      // "unknown or already-answered" — the prompt is already gone
+      // locally (above), so just tell the user why nothing happened.
+      // Any other error is the same 10-minute-timeout-resolves-as-deny
+      // case as before: nothing useful to render.
+      if (err instanceof ChatError && err.status === 404) {
+        toast.error('This request is no longer waiting for a response')
+      }
     })
   }
 


### PR DESCRIPTION
Chat permission asks lived only on the live SSE stream — open a parked session (or reload) and you saw a silently hung turn with no approval prompt. Verified live before the fix.

- New session event kinds `permission_request` / `permission_resolved`, appended by the chat relay as they cross the stream (append-only, mid-turn — a parked ask is exactly the case where the turn hasn't ended).
- New `EventPermissionResolved` stream event emitted by `loop.askUser` on answer, timeout, and cancellation; missions runner ignores it (no default case), sentinel/packet unaffected.
- `UITranscript` replays only unresolved asks (resolved pairs drop, matching live behavior); `LLMContext` ignores both kinds.
- Web: `fromTranscript` folds replayed asks into the assistant item's `permissions[]` — existing modal renders unchanged; stale ask (brain restarted) → POST /v1/permissions 404 → toast + prompt clears.

Live-verified: parked a real ask, fetched the session fresh — transcript carries the pending `permission` item.

Gates: make build test vet lint green; web build+lint+296 tests green; canary PASS (first run flaked on a model-authored $() verify command — D-039 denied it correctly, rerun clean).