### PR TITLE
feat(chat): route image messages to the vision route

### DIFF
--- a/internal/brain/chat/attachments_test.go
+++ b/internal/brain/chat/attachments_test.go
@@ -201,3 +201,135 @@ func TestRetryReplaysImageRefs(t *testing.T) {
 		t.Fatalf("retried message Images = %+v, want the original image replayed", first.Images)
 	}
 }
+
+// TestChatImageMessageAutoFlipsToVisionRoute is the D-046 feature under
+// test: a message carrying an attachment with no explicit route picked
+// gets routed to "vision" instead of riding the agent's/default chain.
+func TestChatImageMessageAutoFlipsToVisionRoute(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("described")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("img1", "image/png", []byte("bytes"))
+	svc.SetAttachments(fa)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what is this?", Attachments: []string{"img1"}})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	sent := gw.lastChatRequest()
+	if sent.Route != "vision" {
+		t.Fatalf("route = %q, want vision (image message, no explicit route)", sent.Route)
+	}
+}
+
+// TestChatImageMessageWithExplicitRouteIsHonored confirms the request's
+// own route pick outranks the vision auto-flip — precedence #2 beats #3.
+func TestChatImageMessageWithExplicitRouteIsHonored(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("described")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("img1", "image/png", []byte("bytes"))
+	svc.SetAttachments(fa)
+
+	_, ch, err := svc.Chat(t.Context(), Request{
+		SessionID: "s1", Message: "what is this?", Attachments: []string{"img1"}, Route: "research",
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	sent := gw.lastChatRequest()
+	if sent.Route != "research" {
+		t.Fatalf("route = %q, want research (explicit request route wins over the vision flip)", sent.Route)
+	}
+}
+
+// TestChatImageMessageOnSensitivePinnedSessionKeepsPinnedRoute confirms
+// the session-wide sensitive pin (precedence #1) beats the vision flip:
+// an image message on a pinned session stays on the pinned route even
+// though it may then correctly fail the gateway's vision capability gate.
+func TestChatImageMessageOnSensitivePinnedSessionKeepsPinnedRoute(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	seedSensitiveSession(t, log, "s1")
+	gw := &fakeGW{events: okEvents("described")}
+	svc := newService(gw, log)
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+	fa := newFakeAttachments()
+	fa.seed("img1", "image/png", []byte("bytes"))
+	svc.SetAttachments(fa)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what is this?", Attachments: []string{"img1"}})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	sent := gw.lastChatRequest()
+	if sent.Route != "local" {
+		t.Fatalf("route = %q, want local (sensitive pin beats the vision flip)", sent.Route)
+	}
+}
+
+// TestChatNoImagesLeavesRouteUnchanged confirms a plain-text message
+// never triggers the vision flip.
+func TestChatNoImagesLeavesRouteUnchanged(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("hi")}
+	svc := newService(gw, log)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "hello"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	sent := gw.lastChatRequest()
+	if sent.Route != defaultRoute {
+		t.Fatalf("route = %q, want %q (no images, no flip)", sent.Route, defaultRoute)
+	}
+}
+
+// TestRetryOfImageTurnStaysOnVisionRoute confirms Retry reuses the
+// persisted (already-flipped) route: the vision flip happens once at
+// Chat time and is durable on the user_message event, so a retried
+// image turn never needs its own vision-detection logic.
+func TestRetryOfImageTurnStaysOnVisionRoute(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: []stream.StreamEvent{{Type: stream.EventError, Err: &stream.StreamError{Code: "boom", Message: "boom"}}}}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("img1", "image/png", []byte("bytes"))
+	svc.SetAttachments(fa)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what is this?", Attachments: []string{"img1"}})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return !svc.TurnActive("s1") })
+
+	gw.mu.Lock()
+	gw.events = okEvents("retried answer")
+	gw.mu.Unlock()
+
+	_, ch, err = svc.Retry(t.Context(), "s1")
+	if err != nil {
+		t.Fatalf("Retry: %v", err)
+	}
+	drain(t, ch)
+
+	sent := gw.lastChatRequest()
+	if sent.Route != "vision" {
+		t.Fatalf("retried route = %q, want vision (persisted route replayed)", sent.Route)
+	}
+}

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -46,6 +46,12 @@ const (
 	// defaultRoute serves plain chat turns when the caller picks
 	// nothing; the web UI exposes a per-message picker.
 	defaultRoute = "default"
+	// visionRoute serves turns whose message carries an image attachment
+	// (D-046) — a cheapest-first vision chain, so an image message never
+	// rides an agent's or the default route's (usually pricier) chain
+	// just because the capability gate happens to find a vision-capable
+	// model there too.
+	visionRoute = "vision"
 	// Each persistence stage gets its OWN deadline: LLM-backed stages
 	// (distill, compaction) must never eat the database writes' clock.
 	persistTimeout = 10 * time.Second
@@ -412,9 +418,23 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 		}
 		skillBody = body
 	}
-	// Routing precedence: explicit request override, then the agent's
-	// route, then the default chain.
+	// Routing precedence: explicit request override, then images auto-flip
+	// to the vision route, then the agent's route, then the default chain
+	// (sensitive-pin below still overrides all of this).
 	route := req.Route
+	if route == "" && len(images) > 0 {
+		// D-046: brain has no cheap way to know whether a "vision" route
+		// exists/is enabled/has a non-empty chain (gwclient exposes no
+		// routes-listing, and adding one just for this check is exactly
+		// the kind of new polling machinery we want to avoid) — so the
+		// flip is unconditional here. The gateway-side safety net
+		// (internal/gateway/api/api.go's handleStream) falls back to
+		// "default" when "vision" resolves to a missing/disabled/empty
+		// chain, so installs that never created the route still work;
+		// an existing vision route wins outright since its cheapest-first
+		// chain is exactly the point of this feature.
+		route = visionRoute
+	}
 	if route == "" {
 		route = profile.Route
 	}

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -351,7 +351,7 @@ func (a *Admin) bootstrapRoutes(ctx context.Context, p router.ProviderRow) {
 		return
 	}
 	existing := map[string][]router.ChainEntry{}
-	for _, name := range []string{"default", "summarize", "embedding"} {
+	for _, name := range []string{"default", "summarize", "embedding", "vision"} {
 		var chainJSON []byte
 		if err := db.QueryRow(ctx, `SELECT chain FROM routes WHERE name = $1`, name).Scan(&chainJSON); err != nil {
 			a.log.Warn("route bootstrap: read route", "route", name, "error", err)

--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -129,11 +129,32 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var nre *router.NoRouteError
 		if errors.As(err, &nre) {
-			jsonError(w, http.StatusBadGateway, "no_route", nre.Error())
+			// D-046 safety net: brain flips an image message to "vision"
+			// unconditionally (it has no cheap way to know whether the
+			// route exists on this install). When "vision" is missing,
+			// disabled, or has an empty chain, Resolve returns a
+			// NoRouteError with no Skipped entries — nothing was even
+			// tried. That's distinct from the chain existing but every
+			// entry lacking the vision capability (Skipped is non-empty
+			// there): THAT case must still error, since falling back
+			// would silently serve an image turn on a model that can't
+			// see it. Any other unknown/misconfigured route keeps
+			// erroring — this fallback is vision-only, not generic
+			// route-aliasing.
+			if req.Route == "vision" && len(nre.Skipped) == 0 {
+				a.log.Warn("vision route unresolvable, falling back to default", "reason", nre.Error())
+				req.Route = "default"
+				attempts, err = snap.Resolve(req.Route, req.ModelHint, sticky, requiredVisionCapability(req.Messages)...)
+			}
+		}
+		if err != nil {
+			if errors.As(err, &nre) {
+				jsonError(w, http.StatusBadGateway, "no_route", nre.Error())
+				return
+			}
+			jsonError(w, http.StatusInternalServerError, "resolve_failed", err.Error())
 			return
 		}
-		jsonError(w, http.StatusInternalServerError, "resolve_failed", err.Error())
-		return
 	}
 
 	flusher, ok := w.(http.Flusher)

--- a/internal/gateway/api/api_test.go
+++ b/internal/gateway/api/api_test.go
@@ -369,6 +369,179 @@ func TestStreamValidation(t *testing.T) {
 	}
 }
 
+// visionMessages is a one-turn request carrying an image, forcing
+// requiredVisionCapability to demand CapVision at Resolve.
+const visionMessages = `[{"role":"user","content":"look","images":[{"media_type":"image/png","data":"AAAA"}]}]`
+
+// TestStreamVisionRouteMissingFallsBackToDefault is the D-046 gateway
+// safety net under test: "vision" was never created on this install (no
+// route row at all), so Resolve's NoRouteError carries zero Skipped
+// entries — nothing was even tried. handleStream retries on "default",
+// which chains a vision-capable model, and the image turn still serves.
+func TestStreamVisionRouteMissingFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+	srv := oaiOK(t, "described")
+	rows := []router.ProviderRow{
+		{ID: "p1", Name: "one", Kind: "api", Driver: "openaicompat", BaseURL: srv.URL,
+			DefaultModel: "m1", Enabled: true,
+			Models: []router.ModelInfo{{ID: "m1", Capabilities: []string{"chat", "vision"}}}},
+	}
+	routes := []router.RouteRow{
+		{Name: "default", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: true},
+		// no "vision" route row at all.
+	}
+	snap, err := router.BuildSnapshot(rows, routes, func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("BuildSnapshot: %v", err)
+	}
+	a, rec := newAPI(snap)
+
+	w := postJSON(t, a.handleStream, fmt.Sprintf(`{"route":"vision","messages":%s}`, visionMessages))
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d body = %s", w.Code, w.Body.String())
+	}
+	events := sseEvents(t, w.Body.String())
+	var text string
+	for _, ev := range events {
+		if ev.Type == stream.EventChunk {
+			text += ev.Text
+		}
+		if ev.Type == stream.EventError {
+			t.Fatalf("error event leaked to client: %+v", ev)
+		}
+	}
+	if text != "described" {
+		t.Fatalf("chunks = %q", text)
+	}
+	entries := rec.all()
+	if len(entries) != 1 || entries[0].Route != "default" {
+		t.Fatalf("ledger = %+v, want single entry booked under the fallback route", entries)
+	}
+}
+
+// TestStreamVisionRouteDisabledFallsBackToDefault covers the "route
+// exists but disabled" flavor of the same missing/empty class: disabled
+// routes never enter the snapshot's routes map (BuildSnapshot only
+// loads Enabled rows), so Resolve produces the identical empty-Skipped
+// NoRouteError as a route that was never created.
+func TestStreamVisionRouteDisabledFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+	srv := oaiOK(t, "described")
+	rows := []router.ProviderRow{
+		{ID: "p1", Name: "one", Kind: "api", Driver: "openaicompat", BaseURL: srv.URL,
+			DefaultModel: "m1", Enabled: true,
+			Models: []router.ModelInfo{{ID: "m1", Capabilities: []string{"chat", "vision"}}}},
+	}
+	routes := []router.RouteRow{
+		{Name: "default", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: true},
+		{Name: "vision", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: false},
+	}
+	snap, err := router.BuildSnapshot(rows, routes, func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("BuildSnapshot: %v", err)
+	}
+	a, rec := newAPI(snap)
+
+	w := postJSON(t, a.handleStream, fmt.Sprintf(`{"route":"vision","messages":%s}`, visionMessages))
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d body = %s", w.Code, w.Body.String())
+	}
+	entries := rec.all()
+	if len(entries) != 1 || entries[0].Route != "default" {
+		t.Fatalf("ledger = %+v, want single entry booked under the fallback route", entries)
+	}
+}
+
+// TestStreamVisionRoutePresentNoFallback confirms a real, enabled,
+// vision-capable "vision" route is served directly — no fallback fires,
+// and the ledger books the request under "vision" itself, not "default".
+func TestStreamVisionRoutePresentNoFallback(t *testing.T) {
+	t.Parallel()
+	visionSrv := oaiOK(t, "from-vision-route")
+	defaultSrv := oaiOK(t, "from-default-route")
+	rows := []router.ProviderRow{
+		{ID: "p1", Name: "vprov", Kind: "api", Driver: "openaicompat", BaseURL: visionSrv.URL,
+			DefaultModel: "vm", Enabled: true,
+			Models: []router.ModelInfo{{ID: "vm", Capabilities: []string{"chat", "vision"}}}},
+		{ID: "p2", Name: "dprov", Kind: "api", Driver: "openaicompat", BaseURL: defaultSrv.URL,
+			DefaultModel: "dm", Enabled: true,
+			Models: []router.ModelInfo{{ID: "dm", Capabilities: []string{"chat", "vision"}}}},
+	}
+	routes := []router.RouteRow{
+		{Name: "vision", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "vm"}}, Enabled: true},
+		{Name: "default", Chain: []router.ChainEntry{{ProviderID: "p2", Model: "dm"}}, Enabled: true},
+	}
+	snap, err := router.BuildSnapshot(rows, routes, func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("BuildSnapshot: %v", err)
+	}
+	a, rec := newAPI(snap)
+
+	w := postJSON(t, a.handleStream, fmt.Sprintf(`{"route":"vision","messages":%s}`, visionMessages))
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d body = %s", w.Code, w.Body.String())
+	}
+	events := sseEvents(t, w.Body.String())
+	var text string
+	for _, ev := range events {
+		if ev.Type == stream.EventChunk {
+			text += ev.Text
+		}
+	}
+	if text != "from-vision-route" {
+		t.Fatalf("chunks = %q, want served by the real vision route (no fallback)", text)
+	}
+	entries := rec.all()
+	if len(entries) != 1 || entries[0].Route != "vision" {
+		t.Fatalf("ledger = %+v, want single entry booked under vision", entries)
+	}
+}
+
+// TestStreamVisionCapabilityExhaustedNoFallback confirms the fallback
+// does NOT fire when "vision" exists and is enabled but every chain
+// entry lacks the vision capability: Resolve's NoRouteError carries
+// non-empty Skipped ("lacks vision capability") in that case, the
+// signal that something was tried and rejected — falling back here
+// would silently serve an image turn on a model that can't see it.
+func TestStreamVisionCapabilityExhaustedNoFallback(t *testing.T) {
+	t.Parallel()
+	rows := []router.ProviderRow{
+		{ID: "p1", Name: "textonly", Kind: "api", Driver: "openaicompat", BaseURL: oaiOK(t, "x").URL,
+			DefaultModel: "m1", Enabled: true,
+			Models: []router.ModelInfo{{ID: "m1", Capabilities: []string{"chat"}}}}, // no vision
+	}
+	routes := []router.RouteRow{
+		{Name: "vision", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: true},
+	}
+	snap, err := router.BuildSnapshot(rows, routes, func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("BuildSnapshot: %v", err)
+	}
+	a, rec := newAPI(snap)
+
+	w := postJSON(t, a.handleStream, fmt.Sprintf(`{"route":"vision","messages":%s}`, visionMessages))
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("code = %d, want 502 (capability-exhausted must still error, no fallback)", w.Code)
+	}
+	if len(rec.all()) != 0 {
+		t.Fatalf("ledger entries = %+v, want none (Resolve failed before any attempt)", rec.all())
+	}
+}
+
+// TestStreamNonVisionUnknownRouteStillErrors confirms the fallback is
+// vision-only: a request for any other unknown/misconfigured route
+// keeps erroring exactly as before (TestStreamValidation's "nope" case,
+// duplicated here to pin it explicitly against this feature).
+func TestStreamNonVisionUnknownRouteStillErrors(t *testing.T) {
+	t.Parallel()
+	a, _ := newAPI(snapshotFor(t, oaiFail(t).URL, oaiFail(t).URL))
+
+	w := postJSON(t, a.handleStream, `{"route":"nope","messages":[{"role":"user","content":"x"}]}`)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("code = %d, want 502 (non-vision unknown route, no fallback)", w.Code)
+	}
+}
+
 func TestEmbedHappyPath(t *testing.T) {
 	t.Parallel()
 	a, rec := newAPI(snapshotFor(t, oaiOK(t, "x").URL, oaiFail(t).URL))

--- a/internal/gateway/router/bootstrap.go
+++ b/internal/gateway/router/bootstrap.go
@@ -7,11 +7,13 @@ import (
 
 // bootstrapRoutes are the fixed system routes a connected provider can
 // auto-fill: chat-capable for default/summarize, embeddings-capable
-// for embedding. research is agent-specific and stays hand-configured.
+// for embedding, vision-capable for vision (D-046). research is
+// agent-specific and stays hand-configured.
 var bootstrapRoutes = map[string]string{
 	"default":   "chat",
 	"summarize": "chat",
 	"embedding": "embeddings",
+	"vision":    "vision",
 }
 
 // BootstrapChain computes route-name -> new-chain-entry for a newly

--- a/internal/gateway/router/bootstrap_test.go
+++ b/internal/gateway/router/bootstrap_test.go
@@ -135,6 +135,35 @@ func TestBootstrapChainExcludedProviderYieldsNoUpdates(t *testing.T) {
 	}
 }
 
+// TestBootstrapChainSeedsVisionRoute confirms a newly connected
+// vision-capable provider auto-chains into the "vision" route (D-046),
+// the same as the other fixed bootstrap routes.
+func TestBootstrapChainSeedsVisionRoute(t *testing.T) {
+	p := ProviderRow{ID: "p1", Models: []ModelInfo{
+		priced("cheap-vision", 2, "chat", "vision"),
+		priced("pricey-vision", 8, "chat", "vision"),
+	}}
+
+	got := BootstrapChain(p, map[string][]ChainEntry{})
+
+	chain := got["vision"]
+	if len(chain) != 1 || chain[0].ProviderID != "p1" || chain[0].Model != "cheap-vision" {
+		t.Fatalf("vision chain = %+v, want single cheapest vision-capable entry", chain)
+	}
+}
+
+// TestBootstrapChainOmitsVisionForNonVisionProvider confirms a provider
+// with no vision-capable model never touches the "vision" route.
+func TestBootstrapChainOmitsVisionForNonVisionProvider(t *testing.T) {
+	p := ProviderRow{ID: "p1", Models: []ModelInfo{priced("chat-only", 1, "chat")}}
+
+	got := BootstrapChain(p, map[string][]ChainEntry{})
+
+	if _, ok := got["vision"]; ok {
+		t.Fatalf("vision present = %+v, want omitted (no vision-capable model)", got["vision"])
+	}
+}
+
 func TestBootstrapChainIgnoresResearchRoute(t *testing.T) {
 	p := ProviderRow{ID: "p1", Models: []ModelInfo{priced("m", 1, "chat")}}
 

--- a/migrations/0002_gateway.sql
+++ b/migrations/0002_gateway.sql
@@ -64,7 +64,10 @@ CREATE INDEX IF NOT EXISTS cost_ledger_session_idx ON cost_ledger (session_id) W
 --   'embedding' — gateway /v1/embeddings (internal/gateway/api)
 --   'research'  — min-retrieval floor keys on this route name (D-009)
 --                 and the researcher agent routes here
+--   'vision'    — image messages auto-flip here (D-046,
+--                 internal/brain/chat); gateway falls back to
+--                 'default' when this route is missing/disabled/empty
 -- All start with an empty chain and disabled.
 INSERT INTO routes (name)
-VALUES ('default'), ('summarize'), ('embedding'), ('research')
+VALUES ('default'), ('summarize'), ('embedding'), ('research'), ('vision')
 ON CONFLICT (name) DO NOTHING;


### PR DESCRIPTION
Image messages now auto-select the `vision` route (chained cheapest-first: nova-lite → glm-4.6v → nova-pro) instead of riding the default chain, where the capability gate lands them on the most expensive vision model.

Precedence (D-046): sensitive pin > explicit route pick > vision auto-flip > agent/default. Retry inherits the persisted route, so replays stay on vision.

Safety net: if the requested vision route is missing/disabled/empty (fresh installs), the gateway retries resolution on `default` — distinguished from genuine capability exhaustion via NoRouteError.Skipped, which still errors loudly. Fresh installs seed the route (0002) and vision-capable providers auto-bootstrap into it.

12 new tests across chat, gateway api, and bootstrap. `make build test vet lint` green.