### PR TITLE
fix(loop): pin sensitive connector tools mid-turn, not just next turn

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -286,6 +286,15 @@ func main() {
 		ConnectorNames: sensitiveConnectorNames,
 		Route:          sensitiveRoute,
 	}
+	// Connector-level sensitivity's in-turn counterpart: a whole
+	// connector flagged sensitive must pin the SAME turn that calls its
+	// tool, not just every turn after (chat.pinSensitiveRoute) — without
+	// this, a search/read tool's own results ride the turn's ORIGINAL
+	// route (e.g. a cloud default) until the NEXT turn notices the
+	// session is sensitive, one turn too late for whatever content that
+	// tool just pulled into context. Wired here, after conns exists,
+	// rather than inside buildAgent (which runs before conns is built).
+	agent.SetForceRouteByConnector(sensitiveConnectorNames, sensitiveRoute)
 
 	svc := chat.New(turnRouter{agent: agent, gw: gwc, flags: flags}, store, distill,
 		gatedCompactor{inner: compactor, flags: flags}, budgetFn, packs, flags.SkillAllowed,

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -115,6 +115,20 @@ type Agent struct {
 	// currently off and no flip happens.
 	forceRouteBySuffix map[string]func(context.Context) string
 
+	// forceRouteByConnectorNames/forceRouteByConnectorRoute cover a
+	// WHOLE connector marked sensitive in settings (session.SensitiveTools'
+	// ConnectorNames), not just a single named tool: connector tools are
+	// namespaced "<connector-name>_<tool-name>", so the connector's own
+	// name is a PREFIX match, never a suffix — its own field/rule rather
+	// than folding into forceRouteBySuffix. A single dynamic name-list
+	// func rather than a map, since the caller (main.go) already
+	// resolves the live sensitive-connector list as one query; each
+	// name shares the one route resolver (same sensitiveRoute the
+	// static suffix floor uses). Both nil-safe: a turn with no
+	// connectors flagged sensitive just never flips this way.
+	forceRouteByConnectorNames func(context.Context) []string
+	forceRouteByConnectorRoute func(context.Context) string
+
 	// waitToolsReady, if set, runs at the start of every turn before the
 	// tool snapshot (D-043): it lets main.go block briefly on the
 	// connectors.Manager's first successful load without loop importing
@@ -183,6 +197,19 @@ func (a *Agent) SetOffloadThreshold(tool string, bytes int) {
 // feature is currently off and the turn's route is left alone.
 func (a *Agent) SetForceRoute(suffix string, route func(context.Context) string) {
 	a.forceRouteBySuffix[suffix] = route
+}
+
+// SetForceRouteByConnector is SetForceRoute's counterpart for a WHOLE
+// connector marked sensitive (as opposed to one hardcoded tool name):
+// once any tool whose name starts with "<name>_" for a name currently
+// in names(ctx) is called, the rest of the turn pins to route(ctx),
+// same sticky/settings-live semantics as SetForceRoute. names and
+// route are both re-resolved at flip time, so toggling a connector's
+// sensitive flag (or the configured route) takes effect on the very
+// next tool call, no restart.
+func (a *Agent) SetForceRouteByConnector(names func(context.Context) []string, route func(context.Context) string) {
+	a.forceRouteByConnectorNames = names
+	a.forceRouteByConnectorRoute = route
 }
 
 // SetWaitToolsReady registers the turn-entry readiness hook (see the
@@ -462,6 +489,17 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 					if forced := fn(ctx); forced != "" {
 						route = forced
 						hint = ""
+					}
+				}
+			}
+			if a.forceRouteByConnectorNames != nil {
+				for _, name := range a.forceRouteByConnectorNames(ctx) {
+					if strings.HasPrefix(c.Name, name+"_") {
+						if forced := a.forceRouteByConnectorRoute(ctx); forced != "" {
+							route = forced
+							hint = ""
+						}
+						break
 					}
 				}
 			}

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -947,6 +947,89 @@ func TestForceRouteIgnoresNonMatchingTools(t *testing.T) {
 	}
 }
 
+// TestForceRouteByConnectorSwitchesRouteAfterMatchingTool pins the
+// connector-level sensitivity counterpart to SetForceRoute: a whole
+// connector flagged sensitive (its name is a PREFIX of every tool it
+// serves, "<connector-name>_<tool-name>") pins the SAME turn that
+// calls one of its tools, not just every turn after — the search/read
+// tool's own results must never ride the turn's original route.
+func TestForceRouteByConnectorSwitchesRouteAfterMatchingTool(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"gmail_search", `{}`}),
+		finalStep("done"),
+	}}
+	search := &tools.Tool{
+		Name:        "gmail_search",
+		Description: "searches fake email",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`),
+		Execute: func(context.Context, json.RawMessage) (string, error) {
+			return "search results", nil
+		},
+	}
+	a, _, _, _ := testAgent(t, gw, search)
+	a.SetForceRouteByConnector(
+		func(context.Context) []string { return []string{"gmail"} },
+		func(context.Context) string { return "local" },
+	)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "default",
+		Messages: []provider.Message{{Role: "user", Content: "search my email"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	if len(gw.requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(gw.requests))
+	}
+	if gw.requests[0].Route != "default" {
+		t.Fatalf("step 1 route = %q, want default (before the sensitive connector's tool ran)", gw.requests[0].Route)
+	}
+	if gw.requests[1].Route != "local" {
+		t.Fatalf("step 2 route = %q, want local (forced after gmail_search ran)", gw.requests[1].Route)
+	}
+}
+
+// TestForceRouteByConnectorIgnoresUnlistedConnector confirms a tool
+// from a connector NOT in the sensitive names list never triggers the
+// override, and that a bare prefix match doesn't false-positive: a
+// connector named "gmail" must not match a tool actually named
+// "gmailbox_search" (no "_" boundary).
+func TestForceRouteByConnectorIgnoresUnlistedConnector(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"gmailbox_search", `{}`}),
+		finalStep("done"),
+	}}
+	tool := &tools.Tool{
+		Name:        "gmailbox_search",
+		Description: "unrelated tool that happens to start with 'gmail'",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`),
+		Execute: func(context.Context, json.RawMessage) (string, error) {
+			return "ok", nil
+		},
+	}
+	a, _, _, _ := testAgent(t, gw, tool)
+	a.SetForceRouteByConnector(
+		func(context.Context) []string { return []string{"gmail"} },
+		func(context.Context) string { return "local" },
+	)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "default",
+		Messages: []provider.Message{{Role: "user", Content: "go"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	for i, req := range gw.requests {
+		if req.Route != "default" {
+			t.Fatalf("request %d route = %q, want default (gmailbox_search must not prefix-match \"gmail\")", i, req.Route)
+		}
+	}
+}
+
 // TestForceRouteDropsModelHint closes the gateway-hint privacy hole: a
 // ModelHint outranks Route in the gateway's Resolve order, so a hint
 // surviving the flip would let a turn escape the forced route entirely

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -46,7 +46,7 @@ import {
 import { TooltipProvider } from './components/ui/tooltip'
 import { useSessions } from './lib/sessions'
 import { usePendingMemories } from './lib/memory'
-import { playAlertSound } from './lib/alertSound'
+import { playAlertSound, unlockAudio } from './lib/alertSound'
 import { newlySeen, usePendingPermissions } from './lib/permissions'
 import { getNotificationSoundEnabled } from './lib/sound'
 import { getTheme, nextTheme, setTheme, type Theme } from './lib/theme'
@@ -270,6 +270,25 @@ function App() {
 
   useEffect(() => {
     if (getToken() === '') setTokenOpen(true)
+  }, [])
+
+  // Primes the shared AudioContext on the app's FIRST real user
+  // gesture: a permission toast can fire from a background SSE signal
+  // with no gesture of its own, and autoplay policy silently blocks a
+  // chime that never rode an unlocked context — one-shot, removes
+  // itself after the first fire so it's not doing work on every click.
+  useEffect(() => {
+    const unlock = () => {
+      unlockAudio()
+      window.removeEventListener('pointerdown', unlock)
+      window.removeEventListener('keydown', unlock)
+    }
+    window.addEventListener('pointerdown', unlock)
+    window.addEventListener('keydown', unlock)
+    return () => {
+      window.removeEventListener('pointerdown', unlock)
+      window.removeEventListener('keydown', unlock)
+    }
   }, [])
 
   // Toast + sound fire only for a NEWLY seen pending permission (a

--- a/web/src/components/settings/ConnectorEdit.tsx
+++ b/web/src/components/settings/ConnectorEdit.tsx
@@ -139,7 +139,8 @@ export function ConnectorEdit() {
           <div className="min-w-0">
             <div className="text-sm font-medium">Treat as sensitive</div>
             <p className="text-sm text-muted-foreground">
-              Pins related turns to the privacy-floor route, same as Gmail message reads.
+              Pins related turns to the privacy-floor route, keeping this connector's
+              data off third-party models.
             </p>
           </div>
           <Toggle

--- a/web/src/lib/alertSound.test.ts
+++ b/web/src/lib/alertSound.test.ts
@@ -1,55 +1,110 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { playAlertSound } from './alertSound'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// sharedCtx (module state) persists across tests within this file, so
+// each test gets its own fresh mock AudioContext constructor and
+// resets vi's module registry to force alertSound.ts to re-evaluate
+// with a clean sharedCtx — otherwise test 2 would reuse test 1's mock
+// context instead of constructing its own.
+beforeEach(() => {
+  vi.resetModules()
+})
 
 afterEach(() => {
   vi.unstubAllGlobals()
 })
 
+function mockAudioContext() {
+  const start = vi.fn()
+  const stop = vi.fn()
+  const connect = vi.fn()
+  const oscillator = { type: '', frequency: { value: 0 }, connect, start, stop }
+  const gain = {
+    gain: {
+      setValueAtTime: vi.fn(),
+      exponentialRampToValueAtTime: vi.fn(),
+    },
+    connect: vi.fn(),
+  }
+  const resume = vi.fn()
+  const ctx = {
+    currentTime: 0,
+    createOscillator: vi.fn(() => oscillator),
+    createGain: vi.fn(() => gain),
+    destination: {},
+    resume,
+  }
+  const MockAudioContext = vi.fn(function AudioContext(this: unknown) {
+    return ctx
+  })
+  return { MockAudioContext, ctx, resume, start }
+}
+
 describe('playAlertSound', () => {
-  it('does nothing when AudioContext is unavailable (e.g. unsupported browser)', () => {
+  it('does nothing when AudioContext is unavailable (e.g. unsupported browser)', async () => {
     vi.stubGlobal('AudioContext', undefined)
-    expect(() => playAlertSound()).not.toThrow()
+    const { playAlertSound: play } = await import('./alertSound')
+    expect(() => play()).not.toThrow()
   })
 
-  it('starts two oscillators through a fresh AudioContext', () => {
-    const start = vi.fn()
-    const stop = vi.fn()
-    const connect = vi.fn()
-    const oscillator = { type: '', frequency: { value: 0 }, connect, start, stop }
-    const gain = {
-      gain: {
-        setValueAtTime: vi.fn(),
-        exponentialRampToValueAtTime: vi.fn(),
-      },
-      connect: vi.fn(),
-    }
-    const close = vi.fn()
-    const ctx = {
-      currentTime: 0,
-      createOscillator: vi.fn(() => oscillator),
-      createGain: vi.fn(() => gain),
-      destination: {},
-      close,
-    }
-    const MockAudioContext = vi.fn(function AudioContext(this: unknown) {
-      return ctx
-    })
+  it('starts two oscillators through the shared AudioContext', async () => {
+    const { MockAudioContext, ctx, start } = mockAudioContext()
     vi.stubGlobal('AudioContext', MockAudioContext)
+    const { playAlertSound: play } = await import('./alertSound')
 
-    playAlertSound()
+    play()
 
     expect(MockAudioContext).toHaveBeenCalledTimes(1)
     expect(ctx.createOscillator).toHaveBeenCalledTimes(2)
     expect(start).toHaveBeenCalledTimes(2)
   })
 
-  it('swallows errors instead of throwing (e.g. blocked autoplay)', () => {
+  it('reuses the same AudioContext across repeated calls', async () => {
+    const { MockAudioContext } = mockAudioContext()
+    vi.stubGlobal('AudioContext', MockAudioContext)
+    const { playAlertSound: play } = await import('./alertSound')
+
+    play()
+    play()
+
+    expect(MockAudioContext).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows errors instead of throwing (e.g. blocked autoplay)', async () => {
     vi.stubGlobal(
       'AudioContext',
       vi.fn(function AudioContext() {
         throw new Error('blocked')
       }),
     )
-    expect(() => playAlertSound()).not.toThrow()
+    const { playAlertSound: play } = await import('./alertSound')
+    expect(() => play()).not.toThrow()
+  })
+})
+
+describe('unlockAudio', () => {
+  it('resumes the shared AudioContext', async () => {
+    const { MockAudioContext, resume } = mockAudioContext()
+    vi.stubGlobal('AudioContext', MockAudioContext)
+    const { unlockAudio: unlock } = await import('./alertSound')
+
+    unlock()
+
+    expect(resume).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when AudioContext is unavailable', async () => {
+    vi.stubGlobal('AudioContext', undefined)
+    const { unlockAudio: unlock } = await import('./alertSound')
+    expect(() => unlock()).not.toThrow()
+  })
+
+  it('swallows a resume() failure instead of throwing', async () => {
+    const { MockAudioContext, resume } = mockAudioContext()
+    resume.mockImplementation(() => {
+      throw new Error('blocked')
+    })
+    vi.stubGlobal('AudioContext', MockAudioContext)
+    const { unlockAudio: unlock } = await import('./alertSound')
+    expect(() => unlock()).not.toThrow()
   })
 })

--- a/web/src/lib/alertSound.ts
+++ b/web/src/lib/alertSound.ts
@@ -1,12 +1,42 @@
+// sharedCtx is one AudioContext reused for every chime, not a fresh
+// one per call: a context created outside a user-gesture handler
+// starts 'suspended' under autoplay policy and a later resume() still
+// needs SOME prior gesture to have unlocked it — unlockAudio (called
+// from a real click elsewhere in the app) is what actually flips it
+// live. Creating fresh contexts per play defeats that: each one starts
+// suspended again with no gesture of its own to unlock it.
+let sharedCtx: AudioContext | undefined
+
+function getCtx(): AudioContext | undefined {
+  if (sharedCtx) return sharedCtx
+  const Ctx = window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+  if (!Ctx) return undefined
+  sharedCtx = new Ctx()
+  return sharedCtx
+}
+
+// unlockAudio resumes the shared context from inside a real user
+// gesture (a click anywhere in the app) — call it once on the app's
+// first pointerdown/keydown so a LATER chime triggered by a background
+// event (an SSE signal, no gesture of its own) isn't silently blocked
+// by autoplay policy. Safe to call repeatedly; a no-op once resumed.
+export function unlockAudio(): void {
+  try {
+    getCtx()?.resume()
+  } catch {
+    // Unsupported/blocked — playAlertSound's own try/catch covers the
+    // actual chime attempt; this is best-effort priming only.
+  }
+}
+
 // playAlertSound synthesizes a short two-tone chime via the Web Audio
-// API — no asset file needed, and it works the moment the tab has had
-// any user interaction (autoplay policies block audio otherwise, which
-// is unavoidable and fine: the visual banner still shows regardless).
+// API — no asset file needed. Reliable only after unlockAudio has run
+// from a real gesture (autoplay policy blocks it otherwise); the
+// visual banner is the fallback either way, never worth erroring over.
 export function playAlertSound(): void {
   try {
-    const Ctx = window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
-    if (!Ctx) return
-    const ctx = new Ctx()
+    const ctx = getCtx()
+    if (!ctx) return
     const now = ctx.currentTime
     ;[880, 660].forEach((freq, i) => {
       const osc = ctx.createOscillator()
@@ -22,7 +52,6 @@ export function playAlertSound(): void {
       osc.start(start)
       osc.stop(start + 0.12)
     })
-    setTimeout(() => void ctx.close(), 400)
   } catch {
     // Audio isn't available (unsupported browser, blocked autoplay) —
     // the visual permission banner is the fallback, never worth erroring over.


### PR DESCRIPTION
Follow-up to #140. Testing that PR surfaced two real gaps:

## In-turn connector sensitivity pin
Connector-level sensitivity only took effect starting the turn AFTER a sensitive tool ran — the loop's in-turn pin (`Agent.SetForceRoute`) was wired solely to the static `gmail_read`/`gmail_read_attachment` floor, never to the new connector flag. So a sensitive connector's own tool call (e.g. a Gmail search) still had its results summarized by whatever route the turn started on — one turn too late for the content that call just pulled into context. `SetForceRouteByConnector` mirrors `SetForceRoute` with a prefix match (connector names prefix their tools, `"<name>_<tool>"`, never suffix) and both names/route are re-resolved at flip time so a settings toggle applies immediately, same as everything else in this mechanism.

Verified against a live turn: turn 1's tool call (`gmail_gmail_search`) now flips the SAME turn's remaining steps to the sensitive route, not just the next turn's.

## Audio unlock
Chimes now share one `AudioContext`, resumed from the app's first real click/keydown anywhere in the app. A permission toast triggered by a background SSE signal has no gesture of its own, so autoplay policy was silently blocking every chime before this — confirmed via manual testing (no sound on a background-triggered toast).

## Copy
Dropped Gmail-specific wording ("same as Gmail message reads") from the connector sensitivity toggle's description — the mechanism applies to any connector, not just email.

All verified: `make build test vet lint` green, new loop tests for the prefix-match pin (including a false-positive guard: a connector named "gmail" must not match a tool actually named "gmailbox_search"), web suite green (386 tests, one pre-existing AgentRoutePicker flake confirmed via isolated rerun).