### PR TITLE
feat(chat): pin sensitive sessions to the sensitive route

### DIFF
--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -36,9 +36,9 @@ const (
 	// "summarize" cloud route — local now serves a reasoning model that
 	// burns its completion budget thinking before the strict-JSON
 	// answer, so it's reserved for sensitive turns pinned there
-	// deliberately. autoTitle uses defaultRoute instead — a session's
-	// name deserves the same model quality as the conversation it's
-	// naming, not the cheapest available one.
+	// deliberately. autoTitle uses defaultRoute instead when the turn
+	// isn't sensitive — a session's name deserves the same model quality
+	// as the conversation it's naming, not the cheapest available one.
 	classifyRoute = "local"
 	// defaultRoute serves plain chat turns when the caller picks
 	// nothing; the web UI exposes a per-message picker.
@@ -391,13 +391,42 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	// instead of "no PRIOR message exists" makes titling retry on every
 	// later message too, until one finally succeeds.
 	needsTitle := !hasCompletedTurn(events)
+	modelHint := req.ModelHint
+	route, modelHint = s.pinSensitiveRoute(ctx, events, route, modelHint)
 
 	if _, err := s.log.Append(ctx, sessionID, session.KindUserMessage, session.UserMessage{
-		Text: req.Message, Route: route, Agent: profile.Name, ModelHint: req.ModelHint,
+		Text: req.Message, Route: route, Agent: profile.Name, ModelHint: modelHint,
 	}); err != nil {
 		return sessionID, nil, err
 	}
-	return s.runTurn(ctx, sessionID, req.Message, req.ModelHint, req.SkillHint, skillBody, route, profile, needsTitle)
+	return s.runTurn(ctx, sessionID, req.Message, modelHint, req.SkillHint, skillBody, route, profile, needsTitle)
+}
+
+// pinSensitiveRoute promotes the session-wide privacy floor above the
+// turn-scoped one (SetForceRoute/turnSensitive): once ANY prior turn in
+// the session has executed a sensitive tool, the email/etc. content it
+// pulled into context is still there on every LATER turn even though
+// this turn ran no sensitive tool itself — so every subsequent turn
+// must start on the sensitive route, not just the turn that triggered
+// it. Overrides the route picker, the agent's own route, and the
+// default alike (same "safety floor beats user choice" rule the in-turn
+// pin already enforces), and drops modelHint for the same reason
+// SetForceRoute does: a hint outranks the route at the gateway's
+// Resolve, so a surviving hint would let the model bypass the pinned
+// route's chain entirely. A no-op whenever sensitive-tool routing is
+// unconfigured (s.sensitive nil or its Route resolves empty) — current
+// behavior everywhere until an operator sets sensitive_tool_route.
+func (s *Service) pinSensitiveRoute(ctx context.Context, events []session.Event, route, modelHint string) (string, string) {
+	if s.sensitive == nil || s.sensitive.Route == nil {
+		return route, modelHint
+	}
+	if !s.sensitive.SessionSensitive(events) {
+		return route, modelHint
+	}
+	if forced := s.sensitive.Route(ctx); forced != "" {
+		return forced, ""
+	}
+	return route, modelHint
 }
 
 // ErrNoRetryableTurn marks a Retry call whose session isn't in a
@@ -439,7 +468,9 @@ func (s *Service) Retry(ctx context.Context, sessionID string) (string, <-chan s
 	if route == "" {
 		route = defaultRoute
 	}
-	return s.runTurn(ctx, sessionID, last.Text, last.ModelHint, "", "", route, profile, needsTitle)
+	modelHint := last.ModelHint
+	route, modelHint = s.pinSensitiveRoute(ctx, events, route, modelHint)
+	return s.runTurn(ctx, sessionID, last.Text, modelHint, "", "", route, profile, needsTitle)
 }
 
 // runTurn is the shared tail of Chat and Retry: compact, project
@@ -468,6 +499,12 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 	if err != nil {
 		return sessionID, nil, err
 	}
+	// sessionSensitive reuses this same fetch: a session pinned by a
+	// PRIOR turn still carries that turn's sensitive content in the
+	// context just projected above, even when THIS turn runs no
+	// sensitive tool itself — so persistTurn's side-calls (distill,
+	// extraction) must be pinned too, same as turnSensitive.
+	sessionSensitive := s.sensitive.SessionSensitive(events)
 
 	// Retrieved memory and a hinted skill both ride the system
 	// prompt's TAIL: the stable prefix stays byte-identical for
@@ -506,15 +543,18 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 	}
 
 	out := make(chan stream.StreamEvent)
-	go s.relay(ctx, sessionID, userText, route, profile, needsTitle, upstream, out)
+	go s.relay(ctx, sessionID, userText, route, profile, needsTitle, sessionSensitive, upstream, out)
 	return sessionID, out, nil
 }
 
 // relay forwards events to the client while accumulating the turn,
 // then persists it. Persistence uses a cancel-detached context: a
 // client disconnect or brain shutdown mid-turn must still leave a
-// durable pending_state (the kill-test contract).
-func (s *Service) relay(ctx context.Context, sessionID, userText, route string, profile agents.Agent, needsTitle bool, upstream <-chan stream.StreamEvent, out chan<- stream.StreamEvent) {
+// durable pending_state (the kill-test contract). sessionSensitive
+// carries forward whether a PRIOR turn in this session already pinned
+// it (see runTurn) — persistTurn ORs it with this turn's own
+// turnSensitive flip so side-calls stay pinned on every later turn too.
+func (s *Service) relay(ctx context.Context, sessionID, userText, route string, profile agents.Agent, needsTitle, sessionSensitive bool, upstream <-chan stream.StreamEvent, out chan<- stream.StreamEvent) {
 	var text, reasoning strings.Builder
 	var meta *stream.Meta
 	var usage *stream.Usage
@@ -601,7 +641,7 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 			notePermission(ev)
 		}
 		close(out)
-		s.persistTurn(sessionID, userText, route, profile, needsTitle, text.String(), reasoning.String(), meta, usage, sawDone, flushed, turnSensitive)
+		s.persistTurn(sessionID, userText, route, profile, needsTitle, text.String(), reasoning.String(), meta, usage, sawDone, flushed, turnSensitive || sessionSensitive)
 	}
 
 	ticker := time.NewTicker(s.flushEvery)
@@ -644,7 +684,7 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 	}
 }
 
-func (s *Service) persistTurn(sessionID, userText, route string, profile agents.Agent, needsTitle bool, text, reasoning string, meta *stream.Meta, usage *stream.Usage, sawDone bool, flushed int, turnSensitive bool) {
+func (s *Service) persistTurn(sessionID, userText, route string, profile agents.Agent, needsTitle bool, text, reasoning string, meta *stream.Meta, usage *stream.Usage, sawDone bool, flushed int, sensitive bool) {
 	if !sawDone {
 		// Abnormal end: keep the partial durable; the projection
 		// splices it into the next request. Skip when the periodic
@@ -698,12 +738,15 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 		s.logger.Warn("persist last category", "session_id", sessionID, "error", err)
 	}
 
-	// A turn that executed a sensitive tool pins its side-calls to the
-	// same route the loop already forced the turn onto — both
-	// distillation and extraction below can see raw sensitive output
-	// (e.g. email), so neither may fall back to its own cheap default.
+	// A turn that executed a sensitive tool itself, OR one served on an
+	// already session-pinned route (a PRIOR turn's sensitive content is
+	// still in this turn's context — see runTurn's sessionSensitive),
+	// pins its side-calls to the same route the loop/pin already forced
+	// the turn onto — both distillation and extraction below can see raw
+	// sensitive output (e.g. email), so neither may fall back to its own
+	// cheap default.
 	sensitiveRoute := ""
-	if turnSensitive && s.sensitive != nil && s.sensitive.Route != nil {
+	if sensitive && s.sensitive != nil && s.sensitive.Route != nil {
 		sensitiveRoute = s.sensitive.Route(context.Background())
 	}
 
@@ -749,21 +792,33 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 		cancel()
 	}
 	if needsTitle {
-		s.autoTitle(sessionID, userText, text)
+		s.autoTitle(sessionID, userText, text, sensitiveRoute)
 	}
 }
 
 // autoTitle names a session after its first exchange via a mini call;
-// best-effort and never clobbers a user-chosen title.
-func (s *Service) autoTitle(sessionID, userText, reply string) {
+// best-effort and never clobbers a user-chosen title. sensitiveRoute is
+// the same pin persistTurn resolved for distill/extraction above: the
+// title prompt's input includes reply (the assistant's own synthesized
+// text, truncated), which is exactly the channel a sensitive tool's
+// output can be quoted through — the same reasoning distill/extract
+// already pin on — so titling rides the identical route pin rather than
+// staying on defaultRoute whenever this turn (or an earlier one this
+// session) is sensitive. An empty sensitiveRoute (the common case) falls
+// through to defaultRoute exactly as before.
+func (s *Service) autoTitle(sessionID, userText, reply, sensitiveRoute string) {
 	ctx, cancel := context.WithTimeout(context.Background(), titleTimeout)
 	defer cancel()
 
 	const titleSystem = `Produce a title for this conversation: at most 6 words, plain text, no quotes, no trailing punctuation. Reply with only the title.`
 	input := userText + "\n\n" + truncateRunes(reply, 200)
 
+	route := defaultRoute
+	if sensitiveRoute != "" {
+		route = sensitiveRoute
+	}
 	events, err := s.gw.Stream(ctx, gwclient.StreamRequest{
-		Route:    defaultRoute,
+		Route:    route,
 		Purpose:  "title",
 		System:   titleSystem,
 		Messages: []provider.Message{{Role: "user", Content: input}},

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -1604,3 +1604,184 @@ func TestDistillUsesEmptyRouteWhenTurnDidNotRunSensitiveTool(t *testing.T) {
 		t.Fatal("distill never invoked")
 	}
 }
+
+// seedSensitiveSession pre-populates a session's log with a completed
+// turn that ran a sensitive tool — standing in for "a prior turn in
+// this session already executed gmail_read", the trigger for the
+// whole-session route pin under test below.
+func seedSensitiveSession(t *testing.T, log *fakeLog, sessionID string) {
+	t.Helper()
+	if _, err := log.Append(t.Context(), sessionID, session.KindToolExecution, session.ToolExecution{
+		CallID: "c0", Name: "personal_gmail_read", Status: "ok",
+	}); err != nil {
+		t.Fatalf("seed tool_execution: %v", err)
+	}
+	if _, err := log.Append(t.Context(), sessionID, session.KindAssistantTurn, session.AssistantTurn{}); err != nil {
+		t.Fatalf("seed assistant_turn: %v", err)
+	}
+}
+
+// TestChatPinsSessionSensitiveRouteOnNextTurn is the feature under
+// test: once a PRIOR turn in the session executed a sensitive tool, the
+// NEXT Chat() call — which itself runs no sensitive tool — must still
+// be served on the sensitive route, with the route picker ignored and
+// the model hint dropped (a hint outranks the route at the gateway,
+// same reason the in-turn SetForceRoute pin drops it).
+func TestChatPinsSessionSensitiveRouteOnNextTurn(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	seedSensitiveSession(t, log, "s1")
+	gw := &fakeGW{events: okEvents("the answer")}
+	svc := newService(gw, log)
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "another question", Route: "mini", ModelHint: "big-model"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	sent := gw.lastRequest()
+	if sent.Route != "local" {
+		t.Fatalf("route = %q, want local (session pinned by a prior sensitive tool call)", sent.Route)
+	}
+	if sent.ModelHint != "" {
+		t.Fatalf("model hint = %q, want empty (dropped alongside the route pin)", sent.ModelHint)
+	}
+}
+
+// TestChatSessionPinNoopWhenSensitiveRouteUnset proves the pin is
+// active only when sensitive_tool_route is actually configured: a nil
+// Route func (the feature off) leaves a sensitive session's next turn
+// on ordinary routing, matching today's behavior everywhere.
+func TestChatSessionPinNoopWhenSensitiveRouteUnset(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	seedSensitiveSession(t, log, "s1")
+	gw := &fakeGW{events: okEvents("the answer")}
+	svc := newService(gw, log)
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "" }})
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "another question", Route: "mini", ModelHint: "big-model"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	sent := gw.lastRequest()
+	if sent.Route != "mini" {
+		t.Fatalf("route = %q, want mini (sensitive route unset, picker honored)", sent.Route)
+	}
+	if sent.ModelHint != "big-model" {
+		t.Fatalf("model hint = %q, want big-model (unset route means no pin)", sent.ModelHint)
+	}
+}
+
+// TestChatFreshSessionRoutesNormally proves the pin only fires once a
+// sensitive tool has actually run: a session with no prior turns at all
+// routes exactly as requested.
+func TestChatFreshSessionRoutesNormally(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("the answer")}
+	svc := newService(gw, log)
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "a question", Route: "mini", ModelHint: "big-model"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	sent := gw.lastRequest()
+	if sent.Route != "mini" {
+		t.Fatalf("route = %q, want mini (fresh session, no sensitive tool ran yet)", sent.Route)
+	}
+	if sent.ModelHint != "big-model" {
+		t.Fatalf("model hint = %q, want big-model (no pin on a fresh session)", sent.ModelHint)
+	}
+}
+
+// TestRetryPinsSessionSensitiveRoute mirrors the Chat pin for Retry: a
+// session already pinned by a prior sensitive tool call re-runs its
+// last turn on the sensitive route even though Retry reuses the
+// original request's own route/model_hint verbatim.
+func TestRetryPinsSessionSensitiveRoute(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	seedSensitiveSession(t, log, "s1")
+	if _, err := log.Append(t.Context(), "s1", session.KindUserMessage, session.UserMessage{
+		Text: "retry me", Route: "mini", Agent: "default", ModelHint: "big-model",
+	}); err != nil {
+		t.Fatalf("seed user_message: %v", err)
+	}
+	gw := &fakeGW{events: okEvents("the answer")}
+	svc := newService(gw, log)
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+
+	_, ch, err := svc.Retry(t.Context(), "s1")
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	drain(t, ch)
+
+	sent := gw.lastRequest()
+	if sent.Route != "local" {
+		t.Fatalf("route = %q, want local (session pinned by a prior sensitive tool call)", sent.Route)
+	}
+	if sent.ModelHint != "" {
+		t.Fatalf("model hint = %q, want empty (dropped alongside the route pin)", sent.ModelHint)
+	}
+}
+
+// TestPersistTurnPinsSideCallsWhenSessionPreviouslySensitive proves
+// persistTurn's side-call route resolution (distill, memory extract)
+// treats "session pinned by an earlier turn" the same as "this turn
+// itself ran a sensitive tool": the context this turn saw still carries
+// the earlier turn's sensitive content even though THIS turn's own
+// tool calls are unrelated.
+func TestPersistTurnPinsSideCallsWhenSessionPreviouslySensitive(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	seedSensitiveSession(t, log, "s1")
+	gw := &fakeGW{events: []stream.StreamEvent{
+		{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{ID: "c1", Name: "shell", Status: "ok"}},
+		{Type: stream.EventChunk, Text: "the answer"},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
+	}}
+	distillRoute := make(chan string, 1)
+	distill := func(_ context.Context, _, _, route string) *session.TurnMemory {
+		distillRoute <- route
+		return nil
+	}
+	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+
+	extractRoute := make(chan string, 1)
+	svc.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) {
+		extractRoute <- route
+	})
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "run a shell command, unrelated to email"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	select {
+	case route := <-distillRoute:
+		if route != "local" {
+			t.Fatalf("distill route = %q, want local (session pinned by an earlier turn)", route)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("distill never invoked")
+	}
+	select {
+	case route := <-extractRoute:
+		if route != "local" {
+			t.Fatalf("memory extract route = %q, want local (session pinned by an earlier turn)", route)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("memory extract never invoked")
+	}
+}

--- a/internal/brain/session/compactor.go
+++ b/internal/brain/session/compactor.go
@@ -107,31 +107,6 @@ func (c *Compactor) budgetFor(ctx context.Context, sessionID string, events []Ev
 	return c.budget(ctx)
 }
 
-// sessionIsSensitive reports whether any tool_execution event anywhere
-// in the session matches sensitive — scoped to the whole session, not
-// just the span about to be summarized, since a later compaction pass
-// can summarize a span that never itself ran the sensitive tool but
-// still sits downstream of a turn that did (D-007 residue can carry
-// content forward). nil sensitive (feature off) always reports false.
-func sessionIsSensitive(events []Event, sensitive *SensitiveTools) bool {
-	if sensitive == nil {
-		return false
-	}
-	for _, ev := range events {
-		if ev.Kind != KindToolExecution {
-			continue
-		}
-		var te ToolExecution
-		if decode(ev, &te) != nil {
-			continue
-		}
-		if sensitive.Matches(te.Name) {
-			return true
-		}
-	}
-	return false
-}
-
 // lastModel returns the model of the newest assistant_turn, or "".
 func lastModel(events []Event) string {
 	for i := len(events) - 1; i >= 0; i-- {
@@ -182,7 +157,7 @@ func (c *Compactor) MaybeCompact(ctx context.Context, sessionID string) error {
 	// the loop pins the rest of a sensitive TURN's route (the content
 	// downstream of it may quote raw sensitive output). Computed once so
 	// extract and summarize agree on the same verdict.
-	sensitive := sessionIsSensitive(events, c.sensitive)
+	sensitive := c.sensitive.SessionSensitive(events)
 
 	// Extract BEFORE summarizing: once the summary replaces these
 	// turns, whatever it dropped is gone for good (D-011). The turns

--- a/internal/brain/session/sensitive.go
+++ b/internal/brain/session/sensitive.go
@@ -36,3 +36,30 @@ func (s *SensitiveTools) Matches(toolName string) bool {
 	}
 	return false
 }
+
+// SessionSensitive reports whether any tool_execution event anywhere in
+// events matches s — scoped to the WHOLE session, not just a span about
+// to be summarized or the current turn, since content downstream of a
+// sensitive tool call (e.g. quoted email text) can carry forward into
+// later turns and later compaction spans alike (D-007 residue). Shared
+// by the compactor (which span to summarize/extract on) and chat
+// (which route to serve the next turn on) so both apply the same
+// verdict. nil sensitive (feature off) always reports false.
+func (s *SensitiveTools) SessionSensitive(events []Event) bool {
+	if s == nil {
+		return false
+	}
+	for _, ev := range events {
+		if ev.Kind != KindToolExecution {
+			continue
+		}
+		var te ToolExecution
+		if decode(ev, &te) != nil {
+			continue
+		}
+		if s.Matches(te.Name) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The turn-scoped pin left a gap: the next turn in a session that had already read email started on the normal route with that content still in context — the cloud provider saw it anyway.

- Once any prior turn executed a sensitive tool, every later turn pins to `sensitive_tool_route`: send, retry, and the distill/extract/title side-calls. Model hint drops with it (hint outranks route at gateway resolve). Picker route can't unpin — safety floor beats user choice.
- Active only while `sensitive_tool_route` is set; unset = current behavior exactly.
- `sessionIsSensitive` promoted to shared `SensitiveTools.SessionSensitive` (nil-safe); compactor unchanged. No extra event fetch — reuses loads Chat/Retry/runTurn already do.
- Trade-off (user-approved): sensitive sessions run at local-model speed permanently; fresh sessions stay fast.

5 new tests. Live-verified: next turn on an email session served Ollama (local) from the first token, and a full task run (search + 3 reads + answer) stayed local end-to-end. make build test vet lint green.