### PR TITLE
fix(chat): reject concurrent turns on one session with 409

### DIFF
--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -430,6 +430,10 @@ func (a *API) streamTurn(w http.ResponseWriter, r *http.Request, run func(contex
 			jsonError(w, http.StatusConflict, "no_retryable_turn", err.Error())
 			return
 		}
+		if errors.Is(err, chat.ErrTurnInFlight) {
+			jsonError(w, http.StatusConflict, "turn_in_flight", err.Error())
+			return
+		}
 		// session_id rides the error when a row was already created so
 		// the client reuses it on retry.
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/brain/api/live_test.go
+++ b/internal/brain/api/live_test.go
@@ -120,6 +120,47 @@ func TestLiveEndpointNoActiveTurn(t *testing.T) {
 	}
 }
 
+// TestMessagesEndpointTurnInFlightReturns409 confirms POST
+// /v1/sessions/{id}/messages maps chat.ErrTurnInFlight (D-042) to a
+// 409 with code "turn_in_flight" — the same error-mapping pattern as
+// the existing no_retryable_turn 409 in streamTurn — when a second
+// send races an already in-flight turn on the same session.
+func TestMessagesEndpointTurnInFlightReturns409(t *testing.T) {
+	t.Parallel()
+	block := make(chan struct{})
+	a, dir, gw := testAPI(t, "tok", okEvents())
+	gw.blockCh = block
+	id, _ := dir.Create(t.Context(), "t")
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		done <- doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages", `{"message":"hello"}`)
+	}()
+	waitForTest(t, func() bool { return a.svc.TurnActive(id) })
+
+	w := doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages", `{"message":"racing"}`)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("racing POST /messages code = %d, want 409; body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["error"] != "turn_in_flight" {
+		t.Fatalf("error = %q, want turn_in_flight", body["error"])
+	}
+
+	close(block)
+	select {
+	case w := <-done:
+		if w.Code != http.StatusOK {
+			t.Fatalf("original POST /messages code = %d body=%s", w.Code, w.Body.String())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("original POST /messages never returned")
+	}
+}
+
 func TestLiveEndpointUnknownSession(t *testing.T) {
 	t.Parallel()
 	a, _, _ := testAPI(t, "tok", nil)

--- a/internal/brain/chat/broadcast.go
+++ b/internal/brain/chat/broadcast.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
@@ -78,20 +79,33 @@ func (b *turnBroadcaster) closeAll() {
 	b.subs = map[chan stream.StreamEvent]struct{}{}
 }
 
-// turnBroadcast registers a fresh broadcaster for sessionID, replacing
-// any previous entry — a session can only have one turn in flight at a
-// time in practice, but a stale entry (e.g. a prior turn whose
-// terminal free lost a race) must never wedge turn_active permanently
-// stuck true, so a new turn always wins the slot outright.
-func (s *Service) turnBroadcast(sessionID string) *turnBroadcaster {
-	b := newTurnBroadcaster()
+// ErrTurnInFlight marks a Chat or Retry call that lost the race to
+// register sessionID's turn: another turn is already live, so this
+// caller must not append anything to the session's event log (D-042,
+// see turnBegin).
+var ErrTurnInFlight = errors.New("turn already in flight")
+
+// turnBegin is the sole entry point onto a session's turn slot:
+// exclusive, atomic registration under turnsMu (D-042). A session can
+// only have one turn in flight; unlike the old turnBroadcast (which
+// always installed a fresh entry, unconditionally evicting whatever
+// was there), this returns ErrTurnInFlight when an entry already
+// exists, so a losing Chat/Retry call can bail out before appending
+// even a user_message — the append-only log must never see the loser's
+// write. Callers MUST call this before the turn's first event append;
+// see Chat and Retry.
+func (s *Service) turnBegin(sessionID string) (*turnBroadcaster, error) {
 	s.turnsMu.Lock()
+	defer s.turnsMu.Unlock()
 	if s.turns == nil {
 		s.turns = map[string]*turnBroadcaster{}
 	}
+	if _, exists := s.turns[sessionID]; exists {
+		return nil, ErrTurnInFlight
+	}
+	b := newTurnBroadcaster()
 	s.turns[sessionID] = b
-	s.turnsMu.Unlock()
-	return b
+	return b, nil
 }
 
 // turnDone frees sessionID's broadcaster entry and closes every live

--- a/internal/brain/chat/broadcast_test.go
+++ b/internal/brain/chat/broadcast_test.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -108,9 +109,12 @@ func TestServiceTurnLifecycleActiveThenFreed(t *testing.T) {
 		t.Fatal("TurnActive true before any turn registered")
 	}
 
-	bc := s.turnBroadcast("s1")
+	bc, err := s.turnBegin("s1")
+	if err != nil {
+		t.Fatalf("turnBegin: %v", err)
+	}
 	if !s.TurnActive("s1") {
-		t.Fatal("TurnActive false immediately after turnBroadcast — presence must mean in-flight even with zero subscribers")
+		t.Fatal("TurnActive false immediately after turnBegin — presence must mean in-flight even with zero subscribers")
 	}
 	if _, _, ok := s.Subscribe("s1"); !ok {
 		t.Fatal("Subscribe ok=false while a turn is registered")
@@ -126,19 +130,36 @@ func TestServiceTurnLifecycleActiveThenFreed(t *testing.T) {
 	}
 }
 
-// TestServiceTurnBroadcastReplacesStaleEntry confirms a fresh
-// turnBroadcast call always wins the slot: a new turn must never find
-// itself unable to register because turn_active is stuck true from an
-// entry whose free lost a race.
-func TestServiceTurnBroadcastReplacesStaleEntry(t *testing.T) {
+// TestServiceTurnBeginExclusiveThenFreedAllowsNext confirms the new
+// exclusivity contract (D-042): a second turnBegin call while an entry
+// is live must fail with ErrTurnInFlight rather than evicting it (the
+// old turnBroadcast's "always install fresh" behavior) — and once the
+// live entry is freed via turnDone, a fresh turnBegin must succeed
+// again, so a completed turn never permanently wedges the slot.
+func TestServiceTurnBeginExclusiveThenFreedAllowsNext(t *testing.T) {
 	t.Parallel()
 	s := &Service{}
-	first := s.turnBroadcast("s1")
-	second := s.turnBroadcast("s1")
-	if first == second {
-		t.Fatal("second turnBroadcast returned the same broadcaster instance")
+	first, err := s.turnBegin("s1")
+	if err != nil {
+		t.Fatalf("first turnBegin: %v", err)
+	}
+	if _, err := s.turnBegin("s1"); !errors.Is(err, ErrTurnInFlight) {
+		t.Fatalf("second turnBegin while live: err = %v, want ErrTurnInFlight", err)
 	}
 	if !s.TurnActive("s1") {
-		t.Fatal("TurnActive false after re-registering")
+		t.Fatal("TurnActive false while the first entry is still live")
+	}
+	_ = first
+
+	s.turnDone("s1")
+	second, err := s.turnBegin("s1")
+	if err != nil {
+		t.Fatalf("turnBegin after turnDone: %v", err)
+	}
+	if first == second {
+		t.Fatal("turnBegin after turnDone returned the same broadcaster instance")
+	}
+	if !s.TurnActive("s1") {
+		t.Fatal("TurnActive false after re-registering post-free")
 	}
 }

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -420,12 +420,21 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	modelHint := req.ModelHint
 	route, modelHint = s.pinSensitiveRoute(ctx, events, route, modelHint)
 
+	// Exclusivity must be won BEFORE the first event append of the turn
+	// (D-042): a loser must never persist even the user_message, or two
+	// concurrent requests interleave writes on the same append-only log.
+	bc, err := s.turnBegin(sessionID)
+	if err != nil {
+		return sessionID, nil, err
+	}
+
 	if _, err := s.log.Append(ctx, sessionID, session.KindUserMessage, session.UserMessage{
 		Text: req.Message, Route: route, Agent: profile.Name, ModelHint: modelHint,
 	}); err != nil {
+		s.turnDone(sessionID)
 		return sessionID, nil, err
 	}
-	return s.runTurn(ctx, sessionID, req.Message, modelHint, req.SkillHint, skillBody, route, profile, needsTitle)
+	return s.runTurn(ctx, sessionID, req.Message, modelHint, req.SkillHint, skillBody, route, profile, needsTitle, bc)
 }
 
 // pinSensitiveRoute promotes the session-wide privacy floor above the
@@ -496,14 +505,27 @@ func (s *Service) Retry(ctx context.Context, sessionID string) (string, <-chan s
 	}
 	modelHint := last.ModelHint
 	route, modelHint = s.pinSensitiveRoute(ctx, events, route, modelHint)
-	return s.runTurn(ctx, sessionID, last.Text, modelHint, "", "", route, profile, needsTitle)
+
+	// Same exclusivity acquisition as Chat (D-042): Retry appends no new
+	// user_message of its own, but it must still win the slot before
+	// runTurn can touch the log — a losing Retry racing a Chat (or
+	// another Retry) must not interleave events with the winner's turn.
+	bc, err := s.turnBegin(sessionID)
+	if err != nil {
+		return sessionID, nil, err
+	}
+	return s.runTurn(ctx, sessionID, last.Text, modelHint, "", "", route, profile, needsTitle, bc)
 }
 
 // runTurn is the shared tail of Chat and Retry: compact, project
 // context, assemble the system prompt, stream, and relay. The caller
 // has already ensured exactly the right user_message sits durable at
-// the end of the log — this never appends one itself.
-func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, skillHint, skillBody, route string, profile agents.Agent, needsTitle bool) (string, <-chan stream.StreamEvent, error) {
+// the end of the log — this never appends one itself. bc is this
+// turn's broadcaster, already registered by the caller's turnBegin
+// (D-042) — runTurn must free it (turnDone) on every path that returns
+// before the relay goroutine takes ownership of that responsibility,
+// so a setup failure here can never wedge the session's slot.
+func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, skillHint, skillBody, route string, profile agents.Agent, needsTitle bool, bc *turnBroadcaster) (string, <-chan stream.StreamEvent, error) {
 	// start marks the turn's wall-clock beginning for the stats line's
 	// duration: here, not Chat/Retry's entry, so a retried turn's
 	// duration covers only the retried run — the dead attempt's gap
@@ -524,10 +546,12 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 	}
 	events, err := s.log.Events(ctx, sessionID)
 	if err != nil {
+		s.turnDone(sessionID)
 		return sessionID, nil, err
 	}
 	msgs, err := session.LLMContext(events, s.budget(ctx))
 	if err != nil {
+		s.turnDone(sessionID)
 		return sessionID, nil, err
 	}
 	// sessionSensitive reuses this same fetch: a session pinned by a
@@ -570,17 +594,15 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 		SessionID: sessionID,
 	})
 	if err != nil {
+		s.turnDone(sessionID)
 		return sessionID, nil, err
 	}
 
-	// Register the broadcaster BEFORE relay can forward a single event:
-	// turn_active and a late /live subscriber's replay both read this
-	// entry, so it must exist the instant the turn starts, not once the
-	// first event happens to land. Registered even with zero
-	// subscribers — presence means "turn in flight", not "someone is
-	// watching" (see broadcast.go).
-	bc := s.turnBroadcast(sessionID)
-
+	// bc was registered by the caller's turnBegin before the turn's
+	// first event append (D-042) — already live the instant the turn
+	// started, not just from here on. From this point, relay's own
+	// defer-equivalent (drainAndPersist, on every exit path) owns
+	// freeing it via turnDone.
 	out := make(chan stream.StreamEvent)
 	go s.relay(ctx, sessionID, userText, route, profile, needsTitle, sessionSensitive, start, bc, upstream, out)
 	return sessionID, out, nil

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -393,6 +393,11 @@ func TestChatHistoryComesFromProjection(t *testing.T) {
 	}
 	drain(t, ch)
 	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+	// The client-facing stream closing does not happen-after turnDone
+	// (see relay's drainAndPersist): wait for the slot to actually free
+	// before a second turn on the same session, or it races turnBegin's
+	// new exclusivity and spuriously hits ErrTurnInFlight (D-042).
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
 
 	gw.mu.Lock()
 	gw.events = okEvents("second answer")
@@ -513,6 +518,11 @@ func TestChatRetriesAutoTitleUntilATurnCompletes(t *testing.T) {
 	}
 	drain(t, ch)
 	waitFor(t, func() bool { return len(log.kinds("s1")) == 2 }) // session_started, user_message only
+	// The slot only frees once persistTurn returns and turnDone runs,
+	// which is not synchronous with drain returning (D-042) — even on
+	// an errored turn, this must still happen so the session isn't
+	// permanently wedged.
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
 
 	log.mu.Lock()
 	title := log.titles["s1"]
@@ -725,8 +735,17 @@ func TestChatSendsCompactedContext(t *testing.T) {
 
 // TestFollowUpSeesCompletedTurnWhileDistillRuns pins turn durability:
 // the assistant turn must be in the log the moment the client stream
-// ends, even while distillation is still running — a fast follow-up
-// projects the completed answer, never a phantom interruption.
+// ends, even while distillation is still running. It also pins the
+// D-042 exclusivity boundary this same window now enforces: distill
+// runs inside persistTurn, BEFORE turnDone frees the slot (see
+// relay's drainAndPersist), so a follow-up landing in that window is
+// correctly rejected with ErrTurnInFlight rather than allowed to
+// interleave — turn "done" means the slot is free, not merely that the
+// client's stream closed. (Before D-042, this test allowed that
+// follow-up to proceed immediately; that was the old
+// always-install-fresh turnBroadcast semantics this design replaces.)
+// Once distill releases and the slot frees, the follow-up proceeds and
+// sees the completed answer, never a phantom interruption.
 func TestFollowUpSeesCompletedTurnWhileDistillRuns(t *testing.T) {
 	t.Parallel()
 	log := newFakeLog()
@@ -742,7 +761,6 @@ func TestFollowUpSeesCompletedTurnWhileDistillRuns(t *testing.T) {
 		}
 		return &session.TurnMemory{KeyFindings: []string{"late residue"}}
 	}
-	defer close(distillRelease)
 	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "first question"})
@@ -769,8 +787,20 @@ func TestFollowUpSeesCompletedTurnWhileDistillRuns(t *testing.T) {
 		}
 	}
 
-	// Follow-up inside the distill window: full answer on the wire, no
-	// phantom interruption.
+	// A follow-up inside the distill window must NOT be allowed to
+	// interleave: the slot is still held (turnDone hasn't run yet).
+	if _, _, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "second question"}); !errors.Is(err, ErrTurnInFlight) {
+		t.Fatalf("Chat during distill window: err = %v, want ErrTurnInFlight", err)
+	}
+	if got := log.kinds("s1"); len(got) != 3 {
+		t.Fatalf("rejected follow-up appended events: kinds = %v, want no change (still 3)", got)
+	}
+
+	close(distillRelease)
+	waitFor(t, func() bool { return !svc.TurnActive("s1") })
+
+	// Now that the slot is free, the follow-up proceeds and sees the
+	// completed answer, never a phantom interruption.
 	_, ch2, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "second question"})
 	if err != nil {
 		t.Fatalf("Chat 2: %v", err)
@@ -1131,6 +1161,10 @@ func TestRetryReusesLastUserMessageWithoutDuplicating(t *testing.T) {
 	if kinds := log.kinds("s1"); strings.Join(kinds, ",") != strings.Join([]string{session.KindSessionStarted, session.KindUserMessage}, ",") {
 		t.Fatalf("kinds after failed attempt = %v, want a dangling user_message", kinds)
 	}
+	// The slot only frees once turnDone runs, not synchronously with
+	// drain returning (D-042) — an errored turn must still free it so
+	// Retry below isn't spuriously rejected.
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
 
 	gw.mu.Lock()
 	gw.events = okEvents("the answer")
@@ -1522,6 +1556,9 @@ func TestChatSeedsApprovalAllowlistOnceIdempotent(t *testing.T) {
 		t.Fatalf("Chat: %v", err)
 	}
 	drain(t, ch)
+	// See TestChatHistoryComesFromProjection: the slot only frees after
+	// drain returns, not synchronously with it (D-042).
+	waitFor(t, func() bool { return !svc.TurnActive("s1") })
 
 	_, ch, err = svc.Chat(t.Context(), Request{SessionID: "s1", Message: "second", Agent: "scheduler"})
 	if err != nil {
@@ -1563,6 +1600,9 @@ func TestChatAgentSwitchGrantsNewAllowlist(t *testing.T) {
 		t.Fatalf("Chat: %v", err)
 	}
 	drain(t, ch)
+	// See TestChatHistoryComesFromProjection: the slot only frees after
+	// drain returns, not synchronously with it (D-042).
+	waitFor(t, func() bool { return !svc.TurnActive("s1") })
 
 	_, ch, err = svc.Chat(t.Context(), Request{SessionID: "s1", Message: "second", Agent: "mailer"})
 	if err != nil {

--- a/internal/brain/chat/turn_active_test.go
+++ b/internal/brain/chat/turn_active_test.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -224,5 +225,113 @@ func TestChatSessionHubNilIsNoop(t *testing.T) {
 		t.Fatalf("Chat: %v", err)
 	}
 	drain(t, ch)
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
+}
+
+// TestConcurrentChatOnSameSessionExactlyOneProceeds pins the D-042
+// exclusivity guarantee: two Chat() calls racing on the same session
+// must not both proceed — exactly one wins the slot and streams, the
+// other gets ErrTurnInFlight and appends ZERO events to the log
+// (neither its user_message nor anything else), since the loser must
+// never touch the append-only log at all.
+func TestConcurrentChatOnSameSessionExactlyOneProceeds(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	block := make(chan struct{})
+	gw := &fakeGW{events: okEvents("the answer"), blockCh: block}
+	s := newService(gw, log)
+
+	// Start the first turn and wait for it to actually register before
+	// racing the second — this pins "one winner" deterministically
+	// rather than depending on goroutine scheduling to decide it.
+	_, ch1, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "first"})
+	if err != nil {
+		t.Fatalf("Chat 1: %v", err)
+	}
+	waitFor(t, func() bool { return s.TurnActive("s1") })
+
+	_, ch2, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "second"})
+	if !errors.Is(err, ErrTurnInFlight) {
+		t.Fatalf("Chat 2 (racing): err = %v, want ErrTurnInFlight", err)
+	}
+	if ch2 != nil {
+		t.Fatal("Chat 2 (racing): channel should be nil on ErrTurnInFlight")
+	}
+	// Only session_started + the winner's user_message so far — the
+	// loser must not have appended anything, not even its own
+	// user_message.
+	if kinds := log.kinds("s1"); len(kinds) != 2 {
+		t.Fatalf("kinds after losing race = %v, want exactly 2 (session_started, winner's user_message)", kinds)
+	}
+
+	close(block)
+	drain(t, ch1)
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
+	// The winner's turn completes normally: session_started,
+	// user_message, assistant_turn — still nothing from the loser.
+	if kinds := log.kinds("s1"); len(kinds) != 3 {
+		t.Fatalf("kinds after winner completes = %v, want exactly 3", kinds)
+	}
+}
+
+// TestConcurrentChatAndRetrySameGuarantee confirms the exclusivity
+// guard applies identically across Chat and Retry: a Retry racing an
+// in-flight Chat-started turn on the same session must lose and touch
+// nothing, same as two Chat calls racing each other.
+func TestConcurrentChatAndRetrySameGuarantee(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	block := make(chan struct{})
+	gw := &fakeGW{events: okEvents("the answer"), blockCh: block}
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "first"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	waitFor(t, func() bool { return s.TurnActive("s1") })
+
+	if _, retryCh, err := s.Retry(t.Context(), "s1"); !errors.Is(err, ErrTurnInFlight) {
+		t.Fatalf("Retry racing an in-flight Chat turn: err = %v, want ErrTurnInFlight", err)
+	} else if retryCh != nil {
+		t.Fatal("Retry racing an in-flight Chat turn: channel should be nil on ErrTurnInFlight")
+	}
+	if kinds := log.kinds("s1"); len(kinds) != 2 {
+		t.Fatalf("kinds after Retry lost the race = %v, want exactly 2", kinds)
+	}
+
+	close(block)
+	drain(t, ch)
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
+}
+
+// TestTurnBeginAfterErrorDoesNotWedgeSession confirms turnDone still
+// runs on an abnormal end (stream error, no EventDone): the cleanup-
+// on-every-exit-path guarantee that keeps a bug in one turn from
+// permanently 409-ing every later request against the same session.
+func TestTurnBeginAfterErrorDoesNotWedgeSession(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: []stream.StreamEvent{
+		{Type: stream.EventError, Err: &stream.StreamError{Code: "boom", Message: "boom"}},
+	}}
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "first"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
+
+	gw.mu.Lock()
+	gw.events = okEvents("second answer")
+	gw.mu.Unlock()
+
+	_, ch2, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "second"})
+	if err != nil {
+		t.Fatalf("Chat after a prior errored turn: %v, want the slot free for a new turn", err)
+	}
+	drain(t, ch2)
 	waitFor(t, func() bool { return !s.TurnActive("s1") })
 }

--- a/web/src/pages/Chat.test.tsx
+++ b/web/src/pages/Chat.test.tsx
@@ -9,9 +9,11 @@ import { Chat } from './Chat'
 vi.mock('../api/client', () => ({
   ChatError: class ChatError extends Error {
     status: number
-    constructor(status: number, message: string) {
+    code?: string
+    constructor(status: number, message: string, code?: string) {
       super(message)
       this.status = status
+      this.code = code
     }
   },
   chatStream: vi.fn(),
@@ -25,7 +27,7 @@ vi.mock('../api/client', () => ({
 
 vi.mock('../lib/events', () => ({ subscribeEvents: vi.fn() }))
 
-vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() } }))
 
 import {
   answerPermission,
@@ -297,6 +299,37 @@ describe('live reattach', () => {
     fireSignal({ kind: 'session', id: 's1' })
 
     await screen.findByText('appeared via signal')
+  })
+
+  it('attaches live instead of showing an error on a 409 turn_in_flight send', async () => {
+    vi.mocked(chatStream).mockRejectedValue(new ChatError(409, 'turn already in flight', 'turn_in_flight'))
+    let feed!: (ev: ChatEvent) => void
+    let resolveStream!: () => void
+    const streamDone = new Promise<void>((r) => {
+      resolveStream = r
+    })
+    vi.mocked(streamLive).mockImplementation(async (_id, onEvent) => {
+      feed = onEvent
+      await streamDone
+    })
+
+    renderChat()
+    const input = screen.getByLabelText('Message')
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(toast.info).toHaveBeenCalled())
+    await waitFor(() => expect(streamLive).toHaveBeenCalled())
+    // No generic failure state rendered — the in-flight turn's own
+    // stream (fed below) is what populates the answer.
+    expect(screen.queryByText(/turn already in flight/)).not.toBeInTheDocument()
+
+    feed({ type: 'chunk', text: 'the other turn wins' })
+    await screen.findByText('the other turn wins')
+
+    feed({ type: 'meta', session_id: 's1' })
+    resolveStream()
+    await waitFor(() => expect(screen.queryByText('▍')).not.toBeInTheDocument())
   })
 
   it('ignores a session signal for a different session', async () => {

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -287,6 +287,7 @@ export function Chat({
       // only re-renders — the live stream keeps its component state.
       navigate(`${basePath}/${id}`, { replace: true })
     }
+    let handedOffToLive = false
     try {
       await chatStream(
         {
@@ -312,15 +313,25 @@ export function Chat({
         // Brain may have created the session before failing: keep it.
         if (err.sessionId) adoptSession(err.sessionId)
         if (err.status === 401 || err.status === 503) onNeedToken()
-        updateLast((m) => ({ ...m, streaming: false, error: err.message }))
+        else if (err.status === 409 && err.code === 'turn_in_flight') {
+          // Lost the race to a turn already running elsewhere (another
+          // tab, a retry) — not a failure, just attach to it like a
+          // page reload mid-turn would. attachLive owns streaming/abort
+          // state from here, so the finally below must not touch it.
+          toast.info('A reply is already in progress — reattaching')
+          handedOffToLive = true
+          attachLive(sessionRef.current!)
+        } else updateLast((m) => ({ ...m, streaming: false, error: err.message }))
       } else {
         updateLast((m) => ({ ...m, streaming: false, error: String(err) }))
       }
     } finally {
-      abortRef.current = null
-      if (!controller.signal.aborted) {
-        setStreaming(false)
-        updateLast((m) => ({ ...m, streaming: false }))
+      if (!handedOffToLive) {
+        abortRef.current = null
+        if (!controller.signal.aborted) {
+          setStreaming(false)
+          updateLast((m) => ({ ...m, streaming: false }))
+        }
       }
     }
   }
@@ -350,6 +361,7 @@ export function Chat({
 
     const controller = new AbortController()
     abortRef.current = controller
+    let handedOffToLive = false
     try {
       await retryStream(
         sessionId,
@@ -361,15 +373,25 @@ export function Chat({
       if (controller.signal.aborted) return
       if (err instanceof ChatError) {
         if (err.status === 401 || err.status === 503) onNeedToken()
-        updateLast((m) => ({ ...m, streaming: false, error: err.message }))
+        else if (err.status === 409 && err.code === 'turn_in_flight') {
+          // Same handoff as sendMessage: a turn is already running
+          // (another tab's send/retry won the race) — attach to it
+          // instead of showing a failure. attachLive owns
+          // streaming/abort state from here.
+          toast.info('A reply is already in progress — reattaching')
+          handedOffToLive = true
+          attachLive(sessionId)
+        } else updateLast((m) => ({ ...m, streaming: false, error: err.message }))
       } else {
         updateLast((m) => ({ ...m, streaming: false, error: String(err) }))
       }
     } finally {
-      abortRef.current = null
-      if (!controller.signal.aborted) {
-        setStreaming(false)
-        updateLast((m) => ({ ...m, streaming: false }))
+      if (!handedOffToLive) {
+        abortRef.current = null
+        if (!controller.signal.aborted) {
+          setStreaming(false)
+          updateLast((m) => ({ ...m, streaming: false }))
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Turn registration on the per-session broadcaster (from #110) is now atomic and exclusive (D-042): a concurrent Chat/Retry gets `ErrTurnInFlight` before appending any event — the loser writes nothing to the session log.
- API maps it to `409 turn_in_flight` on both send and retry endpoints.
- Web catches the 409 and attaches to the in-flight turn via the existing live-attach path (info toast, no error state).

## Test plan
- [x] `make build test vet lint` — race-clean, 0 lint issues (concurrent Chat/Chat, Chat/Retry, no-wedge-after-error races covered)
- [x] web build/lint/test — 310/310 pass