### PR TITLE
fix(brain): stop losing turn terminals to deadline races

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -308,6 +308,21 @@ func main() {
 		agentReg.Resolve, app.Log)
 	svc.SetAutoDispatch(agentReg.Enabled, chat.ClassifyOverGateway(gwc))
 	svc.SetSensitiveTools(sensitiveTools)
+	// TURN_TIMEOUT raises the detached-turn ceiling above the compiled
+	// 30m default — needed when a route serves a slow CPU-only backend
+	// whose provider request_timeout (D-041) would otherwise collide
+	// with the brain ceiling and manufacture a deadline-vs-terminal
+	// race at the exact same instant. Env-gated feature, default off.
+	if v := os.Getenv("TURN_TIMEOUT"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			app.Log.Warn("invalid TURN_TIMEOUT ignored", "value", v, "error", err)
+		} else if err := svc.SetTurnTimeout(d); err != nil {
+			app.Log.Warn("TURN_TIMEOUT rejected", "value", v, "error", err)
+		} else {
+			app.Log.Info("turn timeout overridden", "timeout", d)
+		}
+	}
 	// Nil-safe: missionHub is nil when WORKSPACES is unset (see
 	// buildMissions), in which case SetSessionHub's publish func is
 	// never called (chat.go only invokes it when non-nil), leaving

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -106,6 +106,11 @@ services:
       # cannot do the job — the small local fallback exists for chat
       # resilience, not for missions.
       MISSION_MODEL_FLOOR: ${MISSION_MODEL_FLOOR:-qwen2.5:7b}
+      # Detached-turn ceiling override (Go duration, e.g. "60m").
+      # Empty keeps the compiled 30m default; must exceed 10m. Raise it
+      # alongside a slow provider's request_timeout so the two
+      # deadlines never land at the same instant.
+      TURN_TIMEOUT: ${TURN_TIMEOUT:-}
       # Compose-internal only: the model never sees this address.
       SEARXNG_URL: http://searxng:8080
       # Converts Gmail attachments (PDFs) and HTML-only email bodies to

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -29,6 +29,13 @@ TIMOTHY_API_TOKEN=
 # client's authorized redirect URIs.
 TIMOTHY_PUBLIC_URL=http://localhost:3300
 
+# --- Chat turns ---
+# Detached-turn ceiling override (Go duration, e.g. "60m"). Empty
+# keeps the compiled 30m default; must exceed 10m (permission park
+# timeout). Raise together with a slow provider's request_timeout so
+# the two deadlines never collide.
+TURN_TIMEOUT=
+
 # --- Third-party services ---
 # npm auth token for HugeIcons Pro packages (from your hugeicons.com account)
 HUGEICONS_TOKEN=

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -359,6 +359,21 @@ func New(gw Gateway, log SessionLog, distill Distill, compactor Compactor, budge
 	}
 }
 
+// SetTurnTimeout overrides the detached-turn ceiling (startup-only,
+// same discipline as the loop's SetOffloadThreshold: called from
+// main.go wiring before the service takes traffic, never after). The
+// ceiling must exceed the loop's permission park timeout (10m) or a
+// parked ask could never be answered in time; values at or below it
+// are rejected so a bad env value degrades to the default rather than
+// a broken permission flow.
+func (s *Service) SetTurnTimeout(d time.Duration) error {
+	if d <= 10*time.Minute {
+		return fmt.Errorf("chat: turn timeout %s must exceed the 10m permission park timeout", d)
+	}
+	s.turnTimeout = d
+	return nil
+}
+
 // dispatchAgent resolves the "auto" sentinel to a real agent name via
 // agents.Dispatch. classify is built here (not injected verbatim as
 // Classify) so it always drains through this service's own Gateway —
@@ -1078,7 +1093,18 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 		// No partial worth keeping: a captured terminal error/incomplete
 		// (D-044) becomes durable evidence instead of the turn silently
 		// vanishing — same detached-context, best-effort append as the
-		// pending-state write above.
+		// pending-state write above. No failure AND no text at all means
+		// every upstream producer lost its terminal on the way here
+		// (deadline racing the stream cut) — synthesize one rather than
+		// append nothing: a turn that ran must never leave zero events.
+		// A flushed partial (text non-empty, already checkpointed) keeps
+		// today's behavior: the pending state is the evidence.
+		if failure == nil && text == "" {
+			failure = &session.TurnFailed{
+				Code:    "turn_aborted",
+				Message: "turn ended with no terminal event (deadline exceeded or stream cut)",
+			}
+		}
 		if failure != nil {
 			ctx, cancel := context.WithTimeout(context.Background(), persistTimeout)
 			defer cancel()

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -627,6 +627,58 @@ func TestEmptyResponsePersistsTurnFailed(t *testing.T) {
 	}
 }
 
+// TestBareStreamClosePersistsTurnAborted pins the last backstop in the
+// terminal-delivery chain: when the upstream channel closes with no
+// events at all — every producer's terminal lost to the turn deadline
+// racing a stream cut — persistTurn must synthesize a turn_failed
+// rather than append nothing (a real ~30min turn once vanished with
+// zero session_events this way).
+func TestBareStreamClosePersistsTurnAborted(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{} // no events: channel closes bare
+	s := newService(gw, log)
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "hello"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+
+	want := []string{session.KindSessionStarted, session.KindUserMessage, session.KindTurnFailed}
+	if kinds := log.kinds("s1"); strings.Join(kinds, ",") != strings.Join(want, ",") {
+		t.Fatalf("kinds = %v, want %v", kinds, want)
+	}
+
+	events, _ := log.Events(t.Context(), "s1")
+	var failed session.TurnFailed
+	if err := json.Unmarshal(events[2].Payload, &failed); err != nil {
+		t.Fatalf("decode turn_failed: %v", err)
+	}
+	if failed.Code != "turn_aborted" {
+		t.Fatalf("turn_failed.Code = %q, want turn_aborted", failed.Code)
+	}
+}
+
+// TestSetTurnTimeout pins the ceiling override's floor: anything at or
+// below the loop's 10m permission park timeout is rejected (a parked
+// ask could never be answered in time), and a valid value replaces the
+// compiled default.
+func TestSetTurnTimeout(t *testing.T) {
+	t.Parallel()
+	s := newService(&fakeGW{}, newFakeLog())
+	if err := s.SetTurnTimeout(10 * time.Minute); err == nil {
+		t.Fatal("10m accepted; want rejection at or below the permission park timeout")
+	}
+	if err := s.SetTurnTimeout(60 * time.Minute); err != nil {
+		t.Fatalf("SetTurnTimeout(60m): %v", err)
+	}
+	if s.turnTimeout != 60*time.Minute {
+		t.Fatalf("turnTimeout = %s, want 60m", s.turnTimeout)
+	}
+}
+
 func TestChatValidatesMessage(t *testing.T) {
 	t.Parallel()
 	s := newService(&fakeGW{}, newFakeLog())

--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -240,20 +240,22 @@ func (c *Client) Stream(ctx context.Context, req StreamRequest) (<-chan stream.S
 		})
 		// A read error AFTER the gateway's own terminal is just the
 		// connection tearing down — emitting another terminal would
-		// break the exactly-one-terminal contract. Unlike the previous
-		// version of this guard, ctx already being done does NOT skip
-		// this: turnCtx's own deadline racing gateway's terminal write
-		// must still surface as a real failure (D-044) rather than
-		// silently dropping it (persistTurn has nothing else to persist
-		// once text is empty and failure is nil) — the send below still
-		// only best-effort attempts delivery, racing ctx.Done() so it
-		// never blocks forever on an abandoned consumer.
+		// break the exactly-one-terminal contract. ctx already being
+		// done does NOT skip this: turnCtx's own deadline racing gateway's
+		// terminal write must still surface as a real failure (D-044)
+		// rather than silently dropping it. Delivery deliberately does
+		// NOT race ctx.Done(): with both select cases ready (deadline
+		// fired, consumer mid-receive) Go picks randomly, and that coin
+		// flip has eaten the only evidence of a real ~30min turn. Every
+		// consumer of this channel drains until close, so the send
+		// succeeds immediately in practice; the timeout only bounds a
+		// hypothetically abandoned consumer.
 		if err != nil && !sawTerminal {
 			select {
 			case ch <- stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
 				Code: "gateway_stream_cut", Message: err.Error(), Retryable: true,
 			}}:
-			case <-ctx.Done():
+			case <-time.After(5 * time.Second):
 			}
 		}
 	}()

--- a/internal/brain/gwclient/gwclient_test.go
+++ b/internal/brain/gwclient/gwclient_test.go
@@ -124,46 +124,33 @@ func TestStreamEmitsTerminalWhenCutBeforeDone(t *testing.T) {
 func TestStreamEmitsTerminalWhenCutAfterContextDone(t *testing.T) {
 	t.Parallel()
 
-	// The fix's delivery races ch<- against ctx.Done() once ctx is
-	// already done when the read error surfaces (never blocking
-	// forever on an abandoned consumer is the whole point of racing
-	// against ctx.Done() at all) — so a single attempt can't
-	// distinguish "fixed, lost this particular race" from "the old,
-	// unconditionally-skipped bug". Run many independent attempts and
-	// require the terminal to win at least once; assert it NEVER wins
-	// without the fix by running this same body against a build where
-	// the guard is restored (see the sibling reproduction, which fails
-	// deterministically with terminals=0 on every attempt).
-	const attempts = 40
-	delivered := 0
-	for i := 0; i < attempts; i++ {
-		release := make(chan struct{})
-		c := gatewayStub(t, func(w http.ResponseWriter, r *http.Request) {
-			_, _ = fmt.Fprint(w, "data: {\"type\":\"chunk\",\"text\":\"par\"}\n\n")
-			w.(http.Flusher).Flush()
-			<-release
-			panic(http.ErrAbortHandler)
-		})
+	// Delivery no longer races ctx.Done() (a coin flip there ate real
+	// failures); with a live consumer the terminal must arrive on
+	// every attempt, so a single one asserts it deterministically.
+	release := make(chan struct{})
+	c := gatewayStub(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, "data: {\"type\":\"chunk\",\"text\":\"par\"}\n\n")
+		w.(http.Flusher).Flush()
+		<-release
+		panic(http.ErrAbortHandler)
+	})
 
-		ctx, cancel := context.WithCancel(t.Context())
-		ch, err := c.Stream(ctx, StreamRequest{Route: "mini"})
-		if err != nil {
-			t.Fatalf("Stream: %v", err)
-		}
-
-		first := <-ch
-		if first.Type != stream.EventChunk {
-			t.Fatalf("first event = %+v, want chunk", first)
-		}
-		cancel()
-		close(release)
-
-		if ev, ok := <-ch; ok && ev.Type == stream.EventError && ev.Err.Code == "gateway_stream_cut" {
-			delivered++
-		}
+	ctx, cancel := context.WithCancel(t.Context())
+	ch, err := c.Stream(ctx, StreamRequest{Route: "mini"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
 	}
-	if delivered == 0 {
-		t.Fatalf("gateway_stream_cut never delivered across %d attempts, want at least one", attempts)
+
+	first := <-ch
+	if first.Type != stream.EventChunk {
+		t.Fatalf("first event = %+v, want chunk", first)
+	}
+	cancel()
+	close(release)
+
+	ev, ok := <-ch
+	if !ok || ev.Type != stream.EventError || ev.Err == nil || ev.Err.Code != "gateway_stream_cut" {
+		t.Fatalf("event after cut = %+v (ok=%v), want gateway_stream_cut error", ev, ok)
 	}
 }
 

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -265,6 +266,23 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 		case <-ctx.Done():
 		}
 	}
+	// emitFinal delivers end-of-turn events (the usage/terminal pair)
+	// without racing ctx.Done(): when the turn deadline fires at the
+	// same instant the terminal is sent, both select cases in emit are
+	// ready and Go picks randomly — a lost flip drops the only evidence
+	// the turn ever existed (the relay persists what crosses it, and
+	// persistTurn has nothing without a terminal). Every consumer
+	// drains out until close, so this send succeeds immediately in
+	// practice; the timeout only bounds a hypothetically abandoned
+	// consumer.
+	emitFinal := func(ev stream.StreamEvent) {
+		emitMu.Lock()
+		defer emitMu.Unlock()
+		select {
+		case out <- ev:
+		case <-time.After(5 * time.Second):
+		}
+	}
 
 	if a.waitToolsReady != nil {
 		a.waitToolsReady(ctx)
@@ -374,8 +392,8 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 				// Flush usage accumulated by earlier steps before the
 				// terminal error, matching the in-stream error path — a
 				// mid-loop gateway failure must not undercount the turn.
-				emit(stream.StreamEvent{Type: stream.EventUsage, Usage: &total})
-				emit(stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
+				emitFinal(stream.StreamEvent{Type: stream.EventUsage, Usage: &total})
+				emitFinal(stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
 					Code: "gateway_unavailable", Message: err.Error(), Retryable: true,
 				}})
 				return
@@ -450,8 +468,8 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			} else if incompleteEv != nil {
 				terminal = *incompleteEv
 			}
-			emit(stream.StreamEvent{Type: stream.EventUsage, Usage: &total})
-			emit(terminal)
+			emitFinal(stream.StreamEvent{Type: stream.EventUsage, Usage: &total})
+			emitFinal(terminal)
 			return
 		}
 
@@ -461,8 +479,8 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 		// This is the loop's hard termination: it can never run past
 		// the ceiling no matter what the model returns.
 		if directive == tools.StepForceSynthesis {
-			emit(stream.StreamEvent{Type: stream.EventUsage, Usage: &total})
-			emit(stream.StreamEvent{Type: stream.EventDone, Meta: lastMeta})
+			emitFinal(stream.StreamEvent{Type: stream.EventUsage, Usage: &total})
+			emitFinal(stream.StreamEvent{Type: stream.EventDone, Meta: lastMeta})
 			return
 		}
 
@@ -476,8 +494,8 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 				)
 				continue
 			}
-			emit(stream.StreamEvent{Type: stream.EventUsage, Usage: &total})
-			emit(stream.StreamEvent{Type: stream.EventDone, Meta: lastMeta})
+			emitFinal(stream.StreamEvent{Type: stream.EventUsage, Usage: &total})
+			emitFinal(stream.StreamEvent{Type: stream.EventDone, Meta: lastMeta})
 			return
 		}
 
@@ -570,7 +588,19 @@ func (a *Agent) executeAll(ctx context.Context, exec Executor, sessionID string,
 
 func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, toolNames map[string]bool, unattended bool, emit func(stream.StreamEvent)) provider.ToolResult {
 	start := time.Now()
-	content, status := a.resolveAndRun(ctx, exec, sessionID, call, toolNames, unattended, emit)
+	// A panicking tool must become feedback the model can read (D-009),
+	// never a process crash: executeOne runs inside an errgroup worker,
+	// and an unrecovered panic there takes down the whole brain — every
+	// active turn and mission with it.
+	content, status := func() (content, status string) {
+		defer func() {
+			if p := recover(); p != nil {
+				a.logger.Error("tool panicked", "tool", call.Name, "panic", p, "stack", string(debug.Stack()))
+				content, status = fmt.Sprintf("tool %s failed with an internal error: %v", call.Name, p), "error"
+			}
+		}()
+		return a.resolveAndRun(ctx, exec, sessionID, call, toolNames, unattended, emit)
+	}()
 	isError := status != "ok"
 
 	if status == "ok" {

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -262,6 +262,94 @@ func TestAgentToolCallThenAnswer(t *testing.T) {
 	}
 }
 
+// cancelThenCutGateway streams one chunk, waits until the caller's
+// context is canceled, then closes the channel bare — no terminal.
+// This is the exact shape of the turn deadline racing a provider cut.
+type cancelThenCutGateway struct{ ctxDone <-chan struct{} }
+
+func (g *cancelThenCutGateway) RouteForRole(_ context.Context, role string) (string, bool, error) {
+	return role, true, nil
+}
+
+func (g *cancelThenCutGateway) Stream(_ context.Context, _ gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+	ch := make(chan stream.StreamEvent)
+	go func() {
+		defer close(ch)
+		ch <- stream.StreamEvent{Type: stream.EventChunk, Text: "par"}
+		<-g.ctxDone
+	}()
+	return ch, nil
+}
+
+// TestAgentTerminalSurvivesContextCancel pins the emitFinal fix: when
+// the turn context dies at the same instant the provider stream cuts
+// with no terminal, the loop's synthesized incomplete event must still
+// reach a live consumer — the old emit raced ctx.Done() and could drop
+// it, leaving the relay with nothing to persist (a real ~30min turn
+// once vanished with zero session_events this way).
+func TestAgentTerminalSurvivesContextCancel(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(t.Context())
+	gw := &cancelThenCutGateway{ctxDone: ctx.Done()}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(ctx, Request{SessionID: "s1", Route: "coding", Messages: []provider.Message{{Role: "user", Content: "go"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first := <-ch
+	if first.Type != stream.EventChunk {
+		t.Fatalf("first event = %+v, want chunk", first)
+	}
+	cancel()
+	evs := collect(t, ch)
+
+	inc := ofType(evs, stream.EventIncomplete)
+	if len(inc) != 1 || !strings.Contains(inc[0].Text, "without a terminal event") {
+		t.Fatalf("incomplete events = %+v, want exactly one no-terminal incomplete", inc)
+	}
+}
+
+// TestAgentToolPanicBecomesErrorResult pins the recover in executeOne:
+// a panicking tool must come back to the model as an error result
+// (D-009), not crash the process — executeOne runs inside an errgroup
+// worker, and an unrecovered panic there takes down every active turn
+// and mission with it.
+func TestAgentToolPanicBecomesErrorResult(t *testing.T) {
+	t.Parallel()
+	bomb := &tools.Tool{
+		Name:        "bomb",
+		Description: "panics",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`),
+		Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+			panic("boom")
+		},
+	}
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"bomb", `{}`}),
+		finalStep("survived"),
+	}}
+	a, _, _, _ := testAgent(t, gw, bomb)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding", Messages: []provider.Message{{Role: "user", Content: "go"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	results := ofType(evs, stream.EventToolResult)
+	if len(results) != 1 || results[0].ToolResult.Status != "error" {
+		t.Fatalf("tool results = %+v, want one error result", results)
+	}
+	if !strings.Contains(results[0].ToolResult.Digest, "internal error") {
+		t.Fatalf("digest = %q, want panic folded into feedback", results[0].ToolResult.Digest)
+	}
+	if got := ofType(evs, stream.EventDone); len(got) != 1 {
+		t.Fatalf("done events = %d, want the turn to continue and finish", len(got))
+	}
+}
+
 func TestAgentParallelCallsRunConcurrently(t *testing.T) {
 	t.Parallel()
 	var mu sync.Mutex

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -276,6 +276,13 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 	// not be mistaken for the still-blocked destructive one resolving.
 	parked := map[string]bool{}
 	servedModel := ""
+	// sawTerminal mirrors chat's D-044 discipline: a channel that
+	// closes with no done/error/incomplete means every producer lost
+	// its terminal (deadline racing a stream cut). Without this check a
+	// silent cut returned a clean empty verdict, which the caller read
+	// as a missing sentinel and burned a recovery re-run plus a forced
+	// retry — two full model turns for one infra failure.
+	sawTerminal := false
 	for ev := range events {
 		switch ev.Type {
 		case stream.EventChunk:
@@ -308,15 +315,36 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 				r.parker.OnPermissionDenied(ctx, req.MissionID, ev.ToolResult.Name, ev.ToolResult.Digest)
 			}
 		case stream.EventDone:
+			sawTerminal = true
 			if ev.Meta != nil {
 				servedModel = ev.Meta.Model
 			}
+		case stream.EventIncomplete:
+			// A cut-off stream is an infra failure, not a short clean
+			// answer — without this case it was indistinguishable from
+			// one and flowed into sentinel parsing. Both this and the
+			// error case return directly, so only done needs to mark
+			// sawTerminal.
+			if len(parked) > 0 && r.parker != nil {
+				r.parker.OnPermissionCleared(ctx, req.MissionID)
+			}
+			return b.String(), sentinelArgs, fmt.Errorf("mission runner: incomplete stream: %s", ev.Text)
 		case stream.EventError:
 			if len(parked) > 0 && r.parker != nil {
 				r.parker.OnPermissionCleared(ctx, req.MissionID)
 			}
-			return b.String(), sentinelArgs, fmt.Errorf("mission runner: %s", ev.Err.Message)
+			msg := "provider stream error"
+			if ev.Err != nil {
+				msg = ev.Err.Message
+			}
+			return b.String(), sentinelArgs, fmt.Errorf("mission runner: %s", msg)
 		}
+	}
+	if !sawTerminal {
+		if len(parked) > 0 && r.parker != nil {
+			r.parker.OnPermissionCleared(ctx, req.MissionID)
+		}
+		return b.String(), sentinelArgs, fmt.Errorf("mission runner: stream ended without a terminal event")
 	}
 	if servedModel != "" && r.belowFloor(servedModel) {
 		return b.String(), sentinelArgs, fmt.Errorf("%w: %s", ErrModelFloor, servedModel)

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -20,9 +20,13 @@ import (
 // scriptedAgent is a fake agentStream that replays a fixed sequence of
 // event batches, one batch per call to Start — call N of Start gets
 // batch N. Lets a test script "first turn has no sentinel, recovery
-// turn does" without a real gateway.
+// turn does" without a real gateway. The real loop.Agent guarantees
+// exactly one terminal event before close, so batches that don't end
+// on one get an EventDone appended — a bare close is the abnormal
+// shape runTurn now rejects, and only rawClose tests script it.
 type scriptedAgent struct {
 	batches  [][]stream.StreamEvent
+	rawClose bool // suppress the auto-appended terminal (terminal-loss tests)
 	call     int
 	requests []loop.Request
 }
@@ -34,12 +38,27 @@ func (f *scriptedAgent) Start(ctx context.Context, req loop.Request) (<-chan str
 	if i >= len(f.batches) {
 		i = len(f.batches) - 1
 	}
-	ch := make(chan stream.StreamEvent, len(f.batches[i]))
-	for _, ev := range f.batches[i] {
+	batch := f.batches[i]
+	if !f.rawClose && !endsTerminal(batch) {
+		batch = append(append([]stream.StreamEvent(nil), batch...), stream.StreamEvent{Type: stream.EventDone})
+	}
+	ch := make(chan stream.StreamEvent, len(batch))
+	for _, ev := range batch {
 		ch <- ev
 	}
 	close(ch)
 	return ch, nil
+}
+
+func endsTerminal(batch []stream.StreamEvent) bool {
+	if len(batch) == 0 {
+		return false
+	}
+	switch batch[len(batch)-1].Type {
+	case stream.EventDone, stream.EventError, stream.EventIncomplete:
+		return true
+	}
+	return false
 }
 
 func textEvent(s string) stream.StreamEvent {
@@ -822,5 +841,52 @@ func TestRunWorkerReportsPermissionDenied(t *testing.T) {
 	}
 	if len(parker.denied) != 1 || !strings.HasPrefix(parker.denied[0], "m1:shell:") {
 		t.Fatalf("parker.denied = %v, want exactly one m1:shell:... entry", parker.denied)
+	}
+}
+
+// TestRunTurnBareCloseIsError pins the missions half of D-044: a loop
+// channel that closes with no terminal event at all (every producer
+// lost it to the turn deadline racing a stream cut) must surface as an
+// infra error — previously it returned a clean empty verdict, which
+// the caller read as a missing sentinel and burned a recovery re-run
+// plus a forced retry for one silent infra failure.
+func TestRunTurnBareCloseIsError(t *testing.T) {
+	agent := &scriptedAgent{rawClose: true, batches: [][]stream.StreamEvent{{
+		textEvent("partial work"),
+	}}}
+	r := newTestRunner(agent)
+	text, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName)
+	if err == nil || !strings.Contains(err.Error(), "without a terminal event") {
+		t.Fatalf("err = %v, want no-terminal error", err)
+	}
+	if text != "partial work" {
+		t.Fatalf("text = %q, want the partial preserved", text)
+	}
+}
+
+// TestRunTurnIncompleteIsError: a cut-off stream (EventIncomplete
+// terminal) is an infra failure, not a short clean answer — it must
+// not flow into sentinel parsing as if the worker finished.
+func TestRunTurnIncompleteIsError(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{{
+		textEvent("partial"),
+		{Type: stream.EventIncomplete, Text: "stream ended without a terminal event"},
+	}}}
+	r := newTestRunner(agent)
+	if _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "incomplete stream") {
+		t.Fatalf("err = %v, want incomplete-stream error", err)
+	}
+}
+
+// TestRunTurnNilErrErrorEvent: an EventError carrying a nil Err must
+// not panic the runner (chat's noteFailure guards this; the runner
+// dereferenced ev.Err.Message unconditionally).
+func TestRunTurnNilErrErrorEvent(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{{
+		{Type: stream.EventError},
+	}}}
+	r := newTestRunner(agent)
+	if _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "provider stream error") {
+		t.Fatalf("err = %v, want generic provider stream error", err)
 	}
 }

--- a/web/src/components/missions/FullscreenPanel.tsx
+++ b/web/src/components/missions/FullscreenPanel.tsx
@@ -51,7 +51,14 @@ export function FullscreenDialog({
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex h-[calc(100vh-4rem)] max-w-[calc(100vw-4rem)] flex-col p-0 sm:max-w-[calc(100vw-4rem)]">
+      {/* The panel re-renders its own header inside the dialog, and its
+          FullscreenToggle (now a minimize button) sits exactly where
+          DialogContent's built-in close X lands — suppress the X so the
+          two don't overlap; Escape and the toggle both still exit. */}
+      <DialogContent
+        showCloseButton={false}
+        className="flex h-[calc(100vh-4rem)] max-w-[calc(100vw-4rem)] flex-col p-0 sm:max-w-[calc(100vw-4rem)]"
+      >
         {children}
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Why

The alpha.6 retry of the flight session still died with zero session_events: at the 30m turn ceiling, every producer in the terminal chain raced its send against a done context, and Go's random select pick dropped the only evidence the turn existed. Root-caused to a fourth instance of the #156/#157/#158 bug family, plus two more found in an architecture review of the loop/turn/session surfaces.

## What

**Terminal delivery is now deterministic with a live consumer:**
- `gwclient`: synthetic `gateway_stream_cut` sends with a bounded 5s timeout instead of racing `ctx.Done()` — both chat relay and missions runner always drain until close, so the race protected nothing and randomly ate real failures.
- `loop`: new `emitFinal` (same semantics) for the usage/terminal pair at all four exits.

**Evidence is now structurally guaranteed:**
- `persistTurn`: bare abnormal end (no text, no failure) synthesizes `turn_failed{turn_aborted}` — a turn that ran can never again leave zero events.
- missions runner: bare channel close → infra error (was: clean empty verdict → wasted recovery turn + forced retry); `EventIncomplete` handled; nil-`Err` error event no longer panics.

**Process survival:**
- `executeOne` recovers tool panics into error results (D-009) — previously one panicking tool crashed brain and every active turn/mission with it.

**Operational headroom:**
- `TURN_TIMEOUT` env overrides the compiled 30m ceiling (floor: must exceed the 10m permission park). Companion to per-provider `request_timeout` (D-041) so slow CPU-only backends get real headroom instead of two deadlines landing at the same instant.

Also: fullscreen dialog's built-in X overlapped the panel's own minimize toggle — suppressed (`showCloseButton={false}`).

## Testing

- New: `TestStreamEmitsTerminalWhenCutAfterContextDone` (now deterministic, single attempt), `TestAgentTerminalSurvivesContextCancel`, `TestAgentToolPanicBecomesErrorResult`, `TestBareStreamClosePersistsTurnAborted`, `TestSetTurnTimeout`, `TestRunTurnBareCloseIsError`, `TestRunTurnIncompleteIsError`, `TestRunTurnNilErrErrorEvent`.
- `scriptedAgent` test fake now mirrors the real exactly-one-terminal contract (auto-appends done; `rawClose` scripts the abnormal shape).
- `make build test vet lint` green; web build/lint/tests green (392 passed).