### PR TITLE
fix(deploy): own the attachments volume like the workspace

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -28,7 +28,7 @@ FROM alpine:3.22.2 AS runtime-shell
 RUN apk add --no-cache curl git
 COPY --from=build /out/app /app
 COPY skills/ /skills/
-RUN mkdir -p /workspace && chown nobody:nobody /workspace
+RUN mkdir -p /workspace /attachments && chown nobody:nobody /workspace /attachments
 USER nobody
 ENTRYPOINT ["/app"]
 


### PR DESCRIPTION
Fresh attachments named volume mounts root-owned while brain runs as nobody — every upload 500'd with permission denied. Create /attachments in the image with the right owner (same pattern as /workspace) so the named volume inherits ownership on first mount. Live-verified after chowning the existing volume + rebuild.