### PR TITLE
fix: keep long chat turns alive through idle-killing proxies

### DIFF
--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -461,6 +461,13 @@ type meta struct {
 	DurationMs int64         `json:"duration_ms,omitempty"`
 }
 
+// streamHeartbeat keeps a chat SSE connection alive through proxies
+// that kill an idle one (Cloudflare's ~100s 524 fires on a gap with no
+// bytes flowing, not on total duration) — a slow model can go well
+// past that between tokens. A comment line carries no event, so it
+// never reaches the client's SSE parser or reducer.
+const streamHeartbeat = 20 * time.Second
+
 // streamTurn runs run (chat.Service.Chat or Retry) and relays its
 // terminal-contract channel to the client as SSE; both callers only
 // differ in how the turn starts, not in how it streams or ends.
@@ -511,15 +518,26 @@ func (a *API) streamTurn(w http.ResponseWriter, r *http.Request, run func(contex
 	}
 
 	m := meta{Type: "meta", SessionID: sessionID}
-	for ev := range events {
-		if ev.Type == stream.EventUsage {
-			m.Usage = ev.Usage
+	ticker := time.NewTicker(streamHeartbeat)
+	defer ticker.Stop()
+	for {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				send(m)
+				return
+			}
+			if ev.Type == stream.EventUsage {
+				m.Usage = ev.Usage
+			}
+			if ev.Meta != nil {
+				m.Provider, m.Model, m.LedgerID = ev.Meta.Provider, ev.Meta.Model, ev.Meta.LedgerID
+				m.DurationMs = ev.Meta.DurationMs
+			}
+			send(ev)
+		case <-ticker.C:
+			_, _ = fmt.Fprintf(w, ": ping\n\n")
+			flusher.Flush()
 		}
-		if ev.Meta != nil {
-			m.Provider, m.Model, m.LedgerID = ev.Meta.Provider, ev.Meta.Model, ev.Meta.LedgerID
-			m.DurationMs = ev.Meta.DurationMs
-		}
-		send(ev)
 	}
-	send(m)
 }

--- a/internal/brain/api/live.go
+++ b/internal/brain/api/live.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 )
@@ -79,6 +80,8 @@ func (a *API) handleLive(w http.ResponseWriter, r *http.Request) {
 		send(ev)
 	}
 	ctx := r.Context()
+	ticker := time.NewTicker(streamHeartbeat)
+	defer ticker.Stop()
 	for {
 		select {
 		case ev, chOk := <-live:
@@ -96,6 +99,9 @@ func (a *API) handleLive(w http.ResponseWriter, r *http.Request) {
 			}
 			fold(ev)
 			send(ev)
+		case <-ticker.C:
+			_, _ = fmt.Fprintf(w, ": ping\n\n")
+			flusher.Flush()
 		case <-ctx.Done():
 			return
 		}

--- a/web/src/pages/Chat.test.tsx
+++ b/web/src/pages/Chat.test.tsx
@@ -335,6 +335,47 @@ describe('live reattach', () => {
     await waitFor(() => expect(screen.queryByText('▍')).not.toBeInTheDocument())
   })
 
+  it('reattaches via streamLive instead of showing an error on a dropped connection', async () => {
+    // A plain TypeError (network cut, proxy timeout) — not a ChatError,
+    // so there's no definite server response to treat as a real failure.
+    // Needs an already-adopted session (sessionRef populated from the
+    // route param), since a transport failure carries no session_id to
+    // adopt the way a ChatError with err.sessionId would.
+    vi.mocked(chatStream).mockRejectedValue(new TypeError('Failed to fetch'))
+    let feed!: (ev: ChatEvent) => void
+    let resolveStream!: () => void
+    const streamDone = new Promise<void>((r) => {
+      resolveStream = r
+    })
+    vi.mocked(streamLive).mockImplementation(async (_id, onEvent) => {
+      feed = onEvent
+      await streamDone
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/chat/s1']}>
+        <Routes>
+          <Route path="/chat/:id" element={<Chat onNeedToken={vi.fn()} />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    const input = await screen.findByLabelText('Message')
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(toast.info).toHaveBeenCalledWith('Connection dropped — reattaching'))
+    await waitFor(() => expect(streamLive).toHaveBeenCalledWith('s1', expect.any(Function), expect.anything()))
+    expect(screen.queryByText(/Failed to fetch/)).not.toBeInTheDocument()
+
+    feed({ type: 'chunk', text: 'reattached and still going' })
+    await screen.findByText('reattached and still going')
+
+    feed({ type: 'meta', session_id: 's1' })
+    resolveStream()
+    await waitFor(() => expect(screen.queryByText('▍')).not.toBeInTheDocument())
+  })
+
   it('ignores a session signal for a different session', async () => {
     vi.mocked(getTranscript).mockResolvedValue({
       session: { id: 's1', title: '', archived: false, created_at: '', updated_at: '' },

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -222,17 +222,24 @@ export function Chat({
   // permission modal all just work. The replay buffer already contains
   // every chunk that built up the interrupted partial, so the new item
   // starts empty rather than double-seeding with the persisted text.
-  const attachLive = (sessionId: string) => {
+  // maxLiveReconnects caps how many times a single dropped connection
+  // retries attachLive before giving up — a turn genuinely gone (not
+  // just this subscriber's connection) would otherwise loop forever.
+  const maxLiveReconnects = 5
+
+  const attachLive = (sessionId: string, reconnectAttempt = 0) => {
     setStreaming(true)
     pinnedRef.current = true
-    setItems((prev) => {
-      const next = [...prev]
-      const last = next[next.length - 1]
-      if (last && (last.role === 'interrupted' || last.role === 'assistant'))
-        next[next.length - 1] = { id: last.id, role: 'assistant', ...emptyAssistant() }
-      else next.push({ id: crypto.randomUUID(), role: 'assistant', ...emptyAssistant() })
-      return next
-    })
+    if (reconnectAttempt === 0) {
+      setItems((prev) => {
+        const next = [...prev]
+        const last = next[next.length - 1]
+        if (last && (last.role === 'interrupted' || last.role === 'assistant'))
+          next[next.length - 1] = { id: last.id, role: 'assistant', ...emptyAssistant() }
+        else next.push({ id: crypto.randomUUID(), role: 'assistant', ...emptyAssistant() })
+        return next
+      })
+    }
 
     const controller = new AbortController()
     abortRef.current = controller
@@ -262,17 +269,32 @@ export function Chat({
       })
       .catch((err: unknown) => {
         if (controller.signal.aborted) return
-        // A 404 (no_active_turn) means the turn finished in the gap
-        // between getTranscript and this attach — refetch once to pick
-        // up the now-completed transcript rather than leaving the
-        // freshly-blanked item stuck empty. Any other error just falls
-        // back the same way.
+        if (err instanceof ChatError) {
+          // A 404 (no_active_turn) means the turn finished in the gap
+          // between getTranscript and this attach — refetch once to pick
+          // up the now-completed transcript rather than leaving the
+          // freshly-blanked item stuck empty.
+          getTranscript(sessionId)
+            .then(({ items }) => setItems(fromTranscript(items)))
+            .catch(() => undefined)
+          if (err.status === 401 || err.status === 503) onNeedToken()
+          return
+        }
+        // A transport-level failure (dropped connection, proxy timeout)
+        // rather than a definite server response — the turn is very
+        // likely still running server-side (D-042), so reattach instead
+        // of treating this as final. abortRef must point at the retry's
+        // own controller, not get cleared by this attempt's finally.
+        if (reconnectAttempt < maxLiveReconnects) {
+          attachLive(sessionId, reconnectAttempt + 1)
+          return
+        }
         getTranscript(sessionId)
           .then(({ items }) => setItems(fromTranscript(items)))
           .catch(() => undefined)
-        if (err instanceof ChatError && (err.status === 401 || err.status === 503)) onNeedToken()
       })
       .finally(() => {
+        if (abortRef.current !== controller) return
         abortRef.current = null
         if (!controller.signal.aborted) {
           setStreaming(false)
@@ -363,6 +385,16 @@ export function Chat({
           handedOffToLive = true
           attachLive(sessionRef.current!)
         } else updateLast((m) => ({ ...m, streaming: false, error: err.message }))
+      } else if (sessionRef.current) {
+        // A transport-level failure (dropped connection, proxy timeout,
+        // laptop sleep) throws a plain error, not ChatError — the turn
+        // itself runs detached from this request (D-042), so it's very
+        // likely still alive server-side. Reattach via /live instead of
+        // surfacing a false "failed" state; attachLive's own error path
+        // falls back to a transcript refetch if the turn is in fact gone.
+        toast.info('Connection dropped — reattaching')
+        handedOffToLive = true
+        attachLive(sessionRef.current)
       } else {
         updateLast((m) => ({ ...m, streaming: false, error: String(err) }))
       }
@@ -436,7 +468,14 @@ export function Chat({
           attachLive(sessionId)
         } else updateLast((m) => ({ ...m, streaming: false, error: err.message }))
       } else {
-        updateLast((m) => ({ ...m, streaming: false, error: String(err) }))
+        // A transport-level failure (dropped connection, proxy timeout,
+        // laptop sleep) throws a plain error, not ChatError — the turn
+        // itself runs detached from this request (D-042), so it's very
+        // likely still alive server-side. Reattach via /live instead of
+        // surfacing a false "failed" state.
+        toast.info('Connection dropped — reattaching')
+        handedOffToLive = true
+        attachLive(sessionId)
       }
     } finally {
       if (!handedOffToLive) {


### PR DESCRIPTION
## Summary
- Cloudflare (and similar proxies) kill a connection with no bytes flowing for ~100s, regardless of total duration. Chat's SSE streams (`POST /v1/sessions/{id}/messages`, `/retry`, `GET /v1/sessions/{id}/live`) only wrote bytes when a real event arrived, so a slow model with long gaps between tokens (e.g. remote Ollama at low tok/s) would go idle long enough to trigger a 524, even though the turn itself was progressing fine server-side.
- Added the same heartbeat ping `/v1/events` already uses (`": ping\n\n"` every 20s) to both handlers — no client change needed for this part, comment lines are already ignored by the SSE parser.
- For a connection that drops anyway (network blip, laptop sleep): the web client now reattaches via the existing `/live` replay mechanism instead of showing a false failure. The turn already runs detached from any single request (D-042), so a transport-level error (not a definite server response) is very likely recoverable. Bounded to 5 reconnect attempts to avoid looping forever on a genuinely dead session.

Found while debugging a real deployment where long OCI-routed turns consistently hit Cloudflare 524s.

## Test plan
- [x] `make build test vet lint` clean
- [x] Web `npm run build`, `npm run lint` clean
- [x] New web test: reattaches via `streamLive` on a transport-level failure instead of showing an error
- [x] Existing 409/turn_in_flight reattach and turn_active reattach tests still pass unchanged