### PR TITLE
feat(web): sidebar version/GitHub link, markdown user messages, widen layouts

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -235,6 +235,8 @@ services:
     <<: *service
     build:
       context: ../web
+      args:
+        GIT_SHA: ${GIT_SHA:-}
       # HugeIcons Pro registry auth for npm ci, passed as a BuildKit
       # secret (name-only ref; the value lives in deploy/.env, never in
       # the repo or an image layer).

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,6 +3,8 @@
 # The HugeIcons Pro registry token is consumed as a BuildKit secret so
 # it never lands in an image layer or the build history.
 FROM node:24.18.0-alpine AS build
+ARG GIT_SHA
+ENV GIT_SHA=${GIT_SHA}
 WORKDIR /app
 COPY package.json package-lock.json .npmrc ./
 RUN --mount=type=secret,id=hugeicons_token \

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "timothy-web",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0-alpha.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import {
   Analytics01Icon,
   Brain02Icon,
   BubbleChatIcon,
+  GithubIcon,
   Home01Icon,
   Key01Icon,
   Moon02Icon,
@@ -170,7 +171,18 @@ function AppSidebar({
               <span>API token</span>
             </SidebarMenuButton>
           </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild tooltip="View on GitHub">
+              <a href="https://github.com/timothy-agent/timothy" target="_blank" rel="noreferrer">
+                <HugeiconsIcon icon={GithubIcon} />
+                <span>GitHub</span>
+              </a>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
         </SidebarMenu>
+        <div className="px-2 py-1 text-xs text-muted-foreground group-data-[collapsible=icon]:hidden">
+          v{__APP_VERSION__} ({__GIT_SHA__})
+        </div>
       </SidebarFooter>
     </Sidebar>
   )
@@ -361,7 +373,7 @@ function App() {
                 <Route
                   path="/chat/:id?"
                   element={
-                    <div className="mx-auto flex h-full max-w-4xl flex-col">
+                    <div className="mx-auto flex h-full w-full max-w-full flex-col px-8">
                       <Chat onNeedToken={openToken} />
                     </div>
                   }
@@ -369,7 +381,7 @@ function App() {
                 <Route
                   path="/research/:id?"
                   element={
-                    <div className="mx-auto flex h-full max-w-4xl flex-col">
+                    <div className="mx-auto flex h-full w-full max-w-full flex-col px-8">
                       <Research onNeedToken={openToken} />
                     </div>
                   }

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -171,6 +171,12 @@ describe('copy buttons', () => {
     expect(onRetry).toHaveBeenCalledOnce()
   })
 
+  it('renders markdown in a user message', () => {
+    render(<UserMessage text={'**bold** and `code`'} />)
+    expect(screen.getByText('bold').tagName).toBe('STRONG')
+    expect(screen.getByText('code').tagName).toBe('CODE')
+  })
+
   it('hides the copy button while streaming', () => {
     const msg = play([{ type: 'chunk', text: 'partial' }])
     render(<AssistantMessage msg={msg} />)

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -228,8 +228,8 @@ export function UserMessage({
       <div className="group/message flex items-end justify-end gap-1">
         <CopyButton text={text} label="Copy message" />
         {text !== '' && (
-          <div className="max-w-2xl rounded-2xl bg-blue-600 px-4 py-2.5 text-sm/6 whitespace-pre-wrap text-white">
-            {text}
+          <div className="prose prose-sm prose-invert max-w-2xl rounded-2xl bg-blue-600 px-4 py-2.5 text-sm/6 text-white prose-pre:bg-blue-700">
+            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>{text}</ReactMarkdown>
           </div>
         )}
       </div>

--- a/web/src/pages/Analytics.test.tsx
+++ b/web/src/pages/Analytics.test.tsx
@@ -67,8 +67,9 @@ describe('Analytics budget alert', () => {
     renderPage()
     await waitFor(() => expect(screen.getAllByText('$2.50').length).toBeGreaterThan(0))
     expect(screen.queryByRole('alert')).toBeNull()
-    // A configured limit still surfaces as a tile hint.
-    expect(screen.getByText('of $10.00 budget')).toBeInTheDocument()
+    // The day budget hint only surfaces on the "Today" range.
+    fireEvent.click(screen.getByText('Today'))
+    await waitFor(() => expect(screen.getByText('of $10.00 budget')).toBeInTheDocument())
   })
 
   it('shows a banner naming every window over budget', async () => {
@@ -88,6 +89,19 @@ describe('Analytics budget alert', () => {
     // The shared widget-failure note appears; no budget banner.
     await screen.findByText(/widgets failed to load/)
     expect(screen.queryByRole('alert')).toBeNull()
+  })
+})
+
+describe('Analytics spend tile', () => {
+  it('labels the spend tile after the selected range', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getByText('Spend this week')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('Today'))
+    await waitFor(() => expect(screen.getByText('Spend today')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('30 days'))
+    await waitFor(() => expect(screen.getByText('Spend this month')).toBeInTheDocument())
   })
 })
 

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -52,8 +52,6 @@ function compact(v: number): string {
 
 interface Loaded {
   summary: UsageSummary
-  month: UsageSummary
-  today: UsageSummary
   byProvider: UsagePoint[]
   byModel: UsagePoint[]
   byRoute: UsagePoint[]
@@ -128,11 +126,6 @@ export function Analytics() {
 
   useEffect(() => {
     const { from, to, bucket } = rangeDates(range)
-    const startOfToday = new Date()
-    startOfToday.setHours(0, 0, 0, 0)
-    const startOfMonth = new Date()
-    startOfMonth.setDate(1)
-    startOfMonth.setHours(0, 0, 0, 0)
 
     const emptySummary: UsageSummary = {
       cost_usd: 0,
@@ -151,8 +144,6 @@ export function Analytics() {
     setError(null)
     Promise.allSettled([
       usageSummary(from, to),
-      usageSummary(startOfMonth, to),
-      usageSummary(startOfToday, to),
       usageSeries(from, to, bucket, 'provider'),
       usageSeries(from, to, bucket, 'model'),
       usageSeries(from, to, bucket, 'route'),
@@ -171,17 +162,15 @@ export function Analytics() {
       }
       setData({
         summary: val(results[0], emptySummary),
-        month: val(results[1], emptySummary),
-        today: val(results[2], emptySummary),
-        byProvider: val(results[3], []),
-        byModel: val(results[4], []),
-        byRoute: val(results[5], []),
-        providerTotals: val(results[6], []),
-        modelTotals: val(results[7], []),
-        sessions: val(results[8], []),
-        latency: val(results[9], []),
-        cache: val(results[10], []),
-        budget: val<BudgetStatus | null>(results[11], null),
+        byProvider: val(results[1], []),
+        byModel: val(results[2], []),
+        byRoute: val(results[3], []),
+        providerTotals: val(results[4], []),
+        modelTotals: val(results[5], []),
+        sessions: val(results[6], []),
+        latency: val(results[7], []),
+        cache: val(results[8], []),
+        budget: val<BudgetStatus | null>(results[9], null),
       })
     })
     return () => {
@@ -254,13 +243,11 @@ export function Analytics() {
   const budget = data?.budget
   const budgetHint = (w?: { limit_usd: number | null }) =>
     w?.limit_usd != null ? `of ${money(w.limit_usd)} budget` : undefined
+  const spendLabel =
+    range === 'today' ? 'Spend today' : range === '7d' ? 'Spend this week' : 'Spend this month'
+  const spendHint = range === 'today' ? budgetHint(budget?.day) : range === '30d' ? budgetHint(budget?.month) : undefined
   const tiles = [
-    { label: 'Spend today', value: data ? money(data.today.cost_usd) : '—', hint: budgetHint(budget?.day) },
-    {
-      label: 'Spend this month',
-      value: data ? money(data.month.cost_usd) : '—',
-      hint: budgetHint(budget?.month),
-    },
+    { label: spendLabel, value: s ? money(s.cost_usd) : '—', hint: spendHint },
     {
       label: 'Requests',
       value: s ? compact(s.requests) : '—',
@@ -286,7 +273,7 @@ export function Analytics() {
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="mx-auto max-w-6xl py-8">
+      <div className="mx-auto max-w-full px-8 py-8">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <h1 className="text-2xl font-semibold tracking-tight">Analytics</h1>
@@ -336,7 +323,7 @@ export function Analytics() {
           </div>
         )}
 
-        <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4 lg:grid-cols-7">
+        <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
           {tiles.map((t) => (
             <div key={t.label} className="rounded-xl border border-border p-4">
               <div className="text-xs text-muted-foreground">{t.label}</div>

--- a/web/src/pages/EditSchedule.tsx
+++ b/web/src/pages/EditSchedule.tsx
@@ -28,7 +28,7 @@ export function EditSchedule() {
 
   if (loading) {
     return (
-      <div className="mx-auto w-full max-w-3xl px-4 py-6">
+      <div className="mx-auto w-full max-w-full px-8 py-6">
         <p className="text-sm text-muted-foreground">Loading…</p>
       </div>
     )
@@ -36,7 +36,7 @@ export function EditSchedule() {
 
   if (!schedule) {
     return (
-      <div className="mx-auto w-full max-w-3xl px-4 py-6">
+      <div className="mx-auto w-full max-w-full px-8 py-6">
         <p className="text-sm text-muted-foreground">
           Schedule not found.{' '}
           <Link to="/missions" className="underline underline-offset-2 hover:text-foreground">
@@ -48,7 +48,7 @@ export function EditSchedule() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-3xl px-4 py-6">
+    <div className="mx-auto w-full max-w-full px-8 py-6">
       <div>
         <h1 className="text-xl font-semibold tracking-tight">Edit schedule</h1>
         <p className="text-sm text-muted-foreground">

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,7 +1,8 @@
 import {
   Analytics01Icon,
-  BubbleChatIcon,
   InboxIcon,
+  RocketIcon,
+  Settings02Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useState } from 'react'
@@ -71,7 +72,7 @@ export function Home() {
 
   return (
     <div className="flex h-full flex-col items-center overflow-y-auto px-4">
-      <div className="mt-[max(3rem,12vh)] w-full max-w-2xl text-center">
+      <div className="mt-[max(3rem,12vh)] w-full max-w-4xl text-center">
         <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Timothy</h1>
         <p className="mt-2 text-sm text-muted-foreground">
           Ask anything. Chats remember what matters.
@@ -144,13 +145,13 @@ export function Home() {
         </button>
         <button
           type="button"
-          onClick={() => navigate('/research')}
+          onClick={() => navigate('/missions')}
           className="group flex flex-col items-center gap-2"
         >
           <span className="flex size-11 items-center justify-center rounded-xl border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
-            <HugeiconsIcon icon={BubbleChatIcon} className="size-5.5" />
+            <HugeiconsIcon icon={RocketIcon} className="size-5.5" />
           </span>
-          <span className="text-xs text-muted-foreground">Research</span>
+          <span className="text-xs text-muted-foreground">Missions</span>
         </button>
         <button
           type="button"
@@ -161,6 +162,16 @@ export function Home() {
             <HugeiconsIcon icon={Analytics01Icon} className="size-5.5" />
           </span>
           <span className="text-xs text-muted-foreground">Analytics</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => navigate('/settings')}
+          className="group flex flex-col items-center gap-2"
+        >
+          <span className="flex size-11 items-center justify-center rounded-xl border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
+            <HugeiconsIcon icon={Settings02Icon} className="size-5.5" />
+          </span>
+          <span className="text-xs text-muted-foreground">Settings</span>
         </button>
       </div>
     </div>

--- a/web/src/pages/Memory.tsx
+++ b/web/src/pages/Memory.tsx
@@ -314,9 +314,7 @@ export function Memory() {
   const [tab, setTab] = useState<(typeof tabs)[number]['id']>('queue')
   return (
     <div className="h-full overflow-y-auto">
-      <div
-        className={`mx-auto w-full p-6 space-y-6 ${tab === 'graph' ? 'max-w-5xl' : 'max-w-3xl'}`}
-      >
+      <div className="mx-auto w-full max-w-full space-y-6 p-6">
         <div className="flex items-center gap-2">
           <h1 className="text-lg font-semibold">Memory</h1>
           <div className="ml-auto flex gap-1 rounded-lg border p-0.5">

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -102,7 +102,7 @@ export function MissionDetail() {
   if (!id) return null
   if (!mission) {
     return (
-      <div className="mx-auto w-full max-w-5xl px-4 py-6">
+      <div className="mx-auto w-full max-w-full px-8 py-6">
         <p className="text-sm text-muted-foreground">Loading…</p>
       </div>
     )
@@ -180,7 +180,7 @@ export function MissionDetail() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-5xl space-y-6 px-4 py-6">
+    <div className="mx-auto w-full max-w-full space-y-6 px-8 py-6">
       <Link
         to="/missions"
         className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"
@@ -331,9 +331,6 @@ export function MissionDetail() {
           <h2 className="mb-2 text-sm font-semibold tracking-tight">Result</h2>
           <div className="rounded-lg border border-border bg-muted/50 p-3">
             <p className="text-sm whitespace-pre-wrap">{mission.last_evidence}</p>
-            <p className="mt-2 text-xs text-muted-foreground">
-              Worker-reported — not independently verified.
-            </p>
           </div>
         </section>
       )}

--- a/web/src/pages/Missions.tsx
+++ b/web/src/pages/Missions.tsx
@@ -38,7 +38,7 @@ export function Missions() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-5xl px-4 py-6">
+    <div className="mx-auto w-full max-w-full px-8 py-6">
       <div className="flex items-center justify-between gap-4">
         <div>
           <h1 className="text-xl font-semibold tracking-tight">Missions</h1>

--- a/web/src/pages/NewMission.tsx
+++ b/web/src/pages/NewMission.tsx
@@ -5,7 +5,7 @@ export function NewMission() {
   const navigate = useNavigate()
 
   return (
-    <div className="mx-auto w-full max-w-3xl px-4 py-6">
+    <div className="mx-auto w-full max-w-full px-8 py-6">
       <div>
         <h1 className="text-xl font-semibold tracking-tight">New mission</h1>
         <p className="text-sm text-muted-foreground">

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -26,7 +26,7 @@ export function Settings() {
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="mx-auto max-w-4xl py-8">
+      <div className="mx-auto max-w-full px-8 py-8">
         <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Providers, task allocation, and feature switches — changes serve immediately, no

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+// Injected by vite.config.ts's `define` from the GIT_SHA build arg
+// (or a local `git rev-parse --short HEAD` fallback in dev).
+declare const __GIT_SHA__: string
+// Injected by vite.config.ts's `define` from package.json's version field.
+declare const __APP_VERSION__: string

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,12 +1,32 @@
 /// <reference types="vitest/config" />
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+// GIT_SHA is passed as a build arg in the Docker image build (see
+// web/Dockerfile); falls back to reading the local git HEAD for `npm
+// run dev`/local `npm run build`, where no build arg is set.
+function gitSha() {
+  if (process.env.GIT_SHA) return process.env.GIT_SHA
+  try {
+    return execSync('git rev-parse --short HEAD', { cwd: __dirname }).toString().trim()
+  } catch {
+    return 'unknown'
+  }
+}
+
+const pkgVersion = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8')).version
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    __GIT_SHA__: JSON.stringify(gitSha()),
+    __APP_VERSION__: JSON.stringify(pkgVersion),
+  },
   resolve: {
     alias: { '@': path.resolve(__dirname, './src') },
   },


### PR DESCRIPTION
## Summary
- Sidebar footer: build-time version (package.json + git SHA) and GitHub repo link
- Home page: swap Research shortcut for Missions and Settings
- Chat: render markdown in user-sent messages (was plain text)
- Mission detail: drop the "Worker-reported — not independently verified" disclaimer
- Analytics: collapse "Spend today"/"Spend this month" into one tile that follows the selected range
- Widen page containers (Analytics, Missions, MissionDetail, Memory, Settings, EditSchedule, NewMission, Chat, Research) to fill the viewport
- Fix Analytics stat grid column count (was 7 cols for 6 tiles, left a gap)

## Test plan
- [x] `npm run build && npm run lint && npm test` all pass (pre-existing AgentRoutePicker flake unrelated, reproduces on main)
- [x] Verified locally via `make up` at localhost:3300 across affected pages