### PR TITLE
feat(gateway): bedrock auth via static keys in the secret store

### DIFF
--- a/internal/gateway/provider/bedrock.go
+++ b/internal/gateway/provider/bedrock.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
@@ -23,26 +24,63 @@ import (
 // (Nova and Titan families) so usage bills against AWS credits — no
 // third-party models.
 //
-// Credentials come from the AWS SDK default chain (env vars, shared
-// config, IAM role) — never from code or the providers table. For
-// local development with SSO, set credential_ref to the profile name
-// and run `aws sso login --profile <name>` first. When running on AWS
-// with an IAM role, leave credential_ref empty: a profile name that
-// has no matching shared config makes client construction fail.
+// D-047: credential_ref resolves through the encrypted secret store
+// like every other provider. When it resolves to a non-empty value,
+// that value MUST be the JSON documented on StaticCredentials — a
+// parse failure fails provider construction rather than silently
+// falling back to profile/SSO (config honesty). When credential_ref
+// does not resolve (no secrets row — e.g. the 'sumonmselim' local dev
+// row), the prior behavior stands unchanged: it is an AWS profile
+// name resolved from the SDK's shared config (~/.aws, SSO). Leave
+// credential_ref empty entirely when an IAM role supplies credentials.
 //
-// Providers table example:
+// Providers table example (secret-store static keys):
 //
 //	driver = 'bedrock'
-//	base_url = 'us-east-1'                       -- AWS region
+//	base_url = 'us-east-1'                       -- AWS region; secret JSON region wins if set
 //	default_model = 'us.amazon.nova-pro-v1:0'    -- inference-profile ID
-//	credential_ref = '<aws-profile>'             -- local SSO only; empty on AWS
+//	credential_ref = 'bedrock-static'            -- secret store ref holding StaticCredentials JSON
+//
+// Providers table example (profile/SSO fallback, unchanged):
+//
+//	credential_ref = '<aws-profile>'             -- no matching secrets row; local SSO only, empty on AWS
 //
 // Models must be enabled on the Bedrock console "Model access" page.
 type BedrockConfig struct {
 	Name    string
-	Region  string // e.g. "us-east-1"; defaults to us-east-1
-	Profile string // optional AWS profile name (from credential_ref)
-	Timeout time.Duration
+	Region  string // e.g. "us-east-1"; defaults to us-east-1 unless StaticCredentials.Region overrides it
+	Profile string // AWS profile name (credential_ref), used when StaticCredentials is nil
+	// StaticCredentials, when non-nil, is the resolved secret-store
+	// value for credential_ref parsed as JSON — takes precedence over
+	// Profile. A non-nil pointer with an empty AccessKeyID/SecretAccessKey
+	// never happens: ParseStaticCredentials rejects that at parse time.
+	StaticCredentials *StaticCredentials
+	Timeout           time.Duration
+}
+
+// StaticCredentials is the secret-store JSON shape for Bedrock static
+// IAM keys: {"access_key_id":"...","secret_access_key":"...","session_token":"(optional)","region":"(optional)"}.
+// Unknown keys are ignored; AccessKeyID/SecretAccessKey are required.
+type StaticCredentials struct {
+	AccessKeyID     string `json:"access_key_id"`
+	SecretAccessKey string `json:"secret_access_key"`
+	SessionToken    string `json:"session_token,omitempty"`
+	Region          string `json:"region,omitempty"`
+}
+
+// ParseStaticCredentials parses a secret-store value as Bedrock static
+// credentials JSON. A missing access_key_id or secret_access_key is a
+// parse error — a resolved secret that isn't usable credentials must
+// fail loudly, never fall back to profile/SSO silently.
+func ParseStaticCredentials(raw string) (*StaticCredentials, error) {
+	var c StaticCredentials
+	if err := json.Unmarshal([]byte(raw), &c); err != nil {
+		return nil, fmt.Errorf("bedrock: parse static credentials: %w", err)
+	}
+	if c.AccessKeyID == "" || c.SecretAccessKey == "" {
+		return nil, fmt.Errorf("bedrock: static credentials missing access_key_id or secret_access_key")
+	}
+	return &c, nil
 }
 
 // Bedrock is a Provider implementation backed by Amazon Bedrock.
@@ -67,16 +105,51 @@ func NewBedrock(cfg BedrockConfig) *Bedrock {
 func (b *Bedrock) Name() string { return b.cfg.Name }
 func (b *Bedrock) Kind() Kind   { return KindAPI }
 
+// HasStaticCredentials reports whether this provider was built with a
+// resolved secret-store credential (D-047) rather than the AWS
+// profile/SSO fallback — used by router tests to verify the lookup
+// plumbing reaches the bedrock constructor.
+func (b *Bedrock) HasStaticCredentials() bool { return b.cfg.StaticCredentials != nil }
+
 func (b *Bedrock) Capabilities() []Capability {
 	return []Capability{CapChat, CapStreaming, CapTools, CapEmbeddings, CapVision}
 }
 
-// lazyClient builds the AWS client on first use (default credential
-// chain: env vars, shared config, IAM role). sync.Once makes it safe
-// under concurrent Stream/Embed calls; a load failure is sticky, which
-// is right — a bad profile or region never heals mid-process.
+// lazyClient builds the AWS client on first use. With StaticCredentials
+// set, region precedence is secret JSON region > BedrockConfig.Region
+// (already defaulted to us-east-1 by NewBedrock unless a driver
+// deriving path set it) — a static-keys row with no region anywhere is
+// a construction error, since there is no profile/env to derive it
+// from. Without StaticCredentials, behavior is unchanged: the SDK's
+// default chain (env vars, shared config profile, IAM role). sync.Once
+// makes it safe under concurrent Stream/Embed calls; a load failure is
+// sticky, which is right — bad credentials or a bad region never heal
+// mid-process.
 func (b *Bedrock) lazyClient(ctx context.Context) (*bedrockruntime.Client, error) {
 	b.initOnce.Do(func() {
+		if b.cfg.StaticCredentials != nil {
+			sc := b.cfg.StaticCredentials
+			region := sc.Region
+			if region == "" {
+				region = b.cfg.Region
+			}
+			if region == "" {
+				b.clientErr = fmt.Errorf("bedrock: static credentials require a region (set the secret JSON's %q field or the provider's base_url)", "region")
+				return
+			}
+			awsCfg, err := config.LoadDefaultConfig(ctx,
+				config.WithRegion(region),
+				config.WithCredentialsProvider(
+					credentials.NewStaticCredentialsProvider(sc.AccessKeyID, sc.SecretAccessKey, sc.SessionToken)),
+			)
+			if err != nil {
+				b.clientErr = fmt.Errorf("bedrock: load aws config: %w", err)
+				return
+			}
+			b.client = bedrockruntime.NewFromConfig(awsCfg)
+			return
+		}
+
 		opts := []func(*config.LoadOptions) error{
 			config.WithRegion(b.cfg.Region),
 		}

--- a/internal/gateway/provider/bedrock_test.go
+++ b/internal/gateway/provider/bedrock_test.go
@@ -1,7 +1,9 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
@@ -283,6 +285,150 @@ func TestDocumentFromJSON(t *testing.T) {
 	if documentFromJSON(json.RawMessage(`{"a":1}`)) == nil {
 		t.Fatal("valid JSON must yield a document")
 	}
+}
+
+// TestParseStaticCredentials covers the secret-store JSON contract
+// (D-047): valid input, optional fields, missing required fields, and
+// malformed JSON.
+func TestParseStaticCredentials(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+		want    *StaticCredentials
+	}{
+		{
+			name: "valid minimal",
+			raw:  `{"access_key_id":"AKIA123","secret_access_key":"secret"}`,
+			want: &StaticCredentials{AccessKeyID: "AKIA123", SecretAccessKey: "secret"},
+		},
+		{
+			name: "valid with optional fields",
+			raw:  `{"access_key_id":"AKIA123","secret_access_key":"secret","session_token":"tok","region":"us-west-2"}`,
+			want: &StaticCredentials{AccessKeyID: "AKIA123", SecretAccessKey: "secret", SessionToken: "tok", Region: "us-west-2"},
+		},
+		{
+			name: "unknown keys ignored",
+			raw:  `{"access_key_id":"AKIA123","secret_access_key":"secret","bogus":"x"}`,
+			want: &StaticCredentials{AccessKeyID: "AKIA123", SecretAccessKey: "secret"},
+		},
+		{
+			name:    "missing access_key_id",
+			raw:     `{"secret_access_key":"secret"}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing secret_access_key",
+			raw:     `{"access_key_id":"AKIA123"}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty object",
+			raw:     `{}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed json",
+			raw:     `{not json`,
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseStaticCredentials(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %#v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if *got != *tc.want {
+				t.Fatalf("got %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBedrockLazyClientStaticCredentials covers D-047's region
+// precedence and construction-failure rules: secret JSON region wins
+// over the provider's base_url-derived region, the provider's region
+// is used when the secret carries none, and a static-credentials
+// config with no region anywhere fails construction with a message
+// naming the region field. LoadDefaultConfig with a static credentials
+// provider and an explicit region does no network I/O, so this stays
+// a pure unit test.
+func TestBedrockLazyClientStaticCredentials(t *testing.T) {
+	t.Parallel()
+
+	t.Run("secret region wins over provider region", func(t *testing.T) {
+		t.Parallel()
+		b := NewBedrock(BedrockConfig{
+			Name:              "b",
+			Region:            "us-east-1",
+			StaticCredentials: &StaticCredentials{AccessKeyID: "AKIA", SecretAccessKey: "secret", Region: "eu-west-1"},
+		})
+		client, err := b.lazyClient(context.Background())
+		if err != nil {
+			t.Fatalf("lazyClient: %v", err)
+		}
+		if got := client.Options().Region; got != "eu-west-1" {
+			t.Fatalf("region = %q, want eu-west-1 (secret JSON must win)", got)
+		}
+	})
+
+	t.Run("falls back to provider region when secret has none", func(t *testing.T) {
+		t.Parallel()
+		b := NewBedrock(BedrockConfig{
+			Name:              "b",
+			Region:            "us-west-2",
+			StaticCredentials: &StaticCredentials{AccessKeyID: "AKIA", SecretAccessKey: "secret"},
+		})
+		client, err := b.lazyClient(context.Background())
+		if err != nil {
+			t.Fatalf("lazyClient: %v", err)
+		}
+		if got := client.Options().Region; got != "us-west-2" {
+			t.Fatalf("region = %q, want us-west-2", got)
+		}
+	})
+
+	t.Run("no region anywhere fails construction", func(t *testing.T) {
+		t.Parallel()
+		// Bypass NewBedrock's us-east-1 default to exercise the
+		// no-region-derivable path directly.
+		b := &Bedrock{cfg: BedrockConfig{
+			Name:              "b",
+			StaticCredentials: &StaticCredentials{AccessKeyID: "AKIA", SecretAccessKey: "secret"},
+		}}
+		_, err := b.lazyClient(context.Background())
+		if err == nil {
+			t.Fatal("want error when no region is derivable")
+		}
+		if !strings.Contains(err.Error(), "region") {
+			t.Fatalf("error must name the region field, got: %v", err)
+		}
+	})
+
+	t.Run("static credentials take precedence over profile", func(t *testing.T) {
+		t.Parallel()
+		b := NewBedrock(BedrockConfig{
+			Name:              "b",
+			Region:            "us-east-1",
+			Profile:           "some-profile-that-does-not-exist",
+			StaticCredentials: &StaticCredentials{AccessKeyID: "AKIA", SecretAccessKey: "secret"},
+		})
+		// If Profile were still honored, LoadDefaultConfig would try to
+		// resolve a nonexistent shared-config profile and fail; success
+		// here proves StaticCredentials wins.
+		if _, err := b.lazyClient(context.Background()); err != nil {
+			t.Fatalf("lazyClient: %v, want static credentials to bypass the (invalid) profile", err)
+		}
+	})
 }
 
 func TestParseTitanEmbedding(t *testing.T) {

--- a/internal/gateway/provider/registry.go
+++ b/internal/gateway/provider/registry.go
@@ -66,15 +66,30 @@ func Build(cfgs []Config, lookup func(string) string) (*Registry, error) {
 				ReasoningEffort: c.ReasoningEffort,
 			})
 		case "bedrock":
-			// base_url holds the AWS region; credential_ref names a local
-			// AWS profile (SSO dev) and must be EMPTY when an IAM role
-			// supplies credentials — a missing profile fails client setup.
-			p = NewBedrock(BedrockConfig{
+			// base_url holds the AWS region. D-047: if credential_ref
+			// resolves in the secret store (key is non-empty), it MUST be
+			// static-credentials JSON — parse failure fails provider
+			// construction (config honesty), never a silent profile
+			// fallback. If it does not resolve (no secrets row), the
+			// unchanged prior behavior applies: credential_ref names a
+			// local AWS profile (SSO dev), and must be EMPTY when an IAM
+			// role supplies credentials — a missing profile fails client
+			// setup.
+			bedrockCfg := BedrockConfig{
 				Name:    c.Name,
 				Region:  c.BaseURL,
 				Profile: c.CredentialRef,
 				Timeout: c.Timeout,
-			})
+			}
+			if key != "" {
+				sc, err := ParseStaticCredentials(key)
+				if err != nil {
+					return nil, fmt.Errorf("registry: provider %q: %w", c.Name, err)
+				}
+				bedrockCfg.StaticCredentials = sc
+				bedrockCfg.Profile = ""
+			}
+			p = NewBedrock(bedrockCfg)
 		default:
 			return nil, fmt.Errorf("registry: provider %q: unknown driver %q", c.Name, c.Driver)
 		}

--- a/internal/gateway/provider/registry_test.go
+++ b/internal/gateway/provider/registry_test.go
@@ -96,17 +96,94 @@ func TestBuildErrors(t *testing.T) {
 			cfgs:    []Config{{Driver: "anthropic"}},
 			wantErr: "empty name",
 		},
+		{
+			name: "bedrock credential_ref resolves to malformed secret JSON",
+			cfgs: []Config{
+				{Name: "bedrock", Driver: "bedrock", BaseURL: "us-east-1", CredentialRef: "bedrock-static"},
+			},
+			wantErr: "parse static credentials",
+		},
+		{
+			name: "bedrock credential_ref resolves to secret missing required fields",
+			cfgs: []Config{
+				{Name: "bedrock", Driver: "bedrock", BaseURL: "us-east-1", CredentialRef: "bedrock-static"},
+			},
+			wantErr: "missing access_key_id or secret_access_key",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := Build(tt.cfgs, noLookup)
+			lookup := noLookup
+			switch tt.name {
+			case "bedrock credential_ref resolves to malformed secret JSON":
+				lookup = func(string) string { return `{not json` }
+			case "bedrock credential_ref resolves to secret missing required fields":
+				lookup = func(string) string { return `{"access_key_id":"AKIA123"}` }
+			}
+			_, err := Build(tt.cfgs, lookup)
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("Build() error = %v, want containing %q", err, tt.wantErr)
 			}
 		})
 	}
+}
+
+// TestBuildBedrockCredentialResolutionOrder covers D-047: the static
+// JSON path is used when credential_ref resolves in the secret store,
+// and the existing AWS-profile fallback is used unchanged when it
+// doesn't (a ref that resolves empty, same as no secrets row).
+func TestBuildBedrockCredentialResolutionOrder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("static credentials used when secret resolves", func(t *testing.T) {
+		t.Parallel()
+		secretJSON := `{"access_key_id":"AKIA123","secret_access_key":"shh","region":"eu-west-1"}` // #nosec G101
+		r, err := Build([]Config{
+			{Name: "bedrock", Driver: "bedrock", BaseURL: "us-east-1", CredentialRef: "bedrock-static"},
+		}, func(ref string) string {
+			if ref == "bedrock-static" {
+				return secretJSON
+			}
+			return ""
+		})
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		p, ok := r.Get("bedrock")
+		if !ok {
+			t.Fatal("bedrock missing")
+		}
+		b := p.(*Bedrock)
+		if b.cfg.StaticCredentials == nil {
+			t.Fatal("StaticCredentials must be set when credential_ref resolves")
+		}
+		if b.cfg.StaticCredentials.AccessKeyID != "AKIA123" || b.cfg.StaticCredentials.Region != "eu-west-1" {
+			t.Fatalf("StaticCredentials = %#v", b.cfg.StaticCredentials)
+		}
+		if b.cfg.Profile != "" {
+			t.Fatalf("Profile must be cleared when static credentials are used, got %q", b.cfg.Profile)
+		}
+	})
+
+	t.Run("profile fallback when credential_ref does not resolve", func(t *testing.T) {
+		t.Parallel()
+		r, err := Build([]Config{
+			{Name: "bedrock", Driver: "bedrock", BaseURL: "us-east-1", CredentialRef: "sumonmselim"},
+		}, func(string) string { return "" })
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		p, _ := r.Get("bedrock")
+		b := p.(*Bedrock)
+		if b.cfg.StaticCredentials != nil {
+			t.Fatalf("StaticCredentials must be nil when credential_ref does not resolve, got %#v", b.cfg.StaticCredentials)
+		}
+		if b.cfg.Profile != "sumonmselim" {
+			t.Fatalf("Profile = %q, want sumonmselim (unchanged fallback)", b.cfg.Profile)
+		}
+	})
 }
 
 func TestNewBedrock(t *testing.T) {

--- a/internal/gateway/router/router_test.go
+++ b/internal/gateway/router/router_test.go
@@ -405,6 +405,49 @@ func TestBedrockHealthyWithoutEnvCredential(t *testing.T) {
 	}
 }
 
+// TestBedrockResolvingCredentialRefPassesStaticCredentialsThrough
+// covers D-047 end to end at the router layer: when a bedrock row's
+// credential_ref resolves in the secret store, the resolved JSON value
+// must reach the bedrock constructor and populate StaticCredentials —
+// the same lookup plumbing every other driver's APIKey field uses.
+func TestBedrockResolvingCredentialRefPassesStaticCredentialsThrough(t *testing.T) {
+	t.Parallel()
+	secretJSON := `{"access_key_id":"AKIA123","secret_access_key":"shh"}` // #nosec G101
+	provRows := []ProviderRow{{
+		ID: "p1", Name: "bedrock", Kind: "api", Driver: "bedrock",
+		BaseURL: "us-east-1", DefaultModel: "us.amazon.nova-pro-v1:0",
+		CredentialRef: "bedrock-static", Enabled: true,
+		Models: []ModelInfo{{ID: "us.amazon.nova-pro-v1:0"}},
+	}}
+	routeRows := []RouteRow{{Name: "chat", Chain: []ChainEntry{
+		{ProviderID: "p1", Model: "us.amazon.nova-pro-v1:0"},
+	}, Enabled: true}}
+	snap, err := BuildSnapshot(provRows, routeRows, func(ref string) string {
+		if ref == "bedrock-static" {
+			return secretJSON
+		}
+		return ""
+	})
+	if err != nil {
+		t.Fatalf("BuildSnapshot: %v", err)
+	}
+
+	attempts, err := snap.Resolve("chat", "", Sticky{})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(attempts) != 1 || attempts[0].ProviderName != "bedrock" {
+		t.Fatalf("attempts = %v, want bedrock", attempts)
+	}
+	b, ok := attempts[0].Provider.(*provider.Bedrock)
+	if !ok {
+		t.Fatalf("provider type = %T, want *provider.Bedrock", attempts[0].Provider)
+	}
+	if !b.HasStaticCredentials() {
+		t.Fatal("resolved secret JSON must reach the bedrock constructor as StaticCredentials")
+	}
+}
+
 // A price-strategy route reorders its chain: the cheaper declared
 // model jumps ahead of the written first entry, and dead entries sink.
 func TestScoredStrategyReordersChain(t *testing.T) {

--- a/web/src/components/settings/ProviderAdd.tsx
+++ b/web/src/components/settings/ProviderAdd.tsx
@@ -224,7 +224,7 @@ export function ProviderAdd() {
                 className="mt-1.5 h-10"
               />
             </Field>
-            <Field label="AWS profile (optional)">
+            <Field label="AWS profile or credential reference (optional)">
               <Input
                 value={profile}
                 onChange={(e) => {
@@ -236,8 +236,10 @@ export function ProviderAdd() {
               />
             </Field>
             <p className="text-sm text-muted-foreground sm:col-span-2">
-              Bedrock signs with the AWS credential chain mounted into the gateway — no key is
-              stored here.
+              For static IAM keys, add the provider first, then save a secret under this name
+              (Secrets tab) holding JSON {'{"access_key_id":"…","secret_access_key":"…"}'}. Leave
+              the secret unset to use this as an AWS profile name from the host’s ~/.aws (SSO)
+              instead — the gateway signs with whichever resolves.
             </p>
           </div>
         ) : (

--- a/web/src/components/settings/ProviderEdit.tsx
+++ b/web/src/components/settings/ProviderEdit.tsx
@@ -243,7 +243,7 @@ function CredentialSection({
 
       {bedrock ? (
         <div>
-          <Field label="AWS profile">
+          <Field label="AWS profile or credential reference">
             <Input
               value={ref}
               onChange={(e) => setRef(e.target.value)}
@@ -253,8 +253,10 @@ function CredentialSection({
             />
           </Field>
           <p className="mt-1.5 text-sm text-muted-foreground">
-            Bedrock signs with the AWS credential chain mounted into the gateway — no key is
-            stored here, this only names the profile.
+            For static IAM keys, save this name as a secret (Secrets tab) holding JSON{' '}
+            {'{"access_key_id":"…","secret_access_key":"…"}'} — the gateway resolves it before
+            falling back to an AWS profile. Leave the secret unset to use this as a profile name
+            from the host’s ~/.aws (SSO) instead.
           </p>
         </div>
       ) : (

--- a/web/src/components/settings/presets.ts
+++ b/web/src/components/settings/presets.ts
@@ -63,6 +63,8 @@ export const providerPresets: ProviderPreset[] = [
     baseURL: '',
     region: 'us-east-1',
     requiresKey: false,
+    keyHint:
+      'Paste static IAM keys as JSON ({"access_key_id":"…","secret_access_key":"…"}), or leave the secret unset to use an AWS profile name from the host’s ~/.aws.',
     validateModel: 'amazon.nova-lite-v1:0',
   },
   {


### PR DESCRIPTION
Bedrock was the one credential exception: credential_ref meant an AWS profile name, auth rode the host ~/.aws SSO session, and an expired token killed the provider (InvalidGrantException) until an interactive aws sso login — impossible on a headless server.

Now (D-047): if credential_ref resolves in the encrypted secret store, the value must parse as `{"access_key_id","secret_access_key","session_token"?,"region"?}` and the driver uses static credentials (secret region > provider region, default us-east-1). Parse failure fails the snapshot load loudly — config honesty, no silent fallback. An unresolved ref keeps today's behavior: treated as a profile name, ~/.aws mounts untouched.

Settings copy updated to explain both modes (existing keyHint field, no new form machinery).

Tests: parse table, region precedence, resolution order (static wins/profile fallback), Build error propagation, router lookup plumbing. `make build test vet lint` green; web build/lint/tests green.