### PR TITLE
fix(whisper): make model cache usable at runtime

### DIFF
--- a/whisper-svc/Dockerfile
+++ b/whisper-svc/Dockerfile
@@ -12,8 +12,12 @@ RUN pip install --no-cache-dir -r requirements.txt
 # loads at boot. Pre-download at build time (not first-request) so the
 # running container never reaches the network: fully offline,
 # deterministic startup, no surprise latency on the first transcript.
+# HF_HOME lives outside /root so the model cached at build time stays
+# readable at runtime, where the service runs as nobody.
+ENV HF_HOME=/models
 ARG WHISPER_MODEL=small
-RUN python -c "from faster_whisper import WhisperModel; WhisperModel('${WHISPER_MODEL}', device='cpu', compute_type='int8')"
+RUN python -c "from faster_whisper import WhisperModel; WhisperModel('${WHISPER_MODEL}', device='cpu', compute_type='int8')" \
+    && chmod -R a+rX /models
 
 COPY main.py .
 

--- a/whisper-svc/requirements.txt
+++ b/whisper-svc/requirements.txt
@@ -1,3 +1,4 @@
 faster-whisper==1.2.0
+requests==2.32.5
 fastapi==0.139.2
 uvicorn[standard]==0.51.0


### PR DESCRIPTION
Build-time model download failed (huggingface_hub 1.x no longer depends on requests, which the download path imports), and the cache landed under /root/.cache — unreadable by the runtime user (nobody), so the container would re-download at boot and fail offline. Pin requests; set HF_HOME=/models world-readable. Verified: image builds, whisper container healthy, brain reaches it.