### PR TITLE
feat(chat): pdf attachments + detached turn lifetime

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -148,6 +148,9 @@ func main() {
 
 	searxngURL := os.Getenv("SEARXNG_URL")
 	markitdownURL := os.Getenv("MARKITDOWN_URL")
+	if markitdownURL == "" {
+		app.Log.Warn("MARKITDOWN_URL not set; PDF attachments in chat are unavailable")
+	}
 	whisperURL := os.Getenv("WHISPER_URL")
 	if whisperURL == "" {
 		app.Log.Warn("WHISPER_URL not set; the web mic button's /v1/transcribe endpoint is unavailable")
@@ -321,6 +324,9 @@ func main() {
 	// same guard shape as the missionHub check above.
 	if attachmentStore != nil {
 		svc.SetAttachments(attachmentStore)
+	}
+	if markitdownURL != "" {
+		svc.SetMarkitdown(markitdownURL)
 	}
 
 	api.Register(app.Server, svc, store, broker,

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -104,6 +104,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	srv.Handle("DELETE /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleDelete)))
 	srv.Handle("POST /v1/sessions/{id}/messages", a.auth(http.HandlerFunc(a.handleMessages)))
 	srv.Handle("POST /v1/sessions/{id}/messages/retry", a.auth(http.HandlerFunc(a.handleRetry)))
+	srv.Handle("POST /v1/sessions/{id}/stop", a.auth(http.HandlerFunc(a.handleStop)))
 	srv.Handle("POST /v1/permissions/{id}", a.auth(http.HandlerFunc(a.handlePermission)))
 	// Deprecated shim: same behavior, session_id in the body.
 	srv.Handle("POST /v1/chat", a.auth(http.HandlerFunc(a.handleChatShim)))
@@ -399,6 +400,25 @@ func (a *API) handleRetry(w http.ResponseWriter, r *http.Request) {
 	a.streamTurn(w, r, func(ctx context.Context) (string, <-chan stream.StreamEvent, error) {
 		return a.svc.Retry(ctx, sessionID)
 	})
+}
+
+// handleStop cancels sessionID's in-flight turn server-side (the turn
+// now runs detached from any one request, so a client-side abort alone
+// no longer stops it — see chat.Service.StopTurn). 404 "no_active_turn"
+// mirrors handleLive's framing for the identical "nothing here" case:
+// no turn running, whether because none was ever started or because it
+// already finished by the time this request lands.
+func (a *API) handleStop(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !validSessionID(id) {
+		jsonError(w, http.StatusNotFound, "not_found", "no such session")
+		return
+	}
+	if !a.svc.StopTurn(id) {
+		jsonError(w, http.StatusNotFound, "no_active_turn", "no turn is currently running for this session")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // meta is brain's terminal SSE event: session identity plus whatever

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -224,6 +224,7 @@ func mux(a *API) *http.ServeMux {
 	m.Handle("DELETE /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleDelete)))
 	m.Handle("POST /v1/sessions/{id}/messages", a.auth(http.HandlerFunc(a.handleMessages)))
 	m.Handle("POST /v1/sessions/{id}/messages/retry", a.auth(http.HandlerFunc(a.handleRetry)))
+	m.Handle("POST /v1/sessions/{id}/stop", a.auth(http.HandlerFunc(a.handleStop)))
 	m.Handle("POST /v1/permissions/{id}", a.auth(http.HandlerFunc(a.handlePermission)))
 	m.Handle("POST /v1/chat", a.auth(http.HandlerFunc(a.handleChatShim)))
 	return m

--- a/internal/brain/api/stop_test.go
+++ b/internal/brain/api/stop_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestStopEndpointInvalidSessionID confirms a malformed id 404s the
+// same way every other session-scoped route does (validSessionID),
+// without ever reaching chat.Service.
+func TestStopEndpointInvalidSessionID(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	w := doMux(a, http.MethodPost, "/v1/sessions/not-a-valid-id/stop", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("code = %d, want 404", w.Code)
+	}
+}
+
+// TestStopEndpointNoActiveTurn confirms an idle (but real) session
+// answers 404 no_active_turn — the same "nothing here" framing
+// handleLive uses for the identical case.
+func TestStopEndpointNoActiveTurn(t *testing.T) {
+	t.Parallel()
+	a, dir, _ := testAPI(t, "tok", nil)
+	id, _ := dir.Create(t.Context(), "t")
+
+	w := doMux(a, http.MethodPost, "/v1/sessions/"+id+"/stop", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("code = %d, want 404", w.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["error"] != "no_active_turn" {
+		t.Fatalf("error = %q, want no_active_turn", body["error"])
+	}
+}
+
+// TestStopEndpointStopsActiveTurn confirms POST .../stop cancels a
+// live turn: 204, TurnActive flips false without the fake gateway ever
+// being unblocked (StopTurn's cancel is what winds it down, not the
+// fake completing on its own), and the original POST /messages call
+// still returns normally once the turn's abnormal end persists.
+func TestStopEndpointStopsActiveTurn(t *testing.T) {
+	t.Parallel()
+	block := make(chan struct{})
+	a, dir, gw := testAPI(t, "tok", okEvents())
+	gw.blockCh = block
+	id, _ := dir.Create(t.Context(), "t")
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		done <- doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages", `{"message":"hello"}`)
+	}()
+	waitForTest(t, func() bool { return a.svc.TurnActive(id) })
+
+	w := doMux(a, http.MethodPost, "/v1/sessions/"+id+"/stop", "")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("stop code = %d, want 204; body=%s", w.Code, w.Body.String())
+	}
+
+	waitForTest(t, func() bool { return !a.svc.TurnActive(id) })
+
+	// The blocked send's own goroutine is still parked on <-block; the
+	// turn ending is StopTurn's cancel winding down the loop, not the
+	// fake gateway completing — closing block here just lets that now-
+	// orphaned goroutine exit so the test doesn't leak it.
+	close(block)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("original POST /messages never returned")
+	}
+
+	// Stopping again finds nothing live.
+	w = doMux(a, http.MethodPost, "/v1/sessions/"+id+"/stop", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("second stop code = %d, want 404 (turn already over)", w.Code)
+	}
+}

--- a/internal/brain/attachments/attachments.go
+++ b/internal/brain/attachments/attachments.go
@@ -1,7 +1,7 @@
-// Package attachments stores user-uploaded images content-addressed on
-// a local volume, with metadata only in Postgres — binaries never
-// enter the database (D-045). ATTACHMENTS_DIR unset means the feature
-// is off: callers nil-gate on a nil *Store.
+// Package attachments stores user-uploaded images and PDFs
+// content-addressed on a local volume, with metadata only in Postgres
+// — binaries never enter the database (D-045). ATTACHMENTS_DIR unset
+// means the feature is off: callers nil-gate on a nil *Store.
 package attachments
 
 import (
@@ -33,12 +33,13 @@ var ErrUnsupportedMIME = errors.New("attachments: unsupported mime type")
 var ErrNotFound = errors.New("attachments: not found")
 
 // allowedExt maps the sniffed MIME type to its stored file extension.
-// Only these four are accepted; anything else is ErrUnsupportedMIME.
+// Only these five are accepted; anything else is ErrUnsupportedMIME.
 var allowedExt = map[string]string{
-	"image/png":  ".png",
-	"image/jpeg": ".jpg",
-	"image/webp": ".webp",
-	"image/gif":  ".gif",
+	"image/png":       ".png",
+	"image/jpeg":      ".jpg",
+	"image/webp":      ".webp",
+	"image/gif":       ".gif",
+	"application/pdf": ".pdf",
 }
 
 // Attachment is one stored image's metadata.

--- a/internal/brain/attachments/attachments_integration_test.go
+++ b/internal/brain/attachments/attachments_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -49,6 +50,25 @@ func integrationStore(t *testing.T) *Store {
 		t.Fatalf("migrate: %v", err)
 	}
 	return New(t.TempDir(), pool)
+}
+
+// pdfBytes is a minimal PDF header — enough for http.DetectContentType
+// to sniff "application/pdf" (it only inspects the leading bytes).
+var pdfBytes = []byte("%PDF-1.4\n%\xe2\xe3\xcf\xd3\n1 0 obj\n<< /Type /Catalog >>\nendobj\n")
+
+func TestStoreSavePDF(t *testing.T) {
+	s := integrationStore(t)
+
+	att, err := s.Save(t.Context(), bytes.NewReader(pdfBytes))
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if att.Mime != "application/pdf" {
+		t.Fatalf("Mime = %q, want application/pdf", att.Mime)
+	}
+	if _, err := os.Stat(filepath.Join(s.dir, att.ID+".pdf")); err != nil {
+		t.Fatalf("expected %s.pdf on disk: %v", att.ID, err)
+	}
 }
 
 func TestStoreSaveDedup(t *testing.T) {

--- a/internal/brain/chat/attachments_test.go
+++ b/internal/brain/chat/attachments_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/SumonMSelim/timothy/internal/brain/attachments"
@@ -331,5 +333,104 @@ func TestRetryOfImageTurnStaysOnVisionRoute(t *testing.T) {
 	sent := gw.lastChatRequest()
 	if sent.Route != "vision" {
 		t.Fatalf("retried route = %q, want vision (persisted route replayed)", sent.Route)
+	}
+}
+
+// fakeMarkitdown returns an httptest server standing in for the
+// markitdown sidecar: /convert replies with a fixed markdown body,
+// same wire shape internal/platform/markitdown.Convert expects.
+func fakeMarkitdown(t *testing.T, markdown string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"markdown":"` + markdown + `"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestChatPDFAttachmentConvertsToDocument confirms a PDF attachment
+// ref is split away from images, converted through the markitdown
+// sidecar exactly once at send time, and lands as a DocumentRef on
+// the persisted user_message — the markdown persisted, not re-fetched.
+func TestChatPDFAttachmentConvertsToDocument(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("read your pdf")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("doc1", "application/pdf", []byte("%PDF-1.4 fake"))
+	svc.SetAttachments(fa)
+	md := fakeMarkitdown(t, "# Converted Title")
+	svc.SetMarkitdown(md.URL)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []string{"doc1"}})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+
+	events, _ := log.Events(t.Context(), "s1")
+	var um session.UserMessage
+	if err := json.Unmarshal(events[1].Payload, &um); err != nil {
+		t.Fatalf("decode user_message: %v", err)
+	}
+	if len(um.Images) != 0 {
+		t.Fatalf("images = %+v, want none (pdf only)", um.Images)
+	}
+	if len(um.Documents) != 1 || um.Documents[0].ID != "doc1" || um.Documents[0].Mime != "application/pdf" {
+		t.Fatalf("documents = %+v, want one ref to doc1/application/pdf", um.Documents)
+	}
+	if um.Documents[0].Markdown != "# Converted Title" {
+		t.Fatalf("markdown = %q, want converted markdown persisted", um.Documents[0].Markdown)
+	}
+}
+
+// TestChatPDFAttachmentWithoutMarkitdownIsBadRequest confirms a PDF
+// ref 400s when the sidecar isn't wired (MARKITDOWN_URL unset) —
+// SetMarkitdown never called, so s.markitdownURL stays "".
+func TestChatPDFAttachmentWithoutMarkitdownIsBadRequest(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	svc := newService(&fakeGW{}, log)
+	fa := newFakeAttachments()
+	fa.seed("doc1", "application/pdf", []byte("%PDF-1.4 fake"))
+	svc.SetAttachments(fa)
+	// SetMarkitdown intentionally not called.
+
+	_, _, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []string{"doc1"}})
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("err = %v, want ErrBadRequest", err)
+	}
+	if kinds := log.kinds("s1"); len(kinds) != 0 {
+		t.Fatalf("events appended despite missing markitdown wiring: %v", kinds)
+	}
+}
+
+// TestChatDocumentsOnlyMessageDoesNotFlipToVisionRoute confirms the
+// D-046 vision auto-flip stays keyed on images alone: a message
+// carrying only a PDF (converted to plain text) never rides the
+// vision chain.
+func TestChatDocumentsOnlyMessageDoesNotFlipToVisionRoute(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("read your pdf")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("doc1", "application/pdf", []byte("%PDF-1.4 fake"))
+	svc.SetAttachments(fa)
+	md := fakeMarkitdown(t, "converted text")
+	svc.SetMarkitdown(md.URL)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []string{"doc1"}})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	sent := gw.lastChatRequest()
+	if sent.Route != defaultRoute {
+		t.Fatalf("route = %q, want %q (documents-only message, no vision flip)", sent.Route, defaultRoute)
 	}
 }

--- a/internal/brain/chat/broadcast.go
+++ b/internal/brain/chat/broadcast.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -21,9 +22,10 @@ const broadcastBuf = 64
 // flight" (D-Option-B, see chat.go's turn lifecycle comment) — there
 // is no separate busy-state registry.
 type turnBroadcaster struct {
-	mu   sync.Mutex
-	buf  []stream.StreamEvent
-	subs map[chan stream.StreamEvent]struct{}
+	mu     sync.Mutex
+	buf    []stream.StreamEvent
+	subs   map[chan stream.StreamEvent]struct{}
+	cancel context.CancelFunc // set by Chat/Retry once the turn's detached ctx exists; nil until then
 }
 
 func newTurnBroadcaster() *turnBroadcaster {
@@ -63,6 +65,20 @@ func (b *turnBroadcaster) subscribe() ([]stream.StreamEvent, <-chan stream.Strea
 	ch := make(chan stream.StreamEvent, broadcastBuf)
 	b.subs[ch] = struct{}{}
 	return replay, ch
+}
+
+// setCancel stores the detached turn context's cancel func — called by
+// Chat/Retry right after turnBegin returns, before runTurn does
+// anything else, so StopTurn can never observe a nil cancel for a turn
+// that's actually in flight (turnBegin already made it visible in
+// Service.turns). Guarded by the same mutex as publish/subscribe so a
+// racing StopTurn either sees it set or sees the broadcaster before
+// registration completes at all (turnBegin's own lock covers that
+// earlier race).
+func (b *turnBroadcaster) setCancel(fn context.CancelFunc) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.cancel = fn
 }
 
 // closeAll closes and unregisters every live subscriber — called once
@@ -112,15 +128,50 @@ func (s *Service) turnBegin(sessionID string) (*turnBroadcaster, error) {
 // subscriber. Called after the turn's terminal persist is durable (see
 // persistTurn) so turn_active flips false only once a refetch is
 // guaranteed to see the completed turn — no window where the flag is
-// down but the transcript is still stale.
+// down but the transcript is still stale. Also cancels the turn's
+// detached context (if a cancel was ever stored) so it never leaks past
+// the turn's own lifetime — every path here runs after the turn is
+// truly over, so cancelling now is always safe, never premature.
 func (s *Service) turnDone(sessionID string) {
 	s.turnsMu.Lock()
 	b := s.turns[sessionID]
 	delete(s.turns, sessionID)
 	s.turnsMu.Unlock()
 	if b != nil {
+		b.mu.Lock()
+		cancel := b.cancel
+		b.mu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
 		b.closeAll()
 	}
+}
+
+// StopTurn cancels sessionID's in-flight turn, if any, and reports
+// whether one was actually live. Cancelling the detached turn context
+// makes the tool loop/gateway wind down (same path a real deadline or a
+// brain shutdown already takes); the existing abnormal-end machinery in
+// persistTurn then takes over — pending_state when partial text exists,
+// turn_failed otherwise — and drainAndPersist runs turnDone exactly as
+// on any other exit. StopTurn does NOT remove the Service.turns entry
+// itself: the relay goroutine still owns that (via turnDone), so a
+// caller polling TurnActive right after StopTurn can still see true
+// until the wind-down actually completes.
+func (s *Service) StopTurn(sessionID string) bool {
+	s.turnsMu.Lock()
+	b := s.turns[sessionID]
+	s.turnsMu.Unlock()
+	if b == nil {
+		return false
+	}
+	b.mu.Lock()
+	cancel := b.cancel
+	b.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	return true
 }
 
 // TurnActive reports whether sessionID currently has a turn in flight

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -54,6 +54,10 @@ const (
 	// just because the capability gate happens to find a vision-capable
 	// model there too.
 	visionRoute = "vision"
+	// turnTimeout ceils a detached turn's lifetime (see Chat/Retry's
+	// turnCtx): must exceed loop's permissionTimeout (10m) so a parked
+	// permission ask can't be killed by the ceiling out from under it.
+	turnTimeout = 30 * time.Minute
 	// Each persistence stage gets its OWN deadline: LLM-backed stages
 	// (distill, compaction) must never eat the database writes' clock.
 	persistTimeout = 10 * time.Second
@@ -150,6 +154,7 @@ type Service struct {
 	skillAllow     func(context.Context, string) bool // nil: all packs allowed
 	skillBodies    map[string]string                  // name -> full pack body, for skill_hint
 	flushEvery     time.Duration                      // pending-state flush cadence mid-stream
+	turnTimeout    time.Duration                      // detached-turn ceiling; defaults to the turnTimeout const, overridable in tests
 	sensitive      *session.SensitiveTools            // nil: no sensitive-tool route pin for side-calls
 	attachments    AttachmentStore                    // nil: attachments disabled (ATTACHMENTS_DIR unset)
 	markitdownURL  string                             // "": pdf attachments disabled (MARKITDOWN_URL unset)
@@ -307,7 +312,7 @@ func New(gw Gateway, log SessionLog, distill Distill, compactor Compactor, budge
 		skillAllow:  skillAllow,
 		agents:      resolver,
 		skillBodies: bodies,
-		flushEvery:  2 * time.Second, logger: logger,
+		flushEvery:  2 * time.Second, turnTimeout: turnTimeout, logger: logger,
 	}
 }
 
@@ -490,13 +495,24 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 		return sessionID, nil, err
 	}
 
-	if _, err := s.log.Append(ctx, sessionID, session.KindUserMessage, session.UserMessage{
+	// The turn's lifetime belongs to the session, not the HTTP request
+	// that started it: a navigation/reload aborts ctx, but that must
+	// not kill the loop mid-tool-call. turnCtx drops ctx's cancellation
+	// (WithoutCancel) while keeping its values (auth, trace); StopTurn
+	// is the only thing allowed to cancel it from here on (see
+	// broadcast.go's setCancel). The user_message append below also
+	// rides turnCtx, not ctx: once the slot is won, the message must
+	// land even if the client vanishes that same instant.
+	turnCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.turnTimeout)
+	bc.setCancel(cancel)
+
+	if _, err := s.log.Append(turnCtx, sessionID, session.KindUserMessage, session.UserMessage{
 		Text: req.Message, Route: route, Agent: profile.Name, ModelHint: modelHint, Images: images, Documents: documents,
 	}); err != nil {
 		s.turnDone(sessionID)
 		return sessionID, nil, err
 	}
-	return s.runTurn(ctx, sessionID, req.Message, modelHint, req.SkillHint, skillBody, route, profile, needsTitle, bc)
+	return s.runTurn(turnCtx, ctx, sessionID, req.Message, modelHint, req.SkillHint, skillBody, route, profile, needsTitle, bc)
 }
 
 // resolveImages fills each message's Images from its ImageRefs
@@ -676,7 +692,10 @@ func (s *Service) Retry(ctx context.Context, sessionID string) (string, <-chan s
 	if err != nil {
 		return sessionID, nil, err
 	}
-	return s.runTurn(ctx, sessionID, last.Text, modelHint, "", "", route, profile, needsTitle, bc)
+	// Detached turn context — same reasoning as Chat's (see there).
+	turnCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.turnTimeout)
+	bc.setCancel(cancel)
+	return s.runTurn(turnCtx, ctx, sessionID, last.Text, modelHint, "", "", route, profile, needsTitle, bc)
 }
 
 // runTurn is the shared tail of Chat and Retry: compact, project
@@ -687,31 +706,38 @@ func (s *Service) Retry(ctx context.Context, sessionID string) (string, <-chan s
 // (D-042) — runTurn must free it (turnDone) on every path that returns
 // before the relay goroutine takes ownership of that responsibility,
 // so a setup failure here can never wedge the session's slot.
-func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, skillHint, skillBody, route string, profile agents.Agent, needsTitle bool, bc *turnBroadcaster) (string, <-chan stream.StreamEvent, error) {
+//
+// turnCtx is the detached, session-owned context (survives the client
+// disconnecting) that everything in this function — and the whole tool
+// loop underneath gw.Stream — runs on. reqCtx is the original HTTP
+// request's context; it is only handed to relay, which uses it solely
+// to decide whether the ORIGINAL client is still there to stream to
+// (see relay's doc comment).
+func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, modelHint, skillHint, skillBody, route string, profile agents.Agent, needsTitle bool, bc *turnBroadcaster) (string, <-chan stream.StreamEvent, error) {
 	// start marks the turn's wall-clock beginning for the stats line's
 	// duration: here, not Chat/Retry's entry, so a retried turn's
 	// duration covers only the retried run — the dead attempt's gap
 	// never counts (runTurn is the shared tail both call fresh).
 	start := time.Now()
-	s.seedApprovalGrants(ctx, sessionID, profile)
+	s.seedApprovalGrants(turnCtx, sessionID, profile)
 	// Pre-send guarantee: the context actually sent to the provider
 	// stays under budget even on the turn that crosses it. The
 	// post-turn pass below keeps sessions compacted ahead of time, so
 	// this is a cheap no-op except on the crossing turn; best-effort —
 	// an oversized context beats no answer.
 	if s.compactor != nil {
-		cctx, cancel := context.WithTimeout(ctx, compactBudget)
+		cctx, cancel := context.WithTimeout(turnCtx, compactBudget)
 		if err := s.compactor.MaybeCompact(cctx, sessionID); err != nil {
 			s.logger.Warn("pre-send compaction", "session_id", sessionID, "error", err)
 		}
 		cancel()
 	}
-	events, err := s.log.Events(ctx, sessionID)
+	events, err := s.log.Events(turnCtx, sessionID)
 	if err != nil {
 		s.turnDone(sessionID)
 		return sessionID, nil, err
 	}
-	msgs, err := session.LLMContext(events, s.budget(ctx))
+	msgs, err := session.LLMContext(events, s.budget(turnCtx))
 	if err != nil {
 		s.turnDone(sessionID)
 		return sessionID, nil, err
@@ -720,7 +746,7 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 	// gateway call: this is the sole point in the whole turn where
 	// attachment bytes exist in memory at all (D-045). ImageRefs never
 	// crosses the wire (json:"-"); Images (the resolved payload) does.
-	if err := s.resolveImages(ctx, msgs); err != nil {
+	if err := s.resolveImages(turnCtx, msgs); err != nil {
 		s.turnDone(sessionID)
 		return sessionID, nil, err
 	}
@@ -738,7 +764,7 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 	// (D-011 poisoning defense); the skill body is instructions the
 	// user explicitly selected, deterministically loaded rather than
 	// left to the model's load_skill judgment.
-	system := assembleSystem(skills.Index(s.allowedPacks(ctx, profile)), time.Now())
+	system := assembleSystem(skills.Index(s.allowedPacks(turnCtx, profile)), time.Now())
 	// The agent overlay is stable for a given agent, so it sits ahead
 	// of the per-turn tail and stays inside the cacheable prefix.
 	if profile.PromptOverlay != "" {
@@ -748,12 +774,12 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 		system += "\n\n# Skill: " + skillHint + "\n\n" + skillBody
 	}
 	if s.recall != nil && profile.Memory {
-		if block := s.recall(ctx, sessionID, userText); block != "" {
+		if block := s.recall(turnCtx, sessionID, userText); block != "" {
 			system += "\n\n" + block
 		}
 	}
 
-	upstream, err := s.gw.Stream(ctx, gwclient.StreamRequest{
+	upstream, err := s.gw.Stream(turnCtx, gwclient.StreamRequest{
 		Route:     route,
 		Agent:     profile.Name,
 		ToolAllow: profile.Tools,
@@ -774,7 +800,7 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 	// defer-equivalent (drainAndPersist, on every exit path) owns
 	// freeing it via turnDone.
 	out := make(chan stream.StreamEvent)
-	go s.relay(ctx, sessionID, userText, route, profile, needsTitle, sessionSensitive, start, bc, upstream, out)
+	go s.relay(reqCtx, sessionID, userText, route, profile, needsTitle, sessionSensitive, start, bc, upstream, out)
 	return sessionID, out, nil
 }
 
@@ -793,7 +819,17 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 // because it already disconnected (drainAndPersist) — still reaches
 // bc, since a GET /live subscriber may be attached independently of
 // the POST that started the turn.
-func (s *Service) relay(ctx context.Context, sessionID, userText, route string, profile agents.Agent, needsTitle, sessionSensitive bool, start time.Time, bc *turnBroadcaster, upstream <-chan stream.StreamEvent, out chan<- stream.StreamEvent) {
+//
+// reqCtx is the ORIGINAL request's context, not the turn's — upstream
+// is already bound to the detached turnCtx (runTurn's gw.Stream call),
+// so it keeps producing long after reqCtx dies. reqCtx here gates only
+// whether THIS client is still around to receive forwarded events: the
+// moment it's done, the select's <-reqCtx.Done() branch stops sending
+// to out and falls through to drainAndPersist, which keeps consuming
+// the still-live upstream to completion so the turn finishes and
+// persists normally, with every event still reaching bc for any /live
+// subscriber.
+func (s *Service) relay(reqCtx context.Context, sessionID, userText, route string, profile agents.Agent, needsTitle, sessionSensitive bool, start time.Time, bc *turnBroadcaster, upstream <-chan stream.StreamEvent, out chan<- stream.StreamEvent) {
 	var text, reasoning strings.Builder
 	var meta *stream.Meta
 	var usage *stream.Usage
@@ -888,9 +924,16 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 	}
 
 	drainAndPersist := func() {
-		// Consume whatever the upstream still yields (it shares the
-		// request ctx, so it winds down quickly), free the client,
-		// then persist the final state.
+		// out closes FIRST, before draining upstream: upstream is bound
+		// to turnCtx (session-owned), not reqCtx, so once the client is
+		// gone it may still have minutes left to run. Closing out up
+		// front frees streamTurn's client-facing goroutine immediately
+		// instead of holding it for the remainder of the turn — any
+		// further send() calls on a dead ResponseWriter just fail
+		// silently. The drain loop below then keeps consuming upstream
+		// (publishing every event to bc for /live subscribers) until it
+		// closes on its own, however long that takes.
+		close(out)
 		for ev := range upstream {
 			switch ev.Type {
 			case stream.EventChunk:
@@ -907,7 +950,6 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 			notePermission(ev)
 			bc.publish(ev)
 		}
-		close(out)
 		s.persistTurn(sessionID, userText, route, profile, needsTitle, text.String(), reasoning.String(), meta, usage, sawDone, flushed, turnSensitive || sessionSensitive, failure, ranTool)
 		// Terminal persist is now durable: free the broadcaster (closes
 		// every live /live subscriber) and push the session signal, in
@@ -949,14 +991,14 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 			bc.publish(ev)
 			select {
 			case out <- ev:
-			case <-ctx.Done():
+			case <-reqCtx.Done():
 				flushPending()
 				drainAndPersist()
 				return
 			}
 		case <-ticker.C:
 			flushPending()
-		case <-ctx.Done():
+		case <-reqCtx.Done():
 			flushPending()
 			drainAndPersist()
 			return

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/skills"
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+	"github.com/SumonMSelim/timothy/internal/platform/markitdown"
 )
 
 const (
@@ -134,23 +136,25 @@ type Granter interface {
 
 // Service orchestrates turns against the event store.
 type Service struct {
-	gw          Gateway
-	log         SessionLog
-	distill     Distill
-	compactor   Compactor
-	memory      MemoryExtract   // nil: long-term memory off
-	recall      MemoryRetrieve  // nil: no memory injection
-	agents      AgentResolver   // nil: zero-value agent (everything allowed)
-	candidates  AgentCandidates // nil: auto-dispatch falls back to default
-	classify    agents.Classify // nil: auto-dispatch falls back to default
-	budget      func(context.Context) int
-	packs       []skills.Skill
-	skillAllow  func(context.Context, string) bool // nil: all packs allowed
-	skillBodies map[string]string                  // name -> full pack body, for skill_hint
-	flushEvery  time.Duration                      // pending-state flush cadence mid-stream
-	sensitive   *session.SensitiveTools            // nil: no sensitive-tool route pin for side-calls
-	attachments AttachmentStore                    // nil: attachments disabled (ATTACHMENTS_DIR unset)
-	logger      *slog.Logger
+	gw             Gateway
+	log            SessionLog
+	distill        Distill
+	compactor      Compactor
+	memory         MemoryExtract   // nil: long-term memory off
+	recall         MemoryRetrieve  // nil: no memory injection
+	agents         AgentResolver   // nil: zero-value agent (everything allowed)
+	candidates     AgentCandidates // nil: auto-dispatch falls back to default
+	classify       agents.Classify // nil: auto-dispatch falls back to default
+	budget         func(context.Context) int
+	packs          []skills.Skill
+	skillAllow     func(context.Context, string) bool // nil: all packs allowed
+	skillBodies    map[string]string                  // name -> full pack body, for skill_hint
+	flushEvery     time.Duration                      // pending-state flush cadence mid-stream
+	sensitive      *session.SensitiveTools            // nil: no sensitive-tool route pin for side-calls
+	attachments    AttachmentStore                    // nil: attachments disabled (ATTACHMENTS_DIR unset)
+	markitdownURL  string                             // "": pdf attachments disabled (MARKITDOWN_URL unset)
+	markitdownHTTP *http.Client                       // shared client for the markitdown sidecar call
+	logger         *slog.Logger
 
 	grants Granter // nil: chat never seeds standing grants (today's behavior)
 	// seeded remembers which (session, agent) pairs already had their
@@ -206,6 +210,16 @@ func (s *Service) SetSensitiveTools(t *session.SensitiveTools) { s.sensitive = t
 // SetAttachments wires the attachment store (D-045). Optional — nil
 // (ATTACHMENTS_DIR unset) rejects any Request naming Attachments ids.
 func (s *Service) SetAttachments(store AttachmentStore) { s.attachments = store }
+
+// SetMarkitdown wires the markitdown sidecar's base URL for PDF
+// attachment conversion. Optional — empty (MARKITDOWN_URL unset)
+// rejects any PDF attachment ref with ErrBadRequest.
+func (s *Service) SetMarkitdown(url string) {
+	s.markitdownURL = url
+	if s.markitdownHTTP == nil {
+		s.markitdownHTTP = &http.Client{}
+	}
+}
 
 // SetAutoDispatch wires auto agent dispatch (D-034 follow-up): a
 // request naming the autoAgentName sentinel resolves through candidates
@@ -367,12 +381,12 @@ func profileAllows(allow []string, name string) bool {
 
 // Request is one chat turn.
 type Request struct {
-	SessionID    string `json:"session_id,omitempty"`
-	Message      string `json:"message"`
+	SessionID string `json:"session_id,omitempty"`
+	Message   string `json:"message"`
 	// Agent names who serves this turn; empty = the default agent.
-	Agent string `json:"agent,omitempty"`
-	Route string `json:"route,omitempty"`
-	ModelHint    string `json:"model_hint,omitempty"`
+	Agent     string `json:"agent,omitempty"`
+	Route     string `json:"route,omitempty"`
+	ModelHint string `json:"model_hint,omitempty"`
 	// SkillHint names a skill pack to force-load for this turn — set
 	// when the user picked one explicitly (a UI chip, not parsed
 	// text). Unlike load_skill, this is not a choice the model can
@@ -393,7 +407,7 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	if strings.TrimSpace(req.Message) == "" && len(req.Attachments) == 0 {
 		return "", nil, fmt.Errorf("chat: %w: message or an attachment is required", ErrBadRequest)
 	}
-	images, err := s.validateAttachments(ctx, req.Attachments)
+	images, documents, err := s.validateAttachments(ctx, req.Attachments)
 	if err != nil {
 		return "", nil, err
 	}
@@ -422,6 +436,9 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	// to the vision route, then the agent's route, then the default chain
 	// (sensitive-pin below still overrides all of this).
 	route := req.Route
+	// Only images flip to the vision route — documents are converted to
+	// plain markdown text, not something the model needs vision
+	// capability to read.
 	if route == "" && len(images) > 0 {
 		// D-046: brain has no cheap way to know whether a "vision" route
 		// exists/is enabled/has a non-empty chain (gwclient exposes no
@@ -474,7 +491,7 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	}
 
 	if _, err := s.log.Append(ctx, sessionID, session.KindUserMessage, session.UserMessage{
-		Text: req.Message, Route: route, Agent: profile.Name, ModelHint: modelHint, Images: images,
+		Text: req.Message, Route: route, Agent: profile.Name, ModelHint: modelHint, Images: images, Documents: documents,
 	}); err != nil {
 		s.turnDone(sessionID)
 		return sessionID, nil, err
@@ -530,24 +547,56 @@ func (s *Service) readAttachment(ctx context.Context, id string) (string, error)
 // BEFORE the turn's exclusivity is won or anything is appended (D-042:
 // store lookups are read-only and safe before turnBegin, but a bad ref
 // must 400 before even the user_message persists). Empty ids returns
-// nil, nil without touching the store — attachments stay off when
+// nil, nil, nil without touching the store — attachments stay off when
 // unconfigured, and a message with none never needs it wired.
-func (s *Service) validateAttachments(ctx context.Context, ids []string) ([]session.ImageRef, error) {
+//
+// PDFs are converted to markdown here, once, at send time (not lazily
+// per turn like images): re-converting on every turn would re-call the
+// markitdown sidecar every turn, and any output drift would rewrite an
+// earlier projected message — breaking LLMContext's prefix stability
+// that provider prompt caches depend on. A conversion failure is the
+// sidecar's fault, not the client's, so it returns a plain wrapped
+// error rather than ErrBadRequest.
+func (s *Service) validateAttachments(ctx context.Context, ids []string) ([]session.ImageRef, []session.DocumentRef, error) {
 	if len(ids) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if s.attachments == nil {
-		return nil, fmt.Errorf("chat: %w: attachments are not enabled", ErrBadRequest)
+		return nil, nil, fmt.Errorf("chat: %w: attachments are not enabled", ErrBadRequest)
 	}
-	refs := make([]session.ImageRef, 0, len(ids))
+	var images []session.ImageRef
+	var documents []session.DocumentRef
 	for _, id := range ids {
 		att, err := s.attachments.Get(ctx, id)
 		if err != nil {
-			return nil, fmt.Errorf("chat: %w: attachment %q: %v", ErrBadRequest, id, err)
+			return nil, nil, fmt.Errorf("chat: %w: attachment %q: %v", ErrBadRequest, id, err)
 		}
-		refs = append(refs, session.ImageRef{ID: att.ID, Mime: att.Mime})
+		switch {
+		case strings.HasPrefix(att.Mime, "image/"):
+			images = append(images, session.ImageRef{ID: att.ID, Mime: att.Mime})
+		case att.Mime == "application/pdf":
+			if s.markitdownURL == "" {
+				return nil, nil, fmt.Errorf("chat: %w: pdf attachments require the markitdown sidecar (MARKITDOWN_URL)", ErrBadRequest)
+			}
+			r, _, err := s.attachments.Open(ctx, att.ID)
+			if err != nil {
+				return nil, nil, fmt.Errorf("chat: %w: attachment %q: %v", ErrBadRequest, id, err)
+			}
+			raw, err := io.ReadAll(r)
+			_ = r.Close()
+			if err != nil {
+				return nil, nil, fmt.Errorf("chat: read attachment %q: %w", id, err)
+			}
+			md, err := markitdown.Convert(ctx, s.markitdownHTTP, s.markitdownURL, att.ID+".pdf", att.Mime, raw)
+			if err != nil {
+				return nil, nil, fmt.Errorf("chat: convert attachment %q: %w", id, err)
+			}
+			documents = append(documents, session.DocumentRef{ID: att.ID, Mime: att.Mime, Markdown: md})
+		default:
+			return nil, nil, fmt.Errorf("chat: %w: attachment %q: unsupported mime %q", ErrBadRequest, id, att.Mime)
+		}
 	}
-	return refs, nil
+	return images, documents, nil
 }
 
 // pinSensitiveRoute promotes the session-wide privacy floor above the

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -1945,3 +1945,250 @@ func TestPersistTurnPinsSideCallsWhenSessionPreviouslySensitive(t *testing.T) {
 		t.Fatal("memory extract never invoked")
 	}
 }
+
+// slowGW is a Gateway whose stream keeps producing on its own schedule,
+// gated ONLY by the context passed to Stream — unlike fakeGW, its sends
+// aren't wrapped in a second select that could race the caller's read.
+// Used to prove that once runTurn hands gw.Stream the detached turnCtx
+// (not the request's ctx), the upstream genuinely survives a request-
+// side cancel: production's real gwclient.Stream is bound to whatever
+// ctx runTurn passes it, so this models that binding faithfully instead
+// of asserting it indirectly. delay applies uniformly before every
+// event unless delays is set, giving a per-event delay instead (used
+// when the test needs the first event immediate but later ones held
+// off far past the point the test acts).
+type slowGW struct {
+	events []stream.StreamEvent
+	delay  time.Duration
+	delays []time.Duration
+}
+
+func (g *slowGW) Stream(ctx context.Context, _ gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+	ch := make(chan stream.StreamEvent)
+	go func() {
+		defer close(ch)
+		for i, ev := range g.events {
+			d := g.delay
+			if i < len(g.delays) {
+				d = g.delays[i]
+			}
+			select {
+			case <-time.After(d):
+			case <-ctx.Done():
+				return
+			}
+			select {
+			case ch <- ev:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return ch, nil
+}
+
+// TestChatSurvivesClientDisconnect is the kill-test for the fix this
+// package exists to ship: cancelling the REQUEST context (a browser
+// nav/reload) must not cancel the turn. runTurn hands gw.Stream the
+// detached turnCtx, so slowGW here is bound to that, not to the
+// request ctx passed into Chat — the disconnect must only stop
+// forwarding to the client channel, never the upstream itself.
+func TestChatSurvivesClientDisconnect(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &slowGW{delay: 20 * time.Millisecond, events: []stream.StreamEvent{
+		{Type: stream.EventChunk, Text: "first "},
+		{Type: stream.EventChunk, Text: "second "},
+		{Type: stream.EventChunk, Text: "third"},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
+	}}
+	s := newService(gw, log)
+
+	reqCtx, cancel := context.WithCancel(t.Context())
+	_, ch, err := s.Chat(reqCtx, Request{SessionID: "s1", Message: "long question"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	// A /live subscriber attached independently of the request that
+	// started the turn — it must still see every event, including the
+	// ones the disconnecting client never gets.
+	replay, live, ok := s.Subscribe("s1")
+	if !ok {
+		t.Fatal("Subscribe: no turn in flight")
+	}
+	if len(replay) != 0 {
+		t.Fatalf("replay before any event = %v, want empty", replay)
+	}
+
+	<-ch     // receive the first forwarded chunk
+	cancel() // client disconnects — browser nav/reload
+
+	// out must close promptly: the client-facing channel does not wait
+	// for the whole turn to finish once reqCtx is done.
+	deadline := time.After(2 * time.Second)
+loop:
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				break loop
+			}
+		case <-deadline:
+			t.Fatal("out did not close promptly after client disconnect")
+		}
+	}
+
+	// The broadcaster (and any /live subscriber) keeps seeing events
+	// after the original client disconnected, until the turn's own
+	// terminal.
+	var got []stream.StreamEvent
+	for ev := range live {
+		got = append(got, ev)
+	}
+	var text strings.Builder
+	sawDone := false
+	for _, ev := range got {
+		if ev.Type == stream.EventChunk {
+			text.WriteString(ev.Text)
+		}
+		if ev.Type == stream.EventDone {
+			sawDone = true
+		}
+	}
+	if !sawDone {
+		t.Fatalf("broadcaster never saw the terminal done event: %+v", got)
+	}
+	if text.String() != "first second third" {
+		t.Fatalf("broadcaster text = %q, want full upstream text", text.String())
+	}
+
+	// The turn must persist as a completed assistant_turn — never
+	// turn_failed — despite the client having vanished mid-stream. A
+	// pending_state checkpoint (flushPending, on the disconnect branch
+	// itself) may also land before it; that's an existing, harmless
+	// checkpoint superseded by the real completed turn right after.
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
+	kinds := log.kinds("s1")
+	if kinds[len(kinds)-1] != session.KindAssistantTurn {
+		t.Fatalf("kinds = %v, want assistant_turn last (turn must complete normally, not fail)", kinds)
+	}
+	for _, k := range kinds {
+		if k == session.KindTurnFailed {
+			t.Fatalf("kinds = %v, must not contain turn_failed", kinds)
+		}
+	}
+	events, _ := log.Events(t.Context(), "s1")
+	var turn session.AssistantTurn
+	if err := json.Unmarshal(events[len(events)-1].Payload, &turn); err != nil {
+		t.Fatalf("decode turn: %v", err)
+	}
+	if turn.LLM.Message != "first second third" {
+		t.Fatalf("persisted turn text = %q, want full upstream text", turn.LLM.Message)
+	}
+}
+
+// TestStopTurnCancelsMidStream: StopTurn must let a caller (a "stop"
+// button in the UI) cancel a session's in-flight turn server-side. The
+// upstream (bound to turnCtx) winds down once cancelled, and the
+// existing abnormal-end machinery in persistTurn takes over — partial
+// text becomes a pending_state (the same shape a real client disconnect
+// with no terminal produces).
+func TestStopTurnCancelsMidStream(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	// slowGW (not fakeGW): the upstream must still be live-but-idle
+	// after the first chunk, so the test can call StopTurn
+	// deterministically mid-stream rather than racing the upstream's
+	// own natural close — fakeGW's producer goroutine exits (closing
+	// the channel) right after its last canned event, which can beat
+	// StopTurn to the punch when there is no terminal event to hold it
+	// open. The second event is delayed well past StopTurn's cancel.
+	gw := &slowGW{
+		events: []stream.StreamEvent{
+			{Type: stream.EventChunk, Text: "partial answer"},
+			{Type: stream.EventChunk, Text: " that stalls here"},
+		},
+		delays: []time.Duration{0, 2 * time.Second},
+	}
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "long question"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if !s.TurnActive("s1") {
+		t.Fatal("TurnActive = false right after Chat, want true")
+	}
+
+	<-ch // receive the first chunk, so the turn has partial text before stopping
+
+	if !s.StopTurn("s1") {
+		t.Fatal("StopTurn = false, want true (a turn is live)")
+	}
+	drain(t, ch)
+
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
+
+	found := false
+	for _, k := range log.kinds("s1") {
+		if k == session.KindPendingState {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("kinds = %v, want a pending_state (partial text, abnormal end)", log.kinds("s1"))
+	}
+
+	// Stopping again finds nothing live.
+	if s.StopTurn("s1") {
+		t.Fatal("StopTurn on an already-finished session = true, want false")
+	}
+}
+
+// TestStopTurnNoActiveTurn confirms StopTurn is a plain false, not a
+// panic or error, when the session never had a turn running.
+func TestStopTurnNoActiveTurn(t *testing.T) {
+	t.Parallel()
+	s := newService(&fakeGW{}, newFakeLog())
+	if s.StopTurn("never-started") {
+		t.Fatal("StopTurn on an idle session = true, want false")
+	}
+}
+
+// TestTurnTimeoutCeilingEndsAbandonedTurn confirms the detached turn
+// context actually ceils the turn's lifetime: with turnTimeout set very
+// small, an upstream that outlives it must be cut off and the turn
+// persisted with whatever partial evidence exists, rather than running
+// forever. Production always runs the real 30-minute const; s.turnTimeout
+// exists as a settable field precisely so this deadline path can be
+// exercised without an unreasonably slow test.
+func TestTurnTimeoutCeilingEndsAbandonedTurn(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &slowGW{delay: 500 * time.Millisecond, events: []stream.StreamEvent{
+		{Type: stream.EventChunk, Text: "partial"},
+		{Type: stream.EventChunk, Text: " more"},
+		{Type: stream.EventChunk, Text: " than the ceiling allows"},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
+	}}
+	s := newService(gw, log)
+	s.turnTimeout = 30 * time.Millisecond // far shorter than any event delay above
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "long question"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
+	kinds := log.kinds("s1")
+	// The ceiling fires before any chunk (500ms delay vs 30ms ceiling),
+	// so there is no partial text worth keeping — the turn ends with no
+	// assistant_turn, same shape a real abandoned/stuck upstream leaves.
+	for _, k := range kinds {
+		if k == session.KindAssistantTurn {
+			t.Fatalf("kinds = %v, want no assistant_turn (ceiling cut the turn short)", kinds)
+		}
+	}
+}

--- a/internal/brain/session/events.go
+++ b/internal/brain/session/events.go
@@ -48,13 +48,21 @@ type SessionStarted struct {
 // UserMessage is one user turn.
 type UserMessage struct {
 	Text      string `json:"text"`
-	Route  string `json:"route,omitempty"`
-	Agent  string `json:"agent,omitempty"`
+	Route     string `json:"route,omitempty"`
+	Agent     string `json:"agent,omitempty"`
 	ModelHint string `json:"model_hint,omitempty"`
 	// Images are refs to attachments (internal/brain/attachments),
 	// never bytes — base64 exists only transiently at request-build
 	// time (D-045). Additive: a message with no images omits this.
 	Images []ImageRef `json:"images,omitempty"`
+	// Documents are PDF attachments converted to markdown once, at
+	// message-send time (chat.Chat), with the markdown persisted here.
+	// Re-converting per turn would re-call the markitdown sidecar every
+	// turn, and any output drift would rewrite an earlier projected
+	// message — breaking LLMContext's prefix stability that provider
+	// prompt caches depend on. Additive: a message with no documents
+	// omits this.
+	Documents []DocumentRef `json:"documents,omitempty"`
 }
 
 // ImageRef points at a stored attachment; Mime rides alongside so
@@ -63,6 +71,16 @@ type UserMessage struct {
 type ImageRef struct {
 	ID   string `json:"id"`
 	Mime string `json:"mime"`
+}
+
+// DocumentRef points at a stored PDF attachment; Markdown is its
+// converted text, persisted so projection is deterministic and the
+// markitdown sidecar is called exactly once per attach (see
+// UserMessage.Documents).
+type DocumentRef struct {
+	ID       string `json:"id"`
+	Mime     string `json:"mime"`
+	Markdown string `json:"markdown"`
 }
 
 // UIBlock is one renderable piece of an assistant turn.

--- a/internal/brain/session/projection.go
+++ b/internal/brain/session/projection.go
@@ -80,6 +80,19 @@ func LLMContext(events []Event, budget int) ([]provider.Message, error) {
 			for _, img := range m.Images {
 				msg.ImageRefs = append(msg.ImageRefs, provider.ImageRef{ID: img.ID, Mime: img.Mime})
 			}
+			// Documents carry their markdown already converted and
+			// persisted (chat.Chat, at send time) — projection just
+			// appends it as ordinary text, no store round-trip and no
+			// sidecar call. PDFs never flip the vision route; only
+			// images do.
+			for _, doc := range m.Documents {
+				block := fmt.Sprintf("[attached document %s (%s)]\n%s", doc.ID, doc.Mime, doc.Markdown)
+				if msg.Content == "" {
+					msg.Content = block
+				} else {
+					msg.Content += "\n\n" + block
+				}
+			}
 			msgs = append(msgs, msg)
 		case KindAssistantTurn:
 			var t AssistantTurn
@@ -185,11 +198,14 @@ func renderTurnMemory(tm *TurnMemory) string {
 
 // TranscriptItem is one renderable unit of the UI replay.
 type TranscriptItem struct {
-	Seq        int64              `json:"seq"`
-	Kind       string             `json:"kind"` // user | assistant | tool | permission | compaction | interrupted | error
-	Text       string             `json:"text,omitempty"`
-	Blocks     []UIBlock          `json:"blocks,omitempty"`
-	Images     []ImageRef         `json:"images,omitempty"`
+	Seq    int64      `json:"seq"`
+	Kind   string     `json:"kind"` // user | assistant | tool | permission | compaction | interrupted | error
+	Text   string     `json:"text,omitempty"`
+	Blocks []UIBlock  `json:"blocks,omitempty"`
+	Images []ImageRef `json:"images,omitempty"`
+	// Documents are refs only (id+mime) — never the converted markdown,
+	// which can be huge and has no reason to reach the UI payload.
+	Documents  []ImageRef         `json:"documents,omitempty"`
 	Provider   string             `json:"provider,omitempty"`
 	Model      string             `json:"model,omitempty"`
 	Usage      *stream.Usage      `json:"usage,omitempty"`
@@ -219,6 +235,9 @@ func UITranscript(events []Event) ([]TranscriptItem, error) {
 				return nil, err
 			}
 			item.Kind, item.Text, item.Images = "user", m.Text, m.Images
+			for _, doc := range m.Documents {
+				item.Documents = append(item.Documents, ImageRef{ID: doc.ID, Mime: doc.Mime})
+			}
 		case KindAssistantTurn:
 			var t AssistantTurn
 			if err := decode(ev, &t); err != nil {

--- a/internal/brain/session/projection_test.go
+++ b/internal/brain/session/projection_test.go
@@ -94,6 +94,35 @@ func TestLLMContextCarriesImageRefsNotBytes(t *testing.T) {
 	}
 }
 
+// TestLLMContextRendersDocumentMarkdown confirms a user_message's
+// DocumentRef renders its already-converted markdown straight into the
+// LLM content (no store round-trip, no sidecar call at projection
+// time) — the persisted markdown is the sole source, per D-045/D-046's
+// send-time-conversion design.
+func TestLLMContextRendersDocumentMarkdown(t *testing.T) {
+	t.Parallel()
+	events := []Event{
+		ev(t, 1, KindSessionStarted, SessionStarted{}),
+		ev(t, 2, KindUserMessage, UserMessage{
+			Text:      "summarize this",
+			Documents: []DocumentRef{{ID: "doc1", Mime: "application/pdf", Markdown: "# Title\n\nbody text"}},
+		}),
+	}
+
+	msgs, err := LLMContext(events, 100_000)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("messages = %+v, want 1", msgs)
+	}
+	m := msgs[0]
+	if !strings.Contains(m.Content, "summarize this") || !strings.Contains(m.Content, "# Title") ||
+		!strings.Contains(m.Content, "body text") || !strings.Contains(m.Content, "doc1") {
+		t.Fatalf("Content = %q, want text + rendered document markdown", m.Content)
+	}
+}
+
 func TestLLMContextSerializesTurnMemory(t *testing.T) {
 	t.Parallel()
 	events := []Event{
@@ -306,6 +335,39 @@ func TestUITranscriptCarriesImages(t *testing.T) {
 	}
 	if len(items[0].Images) != 1 || items[0].Images[0].ID != "img1" || items[0].Images[0].Mime != "image/jpeg" {
 		t.Fatalf("Images = %+v, want one ref to img1/image/jpeg", items[0].Images)
+	}
+}
+
+// TestUITranscriptExposesDocumentsWithoutMarkdown confirms a
+// user_message's document refs surface on TranscriptItem.Documents as
+// id+mime only — the converted markdown never rides the UI payload,
+// which can be arbitrarily large.
+func TestUITranscriptExposesDocumentsWithoutMarkdown(t *testing.T) {
+	t.Parallel()
+	events := []Event{
+		ev(t, 1, KindSessionStarted, SessionStarted{}),
+		ev(t, 2, KindUserMessage, UserMessage{
+			Text:      "look",
+			Documents: []DocumentRef{{ID: "doc1", Mime: "application/pdf", Markdown: strings.Repeat("x", 10_000)}},
+		}),
+	}
+
+	items, err := UITranscript(events)
+	if err != nil {
+		t.Fatalf("UITranscript: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items = %+v, want 1", items)
+	}
+	if len(items[0].Documents) != 1 || items[0].Documents[0].ID != "doc1" || items[0].Documents[0].Mime != "application/pdf" {
+		t.Fatalf("Documents = %+v, want one ref to doc1/application/pdf", items[0].Documents)
+	}
+	data, err := json.Marshal(items[0])
+	if err != nil {
+		t.Fatalf("marshal item: %v", err)
+	}
+	if strings.Contains(string(data), "xxxx") {
+		t.Fatal("markdown leaked into the UI transcript payload")
 	}
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -132,6 +132,15 @@ export async function retryStream(
   return postSSE(`/v1/sessions/${sessionId}/messages/retry`, undefined, onEvent, opts)
 }
 
+// stopTurn cancels a session's in-flight turn server-side: the turn now
+// runs detached from the request that started it, so aborting the
+// local fetch (AbortController) no longer stops it — this is the only
+// thing that does. A 404 (no turn running, or it already finished) is
+// a benign race from the caller's point of view, same as streamLive's.
+export async function stopTurn(sessionId: string): Promise<void> {
+  await request<void>(`/v1/sessions/${sessionId}/stop`, { method: 'POST' })
+}
+
 // streamLive reattaches to a session's in-flight turn (Tier 2 of live
 // reattach): GET .../live replays whatever the turn already emitted
 // then follows it live until the terminal, wire-identical to

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -127,6 +127,9 @@ export interface TranscriptItem {
   text?: string
   blocks?: UIBlock[]
   images?: ImageRef[]
+  // documents are attached PDFs, refs only (id+mime) — the converted
+  // markdown never rides this payload.
+  documents?: ImageRef[]
   tool?: ToolExecution
   permission?: PermissionRequestEvent
   provider?: string

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -216,14 +216,43 @@ describe('Composer attachments', () => {
     render(<Composer {...baseProps()} onAttachments={onAttachments} />)
 
     const input = document.querySelector('input[type="file"]') as HTMLInputElement
-    const pdf = makeImageFile('doc.pdf', 'application/pdf')
-    fireEvent.change(input, { target: { files: [pdf] } })
+    const bogus = makeImageFile('notes.txt', 'text/plain')
+    fireEvent.change(input, { target: { files: [bogus] } })
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith('doc.pdf: unsupported image type'),
+      expect(toast.error).toHaveBeenCalledWith('notes.txt: unsupported file type'),
     )
     expect(client.uploadAttachment).not.toHaveBeenCalled()
     expect(onAttachments).not.toHaveBeenCalled()
+  })
+
+  it('uploads a selected PDF and adds a file chip on success', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.uploadAttachment).mockResolvedValue({
+      id: 'att-pdf',
+      mime: 'application/pdf',
+      size_bytes: 2048,
+    })
+    const onAttachments = vi.fn()
+    const { rerender } = render(
+      <Composer {...baseProps()} attachments={[]} onAttachments={onAttachments} />,
+    )
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const pdf = makeImageFile('doc.pdf', 'application/pdf')
+    fireEvent.change(input, { target: { files: [pdf] } })
+
+    await waitFor(() => expect(client.uploadAttachment).toHaveBeenCalledWith(pdf))
+    await waitFor(() =>
+      expect(onAttachments).toHaveBeenLastCalledWith([
+        expect.objectContaining({ id: 'att-pdf', mime: 'application/pdf', uploading: false }),
+      ]),
+    )
+
+    const [[chips]] = onAttachments.mock.calls.slice(-1)
+    rerender(<Composer {...baseProps()} attachments={chips} onAttachments={onAttachments} />)
+    expect(screen.getByText('doc.pdf')).toBeTruthy()
+    expect(screen.queryByAltText('doc.pdf')).toBeNull()
   })
 
   it('removes a chip and revokes its object URL', () => {

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -140,6 +140,27 @@ describe('Composer mic button', () => {
   })
 })
 
+describe('Composer stop button', () => {
+  it('shows Send, not Stop, when not streaming', () => {
+    render(<Composer {...baseProps()} streaming={false} onStop={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Send' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Stop' })).toBeNull()
+  })
+
+  it('shows Stop instead of Send while streaming, and fires onStop', () => {
+    const onStop = vi.fn()
+    render(<Composer {...baseProps()} streaming={true} onStop={onStop} />)
+    expect(screen.queryByRole('button', { name: 'Send' })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }))
+    expect(onStop).toHaveBeenCalledOnce()
+  })
+
+  it('falls back to Send while streaming if onStop is not given', () => {
+    render(<Composer {...baseProps()} streaming={true} />)
+    expect(screen.getByRole('button', { name: 'Send' })).toBeTruthy()
+  })
+})
+
 function makeImageFile(name = 'photo.png', type = 'image/png', size = 1024): File {
   const file = new File([new Uint8Array(size)], name, { type })
   return file

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -5,6 +5,7 @@ import {
   Loading03Icon,
   Mic01Icon,
   Pdf02Icon,
+  StopIcon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import type { ClipboardEvent, DragEvent } from 'react'
@@ -44,6 +45,8 @@ export function Composer({
   skillHint,
   onRemoveSkillHint,
   disabled = false,
+  streaming = false,
+  onStop,
   autoFocus = false,
   placeholder = 'Message Timothy…',
   attachments = [],
@@ -60,6 +63,12 @@ export function Composer({
   skillHint?: string
   onRemoveSkillHint?: () => void
   disabled?: boolean
+  // streaming/onStop swap the send button for a stop control while a
+  // turn is in flight — the turn now runs detached server-side (see
+  // chat.Service.StopTurn), so unmounting or navigating away no longer
+  // stops it; this is the explicit way to.
+  streaming?: boolean
+  onStop?: () => void
   autoFocus?: boolean
   placeholder?: string
   attachments?: PendingAttachment[]
@@ -337,15 +346,26 @@ export function Composer({
             />
           </button>
         </div>
-        <button
-          type="button"
-          onClick={onSend}
-          aria-label="Send"
-          disabled={disabled || (draft.trim() === '' && attachments.length === 0)}
-          className="flex size-9 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 disabled:bg-zinc-200 disabled:text-zinc-400 dark:disabled:bg-zinc-700 dark:disabled:text-zinc-500"
-        >
-          <HugeiconsIcon icon={ArrowUp01Icon} className="size-4" />
-        </button>
+        {streaming && onStop ? (
+          <button
+            type="button"
+            onClick={onStop}
+            aria-label="Stop"
+            className="flex size-9 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500"
+          >
+            <HugeiconsIcon icon={StopIcon} className="size-4" />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onSend}
+            aria-label="Send"
+            disabled={disabled || (draft.trim() === '' && attachments.length === 0)}
+            className="flex size-9 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 disabled:bg-zinc-200 disabled:text-zinc-400 dark:disabled:bg-zinc-700 dark:disabled:text-zinc-500"
+          >
+            <HugeiconsIcon icon={ArrowUp01Icon} className="size-4" />
+          </button>
+        )}
       </div>
     </div>
   )

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -4,6 +4,7 @@ import {
   Cancel01Icon,
   Loading03Icon,
   Mic01Icon,
+  Pdf02Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import type { ClipboardEvent, DragEvent } from 'react'
@@ -24,7 +25,7 @@ export interface PendingAttachment {
   uploading?: boolean
 }
 
-const allowedMimes = ['image/png', 'image/jpeg', 'image/webp', 'image/gif']
+const allowedMimes = ['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'application/pdf']
 const maxAttachmentBytes = 10 * 1024 * 1024
 const maxAttachments = 8
 
@@ -157,7 +158,7 @@ export function Composer({
     if (!onAttachments) return
     for (const file of files) {
       if (!allowedMimes.includes(file.type)) {
-        toast.error(`${file.name || 'file'}: unsupported image type`)
+        toast.error(`${file.name || 'file'}: unsupported file type`)
         continue
       }
       if (file.size > maxAttachmentBytes) {
@@ -165,7 +166,7 @@ export function Composer({
         continue
       }
       if (attachmentsRef.current.length >= maxAttachments) {
-        toast.error(`You can attach up to ${maxAttachments} images`)
+        toast.error(`You can attach up to ${maxAttachments} files`)
         break
       }
       const tempId = crypto.randomUUID()
@@ -229,7 +230,14 @@ export function Composer({
               className="group relative size-12 shrink-0 overflow-hidden rounded-lg border border-zinc-950/10 dark:border-white/10"
               title={a.name}
             >
-              <img src={a.previewUrl} alt={a.name ?? 'attachment'} className="size-full object-cover" />
+              {a.mime === 'application/pdf' ? (
+                <div className="flex size-full flex-col items-center justify-center gap-0.5 bg-zinc-100 text-zinc-500 dark:bg-zinc-700 dark:text-zinc-400">
+                  <HugeiconsIcon icon={Pdf02Icon} className="size-4" />
+                  <span className="max-w-full truncate px-1 text-[9px]">{a.name ?? 'PDF'}</span>
+                </div>
+              ) : (
+                <img src={a.previewUrl} alt={a.name ?? 'attachment'} className="size-full object-cover" />
+              )}
               {a.uploading && (
                 <div className="absolute inset-0 flex items-center justify-center bg-black/40">
                   <HugeiconsIcon icon={Loading03Icon} className="size-4 animate-spin text-white" />
@@ -291,7 +299,7 @@ export function Composer({
               <input
                 ref={fileInputRef}
                 type="file"
-                accept="image/png,image/jpeg,image/webp,image/gif"
+                accept="image/png,image/jpeg,image/webp,image/gif,application/pdf"
                 multiple
                 className="hidden"
                 onChange={(e) => {

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -415,4 +415,24 @@ describe('UserMessage attachments', () => {
     render(<UserMessage text="plain text" />)
     expect(screen.queryByRole('img')).not.toBeInTheDocument()
   })
+
+  it('renders a non-clickable chip per attached document, never fetching it', async () => {
+    const client = await import('../api/client')
+
+    render(
+      <UserMessage
+        text="summarize this"
+        documents={[{ id: 'doc-1', mime: 'application/pdf' }]}
+      />,
+    )
+
+    expect(screen.getByText('PDF')).toBeInTheDocument()
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(client.fetchAttachmentBlob).not.toHaveBeenCalledWith('doc-1')
+  })
+
+  it('renders no document chips when the message carries none', () => {
+    render(<UserMessage text="plain text" />)
+    expect(screen.queryByText('PDF')).not.toBeInTheDocument()
+  })
 })

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -3,6 +3,7 @@ import {
   ImageNotFound01Icon,
   Link04Icon,
   Loading03Icon,
+  Pdf02Icon,
   Tick02Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
@@ -101,6 +102,27 @@ function ImageGrid({ images, localUrls }: { images: ImageRef[]; localUrls?: Map<
   )
 }
 
+// DocumentChips renders a user message's attached PDFs as small,
+// non-clickable chips — unlike images there is no thumbnail to show
+// and no authed fetch to make (the converted markdown already rode
+// the turn server-side); this is just an acknowledgment of what was
+// attached.
+function DocumentChips({ documents }: { documents: ImageRef[] }) {
+  return (
+    <div className="flex max-w-2xl flex-wrap justify-end gap-1.5">
+      {documents.map((doc) => (
+        <div
+          key={doc.id}
+          className="flex items-center gap-1 rounded-lg border border-zinc-950/10 bg-zinc-100 px-2 py-1 text-xs text-zinc-500 dark:border-white/10 dark:bg-zinc-800 dark:text-zinc-400"
+        >
+          <HugeiconsIcon icon={Pdf02Icon} className="size-3.5" />
+          PDF
+        </div>
+      ))}
+    </div>
+  )
+}
+
 // SourcesPanel renders a research answer's citations as a distinct,
 // clickable list — separate from the prose so "these are the sources"
 // reads at a glance instead of blending into the markdown body.
@@ -178,6 +200,7 @@ export function CopyButton({
 export function UserMessage({
   text,
   images,
+  documents,
   localUrls,
   onRetry,
 }: {
@@ -185,6 +208,9 @@ export function UserMessage({
   // Attached images (transcript's Images, or the live turn's own
   // optimistic list) — thumbnails render above the text bubble.
   images?: ImageRef[]
+  // Attached PDFs (transcript's Documents, or the live turn's own
+  // optimistic list) — rendered as small chips, never fetched.
+  documents?: ImageRef[]
   // Optimistic-send local object URLs keyed by attachment id, so a
   // just-sent message's thumbnails render instantly without
   // round-tripping through AuthedImage's authed fetch.
@@ -197,6 +223,7 @@ export function UserMessage({
   return (
     <div className="flex flex-col items-end gap-1">
       {images && images.length > 0 && <ImageGrid images={images} localUrls={localUrls} />}
+      {documents && documents.length > 0 && <DocumentChips documents={documents} />}
       <div className="group/message flex items-end justify-end gap-1">
         <CopyButton text={text} label="Copy message" />
         {text !== '' && (

--- a/web/src/lib/transcript.test.ts
+++ b/web/src/lib/transcript.test.ts
@@ -337,4 +337,28 @@ describe('fromTranscript', () => {
       expect(items[0].images).toBeUndefined()
     }
   })
+
+  it("maps a user item's Documents into the chat item", () => {
+    const items = fromTranscript([
+      {
+        seq: 1,
+        kind: 'user',
+        text: 'summarize this',
+        documents: [{ id: 'doc-1', mime: 'application/pdf' }],
+        created_at: at,
+      },
+    ])
+    expect(items[0]).toMatchObject({
+      role: 'user',
+      text: 'summarize this',
+      documents: [{ id: 'doc-1', mime: 'application/pdf' }],
+    })
+  })
+
+  it('omits documents on a user item that carries none', () => {
+    const items = fromTranscript([{ seq: 1, kind: 'user', text: 'hello', created_at: at }])
+    if (items[0].role === 'user') {
+      expect(items[0].documents).toBeUndefined()
+    }
+  })
 })

--- a/web/src/lib/transcript.ts
+++ b/web/src/lib/transcript.ts
@@ -5,7 +5,7 @@ import type { AssistantState, ToolRun } from './chat'
 // replayed transcript items share this shape so resume is
 // pixel-equivalent with the original stream.
 export type ChatItem = { id: string } & (
-  | { role: 'user'; text: string; images?: ImageRef[] }
+  | { role: 'user'; text: string; images?: ImageRef[]; documents?: ImageRef[] }
   | ({ role: 'assistant' } & AssistantState)
   | { role: 'compaction'; text: string }
   | { role: 'interrupted'; text: string }
@@ -75,6 +75,7 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
           role: 'user',
           text: item.text ?? '',
           images: item.images && item.images.length > 0 ? item.images : undefined,
+          documents: item.documents && item.documents.length > 0 ? item.documents : undefined,
         })
         break
       case 'tool':

--- a/web/src/pages/Chat.test.tsx
+++ b/web/src/pages/Chat.test.tsx
@@ -19,6 +19,7 @@ vi.mock('../api/client', () => ({
   chatStream: vi.fn(),
   retryStream: vi.fn(),
   streamLive: vi.fn(),
+  stopTurn: vi.fn(),
   getTranscript: vi.fn(),
   answerPermission: vi.fn(),
   listRoutes: vi.fn(),
@@ -36,6 +37,7 @@ import {
   getTranscript,
   listAgents,
   listRoutes,
+  stopTurn,
   streamLive,
 } from '../api/client'
 import { subscribeEvents } from '../lib/events'
@@ -94,6 +96,7 @@ beforeEach(() => {
       onEvent({ type: 'meta', session_id: 's1' })
     },
   )
+  vi.mocked(stopTurn).mockResolvedValue(undefined)
 })
 
 describe('Chat route picker', () => {
@@ -353,5 +356,58 @@ describe('live reattach', () => {
     fireSignal({ kind: 'session', id: 'some-other-session' })
     await new Promise((r) => setTimeout(r, 10))
     expect(getTranscript).not.toHaveBeenCalled()
+  })
+})
+
+describe('stop turn', () => {
+  it('calls stopTurn when the Stop button is clicked mid-stream', async () => {
+    // A chatStream that never resolves on its own — the turn is still
+    // "streaming" from the page's point of view until the test clicks
+    // Stop, mirroring a real in-flight turn.
+    let released!: () => void
+    vi.mocked(chatStream).mockImplementation(
+      async (_req: ChatRequest, onEvent: (ev: ChatEvent) => void, opts: ChatStreamOptions = {}) => {
+        opts.onSession?.('s1')
+        await new Promise<void>((r) => {
+          released = r
+        })
+        onEvent({ type: 'meta', session_id: 's1' })
+      },
+    )
+
+    renderChat()
+    const input = screen.getByLabelText('Message')
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    const stopButton = await screen.findByRole('button', { name: 'Stop' })
+    fireEvent.click(stopButton)
+
+    expect(stopTurn).toHaveBeenCalledWith('s1')
+    released() // let the pending chatStream settle so the test can end cleanly
+  })
+
+  it('does NOT call stopTurn on unmount — only the local fetch is aborted', async () => {
+    let released!: () => void
+    vi.mocked(chatStream).mockImplementation(
+      async (_req: ChatRequest, onEvent: (ev: ChatEvent) => void, opts: ChatStreamOptions = {}) => {
+        opts.onSession?.('s1')
+        await new Promise<void>((r) => {
+          released = r
+        })
+        onEvent({ type: 'meta', session_id: 's1' })
+      },
+    )
+
+    const { unmount } = renderChat()
+    const input = screen.getByLabelText('Message')
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await screen.findByRole('button', { name: 'Stop' })
+    unmount()
+
+    expect(stopTurn).not.toHaveBeenCalled()
+    released()
   })
 })

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -301,13 +301,17 @@ export function Chat({
     if (ready.length > 0) {
       localUrlsRef.current.set(userItemId, new Map(ready.map((a) => [a.id, a.previewUrl])))
     }
+    const readyImages = ready.filter((a) => a.mime.startsWith('image/'))
+    const readyDocuments = ready.filter((a) => a.mime === 'application/pdf')
     setItems((prev) => [
       ...prev,
       {
         id: userItemId,
         role: 'user',
         text: message,
-        images: ready.length > 0 ? ready.map((a) => ({ id: a.id, mime: a.mime })) : undefined,
+        images: readyImages.length > 0 ? readyImages.map((a) => ({ id: a.id, mime: a.mime })) : undefined,
+        documents:
+          readyDocuments.length > 0 ? readyDocuments.map((a) => ({ id: a.id, mime: a.mime })) : undefined,
       },
       { id: crypto.randomUUID(), role: 'assistant', ...emptyAssistant() },
     ])
@@ -516,6 +520,7 @@ export function Chat({
                   key={item.id}
                   text={item.text}
                   images={item.images}
+                  documents={item.documents}
                   localUrls={localUrlsRef.current.get(item.id)}
                   // A trailing user message means the turn died before any
                   // assistant event reached the transcript — retry re-runs

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -7,6 +7,7 @@ import {
   chatStream,
   getTranscript,
   retryStream,
+  stopTurn,
   streamLive,
 } from '../api/client'
 import type { ChatEvent } from '../api/types'
@@ -378,6 +379,18 @@ export function Chat({
 
   const send = () => void sendMessage(draft, agent, skillHint, route, attachments)
 
+  // stop asks the server to cancel the in-flight turn (chat.Service now
+  // runs it detached from this request, so abortRef.current?.abort()
+  // alone only stops this tab's rendering, never the turn itself — see
+  // stopTurn's doc comment). Fire-and-forget: the turn's abnormal-end
+  // persistence and the local abort together already leave the UI in a
+  // sane state regardless of whether this call lands.
+  const stop = () => {
+    const sessionId = sessionRef.current
+    abortRef.current?.abort()
+    if (sessionId) stopTurn(sessionId).catch(() => toast.error('Could not stop the reply'))
+  }
+
   // retryLast re-runs the last (failed) turn: the session already
   // carries the dangling user message server-side (chat.Service.Retry),
   // so this never sends a new user message like sendMessage does. Two
@@ -570,6 +583,8 @@ export function Chat({
           skillHint={skillHint}
           onRemoveSkillHint={lockedSkillHint ? undefined : () => setSkillHint(undefined)}
           disabled={streaming}
+          streaming={streaming}
+          onStop={stop}
           placeholder={placeholder}
           attachments={attachments}
           onAttachments={setAttachments}


### PR DESCRIPTION
Two chat features:

## PDF attachments via markitdown
- `application/pdf` accepted by the attachment store (server-side sniff, `.pdf` on disk)
- Converted to markdown once at send time; markdown persisted on the `user_message` event so projection stays deterministic and prefix-stable (provider prompt caches), no per-turn sidecar calls
- Documents never flip the vision route; UI receives id+mime refs only, never the markdown
- Composer accepts PDFs (file chip), Message renders document chips

## Detached turn lifetime
- Turn runs on a detached context (request values kept, cancellation dropped) with a 30m ceiling (> 10m permission park) — navigation/reload no longer kills a running turn
- Client disconnect only stops SSE forwarding; relay drains the live turn and persists normally; existing `/live` re-attach picks it up
- New `POST /v1/sessions/{id}/stop` + composer stop button as the explicit cancel (abort-as-stop no longer stops anything)

Both commits build and test green independently.