### PR TITLE
feat: make routing fully dynamic and user-managed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,21 @@
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-18%20%2B%20pgvector-4169E1?logo=postgresql&logoColor=white)](https://www.postgresql.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Self-hosted personal AI assistant: chat, cost tracking, tasks, and agents — running on your own hardware, talking to whichever LLM providers you configure.
+Self-hosted personal AI assistant: chat, cost tracking, tasks, and agents, running on your own hardware, talking to whichever LLM providers you configure.
 
-**Status: early, personal project.** This is run by its author, in active development. Alpha releases with prebuilt images are available on the [Releases page](https://github.com/timothy-agent/timothy/releases); expect rough edges and breaking changes between releases.
+**Status: early, under active development.** 
+
+Alpha releases with prebuilt images are available on the [Releases page](https://github.com/timothy-agent/timothy/releases); expect rough edges and breaking changes between releases.
 
 ## What works today
 
-- **Multi-provider chat** — Anthropic, Amazon Bedrock, and any OpenAI-compatible API behind one gateway; providers, models, and per-task routing are database configuration, editable at runtime from the settings panel with hot reload.
-- **Sessions that survive** — every conversation is an append-only event log; kill a container mid-stream and the session resumes and replays exactly.
-- **Tools, permissions, skills** — the agent loop executes tools behind a constraint/permission chain (destructive actions require explicit approval in the UI); skill packs load lazily by task.
-- **Missions** — long-running agent tasks with a pure state machine, harness-owned verification (artifacts must exist before any model claim counts), per-mission sandboxes, budgets, and LLM review; recurring missions fire from cron schedules.
-- **Long-term memory** — staged fact extraction with a confirmation queue, hybrid pgvector retrieval (vector + text + entity, RRF-fused) under a strict token budget.
-- **Cost accounting** — every request lands in a ledger with honest pricing (unknown price is recorded as null, never guessed); usage dashboard, spend budgets with alerts, Prometheus metrics on every service.
-- **Privacy floor** — tools whose output carries sensitive data (raw email) pin the rest of their turn, and every downstream side-call (memory extraction, compaction), to a dedicated route you can chain to a local model.
+- **Multi-provider chat**: Anthropic, Amazon Bedrock, and any OpenAI-compatible API behind one gateway; providers, models, and per-task routing are database configuration, editable at runtime from the settings panel with hot reload.
+- **Sessions that survive**: every conversation is an append-only event log; kill a container mid-stream and the session resumes and replays exactly.
+- **Tools, permissions, skills**: the agent loop executes tools behind a constraint/permission chain (destructive actions require explicit approval in the UI); skill packs load lazily by task.
+- **Missions**: long-running agent tasks with a pure state machine, harness-owned verification (artifacts must exist before any model claim counts), per-mission sandboxes, budgets, and LLM review; recurring missions fire from cron schedules.
+- **Long-term memory**: staged fact extraction with a confirmation queue, hybrid pgvector retrieval (vector + text + entity, RRF-fused) under a strict token budget.
+- **Cost accounting**: every request lands in a ledger with honest pricing (unknown price is recorded as null, never guessed); usage dashboard, spend budgets with alerts, Prometheus metrics on every service.
+- **Privacy floor**: tools whose output carries sensitive data (raw email) pin the rest of their turn, and every downstream side-call (memory extraction, compaction), to a dedicated route you can chain to a local model.
 
 ## Architecture
 
@@ -27,20 +29,20 @@ Go microservices behind a single public API, one PostgreSQL database, React web 
 
 | Service      | Role                                                                                         |
 |--------------|----------------------------------------------------------------------------------------------|
-| `brain`      | Public API — chat orchestration, agent loop, missions, event-sourced sessions, SSE streaming |
-| `gateway`    | Internal LLM gateway — multi-provider routing, cost ledger                                   |
-| `memoryd`    | Internal memory service — pgvector-backed recall                                             |
-| `sandboxd`   | Internal service holding the Docker socket — per-mission sandbox containers                  |
-| `web`        | React + Tailwind interface — chat, missions, usage, settings                                 |
+| `brain`      | Public API: chat orchestration, agent loop, missions, event-sourced sessions, SSE streaming |
+| `gateway`    | Internal LLM gateway: multi-provider routing, cost ledger                                   |
+| `memoryd`    | Internal memory service: pgvector-backed recall                                             |
+| `sandboxd`   | Internal service holding the Docker socket: per-mission sandbox containers                  |
+| `web`        | React + Tailwind interface: chat, missions, usage, settings                                 |
 | `searxng`    | Internal metasearch backend for the web_search tool                                          |
-| `markitdown` | Internal Python sidecar — file→markdown conversion                                           |
-| `whisper`    | Internal Python sidecar — local speech-to-text for the web mic button                        |
+| `markitdown` | Internal Python sidecar: file→markdown conversion                                           |
+| `whisper`    | Internal Python sidecar: local speech-to-text for the web mic button                        |
 
-Plus Postgres (18 + pgvector), internal only — no host port. Migrations are embedded in each Go binary and applied automatically at startup; there's no separate migrate command. Every Go service exposes `GET /health` and `GET /metrics`.
+Plus Postgres (18 + pgvector), internal only, no host port. Migrations are embedded in each Go binary and applied automatically at startup; there's no separate migrate command. Every Go service exposes `GET /health` and `GET /metrics`.
 
 Sessions are an append-only event log: every turn, tool run, and compaction is an immutable event, so conversations survive crashes mid-stream and replay exactly as they happened.
 
-**Published ports** — everything else is compose-internal:
+**Published ports** (everything else is compose-internal):
 
 | Port   | What                         |
 |--------|------------------------------|
@@ -67,18 +69,18 @@ The fastest way to run Timothy: no Go/Node toolchain, no build step, just Docker
 
    It downloads `docker-compose.yml` and `env.example`, generates a `.env` with fresh secrets (`POSTGRES_PASSWORD`, `TIMOTHY_MASTER_KEY`, `TIMOTHY_API_TOKEN`), pulls the images, starts the stack, and prints a magic sign-in link once the web UI is up.
 
-3. Open the printed link — the web UI signs in automatically from the token in the URL.
+3. Open the printed link: the web UI signs in automatically from the token in the URL.
 
 To upgrade later: bump `TIMOTHY_VERSION` in `.env` and run `docker compose pull && docker compose up -d`, or just re-run `install.sh` (it leaves an existing `.env` untouched and only refreshes `docker-compose.yml` and the searxng config).
 
 The rest of this README covers building and running from source instead.
 
-## Prerequisites
+## Build from source
+
+Prerequisites:
 
 - Docker (Desktop, or engine + compose plugin).
-- Building from source only: a [hugeicons.com](https://hugeicons.com) account with an active token. The web UI's icons are HugeIcons Pro (a paid icon set) and the token is required to build the `web` image — without it, `make up` fails on the web build step. Not needed for the prebuilt-image quick start above.
-
-## First run
+- A [hugeicons.com](https://hugeicons.com) account with an active token. The web UI's icons are HugeIcons Pro (a paid icon set) and the token is required to build the `web` image; without it, `make up` fails on the web build step. Not needed for the prebuilt-image quick start above.
 
 1. Copy the env file and fill in the required values:
 
@@ -88,10 +90,10 @@ The rest of this README covers building and running from source instead.
 
    Open `deploy/.env` and set:
 
-   - `POSTGRES_PASSWORD` — compose refuses to start without it.
-   - `TIMOTHY_MASTER_KEY` — generate with `openssl rand -base64 32`. This is the root of trust for the encrypted secret store (provider API keys, OAuth tokens all live behind it). Compose hard-fails if it's blank. **Back this up** — losing it makes every stored secret unrecoverable.
-   - `TIMOTHY_API_TOKEN` — generate with `openssl rand -hex 32`. Bearer token for the API; if it's blank, every request 401s.
-   - `HUGEICONS_TOKEN` — your HugeIcons Pro token, needed to build the `web` image.
+   - `POSTGRES_PASSWORD`: compose refuses to start without it.
+   - `TIMOTHY_MASTER_KEY`: generate with `openssl rand -base64 32`. This is the root of trust for the encrypted secret store (provider API keys, OAuth tokens all live behind it). Compose hard-fails if it's blank. **Back this up**: losing it makes every stored secret unrecoverable.
+   - `TIMOTHY_API_TOKEN`: generate with `openssl rand -hex 32`. Bearer token for the API; if it's blank, every request 401s.
+   - `HUGEICONS_TOKEN`: your HugeIcons Pro token, needed to build the `web` image.
 
 2. (Optional) Missions sandbox. `deploy/env.example` prefills `MISSION_SANDBOX_IMAGE=timothy-sandbox:latest`, but that image doesn't exist until you build it:
 
@@ -99,7 +101,7 @@ The rest of this README covers building and running from source instead.
    make sandbox-image
    ```
 
-   Skip this and leave `MISSION_SANDBOX_IMAGE` empty in `.env` if you don't need missions isolated in their own container — mission shell commands then run in-process instead.
+   Skip this and leave `MISSION_SANDBOX_IMAGE` empty in `.env` if you don't need missions isolated in their own container; mission shell commands then run in-process instead.
 
 3. (Linux only) Set `DOCKER_SOCK_GID` so `sandboxd` can use the Docker socket:
 
@@ -107,7 +109,7 @@ The rest of this README covers building and running from source instead.
    stat -c '%g' /var/run/docker.sock
    ```
 
-   Put that number in `.env`. On Docker Desktop the default of `0` works as-is. Note: mounting `docker.sock` gives `sandboxd` root-equivalent access to the host. It's isolated on its own compose network, read-only, and runs with all capabilities dropped — but the socket itself is the trust boundary, so only run this on a host you control.
+   Put that number in `.env`. On Docker Desktop the default of `0` works as-is. Note: mounting `docker.sock` gives `sandboxd` root-equivalent access to the host. It's isolated on its own compose network, read-only, and runs with all capabilities dropped, but the socket itself is the trust boundary, so only run this on a host you control.
 
 4. Start the stack:
 
@@ -117,13 +119,13 @@ The rest of this README covers building and running from source instead.
 
    Web UI: `http://localhost:3300`. API: `http://localhost:8300`.
 
-5. First login. There's no login page — the web UI auto-opens a settings dialog asking for an API token the first time it can't find one. Paste the `TIMOTHY_API_TOKEN` value from `deploy/.env`. It's stored in your browser's `localStorage`.
+5. First login. There's no login page: the web UI auto-opens a settings dialog asking for an API token the first time it can't find one. Paste the `TIMOTHY_API_TOKEN` value from `deploy/.env`. It's stored in your browser's `localStorage`.
 
-6. Add a provider. A fresh install has zero LLM providers and no routing configured — Timothy can't answer anything until you do this. Go to **Settings → Providers → Add**. Presets: OpenAI, Anthropic, Bedrock, GLM, Grok, Ollama, or a custom OpenAI-compatible endpoint. The API key you enter is encrypted into the secret store (default backend `db`, encrypted with `TIMOTHY_MASTER_KEY`) — the database only ever holds a reference to it, never the raw value, and it never appears in `.env`, logs, or API responses. Creating your first provider automatically bootstraps the system routes (`default`, `summarize`, `embedding`).
+6. Add a provider. A fresh install has zero LLM providers and no routing configured, so Timothy can't answer anything until you do this. Go to **Settings → Providers → Add**. Presets: OpenAI, Anthropic, Bedrock, GLM, Grok, Ollama, or a custom OpenAI-compatible endpoint. The API key you enter is encrypted into the secret store (default backend `db`, encrypted with `TIMOTHY_MASTER_KEY`); the database only ever holds a reference to it, never the raw value, and it never appears in `.env`, logs, or API responses. Creating your first provider automatically bootstraps the 4 routes Timothy needs to work (`default`, `summarize`, `embedding`, `vision`); routes are otherwise fully user-managed (create, edit chain/strategy, delete) from **Settings → Routing**.
 
 ## Optional: local models
 
-Run Ollama natively on the host, not in a container — a containerized Ollama only gets CPU, while a host install can use Metal or CUDA. Then add a provider with the **Ollama** preset; it prefills the base URL `http://host.docker.internal:11434/v1`. On Linux, `host.docker.internal` may need a `host-gateway` entry in your Docker config to resolve.
+Run Ollama natively on the host, not in a container: a containerized Ollama only gets CPU, while a host install can use Metal or CUDA. Then add a provider with the **Ollama** preset; it prefills the base URL `http://host.docker.internal:11434/v1`. On Linux, `host.docker.internal` may need a `host-gateway` entry in your Docker config to resolve.
 
 ## Optional: Google connectors (Gmail, Calendar)
 
@@ -132,7 +134,7 @@ Run Ollama natively on the host, not in a container — a containerized Ollama o
 3. Add `<TIMOTHY_PUBLIC_URL>/v1/connectors/oauth/callback` to the OAuth client's authorized redirect URIs.
 4. In the UI: **Settings → Connectors**, pick the Gmail or Calendar tile, paste the client ID and client secret, and complete the consent flow. Scopes requested: `gmail.modify`, `calendar`.
 
-While the Google OAuth app is in "Testing" mode (the default for a new Cloud project), refresh tokens expire roughly every 7 days — when a connector stops working, reconnect it from Settings, or publish the OAuth app to avoid the expiry.
+While the Google OAuth app is in "Testing" mode (the default for a new Cloud project), refresh tokens expire roughly every 7 days; when a connector stops working, reconnect it from Settings, or publish the OAuth app to avoid the expiry.
 
 ## Optional: GitHub connector
 
@@ -140,7 +142,7 @@ Configured as an MCP preset in **Settings → Connectors**: paste a GitHub perso
 
 ## Optional: Amazon Bedrock
 
-Create an IAM user scoped to `bedrock:InvokeModel*` only, generate an access key, and paste it as JSON (`{"access_key_id":"…","secret_access_key":"…"}`) into the Bedrock provider's key field in **Settings → Providers**. Pick a region from the dropdown — no `~/.aws`, no SSO, nothing to run on the host.
+Create an IAM user scoped to `bedrock:InvokeModel*` only, generate an access key, and paste it as JSON (`{"access_key_id":"…","secret_access_key":"…"}`) into the Bedrock provider's key field in **Settings → Providers**. Pick a region from the dropdown; no `~/.aws`, no SSO, nothing to run on the host.
 
 ## Operating the stack
 
@@ -156,12 +158,6 @@ Rebuild and restart a single service after a code change:
 make brain      # or gateway, memoryd, web, markitdown, whisper, sandboxd
 ```
 
-Frontend development with hot reload:
-
-```sh
-make dev   # Vite dev server on :3301, proxies /v1 to brain
-```
-
 ### Backups
 
 Postgres has no host port, so back it up through the container:
@@ -170,7 +166,7 @@ Postgres has no host port, so back it up through the container:
 docker compose -f deploy/docker-compose.yml exec postgres pg_dump -U timothy timothy > backup.sql
 ```
 
-A full backup is the `pgdata` volume plus `deploy/.env` — without `TIMOTHY_MASTER_KEY`, the encrypted secrets in that dump are unrecoverable.
+A full backup is the `pgdata` volume plus `deploy/.env`: without `TIMOTHY_MASTER_KEY`, the encrypted secrets in that dump are unrecoverable.
 
 ### Upgrading
 
@@ -179,17 +175,23 @@ git pull
 make up
 ```
 
-Migrations are additive-only, never edited once applied, and run automatically at service startup — no separate migrate step.
+Migrations are additive-only, never edited once applied, and run automatically at service startup; no separate migrate step.
 
-## Development
+## Local development
 
-The Go toolchain runs fully containerized — no host Go install required.
+The Go toolchain runs fully containerized; no host Go install required.
 
 ```sh
 make build   # compile everything
 make test    # unit tests
 make vet     # go vet
 make lint    # golangci-lint
+```
+
+Frontend development with hot reload:
+
+```sh
+make dev   # Vite dev server on :3301, proxies /v1 to brain
 ```
 
 `make test-integration` and `make canary` need the compose stack up (`make up` first).

--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -233,7 +233,14 @@ func main() {
 	// over the same registry.
 	agentReg := agents.NewStore(app.DB, app.Log)
 
-	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, app.Log)
+	routeForRole := func(ctx context.Context, role string) string {
+		name, ok, err := gwc.RouteForRole(ctx, role)
+		if err != nil || !ok {
+			return ""
+		}
+		return name
+	}
+	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, app.Log)
 	if missionDriver != nil {
 		var sandboxSweeper interface {
 			Sweep(ctx context.Context, isTerminal func(missionID string) bool) error
@@ -369,7 +376,7 @@ func main() {
 	api.Register(app.Server, svc, store, broker,
 		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, app.Log), flags,
 		agentReg, conns, goog, agent, missionStore, missionDriver, missionNotifier,
-		missionWorkspace, resolveSecret, missionHub, attachmentStore, &http.Client{}, whisperURL, token, app.Log)
+		missionWorkspace, resolveSecret, routeForRole, missionHub, attachmentStore, &http.Client{}, whisperURL, token, app.Log)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)
@@ -470,7 +477,7 @@ func missionAgentResolver(agentReg *agents.Store) missions.AgentResolver {
 // time) so an agent edited after the fact still applies. The hub
 // lives inside the same gate as everything else here — no missions,
 // no push events either.
-func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, agentReg *agents.Store, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace, *missions.Hub) {
+func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, agentReg *agents.Store, routeForRole func(context.Context, string) string, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace, *missions.Hub) {
 	root := os.Getenv("WORKSPACES")
 	if root == "" {
 		log.Info("WORKSPACES not set; missions disabled")
@@ -520,7 +527,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	driver.SetAgentResolver(resolveAgent)
 
 	schedulerEnabled := func(ctx context.Context) bool { return flags.Enabled(ctx, settings.KeyScheduler) }
-	scheduler := missions.NewScheduler(db, store, resolveAgent, schedulerEnabled, log)
+	scheduler := missions.NewScheduler(db, store, resolveAgent, schedulerEnabled, routeForRole, log)
 	go scheduler.Run(ctx)
 	return store, driver, notifier, workspace, hub
 }
@@ -610,6 +617,10 @@ func (r turnRouter) Stream(ctx context.Context, req gwclient.StreamRequest) (<-c
 		System:    req.System,
 		Messages:  req.Messages,
 	})
+}
+
+func (r turnRouter) RouteForRole(ctx context.Context, role string) (string, bool, error) {
+	return r.gw.RouteForRole(ctx, role)
 }
 
 // buildAgent assembles the compiled-in tool registry and its guard

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -80,7 +80,7 @@ var memoryRoutePatterns = []string{
 // proxy to the gateway's internal control plane, conns the local
 // connector control plane (nil leaves any of them unmounted).
 // whisperURL empty leaves /v1/transcribe unmounted (WHISPER_URL unset).
-func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, toolset Toolset, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, token string, log *slog.Logger) {
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, toolset Toolset, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, token string, log *slog.Logger) {
 	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log}
 	if memories != nil {
 		for _, pattern := range memoryRoutePatterns {
@@ -92,7 +92,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	a.registerAgents(srv.Handle, agentReg)
 	a.registerConnectors(srv.Handle, conns, goog)
 	a.registerTools(srv.Handle, toolset)
-	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret)
+	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret, routeForRole)
 	a.registerSchedules(srv.Handle, missionStore)
 	a.registerEvents(srv.Handle, hub)
 	a.registerTranscribe(srv.Handle, whisperClient, whisperURL)

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -196,6 +196,10 @@ type fakeGateway struct {
 	blockCh chan struct{}
 }
 
+func (f *fakeGateway) RouteForRole(_ context.Context, role string) (string, bool, error) {
+	return role, true, nil
+}
+
 func (f *fakeGateway) Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
 	f.calls++
 	if f.calls == 1 { // record the chat call, not the title call

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -17,22 +17,20 @@ import (
 	"github.com/SumonMSelim/timothy/internal/secretstore"
 )
 
-// defaultMissionRoute mirrors chat.defaultRoute: an agent's empty
-// route means "the default chain," but the gateway's /v1/stream
-// requires a real, non-empty route name.
-const defaultMissionRoute = "default"
-
 // registerMissions mounts the mission surface: served locally,
 // missions are brain's domain like agents and connectors. nil store
 // leaves the surface unmounted (404s), matching the memories/admin/
 // agents gating pattern. agentReg resolves a mission's route/
 // review_route/budget/approval_allowlist defaults from the chosen
-// agent when the create request omits them.
-func (a *API) registerMissions(handle func(pattern string, h http.Handler), store *missions.Store, driver *missions.Driver, notifier *missions.Notifier, agentReg *agents.Store, workspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error)) {
+// agent when the create request omits them. routeForRole resolves the
+// route bound to the "default" system role (D-049) — an agent's empty
+// route means "the default chain," but the gateway's /v1/stream
+// requires a real, non-empty route name.
+func (a *API) registerMissions(handle func(pattern string, h http.Handler), store *missions.Store, driver *missions.Driver, notifier *missions.Notifier, agentReg *agents.Store, workspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string) {
 	if store == nil {
 		return
 	}
-	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, workspace: workspace, resolveSecret: resolveSecret, perms: a.perms, dir: a.dir, log: a.log}
+	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, workspace: workspace, resolveSecret: resolveSecret, routeForRole: routeForRole, perms: a.perms, dir: a.dir, log: a.log}
 	handle("GET /v1/missions", a.auth(http.HandlerFunc(h.list)))
 	handle("POST /v1/missions", a.auth(http.HandlerFunc(h.create)))
 	handle("GET /v1/missions/{id}", a.auth(http.HandlerFunc(h.get)))
@@ -60,6 +58,10 @@ type missionAPI struct {
 	// resolveSecret resolves a credential_ref to its plaintext value for
 	// push; nil means no secret store is configured.
 	resolveSecret func(context.Context, string) (string, error)
+	// routeForRole resolves the route bound to a system role ("default"
+	// for missions); nil or an unbound role fall back to "" and the
+	// gateway's own no_route error, same as an unconfigured route.
+	routeForRole func(context.Context, string) string
 	// perms answers a mission's pending_permission — the same
 	// PermissionResolver chat sessions use (A.perms), never a
 	// mission-specific broker.
@@ -184,13 +186,18 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 	}
 	// An agent's route (and this handler's own fallback) can still be
 	// "" — that's each agent's shorthand for "the default chain," same
-	// as chat.defaultRoute — but the gateway requires a real route
-	// name, so the substitution has to happen somewhere concrete.
+	// as chat's own default-role fallback — but the gateway requires a
+	// real route name, so the substitution has to happen somewhere
+	// concrete.
+	defaultRoute := ""
+	if h.routeForRole != nil {
+		defaultRoute = h.routeForRole(r.Context(), "default")
+	}
 	if req.Route == "" {
-		req.Route = defaultMissionRoute
+		req.Route = defaultRoute
 	}
 	if req.ReviewRoute == "" {
-		req.ReviewRoute = defaultMissionRoute
+		req.ReviewRoute = defaultRoute
 	}
 
 	autoApproveSafe := true

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -13,7 +13,7 @@ func TestMissionsEndpointsUnmountedWhenStoreNil(t *testing.T) {
 	t.Parallel()
 	a, _, _ := testAPI(t, "tok", nil)
 	m := mux(a)
-	a.registerMissions(m.Handle, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, nil, nil, nil, nil, nil, nil, nil)
 
 	for _, req := range []struct{ method, path string }{
 		{"GET", "/v1/missions"},
@@ -51,7 +51,7 @@ func TestMissionsListFilterValidation(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil)
 
 	call := func(path string) int {
 		req := httptest.NewRequest("GET", path, nil)
@@ -99,7 +99,7 @@ func TestMissionsDeleteReachesStore(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("DELETE", "/v1/missions/abc", nil)
 	req.Header.Set("Authorization", "Bearer tok")

--- a/internal/brain/chat/attachments_test.go
+++ b/internal/brain/chat/attachments_test.go
@@ -296,8 +296,8 @@ func TestChatNoImagesLeavesRouteUnchanged(t *testing.T) {
 	drain(t, ch)
 
 	sent := gw.lastChatRequest()
-	if sent.Route != defaultRoute {
-		t.Fatalf("route = %q, want %q (no images, no flip)", sent.Route, defaultRoute)
+	if sent.Route != "default" {
+		t.Fatalf("route = %q, want %q (no images, no flip)", sent.Route, "default")
 	}
 }
 
@@ -476,7 +476,7 @@ func TestChatDocumentsOnlyMessageDoesNotFlipToVisionRoute(t *testing.T) {
 	drain(t, ch)
 
 	sent := gw.lastChatRequest()
-	if sent.Route != defaultRoute {
-		t.Fatalf("route = %q, want %q (documents-only message, no vision flip)", sent.Route, defaultRoute)
+	if sent.Route != "default" {
+		t.Fatalf("route = %q, want %q (documents-only message, no vision flip)", sent.Route, "default")
 	}
 }

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -45,15 +45,6 @@ const (
 	// isn't sensitive — a session's name deserves the same model quality
 	// as the conversation it's naming, not the cheapest available one.
 	classifyRoute = "local"
-	// defaultRoute serves plain chat turns when the caller picks
-	// nothing; the web UI exposes a per-message picker.
-	defaultRoute = "default"
-	// visionRoute serves turns whose message carries an image attachment
-	// (D-046) — a cheapest-first vision chain, so an image message never
-	// rides an agent's or the default route's (usually pricier) chain
-	// just because the capability gate happens to find a vision-capable
-	// model there too.
-	visionRoute = "vision"
 	// turnTimeout ceils a detached turn's lifetime (see Chat/Retry's
 	// turnCtx): must exceed loop's permissionTimeout (10m) so a parked
 	// permission ask can't be killed by the ceiling out from under it.
@@ -102,9 +93,13 @@ func truncateDocumentMarkdown(md string) string {
 // answer 400 instead of blaming the gateway.
 var ErrBadRequest = errors.New("bad request")
 
-// Gateway is the slice of the gateway client chat needs.
+// Gateway is the slice of the gateway client chat needs. RouteForRole
+// resolves which route currently serves one of the 4 roles Timothy
+// requires to work (D-049) — chat/turnmemory/compactor call it instead
+// of hardcoding a route name.
 type Gateway interface {
 	Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error)
+	RouteForRole(ctx context.Context, role string) (string, bool, error)
 }
 
 // SessionLog is the slice of the session store chat needs; tests fake
@@ -208,6 +203,20 @@ type Service struct {
 
 	publishSession    func(sessionID string) // nil: no session-signal push (today's default)
 	publishPermission func(sessionID string) // nil: no permission-signal push (today's default)
+}
+
+// roleRoute resolves the route currently bound to one of the 4 roles
+// Timothy requires to work (D-049): "default" or "vision". Returns ""
+// on any failure (role unbound, gateway unreachable) — callers must
+// never hard-fail a turn over this; an empty route falls through to
+// the gateway's own no_route error same as an unconfigured route
+// always has.
+func (s *Service) roleRoute(ctx context.Context, role string) string {
+	name, ok, err := s.gw.RouteForRole(ctx, role)
+	if err != nil || !ok {
+		return ""
+	}
+	return name
 }
 
 // SetSessionHub wires the "session" signal push: fires once a turn's
@@ -479,23 +488,19 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	// plain markdown text, not something the model needs vision
 	// capability to read.
 	if route == "" && len(images) > 0 {
-		// D-046: brain has no cheap way to know whether a "vision" route
-		// exists/is enabled/has a non-empty chain (gwclient exposes no
-		// routes-listing, and adding one just for this check is exactly
-		// the kind of new polling machinery we want to avoid) — so the
-		// flip is unconditional here. The gateway-side safety net
-		// (internal/gateway/api/api.go's handleStream) falls back to
-		// "default" when "vision" resolves to a missing/disabled/empty
-		// chain, so installs that never created the route still work;
-		// an existing vision route wins outright since its cheapest-first
+		// D-046: the gateway-side safety net (internal/gateway/api/api.go's
+		// handleStream) falls back to the default role's route when the
+		// vision role resolves to a missing/disabled/empty chain, so
+		// installs that never bound the vision role still work; an
+		// existing vision route wins outright since its cheapest-first
 		// chain is exactly the point of this feature.
-		route = visionRoute
+		route = s.roleRoute(ctx, "vision")
 	}
 	if route == "" {
 		route = profile.Route
 	}
 	if route == "" {
-		route = defaultRoute
+		route = s.roleRoute(ctx, "default")
 	}
 
 	sessionID := req.SessionID
@@ -713,7 +718,7 @@ func (s *Service) Retry(ctx context.Context, sessionID string) (string, <-chan s
 	}
 	route := last.Route
 	if route == "" {
-		route = defaultRoute
+		route = s.roleRoute(ctx, "default")
 	}
 	modelHint := last.ModelHint
 	route, modelHint = s.pinSensitiveRoute(ctx, events, route, modelHint)
@@ -1205,9 +1210,10 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 // text, truncated), which is exactly the channel a sensitive tool's
 // output can be quoted through — the same reasoning distill/extract
 // already pin on — so titling rides the identical route pin rather than
-// staying on defaultRoute whenever this turn (or an earlier one this
-// session) is sensitive. An empty sensitiveRoute (the common case) falls
-// through to defaultRoute exactly as before.
+// staying on the default role's route whenever this turn (or an
+// earlier one this session) is sensitive. An empty sensitiveRoute (the
+// common case) falls through to the default role's route exactly as
+// before.
 func (s *Service) autoTitle(sessionID, userText, reply, sensitiveRoute string) {
 	ctx, cancel := context.WithTimeout(context.Background(), titleTimeout)
 	defer cancel()
@@ -1215,7 +1221,7 @@ func (s *Service) autoTitle(sessionID, userText, reply, sensitiveRoute string) {
 	const titleSystem = `Produce a title for this conversation: at most 6 words, plain text, no quotes, no trailing punctuation. Reply with only the title.`
 	input := userText + "\n\n" + truncateRunes(reply, 200)
 
-	route := defaultRoute
+	route := s.roleRoute(ctx, "default")
 	if sensitiveRoute != "" {
 		route = sensitiveRoute
 	}

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -110,6 +110,10 @@ type fakeGW struct {
 	blockCh  chan struct{}
 }
 
+func (g *fakeGW) RouteForRole(_ context.Context, role string) (string, bool, error) {
+	return role, true, nil
+}
+
 func (g *fakeGW) Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
 	g.mu.Lock()
 	g.requests = append(g.requests, req)
@@ -1442,8 +1446,8 @@ func TestAutoTitleUsesDefaultRouteNotClassifyRoute(t *testing.T) {
 	defer gw.mu.Unlock()
 	for _, r := range gw.requests {
 		if r.Purpose == "title" {
-			if r.Route != defaultRoute {
-				t.Fatalf("auto-title route = %q, want %q", r.Route, defaultRoute)
+			if r.Route != "default" {
+				t.Fatalf("auto-title route = %q, want %q", r.Route, "default")
 			}
 			return
 		}
@@ -1961,6 +1965,10 @@ type slowGW struct {
 	events []stream.StreamEvent
 	delay  time.Duration
 	delays []time.Duration
+}
+
+func (g *slowGW) RouteForRole(_ context.Context, role string) (string, bool, error) {
+	return role, true, nil
 }
 
 func (g *slowGW) Stream(ctx context.Context, _ gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {

--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -50,6 +50,8 @@ type Client struct {
 	mu         sync.Mutex
 	windows    map[string]int
 	windowsExp time.Time
+	roles      map[string]string
+	rolesExp   time.Time
 }
 
 func New(baseURL string) *Client {
@@ -114,6 +116,46 @@ func (c *Client) ModelWindows(ctx context.Context) (map[string]int, error) {
 	c.windows, c.windowsExp = windows, time.Now().Add(windowsTTL)
 	c.mu.Unlock()
 	return windows, nil
+}
+
+// RouteForRole returns the name of the route currently serving role
+// ("default", "embedding", "vision", or "summarize"), or false if no
+// route is bound to it yet. Results are memoized for the gateway's
+// reload cadence, same as ModelWindows.
+func (c *Client) RouteForRole(ctx context.Context, role string) (string, bool, error) {
+	c.mu.Lock()
+	if c.roles != nil && time.Now().Before(c.rolesExp) {
+		roles := c.roles
+		c.mu.Unlock()
+		name, ok := roles[role]
+		return name, ok, nil
+	}
+	c.mu.Unlock()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/routes/roles", nil)
+	if err != nil {
+		return "", false, fmt.Errorf("gwclient: request: %w", err)
+	}
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return "", false, fmt.Errorf("gwclient: gateway unreachable: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return "", false, fmt.Errorf("gwclient: gateway http %d: %s", resp.StatusCode, string(msg))
+	}
+	var out struct {
+		Roles map[string]string `json:"roles"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", false, fmt.Errorf("gwclient: decode roles: %w", err)
+	}
+	c.mu.Lock()
+	c.roles, c.rolesExp = out.Roles, time.Now().Add(windowsTTL)
+	c.mu.Unlock()
+	name, ok := out.Roles[role]
+	return name, ok, nil
 }
 
 // Embed returns one vector per input text via the gateway's

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -31,6 +31,10 @@ type scriptedGateway struct {
 	requests []gwclient.StreamRequest
 }
 
+func (g *scriptedGateway) RouteForRole(_ context.Context, role string) (string, bool, error) {
+	return role, true, nil
+}
+
 func (g *scriptedGateway) Stream(_ context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
 	g.mu.Lock()
 	g.requests = append(g.requests, req)

--- a/internal/brain/loop/turnmemory.go
+++ b/internal/brain/loop/turnmemory.go
@@ -20,6 +20,7 @@ import (
 // Gateway is the slice of the gateway client distillation needs.
 type Gateway interface {
 	Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error)
+	RouteForRole(ctx context.Context, role string) (string, bool, error)
 }
 
 const (
@@ -30,11 +31,6 @@ const (
 	distillTimeout     = 90 * time.Second
 	maxKeyFindings     = 5
 	distillMaxAttempts = 2
-
-	// sideRoute is the default for non-sensitive turns: cheap and fast
-	// enough to run after every turn without burning local GPU time.
-	// Mirrors extract.sideRoute (internal/memory/extract/extract.go).
-	sideRoute = "summarize"
 )
 
 // distillSystem demands strict JSON. The schema mirrors
@@ -52,7 +48,9 @@ Rules: key_findings has at most 5 items, one sentence each, only durable facts w
 // internal/memory/extract/extract.go), "" otherwise.
 func DistillTurn(ctx context.Context, gw Gateway, sessionID, turnText, route string) *session.TurnMemory {
 	if route == "" {
-		route = sideRoute
+		if name, ok, err := gw.RouteForRole(ctx, "summarize"); err == nil && ok {
+			route = name
+		}
 	}
 	for attempt := 0; attempt < distillMaxAttempts; attempt++ {
 		tm, err := distillOnce(ctx, gw, sessionID, turnText, route)

--- a/internal/brain/loop/turnmemory_test.go
+++ b/internal/brain/loop/turnmemory_test.go
@@ -16,6 +16,10 @@ type scriptedGW struct {
 	lastReq gwclient.StreamRequest
 }
 
+func (g *scriptedGW) RouteForRole(_ context.Context, role string) (string, bool, error) {
+	return role, true, nil
+}
+
 func (g *scriptedGW) Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
 	g.lastReq = req
 	i := g.calls

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -27,11 +27,6 @@ const schedulerLockKey = 0x4D495353
 // anyway — at most one backfilled run after downtime, never a burst.
 const misfireGrace = 1 * time.Hour
 
-// defaultMissionRoute mirrors api.defaultMissionRoute: an agent's empty
-// route means "the default chain," but the gateway's /v1/stream
-// requires a real, non-empty route name.
-const defaultMissionRoute = "default"
-
 // Schedule is one schedules row.
 type Schedule struct {
 	ID              string          `json:"id"`
@@ -88,23 +83,27 @@ type AgentResolver func(ctx context.Context, agentID string) (AgentDefaults, boo
 // platform/migrate.go idiom rather than introducing a second
 // scheduling paradigm).
 type Scheduler struct {
-	db       *pgpool.Pool
-	missions *Store
-	resolve  AgentResolver
-	enabled  func(ctx context.Context) bool
-	log      *slog.Logger
+	db           *pgpool.Pool
+	missions     *Store
+	resolve      AgentResolver
+	enabled      func(ctx context.Context) bool
+	routeForRole func(context.Context, string) string
+	log          *slog.Logger
 }
 
 // NewScheduler wires the scheduler with the agent resolver
 // createFromTemplate uses to fill in missing route/review_route/
-// budget/prompt_overlay at fire time, and the scheduler_enabled
-// feature switch (D-032) that tick checks first — nil-safe on both:
-// a nil resolve leaves an unresolved AgentID's fields at whatever the
-// template already specified, and a nil enabled defaults every tick to
-// enabled (degrade open, since a config-read hiccup pausing every
-// schedule silently would be worse than one that keeps firing).
-func NewScheduler(db *pgpool.Pool, missions *Store, resolve AgentResolver, enabled func(ctx context.Context) bool, log *slog.Logger) *Scheduler {
-	return &Scheduler{db: db, missions: missions, resolve: resolve, enabled: enabled, log: log}
+// budget/prompt_overlay at fire time, the scheduler_enabled feature
+// switch (D-032) that tick checks first, and routeForRole (D-049) for
+// the "default" system role's route when an agent's own route is also
+// empty — nil-safe on all three: a nil resolve leaves an unresolved
+// AgentID's fields at whatever the template already specified, a nil
+// enabled defaults every tick to enabled (degrade open, since a
+// config-read hiccup pausing every schedule silently would be worse
+// than one that keeps firing), and a nil/unbound routeForRole leaves
+// the route "".
+func NewScheduler(db *pgpool.Pool, missions *Store, resolve AgentResolver, enabled func(ctx context.Context) bool, routeForRole func(context.Context, string) string, log *slog.Logger) *Scheduler {
+	return &Scheduler{db: db, missions: missions, resolve: resolve, enabled: enabled, routeForRole: routeForRole, log: log}
 }
 
 // Run ticks forever until ctx is done. Double-fire protection across
@@ -263,13 +262,13 @@ func (s *Scheduler) fireOne(ctx context.Context, tx pgx.Tx, sc Schedule, now tim
 // handler): an empty route/review_route/budget/prompt_overlay is
 // filled from the agent's current defaults, and an agent's own empty
 // route (its "use the default chain" shorthand) still falls back to
-// defaultMissionRoute since the gateway requires a real route name.
-// This inserted row bypasses Driver.Create entirely — it has no
-// session, no workspace, no grants yet — so it is provisioned lazily
-// the first time Advance/Drive touches it (see driver.go's
+// the "default" system role's route since the gateway requires a real
+// route name. This inserted row bypasses Driver.Create entirely — it
+// has no session, no workspace, no grants yet — so it is provisioned
+// lazily the first time Advance/Drive touches it (see driver.go's
 // ensureProvisioned).
 func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedule) error {
-	t, promptOverlay := resolveTemplateDefaults(ctx, sc.MissionTemplate, s.resolve)
+	t, promptOverlay := resolveTemplateDefaults(ctx, sc.MissionTemplate, s.resolve, s.routeForRole)
 	spec, _ := json.Marshal(Spec{})
 	_, err := tx.Exec(ctx, `INSERT INTO missions
 			(goal, kind, agent_id, max_iterations, budget_usd, route, review_route, prompt_overlay, auto_approve_safe, spec, schedule_id)
@@ -284,10 +283,10 @@ func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedu
 // a real pgx.Tx: an empty route/review_route/budget is filled from the
 // resolved agent's current defaults (nil-safe — a nil resolve, or one
 // that reports ok=false, leaves the template exactly as given except
-// for the final defaultMissionRoute fallback), and the resolved
-// agent's prompt overlay is returned separately since MissionTemplate
-// itself carries no such field.
-func resolveTemplateDefaults(ctx context.Context, t MissionTemplate, resolve AgentResolver) (MissionTemplate, string) {
+// for the final default-role fallback), and the resolved agent's
+// prompt overlay is returned separately since MissionTemplate itself
+// carries no such field.
+func resolveTemplateDefaults(ctx context.Context, t MissionTemplate, resolve AgentResolver, routeForRole func(context.Context, string) string) (MissionTemplate, string) {
 	promptOverlay := ""
 	if resolve != nil {
 		if defaults, ok := resolve(ctx, t.AgentID); ok {
@@ -303,11 +302,15 @@ func resolveTemplateDefaults(ctx context.Context, t MissionTemplate, resolve Age
 			promptOverlay = defaults.PromptOverlay
 		}
 	}
+	defaultRoute := ""
+	if routeForRole != nil {
+		defaultRoute = routeForRole(ctx, "default")
+	}
 	if t.Route == "" {
-		t.Route = defaultMissionRoute
+		t.Route = defaultRoute
 	}
 	if t.ReviewRoute == "" {
-		t.ReviewRoute = defaultMissionRoute
+		t.ReviewRoute = defaultRoute
 	}
 	return t, promptOverlay
 }

--- a/internal/brain/missions/scheduler_integration_test.go
+++ b/internal/brain/missions/scheduler_integration_test.go
@@ -45,8 +45,8 @@ func TestSchedulerNoDoubleFireAcrossInstances(t *testing.T) {
 		t.Fatalf("backdate schedule: %v", err)
 	}
 
-	sched1 := NewScheduler(store.db, store, nil, nil, store.log)
-	sched2 := NewScheduler(store.db, store, nil, nil, store.log)
+	sched1 := NewScheduler(store.db, store, nil, nil, nil, store.log)
+	sched2 := NewScheduler(store.db, store, nil, nil, nil, store.log)
 
 	now := time.Now()
 	var wg sync.WaitGroup
@@ -93,7 +93,7 @@ func TestSchedulerLiveQueueDedup(t *testing.T) {
 		t.Fatalf("attach schedule: %v", err)
 	}
 
-	sched := NewScheduler(store.db, store, nil, nil, store.log)
+	sched := NewScheduler(store.db, store, nil, nil, nil, store.log)
 	now := time.Now()
 	if err := sched.tick(ctx, now); err != nil {
 		t.Fatalf("tick: %v", err)

--- a/internal/brain/missions/scheduler_test.go
+++ b/internal/brain/missions/scheduler_test.go
@@ -100,20 +100,20 @@ func TestResolveTemplateDefaults(t *testing.T) {
 		wantOverlay string
 	}{
 		{
-			name:       "nil resolver falls back to defaultMissionRoute",
+			name:       "nil resolver falls back to the default role's route",
 			template:   MissionTemplate{Goal: "g", AgentID: "a1"},
 			resolve:    nil,
-			wantRoute:  defaultMissionRoute,
-			wantReview: defaultMissionRoute,
+			wantRoute:  "default",
+			wantReview: "default",
 		},
 		{
-			name:     "unresolved agent id falls back to defaultMissionRoute",
+			name:     "unresolved agent id falls back to the default role's route",
 			template: MissionTemplate{Goal: "g", AgentID: "missing"},
 			resolve: func(ctx context.Context, agentID string) (AgentDefaults, bool) {
 				return AgentDefaults{}, false
 			},
-			wantRoute:  defaultMissionRoute,
-			wantReview: defaultMissionRoute,
+			wantRoute:  "default",
+			wantReview: "default",
 		},
 		{
 			name:     "empty template fields fill from resolved agent",
@@ -140,7 +140,8 @@ func TestResolveTemplateDefaults(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, overlay := resolveTemplateDefaults(context.Background(), tc.template, tc.resolve)
+			routeForRole := func(context.Context, string) string { return "default" }
+			got, overlay := resolveTemplateDefaults(context.Background(), tc.template, tc.resolve, routeForRole)
 			if got.Route != tc.wantRoute {
 				t.Errorf("Route = %q, want %q", got.Route, tc.wantRoute)
 			}

--- a/internal/brain/session/compactor.go
+++ b/internal/brain/session/compactor.go
@@ -30,6 +30,7 @@ func renderForSummary(m provider.Message) string {
 // Gateway is the slice of the gateway client the compactor needs.
 type Gateway interface {
 	Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error)
+	RouteForRole(ctx context.Context, role string) (string, bool, error)
 }
 
 // Log is the slice of the event store the compactor needs; *Store
@@ -300,7 +301,10 @@ func (c *Compactor) summarize(ctx context.Context, sessionID string, msgs []prov
 	ctx, cancel := context.WithTimeout(ctx, compactTimeout)
 	defer cancel()
 
-	route := "summarize"
+	route := ""
+	if name, ok, err := c.gw.RouteForRole(ctx, "summarize"); err == nil && ok {
+		route = name
+	}
 	if sensitive && c.sensitive != nil && c.sensitive.Route != nil {
 		if forced := c.sensitive.Route(ctx); forced != "" {
 			route = forced

--- a/internal/brain/session/compactor_test.go
+++ b/internal/brain/session/compactor_test.go
@@ -45,6 +45,10 @@ type summarizerGW struct {
 	calls     int
 }
 
+func (g *summarizerGW) RouteForRole(_ context.Context, role string) (string, bool, error) {
+	return role, true, nil
+}
+
 func (g *summarizerGW) Stream(_ context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
 	g.calls++
 	g.sawText = req.Messages[0].Content

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -7,6 +7,7 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -338,12 +339,15 @@ func (a *Admin) Create(ctx context.Context, p Provider) (string, error) {
 	return id, nil
 }
 
-// bootstrapRoutes fills the fixed system routes' chains from a newly
-// connected provider's model metadata (D-033 follow-up): cheapest
-// capable model seeds an empty chain, appends as last fallback
-// otherwise, existing order untouched. Best-effort — a failure here
-// must never fail provider creation; the user can always wire routes
-// by hand from the Routing tab.
+// bootstrapRoutes fills the system roles' bound routes' chains from a
+// newly connected provider's model metadata (D-033 follow-up, D-049):
+// cheapest capable model seeds an empty chain, appends as last
+// fallback otherwise, existing order untouched. A role with no route
+// yet (fresh install) gets one created, named after the role itself —
+// a one-time seed value only; the row's role column is the source of
+// truth from then on, and the name is freely renamable. Best-effort —
+// a failure here must never fail provider creation; the user can
+// always wire routes by hand from the Routing tab.
 func (a *Admin) bootstrapRoutes(ctx context.Context, p router.ProviderRow) {
 	db, err := a.db.Get()
 	if err != nil {
@@ -351,21 +355,37 @@ func (a *Admin) bootstrapRoutes(ctx context.Context, p router.ProviderRow) {
 		return
 	}
 	existing := map[string][]router.ChainEntry{}
-	for _, name := range []string{"default", "summarize", "embedding", "vision"} {
-		var chainJSON []byte
-		if err := db.QueryRow(ctx, `SELECT chain FROM routes WHERE name = $1`, name).Scan(&chainJSON); err != nil {
-			a.log.Warn("route bootstrap: read route", "route", name, "error", err)
+	routeName := map[string]string{}
+	for _, sr := range router.SystemRoles {
+		var (
+			name      string
+			chainJSON []byte
+		)
+		err := db.QueryRow(ctx, `SELECT name, chain FROM routes WHERE role = $1`, sr.Role).Scan(&name, &chainJSON)
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			name = sr.Role
+			if _, err := db.Exec(ctx, `INSERT INTO routes (name, capability, role) VALUES ($1, $2, $1)`,
+				name, sr.Capability); err != nil {
+				a.log.Warn("route bootstrap: create role route", "role", sr.Role, "error", err)
+				continue
+			}
+			chainJSON = []byte("[]")
+		case err != nil:
+			a.log.Warn("route bootstrap: read role route", "role", sr.Role, "error", err)
 			continue
 		}
 		var chain []router.ChainEntry
 		if err := json.Unmarshal(chainJSON, &chain); err != nil {
-			a.log.Warn("route bootstrap: decode chain", "route", name, "error", err)
+			a.log.Warn("route bootstrap: decode chain", "role", sr.Role, "error", err)
 			continue
 		}
-		existing[name] = chain
+		routeName[sr.Role] = name
+		existing[sr.Role] = chain
 	}
 	updates := router.BootstrapChain(p, existing)
-	for name, chain := range updates {
+	for role, chain := range updates {
+		name := routeName[role]
 		// A route seeded from empty was unusable before (disabled by
 		// default, D-033) — bootstrap must flip it on, or the whole
 		// point of auto-fill (a freshly connected provider "just
@@ -373,7 +393,7 @@ func (a *Admin) bootstrapRoutes(ctx context.Context, p router.ProviderRow) {
 		// Appending a fallback to an already-configured route leaves
 		// enabled untouched: that route's on/off state is an
 		// operator decision bootstrap has no business overriding.
-		seeded := len(existing[name]) == 0
+		seeded := len(existing[role]) == 0
 		var err error
 		if seeded {
 			_, err = db.Exec(ctx, `UPDATE routes SET chain = $2, enabled = true, updated_at = now() WHERE name = $1`,
@@ -386,7 +406,7 @@ func (a *Admin) bootstrapRoutes(ctx context.Context, p router.ProviderRow) {
 			a.log.Warn("route bootstrap: write chain", "route", name, "error", err)
 			continue
 		}
-		a.audit(ctx, "bootstrap", "route", name, nil, map[string]any{"chain": chain, "provider": p.ID, "enabled": seeded})
+		a.audit(ctx, "bootstrap", "route", name, nil, map[string]any{"chain": chain, "provider": p.ID, "enabled": seeded, "role": role})
 	}
 }
 
@@ -526,12 +546,14 @@ func (a *Admin) Delete(ctx context.Context, id string) error {
 // scores behind it. Both are empty for disabled routes (the snapshot
 // holds enabled routes only) or when no snapshot is loaded yet.
 type Route struct {
-	Name     string              `json:"name"`
-	Chain    []router.ChainEntry `json:"chain"`
-	Strategy string              `json:"strategy"`
-	Enabled  bool                `json:"enabled"`
-	Resolved []RouteEntryStatus  `json:"resolved,omitempty"`
-	Serving  *router.ChainEntry  `json:"serving,omitempty"`
+	Name       string              `json:"name"`
+	Chain      []router.ChainEntry `json:"chain"`
+	Strategy   string              `json:"strategy"`
+	Enabled    bool                `json:"enabled"`
+	Capability string              `json:"capability"`
+	Role       string              `json:"role,omitempty"`
+	Resolved   []RouteEntryStatus  `json:"resolved,omitempty"`
+	Serving    *router.ChainEntry  `json:"serving,omitempty"`
 }
 
 // RouteEntryStatus is one resolved chain entry with the router's gate
@@ -599,7 +621,7 @@ func (a *Admin) Routes(ctx context.Context) ([]Route, error) {
 	if err != nil {
 		return nil, fmt.Errorf("admin routes: %w", err)
 	}
-	rows, err := db.Query(ctx, `SELECT name, chain, strategy, enabled FROM routes ORDER BY name`)
+	rows, err := db.Query(ctx, `SELECT name, chain, strategy, enabled, capability, role FROM routes ORDER BY name`)
 	if err != nil {
 		return nil, fmt.Errorf("admin routes: %w", err)
 	}
@@ -610,12 +632,16 @@ func (a *Admin) Routes(ctx context.Context) ([]Route, error) {
 		var (
 			r     Route
 			chain []byte
+			role  *string
 		)
-		if err := rows.Scan(&r.Name, &chain, &r.Strategy, &r.Enabled); err != nil {
+		if err := rows.Scan(&r.Name, &chain, &r.Strategy, &r.Enabled, &r.Capability, &role); err != nil {
 			return nil, fmt.Errorf("admin routes: %w", err)
 		}
 		if err := json.Unmarshal(chain, &r.Chain); err != nil {
 			return nil, fmt.Errorf("admin routes: chain: %w", err)
+		}
+		if role != nil {
+			r.Role = *role
 		}
 		out = append(out, r)
 	}
@@ -697,6 +723,102 @@ func (a *Admin) PatchRoute(ctx context.Context, name string, patch RoutePatch) e
 		return fmt.Errorf("admin route patch: %w", err)
 	}
 	a.audit(ctx, "update", "route", name, before, after)
+	a.reload(ctx)
+	return nil
+}
+
+var validCapabilities = map[string]bool{"chat": true, "embeddings": true, "vision": true}
+
+// CreateRoute makes a new, plain user-owned route: no role, empty
+// chain, disabled until chained (D-049 — routing has no hardcoded
+// names; any route beyond the 4 required system roles is entirely
+// user-managed).
+func (a *Admin) CreateRoute(ctx context.Context, name, capability string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("route name is required")
+	}
+	if !validCapabilities[capability] {
+		return "", fmt.Errorf("unknown capability %q", capability)
+	}
+	db, err := a.db.Get()
+	if err != nil {
+		return "", fmt.Errorf("admin create route: %w", err)
+	}
+	var id string
+	err = db.QueryRow(ctx, `INSERT INTO routes (name, capability) VALUES ($1, $2) RETURNING id`,
+		name, capability).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("admin create route: %w", err)
+	}
+	a.audit(ctx, "create", "route", name, nil, map[string]any{"capability": capability})
+	a.reload(ctx)
+	return id, nil
+}
+
+// DeleteRoute removes a route unless it's bound to one of the 4
+// required system roles — Timothy would stop working the moment its
+// only chat, embedding, vision, or summarize route disappeared, so
+// that must be an explicit role reassignment first, never an
+// incidental delete.
+func (a *Admin) DeleteRoute(ctx context.Context, name string) error {
+	db, err := a.db.Get()
+	if err != nil {
+		return fmt.Errorf("admin delete route: %w", err)
+	}
+	var role *string
+	err = db.QueryRow(ctx, `SELECT role FROM routes WHERE name = $1`, name).Scan(&role)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("route %s: %w", name, ErrNotFound)
+	}
+	if err != nil {
+		return fmt.Errorf("admin delete route: %w", err)
+	}
+	if role != nil {
+		return fmt.Errorf("route %s serves required role %q: %w", name, *role, ErrInUse)
+	}
+	if _, err := db.Exec(ctx, `DELETE FROM routes WHERE name = $1`, name); err != nil {
+		return fmt.Errorf("admin delete route: %w", err)
+	}
+	a.audit(ctx, "delete", "route", name, nil, nil)
+	a.reload(ctx)
+	return nil
+}
+
+var validRoles = map[string]bool{"default": true, "embedding": true, "vision": true, "summarize": true}
+
+// SetRouteRole moves role to be served by the route named name,
+// unbinding whichever route currently holds it (if any) in the same
+// transaction — the partial unique index on routes.role would reject
+// a bad double-write anyway, but doing it explicitly keeps the audit
+// trail clean.
+func (a *Admin) SetRouteRole(ctx context.Context, name, role string) error {
+	if !validRoles[role] {
+		return fmt.Errorf("unknown role %q", role)
+	}
+	db, err := a.db.Get()
+	if err != nil {
+		return fmt.Errorf("admin set route role: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("admin set route role: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var target string
+	if err := tx.QueryRow(ctx, `SELECT name FROM routes WHERE name = $1 FOR UPDATE`, name).Scan(&target); err != nil {
+		return fmt.Errorf("route %s: %w", name, ErrNotFound)
+	}
+	if _, err := tx.Exec(ctx, `UPDATE routes SET role = NULL, updated_at = now() WHERE role = $1 AND name != $2`, role, name); err != nil {
+		return fmt.Errorf("admin set route role: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `UPDATE routes SET role = $2, updated_at = now() WHERE name = $1`, name, role); err != nil {
+		return fmt.Errorf("admin set route role: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("admin set route role: %w", err)
+	}
+	a.audit(ctx, "update", "route_role", name, nil, map[string]any{"role": role})
 	a.reload(ctx)
 	return nil
 }

--- a/internal/gateway/api/admin.go
+++ b/internal/gateway/api/admin.go
@@ -22,7 +22,10 @@ func RegisterAdmin(srv *httpserver.Server, adm *admin.Admin) {
 	srv.Handle("POST /internal/admin/providers/validate", http.HandlerFunc(h.validate))
 	srv.Handle("GET /internal/admin/providers/health", http.HandlerFunc(h.health))
 	srv.Handle("GET /internal/admin/routes", http.HandlerFunc(h.routes))
+	srv.Handle("POST /internal/admin/routes", http.HandlerFunc(h.createRoute))
 	srv.Handle("PATCH /internal/admin/routes/{name}", http.HandlerFunc(h.patchRoute))
+	srv.Handle("DELETE /internal/admin/routes/{name}", http.HandlerFunc(h.deleteRoute))
+	srv.Handle("PUT /internal/admin/routes/{name}/role", http.HandlerFunc(h.setRouteRole))
 	srv.Handle("PATCH /internal/admin/usage/budget", http.HandlerFunc(h.patchBudget))
 	srv.Handle("PUT /internal/admin/secrets/{ref_name}", http.HandlerFunc(h.setSecret))
 	srv.Handle("DELETE /internal/admin/secrets/{ref_name}", http.HandlerFunc(h.deleteSecret))
@@ -167,6 +170,46 @@ func (h *adminAPI) patchRoute(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.adm.PatchRoute(r.Context(), r.PathValue("name"), patch); err != nil {
+		fail(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *adminAPI) createRoute(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name       string `json:"name"`
+		Capability string `json:"capability"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	id, err := h.adm.CreateRoute(r.Context(), body.Name, body.Capability)
+	if err != nil {
+		fail(w, err)
+		return
+	}
+	writeJSON(w, map[string]string{"id": id})
+}
+
+func (h *adminAPI) deleteRoute(w http.ResponseWriter, r *http.Request) {
+	if err := h.adm.DeleteRoute(r.Context(), r.PathValue("name")); err != nil {
+		fail(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *adminAPI) setRouteRole(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Role string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if err := h.adm.SetRouteRole(r.Context(), r.PathValue("name"), body.Role); err != nil {
 		fail(w, err)
 		return
 	}

--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -50,6 +50,7 @@ func Register(srv *httpserver.Server, store ConfigSource, rec ledger.Recorder, l
 	srv.Handle("POST /v1/stream", http.HandlerFunc(a.handleStream))
 	srv.Handle("POST /v1/embed", http.HandlerFunc(a.handleEmbed))
 	srv.Handle("GET /v1/providers", http.HandlerFunc(a.handleProviders))
+	srv.Handle("GET /v1/routes/roles", http.HandlerFunc(a.handleRoleRoutes))
 	srv.Handle("POST /internal/reload", http.HandlerFunc(a.handleReload))
 }
 
@@ -129,22 +130,26 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var nre *router.NoRouteError
 		if errors.As(err, &nre) {
-			// D-046 safety net: brain flips an image message to "vision"
-			// unconditionally (it has no cheap way to know whether the
-			// route exists on this install). When "vision" is missing,
-			// disabled, or has an empty chain, Resolve returns a
-			// NoRouteError with no Skipped entries — nothing was even
-			// tried. That's distinct from the chain existing but every
-			// entry lacking the vision capability (Skipped is non-empty
-			// there): THAT case must still error, since falling back
-			// would silently serve an image turn on a model that can't
-			// see it. Any other unknown/misconfigured route keeps
-			// erroring — this fallback is vision-only, not generic
-			// route-aliasing.
-			if req.Route == "vision" && len(nre.Skipped) == 0 {
-				a.log.Warn("vision route unresolvable, falling back to default", "reason", nre.Error())
-				req.Route = "default"
-				attempts, err = snap.Resolve(req.Route, req.ModelHint, sticky, requiredVisionCapability(req.Messages)...)
+			// D-046 safety net: brain flips an image message to the
+			// vision role's route unconditionally (it has no cheap way
+			// to know whether that route exists on this install). When
+			// the requested route is missing, disabled, or has an empty
+			// chain, Resolve returns a NoRouteError with no Skipped
+			// entries — nothing was even tried. That's distinct from the
+			// chain existing but every entry lacking the vision
+			// capability (Skipped is non-empty there): THAT case must
+			// still error, since falling back would silently serve an
+			// image turn on a model that can't see it. Keyed on the
+			// message needing vision at all (not on the requested route's
+			// name — routes have no hardcoded names, D-049) so this stays
+			// vision-only, not generic route-aliasing.
+			needsVision := len(requiredVisionCapability(req.Messages)) > 0
+			if needsVision && len(nre.Skipped) == 0 {
+				if defaultRoute, ok := snap.RouteForRole("default"); ok {
+					a.log.Warn("vision route unresolvable, falling back to default", "reason", nre.Error())
+					req.Route = defaultRoute
+					attempts, err = snap.Resolve(req.Route, req.ModelHint, sticky, requiredVisionCapability(req.Messages)...)
+				}
 			}
 		}
 		if err != nil {
@@ -364,7 +369,12 @@ func (a *API) handleEmbed(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusServiceUnavailable, "config_unavailable", "routing configuration not loaded yet")
 		return
 	}
-	attempts, err := snap.Resolve("embedding", req.ModelHint, router.Sticky{})
+	embeddingRoute, ok := snap.RouteForRole("embedding")
+	if !ok {
+		jsonError(w, http.StatusBadGateway, "no_route", "no route is bound to the embedding role")
+		return
+	}
+	attempts, err := snap.Resolve(embeddingRoute, req.ModelHint, router.Sticky{})
 	if err != nil {
 		jsonError(w, http.StatusBadGateway, "no_route", err.Error())
 		return
@@ -383,7 +393,7 @@ func (a *API) handleEmbed(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		entry := ledger.Entry{
 			Provider: att.ProviderName, Model: att.Model,
-			Route: "embedding", Purpose: req.Purpose, SessionID: req.SessionID,
+			Route: embeddingRoute, Purpose: req.Purpose, SessionID: req.SessionID,
 		}
 
 		vecs, usage, err := emb.Embed(r.Context(), att.Model, req.Texts)
@@ -444,6 +454,26 @@ func (a *API) handleProviders(w http.ResponseWriter, r *http.Request) {
 		"providers": list,
 		"routes":    snap.Routes(),
 	})
+}
+
+// handleRoleRoutes reports which route currently serves each of the 4
+// roles Timothy requires to work (D-049) — brain resolves the routes
+// for chat/embedding/vision/summarize through this instead of a
+// hardcoded name, so a route rename or reassignment never needs a
+// brain-side code change.
+func (a *API) handleRoleRoutes(w http.ResponseWriter, r *http.Request) {
+	snap := a.store.Snapshot()
+	if snap == nil {
+		jsonError(w, http.StatusServiceUnavailable, "config_unavailable", "routing configuration not loaded yet")
+		return
+	}
+	roles := map[string]string{}
+	for _, role := range []string{"default", "embedding", "vision", "summarize"} {
+		if name, ok := snap.RouteForRole(role); ok {
+			roles[role] = name
+		}
+	}
+	writeJSON(w, map[string]any{"roles": roles})
 }
 
 func (a *API) handleReload(w http.ResponseWriter, r *http.Request) {

--- a/internal/gateway/api/api_test.go
+++ b/internal/gateway/api/api_test.go
@@ -124,7 +124,7 @@ func snapshotFor(t *testing.T, firstURL, secondURL string) *router.Snapshot {
 		{Name: "coding", Chain: []router.ChainEntry{
 			{ProviderID: "p1", Model: "m1"}, {ProviderID: "p2", Model: "m2"},
 		}, Enabled: true},
-		{Name: "embedding", Chain: []router.ChainEntry{
+		{Name: "embedding", Capability: "embeddings", Role: "embedding", Chain: []router.ChainEntry{
 			{ProviderID: "p1", Model: "m1"},
 		}, Enabled: true},
 	}
@@ -387,7 +387,7 @@ func TestStreamVisionRouteMissingFallsBackToDefault(t *testing.T) {
 			Models: []router.ModelInfo{{ID: "m1", Capabilities: []string{"chat", "vision"}}}},
 	}
 	routes := []router.RouteRow{
-		{Name: "default", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: true},
+		{Name: "default", Role: "default", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: true},
 		// no "vision" route row at all.
 	}
 	snap, err := router.BuildSnapshot(rows, routes, func(string) string { return "" })
@@ -433,8 +433,8 @@ func TestStreamVisionRouteDisabledFallsBackToDefault(t *testing.T) {
 			Models: []router.ModelInfo{{ID: "m1", Capabilities: []string{"chat", "vision"}}}},
 	}
 	routes := []router.RouteRow{
-		{Name: "default", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: true},
-		{Name: "vision", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: false},
+		{Name: "default", Role: "default", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: true},
+		{Name: "vision", Role: "vision", Capability: "vision", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: false},
 	}
 	snap, err := router.BuildSnapshot(rows, routes, func(string) string { return "" })
 	if err != nil {
@@ -468,8 +468,8 @@ func TestStreamVisionRoutePresentNoFallback(t *testing.T) {
 			Models: []router.ModelInfo{{ID: "dm", Capabilities: []string{"chat", "vision"}}}},
 	}
 	routes := []router.RouteRow{
-		{Name: "vision", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "vm"}}, Enabled: true},
-		{Name: "default", Chain: []router.ChainEntry{{ProviderID: "p2", Model: "dm"}}, Enabled: true},
+		{Name: "vision", Role: "vision", Capability: "vision", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "vm"}}, Enabled: true},
+		{Name: "default", Role: "default", Chain: []router.ChainEntry{{ProviderID: "p2", Model: "dm"}}, Enabled: true},
 	}
 	snap, err := router.BuildSnapshot(rows, routes, func(string) string { return "" })
 	if err != nil {
@@ -511,7 +511,7 @@ func TestStreamVisionCapabilityExhaustedNoFallback(t *testing.T) {
 			Models: []router.ModelInfo{{ID: "m1", Capabilities: []string{"chat"}}}}, // no vision
 	}
 	routes := []router.RouteRow{
-		{Name: "vision", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: true},
+		{Name: "vision", Role: "vision", Capability: "vision", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: true},
 	}
 	snap, err := router.BuildSnapshot(rows, routes, func(string) string { return "" })
 	if err != nil {
@@ -583,7 +583,7 @@ func TestEmbedSkipsIncapableDriverAtResolve(t *testing.T) {
 			Models: []router.ModelInfo{{ID: "m1"}}},
 	}
 	routes := []router.RouteRow{
-		{Name: "embedding", Chain: []router.ChainEntry{
+		{Name: "embedding", Capability: "embeddings", Role: "embedding", Chain: []router.ChainEntry{
 			{ProviderID: "p0", Model: "m0"}, {ProviderID: "p1", Model: "m1"},
 		}, Enabled: true},
 	}

--- a/internal/gateway/router/bootstrap.go
+++ b/internal/gateway/router/bootstrap.go
@@ -5,22 +5,28 @@ import (
 	"sort"
 )
 
-// bootstrapRoutes are the fixed system routes a connected provider can
-// auto-fill: chat-capable for default/summarize, embeddings-capable
-// for embedding, vision-capable for vision (D-046). research is
-// agent-specific and stays hand-configured.
-var bootstrapRoutes = map[string]string{
-	"default":   "chat",
-	"summarize": "chat",
-	"embedding": "embeddings",
-	"vision":    "vision",
+// SystemRoles are the roles Timothy requires to work at all — chat
+// (role "default"), the session/turn-memory summarizer (role
+// "summarize"), embeddings (role "embedding"), and vision (role
+// "vision", D-046) — each paired with the driver capability its
+// bound route must serve. A newly connected provider auto-fills
+// whichever of these roles it can. Any other route (e.g. a hand-made
+// "research" or "coding" route) is plain user configuration and is
+// never auto-filled.
+var SystemRoles = []struct{ Role, Capability string }{
+	{"default", "chat"},
+	{"summarize", "chat"},
+	{"embedding", "embeddings"},
+	{"vision", "vision"},
 }
 
-// BootstrapChain computes route-name -> new-chain-entry for a newly
-// connected (or re-saved) provider, applied to routes whose CURRENT
-// chain is passed in via existing. A route with no capable model in
-// the new provider is omitted from the result — callers apply only
-// what's returned, so unrelated routes are untouched.
+// BootstrapChain computes role -> new-chain-entry for a newly
+// connected (or re-saved) provider, applied to the role's CURRENT
+// chain passed in via existing (keyed by role, not route name — the
+// caller resolves each role to its bound route's chain before
+// calling this). A role with no capable model in the new provider is
+// omitted from the result — callers apply only what's returned, so
+// unrelated roles are untouched.
 //
 // Rule (D-033 follow-up): an empty chain is seeded with the provider's
 // cheapest capable model; a non-empty chain gets that model appended
@@ -31,19 +37,19 @@ func BootstrapChain(p ProviderRow, existing map[string][]ChainEntry) map[string]
 		return nil
 	}
 	out := map[string][]ChainEntry{}
-	for route, needed := range bootstrapRoutes {
-		model, ok := cheapestCapable(p.Models, needed)
+	for _, sr := range SystemRoles {
+		model, ok := cheapestCapable(p.Models, sr.Capability)
 		if !ok {
 			continue
 		}
 		entry := ChainEntry{ProviderID: p.ID, Model: model}
-		chain := existing[route]
+		chain := existing[sr.Role]
 		if alreadyChained(chain, p.ID, model) {
 			continue
 		}
 		next := make([]ChainEntry, len(chain), len(chain)+1)
 		copy(next, chain)
-		out[route] = append(next, entry)
+		out[sr.Role] = append(next, entry)
 	}
 	return out
 }

--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -76,18 +76,28 @@ type RouteRow struct {
 	Chain    []ChainEntry
 	Strategy string
 	Enabled  bool
+	// Capability is what this route can serve: "chat", "embeddings", or
+	// "vision" — replaces matching on the route's name to infer this.
+	Capability string
+	// Role marks this route as the one serving a function Timothy
+	// requires to work (D-049): "default", "embedding", "vision", or
+	// "summarize". Empty for a plain, user-owned route. At most one
+	// route holds a given role (enforced by a partial unique index).
+	Role string
 }
 
 // Snapshot is an immutable view of the routing configuration plus the
 // providers built from it. Store swaps whole snapshots atomically.
 type Snapshot struct {
-	rows     map[string]ProviderRow // by id
-	byName   map[string]ProviderRow
-	routes   map[string][]ChainEntry // enabled routes only
-	strategy map[string]string       // route name -> chain strategy
-	stats    map[string]ModelStats   // "provider/model" -> recent ledger stats
-	registry *provider.Registry
-	healthy  map[string]bool // by name: credential ref resolved
+	rows       map[string]ProviderRow // by id
+	byName     map[string]ProviderRow
+	routes     map[string][]ChainEntry // enabled routes only
+	strategy   map[string]string       // route name -> chain strategy
+	capability map[string]string       // route name -> capability (all routes, not just enabled)
+	roleRoute  map[string]string       // role -> route name (all routes, not just enabled)
+	stats      map[string]ModelStats   // "provider/model" -> recent ledger stats
+	registry   *provider.Registry
+	healthy    map[string]bool // by name: credential ref resolved
 }
 
 // ModelStats are time-decayed aggregates from the recent cost ledger,
@@ -133,11 +143,13 @@ func (e *NoRouteError) Error() string {
 // unhealthy (skipped by routing) without failing the build.
 func BuildSnapshot(provRows []ProviderRow, routeRows []RouteRow, lookup func(string) string) (*Snapshot, error) {
 	s := &Snapshot{
-		rows:     make(map[string]ProviderRow, len(provRows)),
-		byName:   make(map[string]ProviderRow, len(provRows)),
-		routes:   map[string][]ChainEntry{},
-		strategy: map[string]string{},
-		healthy:  make(map[string]bool, len(provRows)),
+		rows:       make(map[string]ProviderRow, len(provRows)),
+		byName:     make(map[string]ProviderRow, len(provRows)),
+		routes:     map[string][]ChainEntry{},
+		strategy:   map[string]string{},
+		capability: map[string]string{},
+		roleRoute:  map[string]string{},
+		healthy:    make(map[string]bool, len(provRows)),
 	}
 
 	cfgs := make([]provider.Config, 0, len(provRows))
@@ -169,6 +181,10 @@ func BuildSnapshot(provRows []ProviderRow, routeRows []RouteRow, lookup func(str
 	s.registry = reg
 
 	for _, r := range routeRows {
+		s.capability[r.Name] = r.Capability
+		if r.Role != "" {
+			s.roleRoute[r.Role] = r.Name
+		}
 		if r.Enabled {
 			s.routes[r.Name] = r.Chain
 			s.strategy[r.Name] = r.Strategy
@@ -177,14 +193,28 @@ func BuildSnapshot(provRows []ProviderRow, routeRows []RouteRow, lookup func(str
 	return s, nil
 }
 
+// RouteForRole returns the name of the route currently bound to role
+// ("default", "embedding", "vision", or "summarize"), or false if no
+// route holds that role yet (e.g. not bootstrapped on a fresh
+// install).
+func (s *Snapshot) RouteForRole(role string) (string, bool) {
+	name, ok := s.roleRoute[role]
+	return name, ok
+}
+
 // requiredCapability maps a route to the driver capability its
 // attempts must declare (D-005: routing never assumes an undeclared
-// capability).
-func requiredCapability(route string) provider.Capability {
-	if route == "embedding" {
+// capability), from the route's own declared capability rather than
+// matching its name.
+func (s *Snapshot) requiredCapability(route string) provider.Capability {
+	switch s.capability[route] {
+	case "embeddings":
 		return provider.CapEmbeddings
+	case "vision":
+		return provider.CapVision
+	default:
+		return provider.CapChat
 	}
-	return provider.CapChat
 }
 
 // Sticky names the provider+model that served a session's last
@@ -210,7 +240,7 @@ type Sticky struct {
 // CapVision when the request carries images (D-045); most callers pass
 // none.
 func (s *Snapshot) Resolve(route, hint string, sticky Sticky, extra ...provider.Capability) ([]Attempt, error) {
-	required := append([]provider.Capability{requiredCapability(route)}, extra...)
+	required := append([]provider.Capability{s.requiredCapability(route)}, extra...)
 	var attempts []Attempt
 	var skipped []string
 	seen := map[string]bool{} // "name/model" dedupe across hint + sticky + chain
@@ -336,7 +366,7 @@ type ResolvedEntry struct {
 func (s *Snapshot) ResolveDetail(route string) []ResolvedEntry {
 	chain := s.routes[route]
 	w, scoredStrategy := strategyWeights[s.strategy[route]]
-	required := []provider.Capability{requiredCapability(route)}
+	required := []provider.Capability{s.requiredCapability(route)}
 
 	// Gather each entry's raw factors first: normalization needs the
 	// best value across the candidate set.

--- a/internal/gateway/router/router_test.go
+++ b/internal/gateway/router/router_test.go
@@ -44,7 +44,7 @@ func testSnapshot(t *testing.T, lookups map[string]string) *Snapshot {
 		{Name: "ghost", Chain: []ChainEntry{
 			{ProviderID: "nope", Model: "m"},
 		}, Enabled: true},
-		{Name: "embedding", Chain: []ChainEntry{
+		{Name: "embedding", Capability: "embeddings", Chain: []ChainEntry{
 			{ProviderID: "p1", Model: "embed-a"}, // anthropic driver: no embeddings
 			{ProviderID: "p2", Model: "embed-b"},
 		}, Enabled: true},
@@ -209,7 +209,7 @@ func TestResolveModelLevelCapabilities(t *testing.T) {
 			{ProviderID: "p1", Model: "nova"},
 			{ProviderID: "p1", Model: "undeclared"}, // driver decides: keep
 		}, Enabled: true},
-		{Name: "embedding", Chain: []ChainEntry{
+		{Name: "embedding", Capability: "embeddings", Chain: []ChainEntry{
 			{ProviderID: "p1", Model: "nova"}, // chat-only model: skip
 			{ProviderID: "p1", Model: "titan-embed"},
 		}, Enabled: true},

--- a/internal/gateway/router/store.go
+++ b/internal/gateway/router/store.go
@@ -124,7 +124,7 @@ func (s *Store) Load(ctx context.Context) error {
 		return fmt.Errorf("router: providers rows: %w", err)
 	}
 
-	routeRows, err := tx.Query(ctx, `SELECT name, chain, strategy, enabled FROM routes`)
+	routeRows, err := tx.Query(ctx, `SELECT name, chain, strategy, enabled, capability, role FROM routes`)
 	if err != nil {
 		return fmt.Errorf("router: query routes: %w", err)
 	}
@@ -135,12 +135,16 @@ func (s *Store) Load(ctx context.Context) error {
 		var (
 			row       RouteRow
 			chainJSON []byte
+			role      *string
 		)
-		if err := routeRows.Scan(&row.Name, &chainJSON, &row.Strategy, &row.Enabled); err != nil {
+		if err := routeRows.Scan(&row.Name, &chainJSON, &row.Strategy, &row.Enabled, &row.Capability, &role); err != nil {
 			return fmt.Errorf("router: scan route: %w", err)
 		}
 		if err := json.Unmarshal(chainJSON, &row.Chain); err != nil {
 			return fmt.Errorf("router: route %s chain: %w", row.Name, err)
+		}
+		if role != nil {
+			row.Role = *role
 		}
 		routes = append(routes, row)
 	}

--- a/internal/gateway/router/store_integration_test.go
+++ b/internal/gateway/router/store_integration_test.go
@@ -66,14 +66,16 @@ func TestStoreLoadsSeededConfig(t *testing.T) {
 		t.Fatal("nil snapshot after successful load")
 	}
 
-	// Providers are never seeded — only the route names the code
-	// references (0002), empty-chained and disabled. Disabled routes
-	// don't enter the snapshot, so assert against the table itself.
+	// Providers are never seeded — only the 4 routes Timothy needs to
+	// work, empty-chained and disabled (0036 drops the never-configured
+	// research/local/coding seed rows on a fresh install). Disabled
+	// routes don't enter the snapshot, so assert against the table
+	// itself.
 	db, err := s.db.Get()
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	for _, want := range []string{"default", "summarize", "embedding", "research"} {
+	for _, want := range []string{"default", "summarize", "embedding", "vision"} {
 		var n int
 		if err := db.QueryRow(t.Context(),
 			"SELECT count(*) FROM routes WHERE name = $1", want).Scan(&n); err != nil {

--- a/migrations/0036_dynamic_routes.sql
+++ b/migrations/0036_dynamic_routes.sql
@@ -1,0 +1,29 @@
+-- Routing becomes fully dynamic (no hardcoded route names in code):
+-- capability is what a route can serve (chat/embeddings/vision,
+-- replacing the name=="embedding" special case in
+-- internal/gateway/router/router.go); role marks which route serves
+-- one of the 4 functions Timothy requires to work at all
+-- (default/embedding/vision/summarize). A route's name is now free
+-- text the user can rename at will — code resolves "the route with
+-- role = X", never a literal name.
+ALTER TABLE routes ADD COLUMN IF NOT EXISTS capability text NOT NULL DEFAULT 'chat'
+    CHECK (capability IN ('chat', 'embeddings', 'vision'));
+ALTER TABLE routes ADD COLUMN IF NOT EXISTS role text
+    CHECK (role IN ('default', 'embedding', 'vision', 'summarize'));
+CREATE UNIQUE INDEX IF NOT EXISTS routes_role_unique_idx ON routes (role) WHERE role IS NOT NULL;
+
+-- Backfill existing fixed-name rows so upgraders keep their meaning.
+-- 'research'/'local'/'coding' get no role — they become plain
+-- user-owned routes going forward.
+UPDATE routes SET capability = 'embeddings', role = 'embedding' WHERE name = 'embedding' AND role IS NULL;
+UPDATE routes SET capability = 'vision', role = 'vision' WHERE name = 'vision' AND role IS NULL;
+UPDATE routes SET role = 'default' WHERE name = 'default' AND role IS NULL;
+UPDATE routes SET role = 'summarize' WHERE name = 'summarize' AND role IS NULL;
+
+-- 'research'/'local'/'coding' were seeded by 0002/0022 with an empty
+-- chain and disabled, for every install to date (no create/delete UI
+-- existed before this migration, so no real user chain can exist
+-- under those names yet). Drop the never-configured seed rows so a
+-- fresh install starts with only the 4 required routes; an upgrader
+-- who already gave one of these a chain keeps that row untouched.
+DELETE FROM routes WHERE name IN ('research', 'local', 'coding') AND role IS NULL AND chain = '[]' AND enabled = false;

--- a/skills/coding-task/SKILL.md
+++ b/skills/coding-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding-task
-description: Disciplined software changes — plan first, test first, verify end-to-end. Use when writing, modifying, debugging, or reviewing code, or when a task produces anything a compiler, interpreter, or test suite will judge.
+description: Disciplined software changes: plan first, test first, verify end-to-end. Use when writing, modifying, debugging, or reviewing code, or when a task produces anything a compiler, interpreter, or test suite will judge.
 ---
 
 # Coding task discipline
@@ -10,7 +10,7 @@ description: Disciplined software changes — plan first, test first, verify end
 - State the plan before the first edit: what changes, where, and how you will know it worked.
 - Write or identify the failing test before writing the fix; a bug you cannot reproduce is a bug you cannot claim to have fixed.
 - Make the smallest change that satisfies the requirement; delete nothing you did not orphan yourself.
-- Build and run the tests after every coherent step, not once at the end — a broken intermediate state with ten changes in flight has ten suspects.
+- Build and run the tests after every coherent step, not once at the end: a broken intermediate state with ten changes in flight has ten suspects.
 - Read the actual error message before theorizing; quote it, don't paraphrase it.
 - When a fix doesn't work, revert to the last known-good state before trying the next idea; stacked failed attempts compound.
 - Match the codebase's existing style, naming, and idiom even where you disagree with it.
@@ -27,13 +27,13 @@ description: Disciplined software changes — plan first, test first, verify end
 | "I'll clean this up later" | Later never has more context than now. |
 | "The existing style is bad, I'll improve it while I'm here" | Unrequested churn hides the real change and breaks review. |
 
-## Red flags — stop and re-check
+## Red flags: stop and re-check
 
 - You are about to change a test's expected value to match new output.
 - You cannot explain why the fix works, only that it does.
 - The diff touches files unrelated to the stated task.
 - You are adding a sleep, retry, or timeout to make a test pass.
-- Two consecutive fix attempts failed — stop patching, start reading.
+- Two consecutive fix attempts failed: stop patching, start reading.
 
 ## Evidence required
 

--- a/skills/daily-briefing/SKILL.md
+++ b/skills/daily-briefing/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: daily-briefing
-description: Writes a structured briefing covering every topic named in the mission goal, plus calendar/email highlights when connected. Use when running a scheduled/recurring briefing mission — never for one-off research or chat answers.
+description: Writes a structured briefing covering every topic named in the mission goal, plus calendar/email highlights when connected. Use when running a scheduled/recurring briefing mission, never for one-off research or chat answers.
 ---
 
 # Daily briefing discipline
 
 ## Rules
 
-- Cover EVERY topic named in the mission goal — check each one with web_search. A topic with nothing new still gets a line saying so; never silently drop it.
+- Cover EVERY topic named in the mission goal: check each one with web_search. A topic with nothing new still gets a line saying so; never silently drop it.
 - Last ~24 hours only: this is a daily brief, not a history lesson. Older context only if a topic literally has nothing from the last day.
-- Every claim carries a source URL and a date/time — a briefing fact with no citation is not a fact, it's a guess.
-- Calendar section only when a calendar tool is actually available. If it's not, write "calendar not connected" — never invent events or imply a schedule you cannot see.
+- Every claim carries a source URL and a date/time: a briefing fact with no citation is not a fact, it's a guess.
+- Calendar section only when a calendar tool is actually available. If it's not, write "calendar not connected"; never invent events or imply a schedule you cannot see.
 - Email section only when a gmail tool is available: use `gmail_search is:unread newer_than:1d`, summarize senders and subjects, never long quotes from message bodies. No tool available → "email not connected".
-- Write the full briefing as `briefing.md` at the workspace root via write_file — this is the mission's artifact contract; nothing else counts as the deliverable.
-- Structure every briefing the same way: Topics (one subsection per goal topic), Calendar, Email, Sources — consistency is what makes a recurring brief scannable at a glance.
-- Only call gmail_send if the mission goal explicitly names a recipient. Subject line: "Daily briefing — <date>". No goal-named recipient → never send, the artifact alone is the deliverable.
+- Write the full briefing as `briefing.md` at the workspace root via write_file: this is the mission's artifact contract; nothing else counts as the deliverable.
+- Structure every briefing the same way: Topics (one subsection per goal topic), Calendar, Email, Sources; consistency is what makes a recurring brief scannable at a glance.
+- Only call gmail_send if the mission goal explicitly names a recipient. Subject line: "Daily briefing, <date>". No goal-named recipient → never send, the artifact alone is the deliverable.
 
 ## Anti-rationalization
 
@@ -22,10 +22,10 @@ description: Writes a structured briefing covering every topic named in the miss
 |---|---|
 | "This topic had nothing, skip it" | The reader expects every goal topic accounted for; "nothing new" is itself the answer. |
 | "I remember calendar tools were connected last time" | Check THIS turn's tool list; connectivity can change between runs. |
-| "Paraphrasing the email preview is basically quoting it" | Keep it to sender + subject + one-line gist — the reader can open their own inbox for more. |
+| "Paraphrasing the email preview is basically quoting it" | Keep it to sender + subject + one-line gist; the reader can open their own inbox for more. |
 | "The goal didn't say NOT to email it" | Silence is not permission; only an explicit recipient in the goal authorizes gmail_send. |
 
-## Red flags — stop and re-check
+## Red flags: stop and re-check
 
 - A topic named in the mission goal is missing from the briefing entirely.
 - A claim has no source URL or no date.

--- a/skills/email-research/SKILL.md
+++ b/skills/email-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: email-research
-description: Searches, reads, and aggregates Gmail content — finding bookings, costs, topics, or senders, and summarizing or digesting threads. Use when the ask involves email in any way: finding a message, extracting amounts or dates from mail, summarizing a thread, or digesting what a sender or label contains.
+description: Searches, reads, and aggregates Gmail content, finding bookings, costs, topics, or senders, and summarizing or digesting threads. Use when the ask involves email in any way: finding a message, extracting amounts or dates from mail, summarizing a thread, or digesting what a sender or label contains.
 ---
 
 # Email research discipline
@@ -10,20 +10,20 @@ description: Searches, reads, and aggregates Gmail content — finding bookings,
 - Gmail query operators, used correctly:
   - Quote multi-word phrases: `subject:"booking confirmation"`, not `subject:booking confirmation` (the latter only matches the first word as the operator's argument).
   - `from:`/`to:` take an address or domain: `from:noreply@airline.com`, `from:airline.com`.
-  - OR grouping: `{from:a@x.com from:b@x.com}` or `(from:a@x.com OR from:b@x.com)` — bare `OR` between terms with no parens/braces is parsed unreliably, always group it explicitly.
+  - OR grouping: `{from:a@x.com from:b@x.com}` or `(from:a@x.com OR from:b@x.com)`; bare `OR` between terms with no parens/braces is parsed unreliably, always group it explicitly.
   - Date bounds: `after:YYYY/MM/DD`, `before:YYYY/MM/DD`, `newer_than:Nd` (or `Nm`/`Ny`), `older_than:Nd`.
   - `has:attachment`, `label:`, `category:`, `is:unread`, `is:read`.
-- Date bounds MUST be derived from the current date in the system prompt — never a guessed or recalled year. If a search built from a "today" you assumed returns nothing, re-derive the bound from the actual system-prompt date before concluding the mail isn't there.
-- Pipeline discipline: start broad (wide date range, no subject/keyword narrowing), then narrow iteratively — a `from:` combined with subject/keyword terms narrows twice and a near-miss becomes a zero-result search.
-- A `gmail_search` result (subjects, senders, snippets) is a digest, not content. Before citing or aggregating what is "in" any message, `gmail_read` it — snippets truncate and routinely omit the amount, date, or detail you need.
-- Extract every amount together with its currency (`$42.50`, `€19`, `12.00 USD`) — a bare number is not usable in a total.
-- All arithmetic (sums, counts, averages) goes through the `calculate` tool — never add or estimate in your head. Show the expression you evaluated.
+- Date bounds MUST be derived from the current date in the system prompt, never a guessed or recalled year. If a search built from a "today" you assumed returns nothing, re-derive the bound from the actual system-prompt date before concluding the mail isn't there.
+- Pipeline discipline: start broad (wide date range, no subject/keyword narrowing), then narrow iteratively; a `from:` combined with subject/keyword terms narrows twice and a near-miss becomes a zero-result search.
+- A `gmail_search` result (subjects, senders, snippets) is a digest, not content. Before citing or aggregating what is "in" any message, `gmail_read` it: snippets truncate and routinely omit the amount, date, or detail you need.
+- Extract every amount together with its currency (`$42.50`, `€19`, `12.00 USD`): a bare number is not usable in a total.
+- All arithmetic (sums, counts, averages) goes through the `calculate` tool; never add or estimate in your head. Show the expression you evaluated.
 - Any total or aggregate figure shows its per-item breakdown (each item's amount and source email) alongside the total, not the total alone.
 - Distinguish confirmations/receipts from marketing and reminders, even from the same sender domain: a confirmation states a completed transaction with an amount and reference number; marketing and reminders promise, upsell, or nudge. Label which is which rather than lumping every message from a domain together.
 
 ## Multi-currency
 
-- Report one subtotal PER currency present — never silently convert or combine different currencies into one number.
+- Report one subtotal PER currency present; never silently convert or combine different currencies into one number.
 - If a conversion is explicitly requested, state the rate and its date/source; otherwise leave amounts in their original currency.
 
 ## Anti-rationalization
@@ -31,13 +31,13 @@ description: Searches, reads, and aggregates Gmail content — finding bookings,
 | Excuse | Rebuttal |
 |---|---|
 | "The snippet already shows the amount" | Snippets truncate; gmail_read the message before citing a figure from it. |
-| "I can add these three numbers myself" | Mental arithmetic on amounts you'll report as fact goes through calculate — no exceptions. |
+| "I can add these three numbers myself" | Mental arithmetic on amounts you'll report as fact goes through calculate, no exceptions. |
 | "Combining $40 and €40 into one total is close enough" | Different currencies are different totals; report each separately. |
 | "It's from the same sender as the confirmation, so it counts" | Marketing and reminders from that domain are not the transaction; label them separately. |
-| "The user's message implies this year" | Never guess a year — read it from the system prompt's current date. |
-| "No Gmail tool is available, but I probably know the answer" | Say "email not connected" — never answer from assumption when the tool is simply missing. |
+| "The user's message implies this year" | Never guess a year: read it from the system prompt's current date. |
+| "No Gmail tool is available, but I probably know the answer" | Say "email not connected"; never answer from assumption when the tool is simply missing. |
 
-## Red flags — stop and re-check
+## Red flags: stop and re-check
 
 - An amount is being reported without its currency.
 - A total appears with no per-item breakdown, or was computed without calculate.

--- a/skills/markets-digest/SKILL.md
+++ b/skills/markets-digest/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: markets-digest
-description: Structured watchlist digests of market and asset movements. Use when summarizing market activity, portfolio positions, or price movements for a watchlist — never for advice on what to buy or sell.
+description: Structured watchlist digests of market and asset movements. Use when summarizing market activity, portfolio positions, or price movements for a watchlist, never for advice on what to buy or sell.
 ---
 
 # Markets digest discipline
 
 ## Rules
 
-- Report, never advise: describe what moved and the stated reasons attributed by sources — no buy/sell/hold language, no "opportunity", no "attractive entry".
+- Report, never advise: describe what moved and the stated reasons attributed by sources; no buy/sell/hold language, no "opportunity", no "attractive entry".
 - Every price and percentage carries its timestamp and source; markets move while you write.
-- Structure every digest the same way: headline moves, watchlist detail, notable events, sources — consistency is what makes digests scannable.
+- Structure every digest the same way: headline moves, watchlist detail, notable events, sources; consistency is what makes digests scannable.
 - Percentages need a baseline: "up 3%" means nothing without "since yesterday's close".
-- Attribute causes as attributions ("analysts attributed the drop to…"), not as facts — nobody knows why markets move.
+- Attribute causes as attributions ("analysts attributed the drop to…"), not as facts: nobody knows why markets move.
 - Distinguish realized events (earnings released) from expectations (earnings due Thursday).
 - Note currency and exchange for every quote; the same ticker trades in several places.
-- If data could not be fetched for a watchlist item, list it with "no data" — a silently missing item reads as "nothing happened".
+- If data could not be fetched for a watchlist item, list it with "no data"; a silently missing item reads as "nothing happened".
 
 ## Anti-rationalization
 
@@ -25,7 +25,7 @@ description: Structured watchlist digests of market and asset movements. Use whe
 | "Skipping the flat items keeps it short" | The reader tracks the whole watchlist; flat is information too. |
 | "Yesterday's price is fine" | Stale quotes presented as current are worse than no quote. |
 
-## Red flags — stop and re-check
+## Red flags: stop and re-check
 
 - The draft contains "should", "opportunity", "overvalued", or a price target.
 - A percentage appears without its baseline period.
@@ -36,4 +36,4 @@ description: Structured watchlist digests of market and asset movements. Use whe
 
 - Source and timestamp on every figure.
 - The full watchlist accounted for, including flat and no-data items.
-- Framing check: zero directives, zero recommendations — this is a hard rule, not a style preference.
+- Framing check: zero directives, zero recommendations; this is a hard rule, not a style preference.

--- a/skills/research-brief/SKILL.md
+++ b/skills/research-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-brief
-description: Source-grounded research with verification and citations. Use when a question needs facts you must look up — current events, prices, specifications, laws, schedules, or any claim the user will act on.
+description: Source-grounded research with verification and citations. Use when a question needs facts you must look up: current events, prices, specifications, laws, schedules, or any claim the user will act on.
 ---
 
 # Research brief discipline
@@ -13,19 +13,19 @@ description: Source-grounded research with verification and citations. Use when 
 - Distinguish plainly between what a source states and what you infer from it; label inference as inference.
 - Prefer primary sources (the vendor's page, the law's text, the paper) over aggregators repeating them.
 - Note the date on every time-sensitive fact; an undated price or version number is a trap for the reader.
-- When sources conflict, report the conflict — do not silently pick one.
+- When sources conflict, report the conflict; do not silently pick one.
 - If retrieval fails or the fact cannot be found, say so; a stated gap beats a confident guess.
 - End with the answer to the actual question asked, not a survey of everything found.
 - Close every answer with a `## Sources` section: a numbered markdown
   list, one fetched source per line, formatted exactly as
-  `1. [Title](URL)`. Nothing else on that line — no dates, no notes,
+  `1. [Title](URL)`. Nothing else on that line: no dates, no notes,
   no extra prose. Every URL listed must be one you actually fetched or
   searched this turn.
-- Write arithmetic in plain text or inline code — never LaTeX or math
+- Write arithmetic in plain text or inline code, never LaTeX or math
   notation (`\frac`, `\times`, `\text`, `$...$`); the interface does
   not render it.
 - Before a tool call, write at most one short line saying what you are
-  checking — never the answer itself. The answer comes only after all
+  checking, never the answer itself. The answer comes only after all
   tool results are in.
 - State the final answer exactly once. Never repeat a sentence or
   paragraph you already wrote this turn, and do not add an `## Answer`
@@ -44,7 +44,7 @@ description: Source-grounded research with verification and citations. Use when 
 | "Citing everything clutters the answer" | An uncited actionable claim is a liability, not a courtesy. |
 | "The aggregator summarizes the primary source fine" | Aggregators introduce errors and lag; the primary is one fetch away. |
 
-## Red flags — stop and re-check
+## Red flags: stop and re-check
 
 - You are writing a number, date, or name you did not see in a fetched source this turn.
 - Every citation points at the same domain.

--- a/skills/travel-planning/SKILL.md
+++ b/skills/travel-planning/SKILL.md
@@ -8,7 +8,7 @@ description: Constraint-first trip planning across visas, weather, budget, and l
 ## Rules
 
 - Collect the hard constraints before proposing anything: dates, origin, passport(s) held, budget ceiling, travelers, and non-negotiables.
-- Check visa and entry requirements first for the specific passport — the best itinerary is worthless if entry is refused; verify against a current source, not memory.
+- Check visa and entry requirements first for the specific passport: the best itinerary is worthless if entry is refused; verify against a current source, not memory.
 - Check the season and weather window for the destination and dates before recommending activities.
 - Every price gets a currency, a date checked, and a source; converted totals show the rate used.
 - Build the budget bottom-up (transport, lodging, food, activities, buffer) and compare it to the ceiling explicitly.
@@ -25,7 +25,7 @@ description: Constraint-first trip planning across visas, weather, budget, and l
 | "The connection is probably fine" | A missed once-a-day connection costs a full day; check the actual schedule. |
 | "Everyone loves this spot" | The traveler's constraints outrank popularity. |
 
-## Red flags — stop and re-check
+## Red flags: stop and re-check
 
 - An itinerary crosses a border you haven't checked entry rules for.
 - A budget line is a round number you did not derive from a source.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -783,6 +783,25 @@ export async function patchRoute(
   })
 }
 
+export async function createRoute(name: string, capability: string): Promise<string> {
+  const { id } = await request<{ id: string }>('/v1/admin/routes', {
+    method: 'POST',
+    body: JSON.stringify({ name, capability }),
+  })
+  return id
+}
+
+export async function deleteRoute(name: string): Promise<void> {
+  await request<void>(`/v1/admin/routes/${name}`, { method: 'DELETE' })
+}
+
+export async function setRouteRole(name: string, role: string): Promise<void> {
+  await request<void>(`/v1/admin/routes/${name}/role`, {
+    method: 'PUT',
+    body: JSON.stringify({ role }),
+  })
+}
+
 export interface AdminSettings {
   settings: Record<string, boolean>
   // Typed runtime settings; empty string means the built-in default.

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -357,6 +357,12 @@ export interface AdminRoute {
   // score entries from recent ledger stats and declared prices.
   strategy: string
   enabled: boolean
+  // What this route can serve: 'chat' | 'embeddings' | 'vision'.
+  capability?: string
+  // Set when this route serves one of the 4 roles Timothy requires to
+  // work: 'default' | 'embedding' | 'vision' | 'summarize'. Absent for
+  // a plain, user-owned route.
+  role?: string
   // Router try order with live stats — present for enabled routes once
   // a snapshot is loaded. serving is the first usable resolved entry.
   resolved?: RouteEntryStatus[]

--- a/web/src/components/AgentRoutePicker.tsx
+++ b/web/src/components/AgentRoutePicker.tsx
@@ -147,7 +147,7 @@ export function AgentRoutePicker({
               </div>
               {isRouteAuto && <HugeiconsIcon icon={Tick02Icon} className="mt-1 size-4 shrink-0" />}
             </DropdownMenuItem>
-            {routes?.map((r) => {
+            {routes?.filter((r) => r.enabled).map((r) => {
               const selected = r.name === route
               const chainLabel =
                 r.chain.length > 0 ? r.chain.map((c) => c.model).join(' → ') : 'No models configured'

--- a/web/src/components/settings/FeaturesTab.tsx
+++ b/web/src/components/settings/FeaturesTab.tsx
@@ -125,8 +125,6 @@ function AgentCard({
 }) {
   const [budget, setBudget] = useState(values.session_token_budget ?? '')
   const [allowlist, setAllowlist] = useState(values.skills_allowlist ?? '')
-  const [gitName, setGitName] = useState(values.git_author_name ?? '')
-  const [gitEmail, setGitEmail] = useState(values.git_author_email ?? '')
   const [saved, setSaved] = useState(false)
 
   const save = () => {
@@ -134,8 +132,6 @@ function AgentCard({
     patchSettingValues({
       session_token_budget: budget.trim(),
       skills_allowlist: allowlist.trim(),
-      git_author_name: gitName.trim(),
-      git_author_email: gitEmail.trim(),
     })
       .then(() => {
         setSaved(true)
@@ -172,26 +168,6 @@ function AgentCard({
             aria-label="Skills allowlist"
           />
         </label>
-        <label className="grid gap-1 text-xs text-muted-foreground">
-          Git author name
-          <Input
-            value={gitName}
-            onChange={(e) => setGitName(e.target.value)}
-            placeholder="Your Name"
-            className="w-48"
-            aria-label="Git author name"
-          />
-        </label>
-        <label className="grid gap-1 text-xs text-muted-foreground">
-          Git author email
-          <Input
-            value={gitEmail}
-            onChange={(e) => setGitEmail(e.target.value)}
-            placeholder="you@example.com"
-            className="w-56"
-            aria-label="Git author email"
-          />
-        </label>
         <Button onClick={save}>Save</Button>
         {saved && <span className="text-xs text-muted-foreground">Saved.</span>}
       </div>
@@ -199,10 +175,6 @@ function AgentCard({
         Budget caps the projected context when the serving model&apos;s window is unknown (a
         known window still wins at 60%). Allowlist restricts which skill packs the agent may
         load; empty allows all.
-      </p>
-      <p className="mt-2 text-xs text-muted-foreground">
-        Git author name/email are used for mission commits; set them to your GitHub identity so
-        pushed commits link to your account.
       </p>
     </div>
   )

--- a/web/src/components/settings/RoutesList.tsx
+++ b/web/src/components/settings/RoutesList.tsx
@@ -1,14 +1,37 @@
+import { Delete02Icon, PlusSignIcon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
-import { listProviders, listRoutes, patchRoute } from '../../api/client'
+import {
+  createRoute,
+  deleteRoute,
+  listProviders,
+  listRoutes,
+  patchRoute,
+  setRouteRole,
+} from '../../api/client'
 import type { AdminProvider, AdminRoute } from '../../api/types'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { Toggle } from './shared'
 import { errText } from './util'
+
+const ROLES = [
+  { key: 'default', label: 'Chat (default)' },
+  { key: 'embedding', label: 'Embeddings' },
+  { key: 'vision', label: 'Vision' },
+  { key: 'summarize', label: 'Summarize' },
+]
+const CAPABILITIES = ['chat', 'embeddings', 'vision']
+const ROLE_UNSET = '__unset__'
 
 export function RoutesList() {
   const [routes, setRoutes] = useState<AdminRoute[]>([])
   const [providers, setProviders] = useState<AdminProvider[]>([])
+  const [newName, setNewName] = useState('')
+  const [newCapability, setNewCapability] = useState('chat')
   const navigate = useNavigate()
 
   const refresh = useCallback(() => {
@@ -29,49 +52,160 @@ export function RoutesList() {
     )
   }
 
-  return (
-    <div className="mt-6 space-y-4">
-      <p className="text-sm text-muted-foreground">
-        Routes are named model chains agents route through — reorder providers within a route or
-        add fallbacks from its own page.
-      </p>
+  const create = () => {
+    const name = newName.trim()
+    if (!name) return
+    createRoute(name, newCapability)
+      .then(() => {
+        setNewName('')
+        refresh()
+      })
+      .catch((err: unknown) => toast.error('Could not create route', { description: errText(err) }))
+  }
 
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {routes.map((r) => {
-          // The router's own verdict: first usable entry in try order.
-          const serving = r.serving
-          return (
-            <button
-              key={r.name}
-              type="button"
-              onClick={() => navigate(`/settings/routes/${r.name}`)}
-              className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 text-left shadow-sm transition hover:shadow-md"
-            >
-              <div className="flex items-center gap-3">
-                <span className="truncate text-sm font-semibold">{r.name}</span>
-                <span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-xs font-medium capitalize text-muted-foreground">
-                  {r.strategy || 'ordered'}
-                </span>
-                <span onClick={(e) => e.stopPropagation()}>
-                  <Toggle on={r.enabled} onChange={(v) => toggle(r, v)} label={`${r.name} route enabled`} />
-                </span>
+  const remove = (r: AdminRoute) => {
+    deleteRoute(r.name).then(refresh, (err: unknown) =>
+      toast.error('Could not delete route', { description: errText(err) }),
+    )
+  }
+
+  const assignRole = (role: string, name: string) => {
+    setRouteRole(name, role).then(refresh, (err: unknown) =>
+      toast.error('Could not assign role', { description: errText(err) }),
+    )
+  }
+
+  return (
+    <div className="mt-6 space-y-6">
+      <div className="rounded-xl border border-border p-4">
+        <div className="text-sm font-medium">System roles</div>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          Timothy needs one route bound to each of these 4 roles to work. A newly connected
+          provider fills in whichever are still unbound.
+        </p>
+        <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {ROLES.map((role) => {
+            const bound = routes.find((r) => r.role === role.key)
+            return (
+              <label key={role.key} className="grid gap-1 text-xs text-muted-foreground">
+                {role.label}
+                <Select
+                  value={bound?.name ?? ROLE_UNSET}
+                  onValueChange={(v) => {
+                    if (v !== ROLE_UNSET) assignRole(role.key, v)
+                  }}
+                >
+                  <SelectTrigger className="h-10 w-full" aria-label={`${role.label} route`}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {!bound && <SelectItem value={ROLE_UNSET}>Unbound</SelectItem>}
+                    {routes.map((r) => (
+                      <SelectItem key={r.name} value={r.name}>
+                        {r.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </label>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <p className="text-sm text-muted-foreground">
+            Routes are named model chains agents route through — reorder providers within a route
+            or add fallbacks from its own page.
+          </p>
+          <div className="flex items-end gap-2">
+            <label className="grid gap-1 text-xs text-muted-foreground">
+              New route name
+              <Input
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="my-route"
+                className="w-40"
+                aria-label="New route name"
+              />
+            </label>
+            <label className="grid gap-1 text-xs text-muted-foreground">
+              Capability
+              <Select value={newCapability} onValueChange={setNewCapability}>
+                <SelectTrigger className="h-9 w-32" aria-label="New route capability">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CAPABILITIES.map((c) => (
+                    <SelectItem key={c} value={c}>
+                      {c}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </label>
+            <Button onClick={create} disabled={!newName.trim()}>
+              <HugeiconsIcon icon={PlusSignIcon} className="size-4" />
+              Add route
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {routes.map((r) => {
+            // The router's own verdict: first usable entry in try order.
+            const serving = r.serving
+            return (
+              <div
+                key={r.name}
+                className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 text-left shadow-sm transition hover:shadow-md"
+              >
+                <button
+                  type="button"
+                  onClick={() => navigate(`/settings/routes/${r.name}`)}
+                  className="flex items-center gap-3 text-left"
+                >
+                  <span className="truncate text-sm font-semibold">{r.name}</span>
+                  {r.role && (
+                    <span className="rounded bg-blue-500/10 px-1.5 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-400">
+                      {r.role}
+                    </span>
+                  )}
+                  <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium capitalize text-muted-foreground">
+                    {r.strategy || 'ordered'}
+                  </span>
+                  <span className="ml-auto flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+                    <Toggle on={r.enabled} onChange={(v) => toggle(r, v)} label={`${r.name} route enabled`} />
+                    <button
+                      type="button"
+                      onClick={() => remove(r)}
+                      disabled={!!r.role}
+                      title={r.role ? `Serves the ${r.role} role — reassign that role first` : 'Delete route'}
+                      aria-label={`Delete ${r.name} route`}
+                      className="rounded p-1 text-muted-foreground hover:text-red-600 disabled:opacity-30 disabled:hover:text-muted-foreground"
+                    >
+                      <HugeiconsIcon icon={Delete02Icon} className="size-4" />
+                    </button>
+                  </span>
+                </button>
+                {serving ? (
+                  <p className="text-xs text-muted-foreground">
+                    serving <span className="text-foreground">{nameOf(serving.provider_id)}</span> /{' '}
+                    <span className="font-mono text-foreground">{serving.model}</span>
+                  </p>
+                ) : !r.enabled ? (
+                  <p className="text-xs font-medium text-warning">disabled</p>
+                ) : r.resolved ? (
+                  <p className="text-xs font-medium text-warning">no usable provider</p>
+                ) : (
+                  <p className="text-xs text-muted-foreground">stats loading…</p>
+                )}
+                <p className="text-xs text-muted-foreground">{r.chain.length} provider(s) in chain</p>
               </div>
-              {serving ? (
-                <p className="text-xs text-muted-foreground">
-                  serving <span className="text-foreground">{nameOf(serving.provider_id)}</span> /{' '}
-                  <span className="font-mono text-foreground">{serving.model}</span>
-                </p>
-              ) : !r.enabled ? (
-                <p className="text-xs font-medium text-warning">disabled</p>
-              ) : r.resolved ? (
-                <p className="text-xs font-medium text-warning">no usable provider</p>
-              ) : (
-                <p className="text-xs text-muted-foreground">stats loading…</p>
-              )}
-              <p className="text-xs text-muted-foreground">{r.chain.length} provider(s) in chain</p>
-            </button>
-          )
-        })}
+            )
+          })}
+        </div>
       </div>
     </div>
   )

--- a/web/src/components/settings/RoutesTab.tsx
+++ b/web/src/components/settings/RoutesTab.tsx
@@ -2,9 +2,10 @@ import { Route, Routes } from 'react-router'
 import { RouteEdit } from './RouteEdit'
 import { RoutesList } from './RoutesList'
 
-// RoutesTab is the route container for the routes area. Routes are a
-// fixed, backend-defined set (no create/delete) — the list shows them
-// as cards, and each opens its own chain-editing page.
+// RoutesTab is the route container for the routes area. Routes are
+// fully user-managed (create, rename via chain editing, delete) — the
+// list shows them as cards plus the 4 required system roles, and each
+// route opens its own chain-editing page.
 export function RoutesTab() {
   return (
     <Routes>

--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -145,8 +145,6 @@ describe('Features tab agent settings', () => {
       expect(patchSettingValues).toHaveBeenCalledWith({
         session_token_budget: '120000',
         skills_allowlist: 'coding-task, research',
-        git_author_name: '',
-        git_author_email: '',
       }),
     )
   })


### PR DESCRIPTION
## Summary
- Routes were a fixed set of 7 hardcoded names, string-compared across gateway and brain. Adds `capability` and `role` columns so code resolves "the route serving role X" instead of matching literal names, so routes can be freely renamed/created/deleted.
- Only 4 roles required to bootstrap (`default`, `embedding`, `vision`, `summarize`); everything else is a plain user-owned route (fresh installs no longer seed `research`/`local`/`coding`).
- New route CRUD + role-assignment UI under Settings → Routing.
- Fixes disabled routes still showing up in the chat agent picker.
- Docs: README install-path reorg, stale routing claims fixed, em dashes removed repo-wide.

## Test plan
- [x] `make build test vet lint` clean
- [x] Web `npm run build`, `npm run lint`, `npm test` clean
- [x] Verified fresh-install migration path seeds exactly 4 routes (throwaway Postgres container)
- [x] Verified upgrade path on real dev DB keeps configured `research`/`local`/`coding` routes intact
- [x] `make canary` PASS end-to-end against live stack