### PR TITLE
feat: microphone voice input with local transcription

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -147,6 +147,10 @@ func main() {
 
 	searxngURL := os.Getenv("SEARXNG_URL")
 	markitdownURL := os.Getenv("MARKITDOWN_URL")
+	whisperURL := os.Getenv("WHISPER_URL")
+	if whisperURL == "" {
+		app.Log.Warn("WHISPER_URL not set; the web mic button's /v1/transcribe endpoint is unavailable")
+	}
 
 	toolCalls := app.Metrics.NewCounterVec("tool_calls_total",
 		"Tool executions by tool name and outcome.", "tool", "outcome")
@@ -312,7 +316,7 @@ func main() {
 	api.Register(app.Server, svc, store, broker,
 		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, app.Log), flags,
 		agentReg, conns, goog, agent, missionStore, missionDriver, missionNotifier,
-		missionWorkspace, resolveSecret, missionHub, token, app.Log)
+		missionWorkspace, resolveSecret, missionHub, &http.Client{}, whisperURL, token, app.Log)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -56,6 +56,19 @@ services:
     # internal-only: no published ports, no auth; brain is the sole
     # caller, same trust boundary as searxng.
 
+  whisper:
+    <<: *service
+    build:
+      context: ../whisper-svc
+      args:
+        WHISPER_MODEL: ${WHISPER_MODEL:-small}
+    environment:
+      WHISPER_MODEL: ${WHISPER_MODEL:-small}
+    # internal-only: no published ports, no auth; brain is the sole
+    # caller, same trust boundary as searxng/markitdown. No user-facing
+    # knob in deploy/env.example — WHISPER_MODEL defaults to "small"
+    # here and is only worth changing per-deployment, not per-user.
+
   # Local models: run Ollama natively on the host (Metal/CUDA — a
   # containerized runner gets CPU only and can't serve big models) and
   # register http://host.docker.internal:11434/v1 in Settings as a
@@ -98,6 +111,9 @@ services:
       # Converts Gmail attachments (PDFs) and HTML-only email bodies to
       # markdown/text; compose-internal only.
       MARKITDOWN_URL: http://markitdown:8000
+      # Local speech-to-text for the web mic button; compose-internal
+      # only, audio never leaves the box.
+      WHISPER_URL: http://whisper:8001
       # sandboxd's internal address — set only when MISSION_SANDBOX_IMAGE
       # is configured (sandboxd itself always runs; without an image it
       # just idles degraded). Empty keeps the original in-process exec
@@ -113,6 +129,8 @@ services:
       searxng:
         condition: service_started
       markitdown:
+        condition: service_started
+      whisper:
         condition: service_started
       sandboxd:
         condition: service_started

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -77,7 +77,8 @@ var memoryRoutePatterns = []string{
 // is the reverse proxy to memoryd's management routes, admin the
 // proxy to the gateway's internal control plane, conns the local
 // connector control plane (nil leaves any of them unmounted).
-func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, toolset Toolset, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), hub *missions.Hub, token string, log *slog.Logger) {
+// whisperURL empty leaves /v1/transcribe unmounted (WHISPER_URL unset).
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, toolset Toolset, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), hub *missions.Hub, whisperClient *http.Client, whisperURL string, token string, log *slog.Logger) {
 	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log}
 	if memories != nil {
 		for _, pattern := range memoryRoutePatterns {
@@ -92,6 +93,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret)
 	a.registerSchedules(srv.Handle, missionStore)
 	a.registerEvents(srv.Handle, hub)
+	a.registerTranscribe(srv.Handle, whisperClient, whisperURL)
 	srv.Handle("GET /v1/sessions", a.auth(http.HandlerFunc(a.handleList)))
 	srv.Handle("POST /v1/sessions", a.auth(http.HandlerFunc(a.handleCreate)))
 	srv.Handle("GET /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleTranscript)))

--- a/internal/brain/api/transcribe.go
+++ b/internal/brain/api/transcribe.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/SumonMSelim/timothy/internal/platform/whisper"
+)
+
+// transcribeBodyLimit caps the uploaded audio clip: local speech-to-
+// text is for one turn's dictation, not bulk file transcription.
+const transcribeBodyLimit = 25 << 20 // 25MB
+
+// registerTranscribe mounts the mic-input transcription route. nil
+// leaves it unmounted (WHISPER_URL not set).
+func (a *API) registerTranscribe(handle func(pattern string, h http.Handler), client *http.Client, whisperURL string) {
+	if whisperURL == "" {
+		return
+	}
+	handle("POST /v1/transcribe", a.auth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, transcribeBodyLimit)
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			jsonError(w, http.StatusRequestEntityTooLarge, "bad_request", "audio body too large or unreadable")
+			return
+		}
+		if len(raw) == 0 {
+			jsonError(w, http.StatusBadRequest, "bad_request", "empty request body")
+			return
+		}
+		text, err := whisper.Transcribe(r.Context(), client, whisperURL, raw)
+		if err != nil {
+			jsonError(w, http.StatusBadGateway, "transcribe_failed", err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"text": text})
+	})))
+}

--- a/internal/brain/api/transcribe_test.go
+++ b/internal/brain/api/transcribe_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRegisterTranscribe(t *testing.T) {
+	t.Run("absent when whisperURL unset", func(t *testing.T) {
+		a, _, _ := testAPI(t, "tok", nil)
+		m := http.NewServeMux()
+		a.registerTranscribe(m.Handle, http.DefaultClient, "")
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/transcribe", strings.NewReader("audio"))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("code = %d, want 404 (route unmounted)", w.Code)
+		}
+	})
+
+	t.Run("requires auth", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("sidecar must not be reached without auth")
+		}))
+		defer srv.Close()
+
+		a, _, _ := testAPI(t, "tok", nil)
+		m := http.NewServeMux()
+		a.registerTranscribe(m.Handle, srv.Client(), srv.URL)
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/transcribe", strings.NewReader("audio"))
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("code = %d, want 401", w.Code)
+		}
+	})
+
+	t.Run("proxies body to the sidecar and returns text", func(t *testing.T) {
+		var gotBody []byte
+		var gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotBody, _ = io.ReadAll(r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"text": "hello world"}`))
+		}))
+		defer srv.Close()
+
+		a, _, _ := testAPI(t, "tok", nil)
+		m := http.NewServeMux()
+		a.registerTranscribe(m.Handle, srv.Client(), srv.URL)
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/transcribe", strings.NewReader("fake audio bytes"))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("code = %d body=%s", w.Code, w.Body.String())
+		}
+		if gotPath != "/transcribe" {
+			t.Fatalf("sidecar path = %q, want /transcribe", gotPath)
+		}
+		if string(gotBody) != "fake audio bytes" {
+			t.Fatalf("sidecar body = %q", gotBody)
+		}
+		if !strings.Contains(w.Body.String(), "hello world") {
+			t.Fatalf("response body = %s", w.Body.String())
+		}
+	})
+
+	t.Run("rejects an empty body", func(t *testing.T) {
+		a, _, _ := testAPI(t, "tok", nil)
+		m := http.NewServeMux()
+		a.registerTranscribe(m.Handle, http.DefaultClient, "http://unused")
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/transcribe", strings.NewReader(""))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("code = %d, want 400", w.Code)
+		}
+	})
+
+	t.Run("body over the cap is rejected", func(t *testing.T) {
+		a, _, _ := testAPI(t, "tok", nil)
+		m := http.NewServeMux()
+		a.registerTranscribe(m.Handle, http.DefaultClient, "http://unused")
+
+		big := strings.NewReader(strings.Repeat("a", transcribeBodyLimit+1))
+		req := httptest.NewRequest(http.MethodPost, "/v1/transcribe", big)
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		if w.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("code = %d, want 413", w.Code)
+		}
+	})
+
+	t.Run("non-2xx from the sidecar surfaces as bad gateway", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "transcription failed", http.StatusUnprocessableEntity)
+		}))
+		defer srv.Close()
+
+		a, _, _ := testAPI(t, "tok", nil)
+		m := http.NewServeMux()
+		a.registerTranscribe(m.Handle, srv.Client(), srv.URL)
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/transcribe", strings.NewReader("audio"))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		if w.Code != http.StatusBadGateway {
+			t.Fatalf("code = %d, want 502", w.Code)
+		}
+	})
+}

--- a/internal/platform/whisper/whisper.go
+++ b/internal/platform/whisper/whisper.go
@@ -1,0 +1,59 @@
+// Package whisper is the client for the whisper sidecar
+// (whisper-svc/): one POST /transcribe per audio clip, raw bytes in,
+// transcript text out. Compose-internal, no auth — the sidecar is
+// only reachable inside the compose network.
+package whisper
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// transcribeTimeout is generous: CPU transcription of a minute of
+// audio can take a while on the "small" model.
+const transcribeTimeout = 120 * time.Second
+
+// Transcribe posts raw audio bytes to the whisper sidecar and returns
+// the transcribed text. baseURL empty means the sidecar isn't
+// configured — callers fall back to whatever they'd otherwise do.
+func Transcribe(ctx context.Context, client *http.Client, baseURL string, raw []byte) (string, error) {
+	if baseURL == "" {
+		return "", fmt.Errorf("whisper is not configured")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/transcribe", bytes.NewReader(raw))
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	c := client
+	if c == nil {
+		c = http.DefaultClient
+	}
+	cctx, cancel := context.WithTimeout(ctx, transcribeTimeout)
+	defer cancel()
+	req = req.WithContext(cctx)
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("whisper request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", fmt.Errorf("whisper returned http %d: %s", resp.StatusCode, snippet)
+	}
+	var out struct {
+		Text string `json:"text"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("decode whisper response: %w", err)
+	}
+	return out.Text, nil
+}

--- a/internal/platform/whisper/whisper_test.go
+++ b/internal/platform/whisper/whisper_test.go
@@ -1,0 +1,65 @@
+package whisper
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTranscribe(t *testing.T) {
+	t.Run("posts bytes and returns the transcript", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/transcribe" {
+				t.Errorf("path = %q, want /transcribe", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"text": "hello world"}`))
+		}))
+		defer srv.Close()
+
+		out, err := Transcribe(context.Background(), srv.Client(), srv.URL, []byte("fake audio bytes"))
+		if err != nil {
+			t.Fatalf("Transcribe: %v", err)
+		}
+		if out != "hello world" {
+			t.Fatalf("out = %q", out)
+		}
+	})
+
+	t.Run("unconfigured base URL errors without a request", func(t *testing.T) {
+		if _, err := Transcribe(context.Background(), nil, "", []byte("x")); err == nil {
+			t.Fatal("empty baseURL accepted")
+		}
+	})
+
+	t.Run("non-2xx surfaces status and body snippet", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "transcription failed: bad audio", http.StatusUnprocessableEntity)
+		}))
+		defer srv.Close()
+
+		_, err := Transcribe(context.Background(), srv.Client(), srv.URL, []byte("x"))
+		if err == nil || !strings.Contains(err.Error(), "422") {
+			t.Fatalf("err = %v, want http 422 surfaced", err)
+		}
+	})
+
+	t.Run("caller context already canceled fails fast", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case <-time.After(time.Second):
+			case <-r.Context().Done():
+			}
+		}))
+		defer srv.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if _, err := Transcribe(ctx, srv.Client(), srv.URL, []byte("x")); err == nil {
+			t.Fatal("canceled context accepted")
+		}
+	})
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -297,6 +297,31 @@ export async function deleteSession(id: string): Promise<void> {
   await request<void>(`/v1/sessions/${id}`, { method: 'DELETE' })
 }
 
+// transcribe posts a recorded audio clip (from the mic button) to
+// brain's local speech-to-text proxy and returns the transcript.
+// Raw bytes, not JSON — the body IS the audio, so this bypasses
+// request()'s JSON content type.
+export async function transcribe(blob: Blob): Promise<string> {
+  const res = await fetch('/v1/transcribe', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${getToken()}` },
+    body: blob,
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    let message = body
+    try {
+      const parsed = JSON.parse(body) as { message?: string }
+      message = parsed.message ?? body
+    } catch {
+      // Non-JSON error body: keep the raw text.
+    }
+    throw new ChatError(res.status, message || `transcribe failed (${res.status})`)
+  }
+  const { text } = (await res.json()) as { text: string }
+  return text
+}
+
 // --- Long-term memory (queue + browser) ---
 
 export async function listMemories(

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -1,0 +1,140 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Composer } from './Composer'
+
+vi.mock('../api/client', () => ({
+  listAgents: vi.fn().mockResolvedValue([]),
+  listRoutes: vi.fn().mockResolvedValue([]),
+  transcribe: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+// Minimal MediaRecorder fake: capture the constructed instance so a
+// test can drive its ondataavailable/onstop callbacks directly,
+// exactly like the real recorder would after start()/stop().
+class FakeMediaRecorder {
+  static instances: FakeMediaRecorder[] = []
+  static isTypeSupported = vi.fn().mockReturnValue(true)
+  mimeType = 'audio/webm;codecs=opus'
+  ondataavailable: ((e: { data: Blob }) => void) | null = null
+  onstop: (() => void) | null = null
+  start = vi.fn()
+  stop = vi.fn(() => this.onstop?.())
+
+  constructor() {
+    FakeMediaRecorder.instances.push(this)
+  }
+}
+
+function baseProps() {
+  return {
+    draft: '',
+    onDraft: vi.fn(),
+    onSend: vi.fn(),
+    agent: 'auto',
+    onAgent: vi.fn(),
+  }
+}
+
+const stopTrack = vi.fn()
+const fakeStream = { getTracks: () => [{ stop: stopTrack }] } as unknown as MediaStream
+const getUserMedia = vi.fn().mockResolvedValue(fakeStream)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  FakeMediaRecorder.instances = []
+  vi.stubGlobal('MediaRecorder', FakeMediaRecorder)
+  Object.defineProperty(navigator, 'mediaDevices', {
+    value: { getUserMedia },
+    configurable: true,
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('Composer mic button', () => {
+  it('renders a mic button', () => {
+    render(<Composer {...baseProps()} />)
+    expect(screen.getByRole('button', { name: 'Record voice input' })).toBeTruthy()
+  })
+
+  it('records, stops, transcribes, and appends the text to the draft', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.transcribe).mockResolvedValue('hello world')
+    const onDraft = vi.fn()
+    render(<Composer {...baseProps()} onDraft={onDraft} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Record voice input' }))
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledWith({ audio: true }))
+    await waitFor(() => expect(FakeMediaRecorder.instances).toHaveLength(1))
+    const recorder = FakeMediaRecorder.instances[0]
+    expect(recorder.start).toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Stop recording' })).toBeTruthy()
+
+    recorder.ondataavailable?.({ data: new Blob(['chunk']) })
+    fireEvent.click(screen.getByRole('button', { name: 'Stop recording' }))
+
+    await waitFor(() => expect(client.transcribe).toHaveBeenCalled())
+    await waitFor(() => expect(onDraft).toHaveBeenCalledWith('hello world'))
+    expect(stopTrack).toHaveBeenCalled()
+  })
+
+  it('space-separates the transcript from a non-empty draft', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.transcribe).mockResolvedValue('world')
+    const onDraft = vi.fn()
+    render(<Composer {...baseProps()} draft="hello" onDraft={onDraft} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Record voice input' }))
+    await waitFor(() => expect(FakeMediaRecorder.instances).toHaveLength(1))
+    fireEvent.click(screen.getByRole('button', { name: 'Stop recording' }))
+
+    await waitFor(() => expect(onDraft).toHaveBeenCalledWith('hello world'))
+  })
+
+  it('toasts and leaves the draft untouched when transcription fails', async () => {
+    const client = await import('../api/client')
+    const { toast } = await import('sonner')
+    vi.mocked(client.transcribe).mockRejectedValue(new Error('transcribe failed (502)'))
+    const onDraft = vi.fn()
+    render(<Composer {...baseProps()} draft="untouched" onDraft={onDraft} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Record voice input' }))
+    await waitFor(() => expect(FakeMediaRecorder.instances).toHaveLength(1))
+    fireEvent.click(screen.getByRole('button', { name: 'Stop recording' }))
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('transcribe failed (502)'))
+    expect(onDraft).not.toHaveBeenCalled()
+  })
+
+  it('toasts when the microphone permission is denied', async () => {
+    const { toast } = await import('sonner')
+    getUserMedia.mockRejectedValueOnce(new Error('denied'))
+    render(<Composer {...baseProps()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Record voice input' }))
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('Microphone permission was denied'),
+    )
+    expect(FakeMediaRecorder.instances).toHaveLength(0)
+  })
+
+  it('toasts when getUserMedia is unavailable (insecure context)', async () => {
+    const { toast } = await import('sonner')
+    Object.defineProperty(navigator, 'mediaDevices', { value: undefined, configurable: true })
+    render(<Composer {...baseProps()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Record voice input' }))
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        'Microphone input is not available in this browser or context',
+      ),
+    )
+  })
+})

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -1,6 +1,13 @@
-import { ArrowUp01Icon, Cancel01Icon } from '@hugeicons-pro/core-stroke-rounded'
+import {
+  ArrowUp01Icon,
+  Cancel01Icon,
+  Loading03Icon,
+  Mic01Icon,
+} from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { transcribe } from '../api/client'
 import { skillLabels } from '../lib/skills'
 import { AgentRoutePicker } from './AgentRoutePicker'
 
@@ -37,6 +44,15 @@ export function Composer({
   placeholder?: string
 }) {
   const inputRef = useRef<HTMLTextAreaElement>(null)
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const chunksRef = useRef<BlobPart[]>([])
+  // The recorder's onstop closure outlives renders; read the draft
+  // through a ref so a transcript appends to what the user typed
+  // DURING the recording, not to a stale snapshot from record-start.
+  const draftRef = useRef(draft)
+  draftRef.current = draft
+  const [recording, setRecording] = useState(false)
+  const [transcribing, setTranscribing] = useState(false)
 
   // Auto-grow up to a cap, then scroll inside. Runs on every draft
   // change so programmatic clears (post-send) shrink it back.
@@ -46,6 +62,63 @@ export function Composer({
     el.style.height = 'auto'
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`
   }, [draft])
+
+  // startRecording/stopRecording bracket one mic capture: click starts
+  // it, click again (or unmount) stops it and hands the recorded blob
+  // to /v1/transcribe. Audio never leaves the box beyond that call.
+  async function startRecording() {
+    if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === 'undefined') {
+      toast.error('Microphone input is not available in this browser or context')
+      return
+    }
+    let stream: MediaStream
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+    } catch {
+      toast.error('Microphone permission was denied')
+      return
+    }
+    const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+      ? 'audio/webm;codecs=opus'
+      : ''
+    const recorder = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream)
+    chunksRef.current = []
+    recorder.ondataavailable = (e) => {
+      if (e.data.size > 0) chunksRef.current.push(e.data)
+    }
+    recorder.onstop = () => {
+      stream.getTracks().forEach((t) => t.stop())
+      const blob = new Blob(chunksRef.current, { type: recorder.mimeType || 'audio/webm' })
+      chunksRef.current = []
+      void transcribeBlob(blob)
+    }
+    recorderRef.current = recorder
+    recorder.start()
+    setRecording(true)
+  }
+
+  function stopRecording() {
+    recorderRef.current?.stop()
+    recorderRef.current = null
+    setRecording(false)
+  }
+
+  async function transcribeBlob(blob: Blob) {
+    setTranscribing(true)
+    try {
+      const text = await transcribe(blob)
+      const cur = draftRef.current
+      if (text) onDraft(cur ? `${cur} ${text}` : text)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Transcription failed')
+    } finally {
+      setTranscribing(false)
+    }
+  }
+
+  // Stop cleanly if the composer unmounts mid-recording (e.g. route
+  // change) — the MediaRecorder and its track must not keep running.
+  useEffect(() => () => recorderRef.current?.stop(), [])
 
   return (
     <div className="rounded-2xl border border-zinc-950/10 bg-white shadow-sm transition focus-within:border-blue-500/50 focus-within:ring-4 focus-within:ring-blue-500/10 dark:border-white/10 dark:bg-zinc-800/60 dark:focus-within:border-blue-400/40">
@@ -87,6 +160,23 @@ export function Composer({
           {!hidePicker && (
             <AgentRoutePicker agent={agent} onAgent={onAgent} route={route} onRoute={onRoute} />
           )}
+          <button
+            type="button"
+            onClick={recording ? stopRecording : startRecording}
+            aria-label={recording ? 'Stop recording' : 'Record voice input'}
+            aria-pressed={recording}
+            disabled={disabled || transcribing}
+            className={
+              recording
+                ? 'flex size-8 shrink-0 animate-pulse items-center justify-center rounded-full bg-red-600 text-white transition hover:bg-red-500'
+                : 'flex size-8 shrink-0 items-center justify-center rounded-full text-zinc-500 transition hover:bg-zinc-100 disabled:text-zinc-300 dark:text-zinc-400 dark:hover:bg-zinc-700/50 dark:disabled:text-zinc-600'
+            }
+          >
+            <HugeiconsIcon
+              icon={transcribing ? Loading03Icon : Mic01Icon}
+              className={transcribing ? 'size-4 animate-spin' : 'size-4'}
+            />
+          </button>
         </div>
         <button
           type="button"

--- a/whisper-svc/Dockerfile
+++ b/whisper-svc/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# WHISPER_MODEL must match the value the service runs with — this is
+# what makes the download below actually warm the model the container
+# loads at boot. Pre-download at build time (not first-request) so the
+# running container never reaches the network: fully offline,
+# deterministic startup, no surprise latency on the first transcript.
+ARG WHISPER_MODEL=small
+RUN python -c "from faster_whisper import WhisperModel; WhisperModel('${WHISPER_MODEL}', device='cpu', compute_type='int8')"
+
+COPY main.py .
+
+USER nobody
+EXPOSE 8001
+ENTRYPOINT ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/whisper-svc/main.py
+++ b/whisper-svc/main.py
@@ -1,0 +1,42 @@
+"""HTTP wrapper around faster-whisper: transcribes one audio clip per
+request. Internal-only sidecar — brain is the sole caller, same trust
+boundary as searxng/markitdown. No auth: never expose this port
+outside the compose network.
+"""
+
+import io
+import os
+
+from faster_whisper import WhisperModel
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+model = WhisperModel(os.environ.get("WHISPER_MODEL", "small"), device="cpu", compute_type="int8")
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.post("/transcribe")
+async def transcribe(request: Request):
+    """Transcribes the request body (raw audio bytes) to text.
+
+    Accepts whatever container format the browser recorded (webm/opus
+    from MediaRecorder, also wav/ogg/mp3) — faster-whisper decodes via
+    PyAV, which bundles its own ffmpeg libs, so no separate ffmpeg
+    binary is needed in the image.
+    """
+    body = await request.body()
+    if not body:
+        raise HTTPException(status_code=400, detail="empty request body")
+
+    try:
+        segments, _ = model.transcribe(io.BytesIO(body))
+        text = "".join(segment.text for segment in segments).strip()
+    except Exception as exc:  # faster-whisper/PyAV raise assorted decode errors
+        raise HTTPException(status_code=422, detail=f"transcription failed: {exc}") from exc
+
+    return JSONResponse({"text": text})

--- a/whisper-svc/requirements.txt
+++ b/whisper-svc/requirements.txt
@@ -1,0 +1,3 @@
+faster-whisper==1.2.0
+fastapi==0.139.2
+uvicorn[standard]==0.51.0


### PR DESCRIPTION
## What
Mic button in the composer: record → local speech-to-text → transcript lands in the draft for review before send. Audio never leaves the box.

## How
- **whisper-svc**: faster-whisper sidecar (CPU int8, `WHISPER_MODEL` default `small`, model baked into the image at build so runtime is offline). Internal-only, no auth, no published ports — same trust model as markitdown/searxng.
- **Brain**: `POST /v1/transcribe` — bearer-auth'd, 25MB cap, proxies raw audio to the sidecar; nil-gated on `WHISPER_URL`. Platform client mirrors the markitdown one (120s timeout — CPU transcription is slow).
- **Web**: mic button next to the agent picker; MediaRecorder (webm/opus with fallback), red pulse while recording, spinner while transcribing; transcript appends to the CURRENT draft (read through a ref — typing during recording is not clobbered); permission/context/transcribe failures toast and leave the draft untouched; recorder stops on unmount.

## Tests
Go: whisper client (fake sidecar happy/error/timeout), transcribe handler (auth, cap, nil-gated). Web: 6 Composer tests (render, record→stop→append, space-joining, error paths).

`make build test vet lint` + web build/lint/test green (2 pre-existing AgentRoutePicker flakes reproduced on unmodified main).