### PR TITLE
feat: connector sensitivity, global permission alerts, debug log, ci split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,32 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  go:
+  # Split from go-integration: build/vet/unit-test/vuln-scan share no
+  # state with the integration suite (only artificial ordering forced
+  # them serial before), so running them as separate jobs lets the
+  # runner schedule both in parallel instead of paying their sum on one
+  # job's critical path.
+  go-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test -race ./...
+      - name: Vulnerability scan
+        # Pinned, not @latest: a floating version re-resolves (and can
+        # change) every run, defeating actions/setup-go's module cache
+        # for this one step and risking a surprise break unrelated to
+        # this repo's own changes.
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
+
+  go-integration:
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -36,12 +61,6 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
-      - name: Build
-        run: go build ./...
-      - name: Vet
-        run: go vet ./...
-      - name: Test
-        run: go test -race ./...
       - name: Integration test
         env:
           DATABASE_URL: postgres://timothy:ci@localhost:5432/timothy
@@ -49,8 +68,6 @@ jobs:
         # intentionally-invalid provider fixture row can fail every
         # concurrent Store.Load in other packages, so run sequentially.
         run: go test -race -count=1 -tags integration -p 1 ./internal/...
-      - name: Vulnerability scan
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
   lint:
     runs-on: ubuntu-latest
@@ -144,7 +161,7 @@ jobs:
   # old blocklist missed it, and auto-merge fired on red jobs.)
   ci-ok:
     runs-on: ubuntu-latest
-    needs: [go, lint, web, images, sandbox-image]
+    needs: [go-test, go-integration, lint, web, images, sandbox-image]
     if: always()
     steps:
       - name: All jobs succeeded

--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -107,7 +107,7 @@ func main() {
 		gatewayURL = "http://gateway:8081"
 	}
 	gwc := gwclient.New(gatewayURL)
-	store := session.NewStore(app.DB)
+	store := session.NewStore(app.DB, app.Log)
 	flags := settings.New(app.DB, app.Log)
 	// Runtime settings, editable in the UI without a restart: the
 	// projected-context budget fallback and the skill-pack allowlist.
@@ -252,6 +252,27 @@ func main() {
 		})
 	}
 
+	// sensitiveConnectorNames is the connector-level input to
+	// SensitiveTools: every enabled connector marked sensitive in
+	// settings, matched as a namespace PREFIX (Matches' ConnectorNames
+	// rule) since "<connector-name>_<tool-name>" puts the connector's own
+	// name in front of every tool it serves. Computed fresh each call,
+	// not cached, so toggling a connector's sensitive flag takes effect
+	// on the next side-call without a restart — same reasoning as
+	// sensitiveRoute above. conns is nil when the connector surface
+	// itself is disabled (no secret store).
+	sensitiveConnectorNames := func(ctx context.Context) []string {
+		if conns == nil {
+			return nil
+		}
+		names, err := conns.SensitiveNames(ctx)
+		if err != nil {
+			app.Log.Warn("sensitive connector lookup failed; connector-level sensitivity off this call", "error", err)
+			return nil
+		}
+		return names
+	}
+
 	// Single source of truth for "this turn/session executed a sensitive
 	// tool": the loop's in-turn SetForceRoute pin above and this
 	// SensitiveTools value share sensitiveToolSuffixes and the same
@@ -260,7 +281,11 @@ func main() {
 	// pinned the turn to. Wired unconditionally — sensitiveRoute
 	// resolving to "" at call time means the feature is currently off,
 	// same as before, but now editable at runtime from the settings UI.
-	sensitiveTools := &session.SensitiveTools{Suffixes: sensitiveToolSuffixes, Route: sensitiveRoute}
+	sensitiveTools := &session.SensitiveTools{
+		Suffixes:       func(context.Context) []string { return sensitiveToolSuffixes },
+		ConnectorNames: sensitiveConnectorNames,
+		Route:          sensitiveRoute,
+	}
 
 	svc := chat.New(turnRouter{agent: agent, gw: gwc, flags: flags}, store, distill,
 		gatedCompactor{inner: compactor, flags: flags}, budgetFn, packs, flags.SkillAllowed,
@@ -274,6 +299,9 @@ func main() {
 	if missionHub != nil {
 		svc.SetSessionHub(func(sessionID string) {
 			missionHub.Publish(missions.Signal{Kind: "session", ID: sessionID})
+		})
+		svc.SetPermissionHub(func(sessionID string) {
+			missionHub.Publish(missions.Signal{Kind: "permission", ID: sessionID})
 		})
 	}
 	// Same Permissions instance (and session_grants table) the chat

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -37,6 +37,7 @@ type Directory interface {
 	Events(ctx context.Context, id string) ([]session.Event, error)
 	Update(ctx context.Context, id string, title *string, archived *bool) error
 	Delete(ctx context.Context, id string) error
+	PendingPermissions(ctx context.Context, sessionIDs []string) ([]session.PendingPermission, error)
 }
 
 // PermissionResolver answers parked permission prompts; the loop's
@@ -106,6 +107,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	srv.Handle("POST /v1/sessions/{id}/messages/retry", a.auth(http.HandlerFunc(a.handleRetry)))
 	srv.Handle("POST /v1/sessions/{id}/stop", a.auth(http.HandlerFunc(a.handleStop)))
 	srv.Handle("POST /v1/permissions/{id}", a.auth(http.HandlerFunc(a.handlePermission)))
+	srv.Handle("GET /v1/permissions/pending", a.auth(http.HandlerFunc(a.handlePendingPermissions)))
 	// Deprecated shim: same behavior, session_id in the body.
 	srv.Handle("POST /v1/chat", a.auth(http.HandlerFunc(a.handleChatShim)))
 }
@@ -135,6 +137,25 @@ func (a *API) handlePermission(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = w.Write([]byte(`{"ok":true}`))
+}
+
+// handlePendingPermissions answers "does anything anywhere need my
+// approval right now" for the global badge/toast — read-only, no side
+// effects. Scoped to chat.Service.ActiveSessions() (the in-memory
+// live-turn registry, not a DB column) so a permission_request whose
+// turn already died without resolving it (crash, abandoned) never
+// shows as pending forever: only currently-active turns are queried.
+func (a *API) handlePendingPermissions(w http.ResponseWriter, r *http.Request) {
+	active := a.svc.ActiveSessions()
+	pending, err := a.dir.PendingPermissions(r.Context(), active)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "pending_permissions_failed", err.Error())
+		return
+	}
+	if pending == nil {
+		pending = []session.PendingPermission{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"pending": pending})
 }
 
 // auth enforces the single bearer token. An unconfigured token fails

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -136,8 +136,53 @@ func (d *memDir) Append(_ context.Context, id, kind string, payload any) (int64,
 	return seq, nil
 }
 
-func (d *memDir) SetTitleIfEmpty(context.Context, string, string) error { return nil }
+func (d *memDir) SetTitleIfEmpty(context.Context, string, string) error      { return nil }
 func (d *memDir) SetLastRoute(context.Context, string, string, string) error { return nil }
+
+// PendingPermissions mirrors session.Store's own unresolved-vs-resolved
+// logic over the in-memory event log, scoped to sessionIDs — same
+// contract the real store's SQL enforces (no matching
+// permission_resolved by id).
+func (d *memDir) PendingPermissions(_ context.Context, sessionIDs []string) ([]session.PendingPermission, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	var out []session.PendingPermission
+	for _, id := range sessionIDs {
+		resolved := map[string]bool{}
+		var requests []struct {
+			id string
+			session.PendingPermission
+		}
+		for _, ev := range d.events[id] {
+			switch ev.Kind {
+			case session.KindPermissionResolved:
+				var r session.PermissionResolved
+				if err := json.Unmarshal(ev.Payload, &r); err != nil {
+					return nil, err
+				}
+				resolved[r.ID] = true
+			case session.KindPermissionRequest:
+				var req session.PermissionRequest
+				if err := json.Unmarshal(ev.Payload, &req); err != nil {
+					return nil, err
+				}
+				requests = append(requests, struct {
+					id string
+					session.PendingPermission
+				}{req.ID, session.PendingPermission{
+					SessionID: id, SessionTitle: d.metas[id].Title,
+					Tool: req.Tool, Rationale: req.Rationale, RequestedAt: ev.CreatedAt,
+				}})
+			}
+		}
+		for _, req := range requests {
+			if !resolved[req.id] {
+				out = append(out, req.PendingPermission)
+			}
+		}
+	}
+	return out, nil
+}
 
 // fakeGateway yields a canned event sequence, or fails when err set.
 // blockCh, when set, delays every event past the first until closed —
@@ -226,6 +271,7 @@ func mux(a *API) *http.ServeMux {
 	m.Handle("POST /v1/sessions/{id}/messages/retry", a.auth(http.HandlerFunc(a.handleRetry)))
 	m.Handle("POST /v1/sessions/{id}/stop", a.auth(http.HandlerFunc(a.handleStop)))
 	m.Handle("POST /v1/permissions/{id}", a.auth(http.HandlerFunc(a.handlePermission)))
+	m.Handle("GET /v1/permissions/pending", a.auth(http.HandlerFunc(a.handlePendingPermissions)))
 	m.Handle("POST /v1/chat", a.auth(http.HandlerFunc(a.handleChatShim)))
 	return m
 }

--- a/internal/brain/api/permissions_test.go
+++ b/internal/brain/api/permissions_test.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+// TestPendingPermissionsEmptyWhenNothingActive confirms the endpoint
+// returns an empty list, never null, when no turn is in flight.
+func TestPendingPermissionsEmptyWhenNothingActive(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	w := doMux(a, http.MethodGet, "/v1/permissions/pending", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Pending []map[string]any `json:"pending"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Pending == nil || len(body.Pending) != 0 {
+		t.Fatalf("pending = %#v, want empty (non-nil) slice", body.Pending)
+	}
+}
+
+// TestPendingPermissionsReturnsActiveUnresolvedRequest confirms a
+// session with an in-flight turn parked on an unresolved permission
+// ask shows up, with tool/rationale/session_title carried through.
+func TestPendingPermissionsReturnsActiveUnresolvedRequest(t *testing.T) {
+	t.Parallel()
+	block := make(chan struct{})
+	events := []stream.StreamEvent{
+		{Type: stream.EventPermissionRequest, Permission: &stream.PermissionRequestEvent{
+			ID: "perm-1", CallID: "call-1", Tool: "gmail_search", Danger: "destructive",
+			Rationale: "read the inbox",
+		}},
+	}
+	a, dir, gw := testAPI(t, "tok", events)
+	gw.blockCh = block
+	defer close(block)
+
+	id, _ := dir.Create(t.Context(), "my session")
+
+	done := make(chan struct{})
+	go func() {
+		doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages", `{"message":"hello"}`)
+		close(done)
+	}()
+	waitForTest(t, func() bool { return a.svc.TurnActive(id) })
+	// The permission_request event is appended synchronously by
+	// notePermission before the fake gateway blocks on the next event,
+	// but give the relay goroutine a moment to persist it.
+	waitForTest(t, func() bool {
+		evs, _ := dir.Events(t.Context(), id)
+		for _, ev := range evs {
+			if ev.Kind == "permission_request" {
+				return true
+			}
+		}
+		return false
+	})
+
+	w := doMux(a, http.MethodGet, "/v1/permissions/pending", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Pending []struct {
+			SessionID    string `json:"session_id"`
+			SessionTitle string `json:"session_title"`
+			Tool         string `json:"tool"`
+			Rationale    string `json:"rationale"`
+		} `json:"pending"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Pending) != 1 {
+		t.Fatalf("pending = %#v, want exactly one entry", body.Pending)
+	}
+	got := body.Pending[0]
+	if got.SessionID != id || got.SessionTitle != "my session" ||
+		got.Tool != "gmail_search" || got.Rationale != "read the inbox" {
+		t.Fatalf("pending[0] = %#v, want session %s/my session, tool gmail_search", got, id)
+	}
+}
+
+// TestPendingPermissionsExcludesResolvedRequest confirms a
+// permission_request with a matching permission_resolved in the same
+// session's log never shows as pending, even while the turn is still
+// technically active (a second ask could still be parked, but this one
+// isn't).
+func TestPendingPermissionsExcludesResolvedRequest(t *testing.T) {
+	t.Parallel()
+	block := make(chan struct{})
+	// fakeGateway's blockCh sends events[0] immediately, then waits on
+	// block before sending the rest — so the resolve (events[1]) and a
+	// trailing chunk (events[2], keeping the turn active afterward)
+	// both land only once the test unblocks below.
+	events := []stream.StreamEvent{
+		{Type: stream.EventPermissionRequest, Permission: &stream.PermissionRequestEvent{
+			ID: "perm-1", CallID: "call-1", Tool: "shell", Rationale: "run tests",
+		}},
+		{Type: stream.EventPermissionResolved, Resolved: &stream.PermissionResolvedEvent{
+			ID: "perm-1", Decision: "once",
+		}},
+		{Type: stream.EventChunk, Text: "still going"},
+	}
+	a, dir, gw := testAPI(t, "tok", events)
+	gw.blockCh = block
+
+	id, _ := dir.Create(t.Context(), "t")
+
+	done := make(chan struct{})
+	go func() {
+		doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages", `{"message":"hello"}`)
+		close(done)
+	}()
+	waitForTest(t, func() bool { return a.svc.TurnActive(id) })
+	close(block)
+	waitForTest(t, func() bool {
+		evs, _ := dir.Events(t.Context(), id)
+		for _, ev := range evs {
+			if ev.Kind == "permission_resolved" {
+				return true
+			}
+		}
+		return false
+	})
+
+	w := doMux(a, http.MethodGet, "/v1/permissions/pending", "")
+	var body struct {
+		Pending []map[string]any `json:"pending"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Pending) != 0 {
+		t.Fatalf("pending = %#v, want empty (request already resolved)", body.Pending)
+	}
+}
+
+// TestPendingPermissionsExcludesInactiveSession confirms a session
+// whose turn already ended (crashed/finished without resolving the
+// permission) never shows as pending: the endpoint scopes its query to
+// chat.Service.ActiveSessions(), so a permission_request left in an
+// idle session's log is not a zombie pending flag.
+func TestPendingPermissionsExcludesInactiveSession(t *testing.T) {
+	t.Parallel()
+	a, dir, _ := testAPI(t, "tok", nil)
+	id, _ := dir.Create(t.Context(), "t")
+	// Directly seed an unresolved permission_request into a session
+	// with no active turn — simulates a crash that stranded the ask.
+	if _, err := dir.Append(t.Context(), id, "permission_request", map[string]string{
+		"id": "perm-1", "tool": "shell",
+	}); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	w := doMux(a, http.MethodGet, "/v1/permissions/pending", "")
+	var body struct {
+		Pending []map[string]any `json:"pending"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Pending) != 0 {
+		t.Fatalf("pending = %#v, want empty (session has no active turn)", body.Pending)
+	}
+}

--- a/internal/brain/chat/attachments_test.go
+++ b/internal/brain/chat/attachments_test.go
@@ -264,7 +264,7 @@ func TestChatImageMessageOnSensitivePinnedSessionKeepsPinnedRoute(t *testing.T) 
 	seedSensitiveSession(t, log, "s1")
 	gw := &fakeGW{events: okEvents("described")}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
 	fa := newFakeAttachments()
 	fa.seed("img1", "image/png", []byte("bytes"))
 	svc.SetAttachments(fa)

--- a/internal/brain/chat/broadcast.go
+++ b/internal/brain/chat/broadcast.go
@@ -185,6 +185,25 @@ func (s *Service) TurnActive(sessionID string) bool {
 	return ok
 }
 
+// ActiveSessions returns the IDs of every session with a turn
+// currently in flight — the same Service.turns map TurnActive reads,
+// snapshotted. Used to scope the pending-permissions query to live
+// turns only: a permission_request whose turn already died (crash,
+// abandoned) must not show as pending forever, so the caller queries
+// session_events for just these IDs rather than the whole table.
+func (s *Service) ActiveSessions() []string {
+	s.turnsMu.Lock()
+	defer s.turnsMu.Unlock()
+	if len(s.turns) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(s.turns))
+	for id := range s.turns {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
 // Subscribe attaches to sessionID's in-flight turn, if any: ok is
 // false when no turn is currently running, in which case replay and
 // live are both nil. Otherwise replay is every event buffered so far

--- a/internal/brain/chat/broadcast_test.go
+++ b/internal/brain/chat/broadcast_test.go
@@ -130,6 +130,42 @@ func TestServiceTurnLifecycleActiveThenFreed(t *testing.T) {
 	}
 }
 
+// TestServiceActiveSessions confirms ActiveSessions reflects exactly
+// the sessions with a live turnBegin entry — nil when empty, every
+// live ID present, and a freed entry (turnDone) drops out.
+func TestServiceActiveSessions(t *testing.T) {
+	t.Parallel()
+	s := &Service{}
+
+	if ids := s.ActiveSessions(); ids != nil {
+		t.Fatalf("ActiveSessions = %v, want nil before any turn registered", ids)
+	}
+
+	if _, err := s.turnBegin("s1"); err != nil {
+		t.Fatalf("turnBegin s1: %v", err)
+	}
+	if _, err := s.turnBegin("s2"); err != nil {
+		t.Fatalf("turnBegin s2: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, id := range s.ActiveSessions() {
+		got[id] = true
+	}
+	if !got["s1"] || !got["s2"] || len(got) != 2 {
+		t.Fatalf("ActiveSessions = %v, want exactly [s1 s2]", s.ActiveSessions())
+	}
+
+	s.turnDone("s1")
+	got = map[string]bool{}
+	for _, id := range s.ActiveSessions() {
+		got[id] = true
+	}
+	if got["s1"] || !got["s2"] || len(got) != 1 {
+		t.Fatalf("ActiveSessions after turnDone(s1) = %v, want exactly [s2]", s.ActiveSessions())
+	}
+}
+
 // TestServiceTurnBeginExclusiveThenFreedAllowsNext confirms the new
 // exclusivity contract (D-042): a second turnBegin call while an entry
 // is live must fail with ErrTurnInFlight rather than evicting it (the

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -206,7 +206,8 @@ type Service struct {
 	turnsMu sync.Mutex
 	turns   map[string]*turnBroadcaster
 
-	publishSession func(sessionID string) // nil: no session-signal push (today's default)
+	publishSession    func(sessionID string) // nil: no session-signal push (today's default)
+	publishPermission func(sessionID string) // nil: no permission-signal push (today's default)
 }
 
 // SetSessionHub wires the "session" signal push: fires once a turn's
@@ -220,6 +221,16 @@ type Service struct {
 // and every test) makes this a no-op.
 func (s *Service) SetSessionHub(publish func(sessionID string)) {
 	s.publishSession = publish
+}
+
+// SetPermissionHub wires the "permission" signal push: fires once a
+// permission_request or permission_resolved event is durable (see
+// notePermission), same pattern and same nil-safe default as
+// SetSessionHub above — main wires both to the same missions.Hub, just
+// a different Signal.Kind, so the web's one global /v1/events stream
+// carries both without a second transport.
+func (s *Service) SetPermissionHub(publish func(sessionID string)) {
+	s.publishPermission = publish
 }
 
 // SetMemoryExtract wires the memoryd hook. Optional — nil leaves
@@ -656,7 +667,7 @@ func (s *Service) pinSensitiveRoute(ctx context.Context, events []session.Event,
 	if s.sensitive == nil || s.sensitive.Route == nil {
 		return route, modelHint
 	}
-	if !s.sensitive.SessionSensitive(events) {
+	if !s.sensitive.SessionSensitive(ctx, events) {
 		return route, modelHint
 	}
 	if forced := s.sensitive.Route(ctx); forced != "" {
@@ -778,7 +789,7 @@ func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, 
 	// context just projected above, even when THIS turn runs no
 	// sensitive tool itself — so persistTurn's side-calls (distill,
 	// extraction) must be pinned too, same as turnSensitive.
-	sessionSensitive := s.sensitive.SessionSensitive(events)
+	sessionSensitive := s.sensitive.SessionSensitive(turnCtx, events)
 
 	// Retrieved memory and a hinted skill both ride the system
 	// prompt's TAIL: the stable prefix stays byte-identical for
@@ -878,7 +889,7 @@ func (s *Service) relay(reqCtx context.Context, sessionID, userText, route strin
 			return
 		}
 		ranTool = true
-		if s.sensitive.Matches(ev.ToolResult.Name) {
+		if s.sensitive.Matches(reqCtx, ev.ToolResult.Name) {
 			turnSensitive = true
 		}
 	}
@@ -926,6 +937,10 @@ func (s *Service) relay(reqCtx context.Context, sessionID, userText, route strin
 		defer cancel()
 		if _, err := s.log.Append(wctx, sessionID, kind, payload); err != nil {
 			s.logger.Warn("persist permission event", "session_id", sessionID, "kind", kind, "error", err)
+			return
+		}
+		if s.publishPermission != nil {
+			s.publishPermission(sessionID)
 		}
 	}
 

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -1464,7 +1464,7 @@ func TestMemoryExtractUsesSensitiveRouteWhenTurnRanSensitiveTool(t *testing.T) {
 		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
 	}}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
 
 	got := make(chan string, 1)
 	svc.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) {
@@ -1500,7 +1500,7 @@ func TestMemoryExtractUsesEmptyRouteWhenTurnDidNotRunSensitiveTool(t *testing.T)
 		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
 	}}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
 
 	got := make(chan string, 1)
 	svc.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) {
@@ -1711,7 +1711,7 @@ func TestDistillUsesSensitiveRouteWhenTurnRanSensitiveTool(t *testing.T) {
 		return nil
 	}
 	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize my inbox"})
 	if err != nil {
@@ -1747,7 +1747,7 @@ func TestDistillUsesEmptyRouteWhenTurnDidNotRunSensitiveTool(t *testing.T) {
 		return nil
 	}
 	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "run a shell command"})
 	if err != nil {
@@ -1793,7 +1793,7 @@ func TestChatPinsSessionSensitiveRouteOnNextTurn(t *testing.T) {
 	seedSensitiveSession(t, log, "s1")
 	gw := &fakeGW{events: okEvents("the answer")}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "another question", Route: "mini", ModelHint: "big-model"})
 	if err != nil {
@@ -1820,7 +1820,7 @@ func TestChatSessionPinNoopWhenSensitiveRouteUnset(t *testing.T) {
 	seedSensitiveSession(t, log, "s1")
 	gw := &fakeGW{events: okEvents("the answer")}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "" }})
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "another question", Route: "mini", ModelHint: "big-model"})
 	if err != nil {
@@ -1845,7 +1845,7 @@ func TestChatFreshSessionRoutesNormally(t *testing.T) {
 	log := newFakeLog()
 	gw := &fakeGW{events: okEvents("the answer")}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "a question", Route: "mini", ModelHint: "big-model"})
 	if err != nil {
@@ -1877,7 +1877,7 @@ func TestRetryPinsSessionSensitiveRoute(t *testing.T) {
 	}
 	gw := &fakeGW{events: okEvents("the answer")}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
 
 	_, ch, err := svc.Retry(t.Context(), "s1")
 	if err != nil {
@@ -1915,7 +1915,7 @@ func TestPersistTurnPinsSideCallsWhenSessionPreviouslySensitive(t *testing.T) {
 		return nil
 	}
 	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
 
 	extractRoute := make(chan string, 1)
 	svc.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) {

--- a/internal/brain/connectors/connectors.go
+++ b/internal/brain/connectors/connectors.go
@@ -35,6 +35,13 @@ type Connector struct {
 	Config        json.RawMessage `json:"config"`
 	CredentialRef string          `json:"credential_ref"`
 	Enabled       bool            `json:"enabled"`
+	// Sensitive marks the WHOLE connector as sensitive: every tool it
+	// serves is namespaced "<name>_<tool>" (see Manager.Tools), so the
+	// connector's own name is a PREFIX of every tool it serves —
+	// session.SensitiveTools.Matches checks this prefix in addition to
+	// its existing per-tool suffix rule (D-036), catching all of a
+	// sensitive connector's tools via its name alone.
+	Sensitive bool `json:"sensitive"`
 }
 
 // namePattern keeps connector names usable as tool-name prefixes
@@ -89,7 +96,7 @@ func (s *Store) List(ctx context.Context) ([]Connector, error) {
 	if err != nil {
 		return nil, fmt.Errorf("connectors list: %w", err)
 	}
-	rows, err := db.Query(ctx, `SELECT id, name, kind, config, credential_ref, enabled
+	rows, err := db.Query(ctx, `SELECT id, name, kind, config, credential_ref, enabled, sensitive
 		FROM connectors ORDER BY name`)
 	if err != nil {
 		return nil, fmt.Errorf("connectors list: %w", err)
@@ -99,7 +106,7 @@ func (s *Store) List(ctx context.Context) ([]Connector, error) {
 	out := []Connector{}
 	for rows.Next() {
 		var c Connector
-		if err := rows.Scan(&c.ID, &c.Name, &c.Kind, &c.Config, &c.CredentialRef, &c.Enabled); err != nil {
+		if err := rows.Scan(&c.ID, &c.Name, &c.Kind, &c.Config, &c.CredentialRef, &c.Enabled, &c.Sensitive); err != nil {
 			return nil, fmt.Errorf("connectors list: %w", err)
 		}
 		out = append(out, c)
@@ -130,9 +137,9 @@ func (s *Store) Create(ctx context.Context, c Connector) (string, error) {
 		cfg = json.RawMessage("{}")
 	}
 	var id string
-	err = db.QueryRow(ctx, `INSERT INTO connectors (name, kind, config, credential_ref, enabled)
-		VALUES ($1, $2, $3, $4, $5) RETURNING id`,
-		c.Name, c.Kind, cfg, c.CredentialRef, c.Enabled).Scan(&id)
+	err = db.QueryRow(ctx, `INSERT INTO connectors (name, kind, config, credential_ref, enabled, sensitive)
+		VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
+		c.Name, c.Kind, cfg, c.CredentialRef, c.Enabled, c.Sensitive).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("connectors create: %w", err)
 	}
@@ -148,6 +155,7 @@ type Patch struct {
 	Config        *json.RawMessage `json:"config"`
 	CredentialRef *string          `json:"credential_ref"`
 	Enabled       *bool            `json:"enabled"`
+	Sensitive     *bool            `json:"sensitive"`
 }
 
 func (s *Store) Patch(ctx context.Context, id string, patch Patch) error {
@@ -184,10 +192,13 @@ func (s *Store) Patch(ctx context.Context, id string, patch Patch) error {
 	if patch.Enabled != nil {
 		after.Enabled = *patch.Enabled
 	}
+	if patch.Sensitive != nil {
+		after.Sensitive = *patch.Sensitive
+	}
 
 	if _, err := tx.Exec(ctx, `UPDATE connectors SET config = $2, credential_ref = $3,
-			enabled = $4, updated_at = now() WHERE id = $1`,
-		id, after.Config, after.CredentialRef, after.Enabled); err != nil {
+			enabled = $4, sensitive = $5, updated_at = now() WHERE id = $1`,
+		id, after.Config, after.CredentialRef, after.Enabled, after.Sensitive); err != nil {
 		return fmt.Errorf("connectors patch: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
@@ -223,9 +234,9 @@ type pgxQuerier interface {
 
 func scanConnector(ctx context.Context, q pgxQuerier, id, lock string) (Connector, error) {
 	var c Connector
-	err := q.QueryRow(ctx, `SELECT id, name, kind, config, credential_ref, enabled
+	err := q.QueryRow(ctx, `SELECT id, name, kind, config, credential_ref, enabled, sensitive
 		FROM connectors WHERE id = $1 `+lock, id).
-		Scan(&c.ID, &c.Name, &c.Kind, &c.Config, &c.CredentialRef, &c.Enabled)
+		Scan(&c.ID, &c.Name, &c.Kind, &c.Config, &c.CredentialRef, &c.Enabled, &c.Sensitive)
 	if err != nil {
 		return Connector{}, fmt.Errorf("connector %s: %w", id, ErrNotFound)
 	}

--- a/internal/brain/connectors/connectors_integration_test.go
+++ b/internal/brain/connectors/connectors_integration_test.go
@@ -79,12 +79,16 @@ func TestConnectorCRUDAuditsAndNotifies(t *testing.T) {
 		Name: name, Kind: "mcp",
 		Config:        json.RawMessage(`{"endpoint":"https://api.example/mcp"}`),
 		CredentialRef: "GITHUB_MCP_TOKEN",
+		Sensitive:     true,
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	if changes != 1 {
 		t.Fatalf("changes after create = %d, want 1", changes)
+	}
+	if created, err := store.Get(ctx, id); err != nil || !created.Sensitive {
+		t.Fatalf("Get after create: sensitive = %v, err = %v, want true", created.Sensitive, err)
 	}
 
 	// Duplicate name refused by the unique constraint.
@@ -93,7 +97,8 @@ func TestConnectorCRUDAuditsAndNotifies(t *testing.T) {
 	}
 
 	enabled := true
-	if err := store.Patch(ctx, id, Patch{Enabled: &enabled}); err != nil {
+	sensitive := false
+	if err := store.Patch(ctx, id, Patch{Enabled: &enabled, Sensitive: &sensitive}); err != nil {
 		t.Fatalf("Patch: %v", err)
 	}
 	list, err := store.List(ctx)
@@ -106,8 +111,8 @@ func TestConnectorCRUDAuditsAndNotifies(t *testing.T) {
 			got = &list[i]
 		}
 	}
-	if got == nil || !got.Enabled || got.Kind != "mcp" {
-		t.Fatalf("patched connector = %+v, want enabled mcp", got)
+	if got == nil || !got.Enabled || got.Kind != "mcp" || got.Sensitive {
+		t.Fatalf("patched connector = %+v, want enabled mcp not-sensitive", got)
 	}
 
 	// Ref validation holds on patch too.

--- a/internal/brain/connectors/manager.go
+++ b/internal/brain/connectors/manager.go
@@ -199,6 +199,27 @@ func (m *Manager) Names() []string {
 	return names
 }
 
+// SensitiveNames returns the names of every enabled connector marked
+// sensitive — the connector-level input to session.SensitiveTools'
+// suffix set (D-036): a connector named "gmail" being sensitive means
+// "gmail" joins the set, and Matches' namespace-prefix check catches
+// gmail_search/gmail_read/etc. at once. Reads rows fresh each call (no
+// restart needed for a settings toggle to take effect), same reasoning
+// as sensitiveRoute.
+func (m *Manager) SensitiveNames(ctx context.Context) ([]string, error) {
+	rows, err := m.rows.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, c := range rows {
+		if c.Enabled && c.Sensitive {
+			names = append(names, c.Name)
+		}
+	}
+	return names, nil
+}
+
 // Test builds the connector fresh — enabled or not — and runs its
 // connectivity check, so a connector can be verified before it is
 // switched on. The ephemeral source is closed either way.

--- a/internal/brain/connectors/manager_test.go
+++ b/internal/brain/connectors/manager_test.go
@@ -113,6 +113,36 @@ func TestReloadKeepsSetOnListError(t *testing.T) {
 	}
 }
 
+// TestSensitiveNames pins that it reads rows fresh (via rowSource.List,
+// not the built sources map) and filters to enabled AND sensitive: a
+// disabled-but-sensitive or enabled-but-not-sensitive connector must
+// not appear in the suffix set session.SensitiveTools consumes.
+func TestSensitiveNames(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{rows: []Connector{
+		{ID: "1", Name: "gmail", Kind: "google", Enabled: true, Sensitive: true},
+		{ID: "2", Name: "calendar", Kind: "google", Enabled: true, Sensitive: false},
+		{ID: "3", Name: "slack", Kind: "mcp", Enabled: false, Sensitive: true},
+	}})
+
+	got, err := m.SensitiveNames(t.Context())
+	if err != nil {
+		t.Fatalf("SensitiveNames: %v", err)
+	}
+	slices.Sort(got)
+	if !slices.Equal(got, []string{"gmail"}) {
+		t.Fatalf("SensitiveNames = %v, want [gmail]", got)
+	}
+}
+
+func TestSensitiveNamesPropagatesListError(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{err: errors.New("db down")})
+	if _, err := m.SensitiveNames(t.Context()); err == nil {
+		t.Fatal("SensitiveNames with failing list: want error")
+	}
+}
+
 func TestTestBuildsEphemeralSource(t *testing.T) {
 	t.Parallel()
 	src := &fakeSource{testErr: errors.New("401 unauthorized")}

--- a/internal/brain/missions/driver_integration_test.go
+++ b/internal/brain/missions/driver_integration_test.go
@@ -143,7 +143,7 @@ func TestDriverLazilyProvisionsBareSchedulerStyleMission(t *testing.T) {
 
 	wsRoot := t.TempDir()
 	workspace := NewWorkspace(wsRoot, nil, log)
-	sessions := session.NewStore(store.db)
+	sessions := session.NewStore(store.db, log)
 	perms := tools.NewPermissions(store.db, wsRoot)
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
 	d := NewDriver(store, runner, workspace, nil, sessions, perms, log)

--- a/internal/brain/session/compactor.go
+++ b/internal/brain/session/compactor.go
@@ -170,7 +170,7 @@ func (c *Compactor) MaybeCompact(ctx context.Context, sessionID string) error {
 	// the loop pins the rest of a sensitive TURN's route (the content
 	// downstream of it may quote raw sensitive output). Computed once so
 	// extract and summarize agree on the same verdict.
-	sensitive := c.sensitive.SessionSensitive(events)
+	sensitive := c.sensitive.SessionSensitive(ctx, events)
 
 	// Extract BEFORE summarizing: once the summary replaces these
 	// turns, whatever it dropped is gone for good (D-011). The turns

--- a/internal/brain/session/compactor_test.go
+++ b/internal/brain/session/compactor_test.go
@@ -535,7 +535,7 @@ func TestCompactionUsesSensitiveRouteWhenSessionRanSensitiveTool(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
-	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+	c.SetSensitiveTools(&SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
 
 	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
 		t.Fatalf("MaybeCompact: %v", err)
@@ -558,7 +558,7 @@ func TestCompactionUsesDefaultRouteWithoutSensitiveTool(t *testing.T) {
 	gw := &summarizerGW{summary: "short summary"}
 	seedConversation(t, log, "s1", 10)
 	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
-	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+	c.SetSensitiveTools(&SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
 
 	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
 		t.Fatalf("MaybeCompact: %v", err)
@@ -587,7 +587,7 @@ func TestCompactionExtractUsesSensitiveRouteWhenSessionRanSensitiveTool(t *testi
 		t.Fatal(err)
 	}
 	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
-	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+	c.SetSensitiveTools(&SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
 
 	var sawRoute string
 	c.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) []string {
@@ -613,7 +613,7 @@ func TestCompactionExtractUsesEmptyRouteWithoutSensitiveTool(t *testing.T) {
 	gw := &summarizerGW{summary: "short summary"}
 	seedConversation(t, log, "s1", 10)
 	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
-	c.SetSensitiveTools(&SensitiveTools{Suffixes: []string{"gmail_read"}, Route: func(context.Context) string { return "local" }})
+	c.SetSensitiveTools(&SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
 
 	sawRoute := "unset"
 	c.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) []string {

--- a/internal/brain/session/sensitive.go
+++ b/internal/brain/session/sensitive.go
@@ -18,20 +18,42 @@ import (
 // Route is a func, not a static string, so a settings change applies to
 // the next side-call without a restart; an empty result means the
 // feature is currently off (callers keep their own default route).
+// Suffixes is likewise a func, not a static slice: a specific tool's
+// own name (e.g. "gmail_read") that must stay pinned regardless of
+// which connector namespace wraps it — matched as a suffix, same rule
+// as Agent.SetForceRoute/matchGrant (D-036). ConnectorNames is the
+// separate, additive input for marking a WHOLE connector sensitive:
+// connectors are namespaced "<connector-name>_<tool-name>"
+// (connectors.Manager.Tools), so a connector's own name is the PREFIX
+// of every tool it serves, never a suffix — it needs its own match
+// rule, not Suffixes' suffix check, to avoid a floor entry like
+// "gmail_read" also prefix-matching an unrelated "gmail_read_all"
+// tool. Both are funcs, not static slices, so a settings change
+// applies to the next side-call without a restart, same reasoning as
+// Route.
 type SensitiveTools struct {
-	Suffixes []string
-	Route    func(context.Context) string
+	Suffixes       func(context.Context) []string
+	ConnectorNames func(context.Context) []string
+	Route          func(context.Context) string
 }
 
-// Matches reports whether toolName ends a sensitive suffix: exact
-// match, or toolName ends with "_"+suffix.
-func (s *SensitiveTools) Matches(toolName string) bool {
+// Matches reports whether toolName is covered: exact match or
+// "_"+suffix suffix against Suffixes, or suffix+"_" prefix (a whole
+// connector's namespace) against ConnectorNames.
+func (s *SensitiveTools) Matches(ctx context.Context, toolName string) bool {
 	if s == nil {
 		return false
 	}
-	for _, suffix := range s.Suffixes {
+	for _, suffix := range s.Suffixes(ctx) {
 		if toolName == suffix || strings.HasSuffix(toolName, "_"+suffix) {
 			return true
+		}
+	}
+	if s.ConnectorNames != nil {
+		for _, name := range s.ConnectorNames(ctx) {
+			if strings.HasPrefix(toolName, name+"_") {
+				return true
+			}
 		}
 	}
 	return false
@@ -45,7 +67,7 @@ func (s *SensitiveTools) Matches(toolName string) bool {
 // by the compactor (which span to summarize/extract on) and chat
 // (which route to serve the next turn on) so both apply the same
 // verdict. nil sensitive (feature off) always reports false.
-func (s *SensitiveTools) SessionSensitive(events []Event) bool {
+func (s *SensitiveTools) SessionSensitive(ctx context.Context, events []Event) bool {
 	if s == nil {
 		return false
 	}
@@ -57,7 +79,7 @@ func (s *SensitiveTools) SessionSensitive(events []Event) bool {
 		if decode(ev, &te) != nil {
 			continue
 		}
-		if s.Matches(te.Name) {
+		if s.Matches(ctx, te.Name) {
 			return true
 		}
 	}

--- a/internal/brain/session/sensitive_test.go
+++ b/internal/brain/session/sensitive_test.go
@@ -10,7 +10,10 @@ import (
 // loop.Agent.SetForceRoute/matchGrant (D-036).
 func TestSensitiveToolsMatches(t *testing.T) {
 	t.Parallel()
-	s := &SensitiveTools{Suffixes: []string{"gmail_read", "gmail_read_attachment"}, Route: func(context.Context) string { return "local" }}
+	s := &SensitiveTools{
+		Suffixes: func(context.Context) []string { return []string{"gmail_read", "gmail_read_attachment"} },
+		Route:    func(context.Context) string { return "local" },
+	}
 	tests := []struct {
 		name string
 		tool string
@@ -26,7 +29,7 @@ func TestSensitiveToolsMatches(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := s.Matches(tc.tool); got != tc.want {
+			if got := s.Matches(context.Background(), tc.tool); got != tc.want {
 				t.Fatalf("Matches(%q) = %v, want %v", tc.tool, got, tc.want)
 			}
 		})
@@ -36,7 +39,101 @@ func TestSensitiveToolsMatches(t *testing.T) {
 func TestSensitiveToolsMatchesNilReceiver(t *testing.T) {
 	t.Parallel()
 	var s *SensitiveTools
-	if s.Matches("gmail_read") {
+	if s.Matches(context.Background(), "gmail_read") {
 		t.Fatal("nil SensitiveTools matched a tool, want false (feature off)")
+	}
+}
+
+// TestSensitiveToolsMatchesConnectorPrefix pins the connector-level
+// case: a connector's own name is the NAMESPACE PREFIX of every tool it
+// serves ("<connector-name>_<tool-name>", connectors.Manager.Tools),
+// never a suffix — so marking a whole connector sensitive adds its bare
+// name to ConnectorNames, matched via a prefix check that is separate
+// from Suffixes' tool-name suffix rule (mixing the two in one list
+// would make a floor entry like "gmail_read" falsely prefix-match an
+// unrelated "gmail_read_all_labels" tool).
+func TestSensitiveToolsMatchesConnectorPrefix(t *testing.T) {
+	t.Parallel()
+	s := &SensitiveTools{
+		Suffixes:       func(context.Context) []string { return []string{"gmail_read"} },
+		ConnectorNames: func(context.Context) []string { return []string{"slack"} },
+		Route:          func(context.Context) string { return "local" },
+	}
+	tests := []struct {
+		name string
+		tool string
+		want bool
+	}{
+		{name: "connector-prefixed tool", tool: "slack_read_channel", want: true},
+		{name: "another tool under the same sensitive connector", tool: "slack_send_message", want: true},
+		{name: "unrelated connector", tool: "calendar_list_events", want: false},
+		{name: "connector name embedded but not as a namespace boundary", tool: "backslack_read", want: false},
+		{name: "floor suffix does not falsely prefix-match", tool: "gmail_read_all_labels", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := s.Matches(context.Background(), tc.tool); got != tc.want {
+				t.Fatalf("Matches(%q) = %v, want %v", tc.tool, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSensitiveToolsMatchesConnectorNamesNil pins that a nil
+// ConnectorNames func (not every caller wires it) never panics —
+// Matches falls back to Suffixes alone.
+func TestSensitiveToolsMatchesConnectorNamesNil(t *testing.T) {
+	t.Parallel()
+	s := &SensitiveTools{
+		Suffixes: func(context.Context) []string { return []string{"gmail_read"} },
+		Route:    func(context.Context) string { return "local" },
+	}
+	if s.Matches(context.Background(), "slack_read_channel") {
+		t.Fatal("Matches true with nil ConnectorNames, want false")
+	}
+}
+
+// TestSensitiveToolsMatchesDynamicConnectorNames pins that
+// ConnectorNames is read fresh on every call, not cached at
+// construction: a connector marked sensitive after SensitiveTools is
+// built (e.g. a settings toggle) must still be caught on the next
+// Matches/SessionSensitive call without a restart, same reasoning as
+// Route.
+func TestSensitiveToolsMatchesDynamicConnectorNames(t *testing.T) {
+	t.Parallel()
+	sensitiveConnector := false
+	s := &SensitiveTools{
+		Suffixes: func(context.Context) []string { return []string{"gmail_read"} },
+		ConnectorNames: func(context.Context) []string {
+			if sensitiveConnector {
+				return []string{"slack"}
+			}
+			return nil
+		},
+		Route: func(context.Context) string { return "local" },
+	}
+
+	if s.Matches(context.Background(), "slack_read_channel") {
+		t.Fatal("Matches true before connector marked sensitive, want false")
+	}
+
+	sensitiveConnector = true
+	if !s.Matches(context.Background(), "slack_read_channel") {
+		t.Fatal("Matches false after connector marked sensitive, want true")
+	}
+
+	log := newMemLog()
+	if _, err := log.Append(context.Background(), "s1", KindToolExecution, ToolExecution{
+		CallID: "c1", Name: "slack_read_channel", Status: "ok",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	events, err := log.Events(context.Background(), "s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.SessionSensitive(context.Background(), events) {
+		t.Fatal("SessionSensitive false for a connector-namespaced sensitive tool, want true")
 	}
 }

--- a/internal/brain/session/store.go
+++ b/internal/brain/session/store.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
+	"runtime"
 	"strings"
 	"time"
 
@@ -17,15 +19,28 @@ var ErrMissionReferenced = errors.New("session referenced by a mission")
 
 // Store persists session rows and their append-only event logs.
 type Store struct {
-	db *pgpool.Pool
+	db  *pgpool.Pool
+	log *slog.Logger
 }
 
-func NewStore(db *pgpool.Pool) *Store {
-	return &Store{db: db}
+func NewStore(db *pgpool.Pool, log *slog.Logger) *Store {
+	return &Store{db: db, log: log}
 }
 
-// Create opens a session and writes its session_started event.
+// Create opens a session and writes its session_started event. Debug-
+// logs the immediate caller (file:line) and whether title was blank:
+// an untitled session with no obvious owner (chat.Chat's "no session
+// yet" path, the API's POST /v1/sessions, a mission's bookkeeping
+// session) has shown up unexplained before — this pinpoints which
+// call site created it without threading a caller-identity param
+// through every one of them.
 func (s *Store) Create(ctx context.Context, title string) (string, error) {
+	if s.log != nil {
+		_, file, line, ok := runtime.Caller(1)
+		if ok {
+			s.log.Debug("session: create", "caller", fmt.Sprintf("%s:%d", file, line), "titled", title != "")
+		}
+	}
 	db, err := s.db.Get()
 	if err != nil {
 		return "", fmt.Errorf("session: create: %w", err)
@@ -317,4 +332,62 @@ func (s *Store) SetLastRoute(ctx context.Context, id, route, agent string) error
 	_, err = db.Exec(ctx,
 		"UPDATE sessions SET last_route = $2, agent = $3 WHERE id = $1", id, route, agent)
 	return err
+}
+
+// PendingPermission is one unresolved permission_request, joined with
+// its session's title for the global "you have a permission waiting"
+// indicator.
+type PendingPermission struct {
+	SessionID    string    `json:"session_id"`
+	SessionTitle string    `json:"session_title"`
+	Tool         string    `json:"tool"`
+	Rationale    string    `json:"rationale"`
+	RequestedAt  time.Time `json:"requested_at"`
+}
+
+// PendingPermissions returns every unresolved permission_request among
+// sessionIDs — a targeted query, not a full-table scan: the caller
+// (the API handler) passes chat.Service.ActiveSessions(), so a
+// permission_request whose turn already died (crash, abandoned) is
+// scoped out before this query even runs, rather than filtered after
+// fetching every session's full event log. "Unresolved" means no
+// later permission_resolved event with the same payload->>'id' exists
+// in that session's log. Empty sessionIDs returns nil without a query.
+func (s *Store) PendingPermissions(ctx context.Context, sessionIDs []string) ([]PendingPermission, error) {
+	if len(sessionIDs) == 0 {
+		return nil, nil
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("session: pending permissions: %w", err)
+	}
+	rows, err := db.Query(ctx,
+		`SELECT req.session_id, COALESCE(s.title, ''), req.payload->>'tool',
+		        req.payload->>'rationale', req.created_at
+		 FROM session_events req
+		 JOIN sessions s ON s.id = req.session_id
+		 WHERE req.kind = 'permission_request'
+		   AND req.session_id = ANY($1)
+		   AND NOT EXISTS (
+		       SELECT 1 FROM session_events res
+		       WHERE res.session_id = req.session_id
+		         AND res.kind = 'permission_resolved'
+		         AND res.payload->>'id' = req.payload->>'id'
+		   )
+		 ORDER BY req.created_at`,
+		sessionIDs)
+	if err != nil {
+		return nil, fmt.Errorf("session: pending permissions query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []PendingPermission
+	for rows.Next() {
+		var p PendingPermission
+		if err := rows.Scan(&p.SessionID, &p.SessionTitle, &p.Tool, &p.Rationale, &p.RequestedAt); err != nil {
+			return nil, fmt.Errorf("session: pending permissions scan: %w", err)
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
 }

--- a/internal/brain/session/store_integration_test.go
+++ b/internal/brain/session/store_integration_test.go
@@ -47,7 +47,7 @@ func integrationStore(t *testing.T) (*Store, string) {
 	_, _ = db.Exec(ctx,
 		"DELETE FROM sessions WHERE title IN ('integration test session', 'cursor-tie-test')")
 
-	s := NewStore(pool)
+	s := NewStore(pool, log)
 	id, err := s.Create(ctx, "integration test session")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -239,7 +239,7 @@ func TestListCursorStableOnTiedTimestamps(t *testing.T) {
 	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	s := NewStore(pool)
+	s := NewStore(pool, log)
 
 	const marker = "cursor-tie-test"
 	var ids []string
@@ -325,7 +325,7 @@ func TestListExcludesMissionSessions(t *testing.T) {
 	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	s := NewStore(pool)
+	s := NewStore(pool, log)
 
 	const marker = "mission-session-list-test"
 	chatID, err := s.Create(ctx, marker)

--- a/internal/brain/session/store_integration_test.go
+++ b/internal/brain/session/store_integration_test.go
@@ -381,6 +381,76 @@ func TestListExcludesMissionSessions(t *testing.T) {
 	}
 }
 
+// TestPendingPermissions pins the SQL: an unresolved permission_request
+// in a scoped session is returned with its session's title; a request
+// with a matching permission_resolved (same id) is excluded; and a
+// session outside sessionIDs is excluded even with an unresolved
+// request of its own — the "active turns only" scoping the API handler
+// relies on chat.Service.ActiveSessions() for.
+func TestPendingPermissions(t *testing.T) {
+	s, id := integrationStore(t)
+	ctx := t.Context()
+
+	otherID, err := s.Create(ctx, "other session, not scoped in")
+	if err != nil {
+		t.Fatalf("Create other: %v", err)
+	}
+	t.Cleanup(func() {
+		cctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		conn, err := pgx.Connect(cctx, os.Getenv("DATABASE_URL"))
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close(cctx) }()
+		_, _ = conn.Exec(cctx, "DELETE FROM session_events WHERE session_id = $1", otherID)
+		_, _ = conn.Exec(cctx, "DELETE FROM sessions WHERE id = $1", otherID)
+	})
+
+	// id: one resolved request (must be excluded) and one still
+	// unresolved (must show up).
+	if _, err := s.Append(ctx, id, KindPermissionRequest, PermissionRequest{
+		ID: "resolved-1", CallID: "call-1", Tool: "shell", Rationale: "run tests",
+	}); err != nil {
+		t.Fatalf("append resolved request: %v", err)
+	}
+	if _, err := s.Append(ctx, id, KindPermissionResolved, PermissionResolved{
+		ID: "resolved-1", Decision: "once",
+	}); err != nil {
+		t.Fatalf("append resolved: %v", err)
+	}
+	if _, err := s.Append(ctx, id, KindPermissionRequest, PermissionRequest{
+		ID: "pending-1", CallID: "call-2", Tool: "gmail_search", Rationale: "read inbox",
+	}); err != nil {
+		t.Fatalf("append pending request: %v", err)
+	}
+
+	// otherID: unresolved too, but deliberately left out of sessionIDs.
+	if _, err := s.Append(ctx, otherID, KindPermissionRequest, PermissionRequest{
+		ID: "zombie-1", CallID: "call-3", Tool: "shell", Rationale: "stranded by a crash",
+	}); err != nil {
+		t.Fatalf("append other request: %v", err)
+	}
+
+	got, err := s.PendingPermissions(ctx, []string{id})
+	if err != nil {
+		t.Fatalf("PendingPermissions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("pending = %+v, want exactly one entry", got)
+	}
+	p := got[0]
+	if p.SessionID != id || p.SessionTitle != "integration test session" ||
+		p.Tool != "gmail_search" || p.Rationale != "read inbox" {
+		t.Fatalf("pending[0] = %+v, want the still-unresolved gmail_search request", p)
+	}
+
+	// Empty scope: no query, no rows, ever.
+	if got, err := s.PendingPermissions(ctx, nil); err != nil || got != nil {
+		t.Fatalf("PendingPermissions(nil) = %v, %v; want nil, nil", got, err)
+	}
+}
+
 // TestListQueryMatchesTitleOnlySession pins the NULL guard in the
 // search SQL: a session that has never emitted a user_message (its
 // joined payload is NULL) must still be findable by title.

--- a/migrations/0035_connector_sensitive.sql
+++ b/migrations/0035_connector_sensitive.sql
@@ -1,0 +1,4 @@
+-- Marks a whole connector as sensitive: every tool it serves shares the
+-- connector's name as a suffix (session.SensitiveTools), pinning them
+-- all onto the privacy-floor route without listing tool names in Go.
+ALTER TABLE connectors ADD COLUMN sensitive boolean NOT NULL DEFAULT false;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,9 +11,9 @@ import {
   Sun03Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router'
-import { Toaster } from 'sonner'
+import { toast, Toaster } from 'sonner'
 import { getToken } from './api/client'
 import { SessionList } from './components/SessionList'
 import { SessionsProvider } from './components/SessionsProvider'
@@ -46,6 +46,9 @@ import {
 import { TooltipProvider } from './components/ui/tooltip'
 import { useSessions } from './lib/sessions'
 import { usePendingMemories } from './lib/memory'
+import { playAlertSound } from './lib/alertSound'
+import { newlySeen, usePendingPermissions } from './lib/permissions'
+import { getNotificationSoundEnabled } from './lib/sound'
 import { getTheme, nextTheme, setTheme, type Theme } from './lib/theme'
 import { Chat } from './pages/Chat'
 import { Analytics } from './pages/Analytics'
@@ -97,11 +100,13 @@ function breadcrumbFor(pathname: string): string[] {
 // in a real collapsible Sidebar instead of a hand-rolled drawer.
 function AppSidebar({
   pendingMemories,
+  pendingPermissions,
   theme,
   onCycleTheme,
   onToken,
 }: {
   pendingMemories: number
+  pendingPermissions: number
   theme: Theme
   onCycleTheme: () => void
   onToken: () => void
@@ -135,6 +140,9 @@ function AppSidebar({
                   </SidebarMenuButton>
                   {item.href === '/memory' && pendingMemories > 0 && (
                     <SidebarMenuBadge>{pendingMemories}</SidebarMenuBadge>
+                  )}
+                  {item.href === '/chat' && pendingPermissions > 0 && (
+                    <SidebarMenuBadge>{pendingPermissions}</SidebarMenuBadge>
                   )}
                 </SidebarMenuItem>
               ))}
@@ -257,10 +265,35 @@ function App() {
   const [paletteOpen, setPaletteOpen] = useState(false)
   const [theme, setThemeState] = useState<Theme>(() => getTheme())
   const pendingMemories = usePendingMemories()
+  const pendingPermissions = usePendingPermissions()
+  const navigate = useNavigate()
 
   useEffect(() => {
     if (getToken() === '') setTokenOpen(true)
   }, [])
+
+  // Toast + sound fire only for a NEWLY seen pending permission (a
+  // session_id not present on the previous render) — every poll/signal
+  // refetch would otherwise re-toast the same still-pending ask.
+  const seenPermissions = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    const fresh = newlySeen(seenPermissions.current, pendingPermissions)
+    const current = new Set(pendingPermissions.map((p) => p.session_id))
+    if (fresh.length > 0) {
+      if (getNotificationSoundEnabled()) playAlertSound()
+      for (const p of fresh) {
+        toast(`${p.tool} needs your approval`, {
+          description: p.session_title || 'Untitled session',
+          duration: Infinity,
+          action: {
+            label: 'Review',
+            onClick: () => navigate(`/chat/${p.session_id}`),
+          },
+        })
+      }
+    }
+    seenPermissions.current = current
+  }, [pendingPermissions, navigate])
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
@@ -291,6 +324,7 @@ function App() {
         <SidebarProvider className="min-h-dvh">
           <AppSidebar
             pendingMemories={pendingMemories}
+            pendingPermissions={pendingPermissions.length}
             theme={theme}
             onCycleTheme={cycleTheme}
             onToken={openToken}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -20,6 +20,7 @@ import type {
   MissionUsage,
   MissionTemplate,
   Notification,
+  PendingPermission,
   ProviderHealth,
   RetrievedMemory,
   Schedule,
@@ -294,6 +295,14 @@ export async function answerPermission(
     method: 'POST',
     body: JSON.stringify({ decision }),
   })
+}
+
+// listPendingPermissions returns every permission ask still awaiting a
+// decision across every session with a currently active turn — the
+// global badge/toast's data source.
+export async function listPendingPermissions(): Promise<PendingPermission[]> {
+  const { pending } = await request<{ pending: PendingPermission[] }>('/v1/permissions/pending')
+  return pending ?? []
 }
 
 export async function updateSession(
@@ -720,7 +729,7 @@ export async function createConnector(c: Partial<AdminConnector>): Promise<strin
 
 export async function patchConnector(
   id: string,
-  patch: Partial<Pick<AdminConnector, 'config' | 'credential_ref' | 'enabled'>>,
+  patch: Partial<Pick<AdminConnector, 'config' | 'credential_ref' | 'enabled' | 'sensitive'>>,
 ): Promise<void> {
   await request<void>(`/v1/admin/connectors/${id}`, {
     method: 'PATCH',

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -149,6 +149,16 @@ export interface Transcript {
   turn_active: boolean
 }
 
+// One unresolved permission ask, from GET /v1/permissions/pending —
+// scoped server-side to sessions with a currently active turn.
+export interface PendingPermission {
+  session_id: string
+  session_title: string
+  tool: string
+  rationale: string
+  requested_at: string
+}
+
 // One long-term memory row as served by the management API.
 export interface MemoryItem {
   id: string
@@ -497,6 +507,10 @@ export interface AdminConnector {
   config: Record<string, unknown>
   credential_ref: string
   enabled: boolean
+  // sensitive pins every tool this connector serves onto the
+  // privacy-floor route (session.SensitiveTools), same as gmail_read
+  // is pinned today — additive, connector-wide, no code change needed.
+  sensitive: boolean
 }
 
 // MissionTemplate is the frozen mission-creation payload a schedule

--- a/web/src/components/missions/PushBranchDialog.test.tsx
+++ b/web/src/components/missions/PushBranchDialog.test.tsx
@@ -26,6 +26,7 @@ const githubConnector: AdminConnector = {
   config: { endpoint: 'https://api.githubcopilot.com/mcp/' },
   credential_ref: 'github_pat',
   enabled: true,
+  sensitive: false,
 }
 
 describe('PushBranchDialog', () => {

--- a/web/src/components/settings/ConnectorEdit.tsx
+++ b/web/src/components/settings/ConnectorEdit.tsx
@@ -24,7 +24,7 @@ import { Input } from '../ui/input'
 import { ConnectorLogo } from './ConnectorLogo'
 import { connectorPresets, unknownPreset } from './connectorPresets'
 import { useDefaultSecretBackend } from './useDefaultSecretBackend'
-import { Field } from './shared'
+import { Field, Toggle } from './shared'
 import { errText, secretField } from './util'
 
 export function ConnectorEdit() {
@@ -89,6 +89,13 @@ export function ConnectorEdit() {
     }
   }
 
+  const toggleSensitive = (sensitive: boolean) => {
+    if (!connector) return
+    patchConnector(connector.id, { sensitive })
+      .then(refresh)
+      .catch((err: unknown) => toast.error('Could not update connector', { description: errText(err) }))
+  }
+
   const reconnectGoogle = async () => {
     if (!connector) return
     setOAuthBusy(true)
@@ -128,6 +135,20 @@ export function ConnectorEdit() {
       </div>
 
       <div className="grid max-w-3xl gap-5">
+        <div className="flex items-center justify-between gap-4 rounded-xl border border-border p-4">
+          <div className="min-w-0">
+            <div className="text-sm font-medium">Treat as sensitive</div>
+            <p className="text-sm text-muted-foreground">
+              Pins related turns to the privacy-floor route, same as Gmail message reads.
+            </p>
+          </div>
+          <Toggle
+            on={connector.sensitive}
+            onChange={toggleSensitive}
+            label={`${connector.name} sensitive`}
+          />
+        </div>
+
         <h2 className="text-sm font-semibold">Connection</h2>
 
         <div

--- a/web/src/components/settings/ConnectorsList.tsx
+++ b/web/src/components/settings/ConnectorsList.tsx
@@ -135,7 +135,14 @@ function ConnectorCard({
       <div className="flex items-center gap-3">
         <ConnectorLogo preset={preset} className="size-9" />
         <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-semibold">{connector.name}</div>
+          <div className="flex items-center gap-1.5">
+            <div className="truncate text-sm font-semibold">{connector.name}</div>
+            {connector.sensitive && (
+              <span className="shrink-0 rounded-full border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-600 dark:text-amber-400">
+                Sensitive
+              </span>
+            )}
+          </div>
           <div className="text-xs text-muted-foreground uppercase">{connector.kind}</div>
         </div>
         <Toggle on={connector.enabled} onChange={toggle} label={`${connector.name} enabled`} />

--- a/web/src/components/settings/ConnectorsTab.test.tsx
+++ b/web/src/components/settings/ConnectorsTab.test.tsx
@@ -32,6 +32,7 @@ const calendarConnector: AdminConnector = {
   config: { scopes: ['https://www.googleapis.com/auth/calendar'] },
   credential_ref: 'GOOGLE_CALENDAR_GOOGLE_OAUTH',
   enabled: true,
+  sensitive: false,
 }
 
 const assign = vi.fn()
@@ -66,6 +67,31 @@ describe('Connectors tab', () => {
     for (const name of ['Gmail', 'Google Calendar', 'GitHub']) {
       expect(screen.getByRole('button', { name: new RegExp(name) })).toBeTruthy()
     }
+  })
+
+  it('shows a sensitive badge on the list card when the connector is marked sensitive', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([{ ...calendarConnector, sensitive: true }])
+    renderTab()
+    expect(await screen.findByText('calendar')).toBeTruthy()
+    expect(screen.getByText('Sensitive')).toBeTruthy()
+  })
+
+  it('does not show a sensitive badge for a non-sensitive connector', async () => {
+    renderTab()
+    expect(await screen.findByText('calendar')).toBeTruthy()
+    expect(screen.queryByText('Sensitive')).toBeNull()
+  })
+
+  it('toggles a connector sensitive from the manage page', async () => {
+    vi.mocked(patchConnector).mockResolvedValue()
+    renderTab(`/settings/connectors/${calendarConnector.id}`)
+
+    const toggle = await screen.findByRole('switch', { name: 'google-calendar sensitive' })
+    fireEvent.click(toggle)
+
+    await waitFor(() =>
+      expect(patchConnector).toHaveBeenCalledWith(calendarConnector.id, { sensitive: true }),
+    )
   })
 
   it('shows the OAuth outcome banners from the callback redirect', async () => {

--- a/web/src/components/settings/FeaturesTab.tsx
+++ b/web/src/components/settings/FeaturesTab.tsx
@@ -8,6 +8,7 @@ import {
   usageBudget,
 } from '../../api/client'
 import type { AdminRoute } from '../../api/types'
+import { getNotificationSoundEnabled, setNotificationSoundEnabled } from '../../lib/sound'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
@@ -76,6 +77,35 @@ export function FeaturesTab() {
       {values && <AgentCard values={values} onError={setError} onSaved={refresh} />}
       {values && <SensitiveRouteCard values={values} onError={setError} onSaved={refresh} />}
       <BudgetsCard />
+      <NotificationSoundCard />
+    </div>
+  )
+}
+
+// NotificationSoundCard toggles the synthesized beep that fires
+// alongside the global permission-pending toast — localStorage-backed
+// (lib/sound.ts), not a server setting, so it applies instantly with
+// no save button.
+function NotificationSoundCard() {
+  const [enabled, setEnabled] = useState(() => getNotificationSoundEnabled())
+
+  return (
+    <div className="flex items-center gap-4 rounded-xl border border-border p-4">
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium">Notification sound</div>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          Plays a short beep when a permission ask needs your approval, wherever you are in the
+          app.
+        </p>
+      </div>
+      <Toggle
+        on={enabled}
+        onChange={(v) => {
+          setEnabled(v)
+          setNotificationSoundEnabled(v)
+        }}
+        label="Notification sound"
+      />
     </div>
   )
 }

--- a/web/src/lib/permissions.test.ts
+++ b/web/src/lib/permissions.test.ts
@@ -1,0 +1,112 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PendingPermission } from '../api/types'
+
+vi.mock('../api/client', () => ({
+  listPendingPermissions: vi.fn(),
+}))
+vi.mock('./events', () => ({
+  subscribeEvents: vi.fn(),
+}))
+
+import { listPendingPermissions } from '../api/client'
+import { subscribeEvents } from './events'
+import { newlySeen, usePendingPermissions } from './permissions'
+
+const pending: PendingPermission = {
+  session_id: 's1',
+  session_title: 'Gmail cleanup',
+  tool: 'gmail_search',
+  rationale: 'read the inbox',
+  requested_at: '2026-08-01T10:00:00Z',
+}
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('usePendingPermissions', () => {
+  it('fetches the pending list on mount', async () => {
+    vi.mocked(listPendingPermissions).mockResolvedValue([pending])
+    vi.mocked(subscribeEvents).mockReturnValue(() => {})
+
+    const { result } = renderHook(() => usePendingPermissions())
+
+    await waitFor(() => expect(result.current).toEqual([pending]))
+  })
+
+  it('refetches when a "permission" signal arrives', async () => {
+    vi.mocked(listPendingPermissions)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([pending])
+    let onSignal: ((s: { kind: string; id: string }) => void) | undefined
+    vi.mocked(subscribeEvents).mockImplementation((cb) => {
+      onSignal = cb
+      return () => {}
+    })
+
+    const { result } = renderHook(() => usePendingPermissions())
+    await waitFor(() => expect(result.current).toEqual([]))
+
+    act(() => {
+      onSignal?.({ kind: 'permission', id: 's1' })
+    })
+
+    await waitFor(() => expect(result.current).toEqual([pending]))
+    expect(listPendingPermissions).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores a signal whose kind is not "permission"', async () => {
+    vi.mocked(listPendingPermissions).mockResolvedValue([])
+    let onSignal: ((s: { kind: string; id: string }) => void) | undefined
+    vi.mocked(subscribeEvents).mockImplementation((cb) => {
+      onSignal = cb
+      return () => {}
+    })
+
+    renderHook(() => usePendingPermissions())
+    await waitFor(() => expect(listPendingPermissions).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      onSignal?.({ kind: 'session', id: 's1' })
+      onSignal?.({ kind: 'mission', id: 'm1' })
+    })
+
+    // Neither signal is 'permission', so no extra refetch was triggered.
+    expect(listPendingPermissions).toHaveBeenCalledTimes(1)
+  })
+
+  it('unsubscribes from events on unmount', () => {
+    vi.mocked(listPendingPermissions).mockResolvedValue([])
+    const unsubscribe = vi.fn()
+    vi.mocked(subscribeEvents).mockReturnValue(unsubscribe)
+
+    const { unmount } = renderHook(() => usePendingPermissions())
+    unmount()
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('newlySeen', () => {
+  it('returns entries whose session_id is not already in seen', () => {
+    const other: PendingPermission = { ...pending, session_id: 's2' }
+    const result = newlySeen(new Set(['s1']), [pending, other])
+    expect(result).toEqual([other])
+  })
+
+  it('returns nothing when every entry was already seen (a plain refetch)', () => {
+    const result = newlySeen(new Set(['s1']), [pending])
+    expect(result).toEqual([])
+  })
+
+  it('returns everything when seen is empty (first load)', () => {
+    const result = newlySeen(new Set(), [pending])
+    expect(result).toEqual([pending])
+  })
+})

--- a/web/src/lib/permissions.ts
+++ b/web/src/lib/permissions.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+import { listPendingPermissions } from '../api/client'
+import type { PendingPermission } from '../api/types'
+import { subscribeEvents } from './events'
+
+// usePendingPermissions keeps the global badge/toast current: initial
+// fetch, a slow poll as a safety net for a missed signal, and an
+// instant refetch on the "permission" hub signal (fired on both
+// request and resolve — see chat.Service.SetPermissionHub). Returns
+// the full list, not just a count: the toast needs each entry's tool
+// name and session id to build its message and jump link.
+export function usePendingPermissions(): PendingPermission[] {
+  const [pending, setPending] = useState<PendingPermission[]>([])
+
+  useEffect(() => {
+    let live = true
+    const refresh = () => {
+      listPendingPermissions()
+        .then((p) => live && setPending(p))
+        .catch(() => {})
+    }
+    refresh()
+    const timer = setInterval(refresh, 60_000)
+    const unsubscribe = subscribeEvents((sig) => {
+      if (sig.kind === 'permission') refresh()
+    })
+    return () => {
+      live = false
+      clearInterval(timer)
+      unsubscribe()
+    }
+  }, [])
+
+  return pending
+}
+
+// newlySeen returns the entries in current whose session_id was not
+// present in seen — the pure diff behind App.tsx's "toast only on
+// first-seen" rule, pulled out so it's testable without rendering the
+// app: a raw poll/signal refetch of an unchanged list must not re-diff
+// as new.
+export function newlySeen(
+  seen: ReadonlySet<string>,
+  current: PendingPermission[],
+): PendingPermission[] {
+  return current.filter((p) => !seen.has(p.session_id))
+}

--- a/web/src/lib/sound.ts
+++ b/web/src/lib/sound.ts
@@ -1,0 +1,12 @@
+const soundKey = 'timothy.notificationSound'
+
+// getNotificationSoundEnabled/setNotificationSoundEnabled mirror
+// theme.ts's localStorage get/set pattern; enabled by default so a
+// fresh install still alerts on a parked permission ask.
+export function getNotificationSoundEnabled(): boolean {
+  return localStorage.getItem(soundKey) !== 'off'
+}
+
+export function setNotificationSoundEnabled(enabled: boolean) {
+  localStorage.setItem(soundKey, enabled ? 'on' : 'off')
+}


### PR DESCRIPTION
Four independent improvements, bundled in one PR to save CI runtime as requested:

## Connector-level sensitivity
Any tool call under a connector flagged sensitive now pins the session onto the privacy-floor route — same effect the hardcoded `gmail_read`/`gmail_read_attachment` floor already had, but user-configurable per connector (Gmail, Calendar, future Drive/Slack/etc.) instead of a fixed Go list. `SensitiveTools.Suffixes`/`ConnectorNames` are funcs, not static slices, so a settings toggle applies immediately, no restart. New migration adds `connectors.sensitive`; settings UI gets a toggle + badge.

## Global permission notifications
A parked permission request only ever surfaced on that session's own Chat page — elsewhere it silently sat until the 10-minute auto-deny. New `GET /v1/permissions/pending` (scoped to actually-active turns, never a zombie flag from a crashed one) plus a `"permission"` signal on the existing global event hub drive: a sidebar badge, a persistent toast with a jump-to-session action, and an optional sound — visible from any page now.

## Empty-session debug log
`session.Store.Create` now debug-logs its immediate caller (file:line) — two untitled sessions showed up with no traceable owner; this pinpoints the call site next time it happens.

## CI runtime
The `go` job (build+vet+unit+integration+vuln-scan, all serialized) is split into `go-test` and `go-integration`, which share no state and now run in parallel. `govulncheck` pinned to a fixed version instead of `@latest`, which was re-resolving and defeating the module cache every run.

All four verified together: `make build test vet lint` + `make test-integration` (green except the known pre-existing `TestGoldenRecallAt5` flake, unrelated) + full web suite (43 files / 382 tests green).