### PR TITLE
fix(web): stop request-timeout box from going stale and silent

### DIFF
--- a/web/src/components/settings/ProviderEdit.test.tsx
+++ b/web/src/components/settings/ProviderEdit.test.tsx
@@ -270,4 +270,41 @@ describe('ProviderEdit reasoning section', () => {
 
     await waitFor(() => expect(patchProvider).toHaveBeenCalledWith('p2', { options: {} }))
   })
+
+  it('saves request_timeout on Enter, not just blur', async () => {
+    vi.mocked(listProviders).mockResolvedValue([openaicompatProvider])
+    vi.mocked(patchProvider).mockResolvedValue()
+    renderPage('p2')
+
+    const input = await screen.findByPlaceholderText('5m')
+    fireEvent.change(input, { target: { value: '45m' } })
+    // jsdom doesn't blur on Enter by itself — the component calls
+    // currentTarget.blur() itself, which real browsers do too; fire the
+    // resulting blur here to observe that save path (not onBlur directly).
+    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.blur(input)
+
+    await waitFor(() =>
+      expect(patchProvider).toHaveBeenCalledWith('p2', { options: { request_timeout: '45m' } }),
+    )
+  })
+
+  it('resyncs the displayed request_timeout after a sibling field refetches the provider', async () => {
+    vi.mocked(listProviders)
+      .mockResolvedValueOnce([openaicompatProvider])
+      .mockResolvedValueOnce([{ ...openaicompatProvider, options: { request_timeout: '30m' } }])
+    vi.mocked(patchProvider).mockResolvedValue()
+    renderPage('p2')
+
+    const input = (await screen.findByPlaceholderText('5m')) as HTMLInputElement
+    expect(input.value).toBe('')
+
+    // A different field's save (e.g. the reasoning toggle) triggers the
+    // same refresh() this section relies on — it must pick up the new
+    // provider.options.request_timeout, not keep showing stale state.
+    const toggle = await screen.findByRole('switch', { name: 'Disable reasoning' })
+    fireEvent.click(toggle)
+
+    await waitFor(() => expect(input.value).toBe('30m'))
+  })
 })

--- a/web/src/components/settings/ProviderEdit.tsx
+++ b/web/src/components/settings/ProviderEdit.tsx
@@ -338,7 +338,16 @@ function CredentialSection({
 function ReasoningSection({ provider, onChanged }: { provider: AdminProvider; onChanged: () => void }) {
   const [saving, setSaving] = useState(false)
   const [timeout, setTimeoutValue] = useState(provider.options?.request_timeout ?? '')
+  const [timeoutSaving, setTimeoutSaving] = useState(false)
   const disabled = provider.options?.reasoning_effort === 'none'
+
+  // provider is refetched (via onChanged/refresh) whenever ANY field on
+  // this page saves, including ones outside this section — without this
+  // sync the box silently keeps showing what you typed even after a
+  // sibling edit reloads the provider out from under it.
+  useEffect(() => {
+    setTimeoutValue(provider.options?.request_timeout ?? '')
+  }, [provider.options?.request_timeout])
 
   const toggle = async (on: boolean) => {
     setSaving(true)
@@ -359,6 +368,7 @@ function ReasoningSection({ provider, onChanged }: { provider: AdminProvider; on
     const trimmed = timeout.trim()
     if (trimmed === (provider.options?.request_timeout ?? '')) return
     const { request_timeout: _requestTimeout, ...rest } = provider.options ?? {}
+    setTimeoutSaving(true)
     try {
       await patchProvider(provider.id, {
         options: trimmed ? { ...rest, request_timeout: trimmed } : rest,
@@ -367,6 +377,8 @@ function ReasoningSection({ provider, onChanged }: { provider: AdminProvider; on
     } catch (err) {
       setTimeoutValue(provider.options?.request_timeout ?? '')
       toast.error('Could not update request timeout', { description: errText(err) })
+    } finally {
+      setTimeoutSaving(false)
     }
   }
 
@@ -379,11 +391,24 @@ function ReasoningSection({ provider, onChanged }: { provider: AdminProvider; on
           {saving ? 'Saving…' : 'Disable reasoning ("thinking") for every request to this provider.'}
         </span>
       </label>
-      <Field label="Request timeout" hint='Go duration, e.g. "20m" — empty uses the default'>
+      <Field
+        label="Request timeout"
+        hint={
+          timeoutSaving
+            ? 'Saving…'
+            : 'Go duration, e.g. "20m" — empty uses the default. Enter or click away to save.'
+        }
+      >
         <Input
           value={timeout}
           onChange={(e) => setTimeoutValue(e.target.value)}
           onBlur={() => void saveTimeout()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.currentTarget.blur()
+            }
+          }}
+          disabled={timeoutSaving}
           placeholder="5m"
           className="mt-1.5 h-10 max-w-40"
         />


### PR DESCRIPTION
The request-timeout input in provider settings initialized its state once from props and never resynced — any sibling save on the page (reasoning toggle, model changes, credential rotation) triggers the same refresh() this section relies on, and the box silently kept showing what you'd typed instead of the refetched value. Its only save feedback was a toast on failure, so a successful save was indistinguishable from a dead field. Fixes: resync on prop change, 'Saving…' hint text, commit on Enter as well as blur. 2 new tests, 15/15 green.