### PR TITLE
Analytics revamp + CI path filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,45 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  # Single source of truth for "does this diff touch Go / web / the
+  # sandbox image" — every other job's `if:` and ci-ok's pass/skip
+  # logic read these same outputs, so the two can never disagree.
+  # Workflow-file changes always mark everything relevant: CI's own
+  # logic must run its full suite against itself.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+      web: ${{ steps.filter.outputs.web }}
+      sandbox: ${{ steps.filter.outputs.sandbox }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            go:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'migrations/**'
+              - 'deploy/Dockerfile'
+              - '.github/workflows/ci.yml'
+            web:
+              - 'web/**'
+              - '.github/workflows/ci.yml'
+            sandbox:
+              - 'deploy/sandbox.Dockerfile'
+              - '.github/workflows/ci.yml'
+
   # Split from go-integration: build/vet/unit-test/vuln-scan share no
   # state with the integration suite (only artificial ordering forced
   # them serial before), so running them as separate jobs lets the
   # runner schedule both in parallel instead of paying their sum on one
   # job's critical path.
   go-test:
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -41,6 +74,8 @@ jobs:
         run: go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
 
   go-integration:
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -70,6 +105,8 @@ jobs:
         run: go test -race -count=1 -tags integration -p 1 ./internal/...
 
   lint:
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -81,6 +118,8 @@ jobs:
           version: v2.12.2
 
   web:
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     env:
       # HugeIcons Pro registry auth (web/.npmrc references it by name)
@@ -105,13 +144,23 @@ jobs:
         run: npm test
 
   images:
+    needs: changes
+    # Per-leg, not job-level: the web image only needs a web change,
+    # the four Go images only need a go change. Every step below
+    # repeats the same leg-relevance check — a job-level `if:` would
+    # skip the whole matrix, including legs that ARE relevant. A leg
+    # whose steps all skip still reports "success" (skipped steps
+    # aren't a failure), so ci-ok's blanket check on `images` needs no
+    # path-awareness of its own.
     runs-on: ubuntu-latest
     strategy:
       matrix:
         service: [brain, gateway, memoryd, sandboxd, web]
     steps:
       - uses: actions/checkout@v7
+        if: (matrix.service == 'web' && needs.changes.outputs.web == 'true') || (matrix.service != 'web' && needs.changes.outputs.go == 'true')
       - name: Build image
+        if: (matrix.service == 'web' && needs.changes.outputs.web == 'true') || (matrix.service != 'web' && needs.changes.outputs.go == 'true')
         env:
           # Web only: HugeIcons Pro registry auth, passed as a BuildKit
           # secret so it never lands in an image layer.
@@ -127,6 +176,7 @@ jobs:
               -t timothy-${{ matrix.service }}:ci .
           fi
       - name: Scan image
+        if: (matrix.service == 'web' && needs.changes.outputs.web == 'true') || (matrix.service != 'web' && needs.changes.outputs.go == 'true')
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: timothy-${{ matrix.service }}:ci
@@ -140,6 +190,8 @@ jobs:
   # CI red on churn unrelated to this repo. Scan for visibility
   # (uploaded as a run summary), don't block merges on it.
   sandbox-image:
+    needs: changes
+    if: needs.changes.outputs.sandbox == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -155,20 +207,42 @@ jobs:
 
   # Umbrella gate with a stable name for branch rulesets: matrix legs
   # report as "images (brain)" etc., which rulesets can't reference.
-  # ALLOWLIST, not blocklist: every needed job must report exactly
-  # "success" — failure, cancelled, skipped, and any future state all
-  # fail the gate. (A cancelled run once reported skipped needs, the
-  # old blocklist missed it, and auto-merge fired on red jobs.)
+  # ALLOWLIST, not blocklist: every needed job must report "success",
+  # UNLESS the changes job says that job's path wasn't touched — then
+  # "skipped" is the expected, correct result and passes too. A job
+  # that failure, cancelled, or (unexpectedly) skipped-while-relevant
+  # still fails the gate. (A cancelled run once reported skipped
+  # needs, the old blocklist missed it, and auto-merge fired on red
+  # jobs — path-awareness must not reopen that hole.)
   ci-ok:
     runs-on: ubuntu-latest
-    needs: [go-test, go-integration, lint, web, images, sandbox-image]
+    needs: [changes, go-test, go-integration, lint, web, images, sandbox-image]
     if: always()
     steps:
-      - name: All jobs succeeded
+      - name: All relevant jobs succeeded
         run: |
-          results="${{ join(needs.*.result, ' ') }}"
-          echo "needs results: $results"
-          [ -n "$results" ] || { echo "no results reported"; exit 1; }
-          for r in $results; do
-            [ "$r" = "success" ] || { echo "gate failed: job result '$r'"; exit 1; }
-          done
+          check() {
+            local job="$1" relevant="$2" result="$3"
+            if [ "$relevant" = "true" ]; then
+              [ "$result" = "success" ] || { echo "gate failed: $job result '$result' (relevant)"; exit 1; }
+            else
+              case "$result" in
+                success|skipped) ;;
+                *) echo "gate failed: $job result '$result' (not relevant, but not skipped either)"; exit 1 ;;
+              esac
+            fi
+            echo "$job: $result (relevant=$relevant)"
+          }
+          # changes itself is always relevant: if it fails, every
+          # downstream `if:` evaluates false and everything reports
+          # skipped — the checks below would wrongly wave that
+          # through as "not relevant" if changes weren't gated here.
+          check changes         "true" "${{ needs.changes.result }}"
+          check go-test        "${{ needs.changes.outputs.go }}"  "${{ needs.go-test.result }}"
+          check go-integration  "${{ needs.changes.outputs.go }}"  "${{ needs.go-integration.result }}"
+          check lint            "${{ needs.changes.outputs.go }}"  "${{ needs.lint.result }}"
+          check web             "${{ needs.changes.outputs.web }}" "${{ needs.web.result }}"
+          check sandbox-image   "${{ needs.changes.outputs.sandbox }}" "${{ needs.sandbox-image.result }}"
+          # images always runs (per-leg skips internally) unless
+          # nothing relevant touched it at all.
+          check images "${{ needs.changes.outputs.go == 'true' || needs.changes.outputs.web == 'true' }}" "${{ needs.images.result }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
   # logic must run its full suite against itself.
   changes:
     runs-on: ubuntu-latest
+    # paths-filter needs this to list a PR's changed files via the API
+    # when the local checkout doesn't have enough history for a git
+    # diff — scoped to this job only, not the workflow-wide grant.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       go: ${{ steps.filter.outputs.go }}
       web: ${{ steps.filter.outputs.web }}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24,7 +24,6 @@
         "react-dom": "^19.2.8",
         "react-markdown": "^10.1.0",
         "react-router": "^8.3.0",
-        "recharts": "^3.10.1",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.15.0",
@@ -2967,32 +2966,6 @@
       "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
       "license": "MIT"
     },
-    "node_modules/@reduxjs/toolkit": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
-      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "@standard-schema/utils": "^0.3.0",
-        "immer": "^11.0.0",
-        "redux": "^5.0.1",
-        "redux-thunk": "^3.1.0",
-        "reselect": "^5.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
-        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-redux": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -3281,12 +3254,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT"
-    },
-    "node_modules/@standard-schema/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -3749,69 +3717,6 @@
         "assertion-error": "^2.0.1"
       }
     },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "license": "MIT"
-    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -3900,12 +3805,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
-      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -5122,127 +5021,6 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -5294,12 +5072,6 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/decimal.js-light": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -5603,16 +5375,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-toolkit": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
-      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
-      "license": "MIT",
-      "workspaces": [
-        "docs",
-        "benchmarks"
-      ]
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -5681,12 +5443,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -6310,16 +6066,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immer": {
-      "version": "11.1.11",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.11.tgz",
-      "integrity": "sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6357,15 +6103,6 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
@@ -8951,6 +8688,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -8979,29 +8717,6 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
-      }
-    },
-    "node_modules/react-redux": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
-      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/use-sync-external-store": "^0.0.6",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.2.25 || ^19",
-        "react": "^18.0 || ^19",
-        "redux": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
       }
     },
     "node_modules/react-remove-scroll": {
@@ -9110,36 +8825,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/recharts": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.1.tgz",
-      "integrity": "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==",
-      "license": "MIT",
-      "workspaces": [
-        "www"
-      ],
-      "dependencies": {
-        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
-        "clsx": "^2.1.1",
-        "decimal.js-light": "^2.5.1",
-        "es-toolkit": "^1.39.3",
-        "eventemitter3": "^5.0.1",
-        "immer": "^11.1.8",
-        "react-redux": "8.x.x || 9.x.x",
-        "reselect": "5.2.0",
-        "tiny-invariant": "^1.3.3",
-        "use-sync-external-store": "^1.2.2",
-        "victory-vendor": "^37.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -9152,21 +8837,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
-    },
-    "node_modules/redux-thunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^5.0.0"
       }
     },
     "node_modules/rehype-highlight": {
@@ -9260,12 +8930,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/reselect": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
-      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
-      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -10410,15 +10074,6 @@
         }
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -10469,28 +10124,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/victory-vendor": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
-      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
-      "license": "MIT AND ISC",
-      "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/web/package.json
+++ b/web/package.json
@@ -27,7 +27,6 @@
     "react-dom": "^19.2.8",
     "react-markdown": "^10.1.0",
     "react-router": "^8.3.0",
-    "recharts": "^3.10.1",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.15.0",

--- a/web/src/components/charts/ChartLegend.tsx
+++ b/web/src/components/charts/ChartLegend.tsx
@@ -1,0 +1,35 @@
+// A legend item is a plain text node beside a colored swatch — no extra
+// className on the label — so click targets and tests can select by text.
+export function ChartLegend({
+  groups,
+  colorOf,
+  hidden,
+  onToggle,
+}: {
+  groups: string[]
+  colorOf: (g: string) => string
+  hidden: Set<string>
+  onToggle: (g: string) => void
+}) {
+  if (groups.length === 0) return null
+  return (
+    <div className="mt-2 flex flex-wrap gap-3 text-xs text-muted-foreground">
+      {groups.map((g) => (
+        <span
+          key={g}
+          role="button"
+          tabIndex={0}
+          onClick={() => onToggle(g)}
+          onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && onToggle(g)}
+          className="flex cursor-pointer items-center gap-1.5 select-none"
+        >
+          <span
+            className="h-2 w-2 flex-none rounded-[2.5px]"
+            style={{ background: colorOf(g) }}
+          />
+          <span style={{ textDecoration: hidden.has(g) ? 'line-through' : 'none' }}>{g}</span>
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/web/src/components/charts/ChartTooltip.tsx
+++ b/web/src/components/charts/ChartTooltip.tsx
@@ -1,0 +1,33 @@
+export interface TooltipRow {
+  key: string
+  color: string
+  value: string
+}
+
+export interface TooltipState {
+  x: number
+  y: number
+  label: string
+  rows: TooltipRow[]
+}
+
+export function ChartTooltip({ state }: { state: TooltipState | null }) {
+  if (!state) return null
+  return (
+    <div
+      className="pointer-events-none absolute z-20 min-w-[120px] rounded-md border border-border bg-popover px-2.5 py-2 text-xs shadow-lg"
+      style={{ left: state.x + 12, top: state.y - 8 }}
+    >
+      <div className="mb-1 text-[11px] text-muted-foreground">{state.label}</div>
+      {state.rows.map((r) => (
+        <div key={r.key} className="flex items-center justify-between gap-3 py-0.5">
+          <span className="flex items-center gap-1.5 text-muted-foreground">
+            <span className="h-1.5 w-1.5 flex-none rounded-full" style={{ background: r.color }} />
+            {r.key}
+          </span>
+          <span className="font-medium">{r.value}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/src/components/charts/LatencyBars.tsx
+++ b/web/src/components/charts/LatencyBars.tsx
@@ -1,0 +1,76 @@
+import { useRef, useState } from 'react'
+import { niceMax } from './palette'
+import { ChartTooltip, type TooltipState } from './ChartTooltip'
+import type { LatencyRow } from '../../api/types'
+
+const pctColors = { p50_ms: '#2a78d6', p95_ms: '#eda100', p99_ms: '#e34948' } as const
+const pctLabel = { p50_ms: 'p50', p95_ms: 'p95', p99_ms: 'p99' } as const
+
+export function LatencyBars({ rows }: { rows: LatencyRow[] }) {
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+  const svgRef = useRef<SVGSVGElement>(null)
+
+  const rowH = 46
+  const W = 640
+  const H = rows.length * rowH + 16
+  const padL = 84
+  const padR = 40
+  const plotW = W - padL - padR
+  const maxV = niceMax(Math.max(...rows.map((r) => r.p99_ms), 1) * 1.1)
+
+  function pointerLabel(e: React.PointerEvent, r: LatencyRow, key: keyof typeof pctColors) {
+    const svg = svgRef.current
+    if (!svg) return
+    const rect = svg.getBoundingClientRect()
+    setTooltip({
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+      label: `${r.provider} · ${pctLabel[key]}`,
+      rows: [{ key: pctLabel[key], color: pctColors[key], value: `${Math.round(r[key])} ms` }],
+    })
+  }
+
+  return (
+    <div className="relative">
+      <svg ref={svgRef} viewBox={`0 0 ${W} ${H}`} className="h-auto w-full" onPointerLeave={() => setTooltip(null)}>
+        {rows.map((r, i) => {
+          const cy = 10 + i * rowH
+          return (
+            <g key={r.provider}>
+              <text x={padL - 10} y={cy + 22} textAnchor="end" fontSize={12} fill="currentColor" opacity={0.75}>
+                {r.provider}
+              </text>
+              {(['p50_ms', 'p95_ms', 'p99_ms'] as const).map((key, j) => {
+                const v = r[key]
+                const w = (v / maxV) * plotW
+                const y = cy + j * 9
+                return (
+                  <rect
+                    key={key}
+                    x={padL}
+                    y={y}
+                    width={w}
+                    height={6}
+                    rx={3}
+                    fill={pctColors[key]}
+                    opacity={key === 'p50_ms' ? 1 : key === 'p95_ms' ? 0.75 : 0.5}
+                    onPointerMove={(e) => pointerLabel(e, r, key)}
+                  />
+                )
+              })}
+            </g>
+          )
+        })}
+      </svg>
+      <ChartTooltip state={tooltip} />
+      <div className="mt-1 flex gap-3 text-[11px] text-muted-foreground">
+        {(['p50_ms', 'p95_ms', 'p99_ms'] as const).map((key) => (
+          <span key={key} className="flex items-center gap-1">
+            <span className="h-2 w-2 rounded-[2px]" style={{ background: pctColors[key] }} />
+            {pctLabel[key]}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/charts/MultiLineChart.tsx
+++ b/web/src/components/charts/MultiLineChart.tsx
@@ -1,0 +1,154 @@
+import { useRef, useState } from 'react'
+import { niceMax } from './palette'
+import { ChartTooltip, type TooltipState } from './ChartTooltip'
+
+export interface MultiLineChartProps {
+  rows: Record<string, number | string>[]
+  groups: string[]
+  colorOf: (g: string) => string
+  hidden: Set<string>
+  xKey?: string
+  xLabel: (v: string) => string
+  valueLabel: (v: number) => string
+  height?: number
+}
+
+// 2px lines, round joins, ≥8px end markers with a surface ring, hairline
+// gridlines, and a hover crosshair with a synced tooltip.
+export function MultiLineChart({
+  rows,
+  groups,
+  colorOf,
+  hidden,
+  xKey = 'bucket',
+  xLabel,
+  valueLabel,
+  height = 240,
+}: MultiLineChartProps) {
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+  const [hoverX, setHoverX] = useState<number | null>(null)
+  const svgRef = useRef<SVGSVGElement>(null)
+
+  const W = 640
+  const H = height
+  const padL = 52
+  const padR = 8
+  const padT = 8
+  const padB = 24
+  const plotW = W - padL - padR
+  const plotH = H - padT - padB
+
+  const visibleGroups = groups.filter((g) => !hidden.has(g))
+  const allVals = visibleGroups.flatMap((g) => rows.map((r) => Number(r[g]) || 0))
+  const maxV = niceMax(Math.max(...allVals, 1) * 1.15)
+  const ticks = 4
+  const stepX = rows.length > 1 ? plotW / (rows.length - 1) : plotW
+
+  function yOf(v: number) {
+    return padT + plotH - (v / maxV) * plotH
+  }
+
+  function pointerLabel(e: React.PointerEvent, i: number) {
+    const svg = svgRef.current
+    if (!svg) return
+    const rect = svg.getBoundingClientRect()
+    const row = rows[i]
+    setHoverX(padL + stepX * i)
+    setTooltip({
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+      label: xLabel(String(row[xKey])),
+      rows: visibleGroups.map((g) => ({ key: g, color: colorOf(g), value: valueLabel(Number(row[g]) || 0) })),
+    })
+  }
+
+  return (
+    <div className="relative">
+      <svg
+        ref={svgRef}
+        viewBox={`0 0 ${W} ${H}`}
+        className="h-auto w-full"
+        onPointerLeave={() => {
+          setTooltip(null)
+          setHoverX(null)
+        }}
+      >
+        {Array.from({ length: ticks + 1 }, (_, t) => {
+          const v = (maxV / ticks) * t
+          const y = yOf(v)
+          return (
+            <g key={t}>
+              <line
+                x1={padL}
+                x2={W - padR}
+                y1={y}
+                y2={y}
+                stroke={t === 0 ? 'var(--border)' : 'currentColor'}
+                strokeOpacity={t === 0 ? 1 : 0.12}
+                strokeWidth={1}
+              />
+              <text x={padL - 8} y={y + 3} textAnchor="end" fontSize={10.5} fill="currentColor" opacity={0.55}>
+                {valueLabel(v)}
+              </text>
+            </g>
+          )
+        })}
+        {rows.map((row, i) => (
+          <text
+            key={String(row[xKey])}
+            x={padL + stepX * i}
+            y={H - 6}
+            textAnchor="middle"
+            fontSize={10.5}
+            fill="currentColor"
+            opacity={0.55}
+          >
+            {xLabel(String(row[xKey]))}
+          </text>
+        ))}
+        {hoverX != null && (
+          <line x1={hoverX} x2={hoverX} y1={padT} y2={padT + plotH} stroke="currentColor" strokeOpacity={0.15} />
+        )}
+        {visibleGroups.map((g) => {
+          const points = rows.map((r, i) => `${padL + stepX * i},${yOf(Number(r[g]) || 0)}`).join(' ')
+          const last = rows[rows.length - 1]
+          const lastXY = last ? [padL + stepX * (rows.length - 1), yOf(Number(last[g]) || 0)] : null
+          return (
+            <g key={g}>
+              <polyline
+                points={points}
+                fill="none"
+                stroke={colorOf(g)}
+                strokeWidth={2}
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+              {lastXY && (
+                <circle
+                  cx={lastXY[0]}
+                  cy={lastXY[1]}
+                  r={4}
+                  fill={colorOf(g)}
+                  stroke="var(--background, #fff)"
+                  strokeWidth={2}
+                />
+              )}
+            </g>
+          )
+        })}
+        {rows.map((row, i) => (
+          <rect
+            key={String(row[xKey])}
+            x={padL + stepX * i - stepX / 2}
+            y={padT}
+            width={stepX}
+            height={plotH}
+            fill="transparent"
+            onPointerMove={(e) => pointerLabel(e, i)}
+          />
+        ))}
+      </svg>
+      <ChartTooltip state={tooltip} />
+    </div>
+  )
+}

--- a/web/src/components/charts/StackedBarChart.tsx
+++ b/web/src/components/charts/StackedBarChart.tsx
@@ -1,0 +1,129 @@
+import { useRef, useState } from 'react'
+import { niceMax } from './palette'
+import { ChartTooltip, type TooltipState } from './ChartTooltip'
+
+export interface StackedBarChartProps {
+  rows: Record<string, number | string>[]
+  groups: string[]
+  colorOf: (g: string) => string
+  hidden: Set<string>
+  xKey?: string
+  xLabel: (v: string) => string
+  valueLabel: (v: number) => string
+  height?: number
+}
+
+// Fixed-viewBox SVG stacked bar: 4px rounded data-ends, 2px surface gaps
+// between segments, hairline gridlines. Scales via viewBox, not a
+// measured-container library, so it renders correctly in jsdom too.
+export function StackedBarChart({
+  rows,
+  groups,
+  colorOf,
+  hidden,
+  xKey = 'bucket',
+  xLabel,
+  valueLabel,
+  height = 240,
+}: StackedBarChartProps) {
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+  const svgRef = useRef<SVGSVGElement>(null)
+
+  const W = 640
+  const H = height
+  const padL = 52
+  const padR = 8
+  const padT = 8
+  const padB = 24
+  const plotW = W - padL - padR
+  const plotH = H - padT - padB
+
+  const visibleGroups = groups.filter((g) => !hidden.has(g))
+  const totals = rows.map((r) => visibleGroups.reduce((s, g) => s + (Number(r[g]) || 0), 0))
+  const maxV = niceMax(Math.max(...totals, 0.0001) * 1.15)
+
+  const ticks = 4
+  const slot = rows.length > 0 ? plotW / rows.length : plotW
+  const barW = Math.min(24, slot * 0.5)
+  const gap = 2
+
+  function pointerLabel(e: React.PointerEvent, row: Record<string, number | string>) {
+    const svg = svgRef.current
+    if (!svg) return
+    const rect = svg.getBoundingClientRect()
+    setTooltip({
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+      label: xLabel(String(row[xKey])),
+      rows: visibleGroups
+        .filter((g) => Number(row[g]) > 0)
+        .map((g) => ({ key: g, color: colorOf(g), value: valueLabel(Number(row[g]) || 0) })),
+    })
+  }
+
+  return (
+    <div className="relative">
+      <svg ref={svgRef} viewBox={`0 0 ${W} ${H}`} className="h-auto w-full" onPointerLeave={() => setTooltip(null)}>
+        {Array.from({ length: ticks + 1 }, (_, t) => {
+          const v = (maxV / ticks) * t
+          const y = padT + plotH - (v / maxV) * plotH
+          return (
+            <g key={t}>
+              <line
+                x1={padL}
+                x2={W - padR}
+                y1={y}
+                y2={y}
+                stroke={t === 0 ? 'var(--border)' : 'currentColor'}
+                strokeOpacity={t === 0 ? 1 : 0.12}
+                strokeWidth={1}
+              />
+              <text x={padL - 8} y={y + 3} textAnchor="end" fontSize={10.5} fill="currentColor" opacity={0.55}>
+                {valueLabel(v)}
+              </text>
+            </g>
+          )
+        })}
+        {rows.map((row, i) => {
+          const x = padL + slot * i + (slot - barW) / 2
+          let yCursor = padT + plotH
+          return (
+            <g key={String(row[xKey])} onPointerMove={(e) => pointerLabel(e, row)}>
+              <rect x={x} y={padT} width={barW} height={plotH} fill="transparent" />
+              {visibleGroups.map((g) => {
+                const v = Number(row[g]) || 0
+                if (v <= 0) return null
+                const segH = (v / maxV) * plotH
+                const y = yCursor - segH
+                yCursor -= segH
+                return (
+                  <rect
+                    key={g}
+                    x={x}
+                    y={y + gap / 2}
+                    width={barW}
+                    height={Math.max(segH - gap, 0)}
+                    rx={4}
+                    ry={4}
+                    fill={colorOf(g)}
+                  />
+                )
+              })}
+              <text
+                x={x + barW / 2}
+                y={H - 6}
+                textAnchor="middle"
+                fontSize={10.5}
+                fill="currentColor"
+                opacity={0.55}
+              >
+                {xLabel(String(row[xKey]))}
+              </text>
+            </g>
+          )
+        })}
+      </svg>
+      <ChartTooltip state={tooltip} />
+    </div>
+  )
+}

--- a/web/src/components/charts/palette.ts
+++ b/web/src/components/charts/palette.ts
@@ -1,0 +1,10 @@
+// Validated categorical palette (dataviz skill): fixed hue order, never
+// cycled past slot 8 — CVD-safe adjacent pairs in both light and dark.
+export const palette = ['#2a78d6', '#eb6834', '#1baf7a', '#eda100', '#e87ba4', '#008300', '#4a3aa7', '#e34948']
+
+export function niceMax(v: number): number {
+  const mag = Math.pow(10, Math.floor(Math.log10(v || 1)))
+  const n = v / mag
+  const step = n <= 1 ? 1 : n <= 2 ? 2 : n <= 5 ? 5 : 10
+  return step * mag
+}

--- a/web/src/pages/Analytics.test.tsx
+++ b/web/src/pages/Analytics.test.tsx
@@ -1,5 +1,4 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
-import { cloneElement, type ReactElement } from 'react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BudgetStatus, GroupTotal, UsagePoint, UsageSummary } from '../api/types'
@@ -14,20 +13,6 @@ vi.mock('../api/client', () => ({
   usageSummary: vi.fn(),
   usageTotals: vi.fn(),
 }))
-
-// jsdom never reports a real element size (no layout engine), so the
-// real ResponsiveContainer measures 0x0 and recharts renders nothing —
-// it clones its child with the measured width/height. Cloning with a
-// fixed size here lets BarChart/LineChart/Legend actually mount so the
-// legend-toggle tests below have something to click.
-vi.mock('recharts', async () => {
-  const actual = await vi.importActual<typeof import('recharts')>('recharts')
-  return {
-    ...actual,
-    ResponsiveContainer: ({ children }: { children: ReactElement<{ width?: number; height?: number }> }) =>
-      cloneElement(children, { width: 800, height: 300 }),
-  }
-})
 
 import {
   usageBudget,

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -1,17 +1,10 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router'
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Legend,
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts'
+import { StackedBarChart } from '../components/charts/StackedBarChart'
+import { MultiLineChart } from '../components/charts/MultiLineChart'
+import { LatencyBars } from '../components/charts/LatencyBars'
+import { ChartLegend } from '../components/charts/ChartLegend'
+import { palette } from '../components/charts/palette'
 import {
   usageBudget,
   usageCache,
@@ -31,9 +24,6 @@ import type {
   UsageSummary,
 } from '../api/types'
 import { estimateUnpriced, totalEstimate } from '../lib/costEstimate'
-
-// Accessible categorical palette that reads on light and dark.
-const palette = ['#3b82f6', '#8b5cf6', '#10b981', '#f59e0b', '#f43f5e', '#06b6d4', '#a3a3a3']
 
 const ranges = [
   { key: 'today', label: 'Today', days: 0, bucket: 'hour' as const },
@@ -120,9 +110,7 @@ const bucketLabel = (iso: string, bucket: string) => {
 // in the legend itself) rather than filtering the underlying data.
 function useHiddenKeys() {
   const [hidden, setHidden] = useState<Set<string>>(new Set())
-  const onLegendClick = (entry: { dataKey?: unknown }) => {
-    const key = String(entry.dataKey ?? '')
-    if (!key) return
+  const onToggle = (key: string) => {
     setHidden((prev) => {
       const next = new Set(prev)
       if (next.has(key)) next.delete(key)
@@ -130,11 +118,7 @@ function useHiddenKeys() {
       return next
     })
   }
-  const legendFormatter = (value: string, entry: { dataKey?: unknown }) => {
-    const key = String(entry.dataKey ?? value)
-    return <span style={{ textDecoration: hidden.has(key) ? 'line-through' : 'none' }}>{value}</span>
-  }
-  return { hidden, onLegendClick, legendFormatter }
+  return { hidden, onToggle }
 }
 
 export function Analytics() {
@@ -298,14 +282,7 @@ export function Analytics() {
     { label: 'Cache hit', value: data ? `${(cacheHit * 100).toFixed(0)}%` : '—' },
   ]
 
-  const axis = { stroke: 'currentColor', opacity: 0.45, fontSize: 11 }
-  const tooltipStyle = {
-    backgroundColor: 'var(--color-zinc-900, #18181b)',
-    border: '1px solid rgba(255,255,255,0.1)',
-    borderRadius: 8,
-    color: '#fafafa',
-    fontSize: 12,
-  }
+  const colorOf = (g: string, groups: string[]) => palette[groups.indexOf(g) % palette.length]
 
   return (
     <div className="h-full overflow-y-auto">
@@ -380,119 +357,64 @@ export function Analytics() {
         <div className="mt-6 grid gap-6 lg:grid-cols-2">
           <section className="rounded-xl border border-border p-4">
             <h2 className="text-sm font-medium">Cost by provider</h2>
-            <div className="mt-3 h-64">
-              <ResponsiveContainer>
-                <BarChart data={cost.rows}>
-                  <CartesianGrid strokeOpacity={0.12} vertical={false} />
-                  <XAxis
-                    dataKey="bucket"
-                    tickFormatter={(v: string) => bucketLabel(v, bucket)}
-                    {...axis}
-                  />
-                  <YAxis tickFormatter={(v: number) => money(v)} width={70} {...axis} />
-                  <Tooltip
-                    contentStyle={tooltipStyle}
-                    labelFormatter={(v) => bucketLabel(String(v), bucket)}
-                    formatter={(v) => money(Number(v))}
-                  />
-                  <Legend
-                    wrapperStyle={{ fontSize: 12 }}
-                    onClick={costLegend.onLegendClick}
-                    formatter={costLegend.legendFormatter}
-                  />
-                  {cost.groups.map((g, i) => (
-                    <Bar
-                      key={g}
-                      dataKey={g}
-                      stackId="cost"
-                      fill={palette[i % palette.length]}
-                      hide={costLegend.hidden.has(g)}
-                    />
-                  ))}
-                </BarChart>
-              </ResponsiveContainer>
+            <div className="mt-3">
+              <StackedBarChart
+                rows={cost.rows}
+                groups={cost.groups}
+                colorOf={(g) => colorOf(g, cost.groups)}
+                hidden={costLegend.hidden}
+                xLabel={(v) => bucketLabel(v, bucket)}
+                valueLabel={money}
+              />
             </div>
+            <ChartLegend
+              groups={cost.groups}
+              colorOf={(g) => colorOf(g, cost.groups)}
+              hidden={costLegend.hidden}
+              onToggle={costLegend.onToggle}
+            />
           </section>
 
           <section className="rounded-xl border border-border p-4">
             <h2 className="text-sm font-medium">Tokens in / out</h2>
-            <div className="mt-3 h-64">
-              <ResponsiveContainer>
-                <LineChart data={tokens}>
-                  <CartesianGrid strokeOpacity={0.12} vertical={false} />
-                  <XAxis
-                    dataKey="bucket"
-                    tickFormatter={(v: string) => bucketLabel(v, bucket)}
-                    {...axis}
-                  />
-                  <YAxis tickFormatter={(v: number) => compact(v)} width={55} {...axis} />
-                  <Tooltip
-                    contentStyle={tooltipStyle}
-                    labelFormatter={(v) => bucketLabel(String(v), bucket)}
-                    formatter={(v) => compact(Number(v))}
-                  />
-                  <Legend
-                    wrapperStyle={{ fontSize: 12 }}
-                    onClick={tokensLegend.onLegendClick}
-                    formatter={tokensLegend.legendFormatter}
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="input"
-                    stroke={palette[0]}
-                    dot={false}
-                    strokeWidth={2}
-                    hide={tokensLegend.hidden.has('input')}
-                  />
-                  <Line
-                    type="monotone"
-                    dataKey="output"
-                    stroke={palette[2]}
-                    dot={false}
-                    strokeWidth={2}
-                    hide={tokensLegend.hidden.has('output')}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
+            <div className="mt-3">
+              <MultiLineChart
+                rows={tokens as unknown as Record<string, number | string>[]}
+                groups={['input', 'output']}
+                colorOf={(g) => (g === 'input' ? palette[0] : palette[2])}
+                hidden={tokensLegend.hidden}
+                xLabel={(v) => bucketLabel(v, bucket)}
+                valueLabel={compact}
+              />
             </div>
+            <ChartLegend
+              groups={['input', 'output']}
+              colorOf={(g) => (g === 'input' ? palette[0] : palette[2])}
+              hidden={tokensLegend.hidden}
+              onToggle={tokensLegend.onToggle}
+            />
           </section>
         </div>
 
         <div className="mt-6 grid gap-6 lg:grid-cols-2">
           <section className="rounded-xl border border-border p-4">
             <h2 className="text-sm font-medium">Cost by model</h2>
-            <div className="mt-3 h-64">
-              <ResponsiveContainer>
-                <BarChart data={modelCost.rows}>
-                  <CartesianGrid strokeOpacity={0.12} vertical={false} />
-                  <XAxis
-                    dataKey="bucket"
-                    tickFormatter={(v: string) => bucketLabel(v, bucket)}
-                    {...axis}
-                  />
-                  <YAxis tickFormatter={(v: number) => money(v)} width={70} {...axis} />
-                  <Tooltip
-                    contentStyle={tooltipStyle}
-                    labelFormatter={(v) => bucketLabel(String(v), bucket)}
-                    formatter={(v) => money(Number(v))}
-                  />
-                  <Legend
-                    wrapperStyle={{ fontSize: 12 }}
-                    onClick={modelCostLegend.onLegendClick}
-                    formatter={modelCostLegend.legendFormatter}
-                  />
-                  {modelCost.groups.map((g, i) => (
-                    <Bar
-                      key={g}
-                      dataKey={g}
-                      stackId="modelCost"
-                      fill={palette[i % palette.length]}
-                      hide={modelCostLegend.hidden.has(g)}
-                    />
-                  ))}
-                </BarChart>
-              </ResponsiveContainer>
+            <div className="mt-3">
+              <StackedBarChart
+                rows={modelCost.rows}
+                groups={modelCost.groups}
+                colorOf={(g) => colorOf(g, modelCost.groups)}
+                hidden={modelCostLegend.hidden}
+                xLabel={(v) => bucketLabel(v, bucket)}
+                valueLabel={money}
+              />
             </div>
+            <ChartLegend
+              groups={modelCost.groups}
+              colorOf={(g) => colorOf(g, modelCost.groups)}
+              hidden={modelCostLegend.hidden}
+              onToggle={modelCostLegend.onToggle}
+            />
             {modelCost.groups.length === 0 && data && (
               <p className="mt-2 text-xs text-muted-foreground">
                 No priced model usage in range (free/unpriced models are excluded from cost views).
@@ -502,40 +424,22 @@ export function Analytics() {
 
           <section className="rounded-xl border border-border p-4">
             <h2 className="text-sm font-medium">Token consumption per model</h2>
-            <div className="mt-3 h-64">
-              <ResponsiveContainer>
-                <LineChart data={modelTokens.rows}>
-                  <CartesianGrid strokeOpacity={0.12} vertical={false} />
-                  <XAxis
-                    dataKey="bucket"
-                    tickFormatter={(v: string) => bucketLabel(v, bucket)}
-                    {...axis}
-                  />
-                  <YAxis tickFormatter={(v: number) => compact(v)} width={55} {...axis} />
-                  <Tooltip
-                    contentStyle={tooltipStyle}
-                    labelFormatter={(v) => bucketLabel(String(v), bucket)}
-                    formatter={(v) => compact(Number(v))}
-                  />
-                  <Legend
-                    wrapperStyle={{ fontSize: 12 }}
-                    onClick={modelTokensLegend.onLegendClick}
-                    formatter={modelTokensLegend.legendFormatter}
-                  />
-                  {modelTokens.groups.map((g, i) => (
-                    <Line
-                      key={g}
-                      type="monotone"
-                      dataKey={g}
-                      stroke={palette[i % palette.length]}
-                      dot={false}
-                      strokeWidth={2}
-                      hide={modelTokensLegend.hidden.has(g)}
-                    />
-                  ))}
-                </LineChart>
-              </ResponsiveContainer>
+            <div className="mt-3">
+              <MultiLineChart
+                rows={modelTokens.rows}
+                groups={modelTokens.groups}
+                colorOf={(g) => colorOf(g, modelTokens.groups)}
+                hidden={modelTokensLegend.hidden}
+                xLabel={(v) => bucketLabel(v, bucket)}
+                valueLabel={compact}
+              />
             </div>
+            <ChartLegend
+              groups={modelTokens.groups}
+              colorOf={(g) => colorOf(g, modelTokens.groups)}
+              hidden={modelTokensLegend.hidden}
+              onToggle={modelTokensLegend.onToggle}
+            />
           </section>
         </div>
 
@@ -576,8 +480,15 @@ export function Analytics() {
 
         <section className="mt-6 rounded-xl border border-border p-4">
           <h2 className="text-sm font-medium">Latency per provider</h2>
-          <div className="overflow-x-auto">
-            <table className="mt-3 w-full min-w-md text-sm">
+          {data && data.latency.length > 0 ? (
+            <div className="mt-3">
+              <LatencyBars rows={data.latency} />
+            </div>
+          ) : (
+            <p className="mt-3 py-6 text-center text-sm text-muted-foreground">No requests in range.</p>
+          )}
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full min-w-md text-sm">
               <thead>
                 <tr className="text-left text-xs text-muted-foreground">
                   <th className="pb-2 font-medium">Provider</th>
@@ -597,13 +508,6 @@ export function Analytics() {
                     <td className="py-2 text-right text-muted-foreground">{compact(l.requests)}</td>
                   </tr>
                 ))}
-                {data && data.latency.length === 0 && (
-                  <tr>
-                    <td colSpan={5} className="py-6 text-center text-muted-foreground">
-                      No requests in range.
-                    </td>
-                  </tr>
-                )}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## Summary
- Replace recharts with custom SVG chart components (stacked bar, multi-line, latency bars) — dataviz-skill palette, hover tooltips, toggle-to-isolate legend, drops the recharts dependency.
- Add path filtering to CI: go-test/go-integration/lint skip when no Go paths changed, web skips when no web paths changed, sandbox-image skips when its Dockerfile is untouched. images keeps a single job but skips per-leg. ci-ok is now path-aware so a correctly-skipped job still passes its allowlist gate.

## Test plan
- [x] `npm run build && npm run lint && npm test` in web/ — all pass (386 tests)
- [x] Manually verified in browser via `make dev` (localhost:3301/analytics)
- [x] `actionlint` clean on ci.yml
- [x] Confirm CI actually skips the right jobs on this PR (frontend-only diff should skip go-test/go-integration/lint/sandbox-image, and the images job should only run its `web` leg)