### PR TITLE
fix(loop): match agent tool allowlists across connector name prefixes

### DIFF
--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -724,18 +724,26 @@ func firstLine(s string) string {
 // filterDefs narrows the tool surface to an agent's allowlist. The
 // model never sees a disallowed tool, so there is nothing to refuse
 // at execution time; empty allow means the full surface.
+//
+// D-036: connector tools register namespaced as
+// "<connector-name>_<tool-name>" (connectors.Manager.Tools), so an
+// allowlist entry like "gmail_search" (agent-authored, before any
+// connector name is known) must still match
+// "gmail_gmail_search" at offer time. tools.ToolMatches already
+// implements this suffix rule for the permission-grant chain; reused
+// here so the two layers can never disagree about what a name in an
+// agent config refers to.
 func filterDefs(defs []provider.ToolDef, allow []string) []provider.ToolDef {
 	if len(allow) == 0 {
 		return defs
 	}
-	allowed := make(map[string]bool, len(allow))
-	for _, name := range allow {
-		allowed[name] = true
-	}
 	out := make([]provider.ToolDef, 0, len(defs))
 	for _, d := range defs {
-		if allowed[d.Name] {
-			out = append(out, d)
+		for _, name := range allow {
+			if tools.ToolMatches(d.Name, name) {
+				out = append(out, d)
+				break
+			}
 		}
 	}
 	return out

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -1177,6 +1177,90 @@ func TestAgentUnknownToolRejectedBeforePermissionChain(t *testing.T) {
 	}
 }
 
+// TestFilterDefs pins filterDefs' suffix-matching against an agent's
+// ToolAllow list (D-036): connector tools register namespaced as
+// "<connector-name>_<tool-name>" (connectors.Manager.Tools), so an
+// allowlist entry authored before any connector name is known must
+// still match at offer time. Mirrors tools.ToolMatches' semantics and
+// its existing test expectations exactly — the grants layer and this
+// layer must never disagree about what a config name refers to.
+func TestFilterDefs(t *testing.T) {
+	t.Parallel()
+	defOf := func(name string) provider.ToolDef { return provider.ToolDef{Name: name} }
+
+	tests := []struct {
+		name  string
+		defs  []string
+		allow []string
+		want  []string
+	}{
+		{
+			name:  "empty allow keeps everything",
+			defs:  []string{"web_search", "shell"},
+			allow: nil,
+			want:  []string{"web_search", "shell"},
+		},
+		{
+			name:  "exact name still matches",
+			defs:  []string{"shell"},
+			allow: []string{"shell"},
+			want:  []string{"shell"},
+		},
+		{
+			name:  "gmail_search allows connector-namespaced gmail_gmail_search",
+			defs:  []string{"gmail_gmail_search", "shell"},
+			allow: []string{"gmail_search"},
+			want:  []string{"gmail_gmail_search"},
+		},
+		{
+			name:  "calendar_list_events allows google-calendar_calendar_list_events",
+			defs:  []string{"google-calendar_calendar_list_events"},
+			allow: []string{"calendar_list_events"},
+			want:  []string{"google-calendar_calendar_list_events"},
+		},
+		{
+			name:  "search matches web_search under the same suffix rule as matchGrant",
+			defs:  []string{"web_search"},
+			allow: []string{"search"},
+			want:  []string{"web_search"},
+		},
+		{
+			name:  "no underscore boundary rejected",
+			defs:  []string{"notcalendar_list_events"},
+			allow: []string{"calendar_list_events"},
+			want:  nil,
+		},
+		{
+			name:  "sandbox sentinel never suffix-matches",
+			defs:  []string{"foo___sandbox__"},
+			allow: []string{tools.SandboxGrantTool},
+			want:  nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var defs []provider.ToolDef
+			for _, n := range tc.defs {
+				defs = append(defs, defOf(n))
+			}
+			got := filterDefs(defs, tc.allow)
+			var gotNames []string
+			for _, d := range got {
+				gotNames = append(gotNames, d.Name)
+			}
+			if len(gotNames) != len(tc.want) {
+				t.Fatalf("filterDefs(%v, %v) = %v, want %v", tc.defs, tc.allow, gotNames, tc.want)
+			}
+			for i, n := range gotNames {
+				if n != tc.want[i] {
+					t.Fatalf("filterDefs(%v, %v) = %v, want %v", tc.defs, tc.allow, gotNames, tc.want)
+				}
+			}
+		})
+	}
+}
+
 // TestAgentToolAllowExcludedToolRejected pins the wiring between
 // filterDefs and toolNames (run, agent.go ~line 214/241): toolNames
 // must be built from the POST-ToolAllow-filter defs, not the raw

--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -265,7 +265,7 @@ func (p *Permissions) matchGrant(ctx context.Context, sessionID, tool, subject s
 		if err := rows.Scan(&rowTool, &pattern, &source); err != nil {
 			return false, "", fmt.Errorf("tools: match grant: %w", err)
 		}
-		if !toolMatches(tool, rowTool) {
+		if !ToolMatches(tool, rowTool) {
 			continue
 		}
 		if globMatch(pattern, subject) {
@@ -275,12 +275,14 @@ func (p *Permissions) matchGrant(ctx context.Context, sessionID, tool, subject s
 	return false, "", rows.Err()
 }
 
-// toolMatches reports whether a grant/allowlist row named rowTool
+// ToolMatches reports whether a grant/allowlist row named rowTool
 // covers a call to tool: exact match, or tool ends with "_"+rowTool
 // (connector namespacing — see matchGrant's D-036 note). rowTool ==
 // SandboxGrantTool never suffix-matches; it is a stored sandbox root,
-// not a grantable tool name.
-func toolMatches(tool, rowTool string) bool {
+// not a grantable tool name. Exported so loop.filterDefs can apply the
+// same suffix semantics to an agent's ToolAllow list — the two layers
+// must never disagree about what a config-authored name refers to.
+func ToolMatches(tool, rowTool string) bool {
 	if tool == rowTool {
 		return true
 	}

--- a/internal/brain/tools/permissions_test.go
+++ b/internal/brain/tools/permissions_test.go
@@ -131,8 +131,8 @@ func TestToolMatches(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := toolMatches(tc.tool, tc.rowTool); got != tc.want {
-				t.Errorf("toolMatches(%q, %q) = %v, want %v", tc.tool, tc.rowTool, got, tc.want)
+			if got := ToolMatches(tc.tool, tc.rowTool); got != tc.want {
+				t.Errorf("ToolMatches(%q, %q) = %v, want %v", tc.tool, tc.rowTool, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- `filterDefs` matched agent ToolAllow entries exactly, so allowlisted agents were never offered namespaced connector tools (`gmail_gmail_search` vs allowlist `gmail_search`) — the briefing agent has been answering "email tools are not available".
- Exported the D-036 suffix matcher (`tools.ToolMatches`) and reused it in `filterDefs`, so the tool-surface filter and the permission-grant layer resolve config names identically (including the `__sandbox__` exclusion).

## Test plan
- [x] `make build test vet lint` — green; new table-driven `TestFilterDefs` covers exact/suffix/no-boundary/sentinel/empty cases
- [ ] Live: briefing-agent email summary actually searches gmail after deploy