### PR TITLE
fix: dynamic classify route, sticky reset on route edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Alpha releases with prebuilt images are available on the [Releases page](https:/
 
 Go microservices behind a single public API, one PostgreSQL database, React web UI. All run via Docker Compose.
 
-| Service      | Role                                                                                        |
-|--------------|---------------------------------------------------------------------------------------------|
+| Service      | Role                                                                                         |
+|--------------|----------------------------------------------------------------------------------------------|
 | `brain`      | Public API: chat orchestration, agent loop, missions, event-sourced sessions, SSE streaming |
 | `gateway`    | Internal LLM gateway: multi-provider routing, cost ledger                                   |
 | `memoryd`    | Internal memory service: pgvector-backed recall                                             |
 | `sandboxd`   | Internal service holding the Docker socket: per-mission sandbox containers                  |
 | `web`        | React + Tailwind interface: chat, missions, usage, settings                                 |
-| `searxng`    | Internal metasearch backend for the web_search tool                                         |
+| `searxng`    | Internal metasearch backend for the web_search tool                                          |
 | `markitdown` | Internal Python sidecar: file→markdown conversion                                           |
 | `whisper`    | Internal Python sidecar: local speech-to-text for the web mic button                        |
 
@@ -57,15 +57,15 @@ Sessions are an append-only event log: every turn, tool run, and compaction is a
 
 The fastest way to run Timothy: no Go/Node toolchain, no build step, just Docker and the released images.
 
-1. Make an empty directory and download the installer from the [latest release](https://github.com/timothy-agent/timothy/releases).
-While Timothy is in alpha, every release is marked prerelease, so GitHub's `/releases/latest` redirect doesn't resolve; fetch the newest tag from the API instead (needs `jq`) or check the release badge for the tag (set the `TIMOTHY_VERSION` manually):
+1. Make an empty directory and download the installer from the [latest release](https://github.com/timothy-agent/timothy/releases). While Timothy is alpha, every release is marked prerelease, so GitHub's `/releases/latest` redirect doesn't resolve; look up the newest tag instead:
 
    ```sh
    mkdir timothy && cd timothy
-   TIMOTHY_VERSION=$(curl -fsSL "https://api.github.com/repos/timothy-agent/timothy/releases?per_page=100" | jq -r 'sort_by(.created_at) | last.tag_name')
-   # or
-   TIMOTHY_VERSION=<SET_MANUALLY>
-   curl -fsSLo install.sh "https://github.com/timothy-agent/timothy/releases/download/$TIMOTHY_VERSION/install.sh"
+   TAG=$(curl -fsSL https://api.github.com/repos/timothy-agent/timothy/releases \
+     | grep -E '"tag_name"|"published_at"' | paste - - \
+     | sed -E 's/.*"tag_name": "([^"]+)".*"published_at": "([^"]+)".*/\2 \1/' \
+     | sort -r | head -1 | awk '{print $2}')
+   curl -fsSLo install.sh "https://github.com/timothy-agent/timothy/releases/download/$TAG/install.sh"
    ```
 
 2. Read `install.sh` before running it. Then run it:

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -33,18 +33,6 @@ const (
 	// me" (D-034 follow-up): the composer's "Auto" choice, resolved
 	// through candidates+classify before the normal agent lookup.
 	autoAgentName = "auto"
-	// classifyRoute serves the auto-dispatch classification call.
-	// "local" is a real, always-provisioned fixed route; "mini" was
-	// never seeded by any migration and every call on it failed with
-	// no_route. Unlike
-	// classification, distillation and extraction default to the
-	// "summarize" cloud route — local now serves a reasoning model that
-	// burns its completion budget thinking before the strict-JSON
-	// answer, so it's reserved for sensitive turns pinned there
-	// deliberately. autoTitle uses defaultRoute instead when the turn
-	// isn't sensitive — a session's name deserves the same model quality
-	// as the conversation it's naming, not the cheapest available one.
-	classifyRoute = "local"
 	// turnTimeout ceils a detached turn's lifetime (see Chat/Retry's
 	// turnCtx): must exceed loop's permissionTimeout (10m) so a parked
 	// permission ask can't be killed by the ceiling out from under it.
@@ -386,15 +374,33 @@ func (s *Service) dispatchAgent(ctx context.Context, message string) string {
 	return agents.Dispatch(ctx, s.classify, message, candidates, "")
 }
 
-// ClassifyOverGateway builds an agents.Classify that asks classifyRoute
-// for a one-shot text reply — the same cheap side-call shape as
-// auto-title, distillation, and extraction use. Exported so main can
-// wire it via SetAutoDispatch using the raw gateway client, bypassing
-// the tool loop that only engages for Purpose=="chat".
+// ClassifyOverGateway builds an agents.Classify that asks the
+// "summarize" role's route for a one-shot text reply — the same cheap
+// side-call shape distillation and extraction already ride, resolved
+// dynamically by role (D-049) rather than a hardcoded route name:
+// a fixed name like "local" 502s with no_route on every install that
+// never seeded a route by that exact name. "summarize" over "default"
+// because the classification prompt carries the same message content
+// distillation/extraction already send there — the old "local for
+// privacy" rationale doesn't add anything a cheap cloud role doesn't
+// already get. When the role is unbound (or the gateway lookup fails),
+// this returns an error without calling Stream at all; agents.Dispatch
+// already treats any classify error as "fall back to the default
+// agent", so an unbound role just disables auto-dispatch rather than
+// breaking the turn. Exported so main can wire it via SetAutoDispatch
+// using the raw gateway client, bypassing the tool loop that only
+// engages for Purpose=="chat".
 func ClassifyOverGateway(gw Gateway) agents.Classify {
 	return func(ctx context.Context, prompt string) (string, error) {
+		route, ok, err := gw.RouteForRole(ctx, "summarize")
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", fmt.Errorf("chat: classify: summarize role is unbound")
+		}
 		events, err := gw.Stream(ctx, gwclient.StreamRequest{
-			Route:     classifyRoute,
+			Route:     route,
 			Purpose:   "agent_dispatch",
 			System:    "Answer with only what is requested — no prose, no explanation.",
 			Messages:  []provider.Message{{Role: "user", Content: prompt}},

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -2252,3 +2252,114 @@ func TestTurnTimeoutCeilingEndsAbandonedTurn(t *testing.T) {
 		}
 	}
 }
+
+// roleGW is a fakeGW whose RouteForRole is caller-controlled, for
+// testing ClassifyOverGateway's role resolution directly (fakeGW's
+// default RouteForRole always reports ok=true, which can't exercise
+// the unbound-role path).
+type roleGW struct {
+	fakeGW
+	routeForRole func(context.Context, string) (string, bool, error)
+}
+
+func (g *roleGW) RouteForRole(ctx context.Context, role string) (string, bool, error) {
+	return g.routeForRole(ctx, role)
+}
+
+// ClassifyOverGateway resolves the classification call's route by the
+// "summarize" role (D-049) rather than any hardcoded route name, and
+// streams on whatever route that role currently resolves to.
+func TestClassifyOverGatewayResolvesSummarizeRole(t *testing.T) {
+	t.Parallel()
+	gw := &roleGW{
+		fakeGW: fakeGW{events: okEvents("2")},
+		routeForRole: func(_ context.Context, role string) (string, bool, error) {
+			if role != "summarize" {
+				t.Fatalf("role = %q, want summarize", role)
+			}
+			return "cheap-cloud", true, nil
+		},
+	}
+	classify := ClassifyOverGateway(gw)
+	reply, err := classify(t.Context(), "pick one")
+	if err != nil {
+		t.Fatalf("classify: %v", err)
+	}
+	if reply != "2" {
+		t.Fatalf("reply = %q, want 2", reply)
+	}
+	gw.mu.Lock()
+	defer gw.mu.Unlock()
+	if len(gw.requests) != 1 {
+		t.Fatalf("Stream called %d times, want 1", len(gw.requests))
+	}
+	if got := gw.requests[0].Route; got != "cheap-cloud" {
+		t.Fatalf("route = %q, want cheap-cloud (resolved via summarize role)", got)
+	}
+}
+
+// When the "summarize" role is unbound, ClassifyOverGateway returns an
+// error WITHOUT calling Stream at all — agents.Dispatch already treats
+// any classify error as "fall back to the default agent", so this just
+// disables auto-dispatch rather than breaking the turn or firing an
+// avoidable request.
+func TestClassifyOverGatewaySkipsStreamWhenRoleUnbound(t *testing.T) {
+	t.Parallel()
+	gw := &roleGW{
+		fakeGW: fakeGW{events: okEvents("2")},
+		routeForRole: func(context.Context, string) (string, bool, error) {
+			return "", false, nil
+		},
+	}
+	classify := ClassifyOverGateway(gw)
+	if _, err := classify(t.Context(), "pick one"); err == nil {
+		t.Fatal("classify: want error when summarize role is unbound")
+	}
+	gw.mu.Lock()
+	n := len(gw.requests)
+	gw.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("Stream called %d times, want 0 (no dispatch call when role unbound)", n)
+	}
+}
+
+// Dispatch (agents package) already falls back to the default agent on
+// any classify error, so an unbound summarize role surfaces here as a
+// dispatch fallback, never a broken turn — this is the same contract
+// TestChatAutoWithoutDispatchWiredFallsBackToDefault exercises for a
+// nil classify, extended to a wired-but-erroring one.
+func TestChatAutoDispatchFallsBackWhenClassifyErrors(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGW{events: okEvents("done")}
+	log := newFakeLog()
+	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
+		switch name {
+		case "", "general":
+			return agents.Agent{Name: "general", Route: "default"}, true
+		case "researcher":
+			return agents.Agent{Name: "researcher", Route: "research"}, true
+		default:
+			return agents.Agent{}, false
+		}
+	}
+	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	candidates := []agents.Agent{
+		{Name: "general", Description: "everyday tasks"},
+		{Name: "researcher", Description: "consults sources"},
+	}
+	svc.SetAutoDispatch(
+		func(context.Context) []agents.Agent { return candidates },
+		func(context.Context, string) (string, error) { return "", errors.New("summarize role unbound") },
+	)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what's the RFC say?", Agent: autoAgentName})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	sent := chatRequest(t, gw)
+	if sent.Agent != "general" || sent.Route != "default" {
+		t.Fatalf("agent/route = %s/%s, want general/default (dispatch fallback on classify error)", sent.Agent, sent.Route)
+	}
+}

--- a/internal/gateway/ledger/ledger.go
+++ b/internal/gateway/ledger/ledger.go
@@ -84,6 +84,15 @@ func (l *Ledger) Record(ctx context.Context, e Entry) {
 // LastSuccess returns the provider+model that last served this
 // session successfully on this route — the stickiness signal that
 // keeps a session on one provider's warm prompt cache (D-018).
+//
+// Sticky resets when the route is edited: a ledger row older than the
+// route's own updated_at is ignored, so an operator's deliberate chain
+// reorder or model swap (router.go's Resolve otherwise prefers this
+// hint over the chain's written order) takes effect on the very next
+// request instead of being overridden by a stale sticky pick. Losing
+// prompt-cache affinity once per route edit is the accepted cost —
+// relies on routes.updated_at being bumped on every chain-affecting
+// PATCH (see internal/gateway/admin.go's route update paths).
 func (l *Ledger) LastSuccess(ctx context.Context, sessionID, route string) (providerName, model string, ok bool) {
 	db, err := l.db.Get()
 	if err != nil {
@@ -91,6 +100,7 @@ func (l *Ledger) LastSuccess(ctx context.Context, sessionID, route string) (prov
 	}
 	err = db.QueryRow(ctx, `SELECT provider, model FROM cost_ledger
 		WHERE session_id = $1 AND route = $2 AND status = 'ok'
+		AND ts > COALESCE((SELECT updated_at FROM routes WHERE name = $2), '-infinity'::timestamptz)
 		ORDER BY ts DESC LIMIT 1`, sessionID, route).Scan(&providerName, &model)
 	if err != nil {
 		return "", "", false

--- a/internal/gateway/ledger/ledger_integration_test.go
+++ b/internal/gateway/ledger/ledger_integration_test.go
@@ -79,3 +79,66 @@ func TestRecordWritesRows(t *testing.T) {
 		t.Fatalf("error rows = %d, want 1", nullUsage)
 	}
 }
+
+// LastSuccess must ignore a sticky row older than the route's own
+// updated_at: an operator's deliberate chain reorder (which bumps
+// routes.updated_at) has to take effect on the very next request
+// instead of a stale sticky pick overriding it.
+func TestLastSuccessIgnoresStaleRouteEdit(t *testing.T) {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	const routeName = "itest-sticky-route"
+	_, _ = db.Exec(ctx, "DELETE FROM cost_ledger WHERE provider = 'itest-sticky-provider'")
+	_, _ = db.Exec(ctx, "DELETE FROM routes WHERE name = $1", routeName)
+	defer func() {
+		if _, err := db.Exec(ctx, "DELETE FROM cost_ledger WHERE provider = 'itest-sticky-provider'"); err != nil {
+			t.Errorf("sweep itest-sticky-provider ledger rows: %v", err)
+		}
+		if _, err := db.Exec(ctx, "DELETE FROM routes WHERE name = $1", routeName); err != nil {
+			t.Errorf("sweep %s route: %v", routeName, err)
+		}
+	}()
+
+	if _, err := db.Exec(ctx, `INSERT INTO routes (name, chain, enabled, updated_at)
+		VALUES ($1, '[]', true, now())`, routeName); err != nil {
+		t.Fatalf("insert route: %v", err)
+	}
+
+	l := New(pool, log)
+	l.Record(ctx, Entry{
+		Provider: "itest-sticky-provider", Model: "m1", Route: routeName,
+		SessionID: "sess-sticky", LatencyMS: 10, Status: "ok",
+	})
+
+	// Before any route edit, the fresh success row wins.
+	provider, model, ok := l.LastSuccess(ctx, "sess-sticky", routeName)
+	if !ok || provider != "itest-sticky-provider" || model != "m1" {
+		t.Fatalf("LastSuccess before edit = %q/%q/%v, want itest-sticky-provider/m1/true", provider, model, ok)
+	}
+
+	// Simulate an operator's chain reorder: bump routes.updated_at past
+	// the ledger row's ts.
+	if _, err := db.Exec(ctx, `UPDATE routes SET updated_at = now() + interval '1 second' WHERE name = $1`, routeName); err != nil {
+		t.Fatalf("bump route updated_at: %v", err)
+	}
+
+	if _, _, ok := l.LastSuccess(ctx, "sess-sticky", routeName); ok {
+		t.Fatal("LastSuccess after route edit = ok, want false (stale sticky row invalidated)")
+	}
+}


### PR DESCRIPTION
## Why

Two production findings from debugging a vision-routing issue on a live deployment:

1. **Every chat turn burned a no_route 502.** The agent auto-dispatch classify call streamed to a route literally named `local` (`classifyRoute` const) — never seeded by any migration, violating the dynamic-routing invariant (D-049). The dispatch fallback swallowed the error, so it cost a wasted gateway round-trip per turn and polluted request logs.
2. **Operator chain reorders silently didn't take effect.** Session stickiness (D-018) prefers the provider+model that last served a session over the chain's written order; as long as the old model stayed anywhere in the chain, existing sessions never saw the reorder.

## What

- `ClassifyOverGateway` resolves the **summarize role** at call time via `RouteForRole` — the same cheap side-call role distillation/extraction ride (which already see the same message content). Unbound role → error before any Stream call; `agents.Dispatch` already treats that as fall-back-to-default-agent, so auto-dispatch degrades gracefully instead of 502ing.
- `Ledger.LastSuccess` ignores rows older than the route's `updated_at`: any route edit resets stickiness for that route, at the cost of one cold prompt cache. All admin route-mutation paths bump `updated_at`.
- README: latest-tag lookup uses a POSIX grep/paste pipeline (sorts by `published_at`) instead of requiring jq.

## Verification

`make build test vet lint` (0 issues); new unit tests for role resolution, skip-when-unbound, and dispatch fallback; new integration test for sticky reset (`TestLastSuccessIgnoresStaleRouteEdit`); `go vet -tags integration` clean; full `make test-integration` run locally — gateway/admin/ledger/secretstore all green.