### PR TITLE
fix(missions): reject verify_cmd command substitution at plan time

### DIFF
--- a/internal/brain/missions/packet.go
+++ b/internal/brain/missions/packet.go
@@ -39,7 +39,7 @@ type WorkPacket struct {
 // messages, an earlier note); both pass through NeutralizeSlot before
 // insertion — self-injection hardening.
 func (p WorkPacket) Render() (system, user string) {
-	system = "You are executing one unit of a plan. Work toward the goal, then end your turn with exactly one mission_status tool call: done (with evidence), retry (with analysis), or blocked (with a question). Create or update files ONLY with the write_file tool using workspace-relative paths — never shell redirects (>, >>) or heredocs, which require interactive approval and will stall you. Use shell for reading and checking, not writing. The harness verifies your declared artifacts exist on disk; describing a file is not producing it." + p.ExecEnvironmentNote
+	system = "You are executing one unit of a plan. Work toward the goal, then end your turn with exactly one mission_status tool call: done (with evidence), retry (with analysis), or blocked (with a question). Create or update files ONLY with the write_file tool using workspace-relative paths — never shell redirects (>, >>) or heredocs, which require interactive approval and will stall you. Use shell for reading and checking, not writing. Avoid command substitution ($(...) or backticks) in shell commands too — it classifies as opaque and requires interactive approval, same as the redirects above. The harness verifies your declared artifacts exist on disk; describing a file is not producing it." + p.ExecEnvironmentNote
 	if p.PromptOverlay != "" {
 		// Operator-authored config, not model output — unlike Progress/
 		// GitLog below, this never passes through NeutralizeSlot.

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -520,7 +520,7 @@ func renderReviewContent(p ReviewPacket) string {
 // stuck mission (5 straight "invalid plan JSON" failures, identical
 // each retry since nothing told the model what went wrong).
 func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, researchNotes string) (Spec, error) {
-	system := "You are planning one mission. Break the goal into the SMALLEST ordered list of verifiable units that achieves it — one unit is correct for a simple goal; never pad the plan. artifacts lists the workspace-relative file(s) the unit must produce — the harness itself checks each exists and is non-empty, so name the real deliverables. verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory — it must be a real POSIX shell command (using binaries like grep, test, wc — NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. End your turn with exactly one submit_plan tool call." + r.execEnvironmentNote()
+	system := "You are planning one mission. Break the goal into the SMALLEST ordered list of verifiable units that achieves it — one unit is correct for a simple goal; never pad the plan. artifacts lists the workspace-relative file(s) the unit must produce — the harness itself checks each exists and is non-empty, so name the real deliverables. verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory — it must be a real POSIX shell command (using binaries like grep, test, wc — NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Never use command substitution ($(...) or backticks) in verify_cmd — write the direct command instead. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. End your turn with exactly one submit_plan tool call." + r.execEnvironmentNote()
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if researchNotes != "" {
 		user += "\n\nResearch findings:\n" + NeutralizeSlot(researchNotes)
@@ -623,6 +623,20 @@ func parseSpec(raw string) (Spec, error) {
 	}
 	if len(spec.Units) == 0 {
 		return Spec{}, fmt.Errorf("mission runner: plan has no units")
+	}
+	// verify_cmd runs through RunVerify (a plain /bin/sh -c), but a
+	// worker's own shell classifies $()/backticks as an opaque,
+	// unattended-denied command (D-039, tools/danger.go opaqueForms) —
+	// correct there, but a plan authored with command substitution in
+	// verify_cmd would only discover that after execute/review, parking
+	// the mission far from the actual mistake. Reject it here instead,
+	// at the same point the empty-plan check already rejects a bad
+	// plan, so the planner's retry loop sees the real problem
+	// immediately.
+	for _, u := range spec.Units {
+		if strings.Contains(u.VerifyCmd, "$(") || strings.Contains(u.VerifyCmd, "`") {
+			return Spec{}, fmt.Errorf("mission runner: verify_cmd must not use command substitution ($(...) or backticks) — write the direct command instead")
+		}
 	}
 	// Passes is harness-only evidence (RunVerify); a plan is never born
 	// pre-verified regardless of what the planner's JSON claims.

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -304,6 +304,94 @@ func TestPlanSessionRejectsEmptyPlan(t *testing.T) {
 	}
 }
 
+// TestPlanSessionRejectsCommandSubstitution guards the fix for a real
+// canary flake: a planner-authored verify_cmd containing $(...) parked
+// the mission when the worker's own shell classifier correctly denied
+// it as opaque (D-039) — the plan should be rejected here, at
+// submission, with feedback the planner can act on immediately.
+func TestPlanSessionRejectsCommandSubstitution(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
+	}}
+	r := newTestRunner(agent)
+	_, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
+	if err == nil {
+		t.Fatal("PlanSession accepted a verify_cmd containing command substitution")
+	}
+	if !strings.Contains(err.Error(), "command substitution") {
+		t.Fatalf("PlanSession error = %q, want it to name command substitution", err.Error())
+	}
+}
+
+// TestPlanSessionRejectsBackticks mirrors the $(...) case for the
+// other opaque-form spelling of command substitution.
+func TestPlanSessionRejectsBackticks(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, "{\"units\":[{\"title\":\"Check output\",\"verify_cmd\":\"test `cat out.md` = ok\"}]}")},
+		{toolEndEvent(planToolName, "{\"units\":[{\"title\":\"Check output\",\"verify_cmd\":\"test `cat out.md` = ok\"}]}")},
+	}}
+	r := newTestRunner(agent)
+	_, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
+	if err == nil {
+		t.Fatal("PlanSession accepted a verify_cmd containing backticks")
+	}
+	if !strings.Contains(err.Error(), "command substitution") {
+		t.Fatalf("PlanSession error = %q, want it to name command substitution", err.Error())
+	}
+}
+
+// TestPlanSessionRecoversFromCommandSubstitutionFeedback confirms the
+// substitution rejection feeds the same one-recovery-turn ladder as
+// the empty-plan/malformed-JSON cases: the planner gets told exactly
+// what was wrong and a corrected plan on the next turn is accepted.
+func TestPlanSessionRecoversFromCommandSubstitutionFeedback(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","verify_cmd":"grep -qi ok out.md"}]}`)},
+	}}
+	r := newTestRunner(agent)
+	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if len(spec.Units) != 1 || spec.Units[0].VerifyCmd != "grep -qi ok out.md" {
+		t.Fatalf("PlanSession spec = %+v", spec)
+	}
+	if agent.call != 2 {
+		t.Fatalf("expected exactly two turns (original + one recovery), got %d", agent.call)
+	}
+}
+
+// TestPlanSessionAcceptsLegitimateVerifyCmd confirms the substitution
+// guard doesn't false-positive on real verification commands — a
+// content-checking verify_cmd (the existing tautology guard's whole
+// point: never a bare echo) and a legitimate input redirect (<, which
+// must stay legal — only substitution is banned) both parse cleanly
+// in a single turn, no recovery needed.
+func TestPlanSessionAcceptsLegitimateVerifyCmd(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, `{"units":[`+
+			`{"title":"Check content","verify_cmd":"grep -qi 'foo' out.md"},`+
+			`{"title":"Check line count","verify_cmd":"test -f x && wc -l < x"}`+
+			`]}`)},
+	}}
+	r := newTestRunner(agent)
+	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if len(spec.Units) != 2 {
+		t.Fatalf("PlanSession spec = %+v", spec)
+	}
+	if spec.Units[0].VerifyCmd != "grep -qi 'foo' out.md" || spec.Units[1].VerifyCmd != "test -f x && wc -l < x" {
+		t.Fatalf("PlanSession spec units = %+v", spec.Units)
+	}
+	if agent.call != 1 {
+		t.Fatalf("expected exactly one turn (no recovery needed), got %d", agent.call)
+	}
+}
+
 func TestPlanSessionRejectsMalformedJSON(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{textEvent("I think the plan should have a few steps but I won't format it as JSON")},


### PR DESCRIPTION
## Summary
- Plan units whose `verify_cmd` contains `$(...)` or backticks are rejected at submission via the existing one-retry recovery path (same mechanism as the empty-plan guard) with an actionable message — instead of surviving into execution and parking on the worker's D-039 opaque-command deny.
- Planner system prompt and worker packet each gain one line steering away from command substitution; input redirects (`<`) remain legal.

## Test plan
- [x] `make build test vet lint` — green; new rejection/recovery/legality tests + all existing plan-session tests pass
- [ ] `make canary` against deployed stack after merge