### PR TITLE
feat(chat): seed agent approval allowlist as session grants

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -153,7 +153,7 @@ func main() {
 	sensitiveRoute := func(ctx context.Context) string {
 		return flags.Value(ctx, settings.ValueSensitiveToolRoute)
 	}
-	agent, broker, outputs, builtinSet, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, markitdownURL, packs, flags.SkillAllowed, mc.Add, app.Log, toolCalls, sensitiveRoute)
+	agent, broker, outputs, builtinSet, chatPerms, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, markitdownURL, packs, flags.SkillAllowed, mc.Add, app.Log, toolCalls, sensitiveRoute)
 	if buildErr != nil {
 		fmt.Fprintln(os.Stderr, buildErr)
 		os.Exit(1)
@@ -235,6 +235,10 @@ func main() {
 		agentReg.Resolve, app.Log)
 	svc.SetAutoDispatch(agentReg.Enabled, chat.ClassifyOverGateway(gwc))
 	svc.SetSensitiveTools(sensitiveTools)
+	// Same Permissions instance (and session_grants table) the chat
+	// agent loop's own Resolve chain reads from — seeding here is
+	// visible to that exact chain, not a parallel grant store.
+	svc.SetApprovalGrants(chatPerms)
 	compactor.SetSensitiveTools(sensitiveTools)
 	svc.SetMemoryExtract(func(ctx context.Context, sessionID string, seq int64, text, route string) {
 		if !flags.Enabled(ctx, settings.KeyMemoryExtraction) {
@@ -509,7 +513,7 @@ func (r turnRouter) Stream(ctx context.Context, req gwclient.StreamRequest) (<-c
 // buildAgent assembles the compiled-in tool registry and its guard
 // rails (D-009, D-010). The returned builtin set is the fixed half of
 // the tool surface; connector tools join it via swapAgentTools.
-func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, workspace, searxngURL, markitdownURL string, packs []skills.Skill, skillAllow func(context.Context, string) bool, remember builtin.RememberFunc, log *slog.Logger, toolCalls *prometheus.CounterVec, sensitiveRoute func(context.Context) string) (*loop.Agent, *loop.PermBroker, *tools.Outputs, []*tools.Tool, error) {
+func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, workspace, searxngURL, markitdownURL string, packs []skills.Skill, skillAllow func(context.Context, string) bool, remember builtin.RememberFunc, log *slog.Logger, toolCalls *prometheus.CounterVec, sensitiveRoute func(context.Context) string) (*loop.Agent, *loop.PermBroker, *tools.Outputs, []*tools.Tool, *tools.Permissions, error) {
 	outputs := tools.NewOutputs(db)
 	set := []*tools.Tool{
 		builtin.CurrentTime(time.Now),
@@ -531,7 +535,7 @@ func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, wor
 	}
 	constrained, defs, err := compileToolset(set, nil, log, toolCalls)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 
 	perms := tools.NewPermissions(db, workspace)
@@ -551,7 +555,7 @@ func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, wor
 	for _, suffix := range sensitiveToolSuffixes {
 		agent.SetForceRoute(suffix, sensitiveRoute)
 	}
-	return agent, broker, outputs, set, nil
+	return agent, broker, outputs, set, perms, nil
 }
 
 // compileToolset registers builtin + connector tools into a fresh

--- a/internal/brain/agents/agents.go
+++ b/internal/brain/agents/agents.go
@@ -23,11 +23,13 @@ import (
 // Agent is the API shape of one agents row. Empty Skills/Tools mean
 // "everything allowed"; empty Route means the default route.
 //
-// ReviewRoute, BudgetUSD, and ApprovalAllowlist are meaningless to a
-// chat-only agent and stay at their zero values for one; a
-// mission-capable agent (internal/brain/missions) sets all three —
-// missions reference this table directly rather than a parallel
-// agent_profiles table.
+// ReviewRoute and BudgetUSD are meaningless to a chat-only agent and
+// stay at their zero values for one; a mission-capable agent
+// (internal/brain/missions) sets both — missions reference this table
+// directly rather than a parallel agent_profiles table. ApprovalAllowlist
+// applies to both: missions grant it at provisioning time
+// (missions/driver.go), chat seeds the same session_grants rows on a
+// session's first turn under the agent (chat.Service.SetApprovalGrants).
 type Agent struct {
 	ID                string   `json:"id"`
 	Name              string   `json:"name"`

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/SumonMSelim/timothy/internal/brain/agents"
@@ -49,6 +50,11 @@ const (
 	// clock; the rare pre-send pass accepts the latency.
 	compactBudget = 150 * time.Second
 	titleTimeout  = 15 * time.Second
+	// approvalGrantTTL matches missions/driver.go's missionGrantTTL and
+	// loop's own sessionGrantTTL (12h) — a chat session idle longer than
+	// that just re-seeds the grant on its next turn, same degrade as a
+	// mission outliving its grant.
+	approvalGrantTTL = 12 * time.Hour
 )
 
 // ErrBadRequest marks caller mistakes (empty message) so the API can
@@ -93,6 +99,16 @@ type MemoryExtract func(ctx context.Context, sessionID string, seq int64, text s
 // beats no turn.
 type MemoryRetrieve func(ctx context.Context, sessionID, query string) string
 
+// Granter is the narrow slice of *tools.Permissions chat needs to seed
+// standing grants for a serving agent's ApprovalAllowlist — the same
+// shape missions/driver.go's sessionGranter uses against the same
+// session_grants table, so a grant recorded here is visible to (and
+// glob-matched by) the exact same Permissions.Resolve chain a mission
+// goes through.
+type Granter interface {
+	Grant(ctx context.Context, sessionID, tool, pattern string, ttl time.Duration) error
+}
+
 // Service orchestrates turns against the event store.
 type Service struct {
 	gw          Gateway
@@ -111,6 +127,17 @@ type Service struct {
 	flushEvery  time.Duration                      // pending-state flush cadence mid-stream
 	sensitive   *session.SensitiveTools            // nil: no sensitive-tool route pin for side-calls
 	logger      *slog.Logger
+
+	grants Granter // nil: chat never seeds standing grants (today's behavior)
+	// seeded remembers which (session, agent) pairs already had their
+	// ApprovalAllowlist granted this process's lifetime, so a long chat
+	// session doesn't re-INSERT the same grant row on every turn.
+	// Process-local by design (same tradeoff as driver.go's gatekeepers
+	// map): a restart just re-seeds once more, a harmless duplicate row,
+	// never a correctness problem, since matchGrant only cares whether
+	// an unexpired matching row exists.
+	seededMu sync.Mutex
+	seeded   map[string]bool
 }
 
 // SetMemoryExtract wires the memoryd hook. Optional — nil leaves
@@ -133,6 +160,55 @@ func (s *Service) SetSensitiveTools(t *session.SensitiveTools) { s.sensitive = t
 // an empty name.
 func (s *Service) SetAutoDispatch(candidates AgentCandidates, classify agents.Classify) {
 	s.candidates, s.classify = candidates, classify
+}
+
+// SetApprovalGrants wires the standing-grant seeder: once wired, a
+// turn served by an agent with a non-empty ApprovalAllowlist gets
+// those tools granted for its session before the turn runs, extending
+// the user's Settings-authored per-agent consent to interactive chat.
+// Optional — nil (today's default) leaves every allowlisted tool
+// asking on its first chat call, exactly like before this existed.
+//
+// Safety framing (D-010 chain, see tools/permissions.go): this only
+// ever ADDS a session_grants row that Permissions.Resolve already knew
+// how to consult — it does not change the chain itself. Destructive-
+// classified shell commands still hard-force DecisionAsk before any
+// grant (session or allowlist-seeded) is even looked at, so an
+// allowlisted destructive command parks exactly as it would for a
+// mission. The allowlist is user-authored config (Settings' per-agent
+// editor), not a model choice — seeding it as grants widens nothing
+// beyond what the user already consented to for that agent.
+func (s *Service) SetApprovalGrants(g Granter) {
+	s.grants = g
+	if s.seeded == nil {
+		s.seeded = map[string]bool{}
+	}
+}
+
+// seedApprovalGrants grants every tool in profile's ApprovalAllowlist
+// for sessionID, once per (session, agent) — an agent switch mid-
+// session (a new profile.ID) seeds again, since the key includes it.
+// Best-effort and fire-and-forget on error, same convention as
+// missions/driver.go's grantSessionDefaults: a failed grant just means
+// this turn's allowlisted tools ask once more, never a broken turn.
+func (s *Service) seedApprovalGrants(ctx context.Context, sessionID string, profile agents.Agent) {
+	if s.grants == nil || len(profile.ApprovalAllowlist) == 0 {
+		return
+	}
+	key := sessionID + "\x00" + profile.ID
+	s.seededMu.Lock()
+	if s.seeded[key] {
+		s.seededMu.Unlock()
+		return
+	}
+	s.seeded[key] = true
+	s.seededMu.Unlock()
+
+	for _, tool := range profile.ApprovalAllowlist {
+		if err := s.grants.Grant(ctx, sessionID, tool, "*", approvalGrantTTL); err != nil {
+			s.logger.Warn("chat: approval allowlist grant failed", "session_id", sessionID, "tool", tool, "error", err)
+		}
+	}
 }
 
 // New builds the service. packs are the loaded skill definitions: their
@@ -363,6 +439,7 @@ func (s *Service) Retry(ctx context.Context, sessionID string) (string, <-chan s
 // has already ensured exactly the right user_message sits durable at
 // the end of the log — this never appends one itself.
 func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, skillHint, skillBody, route string, profile agents.Agent, needsTitle bool) (string, <-chan stream.StreamEvent, error) {
+	s.seedApprovalGrants(ctx, sessionID, profile)
 	// Pre-send guarantee: the context actually sent to the provider
 	// stays under budget even on the turn that crosses it. The
 	// post-turn pass below keeps sessions compacted ahead of time, so

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -1251,3 +1251,167 @@ func TestMemoryExtractUsesEmptyRouteWhenTurnDidNotRunSensitiveTool(t *testing.T)
 		t.Fatal("memory extract never invoked")
 	}
 }
+
+// fakeGranter is an in-memory Granter that records every Grant call —
+// stands in for tools.Permissions in chat-level tests, which never
+// touch a real session_grants table.
+type fakeGranter struct {
+	mu    sync.Mutex
+	calls []grantCall
+}
+
+type grantCall struct {
+	sessionID, tool, pattern string
+}
+
+func (g *fakeGranter) Grant(_ context.Context, sessionID, tool, pattern string, _ time.Duration) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.calls = append(g.calls, grantCall{sessionID, tool, pattern})
+	return nil
+}
+
+func (g *fakeGranter) grantedTools(sessionID string) []string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	var out []string
+	for _, c := range g.calls {
+		if c.sessionID == sessionID {
+			out = append(out, c.tool)
+		}
+	}
+	return out
+}
+
+// TestChatSeedsApprovalAllowlistAsStandingGrant proves the mechanism
+// this feature adds: a turn served by an agent with a non-empty
+// ApprovalAllowlist grants every listed tool for the session before
+// the turn runs — the same session_grants row missions/driver.go's
+// grantSessionDefaults writes, so tools.Permissions.Resolve's
+// matchGrant (D-036 suffix rule) allows the connector-namespaced call
+// without an ask on the very first turn.
+func TestChatSeedsApprovalAllowlistAsStandingGrant(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGW{events: okEvents("done")}
+	log := newFakeLog()
+	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
+		return agents.Agent{ID: "agent-1", Name: "scheduler", Memory: true,
+			ApprovalAllowlist: []string{"calendar_list_events"}}, true
+	}
+	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	granter := &fakeGranter{}
+	svc.SetApprovalGrants(granter)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what's on my calendar", Agent: "scheduler"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	got := granter.grantedTools("s1")
+	if len(got) != 1 || got[0] != "calendar_list_events" {
+		t.Fatalf("granted tools = %v, want [calendar_list_events]", got)
+	}
+}
+
+// TestChatWithoutAllowlistGrantsNothing proves the seeder only ever
+// widens consent the agent's own config already lists — an agent with
+// no ApprovalAllowlist gets no grants, so its tools keep asking exactly
+// like before this feature existed.
+func TestChatWithoutAllowlistGrantsNothing(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGW{events: okEvents("done")}
+	log := newFakeLog()
+	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
+		return agents.Agent{ID: "agent-2", Name: "plain", Memory: true}, true
+	}
+	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	granter := &fakeGranter{}
+	svc.SetApprovalGrants(granter)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "hi", Agent: "plain"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	if got := granter.grantedTools("s1"); len(got) != 0 {
+		t.Fatalf("granted tools = %v, want none (agent has no allowlist)", got)
+	}
+}
+
+// TestChatSeedsApprovalAllowlistOnceIdempotent proves a long-lived
+// session doesn't re-INSERT the same grant row on every turn: a second
+// turn served by the SAME agent in the SAME session must not call
+// Grant again.
+func TestChatSeedsApprovalAllowlistOnceIdempotent(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGW{events: okEvents("done")}
+	log := newFakeLog()
+	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
+		return agents.Agent{ID: "agent-1", Name: "scheduler", Memory: true,
+			ApprovalAllowlist: []string{"calendar_list_events"}}, true
+	}
+	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	granter := &fakeGranter{}
+	svc.SetApprovalGrants(granter)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "first", Agent: "scheduler"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	_, ch, err = svc.Chat(t.Context(), Request{SessionID: "s1", Message: "second", Agent: "scheduler"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	if got := granter.grantedTools("s1"); len(got) != 1 {
+		t.Fatalf("granted tools after two turns = %v, want exactly one grant call", got)
+	}
+}
+
+// TestChatAgentSwitchGrantsNewAllowlist proves the "once per
+// session+agent" key (not "once per session") handles a mid-session
+// agent switch: a second turn in the same session served by a
+// DIFFERENT agent grants that agent's own list too.
+func TestChatAgentSwitchGrantsNewAllowlist(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGW{events: okEvents("done")}
+	log := newFakeLog()
+	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
+		switch name {
+		case "scheduler":
+			return agents.Agent{ID: "agent-1", Name: "scheduler", Memory: true,
+				ApprovalAllowlist: []string{"calendar_list_events"}}, true
+		case "mailer":
+			return agents.Agent{ID: "agent-2", Name: "mailer", Memory: true,
+				ApprovalAllowlist: []string{"gmail_search"}}, true
+		default:
+			return agents.Agent{}, false
+		}
+	}
+	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	granter := &fakeGranter{}
+	svc.SetApprovalGrants(granter)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "first", Agent: "scheduler"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	_, ch, err = svc.Chat(t.Context(), Request{SessionID: "s1", Message: "second", Agent: "mailer"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	got := granter.grantedTools("s1")
+	want := []string{"calendar_list_events", "gmail_search"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("granted tools = %v, want %v (both agents' allowlists)", got, want)
+	}
+}


### PR DESCRIPTION
An agent's `approval_allowlist` only worked for missions — in chat, every safe connector read parked a new session on an ask (`gmail_gmail_search`, `github_get_me`, … "no standing grant") despite the user having configured standing consent per agent in Settings.

- Chat seeds the same session grants missions' `grantSessionDefaults` writes, once per (session, agent), through the existing `matchGrant` D-036 suffix chain — visible in the same grant queries, same TTL.
- Agent switch mid-session seeds the new agent's list; re-seeding after restart is a harmless duplicate row.
- Safety unchanged: destructive-classified calls force an ask before any grant is consulted, exactly as missions park.

4 new chat tests. make build test vet lint green.