### PR TITLE
feat(web): per-model cost and token breakdowns with selectable legends

### DIFF
--- a/internal/gateway/api/usage.go
+++ b/internal/gateway/api/usage.go
@@ -17,6 +17,7 @@ func RegisterUsage(srv *httpserver.Server, agg *ledger.Aggregator, budgets *ledg
 	u := &usageAPI{agg: agg, budgets: budgets}
 	srv.Handle("GET /internal/admin/usage/summary", http.HandlerFunc(u.handleSummary))
 	srv.Handle("GET /internal/admin/usage/series", http.HandlerFunc(u.handleSeries))
+	srv.Handle("GET /internal/admin/usage/totals", http.HandlerFunc(u.handleTotals))
 	srv.Handle("GET /internal/admin/usage/sessions", http.HandlerFunc(u.handleSessions))
 	srv.Handle("GET /internal/admin/usage/latency", http.HandlerFunc(u.handleLatency))
 	srv.Handle("GET /internal/admin/usage/cache", http.HandlerFunc(u.handleCache))
@@ -81,6 +82,24 @@ func (u *usageAPI) handleSeries(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, map[string]any{"points": points})
+}
+
+func (u *usageAPI) handleTotals(w http.ResponseWriter, r *http.Request) {
+	from, to, err := timeRange(r)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	group := r.URL.Query().Get("group")
+	if group == "" {
+		group = "provider"
+	}
+	totals, err := u.agg.Totals(r.Context(), from, to, group)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	writeJSON(w, map[string]any{"totals": totals})
 }
 
 func (u *usageAPI) handleSessions(w http.ResponseWriter, r *http.Request) {

--- a/internal/gateway/api/usage_integration_test.go
+++ b/internal/gateway/api/usage_integration_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/ledger"
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+	"github.com/SumonMSelim/timothy/internal/platform/migrate"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+	"github.com/SumonMSelim/timothy/migrations"
+)
+
+const usageMarker = "itest-usage-"
+
+// testUsageAPI wires a usageAPI over a real Postgres so the new
+// /totals handler is exercised through the exact same code path as
+// production, mirroring aggregate_integration_test.go's DB harness.
+func testUsageAPI(t *testing.T) (*usageAPI, *ledger.Ledger) {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	_, _ = db.Exec(ctx, "DELETE FROM cost_ledger WHERE provider LIKE $1 || '%'", usageMarker)
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer ccancel()
+		conn, err := pool.Get()
+		if err != nil {
+			return
+		}
+		_, _ = conn.Exec(cctx, "DELETE FROM cost_ledger WHERE provider LIKE $1 || '%'", usageMarker)
+	})
+
+	return &usageAPI{agg: ledger.NewAggregator(pool), budgets: ledger.NewBudgetStore(pool)},
+		ledger.New(pool, log)
+}
+
+func usd(v float64) *float64 { return &v }
+
+func TestHandleTotalsGroupsWholeRangeAsJSON(t *testing.T) {
+	u, led := testUsageAPI(t)
+	ctx := t.Context()
+	from := time.Now().UTC().Add(-time.Hour)
+
+	led.Record(ctx, ledger.Entry{
+		Provider: usageMarker + "p1", Model: "m1", Route: "coding",
+		Usage:     &stream.Usage{InputTokens: 100, OutputTokens: 50},
+		LatencyMS: 10, Status: "ok", CostUSD: usd(0.05),
+	})
+	led.Record(ctx, ledger.Entry{
+		Provider: usageMarker + "p1", Model: "m1", Route: "coding",
+		Usage:     &stream.Usage{InputTokens: 40, OutputTokens: 10},
+		LatencyMS: 10, Status: "ok", CostUSD: usd(0.02),
+	})
+	// A test-connection probe: must be excluded from the totals, same
+	// as every other aggregate on this ledger.
+	led.Record(ctx, ledger.Entry{
+		Provider: usageMarker + "p1", Model: "m1", Route: "coding", Purpose: "test",
+		Usage:     &stream.Usage{InputTokens: 999999, OutputTokens: 999999},
+		LatencyMS: 10, Status: "ok", CostUSD: usd(99.0),
+	})
+
+	to := time.Now().UTC().Add(time.Hour)
+	url := "/internal/admin/usage/totals?from=" + from.Format(time.RFC3339) +
+		"&to=" + to.Format(time.RFC3339) + "&group=provider"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	w := httptest.NewRecorder()
+	u.handleTotals(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	var out struct {
+		Totals []ledger.GroupTotal `json:"totals"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var got *ledger.GroupTotal
+	for i := range out.Totals {
+		if out.Totals[i].Group == usageMarker+"p1" {
+			got = &out.Totals[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("provider %q missing from totals: %+v", usageMarker+"p1", out.Totals)
+	}
+	if got.Requests != 2 || got.CostUSD != 0.07 || got.InputTokens != 140 || got.OutputTokens != 60 {
+		t.Fatalf("totals[p1] = %+v, want 2 req / $0.07 / 140 in / 60 out (test probe excluded)", got)
+	}
+}
+
+func TestHandleTotalsRejectsUnknownGroup(t *testing.T) {
+	u, _ := testUsageAPI(t)
+	req := httptest.NewRequest(http.MethodGet, "/internal/admin/usage/totals?group=nope", nil)
+	w := httptest.NewRecorder()
+	u.handleTotals(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for unknown group", w.Code)
+	}
+}

--- a/internal/gateway/ledger/aggregate.go
+++ b/internal/gateway/ledger/aggregate.go
@@ -136,6 +136,57 @@ func (a *Aggregator) Series(ctx context.Context, from, to time.Time, bucket, gro
 	return out, rows.Err()
 }
 
+// GroupTotal is one group's totals over a whole range — the
+// non-time-bucketed sibling of SeriesPoint, for tables/charts that
+// rank groups rather than plot them over time.
+type GroupTotal struct {
+	Group                string  `json:"group"`
+	CostUSD              float64 `json:"cost_usd"`
+	InputTokens          int64   `json:"input_tokens"`
+	OutputTokens         int64   `json:"output_tokens"`
+	Requests             int64   `json:"requests"`
+	UnpricedInputTokens  int64   `json:"unpriced_input_tokens"`
+	UnpricedOutputTokens int64   `json:"unpriced_output_tokens"`
+}
+
+// Totals returns one row per group summed over the whole range —
+// Series without the time bucket, for tables/rankings rather than
+// time-series charts.
+func (a *Aggregator) Totals(ctx context.Context, from, to time.Time, groupBy string) ([]GroupTotal, error) {
+	col, ok := groups[groupBy]
+	if !ok {
+		return nil, fmt.Errorf("usage totals: unknown group %q", groupBy)
+	}
+	db, err := a.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("usage totals: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT `+col+`,
+			COALESCE(SUM(cost_usd), 0),
+			COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0),
+			COUNT(*),
+			COALESCE(SUM(input_tokens) FILTER (WHERE cost_usd IS NULL), 0),
+			COALESCE(SUM(output_tokens) FILTER (WHERE cost_usd IS NULL), 0)
+		FROM cost_ledger
+		WHERE ts >= $1 AND ts < $2 AND `+notTest+`
+		GROUP BY 1 ORDER BY 2 DESC`, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("usage totals: %w", err)
+	}
+	defer rows.Close()
+
+	out := []GroupTotal{}
+	for rows.Next() {
+		var g GroupTotal
+		if err := rows.Scan(&g.Group, &g.CostUSD, &g.InputTokens, &g.OutputTokens,
+			&g.Requests, &g.UnpricedInputTokens, &g.UnpricedOutputTokens); err != nil {
+			return nil, fmt.Errorf("usage totals: %w", err)
+		}
+		out = append(out, g)
+	}
+	return out, rows.Err()
+}
+
 // MissionUsage totals one mission's ledger footprint — every turn the
 // missions engine ran for it, across all its sessions.
 type MissionUsage struct {

--- a/internal/gateway/ledger/aggregate_integration_test.go
+++ b/internal/gateway/ledger/aggregate_integration_test.go
@@ -137,6 +137,34 @@ func TestAggregateSummaryExcludesTestTraffic(t *testing.T) {
 	}
 }
 
+func TestAggregateTotalsGroupsWholeRangeExcludingTest(t *testing.T) {
+	agg, led := testAggregator(t)
+	from, to := seedAgg(t, led)
+
+	totals, err := agg.Totals(t.Context(), from, to, "provider")
+	if err != nil {
+		t.Fatalf("Totals: %v", err)
+	}
+	byGroup := map[string]GroupTotal{}
+	for _, g := range totals {
+		byGroup[g.Group] = g
+	}
+	a, b := byGroup[aggMarker+"a"], byGroup[aggMarker+"b"]
+	// Same fixture as the Series-based summary test: 2 real rows for
+	// provider a ($0.30, 300 in / 150 out), 2 for b ($0.01) — the $99
+	// test probe must be absent from both the row count and the sum.
+	if a.Requests != 2 || a.CostUSD != 0.30 || a.InputTokens != 300 || a.OutputTokens != 150 {
+		t.Fatalf("totals[a] = %+v, want 2 req / $0.30 / 300 in / 150 out", a)
+	}
+	if b.Requests != 2 || b.CostUSD != 0.01 {
+		t.Fatalf("totals[b] = %+v, want 2 req / $0.01", b)
+	}
+
+	if _, err := agg.Totals(t.Context(), from, to, "purpose; DROP TABLE"); err == nil {
+		t.Fatal("unknown group must error")
+	}
+}
+
 func TestAggregateMissionUsage(t *testing.T) {
 	agg, led := testAggregator(t)
 	ctx := t.Context()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -11,6 +11,7 @@ import type {
   ChatEvent,
   ChatRequest,
   EntityGraphData,
+  GroupTotal,
   LatencyRow,
   MemoryItem,
   Mission,
@@ -449,6 +450,17 @@ export async function usageSeries(
     `/v1/admin/usage/series?${rangeParams(from, to, { bucket, group })}`,
   )
   return points ?? []
+}
+
+export async function usageTotals(
+  from: Date,
+  to: Date,
+  group: 'provider' | 'model' | 'route',
+): Promise<GroupTotal[]> {
+  const { totals } = await request<{ totals: GroupTotal[] }>(
+    `/v1/admin/usage/totals?${rangeParams(from, to, { group })}`,
+  )
+  return totals ?? []
 }
 
 export async function usageSessions(from: Date, to: Date, limit = 10): Promise<SessionUsage[]> {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -215,6 +215,19 @@ export interface UsagePoint {
   unpriced_output_tokens: number
 }
 
+// GroupTotal is one group's totals over a whole range — the
+// non-time-bucketed sibling of UsagePoint, for tables/charts that rank
+// groups rather than plot them over time.
+export interface GroupTotal {
+  group: string
+  cost_usd: number
+  input_tokens: number
+  output_tokens: number
+  requests: number
+  unpriced_input_tokens: number
+  unpriced_output_tokens: number
+}
+
 // One mission's total ledger footprint. unpriced_requests counts turns
 // whose cost is unknown (NULL in the ledger) — cost_usd is then a
 // floor, not the whole bill.

--- a/web/src/pages/Analytics.test.tsx
+++ b/web/src/pages/Analytics.test.tsx
@@ -1,7 +1,8 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { cloneElement, type ReactElement } from 'react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { BudgetStatus, UsageSummary } from '../api/types'
+import type { BudgetStatus, GroupTotal, UsagePoint, UsageSummary } from '../api/types'
 import { Analytics } from './Analytics'
 
 vi.mock('../api/client', () => ({
@@ -11,7 +12,22 @@ vi.mock('../api/client', () => ({
   usageSeries: vi.fn(),
   usageSessions: vi.fn(),
   usageSummary: vi.fn(),
+  usageTotals: vi.fn(),
 }))
+
+// jsdom never reports a real element size (no layout engine), so the
+// real ResponsiveContainer measures 0x0 and recharts renders nothing —
+// it clones its child with the measured width/height. Cloning with a
+// fixed size here lets BarChart/LineChart/Legend actually mount so the
+// legend-toggle tests below have something to click.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<typeof import('recharts')>('recharts')
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: ReactElement<{ width?: number; height?: number }> }) =>
+      cloneElement(children, { width: 800, height: 300 }),
+  }
+})
 
 import {
   usageBudget,
@@ -20,6 +36,7 @@ import {
   usageSeries,
   usageSessions,
   usageSummary,
+  usageTotals,
 } from '../api/client'
 
 const summary: UsageSummary = {
@@ -53,6 +70,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(usageSummary).mockResolvedValue(summary)
   vi.mocked(usageSeries).mockResolvedValue([])
+  vi.mocked(usageTotals).mockResolvedValue([])
   vi.mocked(usageSessions).mockResolvedValue([])
   vi.mocked(usageLatency).mockResolvedValue([])
   vi.mocked(usageCache).mockResolvedValue([])
@@ -131,5 +149,136 @@ describe('Analytics unpriced usage', () => {
     renderPage()
     await waitFor(() => expect(screen.getAllByText('$2.50').length).toBeGreaterThan(0))
     expect(screen.queryByText(/had no configured price/)).toBeNull()
+  })
+})
+
+const providerPoint: UsagePoint = {
+  bucket: '2026-07-24T00:00:00Z',
+  group: 'openai',
+  cost_usd: 1.5,
+  input_tokens: 100,
+  output_tokens: 50,
+  requests: 3,
+  errors: 0,
+  unpriced_input_tokens: 0,
+  unpriced_output_tokens: 0,
+}
+
+const providerTotal: GroupTotal = {
+  group: 'openai',
+  cost_usd: 1.5,
+  input_tokens: 100,
+  output_tokens: 50,
+  requests: 3,
+  unpriced_input_tokens: 0,
+  unpriced_output_tokens: 0,
+}
+
+describe('Analytics chart legend toggling', () => {
+  it('strikes through a legend entry on click and leaves others untouched', async () => {
+    vi.mocked(usageSeries).mockImplementation(async (_from, _to, _bucket, group) =>
+      group === 'provider' ? [providerPoint] : [],
+    )
+    vi.mocked(usageTotals).mockImplementation(async (_from, _to, group) =>
+      group === 'provider' ? [providerTotal] : [],
+    )
+    renderPage()
+
+    const chart = (await screen.findByText('Cost by provider')).closest('section')
+    if (!chart) throw new Error('chart section not found')
+    // The legend renders inside an SVG <li>/<span>, distinct from the
+    // "By provider"-style breakdown table, which never emits a plain
+    // element with an empty className — the legend text node does.
+    const legendEntry = within(chart)
+      .getAllByText('openai')
+      .find((el) => el.className === '')
+    if (!legendEntry) throw new Error('legend entry not found')
+
+    expect(legendEntry).not.toHaveStyle({ textDecoration: 'line-through' })
+    fireEvent.click(legendEntry)
+    await waitFor(() => expect(legendEntry).toHaveStyle({ textDecoration: 'line-through' }))
+
+    // Clicking again restores it — the toggle is reversible.
+    fireEvent.click(legendEntry)
+    await waitFor(() => expect(legendEntry).not.toHaveStyle({ textDecoration: 'line-through' }))
+  })
+
+  it('toggles the tokens-in/out legend independently of the cost chart', async () => {
+    renderPage()
+    const chart = (await screen.findByText('Tokens in / out')).closest('section')
+    if (!chart) throw new Error('chart section not found')
+    const inputEntry = within(chart)
+      .getAllByText('input')
+      .find((el) => el.className === '')
+    if (!inputEntry) throw new Error('legend entry not found')
+
+    fireEvent.click(inputEntry)
+    await waitFor(() => expect(inputEntry).toHaveStyle({ textDecoration: 'line-through' }))
+    // The sibling "output" entry in the same legend is untouched.
+    const outputEntry = within(chart)
+      .getAllByText('output')
+      .find((el) => el.className === '')
+    expect(outputEntry).not.toHaveStyle({ textDecoration: 'line-through' })
+  })
+})
+
+describe('Analytics zero-cost exclusion', () => {
+  const freeModelPoint: UsagePoint = {
+    bucket: '2026-07-24T00:00:00Z',
+    group: 'local-llama',
+    cost_usd: 0,
+    input_tokens: 5_000,
+    output_tokens: 2_000,
+    requests: 2,
+    errors: 0,
+    unpriced_input_tokens: 0,
+    unpriced_output_tokens: 0,
+  }
+  const freeModelTotal: GroupTotal = {
+    group: 'local-llama',
+    cost_usd: 0,
+    input_tokens: 5_000,
+    output_tokens: 2_000,
+    requests: 2,
+    unpriced_input_tokens: 0,
+    unpriced_output_tokens: 0,
+  }
+  const pricedModelPoint: UsagePoint = { ...providerPoint, group: 'gpt-5.6-sol' }
+  const pricedModelTotal: GroupTotal = { ...providerTotal, group: 'gpt-5.6-sol' }
+
+  it('excludes a zero-cost provider from the cost table but keeps it in token views', async () => {
+    vi.mocked(usageTotals).mockImplementation(async (_from, _to, group) =>
+      group === 'provider' ? [freeModelTotal, providerTotal] : [],
+    )
+    vi.mocked(usageSeries).mockImplementation(async (_from, _to, _bucket, group) =>
+      group === 'model' ? [freeModelPoint, pricedModelPoint] : [],
+    )
+    renderPage()
+
+    const providerTable = (await screen.findByText('Provider cost breakdown')).closest('section')
+    if (!providerTable) throw new Error('provider cost table not found')
+    expect(within(providerTable).queryByText('local-llama')).toBeNull()
+    expect(within(providerTable).getByText('openai')).toBeInTheDocument()
+
+    // Same model, token-consumption chart: the free model's volume is
+    // exactly the signal this chart exists to show, so it must render.
+    const tokenChart = (await screen.findByText('Token consumption per model')).closest('section')
+    if (!tokenChart) throw new Error('token chart section not found')
+    expect(within(tokenChart).getByText('local-llama in')).toBeInTheDocument()
+  })
+
+  it('excludes a zero-cost model from the cost-by-model chart', async () => {
+    vi.mocked(usageTotals).mockImplementation(async (_from, _to, group) =>
+      group === 'model' ? [freeModelTotal, pricedModelTotal] : [],
+    )
+    vi.mocked(usageSeries).mockImplementation(async (_from, _to, _bucket, group) =>
+      group === 'model' ? [freeModelPoint, pricedModelPoint] : [],
+    )
+    renderPage()
+
+    const modelCostChart = (await screen.findByText('Cost by model')).closest('section')
+    if (!modelCostChart) throw new Error('model cost chart section not found')
+    expect(within(modelCostChart).queryByText('local-llama')).toBeNull()
+    expect(within(modelCostChart).getByText('gpt-5.6-sol')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -19,10 +19,12 @@ import {
   usageSeries,
   usageSessions,
   usageSummary,
+  usageTotals,
 } from '../api/client'
 import type {
   BudgetStatus,
   CacheRow,
+  GroupTotal,
   LatencyRow,
   SessionUsage,
   UsagePoint,
@@ -65,6 +67,8 @@ interface Loaded {
   byProvider: UsagePoint[]
   byModel: UsagePoint[]
   byRoute: UsagePoint[]
+  providerTotals: GroupTotal[]
+  modelTotals: GroupTotal[]
   sessions: SessionUsage[]
   latency: LatencyRow[]
   cache: CacheRow[]
@@ -72,11 +76,16 @@ interface Loaded {
 }
 
 // pivot turns (bucket, group) points into recharts rows keyed by
-// bucket with one column per group.
-function pivot(points: UsagePoint[], metric: (p: UsagePoint) => number) {
-  const groups = [...new Set(points.map((p) => p.group))]
+// bucket with one column per group. onlyGroups, when given, restricts
+// both the emitted columns and the rows' contents to that set — how
+// zero-cost groups get excluded from cost charts without touching the
+// token charts fed by the same series.
+function pivot(points: UsagePoint[], metric: (p: UsagePoint) => number, onlyGroups?: Set<string>) {
+  const allGroups = [...new Set(points.map((p) => p.group))]
+  const groups = onlyGroups ? allGroups.filter((g) => onlyGroups.has(g)) : allGroups
   const rows = new Map<string, Record<string, number | string>>()
   for (const p of points) {
+    if (onlyGroups && !onlyGroups.has(p.group)) continue
     const key = p.bucket
     const row = rows.get(key) ?? { bucket: key }
     row[p.group] = ((row[p.group] as number) ?? 0) + metric(p)
@@ -104,6 +113,28 @@ const bucketLabel = (iso: string, bucket: string) => {
   return bucket === 'hour'
     ? d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
     : d.toLocaleDateString([], { month: 'short', day: 'numeric' })
+}
+
+// useHiddenKeys backs a chart's selectable legend: clicking an entry
+// toggles its data key out of the rendered series (and struck-through
+// in the legend itself) rather than filtering the underlying data.
+function useHiddenKeys() {
+  const [hidden, setHidden] = useState<Set<string>>(new Set())
+  const onLegendClick = (entry: { dataKey?: unknown }) => {
+    const key = String(entry.dataKey ?? '')
+    if (!key) return
+    setHidden((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+  const legendFormatter = (value: string, entry: { dataKey?: unknown }) => {
+    const key = String(entry.dataKey ?? value)
+    return <span style={{ textDecoration: hidden.has(key) ? 'line-through' : 'none' }}>{value}</span>
+  }
+  return { hidden, onLegendClick, legendFormatter }
 }
 
 export function Analytics() {
@@ -141,6 +172,8 @@ export function Analytics() {
       usageSeries(from, to, bucket, 'provider'),
       usageSeries(from, to, bucket, 'model'),
       usageSeries(from, to, bucket, 'route'),
+      usageTotals(from, to, 'provider'),
+      usageTotals(from, to, 'model'),
       usageSessions(from, to, 10),
       usageLatency(from, to),
       usageCache(from, to),
@@ -159,10 +192,12 @@ export function Analytics() {
         byProvider: val(results[3], []),
         byModel: val(results[4], []),
         byRoute: val(results[5], []),
-        sessions: val(results[6], []),
-        latency: val(results[7], []),
-        cache: val(results[8], []),
-        budget: val<BudgetStatus | null>(results[9], null),
+        providerTotals: val(results[6], []),
+        modelTotals: val(results[7], []),
+        sessions: val(results[8], []),
+        latency: val(results[9], []),
+        cache: val(results[10], []),
+        budget: val<BudgetStatus | null>(results[11], null),
       })
     })
     return () => {
@@ -171,9 +206,28 @@ export function Analytics() {
   }, [range])
 
   const { bucket } = rangeDates(range)
-  const cost = useMemo(
-    () => (data ? pivot(data.byProvider, (p) => p.cost_usd) : { groups: [], rows: [] }),
+
+  const costLegend = useHiddenKeys()
+  const tokensLegend = useHiddenKeys()
+  const modelCostLegend = useHiddenKeys()
+  const modelTokensLegend = useHiddenKeys()
+
+  // Zero-cost groups (unpriced NULL rows and genuinely-free providers
+  // like local Ollama) add no signal to a cost view — excluded from
+  // the provider/model cost tables and bar charts, but never from
+  // token charts fed by the same series.
+  const pricedProviders = useMemo(
+    () => new Set((data?.providerTotals ?? []).filter((g) => g.cost_usd > 0).map((g) => g.group)),
     [data],
+  )
+  const pricedModels = useMemo(
+    () => new Set((data?.modelTotals ?? []).filter((g) => g.cost_usd > 0).map((g) => g.group)),
+    [data],
+  )
+
+  const cost = useMemo(
+    () => (data ? pivot(data.byProvider, (p) => p.cost_usd, pricedProviders) : { groups: [], rows: [] }),
+    [data, pricedProviders],
   )
   const tokens = useMemo(() => {
     if (!data) return []
@@ -185,6 +239,35 @@ export function Analytics() {
       byBucket.set(p.bucket, row)
     }
     return [...byBucket.values()]
+  }, [data])
+
+  const modelCost = useMemo(
+    () => (data ? pivot(data.byModel, (p) => p.cost_usd, pricedModels) : { groups: [], rows: [] }),
+    [data, pricedModels],
+  )
+  const modelTokens = useMemo(() => {
+    if (!data) return { groups: [], rows: [] }
+    const inputSeries = pivot(data.byModel, (p) => p.input_tokens)
+    const outputByBucket = new Map<string, Record<string, number>>()
+    for (const p of data.byModel) {
+      const row = outputByBucket.get(p.bucket) ?? {}
+      row[p.group] = (row[p.group] ?? 0) + p.output_tokens
+      outputByBucket.set(p.bucket, row)
+    }
+    // Suffix output columns so a stacked bar can show both input and
+    // output per model without one key clobbering the other.
+    const rows = inputSeries.rows.map((row) => {
+      const bucketKey = String(row.bucket)
+      const out = outputByBucket.get(bucketKey) ?? {}
+      const merged: Record<string, number | string> = { bucket: bucketKey }
+      for (const g of inputSeries.groups) {
+        merged[`${g} in`] = (row[g] as number) ?? 0
+        merged[`${g} out`] = out[g] ?? 0
+      }
+      return merged
+    })
+    const groups = inputSeries.groups.flatMap((g) => [`${g} in`, `${g} out`])
+    return { groups, rows }
   }, [data])
 
   // Advisory estimates for calls the ledger recorded without a price
@@ -332,9 +415,19 @@ export function Analytics() {
                     labelFormatter={(v) => bucketLabel(String(v), bucket)}
                     formatter={(v) => money(Number(v))}
                   />
-                  <Legend wrapperStyle={{ fontSize: 12 }} />
+                  <Legend
+                    wrapperStyle={{ fontSize: 12 }}
+                    onClick={costLegend.onLegendClick}
+                    formatter={costLegend.legendFormatter}
+                  />
                   {cost.groups.map((g, i) => (
-                    <Bar key={g} dataKey={g} stackId="cost" fill={palette[i % palette.length]} />
+                    <Bar
+                      key={g}
+                      dataKey={g}
+                      stackId="cost"
+                      fill={palette[i % palette.length]}
+                      hide={costLegend.hidden.has(g)}
+                    />
                   ))}
                 </BarChart>
               </ResponsiveContainer>
@@ -358,47 +451,146 @@ export function Analytics() {
                     labelFormatter={(v) => bucketLabel(String(v), bucket)}
                     formatter={(v) => compact(Number(v))}
                   />
-                  <Legend wrapperStyle={{ fontSize: 12 }} />
-                  <Line type="monotone" dataKey="input" stroke={palette[0]} dot={false} strokeWidth={2} />
-                  <Line type="monotone" dataKey="output" stroke={palette[2]} dot={false} strokeWidth={2} />
+                  <Legend
+                    wrapperStyle={{ fontSize: 12 }}
+                    onClick={tokensLegend.onLegendClick}
+                    formatter={tokensLegend.legendFormatter}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="input"
+                    stroke={palette[0]}
+                    dot={false}
+                    strokeWidth={2}
+                    hide={tokensLegend.hidden.has('input')}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="output"
+                    stroke={palette[2]}
+                    dot={false}
+                    strokeWidth={2}
+                    hide={tokensLegend.hidden.has('output')}
+                  />
                 </LineChart>
               </ResponsiveContainer>
             </div>
           </section>
         </div>
 
-        <div className="mt-6 grid gap-6 lg:grid-cols-3">
-          <BreakdownTable title="By model" rows={data ? totals(data.byModel) : []} estimates={estimates} />
-          <BreakdownTable title="By route" rows={data ? totals(data.byRoute) : []} />
+        <div className="mt-6 grid gap-6 lg:grid-cols-2">
           <section className="rounded-xl border border-border p-4">
-            <h2 className="text-sm font-medium">Top sessions by cost</h2>
-            <table className="mt-3 w-full text-sm">
-              <tbody>
-                {(data?.sessions ?? []).map((sess) => (
-                  <tr key={sess.session_id} className="border-t border-border/60">
-                    <td className="py-2 pr-2">
-                      <Link
-                        to={`/chat/${sess.session_id}`}
-                        className="block max-w-40 truncate text-blue-600 hover:underline dark:text-blue-400"
-                      >
-                        {sess.session_id.slice(0, 8)}…
-                      </Link>
-                    </td>
-                    <td className="py-2 text-right text-muted-foreground">{sess.requests} req</td>
-                    <td className="py-2 text-right font-medium">{money(sess.cost_usd)}</td>
-                  </tr>
-                ))}
-                {data && data.sessions.length === 0 && (
-                  <tr>
-                    <td className="py-6 text-center text-muted-foreground">
-                      No session spend in range.
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
+            <h2 className="text-sm font-medium">Cost by model</h2>
+            <div className="mt-3 h-64">
+              <ResponsiveContainer>
+                <BarChart data={modelCost.rows}>
+                  <CartesianGrid strokeOpacity={0.12} vertical={false} />
+                  <XAxis
+                    dataKey="bucket"
+                    tickFormatter={(v: string) => bucketLabel(v, bucket)}
+                    {...axis}
+                  />
+                  <YAxis tickFormatter={(v: number) => money(v)} width={70} {...axis} />
+                  <Tooltip
+                    contentStyle={tooltipStyle}
+                    labelFormatter={(v) => bucketLabel(String(v), bucket)}
+                    formatter={(v) => money(Number(v))}
+                  />
+                  <Legend
+                    wrapperStyle={{ fontSize: 12 }}
+                    onClick={modelCostLegend.onLegendClick}
+                    formatter={modelCostLegend.legendFormatter}
+                  />
+                  {modelCost.groups.map((g, i) => (
+                    <Bar
+                      key={g}
+                      dataKey={g}
+                      stackId="modelCost"
+                      fill={palette[i % palette.length]}
+                      hide={modelCostLegend.hidden.has(g)}
+                    />
+                  ))}
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+            {modelCost.groups.length === 0 && data && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                No priced model usage in range (free/unpriced models are excluded from cost views).
+              </p>
+            )}
+          </section>
+
+          <section className="rounded-xl border border-border p-4">
+            <h2 className="text-sm font-medium">Token consumption per model</h2>
+            <div className="mt-3 h-64">
+              <ResponsiveContainer>
+                <BarChart data={modelTokens.rows}>
+                  <CartesianGrid strokeOpacity={0.12} vertical={false} />
+                  <XAxis
+                    dataKey="bucket"
+                    tickFormatter={(v: string) => bucketLabel(v, bucket)}
+                    {...axis}
+                  />
+                  <YAxis tickFormatter={(v: number) => compact(v)} width={55} {...axis} />
+                  <Tooltip
+                    contentStyle={tooltipStyle}
+                    labelFormatter={(v) => bucketLabel(String(v), bucket)}
+                    formatter={(v) => compact(Number(v))}
+                  />
+                  <Legend
+                    wrapperStyle={{ fontSize: 12 }}
+                    onClick={modelTokensLegend.onLegendClick}
+                    formatter={modelTokensLegend.legendFormatter}
+                  />
+                  {modelTokens.groups.map((g, i) => (
+                    <Bar
+                      key={g}
+                      dataKey={g}
+                      stackId="modelTokens"
+                      fill={palette[i % palette.length]}
+                      hide={modelTokensLegend.hidden.has(g)}
+                    />
+                  ))}
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
           </section>
         </div>
+
+        <div className="mt-6 grid gap-6 lg:grid-cols-3">
+          <ProviderCostTable rows={data?.providerTotals ?? []} />
+          <BreakdownTable title="By model" rows={data ? totals(data.byModel) : []} estimates={estimates} />
+          <BreakdownTable title="By route" rows={data ? totals(data.byRoute) : []} />
+        </div>
+
+        <section className="mt-6 rounded-xl border border-border p-4">
+          <h2 className="text-sm font-medium">Top sessions by cost</h2>
+          <table className="mt-3 w-full text-sm">
+            <tbody>
+              {(data?.sessions ?? []).map((sess) => (
+                <tr key={sess.session_id} className="border-t border-border/60">
+                  <td className="py-2 pr-2">
+                    <Link
+                      to={`/chat/${sess.session_id}`}
+                      className="block max-w-40 truncate text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      {sess.session_id.slice(0, 8)}…
+                    </Link>
+                  </td>
+                  <td className="py-2 text-right text-muted-foreground">{sess.requests} req</td>
+                  <td className="py-2 text-right font-medium">{money(sess.cost_usd)}</td>
+                </tr>
+              ))}
+              {data && data.sessions.length === 0 && (
+                <tr>
+                  <td className="py-6 text-center text-muted-foreground">
+                    No session spend in range.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </section>
 
         <section className="mt-6 rounded-xl border border-border p-4">
           <h2 className="text-sm font-medium">Latency per provider</h2>
@@ -473,6 +665,87 @@ function BreakdownTable({
           {rows.length === 0 && (
             <tr>
               <td className="py-6 text-center text-muted-foreground">Nothing in range.</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </section>
+  )
+}
+
+type SortKey = 'group' | 'cost_usd' | 'requests'
+
+// ProviderCostTable is the sortable "cost by provider" table backed by
+// usageTotals — the non-time-bucketed sibling of the stacked bar chart
+// above it. Zero-cost providers (unpriced NULL rows tallied elsewhere,
+// or a genuinely free local model) are excluded: they add no signal to
+// a cost ranking.
+function ProviderCostTable({ rows }: { rows: GroupTotal[] }) {
+  const [sortKey, setSortKey] = useState<SortKey>('cost_usd')
+  const [asc, setAsc] = useState(false)
+
+  const priced = useMemo(() => rows.filter((r) => r.cost_usd > 0), [rows])
+  const totalCost = useMemo(() => priced.reduce((n, r) => n + r.cost_usd, 0), [priced])
+  const sorted = useMemo(() => {
+    const copy = [...priced]
+    copy.sort((a, b) => {
+      const dir = asc ? 1 : -1
+      if (sortKey === 'group') return a.group.localeCompare(b.group) * dir
+      return (a[sortKey] - b[sortKey]) * dir
+    })
+    return copy
+  }, [priced, sortKey, asc])
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sortKey) setAsc((a) => !a)
+    else {
+      setSortKey(key)
+      setAsc(false)
+    }
+  }
+
+  const sortIndicator = (key: SortKey) => (sortKey === key ? (asc ? ' ▲' : ' ▼') : '')
+
+  return (
+    <section className="rounded-xl border border-border p-4">
+      <h2 className="text-sm font-medium">Provider cost breakdown</h2>
+      <table className="mt-3 w-full text-sm">
+        <thead>
+          <tr className="text-left text-xs text-muted-foreground">
+            <th className="cursor-pointer pb-2 font-medium" onClick={() => toggleSort('group')}>
+              Provider{sortIndicator('group')}
+            </th>
+            <th
+              className="cursor-pointer pb-2 text-right font-medium"
+              onClick={() => toggleSort('requests')}
+            >
+              Requests{sortIndicator('requests')}
+            </th>
+            <th
+              className="cursor-pointer pb-2 text-right font-medium"
+              onClick={() => toggleSort('cost_usd')}
+            >
+              Cost{sortIndicator('cost_usd')}
+            </th>
+            <th className="pb-2 text-right font-medium">% of total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((r) => (
+            <tr key={r.group} className="border-t border-border/60">
+              <td className="max-w-28 truncate py-2 pr-2">{r.group}</td>
+              <td className="py-2 text-right text-muted-foreground">{compact(r.requests)}</td>
+              <td className="py-2 text-right font-medium">{money(r.cost_usd)}</td>
+              <td className="py-2 text-right text-muted-foreground">
+                {totalCost > 0 ? `${((r.cost_usd / totalCost) * 100).toFixed(0)}%` : '—'}
+              </td>
+            </tr>
+          ))}
+          {sorted.length === 0 && (
+            <tr>
+              <td colSpan={4} className="py-6 text-center text-muted-foreground">
+                Nothing in range.
+              </td>
             </tr>
           )}
         </tbody>


### PR DESCRIPTION
## Summary
- New `Aggregator.Totals` (gateway ledger) + `GET /internal/admin/usage/totals?group=` — non-time-bucketed per-group totals, sibling of the existing bucketed `Series`.
- Analytics page: sortable "Provider cost breakdown" table alongside the existing cost-by-provider chart, new "Cost by model" chart, new "Token consumption per model" chart.
- Zero-cost/unpriced providers and models excluded from cost views (table + both cost charts); token views keep them, since volume is the signal there.
- Click-to-toggle legends on all four charts (the two new ones and the two pre-existing ones), via a `hide` prop toggle so Recharts' legend stays clickable.

## Test plan
- [x] `go build/vet/test ./...` clean
- [x] `npm run build` clean
- [x] `npm run lint` clean (7 pre-existing warnings, unrelated)
- [x] `npm test -- --run` — 356/358 passed; 2 failures are the pre-existing `AgentRoutePicker` timing flake (fails identically on unmodified main under full-suite load)