### PR TITLE
feat(web): bedrock form takes access key id and secret directly

### DIFF
--- a/web/src/components/settings/ProviderAdd.test.tsx
+++ b/web/src/components/settings/ProviderAdd.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AdminProvider } from '../../api/types'
@@ -12,7 +12,7 @@ vi.mock('../../api/client', () => ({
   validateProvider: vi.fn(),
 }))
 
-import { listProviders, listSecretBackends } from '../../api/client'
+import { createProvider, listProviders, listSecretBackends, setSecret, validateProvider } from '../../api/client'
 
 // Both openaicompat, but different endpoints — models declared on one
 // must never suggest for the other.
@@ -41,6 +41,8 @@ function renderPage(presetId: string) {
 
 afterEach(cleanup)
 beforeEach(() => {
+  // jsdom lacks scrollIntoView; Radix Select calls it on open.
+  Element.prototype.scrollIntoView = vi.fn()
   vi.clearAllMocks()
   vi.mocked(listProviders).mockResolvedValue([glm])
   vi.mocked(listSecretBackends).mockResolvedValue([
@@ -78,5 +80,97 @@ describe('ProviderAdd key hint links', () => {
   it('renders no link for a preset without a keyURL', async () => {
     renderPage('ollama')
     expect(screen.queryByRole('link', { name: /Open Ollama/ })).not.toBeInTheDocument()
+  })
+})
+
+describe('ProviderAdd bedrock credential inputs', () => {
+  beforeEach(() => {
+    vi.mocked(validateProvider).mockResolvedValue({ ok: true, latency_ms: 12, model: 'amazon.nova-lite-v1:0' })
+    vi.mocked(setSecret).mockResolvedValue()
+    vi.mocked(createProvider).mockResolvedValue('p-bedrock')
+  })
+
+  it('renders two labeled key inputs instead of a generic key field', async () => {
+    renderPage('bedrock')
+
+    expect(await screen.findByPlaceholderText('AKIA…')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('wJalrXUtnFEMI/K7MDEN...')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('paste key')).not.toBeInTheDocument()
+  })
+
+  it('blocks the test when the secret access key is missing', async () => {
+    renderPage('bedrock')
+
+    fireEvent.change(await screen.findByPlaceholderText('AKIA…'), {
+      target: { value: 'AKIAEXAMPLE' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Test connection' }))
+
+    expect(
+      await screen.findByText('An access key ID and secret access key are required to test this provider.'),
+    ).toBeInTheDocument()
+    expect(setSecret).not.toHaveBeenCalled()
+  })
+
+  it('sends a valid JSON secret built from the two fields and adds the provider', async () => {
+    renderPage('bedrock')
+
+    fireEvent.change(await screen.findByPlaceholderText('AKIA…'), {
+      target: { value: 'AKIAEXAMPLE' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('wJalrXUtnFEMI/K7MDEN...'), {
+      target: { value: 'secretvalue123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Test connection' }))
+
+    await waitFor(() => expect(setSecret).toHaveBeenCalled())
+    const [ref, payload] = vi.mocked(setSecret).mock.calls[0]
+    expect(ref).toBeTruthy()
+    expect(JSON.parse(payload)).toEqual({
+      access_key_id: 'AKIAEXAMPLE',
+      secret_access_key: 'secretvalue123',
+    })
+
+    await screen.findByText(/^OK —/)
+    fireEvent.click(screen.getByRole('button', { name: 'Add provider' }))
+
+    await waitFor(() => expect(createProvider).toHaveBeenCalled())
+  })
+
+  it('includes the session token in the JSON payload when the advanced field is filled', async () => {
+    renderPage('bedrock')
+
+    fireEvent.change(await screen.findByPlaceholderText('AKIA…'), {
+      target: { value: 'AKIAEXAMPLE' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('wJalrXUtnFEMI/K7MDEN...'), {
+      target: { value: 'secretvalue123' },
+    })
+    fireEvent.click(screen.getByText('Advanced — session token'))
+    fireEvent.change(screen.getByPlaceholderText('paste session token'), {
+      target: { value: 'sts-token-abc' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Test connection' }))
+
+    await waitFor(() => expect(setSecret).toHaveBeenCalled())
+    const [, payload] = vi.mocked(setSecret).mock.calls[0]
+    expect(JSON.parse(payload)).toEqual({
+      access_key_id: 'AKIAEXAMPLE',
+      secret_access_key: 'secretvalue123',
+      session_token: 'sts-token-abc',
+    })
+  })
+
+  it('mentions no JSON in the bedrock key hint copy', async () => {
+    renderPage('bedrock')
+    await screen.findByPlaceholderText('AKIA…')
+    expect(screen.queryByText(/JSON/)).not.toBeInTheDocument()
+  })
+
+  it('still renders the generic single key input for a non-bedrock preset', async () => {
+    renderPage('glm')
+
+    expect(await screen.findByPlaceholderText('paste key')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('AKIA…')).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/settings/ProviderAdd.tsx
+++ b/web/src/components/settings/ProviderAdd.tsx
@@ -40,6 +40,9 @@ export function ProviderAdd() {
   const [baseURL, setBaseURL] = useState('')
   const [region, setRegion] = useState('us-east-1')
   const [key, setKey] = useState('')
+  const [accessKeyId, setAccessKeyId] = useState('')
+  const [secretAccessKey, setSecretAccessKey] = useState('')
+  const [sessionToken, setSessionToken] = useState('')
   const [ref, setRef] = useState('')
   const [refEdited, setRefEdited] = useState(false)
   const [model, setModel] = useState('')
@@ -59,6 +62,9 @@ export function ProviderAdd() {
     setBaseURL(preset.baseURL)
     setRegion(preset.region ?? 'us-east-1')
     setKey('')
+    setAccessKeyId('')
+    setSecretAccessKey('')
+    setSessionToken('')
     setRef(preset.id === 'custom' ? '' : refFor(preset, preset.name))
     setRefEdited(false)
     setModel(preset.validateModel)
@@ -108,6 +114,21 @@ export function ProviderAdd() {
   const isBedrock = preset.driver === 'bedrock'
   const wantsKey = preset.requiresKey
 
+  // Bedrock's two-input split (access key id / secret access key) only
+  // applies when the store writes the raw secret value itself (the
+  // "db" backend, secretField's 'password' mode). vault/asm/file take
+  // a reference to a secret already stored externally — the operator
+  // must have pre-populated that external secret with the JSON blob,
+  // so the generic single reference input stays for those backends.
+  const bedrockSplit = isBedrock && secretField(defaultBackend, '').type === 'password'
+  const bedrockKeyJSON = () =>
+    JSON.stringify({
+      access_key_id: stripPaste(accessKeyId.trim()),
+      secret_access_key: stripPaste(secretAccessKey.trim()),
+      ...(sessionToken.trim() ? { session_token: stripPaste(sessionToken.trim()) } : {}),
+    })
+  const hasKey = bedrockSplit ? !!(accessKeyId.trim() && secretAccessKey.trim()) : !!key.trim()
+
   // Any edit invalidates a previous test — the config it validated no
   // longer matches what's on screen.
   const invalidate = () => {
@@ -119,8 +140,12 @@ export function ProviderAdd() {
   }
 
   const runTest = async () => {
-    if (wantsKey && !key.trim()) {
-      setKeyError('An API key is required to test this provider.')
+    if (wantsKey && !hasKey) {
+      setKeyError(
+        bedrockSplit
+          ? 'An access key ID and secret access key are required to test this provider.'
+          : 'An API key is required to test this provider.',
+      )
       return
     }
     if (!name.trim()) {
@@ -131,9 +156,9 @@ export function ProviderAdd() {
     setBusy(true)
     setTest(null)
     try {
-      if (wantsKey && key) {
+      if (wantsKey && hasKey) {
         if (!ref.trim()) throw new Error('a credential reference name is required to store the key')
-        await setSecret(ref.trim(), stripPaste(key))
+        await setSecret(ref.trim(), bedrockSplit ? bedrockKeyJSON() : stripPaste(key))
       }
       const config = {
         name: name.trim(),
@@ -250,7 +275,84 @@ export function ProviderAdd() {
             />
           </Field>
         )}
+        {wantsKey && bedrockSplit && (
+          <div>
+            <div className="grid gap-5 sm:grid-cols-2">
+              <Field label="Access Key ID">
+                <Input
+                  type="password"
+                  value={accessKeyId}
+                  onChange={(e) => {
+                    setAccessKeyId(e.target.value)
+                    invalidate()
+                  }}
+                  placeholder="AKIA…"
+                  className="mt-1.5 h-10"
+                  autoComplete="off"
+                  aria-invalid={keyError != null}
+                />
+              </Field>
+              <Field label="Secret Access Key">
+                <Input
+                  type="password"
+                  value={secretAccessKey}
+                  onChange={(e) => {
+                    setSecretAccessKey(e.target.value)
+                    invalidate()
+                  }}
+                  placeholder="wJalrXUtnFEMI/K7MDEN..."
+                  className="mt-1.5 h-10"
+                  autoComplete="off"
+                  aria-invalid={keyError != null}
+                />
+              </Field>
+            </div>
+            {keyError && (
+              <p className="mt-1.5 flex items-center gap-1.5 text-sm font-medium text-destructive">
+                <HugeiconsIcon icon={AlertCircleIcon} className="size-4 shrink-0" />
+                {keyError}
+              </p>
+            )}
+            {!keyError && preset.keyHint && (
+              <p className="mt-1.5 text-sm text-muted-foreground">
+                {preset.keyHint}
+                {preset.keyURL && (
+                  <>
+                    {' '}
+                    <a
+                      href={preset.keyURL}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+                    >
+                      Open {preset.name} →
+                    </a>
+                  </>
+                )}
+              </p>
+            )}
+            <details className="mt-3">
+              <summary className="cursor-pointer text-sm font-medium text-muted-foreground transition hover:text-foreground">
+                Advanced — session token
+              </summary>
+              <Field label="Session Token (optional)" hint="only needed for temporary STS credentials">
+                <Input
+                  type="password"
+                  value={sessionToken}
+                  onChange={(e) => {
+                    setSessionToken(e.target.value)
+                    invalidate()
+                  }}
+                  placeholder="paste session token"
+                  className="mt-1.5 h-10"
+                  autoComplete="off"
+                />
+              </Field>
+            </details>
+          </div>
+        )}
         {wantsKey &&
+          !bedrockSplit &&
           (() => {
             const field = secretField(defaultBackend, preset.keyPlaceholder ?? 'paste key')
             return (

--- a/web/src/components/settings/ProviderEdit.test.tsx
+++ b/web/src/components/settings/ProviderEdit.test.tsx
@@ -22,6 +22,7 @@ import {
   listSecretBackends,
   patchProvider,
   secretStatus,
+  setSecret,
 } from '../../api/client'
 
 const bedrockProvider: AdminProvider = {
@@ -35,6 +36,11 @@ const bedrockProvider: AdminProvider = {
   credential_ref: '',
   headers: {},
   enabled: true,
+}
+
+const bedrockProviderWithRef: AdminProvider = {
+  ...bedrockProvider,
+  credential_ref: 'BEDROCK_KEY',
 }
 
 const openaicompatProvider: AdminProvider = {
@@ -351,5 +357,75 @@ describe('ProviderEdit region section', () => {
     await waitFor(() =>
       expect(patchProvider).toHaveBeenCalledWith('p1', { options: { region: 'ap-southeast-2' } }),
     )
+  })
+})
+
+describe('ProviderEdit bedrock credential section', () => {
+  beforeEach(() => {
+    vi.mocked(availableModels).mockRejectedValue(new Error('driver bedrock cannot list models'))
+  })
+
+  it('renders two labeled key inputs instead of a generic key field', async () => {
+    vi.mocked(listProviders).mockResolvedValue([bedrockProviderWithRef])
+    renderPage('p1')
+
+    expect(await screen.findByPlaceholderText('AKIA…')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('wJalrXUtnFEMI/K7MDEN...')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('paste key')).not.toBeInTheDocument()
+  })
+
+  it('keeps the generic single key input for a non-bedrock provider', async () => {
+    vi.mocked(listProviders).mockResolvedValue([openaicompatProvider])
+    renderPage('p2')
+
+    expect(await screen.findByPlaceholderText('paste key')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('AKIA…')).not.toBeInTheDocument()
+  })
+
+  it('disables Save until both access key id and secret access key are filled', async () => {
+    vi.mocked(listProviders).mockResolvedValue([bedrockProviderWithRef])
+    renderPage('p1')
+
+    await screen.findByPlaceholderText('AKIA…')
+    const saveButton = screen.getByRole('button', { name: 'Save' })
+    expect(saveButton).toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText('AKIA…'), { target: { value: 'AKIAEXAMPLE' } })
+    expect(saveButton).toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText('wJalrXUtnFEMI/K7MDEN...'), {
+      target: { value: 'secretvalue123' },
+    })
+    expect(saveButton).not.toBeDisabled()
+  })
+
+  it('rotates the stored secret with a JSON blob built from the two fields', async () => {
+    vi.mocked(listProviders).mockResolvedValue([bedrockProviderWithRef])
+    vi.mocked(setSecret).mockResolvedValue()
+    renderPage('p1')
+
+    fireEvent.change(await screen.findByPlaceholderText('AKIA…'), {
+      target: { value: 'AKIAROTATED' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('wJalrXUtnFEMI/K7MDEN...'), {
+      target: { value: 'rotatedsecret' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(setSecret).toHaveBeenCalled())
+    const [ref, payload] = vi.mocked(setSecret).mock.calls[0]
+    expect(ref).toBe('BEDROCK_KEY')
+    expect(JSON.parse(payload)).toEqual({
+      access_key_id: 'AKIAROTATED',
+      secret_access_key: 'rotatedsecret',
+    })
+  })
+
+  it('mentions no JSON in the bedrock credential hint copy', async () => {
+    vi.mocked(listProviders).mockResolvedValue([bedrockProviderWithRef])
+    renderPage('p1')
+
+    await screen.findByPlaceholderText('AKIA…')
+    expect(screen.queryByText(/JSON/)).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/settings/ProviderEdit.tsx
+++ b/web/src/components/settings/ProviderEdit.tsx
@@ -142,6 +142,9 @@ function CredentialSection({
   const [configured, setConfigured] = useState(false)
   const [storedBackend, setStoredBackend] = useState('')
   const [secretValue, setSecretValue] = useState('')
+  const [accessKeyId, setAccessKeyId] = useState('')
+  const [secretAccessKey, setSecretAccessKey] = useState('')
+  const [sessionToken, setSessionToken] = useState('')
   const [savingSecret, setSavingSecret] = useState(false)
   const [test, setTest] = useState<TestResult | null>(null)
   const [testing, setTesting] = useState(false)
@@ -173,12 +176,27 @@ function CredentialSection({
     })
   }
 
+  const bedrockKeyJSON = () =>
+    JSON.stringify({
+      access_key_id: stripPaste(accessKeyId.trim()),
+      secret_access_key: stripPaste(secretAccessKey.trim()),
+      ...(sessionToken.trim() ? { session_token: stripPaste(sessionToken.trim()) } : {}),
+    })
+
   const saveSecretValue = async () => {
-    if (!ref || !secretValue) return
+    if (!ref) return
+    if (bedrock) {
+      if (!accessKeyId.trim() || !secretAccessKey.trim()) return
+    } else if (!secretValue) {
+      return
+    }
     setSavingSecret(true)
     try {
-      await setSecret(ref, stripPaste(secretValue))
+      await setSecret(ref, bedrock ? bedrockKeyJSON() : stripPaste(secretValue))
       setSecretValue('')
+      setAccessKeyId('')
+      setSecretAccessKey('')
+      setSessionToken('')
       refreshSecretStatus()
       onChanged()
       toast.success('Key saved')
@@ -263,25 +281,74 @@ function CredentialSection({
             </button>
           )}
         </div>
-        <div className="flex gap-2">
-          <Input
-            type={secretField(defaultBackend ?? 'db', '').type}
-            value={secretValue}
-            onChange={(e) => setSecretValue(e.target.value)}
-            placeholder={
-              secretField(defaultBackend ?? 'db', configured ? 'paste new key to rotate' : 'paste key')
-                .placeholder
-            }
-            className="h-10"
-            autoComplete="off"
-          />
-          <Button variant="outline" disabled={savingSecret || !secretValue || !ref} onClick={() => void saveSecretValue()}>
-            Save
-          </Button>
-        </div>
+        {bedrock ? (
+          <>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <Input
+                type="password"
+                value={accessKeyId}
+                onChange={(e) => setAccessKeyId(e.target.value)}
+                placeholder="AKIA…"
+                className="h-10"
+                autoComplete="off"
+                aria-label="Access Key ID"
+              />
+              <Input
+                type="password"
+                value={secretAccessKey}
+                onChange={(e) => setSecretAccessKey(e.target.value)}
+                placeholder={configured ? 'paste new secret key to rotate' : 'wJalrXUtnFEMI/K7MDEN...'}
+                className="h-10"
+                autoComplete="off"
+                aria-label="Secret Access Key"
+              />
+            </div>
+            <Button
+              variant="outline"
+              disabled={savingSecret || !accessKeyId.trim() || !secretAccessKey.trim() || !ref}
+              onClick={() => void saveSecretValue()}
+            >
+              Save
+            </Button>
+            <details className="pt-1">
+              <summary className="cursor-pointer text-sm font-medium text-muted-foreground transition hover:text-foreground">
+                Advanced — session token
+              </summary>
+              <Input
+                type="password"
+                value={sessionToken}
+                onChange={(e) => setSessionToken(e.target.value)}
+                placeholder="paste session token"
+                className="mt-1.5 h-10"
+                autoComplete="off"
+                aria-label="Session Token"
+              />
+              <p className="mt-1.5 text-sm text-muted-foreground">
+                Only needed for temporary STS credentials.
+              </p>
+            </details>
+          </>
+        ) : (
+          <div className="flex gap-2">
+            <Input
+              type={secretField(defaultBackend ?? 'db', '').type}
+              value={secretValue}
+              onChange={(e) => setSecretValue(e.target.value)}
+              placeholder={
+                secretField(defaultBackend ?? 'db', configured ? 'paste new key to rotate' : 'paste key')
+                  .placeholder
+              }
+              className="h-10"
+              autoComplete="off"
+            />
+            <Button variant="outline" disabled={savingSecret || !secretValue || !ref} onClick={() => void saveSecretValue()}>
+              Save
+            </Button>
+          </div>
+        )}
         <p className="text-sm text-muted-foreground">
           {bedrock
-            ? 'Paste static IAM keys as JSON ({"access_key_id":"…","secret_access_key":"…"}).'
+            ? 'Create an IAM user with Bedrock access and generate an access key pair.'
             : defaultBackend === 'vault'
               ? 'The key stays in Vault; only its path is saved. The default backend is set in the Secrets tab.'
               : defaultBackend === 'asm'

--- a/web/src/components/settings/presets.ts
+++ b/web/src/components/settings/presets.ts
@@ -91,7 +91,7 @@ export const providerPresets: ProviderPreset[] = [
     baseURL: '',
     region: 'us-east-1',
     requiresKey: true,
-    keyHint: 'Paste static IAM keys as JSON ({"access_key_id":"…","secret_access_key":"…"}).',
+    keyHint: 'Create an IAM user with Bedrock access and generate an access key pair.',
     keyURL: 'https://console.aws.amazon.com/iam/home#/users',
     validateModel: 'amazon.nova-lite-v1:0',
   },

--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -251,8 +251,10 @@ describe('Providers tab', () => {
     expect(await screen.findByText('Add AWS Bedrock')).toBeTruthy()
     expect(screen.getByText('Region')).toBeTruthy()
     expect(screen.getByRole('combobox')).toBeTruthy()
-    // Static keys are the only bedrock auth now: the key field is required.
-    expect(screen.getByText('API key')).toBeTruthy()
+    // Static keys are the only bedrock auth now: access key id + secret
+    // access key are collected directly, not a generic API key field.
+    expect(screen.getByText('Access Key ID')).toBeTruthy()
+    expect(screen.getByText('Secret Access Key')).toBeTruthy()
   })
 
   it('disables Add until a test passes, then stores the key and creates enabled', async () => {


### PR DESCRIPTION
## Summary
- Bedrock provider form (add + edit) now takes plain "Access Key ID" / "Secret Access Key" inputs (+ optional session token under an advanced disclosure) instead of a raw JSON-paste field.
- JSON blob built client-side, submitted through the existing setSecret/createProvider path unchanged — no backend change.
- Split UI only applies when the effective secret backend writes raw values (`db`); vault/asm/file backends keep the single reference input, unaffected.
- `presets.ts` keyHint copy updated to drop JSON mention; keyURL (IAM console link) unchanged.

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm test -- --run` — 354/354 passed
- [x] `make build` (no Go changes)