### PR TITLE
feat(chat): detach turn lifetime from the http request

### DIFF
--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -104,6 +104,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	srv.Handle("DELETE /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleDelete)))
 	srv.Handle("POST /v1/sessions/{id}/messages", a.auth(http.HandlerFunc(a.handleMessages)))
 	srv.Handle("POST /v1/sessions/{id}/messages/retry", a.auth(http.HandlerFunc(a.handleRetry)))
+	srv.Handle("POST /v1/sessions/{id}/stop", a.auth(http.HandlerFunc(a.handleStop)))
 	srv.Handle("POST /v1/permissions/{id}", a.auth(http.HandlerFunc(a.handlePermission)))
 	// Deprecated shim: same behavior, session_id in the body.
 	srv.Handle("POST /v1/chat", a.auth(http.HandlerFunc(a.handleChatShim)))
@@ -399,6 +400,25 @@ func (a *API) handleRetry(w http.ResponseWriter, r *http.Request) {
 	a.streamTurn(w, r, func(ctx context.Context) (string, <-chan stream.StreamEvent, error) {
 		return a.svc.Retry(ctx, sessionID)
 	})
+}
+
+// handleStop cancels sessionID's in-flight turn server-side (the turn
+// now runs detached from any one request, so a client-side abort alone
+// no longer stops it — see chat.Service.StopTurn). 404 "no_active_turn"
+// mirrors handleLive's framing for the identical "nothing here" case:
+// no turn running, whether because none was ever started or because it
+// already finished by the time this request lands.
+func (a *API) handleStop(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !validSessionID(id) {
+		jsonError(w, http.StatusNotFound, "not_found", "no such session")
+		return
+	}
+	if !a.svc.StopTurn(id) {
+		jsonError(w, http.StatusNotFound, "no_active_turn", "no turn is currently running for this session")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // meta is brain's terminal SSE event: session identity plus whatever

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -224,6 +224,7 @@ func mux(a *API) *http.ServeMux {
 	m.Handle("DELETE /v1/sessions/{id}", a.auth(http.HandlerFunc(a.handleDelete)))
 	m.Handle("POST /v1/sessions/{id}/messages", a.auth(http.HandlerFunc(a.handleMessages)))
 	m.Handle("POST /v1/sessions/{id}/messages/retry", a.auth(http.HandlerFunc(a.handleRetry)))
+	m.Handle("POST /v1/sessions/{id}/stop", a.auth(http.HandlerFunc(a.handleStop)))
 	m.Handle("POST /v1/permissions/{id}", a.auth(http.HandlerFunc(a.handlePermission)))
 	m.Handle("POST /v1/chat", a.auth(http.HandlerFunc(a.handleChatShim)))
 	return m

--- a/internal/brain/api/stop_test.go
+++ b/internal/brain/api/stop_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestStopEndpointInvalidSessionID confirms a malformed id 404s the
+// same way every other session-scoped route does (validSessionID),
+// without ever reaching chat.Service.
+func TestStopEndpointInvalidSessionID(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	w := doMux(a, http.MethodPost, "/v1/sessions/not-a-valid-id/stop", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("code = %d, want 404", w.Code)
+	}
+}
+
+// TestStopEndpointNoActiveTurn confirms an idle (but real) session
+// answers 404 no_active_turn — the same "nothing here" framing
+// handleLive uses for the identical case.
+func TestStopEndpointNoActiveTurn(t *testing.T) {
+	t.Parallel()
+	a, dir, _ := testAPI(t, "tok", nil)
+	id, _ := dir.Create(t.Context(), "t")
+
+	w := doMux(a, http.MethodPost, "/v1/sessions/"+id+"/stop", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("code = %d, want 404", w.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["error"] != "no_active_turn" {
+		t.Fatalf("error = %q, want no_active_turn", body["error"])
+	}
+}
+
+// TestStopEndpointStopsActiveTurn confirms POST .../stop cancels a
+// live turn: 204, TurnActive flips false without the fake gateway ever
+// being unblocked (StopTurn's cancel is what winds it down, not the
+// fake completing on its own), and the original POST /messages call
+// still returns normally once the turn's abnormal end persists.
+func TestStopEndpointStopsActiveTurn(t *testing.T) {
+	t.Parallel()
+	block := make(chan struct{})
+	a, dir, gw := testAPI(t, "tok", okEvents())
+	gw.blockCh = block
+	id, _ := dir.Create(t.Context(), "t")
+
+	done := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		done <- doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages", `{"message":"hello"}`)
+	}()
+	waitForTest(t, func() bool { return a.svc.TurnActive(id) })
+
+	w := doMux(a, http.MethodPost, "/v1/sessions/"+id+"/stop", "")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("stop code = %d, want 204; body=%s", w.Code, w.Body.String())
+	}
+
+	waitForTest(t, func() bool { return !a.svc.TurnActive(id) })
+
+	// The blocked send's own goroutine is still parked on <-block; the
+	// turn ending is StopTurn's cancel winding down the loop, not the
+	// fake gateway completing — closing block here just lets that now-
+	// orphaned goroutine exit so the test doesn't leak it.
+	close(block)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("original POST /messages never returned")
+	}
+
+	// Stopping again finds nothing live.
+	w = doMux(a, http.MethodPost, "/v1/sessions/"+id+"/stop", "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("second stop code = %d, want 404 (turn already over)", w.Code)
+	}
+}

--- a/internal/brain/chat/broadcast.go
+++ b/internal/brain/chat/broadcast.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"context"
 	"errors"
 	"sync"
 
@@ -21,9 +22,10 @@ const broadcastBuf = 64
 // flight" (D-Option-B, see chat.go's turn lifecycle comment) — there
 // is no separate busy-state registry.
 type turnBroadcaster struct {
-	mu   sync.Mutex
-	buf  []stream.StreamEvent
-	subs map[chan stream.StreamEvent]struct{}
+	mu     sync.Mutex
+	buf    []stream.StreamEvent
+	subs   map[chan stream.StreamEvent]struct{}
+	cancel context.CancelFunc // set by Chat/Retry once the turn's detached ctx exists; nil until then
 }
 
 func newTurnBroadcaster() *turnBroadcaster {
@@ -63,6 +65,20 @@ func (b *turnBroadcaster) subscribe() ([]stream.StreamEvent, <-chan stream.Strea
 	ch := make(chan stream.StreamEvent, broadcastBuf)
 	b.subs[ch] = struct{}{}
 	return replay, ch
+}
+
+// setCancel stores the detached turn context's cancel func — called by
+// Chat/Retry right after turnBegin returns, before runTurn does
+// anything else, so StopTurn can never observe a nil cancel for a turn
+// that's actually in flight (turnBegin already made it visible in
+// Service.turns). Guarded by the same mutex as publish/subscribe so a
+// racing StopTurn either sees it set or sees the broadcaster before
+// registration completes at all (turnBegin's own lock covers that
+// earlier race).
+func (b *turnBroadcaster) setCancel(fn context.CancelFunc) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.cancel = fn
 }
 
 // closeAll closes and unregisters every live subscriber — called once
@@ -112,15 +128,50 @@ func (s *Service) turnBegin(sessionID string) (*turnBroadcaster, error) {
 // subscriber. Called after the turn's terminal persist is durable (see
 // persistTurn) so turn_active flips false only once a refetch is
 // guaranteed to see the completed turn — no window where the flag is
-// down but the transcript is still stale.
+// down but the transcript is still stale. Also cancels the turn's
+// detached context (if a cancel was ever stored) so it never leaks past
+// the turn's own lifetime — every path here runs after the turn is
+// truly over, so cancelling now is always safe, never premature.
 func (s *Service) turnDone(sessionID string) {
 	s.turnsMu.Lock()
 	b := s.turns[sessionID]
 	delete(s.turns, sessionID)
 	s.turnsMu.Unlock()
 	if b != nil {
+		b.mu.Lock()
+		cancel := b.cancel
+		b.mu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
 		b.closeAll()
 	}
+}
+
+// StopTurn cancels sessionID's in-flight turn, if any, and reports
+// whether one was actually live. Cancelling the detached turn context
+// makes the tool loop/gateway wind down (same path a real deadline or a
+// brain shutdown already takes); the existing abnormal-end machinery in
+// persistTurn then takes over — pending_state when partial text exists,
+// turn_failed otherwise — and drainAndPersist runs turnDone exactly as
+// on any other exit. StopTurn does NOT remove the Service.turns entry
+// itself: the relay goroutine still owns that (via turnDone), so a
+// caller polling TurnActive right after StopTurn can still see true
+// until the wind-down actually completes.
+func (s *Service) StopTurn(sessionID string) bool {
+	s.turnsMu.Lock()
+	b := s.turns[sessionID]
+	s.turnsMu.Unlock()
+	if b == nil {
+		return false
+	}
+	b.mu.Lock()
+	cancel := b.cancel
+	b.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	return true
 }
 
 // TurnActive reports whether sessionID currently has a turn in flight

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -54,6 +54,10 @@ const (
 	// just because the capability gate happens to find a vision-capable
 	// model there too.
 	visionRoute = "vision"
+	// turnTimeout ceils a detached turn's lifetime (see Chat/Retry's
+	// turnCtx): must exceed loop's permissionTimeout (10m) so a parked
+	// permission ask can't be killed by the ceiling out from under it.
+	turnTimeout = 30 * time.Minute
 	// Each persistence stage gets its OWN deadline: LLM-backed stages
 	// (distill, compaction) must never eat the database writes' clock.
 	persistTimeout = 10 * time.Second
@@ -173,6 +177,7 @@ type Service struct {
 	skillAllow     func(context.Context, string) bool // nil: all packs allowed
 	skillBodies    map[string]string                  // name -> full pack body, for skill_hint
 	flushEvery     time.Duration                      // pending-state flush cadence mid-stream
+	turnTimeout    time.Duration                      // detached-turn ceiling; defaults to the turnTimeout const, overridable in tests
 	sensitive      *session.SensitiveTools            // nil: no sensitive-tool route pin for side-calls
 	attachments    AttachmentStore                    // nil: attachments disabled (ATTACHMENTS_DIR unset)
 	markitdownURL  string                             // "": pdf attachments disabled (MARKITDOWN_URL unset)
@@ -330,7 +335,7 @@ func New(gw Gateway, log SessionLog, distill Distill, compactor Compactor, budge
 		skillAllow:  skillAllow,
 		agents:      resolver,
 		skillBodies: bodies,
-		flushEvery:  2 * time.Second, logger: logger,
+		flushEvery:  2 * time.Second, turnTimeout: turnTimeout, logger: logger,
 	}
 }
 
@@ -513,13 +518,24 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 		return sessionID, nil, err
 	}
 
-	if _, err := s.log.Append(ctx, sessionID, session.KindUserMessage, session.UserMessage{
+	// The turn's lifetime belongs to the session, not the HTTP request
+	// that started it: a navigation/reload aborts ctx, but that must
+	// not kill the loop mid-tool-call. turnCtx drops ctx's cancellation
+	// (WithoutCancel) while keeping its values (auth, trace); StopTurn
+	// is the only thing allowed to cancel it from here on (see
+	// broadcast.go's setCancel). The user_message append below also
+	// rides turnCtx, not ctx: once the slot is won, the message must
+	// land even if the client vanishes that same instant.
+	turnCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.turnTimeout)
+	bc.setCancel(cancel)
+
+	if _, err := s.log.Append(turnCtx, sessionID, session.KindUserMessage, session.UserMessage{
 		Text: req.Message, Route: route, Agent: profile.Name, ModelHint: modelHint, Images: images, Documents: documents,
 	}); err != nil {
 		s.turnDone(sessionID)
 		return sessionID, nil, err
 	}
-	return s.runTurn(ctx, sessionID, req.Message, modelHint, req.SkillHint, skillBody, route, profile, needsTitle, bc)
+	return s.runTurn(turnCtx, ctx, sessionID, req.Message, modelHint, req.SkillHint, skillBody, route, profile, needsTitle, bc)
 }
 
 // resolveImages fills each message's Images from its ImageRefs
@@ -699,7 +715,10 @@ func (s *Service) Retry(ctx context.Context, sessionID string) (string, <-chan s
 	if err != nil {
 		return sessionID, nil, err
 	}
-	return s.runTurn(ctx, sessionID, last.Text, modelHint, "", "", route, profile, needsTitle, bc)
+	// Detached turn context — same reasoning as Chat's (see there).
+	turnCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.turnTimeout)
+	bc.setCancel(cancel)
+	return s.runTurn(turnCtx, ctx, sessionID, last.Text, modelHint, "", "", route, profile, needsTitle, bc)
 }
 
 // runTurn is the shared tail of Chat and Retry: compact, project
@@ -710,31 +729,38 @@ func (s *Service) Retry(ctx context.Context, sessionID string) (string, <-chan s
 // (D-042) — runTurn must free it (turnDone) on every path that returns
 // before the relay goroutine takes ownership of that responsibility,
 // so a setup failure here can never wedge the session's slot.
-func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, skillHint, skillBody, route string, profile agents.Agent, needsTitle bool, bc *turnBroadcaster) (string, <-chan stream.StreamEvent, error) {
+//
+// turnCtx is the detached, session-owned context (survives the client
+// disconnecting) that everything in this function — and the whole tool
+// loop underneath gw.Stream — runs on. reqCtx is the original HTTP
+// request's context; it is only handed to relay, which uses it solely
+// to decide whether the ORIGINAL client is still there to stream to
+// (see relay's doc comment).
+func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, modelHint, skillHint, skillBody, route string, profile agents.Agent, needsTitle bool, bc *turnBroadcaster) (string, <-chan stream.StreamEvent, error) {
 	// start marks the turn's wall-clock beginning for the stats line's
 	// duration: here, not Chat/Retry's entry, so a retried turn's
 	// duration covers only the retried run — the dead attempt's gap
 	// never counts (runTurn is the shared tail both call fresh).
 	start := time.Now()
-	s.seedApprovalGrants(ctx, sessionID, profile)
+	s.seedApprovalGrants(turnCtx, sessionID, profile)
 	// Pre-send guarantee: the context actually sent to the provider
 	// stays under budget even on the turn that crosses it. The
 	// post-turn pass below keeps sessions compacted ahead of time, so
 	// this is a cheap no-op except on the crossing turn; best-effort —
 	// an oversized context beats no answer.
 	if s.compactor != nil {
-		cctx, cancel := context.WithTimeout(ctx, compactBudget)
+		cctx, cancel := context.WithTimeout(turnCtx, compactBudget)
 		if err := s.compactor.MaybeCompact(cctx, sessionID); err != nil {
 			s.logger.Warn("pre-send compaction", "session_id", sessionID, "error", err)
 		}
 		cancel()
 	}
-	events, err := s.log.Events(ctx, sessionID)
+	events, err := s.log.Events(turnCtx, sessionID)
 	if err != nil {
 		s.turnDone(sessionID)
 		return sessionID, nil, err
 	}
-	msgs, err := session.LLMContext(events, s.budget(ctx))
+	msgs, err := session.LLMContext(events, s.budget(turnCtx))
 	if err != nil {
 		s.turnDone(sessionID)
 		return sessionID, nil, err
@@ -743,7 +769,7 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 	// gateway call: this is the sole point in the whole turn where
 	// attachment bytes exist in memory at all (D-045). ImageRefs never
 	// crosses the wire (json:"-"); Images (the resolved payload) does.
-	if err := s.resolveImages(ctx, msgs); err != nil {
+	if err := s.resolveImages(turnCtx, msgs); err != nil {
 		s.turnDone(sessionID)
 		return sessionID, nil, err
 	}
@@ -761,7 +787,7 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 	// (D-011 poisoning defense); the skill body is instructions the
 	// user explicitly selected, deterministically loaded rather than
 	// left to the model's load_skill judgment.
-	system := assembleSystem(skills.Index(s.allowedPacks(ctx, profile)), time.Now())
+	system := assembleSystem(skills.Index(s.allowedPacks(turnCtx, profile)), time.Now())
 	// The agent overlay is stable for a given agent, so it sits ahead
 	// of the per-turn tail and stays inside the cacheable prefix.
 	if profile.PromptOverlay != "" {
@@ -771,12 +797,12 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 		system += "\n\n# Skill: " + skillHint + "\n\n" + skillBody
 	}
 	if s.recall != nil && profile.Memory {
-		if block := s.recall(ctx, sessionID, userText); block != "" {
+		if block := s.recall(turnCtx, sessionID, userText); block != "" {
 			system += "\n\n" + block
 		}
 	}
 
-	upstream, err := s.gw.Stream(ctx, gwclient.StreamRequest{
+	upstream, err := s.gw.Stream(turnCtx, gwclient.StreamRequest{
 		Route:     route,
 		Agent:     profile.Name,
 		ToolAllow: profile.Tools,
@@ -797,7 +823,7 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 	// defer-equivalent (drainAndPersist, on every exit path) owns
 	// freeing it via turnDone.
 	out := make(chan stream.StreamEvent)
-	go s.relay(ctx, sessionID, userText, route, profile, needsTitle, sessionSensitive, start, bc, upstream, out)
+	go s.relay(reqCtx, sessionID, userText, route, profile, needsTitle, sessionSensitive, start, bc, upstream, out)
 	return sessionID, out, nil
 }
 
@@ -816,7 +842,17 @@ func (s *Service) runTurn(ctx context.Context, sessionID, userText, modelHint, s
 // because it already disconnected (drainAndPersist) — still reaches
 // bc, since a GET /live subscriber may be attached independently of
 // the POST that started the turn.
-func (s *Service) relay(ctx context.Context, sessionID, userText, route string, profile agents.Agent, needsTitle, sessionSensitive bool, start time.Time, bc *turnBroadcaster, upstream <-chan stream.StreamEvent, out chan<- stream.StreamEvent) {
+//
+// reqCtx is the ORIGINAL request's context, not the turn's — upstream
+// is already bound to the detached turnCtx (runTurn's gw.Stream call),
+// so it keeps producing long after reqCtx dies. reqCtx here gates only
+// whether THIS client is still around to receive forwarded events: the
+// moment it's done, the select's <-reqCtx.Done() branch stops sending
+// to out and falls through to drainAndPersist, which keeps consuming
+// the still-live upstream to completion so the turn finishes and
+// persists normally, with every event still reaching bc for any /live
+// subscriber.
+func (s *Service) relay(reqCtx context.Context, sessionID, userText, route string, profile agents.Agent, needsTitle, sessionSensitive bool, start time.Time, bc *turnBroadcaster, upstream <-chan stream.StreamEvent, out chan<- stream.StreamEvent) {
 	var text, reasoning strings.Builder
 	var meta *stream.Meta
 	var usage *stream.Usage
@@ -911,9 +947,16 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 	}
 
 	drainAndPersist := func() {
-		// Consume whatever the upstream still yields (it shares the
-		// request ctx, so it winds down quickly), free the client,
-		// then persist the final state.
+		// out closes FIRST, before draining upstream: upstream is bound
+		// to turnCtx (session-owned), not reqCtx, so once the client is
+		// gone it may still have minutes left to run. Closing out up
+		// front frees streamTurn's client-facing goroutine immediately
+		// instead of holding it for the remainder of the turn — any
+		// further send() calls on a dead ResponseWriter just fail
+		// silently. The drain loop below then keeps consuming upstream
+		// (publishing every event to bc for /live subscribers) until it
+		// closes on its own, however long that takes.
+		close(out)
 		for ev := range upstream {
 			switch ev.Type {
 			case stream.EventChunk:
@@ -930,7 +973,6 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 			notePermission(ev)
 			bc.publish(ev)
 		}
-		close(out)
 		s.persistTurn(sessionID, userText, route, profile, needsTitle, text.String(), reasoning.String(), meta, usage, sawDone, flushed, turnSensitive || sessionSensitive, failure, ranTool)
 		// Terminal persist is now durable: free the broadcaster (closes
 		// every live /live subscriber) and push the session signal, in
@@ -972,14 +1014,14 @@ func (s *Service) relay(ctx context.Context, sessionID, userText, route string, 
 			bc.publish(ev)
 			select {
 			case out <- ev:
-			case <-ctx.Done():
+			case <-reqCtx.Done():
 				flushPending()
 				drainAndPersist()
 				return
 			}
 		case <-ticker.C:
 			flushPending()
-		case <-ctx.Done():
+		case <-reqCtx.Done():
 			flushPending()
 			drainAndPersist()
 			return

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -1945,3 +1945,250 @@ func TestPersistTurnPinsSideCallsWhenSessionPreviouslySensitive(t *testing.T) {
 		t.Fatal("memory extract never invoked")
 	}
 }
+
+// slowGW is a Gateway whose stream keeps producing on its own schedule,
+// gated ONLY by the context passed to Stream — unlike fakeGW, its sends
+// aren't wrapped in a second select that could race the caller's read.
+// Used to prove that once runTurn hands gw.Stream the detached turnCtx
+// (not the request's ctx), the upstream genuinely survives a request-
+// side cancel: production's real gwclient.Stream is bound to whatever
+// ctx runTurn passes it, so this models that binding faithfully instead
+// of asserting it indirectly. delay applies uniformly before every
+// event unless delays is set, giving a per-event delay instead (used
+// when the test needs the first event immediate but later ones held
+// off far past the point the test acts).
+type slowGW struct {
+	events []stream.StreamEvent
+	delay  time.Duration
+	delays []time.Duration
+}
+
+func (g *slowGW) Stream(ctx context.Context, _ gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+	ch := make(chan stream.StreamEvent)
+	go func() {
+		defer close(ch)
+		for i, ev := range g.events {
+			d := g.delay
+			if i < len(g.delays) {
+				d = g.delays[i]
+			}
+			select {
+			case <-time.After(d):
+			case <-ctx.Done():
+				return
+			}
+			select {
+			case ch <- ev:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return ch, nil
+}
+
+// TestChatSurvivesClientDisconnect is the kill-test for the fix this
+// package exists to ship: cancelling the REQUEST context (a browser
+// nav/reload) must not cancel the turn. runTurn hands gw.Stream the
+// detached turnCtx, so slowGW here is bound to that, not to the
+// request ctx passed into Chat — the disconnect must only stop
+// forwarding to the client channel, never the upstream itself.
+func TestChatSurvivesClientDisconnect(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &slowGW{delay: 20 * time.Millisecond, events: []stream.StreamEvent{
+		{Type: stream.EventChunk, Text: "first "},
+		{Type: stream.EventChunk, Text: "second "},
+		{Type: stream.EventChunk, Text: "third"},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
+	}}
+	s := newService(gw, log)
+
+	reqCtx, cancel := context.WithCancel(t.Context())
+	_, ch, err := s.Chat(reqCtx, Request{SessionID: "s1", Message: "long question"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	// A /live subscriber attached independently of the request that
+	// started the turn — it must still see every event, including the
+	// ones the disconnecting client never gets.
+	replay, live, ok := s.Subscribe("s1")
+	if !ok {
+		t.Fatal("Subscribe: no turn in flight")
+	}
+	if len(replay) != 0 {
+		t.Fatalf("replay before any event = %v, want empty", replay)
+	}
+
+	<-ch     // receive the first forwarded chunk
+	cancel() // client disconnects — browser nav/reload
+
+	// out must close promptly: the client-facing channel does not wait
+	// for the whole turn to finish once reqCtx is done.
+	deadline := time.After(2 * time.Second)
+loop:
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				break loop
+			}
+		case <-deadline:
+			t.Fatal("out did not close promptly after client disconnect")
+		}
+	}
+
+	// The broadcaster (and any /live subscriber) keeps seeing events
+	// after the original client disconnected, until the turn's own
+	// terminal.
+	var got []stream.StreamEvent
+	for ev := range live {
+		got = append(got, ev)
+	}
+	var text strings.Builder
+	sawDone := false
+	for _, ev := range got {
+		if ev.Type == stream.EventChunk {
+			text.WriteString(ev.Text)
+		}
+		if ev.Type == stream.EventDone {
+			sawDone = true
+		}
+	}
+	if !sawDone {
+		t.Fatalf("broadcaster never saw the terminal done event: %+v", got)
+	}
+	if text.String() != "first second third" {
+		t.Fatalf("broadcaster text = %q, want full upstream text", text.String())
+	}
+
+	// The turn must persist as a completed assistant_turn — never
+	// turn_failed — despite the client having vanished mid-stream. A
+	// pending_state checkpoint (flushPending, on the disconnect branch
+	// itself) may also land before it; that's an existing, harmless
+	// checkpoint superseded by the real completed turn right after.
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
+	kinds := log.kinds("s1")
+	if kinds[len(kinds)-1] != session.KindAssistantTurn {
+		t.Fatalf("kinds = %v, want assistant_turn last (turn must complete normally, not fail)", kinds)
+	}
+	for _, k := range kinds {
+		if k == session.KindTurnFailed {
+			t.Fatalf("kinds = %v, must not contain turn_failed", kinds)
+		}
+	}
+	events, _ := log.Events(t.Context(), "s1")
+	var turn session.AssistantTurn
+	if err := json.Unmarshal(events[len(events)-1].Payload, &turn); err != nil {
+		t.Fatalf("decode turn: %v", err)
+	}
+	if turn.LLM.Message != "first second third" {
+		t.Fatalf("persisted turn text = %q, want full upstream text", turn.LLM.Message)
+	}
+}
+
+// TestStopTurnCancelsMidStream: StopTurn must let a caller (a "stop"
+// button in the UI) cancel a session's in-flight turn server-side. The
+// upstream (bound to turnCtx) winds down once cancelled, and the
+// existing abnormal-end machinery in persistTurn takes over — partial
+// text becomes a pending_state (the same shape a real client disconnect
+// with no terminal produces).
+func TestStopTurnCancelsMidStream(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	// slowGW (not fakeGW): the upstream must still be live-but-idle
+	// after the first chunk, so the test can call StopTurn
+	// deterministically mid-stream rather than racing the upstream's
+	// own natural close — fakeGW's producer goroutine exits (closing
+	// the channel) right after its last canned event, which can beat
+	// StopTurn to the punch when there is no terminal event to hold it
+	// open. The second event is delayed well past StopTurn's cancel.
+	gw := &slowGW{
+		events: []stream.StreamEvent{
+			{Type: stream.EventChunk, Text: "partial answer"},
+			{Type: stream.EventChunk, Text: " that stalls here"},
+		},
+		delays: []time.Duration{0, 2 * time.Second},
+	}
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "long question"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if !s.TurnActive("s1") {
+		t.Fatal("TurnActive = false right after Chat, want true")
+	}
+
+	<-ch // receive the first chunk, so the turn has partial text before stopping
+
+	if !s.StopTurn("s1") {
+		t.Fatal("StopTurn = false, want true (a turn is live)")
+	}
+	drain(t, ch)
+
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
+
+	found := false
+	for _, k := range log.kinds("s1") {
+		if k == session.KindPendingState {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("kinds = %v, want a pending_state (partial text, abnormal end)", log.kinds("s1"))
+	}
+
+	// Stopping again finds nothing live.
+	if s.StopTurn("s1") {
+		t.Fatal("StopTurn on an already-finished session = true, want false")
+	}
+}
+
+// TestStopTurnNoActiveTurn confirms StopTurn is a plain false, not a
+// panic or error, when the session never had a turn running.
+func TestStopTurnNoActiveTurn(t *testing.T) {
+	t.Parallel()
+	s := newService(&fakeGW{}, newFakeLog())
+	if s.StopTurn("never-started") {
+		t.Fatal("StopTurn on an idle session = true, want false")
+	}
+}
+
+// TestTurnTimeoutCeilingEndsAbandonedTurn confirms the detached turn
+// context actually ceils the turn's lifetime: with turnTimeout set very
+// small, an upstream that outlives it must be cut off and the turn
+// persisted with whatever partial evidence exists, rather than running
+// forever. Production always runs the real 30-minute const; s.turnTimeout
+// exists as a settable field precisely so this deadline path can be
+// exercised without an unreasonably slow test.
+func TestTurnTimeoutCeilingEndsAbandonedTurn(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &slowGW{delay: 500 * time.Millisecond, events: []stream.StreamEvent{
+		{Type: stream.EventChunk, Text: "partial"},
+		{Type: stream.EventChunk, Text: " more"},
+		{Type: stream.EventChunk, Text: " than the ceiling allows"},
+		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
+	}}
+	s := newService(gw, log)
+	s.turnTimeout = 30 * time.Millisecond // far shorter than any event delay above
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "long question"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	waitFor(t, func() bool { return !s.TurnActive("s1") })
+	kinds := log.kinds("s1")
+	// The ceiling fires before any chunk (500ms delay vs 30ms ceiling),
+	// so there is no partial text worth keeping — the turn ends with no
+	// assistant_turn, same shape a real abandoned/stuck upstream leaves.
+	for _, k := range kinds {
+		if k == session.KindAssistantTurn {
+			t.Fatalf("kinds = %v, want no assistant_turn (ceiling cut the turn short)", kinds)
+		}
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -132,6 +132,15 @@ export async function retryStream(
   return postSSE(`/v1/sessions/${sessionId}/messages/retry`, undefined, onEvent, opts)
 }
 
+// stopTurn cancels a session's in-flight turn server-side: the turn now
+// runs detached from the request that started it, so aborting the
+// local fetch (AbortController) no longer stops it — this is the only
+// thing that does. A 404 (no turn running, or it already finished) is
+// a benign race from the caller's point of view, same as streamLive's.
+export async function stopTurn(sessionId: string): Promise<void> {
+  await request<void>(`/v1/sessions/${sessionId}/stop`, { method: 'POST' })
+}
+
 // streamLive reattaches to a session's in-flight turn (Tier 2 of live
 // reattach): GET .../live replays whatever the turn already emitted
 // then follows it live until the terminal, wire-identical to

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -140,6 +140,27 @@ describe('Composer mic button', () => {
   })
 })
 
+describe('Composer stop button', () => {
+  it('shows Send, not Stop, when not streaming', () => {
+    render(<Composer {...baseProps()} streaming={false} onStop={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Send' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Stop' })).toBeNull()
+  })
+
+  it('shows Stop instead of Send while streaming, and fires onStop', () => {
+    const onStop = vi.fn()
+    render(<Composer {...baseProps()} streaming={true} onStop={onStop} />)
+    expect(screen.queryByRole('button', { name: 'Send' })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }))
+    expect(onStop).toHaveBeenCalledOnce()
+  })
+
+  it('falls back to Send while streaming if onStop is not given', () => {
+    render(<Composer {...baseProps()} streaming={true} />)
+    expect(screen.getByRole('button', { name: 'Send' })).toBeTruthy()
+  })
+})
+
 function makeImageFile(name = 'photo.png', type = 'image/png', size = 1024): File {
   const file = new File([new Uint8Array(size)], name, { type })
   return file

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -5,6 +5,7 @@ import {
   Loading03Icon,
   Mic01Icon,
   Pdf02Icon,
+  StopIcon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import type { ClipboardEvent, DragEvent } from 'react'
@@ -44,6 +45,8 @@ export function Composer({
   skillHint,
   onRemoveSkillHint,
   disabled = false,
+  streaming = false,
+  onStop,
   autoFocus = false,
   placeholder = 'Message Timothy…',
   attachments = [],
@@ -60,6 +63,12 @@ export function Composer({
   skillHint?: string
   onRemoveSkillHint?: () => void
   disabled?: boolean
+  // streaming/onStop swap the send button for a stop control while a
+  // turn is in flight — the turn now runs detached server-side (see
+  // chat.Service.StopTurn), so unmounting or navigating away no longer
+  // stops it; this is the explicit way to.
+  streaming?: boolean
+  onStop?: () => void
   autoFocus?: boolean
   placeholder?: string
   attachments?: PendingAttachment[]
@@ -337,15 +346,26 @@ export function Composer({
             />
           </button>
         </div>
-        <button
-          type="button"
-          onClick={onSend}
-          aria-label="Send"
-          disabled={disabled || (draft.trim() === '' && attachments.length === 0)}
-          className="flex size-9 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 disabled:bg-zinc-200 disabled:text-zinc-400 dark:disabled:bg-zinc-700 dark:disabled:text-zinc-500"
-        >
-          <HugeiconsIcon icon={ArrowUp01Icon} className="size-4" />
-        </button>
+        {streaming && onStop ? (
+          <button
+            type="button"
+            onClick={onStop}
+            aria-label="Stop"
+            className="flex size-9 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500"
+          >
+            <HugeiconsIcon icon={StopIcon} className="size-4" />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onSend}
+            aria-label="Send"
+            disabled={disabled || (draft.trim() === '' && attachments.length === 0)}
+            className="flex size-9 shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 disabled:bg-zinc-200 disabled:text-zinc-400 dark:disabled:bg-zinc-700 dark:disabled:text-zinc-500"
+          >
+            <HugeiconsIcon icon={ArrowUp01Icon} className="size-4" />
+          </button>
+        )}
       </div>
     </div>
   )

--- a/web/src/pages/Chat.test.tsx
+++ b/web/src/pages/Chat.test.tsx
@@ -19,6 +19,7 @@ vi.mock('../api/client', () => ({
   chatStream: vi.fn(),
   retryStream: vi.fn(),
   streamLive: vi.fn(),
+  stopTurn: vi.fn(),
   getTranscript: vi.fn(),
   answerPermission: vi.fn(),
   listRoutes: vi.fn(),
@@ -36,6 +37,7 @@ import {
   getTranscript,
   listAgents,
   listRoutes,
+  stopTurn,
   streamLive,
 } from '../api/client'
 import { subscribeEvents } from '../lib/events'
@@ -94,6 +96,7 @@ beforeEach(() => {
       onEvent({ type: 'meta', session_id: 's1' })
     },
   )
+  vi.mocked(stopTurn).mockResolvedValue(undefined)
 })
 
 describe('Chat route picker', () => {
@@ -353,5 +356,58 @@ describe('live reattach', () => {
     fireSignal({ kind: 'session', id: 'some-other-session' })
     await new Promise((r) => setTimeout(r, 10))
     expect(getTranscript).not.toHaveBeenCalled()
+  })
+})
+
+describe('stop turn', () => {
+  it('calls stopTurn when the Stop button is clicked mid-stream', async () => {
+    // A chatStream that never resolves on its own — the turn is still
+    // "streaming" from the page's point of view until the test clicks
+    // Stop, mirroring a real in-flight turn.
+    let released!: () => void
+    vi.mocked(chatStream).mockImplementation(
+      async (_req: ChatRequest, onEvent: (ev: ChatEvent) => void, opts: ChatStreamOptions = {}) => {
+        opts.onSession?.('s1')
+        await new Promise<void>((r) => {
+          released = r
+        })
+        onEvent({ type: 'meta', session_id: 's1' })
+      },
+    )
+
+    renderChat()
+    const input = screen.getByLabelText('Message')
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    const stopButton = await screen.findByRole('button', { name: 'Stop' })
+    fireEvent.click(stopButton)
+
+    expect(stopTurn).toHaveBeenCalledWith('s1')
+    released() // let the pending chatStream settle so the test can end cleanly
+  })
+
+  it('does NOT call stopTurn on unmount — only the local fetch is aborted', async () => {
+    let released!: () => void
+    vi.mocked(chatStream).mockImplementation(
+      async (_req: ChatRequest, onEvent: (ev: ChatEvent) => void, opts: ChatStreamOptions = {}) => {
+        opts.onSession?.('s1')
+        await new Promise<void>((r) => {
+          released = r
+        })
+        onEvent({ type: 'meta', session_id: 's1' })
+      },
+    )
+
+    const { unmount } = renderChat()
+    const input = screen.getByLabelText('Message')
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await screen.findByRole('button', { name: 'Stop' })
+    unmount()
+
+    expect(stopTurn).not.toHaveBeenCalled()
+    released()
   })
 })

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -7,6 +7,7 @@ import {
   chatStream,
   getTranscript,
   retryStream,
+  stopTurn,
   streamLive,
 } from '../api/client'
 import type { ChatEvent } from '../api/types'
@@ -378,6 +379,18 @@ export function Chat({
 
   const send = () => void sendMessage(draft, agent, skillHint, route, attachments)
 
+  // stop asks the server to cancel the in-flight turn (chat.Service now
+  // runs it detached from this request, so abortRef.current?.abort()
+  // alone only stops this tab's rendering, never the turn itself — see
+  // stopTurn's doc comment). Fire-and-forget: the turn's abnormal-end
+  // persistence and the local abort together already leave the UI in a
+  // sane state regardless of whether this call lands.
+  const stop = () => {
+    const sessionId = sessionRef.current
+    abortRef.current?.abort()
+    if (sessionId) stopTurn(sessionId).catch(() => toast.error('Could not stop the reply'))
+  }
+
   // retryLast re-runs the last (failed) turn: the session already
   // carries the dangling user message server-side (chat.Service.Retry),
   // so this never sends a new user message like sendMessage does. Two
@@ -570,6 +583,8 @@ export function Chat({
           skillHint={skillHint}
           onRemoveSkillHint={lockedSkillHint ? undefined : () => setSkillHint(undefined)}
           disabled={streaming}
+          streaming={streaming}
+          onStop={stop}
           placeholder={placeholder}
           attachments={attachments}
           onAttachments={setAttachments}


### PR DESCRIPTION
A navigation or reload aborted POST /v1/chat and its context cancellation killed the agent loop mid-turn, leaving `turn_failed: stream ended without a terminal event` instead of an answer.

- Turn runs on a detached context (request values kept, cancellation dropped) with a 30-minute ceiling (exceeds the loop's 10-minute permission park)
- Client disconnect only stops SSE forwarding: the relay closes the client channel immediately, keeps draining the live turn, and persists it normally; the existing `/live` re-attach picks it up on return
- Since abort-as-stop no longer stops anything: new `POST /v1/sessions/{id}/stop` + composer stop button as the explicit cancel; `turnDone` always cancels the stored ctx (no leak)

Tests: disconnect-survival kill-test, StopTurn mid-stream, idle-stop 404, timeout ceiling, stop endpoint table test, stop-button + unmount-does-not-stop web tests.