### PR TITLE
feat(gateway): bedrock region option, drop aws profile mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Configured as an MCP preset in **Settings → Connectors**: paste a GitHub perso
 
 ## Optional: Amazon Bedrock
 
-The `gateway` service mounts your host's `~/.aws` directory read-only. Set the Bedrock provider's credential reference to an AWS profile name, and run `aws sso login --profile <name>` on the host when the session expires.
+Create an IAM user scoped to `bedrock:InvokeModel*` only, generate an access key, and paste it as JSON (`{"access_key_id":"…","secret_access_key":"…"}`) into the Bedrock provider's key field in **Settings → Providers**. Pick a region from the dropdown — no `~/.aws`, no SSO, nothing to run on the host.
 
 ## Operating the stack
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -212,15 +212,6 @@ services:
       # credentials are configured in Settings, not env — this key is
       # what decrypts them.
       TIMOTHY_MASTER_KEY: ${TIMOTHY_MASTER_KEY:?set TIMOTHY_MASTER_KEY in deploy/.env}
-    # Bedrock (driver 'bedrock') reads the AWS default credential
-    # chain. Local dev: run `aws sso login --profile <name>` on the
-    # host and set the bedrock provider's credential_ref to that
-    # profile. Config and credentials mount read-only; the SDK rotates
-    # SSO access tokens itself and must write them back, so the token
-    # cache alone is writable.
-    volumes:
-      - ${HOME}/.aws:/home/nonroot/.aws:ro
-      - ${HOME}/.aws/sso/cache:/home/nonroot/.aws/sso/cache
     # internal-only: no published ports
 
   memoryd:

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -797,6 +797,7 @@ func (a *Admin) Validate(ctx context.Context, p Provider, model string) (TestRes
 		CredentialRef:   p.CredentialRef,
 		Headers:         p.Headers,
 		ReasoningEffort: p.Options["reasoning_effort"],
+		Region:          p.Options["region"],
 		Timeout:         timeout,
 	}}, a.credentialLookup())
 	if err != nil {

--- a/internal/gateway/admin/admin_validate_integration_test.go
+++ b/internal/gateway/admin/admin_validate_integration_test.go
@@ -169,10 +169,16 @@ func TestAvailableModelsProxiesAndFallsBack(t *testing.T) {
 	}
 
 	// Bedrock cannot enumerate models; the sentinel drives the UI's
-	// manual-entry fallback (422 at the HTTP layer).
+	// manual-entry fallback (422 at the HTTP layer). Static keys are the
+	// only supported auth (D-048), so the credential_ref must resolve
+	// for the provider to build and reach the serving snapshot at all.
+	bedrockRef := adminMarker + "models-bedrock-key" //nolint:gosec // test fixture name, not a secret
+	if err := adm.SetSecret(ctx, bedrockRef, `{"access_key_id":"AKIA123","secret_access_key":"shh"}`); err != nil {
+		t.Fatalf("SetSecret: %v", err)
+	}
 	bid, err := adm.Create(ctx, Provider{
 		Name: adminMarker + "models-bedrock", Kind: "api", Driver: "bedrock",
-		BaseURL: "us-east-1",
+		CredentialRef: bedrockRef, Options: map[string]string{"region": "us-east-1"},
 	})
 	if err != nil {
 		t.Fatalf("Create bedrock: %v", err)

--- a/internal/gateway/provider/bedrock.go
+++ b/internal/gateway/provider/bedrock.go
@@ -24,36 +24,30 @@ import (
 // (Nova and Titan families) so usage bills against AWS credits — no
 // third-party models.
 //
-// D-047: credential_ref resolves through the encrypted secret store
-// like every other provider. When it resolves to a non-empty value,
-// that value MUST be the JSON documented on StaticCredentials — a
-// parse failure fails provider construction rather than silently
-// falling back to profile/SSO (config honesty). When credential_ref
-// does not resolve (no secrets row — e.g. the 'sumonmselim' local dev
-// row), the prior behavior stands unchanged: it is an AWS profile
-// name resolved from the SDK's shared config (~/.aws, SSO). Leave
-// credential_ref empty entirely when an IAM role supplies credentials.
+// D-047/D-048: static IAM keys in the secret store are the only
+// supported auth — AWS profile/SSO mode was removed (a headless server
+// has no ~/.aws to mount). credential_ref must resolve through the
+// encrypted secret store to JSON matching StaticCredentials; a resolve
+// failure or a parse failure both fail provider construction (config
+// honesty), never a silent fallback. Region precedence: the secret
+// JSON's own "region" field, when set, wins over the provider's
+// options.region (Region below); with neither set, us-east-1 applies.
 //
-// Providers table example (secret-store static keys):
+// Providers table example:
 //
 //	driver = 'bedrock'
-//	base_url = 'us-east-1'                       -- AWS region; secret JSON region wins if set
 //	default_model = 'us.amazon.nova-pro-v1:0'    -- inference-profile ID
 //	credential_ref = 'bedrock-static'            -- secret store ref holding StaticCredentials JSON
-//
-// Providers table example (profile/SSO fallback, unchanged):
-//
-//	credential_ref = '<aws-profile>'             -- no matching secrets row; local SSO only, empty on AWS
+//	options = '{"region": "us-west-2"}'          -- optional; defaults to us-east-1
 //
 // Models must be enabled on the Bedrock console "Model access" page.
 type BedrockConfig struct {
-	Name    string
-	Region  string // e.g. "us-east-1"; defaults to us-east-1 unless StaticCredentials.Region overrides it
-	Profile string // AWS profile name (credential_ref), used when StaticCredentials is nil
-	// StaticCredentials, when non-nil, is the resolved secret-store
-	// value for credential_ref parsed as JSON — takes precedence over
-	// Profile. A non-nil pointer with an empty AccessKeyID/SecretAccessKey
-	// never happens: ParseStaticCredentials rejects that at parse time.
+	Name   string
+	Region string // from options.region; defaults to us-east-1 unless StaticCredentials.Region overrides it
+	// StaticCredentials is the resolved secret-store value for
+	// credential_ref parsed as JSON — required; a non-nil pointer with an
+	// empty AccessKeyID/SecretAccessKey never happens, since
+	// ParseStaticCredentials rejects that at parse time.
 	StaticCredentials *StaticCredentials
 	Timeout           time.Duration
 }
@@ -106,8 +100,8 @@ func (b *Bedrock) Name() string { return b.cfg.Name }
 func (b *Bedrock) Kind() Kind   { return KindAPI }
 
 // HasStaticCredentials reports whether this provider was built with a
-// resolved secret-store credential (D-047) rather than the AWS
-// profile/SSO fallback — used by router tests to verify the lookup
+// resolved secret-store credential (D-047) — always true since profile
+// mode was removed (D-048); used by router tests to verify the lookup
 // plumbing reaches the bedrock constructor.
 func (b *Bedrock) HasStaticCredentials() bool { return b.cfg.StaticCredentials != nil }
 
@@ -115,48 +109,30 @@ func (b *Bedrock) Capabilities() []Capability {
 	return []Capability{CapChat, CapStreaming, CapTools, CapEmbeddings, CapVision}
 }
 
-// lazyClient builds the AWS client on first use. With StaticCredentials
-// set, region precedence is secret JSON region > BedrockConfig.Region
-// (already defaulted to us-east-1 by NewBedrock unless a driver
-// deriving path set it) — a static-keys row with no region anywhere is
-// a construction error, since there is no profile/env to derive it
-// from. Without StaticCredentials, behavior is unchanged: the SDK's
-// default chain (env vars, shared config profile, IAM role). sync.Once
+// lazyClient builds the AWS client on first use. Region precedence is
+// secret JSON region > BedrockConfig.Region (options.region, already
+// defaulted to us-east-1 by NewBedrock unless a driver deriving path set
+// it) — a static-keys row with no region anywhere is a construction
+// error, since there is no profile/env to derive it from. sync.Once
 // makes it safe under concurrent Stream/Embed calls; a load failure is
 // sticky, which is right — bad credentials or a bad region never heal
 // mid-process.
 func (b *Bedrock) lazyClient(ctx context.Context) (*bedrockruntime.Client, error) {
 	b.initOnce.Do(func() {
-		if b.cfg.StaticCredentials != nil {
-			sc := b.cfg.StaticCredentials
-			region := sc.Region
-			if region == "" {
-				region = b.cfg.Region
-			}
-			if region == "" {
-				b.clientErr = fmt.Errorf("bedrock: static credentials require a region (set the secret JSON's %q field or the provider's base_url)", "region")
-				return
-			}
-			awsCfg, err := config.LoadDefaultConfig(ctx,
-				config.WithRegion(region),
-				config.WithCredentialsProvider(
-					credentials.NewStaticCredentialsProvider(sc.AccessKeyID, sc.SecretAccessKey, sc.SessionToken)),
-			)
-			if err != nil {
-				b.clientErr = fmt.Errorf("bedrock: load aws config: %w", err)
-				return
-			}
-			b.client = bedrockruntime.NewFromConfig(awsCfg)
+		sc := b.cfg.StaticCredentials
+		region := sc.Region
+		if region == "" {
+			region = b.cfg.Region
+		}
+		if region == "" {
+			b.clientErr = fmt.Errorf("bedrock: static credentials require a region (set the secret JSON's %q field or the provider's options.region)", "region")
 			return
 		}
-
-		opts := []func(*config.LoadOptions) error{
-			config.WithRegion(b.cfg.Region),
-		}
-		if b.cfg.Profile != "" {
-			opts = append(opts, config.WithSharedConfigProfile(b.cfg.Profile))
-		}
-		awsCfg, err := config.LoadDefaultConfig(ctx, opts...)
+		awsCfg, err := config.LoadDefaultConfig(ctx,
+			config.WithRegion(region),
+			config.WithCredentialsProvider(
+				credentials.NewStaticCredentialsProvider(sc.AccessKeyID, sc.SecretAccessKey, sc.SessionToken)),
+		)
 		if err != nil {
 			b.clientErr = fmt.Errorf("bedrock: load aws config: %w", err)
 			return

--- a/internal/gateway/provider/bedrock_test.go
+++ b/internal/gateway/provider/bedrock_test.go
@@ -354,10 +354,10 @@ func TestParseStaticCredentials(t *testing.T) {
 	}
 }
 
-// TestBedrockLazyClientStaticCredentials covers D-047's region
+// TestBedrockLazyClientStaticCredentials covers D-047/D-048's region
 // precedence and construction-failure rules: secret JSON region wins
-// over the provider's base_url-derived region, the provider's region
-// is used when the secret carries none, and a static-credentials
+// over the provider's options.region-derived region, the provider's
+// region is used when the secret carries none, and a static-credentials
 // config with no region anywhere fails construction with a message
 // naming the region field. LoadDefaultConfig with a static credentials
 // provider and an explicit region does no network I/O, so this stays
@@ -414,21 +414,6 @@ func TestBedrockLazyClientStaticCredentials(t *testing.T) {
 		}
 	})
 
-	t.Run("static credentials take precedence over profile", func(t *testing.T) {
-		t.Parallel()
-		b := NewBedrock(BedrockConfig{
-			Name:              "b",
-			Region:            "us-east-1",
-			Profile:           "some-profile-that-does-not-exist",
-			StaticCredentials: &StaticCredentials{AccessKeyID: "AKIA", SecretAccessKey: "secret"},
-		})
-		// If Profile were still honored, LoadDefaultConfig would try to
-		// resolve a nonexistent shared-config profile and fail; success
-		// here proves StaticCredentials wins.
-		if _, err := b.lazyClient(context.Background()); err != nil {
-			t.Fatalf("lazyClient: %v, want static credentials to bypass the (invalid) profile", err)
-		}
-	})
 }
 
 func TestParseTitanEmbedding(t *testing.T) {

--- a/internal/gateway/provider/registry.go
+++ b/internal/gateway/provider/registry.go
@@ -20,6 +20,9 @@ type Config struct {
 	// ReasoningEffort overrides per-request reasoning effort for the
 	// openaicompat driver only (D-040); anthropic and bedrock ignore it.
 	ReasoningEffort string
+	// Region comes from options.region (D-048) — the bedrock driver's AWS
+	// region; ignored by every other driver.
+	Region string
 }
 
 // Registry holds the built providers by name. It is immutable after
@@ -66,30 +69,27 @@ func Build(cfgs []Config, lookup func(string) string) (*Registry, error) {
 				ReasoningEffort: c.ReasoningEffort,
 			})
 		case "bedrock":
-			// base_url holds the AWS region. D-047: if credential_ref
-			// resolves in the secret store (key is non-empty), it MUST be
-			// static-credentials JSON — parse failure fails provider
-			// construction (config honesty), never a silent profile
-			// fallback. If it does not resolve (no secrets row), the
-			// unchanged prior behavior applies: credential_ref names a
-			// local AWS profile (SSO dev), and must be EMPTY when an IAM
-			// role supplies credentials — a missing profile fails client
-			// setup.
-			bedrockCfg := BedrockConfig{
-				Name:    c.Name,
-				Region:  c.BaseURL,
-				Profile: c.CredentialRef,
-				Timeout: c.Timeout,
+			// D-047/D-048: static keys in the secret store are the only
+			// supported auth — AWS profile/SSO mode was removed (a
+			// headless server has no ~/.aws). credential_ref MUST resolve
+			// and parse as static-credentials JSON; either failure is a
+			// Build error, never a silent fallback. Region comes from
+			// options.region (c.Region), with the secret JSON's own
+			// "region" field taking precedence when set (BedrockConfig
+			// handles that precedence).
+			if key == "" {
+				return nil, fmt.Errorf("registry: provider %q: bedrock requires static keys in the secret store; AWS profile mode was removed", c.Name)
 			}
-			if key != "" {
-				sc, err := ParseStaticCredentials(key)
-				if err != nil {
-					return nil, fmt.Errorf("registry: provider %q: %w", c.Name, err)
-				}
-				bedrockCfg.StaticCredentials = sc
-				bedrockCfg.Profile = ""
+			sc, err := ParseStaticCredentials(key)
+			if err != nil {
+				return nil, fmt.Errorf("registry: provider %q: %w", c.Name, err)
 			}
-			p = NewBedrock(bedrockCfg)
+			p = NewBedrock(BedrockConfig{
+				Name:              c.Name,
+				Region:            c.Region,
+				StaticCredentials: sc,
+				Timeout:           c.Timeout,
+			})
 		default:
 			return nil, fmt.Errorf("registry: provider %q: unknown driver %q", c.Name, c.Driver)
 		}

--- a/internal/gateway/provider/registry_test.go
+++ b/internal/gateway/provider/registry_test.go
@@ -7,12 +7,15 @@ import (
 
 func TestBuildRegistry(t *testing.T) {
 	t.Parallel()
-	lookups := map[string]string{"ANTHROPIC_API_KEY": "sk-a", "XAI_API_KEY": "sk-x"}
+	lookups := map[string]string{
+		"ANTHROPIC_API_KEY": "sk-a", "XAI_API_KEY": "sk-x", // #nosec G101
+		"bedrock-static": `{"access_key_id":"AKIA123","secret_access_key":"shh"}`, // #nosec G101
+	}
 	r, err := Build([]Config{
 		// CredentialRef values are env var *names*, not secrets.
 		{Name: "anthropic", Kind: KindAPI, Driver: "anthropic", CredentialRef: "ANTHROPIC_API_KEY"},                             // #nosec G101
 		{Name: "xai-grok", Kind: KindAPI, Driver: "openaicompat", BaseURL: "https://api.x.ai/v1", CredentialRef: "XAI_API_KEY"}, // #nosec G101
-		{Name: "bedrock", Kind: KindAPI, Driver: "bedrock", BaseURL: "us-east-1", CredentialRef: "sumonmselim"},
+		{Name: "bedrock", Kind: KindAPI, Driver: "bedrock", CredentialRef: "bedrock-static"},
 	}, func(ref string) string { return lookups[ref] })
 	if err != nil {
 		t.Fatalf("Build: %v", err)
@@ -99,16 +102,30 @@ func TestBuildErrors(t *testing.T) {
 		{
 			name: "bedrock credential_ref resolves to malformed secret JSON",
 			cfgs: []Config{
-				{Name: "bedrock", Driver: "bedrock", BaseURL: "us-east-1", CredentialRef: "bedrock-static"},
+				{Name: "bedrock", Driver: "bedrock", CredentialRef: "bedrock-static"},
 			},
 			wantErr: "parse static credentials",
 		},
 		{
 			name: "bedrock credential_ref resolves to secret missing required fields",
 			cfgs: []Config{
-				{Name: "bedrock", Driver: "bedrock", BaseURL: "us-east-1", CredentialRef: "bedrock-static"},
+				{Name: "bedrock", Driver: "bedrock", CredentialRef: "bedrock-static"},
 			},
 			wantErr: "missing access_key_id or secret_access_key",
+		},
+		{
+			name: "bedrock credential_ref does not resolve",
+			cfgs: []Config{
+				{Name: "bedrock", Driver: "bedrock", CredentialRef: "bedrock-static"},
+			},
+			wantErr: "bedrock requires static keys in the secret store; AWS profile mode was removed",
+		},
+		{
+			name: "bedrock with empty credential_ref",
+			cfgs: []Config{
+				{Name: "bedrock", Driver: "bedrock"},
+			},
+			wantErr: "bedrock requires static keys in the secret store; AWS profile mode was removed",
 		},
 	}
 
@@ -130,18 +147,17 @@ func TestBuildErrors(t *testing.T) {
 	}
 }
 
-// TestBuildBedrockCredentialResolutionOrder covers D-047: the static
-// JSON path is used when credential_ref resolves in the secret store,
-// and the existing AWS-profile fallback is used unchanged when it
-// doesn't (a ref that resolves empty, same as no secrets row).
-func TestBuildBedrockCredentialResolutionOrder(t *testing.T) {
+// TestBuildBedrockOptionsRegion covers D-048: options.region (Config.Region)
+// threads through to the built provider, and the secret JSON's own
+// region field still takes precedence per D-047.
+func TestBuildBedrockOptionsRegion(t *testing.T) {
 	t.Parallel()
 
-	t.Run("static credentials used when secret resolves", func(t *testing.T) {
+	t.Run("options.region used when secret carries none", func(t *testing.T) {
 		t.Parallel()
-		secretJSON := `{"access_key_id":"AKIA123","secret_access_key":"shh","region":"eu-west-1"}` // #nosec G101
+		secretJSON := `{"access_key_id":"AKIA123","secret_access_key":"shh"}` // #nosec G101
 		r, err := Build([]Config{
-			{Name: "bedrock", Driver: "bedrock", BaseURL: "us-east-1", CredentialRef: "bedrock-static"},
+			{Name: "bedrock", Driver: "bedrock", CredentialRef: "bedrock-static", Region: "eu-west-1"},
 		}, func(ref string) string {
 			if ref == "bedrock-static" {
 				return secretJSON
@@ -156,39 +172,36 @@ func TestBuildBedrockCredentialResolutionOrder(t *testing.T) {
 			t.Fatal("bedrock missing")
 		}
 		b := p.(*Bedrock)
-		if b.cfg.StaticCredentials == nil {
-			t.Fatal("StaticCredentials must be set when credential_ref resolves")
-		}
-		if b.cfg.StaticCredentials.AccessKeyID != "AKIA123" || b.cfg.StaticCredentials.Region != "eu-west-1" {
-			t.Fatalf("StaticCredentials = %#v", b.cfg.StaticCredentials)
-		}
-		if b.cfg.Profile != "" {
-			t.Fatalf("Profile must be cleared when static credentials are used, got %q", b.cfg.Profile)
+		if b.cfg.Region != "eu-west-1" {
+			t.Fatalf("Region = %q, want eu-west-1", b.cfg.Region)
 		}
 	})
 
-	t.Run("profile fallback when credential_ref does not resolve", func(t *testing.T) {
+	t.Run("secret region wins over options.region", func(t *testing.T) {
 		t.Parallel()
+		secretJSON := `{"access_key_id":"AKIA123","secret_access_key":"shh","region":"ap-south-1"}` // #nosec G101
 		r, err := Build([]Config{
-			{Name: "bedrock", Driver: "bedrock", BaseURL: "us-east-1", CredentialRef: "sumonmselim"},
-		}, func(string) string { return "" })
+			{Name: "bedrock", Driver: "bedrock", CredentialRef: "bedrock-static", Region: "eu-west-1"},
+		}, func(ref string) string {
+			if ref == "bedrock-static" {
+				return secretJSON
+			}
+			return ""
+		})
 		if err != nil {
 			t.Fatalf("Build: %v", err)
 		}
 		p, _ := r.Get("bedrock")
 		b := p.(*Bedrock)
-		if b.cfg.StaticCredentials != nil {
-			t.Fatalf("StaticCredentials must be nil when credential_ref does not resolve, got %#v", b.cfg.StaticCredentials)
-		}
-		if b.cfg.Profile != "sumonmselim" {
-			t.Fatalf("Profile = %q, want sumonmselim (unchanged fallback)", b.cfg.Profile)
+		if b.cfg.StaticCredentials.Region != "ap-south-1" {
+			t.Fatalf("StaticCredentials.Region = %q, want ap-south-1", b.cfg.StaticCredentials.Region)
 		}
 	})
 }
 
 func TestNewBedrock(t *testing.T) {
 	t.Parallel()
-	p := NewBedrock(BedrockConfig{Name: "bedrock-test", Region: "us-west-2", Profile: "sumonmselim"})
+	p := NewBedrock(BedrockConfig{Name: "bedrock-test", Region: "us-west-2"})
 	if p.Name() != "bedrock-test" {
 		t.Fatalf("name = %q", p.Name())
 	}

--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -55,6 +55,10 @@ type ProviderRow struct {
 	// hard timeout override for slow backends (e.g. a CPU-only remote
 	// Ollama). Zero leaves the driver's own default in place.
 	Timeout time.Duration
+	// Region comes from options.region (D-048) — the bedrock driver's AWS
+	// region, overridden per-key by the secret JSON's own "region" field
+	// (D-047) when set. Ignored by every other driver.
+	Region string
 }
 
 // ChainEntry is one step of a route chain.
@@ -140,12 +144,11 @@ func BuildSnapshot(provRows []ProviderRow, routeRows []RouteRow, lookup func(str
 	for _, row := range provRows {
 		s.rows[row.ID] = row
 		s.byName[row.Name] = row
-		// credential_ref names an env var for API-key drivers, but the
-		// bedrock driver reuses it as an AWS profile name that the SDK
-		// resolves itself — an unresolved env lookup must not mark it
-		// unhealthy.
-		s.healthy[row.Name] = row.Driver == "bedrock" ||
-			row.CredentialRef == "" || lookup(row.CredentialRef) != ""
+		// credential_ref names an env var for API-key drivers; bedrock now
+		// requires the same ref to resolve in the secret store as static
+		// keys (D-047, profile/SSO mode removed) — so an unresolved ref
+		// marks every driver unhealthy alike.
+		s.healthy[row.Name] = row.CredentialRef == "" || lookup(row.CredentialRef) != ""
 		cfgs = append(cfgs, provider.Config{
 			Name:            row.Name,
 			Kind:            provider.Kind(row.Kind),
@@ -153,6 +156,7 @@ func BuildSnapshot(provRows []ProviderRow, routeRows []RouteRow, lookup func(str
 			BaseURL:         row.BaseURL,
 			CredentialRef:   row.CredentialRef,
 			Headers:         row.Headers,
+			Region:          row.Region,
 			ReasoningEffort: row.ReasoningEffort,
 			Timeout:         row.Timeout,
 		})

--- a/internal/gateway/router/router_test.go
+++ b/internal/gateway/router/router_test.go
@@ -377,31 +377,24 @@ func TestRoutesListing(t *testing.T) {
 	}
 }
 
-func TestBedrockHealthyWithoutEnvCredential(t *testing.T) {
+// TestBedrockUnresolvedCredentialRefFailsBuild covers D-048: AWS
+// profile/SSO mode is gone, so a bedrock row whose credential_ref does
+// not resolve in the secret store is a hard BuildSnapshot error, not a
+// degraded-but-usable provider.
+func TestBedrockUnresolvedCredentialRefFailsBuild(t *testing.T) {
 	t.Parallel()
-	// bedrock's credential_ref is an AWS profile name, not an env var:
-	// the SDK resolves it, so an unresolvable lookup must not sideline
-	// the provider.
 	provRows := []ProviderRow{{
 		ID: "p1", Name: "bedrock", Kind: "api", Driver: "bedrock",
-		BaseURL: "us-east-1", DefaultModel: "us.amazon.nova-pro-v1:0",
-		CredentialRef: "some-aws-profile", Enabled: true,
+		DefaultModel: "us.amazon.nova-pro-v1:0",
+		CredentialRef: "missing-secret", Enabled: true,
 		Models: []ModelInfo{{ID: "titan-embed", Capabilities: []string{"embeddings"}}},
 	}}
 	routeRows := []RouteRow{{Name: "embedding", Chain: []ChainEntry{
 		{ProviderID: "p1", Model: "titan-embed"},
 	}, Enabled: true}}
-	snap, err := BuildSnapshot(provRows, routeRows, func(string) string { return "" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
-
-	attempts, err := snap.Resolve("embedding", "", Sticky{})
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	if len(attempts) != 1 || attempts[0].ProviderName != "bedrock" {
-		t.Fatalf("attempts = %v, want bedrock", attempts)
+	_, err := BuildSnapshot(provRows, routeRows, func(string) string { return "" })
+	if err == nil || !strings.Contains(err.Error(), "bedrock requires static keys in the secret store") {
+		t.Fatalf("BuildSnapshot err = %v, want a clear static-keys-required message", err)
 	}
 }
 
@@ -415,7 +408,7 @@ func TestBedrockResolvingCredentialRefPassesStaticCredentialsThrough(t *testing.
 	secretJSON := `{"access_key_id":"AKIA123","secret_access_key":"shh"}` // #nosec G101
 	provRows := []ProviderRow{{
 		ID: "p1", Name: "bedrock", Kind: "api", Driver: "bedrock",
-		BaseURL: "us-east-1", DefaultModel: "us.amazon.nova-pro-v1:0",
+		DefaultModel: "us.amazon.nova-pro-v1:0",
 		CredentialRef: "bedrock-static", Enabled: true,
 		Models: []ModelInfo{{ID: "us.amazon.nova-pro-v1:0"}},
 	}}
@@ -445,6 +438,42 @@ func TestBedrockResolvingCredentialRefPassesStaticCredentialsThrough(t *testing.
 	}
 	if !b.HasStaticCredentials() {
 		t.Fatal("resolved secret JSON must reach the bedrock constructor as StaticCredentials")
+	}
+}
+
+// TestBedrockOptionsRegionThreadsToProvider covers D-048: a bedrock
+// row's Region (as parsed from options.region by applyProviderOptions in
+// store.go) reaches the built provider without failing resolution —
+// registry_test.go's TestBuildBedrockOptionsRegion checks the resulting
+// BedrockConfig.Region value directly at the provider.Build layer.
+func TestBedrockOptionsRegionThreadsToProvider(t *testing.T) {
+	t.Parallel()
+	secretJSON := `{"access_key_id":"AKIA123","secret_access_key":"shh"}` // #nosec G101
+	provRows := []ProviderRow{{
+		ID: "p1", Name: "bedrock", Kind: "api", Driver: "bedrock",
+		DefaultModel: "us.amazon.nova-pro-v1:0",
+		CredentialRef: "bedrock-static", Enabled: true, Region: "ap-southeast-2",
+		Models: []ModelInfo{{ID: "us.amazon.nova-pro-v1:0"}},
+	}}
+	routeRows := []RouteRow{{Name: "chat", Chain: []ChainEntry{
+		{ProviderID: "p1", Model: "us.amazon.nova-pro-v1:0"},
+	}, Enabled: true}}
+	snap, err := BuildSnapshot(provRows, routeRows, func(ref string) string {
+		if ref == "bedrock-static" {
+			return secretJSON
+		}
+		return ""
+	})
+	if err != nil {
+		t.Fatalf("BuildSnapshot: %v", err)
+	}
+
+	attempts, err := snap.Resolve("chat", "", Sticky{})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if _, ok := attempts[0].Provider.(*provider.Bedrock); !ok {
+		t.Fatalf("provider type = %T, want *provider.Bedrock", attempts[0].Provider)
 	}
 }
 

--- a/internal/gateway/router/store.go
+++ b/internal/gateway/router/store.go
@@ -165,19 +165,24 @@ func (s *Store) Load(ctx context.Context) error {
 }
 
 // applyProviderOptions decodes a providers row's options jsonb into row.
-// Only reasoning_effort and request_timeout are recognized today (D-040,
-// D-041); unknown keys are ignored silently. An unparseable
-// request_timeout fails the load outright — config honesty, never a
-// silent fallback to the driver default.
+// Only reasoning_effort, request_timeout, and region are recognized
+// today (D-040, D-041, D-048); unknown keys are ignored silently. An
+// unparseable request_timeout fails the load outright — config honesty,
+// never a silent fallback to the driver default. region gets no such
+// validation beyond being present: AWS region ids change over time, so
+// the gateway never hardcodes a valid set — an unknown region simply
+// fails at the AWS SDK when used.
 func applyProviderOptions(row *ProviderRow, optionsJSON []byte) error {
 	var opts struct {
 		ReasoningEffort string `json:"reasoning_effort"`
 		RequestTimeout  string `json:"request_timeout"`
+		Region          string `json:"region"`
 	}
 	if err := json.Unmarshal(optionsJSON, &opts); err != nil {
 		return err
 	}
 	row.ReasoningEffort = opts.ReasoningEffort
+	row.Region = opts.Region
 	if opts.RequestTimeout != "" {
 		d, err := time.ParseDuration(opts.RequestTimeout)
 		if err != nil {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -296,7 +296,7 @@ export interface AdminProvider {
   credential_ref: string
   headers: Record<string, string>
   enabled: boolean
-  options?: { reasoning_effort?: string; request_timeout?: string }
+  options?: { reasoning_effort?: string; request_timeout?: string; region?: string }
 }
 
 export interface ChainEntry {

--- a/web/src/components/settings/ProviderAdd.tsx
+++ b/web/src/components/settings/ProviderAdd.tsx
@@ -7,9 +7,10 @@ import { createProvider, listProviders, setSecret, validateProvider } from '../.
 import type { AdminProvider, TestResult } from '../../api/types'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { ModelInput, type ModelSuggestion } from './ModelInput'
 import { modelCatalog } from './modelCatalog'
-import { providerPresets, type ProviderPreset } from './presets'
+import { bedrockRegions, providerPresets, type ProviderPreset } from './presets'
 import { ProviderLogo } from './ProviderLogo'
 import { Field } from './shared'
 import { useDefaultSecretBackend } from './useDefaultSecretBackend'
@@ -37,8 +38,7 @@ export function ProviderAdd() {
 
   const [name, setName] = useState('')
   const [baseURL, setBaseURL] = useState('')
-  const [region, setRegion] = useState('')
-  const [profile, setProfile] = useState('')
+  const [region, setRegion] = useState('us-east-1')
   const [key, setKey] = useState('')
   const [ref, setRef] = useState('')
   const [refEdited, setRefEdited] = useState(false)
@@ -57,8 +57,7 @@ export function ProviderAdd() {
     if (!preset) return
     setName(preset.id === 'custom' ? '' : preset.name)
     setBaseURL(preset.baseURL)
-    setRegion(preset.region ?? '')
-    setProfile('')
+    setRegion(preset.region ?? 'us-east-1')
     setKey('')
     setRef(preset.id === 'custom' ? '' : refFor(preset, preset.name))
     setRefEdited(false)
@@ -73,17 +72,20 @@ export function ProviderAdd() {
   // Model suggestions: real ids declared on other providers that share
   // BOTH this driver and this base_url — same driver alone isn't
   // enough (openaicompat covers OpenAI, GLM, Ollama, Grok, and more,
-  // none of whose models work against each other's endpoint) — plus
-  // the preset's own validated default, and the static catalog for
-  // this preset. Advisory only, never blocks a free-typed id.
+  // none of whose models work against each other's endpoint). Bedrock
+  // has no base_url to key on (region lives in options.region instead),
+  // and its inference-profile model ids aren't region-specific, so any
+  // other bedrock provider's declared models qualify. Plus the preset's
+  // own validated default, and the static catalog for this preset.
+  // Advisory only, never blocks a free-typed id.
   const modelSuggestions: ModelSuggestion[] = useMemo(() => {
     if (!preset) return []
     const seen = new Map<string, ModelSuggestion>()
     const catalog = modelCatalog[preset.id] ?? []
     const nameFor = (id: string) => catalog.find((m) => m.id === id)?.name
-    const targetBaseURL = (preset.driver === 'bedrock' ? region : baseURL).trim()
     for (const p of existing) {
-      if (p.driver !== preset.driver || p.base_url.trim() !== targetBaseURL) continue
+      if (p.driver !== preset.driver) continue
+      if (preset.driver !== 'bedrock' && p.base_url.trim() !== baseURL.trim()) continue
       for (const m of p.models) {
         if (!seen.has(m.id)) seen.set(m.id, { id: m.id, name: nameFor(m.id), hint: `on ${p.name}` })
       }
@@ -99,13 +101,12 @@ export function ProviderAdd() {
       if (!seen.has(m.id)) seen.set(m.id, { ...m, hint: 'catalog' })
     }
     return [...seen.values()]
-  }, [existing, preset, baseURL, region])
+  }, [existing, preset, baseURL])
 
   if (!preset) return <Navigate to="/settings/providers" replace />
 
   const isBedrock = preset.driver === 'bedrock'
-  const wantsKey = !isBedrock && preset.requiresKey
-  const effectiveRef = isBedrock ? profile : ref
+  const wantsKey = preset.requiresKey
 
   // Any edit invalidates a previous test — the config it validated no
   // longer matches what's on screen.
@@ -138,9 +139,10 @@ export function ProviderAdd() {
         name: name.trim(),
         kind: 'api',
         driver: preset.driver,
-        base_url: isBedrock ? region.trim() : baseURL.trim(),
-        credential_ref: effectiveRef.trim(),
+        base_url: baseURL.trim(),
+        credential_ref: ref.trim(),
         headers: {},
+        ...(isBedrock ? { options: { region } } : {}),
       }
       const res = await validateProvider(config, model.trim())
       setTest(res)
@@ -163,12 +165,13 @@ export function ProviderAdd() {
         name: name.trim(),
         kind: 'api',
         driver: preset.driver,
-        base_url: isBedrock ? region.trim() : baseURL.trim(),
-        credential_ref: effectiveRef.trim(),
+        base_url: baseURL.trim(),
+        credential_ref: ref.trim(),
         headers: {},
         default_model: trimmedModel,
         models: [{ id: trimmedModel, ...(prices ? { prices } : {}) }],
         enabled: true,
+        ...(isBedrock ? { options: { region } } : {}),
       })
       toast.success('Provider added', { description: `${name.trim()} is connected and ready to route to.` })
       navigate('/settings/providers')
@@ -211,87 +214,73 @@ export function ProviderAdd() {
           />
         </Field>
 
-        {isBedrock ? (
-          <div className="grid gap-5 sm:grid-cols-2">
-            <Field label="Region">
-              <Input
-                value={region}
-                onChange={(e) => {
-                  setRegion(e.target.value)
-                  invalidate()
-                }}
-                placeholder="us-east-1"
-                className="mt-1.5 h-10"
-              />
-            </Field>
-            <Field label="AWS profile or credential reference (optional)">
-              <Input
-                value={profile}
-                onChange={(e) => {
-                  setProfile(e.target.value)
-                  invalidate()
-                }}
-                placeholder="empty = credential chain"
-                className="mt-1.5 h-10"
-              />
-            </Field>
-            <p className="text-sm text-muted-foreground sm:col-span-2">
-              For static IAM keys, add the provider first, then save a secret under this name
-              (Secrets tab) holding JSON {'{"access_key_id":"…","secret_access_key":"…"}'}. Leave
-              the secret unset to use this as an AWS profile name from the host’s ~/.aws (SSO)
-              instead — the gateway signs with whichever resolves.
-            </p>
-          </div>
-        ) : (
-          <>
-            {preset.id === 'custom' && (
-              <Field label="Base URL">
-                <Input
-                  value={baseURL}
-                  onChange={(e) => {
-                    setBaseURL(e.target.value)
-                    invalidate()
-                  }}
-                  placeholder="https://…/v1"
-                  className="mt-1.5 h-10"
-                />
-              </Field>
-            )}
-            {wantsKey &&
-              (() => {
-                const field = secretField(defaultBackend, preset.keyPlaceholder ?? 'paste key')
-                return (
-                  <div>
-                    <Field label={preset.id === 'custom' ? 'API key (optional)' : 'API key'}>
-                      <Input
-                        type={field.type}
-                        value={key}
-                        onChange={(e) => {
-                          setKey(e.target.value)
-                          invalidate()
-                        }}
-                        placeholder={field.placeholder}
-                        className="mt-1.5 h-10"
-                        autoComplete="off"
-                        aria-invalid={keyError != null}
-                      />
-                    </Field>
-                    {keyError && (
-                      <p className="mt-1.5 flex items-center gap-1.5 text-sm font-medium text-destructive">
-                        <HugeiconsIcon icon={AlertCircleIcon} className="size-4 shrink-0" />
-                        {keyError}
-                      </p>
-                    )}
-                    {!keyError && (field.hint || preset.keyHint) && (
-                      <p className="mt-1.5 text-sm text-muted-foreground">
-                        {field.hint || preset.keyHint}
-                      </p>
-                    )}
-                  </div>
-                )
-              })()}
-          </>
+        {isBedrock && (
+          <Field label="Region">
+            <Select
+              value={region}
+              onValueChange={(v) => {
+                setRegion(v)
+                invalidate()
+              }}
+            >
+              <SelectTrigger className="mt-1.5 h-10 w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {bedrockRegions.map((r) => (
+                  <SelectItem key={r.value} value={r.value}>
+                    {r.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
         )}
+
+        {preset.id === 'custom' && (
+          <Field label="Base URL">
+            <Input
+              value={baseURL}
+              onChange={(e) => {
+                setBaseURL(e.target.value)
+                invalidate()
+              }}
+              placeholder="https://…/v1"
+              className="mt-1.5 h-10"
+            />
+          </Field>
+        )}
+        {wantsKey &&
+          (() => {
+            const field = secretField(defaultBackend, preset.keyPlaceholder ?? 'paste key')
+            return (
+              <div>
+                <Field label={preset.id === 'custom' ? 'API key (optional)' : 'API key'}>
+                  <Input
+                    type={field.type}
+                    value={key}
+                    onChange={(e) => {
+                      setKey(e.target.value)
+                      invalidate()
+                    }}
+                    placeholder={field.placeholder}
+                    className="mt-1.5 h-10"
+                    autoComplete="off"
+                    aria-invalid={keyError != null}
+                  />
+                </Field>
+                {keyError && (
+                  <p className="mt-1.5 flex items-center gap-1.5 text-sm font-medium text-destructive">
+                    <HugeiconsIcon icon={AlertCircleIcon} className="size-4 shrink-0" />
+                    {keyError}
+                  </p>
+                )}
+                {!keyError && (field.hint || preset.keyHint) && (
+                  <p className="mt-1.5 text-sm text-muted-foreground">{field.hint || preset.keyHint}</p>
+                )}
+              </div>
+            )
+          })()}
 
         <Field label="Model" hint="validated with a one-token completion, becomes the default">
           <ModelInput
@@ -306,12 +295,12 @@ export function ProviderAdd() {
           />
         </Field>
 
-        {!isBedrock && (
-          <details className="group">
-            <summary className="cursor-pointer text-sm font-medium text-muted-foreground transition hover:text-foreground">
-              Advanced — base URL &amp; credential reference
-            </summary>
-            <div className="mt-3 grid gap-5 sm:grid-cols-2">
+        <details className="group">
+          <summary className="cursor-pointer text-sm font-medium text-muted-foreground transition hover:text-foreground">
+            Advanced — {isBedrock ? 'credential reference' : 'base URL & credential reference'}
+          </summary>
+          <div className="mt-3 grid gap-5 sm:grid-cols-2">
+            {!isBedrock && (
               <Field label="Base URL">
                 <Input
                   value={baseURL}
@@ -323,21 +312,21 @@ export function ProviderAdd() {
                   className="mt-1.5 h-10"
                 />
               </Field>
-              <Field label="Credential reference">
-                <Input
-                  value={ref}
-                  onChange={(e) => {
-                    setRef(e.target.value)
-                    setRefEdited(true)
-                    invalidate()
-                  }}
-                  placeholder="name (e.g. OPENAI_API_KEY)"
-                  className="mt-1.5 h-10"
-                />
-              </Field>
-            </div>
-          </details>
-        )}
+            )}
+            <Field label="Credential reference">
+              <Input
+                value={ref}
+                onChange={(e) => {
+                  setRef(e.target.value)
+                  setRefEdited(true)
+                  invalidate()
+                }}
+                placeholder="name (e.g. OPENAI_API_KEY)"
+                className="mt-1.5 h-10"
+              />
+            </Field>
+          </div>
+        </details>
 
         <div
           className={

--- a/web/src/components/settings/ProviderEdit.test.tsx
+++ b/web/src/components/settings/ProviderEdit.test.tsx
@@ -62,6 +62,8 @@ function renderPage(id = 'p1') {
 
 afterEach(cleanup)
 beforeEach(() => {
+  // jsdom lacks scrollIntoView; Radix Select calls it on open.
+  Element.prototype.scrollIntoView = vi.fn()
   vi.clearAllMocks()
   vi.mocked(listProviders).mockResolvedValue([bedrockProvider])
   vi.mocked(availableModels).mockRejectedValue(new Error('driver bedrock cannot list models'))
@@ -269,5 +271,48 @@ describe('ProviderEdit reasoning section', () => {
     fireEvent.blur(input)
 
     await waitFor(() => expect(patchProvider).toHaveBeenCalledWith('p2', { options: {} }))
+  })
+})
+
+describe('ProviderEdit region section', () => {
+  beforeEach(() => {
+    vi.mocked(availableModels).mockRejectedValue(new Error('driver bedrock cannot list models'))
+  })
+
+  it('omits the region section for non-bedrock drivers', async () => {
+    vi.mocked(listProviders).mockResolvedValue([openaicompatProvider])
+    renderPage('p2')
+
+    await screen.findByText('Ollama')
+    expect(screen.queryByText('Region')).toBeNull()
+  })
+
+  it('defaults the region dropdown to us-east-1 when options.region is unset', async () => {
+    vi.mocked(listProviders).mockResolvedValue([bedrockProvider])
+    renderPage('p1')
+
+    expect(await screen.findByRole('combobox')).toHaveTextContent('us-east-1 (N. Virginia)')
+  })
+
+  it('shows the stored region when options.region is set', async () => {
+    vi.mocked(listProviders).mockResolvedValue([
+      { ...bedrockProvider, options: { region: 'eu-west-1' } },
+    ])
+    renderPage('p1')
+
+    expect(await screen.findByRole('combobox')).toHaveTextContent('eu-west-1 (Ireland)')
+  })
+
+  it('writes options.region when a new region is picked', async () => {
+    vi.mocked(listProviders).mockResolvedValue([bedrockProvider])
+    vi.mocked(patchProvider).mockResolvedValue()
+    renderPage('p1')
+
+    fireEvent.click(await screen.findByRole('combobox'))
+    fireEvent.click(await screen.findByText('ap-southeast-2 (Sydney)'))
+
+    await waitFor(() =>
+      expect(patchProvider).toHaveBeenCalledWith('p1', { options: { region: 'ap-southeast-2' } }),
+    )
   })
 })

--- a/web/src/components/settings/ProviderEdit.tsx
+++ b/web/src/components/settings/ProviderEdit.tsx
@@ -23,17 +23,18 @@ import {
   DialogTitle,
 } from '../ui/dialog'
 import { Input } from '../ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { ModelInput, type ModelSuggestion } from './ModelInput'
 import { modelCatalog } from './modelCatalog'
-import { matchPreset } from './presets'
+import { bedrockRegions, matchPreset } from './presets'
 import { ProviderLogo } from './ProviderLogo'
 import { Field, Toggle } from './shared'
 import { useDefaultSecretBackend } from './useDefaultSecretBackend'
 import { backendLabel, errText, stripPaste, secretField } from './util'
 
 // ProviderEdit is a provider's own page for the controls too heavy for
-// its summary card: rotating the stored key (or the Bedrock profile),
-// and declaring which models it serves.
+// its summary card: rotating the stored key, and declaring which
+// models it serves.
 export function ProviderEdit() {
   const { id } = useParams()
   const navigate = useNavigate()
@@ -96,6 +97,7 @@ export function ProviderEdit() {
             defaultBackend={defaultBackend}
           />
         )}
+        {provider.driver === 'bedrock' && <RegionSection provider={provider} onChanged={refresh} />}
         {provider.driver === 'openaicompat' && (
           <ReasoningSection provider={provider} onChanged={refresh} />
         )}
@@ -241,88 +243,70 @@ function CredentialSection({
         </Button>
       </div>
 
-      {bedrock ? (
-        <div>
-          <Field label="AWS profile or credential reference">
-            <Input
-              value={ref}
-              onChange={(e) => setRef(e.target.value)}
-              onBlur={saveRef}
-              placeholder="profile name"
-              className="mt-1.5 h-10"
-            />
-          </Field>
-          <p className="mt-1.5 text-sm text-muted-foreground">
-            For static IAM keys, save this name as a secret (Secrets tab) holding JSON{' '}
-            {'{"access_key_id":"…","secret_access_key":"…"}'} — the gateway resolves it before
-            falling back to an AWS profile. Leave the secret unset to use this as a profile name
-            from the host’s ~/.aws (SSO) instead.
-          </p>
-        </div>
-      ) : (
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <span
-              className={`rounded px-2 py-0.5 text-xs font-semibold uppercase ${
-                configured ? 'bg-good-soft text-good' : 'bg-warning-soft text-warning'
-              }`}
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <span
+            className={`rounded px-2 py-0.5 text-xs font-semibold uppercase ${
+              configured ? 'bg-good-soft text-good' : 'bg-warning-soft text-warning'
+            }`}
+          >
+            {configured ? `stored · ${backendLabel(storedBackend)}` : 'not set'}
+          </span>
+          {configured && (
+            <button
+              type="button"
+              disabled={savingSecret}
+              onClick={() => void clearSecretValue()}
+              className="text-sm text-muted-foreground underline-offset-2 hover:text-destructive hover:underline"
             >
-              {configured ? `stored · ${backendLabel(storedBackend)}` : 'not set'}
-            </span>
-            {configured && (
-              <button
-                type="button"
-                disabled={savingSecret}
-                onClick={() => void clearSecretValue()}
-                className="text-sm text-muted-foreground underline-offset-2 hover:text-destructive hover:underline"
-              >
-                clear
-              </button>
-            )}
-          </div>
-          <div className="flex gap-2">
-            <Input
-              type={secretField(defaultBackend ?? 'db', '').type}
-              value={secretValue}
-              onChange={(e) => setSecretValue(e.target.value)}
-              placeholder={
-                secretField(defaultBackend ?? 'db', configured ? 'paste new key to rotate' : 'paste key')
-                  .placeholder
-              }
-              className="h-10"
-              autoComplete="off"
-            />
-            <Button variant="outline" disabled={savingSecret || !secretValue || !ref} onClick={() => void saveSecretValue()}>
-              Save
-            </Button>
-          </div>
-          <p className="text-sm text-muted-foreground">
-            {defaultBackend === 'vault'
+              clear
+            </button>
+          )}
+        </div>
+        <div className="flex gap-2">
+          <Input
+            type={secretField(defaultBackend ?? 'db', '').type}
+            value={secretValue}
+            onChange={(e) => setSecretValue(e.target.value)}
+            placeholder={
+              secretField(defaultBackend ?? 'db', configured ? 'paste new key to rotate' : 'paste key')
+                .placeholder
+            }
+            className="h-10"
+            autoComplete="off"
+          />
+          <Button variant="outline" disabled={savingSecret || !secretValue || !ref} onClick={() => void saveSecretValue()}>
+            Save
+          </Button>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {bedrock
+            ? 'Paste static IAM keys as JSON ({"access_key_id":"…","secret_access_key":"…"}).'
+            : defaultBackend === 'vault'
               ? 'The key stays in Vault; only its path is saved. The default backend is set in the Secrets tab.'
               : defaultBackend === 'asm'
                 ? 'The key stays in AWS Secrets Manager; only its name is saved. The default backend is set in the Secrets tab.'
                 : defaultBackend === 'file'
                   ? 'The key stays in the mounted file; only its filename is saved. The default backend is set in the Secrets tab.'
                   : 'Encrypted with the master key and kept in Timothy’s database.'}
+        </p>
+        <details className="pt-1">
+          <summary className="cursor-pointer text-sm font-medium text-muted-foreground transition hover:text-foreground">
+            Advanced — reference name
+          </summary>
+          <Input
+            value={ref}
+            onChange={(e) => setRef(e.target.value)}
+            onBlur={saveRef}
+            placeholder="name (e.g. ANTHROPIC_API_KEY)"
+            className="mt-1.5 h-10"
+          />
+          <p className="mt-1.5 text-sm text-muted-foreground">
+            Storage name for this provider’s key — never the key itself. Change it only to
+            share or repoint an already-stored secret.
           </p>
-          <details className="pt-1">
-            <summary className="cursor-pointer text-sm font-medium text-muted-foreground transition hover:text-foreground">
-              Advanced — reference name
-            </summary>
-            <Input
-              value={ref}
-              onChange={(e) => setRef(e.target.value)}
-              onBlur={saveRef}
-              placeholder="name (e.g. ANTHROPIC_API_KEY)"
-              className="mt-1.5 h-10"
-            />
-            <p className="mt-1.5 text-sm text-muted-foreground">
-              Storage name for this provider’s key — never the key itself. Change it only to
-              share or repoint an already-stored secret.
-            </p>
-          </details>
-        </div>
-      )}
+        </details>
+      </div>
     </section>
   )
 }
@@ -387,6 +371,50 @@ function ReasoningSection({ provider, onChanged }: { provider: AdminProvider; on
           placeholder="5m"
           className="mt-1.5 h-10 max-w-40"
         />
+      </Field>
+    </section>
+  )
+}
+
+// RegionSection lets a bedrock provider pick its AWS region
+// (options.region, D-048) — defaults to us-east-1 when unset, same
+// default the gateway driver applies. Overridden per-key by the secret
+// JSON's own "region" field (D-047), which this dropdown never touches.
+function RegionSection({ provider, onChanged }: { provider: AdminProvider; onChanged: () => void }) {
+  const [saving, setSaving] = useState(false)
+  const region = provider.options?.region ?? 'us-east-1'
+
+  const save = async (value: string) => {
+    if (value === region) return
+    setSaving(true)
+    try {
+      await patchProvider(provider.id, {
+        options: { ...provider.options, region: value },
+      })
+      onChanged()
+    } catch (err) {
+      toast.error('Could not update region', { description: errText(err) })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-sm font-semibold">Region</h2>
+      <Field label="AWS region" hint={saving ? 'Saving…' : undefined}>
+        <Select value={region} onValueChange={(v) => void save(v)}>
+          <SelectTrigger className="mt-1.5 h-10 w-full max-w-72">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {bedrockRegions.map((r) => (
+              <SelectItem key={r.value} value={r.value}>
+                {r.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </Field>
     </section>
   )

--- a/web/src/components/settings/presets.ts
+++ b/web/src/components/settings/presets.ts
@@ -11,9 +11,11 @@ export interface ProviderPreset {
   // Sprite symbol in ProviderLogo; custom endpoints render a glyph.
   logo?: string
   brandColor: string
-  // Default base_url ('' lets the driver default apply; bedrock keeps
-  // the region there instead — see the registry contract).
+  // Default base_url ('' lets the driver default apply); unused for
+  // bedrock, whose region lives in options.region instead (see `region`
+  // below and the registry contract).
   baseURL: string
+  // Default AWS region for the bedrock preset's options.region dropdown.
   region?: string
   requiresKey: boolean
   defaultRef?: string
@@ -23,6 +25,27 @@ export interface ProviderPreset {
   // the first declared model and the default on create.
   validateModel: string
 }
+
+// bedrockRegions lists AWS regions where Bedrock serves models, for the
+// provider's region dropdown (options.region). Curated to Bedrock-served
+// regions, not every AWS region — extend as AWS does.
+export const bedrockRegions: { value: string; label: string }[] = [
+  { value: 'us-east-1', label: 'us-east-1 (N. Virginia)' },
+  { value: 'us-east-2', label: 'us-east-2 (Ohio)' },
+  { value: 'us-west-2', label: 'us-west-2 (Oregon)' },
+  { value: 'ca-central-1', label: 'ca-central-1 (Canada)' },
+  { value: 'sa-east-1', label: 'sa-east-1 (São Paulo)' },
+  { value: 'eu-central-1', label: 'eu-central-1 (Frankfurt)' },
+  { value: 'eu-west-1', label: 'eu-west-1 (Ireland)' },
+  { value: 'eu-west-2', label: 'eu-west-2 (London)' },
+  { value: 'eu-west-3', label: 'eu-west-3 (Paris)' },
+  { value: 'eu-north-1', label: 'eu-north-1 (Stockholm)' },
+  { value: 'ap-northeast-1', label: 'ap-northeast-1 (Tokyo)' },
+  { value: 'ap-northeast-2', label: 'ap-northeast-2 (Seoul)' },
+  { value: 'ap-south-1', label: 'ap-south-1 (Mumbai)' },
+  { value: 'ap-southeast-1', label: 'ap-southeast-1 (Singapore)' },
+  { value: 'ap-southeast-2', label: 'ap-southeast-2 (Sydney)' },
+]
 
 export const providerPresets: ProviderPreset[] = [
   {
@@ -62,9 +85,8 @@ export const providerPresets: ProviderPreset[] = [
     brandColor: '#FF9900',
     baseURL: '',
     region: 'us-east-1',
-    requiresKey: false,
-    keyHint:
-      'Paste static IAM keys as JSON ({"access_key_id":"…","secret_access_key":"…"}), or leave the secret unset to use an AWS profile name from the host’s ~/.aws.',
+    requiresKey: true,
+    keyHint: 'Paste static IAM keys as JSON ({"access_key_id":"…","secret_access_key":"…"}).',
     validateModel: 'amazon.nova-lite-v1:0',
   },
   {

--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -245,14 +245,14 @@ describe('Providers tab', () => {
     }
   })
 
-  it('navigates to its own add page: bedrock asks for region, not a key', async () => {
+  it('navigates to its own add page: bedrock asks for a region dropdown and a key', async () => {
     renderPage('/settings/providers')
     fireEvent.click(await screen.findByRole('button', { name: /AWS Bedrock/ }))
     expect(await screen.findByText('Add AWS Bedrock')).toBeTruthy()
     expect(screen.getByText('Region')).toBeTruthy()
-    expect(screen.getByText('AWS profile (optional)')).toBeTruthy()
-    // The card behind the list has a key editor; the bedrock page must not.
-    expect(screen.queryByText('API key')).toBeNull()
+    expect(screen.getByRole('combobox')).toBeTruthy()
+    // Static keys are the only bedrock auth now: the key field is required.
+    expect(screen.getByText('API key')).toBeTruthy()
   })
 
   it('disables Add until a test passes, then stores the key and creates enabled', async () => {


### PR DESCRIPTION
Region becomes visible provider config instead of hiding inside the secret, and Bedrock's AWS-profile/SSO fallback (D-047's secondary path) is removed entirely — a headless server has no ~/.aws, and profile mode was already dead weight for the deployment you're planning.

- `providers.options.region` (plain string) threads through the same path as `reasoning_effort`/`request_timeout`. Precedence: secret JSON's own `region` (per-key override) > options.region > `us-east-1` default.
- Bedrock now REQUIRES static keys resolving from the secret store — an unresolved credential_ref is a loud Build error ("bedrock requires static keys in the secret store; AWS profile mode was removed"), never a silent SDK-default-chain fallback.
- Web: bedrock Add/Edit gets a Region Select (15 curated Bedrock-served regions) instead of a text field; the provider now uses the standard API-key flow like every other driver.
- Compose: gateway's `${HOME}/.aws` mounts removed. README's Bedrock section rewritten (IAM user → paste keys JSON → pick region, no SSO).

Your live Bedrock provider already uses static keys (see #126) — unaffected by the mode removal.