### PR TITLE
feat: image attachments on chat messages

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/SumonMSelim/timothy/internal/brain/agents"
 	"github.com/SumonMSelim/timothy/internal/brain/api"
+	"github.com/SumonMSelim/timothy/internal/brain/attachments"
 	"github.com/SumonMSelim/timothy/internal/brain/chat"
 	"github.com/SumonMSelim/timothy/internal/brain/connectors"
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
@@ -309,10 +310,19 @@ func main() {
 		return memclient.RenderBlock(memories)
 	})
 
+	attachmentStore := buildAttachments(app.DB, app.Log)
+	// Nil-safe: a nil *attachments.Store boxed into the AttachmentStore
+	// interface would be a non-nil interface value, breaking chat.go's
+	// `s.attachments == nil` gate — so this only wires when non-nil,
+	// same guard shape as the missionHub check above.
+	if attachmentStore != nil {
+		svc.SetAttachments(attachmentStore)
+	}
+
 	api.Register(app.Server, svc, store, broker,
 		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, app.Log), flags,
 		agentReg, conns, goog, agent, missionStore, missionDriver, missionNotifier,
-		missionWorkspace, resolveSecret, missionHub, token, app.Log)
+		missionWorkspace, resolveSecret, missionHub, attachmentStore, token, app.Log)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)
@@ -335,6 +345,18 @@ func buildSecretStore(db *pgpool.Pool, log *slog.Logger) (*secretstore.Store, er
 		return nil, fmt.Errorf("secret store init failed: %w", err)
 	}
 	return secrets, nil
+}
+
+// buildAttachments wires the image-attachment store (D-045).
+// ATTACHMENTS_DIR unset means the feature is off: no store, chat
+// rejects attachment refs, and the API surface stays unmounted.
+func buildAttachments(db *pgpool.Pool, log *slog.Logger) *attachments.Store {
+	dir := os.Getenv("ATTACHMENTS_DIR")
+	if dir == "" {
+		log.Info("ATTACHMENTS_DIR not set; image attachments disabled")
+		return nil
+	}
+	return attachments.New(dir, db)
 }
 
 // buildConnectors wires the integration control plane. secrets is

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -103,8 +103,12 @@ services:
       # just idles degraded). Empty keeps the original in-process exec
       # behavior; brain never touches the Docker socket directly.
       SANDBOXD_URL: ${MISSION_SANDBOX_IMAGE:+http://sandboxd:8083}
+      # Content-addressed image attachment bytes (metadata only in
+      # Postgres); compose-internal path, not user-facing.
+      ATTACHMENTS_DIR: /attachments
     volumes:
       - workspace:/workspace
+      - attachments:/attachments
     ports:
       - "${BRAIN_PORT:-8300}:8080"
     depends_on:
@@ -270,6 +274,7 @@ volumes:
   pgdata:
   web_node_modules:
   workspace:
+  attachments:
 
 networks:
   timothy:

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/SumonMSelim/timothy/internal/brain/agents"
+	"github.com/SumonMSelim/timothy/internal/brain/attachments"
 	"github.com/SumonMSelim/timothy/internal/brain/chat"
 	"github.com/SumonMSelim/timothy/internal/brain/connectors"
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
@@ -77,7 +78,7 @@ var memoryRoutePatterns = []string{
 // is the reverse proxy to memoryd's management routes, admin the
 // proxy to the gateway's internal control plane, conns the local
 // connector control plane (nil leaves any of them unmounted).
-func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, toolset Toolset, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), hub *missions.Hub, token string, log *slog.Logger) {
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, toolset Toolset, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), hub *missions.Hub, attachmentStore *attachments.Store, token string, log *slog.Logger) {
 	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log}
 	if memories != nil {
 		for _, pattern := range memoryRoutePatterns {
@@ -92,6 +93,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret)
 	a.registerSchedules(srv.Handle, missionStore)
 	a.registerEvents(srv.Handle, hub)
+	a.registerAttachments(srv.Handle, attachmentStore)
 	srv.Handle("GET /v1/sessions", a.auth(http.HandlerFunc(a.handleList)))
 	srv.Handle("POST /v1/sessions", a.auth(http.HandlerFunc(a.handleCreate)))
 	srv.Handle("GET /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleTranscript)))

--- a/internal/brain/api/attachments.go
+++ b/internal/brain/api/attachments.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/SumonMSelim/timothy/internal/brain/attachments"
+)
+
+// registerAttachments mounts the attachment upload/download surface.
+// Nil-gated: store is nil when ATTACHMENTS_DIR is unset, leaving the
+// surface unmounted (404s), same pattern as missions/schedules/agents.
+func (a *API) registerAttachments(handle func(pattern string, h http.Handler), store *attachments.Store) {
+	if store == nil {
+		return
+	}
+	h := &attachmentAPI{store: store}
+	handle("POST /v1/attachments", a.auth(http.HandlerFunc(h.upload)))
+	handle("GET /v1/attachments/{id}", a.auth(http.HandlerFunc(h.download)))
+}
+
+type attachmentAPI struct {
+	store *attachments.Store
+}
+
+func failAttachment(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, attachments.ErrNotFound):
+		jsonError(w, http.StatusNotFound, "not_found", "attachment not found")
+	case errors.Is(err, attachments.ErrUnsupportedMIME):
+		jsonError(w, http.StatusBadRequest, "unsupported_mime", err.Error())
+	default:
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+	}
+}
+
+type attachmentView struct {
+	ID        string `json:"id"`
+	Mime      string `json:"mime"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+// upload accepts a single multipart file field "file", caps its size
+// at attachments.MaxSizeBytes before any bytes reach the store, and
+// hands the body straight to Store.Save — the store itself sniffs the
+// real MIME type rather than trusting the multipart part's header.
+func (h *attachmentAPI) upload(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, attachments.MaxSizeBytes)
+	if err := r.ParseMultipartForm(attachments.MaxSizeBytes); err != nil { //nolint:gosec // G120: r.Body is already MaxBytesReader-capped above at the same limit
+		jsonError(w, http.StatusBadRequest, "too_large", "file exceeds the 10MB limit")
+		return
+	}
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", "multipart field \"file\" is required")
+		return
+	}
+	defer func() { _ = file.Close() }()
+
+	att, err := h.store.Save(r.Context(), file)
+	if err != nil {
+		failAttachment(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, attachmentView{ID: att.ID, Mime: att.Mime, SizeBytes: att.SizeBytes})
+}
+
+// download serves the raw bytes with Content-Type forced from the DB
+// row (never sniffed at serve time — the row is the sole source of
+// truth once Save already sniffed it once) and an immutable
+// Cache-Control, since the id is the content hash.
+func (h *attachmentAPI) download(w http.ResponseWriter, r *http.Request) {
+	f, att, err := h.store.Open(r.Context(), r.PathValue("id"))
+	if err != nil {
+		failAttachment(w, err)
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	w.Header().Set("Content-Type", att.Mime)
+	w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.Copy(w, f)
+}

--- a/internal/brain/api/attachments_test.go
+++ b/internal/brain/api/attachments_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"mime/multipart"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/attachments"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+// pngBytes is a minimal valid 1x1 PNG — enough for http.DetectContentType
+// to sniff "image/png" without a real file on disk.
+var pngBytes = []byte{
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+	0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00,
+	0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+	0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
+	0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+}
+
+func TestAttachmentsEndpointsUnmountedWhenStoreNil(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	m := mux(a)
+	a.registerAttachments(m.Handle, nil)
+
+	for _, req := range []struct{ method, path string }{
+		{"POST", "/v1/attachments"},
+		{"GET", "/v1/attachments/abc"},
+	} {
+		httpReq := httptest.NewRequest(req.method, req.path, nil)
+		httpReq.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, httpReq)
+		if w.Code != 404 {
+			t.Fatalf("%s %s with a nil attachment store = %d, want 404 (unmounted)", req.method, req.path, w.Code)
+		}
+	}
+}
+
+func TestAttachmentsRequireAuth(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := attachments.New(t.TempDir(), pool)
+	m := mux(a)
+	a.registerAttachments(m.Handle, store)
+
+	req := httptest.NewRequest("POST", "/v1/attachments", nil)
+	// No Authorization header.
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != 401 {
+		t.Fatalf("unauthenticated upload = %d, want 401", w.Code)
+	}
+}
+
+func TestAttachmentsUploadBadMultipartField(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := attachments.New(t.TempDir(), pool)
+	m := mux(a)
+	a.registerAttachments(m.Handle, store)
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	// Wrong field name — handler requires "file".
+	part, err := mw.CreateFormFile("wrong_field", "upload.png")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := part.Write(pngBytes); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/v1/attachments", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Fatalf("missing \"file\" field = %d, want 400", w.Code)
+	}
+}
+
+func TestAttachmentsUploadReachesStore(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	// A never-connecting pool proves upload parses the multipart body
+	// and reaches Store.Save (which then fails at the DB step) —
+	// the actual save/dedup/mime-sniff semantics against a real
+	// Postgres are covered by the attachments package's own
+	// integration tests.
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := attachments.New(t.TempDir(), pool)
+	m := mux(a)
+	a.registerAttachments(m.Handle, store)
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, err := mw.CreateFormFile("file", "upload.png")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := part.Write(pngBytes); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/v1/attachments", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	// A degraded pool surfaces as failAttachment's default 400 mapping
+	// (matches the "bad_request" fallback for a non-sentinel error) —
+	// proving the request passed multipart parsing and reached Save.
+	if w.Code != 400 {
+		t.Fatalf("upload against a degraded store = %d, want 400 (reached the store)", w.Code)
+	}
+}
+
+func TestAttachmentsDownloadUnknownID(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	store := attachments.New(t.TempDir(), pgpool.New(context.Background(), "postgres://invalid/nope", discard()))
+	m := mux(a)
+	a.registerAttachments(m.Handle, store)
+
+	req := httptest.NewRequest("GET", "/v1/attachments/does-not-exist", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	// Degraded store: Get fails before ErrNotFound can even be
+	// distinguished, so this also lands on the generic 400 mapping —
+	// same "reached the store" proof as the upload test above.
+	if w.Code != 400 {
+		t.Fatalf("download against a degraded store = %d, want 400 (reached the store)", w.Code)
+	}
+}

--- a/internal/brain/attachments/attachments.go
+++ b/internal/brain/attachments/attachments.go
@@ -1,0 +1,187 @@
+// Package attachments stores user-uploaded images content-addressed on
+// a local volume, with metadata only in Postgres — binaries never
+// enter the database (D-045). ATTACHMENTS_DIR unset means the feature
+// is off: callers nil-gate on a nil *Store.
+package attachments
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+// MaxSizeBytes caps a single attachment upload; enforced by the caller
+// via http.MaxBytesReader before Save ever sees the body.
+const MaxSizeBytes = 10 << 20 // 10MB
+
+// ErrUnsupportedMIME reports a sniffed content type outside the
+// allowlist — decided server-side (http.DetectContentType), never
+// trusting the client-supplied header.
+var ErrUnsupportedMIME = errors.New("attachments: unsupported mime type")
+
+// ErrNotFound reports an id with no matching row.
+var ErrNotFound = errors.New("attachments: not found")
+
+// allowedExt maps the sniffed MIME type to its stored file extension.
+// Only these four are accepted; anything else is ErrUnsupportedMIME.
+var allowedExt = map[string]string{
+	"image/png":  ".png",
+	"image/jpeg": ".jpg",
+	"image/webp": ".webp",
+	"image/gif":  ".gif",
+}
+
+// Attachment is one stored image's metadata.
+type Attachment struct {
+	ID        string // sha256 hex of the file bytes
+	Mime      string
+	SizeBytes int64
+	CreatedAt time.Time
+}
+
+// Store persists attachment bytes under dir (content-addressed,
+// <sha256><ext>) and metadata in the attachments table.
+type Store struct {
+	dir string
+	db  *pgpool.Pool
+}
+
+// New returns a Store rooted at dir. Callers nil-gate the feature by
+// only calling New when ATTACHMENTS_DIR is set.
+func New(dir string, db *pgpool.Pool) *Store {
+	return &Store{dir: dir, db: db}
+}
+
+// Save streams r to a temp file while computing its sha256, sniffs the
+// MIME type from the leading bytes (never the caller's declared
+// mime), and on success renames into place as <sha256><ext>. Content-
+// addressed: saving identical bytes twice yields the same id and is a
+// no-op on the metadata row (ON CONFLICT DO NOTHING).
+func (s *Store) Save(ctx context.Context, r io.Reader) (Attachment, error) {
+	tmp, err := os.CreateTemp(s.dir, "upload-*")
+	if err != nil {
+		return Attachment{}, fmt.Errorf("attachments: save: temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = os.Remove(tmpPath) // no-op once renamed into place
+	}()
+
+	h := sha256.New()
+	// http.DetectContentType only inspects the first 512 bytes.
+	var sniffBuf [512]byte
+	sniffed := 0
+
+	size, err := copyAndSniff(tmp, r, h, sniffBuf[:], &sniffed)
+	if err != nil {
+		_ = tmp.Close()
+		return Attachment{}, fmt.Errorf("attachments: save: write: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return Attachment{}, fmt.Errorf("attachments: save: close: %w", err)
+	}
+
+	mime := http.DetectContentType(sniffBuf[:sniffed])
+	ext, ok := allowedExt[mime]
+	if !ok {
+		return Attachment{}, fmt.Errorf("attachments: save: mime %q: %w", mime, ErrUnsupportedMIME)
+	}
+
+	id := fmt.Sprintf("%x", h.Sum(nil))
+	finalPath := filepath.Join(s.dir, id+ext)
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		return Attachment{}, fmt.Errorf("attachments: save: rename: %w", err)
+	}
+
+	db, err := s.db.Get()
+	if err != nil {
+		return Attachment{}, fmt.Errorf("attachments: save: %w", err)
+	}
+	// Content-addressed: identical bytes hash to the same id, so a
+	// repeat upload is a no-op here — the file rename above is
+	// likewise a same-content overwrite of itself.
+	if _, err := db.Exec(ctx,
+		"INSERT INTO attachments (id, mime, size_bytes) VALUES ($1, $2, $3) ON CONFLICT (id) DO NOTHING",
+		id, mime, size,
+	); err != nil {
+		return Attachment{}, fmt.Errorf("attachments: save: insert: %w", err)
+	}
+	var createdAt time.Time
+	if err := db.QueryRow(ctx,
+		"SELECT created_at FROM attachments WHERE id = $1", id,
+	).Scan(&createdAt); err != nil {
+		return Attachment{}, fmt.Errorf("attachments: save: read back: %w", err)
+	}
+
+	return Attachment{ID: id, Mime: mime, SizeBytes: size, CreatedAt: createdAt}, nil
+}
+
+// copyAndSniff copies r into w while hashing every byte and capturing
+// up to len(sniffBuf) leading bytes for MIME detection.
+func copyAndSniff(w io.Writer, r io.Reader, h io.Writer, sniffBuf []byte, sniffed *int) (int64, error) {
+	mw := io.MultiWriter(w, h)
+	var total int64
+	buf := make([]byte, 32*1024)
+	for {
+		n, rerr := r.Read(buf)
+		if n > 0 {
+			if _, err := mw.Write(buf[:n]); err != nil {
+				return total, err
+			}
+			if *sniffed < len(sniffBuf) {
+				*sniffed += copy(sniffBuf[*sniffed:], buf[:n])
+			}
+			total += int64(n)
+		}
+		if rerr == io.EOF {
+			return total, nil
+		}
+		if rerr != nil {
+			return total, rerr
+		}
+	}
+}
+
+// Get returns metadata for id without opening the file.
+func (s *Store) Get(ctx context.Context, id string) (Attachment, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return Attachment{}, fmt.Errorf("attachments: get: %w", err)
+	}
+	var a Attachment
+	err = db.QueryRow(ctx,
+		"SELECT id, mime, size_bytes, created_at FROM attachments WHERE id = $1", id,
+	).Scan(&a.ID, &a.Mime, &a.SizeBytes, &a.CreatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Attachment{}, ErrNotFound
+	}
+	if err != nil {
+		return Attachment{}, fmt.Errorf("attachments: get: %w", err)
+	}
+	return a, nil
+}
+
+// Open returns the attachment's bytes plus its metadata. The caller
+// must Close the reader.
+func (s *Store) Open(ctx context.Context, id string) (io.ReadCloser, Attachment, error) {
+	a, err := s.Get(ctx, id)
+	if err != nil {
+		return nil, Attachment{}, err
+	}
+	ext := allowedExt[a.Mime]
+	f, err := os.Open(filepath.Join(s.dir, a.ID+ext))
+	if err != nil {
+		return nil, Attachment{}, fmt.Errorf("attachments: open: %w", err)
+	}
+	return f, a, nil
+}

--- a/internal/brain/attachments/attachments_integration_test.go
+++ b/internal/brain/attachments/attachments_integration_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package attachments
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/platform/migrate"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+	"github.com/SumonMSelim/timothy/migrations"
+)
+
+// pngBytes is a minimal valid 1x1 PNG — enough for http.DetectContentType
+// to sniff "image/png".
+var pngBytes = []byte{
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+	0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, 0x00, 0x00, 0x00,
+	0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+	0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
+	0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+}
+
+func integrationStore(t *testing.T) *Store {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return New(t.TempDir(), pool)
+}
+
+func TestStoreSaveDedup(t *testing.T) {
+	s := integrationStore(t)
+
+	first, err := s.Save(t.Context(), bytes.NewReader(pngBytes))
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if first.Mime != "image/png" {
+		t.Fatalf("Mime = %q, want image/png", first.Mime)
+	}
+	if first.SizeBytes != int64(len(pngBytes)) {
+		t.Fatalf("SizeBytes = %d, want %d", first.SizeBytes, len(pngBytes))
+	}
+
+	second, err := s.Save(t.Context(), bytes.NewReader(pngBytes))
+	if err != nil {
+		t.Fatalf("second Save: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("same bytes produced different ids: %q vs %q", first.ID, second.ID)
+	}
+
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d files on disk, want exactly 1 (content-addressed dedup)", len(entries))
+	}
+}
+
+func TestStoreSaveRejectsFakeExtension(t *testing.T) {
+	s := integrationStore(t)
+
+	// A .png-looking upload that is actually plain text must be rejected
+	// by magic-byte sniffing, not the (absent, since we don't trust it)
+	// client-declared type.
+	_, err := s.Save(t.Context(), bytes.NewReader([]byte("not actually an image, just text")))
+	if !errors.Is(err, ErrUnsupportedMIME) {
+		t.Fatalf("Save err = %v, want ErrUnsupportedMIME", err)
+	}
+}
+
+func TestStoreOpenMissingID(t *testing.T) {
+	s := integrationStore(t)
+
+	_, _, err := s.Open(t.Context(), "does-not-exist")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Open err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStoreGetMissingID(t *testing.T) {
+	s := integrationStore(t)
+
+	_, err := s.Get(t.Context(), "does-not-exist")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStoreSaveRoundTripBytes(t *testing.T) {
+	s := integrationStore(t)
+
+	att, err := s.Save(t.Context(), bytes.NewReader(pngBytes))
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	r, got, err := s.Open(t.Context(), att.ID)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(raw, pngBytes) {
+		t.Fatal("round-tripped bytes do not match original upload")
+	}
+	if got.ID != att.ID || got.Mime != att.Mime {
+		t.Fatalf("Open metadata = %+v, want %+v", got, att)
+	}
+}
+
+func TestStoreSaveSizeCap(t *testing.T) {
+	s := integrationStore(t)
+
+	// The store itself does not cap size (that's http.MaxBytesReader at
+	// the handler); this test exercises a large-but-legal payload to
+	// confirm streaming hashing works past a single buffer's worth of
+	// data, using a size at MaxSizeBytes as the boundary the handler
+	// enforces.
+	big := bytes.Repeat([]byte{0}, 1<<20) // 1MB filler, well under the cap
+	body := append(append([]byte{}, pngBytes...), big...)
+	// Corrupts the PNG (sniffing only reads the header, still valid),
+	// but proves large uploads stream through Save without truncation.
+	att, err := s.Save(t.Context(), bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("Save large payload: %v", err)
+	}
+	if att.SizeBytes != int64(len(body)) {
+		t.Fatalf("SizeBytes = %d, want %d", att.SizeBytes, len(body))
+	}
+	if att.SizeBytes > MaxSizeBytes {
+		t.Fatalf("test payload %d exceeds MaxSizeBytes %d; fix the test", att.SizeBytes, MaxSizeBytes)
+	}
+}

--- a/internal/brain/chat/attachments_test.go
+++ b/internal/brain/chat/attachments_test.go
@@ -1,0 +1,203 @@
+package chat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/attachments"
+	"github.com/SumonMSelim/timothy/internal/brain/session"
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// fakeAttachments is an in-memory AttachmentStore fake: ids map
+// directly to fixed bytes/mime pairs seeded by the test.
+type fakeAttachments struct {
+	byID map[string]attachments.Attachment
+	data map[string][]byte
+}
+
+func newFakeAttachments() *fakeAttachments {
+	return &fakeAttachments{byID: map[string]attachments.Attachment{}, data: map[string][]byte{}}
+}
+
+func (f *fakeAttachments) seed(id, mime string, data []byte) {
+	f.byID[id] = attachments.Attachment{ID: id, Mime: mime, SizeBytes: int64(len(data))}
+	f.data[id] = data
+}
+
+func (f *fakeAttachments) Get(_ context.Context, id string) (attachments.Attachment, error) {
+	a, ok := f.byID[id]
+	if !ok {
+		return attachments.Attachment{}, attachments.ErrNotFound
+	}
+	return a, nil
+}
+
+func (f *fakeAttachments) Open(_ context.Context, id string) (io.ReadCloser, attachments.Attachment, error) {
+	a, ok := f.byID[id]
+	if !ok {
+		return nil, attachments.Attachment{}, attachments.ErrNotFound
+	}
+	return io.NopCloser(bytes.NewReader(f.data[id])), a, nil
+}
+
+// TestChatAcceptsAttachmentOnlyMessage confirms an empty Message with
+// at least one attachment ref is a valid turn, not a 400 — attachments
+// alone are a legitimate reason to send a turn.
+func TestChatAcceptsAttachmentOnlyMessage(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("I see an image")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("abc123", "image/png", []byte("fake-png-bytes"))
+	svc.SetAttachments(fa)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Attachments: []string{"abc123"}})
+	if err != nil {
+		t.Fatalf("Chat with no text but an attachment: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+}
+
+// TestChatRejectsEmptyMessageWithNoAttachments confirms the original
+// empty-message validation still fires when there is also no
+// attachment to justify the turn.
+func TestChatRejectsEmptyMessageWithNoAttachments(t *testing.T) {
+	t.Parallel()
+	svc := newService(&fakeGW{}, newFakeLog())
+	if _, _, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "   "}); !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("err = %v, want ErrBadRequest", err)
+	}
+}
+
+// TestChatRejectsUnknownAttachmentBeforeAnyAppend confirms a bad
+// attachment id 400s BEFORE the user_message (or even session_started
+// on a fresh session) is appended — D-042's "store lookups before
+// turnBegin" ordering extended to attachment validation.
+func TestChatRejectsUnknownAttachmentBeforeAnyAppend(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	svc := newService(&fakeGW{}, log)
+	svc.SetAttachments(newFakeAttachments()) // enabled, but "missing" is unseeded
+
+	_, _, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "look", Attachments: []string{"missing"}})
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("err = %v, want ErrBadRequest", err)
+	}
+	if kinds := log.kinds("s1"); len(kinds) != 0 {
+		t.Fatalf("events appended despite bad ref: %v", kinds)
+	}
+}
+
+// TestChatRejectsAttachmentsWhenDisabled confirms a Request naming
+// attachment ids 400s when no store is wired (ATTACHMENTS_DIR unset).
+func TestChatRejectsAttachmentsWhenDisabled(t *testing.T) {
+	t.Parallel()
+	svc := newService(&fakeGW{}, newFakeLog())
+	// SetAttachments never called: s.attachments stays nil.
+	_, _, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "look", Attachments: []string{"x"}})
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("err = %v, want ErrBadRequest", err)
+	}
+}
+
+// TestChatImageRefsLandInUserMessageEvent confirms the persisted
+// user_message event carries the image refs (id+mime), and that the
+// gateway request the driver sees has the ref resolved into base64
+// Images — never a ref living on the wire request itself.
+func TestChatImageRefsLandInUserMessageEvent(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("described")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("img1", "image/png", []byte("raw-bytes"))
+	svc.SetAttachments(fa)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what is this?", Attachments: []string{"img1"}})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+
+	events, _ := log.Events(t.Context(), "s1")
+	var um session.UserMessage
+	if err := json.Unmarshal(events[1].Payload, &um); err != nil {
+		t.Fatalf("decode user_message: %v", err)
+	}
+	if len(um.Images) != 1 || um.Images[0].ID != "img1" || um.Images[0].Mime != "image/png" {
+		t.Fatalf("persisted images = %+v, want one ref to img1/image/png", um.Images)
+	}
+
+	sent := chatRequest(t, gw)
+	if len(sent.Messages) == 0 {
+		t.Fatal("no messages sent to gateway")
+	}
+	last := sent.Messages[len(sent.Messages)-1]
+	if len(last.Images) != 1 {
+		t.Fatalf("gateway message Images = %+v, want 1 resolved image", last.Images)
+	}
+	if last.Images[0].MediaType != "image/png" {
+		t.Fatalf("resolved image MediaType = %q, want image/png", last.Images[0].MediaType)
+	}
+	wantB64 := "cmF3LWJ5dGVz" // base64("raw-bytes")
+	if last.Images[0].Data != wantB64 {
+		t.Fatalf("resolved image Data = %q, want %q", last.Images[0].Data, wantB64)
+	}
+	if len(last.ImageRefs) != 0 {
+		t.Fatalf("ImageRefs not cleared after resolution: %+v", last.ImageRefs)
+	}
+}
+
+// TestRetryReplaysImageRefs confirms a retried turn's gateway request
+// still carries the original message's images — Retry never touches
+// the persisted event, so LLMContext re-projects the same refs and
+// runTurn resolves them again from the attachment store.
+func TestRetryReplaysImageRefs(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: []stream.StreamEvent{{Type: stream.EventError, Err: &stream.StreamError{Code: "boom", Message: "boom"}}}}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("img1", "image/webp", []byte("webp-data"))
+	svc.SetAttachments(fa)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "q", Attachments: []string{"img1"}})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 }) // session_started, user_message, turn_failed
+	waitFor(t, func() bool { return !svc.TurnActive("s1") })
+
+	gw.mu.Lock()
+	gw.events = okEvents("retried answer")
+	gw.mu.Unlock()
+
+	_, ch, err = svc.Retry(t.Context(), "s1")
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	drain(t, ch)
+
+	sent := gw.lastChatRequest()
+	if len(sent.Messages) == 0 {
+		t.Fatal("no messages sent on retry")
+	}
+	// The original user message (carrying the image) is Messages[0];
+	// a failed-attempt note from the dead first try's turn_failed
+	// event may follow it as a separate user-role message, per
+	// LLMContext's projection — the image rides on the ORIGINAL
+	// message, not whatever happens to be last.
+	first := sent.Messages[0]
+	if len(first.Images) != 1 || first.Images[0].MediaType != "image/webp" {
+		t.Fatalf("retried message Images = %+v, want the original image replayed", first.Images)
+	}
+}

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -7,15 +7,18 @@ package chat
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/SumonMSelim/timothy/internal/brain/agents"
+	"github.com/SumonMSelim/timothy/internal/brain/attachments"
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
 	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/brain/skills"
@@ -104,6 +107,15 @@ type MemoryExtract func(ctx context.Context, sessionID string, seq int64, text s
 // beats no turn.
 type MemoryRetrieve func(ctx context.Context, sessionID, query string) string
 
+// AttachmentStore is the slice of *attachments.Store chat needs: Get
+// validates a ref exists (400 before any event append), Open resolves
+// its bytes to base64 at request-build time. Nil disables attachments
+// — a Request naming any Attachments id gets ErrBadRequest.
+type AttachmentStore interface {
+	Get(ctx context.Context, id string) (attachments.Attachment, error)
+	Open(ctx context.Context, id string) (io.ReadCloser, attachments.Attachment, error)
+}
+
 // Granter is the narrow slice of *tools.Permissions chat needs to seed
 // standing grants for a serving agent's ApprovalAllowlist — the same
 // shape missions/driver.go's sessionGranter uses against the same
@@ -131,6 +143,7 @@ type Service struct {
 	skillBodies map[string]string                  // name -> full pack body, for skill_hint
 	flushEvery  time.Duration                      // pending-state flush cadence mid-stream
 	sensitive   *session.SensitiveTools            // nil: no sensitive-tool route pin for side-calls
+	attachments AttachmentStore                    // nil: attachments disabled (ATTACHMENTS_DIR unset)
 	logger      *slog.Logger
 
 	grants Granter // nil: chat never seeds standing grants (today's behavior)
@@ -183,6 +196,10 @@ func (s *Service) SetMemoryRetrieve(fn MemoryRetrieve) { s.recall = fn }
 // extraction on t.Route instead of memoryd's own default. Optional —
 // nil leaves every turn's side-calls on today's behavior.
 func (s *Service) SetSensitiveTools(t *session.SensitiveTools) { s.sensitive = t }
+
+// SetAttachments wires the attachment store (D-045). Optional — nil
+// (ATTACHMENTS_DIR unset) rejects any Request naming Attachments ids.
+func (s *Service) SetAttachments(store AttachmentStore) { s.attachments = store }
 
 // SetAutoDispatch wires auto agent dispatch (D-034 follow-up): a
 // request naming the autoAgentName sentinel resolves through candidates
@@ -356,6 +373,10 @@ type Request struct {
 	// skip: the pack's body is in the system prompt before the first
 	// token streams.
 	SkillHint string `json:"skill_hint,omitempty"`
+	// Attachments are attachment ids (internal/brain/attachments)
+	// the user attached to this message — refs only, resolved into
+	// base64 at request-build time (D-045).
+	Attachments []string `json:"attachments,omitempty"`
 }
 
 // Chat streams one turn. The user message is durably appended before
@@ -363,8 +384,12 @@ type Request struct {
 // abnormal end) is appended when the stream finishes. The returned
 // channel follows the stream package's terminal contract.
 func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.StreamEvent, error) {
-	if strings.TrimSpace(req.Message) == "" {
-		return "", nil, fmt.Errorf("chat: %w: message is required", ErrBadRequest)
+	if strings.TrimSpace(req.Message) == "" && len(req.Attachments) == 0 {
+		return "", nil, fmt.Errorf("chat: %w: message or an attachment is required", ErrBadRequest)
+	}
+	images, err := s.validateAttachments(ctx, req.Attachments)
+	if err != nil {
+		return "", nil, err
 	}
 	agentName := req.Agent
 	if agentName == autoAgentName {
@@ -429,12 +454,80 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	}
 
 	if _, err := s.log.Append(ctx, sessionID, session.KindUserMessage, session.UserMessage{
-		Text: req.Message, Route: route, Agent: profile.Name, ModelHint: modelHint,
+		Text: req.Message, Route: route, Agent: profile.Name, ModelHint: modelHint, Images: images,
 	}); err != nil {
 		s.turnDone(sessionID)
 		return sessionID, nil, err
 	}
 	return s.runTurn(ctx, sessionID, req.Message, modelHint, req.SkillHint, skillBody, route, profile, needsTitle, bc)
+}
+
+// resolveImages fills each message's Images from its ImageRefs
+// in-place, reading each attachment's bytes and base64-encoding them.
+// The only call site (runTurn, immediately before the gateway request
+// is built) — nothing else in the turn's lifecycle ever needs bytes
+// (D-045). A no-op when nothing carries refs (the common case). Once
+// resolved, ImageRefs is cleared: it never crosses the gwclient wire
+// anyway (json:"-"), but clearing avoids holding two views of the same
+// data past the point either is needed.
+func (s *Service) resolveImages(ctx context.Context, msgs []provider.Message) error {
+	for i := range msgs {
+		if len(msgs[i].ImageRefs) == 0 {
+			continue
+		}
+		if s.attachments == nil {
+			return fmt.Errorf("chat: resolve images: attachments are not enabled")
+		}
+		images := make([]provider.ImageData, 0, len(msgs[i].ImageRefs))
+		for _, ref := range msgs[i].ImageRefs {
+			data, err := s.readAttachment(ctx, ref.ID)
+			if err != nil {
+				return fmt.Errorf("chat: resolve image %q: %w", ref.ID, err)
+			}
+			images = append(images, provider.ImageData{MediaType: ref.Mime, Data: data})
+		}
+		msgs[i].Images = images
+		msgs[i].ImageRefs = nil
+	}
+	return nil
+}
+
+// readAttachment opens and base64-encodes one attachment's bytes.
+func (s *Service) readAttachment(ctx context.Context, id string) (string, error) {
+	r, _, err := s.attachments.Open(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = r.Close() }()
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(raw), nil
+}
+
+// validateAttachments checks every id exists in the attachment store
+// BEFORE the turn's exclusivity is won or anything is appended (D-042:
+// store lookups are read-only and safe before turnBegin, but a bad ref
+// must 400 before even the user_message persists). Empty ids returns
+// nil, nil without touching the store — attachments stay off when
+// unconfigured, and a message with none never needs it wired.
+func (s *Service) validateAttachments(ctx context.Context, ids []string) ([]session.ImageRef, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	if s.attachments == nil {
+		return nil, fmt.Errorf("chat: %w: attachments are not enabled", ErrBadRequest)
+	}
+	refs := make([]session.ImageRef, 0, len(ids))
+	for _, id := range ids {
+		att, err := s.attachments.Get(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("chat: %w: attachment %q: %v", ErrBadRequest, id, err)
+		}
+		refs = append(refs, session.ImageRef{ID: att.ID, Mime: att.Mime})
+	}
+	return refs, nil
 }
 
 // pinSensitiveRoute promotes the session-wide privacy floor above the
@@ -551,6 +644,14 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 	}
 	msgs, err := session.LLMContext(events, s.budget(ctx))
 	if err != nil {
+		s.turnDone(sessionID)
+		return sessionID, nil, err
+	}
+	// Resolve image refs into base64 ONLY here, right before the
+	// gateway call: this is the sole point in the whole turn where
+	// attachment bytes exist in memory at all (D-045). ImageRefs never
+	// crosses the wire (json:"-"); Images (the resolved payload) does.
+	if err := s.resolveImages(ctx, msgs); err != nil {
 		s.turnDone(sessionID)
 		return sessionID, nil, err
 	}

--- a/internal/brain/session/compactor.go
+++ b/internal/brain/session/compactor.go
@@ -14,6 +14,19 @@ import (
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 )
 
+// renderForSummary flattens one message to plain text for extraction/
+// summarization prompts: image content never rides as bytes here (only
+// runTurn resolves ImageRefs into base64, and only just before the
+// gateway call for the real turn) — a ref becomes a short textual note
+// instead (D-045).
+func renderForSummary(m provider.Message) string {
+	text := m.Content
+	for range m.ImageRefs {
+		text += " [image attached]"
+	}
+	return m.Role + ": " + text + "\n\n"
+}
+
 // Gateway is the slice of the gateway client the compactor needs.
 type Gateway interface {
 	Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error)
@@ -167,7 +180,7 @@ func (c *Compactor) MaybeCompact(ctx context.Context, sessionID string) error {
 	if c.extract != nil {
 		var b strings.Builder
 		for _, m := range toSummarize {
-			b.WriteString(m.Role + ": " + m.Content + "\n\n")
+			b.WriteString(renderForSummary(m))
 		}
 		extractRoute := ""
 		if sensitive && c.sensitive != nil && c.sensitive.Route != nil {
@@ -295,7 +308,7 @@ func (c *Compactor) summarize(ctx context.Context, sessionID string, msgs []prov
 	}
 	var b strings.Builder
 	for _, m := range msgs {
-		b.WriteString(m.Role + ": " + m.Content + "\n\n")
+		b.WriteString(renderForSummary(m))
 	}
 	events, err := c.gw.Stream(ctx, gwclient.StreamRequest{
 		Route: route,

--- a/internal/brain/session/compactor_test.go
+++ b/internal/brain/session/compactor_test.go
@@ -370,6 +370,44 @@ func TestSummarizeInputPreservesFacts(t *testing.T) {
 	}
 }
 
+// TestSummarizeInputRendersImageNoteNotBytes confirms a user_message
+// carrying image refs reaches the summarizer as a short textual note
+// ("[image attached]"), never as base64 or any image identifier — the
+// summarizer must never see attachment bytes (D-045), and refs alone
+// (ids, mime types) are not useful summary content either.
+func TestSummarizeInputRendersImageNoteNotBytes(t *testing.T) {
+	t.Parallel()
+	log, gw := newMemLog(), &summarizerGW{summary: "s"}
+	ctx := context.Background()
+	pad := strings.Repeat("lorem ipsum dolor sit amet ", 30)
+	if _, err := log.Append(ctx, "s1", KindUserMessage, UserMessage{
+		Text:   "what is in this photo? " + pad,
+		Images: []ImageRef{{ID: "abc123", Mime: "image/png"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var turn AssistantTurn
+	turn.LLM.Message = "a cat " + pad
+	if _, err := log.Append(ctx, "s1", KindAssistantTurn, turn); err != nil {
+		t.Fatal(err)
+	}
+	seedConversation(t, log, "s1", 6) // push the image message into the oldest half
+
+	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
+	if err := c.MaybeCompact(ctx, "s1"); err != nil {
+		t.Fatalf("MaybeCompact: %v", err)
+	}
+	if gw.calls != 1 {
+		t.Fatalf("summarizer calls = %d, want 1", gw.calls)
+	}
+	if !strings.Contains(gw.sawText, "[image attached]") {
+		t.Fatalf("summarizer input missing the image note:\n%s", gw.sawText)
+	}
+	if strings.Contains(gw.sawText, "abc123") {
+		t.Fatalf("summarizer input leaked the attachment id:\n%s", gw.sawText)
+	}
+}
+
 // TestHundredTurnSessionPreservesReference is the acceptance harness
 // in miniature: a 100-turn session compacts (possibly repeatedly)
 // under a tight budget, and afterwards a commitment stated in turn 3

--- a/internal/brain/session/events.go
+++ b/internal/brain/session/events.go
@@ -51,6 +51,18 @@ type UserMessage struct {
 	Route  string `json:"route,omitempty"`
 	Agent  string `json:"agent,omitempty"`
 	ModelHint string `json:"model_hint,omitempty"`
+	// Images are refs to attachments (internal/brain/attachments),
+	// never bytes — base64 exists only transiently at request-build
+	// time (D-045). Additive: a message with no images omits this.
+	Images []ImageRef `json:"images,omitempty"`
+}
+
+// ImageRef points at a stored attachment; Mime rides alongside so
+// projections and drivers can build a data: URL without a store
+// round-trip.
+type ImageRef struct {
+	ID   string `json:"id"`
+	Mime string `json:"mime"`
 }
 
 // UIBlock is one renderable piece of an assistant turn.

--- a/internal/brain/session/projection.go
+++ b/internal/brain/session/projection.go
@@ -73,7 +73,14 @@ func LLMContext(events []Event, budget int) ([]provider.Message, error) {
 			if err := decode(ev, &m); err != nil {
 				return nil, err
 			}
-			msgs = append(msgs, provider.Message{Role: "user", Content: m.Text})
+			msg := provider.Message{Role: "user", Content: m.Text}
+			// Refs only, no bytes (D-045): chat.runTurn resolves these
+			// into Images just before the gateway call. Projection stays
+			// store-free.
+			for _, img := range m.Images {
+				msg.ImageRefs = append(msg.ImageRefs, provider.ImageRef{ID: img.ID, Mime: img.Mime})
+			}
+			msgs = append(msgs, msg)
 		case KindAssistantTurn:
 			var t AssistantTurn
 			if err := decode(ev, &t); err != nil {
@@ -182,6 +189,7 @@ type TranscriptItem struct {
 	Kind       string             `json:"kind"` // user | assistant | tool | permission | compaction | interrupted | error
 	Text       string             `json:"text,omitempty"`
 	Blocks     []UIBlock          `json:"blocks,omitempty"`
+	Images     []ImageRef         `json:"images,omitempty"`
 	Provider   string             `json:"provider,omitempty"`
 	Model      string             `json:"model,omitempty"`
 	Usage      *stream.Usage      `json:"usage,omitempty"`
@@ -210,7 +218,7 @@ func UITranscript(events []Event) ([]TranscriptItem, error) {
 			if err := decode(ev, &m); err != nil {
 				return nil, err
 			}
-			item.Kind, item.Text = "user", m.Text
+			item.Kind, item.Text, item.Images = "user", m.Text, m.Images
 		case KindAssistantTurn:
 			var t AssistantTurn
 			if err := decode(ev, &t); err != nil {

--- a/internal/brain/session/projection_test.go
+++ b/internal/brain/session/projection_test.go
@@ -60,6 +60,40 @@ func TestLLMContextBasicConversation(t *testing.T) {
 	}
 }
 
+// TestLLMContextCarriesImageRefsNotBytes confirms a user_message event
+// with attached images projects into ImageRefs (id+mime only) on the
+// provider.Message — never into Content, and never into Images (which
+// only chat.runTurn fills, from the store, at request-build time).
+// Projection has no store dependency; this pins that it stays that way.
+func TestLLMContextCarriesImageRefsNotBytes(t *testing.T) {
+	t.Parallel()
+	events := []Event{
+		ev(t, 1, KindSessionStarted, SessionStarted{}),
+		ev(t, 2, KindUserMessage, UserMessage{
+			Text:   "what is this?",
+			Images: []ImageRef{{ID: "abc123", Mime: "image/png"}},
+		}),
+	}
+
+	msgs, err := LLMContext(events, 100_000)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("messages = %+v, want 1", msgs)
+	}
+	m := msgs[0]
+	if m.Content != "what is this?" {
+		t.Fatalf("Content = %q, want the text only (no image data)", m.Content)
+	}
+	if len(m.Images) != 0 {
+		t.Fatalf("Images = %+v, want empty (projection never resolves bytes)", m.Images)
+	}
+	if len(m.ImageRefs) != 1 || m.ImageRefs[0].ID != "abc123" || m.ImageRefs[0].Mime != "image/png" {
+		t.Fatalf("ImageRefs = %+v, want one ref to abc123/image/png", m.ImageRefs)
+	}
+}
+
 func TestLLMContextSerializesTurnMemory(t *testing.T) {
 	t.Parallel()
 	events := []Event{
@@ -247,6 +281,31 @@ func TestUITranscript(t *testing.T) {
 	}
 	if items[2].Provider != "prov" || len(items[2].Blocks) != 1 {
 		t.Fatalf("assistant item = %+v", items[2])
+	}
+}
+
+// TestUITranscriptCarriesImages confirms a user_message's image refs
+// surface on TranscriptItem.Images for UI replay (additive field; the
+// web PR renders thumbnails from it later).
+func TestUITranscriptCarriesImages(t *testing.T) {
+	t.Parallel()
+	events := []Event{
+		ev(t, 1, KindSessionStarted, SessionStarted{}),
+		ev(t, 2, KindUserMessage, UserMessage{
+			Text:   "look",
+			Images: []ImageRef{{ID: "img1", Mime: "image/jpeg"}},
+		}),
+	}
+
+	items, err := UITranscript(events)
+	if err != nil {
+		t.Fatalf("UITranscript: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items = %+v, want 1", items)
+	}
+	if len(items[0].Images) != 1 || items[0].Images[0].ID != "img1" || items[0].Images[0].Mime != "image/jpeg" {
+		t.Fatalf("Images = %+v, want one ref to img1/image/jpeg", items[0].Images)
 	}
 }
 

--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -74,6 +74,21 @@ type streamRequest struct {
 	MissionID string             `json:"mission_id,omitempty"`
 }
 
+// requiredVisionCapability derives whether this request needs a
+// vision-capable chain entry from the message content itself — no
+// explicit flag on streamRequest (D-045). A sensitive-pinned session
+// routed to a local non-vision model correctly gets NoRouteError's
+// "lacks vision capability" here; that's the intended v1 behavior, not
+// a bug to route around.
+func requiredVisionCapability(msgs []provider.Message) []provider.Capability {
+	for _, m := range msgs {
+		if len(m.Images) > 0 {
+			return []provider.Capability{provider.CapVision}
+		}
+	}
+	return nil
+}
+
 func jsonError(w http.ResponseWriter, status int, code, msg string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -110,7 +125,7 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	attempts, err := snap.Resolve(req.Route, req.ModelHint, sticky)
+	attempts, err := snap.Resolve(req.Route, req.ModelHint, sticky, requiredVisionCapability(req.Messages)...)
 	if err != nil {
 		var nre *router.NoRouteError
 		if errors.As(err, &nre) {

--- a/internal/gateway/api/vision_test.go
+++ b/internal/gateway/api/vision_test.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
+)
+
+// TestRequiredVisionCapabilityDerivesFromMessages confirms the gateway
+// derives the vision requirement purely from message content (D-045):
+// no explicit flag on streamRequest, so a plain-text turn never adds
+// the requirement and a turn with an image always does, regardless of
+// which message in the list carries it.
+func TestRequiredVisionCapabilityDerivesFromMessages(t *testing.T) {
+	t.Parallel()
+
+	textOnly := []provider.Message{
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "hi"},
+	}
+	if got := requiredVisionCapability(textOnly); got != nil {
+		t.Fatalf("text-only messages required = %v, want nil", got)
+	}
+
+	withImage := []provider.Message{
+		{Role: "user", Content: "hello"},
+		{Role: "user", Content: "look", Images: []provider.ImageData{{MediaType: "image/png", Data: "AAAA"}}},
+	}
+	got := requiredVisionCapability(withImage)
+	if len(got) != 1 || got[0] != provider.CapVision {
+		t.Fatalf("required = %v, want [CapVision]", got)
+	}
+}

--- a/internal/gateway/provider/anthropic.go
+++ b/internal/gateway/provider/anthropic.go
@@ -51,7 +51,7 @@ func (a *Anthropic) Name() string { return a.cfg.Name }
 func (a *Anthropic) Kind() Kind   { return KindAPI }
 
 func (a *Anthropic) Capabilities() []Capability {
-	return []Capability{CapChat, CapStreaming, CapTools}
+	return []Capability{CapChat, CapStreaming, CapTools, CapVision}
 }
 
 // anthropic wire types (request)
@@ -85,14 +85,22 @@ type anthropicMessage struct {
 }
 
 type anthropicContentBlock struct {
-	Type      string          `json:"type"`
-	Text      string          `json:"text,omitempty"`
-	ID        string          `json:"id,omitempty"`
-	Name      string          `json:"name,omitempty"`
-	Input     json.RawMessage `json:"input,omitempty"`
-	ToolUseID string          `json:"tool_use_id,omitempty"`
-	Content   string          `json:"content,omitempty"`
-	IsError   bool            `json:"is_error,omitempty"`
+	Type      string                `json:"type"`
+	Text      string                `json:"text,omitempty"`
+	ID        string                `json:"id,omitempty"`
+	Name      string                `json:"name,omitempty"`
+	Input     json.RawMessage       `json:"input,omitempty"`
+	ToolUseID string                `json:"tool_use_id,omitempty"`
+	Content   string                `json:"content,omitempty"`
+	IsError   bool                  `json:"is_error,omitempty"`
+	Source    *anthropicImageSource `json:"source,omitempty"`
+}
+
+// anthropicImageSource is a base64 image block's source (D-045).
+type anthropicImageSource struct {
+	Type      string `json:"type"` // "base64"
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
 }
 
 // anthropicMessages translates normalized messages to the wire shape:
@@ -133,6 +141,23 @@ func anthropicMessages(msgs []Message) []anthropicMessage {
 				})
 			}
 			out = append(out, anthropicMessage{Role: "assistant", Content: blocks})
+		case len(m.Images) > 0:
+			// Text-only messages keep the plain-string shape (unchanged);
+			// only a message actually carrying images pays for the block
+			// array (D-045).
+			blocks := make([]anthropicContentBlock, 0, len(m.Images)+1)
+			if m.Content != "" {
+				blocks = append(blocks, anthropicContentBlock{Type: "text", Text: m.Content})
+			}
+			for _, img := range m.Images {
+				blocks = append(blocks, anthropicContentBlock{
+					Type: "image",
+					Source: &anthropicImageSource{
+						Type: "base64", MediaType: img.MediaType, Data: img.Data,
+					},
+				})
+			}
+			out = append(out, anthropicMessage{Role: m.Role, Content: blocks})
 		default:
 			out = append(out, anthropicMessage{Role: m.Role, Content: m.Content})
 		}

--- a/internal/gateway/provider/bedrock.go
+++ b/internal/gateway/provider/bedrock.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -67,7 +68,7 @@ func (b *Bedrock) Name() string { return b.cfg.Name }
 func (b *Bedrock) Kind() Kind   { return KindAPI }
 
 func (b *Bedrock) Capabilities() []Capability {
-	return []Capability{CapChat, CapStreaming, CapTools, CapEmbeddings}
+	return []Capability{CapChat, CapStreaming, CapTools, CapEmbeddings, CapVision}
 }
 
 // lazyClient builds the AWS client on first use (default credential
@@ -280,9 +281,24 @@ func converseMessages(msgs []Message) []types.Message {
 	for _, m := range msgs {
 		switch m.Role {
 		case "user":
+			blocks := []types.ContentBlock{&types.ContentBlockMemberText{Value: m.Content}}
+			// Text-only messages keep the single text block (unchanged);
+			// only a message actually carrying images pays for decoding
+			// them (D-045). Bytes only exist here transiently, decoded
+			// straight from the base64 chat.runTurn filled in.
+			for _, img := range m.Images {
+				raw, err := base64.StdEncoding.DecodeString(img.Data)
+				if err != nil {
+					continue // malformed image data must not abort the whole turn
+				}
+				blocks = append(blocks, &types.ContentBlockMemberImage{Value: types.ImageBlock{
+					Format: bedrockImageFormat(img.MediaType),
+					Source: &types.ImageSourceMemberBytes{Value: raw},
+				}})
+			}
 			out = append(out, types.Message{
 				Role:    types.ConversationRoleUser,
-				Content: []types.ContentBlock{&types.ContentBlockMemberText{Value: m.Content}},
+				Content: blocks,
 			})
 		case "assistant":
 			blocks := []types.ContentBlock{}
@@ -333,6 +349,24 @@ func converseMessages(msgs []Message) []types.Message {
 		}
 	}
 	return out
+}
+
+// bedrockImageFormat maps an attachment MIME type to Converse's
+// ImageFormat enum. Callers only ever pass one of the four MIME types
+// the attachments store allows (image/png, image/jpeg, image/webp,
+// image/gif); anything else falls back to png rather than sending an
+// empty Format Converse would reject outright.
+func bedrockImageFormat(mime string) types.ImageFormat {
+	switch mime {
+	case "image/jpeg":
+		return types.ImageFormatJpeg
+	case "image/webp":
+		return types.ImageFormatWebp
+	case "image/gif":
+		return types.ImageFormatGif
+	default:
+		return types.ImageFormatPng
+	}
 }
 
 func toolResultStatus(isError bool) types.ToolResultStatus {

--- a/internal/gateway/provider/images_test.go
+++ b/internal/gateway/provider/images_test.go
@@ -1,0 +1,207 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+)
+
+// imageMsg is a small helper: one user message carrying text plus one
+// image (D-045's transient, request-build-time Images field).
+func imageMsg(text, mediaType, data string) Message {
+	return Message{Role: "user", Content: text, Images: []ImageData{{MediaType: mediaType, Data: data}}}
+}
+
+// --- openaicompat ---
+
+func TestOpenAICompatImageMessageBuildsContentPartsArray(t *testing.T) {
+	t.Parallel()
+	o := NewOpenAICompat(OpenAICompatConfig{BaseURL: "http://x", APIKey: "k"})
+	req := o.buildRequest(CompletionRequest{
+		Model:    "m",
+		Messages: []Message{imageMsg("what is this?", "image/png", "AAAA")},
+	})
+
+	if len(req.Messages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(req.Messages))
+	}
+	parts, ok := req.Messages[0].Content.([]oaiContentPart)
+	if !ok {
+		t.Fatalf("Content = %T, want []oaiContentPart", req.Messages[0].Content)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("got %d content parts, want 2 (text + image_url)", len(parts))
+	}
+	if parts[0].Type != "text" || parts[0].Text != "what is this?" {
+		t.Fatalf("text part = %+v", parts[0])
+	}
+	if parts[1].Type != "image_url" || parts[1].ImageURL == nil {
+		t.Fatalf("image part = %+v", parts[1])
+	}
+	wantURL := "data:image/png;base64,AAAA"
+	if parts[1].ImageURL.URL != wantURL {
+		t.Fatalf("image_url.url = %q, want %q", parts[1].ImageURL.URL, wantURL)
+	}
+
+	// The wire shape must serialize with a content-parts array, not a
+	// bare string, for a message carrying images.
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded struct {
+		Messages []struct {
+			Content []map[string]any `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("decode wire JSON: %v (raw: %s)", err, data)
+	}
+	if len(decoded.Messages) != 1 || len(decoded.Messages[0].Content) != 2 {
+		t.Fatalf("wire JSON content = %s, want a 2-element array", data)
+	}
+}
+
+// TestOpenAICompatTextOnlyMessageUnchangedWireShape pins the existing
+// wire shape: a message with no images marshals content as a bare
+// string, exactly as before D-045 — some OpenAI-compat servers reject
+// a content-parts array, so this must never regress.
+func TestOpenAICompatTextOnlyMessageUnchangedWireShape(t *testing.T) {
+	t.Parallel()
+	o := NewOpenAICompat(OpenAICompatConfig{BaseURL: "http://x", APIKey: "k"})
+	req := o.buildRequest(CompletionRequest{
+		Model:    "m",
+		Messages: []Message{{Role: "user", Content: "hello"}},
+	})
+
+	content, ok := req.Messages[0].Content.(string)
+	if !ok || content != "hello" {
+		t.Fatalf("Content = %+v, want the bare string %q", req.Messages[0].Content, "hello")
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded struct {
+		Messages []struct {
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("decode wire JSON (expected a plain string content): %v (raw: %s)", err, data)
+	}
+	if decoded.Messages[0].Content != "hello" {
+		t.Fatalf("wire content = %q, want %q", decoded.Messages[0].Content, "hello")
+	}
+}
+
+// --- anthropic ---
+
+func TestAnthropicMessagesImageBlock(t *testing.T) {
+	t.Parallel()
+	msgs := anthropicMessages([]Message{imageMsg("what is this?", "image/jpeg", "BBBB")})
+
+	if len(msgs) != 1 || msgs[0].Role != "user" {
+		t.Fatalf("messages = %+v, want 1 user message", msgs)
+	}
+	blocks, ok := msgs[0].Content.([]anthropicContentBlock)
+	if !ok {
+		t.Fatalf("Content = %T, want []anthropicContentBlock", msgs[0].Content)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("got %d blocks, want 2 (text + image)", len(blocks))
+	}
+	if blocks[0].Type != "text" || blocks[0].Text != "what is this?" {
+		t.Fatalf("text block = %+v", blocks[0])
+	}
+	if blocks[1].Type != "image" || blocks[1].Source == nil {
+		t.Fatalf("image block = %+v", blocks[1])
+	}
+	if blocks[1].Source.Type != "base64" || blocks[1].Source.MediaType != "image/jpeg" || blocks[1].Source.Data != "BBBB" {
+		t.Fatalf("image source = %+v", blocks[1].Source)
+	}
+
+	if _, err := json.Marshal(msgs); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+}
+
+// TestAnthropicMessagesTextOnlyUnchangedWireShape pins the existing
+// wire shape for a plain user/assistant message: content stays a bare
+// string, not a block array, when there is nothing but text.
+func TestAnthropicMessagesTextOnlyUnchangedWireShape(t *testing.T) {
+	t.Parallel()
+	msgs := anthropicMessages([]Message{{Role: "user", Content: "hello"}})
+
+	if len(msgs) != 1 {
+		t.Fatalf("messages = %+v, want 1", msgs)
+	}
+	content, ok := msgs[0].Content.(string)
+	if !ok || content != "hello" {
+		t.Fatalf("Content = %+v, want the bare string %q", msgs[0].Content, "hello")
+	}
+}
+
+// --- bedrock ---
+
+func TestConverseMessagesImageBlock(t *testing.T) {
+	t.Parallel()
+	out := converseMessages([]Message{imageMsg("what is this?", "image/webp", "Q0M=")}) // base64("CC")
+
+	if len(out) != 1 || out[0].Role != types.ConversationRoleUser {
+		t.Fatalf("messages = %+v, want 1 user message", out)
+	}
+	if len(out[0].Content) != 2 {
+		t.Fatalf("got %d content blocks, want 2 (text + image)", len(out[0].Content))
+	}
+	if _, ok := out[0].Content[0].(*types.ContentBlockMemberText); !ok {
+		t.Fatalf("block 0 = %#v, want text", out[0].Content[0])
+	}
+	imgBlock, ok := out[0].Content[1].(*types.ContentBlockMemberImage)
+	if !ok {
+		t.Fatalf("block 1 = %#v, want image", out[0].Content[1])
+	}
+	if imgBlock.Value.Format != types.ImageFormatWebp {
+		t.Fatalf("image format = %v, want webp", imgBlock.Value.Format)
+	}
+	src, ok := imgBlock.Value.Source.(*types.ImageSourceMemberBytes)
+	if !ok {
+		t.Fatalf("image source = %#v, want bytes member", imgBlock.Value.Source)
+	}
+	if string(src.Value) != "CC" {
+		t.Fatalf("decoded image bytes = %q, want %q", src.Value, "CC")
+	}
+}
+
+// TestConverseMessagesTextOnlyUnchangedWireShape pins the existing
+// shape: a plain user message keeps its single text block, no image
+// block appended, when Images is empty.
+func TestConverseMessagesTextOnlyUnchangedWireShape(t *testing.T) {
+	t.Parallel()
+	out := converseMessages([]Message{{Role: "user", Content: "hello"}})
+
+	if len(out) != 1 || len(out[0].Content) != 1 {
+		t.Fatalf("messages = %+v, want 1 message with exactly 1 content block", out)
+	}
+	text, ok := out[0].Content[0].(*types.ContentBlockMemberText)
+	if !ok || text.Value != "hello" {
+		t.Fatalf("block = %#v, want text %q", out[0].Content[0], "hello")
+	}
+}
+
+func TestBedrockImageFormatMapping(t *testing.T) {
+	t.Parallel()
+	cases := map[string]types.ImageFormat{
+		"image/png":  types.ImageFormatPng,
+		"image/jpeg": types.ImageFormatJpeg,
+		"image/webp": types.ImageFormatWebp,
+		"image/gif":  types.ImageFormatGif,
+	}
+	for mime, want := range cases {
+		if got := bedrockImageFormat(mime); got != want {
+			t.Fatalf("bedrockImageFormat(%q) = %v, want %v", mime, got, want)
+		}
+	}
+}

--- a/internal/gateway/provider/openaicompat.go
+++ b/internal/gateway/provider/openaicompat.go
@@ -48,7 +48,7 @@ func (o *OpenAICompat) Name() string { return o.cfg.Name }
 func (o *OpenAICompat) Kind() Kind   { return KindAPI }
 
 func (o *OpenAICompat) Capabilities() []Capability {
-	return []Capability{CapChat, CapStreaming, CapTools, CapEmbeddings}
+	return []Capability{CapChat, CapStreaming, CapTools, CapEmbeddings, CapVision}
 }
 
 // Embed implements Embedder via the /embeddings endpoint, under the
@@ -126,10 +126,24 @@ func (o *OpenAICompat) Embed(ctx context.Context, model string, texts []string) 
 // wire types (request)
 
 type oaiMessage struct {
-	Role       string        `json:"role"`
-	Content    string        `json:"content"`
+	Role string `json:"role"`
+	// Content is a plain string for every text-only message (the
+	// original, unchanged wire shape — some OpenAI-compat servers
+	// reject a content-parts array) and only becomes []oaiContentPart
+	// when the message carries images (D-045).
+	Content    any           `json:"content"`
 	ToolCalls  []oaiToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string        `json:"tool_call_id,omitempty"`
+}
+
+// oaiContentPart is one OpenAI chat/completions content-parts array
+// entry: {"type":"text",...} or {"type":"image_url",...}.
+type oaiContentPart struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	ImageURL *struct {
+		URL string `json:"url"`
+	} `json:"image_url,omitempty"`
 }
 
 type oaiToolCall struct {
@@ -295,6 +309,26 @@ func isHTTP400(ev stream.StreamEvent) bool {
 	return ev.Type == stream.EventError && ev.Err != nil && ev.Err.Code == "http_400"
 }
 
+// imageContentParts builds the OpenAI chat/completions content-parts
+// array for a message carrying images: a leading text part (only when
+// non-empty — an image-only message needs no empty text part) followed
+// by one image_url part per image, each a data: URL (D-045).
+func imageContentParts(text string, images []ImageData) []oaiContentPart {
+	parts := make([]oaiContentPart, 0, len(images)+1)
+	if text != "" {
+		parts = append(parts, oaiContentPart{Type: "text", Text: text})
+	}
+	for _, img := range images {
+		parts = append(parts, oaiContentPart{
+			Type: "image_url",
+			ImageURL: &struct {
+				URL string `json:"url"`
+			}{URL: "data:" + img.MediaType + ";base64," + img.Data},
+		})
+	}
+	return parts
+}
+
 func (o *OpenAICompat) buildRequest(req CompletionRequest) oaiRequest {
 	out := oaiRequest{
 		Model:     req.Model,
@@ -316,15 +350,19 @@ func (o *OpenAICompat) buildRequest(req CompletionRequest) oaiRequest {
 	}
 	for _, m := range req.Messages {
 		om := oaiMessage{Role: m.Role, Content: m.Content}
+		if len(m.Images) > 0 {
+			om.Content = imageContentParts(m.Content, m.Images)
+		}
 		switch {
 		case m.Role == "tool" && m.ToolResult != nil:
 			om.ToolCallID = m.ToolResult.ID
-			om.Content = m.ToolResult.Content
+			content := m.ToolResult.Content
 			if m.ToolResult.IsError {
 				// The chat/completions shape has no is_error flag;
 				// the marker keeps the failure visible to the model.
-				om.Content = "ERROR: " + om.Content
+				content = "ERROR: " + content
 			}
+			om.Content = content
 		case len(m.ToolCalls) > 0:
 			for _, tc := range m.ToolCalls {
 				var oc oaiToolCall

--- a/internal/gateway/provider/provider.go
+++ b/internal/gateway/provider/provider.go
@@ -27,6 +27,11 @@ const (
 	CapStreaming  Capability = "streaming"
 	CapTools      Capability = "tools"
 	CapEmbeddings Capability = "embeddings"
+	// CapVision marks a driver that can carry image content parts to
+	// its provider; whether a specific MODEL can see images is the
+	// model row's own capability declaration (router.attemptCapable
+	// double-checks both — D-045).
+	CapVision Capability = "vision"
 )
 
 // Message is one conversation turn. The tool fields ride only on
@@ -37,6 +42,29 @@ type Message struct {
 	Content    string      `json:"content"`
 	ToolCalls  []ToolCall  `json:"tool_calls,omitempty"`
 	ToolResult *ToolResult `json:"tool_result,omitempty"`
+	// Images are transient content parts filled in at request-build
+	// time (brain's chat.runTurn, resolving attachment refs into
+	// base64) and never persisted anywhere — session_events and logs
+	// carry refs only, never bytes (D-045).
+	Images []ImageData `json:"images,omitempty"`
+	// ImageRefs carries attachment refs (no bytes) from brain's
+	// session projection through to chat.runTurn, which resolves them
+	// into Images just before the gateway call and clears this field.
+	// json:"-": brain-internal only, never crosses the gateway wire
+	// (D-045).
+	ImageRefs []ImageRef `json:"-"`
+}
+
+// ImageData is one base64-encoded image content part.
+type ImageData struct {
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"` // base64, no data: URL prefix
+}
+
+// ImageRef points at a brain-side stored attachment, never bytes.
+type ImageRef struct {
+	ID   string
+	Mime string
 }
 
 // ToolCall is one tool invocation the model made.

--- a/internal/gateway/provider/registry_test.go
+++ b/internal/gateway/provider/registry_test.go
@@ -119,7 +119,7 @@ func TestNewBedrock(t *testing.T) {
 		t.Fatalf("kind = %v", p.Kind())
 	}
 	caps := p.Capabilities()
-	if len(caps) != 4 || caps[0] != CapChat || caps[2] != CapTools {
+	if len(caps) != 5 || caps[0] != CapChat || caps[2] != CapTools || caps[4] != CapVision {
 		t.Fatalf("caps = %v", caps)
 	}
 }

--- a/internal/gateway/provider/toolwire_test.go
+++ b/internal/gateway/provider/toolwire_test.go
@@ -96,7 +96,8 @@ func TestOpenAICompatToolRoundTrip(t *testing.T) {
 		t.Fatalf("tool result = %+v", res1)
 	}
 	res2 := req.Messages[3]
-	if !strings.HasPrefix(res2.Content, "ERROR: ") {
+	content, ok := res2.Content.(string)
+	if !ok || !strings.HasPrefix(content, "ERROR: ") {
 		t.Fatalf("error result unmarked: %+v", res2)
 	}
 }

--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -201,9 +201,12 @@ type Sticky struct {
 // "ordered" routes, score order for "auto"/"price"/"latency" (recent
 // ledger stats + declared prices). Disabled, unhealthy, and
 // capability-lacking providers are skipped; each candidate is tried at
-// most once.
-func (s *Snapshot) Resolve(route, hint string, sticky Sticky) ([]Attempt, error) {
-	required := requiredCapability(route)
+// most once. extra names additional capabilities every candidate must
+// also declare beyond the route's own requiredCapability — e.g.
+// CapVision when the request carries images (D-045); most callers pass
+// none.
+func (s *Snapshot) Resolve(route, hint string, sticky Sticky, extra ...provider.Capability) ([]Attempt, error) {
+	required := append([]provider.Capability{requiredCapability(route)}, extra...)
 	var attempts []Attempt
 	var skipped []string
 	seen := map[string]bool{} // "name/model" dedupe across hint + sticky + chain
@@ -267,7 +270,7 @@ func (s *Snapshot) Resolve(route, hint string, sticky Sticky) ([]Attempt, error)
 // candidate. It returns the built driver plus empty subject/reason when
 // usable, or a skip subject ("name", or "name/model" for capability
 // misses) and reason matching the NoRouteError wording.
-func (s *Snapshot) entryGate(row ProviderRow, model string, required provider.Capability) (provider.Provider, string, string) {
+func (s *Snapshot) entryGate(row ProviderRow, model string, required []provider.Capability) (provider.Provider, string, string) {
 	p, inRegistry := s.registry.Get(row.Name)
 	switch {
 	case !row.Enabled:
@@ -276,8 +279,11 @@ func (s *Snapshot) entryGate(row ProviderRow, model string, required provider.Ca
 		return nil, row.Name, fmt.Sprintf("unhealthy: credential %s unresolved", row.CredentialRef)
 	case !inRegistry:
 		return nil, row.Name, "not in registry"
-	case !attemptCapable(p, row, model, required):
-		return nil, row.Name + "/" + model, fmt.Sprintf("lacks %s capability", required)
+	}
+	for _, want := range required {
+		if !attemptCapable(p, row, model, want) {
+			return nil, row.Name + "/" + model, fmt.Sprintf("lacks %s capability", want)
+		}
 	}
 	return p, "", ""
 }
@@ -326,7 +332,7 @@ type ResolvedEntry struct {
 func (s *Snapshot) ResolveDetail(route string) []ResolvedEntry {
 	chain := s.routes[route]
 	w, scoredStrategy := strategyWeights[s.strategy[route]]
-	required := requiredCapability(route)
+	required := []provider.Capability{requiredCapability(route)}
 
 	// Gather each entry's raw factors first: normalization needs the
 	// best value across the candidate set.

--- a/internal/gateway/router/router_test.go
+++ b/internal/gateway/router/router_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 )
 
 func testSnapshot(t *testing.T, lookups map[string]string) *Snapshot {
@@ -253,6 +255,84 @@ func TestResolveModelCapabilityExhaustionNamesModel(t *testing.T) {
 	_, err = snap.Resolve("coding", "", Sticky{})
 	if err == nil || !strings.Contains(err.Error(), "bedrock/titan-embed (lacks chat capability") {
 		t.Fatalf("err = %v, want model-naming capability reason", err)
+	}
+}
+
+// TestResolveVisionRejectsModelDeclaringOnlyChat confirms a model row
+// that lists capabilities WITHOUT "vision" is skipped when the caller
+// asks for CapVision as an extra requirement (D-045) — the model's own
+// declaration wins over the driver's Capabilities() honesty.
+func TestResolveVisionRejectsModelDeclaringOnlyChat(t *testing.T) {
+	t.Parallel()
+	provRows := []ProviderRow{{
+		ID: "p1", Name: "anthropic", Kind: "api", Driver: "anthropic",
+		DefaultModel: "haiku", CredentialRef: "A_KEY", Enabled: true,
+		Models: []ModelInfo{
+			{ID: "haiku", Capabilities: []string{"chat", "streaming", "tools"}}, // no vision
+			{ID: "sonnet"}, // undeclared: driver decides
+		},
+	}}
+	routeRows := []RouteRow{{Name: "coding", Chain: []ChainEntry{
+		{ProviderID: "p1", Model: "haiku"},
+		{ProviderID: "p1", Model: "sonnet"},
+	}, Enabled: true}}
+	snap, err := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
+	if err != nil {
+		t.Fatalf("BuildSnapshot: %v", err)
+	}
+
+	attempts, err := snap.Resolve("coding", "", Sticky{}, provider.CapVision)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	// haiku's explicit capability list omits vision: skipped. sonnet is
+	// undeclared, so the anthropic driver's own CapVision decides: kept.
+	if got := attemptNames(attempts); got != "anthropic/sonnet" {
+		t.Fatalf("attempts = %s, want anthropic/sonnet only", got)
+	}
+}
+
+// TestResolveVisionFallsToDriverWhenModelUndeclared confirms a model
+// with NO capability list at all is judged by the driver alone, same
+// rule attemptCapable already applies to every other capability.
+func TestResolveVisionFallsToDriverWhenModelUndeclared(t *testing.T) {
+	t.Parallel()
+	snap := testSnapshot(t, allKeys()) // "sonnet" and "grok-4" both undeclared
+
+	attempts, err := snap.Resolve("coding", "", Sticky{}, provider.CapVision)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	// Both the anthropic and openaicompat drivers declare CapVision;
+	// neither model row restricts it, so both survive same as Resolve
+	// without the extra requirement.
+	if got := attemptNames(attempts); got != "anthropic/sonnet,grok/grok-4" {
+		t.Fatalf("attempts = %s", got)
+	}
+}
+
+// TestResolveVisionExhaustionMentionsVision confirms a chain with no
+// vision-capable entry surfaces NoRouteError text naming "vision" —
+// the sensitive-pinned-session-to-local-non-vision-model case reads
+// clearly rather than a generic "no usable provider".
+func TestResolveVisionExhaustionMentionsVision(t *testing.T) {
+	t.Parallel()
+	provRows := []ProviderRow{{
+		ID: "p1", Name: "local", Kind: "api", Driver: "anthropic",
+		DefaultModel: "haiku", CredentialRef: "A_KEY", Enabled: true,
+		Models: []ModelInfo{{ID: "haiku", Capabilities: []string{"chat", "streaming"}}}, // no vision
+	}}
+	routeRows := []RouteRow{{Name: "coding", Chain: []ChainEntry{
+		{ProviderID: "p1", Model: "haiku"},
+	}, Enabled: true}}
+	snap, err := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
+	if err != nil {
+		t.Fatalf("BuildSnapshot: %v", err)
+	}
+
+	_, err = snap.Resolve("coding", "", Sticky{}, provider.CapVision)
+	if err == nil || !strings.Contains(err.Error(), "lacks vision capability") {
+		t.Fatalf("err = %v, want a reason mentioning vision", err)
 	}
 }
 

--- a/migrations/0034_attachments.sql
+++ b/migrations/0034_attachments.sql
@@ -1,0 +1,10 @@
+-- Content-addressed image attachments (internal/brain/attachments):
+-- binaries live on the ATTACHMENTS_DIR volume as <sha256><ext>, never
+-- in Postgres; this table is metadata only, keyed by that same sha256
+-- so re-uploading identical bytes is a no-op (D-045).
+CREATE TABLE IF NOT EXISTS attachments (
+    id         text PRIMARY KEY,
+    mime       text NOT NULL,
+    size_bytes bigint NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
## What
Paste/upload images with a chat message; they reach vision-capable providers as multimodal content parts. Backend only — web UI follows in a separate PR.

## Design (D-045)
- **Content-addressed store**: bytes live on a volume as `<sha256>.<ext>`, never in Postgres; `attachments` table holds metadata only (migration 0034). MIME sniffed server-side (magic bytes, never the client header), allowlist png/jpeg/webp/gif, 10MB cap, dedup by content hash.
- **API**: `POST /v1/attachments` (multipart) + `GET /v1/attachments/{id}` (auth'd, Content-Type forced from the DB row, immutable cache) — nil-gated on `ATTACHMENTS_DIR`.
- **Events carry refs, never bytes**: `UserMessage.Images []ImageRef` (additive); base64 exists only transiently at gateway-request build (`resolveImages`), immediately before the call. LLM context, logs, token estimation, and compaction never see image bytes; summarize paths render `[image attached]`.
- **Drivers**: openaicompat emits OpenAI content-parts with data: URLs; anthropic emits base64 source blocks; bedrock emits Converse image blocks. Text-only wire shapes pinned unchanged by tests.
- **Routing**: new `vision` capability. Gateway derives the requirement from message content (no wire flag); `Resolve` threads it as an extra required capability — a chain with no vision-capable entry fails with a readable NoRouteError. Model rows declaring capabilities without "vision" are correctly excluded; undeclared models defer to the driver. Note: sensitive-pinned sessions route local (non-vision) — images there error cleanly by design.

## Tests
Store (dedup, sniff, caps), handlers (auth, nil-gated, content-type), chat (attachment-only accepted, unknown ref 400 before any append, retry replays refs), projections, per-driver wire shapes, router vision gate.

`make build test vet lint` green.