### PR TITLE
fix(chat): allow retry after a turn dies mid-flight

### DIFF
--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -320,14 +320,17 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 }
 
 // ErrNoRetryableTurn marks a Retry call whose session isn't in a
-// retryable state — its last event isn't a user message left dangling
-// by a failed attempt (persistTurn only completes a turn on sawDone).
+// retryable state — its last user_message already has a completed
+// (assistant_turn) turn after it, or there's no user_message at all.
 var ErrNoRetryableTurn = errors.New("no retryable turn")
 
 // Retry re-runs generation for a session's last turn WITHOUT persisting
 // a second user_message: Chat unconditionally appends before streaming
 // (line above), so a failed attempt already leaves that message durable
-// with no assistant_turn after it. Retry reuses it verbatim — same
+// with no assistant_turn after it. A dead attempt (brain restart mid-turn)
+// can also leave trailing tool_execution/pending_state/permission events
+// after that message — lastUserMessage looks past those; only a
+// completed turn blocks retry. Retry reuses the message verbatim — same
 // route/agent/model_hint the original request resolved to, since those
 // live on the persisted UserMessage, not the transient Request. A
 // skill_hint is NOT persisted (it's a rare, deliberate one-off pick),
@@ -760,16 +763,34 @@ func hasCompletedTurn(events []session.Event) bool {
 	return false
 }
 
-// lastUserMessage returns the log's last event when — and only when —
-// it is a user_message: the signature of a turn that never completed
-// (persistTurn only appends assistant_turn on sawDone). Any other
-// trailing kind means there's nothing dangling to retry.
+// lastUserMessage returns the session's last user_message when it has
+// no completed turn after it — the signature of a turn that never
+// finished (persistTurn only appends assistant_turn on sawDone). A
+// brain restart or crash mid-turn can leave trailing tool_execution,
+// pending_state, or permission_request/resolved events after that
+// message; none of those are turn-terminal, so they must not block a
+// retry. LLMContext already treats them as inert for anything but the
+// newest pending_state (spliced in as an interrupted assistant message
+// only if still live), so replaying them costs nothing — the retried
+// turn's context is exactly what the dead attempt's would have been.
 func lastUserMessage(events []session.Event) (session.UserMessage, bool) {
-	if len(events) == 0 || events[len(events)-1].Kind != session.KindUserMessage {
+	var lastMsg *session.Event
+	for i := len(events) - 1; i >= 0; i-- {
+		switch events[i].Kind {
+		case session.KindAssistantTurn:
+			return session.UserMessage{}, false // turn after it completed
+		case session.KindUserMessage:
+			lastMsg = &events[i]
+		}
+		if lastMsg != nil {
+			break
+		}
+	}
+	if lastMsg == nil {
 		return session.UserMessage{}, false
 	}
 	var msg session.UserMessage
-	if err := json.Unmarshal(events[len(events)-1].Payload, &msg); err != nil {
+	if err := json.Unmarshal(lastMsg.Payload, &msg); err != nil {
 		return session.UserMessage{}, false
 	}
 	return msg, true

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -1146,6 +1146,123 @@ func TestRetryRejectsWhenNothingToRetry(t *testing.T) {
 	}
 }
 
+// A brain restart mid-turn can leave tool_execution/permission events
+// (and no pending_state, if the crash landed before a flush) after the
+// dangling user_message — the turn never reached persistTurn at all.
+// Retry must still treat that message as retryable: none of those
+// trailing kinds are turn-terminal, and LLMContext already excludes
+// tool_execution/permission_request/permission_resolved from the
+// model-facing projection, so the retried turn sees exactly the
+// original user message with nothing appended — a clean restart.
+func TestRetrySurvivesTrailingToolAndPermissionEvents(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	if _, err := log.Append(t.Context(), "s1", session.KindUserMessage, session.UserMessage{
+		Text: "the question", Route: "mini", Agent: "default",
+	}); err != nil {
+		t.Fatalf("seed user_message: %v", err)
+	}
+	if _, err := log.Append(t.Context(), "s1", session.KindToolExecution, session.ToolExecution{
+		CallID: "c1", Name: "shell", Status: "ok",
+	}); err != nil {
+		t.Fatalf("seed tool_execution: %v", err)
+	}
+	if _, err := log.Append(t.Context(), "s1", session.KindPermissionRequest, session.PermissionRequest{
+		ID: "p1", CallID: "c2", Tool: "shell",
+	}); err != nil {
+		t.Fatalf("seed permission_request: %v", err)
+	}
+	if _, err := log.Append(t.Context(), "s1", session.KindPermissionResolved, session.PermissionResolved{
+		ID: "p1", Decision: "once",
+	}); err != nil {
+		t.Fatalf("seed permission_resolved: %v", err)
+	}
+	if _, err := log.Append(t.Context(), "s1", session.KindToolExecution, session.ToolExecution{
+		CallID: "c2", Name: "shell", Status: "ok",
+	}); err != nil {
+		t.Fatalf("seed second tool_execution: %v", err)
+	}
+
+	gw := &fakeGW{events: okEvents("the answer")}
+	s := newService(gw, log)
+
+	_, ch, err := s.Retry(t.Context(), "s1")
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool {
+		kinds := log.kinds("s1")
+		return len(kinds) > 0 && kinds[len(kinds)-1] == session.KindAssistantTurn
+	})
+
+	kinds := log.kinds("s1")
+	want := []string{
+		session.KindUserMessage, session.KindToolExecution, session.KindPermissionRequest,
+		session.KindPermissionResolved, session.KindToolExecution, session.KindAssistantTurn,
+	}
+	if strings.Join(kinds, ",") != strings.Join(want, ",") {
+		t.Fatalf("kinds after retry = %v, want %v (no duplicated user_message)", kinds, want)
+	}
+
+	// The context handed to the gateway must be exactly the original
+	// user message — tool_execution and permission events never enter
+	// LLMContext, and there is no pending_state here to splice in as an
+	// interrupted assistant message. A clean restart, not a replay of
+	// the dead attempt's partial state.
+	sent := chatRequest(t, gw)
+	if len(sent.Messages) != 1 || sent.Messages[0].Role != "user" || sent.Messages[0].Content != "the question" {
+		t.Fatalf("retried context = %+v, want exactly [{user the question}]", sent.Messages)
+	}
+	if sent.Route != "mini" {
+		t.Fatalf("retried route = %q, want mini (the original message's persisted route)", sent.Route)
+	}
+}
+
+// A trailing pending_state (a periodic checkpoint the dead attempt
+// flushed before dying) is the one trailing kind LLMContext does splice
+// back in — as an interrupted assistant message — so the retried turn
+// picks up where the checkpoint left off instead of starting blind.
+func TestRetryReplaysTrailingPendingStateAsInterrupted(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	if _, err := log.Append(t.Context(), "s1", session.KindUserMessage, session.UserMessage{
+		Text: "the question", Route: "mini", Agent: "default",
+	}); err != nil {
+		t.Fatalf("seed user_message: %v", err)
+	}
+	if _, err := log.Append(t.Context(), "s1", session.KindPendingState, session.PendingState{
+		Partial: "partial answer so far",
+	}); err != nil {
+		t.Fatalf("seed pending_state: %v", err)
+	}
+
+	gw := &fakeGW{events: okEvents("the rest of the answer")}
+	s := newService(gw, log)
+
+	_, ch, err := s.Retry(t.Context(), "s1")
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool {
+		kinds := log.kinds("s1")
+		return len(kinds) > 0 && kinds[len(kinds)-1] == session.KindAssistantTurn
+	})
+
+	sent := chatRequest(t, gw)
+	if len(sent.Messages) != 2 {
+		t.Fatalf("retried context = %+v, want [user, interrupted-assistant]", sent.Messages)
+	}
+	if sent.Messages[0].Role != "user" || sent.Messages[0].Content != "the question" {
+		t.Fatalf("message[0] = %+v", sent.Messages[0])
+	}
+	if sent.Messages[1].Role != "assistant" || !strings.Contains(sent.Messages[1].Content, "partial answer so far") ||
+		!strings.Contains(sent.Messages[1].Content, "interrupted") {
+		t.Fatalf("message[1] = %+v, want the spliced interrupted partial", sent.Messages[1])
+	}
+}
+
 // TestAutoTitleUsesDefaultRouteNotClassifyRoute pins a real behavior
 // change: a session's name deserves the same model quality as the
 // conversation it's naming, not the cheapest classification route


### PR DESCRIPTION
`lastUserMessage` required the session's literal last event to be `user_message`, so a brain restart mid-turn (after tool executions persisted) left the turn permanently unretryable — retry 409'd. Observed live.

- Retryable = last `user_message` with no `assistant_turn` after it (the sole turn-terminal event).
- Trailing `tool_execution`/`permission_*` events never enter `LLMContext` (verified, now pinned by test); a trailing `pending_state` intentionally resumes as an interrupted checkpoint.
- No web change needed — transcript already folds trailing tool runs and `retryLast` handles both shapes.

make build test vet lint green.