### PR TITLE
fix(gateway): surface a real error when a stream closes silently

### DIFF
--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -281,9 +281,11 @@ func streamAttempt(ctx context.Context, att router.Attempt, completion provider.
 		return res
 	}
 
+	sawTerminal := false
 	for ev := range ch {
 		switch ev.Type {
 		case stream.EventError:
+			sawTerminal = true
 			res.entry.ErrorCode = ev.Err.Code
 			if !res.streamed {
 				res.failed, res.reason = true, ev.Err.Message
@@ -294,6 +296,7 @@ func streamAttempt(ctx context.Context, att router.Attempt, completion provider.
 			res.entry.Usage = ev.Usage
 			send(ev)
 		case stream.EventIncomplete:
+			sawTerminal = true
 			if res.entry.Status == "" {
 				res.entry.Status = "incomplete"
 			}
@@ -302,6 +305,7 @@ func streamAttempt(ctx context.Context, att router.Attempt, completion provider.
 			res.streamed = true
 			send(ev)
 		case stream.EventDone:
+			sawTerminal = true
 			// A stream that closes clean but produced no content (e.g.
 			// [DONE] with zero deltas) is not a success (D-044): tell the
 			// client before the terminal done, the same incomplete-then-
@@ -320,6 +324,20 @@ func streamAttempt(ctx context.Context, att router.Attempt, completion provider.
 		default:
 			send(ev)
 		}
+	}
+
+	// A provider channel can close having delivered nothing at all — no
+	// chunk, no EventDone, no EventError — if runStream's own terminal
+	// emit lost its race against the parent context right as the
+	// upstream connection cut (httpx.go's emit silently no-ops when its
+	// ctx is done). Left alone, this is a well-formed empty SSE
+	// response: brain sees a clean channel close with no error to show,
+	// and falls back to a generic "stream ended without a terminal
+	// event." Surface a real reason here instead, same as any other
+	// pre-content failure.
+	if !sawTerminal && !res.failed {
+		res.failed, res.reason = true, "provider stream closed without a terminal event"
+		res.entry.ErrorCode = "stream_cut"
 	}
 
 	res.entry.Status = finalStatus(res)

--- a/internal/gateway/api/api_test.go
+++ b/internal/gateway/api/api_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/ledger"
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/router"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 	"github.com/SumonMSelim/timothy/internal/platform/metrics"
@@ -105,6 +106,22 @@ func oaiEmptyDone(t *testing.T) *httptest.Server {
 	}))
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+// silentCutProvider's Stream returns a channel that closes having
+// delivered zero events — no chunk, no done, no error — standing in
+// for the upstream-cut race where runStream's own terminal emit lost
+// against the parent context (httpx.go's emit silently no-ops when
+// its ctx is done), so the provider layer never surfaces why.
+type silentCutProvider struct{ name string }
+
+func (p silentCutProvider) Name() string                    { return p.name }
+func (p silentCutProvider) Kind() provider.Kind              { return provider.KindAPI }
+func (p silentCutProvider) Capabilities() []provider.Capability { return nil }
+func (p silentCutProvider) Stream(context.Context, provider.CompletionRequest) (<-chan stream.StreamEvent, error) {
+	ch := make(chan stream.StreamEvent)
+	close(ch)
+	return ch, nil
 }
 
 // snapshotFor builds a two-provider snapshot with a coding route
@@ -349,6 +366,35 @@ func TestStreamChainExhausted(t *testing.T) {
 	}
 	if len(rec.all()) != 2 {
 		t.Fatalf("ledger entries = %d, want 2 failures", len(rec.all()))
+	}
+}
+
+// TestStreamAttemptSilentCloseIsAFailure pins the fix for a provider
+// channel closing with zero events (no chunk, no done, no error)
+// instead of any well-formed terminal — previously streamAttempt's
+// range loop simply never ran its body, leaving res all zero values
+// and nothing sent to the client, indistinguishable from a legitimate
+// empty completion. It must now report a real failure so the chain
+// can fail over (or the client at least gets a reason).
+func TestStreamAttemptSilentCloseIsAFailure(t *testing.T) {
+	t.Parallel()
+	att := router.Attempt{Provider: silentCutProvider{name: "one"}, ProviderName: "one", Model: "m1"}
+	var sent []stream.StreamEvent
+	res := streamAttempt(t.Context(), att, provider.CompletionRequest{}, ledger.Entry{}, func(ev stream.StreamEvent) {
+		sent = append(sent, ev)
+	})
+
+	if !res.failed {
+		t.Fatalf("res.failed = false, want true for a silently closed channel")
+	}
+	if res.entry.ErrorCode != "stream_cut" {
+		t.Fatalf("entry.ErrorCode = %q, want stream_cut", res.entry.ErrorCode)
+	}
+	if len(sent) != 0 {
+		t.Fatalf("sent = %+v, want nothing relayed to the client for a pre-content failure", sent)
+	}
+	if !res.failedOver() {
+		t.Fatalf("failedOver() = false, want true so the chain can advance")
 	}
 }
 


### PR DESCRIPTION
## Summary
- A provider channel that closes with zero events (no chunk, no done, no error) previously left `streamAttempt` reporting nothing — indistinguishable from a legit empty completion.
- Root cause: `runStream`'s own terminal-emit races the parent context via `emit()`'s ctx-done check right as the upstream connection cuts (e.g. remote Ollama dropping mid-generation), silently no-oping the emit.
- Now `streamAttempt` tracks whether any terminal event (done/error/incomplete) was ever seen; if the channel closes without one, it's treated as a real failure (`stream_cut`) so the chain can fail over instead of falling back to the generic "stream ended without a terminal event".

## Test plan
- [x] `make build test vet lint`
- [x] New unit test `TestStreamAttemptSilentCloseIsAFailure` using a fake provider whose `Stream()` returns an already-closed empty channel