### PR TITLE
feat(web): add delete option for terminal missions

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -838,6 +838,10 @@ export async function cancelMission(id: string): Promise<void> {
   await request<void>(`/v1/missions/${id}/cancel`, { method: 'POST' })
 }
 
+export async function deleteMission(id: string): Promise<void> {
+  await request<void>(`/v1/missions/${id}`, { method: 'DELETE' })
+}
+
 export async function answerMissionPermission(
   id: string,
   decision: 'once' | 'session' | 'deny',

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Mission, MissionEvent } from '../api/types'
@@ -14,6 +14,7 @@ vi.mock('../api/client', () => ({
   missionUsage: vi.fn(),
   resumeMission: vi.fn(),
   cancelMission: vi.fn(),
+  deleteMission: vi.fn(),
   answerMissionPermission: vi.fn(),
   listMissionFiles: vi.fn(),
   listSchedules: vi.fn(),
@@ -27,6 +28,7 @@ vi.mock('../api/client', () => ({
 import {
   answerMissionPermission,
   cancelMission,
+  deleteMission,
   getMission,
   listConnectors,
   listMissionFiles,
@@ -114,6 +116,7 @@ function renderPage(id = 'm1') {
     <MemoryRouter initialEntries={[`/missions/${id}`]}>
       <Routes>
         <Route path="/missions/:id" element={<MissionDetail />} />
+        <Route path="/missions" element={<div>Missions list</div>} />
       </Routes>
     </MemoryRouter>,
   )
@@ -308,6 +311,23 @@ describe('MissionDetail', () => {
     await screen.findByText('Fix the login bug')
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
     await waitFor(() => expect(cancelMission).toHaveBeenCalledWith('m1'))
+  })
+
+  it('hides delete for a non-terminal mission', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull()
+  })
+
+  it('shows delete for a done mission and deletes on confirm', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, phase: 'done', status: 'done' })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(deleteMission).toHaveBeenCalledWith('m1'))
+    await screen.findByText('Missions list')
   })
 
   it('shows the push branch button for a coding mission with a branch', async () => {

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -1,11 +1,12 @@
 import { ArrowLeft01Icon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Link, useParams } from 'react-router'
+import { Link, useNavigate, useParams } from 'react-router'
 import { toast } from 'sonner'
 import {
   answerMissionPermission,
   cancelMission,
+  deleteMission,
   getMission,
   listSchedules,
   missionEvents,
@@ -21,6 +22,13 @@ import { PushBranchDialog } from '../components/missions/PushBranchDialog'
 import { TimelineSection } from '../components/missions/TimelineSection'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../components/ui/dialog'
 import { errText } from '../components/settings/util'
 import { describeCron } from '../lib/schedules'
 import { playAlertSound } from '../lib/alertSound'
@@ -36,12 +44,14 @@ const terminalPhases = new Set(['done', 'failed'])
 
 export function MissionDetail() {
   const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
   const [mission, setMission] = useState<Mission | null>(null)
   const [events, setEvents] = useState<MissionEvent[]>([])
   const [usage, setUsage] = useState<MissionUsage | null>(null)
   const [schedule, setSchedule] = useState<Schedule | null>(null)
   const [busy, setBusy] = useState(false)
   const [pushOpen, setPushOpen] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
 
   const refresh = useCallback(() => {
     if (!id) return
@@ -148,6 +158,18 @@ export function MissionDetail() {
     }
   }
 
+  const remove = async () => {
+    setBusy(true)
+    try {
+      await deleteMission(id)
+      toast.success('Mission deleted')
+      navigate('/missions')
+    } catch (err) {
+      toast.error('Could not delete mission', { description: errText(err) })
+      setBusy(false)
+    }
+  }
+
   const decidePermission = async (decision: 'once' | 'session' | 'deny') => {
     try {
       await answerMissionPermission(id, decision)
@@ -220,9 +242,33 @@ export function MissionDetail() {
                 Cancel
               </Button>
             )}
+            {terminalPhases.has(mission.phase) && (
+              <Button variant="destructive" disabled={busy} onClick={() => setConfirmDelete(true)}>
+                Delete
+              </Button>
+            )}
           </div>
         </div>
       </div>
+
+      <Dialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete this mission?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            This removes the mission, its events, and its workspace. This cannot be undone.
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmDelete(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" disabled={busy} onClick={() => void remove()}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {usage && usage.requests > 0 && (
         <section>


### PR DESCRIPTION
## Summary
- Mission detail page gets a Delete button next to Cancel, visible only for terminal missions (done/failed) — matches the backend's existing `Store.Delete` invariant, which refuses non-terminal ones.
- Confirm dialog (same shape as the recurring-schedules delete flow) before calling `DELETE /v1/missions/{id}`.
- On success, navigates back to `/missions`.

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm test -- --run` — 360/362 passed (2 pre-existing `AgentRoutePicker` flake, unrelated)