### PR TITLE
feat: alpha release pipeline, prebuilt-image deploy, magic-link sign-in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,129 @@
+name: release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+# One release run per tag, no cancellation: a half-published set of
+# multi-arch images or a half-assembled GitHub release is worse than a
+# slow one, and tags are immutable so there's never a newer run to
+# prefer over an in-flight one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # No test jobs here on purpose: releases are cut by tagging a commit
+  # on main that already went green through ci-ok. Re-running build/
+  # vet/test/lint against the same commit here would only slow the
+  # release down for no new signal.
+  images:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - name: brain
+            context: .
+            dockerfile: deploy/Dockerfile
+            build-args: |
+              SERVICE=brain
+            target: runtime-shell
+          - name: gateway
+            context: .
+            dockerfile: deploy/Dockerfile
+            build-args: |
+              SERVICE=gateway
+          - name: memoryd
+            context: .
+            dockerfile: deploy/Dockerfile
+            build-args: |
+              SERVICE=memoryd
+          - name: sandboxd
+            context: .
+            dockerfile: deploy/Dockerfile
+            build-args: |
+              SERVICE=sandboxd
+          - name: web
+            context: web
+            dockerfile: web/Dockerfile
+            secret: "true"
+          - name: markitdown
+            context: markitdown-svc
+            dockerfile: markitdown-svc/Dockerfile
+          - name: whisper
+            context: whisper-svc
+            dockerfile: whisper-svc/Dockerfile
+            build-args: |
+              WHISPER_MODEL=small
+          - name: sandbox
+            context: .
+            dockerfile: deploy/sandbox.Dockerfile
+    steps:
+      - uses: actions/checkout@v7
+      - id: version
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target }}
+          build-args: ${{ matrix.build-args }}
+          # web only: HugeIcons Pro registry auth, passed as a BuildKit
+          # secret so it never lands in an image layer (not as a
+          # build-arg or env, both of which persist into layer history).
+          secrets: ${{ matrix.secret == 'true' && format('hugeicons_token={0}', secrets.HUGEICONS_TOKEN) || '' }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          # repository_owner, not a literal: survives org renames and
+          # keeps images under whatever org the repo lives in.
+          tags: ghcr.io/${{ github.repository_owner }}/timothy-${{ matrix.name }}:${{ steps.version.outputs.value }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+  release:
+    needs: images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - id: version
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Assemble release assets
+        run: |
+          mkdir -p /tmp/release-assets
+          cp deploy/release/docker-compose.yml /tmp/release-assets/docker-compose.yml
+          cp deploy/release/env.example /tmp/release-assets/env.example
+          cp deploy/release/install.sh /tmp/release-assets/install.sh
+          cp deploy/searxng/settings.yml /tmp/release-assets/searxng-settings.yml
+          sed -i "s/__TIMOTHY_TAG__/${{ steps.version.outputs.value }}/g" \
+            /tmp/release-assets/env.example /tmp/release-assets/install.sh
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # Prerelease only for pre-release tags (-alpha/-beta/-rc etc.):
+        # a hyphen in the version marks it as such per semver, a bare
+        # vX.Y.Z does not.
+        run: |
+          args=(--generate-notes --title "$GITHUB_REF_NAME")
+          case "${{ steps.version.outputs.value }}" in
+            *-*) args+=(--prerelease) ;;
+          esac
+          gh release create "$GITHUB_REF_NAME" "${args[@]}" \
+            /tmp/release-assets/docker-compose.yml \
+            /tmp/release-assets/env.example \
+            /tmp/release-assets/install.sh \
+            /tmp/release-assets/searxng-settings.yml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Timothy
 
-[![CI](https://github.com/SumonMSelim/timothy/actions/workflows/ci.yml/badge.svg)](https://github.com/SumonMSelim/timothy/actions/workflows/ci.yml)
+[![CI](https://github.com/timothy-agent/timothy/actions/workflows/ci.yml/badge.svg)](https://github.com/timothy-agent/timothy/actions/workflows/ci.yml)
 [![Go](https://img.shields.io/badge/Go-1.26-00ADD8?logo=go&logoColor=white)](https://go.dev)
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)](https://react.dev)
 [![TypeScript](https://img.shields.io/badge/TypeScript-7.0-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
@@ -9,7 +9,7 @@
 
 Self-hosted personal AI assistant: chat, cost tracking, tasks, and agents — running on your own hardware, talking to whichever LLM providers you configure.
 
-**Status: early, personal project.** This is run by its author, in active development, with no versioned releases yet. Expect rough edges and breaking changes between commits.
+**Status: early, personal project.** This is run by its author, in active development. Alpha releases with prebuilt images are available on the [Releases page](https://github.com/timothy-agent/timothy/releases); expect rough edges and breaking changes between releases.
 
 ## What works today
 
@@ -47,10 +47,35 @@ Sessions are an append-only event log: every turn, tool run, and compaction is a
 | `8300` | Brain (public API)             |
 | `3301` | Vite dev server (`make dev`)   |
 
+## Quick start (prebuilt images)
+
+The fastest way to run Timothy: no Go/Node toolchain, no build step, just Docker and the released images.
+
+1. Make an empty directory and download the installer from the [latest release](https://github.com/timothy-agent/timothy/releases/latest):
+
+   ```sh
+   mkdir timothy && cd timothy
+   curl -fsSLo install.sh https://github.com/timothy-agent/timothy/releases/latest/download/install.sh
+   ```
+
+2. Read `install.sh` before running it. Then run it:
+
+   ```sh
+   sh install.sh
+   ```
+
+   It downloads `docker-compose.yml` and `env.example`, generates a `.env` with fresh secrets (`POSTGRES_PASSWORD`, `TIMOTHY_MASTER_KEY`, `TIMOTHY_API_TOKEN`), pulls the images, starts the stack, and prints a magic sign-in link once the web UI is up.
+
+3. Open the printed link — the web UI signs in automatically from the token in the URL.
+
+To upgrade later: bump `TIMOTHY_VERSION` in `.env` and run `docker compose pull && docker compose up -d`, or just re-run `install.sh` (it leaves an existing `.env` untouched and only refreshes `docker-compose.yml` and the searxng config).
+
+The rest of this README covers building and running from source instead.
+
 ## Prerequisites
 
 - Docker (Desktop, or engine + compose plugin).
-- A [hugeicons.com](https://hugeicons.com) account with an active token. The web UI's icons are HugeIcons Pro (a paid icon set) and the token is required to build the `web` image — without it, `make up` fails on the web build step.
+- Building from source only: a [hugeicons.com](https://hugeicons.com) account with an active token. The web UI's icons are HugeIcons Pro (a paid icon set) and the token is required to build the `web` image — without it, `make up` fails on the web build step. Not needed for the prebuilt-image quick start above.
 
 ## First run
 

--- a/deploy/release/docker-compose.yml
+++ b/deploy/release/docker-compose.yml
@@ -1,0 +1,232 @@
+name: timothy
+
+x-service: &service
+  restart: unless-stopped
+  networks: [timothy]
+  logging: &logging
+    options:
+      max-size: "10m"
+      max-file: "3"
+
+x-go-service: &go-service
+  <<: *service
+  depends_on:
+    postgres:
+      condition: service_healthy
+  healthcheck:
+    test: ["CMD", "/app", "-healthcheck"]
+    interval: 10s
+    timeout: 5s
+    retries: 3
+    start_period: 10s
+
+x-db-env: &db-env
+  DATABASE_URL: postgres://timothy:${POSTGRES_PASSWORD}@postgres:5432/timothy
+  LOG_LEVEL: ${LOG_LEVEL:-info}
+
+services:
+  postgres:
+    <<: *service
+    image: pgvector/pgvector:0.8.4-pg18-trixie
+    environment:
+      POSTGRES_USER: timothy
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: timothy
+    volumes:
+      - pgdata:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U timothy -d timothy"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  searxng:
+    <<: *service
+    image: searxng/searxng@sha256:aaf56bb5ad737d48a8a375778d42eb4ab1757231e6b1eb7980e71d8dd5bdf0de
+    environment:
+      SEARXNG_BASE_URL: http://searxng:8080/
+    volumes:
+      - ./searxng:/etc/searxng:ro
+    # internal-only: no published ports; brain is the sole caller
+
+  markitdown:
+    <<: *service
+    image: ghcr.io/timothy-agent/timothy-markitdown:${TIMOTHY_VERSION:?set TIMOTHY_VERSION in .env}
+    # internal-only: no published ports, no auth; brain is the sole
+    # caller, same trust boundary as searxng.
+
+  whisper:
+    <<: *service
+    image: ghcr.io/timothy-agent/timothy-whisper:${TIMOTHY_VERSION:?set TIMOTHY_VERSION in .env}
+    environment:
+      # The published image bakes model "small" at build time;
+      # overriding this requires rebuilding the image, not just
+      # changing the value here.
+      WHISPER_MODEL: small
+    # internal-only: no published ports, no auth; brain is the sole
+    # caller, same trust boundary as searxng/markitdown.
+
+  # Local models: run Ollama natively on the host (Metal/CUDA — a
+  # containerized runner gets CPU only and can't serve big models) and
+  # register http://host.docker.internal:11434/v1 in Settings as a
+  # regular "openaicompat" provider — no gateway code needed.
+
+  brain:
+    <<: *go-service
+    image: ghcr.io/timothy-agent/timothy-brain:${TIMOTHY_VERSION:?set TIMOTHY_VERSION in .env}
+    environment:
+      <<: *db-env
+      PORT: "8080"
+      GATEWAY_URL: http://gateway:8081
+      MEMORYD_URL: http://memoryd:8082
+      # Brain-only secret: the public API bearer token.
+      TIMOTHY_API_TOKEN: ${TIMOTHY_API_TOKEN:-}
+      # Connector credentials resolve through brain's own secret-store
+      # handle — same key the gateway uses.
+      TIMOTHY_MASTER_KEY: ${TIMOTHY_MASTER_KEY:?set TIMOTHY_MASTER_KEY in .env}
+      # Public base URL (as the browser sees it) for OAuth redirects;
+      # empty disables google connector OAuth.
+      TIMOTHY_PUBLIC_URL: ${TIMOTHY_PUBLIC_URL:-}
+      # Where the shell tool runs; the only tree tools may touch.
+      WORKSPACE_ROOT: /workspace
+      # Root for mission workspaces/worktrees; unset disables the
+      # missions feature entirely (API surface stays unmounted).
+      WORKSPACES: /workspace/missions
+      # Models too weak to drive tool-using mission work (substring
+      # match on the served model id). A turn served by one pauses the
+      # mission as infra instead of burning iterations on a model that
+      # cannot do the job — the small local fallback exists for chat
+      # resilience, not for missions.
+      MISSION_MODEL_FLOOR: ${MISSION_MODEL_FLOOR:-qwen2.5:7b}
+      # Compose-internal only: the model never sees this address.
+      SEARXNG_URL: http://searxng:8080
+      # Converts Gmail attachments (PDFs) and HTML-only email bodies to
+      # markdown/text; compose-internal only.
+      MARKITDOWN_URL: http://markitdown:8000
+      # Local speech-to-text for the web mic button; compose-internal
+      # only, audio never leaves the box.
+      WHISPER_URL: http://whisper:8001
+      # sandboxd's internal address — set only when MISSION_SANDBOX_IMAGE
+      # is configured (sandboxd itself always runs; without an image it
+      # just idles degraded). Empty keeps the original in-process exec
+      # behavior; brain never touches the Docker socket directly.
+      SANDBOXD_URL: ${MISSION_SANDBOX_IMAGE:+http://sandboxd:8083}
+      # Content-addressed image attachment bytes (metadata only in
+      # Postgres); compose-internal path, not user-facing.
+      ATTACHMENTS_DIR: /attachments
+    volumes:
+      - workspace:/workspace
+      - attachments:/attachments
+    ports:
+      - "${BRAIN_PORT:-8300}:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      searxng:
+        condition: service_started
+      markitdown:
+        condition: service_started
+      whisper:
+        condition: service_started
+      sandboxd:
+        condition: service_started
+    networks: [timothy, timothy-sandbox]
+
+  # Holds the Docker socket on brain's behalf: the only service that
+  # talks to the Docker daemon, exposing a narrow mission-scoped API
+  # (missionID in — never container names, images, mounts, env) that
+  # brain's sandboxclient calls instead. Not a *go-service: no postgres
+  # dependency, no database at all.
+  sandboxd:
+    <<: *service
+    image: ghcr.io/timothy-agent/timothy-sandboxd:${TIMOTHY_VERSION:?set TIMOTHY_VERSION in .env}
+    environment:
+      PORT: "8083"
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      # The one operator knob: empty keeps sandboxd up but degraded
+      # (nothing to Ping/CheckImage), same parity as brain's old
+      # in-process behavior when this was unset.
+      MISSION_SANDBOX_IMAGE: ${MISSION_SANDBOX_IMAGE:-}
+    volumes:
+      # Metadata-only read: resolveWorkspaceMount inspects this mount to
+      # learn the exact volume/bind spec, then replicates it (rw) into
+      # each sandbox container it creates — sandboxd itself never reads
+      # or writes mission files through this mount. A container's own
+      # replicated mount is unaffected by the ro flag here.
+      - workspace:/workspace:ro
+      # The socket this service exists to hold instead of brain.
+      # group_add grants its group inside the container; Docker
+      # Desktop's socket is group 0 (root), Linux hosts typically use a
+      # "docker" group with an arbitrary gid — override via
+      # DOCKER_SOCK_GID in .env if 0 doesn't work on your host.
+      - /var/run/docker.sock:/var/run/docker.sock
+    group_add:
+      - "${DOCKER_SOCK_GID:-0}"
+    # Hardening against non-socket bugs in this service — it cannot stop
+    # the socket itself being root-equivalent, but everything else about
+    # the container is locked down.
+    read_only: true
+    cap_drop: [ALL]
+    security_opt: ["no-new-privileges:true"]
+    healthcheck:
+      test: ["CMD", "/app", "-healthcheck"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    # internal-only: no published ports; brain is the sole caller.
+    # Second network (not just `timothy`): sandboxd is strictly more
+    # privileged than any other internal service (it holds the socket),
+    # so it reaches only brain, not searxng/markitdown/web. No
+    # auth header on the API — a shared secret would have to live in
+    # brain's own env, the exact thing this split assumes may be
+    # compromised (same reasoning as memoryd's unauthenticated internal
+    # API).
+    networks: [timothy-sandbox]
+
+  gateway:
+    <<: *go-service
+    image: ghcr.io/timothy-agent/timothy-gateway:${TIMOTHY_VERSION:?set TIMOTHY_VERSION in .env}
+    environment:
+      <<: *db-env
+      PORT: "8081"
+      # Root of trust for the encrypted secret store (base64, 32
+      # bytes). Generate with: openssl rand -base64 32. Provider
+      # credentials are configured in Settings, not env — this key is
+      # what decrypts them.
+      TIMOTHY_MASTER_KEY: ${TIMOTHY_MASTER_KEY:?set TIMOTHY_MASTER_KEY in .env}
+    # internal-only: no published ports
+
+  memoryd:
+    <<: *go-service
+    image: ghcr.io/timothy-agent/timothy-memoryd:${TIMOTHY_VERSION:?set TIMOTHY_VERSION in .env}
+    environment:
+      <<: *db-env
+      PORT: "8082"
+      GATEWAY_URL: http://gateway:8081
+    # internal-only: no published ports
+
+  web:
+    <<: *service
+    image: ghcr.io/timothy-agent/timothy-web:${TIMOTHY_VERSION:?set TIMOTHY_VERSION in .env}
+    environment:
+      # nginx proxy target for /v1 (browser stays same-origin)
+      BRAIN_URL: http://brain:8080
+    ports:
+      - "${WEB_PORT:-3300}:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/ >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  pgdata:
+  workspace:
+  attachments:
+
+networks:
+  timothy:
+  # brain + sandboxd only — see the sandboxd service comment.
+  timothy-sandbox:

--- a/deploy/release/env.example
+++ b/deploy/release/env.example
@@ -1,0 +1,47 @@
+# Copy to .env and fill in. Never commit .env.
+
+# Image tag to pull for all Timothy services (set by the installer,
+# or by hand when upgrading: bump this and run
+# `docker compose pull && docker compose up -d`).
+TIMOTHY_VERSION=__TIMOTHY_TAG__
+
+# --- Database ---
+POSTGRES_PASSWORD=change-me
+
+# --- Ports ---
+# Host ports (containers keep their internal ports)
+WEB_PORT=3300
+BRAIN_PORT=8300
+
+# --- Logging ---
+LOG_LEVEL=info
+
+# --- Secrets ---
+# Root of trust for the encrypted secret store (generate: openssl rand
+# -base64 32). Provider keys and connector credentials entered in
+# Settings are encrypted with this; losing it makes stored secrets
+# unrecoverable. Shared by gateway and brain.
+TIMOTHY_MASTER_KEY=
+
+# Bearer token for brain's public API (generate: openssl rand -hex 32)
+TIMOTHY_API_TOKEN=
+
+# Public base URL as the browser reaches Timothy, e.g.
+# http://localhost:3300 — used for connector OAuth redirects (Google).
+# The same URL + /v1/connectors/oauth/callback goes in the OAuth
+# client's authorized redirect URIs.
+TIMOTHY_PUBLIC_URL=http://localhost:3300
+
+# --- Mission sandbox ---
+# Image for per-mission sandbox containers that run model-authored
+# shell/verify_cmd commands OUTSIDE brain's own process, via sandboxd
+# (the only service holding the Docker socket). Leave empty to keep
+# the original in-process exec behavior; sandboxd itself still runs,
+# just idling degraded with nothing to do.
+MISSION_SANDBOX_IMAGE=ghcr.io/timothy-agent/timothy-sandbox:__TIMOTHY_TAG__
+
+# Group ID of the docker.sock on your host, needed so sandboxd (running
+# as a non-root user) can use it. Docker Desktop: 0 (the default)
+# works. Linux hosts: run `stat -c '%g' /var/run/docker.sock` and set
+# it here if it isn't 0.
+DOCKER_SOCK_GID=0

--- a/deploy/release/install.sh
+++ b/deploy/release/install.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+# Timothy installer: downloads release assets into the current
+# directory, generates secrets on first run, and starts the stack.
+set -eu
+
+TAG="__TIMOTHY_TAG__"
+RELEASE_TAG="v${TAG}"
+BASE_URL="https://github.com/timothy-agent/timothy/releases/download/${RELEASE_TAG}"
+
+fail() {
+  echo "error: $1" >&2
+  exit 1
+}
+
+fetch() {
+  # fetch <url> <dest>
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$1" -o "$2"
+  else
+    wget -q "$1" -O "$2"
+  fi
+}
+
+echo "Timothy installer (${RELEASE_TAG})"
+
+# --- Preflight ---
+command -v docker >/dev/null 2>&1 || fail "docker not found on PATH. Install Docker first: https://docs.docker.com/get-docker/"
+docker compose version >/dev/null 2>&1 || fail "'docker compose' plugin not available. Install/update Docker to a version with Compose v2."
+command -v openssl >/dev/null 2>&1 || fail "openssl not found on PATH. Install it to generate secrets."
+if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
+  fail "neither curl nor wget found on PATH."
+fi
+
+# --- Download assets ---
+echo "Downloading release assets..."
+fetch "${BASE_URL}/docker-compose.yml" docker-compose.yml
+fetch "${BASE_URL}/env.example" env.example
+mkdir -p searxng
+fetch "${BASE_URL}/searxng-settings.yml" searxng/settings.yml
+
+# --- .env ---
+if [ -f .env ]; then
+  echo "Existing .env found — leaving it untouched (upgrade path)."
+else
+  echo "Generating .env with fresh secrets..."
+  cp env.example .env
+
+  postgres_password=$(openssl rand -hex 24)
+  master_key=$(openssl rand -base64 32)
+  api_token=$(openssl rand -hex 32)
+
+  if [ "$(uname -s)" = "Linux" ] && [ -S /var/run/docker.sock ]; then
+    sock_gid=$(stat -c '%g' /var/run/docker.sock)
+  else
+    sock_gid=0
+  fi
+
+  # Portable in-place sed edit (BSD/macOS requires an extension arg to -i).
+  sed_inplace() {
+    sed -i.bak "$1" .env && rm -f .env.bak
+  }
+
+  sed_inplace "s#^POSTGRES_PASSWORD=.*#POSTGRES_PASSWORD=${postgres_password}#"
+  sed_inplace "s#^TIMOTHY_MASTER_KEY=.*#TIMOTHY_MASTER_KEY=${master_key}#"
+  sed_inplace "s#^TIMOTHY_API_TOKEN=.*#TIMOTHY_API_TOKEN=${api_token}#"
+  sed_inplace "s#^DOCKER_SOCK_GID=.*#DOCKER_SOCK_GID=${sock_gid}#"
+  sed_inplace "s#^TIMOTHY_VERSION=.*#TIMOTHY_VERSION=${TAG}#"
+  sed_inplace "s#__TIMOTHY_TAG__#${TAG}#"
+
+  echo ".env generated. Secrets were not printed to the terminal."
+fi
+
+# --- Start ---
+echo "Pulling images..."
+docker compose pull
+
+# compose pull only covers services; the mission sandbox image is an
+# env var handed to sandboxd, so pull it explicitly or missions stay
+# degraded until someone pulls it by hand.
+sandbox_image=$(sed -n 's/^MISSION_SANDBOX_IMAGE=//p' .env | head -n1)
+if [ -n "$sandbox_image" ]; then
+  echo "Pulling mission sandbox image..."
+  docker pull "$sandbox_image"
+fi
+
+echo "Starting Timothy..."
+docker compose up -d
+
+# --- Wait for web ---
+web_port=$(sed -n 's/^WEB_PORT=//p' .env | head -n1)
+web_port=${web_port:-3300}
+
+echo "Waiting for the web UI to come up on port ${web_port}..."
+i=0
+until curl -fsS "http://localhost:${web_port}/" >/dev/null 2>&1 || wget -q -O /dev/null "http://localhost:${web_port}/" >/dev/null 2>&1; do
+  i=$((i + 1))
+  if [ "$i" -ge 30 ]; then
+    echo "warning: web UI did not respond after ~60s; check 'docker compose logs -f'" >&2
+    break
+  fi
+  sleep 2
+done
+
+api_token=$(sed -n 's/^TIMOTHY_API_TOKEN=//p' .env | head -n1)
+
+echo ""
+echo "================================================================"
+echo " Timothy is up."
+echo ""
+echo " Sign in:  http://localhost:${web_port}/#token=${api_token}"
+echo " (this magic link signs the web UI in automatically)"
+echo ""
+echo " Follow logs:  docker compose logs -f"
+echo "================================================================"

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   ChatError,
   chatStream,
+  consumeTokenFragment,
   createSSEParser,
   downloadMissionFile,
+  getToken,
   listMissionFiles,
   listProviders,
   listSessions,
@@ -14,6 +16,49 @@ import {
 import type { ChatEvent } from './types'
 
 afterEach(() => vi.unstubAllGlobals())
+
+describe('consumeTokenFragment', () => {
+  afterEach(() => {
+    localStorage.clear()
+    history.replaceState(null, '', '/')
+  })
+
+  it('stores the token from the fragment and strips it from the URL', () => {
+    history.replaceState(null, '', '/#token=abc123')
+
+    consumeTokenFragment()
+
+    expect(getToken()).toBe('abc123')
+    expect(window.location.hash).toBe('')
+    expect(window.location.href).not.toContain('token=')
+  })
+
+  it('parses a token alongside other fragment params', () => {
+    history.replaceState(null, '', '/#token=abc123&other=y')
+
+    consumeTokenFragment()
+
+    expect(getToken()).toBe('abc123')
+    expect(window.location.hash).toBe('')
+  })
+
+  it('leaves localStorage untouched when there is no fragment', () => {
+    history.replaceState(null, '', '/')
+
+    consumeTokenFragment()
+
+    expect(getToken()).toBe('')
+  })
+
+  it('ignores an empty token value', () => {
+    history.replaceState(null, '', '/#token=')
+
+    consumeTokenFragment()
+
+    expect(getToken()).toBe('')
+    expect(window.location.hash).toBe('#token=')
+  })
+})
 
 describe('createSSEParser', () => {
   it('parses complete events', () => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -42,6 +42,18 @@ export function setToken(token: string) {
   localStorage.setItem(tokenKey, token.trim())
 }
 
+// consumeTokenFragment reads a `#token=...` value from the URL fragment
+// (as printed by the installer), stores it, and strips the fragment so
+// it doesn't linger in the address bar or history. No-op if absent.
+export function consumeTokenFragment() {
+  const params = new URLSearchParams(window.location.hash.replace(/^#/, ''))
+  const token = params.get('token')
+  if (!token) return
+
+  setToken(token)
+  history.replaceState(null, '', window.location.pathname + window.location.search)
+}
+
 // createSSEParser incrementally parses an SSE byte stream that may be
 // chunked at arbitrary boundaries. Each complete "data:" block is
 // JSON-decoded and passed to onEvent; malformed blocks are skipped.

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,10 +1,12 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router'
+import { consumeTokenFragment } from './api/client'
 import { applyTheme, watchSystemTheme } from './lib/theme'
 import './index.css'
 import App from './App.tsx'
 
+consumeTokenFragment()
 applyTheme()
 watchSystemTheme()
 


### PR DESCRIPTION
## What

First public alpha (v0.1.0-alpha.1) infrastructure:

- **`.github/workflows/release.yml`** — on `v*` tags: builds all 8 service images (brain, gateway, memoryd, sandboxd, web, markitdown, whisper, sandbox) multi-arch (amd64+arm64) via buildx, pushes to `ghcr.io/<owner>/timothy-*`, then creates a GitHub release (auto `--prerelease` for hyphenated versions) with pinned deploy assets. No test jobs — tags are cut from main that already passed ci-ok.
- **`deploy/release/`** — image-based `docker-compose.yml` (pinned via `TIMOTHY_VERSION`), release `env.example`, and a POSIX `install.sh`: preflight, asset download, local secret generation (never printed), `DOCKER_SOCK_GID` autodetect, image pull (incl. the mission sandbox image compose pull misses), health wait, prints a magic sign-in link.
- **Magic-link sign-in** — web app consumes `#token=` from the URL fragment on load, stores it, strips the fragment. Fragments never reach server logs.
- README: prebuilt-image quick start; HugeIcons prerequisite scoped to source builds.

## Test plan

- [x] web: build + lint + 390 tests green (node:24 container)
- [x] shellcheck clean on install.sh
- [x] actionlint + YAML parse clean on release.yml
- [x] `docker compose config` validates release compose
- [ ] Real release run validates image publish + asset assembly (first tag)