### PR TITLE
feat(chat): stamp turn duration and show it as a footer pill

### DIFF
--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -399,12 +399,13 @@ func (a *API) handleRetry(w http.ResponseWriter, r *http.Request) {
 // model, usage, and ledger_id are best-effort — absent when no
 // provider attempt succeeded.
 type meta struct {
-	Type      string        `json:"type"` // always "meta"
-	SessionID string        `json:"session_id"`
-	Provider  string        `json:"provider,omitempty"`
-	Model     string        `json:"model,omitempty"`
-	Usage     *stream.Usage `json:"usage,omitempty"`
-	LedgerID  string        `json:"ledger_id,omitempty"`
+	Type       string        `json:"type"` // always "meta"
+	SessionID  string        `json:"session_id"`
+	Provider   string        `json:"provider,omitempty"`
+	Model      string        `json:"model,omitempty"`
+	Usage      *stream.Usage `json:"usage,omitempty"`
+	LedgerID   string        `json:"ledger_id,omitempty"`
+	DurationMs int64         `json:"duration_ms,omitempty"`
 }
 
 // streamTurn runs run (chat.Service.Chat or Retry) and relays its
@@ -459,6 +460,7 @@ func (a *API) streamTurn(w http.ResponseWriter, r *http.Request, run func(contex
 		}
 		if ev.Meta != nil {
 			m.Provider, m.Model, m.LedgerID = ev.Meta.Provider, ev.Meta.Model, ev.Meta.LedgerID
+			m.DurationMs = ev.Meta.DurationMs
 		}
 		send(ev)
 	}

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -478,6 +478,11 @@ func (s *Service) Retry(ctx context.Context, sessionID string) (string, <-chan s
 // has already ensured exactly the right user_message sits durable at
 // the end of the log — this never appends one itself.
 func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, skillHint, skillBody, route string, profile agents.Agent, needsTitle bool) (string, <-chan stream.StreamEvent, error) {
+	// start marks the turn's wall-clock beginning for the stats line's
+	// duration: here, not Chat/Retry's entry, so a retried turn's
+	// duration covers only the retried run — the dead attempt's gap
+	// never counts (runTurn is the shared tail both call fresh).
+	start := time.Now()
 	s.seedApprovalGrants(ctx, sessionID, profile)
 	// Pre-send guarantee: the context actually sent to the provider
 	// stays under budget even on the turn that crosses it. The
@@ -543,7 +548,7 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 	}
 
 	out := make(chan stream.StreamEvent)
-	go s.relay(ctx, sessionID, userText, route, profile, needsTitle, sessionSensitive, upstream, out)
+	go s.relay(ctx, sessionID, userText, route, profile, needsTitle, sessionSensitive, start, upstream, out)
 	return sessionID, out, nil
 }
 
@@ -554,7 +559,10 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 // carries forward whether a PRIOR turn in this session already pinned
 // it (see runTurn) — persistTurn ORs it with this turn's own
 // turnSensitive flip so side-calls stay pinned on every later turn too.
-func (s *Service) relay(ctx context.Context, sessionID, userText, route string, profile agents.Agent, needsTitle, sessionSensitive bool, upstream <-chan stream.StreamEvent, out chan<- stream.StreamEvent) {
+// start is runTurn's wall-clock beginning, stamped onto the terminal
+// done event's Meta (and passed to persistTurn) so live and replayed
+// stats show the same duration.
+func (s *Service) relay(ctx context.Context, sessionID, userText, route string, profile agents.Agent, needsTitle, sessionSensitive bool, start time.Time, upstream <-chan stream.StreamEvent, out chan<- stream.StreamEvent) {
 	var text, reasoning strings.Builder
 	var meta *stream.Meta
 	var usage *stream.Usage
@@ -635,7 +643,8 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 				usage = ev.Usage
 			case stream.EventDone:
 				sawDone = true
-				meta = ev.Meta
+				meta = stampDuration(ev.Meta, start)
+				ev.Meta = meta
 			}
 			noteToolResult(ev)
 			notePermission(ev)
@@ -663,7 +672,8 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 				usage = ev.Usage
 			case stream.EventDone:
 				sawDone = true
-				meta = ev.Meta
+				meta = stampDuration(ev.Meta, start)
+				ev.Meta = meta
 			}
 			noteToolResult(ev)
 			notePermission(ev)
@@ -682,6 +692,19 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 			return
 		}
 	}
+}
+
+// stampDuration copies base (the gateway-attributed Meta, possibly
+// nil when no provider attempt succeeded) and sets DurationMs from
+// start — a copy because base may be a shared struct decoded once per
+// SSE event, not something relay owns to mutate in place.
+func stampDuration(base *stream.Meta, start time.Time) *stream.Meta {
+	m := stream.Meta{}
+	if base != nil {
+		m = *base
+	}
+	m.DurationMs = time.Since(start).Milliseconds()
+	return &m
 }
 
 func (s *Service) persistTurn(sessionID, userText, route string, profile agents.Agent, needsTitle bool, text, reasoning string, meta *stream.Meta, usage *stream.Usage, sawDone bool, flushed int, sensitive bool) {
@@ -719,6 +742,7 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 	}
 	if meta != nil {
 		turn.Provider, turn.Model, turn.LedgerID = meta.Provider, meta.Model, meta.LedgerID
+		turn.DurationMs = meta.DurationMs
 	}
 	turn.Usage = usage
 

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -140,6 +140,20 @@ func (g *fakeGW) lastRequest() gwclient.StreamRequest {
 	return g.requests[len(g.requests)-1]
 }
 
+// lastChatRequest skips side-calls (title, distill, extract) that race
+// the assertion after drain — the async auto-title on a fresh session
+// can land after the chat request and make lastRequest nondeterministic.
+func (g *fakeGW) lastChatRequest() gwclient.StreamRequest {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for i := len(g.requests) - 1; i >= 0; i-- {
+		if g.requests[i].Purpose == "chat" {
+			return g.requests[i]
+		}
+	}
+	return gwclient.StreamRequest{}
+}
+
 func okEvents(text string) []stream.StreamEvent {
 	return []stream.StreamEvent{
 		{Type: stream.EventChunk, Text: text},
@@ -212,6 +226,36 @@ func TestChatPersistsTurnAsEvents(t *testing.T) {
 	}
 	if turn.LLM.Message != "the answer" || turn.Provider != "prov" || turn.LedgerID != "led" {
 		t.Fatalf("turn = %+v", turn)
+	}
+}
+
+// TestChatPersistsTurnDuration confirms the persisted assistant_turn
+// carries a wall-clock DurationMs covering the turn — a stand-in
+// upstream delay proves it's measuring real elapsed time, not just
+// echoing a zero default.
+func TestChatPersistsTurnDuration(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	block := make(chan struct{})
+	gw := &fakeGW{events: okEvents("the answer"), blockCh: block}
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "the question"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	close(block)
+	drain(t, ch)
+
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+	events, _ := log.Events(t.Context(), "s1")
+	var turn session.AssistantTurn
+	if err := json.Unmarshal(events[2].Payload, &turn); err != nil {
+		t.Fatalf("decode turn: %v", err)
+	}
+	if turn.DurationMs < 50 {
+		t.Fatalf("turn.DurationMs = %d, want >= 50ms", turn.DurationMs)
 	}
 }
 
@@ -1641,7 +1685,7 @@ func TestChatPinsSessionSensitiveRouteOnNextTurn(t *testing.T) {
 	}
 	drain(t, ch)
 
-	sent := gw.lastRequest()
+	sent := gw.lastChatRequest()
 	if sent.Route != "local" {
 		t.Fatalf("route = %q, want local (session pinned by a prior sensitive tool call)", sent.Route)
 	}
@@ -1668,7 +1712,7 @@ func TestChatSessionPinNoopWhenSensitiveRouteUnset(t *testing.T) {
 	}
 	drain(t, ch)
 
-	sent := gw.lastRequest()
+	sent := gw.lastChatRequest()
 	if sent.Route != "mini" {
 		t.Fatalf("route = %q, want mini (sensitive route unset, picker honored)", sent.Route)
 	}
@@ -1693,7 +1737,7 @@ func TestChatFreshSessionRoutesNormally(t *testing.T) {
 	}
 	drain(t, ch)
 
-	sent := gw.lastRequest()
+	sent := gw.lastChatRequest()
 	if sent.Route != "mini" {
 		t.Fatalf("route = %q, want mini (fresh session, no sensitive tool ran yet)", sent.Route)
 	}
@@ -1725,7 +1769,7 @@ func TestRetryPinsSessionSensitiveRoute(t *testing.T) {
 	}
 	drain(t, ch)
 
-	sent := gw.lastRequest()
+	sent := gw.lastChatRequest()
 	if sent.Route != "local" {
 		t.Fatalf("route = %q, want local (session pinned by a prior sensitive tool call)", sent.Route)
 	}

--- a/internal/brain/session/events.go
+++ b/internal/brain/session/events.go
@@ -93,6 +93,10 @@ type AssistantTurn struct {
 	Model    string        `json:"model,omitempty"`
 	LedgerID string        `json:"ledger_id,omitempty"`
 	Usage    *stream.Usage `json:"usage,omitempty"`
+	// DurationMs is the turn's wall-clock time (runTurn entry to
+	// persistence), not the sum of tool durations — set by chat.go so
+	// live and replayed stats agree.
+	DurationMs int64 `json:"duration_ms,omitempty"`
 }
 
 // ToolExecution stores a digest only; full results are transient.

--- a/internal/brain/session/projection.go
+++ b/internal/brain/session/projection.go
@@ -176,6 +176,7 @@ type TranscriptItem struct {
 	Provider   string             `json:"provider,omitempty"`
 	Model      string             `json:"model,omitempty"`
 	Usage      *stream.Usage      `json:"usage,omitempty"`
+	DurationMs int64              `json:"duration_ms,omitempty"`
 	Tool       *ToolExecution     `json:"tool,omitempty"`
 	Permission *PermissionRequest `json:"permission,omitempty"`
 	CreatedAt  time.Time          `json:"created_at"`
@@ -210,6 +211,7 @@ func UITranscript(events []Event) ([]TranscriptItem, error) {
 			item.Blocks = t.UI.Blocks
 			item.Provider, item.Model = t.Provider, t.Model
 			item.Usage = t.Usage
+			item.DurationMs = t.DurationMs
 		case KindToolExecution:
 			var te ToolExecution
 			if err := decode(ev, &te); err != nil {

--- a/internal/brain/session/projection_test.go
+++ b/internal/brain/session/projection_test.go
@@ -226,6 +226,27 @@ func TestUITranscript(t *testing.T) {
 	}
 }
 
+// TestUITranscriptExposesDuration confirms UITranscript carries an
+// assistant_turn's DurationMs through to the replay item — replayed
+// sessions must show the same turn-stats duration the live SSE meta
+// event carried.
+func TestUITranscriptExposesDuration(t *testing.T) {
+	t.Parallel()
+	var a AssistantTurn
+	a.LLM.Message = "hi"
+	a.UI.Blocks = []UIBlock{{Type: "text", Text: "hi"}}
+	a.DurationMs = 81234
+	events := []Event{ev(t, 1, KindAssistantTurn, a)}
+
+	items, err := UITranscript(events)
+	if err != nil {
+		t.Fatalf("UITranscript: %v", err)
+	}
+	if len(items) != 1 || items[0].DurationMs != 81234 {
+		t.Fatalf("items = %+v, want duration_ms 81234", items)
+	}
+}
+
 // TestLLMContextPrefixStability pins the D-018 contract: growing a log
 // without a compaction never rewrites earlier projected messages.
 // Pending checkpoints are deliberately absent from the generator: an

--- a/internal/gateway/stream/events.go
+++ b/internal/gateway/stream/events.go
@@ -81,10 +81,14 @@ type PermissionResolvedEvent struct {
 
 // Meta identifies who served a request — attached to the done event by
 // the gateway API so callers attribute without a second lookup.
+// DurationMs is never set by the gateway (it has no notion of a brain-
+// level turn); brain's chat package stamps it on the relayed event
+// before forwarding downstream.
 type Meta struct {
-	Provider string `json:"provider"`
-	Model    string `json:"model"`
-	LedgerID string `json:"ledger_id,omitempty"`
+	Provider   string `json:"provider"`
+	Model      string `json:"model"`
+	LedgerID   string `json:"ledger_id,omitempty"`
+	DurationMs int64  `json:"duration_ms,omitempty"`
 }
 
 // ToolCallEvent identifies a tool call. Input carries the complete

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -68,6 +68,7 @@ export interface MetaEvent {
   model?: string
   usage?: Usage
   ledger_id?: string
+  duration_ms?: number
 }
 
 export type ChatEvent = StreamEvent | MetaEvent
@@ -122,6 +123,7 @@ export interface TranscriptItem {
   provider?: string
   model?: string
   usage?: Usage
+  duration_ms?: number
   created_at: string
 }
 

--- a/web/src/components/Activity.tsx
+++ b/web/src/components/Activity.tsx
@@ -5,11 +5,17 @@ import { SheetContent, SheetHeader, SheetTitle } from './ui/sheet'
 import { CopyButton } from './Message'
 import type { AssistantState, ToolRun } from '../lib/chat'
 
-// formatDuration renders a tool call's wall time compactly: sub-second
-// as milliseconds, otherwise one decimal of seconds.
+// formatDuration renders a wall time compactly: sub-second as
+// milliseconds, sub-minute as one decimal of seconds, otherwise whole
+// minutes plus whole seconds (e.g. "1m 21s") — a turn's duration can
+// run minutes, unlike a single tool call.
 export function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms}ms`
-  return `${(ms / 1000).toFixed(1)}s`
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
+  const totalSeconds = Math.round(ms / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}m ${seconds}s`
 }
 
 // prettyArgs pretty-prints a tool call's JSON args; malformed or

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -319,3 +319,44 @@ describe('tool calls', () => {
     expect(msg.permissions[0].call_id).toBe('c2')
   })
 })
+
+describe('duration badge', () => {
+  it('renders a duration pill beside the existing meta pills', () => {
+    const msg = play([
+      { type: 'chunk', text: 'hi' },
+      {
+        type: 'meta',
+        session_id: 's',
+        provider: 'zai-glm',
+        model: 'glm-4.7',
+        usage: { input_tokens: 11, output_tokens: 204 },
+        duration_ms: 81_000,
+      },
+    ])
+    render(<AssistantMessage msg={msg} />)
+
+    const badge = screen.getByTestId('meta-badge')
+    expect(badge).toHaveTextContent('zai-glm')
+    expect(badge).toHaveTextContent('glm-4.7')
+    expect(badge).toHaveTextContent('11→204 tok')
+    expect(screen.getByTestId('duration-badge')).toHaveTextContent('1m 21s')
+  })
+
+  it('renders sub-minute durations via formatDuration', () => {
+    const msg = play([
+      { type: 'chunk', text: 'hi' },
+      { type: 'meta', session_id: 's', provider: 'zai-glm', model: 'glm-4.7', duration_ms: 6700 },
+    ])
+    render(<AssistantMessage msg={msg} />)
+    expect(screen.getByTestId('duration-badge')).toHaveTextContent('6.7s')
+  })
+
+  it('omits the duration pill when duration_ms is absent (old turns)', () => {
+    const msg = play([
+      { type: 'chunk', text: 'hi' },
+      { type: 'meta', session_id: 's', provider: 'zai-glm', model: 'glm-4.7' },
+    ])
+    render(<AssistantMessage msg={msg} />)
+    expect(screen.queryByTestId('duration-badge')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import rehypeHighlight from 'rehype-highlight'
 import remarkGfm from 'remark-gfm'
-import { ActivityLine } from './Activity'
+import { ActivityLine, formatDuration } from './Activity'
 import { Badge } from './ui/badge'
 import { collapseRepeatedTail, splitSources } from '../lib/citations'
 import type { AssistantState } from '../lib/chat'
@@ -172,6 +172,9 @@ export function AssistantMessage({
   const tokens = msg.meta?.usage
     ? `${msg.meta.usage.input_tokens}→${msg.meta.usage.output_tokens} tok`
     : null
+  // Absent on turns persisted before duration tracking shipped — the
+  // pill simply doesn't render rather than showing a guessed 0.
+  const duration = msg.meta?.durationMs !== undefined ? formatDuration(msg.meta.durationMs) : null
   // Citations only split out once the answer is done streaming: a
   // partial "## Sources" heading mid-stream would otherwise flicker
   // the body text as more of it arrives.
@@ -233,6 +236,11 @@ export function AssistantMessage({
               <Badge variant="secondary">{msg.meta.provider}</Badge>
               <Badge variant="secondary">{msg.meta.model}</Badge>
               {tokens && <Badge variant="secondary">{tokens}</Badge>}
+              {duration && (
+                <Badge variant="secondary" data-testid="duration-badge">
+                  {duration}
+                </Badge>
+              )}
             </div>
           )}
           {msg.text !== '' && <CopyButton text={msg.text} label="Copy reply" />}

--- a/web/src/lib/chat.ts
+++ b/web/src/lib/chat.ts
@@ -20,7 +20,7 @@ export interface AssistantState {
   tools: ToolRun[]
   permissions: PermissionRequestEvent[]
   error?: string
-  meta?: { provider?: string; model?: string; usage?: Usage }
+  meta?: { provider?: string; model?: string; usage?: Usage; durationMs?: number }
   streaming: boolean
 }
 
@@ -85,7 +85,7 @@ export function applyEvent(msg: AssistantState, ev: ChatEvent): AssistantState {
         ...msg,
         streaming: false,
         permissions: [],
-        meta: { provider: ev.provider, model: ev.model, usage: ev.usage },
+        meta: { provider: ev.provider, model: ev.model, usage: ev.usage, durationMs: ev.duration_ms },
       }
     default:
       // done (terminal marker) and usage (folded into meta by brain)

--- a/web/src/lib/transcript.test.ts
+++ b/web/src/lib/transcript.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import type { TranscriptItem } from '../api/types'
+import type { ChatEvent, TranscriptItem } from '../api/types'
+import { applyEvent, emptyAssistant } from './chat'
 import { fromTranscript } from './transcript'
 
 const at = '2026-07-10T12:00:00Z'
@@ -235,6 +236,53 @@ describe('fromTranscript', () => {
     if (items[0].role === 'assistant') {
       expect(items[0].permissions.map((p) => p.id)).toEqual(['perm-1'])
     }
+  })
+
+  it('carries turn-stats duration on replay, matching the live meta event shape', () => {
+    // Replay path: server projection's duration_ms on the assistant item.
+    const items = fromTranscript([
+      {
+        seq: 1,
+        kind: 'assistant',
+        blocks: [{ type: 'text', text: 'done' }],
+        provider: 'zai-glm',
+        model: 'glm-4.7',
+        usage: { input_tokens: 81, output_tokens: 396 },
+        duration_ms: 81234,
+        created_at: at,
+      },
+    ])
+    expect(items[0]).toMatchObject({
+      role: 'assistant',
+      meta: {
+        provider: 'zai-glm',
+        model: 'glm-4.7',
+        usage: { input_tokens: 81, output_tokens: 396 },
+        durationMs: 81234,
+      },
+    })
+
+    // Live path: the same fields, folded from usage + terminal meta
+    // events, must land in the same shape on AssistantState.
+    const events: ChatEvent[] = [
+      { type: 'chunk', text: 'done' },
+      { type: 'usage', usage: { input_tokens: 81, output_tokens: 396 } },
+      {
+        type: 'meta',
+        session_id: 's',
+        provider: 'zai-glm',
+        model: 'glm-4.7',
+        usage: { input_tokens: 81, output_tokens: 396 },
+        duration_ms: 81234,
+      },
+    ]
+    const live = events.reduce(applyEvent, emptyAssistant())
+    expect(live.meta).toEqual({
+      provider: 'zai-glm',
+      model: 'glm-4.7',
+      usage: { input_tokens: 81, output_tokens: 396 },
+      durationMs: 81234,
+    })
   })
 
   it('never surfaces a resolved ask — the server projection already drops it', () => {

--- a/web/src/lib/transcript.ts
+++ b/web/src/lib/transcript.ts
@@ -100,7 +100,7 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
           permissions,
           streaming: false,
           meta: item.provider
-            ? { provider: item.provider, model: item.model, usage: item.usage }
+            ? { provider: item.provider, model: item.model, usage: item.usage, durationMs: item.duration_ms }
             : undefined,
         })
         break


### PR DESCRIPTION
Turns report provider/model/tokens but nothing tied a turn to its wall-clock cost.

- Brain stamps `duration_ms` onto the terminal meta it already sends live and persists (`assistant_turn`, transcript item) — measured from runTurn entry, so a retried turn counts only the retried run. Live and replay render identical values.
- Web: one new duration pill (`6.7s`, `1m 21s`) beside the existing provider/model/token pills; omitted for old turns without the field. No extra footer line.
- Test hardening: fakeGW.lastChatRequest skips async side-calls (auto-title) that raced route assertions.

(Original branch feat/turn-stats rebased onto #108; force-push disallowed locally, hence fresh branch.)

Go + web suites green (300 web tests); live-verified duration_ms identical on live meta event and replay transcript.