### PR TITLE
fix(gateway): bound provider streams by idle gap, not total duration

### DIFF
--- a/internal/gateway/provider/httpx.go
+++ b/internal/gateway/provider/httpx.go
@@ -150,16 +150,28 @@ type relayFunc func(ctx context.Context, body io.Reader, ch chan<- stream.Stream
 // lifecycle, terminal error emission, and the incomplete+done tail
 // when a stream cuts off mid-flight. Drivers own only request building
 // and delta parsing.
+//
+// timeout bounds IDLE gaps, not the call's total wall-clock: a slow
+// CPU-only backend (e.g. remote Ollama) can take longer than any fixed
+// ceiling to finish a response while still emitting chunks the whole
+// time, so a flat deadline forces an impossible choice between cutting
+// live generation short and leaving a genuinely stuck stream to hang
+// forever. The watchdog resets on every relayed event; only a gap with
+// no activity for a full `timeout` cancels the call.
 func runStream(ctx context.Context, client *http.Client, timeout time.Duration, retries int, build func(ctx context.Context) (*http.Request, error), relay relayFunc) <-chan stream.StreamEvent {
 	ch := make(chan stream.StreamEvent)
 	go func() {
 		defer close(ch)
-		callCtx, cancel := context.WithTimeout(ctx, timeout)
-		defer cancel()
+		callCtx, cancel := context.WithCancelCause(ctx)
+		defer cancel(nil)
+		idle := time.AfterFunc(timeout, func() { cancel(context.DeadlineExceeded) })
+		defer idle.Stop()
+		resetIdle := func() { idle.Reset(timeout) }
 
 		resp, err := doWithRetry(callCtx, client, retries, func() (*http.Request, error) {
 			return build(callCtx)
 		}, func(ri stream.RetryInfo) bool {
+			resetIdle()
 			return emit(callCtx, ch, stream.StreamEvent{Type: stream.EventRetry, Retry: &ri})
 		})
 		if err != nil {
@@ -171,7 +183,24 @@ func runStream(ctx context.Context, client *http.Client, timeout time.Duration, 
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		finished, readErr := relay(callCtx, resp.Body, ch)
+		// relayCh proxies every event to ch and resets the idle watchdog
+		// on each one, so any activity (chunk, tool call, usage, retry)
+		// counts — not just raw bytes off the wire.
+		relayCh := make(chan stream.StreamEvent)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for ev := range relayCh {
+				resetIdle()
+				if !emit(callCtx, ch, ev) {
+					return
+				}
+			}
+		}()
+		finished, readErr := relay(callCtx, resp.Body, relayCh)
+		close(relayCh)
+		<-done
+
 		if finished {
 			return
 		}

--- a/internal/gateway/provider/runstream_test.go
+++ b/internal/gateway/provider/runstream_test.go
@@ -101,6 +101,67 @@ func TestRunStreamFinishedRelayGetsNoTail(t *testing.T) {
 	}
 }
 
+// TestRunStreamSurvivesSlowButActiveRelay pins the fix for a slow
+// CPU-only backend (e.g. remote Ollama) being cut off mid-generation:
+// the timeout bounds IDLE gaps, not the call's total wall-clock, so a
+// relay that keeps emitting well past `timeout` must still finish
+// cleanly as long as no single gap exceeds it.
+func TestRunStreamSurvivesSlowButActiveRelay(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(srv.Close)
+
+	const idle = 40 * time.Millisecond
+	ch := runStream(t.Context(), &http.Client{}, idle, maxRetries, buildFor(srv.URL),
+		func(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (bool, error) {
+			for i := 0; i < 5; i++ {
+				time.Sleep(idle / 2)
+				if !emit(ctx, ch, stream.StreamEvent{Type: stream.EventChunk, Text: "tok"}) {
+					return false, ctx.Err()
+				}
+			}
+			emit(ctx, ch, stream.StreamEvent{Type: stream.EventDone})
+			return true, nil
+		})
+	events := collect(t, ch)
+
+	chunks := eventsOfType(events, stream.EventChunk)
+	if len(chunks) != 5 {
+		t.Fatalf("want 5 chunks despite total runtime exceeding the idle timeout, got %+v", events)
+	}
+	if lastType(t, events) != stream.EventDone {
+		t.Fatalf("last = %v, want done", lastType(t, events))
+	}
+}
+
+// TestRunStreamCutsOffOnRealIdleGap confirms a genuine stall (no
+// activity at all) still cancels the call — the watchdog must not
+// become a way to hang forever.
+func TestRunStreamCutsOffOnRealIdleGap(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(srv.Close)
+
+	relayReturned := make(chan struct{})
+	ch := runStream(t.Context(), &http.Client{}, 30*time.Millisecond, maxRetries, buildFor(srv.URL),
+		func(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (bool, error) {
+			defer close(relayReturned)
+			<-ctx.Done()
+			return false, ctx.Err()
+		})
+	events := collect(t, ch)
+
+	select {
+	case <-relayReturned:
+	default:
+		t.Fatal("relay never observed cancellation")
+	}
+	inc := eventsOfType(events, stream.EventIncomplete)
+	if len(inc) != 1 {
+		t.Fatalf("want one incomplete event on genuine stall, got %+v", events)
+	}
+}
+
 func TestRunStreamRetryEventsPrecedeSuccess(t *testing.T) {
 	t.Parallel()
 	var calls atomic.Int32

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -4,6 +4,7 @@ import {
   Link04Icon,
   Loading03Icon,
   Pdf02Icon,
+  ReloadIcon,
   Tick02Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
@@ -238,11 +239,12 @@ export function UserMessage({
           <span className="text-xs">No reply — the turn failed.</span>
           <button
             type="button"
+            aria-label="Retry"
             data-testid="retry-button"
             onClick={onRetry}
-            className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+            className="rounded p-1 text-muted-foreground transition hover:bg-accent hover:text-foreground"
           >
-            retry
+            <HugeiconsIcon icon={ReloadIcon} className="size-3.5" />
           </button>
         </div>
       )}
@@ -304,11 +306,12 @@ export function ErrorMessage({
       {onRetry && (
         <button
           type="button"
+          aria-label="Retry"
           data-testid="retry-button"
           onClick={onRetry}
-          className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          className="rounded p-1 text-muted-foreground transition hover:bg-accent hover:text-foreground"
         >
-          retry
+          <HugeiconsIcon icon={ReloadIcon} className="size-3.5" />
         </button>
       )}
     </div>
@@ -381,11 +384,12 @@ export function AssistantMessage({
           {onRetry && (
             <button
               type="button"
+              aria-label="Retry"
               data-testid="retry-button"
               onClick={onRetry}
-              className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+              className="rounded p-1 text-muted-foreground transition hover:bg-accent hover:text-foreground"
             >
-              retry
+              <HugeiconsIcon icon={ReloadIcon} className="size-3.5" />
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Gateway's `runStream` timeout now bounds idle gaps (no activity), not total call duration — a slow CPU-only remote Ollama can run long while still streaming and no longer gets cut off by `request_timeout` mid-generation.
- Retry buttons (UserMessage/ErrorMessage/AssistantMessage) now use a reload icon instead of text, matching the other message action buttons.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...` + `go test -race ./...`
- [x] `make lint` (0 issues)
- [x] New tests: `TestRunStreamSurvivesSlowButActiveRelay`, `TestRunStreamCutsOffOnRealIdleGap`
- [x] web build/lint/test via `docker compose ... web-dev`