### PR TITLE
fix(missions): unit_verified on review approval was rendered as failed

### DIFF
--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -309,7 +309,7 @@ func stepReviewApprove(s StepState) Transition {
 	s.Status = StatusIdle
 	s.Iteration = 0
 	s.ConsecutiveFailures = 0
-	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.unit_verified"}}}
+	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.unit_verified", Payload: map[string]any{"passed": true, "check": "review"}}}}
 }
 
 // stepReviewRework sends the mission back to execute for another

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -230,6 +230,26 @@ func TestStep(t *testing.T) {
 	}
 }
 
+// TestStepReviewApproveEmitsPassedTrue guards against the web
+// timeline rendering an approved unit as "failed": stepReviewApprove
+// only ever fires on approval, so its mission.unit_verified event must
+// carry passed=true rather than an empty payload (which the renderer
+// treats as false).
+func TestStepReviewApproveEmitsPassedTrue(t *testing.T) {
+	got := Step(
+		StepState{Phase: PhaseReview, Status: StatusWorking, LastUnit: false},
+		StepInput{Input: InputReviewApprove},
+		DefaultConfig,
+	)
+	if len(got.Events) != 1 || got.Events[0].Kind != "mission.unit_verified" {
+		t.Fatalf("Events = %+v, want exactly one mission.unit_verified event", got.Events)
+	}
+	passed, ok := got.Events[0].Payload["passed"].(bool)
+	if !ok || !passed {
+		t.Fatalf("Events[0].Payload = %+v, want passed=true", got.Events[0].Payload)
+	}
+}
+
 func TestParsePhase(t *testing.T) {
 	valid := []Phase{PhaseResearch, PhasePlan, PhaseExecute, PhaseReview, PhaseDone, PhaseFailed}
 	for _, p := range valid {

--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import type { MissionEvent } from '../../api/types'
+import { renderEvent } from './eventRenderers'
+
+function event(payload: unknown): MissionEvent {
+  return {
+    mission_id: 'm1',
+    seq: 1,
+    kind: 'mission.unit_verified',
+    payload,
+    provenance: 'harness',
+    created_at: '2026-01-01T00:00:00Z',
+  }
+}
+
+describe('mission.unit_verified rendering', () => {
+  it('names the unit when the payload carries an index', () => {
+    expect(renderEvent(event({ unit: 0, passed: true }))).toBe('Unit 0 verification: passed')
+    expect(renderEvent(event({ unit: 2, passed: false }))).toBe('Unit 2 verification: failed')
+  })
+
+  it('omits the unit index when the payload has none, rather than showing "Unit ?"', () => {
+    expect(renderEvent(event({ passed: true }))).toBe('Unit verification: passed')
+  })
+})

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -28,7 +28,8 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
   },
   'mission.unit_verified': (p) => {
     const { unit, passed } = asRecord(p)
-    return `Unit ${String(unit ?? '?')} verification: ${passed ? 'passed' : 'failed'}`
+    const label = unit != null ? `Unit ${String(unit)} verification` : 'Unit verification'
+    return `${label}: ${passed ? 'passed' : 'failed'}`
   },
   'mission.review_verdict': (p) => {
     const { decision } = asRecord(p)


### PR DESCRIPTION
## Summary
- `stepReviewApprove`'s `mission.unit_verified` event fired with no payload — the web timeline's renderer defaults `unit`/`passed` to fallback values when absent, so an approved unit displayed as "Unit ? verification: failed" even though this code path only runs on approval.
- Fixed at the source: the event now carries `passed: true`.
- Renderer also updated to say "Unit verification" (no bogus index) instead of "Unit ?" when the payload has no unit number — this path has no unit index available to report, unlike the other two `mission.unit_verified` call sites in driver.go.

## Test plan
- [x] `go build/vet/test ./internal/brain/missions/...` clean, new `TestStepReviewApproveEmitsPassedTrue`
- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm test -- --run` — 362/362 passed
- [x] `make canary` PASS