### PR TITLE
feat(chat): reattach to in-flight turns across page reloads

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -235,6 +235,15 @@ func main() {
 		agentReg.Resolve, app.Log)
 	svc.SetAutoDispatch(agentReg.Enabled, chat.ClassifyOverGateway(gwc))
 	svc.SetSensitiveTools(sensitiveTools)
+	// Nil-safe: missionHub is nil when WORKSPACES is unset (see
+	// buildMissions), in which case SetSessionHub's publish func is
+	// never called (chat.go only invokes it when non-nil), leaving
+	// today's behavior (no push) unchanged.
+	if missionHub != nil {
+		svc.SetSessionHub(func(sessionID string) {
+			missionHub.Publish(missions.Signal{Kind: "session", ID: sessionID})
+		})
+	}
 	// Same Permissions instance (and session_grants table) the chat
 	// agent loop's own Resolve chain reads from — seeding here is
 	// visible to that exact chain, not a parallel grant store.

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -95,6 +95,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	srv.Handle("GET /v1/sessions", a.auth(http.HandlerFunc(a.handleList)))
 	srv.Handle("POST /v1/sessions", a.auth(http.HandlerFunc(a.handleCreate)))
 	srv.Handle("GET /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleTranscript)))
+	a.registerLive(srv.Handle)
 	srv.Handle("PATCH /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleUpdate)))
 	srv.Handle("DELETE /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleDelete)))
 	srv.Handle("POST /v1/sessions/{id}/messages", a.auth(http.HandlerFunc(a.handleMessages)))
@@ -269,7 +270,14 @@ func (a *API) handleTranscript(w http.ResponseWriter, r *http.Request) {
 	if items == nil {
 		items = []session.TranscriptItem{}
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"session": meta, "items": items})
+	// turn_active is read straight off chat.Service's own broadcaster
+	// registry (TurnActive) — the single source of truth for "is a turn
+	// running right now", not a separate flag that could drift from it.
+	// a.svc is never nil (Register always constructs one), and
+	// TurnActive itself is nil-map-safe, so this needs no guard.
+	writeJSON(w, http.StatusOK, map[string]any{
+		"session": meta, "items": items, "turn_active": a.svc.TurnActive(id),
+	})
 }
 
 func (a *API) handleUpdate(w http.ResponseWriter, r *http.Request) {

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -140,14 +140,18 @@ func (d *memDir) SetTitleIfEmpty(context.Context, string, string) error { return
 func (d *memDir) SetLastRoute(context.Context, string, string, string) error { return nil }
 
 // fakeGateway yields a canned event sequence, or fails when err set.
+// blockCh, when set, delays every event past the first until closed —
+// lets a test observe "mid-turn" state (turn_active, a /live replay)
+// before the stream completes.
 type fakeGateway struct {
-	events []stream.StreamEvent
-	err    error
-	got    gwclient.StreamRequest
-	calls  int
+	events  []stream.StreamEvent
+	err     error
+	got     gwclient.StreamRequest
+	calls   int
+	blockCh chan struct{}
 }
 
-func (f *fakeGateway) Stream(_ context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+func (f *fakeGateway) Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
 	f.calls++
 	if f.calls == 1 { // record the chat call, not the title call
 		f.got = req
@@ -155,11 +159,39 @@ func (f *fakeGateway) Stream(_ context.Context, req gwclient.StreamRequest) (<-c
 	if f.err != nil {
 		return nil, f.err
 	}
-	ch := make(chan stream.StreamEvent, len(f.events))
-	for _, ev := range f.events {
-		ch <- ev
+	if f.blockCh == nil {
+		ch := make(chan stream.StreamEvent, len(f.events))
+		for _, ev := range f.events {
+			ch <- ev
+		}
+		close(ch)
+		return ch, nil
 	}
-	close(ch)
+	ch := make(chan stream.StreamEvent)
+	events := append([]stream.StreamEvent(nil), f.events...)
+	block := f.blockCh
+	go func() {
+		defer close(ch)
+		if len(events) > 0 {
+			select {
+			case ch <- events[0]:
+			case <-ctx.Done():
+				return
+			}
+		}
+		select {
+		case <-block:
+		case <-ctx.Done():
+			return
+		}
+		for _, ev := range events[1:] {
+			select {
+			case ch <- ev:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 	return ch, nil
 }
 
@@ -187,6 +219,7 @@ func mux(a *API) *http.ServeMux {
 	m.Handle("GET /v1/sessions", a.auth(http.HandlerFunc(a.handleList)))
 	m.Handle("POST /v1/sessions", a.auth(http.HandlerFunc(a.handleCreate)))
 	m.Handle("GET /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleTranscript)))
+	a.registerLive(m.Handle)
 	m.Handle("PATCH /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleUpdate)))
 	m.Handle("DELETE /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleDelete)))
 	m.Handle("POST /v1/sessions/{id}/messages", a.auth(http.HandlerFunc(a.handleMessages)))

--- a/internal/brain/api/live.go
+++ b/internal/brain/api/live.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// registerLive mounts GET /v1/sessions/{id}/live, Tier 2 of the
+// live-reattach feature: a tab that opens a session mid-turn replays
+// whatever the turn already emitted, then follows it live until the
+// terminal, using the IDENTICAL wire format as POST .../messages
+// (streamTurn below) so the web reuses the same SSE parser and
+// applyEvent reducer — a reattached turn renders exactly like one this
+// tab started itself.
+func (a *API) registerLive(handle func(pattern string, h http.Handler)) {
+	handle("GET /v1/sessions/{id}/live", a.auth(http.HandlerFunc(a.handleLive)))
+}
+
+// handleLive answers 404 "no_active_turn" when chat.Service has no
+// turn in flight for this session — chosen over 204 because this is a
+// GET whose resource (the live stream) simply doesn't exist right now,
+// the same "nothing here" framing handleTranscript/handleRetry already
+// use (not_found, no_retryable_turn), rather than a mutation's "done,
+// nothing to report". A client seeing 404 falls back to its normal
+// transcript fetch — turn_active having already gone false by the time
+// this request lands is a benign race, not an error: the transcript it
+// then fetches already reflects the finished turn (turnDone frees the
+// broadcaster only after persistTurn's write is durable).
+func (a *API) handleLive(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !validSessionID(id) {
+		jsonError(w, http.StatusNotFound, "not_found", "no such session")
+		return
+	}
+	replay, live, ok := a.svc.Subscribe(id)
+	if !ok {
+		jsonError(w, http.StatusNotFound, "no_active_turn", "no turn is currently running for this session")
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		jsonError(w, http.StatusInternalServerError, "streaming_unsupported", "response writer cannot flush")
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+
+	send := func(v any) {
+		data, err := json.Marshal(v)
+		if err != nil {
+			return
+		}
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+	}
+
+	// m accumulates the same terminal meta contract streamTurn emits —
+	// scanning the replay AND the live tail identically, so a client
+	// attaching mid-turn ends up with the same meta a client that was
+	// there from the start would see.
+	m := meta{Type: "meta", SessionID: id}
+	fold := func(ev stream.StreamEvent) {
+		if ev.Type == stream.EventUsage {
+			m.Usage = ev.Usage
+		}
+		if ev.Meta != nil {
+			m.Provider, m.Model, m.LedgerID = ev.Meta.Provider, ev.Meta.Model, ev.Meta.LedgerID
+			m.DurationMs = ev.Meta.DurationMs
+		}
+	}
+
+	for _, ev := range replay {
+		fold(ev)
+		send(ev)
+	}
+	ctx := r.Context()
+	for {
+		select {
+		case ev, chOk := <-live:
+			if !chOk {
+				// Either the turn reached its terminal (persistTurn ran,
+				// turnDone closed every subscriber) or this subscriber got
+				// dropped for being too slow (turnBroadcaster.publish) — in
+				// both cases nothing more is coming on this connection.
+				// Sending the terminal meta unconditionally is safe: a
+				// dropped-for-slowness client falls back to a transcript
+				// refetch per the web's contract regardless of what this
+				// meta says.
+				send(m)
+				return
+			}
+			fold(ev)
+			send(ev)
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/internal/brain/api/live_test.go
+++ b/internal/brain/api/live_test.go
@@ -1,0 +1,285 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/session"
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// TestTranscriptTurnActiveReflectsInFlightTurn confirms GET
+// /v1/sessions/{id} carries turn_active straight off chat.Service's
+// broadcaster registry: false before any turn, true mid-turn, false
+// again once the turn's terminal persist is durable.
+func TestTranscriptTurnActiveReflectsInFlightTurn(t *testing.T) {
+	t.Parallel()
+	block := make(chan struct{})
+	a, dir, gw := testAPI(t, "tok", okEvents())
+	gw.blockCh = block
+	id, _ := dir.Create(t.Context(), "t")
+
+	if active := transcriptTurnActive(t, a, id); active {
+		t.Fatal("turn_active = true before any turn started")
+	}
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		done <- doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages", `{"message":"hello"}`)
+	}()
+
+	waitForTest(t, func() bool { return a.svc.TurnActive(id) })
+	if active := transcriptTurnActive(t, a, id); !active {
+		t.Fatal("turn_active = false while a turn is in flight")
+	}
+
+	close(block)
+	select {
+	case w := <-done:
+		if w.Code != http.StatusOK {
+			t.Fatalf("messages code = %d body=%s", w.Code, w.Body.String())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("POST /messages never returned")
+	}
+
+	waitForTest(t, func() bool { return !a.svc.TurnActive(id) })
+	if active := transcriptTurnActive(t, a, id); active {
+		t.Fatal("turn_active = true after the turn's terminal persist")
+	}
+	// The transcript itself must already show the completed turn by the
+	// time turn_active reads false — no window where the flag is down
+	// but a refetch would still see the stale state.
+	w := doMux(a, http.MethodGet, "/v1/sessions/"+id, "")
+	var resp struct {
+		Items []session.TranscriptItem `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found := false
+	for _, item := range resp.Items {
+		if item.Kind == "assistant" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("transcript missing the completed assistant turn once turn_active went false")
+	}
+}
+
+func transcriptTurnActive(t *testing.T, a *API, id string) bool {
+	t.Helper()
+	w := doMux(a, http.MethodGet, "/v1/sessions/"+id, "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("transcript: %d %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		TurnActive bool `json:"turn_active"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return resp.TurnActive
+}
+
+func waitForTest(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition not met in time")
+}
+
+// TestLiveEndpointNoActiveTurn confirms GET .../live answers 404
+// no_active_turn when nothing is running — the status a client falls
+// back to a normal transcript fetch on.
+func TestLiveEndpointNoActiveTurn(t *testing.T) {
+	t.Parallel()
+	a, dir, _ := testAPI(t, "tok", nil)
+	id, _ := dir.Create(t.Context(), "t")
+
+	w := doMux(a, http.MethodGet, "/v1/sessions/"+id+"/live", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("code = %d, want 404", w.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["error"] != "no_active_turn" {
+		t.Fatalf("error = %q, want no_active_turn", body["error"])
+	}
+}
+
+func TestLiveEndpointUnknownSession(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	w := doMux(a, http.MethodGet, "/v1/sessions/not-a-valid-id/live", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("code = %d, want 404", w.Code)
+	}
+}
+
+func TestLiveEndpointRequiresAuth(t *testing.T) {
+	t.Parallel()
+	a, dir, _ := testAPI(t, "tok", nil)
+	id, _ := dir.Create(t.Context(), "t")
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/"+id+"/live", nil)
+	w := httptest.NewRecorder()
+	mux(a).ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("code = %d, want 401 without a bearer token", w.Code)
+	}
+}
+
+// TestLiveEndpointReplaysThenFollowsLiveThenCloses is the end-to-end
+// Tier-2 contract: attaching mid-turn gets the buffered prefix, then
+// the rest of the turn as it happens, wire-identical to POST
+// .../messages (same "data: {...}\n\n" frames, terminal meta last).
+func TestLiveEndpointReplaysThenFollowsLiveThenCloses(t *testing.T) {
+	t.Parallel()
+	block := make(chan struct{})
+	a, dir, gw := testAPI(t, "tok", []stream.StreamEvent{
+		{Type: stream.EventChunk, Text: "hi "},
+		{Type: stream.EventChunk, Text: "there"},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod", LedgerID: "led-1"}},
+	})
+	gw.blockCh = block
+	id, _ := dir.Create(t.Context(), "t")
+
+	sendDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		sendDone <- doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages", `{"message":"hello"}`)
+	}()
+	waitForTest(t, func() bool { return a.svc.TurnActive(id) })
+
+	liveReq := httptest.NewRequest(http.MethodGet, "/v1/sessions/"+id+"/live", nil)
+	liveReq.Header.Set("Authorization", "Bearer tok")
+	liveRec := newSyncRecorder()
+	liveDone := make(chan struct{})
+	go func() {
+		mux(a).ServeHTTP(liveRec, liveReq)
+		close(liveDone)
+	}()
+
+	// Wait for the replayed prefix (the "hi " chunk the fake gateway
+	// sends before blocking) to show up on the live connection.
+	deadline := time.Now().Add(2 * time.Second)
+	for !strings.Contains(liveRec.body(), `"hi "`) {
+		if time.Now().After(deadline) {
+			t.Fatalf("live stream never showed the replayed prefix; body=%s", liveRec.body())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	close(block) // let the turn finish
+
+	select {
+	case w := <-sendDone:
+		if w.Code != http.StatusOK {
+			t.Fatalf("messages code = %d body=%s", w.Code, w.Body.String())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("POST /messages never returned")
+	}
+
+	select {
+	case <-liveDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("GET /live never closed after the turn's terminal")
+	}
+
+	body := liveRec.body()
+	if !strings.Contains(body, `"there"`) {
+		t.Fatalf("live stream missing the post-attach chunk; body=%s", body)
+	}
+	if strings.Count(body, `"hi "`) != 1 {
+		t.Fatalf("replayed chunk appeared %d times, want exactly once; body=%s", strings.Count(body, `"hi "`), body)
+	}
+	lines := strings.Split(strings.TrimSpace(body), "\n\n")
+	last := strings.TrimPrefix(lines[len(lines)-1], "data: ")
+	var m meta
+	if err := json.Unmarshal([]byte(last), &m); err != nil {
+		t.Fatalf("terminal frame not meta: %v (%s)", err, last)
+	}
+	if m.Type != "meta" || m.SessionID != id || m.Provider != "prov" {
+		t.Fatalf("meta = %+v", m)
+	}
+	if liveRec.Header().Get("Content-Type") != "text/event-stream" {
+		t.Fatalf("Content-Type = %q, want text/event-stream", liveRec.Header().Get("Content-Type"))
+	}
+}
+
+// TestLiveEndpointTwoSubscribersBothWork confirms N simultaneous
+// attaches to the same in-flight turn each get their own full replay
+// and live tail — two tabs opening the same session mid-turn.
+func TestLiveEndpointTwoSubscribersBothWork(t *testing.T) {
+	t.Parallel()
+	block := make(chan struct{})
+	a, dir, gw := testAPI(t, "tok", []stream.StreamEvent{
+		{Type: stream.EventChunk, Text: "hi "},
+		{Type: stream.EventChunk, Text: "there"},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
+	})
+	gw.blockCh = block
+	id, _ := dir.Create(t.Context(), "t")
+
+	sendDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		sendDone <- doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages", `{"message":"hello"}`)
+	}()
+	waitForTest(t, func() bool { return a.svc.TurnActive(id) })
+
+	recs := make([]*syncRecorder, 2)
+	dones := make([]chan struct{}, 2)
+	for i := range recs {
+		recs[i] = newSyncRecorder()
+		dones[i] = make(chan struct{})
+		req := httptest.NewRequest(http.MethodGet, "/v1/sessions/"+id+"/live", nil)
+		req.Header.Set("Authorization", "Bearer tok")
+		rec, d := recs[i], dones[i]
+		go func() {
+			mux(a).ServeHTTP(rec, req)
+			close(d)
+		}()
+	}
+
+	for _, rec := range recs {
+		deadline := time.Now().Add(2 * time.Second)
+		for !strings.Contains(rec.body(), `"hi "`) {
+			if time.Now().After(deadline) {
+				t.Fatalf("a subscriber never saw the replayed prefix; body=%s", rec.body())
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	close(block)
+	select {
+	case <-sendDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("POST /messages never returned")
+	}
+	for i, d := range dones {
+		select {
+		case <-d:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("subscriber %d never closed", i)
+		}
+	}
+	for i, rec := range recs {
+		if !strings.Contains(rec.body(), `"there"`) {
+			t.Fatalf("subscriber %d missing post-attach chunk; body=%s", i, rec.body())
+		}
+	}
+}

--- a/internal/brain/chat/broadcast.go
+++ b/internal/brain/chat/broadcast.go
@@ -1,0 +1,138 @@
+package chat
+
+import (
+	"sync"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// broadcastBuf caps a subscriber's backlog of live turn events. A
+// slow subscriber that fills this buffer is dropped rather than
+// stalling the turn (same drop-on-full philosophy as missions.Hub) —
+// losing the live tail is benign since a dropped subscriber's client
+// falls back to a transcript refetch once the turn ends.
+const broadcastBuf = 64
+
+// turnBroadcaster is one turn's live event fan-out: every StreamEvent
+// the relay forwards lands in buf (for late subscribers' replay) and
+// is pushed to every live subscriber's channel. Presence of a
+// broadcaster entry in Service.turns IS "this session has a turn in
+// flight" (D-Option-B, see chat.go's turn lifecycle comment) — there
+// is no separate busy-state registry.
+type turnBroadcaster struct {
+	mu   sync.Mutex
+	buf  []stream.StreamEvent
+	subs map[chan stream.StreamEvent]struct{}
+}
+
+func newTurnBroadcaster() *turnBroadcaster {
+	return &turnBroadcaster{subs: map[chan stream.StreamEvent]struct{}{}}
+}
+
+// publish appends ev to the replay buffer and fans it out to every
+// live subscriber. Non-blocking per subscriber: a full channel has ev
+// dropped for that subscriber only, and the subscriber is then closed
+// and unregistered — it will never see a gap-free stream again, so it
+// is cut loose rather than left silently behind. The publisher (the
+// turn's relay goroutine) never blocks on a slow watcher.
+func (b *turnBroadcaster) publish(ev stream.StreamEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf = append(b.buf, ev)
+	for ch := range b.subs {
+		select {
+		case ch <- ev:
+		default:
+			delete(b.subs, ch)
+			close(ch)
+		}
+	}
+}
+
+// subscribe registers a new live subscriber and returns a snapshot of
+// everything buffered so far plus the channel that carries every
+// event published from this point on — the snapshot and the
+// subscription share one lock acquisition, so no event can land in
+// the gap between "read the buffer" and "start receiving live" (no
+// duplication, no drop).
+func (b *turnBroadcaster) subscribe() ([]stream.StreamEvent, <-chan stream.StreamEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	replay := append([]stream.StreamEvent(nil), b.buf...)
+	ch := make(chan stream.StreamEvent, broadcastBuf)
+	b.subs[ch] = struct{}{}
+	return replay, ch
+}
+
+// closeAll closes and unregisters every live subscriber — called once
+// the turn reaches its terminal persist, after which no further event
+// will ever publish. Subsequent subscribe calls never happen because
+// the broadcaster entry is removed from Service.turns in the same
+// breath (see chat.go's runTurn/relay).
+func (b *turnBroadcaster) closeAll() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for ch := range b.subs {
+		close(ch)
+	}
+	b.subs = map[chan stream.StreamEvent]struct{}{}
+}
+
+// turnBroadcast registers a fresh broadcaster for sessionID, replacing
+// any previous entry — a session can only have one turn in flight at a
+// time in practice, but a stale entry (e.g. a prior turn whose
+// terminal free lost a race) must never wedge turn_active permanently
+// stuck true, so a new turn always wins the slot outright.
+func (s *Service) turnBroadcast(sessionID string) *turnBroadcaster {
+	b := newTurnBroadcaster()
+	s.turnsMu.Lock()
+	if s.turns == nil {
+		s.turns = map[string]*turnBroadcaster{}
+	}
+	s.turns[sessionID] = b
+	s.turnsMu.Unlock()
+	return b
+}
+
+// turnDone frees sessionID's broadcaster entry and closes every live
+// subscriber. Called after the turn's terminal persist is durable (see
+// persistTurn) so turn_active flips false only once a refetch is
+// guaranteed to see the completed turn — no window where the flag is
+// down but the transcript is still stale.
+func (s *Service) turnDone(sessionID string) {
+	s.turnsMu.Lock()
+	b := s.turns[sessionID]
+	delete(s.turns, sessionID)
+	s.turnsMu.Unlock()
+	if b != nil {
+		b.closeAll()
+	}
+}
+
+// TurnActive reports whether sessionID currently has a turn in flight
+// — the single source of truth GET /v1/sessions/{id} reads for
+// turn_active, and the one Subscribe below reads to decide whether
+// there is anything to replay.
+func (s *Service) TurnActive(sessionID string) bool {
+	s.turnsMu.Lock()
+	defer s.turnsMu.Unlock()
+	_, ok := s.turns[sessionID]
+	return ok
+}
+
+// Subscribe attaches to sessionID's in-flight turn, if any: ok is
+// false when no turn is currently running, in which case replay and
+// live are both nil. Otherwise replay is every event buffered so far
+// (send these to the client first, in order) and live is the channel
+// to range over afterward until it closes (the turn's terminal, or
+// this subscriber got dropped for being too slow — see publish).
+func (s *Service) Subscribe(sessionID string) (replay []stream.StreamEvent, live <-chan stream.StreamEvent, ok bool) {
+	s.turnsMu.Lock()
+	b := s.turns[sessionID]
+	s.turnsMu.Unlock()
+	if b == nil {
+		return nil, nil, false
+	}
+	replay, ch := b.subscribe()
+	return replay, ch, true
+}

--- a/internal/brain/chat/broadcast_test.go
+++ b/internal/brain/chat/broadcast_test.go
@@ -1,0 +1,144 @@
+package chat
+
+import (
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+func TestTurnBroadcasterReplayThenLiveExactlyOnce(t *testing.T) {
+	t.Parallel()
+	b := newTurnBroadcaster()
+
+	// Two events land before anyone subscribes.
+	b.publish(stream.StreamEvent{Type: stream.EventChunk, Text: "a"})
+	b.publish(stream.StreamEvent{Type: stream.EventChunk, Text: "b"})
+
+	replay, live := b.subscribe()
+	if len(replay) != 2 || replay[0].Text != "a" || replay[1].Text != "b" {
+		t.Fatalf("replay = %+v, want [a b]", replay)
+	}
+
+	// A third event, published AFTER subscribe, must arrive on live —
+	// not duplicated into a second replay copy.
+	b.publish(stream.StreamEvent{Type: stream.EventChunk, Text: "c"})
+
+	select {
+	case ev := <-live:
+		if ev.Text != "c" {
+			t.Fatalf("live event = %q, want %q", ev.Text, "c")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("subscriber never received the live event")
+	}
+
+	// Nothing else should be queued — "a"/"b" arrived exactly once, via
+	// replay, never re-delivered on the live channel.
+	select {
+	case ev, ok := <-live:
+		t.Fatalf("unexpected extra event on live channel: %+v (ok=%v)", ev, ok)
+	default:
+	}
+}
+
+func TestTurnBroadcasterSlowSubscriberDroppedNotStalled(t *testing.T) {
+	t.Parallel()
+	b := newTurnBroadcaster()
+	_, live := b.subscribe() // never drained — a permanently slow subscriber
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < broadcastBuf+10; i++ {
+			b.publish(stream.StreamEvent{Type: stream.EventChunk, Text: "x"})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("publish blocked on a full subscriber instead of dropping it")
+	}
+
+	// The subscriber must have been dropped (channel closed) once its
+	// buffer filled — publish never blocks the turn, but a subscriber
+	// that can't keep up gets cut loose rather than silently lagging
+	// forever.
+	deadline := time.Now().Add(time.Second)
+	for {
+		select {
+		case _, ok := <-live:
+			if !ok {
+				return // closed, as expected
+			}
+		case <-time.After(10 * time.Millisecond):
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("dropped subscriber's channel was never closed")
+		}
+	}
+}
+
+func TestTurnBroadcasterCloseAllClosesSubscribers(t *testing.T) {
+	t.Parallel()
+	b := newTurnBroadcaster()
+	_, live1 := b.subscribe()
+	_, live2 := b.subscribe()
+
+	b.closeAll()
+
+	for i, ch := range []<-chan stream.StreamEvent{live1, live2} {
+		select {
+		case _, ok := <-ch:
+			if ok {
+				t.Fatalf("subscriber %d: channel delivered a value instead of closing", i)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("subscriber %d: channel never closed", i)
+		}
+	}
+}
+
+func TestServiceTurnLifecycleActiveThenFreed(t *testing.T) {
+	t.Parallel()
+	s := &Service{}
+
+	if s.TurnActive("s1") {
+		t.Fatal("TurnActive true before any turn registered")
+	}
+
+	bc := s.turnBroadcast("s1")
+	if !s.TurnActive("s1") {
+		t.Fatal("TurnActive false immediately after turnBroadcast — presence must mean in-flight even with zero subscribers")
+	}
+	if _, _, ok := s.Subscribe("s1"); !ok {
+		t.Fatal("Subscribe ok=false while a turn is registered")
+	}
+	_ = bc
+
+	s.turnDone("s1")
+	if s.TurnActive("s1") {
+		t.Fatal("TurnActive true after turnDone freed the entry")
+	}
+	if _, _, ok := s.Subscribe("s1"); ok {
+		t.Fatal("Subscribe ok=true after the turn was freed")
+	}
+}
+
+// TestServiceTurnBroadcastReplacesStaleEntry confirms a fresh
+// turnBroadcast call always wins the slot: a new turn must never find
+// itself unable to register because turn_active is stuck true from an
+// entry whose free lost a race.
+func TestServiceTurnBroadcastReplacesStaleEntry(t *testing.T) {
+	t.Parallel()
+	s := &Service{}
+	first := s.turnBroadcast("s1")
+	second := s.turnBroadcast("s1")
+	if first == second {
+		t.Fatal("second turnBroadcast returned the same broadcaster instance")
+	}
+	if !s.TurnActive("s1") {
+		t.Fatal("TurnActive false after re-registering")
+	}
+}

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -143,6 +143,32 @@ type Service struct {
 	// an unexpired matching row exists.
 	seededMu sync.Mutex
 	seeded   map[string]bool
+
+	// turns is the live-turn broadcaster registry (broadcast.go): a
+	// session ID present here means that session has a turn in flight,
+	// full stop. There is no separate turn_active bool anywhere — the
+	// GET /v1/sessions/{id} handler and the live-reattach endpoint both
+	// read this same map through TurnActive/Subscribe, so the flag and
+	// the broadcaster can never disagree about whether a turn is
+	// running (no prior busy-state registry existed to reuse; this is
+	// the only one).
+	turnsMu sync.Mutex
+	turns   map[string]*turnBroadcaster
+
+	publishSession func(sessionID string) // nil: no session-signal push (today's default)
+}
+
+// SetSessionHub wires the "session" signal push: fires once a turn's
+// terminal is durable (see persistTurn), same after-commit ordering
+// missions.Store/Notifier already use for their own hub.Publish calls.
+// A plain func rather than an interface on *missions.Hub: chat sits
+// lower than missions in the import graph (missions already reaches
+// into session-shaped types; the reverse would cycle), so main wires
+// this the same way it wires every other optional side-effect hook
+// (SetMemoryExtract, SetApprovalGrants, ...). Nil (today's default,
+// and every test) makes this a no-op.
+func (s *Service) SetSessionHub(publish func(sessionID string)) {
+	s.publishSession = publish
 }
 
 // SetMemoryExtract wires the memoryd hook. Optional — nil leaves
@@ -547,8 +573,16 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 		return sessionID, nil, err
 	}
 
+	// Register the broadcaster BEFORE relay can forward a single event:
+	// turn_active and a late /live subscriber's replay both read this
+	// entry, so it must exist the instant the turn starts, not once the
+	// first event happens to land. Registered even with zero
+	// subscribers — presence means "turn in flight", not "someone is
+	// watching" (see broadcast.go).
+	bc := s.turnBroadcast(sessionID)
+
 	out := make(chan stream.StreamEvent)
-	go s.relay(ctx, sessionID, userText, route, profile, needsTitle, sessionSensitive, start, upstream, out)
+	go s.relay(ctx, sessionID, userText, route, profile, needsTitle, sessionSensitive, start, bc, upstream, out)
 	return sessionID, out, nil
 }
 
@@ -561,8 +595,13 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 // turnSensitive flip so side-calls stay pinned on every later turn too.
 // start is runTurn's wall-clock beginning, stamped onto the terminal
 // done event's Meta (and passed to persistTurn) so live and replayed
-// stats show the same duration.
-func (s *Service) relay(ctx context.Context, sessionID, userText, route string, profile agents.Agent, needsTitle, sessionSensitive bool, start time.Time, upstream <-chan stream.StreamEvent, out chan<- stream.StreamEvent) {
+// stats show the same duration. bc is this turn's broadcaster
+// (registered by runTurn before this goroutine started): every event
+// this relay sees — including ones the ORIGINAL client never gets
+// because it already disconnected (drainAndPersist) — still reaches
+// bc, since a GET /live subscriber may be attached independently of
+// the POST that started the turn.
+func (s *Service) relay(ctx context.Context, sessionID, userText, route string, profile agents.Agent, needsTitle, sessionSensitive bool, start time.Time, bc *turnBroadcaster, upstream <-chan stream.StreamEvent, out chan<- stream.StreamEvent) {
 	var text, reasoning strings.Builder
 	var meta *stream.Meta
 	var usage *stream.Usage
@@ -648,9 +687,20 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 			}
 			noteToolResult(ev)
 			notePermission(ev)
+			bc.publish(ev)
 		}
 		close(out)
 		s.persistTurn(sessionID, userText, route, profile, needsTitle, text.String(), reasoning.String(), meta, usage, sawDone, flushed, turnSensitive || sessionSensitive)
+		// Terminal persist is now durable: free the broadcaster (closes
+		// every live /live subscriber) and push the session signal, in
+		// that order — mirrors missions.Store's own "publish only after
+		// commit" discipline, so a client that sees turn_active flip
+		// false (via the freed entry) or gets a session signal is
+		// guaranteed the transcript already reflects the finished turn.
+		s.turnDone(sessionID)
+		if s.publishSession != nil {
+			s.publishSession(sessionID)
+		}
 	}
 
 	ticker := time.NewTicker(s.flushEvery)
@@ -677,6 +727,7 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 			}
 			noteToolResult(ev)
 			notePermission(ev)
+			bc.publish(ev)
 			select {
 			case out <- ev:
 			case <-ctx.Done():

--- a/internal/brain/chat/turn_active_test.go
+++ b/internal/brain/chat/turn_active_test.go
@@ -1,0 +1,228 @@
+package chat
+
+import (
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// TestChatTurnActiveDuringThenFalseAfter confirms TurnActive tracks a
+// real Chat() turn's lifecycle end to end: true the instant the turn
+// is registered (before the blocked gateway yields anything), false
+// only once the turn's terminal persist has actually run.
+func TestChatTurnActiveDuringThenFalseAfter(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	block := make(chan struct{})
+	gw := &fakeGW{events: okEvents("the answer"), blockCh: block}
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "the question"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	waitFor(t, func() bool { return s.TurnActive("s1") })
+
+	close(block) // let the stream complete
+	drain(t, ch)
+
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
+	// The transcript must already be durable by the time the flag
+	// drops — no window where turn_active is false but a refetch would
+	// still see the old (interrupted) state.
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+}
+
+// TestChatRetryRegistersBroadcasterSameAsChat confirms Retry follows
+// the identical lifecycle as Chat — both funnel through runTurn, but
+// this pins that behavior explicitly since Retry is a separate public
+// entry point.
+func TestChatRetryRegistersBroadcasterSameAsChat(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("first")}
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "the question"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
+
+	block := make(chan struct{})
+	gw.mu.Lock()
+	gw.events = okEvents("second")
+	gw.blockCh = block
+	gw.mu.Unlock()
+
+	// Retry needs a dangling user_message with no completed turn after
+	// it; force that shape directly rather than depending on internal
+	// persistTurn timing.
+	if _, err := log.Append(t.Context(), "s1", "user_message", map[string]string{"text": "retry me"}); err != nil {
+		t.Fatalf("append user message: %v", err)
+	}
+
+	_, retryCh, err := s.Retry(t.Context(), "s1")
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	waitFor(t, func() bool { return s.TurnActive("s1") })
+	if _, _, ok := s.Subscribe("s1"); !ok {
+		t.Fatal("Subscribe ok=false during a Retry-started turn")
+	}
+
+	close(block)
+	drain(t, retryCh)
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
+}
+
+// TestChatSubscribeMidTurnGetsBufferedPrefixThenLiveTail is the core
+// Tier-2 contract: a subscriber attaching after some events already
+// happened sees exactly the buffered prefix once, then the rest of the
+// turn live, then the channel closes at the terminal — no gap, no
+// duplication.
+func TestChatSubscribeMidTurnGetsBufferedPrefixThenLiveTail(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: []stream.StreamEvent{
+		{Type: stream.EventChunk, Text: "one"},
+		{Type: stream.EventChunk, Text: "two"},
+		{Type: stream.EventChunk, Text: "three"},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
+	}}
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "go"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	// Drain the first event off the client-facing channel so the relay
+	// has definitely published at least one event to the broadcaster
+	// before this subscribes — a real "mid-turn" attach.
+	first := <-ch
+	if first.Text != "one" {
+		t.Fatalf("first event = %+v, want text=one", first)
+	}
+
+	replay, live, ok := s.Subscribe("s1")
+	if !ok {
+		t.Fatal("Subscribe ok=false while turn in flight")
+	}
+	if len(replay) == 0 || replay[0].Text != "one" {
+		t.Fatalf("replay = %+v, want to start with the already-published %q event", replay, "one")
+	}
+	// The relay races ahead of this test goroutine, so replay may have
+	// captured more than just "one" by the time Subscribe's lock was
+	// taken — that's fine (no gap), as long as whatever it captured
+	// never repeats on live afterward. Record exactly the replay
+	// contents so the live-side assertion below can check against it,
+	// rather than assuming a fixed split point.
+	inReplay := map[string]bool{}
+	for _, ev := range replay {
+		inReplay[ev.Text] = true
+	}
+
+	// Drain the rest of the client-facing stream so the turn completes.
+	for range ch {
+	}
+
+	// The broadcaster's live channel must deliver every remaining event
+	// exactly once (never one already in replay) and then close.
+	var texts []string
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case ev, chOk := <-live:
+			if !chOk {
+				goto done
+			}
+			if ev.Text != "" {
+				texts = append(texts, ev.Text)
+			}
+		case <-deadline:
+			t.Fatal("live channel never closed")
+		}
+	}
+done:
+	seen := map[string]int{}
+	for _, tx := range texts {
+		seen[tx]++
+	}
+	for text, n := range seen {
+		if inReplay[text] {
+			t.Fatalf("live delivered %q again after it was already in replay", text)
+		}
+		if n != 1 {
+			t.Fatalf("live delivered %q %d times, want exactly once", text, n)
+		}
+	}
+	// Every event not captured in replay must show up exactly once live
+	// — nothing silently dropped between replay and live.
+	all := []string{"one", "two", "three"}
+	for _, text := range all {
+		if inReplay[text] {
+			continue
+		}
+		if seen[text] != 1 {
+			t.Fatalf("event %q missing from live (seen=%+v, inReplay=%+v)", text, seen, inReplay)
+		}
+	}
+}
+
+// TestChatSessionHubPublishesOnlyAfterTerminalPersist confirms the
+// session signal fires after the turn's terminal event is durable in
+// the log — mirroring missions' own publish-after-commit discipline —
+// not merely after the stream's channel closes to the caller.
+func TestChatSessionHubPublishesOnlyAfterTerminalPersist(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("the answer")}
+	s := newService(gw, log)
+
+	published := make(chan string, 1)
+	s.SetSessionHub(func(sessionID string) { published <- sessionID })
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "the question"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	select {
+	case id := <-published:
+		if id != "s1" {
+			t.Fatalf("published session id = %q, want s1", id)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("session hub was never published to")
+	}
+	// By the time the publish fires, the assistant turn must already be
+	// durable — otherwise a client reacting to the signal could refetch
+	// and still see the stale (interrupted) state.
+	kinds := log.kinds("s1")
+	if len(kinds) == 0 || kinds[len(kinds)-1] != "assistant_turn" {
+		t.Fatalf("kinds = %v, want the last one to be assistant_turn by the time the signal published", kinds)
+	}
+}
+
+// TestChatSessionHubNilIsNoop confirms an unwired hub (nil
+// publishSession, today's default and every other test's setup) never
+// panics — the same nil-safe convention every other optional Service
+// hook in this package already follows.
+func TestChatSessionHubNilIsNoop(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("the answer")}
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "the question"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -131,6 +131,49 @@ export async function retryStream(
   return postSSE(`/v1/sessions/${sessionId}/messages/retry`, undefined, onEvent, opts)
 }
 
+// streamLive reattaches to a session's in-flight turn (Tier 2 of live
+// reattach): GET .../live replays whatever the turn already emitted
+// then follows it live until the terminal, wire-identical to
+// chatStream/retryStream's SSE frames — same createSSEParser, same
+// ChatEvent shape, same terminal meta contract — so a caller feeds
+// events through the exact same applyEvent reducer regardless of
+// which of the three started the stream. Throws ChatError(404,
+// 'no_active_turn') when nothing is running; the caller's fallback is
+// a plain transcript refetch, not a retry loop.
+export async function streamLive(
+  sessionId: string,
+  onEvent: (ev: ChatEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const res = await fetch(`/v1/sessions/${sessionId}/live`, {
+    headers: { Authorization: `Bearer ${getToken()}` },
+    signal,
+  })
+  if (!res.ok || !res.body) {
+    const text = await res.text().catch(() => '')
+    let code: string | undefined
+    let message = text
+    try {
+      const parsed = JSON.parse(text) as { error?: string; message?: string }
+      code = parsed.error
+      message = parsed.message ?? text
+    } catch {
+      // Non-JSON error body: keep the raw text.
+    }
+    throw new ChatError(res.status, message || `live stream failed (${res.status})`, code)
+  }
+
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  const parser = createSSEParser(onEvent)
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    parser.feed(decoder.decode(value, { stream: true }))
+  }
+  parser.end()
+}
+
 // postSSE is chatStream and retryStream's shared body: POST, surface a
 // structured ChatError on failure, then relay the SSE stream until the
 // terminal meta event.

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -130,6 +130,11 @@ export interface TranscriptItem {
 export interface Transcript {
   session: SessionMeta
   items: TranscriptItem[]
+  // Whether a turn is currently streaming for this session server-side
+  // — sourced from chat.Service's own turn registry, not a client
+  // guess. Lets a tab that opens a session mid-turn know to attach
+  // streamLive instead of rendering the last event as stale/interrupted.
+  turn_active: boolean
 }
 
 // One long-term memory row as served by the management API.

--- a/web/src/pages/Chat.test.tsx
+++ b/web/src/pages/Chat.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Routes } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ChatStreamOptions } from '../api/client'
 import type { ChatEvent, ChatRequest } from '../api/types'
+import type { Signal } from '../lib/events'
 import { Chat } from './Chat'
 
 vi.mock('../api/client', () => ({
@@ -15,16 +16,38 @@ vi.mock('../api/client', () => ({
   },
   chatStream: vi.fn(),
   retryStream: vi.fn(),
+  streamLive: vi.fn(),
   getTranscript: vi.fn(),
   answerPermission: vi.fn(),
   listRoutes: vi.fn(),
   listAgents: vi.fn(),
 }))
 
+vi.mock('../lib/events', () => ({ subscribeEvents: vi.fn() }))
+
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
 
-import { answerPermission, ChatError, chatStream, getTranscript, listAgents, listRoutes } from '../api/client'
+import {
+  answerPermission,
+  ChatError,
+  chatStream,
+  getTranscript,
+  listAgents,
+  listRoutes,
+  streamLive,
+} from '../api/client'
+import { subscribeEvents } from '../lib/events'
 import { toast } from 'sonner'
+
+// captureSubscribe grabs the onSignal callback subscribeEvents was
+// last called with, so a test can fire a "session" signal directly
+// instead of driving a real SSE stream — same helper shape as
+// Missions.test.tsx's own captureSubscribe.
+function captureSubscribe() {
+  return {
+    fireSignal: (sig: Signal) => vi.mocked(subscribeEvents).mock.calls.at(-1)?.[0](sig),
+  }
+}
 
 function renderChat() {
   return render(
@@ -57,9 +80,11 @@ beforeEach(() => {
   Element.prototype.scrollIntoView = vi.fn()
   vi.mocked(listAgents).mockResolvedValue([])
   vi.mocked(listRoutes).mockResolvedValue(routes)
+  vi.mocked(subscribeEvents).mockReturnValue(vi.fn())
   vi.mocked(getTranscript).mockResolvedValue({
     session: { id: 's1', title: '', archived: false, created_at: '', updated_at: '' },
     items: [],
+    turn_active: false,
   })
   vi.mocked(chatStream).mockImplementation(
     async (_req: ChatRequest, onEvent: (ev: ChatEvent) => void, opts: ChatStreamOptions = {}) => {
@@ -120,6 +145,7 @@ describe('replayed permission asks', () => {
           created_at: '',
         },
       ],
+      turn_active: false,
     })
 
     render(
@@ -137,6 +163,7 @@ describe('replayed permission asks', () => {
     vi.mocked(getTranscript).mockResolvedValue({
       session: { id: 's1', title: '', archived: false, created_at: '', updated_at: '' },
       items: [{ seq: 1, kind: 'user', text: 'do the thing', created_at: '' }],
+      turn_active: false,
     })
 
     render(
@@ -169,6 +196,7 @@ describe('replayed permission asks', () => {
           created_at: '',
         },
       ],
+      turn_active: false,
     })
     vi.mocked(answerPermission).mockRejectedValue(new ChatError(404, 'unknown or already-answered'))
 
@@ -185,5 +213,112 @@ describe('replayed permission asks', () => {
 
     await waitFor(() => expect(toast.error).toHaveBeenCalled())
     expect(screen.queryByTestId('permission-modal')).not.toBeInTheDocument()
+  })
+})
+
+describe('live reattach', () => {
+  it('attaches streamLive when the session is turn_active, replacing the stale interrupted item', async () => {
+    vi.mocked(getTranscript).mockResolvedValue({
+      session: { id: 's1', title: '', archived: false, created_at: '', updated_at: '' },
+      items: [
+        { seq: 1, kind: 'user', text: 'do the thing', created_at: '' },
+        { seq: 2, kind: 'interrupted', text: 'partial answer so ', created_at: '' },
+      ],
+      turn_active: true,
+    })
+    // A real streamLive's promise stays pending until the stream
+    // actually ends (terminal meta) — resolve it ourselves once the
+    // test feeds that terminal event, matching that lifecycle instead
+    // of settling immediately like a bare mock would.
+    let feed!: (ev: ChatEvent) => void
+    let resolveStream!: () => void
+    const streamDone = new Promise<void>((r) => {
+      resolveStream = r
+    })
+    vi.mocked(streamLive).mockImplementation(async (_id, onEvent) => {
+      feed = onEvent
+      await streamDone
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/chat/s1']}>
+        <Routes>
+          <Route path="/chat/:id" element={<Chat onNeedToken={vi.fn()} />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(streamLive).toHaveBeenCalledWith('s1', expect.any(Function), expect.anything()))
+    // The stale 'interrupted' item is gone; the replay buffer (fed
+    // below) is what repopulates the text, not the persisted partial.
+    expect(screen.queryByTestId('interrupted')).not.toBeInTheDocument()
+
+    feed({ type: 'chunk', text: 'far so good' })
+    await screen.findByText('far so good')
+
+    feed({ type: 'meta', session_id: 's1' })
+    resolveStream()
+    // Terminal meta clears streaming — same reducer/finalization path a
+    // locally-started turn goes through.
+    await waitFor(() => expect(screen.queryByText('▍')).not.toBeInTheDocument())
+  })
+
+  it('does not attach live when turn_active is false', async () => {
+    renderChat()
+    await screen.findByRole('button', { name: 'Agent and route' })
+    expect(streamLive).not.toHaveBeenCalled()
+  })
+
+  it('refetches the transcript on a session signal for the open session while unattached', async () => {
+    vi.mocked(getTranscript).mockResolvedValue({
+      session: { id: 's1', title: '', archived: false, created_at: '', updated_at: '' },
+      items: [{ seq: 1, kind: 'user', text: 'first load', created_at: '' }],
+      turn_active: false,
+    })
+    const { fireSignal } = captureSubscribe()
+
+    render(
+      <MemoryRouter initialEntries={['/chat/s1']}>
+        <Routes>
+          <Route path="/chat/:id" element={<Chat onNeedToken={vi.fn()} />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    await screen.findByText('first load')
+
+    vi.mocked(getTranscript).mockResolvedValue({
+      session: { id: 's1', title: '', archived: false, created_at: '', updated_at: '' },
+      items: [
+        { seq: 1, kind: 'user', text: 'first load', created_at: '' },
+        { seq: 2, kind: 'user', text: 'appeared via signal', created_at: '' },
+      ],
+      turn_active: false,
+    })
+    fireSignal({ kind: 'session', id: 's1' })
+
+    await screen.findByText('appeared via signal')
+  })
+
+  it('ignores a session signal for a different session', async () => {
+    vi.mocked(getTranscript).mockResolvedValue({
+      session: { id: 's1', title: '', archived: false, created_at: '', updated_at: '' },
+      items: [{ seq: 1, kind: 'user', text: 'first load', created_at: '' }],
+      turn_active: false,
+    })
+    const { fireSignal } = captureSubscribe()
+
+    render(
+      <MemoryRouter initialEntries={['/chat/s1']}>
+        <Routes>
+          <Route path="/chat/:id" element={<Chat onNeedToken={vi.fn()} />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    await screen.findByText('first load')
+    vi.mocked(getTranscript).mockClear()
+
+    fireSignal({ kind: 'session', id: 'some-other-session' })
+    await new Promise((r) => setTimeout(r, 10))
+    expect(getTranscript).not.toHaveBeenCalled()
   })
 })

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router'
 import { toast } from 'sonner'
-import { answerPermission, ChatError, chatStream, getTranscript, retryStream } from '../api/client'
+import {
+  answerPermission,
+  ChatError,
+  chatStream,
+  getTranscript,
+  retryStream,
+  streamLive,
+} from '../api/client'
 import type { ChatEvent } from '../api/types'
 import { ActivityPanel } from '../components/Activity'
 import { Composer } from '../components/Composer'
@@ -14,6 +21,7 @@ import {
   emptyAssistant,
   type AssistantState,
 } from '../lib/chat'
+import { subscribeEvents } from '../lib/events'
 import { useSessions } from '../lib/sessions'
 import { fromTranscript, type ChatItem } from '../lib/transcript'
 import type { ChatIntent } from './Home'
@@ -112,11 +120,15 @@ export function Chat({
     adoptedRef.current = null
     let stale = false
     getTranscript(routeSession)
-      .then(({ session, items }) => {
+      .then(({ session, items, turn_active }) => {
         if (stale) return
         setItems(fromTranscript(items))
         if (session.agent) setAgent(session.agent)
         setRoute(session.last_route ?? '')
+        // A turn was already streaming when this tab opened the session
+        // (opened mid-turn, or a reload during one): attach to it live
+        // instead of leaving the transcript's replay looking stale.
+        if (turn_active) attachLive(routeSession)
       })
       .catch((err: unknown) => {
         if (stale) return
@@ -126,7 +138,28 @@ export function Chat({
     return () => {
       stale = true
     }
+    // attachLive is stable across renders in effect (closes over setters
+    // only) but isn't itself memoized — omitted deliberately, same
+    // pattern as the intent-consuming effect below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [routeSession, onNeedToken])
+
+  // Tier 1 fallback: while NOT attached to a live stream for the open
+  // session, a "session" signal means some turn elsewhere finished (or
+  // this tab missed the transition) — refetch the transcript so a tab
+  // that never got to attach live still catches up promptly instead of
+  // waiting on the next navigation. Attached tabs skip this: they're
+  // already getting every event live, and a mid-stream refetch would
+  // race the reducer's own state.
+  useEffect(() => {
+    return subscribeEvents((sig) => {
+      if (sig.kind !== 'session' || sig.id !== sessionRef.current) return
+      if (streaming) return
+      getTranscript(sig.id)
+        .then(({ items }) => setItems(fromTranscript(items)))
+        .catch(() => undefined)
+    })
+  }, [streaming])
 
   useEffect(() => {
     if (pinnedRef.current) bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
@@ -156,6 +189,76 @@ export function Chat({
         next[next.length - 1] = { ...fn(last), id: last.id, role: 'assistant' }
       return next
     })
+
+  // attachLive reattaches to a turn that was already streaming when
+  // this tab opened the session (turn_active from getTranscript): a
+  // trailing 'interrupted' item is the server's replay of a mid-turn
+  // pending_state checkpoint — without this it would sit there forever
+  // looking dead. Replacing it with a live streaming assistant item and
+  // feeding streamLive's events through the SAME applyEvent reducer
+  // sendMessage uses makes a reattached turn indistinguishable from one
+  // this tab started itself: streaming indicator, activity line,
+  // permission modal all just work. The replay buffer already contains
+  // every chunk that built up the interrupted partial, so the new item
+  // starts empty rather than double-seeding with the persisted text.
+  const attachLive = (sessionId: string) => {
+    setStreaming(true)
+    pinnedRef.current = true
+    setItems((prev) => {
+      const next = [...prev]
+      const last = next[next.length - 1]
+      if (last && (last.role === 'interrupted' || last.role === 'assistant'))
+        next[next.length - 1] = { id: last.id, role: 'assistant', ...emptyAssistant() }
+      else next.push({ id: crypto.randomUUID(), role: 'assistant', ...emptyAssistant() })
+      return next
+    })
+
+    const controller = new AbortController()
+    abortRef.current = controller
+    let sawTerminal = false
+    streamLive(
+      sessionId,
+      (ev: ChatEvent) => {
+        if (ev.type === 'meta') sawTerminal = true
+        updateLast((m) => applyEvent(m, ev))
+      },
+      controller.signal,
+    )
+      .then(() => {
+        if (controller.signal.aborted) return
+        // The live stream can end without a terminal meta event if this
+        // subscriber got dropped for lagging (turnBroadcaster's
+        // drop-on-full) rather than the turn actually finishing — a
+        // one-shot refetch recovers either way: either it shows the
+        // now-completed turn, or it shows the turn still running and
+        // the next session signal (Tier 1) prompts another refetch.
+        if (!sawTerminal) {
+          getTranscript(sessionId)
+            .then(({ items }) => setItems(fromTranscript(items)))
+            .catch(() => undefined)
+        }
+        refresh()
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return
+        // A 404 (no_active_turn) means the turn finished in the gap
+        // between getTranscript and this attach — refetch once to pick
+        // up the now-completed transcript rather than leaving the
+        // freshly-blanked item stuck empty. Any other error just falls
+        // back the same way.
+        getTranscript(sessionId)
+          .then(({ items }) => setItems(fromTranscript(items)))
+          .catch(() => undefined)
+        if (err instanceof ChatError && (err.status === 401 || err.status === 503)) onNeedToken()
+      })
+      .finally(() => {
+        abortRef.current = null
+        if (!controller.signal.aborted) {
+          setStreaming(false)
+          updateLast((m) => ({ ...m, streaming: false }))
+        }
+      })
+  }
 
   const sendMessage = async (
     text: string,


### PR DESCRIPTION
## Summary
- Transcript now reports `turn_active`, sourced from a per-session turn broadcaster in `chat.Service` (single source of truth backing both the flag and the live-subscribe path).
- `GET /v1/sessions/{id}/live` replays buffered turn events then follows live, wire-identical to `POST /messages` — client reattaches through the same event reducer.
- Missions SSE hub gets a session-scoped signal after a turn's terminal event is durably persisted; other open tabs on that session refetch instead of showing stale/"interrupted" state.

## Test plan
- [x] `make build test vet lint` — race-clean, 0 lint issues
- [x] web build/lint/test — 304/304 pass
- [ ] Live: open a session mid-turn in the UI, confirm live attach instead of "interrupted"