### PR TITLE
feat(gateway): add per-provider reasoning and timeout options

### DIFF
--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -230,6 +230,10 @@ type Provider struct {
 	// providers (e.g. Ollama) that should never silently serve
 	// production traffic as a fallback.
 	ExcludeFromBootstrap bool `json:"exclude_from_bootstrap"`
+	// Options is an open bag of driver-specific settings; only
+	// reasoning_effort (D-040, openaicompat) and request_timeout (D-041,
+	// a Go duration string like "20m") are recognized today.
+	Options map[string]string `json:"options"`
 }
 
 func validateProvider(p Provider) error {
@@ -248,7 +252,26 @@ func validateProvider(p Provider) error {
 	if !credentialRefPattern.MatchString(p.CredentialRef) {
 		return fmt.Errorf("credential_ref must be a name or path (env var, Vault path, AWS profile), never a secret value")
 	}
+	if _, err := parseRequestTimeout(p.Options); err != nil {
+		return err
+	}
 	return nil
+}
+
+// parseRequestTimeout parses options.request_timeout (D-041) into a
+// duration. An absent or empty value returns zero — the driver's own
+// default applies. An unparseable value is a config error, never a
+// silent fallback.
+func parseRequestTimeout(opts map[string]string) (time.Duration, error) {
+	raw := opts["request_timeout"]
+	if raw == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("options.request_timeout %q: %w", raw, err)
+	}
+	return d, nil
 }
 
 // List returns every provider row, config order by name.
@@ -258,7 +281,7 @@ func (a *Admin) List(ctx context.Context) ([]Provider, error) {
 		return nil, fmt.Errorf("admin providers: %w", err)
 	}
 	rows, err := db.Query(ctx, `SELECT id, name, kind, driver, base_url, default_model,
-		models, credential_ref, headers, enabled, exclude_from_bootstrap FROM providers ORDER BY name`)
+		models, credential_ref, headers, options, enabled, exclude_from_bootstrap FROM providers ORDER BY name`)
 	if err != nil {
 		return nil, fmt.Errorf("admin providers: %w", err)
 	}
@@ -267,11 +290,11 @@ func (a *Admin) List(ctx context.Context) ([]Provider, error) {
 	out := []Provider{}
 	for rows.Next() {
 		var (
-			p            Provider
-			models, hdrs []byte
+			p                  Provider
+			models, hdrs, opts []byte
 		)
 		if err := rows.Scan(&p.ID, &p.Name, &p.Kind, &p.Driver, &p.BaseURL,
-			&p.DefaultModel, &models, &p.CredentialRef, &hdrs, &p.Enabled, &p.ExcludeFromBootstrap); err != nil {
+			&p.DefaultModel, &models, &p.CredentialRef, &hdrs, &opts, &p.Enabled, &p.ExcludeFromBootstrap); err != nil {
 			return nil, fmt.Errorf("admin providers: %w", err)
 		}
 		if err := json.Unmarshal(models, &p.Models); err != nil {
@@ -279,6 +302,9 @@ func (a *Admin) List(ctx context.Context) ([]Provider, error) {
 		}
 		if err := json.Unmarshal(hdrs, &p.Headers); err != nil {
 			return nil, fmt.Errorf("admin providers: headers: %w", err)
+		}
+		if err := json.Unmarshal(opts, &p.Options); err != nil {
+			return nil, fmt.Errorf("admin providers: options: %w", err)
 		}
 		normalizeProvider(&p)
 		out = append(out, p)
@@ -297,12 +323,12 @@ func (a *Admin) Create(ctx context.Context, p Provider) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("admin create: %w", err)
 	}
-	models, hdrs := jsonOr(p.Models, "[]"), jsonOr(p.Headers, "{}")
+	models, hdrs, opts := jsonOr(p.Models, "[]"), jsonOr(p.Headers, "{}"), jsonOr(p.Options, "{}")
 	var id string
 	err = db.QueryRow(ctx, `INSERT INTO providers
-			(name, kind, driver, base_url, default_model, models, credential_ref, headers, enabled, exclude_from_bootstrap)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING id`,
-		p.Name, p.Kind, p.Driver, p.BaseURL, p.DefaultModel, models, p.CredentialRef, hdrs, p.Enabled, p.ExcludeFromBootstrap).Scan(&id)
+			(name, kind, driver, base_url, default_model, models, credential_ref, headers, options, enabled, exclude_from_bootstrap)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING id`,
+		p.Name, p.Kind, p.Driver, p.BaseURL, p.DefaultModel, models, p.CredentialRef, hdrs, opts, p.Enabled, p.ExcludeFromBootstrap).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("admin create: %w", err)
 	}
@@ -374,11 +400,17 @@ type ProviderPatch struct {
 	Headers              *map[string]string  `json:"headers"`
 	Enabled              *bool               `json:"enabled"`
 	ExcludeFromBootstrap *bool               `json:"exclude_from_bootstrap"`
+	Options              *map[string]string  `json:"options"`
 }
 
 func (a *Admin) Patch(ctx context.Context, id string, patch ProviderPatch) error {
 	if patch.CredentialRef != nil && !credentialRefPattern.MatchString(*patch.CredentialRef) {
 		return fmt.Errorf("credential_ref must be a name or path, never a secret value")
+	}
+	if patch.Options != nil {
+		if _, err := parseRequestTimeout(*patch.Options); err != nil {
+			return err
+		}
 	}
 
 	db, err := a.db.Get()
@@ -420,12 +452,15 @@ func (a *Admin) Patch(ctx context.Context, id string, patch ProviderPatch) error
 	if patch.ExcludeFromBootstrap != nil {
 		after.ExcludeFromBootstrap = *patch.ExcludeFromBootstrap
 	}
+	if patch.Options != nil {
+		after.Options = *patch.Options
+	}
 
 	tag, err := tx.Exec(ctx, `UPDATE providers SET base_url = $2, default_model = $3,
-			models = $4, credential_ref = $5, headers = $6, enabled = $7, exclude_from_bootstrap = $8, updated_at = now()
+			models = $4, credential_ref = $5, headers = $6, enabled = $7, exclude_from_bootstrap = $8, options = $9, updated_at = now()
 		WHERE id = $1`,
 		id, after.BaseURL, after.DefaultModel, jsonOr(after.Models, "[]"),
-		after.CredentialRef, jsonOr(after.Headers, "{}"), after.Enabled, after.ExcludeFromBootstrap)
+		after.CredentialRef, jsonOr(after.Headers, "{}"), after.Enabled, after.ExcludeFromBootstrap, jsonOr(after.Options, "{}"))
 	if err != nil {
 		return fmt.Errorf("admin patch: %w", err)
 	}
@@ -729,7 +764,7 @@ func (a *Admin) Test(ctx context.Context, id, model string) (TestResult, error) 
 		return TestResult{}, fmt.Errorf("provider %s has no default model; pass one", p.Name)
 	}
 
-	res := a.probe(ctx, drv, p.Name, model, snap.Prices(p.Name, model))
+	res := a.probe(ctx, drv, p.Name, model, snap.Prices(p.Name, model), probeTimeout(p.Options))
 	a.audit(ctx, "test", "provider", id, nil, res)
 	return res, nil
 }
@@ -750,20 +785,26 @@ func (a *Admin) Validate(ctx context.Context, p Provider, model string) (TestRes
 		return TestResult{}, fmt.Errorf("a model is required to validate a provider")
 	}
 
+	timeout, err := parseRequestTimeout(p.Options)
+	if err != nil {
+		return TestResult{}, err
+	}
 	reg, err := provider.Build([]provider.Config{{
-		Name:          p.Name,
-		Kind:          provider.KindAPI,
-		Driver:        p.Driver,
-		BaseURL:       p.BaseURL,
-		CredentialRef: p.CredentialRef,
-		Headers:       p.Headers,
+		Name:            p.Name,
+		Kind:            provider.KindAPI,
+		Driver:          p.Driver,
+		BaseURL:         p.BaseURL,
+		CredentialRef:   p.CredentialRef,
+		Headers:         p.Headers,
+		ReasoningEffort: p.Options["reasoning_effort"],
+		Timeout:         timeout,
 	}}, a.credentialLookup())
 	if err != nil {
 		return TestResult{}, err
 	}
 	drv, _ := reg.Get(p.Name)
 
-	res := a.probe(ctx, drv, p.Name, model, nil)
+	res := a.probe(ctx, drv, p.Name, model, nil, probeTimeout(p.Options))
 	a.audit(ctx, "validate", "provider", p.Name, nil, res)
 	return res, nil
 }
@@ -808,11 +849,27 @@ func (a *Admin) credentialLookup() func(string) string {
 	}
 }
 
+// probeTimeout bounds a connection probe's context: a provider with
+// options.request_timeout set (D-041) — a slow CPU-only remote Ollama,
+// say — gets that value instead of the fixed 20s default, so its own
+// probe isn't killed by a ceiling shorter than the timeout it declared
+// for real traffic. request_timeout was already validated when the
+// provider was written, so a parse failure here can only mean stale
+// data racing a concurrent edit; falling back to the default is safer
+// than failing the probe outright.
+func probeTimeout(opts map[string]string) time.Duration {
+	if d, err := parseRequestTimeout(opts); err == nil && d > 0 {
+		return d
+	}
+	return testTimeout
+}
+
 // probe runs one one-token completion against drv and books it under
 // purpose='test'. Shared by Test (persisted provider) and Validate
-// (unsaved config).
-func (a *Admin) probe(ctx context.Context, drv provider.Provider, providerName, model string, prices *router.ModelPrices) TestResult {
-	tctx, cancel := context.WithTimeout(ctx, testTimeout)
+// (unsaved config). timeout bounds the probe's context — testTimeout
+// (20s) unless the provider declares its own options.request_timeout.
+func (a *Admin) probe(ctx context.Context, drv provider.Provider, providerName, model string, prices *router.ModelPrices, timeout time.Duration) TestResult {
+	tctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	start := time.Now()
 	ch, err := drv.Stream(tctx, provider.CompletionRequest{
@@ -873,18 +930,19 @@ func (a *Admin) getForUpdate(ctx context.Context, tx pgx.Tx, id string) (Provide
 
 func scanProvider(ctx context.Context, q pgxQuerier, id, lock string) (Provider, error) {
 	var (
-		p            Provider
-		models, hdrs []byte
+		p                  Provider
+		models, hdrs, opts []byte
 	)
 	err := q.QueryRow(ctx, `SELECT id, name, kind, driver, base_url, default_model,
-			models, credential_ref, headers, enabled, exclude_from_bootstrap FROM providers WHERE id = $1 `+lock, id).
+			models, credential_ref, headers, options, enabled, exclude_from_bootstrap FROM providers WHERE id = $1 `+lock, id).
 		Scan(&p.ID, &p.Name, &p.Kind, &p.Driver, &p.BaseURL, &p.DefaultModel,
-			&models, &p.CredentialRef, &hdrs, &p.Enabled, &p.ExcludeFromBootstrap)
+			&models, &p.CredentialRef, &hdrs, &opts, &p.Enabled, &p.ExcludeFromBootstrap)
 	if err != nil {
 		return Provider{}, fmt.Errorf("provider %s: %w", id, ErrNotFound)
 	}
 	_ = json.Unmarshal(models, &p.Models)
 	_ = json.Unmarshal(hdrs, &p.Headers)
+	_ = json.Unmarshal(opts, &p.Options)
 	normalizeProvider(&p)
 	return p, nil
 }
@@ -897,6 +955,9 @@ func normalizeProvider(p *Provider) {
 	}
 	if p.Headers == nil {
 		p.Headers = map[string]string{}
+	}
+	if p.Options == nil {
+		p.Options = map[string]string{}
 	}
 }
 

--- a/internal/gateway/admin/admin_options_test.go
+++ b/internal/gateway/admin/admin_options_test.go
@@ -1,0 +1,67 @@
+package admin
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseRequestTimeout(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		opts    map[string]string
+		want    time.Duration
+		wantErr string
+	}{
+		{name: "valid duration", opts: map[string]string{"request_timeout": "20m"}, want: 20 * time.Minute},
+		{name: "absent leaves zero", opts: map[string]string{}, want: 0},
+		{name: "nil map leaves zero", opts: nil, want: 0},
+		{name: "invalid duration errors", opts: map[string]string{"request_timeout": "banana"}, wantErr: "request_timeout"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseRequestTimeout(tt.opts)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseRequestTimeout: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("timeout = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateProviderRejectsInvalidRequestTimeout(t *testing.T) {
+	t.Parallel()
+	p := Provider{Name: "p", Kind: "api", Driver: "openaicompat", Options: map[string]string{"request_timeout": "banana"}}
+	if err := validateProvider(p); err == nil || !strings.Contains(err.Error(), "request_timeout") {
+		t.Fatalf("validateProvider error = %v, want containing request_timeout", err)
+	}
+}
+
+func TestProbeTimeout(t *testing.T) {
+	t.Parallel()
+	if got := probeTimeout(nil); got != testTimeout {
+		t.Fatalf("probeTimeout(nil) = %v, want default %v", got, testTimeout)
+	}
+	if got := probeTimeout(map[string]string{}); got != testTimeout {
+		t.Fatalf("probeTimeout(empty) = %v, want default %v", got, testTimeout)
+	}
+	if got := probeTimeout(map[string]string{"request_timeout": "20m"}); got != 20*time.Minute {
+		t.Fatalf("probeTimeout(20m) = %v, want 20m", got)
+	}
+	// An unparseable value falls back to the default rather than
+	// killing the probe outright — validateProvider is the gate that
+	// should have already rejected it on write.
+	if got := probeTimeout(map[string]string{"request_timeout": "banana"}); got != testTimeout {
+		t.Fatalf("probeTimeout(invalid) = %v, want default %v", got, testTimeout)
+	}
+}

--- a/internal/gateway/provider/openaicompat.go
+++ b/internal/gateway/provider/openaicompat.go
@@ -23,6 +23,11 @@ type OpenAICompatConfig struct {
 	APIKey  string            // resolved secret value, never logged
 	Headers map[string]string // extra request headers
 	Timeout time.Duration     // hard per-request timeout, default 5m
+	// ReasoningEffort, when set, overrides the request's own Effort on
+	// every call to this provider instance (D-040) — e.g. "none" to
+	// disable a local Ollama model's thinking on its OpenAI-compat
+	// endpoint, where the native "think": false flag is ignored.
+	ReasoningEffort string
 }
 
 // OpenAICompat streams from an OpenAI-compatible chat/completions API.
@@ -299,6 +304,12 @@ func (o *OpenAICompat) buildRequest(req CompletionRequest) oaiRequest {
 	out.StreamOptions.IncludeUsage = true
 	if req.Effort == "low" {
 		out.ReasoningEffort = "low"
+	}
+	// A provider-level override wins over the per-request hint (D-040):
+	// some OpenAI-compat backends need reasoning_effort forced (e.g.
+	// "none") regardless of what the caller asked for.
+	if o.cfg.ReasoningEffort != "" {
+		out.ReasoningEffort = o.cfg.ReasoningEffort
 	}
 	if req.System != "" {
 		out.Messages = append(out.Messages, oaiMessage{Role: "system", Content: req.System})

--- a/internal/gateway/provider/openaicompat_test.go
+++ b/internal/gateway/provider/openaicompat_test.go
@@ -320,6 +320,50 @@ func TestOpenAICompat400ReasoningEffortStripAndRetry(t *testing.T) {
 	}
 }
 
+func TestOpenAICompat400ConfigReasoningEffortStripAndRetry(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	var efforts []string
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		efforts = append(efforts, readReasoningEffort(t, r))
+		mu.Unlock()
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		oaiWrite(w, `{"choices":[{"delta":{"content":"ok"}}]}`)
+		oaiWrite(w, "[DONE]")
+	}))
+	t.Cleanup(srv.Close)
+	p := NewOpenAICompat(OpenAICompatConfig{
+		Name: "oai-test", BaseURL: srv.URL, APIKey: "test-key",
+		Timeout: 10 * time.Second, ReasoningEffort: "none",
+	})
+
+	ch, err := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	if calls.Load() != 2 {
+		t.Fatalf("calls = %d, want 2 (retry after 400)", calls.Load())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(efforts) != 2 || efforts[0] != "none" || efforts[1] != "" {
+		t.Fatalf("efforts across attempts = %v, want [none, \"\"]", efforts)
+	}
+	if got := textOf(events, stream.EventChunk); got != "ok" {
+		t.Fatalf("chunks = %q, want ok", got)
+	}
+	if lastType(t, events) != stream.EventDone {
+		t.Fatalf("last = %v, want done", lastType(t, events))
+	}
+}
+
 func TestOpenAICompat400TwiceSurfacesError(t *testing.T) {
 	t.Parallel()
 	var calls atomic.Int32

--- a/internal/gateway/provider/registry.go
+++ b/internal/gateway/provider/registry.go
@@ -17,6 +17,9 @@ type Config struct {
 	CredentialRef string
 	Headers       map[string]string
 	Timeout       time.Duration
+	// ReasoningEffort overrides per-request reasoning effort for the
+	// openaicompat driver only (D-040); anthropic and bedrock ignore it.
+	ReasoningEffort string
 }
 
 // Registry holds the built providers by name. It is immutable after
@@ -60,6 +63,7 @@ func Build(cfgs []Config, lookup func(string) string) (*Registry, error) {
 			p = NewOpenAICompat(OpenAICompatConfig{
 				Name: c.Name, BaseURL: c.BaseURL, APIKey: key,
 				Headers: c.Headers, Timeout: c.Timeout,
+				ReasoningEffort: c.ReasoningEffort,
 			})
 		case "bedrock":
 			// base_url holds the AWS region; credential_ref names a local

--- a/internal/gateway/provider/registry_test.go
+++ b/internal/gateway/provider/registry_test.go
@@ -36,6 +36,35 @@ func TestBuildRegistry(t *testing.T) {
 	}
 }
 
+func TestBuildPassesReasoningEffortToOpenAICompat(t *testing.T) {
+	t.Parallel()
+	r, err := Build([]Config{
+		{Name: "ollama", Kind: KindAPI, Driver: "openaicompat", BaseURL: "http://ollama.local/v1", ReasoningEffort: "none"},
+		{Name: "grok", Kind: KindAPI, Driver: "openaicompat", BaseURL: "https://api.x.ai/v1"},
+	}, func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	p, ok := r.Get("ollama")
+	if !ok {
+		t.Fatal("ollama missing")
+	}
+	oai, ok := p.(*OpenAICompat)
+	if !ok {
+		t.Fatalf("ollama provider type = %T, want *OpenAICompat", p)
+	}
+	if oai.cfg.ReasoningEffort != "none" {
+		t.Fatalf("ReasoningEffort = %q, want %q", oai.cfg.ReasoningEffort, "none")
+	}
+
+	p2, _ := r.Get("grok")
+	grokOai := p2.(*OpenAICompat)
+	if grokOai.cfg.ReasoningEffort != "" {
+		t.Fatalf("grok ReasoningEffort = %q, want empty when unset", grokOai.cfg.ReasoningEffort)
+	}
+}
+
 func TestBuildErrors(t *testing.T) {
 	t.Parallel()
 	noLookup := func(string) string { return "" }

--- a/internal/gateway/provider/toolwire_test.go
+++ b/internal/gateway/provider/toolwire_test.go
@@ -118,3 +118,17 @@ func TestOpenAICompatEffortDial(t *testing.T) {
 		t.Fatal("normal effort must omit the field entirely")
 	}
 }
+
+func TestOpenAICompatConfigReasoningEffortOverridesEffort(t *testing.T) {
+	t.Parallel()
+	o := NewOpenAICompat(OpenAICompatConfig{BaseURL: "http://x", APIKey: "k", ReasoningEffort: "none"})
+
+	withLow := o.buildRequest(CompletionRequest{Model: "m", Effort: "low"})
+	if withLow.ReasoningEffort != "none" {
+		t.Fatalf("ReasoningEffort = %q, want %q (config overrides Effort=low)", withLow.ReasoningEffort, "none")
+	}
+	withoutEffort := o.buildRequest(CompletionRequest{Model: "m"})
+	if withoutEffort.ReasoningEffort != "none" {
+		t.Fatalf("ReasoningEffort = %q, want %q (config applies even without a request Effort)", withoutEffort.ReasoningEffort, "none")
+	}
+}

--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 )
@@ -46,6 +47,14 @@ type ProviderRow struct {
 	// should never be silently appended as a fallback on the shared
 	// default/summarize/embedding routes production mission traffic runs on.
 	ExcludeFromBootstrap bool
+	// ReasoningEffort comes from options.reasoning_effort (D-040) and
+	// overrides per-request reasoning effort for the openaicompat driver
+	// only — e.g. "none" to disable a local Ollama model's thinking.
+	ReasoningEffort string
+	// Timeout comes from options.request_timeout (D-041) — a per-request
+	// hard timeout override for slow backends (e.g. a CPU-only remote
+	// Ollama). Zero leaves the driver's own default in place.
+	Timeout time.Duration
 }
 
 // ChainEntry is one step of a route chain.
@@ -138,12 +147,14 @@ func BuildSnapshot(provRows []ProviderRow, routeRows []RouteRow, lookup func(str
 		s.healthy[row.Name] = row.Driver == "bedrock" ||
 			row.CredentialRef == "" || lookup(row.CredentialRef) != ""
 		cfgs = append(cfgs, provider.Config{
-			Name:          row.Name,
-			Kind:          provider.Kind(row.Kind),
-			Driver:        row.Driver,
-			BaseURL:       row.BaseURL,
-			CredentialRef: row.CredentialRef,
-			Headers:       row.Headers,
+			Name:            row.Name,
+			Kind:            provider.Kind(row.Kind),
+			Driver:          row.Driver,
+			BaseURL:         row.BaseURL,
+			CredentialRef:   row.CredentialRef,
+			Headers:         row.Headers,
+			ReasoningEffort: row.ReasoningEffort,
+			Timeout:         row.Timeout,
 		})
 	}
 

--- a/internal/gateway/router/store.go
+++ b/internal/gateway/router/store.go
@@ -91,7 +91,7 @@ func (s *Store) Load(ctx context.Context) error {
 	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
 
 	rows, err := tx.Query(ctx, `SELECT id, name, kind, driver, base_url, default_model,
-		models, credential_ref, headers, enabled FROM providers`)
+		models, credential_ref, headers, options, enabled FROM providers`)
 	if err != nil {
 		return fmt.Errorf("router: query providers: %w", err)
 	}
@@ -103,9 +103,10 @@ func (s *Store) Load(ctx context.Context) error {
 			row         ProviderRow
 			modelsJSON  []byte
 			headersJSON []byte
+			optionsJSON []byte
 		)
 		if err := rows.Scan(&row.ID, &row.Name, &row.Kind, &row.Driver, &row.BaseURL,
-			&row.DefaultModel, &modelsJSON, &row.CredentialRef, &headersJSON, &row.Enabled); err != nil {
+			&row.DefaultModel, &modelsJSON, &row.CredentialRef, &headersJSON, &optionsJSON, &row.Enabled); err != nil {
 			return fmt.Errorf("router: scan provider: %w", err)
 		}
 		if err := json.Unmarshal(modelsJSON, &row.Models); err != nil {
@@ -113,6 +114,9 @@ func (s *Store) Load(ctx context.Context) error {
 		}
 		if err := json.Unmarshal(headersJSON, &row.Headers); err != nil {
 			return fmt.Errorf("router: provider %s headers: %w", row.Name, err)
+		}
+		if err := applyProviderOptions(&row, optionsJSON); err != nil {
+			return fmt.Errorf("router: provider %s options: %w", row.Name, err)
 		}
 		provRows = append(provRows, row)
 	}
@@ -157,6 +161,30 @@ func (s *Store) Load(ctx context.Context) error {
 	}
 	s.snap.Store(snap)
 	s.log.Info("routing config loaded", "providers", len(provRows), "routes", len(routes))
+	return nil
+}
+
+// applyProviderOptions decodes a providers row's options jsonb into row.
+// Only reasoning_effort and request_timeout are recognized today (D-040,
+// D-041); unknown keys are ignored silently. An unparseable
+// request_timeout fails the load outright — config honesty, never a
+// silent fallback to the driver default.
+func applyProviderOptions(row *ProviderRow, optionsJSON []byte) error {
+	var opts struct {
+		ReasoningEffort string `json:"reasoning_effort"`
+		RequestTimeout  string `json:"request_timeout"`
+	}
+	if err := json.Unmarshal(optionsJSON, &opts); err != nil {
+		return err
+	}
+	row.ReasoningEffort = opts.ReasoningEffort
+	if opts.RequestTimeout != "" {
+		d, err := time.ParseDuration(opts.RequestTimeout)
+		if err != nil {
+			return fmt.Errorf("request_timeout %q: %w", opts.RequestTimeout, err)
+		}
+		row.Timeout = d
+	}
 	return nil
 }
 

--- a/internal/gateway/router/store_integration_test.go
+++ b/internal/gateway/router/store_integration_test.go
@@ -135,3 +135,135 @@ func TestStoreReloadReflectsSQLChanges(t *testing.T) {
 		t.Fatalf("attempts = %+v, want itest-prov/itest-model", attempts)
 	}
 }
+
+func TestStoreLoadsReasoningEffortFromOptions(t *testing.T) {
+	s := integrationStore(t)
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	_, _ = db.Exec(t.Context(), "DELETE FROM providers WHERE name = 'itest-reasoning-prov'")
+	if _, err := db.Exec(t.Context(), `INSERT INTO providers
+		(name, kind, driver, base_url, default_model, credential_ref, options, enabled)
+		VALUES ('itest-reasoning-prov', 'api', 'openaicompat', 'https://itest.invalid/v1', 'itest-model',
+			'ITEST_REASONING_KEY', '{"reasoning_effort": "none"}'::jsonb, true)`); err != nil {
+		t.Fatalf("insert provider: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		conn, err := pgx.Connect(ctx, os.Getenv("DATABASE_URL"))
+		if err != nil {
+			t.Errorf("cleanup connect: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close(ctx) }()
+		if _, err := conn.Exec(ctx, "DELETE FROM providers WHERE name = 'itest-reasoning-prov'"); err != nil {
+			t.Errorf("cleanup provider: %v", err)
+		}
+	})
+
+	t.Setenv("ITEST_REASONING_KEY", "test-key-value")
+	if err := s.Load(t.Context()); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	rows, _ := s.Snapshot().Providers()
+	var found bool
+	for _, row := range rows {
+		if row.Name != "itest-reasoning-prov" {
+			continue
+		}
+		found = true
+		if row.ReasoningEffort != "none" {
+			t.Fatalf("ReasoningEffort = %q, want %q", row.ReasoningEffort, "none")
+		}
+	}
+	if !found {
+		t.Fatal("itest-reasoning-prov not found in snapshot")
+	}
+}
+
+func TestStoreLoadsRequestTimeoutFromOptions(t *testing.T) {
+	s := integrationStore(t)
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	_, _ = db.Exec(t.Context(), "DELETE FROM providers WHERE name = 'itest-timeout-prov'")
+	if _, err := db.Exec(t.Context(), `INSERT INTO providers
+		(name, kind, driver, base_url, default_model, credential_ref, options, enabled)
+		VALUES ('itest-timeout-prov', 'api', 'openaicompat', 'https://itest.invalid/v1', 'itest-model',
+			'ITEST_TIMEOUT_KEY', '{"request_timeout": "20m"}'::jsonb, true)`); err != nil {
+		t.Fatalf("insert provider: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		conn, err := pgx.Connect(ctx, os.Getenv("DATABASE_URL"))
+		if err != nil {
+			t.Errorf("cleanup connect: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close(ctx) }()
+		if _, err := conn.Exec(ctx, "DELETE FROM providers WHERE name = 'itest-timeout-prov'"); err != nil {
+			t.Errorf("cleanup provider: %v", err)
+		}
+	})
+
+	t.Setenv("ITEST_TIMEOUT_KEY", "test-key-value")
+	if err := s.Load(t.Context()); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	rows, _ := s.Snapshot().Providers()
+	var found bool
+	for _, row := range rows {
+		if row.Name != "itest-timeout-prov" {
+			continue
+		}
+		found = true
+		if row.Timeout != 20*time.Minute {
+			t.Fatalf("Timeout = %v, want 20m", row.Timeout)
+		}
+	}
+	if !found {
+		t.Fatal("itest-timeout-prov not found in snapshot")
+	}
+}
+
+func TestStoreLoadFailsOnInvalidRequestTimeout(t *testing.T) {
+	s := integrationStore(t)
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	_, _ = db.Exec(t.Context(), "DELETE FROM providers WHERE name = 'itest-bad-timeout-prov'")
+	if _, err := db.Exec(t.Context(), `INSERT INTO providers
+		(name, kind, driver, base_url, default_model, credential_ref, options, enabled)
+		VALUES ('itest-bad-timeout-prov', 'api', 'openaicompat', 'https://itest.invalid/v1', 'itest-model',
+			'ITEST_BAD_TIMEOUT_KEY', '{"request_timeout": "banana"}'::jsonb, true)`); err != nil {
+		t.Fatalf("insert provider: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		conn, err := pgx.Connect(ctx, os.Getenv("DATABASE_URL"))
+		if err != nil {
+			t.Errorf("cleanup connect: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close(ctx) }()
+		if _, err := conn.Exec(ctx, "DELETE FROM providers WHERE name = 'itest-bad-timeout-prov'"); err != nil {
+			t.Errorf("cleanup provider: %v", err)
+		}
+	})
+
+	t.Setenv("ITEST_BAD_TIMEOUT_KEY", "test-key-value")
+	if err := s.Load(t.Context()); err == nil {
+		t.Fatal("Load succeeded with an invalid request_timeout, want error")
+	}
+}

--- a/internal/gateway/router/store_test.go
+++ b/internal/gateway/router/store_test.go
@@ -1,0 +1,53 @@
+package router
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestApplyProviderOptionsRequestTimeout(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		options string
+		want    time.Duration
+		wantErr string
+	}{
+		{name: "parses a valid duration", options: `{"request_timeout": "20m"}`, want: 20 * time.Minute},
+		{name: "parses seconds", options: `{"request_timeout": "300s"}`, want: 300 * time.Second},
+		{name: "absent leaves zero", options: `{}`, want: 0},
+		{name: "empty string leaves zero", options: `{"request_timeout": ""}`, want: 0},
+		{name: "invalid duration errors", options: `{"request_timeout": "banana"}`, wantErr: "request_timeout"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var row ProviderRow
+			err := applyProviderOptions(&row, []byte(tt.options))
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("applyProviderOptions: %v", err)
+			}
+			if row.Timeout != tt.want {
+				t.Fatalf("Timeout = %v, want %v", row.Timeout, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyProviderOptionsReasoningEffort(t *testing.T) {
+	t.Parallel()
+	var row ProviderRow
+	if err := applyProviderOptions(&row, []byte(`{"reasoning_effort": "none"}`)); err != nil {
+		t.Fatalf("applyProviderOptions: %v", err)
+	}
+	if row.ReasoningEffort != "none" {
+		t.Fatalf("ReasoningEffort = %q, want none", row.ReasoningEffort)
+	}
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -282,6 +282,7 @@ export interface AdminProvider {
   credential_ref: string
   headers: Record<string, string>
   enabled: boolean
+  options?: { reasoning_effort?: string; request_timeout?: string }
 }
 
 export interface ChainEntry {

--- a/web/src/components/settings/ProviderEdit.test.tsx
+++ b/web/src/components/settings/ProviderEdit.test.tsx
@@ -37,9 +37,22 @@ const bedrockProvider: AdminProvider = {
   enabled: true,
 }
 
-function renderPage() {
+const openaicompatProvider: AdminProvider = {
+  id: 'p2',
+  name: 'Ollama',
+  kind: 'api',
+  driver: 'openaicompat',
+  base_url: 'http://ollama.local/v1',
+  default_model: 'qwen3',
+  models: [{ id: 'qwen3' }],
+  credential_ref: '',
+  headers: {},
+  enabled: true,
+}
+
+function renderPage(id = 'p1') {
   return render(
-    <MemoryRouter initialEntries={['/settings/providers/p1']}>
+    <MemoryRouter initialEntries={[`/settings/providers/${id}`]}>
       <Routes>
         <Route path="/settings/providers/:id" element={<ProviderEdit />} />
       </Routes>
@@ -137,5 +150,76 @@ describe('ProviderEdit models section', () => {
 
     expect(await screen.findByText('amazon.titan-embed-text-v1')).toBeTruthy()
     expect(screen.getByText('embeddings')).toBeTruthy()
+  })
+})
+
+describe('ProviderEdit reasoning section', () => {
+  beforeEach(() => {
+    vi.mocked(availableModels).mockResolvedValue([])
+  })
+
+  it('omits the reasoning section for non-openaicompat drivers', async () => {
+    vi.mocked(listProviders).mockResolvedValue([bedrockProvider])
+    renderPage('p1')
+
+    await screen.findByText('AWS Bedrock')
+    expect(screen.queryByRole('switch', { name: 'Disable reasoning' })).toBeNull()
+  })
+
+  it('writes options.reasoning_effort = "none" when the toggle is switched on', async () => {
+    vi.mocked(listProviders).mockResolvedValue([openaicompatProvider])
+    vi.mocked(patchProvider).mockResolvedValue()
+    renderPage('p2')
+
+    const toggle = await screen.findByRole('switch', { name: 'Disable reasoning' })
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
+    fireEvent.click(toggle)
+
+    await waitFor(() =>
+      expect(patchProvider).toHaveBeenCalledWith('p2', { options: { reasoning_effort: 'none' } }),
+    )
+  })
+
+  it('omits reasoning_effort entirely when the toggle is switched back off', async () => {
+    vi.mocked(listProviders).mockResolvedValue([
+      { ...openaicompatProvider, options: { reasoning_effort: 'none' } },
+    ])
+    vi.mocked(patchProvider).mockResolvedValue()
+    renderPage('p2')
+
+    const toggle = await screen.findByRole('switch', { name: 'Disable reasoning' })
+    expect(toggle.getAttribute('aria-checked')).toBe('true')
+    fireEvent.click(toggle)
+
+    await waitFor(() => expect(patchProvider).toHaveBeenCalledWith('p2', { options: {} }))
+  })
+
+  it('writes options.request_timeout on blur', async () => {
+    vi.mocked(listProviders).mockResolvedValue([openaicompatProvider])
+    vi.mocked(patchProvider).mockResolvedValue()
+    renderPage('p2')
+
+    const input = await screen.findByPlaceholderText('5m')
+    fireEvent.change(input, { target: { value: '20m' } })
+    fireEvent.blur(input)
+
+    await waitFor(() =>
+      expect(patchProvider).toHaveBeenCalledWith('p2', { options: { request_timeout: '20m' } }),
+    )
+  })
+
+  it('omits request_timeout entirely when cleared', async () => {
+    vi.mocked(listProviders).mockResolvedValue([
+      { ...openaicompatProvider, options: { request_timeout: '20m' } },
+    ])
+    vi.mocked(patchProvider).mockResolvedValue()
+    renderPage('p2')
+
+    const input = await screen.findByPlaceholderText('5m')
+    expect((input as HTMLInputElement).value).toBe('20m')
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(patchProvider).toHaveBeenCalledWith('p2', { options: {} }))
   })
 })

--- a/web/src/components/settings/ProviderEdit.tsx
+++ b/web/src/components/settings/ProviderEdit.tsx
@@ -27,7 +27,7 @@ import { ModelInput, type ModelSuggestion } from './ModelInput'
 import { modelCatalog } from './modelCatalog'
 import { matchPreset } from './presets'
 import { ProviderLogo } from './ProviderLogo'
-import { Field } from './shared'
+import { Field, Toggle } from './shared'
 import { useDefaultSecretBackend } from './useDefaultSecretBackend'
 import { backendLabel, errText, stripPaste, secretField } from './util'
 
@@ -95,6 +95,9 @@ export function ProviderEdit() {
             onChanged={refresh}
             defaultBackend={defaultBackend}
           />
+        )}
+        {provider.driver === 'openaicompat' && (
+          <ReasoningSection provider={provider} onChanged={refresh} />
         )}
         <ModelsSection provider={provider} onChanged={refresh} />
       </div>
@@ -318,6 +321,71 @@ function CredentialSection({
           </details>
         </div>
       )}
+    </section>
+  )
+}
+
+// ReasoningSection lets an openaicompat provider force reasoning off
+// (D-040) — e.g. Ollama's /v1/chat/completions endpoint silently
+// ignores the native "think": false flag but honors
+// reasoning_effort: "none". Disabled is the only override exposed;
+// toggling on omits the key entirely rather than writing a default.
+// The same section also holds the request timeout override (D-041), a
+// Go duration string (e.g. "20m") for slow backends — a CPU-only
+// remote Ollama, say — that need more than the driver's 5m default.
+function ReasoningSection({ provider, onChanged }: { provider: AdminProvider; onChanged: () => void }) {
+  const [saving, setSaving] = useState(false)
+  const [timeout, setTimeoutValue] = useState(provider.options?.request_timeout ?? '')
+  const disabled = provider.options?.reasoning_effort === 'none'
+
+  const toggle = async (on: boolean) => {
+    setSaving(true)
+    try {
+      const { reasoning_effort: _reasoningEffort, ...rest } = provider.options ?? {}
+      await patchProvider(provider.id, {
+        options: on ? { ...rest, reasoning_effort: 'none' } : rest,
+      })
+      onChanged()
+    } catch (err) {
+      toast.error('Could not update reasoning setting', { description: errText(err) })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const saveTimeout = async () => {
+    const trimmed = timeout.trim()
+    if (trimmed === (provider.options?.request_timeout ?? '')) return
+    const { request_timeout: _requestTimeout, ...rest } = provider.options ?? {}
+    try {
+      await patchProvider(provider.id, {
+        options: trimmed ? { ...rest, request_timeout: trimmed } : rest,
+      })
+      onChanged()
+    } catch (err) {
+      setTimeoutValue(provider.options?.request_timeout ?? '')
+      toast.error('Could not update request timeout', { description: errText(err) })
+    }
+  }
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-sm font-semibold">Reasoning</h2>
+      <label className="flex items-center gap-3 text-sm">
+        <Toggle on={disabled} onChange={(v) => void toggle(v)} label="Disable reasoning" />
+        <span className="text-muted-foreground">
+          {saving ? 'Saving…' : 'Disable reasoning ("thinking") for every request to this provider.'}
+        </span>
+      </label>
+      <Field label="Request timeout" hint='Go duration, e.g. "20m" — empty uses the default'>
+        <Input
+          value={timeout}
+          onChange={(e) => setTimeoutValue(e.target.value)}
+          onBlur={() => void saveTimeout()}
+          placeholder="5m"
+          className="mt-1.5 h-10 max-w-40"
+        />
+      </Field>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- Ollama's OpenAI-compatible endpoint ignores `think: false`; providers can now set `options.reasoning_effort` (e.g. `"none"`) to override per-request effort.
- Slow/CPU-only providers can set `options.request_timeout` (Go duration, e.g. `"20m"`) to raise the 5m default per-request timeout.
- The settings-page test-connection probe now uses the same `request_timeout` instead of a fixed 20s cap, so it no longer false-fails on slow providers.

## Test plan
- [x] `make build test vet lint` — race-clean, 0 lint issues
- [x] web build/lint/test — 307+/307+ pass (ProviderEdit new cases included)