### PR TITLE
fix(web): source sidebar version from the release tag, not package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,14 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           target: ${{ matrix.target }}
-          build-args: ${{ matrix.build-args }}
+          # GIT_SHA/APP_VERSION are appended for every image, harmlessly
+          # ignored by Dockerfiles that don't declare the ARG. Sourced
+          # from the tag, not package.json, so the web sidebar's version
+          # can never drift from what was actually released.
+          build-args: |
+            ${{ matrix.build-args }}
+            GIT_SHA=${{ github.sha }}
+            APP_VERSION=${{ steps.version.outputs.value }}
           # web only: HugeIcons Pro registry auth, passed as a BuildKit
           # secret so it never lands in an image layer (not as a
           # build-arg or env, both of which persist into layer history).

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -4,7 +4,9 @@
 # it never lands in an image layer or the build history.
 FROM node:24.18.0-alpine AS build
 ARG GIT_SHA
+ARG APP_VERSION
 ENV GIT_SHA=${GIT_SHA}
+ENV APP_VERSION=${APP_VERSION}
 WORKDIR /app
 COPY package.json package-lock.json .npmrc ./
 RUN --mount=type=secret,id=hugeicons_token \

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "timothy-web",
-  "version": "0.0.0",
+  "version": "0.1.0-alpha.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "timothy-web",
-      "version": "0.0.0",
+      "version": "0.1.0-alpha.8",
       "dependencies": {
         "@fontsource-variable/geist": "^5.3.0",
         "@fontsource/geist-mono": "^5.3.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "timothy-web",
   "private": true,
-  "version": "0.1.0-alpha.7",
+  "version": "0.1.0-alpha.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -18,14 +18,23 @@ function gitSha() {
   }
 }
 
-const pkgVersion = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8')).version
+// APP_VERSION is passed as a build arg in the Docker image build (see
+// web/Dockerfile), set from the release tag so the sidebar always
+// shows what was actually deployed — package.json's own version field
+// is a source file that drifts from the tag whenever a release ships
+// without a matching bump. Falls back to package.json for `npm run
+// dev`/local `npm run build`, where no build arg is set.
+function appVersion() {
+  if (process.env.APP_VERSION) return process.env.APP_VERSION
+  return JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8')).version
+}
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   define: {
     __GIT_SHA__: JSON.stringify(gitSha()),
-    __APP_VERSION__: JSON.stringify(pkgVersion),
+    __APP_VERSION__: JSON.stringify(appVersion()),
   },
   resolve: {
     alias: { '@': path.resolve(__dirname, './src') },


### PR DESCRIPTION
## Why

After deploying alpha.8, the sidebar still showed "v0.1.0-alpha.7 (unknown)". Two independent drift bugs:

- `__APP_VERSION__` read `package.json`'s static `version` field at build time — nothing bumps that file when a release is tagged, so it silently lags.
- `__GIT_SHA__`'s `GIT_SHA` build-arg is declared in `web/Dockerfile` but the release workflow never passed it, so it fell back to `git rev-parse` inside the build container — which has no `.git` dir (the build context is `web/` only) — landing on the `catch` branch's literal `'unknown'`.

## What

Both now flow from the release tag/commit instead of a source file:
- `release.yml`: appends `GIT_SHA=${{ github.sha }}` and `APP_VERSION=${{ steps.version.outputs.value }}` to every image's build-args (no-ops for Dockerfiles without the ARG).
- `web/Dockerfile`: declares `ARG APP_VERSION` / `ENV APP_VERSION`, mirroring the existing `GIT_SHA` plumbing.
- `vite.config.ts`: `appVersion()` prefers `process.env.APP_VERSION`, falling back to `package.json` only when no build-arg is set (local `npm run dev`/`build`).
- `package.json` version bumped to 0.1.0-alpha.8 to match current main, so the local-dev fallback isn't itself stale.

## Testing

Built the web image locally with `APP_VERSION=0.1.0-alpha.8 GIT_SHA=deadbeef` and confirmed both strings land in the built bundle. Full `npm run build && npm run lint && npm test` green (394 tests).