### PR TITLE
fix(brain): wait for connector load before first turns

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -66,6 +66,11 @@ const (
 	// compaction pass so a slow extraction degrades to empty facts
 	// instead of starving the summarize.
 	preCompactExtractBudget = 45 * time.Second
+	// connectorReadyWait bounds how long a turn waits at entry for the
+	// first connector load (D-043) — long enough to absorb the DB pool
+	// warming at boot, short enough that a turn never meaningfully hangs
+	// on it.
+	connectorReadyWait = 15 * time.Second
 )
 
 func main() {
@@ -179,6 +184,25 @@ func main() {
 			swapAgentTools(agent, builtinSet, conns, app.Log, toolCalls)
 		})
 		go runConnectorReload(ctx, conns, app.Log)
+		app.AddCheck("connectors", func() httpserver.Check {
+			select {
+			case <-conns.Ready():
+				return httpserver.Check{Status: "ok"}
+			default:
+				return httpserver.Check{Status: "degraded", Detail: "initial connector load not yet complete"}
+			}
+		})
+		// Only the first turn after boot pays this: once conns.Ready()
+		// closes, WaitReady returns instantly on every later call. Bounded
+		// so a turn NEVER blocks indefinitely — a slow/never-ready load
+		// degrades to builtins-only instead of hanging the turn.
+		agent.SetWaitToolsReady(func(ctx context.Context) {
+			wctx, cancel := context.WithTimeout(ctx, connectorReadyWait)
+			defer cancel()
+			if err := conns.WaitReady(wctx); err != nil {
+				app.Log.Warn("connector tools not yet loaded; turn proceeds with builtin tools only")
+			}
+		})
 	}
 
 	// SANDBOXD_URL empty (MISSION_SANDBOX_IMAGE unset in compose) keeps a
@@ -609,13 +633,31 @@ func swapAgentTools(agent *loop.Agent, builtins []*tools.Tool, conns *connectors
 	log.Info("agent tool surface updated", "tools", len(defs))
 }
 
+// initialReloadRetry bounds the wait between initial-load retries: the
+// DB pool is often still warming right at boot (ErrDegraded), and
+// falling back to the full-minute ticker for that first success would
+// leave chat turns running builtins-only tools for up to a minute.
+const initialReloadRetry = 5 * time.Second
+
 // runConnectorReload loads connector sources at startup and keeps
 // retrying/refreshing on a slow tick, mirroring the gateway's snapshot
 // poll: a DB that wasn't ready at boot, or a row edited outside the
-// admin API, converges within a minute.
+// admin API, converges within a minute. The first load retries on the
+// short initialReloadRetry cadence until it succeeds once, THEN falls
+// into the normal minute ticker — later reloads don't need the fast
+// path since the agent already has a tool surface.
 func runConnectorReload(ctx context.Context, conns *connectors.Manager, log *slog.Logger) {
-	if err := conns.Reload(ctx); err != nil {
-		log.Warn("initial connector load failed; will retry", "error", err)
+	for {
+		if err := conns.Reload(ctx); err != nil {
+			log.Warn("initial connector load failed; will retry", "error", err)
+		} else {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(initialReloadRetry):
+		}
 	}
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()

--- a/internal/brain/connectors/manager.go
+++ b/internal/brain/connectors/manager.go
@@ -56,6 +56,13 @@ type Manager struct {
 
 	mu      sync.RWMutex
 	sources map[string]Source // by connector name
+
+	// ready closes after the first successful Reload — including its
+	// onReload hook (D-043): a chat turn that waits on it is guaranteed
+	// the agent's tool surface already reflects connector tools, not
+	// just that Reload's DB read finished.
+	ready     chan struct{}
+	readyOnce sync.Once
 }
 
 func NewManager(store *Store, resolve Resolve, log *slog.Logger) *Manager {
@@ -66,6 +73,7 @@ func NewManager(store *Store, resolve Resolve, log *slog.Logger) *Manager {
 		builders: map[string]Builder{},
 		log:      log,
 		sources:  map[string]Source{},
+		ready:    make(chan struct{}),
 	}
 	store.SetOnChange(func(ctx context.Context) {
 		if err := m.Reload(ctx); err != nil {
@@ -123,6 +131,11 @@ func (m *Manager) Reload(ctx context.Context) error {
 	if m.onReload != nil {
 		m.onReload(ctx)
 	}
+	// Closed AFTER onReload, not before: ready must mean "the agent's
+	// tool surface already includes this load's connector tools", not
+	// merely "sources swapped" — a waiter that saw ready but raced
+	// onReload would still get a stale (builtins-only) tool snapshot.
+	m.readyOnce.Do(func() { close(m.ready) })
 	return nil
 }
 
@@ -154,6 +167,25 @@ func (m *Manager) Tools() []*tools.Tool {
 // Reload — the agent's tool set rebuilds from it. Startup-time only.
 func (m *Manager) SetOnReload(fn func(context.Context)) {
 	m.onReload = fn
+}
+
+// Ready returns a channel that closes once the first successful Reload
+// (and its onReload hook) has completed. A manager with zero
+// configured connectors still becomes ready — ready means "initial
+// load ran", not "connectors exist".
+func (m *Manager) Ready() <-chan struct{} {
+	return m.ready
+}
+
+// WaitReady blocks until Ready() closes or ctx ends, whichever comes
+// first.
+func (m *Manager) WaitReady(ctx context.Context) error {
+	select {
+	case <-m.ready:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // Names returns the currently-built connector names (unordered).

--- a/internal/brain/connectors/manager_test.go
+++ b/internal/brain/connectors/manager_test.go
@@ -45,6 +45,7 @@ func testManager(rows rowSource) *Manager {
 		builders: map[string]Builder{},
 		log:      slog.New(slog.NewTextHandler(io.Discard, nil)),
 		sources:  map[string]Source{},
+		ready:    make(chan struct{}),
 	}
 }
 
@@ -172,5 +173,96 @@ func TestValidateRejectsBadInput(t *testing.T) {
 	ok.CredentialRef = "GITHUB_MCP_TOKEN"
 	if err := validate(ok); err != nil {
 		t.Fatalf("valid connector rejected: %v", err)
+	}
+}
+
+func isReady(m *Manager) bool {
+	select {
+	case <-m.Ready():
+		return true
+	default:
+		return false
+	}
+}
+
+func TestReadyNotClosedBeforeFirstReload(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{rows: []Connector{
+		{ID: "1", Name: "github", Kind: "mcp", Enabled: true},
+	}})
+	if isReady(m) {
+		t.Fatal("Ready closed before any Reload ran")
+	}
+}
+
+func TestReadyClosesAfterSuccessfulReloadAndOnReloadHook(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{rows: []Connector{
+		{ID: "1", Name: "github", Kind: "mcp", Enabled: true},
+	}})
+	m.RegisterBuilder("mcp", func(context.Context, Connector, Resolve) (Source, error) {
+		return &fakeSource{}, nil
+	})
+	var onReloadRanBeforeReady bool
+	m.SetOnReload(func(context.Context) {
+		onReloadRanBeforeReady = !isReady(m)
+	})
+
+	if err := m.Reload(t.Context()); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if !isReady(m) {
+		t.Fatal("Ready not closed after successful Reload")
+	}
+	if !onReloadRanBeforeReady {
+		t.Fatal("onReload hook must observe Ready still open — ready closes AFTER onReload")
+	}
+}
+
+func TestReadyClosesWithZeroConnectorsConfigured(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{rows: nil})
+
+	if err := m.Reload(t.Context()); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if !isReady(m) {
+		t.Fatal("Ready must close even with zero connectors — ready means the load ran, not that connectors exist")
+	}
+}
+
+func TestFailedReloadDoesNotMarkReady(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{err: errors.New("db down")})
+
+	if err := m.Reload(t.Context()); err == nil {
+		t.Fatal("Reload with failing list: want error")
+	}
+	if isReady(m) {
+		t.Fatal("Ready closed after a failed Reload")
+	}
+}
+
+func TestWaitReadyRespectsContextCancel(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{rows: []Connector{
+		{ID: "1", Name: "github", Kind: "mcp", Enabled: true},
+	}})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := m.WaitReady(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("WaitReady after cancel = %v, want context.Canceled", err)
+	}
+}
+
+func TestWaitReadyReturnsAfterReload(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{rows: nil})
+	if err := m.Reload(t.Context()); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if err := m.WaitReady(t.Context()); err != nil {
+		t.Fatalf("WaitReady after Reload = %v, want nil", err)
 	}
 }

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -114,6 +114,14 @@ type Agent struct {
 	// next turn without a restart; an empty result means the feature is
 	// currently off and no flip happens.
 	forceRouteBySuffix map[string]func(context.Context) string
+
+	// waitToolsReady, if set, runs at the start of every turn before the
+	// tool snapshot (D-043): it lets main.go block briefly on the
+	// connectors.Manager's first successful load without loop importing
+	// the connectors package (layering). nil = no-op — the default until
+	// main.go wires it, and always a no-op once the manager is ready
+	// (the hook should return instantly by then).
+	waitToolsReady func(context.Context)
 }
 
 func NewAgent(gw Gateway, exec Executor, perms Permissioner, outputs OutputSink, audit AuditSink, events EventAppender, broker *PermBroker, defs []provider.ToolDef, logger *slog.Logger) *Agent {
@@ -177,6 +185,12 @@ func (a *Agent) SetForceRoute(suffix string, route func(context.Context) string)
 	a.forceRouteBySuffix[suffix] = route
 }
 
+// SetWaitToolsReady registers the turn-entry readiness hook (see the
+// waitToolsReady field doc). Startup-time only.
+func (a *Agent) SetWaitToolsReady(fn func(context.Context)) {
+	a.waitToolsReady = fn
+}
+
 // Request is one turn's loop input.
 type Request struct {
 	SessionID string
@@ -223,6 +237,10 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 		case out <- ev:
 		case <-ctx.Done():
 		}
+	}
+
+	if a.waitToolsReady != nil {
+		a.waitToolsReady(ctx)
 	}
 
 	exec, defs := a.toolset()

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -1598,3 +1598,98 @@ func TestAskUserEmitsResolvedOnAnswer(t *testing.T) {
 	}
 }
 
+// TestWaitToolsReadyNilIsNoOp confirms the default (before main.go
+// wires SetWaitToolsReady) behaves exactly as before D-043 — no hook,
+// no wait.
+func TestWaitToolsReadyNilIsNoOp(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{finalStep("hi")}}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+}
+
+// TestWaitToolsReadyRunsBeforeToolSnapshot proves the hook fires
+// BEFORE the turn snapshots its tool surface: swapping tools inside
+// the hook must be visible to the very first request the turn sends.
+func TestWaitToolsReadyRunsBeforeToolSnapshot(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{finalStep("hi")}}
+	a, _, _, _ := testAgent(t, gw)
+
+	reg := tools.NewRegistry()
+	swapped := &tools.Tool{
+		Name:        "swapped_in",
+		Description: "arrived via the readiness hook",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+		Execute: func(context.Context, json.RawMessage) (string, error) {
+			return "ok", nil
+		},
+	}
+	if err := reg.Register(swapped); err != nil {
+		t.Fatal(err)
+	}
+	c, err := tools.NewConstrained(reg, testToolCalls())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var hookCalled bool
+	a.SetWaitToolsReady(func(context.Context) {
+		hookCalled = true
+		a.SwapTools(registryExec{c}, []provider.ToolDef{
+			{Name: swapped.Name, Description: swapped.Description, InputSchema: swapped.InputSchema},
+		})
+	})
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	if !hookCalled {
+		t.Fatal("waitToolsReady hook never ran")
+	}
+	gw.mu.Lock()
+	defer gw.mu.Unlock()
+	if len(gw.requests) == 0 || len(gw.requests[0].Tools) != 1 || gw.requests[0].Tools[0].Name != "swapped_in" {
+		t.Fatalf("first request tools = %+v, want only swapped_in (hook must run before the snapshot)", gw.requests[0].Tools)
+	}
+}
+
+// TestWaitToolsReadyTimeoutStillProceeds confirms a hook that never
+// becomes ready (bounded by ctx, as main.go's WaitReady wiring does)
+// still lets the turn through — it must never block the turn
+// indefinitely.
+func TestWaitToolsReadyTimeoutStillProceeds(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{finalStep("hi")}}
+	a, _, _, _ := testAgent(t, gw)
+
+	neverReady := make(chan struct{})
+	a.SetWaitToolsReady(func(ctx context.Context) {
+		// Mirrors main.go's real hook: bound the wait via context
+		// rather than a real timer, so the test stays instant.
+		wctx, cancel := context.WithTimeout(ctx, time.Nanosecond)
+		defer cancel()
+		select {
+		case <-neverReady:
+		case <-wctx.Done():
+		}
+	})
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+	if len(ofType(evs, stream.EventDone)) != 1 {
+		t.Fatalf("turn did not complete after wait timeout: %+v", evs)
+	}
+}
+


### PR DESCRIPTION
## Problem
For ~60s after brain boots, chat turns run with builtin tools only: connector loading is async, nothing signals readiness, and a failed first Reload (common while the DB pool is warming) retries only on the 60s ticker. The model truthfully reports "email tools not available" — looks like a model failure, is a boot race.

## Fix
- `connectors.Manager` gains a `Ready()` channel that closes after the first successful `Reload` **including its `onReload` hook** — ready means the agent's tool surface already swapped, not merely that the DB read finished (D-043).
- Initial load retries every 5s until first success, then the normal 60s ticker.
- `/health` gains a `connectors` check (degraded until ready).
- Turns wait on readiness at entry, bounded at 15s: timeout logs a warning and proceeds builtins-only — never hangs, never fails the turn. Injected from main.go as a nil-able hook so `loop` keeps zero imports on `connectors`.

## Tests
9 new: ready-channel lifecycle (not-closed-before, closes-after-reload+hook, zero-connectors still ready, failed reload not ready, ctx cancel) + turn-entry hook (nil no-op, runs before tool snapshot, timeout proceeds).

`make build test vet lint` green.