### PR TITLE
feat(secrets): write keys through to the selected backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Alpha releases with prebuilt images are available on the [Releases page](https:/
 
 Go microservices behind a single public API, one PostgreSQL database, React web UI. All run via Docker Compose.
 
-| Service      | Role                                                                                         |
-|--------------|----------------------------------------------------------------------------------------------|
+| Service      | Role                                                                                        |
+|--------------|---------------------------------------------------------------------------------------------|
 | `brain`      | Public API: chat orchestration, agent loop, missions, event-sourced sessions, SSE streaming |
 | `gateway`    | Internal LLM gateway: multi-provider routing, cost ledger                                   |
 | `memoryd`    | Internal memory service: pgvector-backed recall                                             |
 | `sandboxd`   | Internal service holding the Docker socket: per-mission sandbox containers                  |
 | `web`        | React + Tailwind interface: chat, missions, usage, settings                                 |
-| `searxng`    | Internal metasearch backend for the web_search tool                                          |
+| `searxng`    | Internal metasearch backend for the web_search tool                                         |
 | `markitdown` | Internal Python sidecar: file→markdown conversion                                           |
 | `whisper`    | Internal Python sidecar: local speech-to-text for the web mic button                        |
 
@@ -57,15 +57,15 @@ Sessions are an append-only event log: every turn, tool run, and compaction is a
 
 The fastest way to run Timothy: no Go/Node toolchain, no build step, just Docker and the released images.
 
-1. Make an empty directory and download the installer from the [latest release](https://github.com/timothy-agent/timothy/releases). While Timothy is alpha, every release is marked prerelease, so GitHub's `/releases/latest` redirect doesn't resolve; look up the newest tag instead:
+1. Make an empty directory and download the installer from the [latest release](https://github.com/timothy-agent/timothy/releases).
+While Timothy is in alpha, every release is marked prerelease, so GitHub's `/releases/latest` redirect doesn't resolve; fetch the newest tag from the API instead (needs `jq`) or check the release badge for the tag (set the `TIMOTHY_VERSION` manually):
 
    ```sh
    mkdir timothy && cd timothy
-   TAG=$(curl -fsSL https://api.github.com/repos/timothy-agent/timothy/releases \
-     | grep -E '"tag_name"|"published_at"' | paste - - \
-     | sed -E 's/.*"tag_name": "([^"]+)".*"published_at": "([^"]+)".*/\2 \1/' \
-     | sort -r | head -1 | awk '{print $2}')
-   curl -fsSLo install.sh "https://github.com/timothy-agent/timothy/releases/download/$TAG/install.sh"
+   TIMOTHY_VERSION=$(curl -fsSL "https://api.github.com/repos/timothy-agent/timothy/releases?per_page=100" | jq -r 'sort_by(.created_at) | last.tag_name')
+   # or
+   TIMOTHY_VERSION=<SET_MANUALLY>
+   curl -fsSLo install.sh "https://github.com/timothy-agent/timothy/releases/download/$TIMOTHY_VERSION/install.sh"
    ```
 
 2. Read `install.sh` before running it. Then run it:

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -56,9 +56,12 @@ func New(db *pgpool.Pool, store *router.Store, rec ledger.Recorder, budgets *led
 	return &Admin{db: db, store: store, rec: rec, budgets: budgets, secrets: secrets, log: log}
 }
 
-// SetSecret stores value under refName (write-only: the value is never
-// read back through any admin endpoint) and reloads the serving
-// snapshot so a provider whose credential_ref matches starts resolving
+// SetSecret pins refName's value to built-in storage regardless of the
+// store-wide default backend — for backend-bootstrap credentials (the
+// vault token, the ASM static secret key) that can never live behind
+// the external backend they unlock. Write-only: the value is never
+// read back through any admin endpoint. Reloads the serving snapshot
+// so a provider whose credential_ref matches starts resolving
 // immediately.
 func (a *Admin) SetSecret(ctx context.Context, refName, value string) error {
 	if refName == "" {
@@ -67,7 +70,7 @@ func (a *Admin) SetSecret(ctx context.Context, refName, value string) error {
 	if value == "" {
 		return fmt.Errorf("value is required")
 	}
-	if err := a.secrets.Set(ctx, refName, value); err != nil {
+	if err := a.secrets.SetDB(ctx, refName, value); err != nil {
 		return err
 	}
 	a.audit(ctx, "set", "secret", refName, nil, map[string]bool{"configured": true})
@@ -85,34 +88,22 @@ func (a *Admin) DeleteSecret(ctx context.Context, refName string) error {
 	return nil
 }
 
-// SetSecretExternal points refName at a secret held in an external
-// backend (vault, asm) instead of storing a value. backendRef is the
-// path/name in that system.
-func (a *Admin) SetSecretExternal(ctx context.Context, refName, backend, backendRef string) error {
+// SetSecretValue stores value under refName through the store-wide
+// default backend: built-in storage encrypts the value itself, while
+// vault/asm write the value into that system.
+func (a *Admin) SetSecretValue(ctx context.Context, refName, value string) error {
 	if refName == "" {
 		return fmt.Errorf("ref name is required")
 	}
-	if err := a.secrets.SetExternal(ctx, refName, backend, backendRef); err != nil {
+	if value == "" {
+		return fmt.Errorf("value is required")
+	}
+	if err := a.secrets.Set(ctx, refName, value); err != nil {
 		return err
 	}
-	a.audit(ctx, "set", "secret", refName, nil, map[string]string{"backend": backend})
+	a.audit(ctx, "set", "secret", refName, nil, map[string]bool{"configured": true})
 	a.reload(ctx)
 	return nil
-}
-
-// SetSecretValue stores value under refName through the store-wide
-// default backend: built-in storage encrypts the value itself, while
-// vault/asm treat it as the reference (path or name) of a secret that
-// already lives there — Timothy never writes into external systems.
-func (a *Admin) SetSecretValue(ctx context.Context, refName, value string) error {
-	backend, err := a.secrets.DefaultBackend(ctx)
-	if err != nil {
-		return err
-	}
-	if backend == "db" {
-		return a.SetSecret(ctx, refName, value)
-	}
-	return a.SetSecretExternal(ctx, refName, backend, value)
 }
 
 // SecretBackends lists every secret backend with configured/default

--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -231,9 +231,11 @@ func TestProviderCRUDAuditsAndReloads(t *testing.T) {
 	}
 }
 
-// SetSecretValue routes through the store-wide default backend: the
-// built-in store encrypts the value itself, an external default
-// records the value as that backend's reference.
+// SetSecretValue routes through the store-wide default backend: with
+// db (the seeded default) the built-in store encrypts the value
+// itself. The external-default half of this contract is write-through
+// and needs a live backend — TestSecretValueWriteThrough covers it
+// against a fake KV v2 server.
 func TestSetSecretValueFollowsDefaultBackend(t *testing.T) {
 	adm, _, _ := testAdmin(t)
 	ctx := t.Context()
@@ -244,39 +246,6 @@ func TestSetSecretValueFollowsDefaultBackend(t *testing.T) {
 	}
 	if configured, backend, err := adm.SecretStatus(ctx, ref); err != nil || !configured || backend != "db" {
 		t.Fatalf("Status = %v %q %v, want configured via db", configured, backend, err)
-	}
-
-	// Shared table: restore the pre-test vault config and default flag.
-	// Defers run while t.Context() is still alive; t.Cleanup would not.
-	origCfg, err := adm.SecretBackendConfig(ctx, "vault")
-	if err != nil {
-		t.Fatalf("SecretBackendConfig: %v", err)
-	}
-	defer func() {
-		if string(origCfg) != "{}" {
-			if err := adm.SetSecretBackendConfig(ctx, "vault", origCfg); err != nil {
-				t.Errorf("restore vault config: %v", err)
-			}
-		} else if err := adm.DeleteSecretBackendConfig(ctx, "vault"); err != nil {
-			t.Errorf("remove test vault config: %v", err)
-		}
-		if err := adm.SetDefaultSecretBackend(ctx, "db"); err != nil {
-			t.Errorf("restore default backend: %v", err)
-		}
-	}()
-
-	if err := adm.SetSecretBackendConfig(ctx, "vault", []byte(`{"address":"http://127.0.0.1:1"}`)); err != nil {
-		t.Fatalf("SetSecretBackendConfig: %v", err)
-	}
-	if err := adm.SetDefaultSecretBackend(ctx, "vault"); err != nil {
-		t.Fatalf("SetDefaultSecretBackend: %v", err)
-	}
-	extRef := adminMarker + "SECRET_VAULT"
-	if err := adm.SetSecretValue(ctx, extRef, "timothy/key#api_key"); err != nil {
-		t.Fatalf("SetSecretValue external: %v", err)
-	}
-	if configured, backend, err := adm.SecretStatus(ctx, extRef); err != nil || !configured || backend != "vault" {
-		t.Fatalf("Status = %v %q %v, want configured via vault", configured, backend, err)
 	}
 }
 

--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -785,17 +787,83 @@ func TestSecretExternalBackendConfig(t *testing.T) {
 		}
 	}
 
-	if err := adm.SetSecretExternal(ctx, ref, "vault", "timothy/anthropic#api_key"); err != nil {
-		t.Fatalf("SetSecretExternal: %v", err)
+	// SetSecretValue with backend "db" pinned bypasses the vault
+	// default entirely — no need for a live vault to serve this path.
+	if err := adm.SetSecret(ctx, ref, "x"); err != nil {
+		t.Fatalf("SetSecret (db pin): %v", err)
+	}
+	if configured, backend, err := adm.SecretStatus(ctx, ref); err != nil || !configured || backend != "db" {
+		t.Fatalf("SecretStatus: configured=%v backend=%q err=%v", configured, backend, err)
+	}
+}
+
+// TestSecretValueWriteThrough drives SetSecretValue against a fake KV
+// v2 server with vault as the default backend: the routed Set must
+// write the raw value into vault itself, not just record a reference.
+func TestSecretValueWriteThrough(t *testing.T) {
+	adm, _, _ := testAdmin(t)
+	ctx := t.Context()
+	ref := adminMarker + "vault-writethrough"
+
+	origCfg, err := adm.SecretBackendConfig(ctx, "vault")
+	if err != nil {
+		t.Fatalf("SecretBackendConfig (orig): %v", err)
+	}
+	origDefault, err := adm.secrets.DefaultBackend(ctx)
+	if err != nil {
+		t.Fatalf("DefaultBackend (orig): %v", err)
+	}
+	defer func() {
+		if string(origCfg) != "{}" {
+			if err := adm.SetSecretBackendConfig(ctx, "vault", origCfg); err != nil {
+				t.Errorf("restore vault config: %v", err)
+			}
+		} else if err := adm.DeleteSecretBackendConfig(ctx, "vault"); err != nil {
+			t.Errorf("remove test vault config: %v", err)
+		}
+		if err := adm.SetDefaultSecretBackend(ctx, origDefault); err != nil {
+			t.Errorf("restore default backend: %v", err)
+		}
+	}()
+
+	var wroteValue string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/auth/token/lookup-self":
+			w.Write([]byte(`{}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/kv/data/timothy/"+ref:
+			var body struct {
+				Data struct {
+					Value string `json:"value"`
+				} `json:"data"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			wroteValue = body.Data.Value
+			w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	if err := adm.SetSecretBackendConfig(ctx, "vault",
+		[]byte(`{"address":"`+srv.URL+`","mount":"kv","token_ref":"`+ref+`_TOKEN"}`)); err != nil {
+		t.Fatalf("SetSecretBackendConfig: %v", err)
+	}
+	if err := adm.SetSecret(ctx, ref+"_TOKEN", "vault-tok"); err != nil {
+		t.Fatalf("SetSecret token: %v", err)
+	}
+	if err := adm.SetDefaultSecretBackend(ctx, "vault"); err != nil {
+		t.Fatalf("SetDefaultSecretBackend: %v", err)
+	}
+
+	if err := adm.SetSecretValue(ctx, ref, "sk-live-through"); err != nil {
+		t.Fatalf("SetSecretValue: %v", err)
+	}
+	if wroteValue != "sk-live-through" {
+		t.Fatalf("vault received value %q, want sk-live-through", wroteValue)
 	}
 	if configured, backend, err := adm.SecretStatus(ctx, ref); err != nil || !configured || backend != "vault" {
 		t.Fatalf("SecretStatus: configured=%v backend=%q err=%v", configured, backend, err)
-	}
-
-	if err := adm.SetSecretExternal(ctx, ref, "db", "x"); err == nil {
-		t.Fatal("SetSecretExternal with backend db: want error")
-	}
-	if err := adm.SetSecretExternal(ctx, ref, "vault", ""); err == nil {
-		t.Fatal("SetSecretExternal without backend_ref: want error")
 	}
 }

--- a/internal/secretstore/backends.go
+++ b/internal/secretstore/backends.go
@@ -9,15 +9,13 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
-	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -33,17 +31,6 @@ type VaultConfig struct {
 	// AppRole fields; SecretIDRef names the stored secret_id.
 	RoleID      string `json:"role_id"`
 	SecretIDRef string `json:"secret_id_ref"`
-}
-
-// FileConfig connects the file backend to a directory of secret files
-// mounted into the container — Docker/Kubernetes secrets convention:
-// one file per secret, named by its ref, holding the raw value with an
-// optional trailing newline. No credentials of its own: the mount
-// itself is the trust boundary, set up outside Timothy.
-type FileConfig struct {
-	// Dir is the mount directory secret files live under. Defaults to
-	// /run/secrets, the Docker/Compose/Kubernetes convention.
-	Dir string `json:"dir"`
 }
 
 // ASMConfig connects the asm backend to AWS Secrets Manager. Region
@@ -67,6 +54,12 @@ type asmAPI interface {
 		opts ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
 	ListSecrets(ctx context.Context, in *secretsmanager.ListSecretsInput,
 		opts ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error)
+	CreateSecret(ctx context.Context, in *secretsmanager.CreateSecretInput,
+		opts ...func(*secretsmanager.Options)) (*secretsmanager.CreateSecretOutput, error)
+	PutSecretValue(ctx context.Context, in *secretsmanager.PutSecretValueInput,
+		opts ...func(*secretsmanager.Options)) (*secretsmanager.PutSecretValueOutput, error)
+	DeleteSecret(ctx context.Context, in *secretsmanager.DeleteSecretInput,
+		opts ...func(*secretsmanager.Options)) (*secretsmanager.DeleteSecretOutput, error)
 }
 
 const (
@@ -76,14 +69,7 @@ const (
 	//nolint:gosec // G101: a ref NAME in the secret store, not a credential value.
 	defaultASMSecretKeyRef = "AWS_SECRET_ACCESS_KEY"
 	backendHTTPTimeout     = 10 * time.Second
-	defaultFileDir         = "/run/secrets"
 )
-
-// backendRefPattern bounds what a backend_ref may look like (vault
-// paths, ASM names/ARNs, an optional #field suffix). Like
-// credential_ref it must be a name, never a value: no spaces, quotes,
-// or long opaque blobs.
-var backendRefPattern = regexp.MustCompile(`^[A-Za-z0-9_.:/#=+@-]{1,256}$`)
 
 // vaultHTTP never follows redirects: Go strips only Authorization and
 // Cookie on cross-host redirects, so a malicious or compromised
@@ -224,7 +210,7 @@ func (s *Store) Backends(ctx context.Context) ([]BackendStatus, error) {
 		return nil, fmt.Errorf("secretstore: list backends: %w", err)
 	}
 	out := []BackendStatus{{Backend: "db", Configured: true}}
-	for _, b := range []string{"vault", "asm", "file"} {
+	for _, b := range []string{"vault", "asm"} {
 		if isDefault, ok := state[b]; ok {
 			out = append(out, BackendStatus{Backend: b, Configured: true, Default: isDefault})
 		} else {
@@ -298,36 +284,15 @@ func (s *Store) SetDefaultBackend(ctx context.Context, backend string) error {
 	return nil
 }
 
-// SetExternal points refName at a secret held in an external backend.
-// backendRef is the path/name in that system (vault: "path[#field]"
-// within the configured mount, field default "value"; asm:
-// "name-or-arn[#json_key]").
-func (s *Store) SetExternal(ctx context.Context, refName, backend, backendRef string) error {
-	if err := validExternalBackend(backend); err != nil {
-		return err
-	}
-	if err := validBackendRef(backendRef); err != nil {
-		return err
-	}
-	db, err := s.db.Get()
-	if err != nil {
-		return fmt.Errorf("secretstore: %w", err)
-	}
-	_, err = db.Exec(ctx, `
-		INSERT INTO secrets (ref_name, backend, backend_ref, updated_at)
-		VALUES ($1, $2, $3, now())
-		ON CONFLICT (ref_name) DO UPDATE
-			SET backend = $2, backend_ref = $3, ciphertext = NULL, nonce = NULL, updated_at = now()`,
-		refName, backend, backendRef)
-	if err != nil {
-		return fmt.Errorf("secretstore: set external %s: %w", refName, err)
-	}
-	return nil
-}
+// probeRef is the backend_ref TestBackend's write probe uses — outside
+// the timothy/<ref_name> convention any real secret would use, so it
+// can never collide with or masquerade as one.
+const probeRef = "timothy/__probe"
 
-// TestBackend checks a backend's connectivity and auth without
-// touching any stored secret: vault does a token lookup-self, asm
-// lists at most one secret.
+// TestBackend checks a backend's connectivity, auth, and write access
+// without touching any stored secret: vault and asm each write then
+// delete a throwaway probe secret, so a backend missing write
+// permissions is caught at config time rather than on the next Set.
 func (s *Store) TestBackend(ctx context.Context, backend string) error {
 	switch backend {
 	case "vault":
@@ -339,7 +304,13 @@ func (s *Store) TestBackend(ctx context.Context, backend string) error {
 		if err != nil {
 			return err
 		}
-		return vaultRequest(ctx, cfg.Address, "/v1/auth/token/lookup-self", token, nil)
+		if err := vaultRequest(ctx, cfg.Address, "/v1/auth/token/lookup-self", token, nil); err != nil {
+			return err
+		}
+		if err := s.writeVault(ctx, probeRef, "probe"); err != nil {
+			return err
+		}
+		return s.deleteVault(ctx, probeRef)
 	case "asm":
 		client, err := s.asmClient(ctx)
 		if err != nil {
@@ -348,40 +319,20 @@ func (s *Store) TestBackend(ctx context.Context, backend string) error {
 		one := int32(1)
 		_, err = client.ListSecrets(ctx, &secretsmanager.ListSecretsInput{MaxResults: &one})
 		if err != nil {
-			return fmt.Errorf("secretstore: asm test (needs secretsmanager:ListSecrets; resolution itself only needs GetSecretValue): %w", err)
+			return fmt.Errorf("secretstore: asm test (needs secretsmanager:ListSecrets, CreateSecret, PutSecretValue, DeleteSecret; resolution itself only needs GetSecretValue): %w", err)
 		}
-		return nil
-	case "file":
-		cfg, err := s.fileConfig(ctx)
-		if err != nil {
+		if err := s.writeASM(ctx, probeRef, "probe"); err != nil {
 			return err
 		}
-		info, err := os.Stat(cfg.Dir)
-		if err != nil {
-			return fmt.Errorf("secretstore: file backend: %w", err)
-		}
-		if !info.IsDir() {
-			return fmt.Errorf("secretstore: file backend: %s is not a directory", cfg.Dir)
-		}
-		return nil
+		return s.deleteASM(ctx, probeRef)
 	default:
 		return validExternalBackend(backend)
 	}
 }
 
 func validExternalBackend(backend string) error {
-	if backend != "vault" && backend != "asm" && backend != "file" {
+	if backend != "vault" && backend != "asm" {
 		return fmt.Errorf("secretstore: unknown backend %q", backend)
-	}
-	return nil
-}
-
-// validBackendRef rejects anything that isn't a plausible path or
-// name, and any ".." segment that could escape the vault mount when
-// spliced into the request path.
-func validBackendRef(ref string) error {
-	if !backendRefPattern.MatchString(ref) || strings.Contains(ref, "..") {
-		return fmt.Errorf("secretstore: backend_ref must be a path or name (vault path, ASM name/ARN), never a secret value")
 	}
 	return nil
 }
@@ -446,18 +397,6 @@ func normalizeBackendConfig(backend string, cfg json.RawMessage) (json.RawMessag
 			return nil, fmt.Errorf("secretstore: asm config: auth must be chain, profile or keys")
 		}
 		return json.Marshal(a)
-	case "file":
-		var f FileConfig
-		if err := json.Unmarshal(cfg, &f); err != nil {
-			return nil, fmt.Errorf("secretstore: file config: %w", err)
-		}
-		if f.Dir == "" {
-			f.Dir = defaultFileDir
-		}
-		if !filepath.IsAbs(f.Dir) {
-			return nil, fmt.Errorf("secretstore: file config: dir must be an absolute path")
-		}
-		return json.Marshal(f)
 	default:
 		return nil, validExternalBackend(backend)
 	}
@@ -482,50 +421,6 @@ func (s *Store) vaultConfig(ctx context.Context) (VaultConfig, error) {
 		cfg.TokenRef = defaultVaultTokenRef
 	}
 	return cfg, nil
-}
-
-func (s *Store) fileConfig(ctx context.Context) (FileConfig, error) {
-	raw, err := s.GetBackendConfig(ctx, "file")
-	if err != nil {
-		return FileConfig{}, err
-	}
-	var cfg FileConfig
-	if err := json.Unmarshal(raw, &cfg); err != nil {
-		return FileConfig{}, fmt.Errorf("secretstore: file config: %w", err)
-	}
-	if cfg.Dir == "" {
-		cfg.Dir = defaultFileDir
-	}
-	return cfg, nil
-}
-
-// resolveFile reads a secret file from the configured mount directory.
-func (s *Store) resolveFile(ctx context.Context, backendRef string) (string, error) {
-	cfg, err := s.fileConfig(ctx)
-	if err != nil {
-		return "", err
-	}
-	return readFileSecret(cfg.Dir, backendRef)
-}
-
-// readFileSecret reads backendRef as a secret file under dir.
-// backendRef must be a bare filename — never a path with its own
-// directory components, so a stored ref can't escape the mount via
-// "../" traversal or an absolute path. The file's content is trimmed
-// of a single trailing newline (the common `printf`/`echo`-without-
-// `-n` case); interior whitespace is preserved as part of the value.
-func readFileSecret(dir, backendRef string) (string, error) {
-	if backendRef == "" || strings.ContainsAny(backendRef, "/\\") || strings.Contains(backendRef, "..") {
-		return "", fmt.Errorf("secretstore: file backend_ref must be a bare filename, got %q", backendRef)
-	}
-	path := filepath.Join(dir, backendRef)
-	//nolint:gosec // G304: backendRef is validated above to be a bare filename,
-	// no separators or "..", so path cannot escape dir.
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("secretstore: file %s: %w", path, err)
-	}
-	return strings.TrimSuffix(string(data), "\n"), nil
 }
 
 // dbSecret decrypts a db-backed secret directly — never via Resolve —
@@ -606,6 +501,42 @@ func vaultRequest(ctx context.Context, address, endpoint, token string, out any)
 	return vaultDo(ctx, http.MethodGet, address, endpoint, token, nil, out)
 }
 
+// writeVault stores value in the configured KV v2 mount at path,
+// always under the "value" field so resolveVault's default field
+// convention reads it back.
+func (s *Store) writeVault(ctx context.Context, path, value string) error {
+	cfg, err := s.vaultConfig(ctx)
+	if err != nil {
+		return err
+	}
+	token, err := s.vaultToken(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	body, err := json.Marshal(map[string]any{"data": map[string]string{"value": value}})
+	if err != nil {
+		return fmt.Errorf("secretstore: vault: %w", err)
+	}
+	endpoint := "/v1/" + cfg.Mount + "/data/" + strings.TrimPrefix(path, "/")
+	return vaultDo(ctx, http.MethodPost, cfg.Address, endpoint, token, body, nil)
+}
+
+// deleteVault permanently removes path and all its versions (metadata
+// delete, not just the current version) from the configured KV v2
+// mount.
+func (s *Store) deleteVault(ctx context.Context, path string) error {
+	cfg, err := s.vaultConfig(ctx)
+	if err != nil {
+		return err
+	}
+	token, err := s.vaultToken(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	endpoint := "/v1/" + cfg.Mount + "/metadata/" + strings.TrimPrefix(path, "/")
+	return vaultDo(ctx, http.MethodDelete, cfg.Address, endpoint, token, nil, nil)
+}
+
 func vaultDo(ctx context.Context, method, address, endpoint, token string, body []byte, out any) error {
 	ctx, cancel := context.WithTimeout(ctx, backendHTTPTimeout)
 	defer cancel()
@@ -626,7 +557,7 @@ func vaultDo(ctx context.Context, method, address, endpoint, token string, body 
 		return fmt.Errorf("secretstore: vault: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
 		return fmt.Errorf("secretstore: vault %s: status %d: %s", endpoint, resp.StatusCode, snippet)
 	}
@@ -663,6 +594,43 @@ func (s *Store) resolveASM(ctx context.Context, backendRef string) (string, erro
 		return "", fmt.Errorf("secretstore: asm %s: %w", id, err)
 	}
 	return val, nil
+}
+
+// writeASM creates a new secret named id, falling back to overwriting
+// its current value if one already exists under that name.
+func (s *Store) writeASM(ctx context.Context, id, value string) error {
+	client, err := s.asmClient(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = client.CreateSecret(ctx, &secretsmanager.CreateSecretInput{Name: &id, SecretString: &value})
+	if err == nil {
+		return nil
+	}
+	var exists *types.ResourceExistsException
+	if !errors.As(err, &exists) {
+		return fmt.Errorf("secretstore: asm create %s: %w", id, err)
+	}
+	if _, err := client.PutSecretValue(ctx, &secretsmanager.PutSecretValueInput{SecretId: &id, SecretString: &value}); err != nil {
+		return fmt.Errorf("secretstore: asm put %s: %w", id, err)
+	}
+	return nil
+}
+
+// deleteASM permanently removes a secret without the recovery window
+// — a Timothy-owned secret has no independent lifecycle to recover
+// into once its ref_name row is gone.
+func (s *Store) deleteASM(ctx context.Context, id string) error {
+	client, err := s.asmClient(ctx)
+	if err != nil {
+		return err
+	}
+	force := true
+	_, err = client.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{SecretId: &id, ForceDeleteWithoutRecovery: &force})
+	if err != nil {
+		return fmt.Errorf("secretstore: asm delete %s: %w", id, err)
+	}
+	return nil
 }
 
 func (s *Store) asmClient(ctx context.Context) (asmAPI, error) {

--- a/internal/secretstore/backends_test.go
+++ b/internal/secretstore/backends_test.go
@@ -5,12 +5,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 )
 
 func TestSplitRef(t *testing.T) {
@@ -118,130 +117,97 @@ func TestNormalizeBackendConfigAuthMethods(t *testing.T) {
 	}
 }
 
-func TestValidBackendRef(t *testing.T) {
-	for _, ok := range []string{
-		"timothy/anthropic#api_key",
-		"arn:aws:secretsmanager:eu-west-1:123456789012:secret:prod/key-AbC123",
-		"prod/api#key",
-	} {
-		if err := validBackendRef(ok); err != nil {
-			t.Errorf("validBackendRef(%q) = %v, want nil", ok, err)
+func TestValidExternalBackend(t *testing.T) {
+	for _, ok := range []string{"vault", "asm"} {
+		if err := validExternalBackend(ok); err != nil {
+			t.Errorf("validExternalBackend(%q) = %v, want nil", ok, err)
 		}
 	}
-	for _, bad := range []string{
-		"",
-		"has space",
-		"../auth/token/lookup-self",
-		"a/../../b",
-		`{"looks":"like a secret"}`,
-	} {
-		if err := validBackendRef(bad); err == nil {
-			t.Errorf("validBackendRef(%q) = nil, want error", bad)
+	for _, bad := range []string{"file", "db", "nope"} {
+		if err := validExternalBackend(bad); err == nil {
+			t.Errorf("validExternalBackend(%q) = nil, want error", bad)
 		}
 	}
 }
 
-func TestNormalizeBackendConfigFile(t *testing.T) {
-	got, err := normalizeBackendConfig("file", json.RawMessage(`{}`))
-	if err != nil {
-		t.Fatal(err)
+func TestValidExternalRefName(t *testing.T) {
+	for _, ok := range []string{"OPENAI_API_KEY", "zai.api-key", "a"} {
+		if err := validExternalRefName(ok); err != nil {
+			t.Errorf("validExternalRefName(%q) = %v, want nil", ok, err)
+		}
 	}
-	var cfg FileConfig
-	if err := json.Unmarshal(got, &cfg); err != nil {
-		t.Fatal(err)
-	}
-	if cfg.Dir != defaultFileDir {
-		t.Errorf("default dir = %q, want %q", cfg.Dir, defaultFileDir)
-	}
-
-	got, err = normalizeBackendConfig("file", json.RawMessage(`{"dir":"/mnt/secrets"}`))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := json.Unmarshal(got, &cfg); err != nil {
-		t.Fatal(err)
-	}
-	if cfg.Dir != "/mnt/secrets" {
-		t.Errorf("dir = %q, want /mnt/secrets", cfg.Dir)
-	}
-
-	if _, err := normalizeBackendConfig("file", json.RawMessage(`{"dir":"relative/path"}`)); err == nil {
-		t.Fatal("relative dir: want error")
-	}
-}
-
-func TestValidExternalBackendAcceptsFile(t *testing.T) {
-	if err := validExternalBackend("file"); err != nil {
-		t.Errorf("validExternalBackend(file) = %v, want nil", err)
-	}
-	if err := validExternalBackend("nope"); err == nil {
-		t.Fatal("unknown backend: want error")
-	}
-}
-
-func TestReadFileSecret(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "api_key"), []byte("sk-live-123\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "no_newline"), []byte("sk-no-nl"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := readFileSecret(dir, "api_key")
-	if err != nil || got != "sk-live-123" {
-		t.Fatalf("readFileSecret = (%q, %v), want (sk-live-123, nil)", got, err)
-	}
-	// Only ONE trailing newline is trimmed — interior/multiple trailing
-	// whitespace is preserved as part of the value, not guessed at.
-	got, err = readFileSecret(dir, "no_newline")
-	if err != nil || got != "sk-no-nl" {
-		t.Fatalf("readFileSecret (no trailing newline) = (%q, %v), want (sk-no-nl, nil)", got, err)
-	}
-
-	if _, err := readFileSecret(dir, "missing"); err == nil {
-		t.Fatal("missing file: want error")
-	}
-}
-
-func TestReadFileSecretRejectsPathEscapes(t *testing.T) {
-	dir := t.TempDir()
-	for _, bad := range []string{
-		"",
-		"../outside",
-		"a/../../b",
-		"sub/dir/file",
-		"/etc/passwd",
-		`C:\Windows\file`,
-	} {
-		if _, err := readFileSecret(dir, bad); err == nil {
-			t.Errorf("readFileSecret(%q) = nil, want error (path escape)", bad)
+	for _, bad := range []string{"", "a/b", "../admin", "a..b", "a b", "a#b", strings.Repeat("x", 129)} {
+		if err := validExternalRefName(bad); err == nil {
+			t.Errorf("validExternalRefName(%q) = nil, want error", bad)
 		}
 	}
 }
 
-// stubASM fakes the Secrets Manager slice the store uses.
+// stubASM fakes the Secrets Manager slice the store uses. secrets maps
+// name -> current SecretString, mutated by Create/Put/Delete so tests
+// can assert write-through behavior, not just reads.
 type stubASM struct {
-	secret string
-	err    error
+	secrets map[string]string
+	err     error
 }
 
-func (s stubASM) GetSecretValue(context.Context, *secretsmanager.GetSecretValueInput,
-	...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+func newStubASM(seed map[string]string) *stubASM {
+	if seed == nil {
+		seed = map[string]string{}
+	}
+	return &stubASM{secrets: seed}
+}
+
+func (s *stubASM) GetSecretValue(_ context.Context, in *secretsmanager.GetSecretValueInput,
+	_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
 	if s.err != nil {
 		return nil, s.err
 	}
-	return &secretsmanager.GetSecretValueOutput{SecretString: &s.secret}, nil
+	val, ok := s.secrets[*in.SecretId]
+	if !ok {
+		return nil, &types.ResourceNotFoundException{}
+	}
+	return &secretsmanager.GetSecretValueOutput{SecretString: &val}, nil
 }
 
-func (s stubASM) ListSecrets(context.Context, *secretsmanager.ListSecretsInput,
+func (s *stubASM) ListSecrets(context.Context, *secretsmanager.ListSecretsInput,
 	...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error) {
 	return &secretsmanager.ListSecretsOutput{}, s.err
 }
 
+func (s *stubASM) CreateSecret(_ context.Context, in *secretsmanager.CreateSecretInput,
+	_ ...func(*secretsmanager.Options)) (*secretsmanager.CreateSecretOutput, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if _, exists := s.secrets[*in.Name]; exists {
+		return nil, &types.ResourceExistsException{}
+	}
+	s.secrets[*in.Name] = *in.SecretString
+	return &secretsmanager.CreateSecretOutput{Name: in.Name}, nil
+}
+
+func (s *stubASM) PutSecretValue(_ context.Context, in *secretsmanager.PutSecretValueInput,
+	_ ...func(*secretsmanager.Options)) (*secretsmanager.PutSecretValueOutput, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	s.secrets[*in.SecretId] = *in.SecretString
+	return &secretsmanager.PutSecretValueOutput{Name: in.SecretId}, nil
+}
+
+func (s *stubASM) DeleteSecret(_ context.Context, in *secretsmanager.DeleteSecretInput,
+	_ ...func(*secretsmanager.Options)) (*secretsmanager.DeleteSecretOutput, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	delete(s.secrets, *in.SecretId)
+	return &secretsmanager.DeleteSecretOutput{Name: in.SecretId}, nil
+}
+
 func TestResolveASMWithStub(t *testing.T) {
 	//nolint:gosec // G101: fake stub value, not a credential.
-	s := &Store{asm: stubASM{secret: `{"api_key":"sk-9","port":443}`}}
+	s := &Store{asm: newStubASM(map[string]string{"prod/key": `{"api_key":"sk-9","port":443}`})}
 
 	got, err := s.resolveASM(context.Background(), "prod/key#api_key")
 	if err != nil || got != "sk-9" {
@@ -258,9 +224,52 @@ func TestResolveASMWithStub(t *testing.T) {
 	if _, err := s.resolveASM(context.Background(), "prod/key#port"); err == nil {
 		t.Fatal("non-string field: want error")
 	}
+}
+
+// TestWriteASMCreatesThenFallsBackToPut pins write-through: a fresh
+// name goes through CreateSecret, a name that already exists falls
+// back to PutSecretValue (ResourceExistsException) rather than
+// erroring.
+func TestWriteASMCreatesThenFallsBackToPut(t *testing.T) {
+	stub := newStubASM(nil)
+	s := &Store{asm: stub}
+
+	if err := s.writeASM(context.Background(), "timothy/new", "sk-1"); err != nil {
+		t.Fatalf("writeASM (create): %v", err)
+	}
+	if stub.secrets["timothy/new"] != "sk-1" {
+		t.Fatalf("secrets[timothy/new] = %q, want sk-1", stub.secrets["timothy/new"])
+	}
+
+	if err := s.writeASM(context.Background(), "timothy/new", "sk-2"); err != nil {
+		t.Fatalf("writeASM (put fallback): %v", err)
+	}
+	if stub.secrets["timothy/new"] != "sk-2" {
+		t.Fatalf("secrets[timothy/new] = %q, want sk-2 after overwrite", stub.secrets["timothy/new"])
+	}
+}
+
+func TestDeleteASM(t *testing.T) {
+	stub := newStubASM(map[string]string{"timothy/gone": "sk-x"})
+	s := &Store{asm: stub}
+
+	if err := s.deleteASM(context.Background(), "timothy/gone"); err != nil {
+		t.Fatalf("deleteASM: %v", err)
+	}
+	if _, ok := stub.secrets["timothy/gone"]; ok {
+		t.Fatal("deleteASM left the secret behind")
+	}
+}
+
+func TestTestBackendASMWriteProbe(t *testing.T) {
+	stub := newStubASM(nil)
+	s := &Store{asm: stub}
 
 	if err := s.TestBackend(context.Background(), "asm"); err != nil {
-		t.Fatalf("TestBackend(asm) with stub: %v", err)
+		t.Fatalf("TestBackend(asm): %v", err)
+	}
+	if _, ok := stub.secrets[probeRef]; ok {
+		t.Error("TestBackend left its write probe behind in asm")
 	}
 }
 

--- a/internal/secretstore/secretstore.go
+++ b/internal/secretstore/secretstore.go
@@ -4,13 +4,18 @@
 // up in the secrets table; its backend column says how to fetch the
 // value: envelope-decrypt a ciphertext column (db), or read from an
 // external system by backend_ref (vault: KV v2, asm: AWS Secrets
-// Manager).
+// Manager). Writes are through: Set always takes a raw secret value
+// and, for external backends, writes it into that system itself under
+// a backend_ref Timothy generates and owns (timothy/<ref_name>) —
+// there is no user-typed external reference.
 package secretstore
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/jackc/pgx/v5"
@@ -89,8 +94,6 @@ func (s *Store) Resolve(ctx context.Context, refName string) (string, error) {
 		return s.resolveVault(ctx, r.backendRef)
 	case "asm":
 		return s.resolveASM(ctx, r.backendRef)
-	case "file":
-		return s.resolveFile(ctx, r.backendRef)
 	default:
 		return "", fmt.Errorf("secretstore: unknown backend %q for %s", r.backend, refName)
 	}
@@ -110,10 +113,61 @@ func (s *Store) Status(ctx context.Context, refName string) (configured bool, ba
 	return true, r.backend, nil
 }
 
-// Set encrypts value and upserts it under refName with backend "db".
-// External backends (vault, asm) are configured by writing their
-// secret out-of-band and pointing backend_ref at it — not through Set.
+// externalRef is the backend_ref every write-through secret gets in an
+// external backend — Timothy-owned, never user input, so Delete can
+// safely tell "a copy we wrote" from a pre-existing reference.
+func externalRef(refName string) string {
+	return "timothy/" + refName
+}
+
+// refNamePattern bounds ref names that become external paths/names:
+// externalRef embeds refName in a Vault URL path and an ASM secret
+// name, so separators or ".." would escape the timothy/ prefix.
+var refNamePattern = regexp.MustCompile(`^[A-Za-z0-9_.-]{1,128}$`)
+
+func validExternalRefName(refName string) error {
+	if !refNamePattern.MatchString(refName) || strings.Contains(refName, "..") {
+		return fmt.Errorf("secretstore: ref name %q: external backends need a plain name (letters, digits, _ . -)", refName)
+	}
+	return nil
+}
+
+// Set stores value under refName through the store-wide default
+// backend: "db" encrypts it in place, "vault"/"asm" write it into that
+// system (at a Timothy-owned path/name derived from refName) and keep
+// only the pointer locally.
 func (s *Store) Set(ctx context.Context, refName, value string) error {
+	backend, err := s.DefaultBackend(ctx)
+	if err != nil {
+		return err
+	}
+	switch backend {
+	case "vault":
+		if err := validExternalRefName(refName); err != nil {
+			return err
+		}
+		if err := s.writeVault(ctx, externalRef(refName), value); err != nil {
+			return err
+		}
+		return s.upsertRef(ctx, refName, "vault", externalRef(refName)+"#value")
+	case "asm":
+		if err := validExternalRefName(refName); err != nil {
+			return err
+		}
+		if err := s.writeASM(ctx, externalRef(refName), value); err != nil {
+			return err
+		}
+		return s.upsertRef(ctx, refName, "asm", externalRef(refName))
+	default:
+		return s.SetDB(ctx, refName, value)
+	}
+}
+
+// SetDB encrypts value and upserts it under refName with backend "db",
+// bypassing the store-wide default. Used to pin backend-bootstrap
+// credentials (the vault token, the ASM static secret key) that can
+// never live behind the external backend they unlock.
+func (s *Store) SetDB(ctx context.Context, refName, value string) error {
 	db, err := s.db.Get()
 	if err != nil {
 		return fmt.Errorf("secretstore: %w", err)
@@ -134,8 +188,51 @@ func (s *Store) Set(ctx context.Context, refName, value string) error {
 	return nil
 }
 
-// Delete removes a secret reference entirely.
+// upsertRef points refName at an external secret this store just wrote
+// (or overwrote) — ciphertext/nonce cleared, since the value now lives
+// out there, not here.
+func (s *Store) upsertRef(ctx context.Context, refName, backend, backendRef string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("secretstore: %w", err)
+	}
+	_, err = db.Exec(ctx, `
+		INSERT INTO secrets (ref_name, backend, backend_ref, updated_at)
+		VALUES ($1, $2, $3, now())
+		ON CONFLICT (ref_name) DO UPDATE
+			SET backend = $2, backend_ref = $3, ciphertext = NULL, nonce = NULL, updated_at = now()`,
+		refName, backend, backendRef)
+	if err != nil {
+		return fmt.Errorf("secretstore: set %s: %w", refName, err)
+	}
+	return nil
+}
+
+// Delete removes a secret reference entirely, best-effort deleting its
+// external copy first when this store owns it (backend_ref follows the
+// timothy/<ref_name> convention it writes in Set) — a reference typed
+// against the old external-reference model points at a secret Timothy
+// never owned and must never delete.
 func (s *Store) Delete(ctx context.Context, refName string) error {
+	r, err := s.row(ctx, refName)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return err
+	}
+	if err == nil {
+		path, _ := splitRef(r.backendRef, "")
+		if path == externalRef(refName) {
+			// Best-effort: the external copy failing to delete must
+			// never block the row delete below. Nothing to log to here
+			// (the store carries no logger) — the row is the source of
+			// truth for "is refName configured", and it's gone either way.
+			switch r.backend {
+			case "vault":
+				_ = s.deleteVault(ctx, path)
+			case "asm":
+				_ = s.deleteASM(ctx, path)
+			}
+		}
+	}
 	db, err := s.db.Get()
 	if err != nil {
 		return fmt.Errorf("secretstore: %w", err)

--- a/internal/secretstore/secretstore_integration_test.go
+++ b/internal/secretstore/secretstore_integration_test.go
@@ -5,12 +5,15 @@ package secretstore
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -96,24 +99,54 @@ func TestStoreSetResolveDelete(t *testing.T) {
 	}
 }
 
-// TestVaultResolve drives the vault backend end to end against a fake
-// KV v2 server: config + token stored through the store's own API,
-// then Resolve fetches through HTTP.
-func TestVaultResolve(t *testing.T) {
+// TestVaultWriteThrough drives the vault backend end to end against a
+// fake KV v2 server: with vault as the store-wide default, Set must
+// write the raw value into vault itself (not just record a reference),
+// Resolve must read it back through HTTP, and TestBackend's write
+// probe and Delete's external cleanup must round-trip against the
+// same fake mount.
+func TestVaultWriteThrough(t *testing.T) {
 	s := integrationStore(t)
 	ctx := t.Context()
 	ref := "TEST_VAULT_" + t.Name()
 
+	kv := map[string]string{} // path -> value, simulates the KV v2 mount
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("X-Vault-Token") != "vault-tok" {
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
-		switch r.URL.Path {
-		case "/v1/kv/data/timothy/anthropic":
-			w.Write([]byte(`{"data":{"data":{"api_key":"sk-from-vault"}}}`))
-		case "/v1/auth/token/lookup-self":
+		switch {
+		case r.URL.Path == "/v1/auth/token/lookup-self":
 			w.Write([]byte(`{}`))
+		case strings.HasPrefix(r.URL.Path, "/v1/kv/data/"):
+			path := strings.TrimPrefix(r.URL.Path, "/v1/kv/data/")
+			switch r.Method {
+			case http.MethodPost:
+				var body struct {
+					Data struct {
+						Value string `json:"value"`
+					} `json:"data"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				kv[path] = body.Data.Value
+				w.Write([]byte(`{}`))
+			case http.MethodGet:
+				val, ok := kv[path]
+				if !ok {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				_, _ = w.Write([]byte(`{"data":{"data":{"value":` + strconv.Quote(val) + `}}}`))
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		case strings.HasPrefix(r.URL.Path, "/v1/kv/metadata/") && r.Method == http.MethodDelete:
+			delete(kv, strings.TrimPrefix(r.URL.Path, "/v1/kv/metadata/"))
+			w.WriteHeader(http.StatusNoContent)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -121,7 +154,8 @@ func TestVaultResolve(t *testing.T) {
 	defer srv.Close()
 
 	// Sweep leftovers from a crashed run, then save the shared vault
-	// config so it can be restored — a dev database may hold a real one.
+	// config/default so they can be restored — a dev database may hold
+	// real ones.
 	db, err := s.db.Get()
 	if err != nil {
 		t.Fatalf("Get: %v", err)
@@ -130,6 +164,10 @@ func TestVaultResolve(t *testing.T) {
 	origCfg, err := s.GetBackendConfig(ctx, "vault")
 	if err != nil {
 		t.Fatalf("GetBackendConfig: %v", err)
+	}
+	origDefault, err := s.DefaultBackend(ctx)
+	if err != nil {
+		t.Fatalf("DefaultBackend: %v", err)
 	}
 	// A defer, not t.Cleanup — it runs while t.Context() and the pool
 	// are still alive, so the sweep cannot be silently lost.
@@ -141,6 +179,9 @@ func TestVaultResolve(t *testing.T) {
 		} else if err := s.DeleteBackendConfig(ctx, "vault"); err != nil {
 			t.Errorf("delete vault config: %v", err)
 		}
+		if err := s.SetDefaultBackend(ctx, origDefault); err != nil {
+			t.Errorf("restore default backend: %v", err)
+		}
 		if _, err := db.Exec(ctx, `DELETE FROM secrets WHERE ref_name LIKE 'TEST_VAULT_%'`); err != nil {
 			t.Errorf("sweep vault secrets: %v", err)
 		}
@@ -150,11 +191,21 @@ func TestVaultResolve(t *testing.T) {
 	if _, err := s.SetBackendConfig(ctx, "vault", []byte(cfg)); err != nil {
 		t.Fatalf("SetBackendConfig: %v", err)
 	}
-	if err := s.Set(ctx, ref+"_TOKEN", "vault-tok"); err != nil {
-		t.Fatalf("Set token: %v", err)
+	// SetDB, not Set: the vault token is bootstrap for vault itself and
+	// must land in built-in storage regardless of the default backend
+	// (which is not vault yet at this point anyway).
+	if err := s.SetDB(ctx, ref+"_TOKEN", "vault-tok"); err != nil {
+		t.Fatalf("SetDB token: %v", err)
 	}
-	if err := s.SetExternal(ctx, ref, "vault", "timothy/anthropic#api_key"); err != nil {
-		t.Fatalf("SetExternal: %v", err)
+	if err := s.SetDefaultBackend(ctx, "vault"); err != nil {
+		t.Fatalf("SetDefaultBackend: %v", err)
+	}
+
+	if err := s.Set(ctx, ref, "sk-from-vault"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if kv["timothy/"+ref] != "sk-from-vault" {
+		t.Fatalf("vault mount holds %q, want sk-from-vault", kv["timothy/"+ref])
 	}
 
 	got, err := s.Resolve(ctx, ref)
@@ -164,13 +215,25 @@ func TestVaultResolve(t *testing.T) {
 	if got != "sk-from-vault" {
 		t.Fatalf("Resolve: got %q, want sk-from-vault", got)
 	}
+	if configured, backend, err := s.Status(ctx, ref); err != nil || !configured || backend != "vault" {
+		t.Fatalf("Status: configured=%v backend=%q err=%v", configured, backend, err)
+	}
 
 	if err := s.TestBackend(ctx, "vault"); err != nil {
 		t.Fatalf("TestBackend: %v", err)
 	}
+	if _, ok := kv["timothy/__probe"]; ok {
+		t.Error("TestBackend left its write probe behind in vault")
+	}
 
-	if configured, backend, err := s.Status(ctx, ref); err != nil || !configured || backend != "vault" {
-		t.Fatalf("Status: configured=%v backend=%q err=%v", configured, backend, err)
+	if err := s.Delete(ctx, ref); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok := kv["timothy/"+ref]; ok {
+		t.Error("Delete left the secret behind in vault")
+	}
+	if _, err := s.Resolve(ctx, ref); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Resolve after Delete: got %v, want ErrNotFound", err)
 	}
 }
 

--- a/migrations/0007_secrets.sql
+++ b/migrations/0007_secrets.sql
@@ -2,10 +2,9 @@
 -- connectors). A ref name resolves only here — there is no env var
 -- fallback; an unresolved ref leaves its provider keyless/unhealthy.
 -- backend='db' secrets are envelope-encrypted with TIMOTHY_MASTER_KEY;
--- backend='vault'/'asm'/'file' rows carry no ciphertext, only
--- backend_ref (the external path/id, or filename under the file
--- backend's mount dir), the value is fetched from that system at read
--- time.
+-- backend='vault'/'asm' rows carry no ciphertext, only backend_ref (a
+-- Timothy-owned path/id under timothy/<ref_name>, written by the store
+-- itself), the value is fetched from that system at read time.
 CREATE TABLE IF NOT EXISTS secrets (
     ref_name    text PRIMARY KEY,
     backend     text NOT NULL DEFAULT 'db',
@@ -14,7 +13,7 @@ CREATE TABLE IF NOT EXISTS secrets (
     backend_ref text NOT NULL DEFAULT '',
     created_at  timestamptz NOT NULL DEFAULT now(),
     updated_at  timestamptz NOT NULL DEFAULT now(),
-    CONSTRAINT secrets_backend_check CHECK (backend IN ('db', 'vault', 'asm', 'file')),
+    CONSTRAINT secrets_backend_check CHECK (backend IN ('db', 'vault', 'asm')),
     CONSTRAINT secrets_db_has_ciphertext
         CHECK (backend <> 'db' OR (ciphertext IS NOT NULL AND nonce IS NOT NULL)),
     CONSTRAINT secrets_external_has_ref
@@ -35,7 +34,7 @@ CREATE TABLE IF NOT EXISTS secret_backend_config (
     config     jsonb NOT NULL DEFAULT '{}'::jsonb,
     is_default boolean NOT NULL DEFAULT false,
     updated_at timestamptz NOT NULL DEFAULT now(),
-    CONSTRAINT secret_backend_config_check CHECK (backend IN ('db', 'vault', 'asm', 'file'))
+    CONSTRAINT secret_backend_config_check CHECK (backend IN ('db', 'vault', 'asm'))
 );
 
 -- At most one default, enforced by the database not the application.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -596,12 +596,12 @@ export async function providersHealth(): Promise<ProviderHealth[]> {
   return providers ?? []
 }
 
-// setSecret stores a credential under refName through the store-wide
-// default backend (write-only: it is never returned by any endpoint).
-// Built-in storage encrypts the value; a Vault/ASM default records it
-// as the reference of a secret already held there. deleteSecret
-// removes it; the provider then builds without a key and shows
-// unhealthy until a new value is set.
+// setSecret writes a raw credential value under refName through the
+// store-wide default backend (write-only: it is never returned by any
+// endpoint). Built-in storage encrypts it in Timothy's database; a
+// Vault/ASM default has Timothy write it into that backend under the
+// name timothy/refName. deleteSecret removes it; the provider then
+// builds without a key and shows unhealthy until a new value is set.
 export async function setSecret(refName: string, value: string): Promise<void> {
   await request<void>(`/v1/admin/secrets/${encodeURIComponent(refName)}`, {
     method: 'PUT',
@@ -657,7 +657,7 @@ export async function setDefaultSecretBackend(backend: string): Promise<void> {
 }
 
 export async function getSecretBackendConfig(
-  backend: 'vault' | 'asm' | 'file',
+  backend: 'vault' | 'asm',
 ): Promise<Record<string, string>> {
   const { config } = await request<{ config: Record<string, string> }>(
     `/v1/admin/secret-backends/${backend}`,
@@ -666,7 +666,7 @@ export async function getSecretBackendConfig(
 }
 
 export async function putSecretBackendConfig(
-  backend: 'vault' | 'asm' | 'file',
+  backend: 'vault' | 'asm',
   config: Record<string, string>,
 ): Promise<void> {
   await request<void>(`/v1/admin/secret-backends/${backend}`, {
@@ -675,12 +675,12 @@ export async function putSecretBackendConfig(
   })
 }
 
-export async function deleteSecretBackendConfig(backend: 'vault' | 'asm' | 'file'): Promise<void> {
+export async function deleteSecretBackendConfig(backend: 'vault' | 'asm'): Promise<void> {
   await request<void>(`/v1/admin/secret-backends/${backend}`, { method: 'DELETE' })
 }
 
 export async function testSecretBackend(
-  backend: 'vault' | 'asm' | 'file',
+  backend: 'vault' | 'asm',
 ): Promise<{ ok: boolean; error?: string }> {
   return request<{ ok: boolean; error?: string }>(`/v1/admin/secret-backends/${backend}/test`, {
     method: 'POST',

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -305,8 +305,9 @@ export interface BudgetStatus {
   month: BudgetWindow
 }
 
-// Control-plane shapes (/v1/admin/*). credential_ref is a NAME (env
-// var / Vault path / AWS profile) — secret values never travel.
+// Control-plane shapes (/v1/admin/*). credential_ref is a NAME the
+// secret is stored under (in whichever backend is default) — secret
+// values never travel.
 export interface AdminModel {
   id: string
   context_window?: number

--- a/web/src/components/settings/ConnectorAdd.tsx
+++ b/web/src/components/settings/ConnectorAdd.tsx
@@ -16,7 +16,7 @@ import { ConnectorLogo } from './ConnectorLogo'
 import { connectorPresets } from './connectorPresets'
 import { Field } from './shared'
 import { useDefaultSecretBackend } from './useDefaultSecretBackend'
-import { errText, secretField } from './util'
+import { errText, secretDestination } from './util'
 
 // slugify turns a display name into a connector name (tool-name
 // prefix): lowercase slug, the backend rejects anything else.
@@ -189,10 +189,10 @@ export function ConnectorAdd() {
               </Field>
               <Field label="OAuth client secret">
                 <Input
-                  type={secretField(defaultBackend, '').type}
+                  type="password"
                   value={clientSecret}
                   onChange={(e) => setClientSecret(e.target.value)}
-                  placeholder={secretField(defaultBackend, 'GOCSPX-…').placeholder}
+                  placeholder="GOCSPX-…"
                   className="mt-1.5 h-10"
                   autoComplete="off"
                 />
@@ -233,22 +233,21 @@ export function ConnectorAdd() {
             <div>
               <Field label={preset.id === 'custom-mcp' ? 'Bearer token (optional)' : 'Bearer token'}>
                 <Input
-                  type={secretField(defaultBackend, '').type}
+                  type="password"
                   value={token}
                   onChange={(e) => {
                     setToken(e.target.value)
                     invalidate()
                   }}
-                  placeholder={secretField(defaultBackend, preset.tokenPlaceholder ?? 'token').placeholder}
+                  placeholder={preset.tokenPlaceholder ?? 'token'}
                   className="mt-1.5 h-10"
                   autoComplete="off"
                 />
               </Field>
-              {(secretField(defaultBackend, '').hint || preset.tokenHint) && (
-                <p className="mt-1.5 text-sm text-muted-foreground">
-                  {secretField(defaultBackend, '').hint || preset.tokenHint}
-                </p>
-              )}
+              <p className="mt-1.5 text-sm text-muted-foreground">
+                {preset.tokenHint ? `${preset.tokenHint} ` : ''}
+                {secretDestination(defaultBackend, `${refBase}_MCP_TOKEN`)}
+              </p>
             </div>
 
             <div

--- a/web/src/components/settings/ConnectorEdit.tsx
+++ b/web/src/components/settings/ConnectorEdit.tsx
@@ -23,14 +23,12 @@ import {
 import { Input } from '../ui/input'
 import { ConnectorLogo } from './ConnectorLogo'
 import { connectorPresets, unknownPreset } from './connectorPresets'
-import { useDefaultSecretBackend } from './useDefaultSecretBackend'
 import { Field, Toggle } from './shared'
-import { errText, secretField } from './util'
+import { errText } from './util'
 
 export function ConnectorEdit() {
   const { id } = useParams()
   const navigate = useNavigate()
-  const defaultBackend = useDefaultSecretBackend()
 
   const [connector, setConnector] = useState<AdminConnector | null | undefined>(undefined)
   const [confirmDelete, setConfirmDelete] = useState(false)
@@ -193,7 +191,7 @@ export function ConnectorEdit() {
             <Field label="Rotate bearer token">
               <div className="mt-1.5 flex gap-2">
                 <Input
-                  type={secretField(defaultBackend, '').type}
+                  type="password"
                   value={token}
                   onChange={(e) => setToken(e.target.value)}
                   placeholder="paste new token"

--- a/web/src/components/settings/ProviderAdd.tsx
+++ b/web/src/components/settings/ProviderAdd.tsx
@@ -14,7 +14,7 @@ import { bedrockRegions, providerPresets, type ProviderPreset } from './presets'
 import { ProviderLogo } from './ProviderLogo'
 import { Field } from './shared'
 import { useDefaultSecretBackend } from './useDefaultSecretBackend'
-import { errText, secretField, stripPaste } from './util'
+import { errText, secretDestination, stripPaste } from './util'
 
 // refFor derives a credential ref for a named provider instance: the
 // preset's conventional storage-key name, or one from the user's name.
@@ -112,13 +112,10 @@ export function ProviderAdd() {
   const isBedrock = preset.driver === 'bedrock'
   const wantsKey = preset.requiresKey
 
-  // Bedrock's two-input split (access key id / secret access key) only
-  // applies when the store writes the raw secret value itself (the
-  // "db" backend, secretField's 'password' mode). vault/asm/file take
-  // a reference to a secret already stored externally — the operator
-  // must have pre-populated that external secret with the JSON blob,
-  // so the generic single reference input stays for those backends.
-  const bedrockSplit = isBedrock && secretField(defaultBackend, '').type === 'password'
+  // Bedrock always splits into access key id / secret access key —
+  // every backend now writes through the raw value Timothy is given,
+  // so the split no longer depends on which backend is default.
+  const bedrockSplit = isBedrock
   const bedrockKeyJSON = () =>
     JSON.stringify({
       access_key_id: stripPaste(accessKeyId.trim()),
@@ -312,36 +309,34 @@ export function ProviderAdd() {
             )}
           </div>
         )}
-        {wantsKey &&
-          !bedrockSplit &&
-          (() => {
-            const field = secretField(defaultBackend, preset.keyPlaceholder ?? 'paste key')
-            return (
-              <div>
-                <Field label={preset.id === 'custom' ? 'API key (optional)' : 'API key'}>
-                  <Input
-                    type={field.type}
-                    value={key}
-                    onChange={(e) => {
-                      setKey(e.target.value)
-                      invalidate()
-                    }}
-                    placeholder={field.placeholder}
-                    className="mt-1.5 h-10"
-                    autoComplete="off"
-                    aria-invalid={keyError != null}
-                  />
-                </Field>
-                {keyError && (
-                  <p className="mt-1.5 flex items-center gap-1.5 text-sm font-medium text-destructive">
-                    <HugeiconsIcon icon={AlertCircleIcon} className="size-4 shrink-0" />
-                    {keyError}
-                  </p>
-                )}
-                {!keyError && (field.hint || preset.keyHint) && (
-                  <p className="mt-1.5 text-sm text-muted-foreground">
-                    {field.hint || preset.keyHint}
-                    {!field.hint && preset.keyURL && (
+        {wantsKey && !bedrockSplit && (
+          <div>
+            <Field label={preset.id === 'custom' ? 'API key (optional)' : 'API key'}>
+              <Input
+                type="password"
+                value={key}
+                onChange={(e) => {
+                  setKey(e.target.value)
+                  invalidate()
+                }}
+                placeholder={preset.keyPlaceholder ?? 'paste key'}
+                className="mt-1.5 h-10"
+                autoComplete="off"
+                aria-invalid={keyError != null}
+              />
+            </Field>
+            {keyError && (
+              <p className="mt-1.5 flex items-center gap-1.5 text-sm font-medium text-destructive">
+                <HugeiconsIcon icon={AlertCircleIcon} className="size-4 shrink-0" />
+                {keyError}
+              </p>
+            )}
+            {!keyError && (
+              <div className="mt-1.5 space-y-1 text-sm text-muted-foreground">
+                {preset.keyHint && (
+                  <p>
+                    {preset.keyHint}
+                    {preset.keyURL && (
                       <>
                         {' '}
                         <a
@@ -356,9 +351,11 @@ export function ProviderAdd() {
                     )}
                   </p>
                 )}
+                <p>{secretDestination(defaultBackend, ref)}</p>
               </div>
-            )
-          })()}
+            )}
+          </div>
+        )}
 
         <Field label="Model" hint="validated with a one-token completion, becomes the default">
           <ModelInput

--- a/web/src/components/settings/ProviderEdit.tsx
+++ b/web/src/components/settings/ProviderEdit.tsx
@@ -30,7 +30,7 @@ import { bedrockRegions, matchPreset } from './presets'
 import { ProviderLogo } from './ProviderLogo'
 import { Field, Toggle } from './shared'
 import { useDefaultSecretBackend } from './useDefaultSecretBackend'
-import { backendLabel, errText, stripPaste, secretField } from './util'
+import { backendLabel, errText, secretDestination, stripPaste } from './util'
 
 // ProviderEdit is a provider's own page for the controls too heavy for
 // its summary card: rotating the stored key, and declaring which
@@ -311,13 +311,10 @@ function CredentialSection({
         ) : (
           <div className="flex gap-2">
             <Input
-              type={secretField(defaultBackend ?? 'db', '').type}
+              type="password"
               value={secretValue}
               onChange={(e) => setSecretValue(e.target.value)}
-              placeholder={
-                secretField(defaultBackend ?? 'db', configured ? 'paste new key to rotate' : 'paste key')
-                  .placeholder
-              }
+              placeholder={configured ? 'paste new key to rotate' : 'paste key'}
               className="h-10"
               autoComplete="off"
             />
@@ -326,17 +323,7 @@ function CredentialSection({
             </Button>
           </div>
         )}
-        {!bedrock && (
-          <p className="text-sm text-muted-foreground">
-            {defaultBackend === 'vault'
-              ? 'The key stays in Vault; only its path is saved. The default backend is set in the Secrets tab.'
-              : defaultBackend === 'asm'
-                ? 'The key stays in AWS Secrets Manager; only its name is saved. The default backend is set in the Secrets tab.'
-                : defaultBackend === 'file'
-                  ? 'The key stays in the mounted file; only its filename is saved. The default backend is set in the Secrets tab.'
-                  : 'Encrypted with the master key and kept in Timothy’s database.'}
-          </p>
-        )}
+        {!bedrock && <p className="text-sm text-muted-foreground">{secretDestination(defaultBackend ?? 'db', ref)}</p>}
         <details className="pt-1">
           <summary className="cursor-pointer text-sm font-medium text-muted-foreground transition hover:text-foreground">
             Advanced: reference name
@@ -441,7 +428,7 @@ function ReasoningSection({ provider, onChanged }: { provider: AdminProvider; on
           }}
           disabled={timeoutSaving}
           placeholder="5m"
-          className="mt-1.5 h-10 max-w-40"
+          className="mt-1.5 block h-10 max-w-40"
         />
       </Field>
     </section>

--- a/web/src/components/settings/SecretsTab.tsx
+++ b/web/src/components/settings/SecretsTab.tsx
@@ -1,4 +1,4 @@
-import { Delete02Icon, Folder01Icon, LockIcon } from '@hugeicons-pro/core-stroke-rounded'
+import { Delete02Icon, LockIcon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon, type IconSvgElement } from '@hugeicons/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
@@ -80,28 +80,16 @@ export function SecretsTab() {
         />
       ),
     },
-    {
-      key: 'file',
-      isDefault: state('file')?.default ?? false,
-      render: () => (
-        <FileCard
-          isDefault={state('file')?.default ?? false}
-          onMakeDefault={() => makeDefault('file')}
-          onBackendsChanged={refresh}
-          onError={setError}
-        />
-      ),
-    },
   ].sort((a, b) => Number(b.isDefault) - Number(a.isDefault))
 
   return (
     <div className="mt-6 space-y-4">
       <p className="text-sm text-muted-foreground">
         Where credentials live. Exactly one backend is the default: every key or token entered
-        anywhere (providers, connectors) is stored through it. Timothy storage keeps values
-        encrypted in its own database; with Vault or AWS Secrets Manager as default you enter
-        the reference of a secret already held there, Timothy only reads, never writes,
-        external systems.
+        anywhere (providers, connectors) is written there by Timothy. Timothy storage keeps
+        values encrypted in its own database; making Vault or AWS Secrets Manager the default
+        means Timothy needs write access there, every key entered in the UI is written into it
+        under a timothy/ prefix.
       </p>
       <ErrorBanner message={error} />
       {cards.map((c) => (
@@ -112,9 +100,9 @@ export function SecretsTab() {
 }
 
 // BackendIcon tiles a backend's icon consistently across cards. A
-// generic Hugeicon renders muted (Timothy storage, file mount); a
-// `logo` name renders the official mark from ProviderLogo's sprite on
-// its brand-color tile, same treatment as a configured provider.
+// generic Hugeicon renders muted (Timothy storage); a `logo` name
+// renders the official mark from ProviderLogo's sprite on its
+// brand-color tile, same treatment as a configured provider.
 function BackendIcon({
   icon,
   logo,
@@ -205,7 +193,7 @@ function StorageCard({
 // useBackendCard holds the shared load/save/test/remove machinery for
 // one external secret backend's card.
 function useBackendCard(
-  backend: 'vault' | 'asm' | 'file',
+  backend: 'vault' | 'asm',
   onLoaded: (cfg: Record<string, string>) => void,
   onError: (msg: string) => void,
   onChanged: () => void,
@@ -412,7 +400,7 @@ function VaultCard({ isDefault, onMakeDefault, onBackendsChanged, onError }: Bac
         logo="vault"
         brandColor={VAULT_BRAND_COLOR}
         title="HashiCorp Vault"
-        subtitle="KV v2 mount. Credentials pasted here are kept in the encrypted store, never in this config."
+        subtitle="KV v2 mount. Timothy needs write access: every key entered in the UI is written here as the default."
         configured={card.configured}
         status={card.status}
         busy={card.busy}
@@ -533,7 +521,7 @@ function ASMCard({ isDefault, onMakeDefault, onBackendsChanged, onError }: Backe
         logo="aws"
         brandColor={AWS_BRAND_COLOR}
         title="AWS Secrets Manager"
-        subtitle="Test requires secretsmanager:ListSecrets; resolving keys only needs GetSecretValue."
+        subtitle="Timothy needs write access (CreateSecret/PutSecretValue) to store keys here as the default."
         configured={card.configured}
         status={card.status}
         busy={card.busy}
@@ -612,62 +600,6 @@ function ASMCard({ isDefault, onMakeDefault, onBackendsChanged, onError }: Backe
             </Field>
           </>
         )}
-      </div>
-    </div>
-  )
-}
-
-// FileCard is the non-third-party external option: secrets read from
-// files mounted into the container (Docker/Kubernetes secrets
-// convention). No credentials of its own — the mount itself is the
-// trust boundary, set up outside Timothy — so unlike Vault/ASM there's
-// nothing to paste here beyond the directory path.
-function FileCard({ isDefault, onMakeDefault, onBackendsChanged, onError }: BackendCardProps) {
-  const [cfg, setCfg] = useState({ dir: '' })
-  const card = useBackendCard(
-    'file',
-    (c) => setCfg((v) => ({ ...v, ...c })),
-    onError,
-    onBackendsChanged,
-  )
-
-  const save = () =>
-    card.run(async () => {
-      await putSecretBackendConfig('file', cfg)
-      card.setConfigured(true)
-      onBackendsChanged()
-      return 'saved'
-    })
-
-  return (
-    <div className="rounded-xl border border-border p-4">
-      <BackendCardHeader
-        icon={Folder01Icon}
-        title="File mount"
-        subtitle="Reads one file per secret from a directory mounted into the container, no third-party service, no credentials of its own."
-        configured={card.configured}
-        status={card.status}
-        busy={card.busy}
-        canSave
-        isDefault={isDefault}
-        onMakeDefault={onMakeDefault}
-        onSave={save}
-        onTest={card.test}
-        onRemove={card.remove}
-      />
-      <div className="mt-3 grid gap-3 sm:grid-cols-3">
-        <Field label="Directory">
-          <Input
-            value={cfg.dir}
-            onChange={(e) => setCfg((v) => ({ ...v, dir: e.target.value }))}
-            placeholder="/run/secrets (default)"
-            className="mt-1 h-8"
-          />
-        </Field>
-        <p className="self-end pb-1.5 text-xs text-muted-foreground sm:col-span-2">
-          Each secret is a file in this directory named by its reference; the file&apos;s content
-          is the value. Mount it read-only.
-        </p>
       </div>
     </div>
   )

--- a/web/src/components/settings/util.ts
+++ b/web/src/components/settings/util.ts
@@ -3,7 +3,6 @@ const backendLabels: Record<string, string> = {
   db: 'encrypted',
   vault: 'vault',
   asm: 'aws',
-  file: 'file mount',
 }
 export function backendLabel(b: string): string {
   return backendLabels[b] ?? b
@@ -19,33 +18,17 @@ export function stripPaste(v: string): string {
   return v.replace(/[\s​-‍⁠﻿]/g, '')
 }
 
-// secretField shapes a credential input for the store-wide default
-// backend: built-in storage takes the value itself (masked), an
-// external backend takes the reference of a secret already there.
-export function secretField(
-  backend: string,
-  dbPlaceholder: string,
-): { type: 'password' | 'text'; placeholder: string; hint: string } {
+// secretDestination describes where a pasted credential ends up under
+// the store-wide default backend — every backend now writes through
+// Timothy, so this is copy only, never a field shape.
+export function secretDestination(backend: string, ref: string): string {
+  const name = ref.trim() || 'reference name'
   switch (backend) {
     case 'vault':
-      return {
-        type: 'text',
-        placeholder: 'Vault path, e.g. timothy/anthropic#api_key',
-        hint: 'Default backend is Vault, paste the path of the secret, not the secret itself.',
-      }
+      return `Timothy stores the key in Vault (path timothy/${name}).`
     case 'asm':
-      return {
-        type: 'text',
-        placeholder: 'ASM name or ARN, optional #json_key',
-        hint: 'Default backend is AWS Secrets Manager, paste the secret name, not the secret itself.',
-      }
-    case 'file':
-      return {
-        type: 'text',
-        placeholder: 'filename in the mounted secrets directory',
-        hint: 'Default backend is a file mount, enter the filename, not the secret itself.',
-      }
+      return `Timothy stores the key in AWS Secrets Manager (name timothy/${name}).`
     default:
-      return { type: 'password', placeholder: dbPlaceholder, hint: '' }
+      return "Encrypted with the master key and kept in Timothy's database."
   }
 }

--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -173,9 +173,9 @@ describe('Secrets tab default backend', () => {
     renderPage('/settings/secrets')
     expect(await screen.findByText('Timothy storage')).toBeTruthy()
     expect(screen.getByText('default')).toBeTruthy()
-    // Unconfigured backends cannot claim the default: vault, asm, file.
+    // Unconfigured backends cannot claim the default: vault, asm.
     const buttons = screen.getAllByRole('button', { name: 'Make default' })
-    expect(buttons.length).toBe(3)
+    expect(buttons.length).toBe(2)
     for (const b of buttons) expect((b as HTMLButtonElement).disabled).toBe(true)
   })
 
@@ -280,7 +280,7 @@ describe('Providers tab', () => {
     expect((addButton as HTMLButtonElement).disabled).toBe(true)
   })
 
-  it('asks for a reference, not a key, when the default backend is external', async () => {
+  it('still asks for the raw key, and names Vault as its destination, when the default backend is external', async () => {
     vi.mocked(listAgents).mockResolvedValue([
       { id: 'a1', name: 'general', description: 'Everyday', prompt_overlay: '', route: '', skills: [], tools: [], memory: true, is_default: true, enabled: true },
     ])
@@ -293,10 +293,10 @@ describe('Providers tab', () => {
 
     renderPage('/settings/providers')
     fireEvent.click(await screen.findByRole('button', { name: /GLM/ }))
-    const input = await screen.findByPlaceholderText(/Vault path/)
-    // A reference is not a secret: no password masking.
-    expect((input as HTMLInputElement).type).toBe('text')
-    expect(screen.getByText(/paste the path of the secret/)).toBeTruthy()
+    const input = await screen.findByPlaceholderText('paste key')
+    // Every backend takes the raw key now, still masked.
+    expect((input as HTMLInputElement).type).toBe('password')
+    expect(screen.getByText(/Timothy stores the key in Vault \(path timothy\/ZAI_API_KEY\)/)).toBeTruthy()
   })
 
   it('keeps Add disabled and skips create when validation fails', async () => {


### PR DESCRIPTION
## Why

The provider/connector key fields were labeled "API key" but, with an external default backend (Vault/ASM), expected a *path* — pasting the actual key stored it plaintext in `secrets.backend_ref` (a raw key passes the old `backendRefPattern`). Bedrock's raw-key form couldn't save at all under an external default: its JSON payload failed the ref validation. The two forms disagreed on what to paste, and the `STORED · ENCRYPTED` badge contradicted the "Vault path" input beneath it.

## What

Secrets are now **write-through**: the user always pastes the raw value and Timothy writes it into the store-wide default backend itself.

- `Set` routes by default backend: `db` encrypts as before; `vault` writes KV v2 at `timothy/<ref>` (field `value`, matching the read convention); `asm` uses `CreateSecret` → `PutSecretValue` fallback. `SetDB` pins built-in storage for backend-bootstrap credentials (the vault token can't live behind vault).
- `Delete` best-effort removes the external copy, only when `backend_ref` matches the Timothy-owned `timothy/<ref>` convention — never a user-managed secret from the old reference model.
- `TestBackend` write+delete probes `timothy/__probe` so missing write permissions surface at config time, not first key save.
- Ref names used in external paths are validated (`^[A-Za-z0-9_.-]{1,128}$`, no `..`) so a ref can't escape the `timothy/` prefix in the Vault URL.
- The read-only external-reference model (`SetExternal`) and the `file` backend are removed; `0007_secrets.sql` CHECKs edited in place per pre-release baseline policy.
- Web: every key input is a masked raw-value field with copy stating the destination; Bedrock consistent by construction; connectors fixed too; file backend card removed; request-timeout input moved to its own line.
- README: quick start resolves the newest release tag via the API (`sort_by(.created_at)`) instead of a placeholder that went stale each release.

## Notes

- HTTP API unchanged: `PUT /v1/admin/secrets/{ref}` `{value}` routes through the default backend; `{value, backend:"db"}` pins db.
- With Vault/ASM as default, Timothy's backend credentials now need **write** access (documented in the Secrets tab copy).
- Existing db-encrypted secrets untouched; nothing migrates.

## Verification

`make build test vet lint` (0 issues) and web `npm run build && npm run lint && npm test` (394/394) green.