### PR TITLE
feat(web): make assistant responses full width

### DIFF
--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -269,8 +269,8 @@ export function CompactionDivider({ text }: { text: string }) {
 // answer plus an honest marker.
 export function InterruptedMessage({ text }: { text: string }) {
   return (
-    <div className="group/message flex flex-col items-start gap-2" data-testid="interrupted">
-      <div className="prose prose-sm max-w-3xl dark:prose-invert prose-pre:bg-zinc-900">
+    <div className="group/message flex w-full flex-col items-start gap-2" data-testid="interrupted">
+      <div className="prose prose-sm w-full max-w-none dark:prose-invert prose-pre:bg-zinc-900">
         <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>{text}</ReactMarkdown>
       </div>
       <div className="flex items-center gap-1.5">
@@ -346,7 +346,7 @@ export function AssistantMessage({
     ? { body: msg.text, citations: [] }
     : splitSources(collapseRepeatedTail(msg.text))
   return (
-    <div className="group/message flex flex-col items-start gap-2">
+    <div className="group/message flex w-full flex-col items-start gap-2">
       {onShowActivity && <ActivityLine msg={msg} onOpen={onShowActivity} />}
 
       {msg.permissions.length > 0 && (
@@ -359,7 +359,7 @@ export function AssistantMessage({
         </Badge>
       )}
 
-      <div className="prose prose-sm max-w-3xl dark:prose-invert prose-pre:bg-zinc-900">
+      <div className="prose prose-sm w-full max-w-none dark:prose-invert prose-pre:bg-zinc-900">
         <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>{body}</ReactMarkdown>
         {msg.streaming && msg.permissions.length === 0 && <span className="animate-pulse">▍</span>}
       </div>


### PR DESCRIPTION
## Why

The `prose` class caps text at ~65ch and the container at `max-w-3xl`, wasting most of the chat column on wide screens. Long answers with tables and code read better at full width.

## What

- `AssistantMessage` and `InterruptedMessage` prose containers: `max-w-3xl` → `w-full max-w-none`; flex wrappers get `w-full`.
- User bubbles keep `max-w-2xl` so the two sides stay visually distinct.

## Verification

Containerized `npm run build && npm run lint && npm test` — 394 tests green.