### PR TITLE
feat(web): link each provider preset to its key-creation page

### DIFF
--- a/web/src/components/settings/ProviderAdd.test.tsx
+++ b/web/src/components/settings/ProviderAdd.test.tsx
@@ -66,3 +66,17 @@ describe('ProviderAdd model suggestions', () => {
     expect(await screen.findByText('glm-4.7-flash')).toBeInTheDocument()
   })
 })
+
+describe('ProviderAdd key hint links', () => {
+  it('links to the provider\'s key-creation page', async () => {
+    renderPage('glm')
+    const link = await screen.findByRole('link', { name: 'Open GLM (Z.ai) →' })
+    expect(link).toHaveAttribute('href', 'https://z.ai/manage-apikey/apikey-list')
+    expect(link).toHaveAttribute('target', '_blank')
+  })
+
+  it('renders no link for a preset without a keyURL', async () => {
+    renderPage('ollama')
+    expect(screen.queryByRole('link', { name: /Open Ollama/ })).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/settings/ProviderAdd.tsx
+++ b/web/src/components/settings/ProviderAdd.tsx
@@ -276,7 +276,22 @@ export function ProviderAdd() {
                   </p>
                 )}
                 {!keyError && (field.hint || preset.keyHint) && (
-                  <p className="mt-1.5 text-sm text-muted-foreground">{field.hint || preset.keyHint}</p>
+                  <p className="mt-1.5 text-sm text-muted-foreground">
+                    {field.hint || preset.keyHint}
+                    {!field.hint && preset.keyURL && (
+                      <>
+                        {' '}
+                        <a
+                          href={preset.keyURL}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+                        >
+                          Open {preset.name} →
+                        </a>
+                      </>
+                    )}
+                  </p>
                 )}
               </div>
             )

--- a/web/src/components/settings/presets.ts
+++ b/web/src/components/settings/presets.ts
@@ -21,6 +21,9 @@ export interface ProviderPreset {
   defaultRef?: string
   keyPlaceholder?: string
   keyHint?: string
+  // Provider's own key/API-key management page — rendered as a link
+  // right where the operator is about to paste one in.
+  keyURL?: string
   // Prefill for the validation model — editable in the dialog, becomes
   // the first declared model and the default on create.
   validateModel: string
@@ -60,6 +63,7 @@ export const providerPresets: ProviderPreset[] = [
     defaultRef: 'OPENAI_API_KEY',
     keyPlaceholder: 'sk-…',
     keyHint: 'Create one at platform.openai.com/api-keys.',
+    keyURL: 'https://platform.openai.com/api-keys',
     validateModel: 'gpt-4o-mini',
   },
   {
@@ -74,6 +78,7 @@ export const providerPresets: ProviderPreset[] = [
     defaultRef: 'ANTHROPIC_API_KEY',
     keyPlaceholder: 'sk-ant-…',
     keyHint: 'Create one at console.anthropic.com — keys start with sk-ant-.',
+    keyURL: 'https://console.anthropic.com/settings/keys',
     validateModel: 'claude-haiku-4-5',
   },
   {
@@ -87,6 +92,7 @@ export const providerPresets: ProviderPreset[] = [
     region: 'us-east-1',
     requiresKey: true,
     keyHint: 'Paste static IAM keys as JSON ({"access_key_id":"…","secret_access_key":"…"}).',
+    keyURL: 'https://console.aws.amazon.com/iam/home#/users',
     validateModel: 'amazon.nova-lite-v1:0',
   },
   {
@@ -101,6 +107,7 @@ export const providerPresets: ProviderPreset[] = [
     defaultRef: 'ZAI_API_KEY',
     keyPlaceholder: 'paste key',
     keyHint: 'Create one at z.ai.',
+    keyURL: 'https://z.ai/manage-apikey/apikey-list',
     validateModel: 'glm-4.7-flash',
   },
   {
@@ -115,6 +122,7 @@ export const providerPresets: ProviderPreset[] = [
     defaultRef: 'XAI_API_KEY',
     keyPlaceholder: 'xai-…',
     keyHint: 'Create one at console.x.ai — keys start with xai-.',
+    keyURL: 'https://console.x.ai',
     validateModel: 'grok-4',
   },
   {


### PR DESCRIPTION
Add Provider's key hint named where to get a key as plain text ("Create one at platform.openai.com/api-keys") — now an actual link so you don't retype the domain. Added for OpenAI, Anthropic, Bedrock (IAM users console), GLM (z.ai/manage-apikey/apikey-list), and Grok; Ollama/custom have no key page so no link renders. 2 new tests, full settings suite 63/63 green.