### PR TITLE
feat(chat): support pdf attachments via markitdown conversion

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -148,6 +148,9 @@ func main() {
 
 	searxngURL := os.Getenv("SEARXNG_URL")
 	markitdownURL := os.Getenv("MARKITDOWN_URL")
+	if markitdownURL == "" {
+		app.Log.Warn("MARKITDOWN_URL not set; PDF attachments in chat are unavailable")
+	}
 	whisperURL := os.Getenv("WHISPER_URL")
 	if whisperURL == "" {
 		app.Log.Warn("WHISPER_URL not set; the web mic button's /v1/transcribe endpoint is unavailable")
@@ -321,6 +324,9 @@ func main() {
 	// same guard shape as the missionHub check above.
 	if attachmentStore != nil {
 		svc.SetAttachments(attachmentStore)
+	}
+	if markitdownURL != "" {
+		svc.SetMarkitdown(markitdownURL)
 	}
 
 	api.Register(app.Server, svc, store, broker,

--- a/internal/brain/attachments/attachments.go
+++ b/internal/brain/attachments/attachments.go
@@ -1,7 +1,7 @@
-// Package attachments stores user-uploaded images content-addressed on
-// a local volume, with metadata only in Postgres — binaries never
-// enter the database (D-045). ATTACHMENTS_DIR unset means the feature
-// is off: callers nil-gate on a nil *Store.
+// Package attachments stores user-uploaded images and PDFs
+// content-addressed on a local volume, with metadata only in Postgres
+// — binaries never enter the database (D-045). ATTACHMENTS_DIR unset
+// means the feature is off: callers nil-gate on a nil *Store.
 package attachments
 
 import (
@@ -33,12 +33,13 @@ var ErrUnsupportedMIME = errors.New("attachments: unsupported mime type")
 var ErrNotFound = errors.New("attachments: not found")
 
 // allowedExt maps the sniffed MIME type to its stored file extension.
-// Only these four are accepted; anything else is ErrUnsupportedMIME.
+// Only these five are accepted; anything else is ErrUnsupportedMIME.
 var allowedExt = map[string]string{
-	"image/png":  ".png",
-	"image/jpeg": ".jpg",
-	"image/webp": ".webp",
-	"image/gif":  ".gif",
+	"image/png":       ".png",
+	"image/jpeg":      ".jpg",
+	"image/webp":      ".webp",
+	"image/gif":       ".gif",
+	"application/pdf": ".pdf",
 }
 
 // Attachment is one stored image's metadata.

--- a/internal/brain/attachments/attachments_integration_test.go
+++ b/internal/brain/attachments/attachments_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -49,6 +50,25 @@ func integrationStore(t *testing.T) *Store {
 		t.Fatalf("migrate: %v", err)
 	}
 	return New(t.TempDir(), pool)
+}
+
+// pdfBytes is a minimal PDF header — enough for http.DetectContentType
+// to sniff "application/pdf" (it only inspects the leading bytes).
+var pdfBytes = []byte("%PDF-1.4\n%\xe2\xe3\xcf\xd3\n1 0 obj\n<< /Type /Catalog >>\nendobj\n")
+
+func TestStoreSavePDF(t *testing.T) {
+	s := integrationStore(t)
+
+	att, err := s.Save(t.Context(), bytes.NewReader(pdfBytes))
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if att.Mime != "application/pdf" {
+		t.Fatalf("Mime = %q, want application/pdf", att.Mime)
+	}
+	if _, err := os.Stat(filepath.Join(s.dir, att.ID+".pdf")); err != nil {
+		t.Fatalf("expected %s.pdf on disk: %v", att.ID, err)
+	}
 }
 
 func TestStoreSaveDedup(t *testing.T) {

--- a/internal/brain/chat/attachments_test.go
+++ b/internal/brain/chat/attachments_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/SumonMSelim/timothy/internal/brain/attachments"
@@ -343,7 +344,11 @@ func fakeMarkitdown(t *testing.T, markdown string) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"markdown":"` + markdown + `"}`))
+		body, err := json.Marshal(map[string]string{"markdown": markdown})
+		if err != nil {
+			t.Fatalf("marshal fake markitdown response: %v", err)
+		}
+		_, _ = w.Write(body)
 	}))
 	t.Cleanup(srv.Close)
 	return srv
@@ -405,6 +410,47 @@ func TestChatPDFAttachmentWithoutMarkitdownIsBadRequest(t *testing.T) {
 	}
 	if kinds := log.kinds("s1"); len(kinds) != 0 {
 		t.Fatalf("events appended despite missing markitdown wiring: %v", kinds)
+	}
+}
+
+// TestChatPDFAttachmentTruncatesOversizedMarkdown confirms a converted
+// document past maxDocumentMarkdownBytes is cut at the cap and marked,
+// never persisted unbounded — a huge PDF must not blow the current
+// turn's context (LLMContext can't trim it, and the compactor only
+// shrinks older turns).
+func TestChatPDFAttachmentTruncatesOversizedMarkdown(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("read your huge pdf")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("doc1", "application/pdf", []byte("%PDF-1.4 fake"))
+	svc.SetAttachments(fa)
+	huge := strings.Repeat("a", maxDocumentMarkdownBytes+1024)
+	md := fakeMarkitdown(t, huge)
+	svc.SetMarkitdown(md.URL)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []string{"doc1"}})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+
+	events, _ := log.Events(t.Context(), "s1")
+	var um session.UserMessage
+	if err := json.Unmarshal(events[1].Payload, &um); err != nil {
+		t.Fatalf("decode user_message: %v", err)
+	}
+	if len(um.Documents) != 1 {
+		t.Fatalf("documents = %+v, want one", um.Documents)
+	}
+	got := um.Documents[0].Markdown
+	if !strings.HasSuffix(got, truncatedDocumentMarker) {
+		t.Fatalf("markdown does not end with truncation marker: %q", got[max(0, len(got)-60):])
+	}
+	if len(got) > maxDocumentMarkdownBytes+len(truncatedDocumentMarker) {
+		t.Fatalf("markdown len = %d, want <= %d", len(got), maxDocumentMarkdownBytes+len(truncatedDocumentMarker))
 	}
 }
 

--- a/internal/brain/chat/attachments_test.go
+++ b/internal/brain/chat/attachments_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/SumonMSelim/timothy/internal/brain/attachments"
@@ -331,5 +333,104 @@ func TestRetryOfImageTurnStaysOnVisionRoute(t *testing.T) {
 	sent := gw.lastChatRequest()
 	if sent.Route != "vision" {
 		t.Fatalf("retried route = %q, want vision (persisted route replayed)", sent.Route)
+	}
+}
+
+// fakeMarkitdown returns an httptest server standing in for the
+// markitdown sidecar: /convert replies with a fixed markdown body,
+// same wire shape internal/platform/markitdown.Convert expects.
+func fakeMarkitdown(t *testing.T, markdown string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"markdown":"` + markdown + `"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestChatPDFAttachmentConvertsToDocument confirms a PDF attachment
+// ref is split away from images, converted through the markitdown
+// sidecar exactly once at send time, and lands as a DocumentRef on
+// the persisted user_message — the markdown persisted, not re-fetched.
+func TestChatPDFAttachmentConvertsToDocument(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("read your pdf")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("doc1", "application/pdf", []byte("%PDF-1.4 fake"))
+	svc.SetAttachments(fa)
+	md := fakeMarkitdown(t, "# Converted Title")
+	svc.SetMarkitdown(md.URL)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []string{"doc1"}})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+
+	events, _ := log.Events(t.Context(), "s1")
+	var um session.UserMessage
+	if err := json.Unmarshal(events[1].Payload, &um); err != nil {
+		t.Fatalf("decode user_message: %v", err)
+	}
+	if len(um.Images) != 0 {
+		t.Fatalf("images = %+v, want none (pdf only)", um.Images)
+	}
+	if len(um.Documents) != 1 || um.Documents[0].ID != "doc1" || um.Documents[0].Mime != "application/pdf" {
+		t.Fatalf("documents = %+v, want one ref to doc1/application/pdf", um.Documents)
+	}
+	if um.Documents[0].Markdown != "# Converted Title" {
+		t.Fatalf("markdown = %q, want converted markdown persisted", um.Documents[0].Markdown)
+	}
+}
+
+// TestChatPDFAttachmentWithoutMarkitdownIsBadRequest confirms a PDF
+// ref 400s when the sidecar isn't wired (MARKITDOWN_URL unset) —
+// SetMarkitdown never called, so s.markitdownURL stays "".
+func TestChatPDFAttachmentWithoutMarkitdownIsBadRequest(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	svc := newService(&fakeGW{}, log)
+	fa := newFakeAttachments()
+	fa.seed("doc1", "application/pdf", []byte("%PDF-1.4 fake"))
+	svc.SetAttachments(fa)
+	// SetMarkitdown intentionally not called.
+
+	_, _, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []string{"doc1"}})
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("err = %v, want ErrBadRequest", err)
+	}
+	if kinds := log.kinds("s1"); len(kinds) != 0 {
+		t.Fatalf("events appended despite missing markitdown wiring: %v", kinds)
+	}
+}
+
+// TestChatDocumentsOnlyMessageDoesNotFlipToVisionRoute confirms the
+// D-046 vision auto-flip stays keyed on images alone: a message
+// carrying only a PDF (converted to plain text) never rides the
+// vision chain.
+func TestChatDocumentsOnlyMessageDoesNotFlipToVisionRoute(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("read your pdf")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("doc1", "application/pdf", []byte("%PDF-1.4 fake"))
+	svc.SetAttachments(fa)
+	md := fakeMarkitdown(t, "converted text")
+	svc.SetMarkitdown(md.URL)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []string{"doc1"}})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	sent := gw.lastChatRequest()
+	if sent.Route != defaultRoute {
+		t.Fatalf("route = %q, want %q (documents-only message, no vision flip)", sent.Route, defaultRoute)
 	}
 }

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/skills"
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+	"github.com/SumonMSelim/timothy/internal/platform/markitdown"
 )
 
 const (
@@ -134,23 +136,25 @@ type Granter interface {
 
 // Service orchestrates turns against the event store.
 type Service struct {
-	gw          Gateway
-	log         SessionLog
-	distill     Distill
-	compactor   Compactor
-	memory      MemoryExtract   // nil: long-term memory off
-	recall      MemoryRetrieve  // nil: no memory injection
-	agents      AgentResolver   // nil: zero-value agent (everything allowed)
-	candidates  AgentCandidates // nil: auto-dispatch falls back to default
-	classify    agents.Classify // nil: auto-dispatch falls back to default
-	budget      func(context.Context) int
-	packs       []skills.Skill
-	skillAllow  func(context.Context, string) bool // nil: all packs allowed
-	skillBodies map[string]string                  // name -> full pack body, for skill_hint
-	flushEvery  time.Duration                      // pending-state flush cadence mid-stream
-	sensitive   *session.SensitiveTools            // nil: no sensitive-tool route pin for side-calls
-	attachments AttachmentStore                    // nil: attachments disabled (ATTACHMENTS_DIR unset)
-	logger      *slog.Logger
+	gw             Gateway
+	log            SessionLog
+	distill        Distill
+	compactor      Compactor
+	memory         MemoryExtract   // nil: long-term memory off
+	recall         MemoryRetrieve  // nil: no memory injection
+	agents         AgentResolver   // nil: zero-value agent (everything allowed)
+	candidates     AgentCandidates // nil: auto-dispatch falls back to default
+	classify       agents.Classify // nil: auto-dispatch falls back to default
+	budget         func(context.Context) int
+	packs          []skills.Skill
+	skillAllow     func(context.Context, string) bool // nil: all packs allowed
+	skillBodies    map[string]string                  // name -> full pack body, for skill_hint
+	flushEvery     time.Duration                      // pending-state flush cadence mid-stream
+	sensitive      *session.SensitiveTools            // nil: no sensitive-tool route pin for side-calls
+	attachments    AttachmentStore                    // nil: attachments disabled (ATTACHMENTS_DIR unset)
+	markitdownURL  string                             // "": pdf attachments disabled (MARKITDOWN_URL unset)
+	markitdownHTTP *http.Client                       // shared client for the markitdown sidecar call
+	logger         *slog.Logger
 
 	grants Granter // nil: chat never seeds standing grants (today's behavior)
 	// seeded remembers which (session, agent) pairs already had their
@@ -206,6 +210,16 @@ func (s *Service) SetSensitiveTools(t *session.SensitiveTools) { s.sensitive = t
 // SetAttachments wires the attachment store (D-045). Optional — nil
 // (ATTACHMENTS_DIR unset) rejects any Request naming Attachments ids.
 func (s *Service) SetAttachments(store AttachmentStore) { s.attachments = store }
+
+// SetMarkitdown wires the markitdown sidecar's base URL for PDF
+// attachment conversion. Optional — empty (MARKITDOWN_URL unset)
+// rejects any PDF attachment ref with ErrBadRequest.
+func (s *Service) SetMarkitdown(url string) {
+	s.markitdownURL = url
+	if s.markitdownHTTP == nil {
+		s.markitdownHTTP = &http.Client{}
+	}
+}
 
 // SetAutoDispatch wires auto agent dispatch (D-034 follow-up): a
 // request naming the autoAgentName sentinel resolves through candidates
@@ -367,12 +381,12 @@ func profileAllows(allow []string, name string) bool {
 
 // Request is one chat turn.
 type Request struct {
-	SessionID    string `json:"session_id,omitempty"`
-	Message      string `json:"message"`
+	SessionID string `json:"session_id,omitempty"`
+	Message   string `json:"message"`
 	// Agent names who serves this turn; empty = the default agent.
-	Agent string `json:"agent,omitempty"`
-	Route string `json:"route,omitempty"`
-	ModelHint    string `json:"model_hint,omitempty"`
+	Agent     string `json:"agent,omitempty"`
+	Route     string `json:"route,omitempty"`
+	ModelHint string `json:"model_hint,omitempty"`
 	// SkillHint names a skill pack to force-load for this turn — set
 	// when the user picked one explicitly (a UI chip, not parsed
 	// text). Unlike load_skill, this is not a choice the model can
@@ -393,7 +407,7 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	if strings.TrimSpace(req.Message) == "" && len(req.Attachments) == 0 {
 		return "", nil, fmt.Errorf("chat: %w: message or an attachment is required", ErrBadRequest)
 	}
-	images, err := s.validateAttachments(ctx, req.Attachments)
+	images, documents, err := s.validateAttachments(ctx, req.Attachments)
 	if err != nil {
 		return "", nil, err
 	}
@@ -422,6 +436,9 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	// to the vision route, then the agent's route, then the default chain
 	// (sensitive-pin below still overrides all of this).
 	route := req.Route
+	// Only images flip to the vision route — documents are converted to
+	// plain markdown text, not something the model needs vision
+	// capability to read.
 	if route == "" && len(images) > 0 {
 		// D-046: brain has no cheap way to know whether a "vision" route
 		// exists/is enabled/has a non-empty chain (gwclient exposes no
@@ -474,7 +491,7 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	}
 
 	if _, err := s.log.Append(ctx, sessionID, session.KindUserMessage, session.UserMessage{
-		Text: req.Message, Route: route, Agent: profile.Name, ModelHint: modelHint, Images: images,
+		Text: req.Message, Route: route, Agent: profile.Name, ModelHint: modelHint, Images: images, Documents: documents,
 	}); err != nil {
 		s.turnDone(sessionID)
 		return sessionID, nil, err
@@ -530,24 +547,56 @@ func (s *Service) readAttachment(ctx context.Context, id string) (string, error)
 // BEFORE the turn's exclusivity is won or anything is appended (D-042:
 // store lookups are read-only and safe before turnBegin, but a bad ref
 // must 400 before even the user_message persists). Empty ids returns
-// nil, nil without touching the store — attachments stay off when
+// nil, nil, nil without touching the store — attachments stay off when
 // unconfigured, and a message with none never needs it wired.
-func (s *Service) validateAttachments(ctx context.Context, ids []string) ([]session.ImageRef, error) {
+//
+// PDFs are converted to markdown here, once, at send time (not lazily
+// per turn like images): re-converting on every turn would re-call the
+// markitdown sidecar every turn, and any output drift would rewrite an
+// earlier projected message — breaking LLMContext's prefix stability
+// that provider prompt caches depend on. A conversion failure is the
+// sidecar's fault, not the client's, so it returns a plain wrapped
+// error rather than ErrBadRequest.
+func (s *Service) validateAttachments(ctx context.Context, ids []string) ([]session.ImageRef, []session.DocumentRef, error) {
 	if len(ids) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if s.attachments == nil {
-		return nil, fmt.Errorf("chat: %w: attachments are not enabled", ErrBadRequest)
+		return nil, nil, fmt.Errorf("chat: %w: attachments are not enabled", ErrBadRequest)
 	}
-	refs := make([]session.ImageRef, 0, len(ids))
+	var images []session.ImageRef
+	var documents []session.DocumentRef
 	for _, id := range ids {
 		att, err := s.attachments.Get(ctx, id)
 		if err != nil {
-			return nil, fmt.Errorf("chat: %w: attachment %q: %v", ErrBadRequest, id, err)
+			return nil, nil, fmt.Errorf("chat: %w: attachment %q: %v", ErrBadRequest, id, err)
 		}
-		refs = append(refs, session.ImageRef{ID: att.ID, Mime: att.Mime})
+		switch {
+		case strings.HasPrefix(att.Mime, "image/"):
+			images = append(images, session.ImageRef{ID: att.ID, Mime: att.Mime})
+		case att.Mime == "application/pdf":
+			if s.markitdownURL == "" {
+				return nil, nil, fmt.Errorf("chat: %w: pdf attachments require the markitdown sidecar (MARKITDOWN_URL)", ErrBadRequest)
+			}
+			r, _, err := s.attachments.Open(ctx, att.ID)
+			if err != nil {
+				return nil, nil, fmt.Errorf("chat: %w: attachment %q: %v", ErrBadRequest, id, err)
+			}
+			raw, err := io.ReadAll(r)
+			_ = r.Close()
+			if err != nil {
+				return nil, nil, fmt.Errorf("chat: read attachment %q: %w", id, err)
+			}
+			md, err := markitdown.Convert(ctx, s.markitdownHTTP, s.markitdownURL, att.ID+".pdf", att.Mime, raw)
+			if err != nil {
+				return nil, nil, fmt.Errorf("chat: convert attachment %q: %w", id, err)
+			}
+			documents = append(documents, session.DocumentRef{ID: att.ID, Mime: att.Mime, Markdown: md})
+		default:
+			return nil, nil, fmt.Errorf("chat: %w: attachment %q: unsupported mime %q", ErrBadRequest, id, att.Mime)
+		}
 	}
-	return refs, nil
+	return images, documents, nil
 }
 
 // pinSensitiveRoute promotes the session-wide privacy floor above the

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -69,7 +69,30 @@ const (
 	// that just re-seeds the grant on its next turn, same degrade as a
 	// mission outliving its grant.
 	approvalGrantTTL = 12 * time.Hour
+	// maxDocumentMarkdownBytes caps a converted PDF's persisted markdown
+	// (128KB ≈ ~32k tokens): the markdown lands unbounded in the current
+	// turn's message, and LLMContext never trims it — the compactor only
+	// summarizes OLDER turns, so a huge PDF would blow the model's
+	// context on the very turn that attached it.
+	maxDocumentMarkdownBytes = 128 << 10
 )
+
+// truncatedDocumentMarker is appended when a converted document's
+// markdown is cut at maxDocumentMarkdownBytes, so the model (and the
+// user re-reading the transcript) knows the document wasn't fully
+// captured rather than silently ending mid-sentence.
+const truncatedDocumentMarker = "\n\n[document truncated: markdown exceeded 128KB]"
+
+// truncateDocumentMarkdown caps md at maxDocumentMarkdownBytes, cutting
+// at a valid rune boundary (strings.ToValidUTF8 drops any partial rune
+// left dangling by the byte-level slice) and appending
+// truncatedDocumentMarker. A no-op when md is already within budget.
+func truncateDocumentMarkdown(md string) string {
+	if len(md) <= maxDocumentMarkdownBytes {
+		return md
+	}
+	return strings.ToValidUTF8(md[:maxDocumentMarkdownBytes], "") + truncatedDocumentMarker
+}
 
 // ErrBadRequest marks caller mistakes (empty message) so the API can
 // answer 400 instead of blaming the gateway.
@@ -591,7 +614,7 @@ func (s *Service) validateAttachments(ctx context.Context, ids []string) ([]sess
 			if err != nil {
 				return nil, nil, fmt.Errorf("chat: convert attachment %q: %w", id, err)
 			}
-			documents = append(documents, session.DocumentRef{ID: att.ID, Mime: att.Mime, Markdown: md})
+			documents = append(documents, session.DocumentRef{ID: att.ID, Mime: att.Mime, Markdown: truncateDocumentMarkdown(md)})
 		default:
 			return nil, nil, fmt.Errorf("chat: %w: attachment %q: unsupported mime %q", ErrBadRequest, id, att.Mime)
 		}

--- a/internal/brain/session/events.go
+++ b/internal/brain/session/events.go
@@ -48,13 +48,21 @@ type SessionStarted struct {
 // UserMessage is one user turn.
 type UserMessage struct {
 	Text      string `json:"text"`
-	Route  string `json:"route,omitempty"`
-	Agent  string `json:"agent,omitempty"`
+	Route     string `json:"route,omitempty"`
+	Agent     string `json:"agent,omitempty"`
 	ModelHint string `json:"model_hint,omitempty"`
 	// Images are refs to attachments (internal/brain/attachments),
 	// never bytes — base64 exists only transiently at request-build
 	// time (D-045). Additive: a message with no images omits this.
 	Images []ImageRef `json:"images,omitempty"`
+	// Documents are PDF attachments converted to markdown once, at
+	// message-send time (chat.Chat), with the markdown persisted here.
+	// Re-converting per turn would re-call the markitdown sidecar every
+	// turn, and any output drift would rewrite an earlier projected
+	// message — breaking LLMContext's prefix stability that provider
+	// prompt caches depend on. Additive: a message with no documents
+	// omits this.
+	Documents []DocumentRef `json:"documents,omitempty"`
 }
 
 // ImageRef points at a stored attachment; Mime rides alongside so
@@ -63,6 +71,16 @@ type UserMessage struct {
 type ImageRef struct {
 	ID   string `json:"id"`
 	Mime string `json:"mime"`
+}
+
+// DocumentRef points at a stored PDF attachment; Markdown is its
+// converted text, persisted so projection is deterministic and the
+// markitdown sidecar is called exactly once per attach (see
+// UserMessage.Documents).
+type DocumentRef struct {
+	ID       string `json:"id"`
+	Mime     string `json:"mime"`
+	Markdown string `json:"markdown"`
 }
 
 // UIBlock is one renderable piece of an assistant turn.

--- a/internal/brain/session/projection.go
+++ b/internal/brain/session/projection.go
@@ -80,6 +80,19 @@ func LLMContext(events []Event, budget int) ([]provider.Message, error) {
 			for _, img := range m.Images {
 				msg.ImageRefs = append(msg.ImageRefs, provider.ImageRef{ID: img.ID, Mime: img.Mime})
 			}
+			// Documents carry their markdown already converted and
+			// persisted (chat.Chat, at send time) — projection just
+			// appends it as ordinary text, no store round-trip and no
+			// sidecar call. PDFs never flip the vision route; only
+			// images do.
+			for _, doc := range m.Documents {
+				block := fmt.Sprintf("[attached document %s (%s)]\n%s", doc.ID, doc.Mime, doc.Markdown)
+				if msg.Content == "" {
+					msg.Content = block
+				} else {
+					msg.Content += "\n\n" + block
+				}
+			}
 			msgs = append(msgs, msg)
 		case KindAssistantTurn:
 			var t AssistantTurn
@@ -185,11 +198,14 @@ func renderTurnMemory(tm *TurnMemory) string {
 
 // TranscriptItem is one renderable unit of the UI replay.
 type TranscriptItem struct {
-	Seq        int64              `json:"seq"`
-	Kind       string             `json:"kind"` // user | assistant | tool | permission | compaction | interrupted | error
-	Text       string             `json:"text,omitempty"`
-	Blocks     []UIBlock          `json:"blocks,omitempty"`
-	Images     []ImageRef         `json:"images,omitempty"`
+	Seq    int64      `json:"seq"`
+	Kind   string     `json:"kind"` // user | assistant | tool | permission | compaction | interrupted | error
+	Text   string     `json:"text,omitempty"`
+	Blocks []UIBlock  `json:"blocks,omitempty"`
+	Images []ImageRef `json:"images,omitempty"`
+	// Documents are refs only (id+mime) — never the converted markdown,
+	// which can be huge and has no reason to reach the UI payload.
+	Documents  []ImageRef         `json:"documents,omitempty"`
 	Provider   string             `json:"provider,omitempty"`
 	Model      string             `json:"model,omitempty"`
 	Usage      *stream.Usage      `json:"usage,omitempty"`
@@ -219,6 +235,9 @@ func UITranscript(events []Event) ([]TranscriptItem, error) {
 				return nil, err
 			}
 			item.Kind, item.Text, item.Images = "user", m.Text, m.Images
+			for _, doc := range m.Documents {
+				item.Documents = append(item.Documents, ImageRef{ID: doc.ID, Mime: doc.Mime})
+			}
 		case KindAssistantTurn:
 			var t AssistantTurn
 			if err := decode(ev, &t); err != nil {

--- a/internal/brain/session/projection_test.go
+++ b/internal/brain/session/projection_test.go
@@ -94,6 +94,35 @@ func TestLLMContextCarriesImageRefsNotBytes(t *testing.T) {
 	}
 }
 
+// TestLLMContextRendersDocumentMarkdown confirms a user_message's
+// DocumentRef renders its already-converted markdown straight into the
+// LLM content (no store round-trip, no sidecar call at projection
+// time) — the persisted markdown is the sole source, per D-045/D-046's
+// send-time-conversion design.
+func TestLLMContextRendersDocumentMarkdown(t *testing.T) {
+	t.Parallel()
+	events := []Event{
+		ev(t, 1, KindSessionStarted, SessionStarted{}),
+		ev(t, 2, KindUserMessage, UserMessage{
+			Text:      "summarize this",
+			Documents: []DocumentRef{{ID: "doc1", Mime: "application/pdf", Markdown: "# Title\n\nbody text"}},
+		}),
+	}
+
+	msgs, err := LLMContext(events, 100_000)
+	if err != nil {
+		t.Fatalf("LLMContext: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("messages = %+v, want 1", msgs)
+	}
+	m := msgs[0]
+	if !strings.Contains(m.Content, "summarize this") || !strings.Contains(m.Content, "# Title") ||
+		!strings.Contains(m.Content, "body text") || !strings.Contains(m.Content, "doc1") {
+		t.Fatalf("Content = %q, want text + rendered document markdown", m.Content)
+	}
+}
+
 func TestLLMContextSerializesTurnMemory(t *testing.T) {
 	t.Parallel()
 	events := []Event{
@@ -306,6 +335,39 @@ func TestUITranscriptCarriesImages(t *testing.T) {
 	}
 	if len(items[0].Images) != 1 || items[0].Images[0].ID != "img1" || items[0].Images[0].Mime != "image/jpeg" {
 		t.Fatalf("Images = %+v, want one ref to img1/image/jpeg", items[0].Images)
+	}
+}
+
+// TestUITranscriptExposesDocumentsWithoutMarkdown confirms a
+// user_message's document refs surface on TranscriptItem.Documents as
+// id+mime only — the converted markdown never rides the UI payload,
+// which can be arbitrarily large.
+func TestUITranscriptExposesDocumentsWithoutMarkdown(t *testing.T) {
+	t.Parallel()
+	events := []Event{
+		ev(t, 1, KindSessionStarted, SessionStarted{}),
+		ev(t, 2, KindUserMessage, UserMessage{
+			Text:      "look",
+			Documents: []DocumentRef{{ID: "doc1", Mime: "application/pdf", Markdown: strings.Repeat("x", 10_000)}},
+		}),
+	}
+
+	items, err := UITranscript(events)
+	if err != nil {
+		t.Fatalf("UITranscript: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items = %+v, want 1", items)
+	}
+	if len(items[0].Documents) != 1 || items[0].Documents[0].ID != "doc1" || items[0].Documents[0].Mime != "application/pdf" {
+		t.Fatalf("Documents = %+v, want one ref to doc1/application/pdf", items[0].Documents)
+	}
+	data, err := json.Marshal(items[0])
+	if err != nil {
+		t.Fatalf("marshal item: %v", err)
+	}
+	if strings.Contains(string(data), "xxxx") {
+		t.Fatal("markdown leaked into the UI transcript payload")
 	}
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -127,6 +127,9 @@ export interface TranscriptItem {
   text?: string
   blocks?: UIBlock[]
   images?: ImageRef[]
+  // documents are attached PDFs, refs only (id+mime) — the converted
+  // markdown never rides this payload.
+  documents?: ImageRef[]
   tool?: ToolExecution
   permission?: PermissionRequestEvent
   provider?: string

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -216,14 +216,43 @@ describe('Composer attachments', () => {
     render(<Composer {...baseProps()} onAttachments={onAttachments} />)
 
     const input = document.querySelector('input[type="file"]') as HTMLInputElement
-    const pdf = makeImageFile('doc.pdf', 'application/pdf')
-    fireEvent.change(input, { target: { files: [pdf] } })
+    const bogus = makeImageFile('notes.txt', 'text/plain')
+    fireEvent.change(input, { target: { files: [bogus] } })
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith('doc.pdf: unsupported image type'),
+      expect(toast.error).toHaveBeenCalledWith('notes.txt: unsupported file type'),
     )
     expect(client.uploadAttachment).not.toHaveBeenCalled()
     expect(onAttachments).not.toHaveBeenCalled()
+  })
+
+  it('uploads a selected PDF and adds a file chip on success', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.uploadAttachment).mockResolvedValue({
+      id: 'att-pdf',
+      mime: 'application/pdf',
+      size_bytes: 2048,
+    })
+    const onAttachments = vi.fn()
+    const { rerender } = render(
+      <Composer {...baseProps()} attachments={[]} onAttachments={onAttachments} />,
+    )
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const pdf = makeImageFile('doc.pdf', 'application/pdf')
+    fireEvent.change(input, { target: { files: [pdf] } })
+
+    await waitFor(() => expect(client.uploadAttachment).toHaveBeenCalledWith(pdf))
+    await waitFor(() =>
+      expect(onAttachments).toHaveBeenLastCalledWith([
+        expect.objectContaining({ id: 'att-pdf', mime: 'application/pdf', uploading: false }),
+      ]),
+    )
+
+    const [[chips]] = onAttachments.mock.calls.slice(-1)
+    rerender(<Composer {...baseProps()} attachments={chips} onAttachments={onAttachments} />)
+    expect(screen.getByText('doc.pdf')).toBeTruthy()
+    expect(screen.queryByAltText('doc.pdf')).toBeNull()
   })
 
   it('removes a chip and revokes its object URL', () => {

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -4,6 +4,7 @@ import {
   Cancel01Icon,
   Loading03Icon,
   Mic01Icon,
+  Pdf02Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import type { ClipboardEvent, DragEvent } from 'react'
@@ -24,7 +25,7 @@ export interface PendingAttachment {
   uploading?: boolean
 }
 
-const allowedMimes = ['image/png', 'image/jpeg', 'image/webp', 'image/gif']
+const allowedMimes = ['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'application/pdf']
 const maxAttachmentBytes = 10 * 1024 * 1024
 const maxAttachments = 8
 
@@ -157,7 +158,7 @@ export function Composer({
     if (!onAttachments) return
     for (const file of files) {
       if (!allowedMimes.includes(file.type)) {
-        toast.error(`${file.name || 'file'}: unsupported image type`)
+        toast.error(`${file.name || 'file'}: unsupported file type`)
         continue
       }
       if (file.size > maxAttachmentBytes) {
@@ -165,7 +166,7 @@ export function Composer({
         continue
       }
       if (attachmentsRef.current.length >= maxAttachments) {
-        toast.error(`You can attach up to ${maxAttachments} images`)
+        toast.error(`You can attach up to ${maxAttachments} files`)
         break
       }
       const tempId = crypto.randomUUID()
@@ -229,7 +230,14 @@ export function Composer({
               className="group relative size-12 shrink-0 overflow-hidden rounded-lg border border-zinc-950/10 dark:border-white/10"
               title={a.name}
             >
-              <img src={a.previewUrl} alt={a.name ?? 'attachment'} className="size-full object-cover" />
+              {a.mime === 'application/pdf' ? (
+                <div className="flex size-full flex-col items-center justify-center gap-0.5 bg-zinc-100 text-zinc-500 dark:bg-zinc-700 dark:text-zinc-400">
+                  <HugeiconsIcon icon={Pdf02Icon} className="size-4" />
+                  <span className="max-w-full truncate px-1 text-[9px]">{a.name ?? 'PDF'}</span>
+                </div>
+              ) : (
+                <img src={a.previewUrl} alt={a.name ?? 'attachment'} className="size-full object-cover" />
+              )}
               {a.uploading && (
                 <div className="absolute inset-0 flex items-center justify-center bg-black/40">
                   <HugeiconsIcon icon={Loading03Icon} className="size-4 animate-spin text-white" />
@@ -291,7 +299,7 @@ export function Composer({
               <input
                 ref={fileInputRef}
                 type="file"
-                accept="image/png,image/jpeg,image/webp,image/gif"
+                accept="image/png,image/jpeg,image/webp,image/gif,application/pdf"
                 multiple
                 className="hidden"
                 onChange={(e) => {

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -428,7 +428,7 @@ describe('UserMessage attachments', () => {
 
     expect(screen.getByText('PDF')).toBeInTheDocument()
     expect(screen.queryByRole('img')).not.toBeInTheDocument()
-    expect(client.fetchAttachmentBlob).not.toHaveBeenCalledWith('doc-1')
+    expect(vi.mocked(client.fetchAttachmentBlob).mock.calls.flat()).not.toContain('doc-1')
   })
 
   it('renders no document chips when the message carries none', () => {

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -415,4 +415,24 @@ describe('UserMessage attachments', () => {
     render(<UserMessage text="plain text" />)
     expect(screen.queryByRole('img')).not.toBeInTheDocument()
   })
+
+  it('renders a non-clickable chip per attached document, never fetching it', async () => {
+    const client = await import('../api/client')
+
+    render(
+      <UserMessage
+        text="summarize this"
+        documents={[{ id: 'doc-1', mime: 'application/pdf' }]}
+      />,
+    )
+
+    expect(screen.getByText('PDF')).toBeInTheDocument()
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(client.fetchAttachmentBlob).not.toHaveBeenCalledWith('doc-1')
+  })
+
+  it('renders no document chips when the message carries none', () => {
+    render(<UserMessage text="plain text" />)
+    expect(screen.queryByText('PDF')).not.toBeInTheDocument()
+  })
 })

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -3,6 +3,7 @@ import {
   ImageNotFound01Icon,
   Link04Icon,
   Loading03Icon,
+  Pdf02Icon,
   Tick02Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
@@ -101,6 +102,27 @@ function ImageGrid({ images, localUrls }: { images: ImageRef[]; localUrls?: Map<
   )
 }
 
+// DocumentChips renders a user message's attached PDFs as small,
+// non-clickable chips — unlike images there is no thumbnail to show
+// and no authed fetch to make (the converted markdown already rode
+// the turn server-side); this is just an acknowledgment of what was
+// attached.
+function DocumentChips({ documents }: { documents: ImageRef[] }) {
+  return (
+    <div className="flex max-w-2xl flex-wrap justify-end gap-1.5">
+      {documents.map((doc) => (
+        <div
+          key={doc.id}
+          className="flex items-center gap-1 rounded-lg border border-zinc-950/10 bg-zinc-100 px-2 py-1 text-xs text-zinc-500 dark:border-white/10 dark:bg-zinc-800 dark:text-zinc-400"
+        >
+          <HugeiconsIcon icon={Pdf02Icon} className="size-3.5" />
+          PDF
+        </div>
+      ))}
+    </div>
+  )
+}
+
 // SourcesPanel renders a research answer's citations as a distinct,
 // clickable list — separate from the prose so "these are the sources"
 // reads at a glance instead of blending into the markdown body.
@@ -178,6 +200,7 @@ export function CopyButton({
 export function UserMessage({
   text,
   images,
+  documents,
   localUrls,
   onRetry,
 }: {
@@ -185,6 +208,9 @@ export function UserMessage({
   // Attached images (transcript's Images, or the live turn's own
   // optimistic list) — thumbnails render above the text bubble.
   images?: ImageRef[]
+  // Attached PDFs (transcript's Documents, or the live turn's own
+  // optimistic list) — rendered as small chips, never fetched.
+  documents?: ImageRef[]
   // Optimistic-send local object URLs keyed by attachment id, so a
   // just-sent message's thumbnails render instantly without
   // round-tripping through AuthedImage's authed fetch.
@@ -197,6 +223,7 @@ export function UserMessage({
   return (
     <div className="flex flex-col items-end gap-1">
       {images && images.length > 0 && <ImageGrid images={images} localUrls={localUrls} />}
+      {documents && documents.length > 0 && <DocumentChips documents={documents} />}
       <div className="group/message flex items-end justify-end gap-1">
         <CopyButton text={text} label="Copy message" />
         {text !== '' && (

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -113,6 +113,7 @@ function DocumentChips({ documents }: { documents: ImageRef[] }) {
       {documents.map((doc) => (
         <div
           key={doc.id}
+          title={doc.id.slice(0, 8)}
           className="flex items-center gap-1 rounded-lg border border-zinc-950/10 bg-zinc-100 px-2 py-1 text-xs text-zinc-500 dark:border-white/10 dark:bg-zinc-800 dark:text-zinc-400"
         >
           <HugeiconsIcon icon={Pdf02Icon} className="size-3.5" />

--- a/web/src/lib/transcript.test.ts
+++ b/web/src/lib/transcript.test.ts
@@ -337,4 +337,28 @@ describe('fromTranscript', () => {
       expect(items[0].images).toBeUndefined()
     }
   })
+
+  it("maps a user item's Documents into the chat item", () => {
+    const items = fromTranscript([
+      {
+        seq: 1,
+        kind: 'user',
+        text: 'summarize this',
+        documents: [{ id: 'doc-1', mime: 'application/pdf' }],
+        created_at: at,
+      },
+    ])
+    expect(items[0]).toMatchObject({
+      role: 'user',
+      text: 'summarize this',
+      documents: [{ id: 'doc-1', mime: 'application/pdf' }],
+    })
+  })
+
+  it('omits documents on a user item that carries none', () => {
+    const items = fromTranscript([{ seq: 1, kind: 'user', text: 'hello', created_at: at }])
+    if (items[0].role === 'user') {
+      expect(items[0].documents).toBeUndefined()
+    }
+  })
 })

--- a/web/src/lib/transcript.ts
+++ b/web/src/lib/transcript.ts
@@ -5,7 +5,7 @@ import type { AssistantState, ToolRun } from './chat'
 // replayed transcript items share this shape so resume is
 // pixel-equivalent with the original stream.
 export type ChatItem = { id: string } & (
-  | { role: 'user'; text: string; images?: ImageRef[] }
+  | { role: 'user'; text: string; images?: ImageRef[]; documents?: ImageRef[] }
   | ({ role: 'assistant' } & AssistantState)
   | { role: 'compaction'; text: string }
   | { role: 'interrupted'; text: string }
@@ -75,6 +75,7 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
           role: 'user',
           text: item.text ?? '',
           images: item.images && item.images.length > 0 ? item.images : undefined,
+          documents: item.documents && item.documents.length > 0 ? item.documents : undefined,
         })
         break
       case 'tool':

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -301,13 +301,17 @@ export function Chat({
     if (ready.length > 0) {
       localUrlsRef.current.set(userItemId, new Map(ready.map((a) => [a.id, a.previewUrl])))
     }
+    const readyImages = ready.filter((a) => a.mime.startsWith('image/'))
+    const readyDocuments = ready.filter((a) => a.mime === 'application/pdf')
     setItems((prev) => [
       ...prev,
       {
         id: userItemId,
         role: 'user',
         text: message,
-        images: ready.length > 0 ? ready.map((a) => ({ id: a.id, mime: a.mime })) : undefined,
+        images: readyImages.length > 0 ? readyImages.map((a) => ({ id: a.id, mime: a.mime })) : undefined,
+        documents:
+          readyDocuments.length > 0 ? readyDocuments.map((a) => ({ id: a.id, mime: a.mime })) : undefined,
       },
       { id: crypto.randomUUID(), role: 'assistant', ...emptyAssistant() },
     ])
@@ -516,6 +520,7 @@ export function Chat({
                   key={item.id}
                   text={item.text}
                   images={item.images}
+                  documents={item.documents}
                   localUrls={localUrlsRef.current.get(item.id)}
                   // A trailing user message means the turn died before any
                   // assistant event reached the transcript — retry re-runs


### PR DESCRIPTION
PDFs are converted to markdown once at message-send time and the markdown is persisted on the `user_message` event: lazy per-turn conversion would re-call the sidecar every turn and any output drift would rewrite earlier projected messages, breaking the LLM context prefix stability that provider prompt caches depend on.

- `application/pdf` in the attachment store allowlist (server-side sniff, `.pdf` on disk, no migration needed)
- `UserMessage.Documents []DocumentRef{ID, Mime, Markdown}` on the event; projection appends the markdown as text
- Documents never flip the vision route; the UI receives id+mime refs only, never the markdown
- Composer accepts PDFs (file chip), Message renders document chips

Tests: PDF save, conversion via fake sidecar, missing-sidecar 400, no vision flip on documents-only, projection rendering, web chip tests.