### PR TITLE
fix(web): short git sha in sidebar, retry button on failed turns

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,8 @@ jobs:
       - uses: actions/checkout@v7
       - id: version
         run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - id: sha
+        run: echo "short=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -86,7 +88,7 @@ jobs:
           # can never drift from what was actually released.
           build-args: |
             ${{ matrix.build-args }}
-            GIT_SHA=${{ github.sha }}
+            GIT_SHA=${{ steps.sha.outputs.short }}
             APP_VERSION=${{ steps.version.outputs.value }}
           # web only: HugeIcons Pro registry auth, passed as a BuildKit
           # secret so it never lands in an image layer (not as a

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -2,7 +2,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ChatEvent } from '../api/types'
 import { applyEvent, emptyAssistant, type AssistantState } from '../lib/chat'
-import { AssistantMessage, CompactionDivider, InterruptedMessage, UserMessage } from './Message'
+import { AssistantMessage, CompactionDivider, ErrorMessage, InterruptedMessage, UserMessage } from './Message'
 
 vi.mock('../api/client', () => ({
   fetchAttachmentBlob: vi.fn(),
@@ -130,6 +130,19 @@ describe('replay-only components', () => {
     const el = screen.getByTestId('interrupted')
     expect(el).toHaveTextContent('Once upon a')
     expect(el).toHaveTextContent('interrupted')
+  })
+
+  it('renders no retry button on a failed turn without onRetry', () => {
+    render(<ErrorMessage text="context deadline exceeded" />)
+    expect(screen.getByTestId('turn-failed')).toHaveTextContent('context deadline exceeded')
+    expect(screen.queryByTestId('retry-button')).not.toBeInTheDocument()
+  })
+
+  it('shows a retry button on a failed turn when onRetry is given, and calls it on click', () => {
+    const onRetry = vi.fn()
+    render(<ErrorMessage text="context deadline exceeded" onRetry={onRetry} />)
+    fireEvent.click(screen.getByTestId('retry-button'))
+    expect(onRetry).toHaveBeenCalledOnce()
   })
 })
 

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -288,10 +288,29 @@ export function InterruptedMessage({ text }: { text: string }) {
 // terminal error/incomplete with nothing worth keeping, or a completed
 // turn with no text, reasoning, or tool calls. Surfacing this IS the
 // point — the turn used to vanish from the transcript silently.
-export function ErrorMessage({ text }: { text: string }) {
+export function ErrorMessage({
+  text,
+  onRetry,
+}: {
+  text: string
+  // Present only for the trailing item when it's safe to retry (same
+  // trailing-only condition Chat.tsx applies to user/assistant items) —
+  // without this a failed turn had no way back into the UI at all.
+  onRetry?: () => void
+}) {
   return (
     <div className="flex items-center gap-2" data-testid="turn-failed">
       <Badge variant="destructive">{text || 'this turn failed'}</Badge>
+      {onRetry && (
+        <button
+          type="button"
+          data-testid="retry-button"
+          onClick={onRetry}
+          className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+        >
+          retry
+        </button>
+      )}
     </div>
   )
 }

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -585,7 +585,16 @@ export function Chat({
             case 'interrupted':
               return <InterruptedMessage key={item.id} text={item.text} />
             case 'error':
-              return <ErrorMessage key={item.id} text={item.text} />
+              return (
+                <ErrorMessage
+                  key={item.id}
+                  text={item.text}
+                  // Same trailing-only condition as user/assistant items:
+                  // a failed turn had no way back into the UI at all
+                  // without this — the user had to type the message again.
+                  onRetry={i === items.length - 1 && !streaming ? retryLast : undefined}
+                />
+              )
             default:
               return (
                 <AssistantMessage


### PR DESCRIPTION
## Why

Two bugs spotted on alpha.9:

1. Sidebar showed the full 40-char commit sha, overflowing the sidebar container — my own PR #161 fix passed `github.sha` (full) as the `GIT_SHA` build-arg, where the local-dev fallback (`git rev-parse --short HEAD`) had always been 7 chars.
2. A turn that failed (persisted as `turn_failed`, e.g. a `context deadline exceeded`) rendered with no way to retry — Chat.tsx's transcript render wires `onRetry` for the trailing user/assistant item but the `error` case never got it, so the only recovery was retyping the message.

## What

- `release.yml`: adds a `sha` step computing the 7-char short form, used for `GIT_SHA` instead of the raw `github.sha`.
- `ErrorMessage` takes an optional `onRetry`, rendering the same `retry` button as `UserMessage`/`AssistantMessage`.
- `Chat.tsx`'s `error` case now passes `onRetry={retryLast}` under the same trailing-only condition as the other two cases.

## Testing

Two new `Message.test.tsx` cases (mirroring the existing user/assistant retry-button tests). Full `npm run build && npm run lint && npm test` green (396 tests).