### PR TITLE
feat(web): image attachments in the chat composer

### DIFF
--- a/web/nginx/default.conf.template
+++ b/web/nginx/default.conf.template
@@ -23,6 +23,10 @@ server {
         set $brain ${BRAIN_URL};
         proxy_pass $brain;
         proxy_http_version 1.1;
+        # attachments cap at 10MB (internal/brain/attachments) plus
+        # multipart overhead; nginx's 1MB default would 413 before the
+        # request reaches brain.
+        client_max_body_size 12m;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -322,6 +322,53 @@ export async function transcribe(blob: Blob): Promise<string> {
   return text
 }
 
+// AttachmentUpload is the store's view of a saved attachment (PR
+// #120): id is the content hash, used as both the transcript
+// reference and the /v1/attachments/{id} download path.
+export interface AttachmentUpload {
+  id: string
+  mime: string
+  size_bytes: number
+}
+
+// uploadAttachment posts one file to /v1/attachments (multipart field
+// "file") and returns its stored id/mime/size. Raw multipart, not
+// JSON — same bypass of request()'s JSON content type as transcribe.
+export async function uploadAttachment(file: File): Promise<AttachmentUpload> {
+  const form = new FormData()
+  form.append('file', file)
+  const res = await fetch('/v1/attachments', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${getToken()}` },
+    body: form,
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    let message = body
+    try {
+      const parsed = JSON.parse(body) as { message?: string }
+      message = parsed.message ?? body
+    } catch {
+      // Non-JSON error body: keep the raw text.
+    }
+    throw new ChatError(res.status, message || `upload failed (${res.status})`)
+  }
+  return (await res.json()) as AttachmentUpload
+}
+
+// fetchAttachmentBlob reads an uploaded attachment's bytes for inline
+// rendering (AuthedImage) — GET /v1/attachments/{id} requires the
+// bearer header, so a bare <img src> cannot fetch it directly.
+export async function fetchAttachmentBlob(id: string): Promise<Blob> {
+  const res = await fetch(`/v1/attachments/${id}`, {
+    headers: { Authorization: `Bearer ${getToken()}` },
+  })
+  if (!res.ok) {
+    throw new ChatError(res.status, `request failed (${res.status})`)
+  }
+  return res.blob()
+}
+
 // --- Long-term memory (queue + browser) ---
 
 export async function listMemories(

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -80,6 +80,7 @@ export interface ChatRequest {
   route?: string
   model_hint?: string
   skill_hint?: string
+  attachments?: string[]
 }
 
 // --- session management (mirrors brain's /v1/sessions surface) ---
@@ -97,6 +98,13 @@ export interface SessionMeta {
 export interface UIBlock {
   type: 'text' | 'reasoning'
   text: string
+}
+
+// ImageRef is one attachment carried by a user transcript item — the
+// attachment's id (content hash) and MIME type, never the bytes.
+export interface ImageRef {
+  id: string
+  mime: string
 }
 
 // One executed tool call in the replay projection (digest only).
@@ -118,6 +126,7 @@ export interface TranscriptItem {
   kind: 'user' | 'assistant' | 'tool' | 'permission' | 'compaction' | 'interrupted' | 'error'
   text?: string
   blocks?: UIBlock[]
+  images?: ImageRef[]
   tool?: ToolExecution
   permission?: PermissionRequestEvent
   provider?: string

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -1,11 +1,12 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { Composer } from './Composer'
+import { Composer, type PendingAttachment } from './Composer'
 
 vi.mock('../api/client', () => ({
   listAgents: vi.fn().mockResolvedValue([]),
   listRoutes: vi.fn().mockResolvedValue([]),
   transcribe: vi.fn(),
+  uploadAttachment: vi.fn(),
 }))
 
 vi.mock('sonner', () => ({
@@ -136,5 +137,143 @@ describe('Composer mic button', () => {
         'Microphone input is not available in this browser or context',
       ),
     )
+  })
+})
+
+function makeImageFile(name = 'photo.png', type = 'image/png', size = 1024): File {
+  const file = new File([new Uint8Array(size)], name, { type })
+  return file
+}
+
+describe('Composer attachments', () => {
+  beforeEach(() => {
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => `blob:mock-${Math.random()}`),
+      revokeObjectURL: vi.fn(),
+    })
+  })
+
+  it('does not render the paperclip button when onAttachments is omitted', () => {
+    render(<Composer {...baseProps()} />)
+    expect(screen.queryByRole('button', { name: 'Attach image' })).toBeNull()
+  })
+
+  it('renders the paperclip button when onAttachments is given', () => {
+    render(<Composer {...baseProps()} onAttachments={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Attach image' })).toBeTruthy()
+  })
+
+  it('uploads a selected file and adds a chip on success', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.uploadAttachment).mockResolvedValue({
+      id: 'att-1',
+      mime: 'image/png',
+      size_bytes: 1024,
+    })
+    const onAttachments = vi.fn()
+    const { rerender } = render(
+      <Composer {...baseProps()} attachments={[]} onAttachments={onAttachments} />,
+    )
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const file = makeImageFile()
+    fireEvent.change(input, { target: { files: [file] } })
+
+    await waitFor(() => expect(client.uploadAttachment).toHaveBeenCalledWith(file))
+    await waitFor(() =>
+      expect(onAttachments).toHaveBeenLastCalledWith([
+        expect.objectContaining({ id: 'att-1', mime: 'image/png', uploading: false }),
+      ]),
+    )
+
+    const [[chips]] = onAttachments.mock.calls.slice(-1)
+    rerender(<Composer {...baseProps()} attachments={chips} onAttachments={onAttachments} />)
+    expect(screen.getByAltText('photo.png')).toBeTruthy()
+  })
+
+  it('toasts and skips the upload for an oversize file', async () => {
+    const client = await import('../api/client')
+    const { toast } = await import('sonner')
+    const onAttachments = vi.fn()
+    render(<Composer {...baseProps()} onAttachments={onAttachments} />)
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const big = makeImageFile('big.png', 'image/png', 11 * 1024 * 1024)
+    fireEvent.change(input, { target: { files: [big] } })
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('big.png: exceeds the 10MB limit'),
+    )
+    expect(client.uploadAttachment).not.toHaveBeenCalled()
+    expect(onAttachments).not.toHaveBeenCalled()
+  })
+
+  it('toasts and skips the upload for an unsupported file type', async () => {
+    const client = await import('../api/client')
+    const { toast } = await import('sonner')
+    const onAttachments = vi.fn()
+    render(<Composer {...baseProps()} onAttachments={onAttachments} />)
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const pdf = makeImageFile('doc.pdf', 'application/pdf')
+    fireEvent.change(input, { target: { files: [pdf] } })
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('doc.pdf: unsupported image type'),
+    )
+    expect(client.uploadAttachment).not.toHaveBeenCalled()
+    expect(onAttachments).not.toHaveBeenCalled()
+  })
+
+  it('removes a chip and revokes its object URL', () => {
+    const onAttachments = vi.fn()
+    const attachments: PendingAttachment[] = [
+      { id: 'att-1', mime: 'image/png', previewUrl: 'blob:existing', name: 'a.png' },
+    ]
+    render(<Composer {...baseProps()} attachments={attachments} onAttachments={onAttachments} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove a.png' }))
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:existing')
+    expect(onAttachments).toHaveBeenCalledWith([])
+  })
+
+  it('enables send when attachments exist even with an empty draft', () => {
+    const attachments: PendingAttachment[] = [
+      { id: 'att-1', mime: 'image/png', previewUrl: 'blob:existing', name: 'a.png' },
+    ]
+    render(
+      <Composer
+        {...baseProps()}
+        draft=""
+        attachments={attachments}
+        onAttachments={vi.fn()}
+      />,
+    )
+    expect(screen.getByRole('button', { name: 'Send' })).not.toBeDisabled()
+  })
+
+  it('keeps send disabled with an empty draft and no attachments', () => {
+    render(<Composer {...baseProps()} draft="" onAttachments={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled()
+  })
+
+  it('uploads a pasted image from the clipboard', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.uploadAttachment).mockResolvedValue({
+      id: 'att-2',
+      mime: 'image/png',
+      size_bytes: 1024,
+    })
+    const onAttachments = vi.fn()
+    render(<Composer {...baseProps()} onAttachments={onAttachments} />)
+
+    const file = makeImageFile('pasted.png')
+    const clipboardData = {
+      items: [{ kind: 'file', type: 'image/png', getAsFile: () => file }],
+    }
+    fireEvent.paste(screen.getByRole('textbox', { name: 'Message' }), { clipboardData })
+
+    await waitFor(() => expect(client.uploadAttachment).toHaveBeenCalledWith(file))
   })
 })

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -1,15 +1,32 @@
 import {
+  Attachment02Icon,
   ArrowUp01Icon,
   Cancel01Icon,
   Loading03Icon,
   Mic01Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
+import type { ClipboardEvent, DragEvent } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { transcribe } from '../api/client'
+import { transcribe, uploadAttachment } from '../api/client'
 import { skillLabels } from '../lib/skills'
 import { AgentRoutePicker } from './AgentRoutePicker'
+
+// PendingAttachment is one upload in flight or done, owned by the
+// page (same pattern as `draft`) so the send flow can read and clear
+// it. previewUrl is a local object URL — revoked on removal/send.
+export interface PendingAttachment {
+  id: string
+  mime: string
+  previewUrl: string
+  name?: string
+  uploading?: boolean
+}
+
+const allowedMimes = ['image/png', 'image/jpeg', 'image/webp', 'image/gif']
+const maxAttachmentBytes = 10 * 1024 * 1024
+const maxAttachments = 8
 
 // Composer is the one message box: the chat page's docked input and
 // the home page's hero input are the same component so behavior
@@ -28,6 +45,8 @@ export function Composer({
   disabled = false,
   autoFocus = false,
   placeholder = 'Message Timothy…',
+  attachments = [],
+  onAttachments,
 }: {
   draft: string
   onDraft: (v: string) => void
@@ -42,10 +61,18 @@ export function Composer({
   disabled?: boolean
   autoFocus?: boolean
   placeholder?: string
+  attachments?: PendingAttachment[]
+  onAttachments?: (next: PendingAttachment[]) => void
 }) {
   const inputRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const recorderRef = useRef<MediaRecorder | null>(null)
   const chunksRef = useRef<BlobPart[]>([])
+  // The attachments array is owned by the page, but the upload flow
+  // needs the latest value inside async callbacks that started before
+  // a later render — same stale-closure guard as draftRef below.
+  const attachmentsRef = useRef(attachments)
+  attachmentsRef.current = attachments
   // The recorder's onstop closure outlives renders; read the draft
   // through a ref so a transcript appends to what the user typed
   // DURING the recording, not to a stale snapshot from record-start.
@@ -120,8 +147,106 @@ export function Composer({
   // change) — the MediaRecorder and its track must not keep running.
   useEffect(() => () => recorderRef.current?.stop(), [])
 
+  // uploadFiles validates each file client-side (type, size, cap) then
+  // uploads it, adding a chip immediately in an "uploading" state so
+  // the spinner overlay has something to render, and swapping it for
+  // the real id on success or dropping it on failure. previewUrl uses
+  // the local file directly — no need to round-trip through the
+  // server just to show a thumbnail.
+  async function uploadFiles(files: File[]) {
+    if (!onAttachments) return
+    for (const file of files) {
+      if (!allowedMimes.includes(file.type)) {
+        toast.error(`${file.name || 'file'}: unsupported image type`)
+        continue
+      }
+      if (file.size > maxAttachmentBytes) {
+        toast.error(`${file.name || 'file'}: exceeds the 10MB limit`)
+        continue
+      }
+      if (attachmentsRef.current.length >= maxAttachments) {
+        toast.error(`You can attach up to ${maxAttachments} images`)
+        break
+      }
+      const tempId = crypto.randomUUID()
+      const previewUrl = URL.createObjectURL(file)
+      const placeholder: PendingAttachment = {
+        id: tempId,
+        mime: file.type,
+        previewUrl,
+        name: file.name,
+        uploading: true,
+      }
+      attachmentsRef.current = [...attachmentsRef.current, placeholder]
+      onAttachments(attachmentsRef.current)
+      try {
+        const uploaded = await uploadAttachment(file)
+        attachmentsRef.current = attachmentsRef.current.map((a) =>
+          a.id === tempId ? { ...a, id: uploaded.id, uploading: false } : a,
+        )
+        onAttachments(attachmentsRef.current)
+      } catch (err) {
+        URL.revokeObjectURL(previewUrl)
+        attachmentsRef.current = attachmentsRef.current.filter((a) => a.id !== tempId)
+        onAttachments(attachmentsRef.current)
+        toast.error(err instanceof Error ? err.message : 'Upload failed')
+      }
+    }
+  }
+
+  function removeAttachment(id: string) {
+    if (!onAttachments) return
+    const target = attachments.find((a) => a.id === id)
+    if (target) URL.revokeObjectURL(target.previewUrl)
+    onAttachments(attachments.filter((a) => a.id !== id))
+  }
+
+  function handlePaste(e: ClipboardEvent<HTMLTextAreaElement>) {
+    const files = [...e.clipboardData.items]
+      .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
+      .map((item) => item.getAsFile())
+      .filter((f): f is File => f !== null)
+    if (files.length > 0) void uploadFiles(files)
+  }
+
+  function handleDrop(e: DragEvent<HTMLDivElement>) {
+    e.preventDefault()
+    const files = [...e.dataTransfer.files].filter((f) => f.type.startsWith('image/'))
+    if (files.length > 0) void uploadFiles(files)
+  }
+
   return (
-    <div className="rounded-2xl border border-zinc-950/10 bg-white shadow-sm transition focus-within:border-blue-500/50 focus-within:ring-4 focus-within:ring-blue-500/10 dark:border-white/10 dark:bg-zinc-800/60 dark:focus-within:border-blue-400/40">
+    <div
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleDrop}
+      className="rounded-2xl border border-zinc-950/10 bg-white shadow-sm transition focus-within:border-blue-500/50 focus-within:ring-4 focus-within:ring-blue-500/10 dark:border-white/10 dark:bg-zinc-800/60 dark:focus-within:border-blue-400/40"
+    >
+      {attachments.length > 0 && (
+        <div className="flex flex-wrap gap-2 px-3 pt-2.5">
+          {attachments.map((a) => (
+            <div
+              key={a.id}
+              className="group relative size-12 shrink-0 overflow-hidden rounded-lg border border-zinc-950/10 dark:border-white/10"
+              title={a.name}
+            >
+              <img src={a.previewUrl} alt={a.name ?? 'attachment'} className="size-full object-cover" />
+              {a.uploading && (
+                <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+                  <HugeiconsIcon icon={Loading03Icon} className="size-4 animate-spin text-white" />
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={() => removeAttachment(a.id)}
+                aria-label={`Remove ${a.name ?? 'attachment'}`}
+                className="absolute top-0.5 right-0.5 flex size-4 items-center justify-center rounded-full bg-black/60 text-white opacity-0 transition group-hover:opacity-100"
+              >
+                <HugeiconsIcon icon={Cancel01Icon} className="size-2.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
       {skillHint && (
         <div className="flex items-center gap-1 px-3 pt-2.5">
           <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 py-1 pr-1.5 pl-2.5 text-xs font-medium text-blue-700 dark:bg-blue-500/10 dark:text-blue-300">
@@ -148,6 +273,7 @@ export function Composer({
         placeholder={placeholder}
         className="max-h-50 w-full resize-none bg-transparent px-4 pt-3.5 pb-1.5 text-base/6 text-zinc-900 outline-none placeholder:text-zinc-400 sm:text-sm/6 dark:text-white dark:placeholder:text-zinc-500"
         onChange={(e) => onDraft(e.target.value)}
+        onPaste={onAttachments ? handlePaste : undefined}
         onKeyDown={(e) => {
           if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault()
@@ -159,6 +285,31 @@ export function Composer({
         <div className="flex items-center gap-2">
           {!hidePicker && (
             <AgentRoutePicker agent={agent} onAgent={onAgent} route={route} onRoute={onRoute} />
+          )}
+          {onAttachments && (
+            <>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/png,image/jpeg,image/webp,image/gif"
+                multiple
+                className="hidden"
+                onChange={(e) => {
+                  const files = [...(e.target.files ?? [])]
+                  e.target.value = ''
+                  if (files.length > 0) void uploadFiles(files)
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                aria-label="Attach image"
+                disabled={disabled}
+                className="flex size-8 shrink-0 items-center justify-center rounded-full text-zinc-500 transition hover:bg-zinc-100 disabled:text-zinc-300 dark:text-zinc-400 dark:hover:bg-zinc-700/50 dark:disabled:text-zinc-600"
+              >
+                <HugeiconsIcon icon={Attachment02Icon} className="size-4" />
+              </button>
+            </>
           )}
           <button
             type="button"
@@ -182,7 +333,7 @@ export function Composer({
           type="button"
           onClick={onSend}
           aria-label="Send"
-          disabled={disabled || draft.trim() === ''}
+          disabled={disabled || (draft.trim() === '' && attachments.length === 0)}
           className="flex size-9 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 disabled:bg-zinc-200 disabled:text-zinc-400 dark:disabled:bg-zinc-700 dark:disabled:text-zinc-500"
         >
           <HugeiconsIcon icon={ArrowUp01Icon} className="size-4" />

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -1,8 +1,12 @@
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ChatEvent } from '../api/types'
 import { applyEvent, emptyAssistant, type AssistantState } from '../lib/chat'
 import { AssistantMessage, CompactionDivider, InterruptedMessage, UserMessage } from './Message'
+
+vi.mock('../api/client', () => ({
+  fetchAttachmentBlob: vi.fn(),
+}))
 
 afterEach(cleanup)
 
@@ -358,5 +362,57 @@ describe('duration badge', () => {
     ])
     render(<AssistantMessage msg={msg} />)
     expect(screen.queryByTestId('duration-badge')).not.toBeInTheDocument()
+  })
+})
+
+describe('UserMessage attachments', () => {
+  beforeEach(() => {
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:mock-fetched'),
+      revokeObjectURL: vi.fn(),
+    })
+  })
+
+  it('renders an AuthedImage per attached image, fetched through the authed client', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.fetchAttachmentBlob).mockResolvedValue(new Blob(['x'], { type: 'image/png' }))
+
+    render(
+      <UserMessage
+        text="check this out"
+        images={[
+          { id: 'att-1', mime: 'image/png' },
+          { id: 'att-2', mime: 'image/jpeg' },
+        ]}
+      />,
+    )
+
+    await waitFor(() => expect(client.fetchAttachmentBlob).toHaveBeenCalledWith('att-1'))
+    expect(client.fetchAttachmentBlob).toHaveBeenCalledWith('att-2')
+    await waitFor(() => expect(screen.getAllByRole('img')).toHaveLength(2))
+  })
+
+  it('uses the optimistic local object URL directly, skipping the fetch', () => {
+    const localUrls = new Map([['att-1', 'blob:local-preview']])
+    render(
+      <UserMessage text="sending…" images={[{ id: 'att-1', mime: 'image/png' }]} localUrls={localUrls} />,
+    )
+    const img = screen.getByRole('img') as HTMLImageElement
+    expect(img.src).toBe('blob:local-preview')
+  })
+
+  it('shows a broken-image fallback when the fetch fails', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.fetchAttachmentBlob).mockRejectedValue(new Error('404'))
+
+    render(<UserMessage text="oops" images={[{ id: 'att-missing', mime: 'image/png' }]} />)
+
+    await waitFor(() => expect(screen.getByTestId('attachment-error')).toBeInTheDocument())
+  })
+
+  it('renders no image grid when the message carries no images', () => {
+    render(<UserMessage text="plain text" />)
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -1,15 +1,105 @@
-import { Copy01Icon, Link04Icon, Tick02Icon } from '@hugeicons-pro/core-stroke-rounded'
+import {
+  Copy01Icon,
+  ImageNotFound01Icon,
+  Link04Icon,
+  Loading03Icon,
+  Tick02Icon,
+} from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import rehypeHighlight from 'rehype-highlight'
 import remarkGfm from 'remark-gfm'
+import { fetchAttachmentBlob } from '../api/client'
+import type { ImageRef } from '../api/types'
 import { ActivityLine, formatDuration } from './Activity'
 import { Badge } from './ui/badge'
 import { collapseRepeatedTail, splitSources } from '../lib/citations'
 import type { AssistantState } from '../lib/chat'
 import { cn } from '../lib/utils'
 import 'highlight.js/styles/github-dark.css'
+
+// Object URLs fetched per attachment id, cached module-level: an
+// attachment is content-addressed and immutable (D-045), so replaying
+// the same transcript (reload, resumed session) never refetches it.
+const attachmentURLCache = new Map<string, string>()
+
+// AuthedImage renders one attachment thumbnail. GET
+// /v1/attachments/{id} requires the bearer header, so a bare <img
+// src> can't fetch it directly — this fetches the bytes through the
+// authed client and renders them as a blob object URL, with a loading
+// shimmer while in flight and a broken-image fallback on failure.
+// Click opens the same resolved blob URL in a new tab — a raw
+// /v1/attachments/{id} href would 401 without the bearer header.
+// `localUrl`, when given (an optimistic item's own object URL from
+// the composer), is used directly and never fetched.
+function AuthedImage({ id, mime, localUrl }: { id: string; mime: string; localUrl?: string }) {
+  const [url, setUrl] = useState<string | undefined>(localUrl ?? attachmentURLCache.get(id))
+  const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    if (localUrl || url) return
+    let stale = false
+    fetchAttachmentBlob(id)
+      .then((blob) => {
+        if (stale) return
+        const objectUrl = URL.createObjectURL(blob)
+        attachmentURLCache.set(id, objectUrl)
+        setUrl(objectUrl)
+      })
+      .catch(() => {
+        if (!stale) setFailed(true)
+      })
+    return () => {
+      stale = true
+    }
+  }, [id, localUrl, url])
+
+  if (failed) {
+    return (
+      <div
+        data-testid="attachment-error"
+        className="flex size-full min-h-24 items-center justify-center rounded-lg bg-zinc-100 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500"
+        title={id}
+      >
+        <HugeiconsIcon icon={ImageNotFound01Icon} className="size-6" />
+      </div>
+    )
+  }
+
+  if (!url) {
+    return (
+      <div
+        data-testid="attachment-loading"
+        className="flex size-full min-h-24 items-center justify-center rounded-lg bg-zinc-100 dark:bg-zinc-800"
+      >
+        <HugeiconsIcon icon={Loading03Icon} className="size-5 animate-spin text-zinc-400" />
+      </div>
+    )
+  }
+
+  return (
+    <img
+      src={url}
+      alt={mime}
+      onClick={() => window.open(url, '_blank')}
+      className="max-h-50 max-w-full cursor-pointer rounded-lg object-cover"
+    />
+  )
+}
+
+// ImageGrid renders a user message's attached images above the text.
+// Optimistic items carry their own local object URL (localUrls keyed
+// by id) so the just-sent thumbnail never round-trips the network.
+function ImageGrid({ images, localUrls }: { images: ImageRef[]; localUrls?: Map<string, string> }) {
+  return (
+    <div className="flex max-w-2xl flex-wrap justify-end gap-1.5">
+      {images.map((img) => (
+        <AuthedImage key={img.id} id={img.id} mime={img.mime} localUrl={localUrls?.get(img.id)} />
+      ))}
+    </div>
+  )
+}
 
 // SourcesPanel renders a research answer's citations as a distinct,
 // clickable list — separate from the prose so "these are the sources"
@@ -87,9 +177,18 @@ export function CopyButton({
 
 export function UserMessage({
   text,
+  images,
+  localUrls,
   onRetry,
 }: {
   text: string
+  // Attached images (transcript's Images, or the live turn's own
+  // optimistic list) — thumbnails render above the text bubble.
+  images?: ImageRef[]
+  // Optimistic-send local object URLs keyed by attachment id, so a
+  // just-sent message's thumbnails render instantly without
+  // round-tripping through AuthedImage's authed fetch.
+  localUrls?: Map<string, string>
   // Present only for a trailing dangling user message (the turn died
   // before any assistant event landed) — Chat.tsx decides that, this
   // component just renders whatever it's handed.
@@ -97,11 +196,14 @@ export function UserMessage({
 }) {
   return (
     <div className="flex flex-col items-end gap-1">
+      {images && images.length > 0 && <ImageGrid images={images} localUrls={localUrls} />}
       <div className="group/message flex items-end justify-end gap-1">
         <CopyButton text={text} label="Copy message" />
-        <div className="max-w-2xl rounded-2xl bg-blue-600 px-4 py-2.5 text-sm/6 whitespace-pre-wrap text-white">
-          {text}
-        </div>
+        {text !== '' && (
+          <div className="max-w-2xl rounded-2xl bg-blue-600 px-4 py-2.5 text-sm/6 whitespace-pre-wrap text-white">
+            {text}
+          </div>
+        )}
       </div>
       {onRetry && (
         <div className="flex items-center gap-2 text-muted-foreground">

--- a/web/src/components/settings/ProviderEdit.test.tsx
+++ b/web/src/components/settings/ProviderEdit.test.tsx
@@ -125,6 +125,54 @@ describe('ProviderEdit models section', () => {
     )
   })
 
+  it('adds a vision model with the capability flag and keeps it as default', async () => {
+    vi.mocked(patchProvider).mockResolvedValue()
+    renderPage()
+
+    const input = await screen.findByPlaceholderText('model id')
+    fireEvent.change(input, { target: { value: 'amazon.nova-pro-vision' } })
+    fireEvent.click(screen.getByRole('checkbox', { name: /Vision/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() =>
+      expect(patchProvider).toHaveBeenCalledWith('p1', {
+        models: [{ id: 'amazon.nova-pro-vision', capabilities: ['vision'] }],
+        default_model: 'amazon.nova-pro-vision',
+      }),
+    )
+  })
+
+  it('combines embeddings and vision flags into one capabilities array', async () => {
+    vi.mocked(patchProvider).mockResolvedValue()
+    renderPage()
+
+    const input = await screen.findByPlaceholderText('model id')
+    fireEvent.change(input, { target: { value: 'combo-model' } })
+    fireEvent.click(screen.getByRole('checkbox', { name: /Embeddings model/ }))
+    fireEvent.click(screen.getByRole('checkbox', { name: /Vision/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() =>
+      expect(patchProvider).toHaveBeenCalledWith('p1', {
+        models: [{ id: 'combo-model', capabilities: ['embeddings', 'vision'] }],
+      }),
+    )
+  })
+
+  it('shows a vision badge on declared vision models', async () => {
+    vi.mocked(listProviders).mockResolvedValue([
+      {
+        ...bedrockProvider,
+        default_model: 'us.amazon.nova-pro-v1:0',
+        models: [{ id: 'us.amazon.nova-pro-v1:0', capabilities: ['vision'] }],
+      },
+    ])
+    renderPage()
+
+    expect(await screen.findByText('us.amazon.nova-pro-v1:0')).toBeTruthy()
+    expect(screen.getByText('vision')).toBeTruthy()
+  })
+
   it('suggests catalog model ids for bedrock, which has no live listing', async () => {
     renderPage()
 

--- a/web/src/components/settings/ProviderEdit.tsx
+++ b/web/src/components/settings/ProviderEdit.tsx
@@ -398,6 +398,7 @@ function ModelsSection({ provider, onChanged }: { provider: AdminProvider; onCha
   const [fetched, setFetched] = useState<string[]>([])
   const [entry, setEntry] = useState('')
   const [embeddings, setEmbeddings] = useState(false)
+  const [vision, setVision] = useState(false)
   const [saving, setSaving] = useState(false)
 
   const declared = useMemo(() => new Set(provider.models.map((m) => m.id)), [provider.models])
@@ -440,15 +441,17 @@ function ModelsSection({ provider, onChanged }: { provider: AdminProvider; onCha
     const trimmed = entry.trim()
     if (!trimmed || declared.has(trimmed)) return
     const prices = (modelCatalog[preset.id] ?? []).find((m) => m.id === trimmed)?.prices
+    const capabilities = [...(embeddings ? ['embeddings'] : []), ...(vision ? ['vision'] : [])]
     const model: AdminModel = {
       id: trimmed,
-      ...(embeddings ? { capabilities: ['embeddings'] } : {}),
+      ...(capabilities.length > 0 ? { capabilities } : {}),
       ...(prices ? { prices } : {}),
     }
     const models = [...provider.models, model]
     await patchModels(models, embeddings ? undefined : provider.default_model || trimmed)
     setEntry('')
     setEmbeddings(false)
+    setVision(false)
   }
 
   const remove = async (id: string) => {
@@ -471,6 +474,11 @@ function ModelsSection({ provider, onChanged }: { provider: AdminProvider; onCha
             {m.capabilities?.includes('embeddings') && (
               <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-semibold text-muted-foreground">
                 embeddings
+              </span>
+            )}
+            {m.capabilities?.includes('vision') && (
+              <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-semibold text-muted-foreground">
+                vision
               </span>
             )}
             {provider.default_model === m.id ? (
@@ -528,6 +536,15 @@ function ModelsSection({ provider, onChanged }: { provider: AdminProvider; onCha
           className="size-4 rounded border-border"
         />
         Embeddings model — routes the embedding route to this instead of chat
+      </label>
+      <label className="flex items-center gap-2 text-sm text-muted-foreground">
+        <input
+          type="checkbox"
+          checked={vision}
+          onChange={(e) => setVision(e.target.checked)}
+          className="size-4 rounded border-border"
+        />
+        Vision — this model can accept image attachments
       </label>
     </section>
   )

--- a/web/src/lib/transcript.test.ts
+++ b/web/src/lib/transcript.test.ts
@@ -307,4 +307,34 @@ describe('fromTranscript', () => {
       expect(items[1].permissions).toEqual([])
     }
   })
+
+  it('maps a user item\'s Images into the chat item', () => {
+    const items = fromTranscript([
+      {
+        seq: 1,
+        kind: 'user',
+        text: 'look at this',
+        images: [
+          { id: 'att-1', mime: 'image/png' },
+          { id: 'att-2', mime: 'image/jpeg' },
+        ],
+        created_at: at,
+      },
+    ])
+    expect(items[0]).toMatchObject({
+      role: 'user',
+      text: 'look at this',
+      images: [
+        { id: 'att-1', mime: 'image/png' },
+        { id: 'att-2', mime: 'image/jpeg' },
+      ],
+    })
+  })
+
+  it('omits images on a user item that carries none', () => {
+    const items = fromTranscript([{ seq: 1, kind: 'user', text: 'hello', created_at: at }])
+    if (items[0].role === 'user') {
+      expect(items[0].images).toBeUndefined()
+    }
+  })
 })

--- a/web/src/lib/transcript.ts
+++ b/web/src/lib/transcript.ts
@@ -1,11 +1,11 @@
-import type { TranscriptItem } from '../api/types'
+import type { ImageRef, TranscriptItem } from '../api/types'
 import type { AssistantState, ToolRun } from './chat'
 
 // ChatItem is one renderable unit of the chat page: live turns and
 // replayed transcript items share this shape so resume is
 // pixel-equivalent with the original stream.
 export type ChatItem = { id: string } & (
-  | { role: 'user'; text: string }
+  | { role: 'user'; text: string; images?: ImageRef[] }
   | ({ role: 'assistant' } & AssistantState)
   | { role: 'compaction'; text: string }
   | { role: 'interrupted'; text: string }
@@ -70,7 +70,12 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
     switch (item.kind) {
       case 'user':
         flush()
-        out.push({ id, role: 'user', text: item.text ?? '' })
+        out.push({
+          id,
+          role: 'user',
+          text: item.text ?? '',
+          images: item.images && item.images.length > 0 ? item.images : undefined,
+        })
         break
       case 'tool':
         if (item.tool) pendingTools.push({ seq: item.seq, tool: item.tool })

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -11,7 +11,7 @@ import {
 } from '../api/client'
 import type { ChatEvent } from '../api/types'
 import { ActivityPanel } from '../components/Activity'
-import { Composer } from '../components/Composer'
+import { Composer, type PendingAttachment } from '../components/Composer'
 import { AssistantMessage, CompactionDivider, ErrorMessage, InterruptedMessage, UserMessage } from '../components/Message'
 import { PermissionModal } from '../components/PermissionModal'
 import { Sheet } from '../components/ui/sheet'
@@ -56,6 +56,13 @@ export function Chat({
   const { refresh } = useSessions()
   const [items, setItems] = useState<ChatItem[]>([])
   const [draft, setDraft] = useState('')
+  const [attachments, setAttachments] = useState<PendingAttachment[]>([])
+  // Optimistic sends' local object URLs, keyed by chat item id, so a
+  // just-sent message's thumbnails render instantly (UserMessage's
+  // localUrls prop) without round-tripping through AuthedImage's
+  // authed fetch — cleared per item only on unmount of the page, since
+  // a resumed/replayed session recreates items server-side anyway.
+  const localUrlsRef = useRef(new Map<string, Map<string, string>>())
   // Locked pages fix their own agent and never touch the shared
   // localStorage preference — a research page reading (or clobbering)
   // whatever agent general chat last used would be a leak either
@@ -95,6 +102,19 @@ export function Chat({
 
   // Cancel any in-flight stream when the page unmounts (route change).
   useEffect(() => () => abortRef.current?.abort(), [])
+
+  // Revoke every optimistic-send object URL when the page unmounts —
+  // they only exist to make a just-sent thumbnail instant, and a
+  // route change means AuthedImage's authed fetch takes over on
+  // remount (resume replays the transcript from scratch either way).
+  useEffect(
+    () => () => {
+      for (const urls of localUrlsRef.current.values()) {
+        for (const url of urls.values()) URL.revokeObjectURL(url)
+      }
+    },
+    [],
+  )
 
   // Resume: replay the session's transcript projection, exactly as the
   // server recorded it, and restore its last task category.
@@ -265,15 +285,30 @@ export function Chat({
     agentName: string,
     hint = skillHint,
     routeName = route,
+    sentAttachments: PendingAttachment[] = [],
   ) => {
     const message = text.trim()
-    if (!message || streaming) return
+    // Uploads still in flight aren't sendable ids yet — only completed
+    // ones ride the request; the composer's cap+toast already stops a
+    // user from expecting an in-flight one to count.
+    const ready = sentAttachments.filter((a) => !a.uploading)
+    if ((!message && ready.length === 0) || streaming) return
     setDraft('')
+    setAttachments([])
     setStreaming(true)
     pinnedRef.current = true // sending always re-follows the answer
+    const userItemId = crypto.randomUUID()
+    if (ready.length > 0) {
+      localUrlsRef.current.set(userItemId, new Map(ready.map((a) => [a.id, a.previewUrl])))
+    }
     setItems((prev) => [
       ...prev,
-      { id: crypto.randomUUID(), role: 'user', text: message },
+      {
+        id: userItemId,
+        role: 'user',
+        text: message,
+        images: ready.length > 0 ? ready.map((a) => ({ id: a.id, mime: a.mime })) : undefined,
+      },
       { id: crypto.randomUUID(), role: 'assistant', ...emptyAssistant() },
     ])
 
@@ -296,6 +331,7 @@ export function Chat({
           agent: agentName,
           route: routeName || undefined,
           skill_hint: hint,
+          attachments: ready.length > 0 ? ready.map((a) => a.id) : undefined,
         },
         (ev: ChatEvent) => {
           if (ev.type === 'meta') adoptSession(ev.session_id)
@@ -336,7 +372,7 @@ export function Chat({
     }
   }
 
-  const send = () => void sendMessage(draft, agent)
+  const send = () => void sendMessage(draft, agent, skillHint, route, attachments)
 
   // retryLast re-runs the last (failed) turn: the session already
   // carries the dangling user message server-side (chat.Service.Retry),
@@ -404,7 +440,15 @@ export function Chat({
   useEffect(() => {
     if (lockedSkillHint || intentConsumedRef.current) return
     const intent = location.state as ChatIntent | null
-    if (!intent || (!intent.send && !intent.draft && !intent.agent && !intent.route && !intent.skillHint))
+    if (
+      !intent ||
+      (!intent.send &&
+        !intent.draft &&
+        !intent.agent &&
+        !intent.route &&
+        !intent.skillHint &&
+        !intent.attachments)
+    )
       return
     intentConsumedRef.current = true
     window.history.replaceState(null, '') // don't refire on back/refresh
@@ -413,7 +457,8 @@ export function Chat({
     if (intent.agent) pickAgent(intent.agent)
     if (intent.route) pickRoute(intent.route)
     if (intent.skillHint) setSkillHint(intent.skillHint)
-    if (intent.send) void sendMessage(intent.send, who, intent.skillHint, whichRoute)
+    if (intent.send || intent.attachments)
+      void sendMessage(intent.send ?? '', who, intent.skillHint, whichRoute, intent.attachments)
     else if (intent.draft) setDraft(intent.draft)
     // Mount-time only by design: the intent rides the navigation that
     // created this page instance; the ref guards strict-mode replays.
@@ -470,6 +515,8 @@ export function Chat({
                 <UserMessage
                   key={item.id}
                   text={item.text}
+                  images={item.images}
+                  localUrls={localUrlsRef.current.get(item.id)}
                   // A trailing user message means the turn died before any
                   // assistant event reached the transcript — retry re-runs
                   // it server-side, same trailing-only condition as above.
@@ -519,6 +566,8 @@ export function Chat({
           onRemoveSkillHint={lockedSkillHint ? undefined : () => setSkillHint(undefined)}
           disabled={streaming}
           placeholder={placeholder}
+          attachments={attachments}
+          onAttachments={setAttachments}
         />
         <p className="mt-2 text-center text-xs text-zinc-400 dark:text-zinc-500">
           Enter to send · Shift+Enter for a new line

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -7,7 +7,7 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import { useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useAgents } from '../components/AgentPicker'
-import { Composer } from '../components/Composer'
+import { Composer, type PendingAttachment } from '../components/Composer'
 import { usePendingMemories } from '../lib/memory'
 
 const agentKey = 'timothy.agent'
@@ -16,12 +16,15 @@ const routeKey = 'timothy.route'
 // ChatIntent carries a home-screen action into the chat page: `send`
 // fires immediately, `draft` only prefills the composer, `skillHint`
 // pins a skill chip (deterministic — never text the user can mangle).
+// `attachments` rides alongside `send` only — images uploaded from the
+// home composer before Chat.tsx even mounts.
 export interface ChatIntent {
   send?: string
   draft?: string
   agent?: string
   route?: string
   skillHint?: string
+  attachments?: PendingAttachment[]
 }
 
 // Home is the workspace launcher: a hero composer that starts a chat,
@@ -35,6 +38,7 @@ export function Home() {
   const [draft, setDraft] = useState('')
   const [agent, setAgent] = useState(() => localStorage.getItem(agentKey) ?? '')
   const [route, setRoute] = useState(() => localStorage.getItem(routeKey) ?? '')
+  const [attachments, setAttachments] = useState<PendingAttachment[]>([])
 
   const pickAgent = (a: string) => {
     setAgent(a)
@@ -48,8 +52,16 @@ export function Home() {
 
   const send = () => {
     const message = draft.trim()
-    if (!message) return
-    navigate('/chat', { state: { send: message, agent, route: route || undefined } satisfies ChatIntent })
+    const ready = attachments.filter((a) => !a.uploading)
+    if (!message && ready.length === 0) return
+    navigate('/chat', {
+      state: {
+        send: message,
+        agent,
+        route: route || undefined,
+        attachments: ready.length > 0 ? ready : undefined,
+      } satisfies ChatIntent,
+    })
   }
 
   const openAgent = (name: string) => {
@@ -75,6 +87,8 @@ export function Home() {
             onRoute={pickRoute}
             autoFocus
             placeholder="Ask anything…"
+            attachments={attachments}
+            onAttachments={setAttachments}
           />
         </div>
       </div>


### PR DESCRIPTION
Completes the image-attachments feature (#120 shipped the backend).

- Composer: paperclip button, paste, and drag-drop all feed the same upload path (client-side type/size checks → authed multipart POST → preview chip with spinner, removable, 8 max). Send enabled for image-only messages.
- Chat/Home: attachment ids ride the existing send path (Home hands off via ChatIntent); optimistic user items use local object URLs, revoked on unmount.
- Message rendering: AuthedImage fetches attachment bytes with the bearer header into a blob URL (a bare img src can't authenticate) — module-level cache keyed by id since attachments are content-addressed/immutable; shimmer + broken-image fallback.
- Provider settings: per-model "Vision" checkbox + badge so operators can declare which models take images.
- nginx: client_max_body_size 12m on /v1/ (default 1MB 413'd uploads before they reached brain).

Tests: 15 Composer, Message AuthedImage suite, transcript mapping, ProviderEdit vision round-trip. Build/lint/test green (1 pre-existing AgentRoutePicker flake, file untouched).