### PR TITLE
fix(loop): distill turns on summarize route with reasoning budget

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -108,8 +108,8 @@ func main() {
 	budgetFn := func(ctx context.Context) int { return flags.TokenBudget(ctx, defaultTokenBudget) }
 	compactor := session.NewCompactor(store, gwc, gwc, budgetFn, app.Log,
 		app.Metrics.NewCounter("session_compactions_total", "Sessions compacted to stay under the context budget."))
-	distill := func(ctx context.Context, sessionID, turnText string) *session.TurnMemory {
-		return loop.DistillTurn(ctx, gwc, sessionID, turnText)
+	distill := func(ctx context.Context, sessionID, turnText, route string) *session.TurnMemory {
+		return loop.DistillTurn(ctx, gwc, sessionID, turnText, route)
 	}
 
 	workspace := os.Getenv("WORKSPACE_ROOT")

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -27,14 +27,17 @@ const (
 	// me" (D-034 follow-up): the composer's "Auto" choice, resolved
 	// through candidates+classify before the normal agent lookup.
 	autoAgentName = "auto"
-	// classifyRoute serves the auto-dispatch classification call —
-	// same cheap side-call route distillation and extraction still use.
+	// classifyRoute serves the auto-dispatch classification call.
 	// "local" is a real, always-provisioned fixed route
 	// (migrations/0022_local_route.sql); "mini" was never seeded by
-	// any migration and every call on it failed with no_route. autoTitle
-	// uses defaultRoute instead — a session's name deserves the same
-	// model quality as the conversation it's naming, not the cheapest
-	// available one.
+	// any migration and every call on it failed with no_route. Unlike
+	// classification, distillation and extraction default to the
+	// "summarize" cloud route — local now serves a reasoning model that
+	// burns its completion budget thinking before the strict-JSON
+	// answer, so it's reserved for sensitive turns pinned there
+	// deliberately. autoTitle uses defaultRoute instead — a session's
+	// name deserves the same model quality as the conversation it's
+	// naming, not the cheapest available one.
 	classifyRoute = "local"
 	// defaultRoute serves plain chat turns when the caller picks
 	// nothing; the web UI exposes a per-message picker.
@@ -42,7 +45,7 @@ const (
 	// Each persistence stage gets its OWN deadline: LLM-backed stages
 	// (distill, compaction) must never eat the database writes' clock.
 	persistTimeout = 10 * time.Second
-	distillBudget  = 65 * time.Second // two 30s attempts + slack
+	distillBudget  = 190 * time.Second // two 90s attempts + slack
 	// Compaction runs an extraction round trip AND a summarize on slow
 	// reasoning providers; a tight budget starves the summarize and
 	// compaction never converges. Post-turn passes are off the user's
@@ -71,8 +74,10 @@ type SessionLog interface {
 }
 
 // Distill extracts turn residue; loop.DistillTurn curried with the
-// gateway in main, stubbed in tests. May return nil.
-type Distill func(ctx context.Context, sessionID, turnText string) *session.TurnMemory
+// gateway in main, stubbed in tests. May return nil. route is "" for
+// the normal side-call route, or the sensitive route pin when the turn
+// executed a sensitive tool — same convention as MemoryExtract's route.
+type Distill func(ctx context.Context, sessionID, turnText, route string) *session.TurnMemory
 
 // Compactor keeps a session's projection under budget.
 type Compactor interface {
@@ -613,10 +618,19 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 		s.logger.Warn("persist last category", "session_id", sessionID, "error", err)
 	}
 
+	// A turn that executed a sensitive tool pins its side-calls to the
+	// same route the loop already forced the turn onto — both
+	// distillation and extraction below can see raw sensitive output
+	// (e.g. email), so neither may fall back to its own cheap default.
+	sensitiveRoute := ""
+	if turnSensitive && s.sensitive != nil && s.sensitive.Route != nil {
+		sensitiveRoute = s.sensitive.Route(context.Background())
+	}
+
 	var tm *session.TurnMemory
 	if s.distill != nil && text != "" {
 		dctx, dcancel := context.WithTimeout(context.Background(), distillBudget)
-		tm = s.distill(dctx, sessionID, "user: "+userText+"\n\nassistant: "+text)
+		tm = s.distill(dctx, sessionID, "user: "+userText+"\n\nassistant: "+text, sensitiveRoute)
 		dcancel()
 		if tm != nil && (len(tm.FilesChanged) > 0 || len(tm.Failures) > 0 || len(tm.KeyFindings) > 0) {
 			mctx, mcancel := context.WithTimeout(context.Background(), persistTimeout)
@@ -644,16 +658,7 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 		} else if text != "" {
 			mtext += "\n\nassistant: " + text
 		}
-		// A turn that executed a sensitive tool pins its extraction to
-		// the same route the loop already forced the turn onto — the
-		// text extraction sees can quote raw sensitive output (e.g.
-		// email), so it must never fall back to memoryd's own default
-		// side-call route.
-		extractRoute := ""
-		if turnSensitive && s.sensitive != nil && s.sensitive.Route != nil {
-			extractRoute = s.sensitive.Route(context.Background())
-		}
-		go s.memory(context.Background(), sessionID, turnSeq, mtext, extractRoute)
+		go s.memory(context.Background(), sessionID, turnSeq, mtext, sensitiveRoute)
 	}
 
 	if s.compactor != nil {

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -690,7 +690,7 @@ func TestFollowUpSeesCompletedTurnWhileDistillRuns(t *testing.T) {
 	distillStarted := make(chan struct{})
 	distillRelease := make(chan struct{})
 	var startedOnce sync.Once
-	distill := func(ctx context.Context, sessionID, turnText string) *session.TurnMemory {
+	distill := func(ctx context.Context, sessionID, turnText, route string) *session.TurnMemory {
 		startedOnce.Do(func() { close(distillStarted) })
 		select {
 		case <-distillRelease:
@@ -746,7 +746,7 @@ func TestMemoryExtractGetsUserTextAndResidue(t *testing.T) {
 	t.Parallel()
 	log := newFakeLog()
 	gw := &fakeGW{events: okEvents("the answer")}
-	distill := func(context.Context, string, string) *session.TurnMemory {
+	distill := func(context.Context, string, string, string) *session.TurnMemory {
 		return &session.TurnMemory{KeyFindings: []string{"user moved to Porto"}}
 	}
 	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
@@ -1249,5 +1249,77 @@ func TestMemoryExtractUsesEmptyRouteWhenTurnDidNotRunSensitiveTool(t *testing.T)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("memory extract never invoked")
+	}
+}
+
+// TestDistillUsesSensitiveRouteWhenTurnRanSensitiveTool mirrors the
+// memory-extract pin above: a turn that executed a sensitive tool must
+// keep its distillation on the same pinned route, not the cheap
+// "summarize" default — the turn text can quote raw sensitive output.
+func TestDistillUsesSensitiveRouteWhenTurnRanSensitiveTool(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: []stream.StreamEvent{
+		{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{ID: "c1", Name: "personal_gmail_read", Status: "ok"}},
+		{Type: stream.EventChunk, Text: "the answer"},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
+	}}
+	got := make(chan string, 1)
+	distill := func(_ context.Context, _, _, route string) *session.TurnMemory {
+		got <- route
+		return nil
+	}
+	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize my inbox"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	select {
+	case route := <-got:
+		if route != "local" {
+			t.Fatalf("route = %q, want local (sensitive tool ran this turn)", route)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("distill never invoked")
+	}
+}
+
+// TestDistillUsesEmptyRouteWhenTurnDidNotRunSensitiveTool proves the
+// pin is per-turn: a turn with no matching tool call leaves the route
+// empty (loop.DistillTurn's own "summarize" default) even with
+// SensitiveTools wired.
+func TestDistillUsesEmptyRouteWhenTurnDidNotRunSensitiveTool(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: []stream.StreamEvent{
+		{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{ID: "c1", Name: "shell", Status: "ok"}},
+		{Type: stream.EventChunk, Text: "the answer"},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
+	}}
+	got := make(chan string, 1)
+	distill := func(_ context.Context, _, _, route string) *session.TurnMemory {
+		got <- route
+		return nil
+	}
+	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "run a shell command"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	select {
+	case route := <-got:
+		if route != "" {
+			t.Fatalf("route = %q, want empty (no sensitive tool ran)", route)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("distill never invoked")
 	}
 }

--- a/internal/brain/loop/turnmemory.go
+++ b/internal/brain/loop/turnmemory.go
@@ -23,9 +23,18 @@ type Gateway interface {
 }
 
 const (
-	distillTimeout     = 30 * time.Second
+	// distillTimeout must cover the reasoning route: qwen3 (the local
+	// route's model) spends completion budget THINKING before it emits
+	// the strict-JSON answer, so both the timeout and MaxTokens below
+	// are sized for a thinking model, not a plain instruct one.
+	distillTimeout     = 90 * time.Second
 	maxKeyFindings     = 5
 	distillMaxAttempts = 2
+
+	// sideRoute is the default for non-sensitive turns: cheap and fast
+	// enough to run after every turn without burning local GPU time.
+	// Mirrors extract.sideRoute (internal/memory/extract/extract.go).
+	sideRoute = "summarize"
 )
 
 // distillSystem demands strict JSON. The schema mirrors
@@ -37,10 +46,16 @@ Rules: key_findings has at most 5 items, one sentence each, only durable facts w
 // DistillTurn extracts a TurnMemory from one turn's raw text via a
 // mini-category call. Invalid output retries once; a second failure
 // returns nil — distillation must never block or fail the turn
-// (callers log and move on).
-func DistillTurn(ctx context.Context, gw Gateway, sessionID, turnText string) *session.TurnMemory {
+// (callers log and move on). route overrides sideRoute for this
+// call — the caller passes the sensitive route pin when the turn
+// executed a sensitive tool (same pattern as extract.Request.Route,
+// internal/memory/extract/extract.go), "" otherwise.
+func DistillTurn(ctx context.Context, gw Gateway, sessionID, turnText, route string) *session.TurnMemory {
+	if route == "" {
+		route = sideRoute
+	}
 	for attempt := 0; attempt < distillMaxAttempts; attempt++ {
-		tm, err := distillOnce(ctx, gw, sessionID, turnText)
+		tm, err := distillOnce(ctx, gw, sessionID, turnText, route)
 		if err == nil {
 			return tm
 		}
@@ -51,19 +66,16 @@ func DistillTurn(ctx context.Context, gw Gateway, sessionID, turnText string) *s
 	return nil
 }
 
-func distillOnce(ctx context.Context, gw Gateway, sessionID, turnText string) (*session.TurnMemory, error) {
+func distillOnce(ctx context.Context, gw Gateway, sessionID, turnText, route string) (*session.TurnMemory, error) {
 	ctx, cancel := context.WithTimeout(ctx, distillTimeout)
 	defer cancel()
 
-	// "local" is the real, always-provisioned fixed route
-	// (migrations/0022_local_route.sql); "mini" was never seeded by
-	// any migration and every call on it failed with no_route.
 	events, err := gw.Stream(ctx, gwclient.StreamRequest{
-		Route: "local",
+		Route:        route,
 		Purpose:      "distill",
 		System:       distillSystem,
 		Messages:     []provider.Message{{Role: "user", Content: turnText}},
-		MaxTokens:    500,
+		MaxTokens:    1500,
 		SessionID:    sessionID,
 	})
 	if err != nil {

--- a/internal/brain/loop/turnmemory_test.go
+++ b/internal/brain/loop/turnmemory_test.go
@@ -13,9 +13,11 @@ type scriptedGW struct {
 	replies []string
 	errs    []bool
 	calls   int
+	lastReq gwclient.StreamRequest
 }
 
 func (g *scriptedGW) Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+	g.lastReq = req
 	i := g.calls
 	g.calls++
 	ch := make(chan stream.StreamEvent, 3)
@@ -38,7 +40,7 @@ func TestDistillTurnParsesValidReply(t *testing.T) {
 	t.Parallel()
 	gw := &scriptedGW{replies: []string{validJSON}}
 
-	tm := DistillTurn(t.Context(), gw, "s1", "user: hi / assistant: hello")
+	tm := DistillTurn(t.Context(), gw, "s1", "user: hi / assistant: hello", "")
 	if tm == nil {
 		t.Fatal("DistillTurn returned nil for valid reply")
 	}
@@ -54,7 +56,7 @@ func TestDistillTurnStripsFences(t *testing.T) {
 	t.Parallel()
 	gw := &scriptedGW{replies: []string{"```json\n" + validJSON + "\n```"}}
 
-	if tm := DistillTurn(t.Context(), gw, "s1", "turn"); tm == nil || tm.FilesChanged[0] != "main.go" {
+	if tm := DistillTurn(t.Context(), gw, "s1", "turn", ""); tm == nil || tm.FilesChanged[0] != "main.go" {
 		t.Fatalf("fenced reply not parsed: %+v", tm)
 	}
 }
@@ -63,7 +65,7 @@ func TestDistillTurnRetriesOnceThenGivesUp(t *testing.T) {
 	t.Parallel()
 	// invalid then valid → parsed on the retry
 	gw := &scriptedGW{replies: []string{"sorry, here is the JSON you asked for", validJSON}}
-	if tm := DistillTurn(t.Context(), gw, "s1", "turn"); tm == nil {
+	if tm := DistillTurn(t.Context(), gw, "s1", "turn", ""); tm == nil {
 		t.Fatal("retry after invalid output did not recover")
 	}
 	if gw.calls != 2 {
@@ -72,7 +74,7 @@ func TestDistillTurnRetriesOnceThenGivesUp(t *testing.T) {
 
 	// invalid twice → nil, never an error that blocks the turn
 	gw = &scriptedGW{replies: []string{"not json", "still not json"}}
-	if tm := DistillTurn(t.Context(), gw, "s1", "turn"); tm != nil {
+	if tm := DistillTurn(t.Context(), gw, "s1", "turn", ""); tm != nil {
 		t.Fatalf("expected nil after two invalid replies, got %+v", tm)
 	}
 	if gw.calls != 2 {
@@ -83,8 +85,38 @@ func TestDistillTurnRetriesOnceThenGivesUp(t *testing.T) {
 func TestDistillTurnProviderErrorRetries(t *testing.T) {
 	t.Parallel()
 	gw := &scriptedGW{errs: []bool{true, false}, replies: []string{validJSON, validJSON}}
-	if tm := DistillTurn(t.Context(), gw, "s1", "turn"); tm == nil {
+	if tm := DistillTurn(t.Context(), gw, "s1", "turn", ""); tm == nil {
 		t.Fatal("provider error on first attempt should retry and recover")
+	}
+}
+
+// TestDistillTurnDefaultsToSummarizeRoute pins the fix: non-sensitive
+// turns distill on the cheap cloud side-call route, not always-local —
+// the local route now serves a reasoning model that burns its whole
+// completion budget thinking before the JSON answer.
+func TestDistillTurnDefaultsToSummarizeRoute(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGW{replies: []string{validJSON}}
+
+	DistillTurn(t.Context(), gw, "s1", "turn", "")
+
+	if gw.lastReq.Route != "summarize" {
+		t.Fatalf("route = %q, want summarize", gw.lastReq.Route)
+	}
+}
+
+// TestDistillTurnHonorsSensitiveRoutePin proves a turn that ran a
+// sensitive tool keeps its distillation on the pinned route instead of
+// falling back to the cheap default — same privacy floor as memory
+// extraction (extract.Request.Route).
+func TestDistillTurnHonorsSensitiveRoutePin(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGW{replies: []string{validJSON}}
+
+	DistillTurn(t.Context(), gw, "s1", "turn", "local")
+
+	if gw.lastReq.Route != "local" {
+		t.Fatalf("route = %q, want local (sensitive pin)", gw.lastReq.Route)
 	}
 }
 


### PR DESCRIPTION
Turn distillation (D-007) hardcoded `Route: "local"`, `MaxTokens: 500`, 30s timeout. `local` now serves a reasoning model that spends the whole budget thinking before the strict-JSON answer — every chat turn burned 30–60s of local GPU and wrote an `incomplete` ledger row.

- Default distillation route → `summarize` (cheap cloud side-call, same as memory extraction), threaded exactly like `extract.Request.Route`.
- Sensitive turns keep their pinned local route (turn text carries raw email) with a budget a thinking model can finish: 1500 tokens / 90s / 190s total.
- Comment cleanup where the old hardcoding was documented.

Live-verified: `distill` ledger row now `glm-4.7-flash / summarize / ok / 6s`. make build test vet lint green.