### PR TITLE
fix(missions): periodically re-drive stale working missions

### DIFF
--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -673,3 +673,34 @@ func (s *Store) RecoverWorking(ctx context.Context) ([]Mission, error) {
 	}
 	return out, rows.Err()
 }
+
+// RecoverStaleWorking returns status='working' missions whose updated_at
+// is older than staleAfter — the periodic sweep's input. A mission stays
+// 'working' across every retry-eligible turn (stepWorkerFailed leaves
+// status untouched below the backoff threshold), so Drive's own
+// in-process loop is normally what keeps it moving; this is the backstop
+// for the rare case that loop stops advancing without a crash (no
+// process restart, so RecoverWorking's boot-only pass never sees it) —
+// same re-Drive path, just periodic and staleness-gated so it never
+// interferes with a mission genuinely mid-turn.
+func (s *Store) RecoverStaleWorking(ctx context.Context, staleAfter time.Duration) ([]Mission, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("missions recover stale working: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT `+missionColumns+` FROM missions
+		WHERE status = 'working' AND updated_at < now() - $1::interval`, staleAfter)
+	if err != nil {
+		return nil, fmt.Errorf("missions recover stale working: %w", err)
+	}
+	defer rows.Close()
+	out := []Mission{}
+	for rows.Next() {
+		m, err := scanMission(rows)
+		if err != nil {
+			return nil, fmt.Errorf("missions recover stale working: %w", err)
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -623,3 +623,46 @@ func TestRecoverWorking(t *testing.T) {
 		t.Fatal("RecoverWorking incorrectly returned an idle mission")
 	}
 }
+
+func TestRecoverStaleWorking(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	freshID, err := s.Create(ctx, Mission{Goal: marker + "stale-fresh", Kind: "research"})
+	if err != nil {
+		t.Fatalf("Create fresh: %v", err)
+	}
+	if err := s.ApplyTransition(ctx, freshID, Transition{Next: StepState{Phase: PhaseExecute, Status: StatusWorking}}); err != nil {
+		t.Fatalf("ApplyTransition fresh: %v", err)
+	}
+
+	staleID, err := s.Create(ctx, Mission{Goal: marker + "stale-old", Kind: "research"})
+	if err != nil {
+		t.Fatalf("Create stale: %v", err)
+	}
+	if err := s.ApplyTransition(ctx, staleID, Transition{Next: StepState{Phase: PhaseExecute, Status: StatusWorking}}); err != nil {
+		t.Fatalf("ApplyTransition stale: %v", err)
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("db.Get: %v", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE missions SET updated_at = now() - interval '1 hour' WHERE id = $1`, staleID); err != nil {
+		t.Fatalf("backdate updated_at: %v", err)
+	}
+
+	stale, err := s.RecoverStaleWorking(ctx, 15*time.Minute)
+	if err != nil {
+		t.Fatalf("RecoverStaleWorking: %v", err)
+	}
+	byID := map[string]bool{}
+	for _, m := range stale {
+		byID[m.ID] = true
+	}
+	if !byID[staleID] {
+		t.Fatal("RecoverStaleWorking did not return the stale mission")
+	}
+	if byID[freshID] {
+		t.Fatal("RecoverStaleWorking incorrectly returned a fresh working mission")
+	}
+}

--- a/internal/brain/missions/sweep.go
+++ b/internal/brain/missions/sweep.go
@@ -8,8 +8,17 @@ import (
 
 // workSlotSweepInterval is how often the idle-over-cap sweep retries
 // claiming a work slot for missions parked idle because the
-// concurrency cap was full when they last tried.
+// concurrency cap was full when they last tried, and how often the
+// stale-working sweep below checks for a mission whose Drive loop
+// stopped advancing without a crash.
 const workSlotSweepInterval = 30 * time.Second
+
+// staleWorkingAfter bounds how long a 'working' mission may go without a
+// turn before the periodic sweep re-Drives it — well above any observed
+// legit single-turn duration (the slowest logged this project: ~9.4min,
+// a remote-model turn), so this never fires on a mission genuinely
+// mid-turn, only one whose Drive loop has actually stopped.
+const staleWorkingAfter = 15 * time.Minute
 
 // recoverWorkingRetries and recoverWorkingRetryDelay bound the boot
 // recovery pass's tolerance for Postgres not yet accepting connections
@@ -106,7 +115,8 @@ func recoverWorking(ctx context.Context, d *Driver, store *Store, log *slog.Logg
 
 // runWorkSlotSweep retries missions parked idle over the work-slot cap
 // every workSlotSweepInterval via ClaimWorkSlot, kicking off a Drive
-// for whichever gets claimed, and sweeps orphaned sandbox containers on
+// for whichever gets claimed, sweeps orphaned sandbox containers, and
+// re-Drives any 'working' mission stale past staleWorkingAfter — all on
 // the same tick. Runs until ctx is done — this call blocks, so
 // RecoverAndSweep's caller runs it in its own goroutine.
 func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, log *slog.Logger) {
@@ -118,6 +128,7 @@ func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurren
 			return
 		case <-ticker.C:
 			sweepOrphanSandboxes(ctx, store, sandbox, log)
+			reDriveStaleWorking(ctx, d, store, log)
 			id, ok, err := store.ClaimWorkSlot(ctx, maxConcurrent)
 			if err != nil {
 				log.Error("work slot sweep: claim failed", "error", err)
@@ -132,5 +143,26 @@ func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurren
 				}
 			}(id)
 		}
+	}
+}
+
+// reDriveStaleWorking re-Drives any mission RecoverStaleWorking reports.
+// Safe to call on a mission that is, in fact, still being actively
+// Driven: Driver.claimDriving makes a second concurrent Drive for the
+// same id a no-op, so this can never race or duplicate a live turn — it
+// only ever rescues a genuinely stopped loop.
+func reDriveStaleWorking(ctx context.Context, d *Driver, store *Store, log *slog.Logger) {
+	missions, err := store.RecoverStaleWorking(ctx, staleWorkingAfter)
+	if err != nil {
+		log.Error("stale working sweep: list failed", "error", err)
+		return
+	}
+	for _, m := range missions {
+		log.Warn("stale working sweep: re-driving a mission whose Drive loop stopped advancing", "mission_id", m.ID)
+		go func(id string) {
+			if err := d.Drive(ctx, id); err != nil {
+				log.Error("stale working sweep: drive failed", "mission_id", id, "error", err)
+			}
+		}(m.ID)
 	}
 }


### PR DESCRIPTION
## Summary
- New `Store.RecoverStaleWorking(ctx, staleAfter)` — status='working' missions whose `updated_at` predates the threshold.
- Wired into the existing `runWorkSlotSweep` tick (every 30s): any mission stuck in `working` past 15 minutes gets re-Driven.
- Backstop for a real observed bug: a mission's `Drive` loop stopped advancing after one retry-eligible `worker_failed` turn — no crash, no panic, no process restart, so boot-time `RecoverWorking` never saw it. Root cause of the loop itself stopping is still open; this bounds the damage instead of leaving affected missions stuck indefinitely.
- Safe against a mission that's genuinely still mid-turn: `Driver.claimDriving` makes a concurrent `Drive` call for the same id a no-op.
- 15-minute threshold chosen well above the slowest observed single legit turn this project (~9.4min, a remote-model call).

## Test plan
- [x] `go build/vet/test ./...` clean
- [x] `make test-integration` — `internal/brain/missions` package passes clean including new `TestRecoverStaleWorking`; unrelated pre-existing failures in gateway/router (dev-DB bedrock config, not touched by this change)
- [x] `make canary` PASS