### PR TITLE
fix: surface zero-output and cut-off turns instead of silence

### DIFF
--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -606,8 +606,11 @@ func TestRetryEndpoint(t *testing.T) {
 
 	// persistTurn runs after the SSE body closes (close(out) unblocks
 	// the client write, persistence follows), so the assistant_turn
-	// isn't guaranteed durable the instant doMux returns.
-	want := []string{session.KindSessionStarted, session.KindUserMessage, session.KindAssistantTurn}
+	// isn't guaranteed durable the instant doMux returns. The failed
+	// initial send leaves turn_failed (D-044) between the dangling
+	// user_message and the retried assistant_turn — it doesn't block
+	// retry (lastUserMessage only stops at a completed assistant_turn).
+	want := []string{session.KindSessionStarted, session.KindUserMessage, session.KindTurnFailed, session.KindAssistantTurn}
 	deadline := time.Now().Add(5 * time.Second)
 	var kinds []string
 	for {

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -633,9 +633,34 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 	// s.sensitive — memory extraction then rides the sensitive route
 	// pin instead of its own default (see persistTurn).
 	turnSensitive := false
+	// ranTool records whether ANY tool executed this turn (regardless of
+	// sensitivity) — persistTurn's empty-response guard (D-044) must not
+	// flag a turn whose answer is entirely tool/reasoning traffic with
+	// no text.
+	ranTool := false
+	// failure captures a terminal EventError/EventIncomplete's code and
+	// message (D-044): the relay used to just drop these on the floor
+	// after streaming them to the client, leaving a turn with nothing
+	// persisted. persistTurn appends it as KindTurnFailed when there is
+	// no partial text worth keeping instead.
+	var failure *session.TurnFailed
 	noteToolResult := func(ev stream.StreamEvent) {
-		if ev.Type == stream.EventToolResult && ev.ToolResult != nil && s.sensitive.Matches(ev.ToolResult.Name) {
+		if ev.Type != stream.EventToolResult || ev.ToolResult == nil {
+			return
+		}
+		ranTool = true
+		if s.sensitive.Matches(ev.ToolResult.Name) {
 			turnSensitive = true
+		}
+	}
+	noteFailure := func(ev stream.StreamEvent) {
+		switch ev.Type {
+		case stream.EventError:
+			if ev.Err != nil {
+				failure = &session.TurnFailed{Code: ev.Err.Code, Message: ev.Err.Message}
+			}
+		case stream.EventIncomplete:
+			failure = &session.TurnFailed{Code: "incomplete", Message: ev.Text}
 		}
 	}
 
@@ -708,11 +733,12 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 				ev.Meta = meta
 			}
 			noteToolResult(ev)
+			noteFailure(ev)
 			notePermission(ev)
 			bc.publish(ev)
 		}
 		close(out)
-		s.persistTurn(sessionID, userText, route, profile, needsTitle, text.String(), reasoning.String(), meta, usage, sawDone, flushed, turnSensitive || sessionSensitive)
+		s.persistTurn(sessionID, userText, route, profile, needsTitle, text.String(), reasoning.String(), meta, usage, sawDone, flushed, turnSensitive || sessionSensitive, failure, ranTool)
 		// Terminal persist is now durable: free the broadcaster (closes
 		// every live /live subscriber) and push the session signal, in
 		// that order — mirrors missions.Store's own "publish only after
@@ -748,6 +774,7 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 				ev.Meta = meta
 			}
 			noteToolResult(ev)
+			noteFailure(ev)
 			notePermission(ev)
 			bc.publish(ev)
 			select {
@@ -780,7 +807,7 @@ func stampDuration(base *stream.Meta, start time.Time) *stream.Meta {
 	return &m
 }
 
-func (s *Service) persistTurn(sessionID, userText, route string, profile agents.Agent, needsTitle bool, text, reasoning string, meta *stream.Meta, usage *stream.Usage, sawDone bool, flushed int, sensitive bool) {
+func (s *Service) persistTurn(sessionID, userText, route string, profile agents.Agent, needsTitle bool, text, reasoning string, meta *stream.Meta, usage *stream.Usage, sawDone bool, flushed int, sensitive bool, failure *session.TurnFailed, ranTool bool) {
 	if !sawDone {
 		// Abnormal end: keep the partial durable; the projection
 		// splices it into the next request. Skip when the periodic
@@ -791,6 +818,34 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 			if _, err := s.log.Append(ctx, sessionID, session.KindPendingState, session.PendingState{Partial: text}); err != nil {
 				s.logger.Error("persist pending state", "session_id", sessionID, "error", err)
 			}
+			return
+		}
+		// No partial worth keeping: a captured terminal error/incomplete
+		// (D-044) becomes durable evidence instead of the turn silently
+		// vanishing — same detached-context, best-effort append as the
+		// pending-state write above.
+		if failure != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), persistTimeout)
+			defer cancel()
+			if _, err := s.log.Append(ctx, sessionID, session.KindTurnFailed, *failure); err != nil {
+				s.logger.Error("persist turn failed", "session_id", sessionID, "error", err)
+			}
+		}
+		return
+	}
+
+	// A completed turn with no text, no reasoning, and no tool
+	// executions is not a success (D-044) — persist evidence instead of
+	// a blank assistant_turn. Keyed on all three being empty so a
+	// tool/reasoning-only turn (a real, valid shape some providers use)
+	// stays untouched.
+	if text == "" && reasoning == "" && !ranTool {
+		ctx, cancel := context.WithTimeout(context.Background(), persistTimeout)
+		defer cancel()
+		if _, err := s.log.Append(ctx, sessionID, session.KindTurnFailed, session.TurnFailed{
+			Code: "empty_response", Message: "the turn completed with no text, reasoning, or tool calls",
+		}); err != nil {
+			s.logger.Error("persist turn failed", "session_id", sessionID, "error", err)
 		}
 		return
 	}

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -517,7 +517,7 @@ func TestChatRetriesAutoTitleUntilATurnCompletes(t *testing.T) {
 		t.Fatalf("Chat 1: %v", err)
 	}
 	drain(t, ch)
-	waitFor(t, func() bool { return len(log.kinds("s1")) == 2 }) // session_started, user_message only
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 }) // session_started, user_message, turn_failed
 	// The slot only frees once persistTurn returns and turnDone runs,
 	// which is not synchronous with drain returning (D-042) — even on
 	// an errored turn, this must still happen so the session isn't
@@ -550,6 +550,76 @@ func TestChatRetriesAutoTitleUntilATurnCompletes(t *testing.T) {
 	log.mu.Unlock()
 	if title != "second answer" {
 		t.Fatalf("title = %q, want the second (first-completed) exchange's text", title)
+	}
+}
+
+// TestTerminalErrorPersistsTurnFailed pins D-044: a turn that ends on
+// a terminal EventError with no partial text must not vanish silently
+// — relay used to drop the error after streaming it to the client,
+// leaving nothing durable. persistTurn now appends a KindTurnFailed
+// event carrying the error's code and message.
+func TestTerminalErrorPersistsTurnFailed(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: []stream.StreamEvent{
+		{Type: stream.EventError, Err: &stream.StreamError{Code: "chain_exhausted", Message: "every provider failed"}},
+	}}
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "hello"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+
+	want := []string{session.KindSessionStarted, session.KindUserMessage, session.KindTurnFailed}
+	if kinds := log.kinds("s1"); strings.Join(kinds, ",") != strings.Join(want, ",") {
+		t.Fatalf("kinds = %v, want %v", kinds, want)
+	}
+
+	events, _ := log.Events(t.Context(), "s1")
+	var failed session.TurnFailed
+	if err := json.Unmarshal(events[2].Payload, &failed); err != nil {
+		t.Fatalf("decode turn_failed: %v", err)
+	}
+	if failed.Code != "chain_exhausted" || failed.Message != "every provider failed" {
+		t.Fatalf("turn_failed = %+v", failed)
+	}
+}
+
+// TestEmptyResponsePersistsTurnFailed pins D-044's other half: a turn
+// that reaches a clean EventDone with no text, no reasoning, and no
+// tool executions is not a success either — persistTurn must not write
+// a blank assistant_turn, and must instead persist evidence the model
+// answered with nothing at all.
+func TestEmptyResponsePersistsTurnFailed(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: []stream.StreamEvent{
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
+	}}
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "hello"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+
+	want := []string{session.KindSessionStarted, session.KindUserMessage, session.KindTurnFailed}
+	if kinds := log.kinds("s1"); strings.Join(kinds, ",") != strings.Join(want, ",") {
+		t.Fatalf("kinds = %v, want %v (no blank assistant_turn)", kinds, want)
+	}
+
+	events, _ := log.Events(t.Context(), "s1")
+	var failed session.TurnFailed
+	if err := json.Unmarshal(events[2].Payload, &failed); err != nil {
+		t.Fatalf("decode turn_failed: %v", err)
+	}
+	if failed.Code != "empty_response" {
+		t.Fatalf("turn_failed.Code = %q, want empty_response", failed.Code)
 	}
 }
 
@@ -955,8 +1025,11 @@ func TestMemoryExtractFiresOnTextlessTurn(t *testing.T) {
 	t.Parallel()
 	log := newFakeLog()
 	// Provider quirk: turn completes with reasoning/tool traffic but
-	// no text. The user's words still carry facts.
+	// no text. The user's words still carry facts. A tool execution
+	// keeps this a valid non-empty turn (D-044's empty-response guard
+	// keys on text+reasoning+tools all being empty).
 	gw := &fakeGW{events: []stream.StreamEvent{
+		{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{ID: "c1", Name: "time", Status: "ok"}},
 		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
 	}}
 	svc := newService(gw, log)
@@ -1144,8 +1217,10 @@ func TestAgentProfileShapesTurn(t *testing.T) {
 }
 
 // A failed attempt (no EventDone) leaves the user_message durable with
-// nothing after it — persistTurn only appends assistant_turn on
-// sawDone. Retry must reuse that message, not append a second one.
+// a turn_failed event after it (D-044) — persistTurn only appends
+// assistant_turn on sawDone. Retry must reuse that message, not append
+// a second one; turn_failed doesn't block retry (lastUserMessage only
+// stops at a completed assistant_turn).
 func TestRetryReusesLastUserMessageWithoutDuplicating(t *testing.T) {
 	t.Parallel()
 	log := newFakeLog()
@@ -1157,9 +1232,10 @@ func TestRetryReusesLastUserMessageWithoutDuplicating(t *testing.T) {
 		t.Fatalf("Chat: %v", err)
 	}
 	drain(t, ch)
-	waitFor(t, func() bool { return len(log.kinds("s1")) == 2 })
-	if kinds := log.kinds("s1"); strings.Join(kinds, ",") != strings.Join([]string{session.KindSessionStarted, session.KindUserMessage}, ",") {
-		t.Fatalf("kinds after failed attempt = %v, want a dangling user_message", kinds)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+	want := []string{session.KindSessionStarted, session.KindUserMessage, session.KindTurnFailed}
+	if kinds := log.kinds("s1"); strings.Join(kinds, ",") != strings.Join(want, ",") {
+		t.Fatalf("kinds after failed attempt = %v, want a dangling user_message plus turn_failed", kinds)
 	}
 	// The slot only frees once turnDone runs, not synchronously with
 	// drain returning (D-042) — an errored turn must still free it so
@@ -1175,10 +1251,10 @@ func TestRetryReusesLastUserMessageWithoutDuplicating(t *testing.T) {
 		t.Fatalf("Retry: %v", err)
 	}
 	drain(t, ch)
-	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 4 })
 
 	kinds := log.kinds("s1")
-	want := []string{session.KindSessionStarted, session.KindUserMessage, session.KindAssistantTurn}
+	want = []string{session.KindSessionStarted, session.KindUserMessage, session.KindTurnFailed, session.KindAssistantTurn}
 	if strings.Join(kinds, ",") != strings.Join(want, ",") {
 		t.Fatalf("kinds after retry = %v, want %v (no duplicated user_message)", kinds, want)
 	}
@@ -1190,7 +1266,7 @@ func TestRetryReusesLastUserMessageWithoutDuplicating(t *testing.T) {
 
 	events, _ := log.Events(t.Context(), "s1")
 	var turn session.AssistantTurn
-	if err := json.Unmarshal(events[2].Payload, &turn); err != nil {
+	if err := json.Unmarshal(events[3].Payload, &turn); err != nil {
 		t.Fatalf("decode turn: %v", err)
 	}
 	if turn.LLM.Message != "the answer" {

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -313,6 +313,12 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 		var calls []provider.ToolCall
 		terminal := stream.StreamEvent{}
 		emittedThisAttempt := false
+		// incompleteEv is sticky across this attempt: the gateway sends
+		// incomplete THEN done for a cut-off or zero-output stream
+		// (D-044), and terminal is last-write-wins — done would
+		// otherwise clobber incomplete and the abnormal-end guard below
+		// would never fire. done cannot clear this.
+		var incompleteEv *stream.StreamEvent
 
 		for attempt := 0; ; attempt++ {
 			upstream, err := a.gw.Stream(ctx, sreq)
@@ -334,6 +340,7 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			calls = nil
 			terminal = stream.StreamEvent{}
 			emittedThisAttempt = false
+			incompleteEv = nil
 			for ev := range upstream {
 				switch ev.Type {
 				case stream.EventChunk:
@@ -365,7 +372,11 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 					if ev.Meta != nil {
 						lastMeta = ev.Meta
 					}
-				case stream.EventIncomplete, stream.EventError:
+				case stream.EventIncomplete:
+					terminal = ev
+					evCopy := ev
+					incompleteEv = &evCopy
+				case stream.EventError:
 					terminal = ev
 				}
 			}
@@ -383,10 +394,16 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 		}
 
 		// Abnormal step end: surface it and stop — the relay persists
-		// the partial exactly as before.
-		if terminal.Type != stream.EventDone {
+		// the partial exactly as before. incompleteEv keeps a cut-off or
+		// zero-output stream on this path even though done arrived after
+		// incomplete and would otherwise look like a clean finish; it
+		// carries the incomplete event's own text instead of the terminal
+		// done event's (near-empty) content.
+		if terminal.Type != stream.EventDone || incompleteEv != nil {
 			if terminal.Type == "" {
 				terminal = stream.StreamEvent{Type: stream.EventIncomplete, Text: "stream ended without a terminal event"}
+			} else if incompleteEv != nil {
+				terminal = *incompleteEv
 			}
 			emit(stream.StreamEvent{Type: stream.EventUsage, Usage: &total})
 			emit(terminal)

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -439,6 +439,42 @@ func TestAgentFlushesUsageOnGatewayError(t *testing.T) {
 	}
 }
 
+// TestAgentIncompleteThenDoneNotTreatedAsCleanFinish pins D-044: the
+// gateway sends incomplete THEN done for a cut-off or zero-output
+// stream. Before the fix, terminal was last-write-wins, so done
+// clobbered incomplete and the step's abnormal-end guard never fired —
+// the turn looked like a clean finish with an empty answer. The loop
+// must instead follow the same surface-and-stop path an error step
+// takes today: the client sees the incomplete terminal, never a done.
+func TestAgentIncompleteThenDoneNotTreatedAsCleanFinish(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		{
+			{Type: stream.EventUsage, Usage: &stream.Usage{InputTokens: 10, OutputTokens: 0}},
+			{Type: stream.EventIncomplete, Text: "provider produced no output"},
+			{Type: stream.EventDone, Meta: &stream.Meta{Provider: "fake", Model: "fake-1"}},
+		},
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	if len(ofType(evs, stream.EventDone)) != 0 {
+		t.Fatalf("events = %+v, want no done event reaching the client", evs)
+	}
+	incomplete := ofType(evs, stream.EventIncomplete)
+	if len(incomplete) != 1 || incomplete[0].Text != "provider produced no output" {
+		t.Fatalf("incomplete events = %+v, want exactly one carrying the original text", incomplete)
+	}
+	if evs[len(evs)-1].Type != stream.EventIncomplete {
+		t.Fatalf("last event = %v, want incomplete (the step's abnormal-end terminal)", evs[len(evs)-1].Type)
+	}
+}
+
 func TestAgentPerToolOffloadThreshold(t *testing.T) {
 	t.Parallel()
 	// A 100-byte result: default threshold keeps it inline, a 50-byte

--- a/internal/brain/session/events.go
+++ b/internal/brain/session/events.go
@@ -23,6 +23,12 @@ const (
 	KindTurnMemory         = "turn_memory"
 	KindPermissionRequest  = "permission_request"
 	KindPermissionResolved = "permission_resolved"
+	// KindTurnFailed records a turn that ended without a usable answer —
+	// a terminal error/incomplete with nothing worth keeping as partial
+	// text, or a completed turn with no text, reasoning, or tool
+	// executions (D-044) — so the event log carries evidence instead of
+	// silence.
+	KindTurnFailed = "turn_failed"
 )
 
 // Event is one row of a session's log.
@@ -121,6 +127,15 @@ type CompactionApplied struct {
 // abnormally; the next request splices it in, then it is superseded.
 type PendingState struct {
 	Partial string `json:"partial"`
+}
+
+// TurnFailed records a turn that produced no usable answer: Code is a
+// short machine-readable reason (e.g. a terminal error/incomplete's
+// code, or "empty_response" for a completed turn with nothing to
+// show), Message is the human-readable detail.
+type TurnFailed struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
 }
 
 // PermissionRequest records a parked tool call awaiting approval

--- a/internal/brain/session/projection.go
+++ b/internal/brain/session/projection.go
@@ -103,6 +103,15 @@ func LLMContext(events []Event, budget int) ([]provider.Message, error) {
 			if block := renderTurnMemory(&tm.TurnMemory); block != "" {
 				msgs = append(msgs, provider.Message{Role: "user", Content: block})
 			}
+		case KindTurnFailed:
+			var f TurnFailed
+			if err := decode(ev, &f); err != nil {
+				return nil, err
+			}
+			// A bracketed note, same register as the compaction/turn-memory
+			// asides above — the model sees that the prior turn failed
+			// without the failure reading as its own answer.
+			msgs = append(msgs, provider.Message{Role: "user", Content: fmt.Sprintf("[previous turn failed: %s]", f.Message)})
 		}
 	}
 	return msgs, nil
@@ -170,7 +179,7 @@ func renderTurnMemory(tm *TurnMemory) string {
 // TranscriptItem is one renderable unit of the UI replay.
 type TranscriptItem struct {
 	Seq        int64              `json:"seq"`
-	Kind       string             `json:"kind"` // user | assistant | tool | permission | compaction | interrupted
+	Kind       string             `json:"kind"` // user | assistant | tool | permission | compaction | interrupted | error
 	Text       string             `json:"text,omitempty"`
 	Blocks     []UIBlock          `json:"blocks,omitempty"`
 	Provider   string             `json:"provider,omitempty"`
@@ -245,6 +254,12 @@ func UITranscript(events []Event) ([]TranscriptItem, error) {
 				return nil, err
 			}
 			item.Kind, item.Text = "interrupted", p.Partial
+		case KindTurnFailed:
+			var f TurnFailed
+			if err := decode(ev, &f); err != nil {
+				return nil, err
+			}
+			item.Kind, item.Text = "error", f.Message
 		default:
 			continue // session_started renders nothing
 		}

--- a/internal/brain/session/projection_test.go
+++ b/internal/brain/session/projection_test.go
@@ -193,6 +193,30 @@ func TestLLMContextIgnoresToolExecutions(t *testing.T) {
 	}
 }
 
+// TestLLMContextRendersTurnFailed pins D-044: a persisted turn_failed
+// event rides the LLM context as a bracketed user-role note (same
+// register as compaction/turn-memory asides), never as an assistant
+// message the model might imitate.
+func TestLLMContextRendersTurnFailed(t *testing.T) {
+	t.Parallel()
+	events := []Event{
+		user(t, 1, "do the thing"),
+		ev(t, 2, KindTurnFailed, TurnFailed{Code: "chain_exhausted", Message: "every provider failed"}),
+		user(t, 3, "try again"),
+	}
+
+	msgs, err := LLMContext(events, 0)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("messages = %+v, want 3 (user, failed note, user)", msgs)
+	}
+	if msgs[1].Role != "user" || !strings.Contains(msgs[1].Content, "every provider failed") {
+		t.Fatalf("turn_failed note = %+v", msgs[1])
+	}
+}
+
 func TestUITranscript(t *testing.T) {
 	t.Parallel()
 	events := []Event{
@@ -223,6 +247,29 @@ func TestUITranscript(t *testing.T) {
 	}
 	if items[2].Provider != "prov" || len(items[2].Blocks) != 1 {
 		t.Fatalf("assistant item = %+v", items[2])
+	}
+}
+
+// TestUITranscriptRendersTurnFailed pins D-044's UI side: a persisted
+// turn_failed event surfaces as its own "error" replay item carrying
+// the human-readable message — the whole point is that a failed turn
+// is visible on reload, not silently dropped like session_started.
+func TestUITranscriptRendersTurnFailed(t *testing.T) {
+	t.Parallel()
+	events := []Event{
+		user(t, 1, "do the thing"),
+		ev(t, 2, KindTurnFailed, TurnFailed{Code: "empty_response", Message: "the turn completed with no text, reasoning, or tool calls"}),
+	}
+
+	items, err := UITranscript(events)
+	if err != nil {
+		t.Fatalf("UITranscript: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %+v, want 2", items)
+	}
+	if items[1].Kind != "error" || items[1].Text != "the turn completed with no text, reasoning, or tool calls" {
+		t.Fatalf("turn_failed item = %+v", items[1])
 	}
 }
 

--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -261,6 +261,13 @@ func streamAttempt(ctx context.Context, att router.Attempt, completion provider.
 			res.streamed = true
 			send(ev)
 		case stream.EventDone:
+			// A stream that closes clean but produced no content (e.g.
+			// [DONE] with zero deltas) is not a success (D-044): tell the
+			// client before the terminal done, the same incomplete-then-
+			// done shape a cut-off stream already uses (see httpx.go).
+			if !res.streamed {
+				send(stream.StreamEvent{Type: stream.EventIncomplete, Text: "provider produced no output"})
+			}
 			// Attribute the serving provider on the terminal event so
 			// callers need no second lookup.
 			ev.Meta = &stream.Meta{
@@ -285,6 +292,14 @@ func finalStatus(res attemptResult) string {
 		return res.entry.Status
 	case res.failed, res.entry.ErrorCode != "":
 		return "error"
+	// A drained stream that produced no content is not a success (D-044):
+	// booking it "ok" would also poison LastSuccess stickiness (ledger.go
+	// filters status='ok'), sticking a session onto a provider that just
+	// returned nothing. res.streamed is set only by content events
+	// (chunk/reasoning/tool); EventUsage deliberately does not set it, so
+	// a usage-only stream still lands here.
+	case !res.streamed:
+		return "incomplete"
 	default:
 		return "ok"
 	}

--- a/internal/gateway/api/api_test.go
+++ b/internal/gateway/api/api_test.go
@@ -94,6 +94,19 @@ func oaiFail(t *testing.T) *httptest.Server {
 	return srv
 }
 
+// oaiEmptyDone streams usage then [DONE] with zero content deltas — a
+// provider stream that terminates cleanly but produced no output
+// (D-044).
+func oaiEmptyDone(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":0}}\n\n")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
 // snapshotFor builds a two-provider snapshot with a coding route
 // chaining first→second and an embedding route on first.
 func snapshotFor(t *testing.T, firstURL, secondURL string) *router.Snapshot {
@@ -195,6 +208,46 @@ func TestStreamHappyPathWithLedger(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(a.providerCalls.WithLabelValues("one", "coding", "ok")); got != 1 {
 		t.Fatalf("provider_calls_total{one,coding,ok} = %v, want 1", got)
+	}
+}
+
+// TestStreamEmptyOutputBookedIncomplete pins D-044: a provider stream
+// that terminates cleanly with zero content deltas ([DONE] only) must
+// not be booked as a success. res.streamed is set only by content
+// events (chunk/reasoning/tool) — never by EventUsage — so the ledger
+// status flips to "incomplete" even though usage/cost are still known
+// (a real, reported zero, not the unknown-so-NULL case D-013 covers).
+// The client sees an EventIncomplete before the terminal done, the same
+// shape a cut-off stream already uses.
+func TestStreamEmptyOutputBookedIncomplete(t *testing.T) {
+	t.Parallel()
+	a, rec := newAPI(snapshotFor(t, oaiEmptyDone(t).URL, oaiFail(t).URL))
+
+	w := postJSON(t, a.handleStream, `{"route":"coding","session_id":"s1","messages":[{"role":"user","content":"hi"}]}`)
+
+	events := sseEvents(t, w.Body.String())
+	if len(events) < 2 {
+		t.Fatalf("events = %+v, want at least incomplete+done", events)
+	}
+	last := events[len(events)-1]
+	if last.Type != stream.EventDone {
+		t.Fatalf("last event = %v, want done", last.Type)
+	}
+	prev := events[len(events)-2]
+	if prev.Type != stream.EventIncomplete {
+		t.Fatalf("event before done = %v, want incomplete", prev.Type)
+	}
+
+	entries := rec.all()
+	if len(entries) != 1 {
+		t.Fatalf("ledger entries = %d, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Status != "incomplete" {
+		t.Fatalf("status = %q, want incomplete", e.Status)
+	}
+	if e.Usage == nil || e.Usage.OutputTokens != 0 {
+		t.Fatalf("usage = %+v, want reported zero output tokens", e.Usage)
 	}
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -115,7 +115,7 @@ export interface ToolExecution {
 // dropped by the server projection, same as the live client drops it).
 export interface TranscriptItem {
   seq: number
-  kind: 'user' | 'assistant' | 'tool' | 'permission' | 'compaction' | 'interrupted'
+  kind: 'user' | 'assistant' | 'tool' | 'permission' | 'compaction' | 'interrupted' | 'error'
   text?: string
   blocks?: UIBlock[]
   tool?: ToolExecution

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -154,6 +154,18 @@ export function InterruptedMessage({ text }: { text: string }) {
   )
 }
 
+// ErrorMessage renders a turn that persisted as failed (D-043): a
+// terminal error/incomplete with nothing worth keeping, or a completed
+// turn with no text, reasoning, or tool calls. Surfacing this IS the
+// point — the turn used to vanish from the transcript silently.
+export function ErrorMessage({ text }: { text: string }) {
+  return (
+    <div className="flex items-center gap-2" data-testid="turn-failed">
+      <Badge variant="destructive">{text || 'this turn failed'}</Badge>
+    </div>
+  )
+}
+
 export function AssistantMessage({
   msg,
   onRetry,

--- a/web/src/lib/transcript.test.ts
+++ b/web/src/lib/transcript.test.ts
@@ -182,6 +182,15 @@ describe('fromTranscript', () => {
     expect(fromTranscript([])).toEqual([])
   })
 
+  it('renders a turn_failed event as its own error item', () => {
+    const items = fromTranscript([
+      { seq: 1, kind: 'user', text: 'do the thing', created_at: at },
+      { seq: 2, kind: 'error', text: 'every provider failed', created_at: at },
+    ])
+    expect(items.map((i) => i.role)).toEqual(['user', 'error'])
+    expect(items[1]).toMatchObject({ role: 'error', text: 'every provider failed' })
+  })
+
   it('exposes a still-unresolved replayed ask in permissions[]', () => {
     const items = fromTranscript([
       { seq: 1, kind: 'user', text: 'q', created_at: at },

--- a/web/src/lib/transcript.ts
+++ b/web/src/lib/transcript.ts
@@ -9,6 +9,7 @@ export type ChatItem = { id: string } & (
   | ({ role: 'assistant' } & AssistantState)
   | { role: 'compaction'; text: string }
   | { role: 'interrupted'; text: string }
+  | { role: 'error'; text: string }
 )
 
 function toToolRun(tool: NonNullable<TranscriptItem['tool']>): ToolRun {
@@ -112,6 +113,10 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
       case 'interrupted':
         flush()
         out.push({ id, role: 'interrupted', text: item.text ?? '' })
+        break
+      case 'error':
+        flush()
+        out.push({ id, role: 'error', text: item.text ?? '' })
         break
     }
   }

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -12,7 +12,7 @@ import {
 import type { ChatEvent } from '../api/types'
 import { ActivityPanel } from '../components/Activity'
 import { Composer } from '../components/Composer'
-import { AssistantMessage, CompactionDivider, InterruptedMessage, UserMessage } from '../components/Message'
+import { AssistantMessage, CompactionDivider, ErrorMessage, InterruptedMessage, UserMessage } from '../components/Message'
 import { PermissionModal } from '../components/PermissionModal'
 import { Sheet } from '../components/ui/sheet'
 import {
@@ -480,6 +480,8 @@ export function Chat({
               return <CompactionDivider key={item.id} text={item.text} />
             case 'interrupted':
               return <InterruptedMessage key={item.id} text={item.text} />
+            case 'error':
+              return <ErrorMessage key={item.id} text={item.text} />
             default:
               return (
                 <AssistantMessage


### PR DESCRIPTION
## Problem
A provider stream that terminates cleanly with zero content deltas was booked in cost_ledger as status `ok` with NULL tokens, and the brain persisted zero (or a blank) session event — the turn silently vanished. The session then looked retryable, inviting retry storms (observed: a 924s retry against a wedged provider, ledger "ok", nothing persisted). Separately, a cut-off stream's `incomplete` terminal was overwritten by the trailing `done` in the loop, so the brain could not see cut-off streams at all.

## Fix (D-044)
**Gateway**
- `finalStatus` books a drained-but-empty stream as `incomplete`, not `ok` — also stops such calls poisoning LastSuccess provider stickiness. Failover logic untouched; tokens/cost stay NULL when unknown (D-013).
- Client now receives `EventIncomplete("provider produced no output")` before `done`.

**Brain**
- Loop: `incomplete` is sticky — a trailing `done` no longer clears it; cut-off streams follow the same retry/surface path as errors.
- New `KindTurnFailed` session event (code + message): terminal errors with no partial text, and "completed" turns with no text/reasoning/tools, now persist evidence instead of nothing. Rendered as an error notice in the web UI.
- Retry semantics preserved: `turn_failed` between a dangling user_message and a later retry is inert.

## Tests
Gateway empty-[DONE] booking, loop incomplete-then-done, chat turn-failed persistence (both branches), projection table cases, web transcript error item. Three pre-existing exact-event-count tests updated for the new third event.

`make build test vet lint` + web build/lint/test green.