### PR TITLE
feat(gateway): surface provider failover and shorten chain_exhausted

### DIFF
--- a/internal/brain/session/projection.go
+++ b/internal/brain/session/projection.go
@@ -286,7 +286,15 @@ func UITranscript(events []Event) ([]TranscriptItem, error) {
 			if err := decode(ev, &f); err != nil {
 				return nil, err
 			}
-			item.Kind, item.Text = "error", f.Message
+			item.Kind = "error"
+			if f.Code == "chain_exhausted" {
+				// Older rows persisted the raw, provider-error-laden
+				// message; always render the short form regardless of
+				// what's stored so history and new turns read the same way.
+				item.Text = "all providers failed (chain_exhausted)"
+			} else {
+				item.Text = f.Message
+			}
 		default:
 			continue // session_started renders nothing
 		}

--- a/internal/brain/session/projection_test.go
+++ b/internal/brain/session/projection_test.go
@@ -394,6 +394,33 @@ func TestUITranscriptRendersTurnFailed(t *testing.T) {
 	}
 }
 
+// TestUITranscriptShortensChainExhausted confirms chain_exhausted
+// always renders as a short, code-based message — even for rows
+// persisted before the codes-only summary shipped, whose stored
+// message carries raw per-provider wire error text with no use to a
+// user reading history.
+func TestUITranscriptShortensChainExhausted(t *testing.T) {
+	t.Parallel()
+	events := []Event{
+		user(t, 1, "do the thing"),
+		ev(t, 2, KindTurnFailed, TurnFailed{
+			Code:    "chain_exhausted",
+			Message: `every provider attempt failed: AWS Bedrock/nova-pro: operation error Bedrock Runtime: ConverseStream, context canceled; GLM (Z.ai)/glm-5.2: terminated signal received`,
+		}),
+	}
+
+	items, err := UITranscript(events)
+	if err != nil {
+		t.Fatalf("UITranscript: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %+v, want 2", items)
+	}
+	if items[1].Kind != "error" || items[1].Text != "all providers failed (chain_exhausted)" {
+		t.Fatalf("chain_exhausted item = %+v, want short form", items[1])
+	}
+}
+
 // TestUITranscriptExposesDuration confirms UITranscript carries an
 // assistant_turn's DurationMs through to the replay item — replayed
 // sessions must show the same turn-stats duration the live SSE meta

--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -194,7 +194,7 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 		Effort:    req.Effort,
 	}
 
-	var failed []string
+	var codes []string
 	for i, att := range attempts {
 		completion.Model = att.Model
 		// Last chain entry gets the full in-provider retry budget;
@@ -208,8 +208,15 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 		}, send)
 
 		if res.failedOver() {
-			failed = append(failed, fmt.Sprintf("%s/%s: %s", att.ProviderName, att.Model, res.reason))
+			codes = append(codes, res.entry.ErrorCode)
 			a.recordAttempt(r.Context(), res.entry)
+			if next := i + 1; next < len(attempts) {
+				send(stream.StreamEvent{Type: stream.EventFailover, Failover: &stream.FailoverInfo{
+					FromProvider: att.ProviderName, FromModel: att.Model,
+					ToProvider: attempts[next].ProviderName, ToModel: attempts[next].Model,
+					Code: res.entry.ErrorCode,
+				}})
+			}
 			continue
 		}
 
@@ -218,13 +225,14 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Chain exhausted with nothing streamed: report every attempt. The
-	// per-attempt error rows recorded above ARE this request's
-	// accounting (one ledger row per provider call); no synthetic
-	// summary row is written.
+	// Chain exhausted with nothing streamed: report every attempt by
+	// error code only, never the raw provider error text (can carry
+	// wire-level detail with no use to the client). The per-attempt
+	// error rows recorded above ARE this request's accounting (one
+	// ledger row per provider call); no synthetic summary row is written.
 	send(stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
 		Code:    "chain_exhausted",
-		Message: "every provider attempt failed: " + strings.Join(failed, "; "),
+		Message: "every provider failed: " + strings.Join(codes, ", "),
 	}})
 }
 

--- a/internal/gateway/api/api_test.go
+++ b/internal/gateway/api/api_test.go
@@ -375,11 +375,14 @@ func TestStreamChainExhausted(t *testing.T) {
 	w := postJSON(t, a.handleStream, `{"route":"coding","messages":[{"role":"user","content":"hi"}]}`)
 
 	events := sseEvents(t, w.Body.String())
-	if len(events) != 1 || events[0].Type != stream.EventError || events[0].Err.Code != "chain_exhausted" {
-		t.Fatalf("events = %+v, want single chain_exhausted error", events)
+	if len(events) != 2 || events[0].Type != stream.EventFailover || events[1].Type != stream.EventError || events[1].Err.Code != "chain_exhausted" {
+		t.Fatalf("events = %+v, want [failover, chain_exhausted error]", events)
 	}
-	if !strings.Contains(events[0].Err.Message, "one/m1") || !strings.Contains(events[0].Err.Message, "two/m2") {
-		t.Fatalf("exhaustion message misses attempts: %s", events[0].Err.Message)
+	if events[0].Failover.FromProvider != "one" || events[0].Failover.ToProvider != "two" {
+		t.Fatalf("failover event = %+v, want from one to two", events[0].Failover)
+	}
+	if !strings.Contains(events[1].Err.Message, "http_401") {
+		t.Fatalf("exhaustion message missing error codes: %s", events[1].Err.Message)
 	}
 	if len(rec.all()) != 2 {
 		t.Fatalf("ledger entries = %d, want 2 failures", len(rec.all()))

--- a/internal/gateway/stream/events.go
+++ b/internal/gateway/stream/events.go
@@ -20,6 +20,7 @@ const (
 	EventToolEnd        EventType = "tool_end"        // tool call arguments complete
 	EventUsage          EventType = "usage"           // token accounting
 	EventRetry          EventType = "retry"           // transient failure, retrying
+	EventFailover       EventType = "failover"        // chain moved to the next provider
 	EventIncomplete     EventType = "incomplete"      // stream cut off before finish
 	EventDone           EventType = "done"            // terminal: success
 	EventError          EventType = "error"           // terminal: failure
@@ -43,6 +44,7 @@ type StreamEvent struct {
 	Usage      *Usage                   `json:"usage,omitempty"`
 	Err        *StreamError             `json:"error,omitempty"`
 	Retry      *RetryInfo               `json:"retry,omitempty"`
+	Failover   *FailoverInfo            `json:"failover,omitempty"`
 	Meta       *Meta                    `json:"meta,omitempty"`
 }
 
@@ -122,4 +124,16 @@ type RetryInfo struct {
 	Attempt   int    `json:"attempt"`
 	BackoffMs int64  `json:"backoff_ms"`
 	Reason    string `json:"reason"`
+}
+
+// FailoverInfo reports the chain moving from one provider to the
+// next after a failed attempt. Code is the classified error (e.g.
+// "timeout", "http_500") — never the raw provider error text, which
+// can leak wire-level detail the client has no use for.
+type FailoverInfo struct {
+	FromProvider string `json:"from_provider"`
+	FromModel    string `json:"from_model"`
+	ToProvider   string `json:"to_provider"`
+	ToModel      string `json:"to_model"`
+	Code         string `json:"code"`
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -47,6 +47,7 @@ export interface StreamEvent {
     | 'permission_resolved'
     | 'usage'
     | 'retry'
+    | 'failover'
     | 'incomplete'
     | 'done'
     | 'error'
@@ -58,6 +59,13 @@ export interface StreamEvent {
   usage?: Usage
   error?: { code: string; message: string; retryable: boolean }
   retry?: { attempt: number; backoff_ms: number; reason: string }
+  failover?: {
+    from_provider: string
+    from_model: string
+    to_provider: string
+    to_model: string
+    code: string
+  }
   meta?: { provider: string; model: string; ledger_id?: string }
 }
 

--- a/web/src/lib/chat.ts
+++ b/web/src/lib/chat.ts
@@ -76,6 +76,17 @@ export function applyEvent(msg: AssistantState, ev: ChatEvent): AssistantState {
         ...msg,
         notices: [...msg.notices, `retrying (attempt ${ev.retry?.attempt}): ${ev.retry?.reason}`],
       }
+    case 'failover': {
+      const f = ev.failover
+      if (!f) return msg
+      return {
+        ...msg,
+        notices: [
+          ...msg.notices,
+          `${f.from_provider} failed (${f.code}), switching to ${f.to_provider}`,
+        ],
+      }
+    }
     case 'incomplete':
       return { ...msg, notices: [...msg.notices, `incomplete: ${ev.text || 'stream cut off'}`] }
     case 'error':


### PR DESCRIPTION
## Summary
- Chain failover between providers was silent — the user only saw a final answer, or on full chain exhaustion, a raw string concatenating every provider's wire-level error text (e.g. Bedrock's `operation error Bedrock Runtime: ConverseStream, https response error StatusCode: 0...`).
- Emits a new `failover` stream event on each provider switch: from/to provider+model plus a classified error code only (never raw provider error text).
- `chain_exhausted` message now lists error codes only (`every provider failed: http_401, timeout`).
- Web renders failover as a notice badge, reusing the existing retry/incomplete notices UI: `"<Provider> failed (<code>), switching to <Provider>"`.

## Test plan
- [x] `go test ./internal/gateway/... ./internal/brain/...`
- [x] `npm run build && npm run lint && npm test` (web)
- [x] Updated `TestStreamChainExhausted` for the new event shape and codes-only message