### PR TITLE
refactor: make mission sandbox execution mandatory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,10 @@ skills-validate:
 		-e GATEWAY_URL=http://gateway:8081 \
 		$(GO_IMAGE) go run ./cmd/skills-validate -dir skills
 
-up:
+# sandbox-image first: sandboxd is mandatory infrastructure and fails
+# to boot (NewManager errors on a missing image) without it — a fresh
+# clone's first `make up` must not crash-loop waiting on a manual step.
+up: sandbox-image
 	$(COMPOSE) up -d --build
 
 # Per-service rebuild+restart for when only one service changed:
@@ -90,16 +93,16 @@ canary:
 	./scripts/canary-mission.sh
 
 # Same gate for the coding path: worktree provisioning, LLM review,
-# artifact verified inside the worktree. Needs the stack up. If
-# MISSION_SANDBOX_IMAGE is set in deploy/.env, run `make sandbox-image`
-# first — otherwise mission shell calls fail opaquely.
+# artifact verified inside the worktree. Needs the stack up and
+# `make sandbox-image` run first — mission shell calls fail opaquely
+# without it.
 canary-coding:
 	./scripts/canary-coding.sh
 
 # Builds the per-mission sandbox image (python3/node/git/bash — see
 # deploy/sandbox.Dockerfile). Not a compose service: sandboxes are
 # containers brain creates dynamically via the Docker Go SDK, not
-# something `docker compose up` runs on its own. Only needed when
-# MISSION_SANDBOX_IMAGE is set.
+# something `docker compose up` runs on its own. Required before
+# running any mission.
 sandbox-image:
 	docker build -f deploy/sandbox.Dockerfile -t timothy-sandbox:latest .

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The fastest way to run Timothy: no Go/Node toolchain, no build step, just Docker
 
 3. Open the printed link: the web UI signs in automatically from the token in the URL.
 
-To upgrade later: bump `TIMOTHY_VERSION` in `.env` and run `docker compose pull && docker compose up -d`, or just re-run `install.sh` (it leaves an existing `.env` untouched and only refreshes `docker-compose.yml` and the searxng config).
+To upgrade later: bump `TIMOTHY_VERSION` in `.env`, run `docker compose pull && docker compose up -d`, then `docker pull ghcr.io/timothy-agent/timothy-sandbox:$TIMOTHY_VERSION` (the per-mission sandbox image sandboxd pulls via the Docker socket, outside compose's own pull) — or just re-run `install.sh`, which does all three (it leaves an existing `.env` untouched and only refreshes `docker-compose.yml`, the searxng config, and the sandbox image).
 
 The rest of this README covers building and running from source instead.
 

--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
@@ -213,19 +212,16 @@ func main() {
 		})
 	}
 
-	// SANDBOXD_URL empty (MISSION_SANDBOX_IMAGE unset in compose) keeps a
-	// nil client and the original in-process exec fallback — same
-	// nil-able-dependency convention as every other optional brain
-	// dependency. Unlike the old direct-socket path, brain itself can no
-	// longer fail closed on a Docker problem: that fail-closed behavior
-	// moved to sandboxd's own boot (it holds the socket now), and a
-	// sandboxd that's unreachable or degraded surfaces here as a
-	// degraded health check, with missions failing as infra at exec
-	// time instead of brain refusing to start.
-	var missionSandbox *sandboxclient.Client
-	if sandboxdURL := os.Getenv("SANDBOXD_URL"); sandboxdURL != "" {
-		missionSandbox = sandboxclient.New(sandboxdURL)
+	// Mission shell/verify_cmd execution always runs sandboxed via
+	// sandboxd (it holds the Docker socket, brain no longer touches it
+	// directly). Brain doesn't fail closed if sandboxd itself is
+	// unreachable at boot — that surfaces as a degraded health check
+	// below, with missions failing as infra at exec time instead.
+	sandboxdURL := os.Getenv("SANDBOXD_URL")
+	if sandboxdURL == "" {
+		sandboxdURL = "http://sandboxd:8083"
 	}
+	missionSandbox := sandboxclient.New(sandboxdURL)
 
 	// Built here, above buildMissions, so both the scheduler (fire-time
 	// route/review_route/budget/prompt_overlay resolution) and the
@@ -242,22 +238,14 @@ func main() {
 	}
 	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, app.Log)
 	if missionDriver != nil {
-		var sandboxSweeper interface {
-			Sweep(ctx context.Context, isTerminal func(missionID string) bool) error
-		}
-		if missionSandbox != nil {
-			sandboxSweeper = missionSandbox
-		}
-		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, sandboxSweeper, app.Log)
+		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, app.Log)
 	}
-	if missionSandbox != nil {
-		app.AddCheck("sandbox", func() httpserver.Check {
-			if err := missionSandbox.Health(ctx); err != nil {
-				return httpserver.Check{Status: "degraded", Detail: err.Error()}
-			}
-			return httpserver.Check{Status: "ok"}
-		})
-	}
+	app.AddCheck("sandbox", func() httpserver.Check {
+		if err := missionSandbox.Health(ctx); err != nil {
+			return httpserver.Check{Status: "degraded", Detail: err.Error()}
+		}
+		return httpserver.Check{Status: "ok"}
+	})
 
 	// sensitiveConnectorNames is the connector-level input to
 	// SensitiveTools: every enabled connector marked sensitive in
@@ -516,16 +504,10 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 			floorDeny = append(floorDeny, s)
 		}
 	}
-	// sandboxMgr non-nil routes model-authored command execution (the
+	// sandboxMgr routes model-authored command execution (the
 	// worker/reviewer shell, verify_cmd) OUT of brain's own process,
-	// through sandboxd, into a per-mission Docker container; nil
-	// (SANDBOXD_URL unset) keeps the original in-process
-	// exec.CommandContext behavior.
-	var sandboxExec func(context.Context, string, string, string, time.Duration, io.Writer) (int, error)
-	if sandboxMgr != nil {
-		sandboxExec = sandboxMgr.Exec
-	}
-	runner := missions.NewNativeRunnerWithFloor(agent, parker, floorDeny, sandboxExec, log)
+	// through sandboxd, into a per-mission Docker container.
+	runner := missions.NewNativeRunnerWithFloor(agent, parker, floorDeny, sandboxMgr.Exec, log)
 	webhookURL := os.Getenv("NOTIFY_WEBHOOK_URL")
 	notifier := missions.NewNotifier(db, webhookURL, log)
 	notifier.SetHub(hub)
@@ -534,10 +516,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	// Postgres directly), so a fresh instance behaves identically. Used
 	// only to pre-authorize a mission's hidden session at creation.
 	perms := tools.NewPermissions(db, toolWorkspaceRoot)
-	driver := missions.NewDriver(store, runner, workspace, notifier, sessions, perms, log)
-	if sandboxMgr != nil {
-		driver.SetSandbox(sandboxExec, sandboxMgr)
-	}
+	driver := missions.NewDriver(store, runner, workspace, notifier, sessions, perms, sandboxMgr.Exec, sandboxMgr, log)
 	resolveAgent := missionAgentResolver(agentReg)
 	driver.SetAgentResolver(resolveAgent)
 

--- a/cmd/sandboxd/main.go
+++ b/cmd/sandboxd/main.go
@@ -47,12 +47,10 @@ func main() {
 	log := logging.New(cfg.Name, cfg.LogLevel)
 	m := metrics.New()
 
-	// Fail closed: an operator who set MISSION_SANDBOX_IMAGE opted into
-	// sandboxed execution, so a manager that cannot initialize (daemon
-	// unreachable, workspace mount unresolvable) must stop this service
-	// loudly rather than come up in a state where every exec fails
-	// opaquely. A missing image is deliberately NOT fatal: the health
-	// check below reports it, and building the image needs no restart.
+	// Fail closed: sandboxed execution is mandatory, so a manager that
+	// cannot initialize (image not set, daemon unreachable, workspace
+	// mount unresolvable) must stop this service loudly rather than come
+	// up in a state where every exec fails opaquely.
 	mgr, err := sandboxd.NewManager(ctx, os.Getenv("MISSION_SANDBOX_IMAGE"), log)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -71,19 +69,10 @@ func main() {
 	}
 }
 
-// health assembles /health's checks from the Manager: a nil manager
-// (MISSION_SANDBOX_IMAGE unset) reports one degraded check rather than
-// the usual docker+image pair, since there is nothing to Ping or
-// CheckImage yet.
+// health assembles /health's checks from the Manager: docker daemon
+// reachability and whether the configured sandbox image actually
+// exists locally.
 func health(ctx context.Context, mgr *sandboxd.Manager) httpserver.Health {
-	if mgr == nil {
-		return httpserver.Health{
-			Status: "degraded",
-			Checks: map[string]httpserver.Check{
-				"sandbox": {Status: "degraded", Detail: "MISSION_SANDBOX_IMAGE not set"},
-			},
-		}
-	}
 	checks := map[string]httpserver.Check{}
 	status := "ok"
 	if err := mgr.Ping(ctx); err != nil {

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -119,11 +119,10 @@ services:
       # Local speech-to-text for the web mic button; compose-internal
       # only, audio never leaves the box.
       WHISPER_URL: http://whisper:8001
-      # sandboxd's internal address — set only when MISSION_SANDBOX_IMAGE
-      # is configured (sandboxd itself always runs; without an image it
-      # just idles degraded). Empty keeps the original in-process exec
-      # behavior; brain never touches the Docker socket directly.
-      SANDBOXD_URL: ${MISSION_SANDBOX_IMAGE:+http://sandboxd:8083}
+      # sandboxd's internal address — mission shell/verify_cmd execution
+      # always runs there; brain never touches the Docker socket
+      # directly.
+      SANDBOXD_URL: http://sandboxd:8083
       # Content-addressed image attachment bytes (metadata only in
       # Postgres); compose-internal path, not user-facing.
       ATTACHMENTS_DIR: /attachments
@@ -162,10 +161,10 @@ services:
     environment:
       PORT: "8083"
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      # The one operator knob: empty keeps sandboxd up but degraded
-      # (nothing to Ping/CheckImage), same parity as brain's old
-      # in-process behavior when this was unset.
-      MISSION_SANDBOX_IMAGE: ${MISSION_SANDBOX_IMAGE:-}
+      # Built by `make sandbox-image` (deploy/sandbox.Dockerfile) —
+      # always this fixed tag locally, same as every other local image
+      # in this file has no separate version-tag env of its own.
+      MISSION_SANDBOX_IMAGE: timothy-sandbox:latest
     volumes:
       # Metadata-only read: resolveWorkspaceMount inspects this mount to
       # learn the exact volume/bind spec, then replicates it (rw) into

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -41,14 +41,6 @@ TURN_TIMEOUT=
 HUGEICONS_TOKEN=
 
 # --- Mission sandbox ---
-# Image tag for per-mission sandbox containers that run model-authored
-# shell/verify_cmd commands OUTSIDE brain's own process, via sandboxd
-# (the only service holding the Docker socket — build the image with
-# `make sandbox-image`, then set this to timothy-sandbox:latest). Leave
-# empty to keep the original in-process exec behavior; sandboxd itself
-# still runs, just idling degraded with nothing to do.
-MISSION_SANDBOX_IMAGE=timothy-sandbox:latest
-
 # Group ID of the docker.sock on your host, needed so sandboxd (running
 # as a non-root user) can use it. Docker Desktop: 0 (the default)
 # works. Linux hosts: run `stat -c '%g' /var/run/docker.sock` and set

--- a/deploy/release/docker-compose.yml
+++ b/deploy/release/docker-compose.yml
@@ -106,11 +106,10 @@ services:
       # Local speech-to-text for the web mic button; compose-internal
       # only, audio never leaves the box.
       WHISPER_URL: http://whisper:8001
-      # sandboxd's internal address — set only when MISSION_SANDBOX_IMAGE
-      # is configured (sandboxd itself always runs; without an image it
-      # just idles degraded). Empty keeps the original in-process exec
-      # behavior; brain never touches the Docker socket directly.
-      SANDBOXD_URL: ${MISSION_SANDBOX_IMAGE:+http://sandboxd:8083}
+      # sandboxd's internal address — mission shell/verify_cmd execution
+      # always runs there; brain never touches the Docker socket
+      # directly.
+      SANDBOXD_URL: http://sandboxd:8083
       # Content-addressed image attachment bytes (metadata only in
       # Postgres); compose-internal path, not user-facing.
       ATTACHMENTS_DIR: /attachments
@@ -143,10 +142,9 @@ services:
     environment:
       PORT: "8083"
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      # The one operator knob: empty keeps sandboxd up but degraded
-      # (nothing to Ping/CheckImage), same parity as brain's old
-      # in-process behavior when this was unset.
-      MISSION_SANDBOX_IMAGE: ${MISSION_SANDBOX_IMAGE:-}
+      # Always the same release as every other service — one version
+      # knob, no separate tag to fall out of sync on upgrade.
+      MISSION_SANDBOX_IMAGE: ghcr.io/timothy-agent/timothy-sandbox:${TIMOTHY_VERSION:?set TIMOTHY_VERSION in .env}
     volumes:
       # Metadata-only read: resolveWorkspaceMount inspects this mount to
       # learn the exact volume/bind spec, then replicates it (rw) into

--- a/deploy/release/env.example
+++ b/deploy/release/env.example
@@ -33,13 +33,6 @@ TIMOTHY_API_TOKEN=
 TIMOTHY_PUBLIC_URL=http://localhost:3300
 
 # --- Mission sandbox ---
-# Image for per-mission sandbox containers that run model-authored
-# shell/verify_cmd commands OUTSIDE brain's own process, via sandboxd
-# (the only service holding the Docker socket). Leave empty to keep
-# the original in-process exec behavior; sandboxd itself still runs,
-# just idling degraded with nothing to do.
-MISSION_SANDBOX_IMAGE=ghcr.io/timothy-agent/timothy-sandbox:__TIMOTHY_TAG__
-
 # Group ID of the docker.sock on your host, needed so sandboxd (running
 # as a non-root user) can use it. Docker Desktop: 0 (the default)
 # works. Linux hosts: run `stat -c '%g' /var/run/docker.sock` and set

--- a/deploy/release/install.sh
+++ b/deploy/release/install.sh
@@ -75,13 +75,14 @@ echo "Pulling images..."
 docker compose pull
 
 # compose pull only covers services; the mission sandbox image is an
-# env var handed to sandboxd, so pull it explicitly or missions stay
-# degraded until someone pulls it by hand.
-sandbox_image=$(sed -n 's/^MISSION_SANDBOX_IMAGE=//p' .env | head -n1)
-if [ -n "$sandbox_image" ]; then
-  echo "Pulling mission sandbox image..."
-  docker pull "$sandbox_image"
-fi
+# env var handed to sandboxd (which pulls per-mission containers via
+# the Docker socket, not through compose), so pull it explicitly here —
+# same TIMOTHY_VERSION tag as everything else, read back from .env so
+# an upgrade (TIMOTHY_VERSION bumped by hand, .env otherwise untouched)
+# pulls the matching sandbox tag too.
+timothy_version=$(sed -n 's/^TIMOTHY_VERSION=//p' .env | head -n1)
+echo "Pulling mission sandbox image..."
+docker pull "ghcr.io/timothy-agent/timothy-sandbox:${timothy_version}"
 
 echo "Starting Timothy..."
 docker compose up -d

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -78,8 +78,7 @@ type driverStore interface {
 // sandboxRemover is the narrow slice of *sandbox.Manager Driver needs —
 // kept as an interface (not an import of the sandbox package) so
 // missions has no compile-time dependency on Docker; cmd/brain/main.go
-// wires the real *sandbox.Manager. Nil means no sandbox is configured
-// (the in-process-exec fallback everywhere else in this package).
+// wires the real *sandbox.Manager.
 type sandboxRemover interface {
 	Remove(ctx context.Context, missionID string) error
 }
@@ -99,12 +98,10 @@ type Driver struct {
 	log       *slog.Logger
 	cfg       Config
 
-	// sandboxExec, when set, routes a plan unit's verify_cmd through the
-	// mission's sandbox container instead of brain's own process — the
-	// same backend nativeRunner uses for worker/reviewer shell calls
-	// (see SetSandboxExec). sandboxRemove tears the container down at a
-	// mission's terminal transition; both are nil in the fully
-	// in-process fallback (MISSION_SANDBOX_IMAGE unset).
+	// sandboxExec routes a plan unit's verify_cmd through the mission's
+	// sandbox container — the same backend nativeRunner uses for
+	// worker/reviewer shell calls. sandboxRemove tears the container
+	// down at a mission's terminal transition.
 	sandboxExec   sandboxExec
 	sandboxRemove sandboxRemover
 
@@ -136,21 +133,14 @@ type Driver struct {
 	driving   map[string]bool
 }
 
-func NewDriver(store driverStore, runner Runner, workspace *Workspace, notify notifier, sessions sessionCreator, perms sessionGranter, log *slog.Logger) *Driver {
+func NewDriver(store driverStore, runner Runner, workspace *Workspace, notify notifier, sessions sessionCreator, perms sessionGranter, sandboxExec sandboxExec, sandboxRemove sandboxRemover, log *slog.Logger) *Driver {
 	return &Driver{
 		store: store, runner: runner, workspace: workspace, notify: notify, sessions: sessions, perms: perms, log: log,
+		sandboxExec: sandboxExec, sandboxRemove: sandboxRemove,
 		cfg:         DefaultConfig,
 		gatekeepers: map[string]*GatekeeperState{},
 		driving:     map[string]bool{},
 	}
-}
-
-// SetSandbox wires a per-mission sandbox exec backend and its
-// container remover — cmd/brain/main.go calls this only when
-// MISSION_SANDBOX_IMAGE is configured, leaving both nil (the
-// in-process fallback) otherwise.
-func (d *Driver) SetSandbox(exec sandboxExec, remove sandboxRemover) {
-	d.sandboxExec, d.sandboxRemove = exec, remove
 }
 
 // SetAgentResolver wires the resolver ensureProvisioned uses to grant
@@ -803,18 +793,14 @@ func (d *Driver) packet(ctx context.Context, m Mission) (WorkPacket, error) {
 	return WorkPacket{
 		Goal: m.Goal, Kind: m.Kind, Spec: m.Spec, Progress: m.Progress,
 		GitLog: gitLog, Iteration: m.Iteration, PromptOverlay: m.PromptOverlay,
-		ExecEnvironmentNote: execEnvironmentNote(d.sandboxExec != nil),
+		ExecEnvironmentNote: execEnvironmentNote(),
 	}, nil
 }
 
-// runVerify executes verify_cmd via the mission's sandbox container
-// when one is configured, or brain's own process otherwise — the
-// verify-side counterpart of nativeRunner routing shell/write_file
+// runVerify executes verify_cmd via the mission's sandbox container —
+// the verify-side counterpart of nativeRunner routing shell/write_file
 // through the same backend.
 func (d *Driver) runVerify(ctx context.Context, missionID, workRoot, verifyCmd string) (VerifyResult, error) {
-	if d.sandboxExec == nil {
-		return RunVerify(ctx, workRoot, verifyCmd)
-	}
 	backend := func(ctx context.Context, workdir, command string, timeout time.Duration, out io.Writer) (int, error) {
 		return d.sandboxExec(ctx, missionID, workdir, command, timeout, out)
 	}

--- a/internal/brain/missions/driver_integration_test.go
+++ b/internal/brain/missions/driver_integration_test.go
@@ -48,7 +48,7 @@ func TestDriverEndToEndCodingMission(t *testing.T) {
 		},
 		reviewVerdicts: []ReviewVerdict{{Approved: true}},
 	}
-	d := NewDriver(store, runner, workspace, nil, nil, nil, log)
+	d := NewDriver(store, runner, workspace, nil, nil, nil, fakeSandboxExec, nil, log)
 
 	// The scripted worker "does the work" by actually creating the file
 	// the verify_cmd checks for — RunVerify runs for real against the
@@ -146,7 +146,7 @@ func TestDriverLazilyProvisionsBareSchedulerStyleMission(t *testing.T) {
 	sessions := session.NewStore(store.db, log)
 	perms := tools.NewPermissions(store.db, wsRoot)
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
-	d := NewDriver(store, runner, workspace, nil, sessions, perms, log)
+	d := NewDriver(store, runner, workspace, nil, sessions, perms, nil, nil, log)
 
 	if _, err := d.Advance(ctx, id); err != nil {
 		t.Fatalf("Advance: %v", err)

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -174,8 +176,25 @@ func (r *scriptedRunner) PlanSession(ctx context.Context, m Mission, researchNot
 	return s, nil
 }
 
+// fakeSandboxExec runs command via /bin/sh -c directly in workdir —
+// tests exercising verify_cmd need the real exit code/output a plan's
+// check produces, not a mocked one, and don't care that it isn't
+// actually containerized.
+func fakeSandboxExec(ctx context.Context, missionID, workdir, command string, timeout time.Duration, out io.Writer) (int, error) {
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", command) //nolint:gosec // test-only, command is test-authored
+	cmd.Dir = workdir
+	cmd.Stdout, cmd.Stderr = out, out
+	if err := cmd.Run(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return ee.ExitCode(), nil
+		}
+		return 0, err
+	}
+	return 0, nil
+}
+
 func testDriver(store driverStore, runner Runner) *Driver {
-	return NewDriver(store, runner, nil, nil, nil, nil, slog.Default())
+	return NewDriver(store, runner, nil, nil, nil, nil, fakeSandboxExec, nil, slog.Default())
 }
 
 // driveN calls Advance up to n times, stopping early if it returns
@@ -489,7 +508,7 @@ func (f *fakeGranter) Grant(ctx context.Context, sessionID, tool, pattern string
 func TestDriverCreateGrantsShellAutoApproveWhenEnabled(t *testing.T) {
 	store := newFakeStore()
 	granter := &fakeGranter{}
-	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, slog.Default())
+	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, nil, nil, slog.Default())
 
 	id, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: true}, "")
 	if err != nil {
@@ -511,7 +530,7 @@ func TestDriverCreateGrantsShellAutoApproveWhenEnabled(t *testing.T) {
 func TestDriverCreateSkipsGrantWhenAutoApproveDisabled(t *testing.T) {
 	store := newFakeStore()
 	granter := &fakeGranter{}
-	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, slog.Default())
+	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, nil, nil, slog.Default())
 
 	if _, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: false}, ""); err != nil {
 		t.Fatalf("Create: %v", err)
@@ -528,7 +547,7 @@ func TestDriverCreateSkipsGrantWhenAutoApproveDisabled(t *testing.T) {
 func TestDriverCreateGrantsApprovalAllowlist(t *testing.T) {
 	store := newFakeStore()
 	granter := &fakeGranter{}
-	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, slog.Default())
+	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, nil, nil, slog.Default())
 	d.SetAgentResolver(func(ctx context.Context, agentID string) (AgentDefaults, bool) {
 		if agentID != "briefing-agent" {
 			return AgentDefaults{}, false
@@ -566,7 +585,7 @@ func TestDriverCreateGrantsApprovalAllowlist(t *testing.T) {
 func TestDriverCreateSkipsAllowlistGrantWhenAgentUnresolved(t *testing.T) {
 	store := newFakeStore()
 	granter := &fakeGranter{}
-	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, slog.Default())
+	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, nil, nil, slog.Default())
 	d.SetAgentResolver(func(ctx context.Context, agentID string) (AgentDefaults, bool) {
 		return AgentDefaults{}, false
 	})
@@ -601,7 +620,7 @@ func TestDriverAdvanceLazilyProvisionsBareMission(t *testing.T) {
 	wsRoot := t.TempDir()
 	workspace := NewWorkspace(wsRoot, nil, slog.Default())
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
-	d := NewDriver(store, runner, workspace, nil, sessions, granter, slog.Default())
+	d := NewDriver(store, runner, workspace, nil, sessions, granter, nil, nil, slog.Default())
 
 	if _, err := d.Advance(context.Background(), "m1"); err != nil {
 		t.Fatalf("Advance: %v", err)
@@ -639,7 +658,7 @@ func TestDriverAdvanceSkipsProvisioningWhenAlreadyProvisioned(t *testing.T) {
 	granter := &fakeGranter{}
 	sessions := &fakeSessionCreator{}
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
-	d := NewDriver(store, runner, nil, nil, sessions, granter, slog.Default())
+	d := NewDriver(store, runner, nil, nil, sessions, granter, nil, nil, slog.Default())
 
 	if _, err := d.Advance(context.Background(), "m1"); err != nil {
 		t.Fatalf("Advance: %v", err)

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -123,9 +123,6 @@ type parkNotifier interface {
 // needs — kept as a function type (not an import of the sandbox
 // package) so missions has no compile-time dependency on Docker; the
 // driver wires the real *sandbox.Manager.Exec in cmd/brain/main.go.
-// nil means no sandbox is configured: missionTools then builds a
-// Runner-less shell, which falls back to shell.go's original
-// in-process exec.CommandContext.
 type sandboxExec func(ctx context.Context, missionID, workdir, command string, timeout time.Duration, out io.Writer) (exitCode int, err error)
 
 // nativeRunner is Phase 1's only Runner: every call is one loop.Agent
@@ -141,9 +138,7 @@ type nativeRunner struct {
 	// instead of burning iterations. Empty = floor disabled.
 	modelFloorDeny []string
 	// sandbox executes worker/reviewer shell commands in a per-mission
-	// Docker container instead of brain's own process — never nil in
-	// the fully in-process fallback, since missionTools checks it and
-	// only wires builtin.ShellConfig.Runner when it's set.
+	// Docker container instead of brain's own process.
 	sandbox sandboxExec
 }
 
@@ -159,9 +154,7 @@ func NewNativeRunner(agent *loop.Agent, parker parkNotifier, log *slog.Logger) R
 // NewNativeRunnerWithFloor is NewNativeRunner plus a model floor deny
 // list (see nativeRunner.modelFloorDeny) and a sandbox exec backend
 // (a *sandbox.Manager.Exec closure) — worker and reviewer shell calls
-// route through it instead of brain's own process. sandbox nil (what
-// happens when MISSION_SANDBOX_IMAGE is unset) keeps the original
-// in-process behavior.
+// route through it instead of brain's own process.
 func NewNativeRunnerWithFloor(agent *loop.Agent, parker parkNotifier, floorDeny []string, sandbox sandboxExec, log *slog.Logger) Runner {
 	return &nativeRunner{agent: agent, parker: parker, modelFloorDeny: floorDeny, sandbox: sandbox, log: log}
 }
@@ -172,10 +165,9 @@ func NewNativeRunnerWithFloor(agent *loop.Agent, parker parkNotifier, floorDeny 
 // the root cause of a whole failure family was workers writing into
 // the shared root while verify_cmd and the reviewer looked in the
 // per-mission directory — and write_file, so artifact writes never go
-// through destructive-classified shell redirects. When r.sandbox is
-// set, the shell's Runner routes commands into the mission's own
-// Docker container (see builtin.ShellConfig.Runner) instead of
-// brain's own process.
+// through destructive-classified shell redirects. The shell's Runner
+// routes commands into the mission's own Docker container (see
+// builtin.ShellConfig.Runner) instead of brain's own process.
 // sandboxShellMaxTimeout is the mission shell's timeout ceiling when
 // backed by a sandbox container — 120s (chat's shell ceiling) is far
 // too tight for app-development work: package installs, builds, and
@@ -189,11 +181,11 @@ func (r *nativeRunner) missionTools(m Mission) []*tools.Tool {
 	if root == "" {
 		return nil
 	}
-	shellCfg := builtin.ShellConfig{WorkspaceRoot: root}
-	if r.sandbox != nil {
-		shellCfg.MaxTimeout = sandboxShellMaxTimeout
-		missionID, workdir := m.ID, root
-		shellCfg.Runner = func(ctx context.Context, command string, timeout time.Duration) (string, error) {
+	missionID, workdir := m.ID, root
+	shellCfg := builtin.ShellConfig{
+		WorkspaceRoot: root,
+		MaxTimeout:    sandboxShellMaxTimeout,
+		Runner: func(ctx context.Context, command string, timeout time.Duration) (string, error) {
 			var out strings.Builder
 			capped := &cappedStringWriter{w: &out, max: shellOutputCap}
 			exitCode, err := r.sandbox(ctx, missionID, workdir, command, timeout, capped)
@@ -212,7 +204,7 @@ func (r *nativeRunner) missionTools(m Mission) []*tools.Tool {
 				result = fmt.Sprintf("%s\n(exit status %d)", result, exitCode)
 			}
 			return result, nil
-		}
+		},
 	}
 	return []*tools.Tool{
 		builtin.Shell(shellCfg),
@@ -619,18 +611,15 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, researchNotes
 // assumed Python in an environment that had none). WorkPacket.Render
 // carries the same text to the worker via ExecEnvironmentNote.
 func (r *nativeRunner) execEnvironmentNote() string {
-	return execEnvironmentNote(r.sandbox != nil)
+	return execEnvironmentNote()
 }
 
 // execEnvironmentNote is the shared wording nativeRunner (planner
 // prompt) and Driver (worker packet) both need — kept as one function
 // so the two prompts never drift out of sync about what's actually
 // available.
-func execEnvironmentNote(sandboxed bool) string {
-	if sandboxed {
-		return " Commands run inside an isolated Linux container with python3, node, git, and standard POSIX/coreutils tools available; each mission gets its own container, state persists across your commands within the mission."
-	}
-	return " Commands run in a minimal shell environment — do not assume python3, node, or any interpreter beyond POSIX shell builtins and coreutils (grep, sed, awk, wc, test) are present; verify_cmd must only rely on tools you can confirm exist."
+func execEnvironmentNote() string {
+	return " Commands run inside an isolated Linux container with python3, node, git, and standard POSIX/coreutils tools available; each mission gets its own container, state persists across your commands within the mission."
 }
 
 // parseSpec decodes the planner's reply strictly: fences stripped,

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -700,23 +700,6 @@ func shellExtraTool(t *testing.T, extras []*tools.Tool) *tools.Tool {
 	return nil
 }
 
-// TestMissionToolsNoSandboxUsesLocalExec confirms a runner with no
-// sandbox configured builds a shell with no Runner set — the local
-// exec.CommandContext fallback shell.go already had.
-func TestMissionToolsNoSandboxUsesLocalExec(t *testing.T) {
-	r := newTestRunner(&scriptedAgent{})
-	extraTools := r.missionTools(Mission{ID: "m1", Workspace: t.TempDir()})
-	shell := shellExtraTool(t, extraTools)
-	args, _ := json.Marshal(map[string]string{"command": "echo real-exec"})
-	out, err := shell.Execute(context.Background(), args)
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if strings.TrimSpace(out) != "real-exec" {
-		t.Fatalf("output = %q, want local exec to have actually run", out)
-	}
-}
-
 // TestMissionToolsSandboxRoutesShell confirms that with r.sandbox set,
 // missionTools wires a shell whose Runner calls the sandbox backend
 // (never local exec) with the mission id and mission's own work root,

--- a/internal/brain/missions/sweep.go
+++ b/internal/brain/missions/sweep.go
@@ -45,8 +45,6 @@ type sandboxSweeper interface {
 // sweeps orphaned sandbox containers on the same tick (see
 // runWorkSlotSweep). This is the one entry point cmd/brain/main.go
 // needs — it owns the Driver, which carries its own Store reference.
-// sandbox may be nil (SANDBOXD_URL unset), in which case the container
-// sweep is skipped entirely.
 func RecoverAndSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, log *slog.Logger) {
 	recoverWorking(ctx, d, store, log)
 	runWorkSlotSweep(ctx, d, store, maxConcurrent, sandbox, log)

--- a/internal/brain/missions/units_test.go
+++ b/internal/brain/missions/units_test.go
@@ -42,7 +42,7 @@ func TestIsLastUnit(t *testing.T) {
 // full round before the harness ever verified it.
 func TestMarkUnitPassedDoesNotAliasCaller(t *testing.T) {
 	store := newFakeStore()
-	d := NewDriver(store, nil, nil, nil, nil, nil, slog.Default())
+	d := NewDriver(store, nil, nil, nil, nil, nil, nil, nil, slog.Default())
 
 	units := []PlanUnit{{Title: "a", Passes: true}, {Title: "b", Passes: false}, {Title: "c", Passes: false}}
 	m := Mission{ID: "m1", Spec: Spec{Units: units}}

--- a/internal/brain/missions/verify.go
+++ b/internal/brain/missions/verify.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -30,9 +29,9 @@ const verifyTimeout = 10 * time.Minute
 // full digest — enough to see what failed without storing megabytes.
 const verifyExcerptCap = 2 << 10
 
-// VerifyResult is a plan unit's verification evidence. Only RunVerify
-// produces this — never model output — and only this evidence may
-// flip a PlanUnit's Passes flag.
+// VerifyResult is a plan unit's verification evidence. Only
+// RunVerifyWithBackend produces this — never model output — and only
+// this evidence may flip a PlanUnit's Passes flag.
 type VerifyResult struct {
 	ExitCode     int
 	OutputSHA256 string
@@ -40,35 +39,13 @@ type VerifyResult struct {
 	Passed       bool
 }
 
-// RunVerify executes a plan unit's verify_cmd via /bin/sh -c in the
-// work root. Evidence recorded: exit code, sha256 digest of the full
-// output, and a trailing excerpt — "done is auditable from events
-// alone."
-func RunVerify(ctx context.Context, workRoot, verifyCmd string) (VerifyResult, error) {
-	cctx, cancel := context.WithTimeout(ctx, verifyTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(cctx, "/bin/sh", "-c", verifyCmd) //nolint:gosec // verify_cmd is operator-authored plan content, not user input
-	cmd.Dir = workRoot
-	out, runErr := cmd.CombinedOutput()
-
-	exitCode := 0
-	if runErr != nil {
-		if ee, ok := runErr.(*exec.ExitError); ok {
-			exitCode = ee.ExitCode()
-		} else {
-			return VerifyResult{}, runErr // context deadline, command not found, etc.
-		}
-	}
-	return newVerifyResult(exitCode, out), nil
-}
-
-// RunVerifyWithBackend is RunVerify's sandbox-routed counterpart:
-// verify_cmd runs via backend (a sandbox container) instead of
-// brain's own process. Output is streamed into a sha256 hash and a
-// bounded tail buffer rather than collected in full — a verify_cmd
-// with runaway output must not balloon memory the way a plain
-// CombinedOutput() would, and the resulting VerifyResult carries the
-// same evidence shape (digest + excerpt) either way.
+// RunVerifyWithBackend executes a plan unit's verify_cmd via backend
+// (the mission's sandbox container) in the work root. Output is
+// streamed into a sha256 hash and a bounded tail buffer rather than
+// collected in full — a verify_cmd with runaway output must not
+// balloon memory. Evidence recorded: exit code, sha256 digest of the
+// full output, and a trailing excerpt — "done is auditable from
+// events alone."
 func RunVerifyWithBackend(ctx context.Context, backend verifyBackend, workRoot, verifyCmd string) (VerifyResult, error) {
 	cctx, cancel := context.WithTimeout(ctx, verifyTimeout)
 	defer cancel()
@@ -85,23 +62,6 @@ func RunVerifyWithBackend(ctx context.Context, backend verifyBackend, workRoot, 
 		Excerpt:      tail.String(),
 		Passed:       exitCode == 0,
 	}, nil
-}
-
-// newVerifyResult builds a VerifyResult from a fully-collected output
-// buffer — RunVerify's local-exec shape, where CombinedOutput already
-// returns the whole thing.
-func newVerifyResult(exitCode int, out []byte) VerifyResult {
-	digest := sha256.Sum256(out)
-	excerpt := out
-	if len(excerpt) > verifyExcerptCap {
-		excerpt = excerpt[len(excerpt)-verifyExcerptCap:]
-	}
-	return VerifyResult{
-		ExitCode:     exitCode,
-		OutputSHA256: hex.EncodeToString(digest[:]),
-		Excerpt:      string(excerpt),
-		Passed:       exitCode == 0,
-	}
 }
 
 // tailBuffer keeps only the last max bytes written to it — a bounded

--- a/internal/brain/missions/verify_test.go
+++ b/internal/brain/missions/verify_test.go
@@ -10,66 +10,6 @@ import (
 	"time"
 )
 
-func TestRunVerifySuccess(t *testing.T) {
-	res, err := RunVerify(context.Background(), t.TempDir(), "true")
-	if err != nil {
-		t.Fatalf("RunVerify: %v", err)
-	}
-	if !res.Passed || res.ExitCode != 0 {
-		t.Fatalf("RunVerify(true) = %+v, want passed with exit 0", res)
-	}
-}
-
-func TestRunVerifyFailure(t *testing.T) {
-	res, err := RunVerify(context.Background(), t.TempDir(), "false")
-	if err != nil {
-		t.Fatalf("RunVerify: %v", err)
-	}
-	if res.Passed || res.ExitCode != 1 {
-		t.Fatalf("RunVerify(false) = %+v, want failed with exit 1", res)
-	}
-}
-
-func TestRunVerifyExitCode(t *testing.T) {
-	res, err := RunVerify(context.Background(), t.TempDir(), "exit 3")
-	if err != nil {
-		t.Fatalf("RunVerify: %v", err)
-	}
-	if res.Passed || res.ExitCode != 3 {
-		t.Fatalf("RunVerify(exit 3) = %+v, want failed with exit 3", res)
-	}
-}
-
-func TestRunVerifyDigestCorrectness(t *testing.T) {
-	res, err := RunVerify(context.Background(), t.TempDir(), "printf hello")
-	if err != nil {
-		t.Fatalf("RunVerify: %v", err)
-	}
-	// sha256("hello")
-	const wantDigest = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
-	if res.OutputSHA256 != wantDigest {
-		t.Fatalf("digest = %q, want %q", res.OutputSHA256, wantDigest)
-	}
-}
-
-func TestRunVerifyExcerptTruncatesFromEnd(t *testing.T) {
-	// Produce output well over the excerpt cap; the excerpt must be the
-	// TRAILING slice, not the head.
-	res, err := RunVerify(context.Background(), t.TempDir(), `for i in $(seq 1 5000); do echo "line $i"; done`)
-	if err != nil {
-		t.Fatalf("RunVerify: %v", err)
-	}
-	if len(res.Excerpt) > verifyExcerptCap {
-		t.Fatalf("excerpt length %d exceeds cap %d", len(res.Excerpt), verifyExcerptCap)
-	}
-	if !strings.Contains(res.Excerpt, "line 5000") {
-		t.Fatalf("excerpt does not contain the LAST line of output: %q", res.Excerpt[:min(200, len(res.Excerpt))])
-	}
-	if strings.Contains(res.Excerpt, "line 1\n") {
-		t.Fatal("excerpt contains the first line — truncation kept the head instead of the tail")
-	}
-}
-
 func TestCheckArtifacts(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "summary.md"), []byte("429 means Too Many Requests"), 0o600); err != nil {
@@ -143,21 +83,27 @@ func fakeVerifyBackend(output string, exitCode int, err error) verifyBackend {
 	}
 }
 
-// TestRunVerifyWithBackendMatchesLocalDigest confirms the sandbox-
-// routed path produces byte-identical evidence (digest, excerpt,
-// passed) to RunVerify's local exec path for the same output — the
-// backend must not change what "passed" evidence means, only where
-// the command actually ran.
-func TestRunVerifyWithBackendMatchesLocalDigest(t *testing.T) {
+// TestRunVerifyWithBackendDigestCorrectness confirms the streamed
+// evidence (digest, excerpt, passed) matches what's actually written
+// by the backend, byte for byte — the sha256 hash and tail buffer must
+// see exactly what a full CombinedOutput() collection would have.
+func TestRunVerifyWithBackendDigestCorrectness(t *testing.T) {
 	const output = "hello"
-	local := newVerifyResult(0, []byte(output))
+	// sha256("hello")
+	const wantDigest = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
 
 	got, err := RunVerifyWithBackend(context.Background(), fakeVerifyBackend(output, 0, nil), "/workspace", "printf hello")
 	if err != nil {
 		t.Fatalf("RunVerifyWithBackend: %v", err)
 	}
-	if got != local {
-		t.Fatalf("RunVerifyWithBackend = %+v, want %+v (identical to the local-exec path)", got, local)
+	if !got.Passed || got.ExitCode != 0 {
+		t.Fatalf("RunVerifyWithBackend(exit 0) = %+v, want passed with exit 0", got)
+	}
+	if got.OutputSHA256 != wantDigest {
+		t.Fatalf("digest = %q, want %q", got.OutputSHA256, wantDigest)
+	}
+	if got.Excerpt != output {
+		t.Fatalf("excerpt = %q, want %q", got.Excerpt, output)
 	}
 }
 
@@ -179,10 +125,10 @@ func TestRunVerifyWithBackendInfraErrorPropagates(t *testing.T) {
 	}
 }
 
-// TestTailBufferBoundsMemoryKeepsEnd confirms the streamed excerpt path
-// is bounded like the local path's slice-from-the-end truncation, and
-// keeps the TAIL, not the head — same contract as
-// TestRunVerifyExcerptTruncatesFromEnd for the local path.
+// TestTailBufferBoundsMemoryKeepsEnd confirms the streamed excerpt is
+// bounded to the cap and keeps the TAIL of the output, not the head —
+// a verify_cmd with runaway output must not balloon memory, and the
+// kept slice must still show what actually failed at the end.
 func TestTailBufferBoundsMemoryKeepsEnd(t *testing.T) {
 	tail := &tailBuffer{max: 5}
 	full := "0123456789" // 10 bytes written in one shot, cap is 5

--- a/internal/sandboxd/api.go
+++ b/internal/sandboxd/api.go
@@ -68,9 +68,7 @@ type API struct {
 	maxContainers int
 }
 
-// Register mounts sandboxd's routes on the shared server. mgr may be
-// nil (MISSION_SANDBOX_IMAGE unset) — every route reports 503 rather
-// than panicking.
+// Register mounts sandboxd's routes on the shared server.
 func Register(s *httpserver.Server, mgr *Manager, cfg Config, log *slog.Logger) {
 	maxExecs := cfg.MaxExecs
 	if maxExecs <= 0 {
@@ -133,11 +131,6 @@ func (a *API) handleExec(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "bad_request", "invalid mission id")
 		return
 	}
-	if a.mgr == nil {
-		jsonError(w, http.StatusServiceUnavailable, "not_configured", ErrDisabled.Error())
-		return
-	}
-
 	r.Body = http.MaxBytesReader(w, r.Body, execBodyLimit)
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
@@ -259,10 +252,6 @@ func (a *API) handleRemove(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "bad_request", "invalid mission id")
 		return
 	}
-	if a.mgr == nil {
-		jsonError(w, http.StatusServiceUnavailable, "not_configured", ErrDisabled.Error())
-		return
-	}
 	if err := a.mgr.Remove(r.Context(), missionID); err != nil {
 		a.log.Warn("sandbox remove failed", "mission_id", missionID, "error", err)
 		jsonError(w, http.StatusBadGateway, "infra", err.Error())
@@ -280,10 +269,6 @@ type listResponse struct {
 // remove; this service holds no Postgres state to make that decision
 // itself.
 func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
-	if a.mgr == nil {
-		jsonError(w, http.StatusServiceUnavailable, "not_configured", ErrDisabled.Error())
-		return
-	}
 	ids, err := a.mgr.List(r.Context())
 	if err != nil {
 		a.log.Warn("sandbox list failed", "error", err)

--- a/internal/sandboxd/api_test.go
+++ b/internal/sandboxd/api_test.go
@@ -67,33 +67,6 @@ func TestHandleRemoveInvalidMissionID(t *testing.T) {
 	}
 }
 
-func TestHandleExecNilManagerReturns503(t *testing.T) {
-	t.Parallel()
-	rec := httptest.NewRecorder()
-	testAPI(nil).handleExec(rec, execReq(validUUID, `{"workdir":"/workspace","command":"true","timeout_seconds":5}`))
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want 503", rec.Code)
-	}
-}
-
-func TestHandleRemoveNilManagerReturns503(t *testing.T) {
-	t.Parallel()
-	rec := httptest.NewRecorder()
-	testAPI(nil).handleRemove(rec, removeReq(validUUID))
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want 503", rec.Code)
-	}
-}
-
-func TestHandleListNilManagerReturns503(t *testing.T) {
-	t.Parallel()
-	rec := httptest.NewRecorder()
-	testAPI(nil).handleList(rec, httptest.NewRequest(http.MethodGet, "/v1/sandboxes", nil))
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want 503", rec.Code)
-	}
-}
-
 func TestHandleExecWorkdirEscape(t *testing.T) {
 	t.Parallel()
 	cli := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/sandboxd/manager.go
+++ b/internal/sandboxd/manager.go
@@ -71,10 +71,6 @@ const (
 	execClientSlack = 35 * time.Second
 )
 
-// ErrDisabled is returned by every Manager method when no image was
-// configured — callers check this to fall back to in-process exec.
-var ErrDisabled = errors.New("sandbox: not configured")
-
 // ErrTimeout wraps Exec's two timeout-return paths so the HTTP handler
 // can classify a timeout (SSE event: error, code "timeout") separately
 // from every other infrastructure failure via errors.Is, without
@@ -105,12 +101,10 @@ type Manager struct {
 // only reliable way to learn the exact volume name (or bind source)
 // brain is running under, since it may differ from any assumed
 // compose-project prefix and a wrong name would silently create a
-// fresh, empty volume instead of failing loudly. image empty disables
-// the manager entirely (nil-able-dependency convention: callers get
-// ErrDisabled and fall back to local exec).
+// fresh, empty volume instead of failing loudly.
 func NewManager(ctx context.Context, image string, log *slog.Logger) (*Manager, error) {
 	if image == "" {
-		return nil, nil //nolint:nilnil // disabled-by-config sentinel; callers check for a nil *Manager exactly like every other optional brain dependency
+		return nil, fmt.Errorf("sandbox: MISSION_SANDBOX_IMAGE not set")
 	}
 	// API-version negotiation is on by default in this client (unlike the
 	// old github.com/docker/docker client, which required
@@ -155,21 +149,15 @@ func resolveWorkspaceMount(ctx context.Context, cli *client.Client) (mount.Mount
 // Ping reports whether the Docker daemon is reachable — the sandbox
 // health check.
 func (m *Manager) Ping(ctx context.Context) error {
-	if m == nil {
-		return ErrDisabled
-	}
 	_, err := m.cli.Ping(ctx, client.PingOptions{})
 	return err
 }
 
 // CheckImage confirms the configured sandbox image actually exists
-// locally — an operator who set MISSION_SANDBOX_IMAGE but never ran
-// `make sandbox-image` would otherwise see every mission shell call
-// fail opaquely instead of a clear boot-time health signal.
+// locally — an operator who never ran `make sandbox-image` would
+// otherwise see every mission shell call fail opaquely instead of a
+// clear boot-time health signal.
 func (m *Manager) CheckImage(ctx context.Context) error {
-	if m == nil {
-		return ErrDisabled
-	}
 	_, err := m.cli.ImageInspect(ctx, m.image)
 	return err
 }
@@ -306,9 +294,6 @@ func (m *Manager) createContainer(ctx context.Context, missionID, name string) (
 // builtin.Shell's contract: a command that ran and exited non-zero is
 // reported via exitCode, not err).
 func (m *Manager) Exec(ctx context.Context, missionID, workdir, command string, timeout time.Duration, out io.Writer) (exitCode int, err error) {
-	if m == nil {
-		return 0, ErrDisabled
-	}
 	containerID, err := m.ensureContainer(ctx, missionID)
 	if err != nil {
 		return 0, err
@@ -410,9 +395,6 @@ func (m *Manager) Exec(ctx context.Context, missionID, workdir, command string, 
 // treat this as best-effort — a slow or unreachable daemon must never
 // block a mission's terminal state transition.
 func (m *Manager) Remove(ctx context.Context, missionID string) error {
-	if m == nil {
-		return ErrDisabled
-	}
 	name := containerName(missionID)
 	_, err := m.cli.ContainerRemove(ctx, name, client.ContainerRemoveOptions{Force: true})
 	if err != nil && !errdefs.IsNotFound(err) {
@@ -431,9 +413,6 @@ func (m *Manager) Remove(ctx context.Context, missionID string) error {
 // remove — this package holds no Postgres state to make that call
 // itself.
 func (m *Manager) List(ctx context.Context) ([]string, error) {
-	if m == nil {
-		return nil, ErrDisabled
-	}
 	result, err := m.cli.ContainerList(ctx, client.ContainerListOptions{
 		All:     true,
 		Filters: make(client.Filters).Add("label", missionLabel),

--- a/internal/sandboxd/manager_test.go
+++ b/internal/sandboxd/manager_test.go
@@ -1,7 +1,6 @@
 package sandboxd
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -9,7 +8,6 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
@@ -241,32 +239,12 @@ func TestEnsureContainerCreateConflictReinspects(t *testing.T) {
 	}
 }
 
-func TestManagerDisabledReturnsErrDisabled(t *testing.T) {
-	var mgr *Manager // simulates MISSION_SANDBOX_IMAGE unset
-	ctx := context.Background()
-	if err := mgr.Ping(ctx); err != ErrDisabled {
-		t.Errorf("Ping on nil manager = %v, want ErrDisabled", err)
-	}
-	if err := mgr.CheckImage(ctx); err != ErrDisabled {
-		t.Errorf("CheckImage on nil manager = %v, want ErrDisabled", err)
-	}
-	if _, err := mgr.Exec(ctx, "m1", "/workspace", "true", time.Second, &bytes.Buffer{}); err != ErrDisabled {
-		t.Errorf("Exec on nil manager = %v, want ErrDisabled", err)
-	}
-	if err := mgr.Remove(ctx, "m1"); err != ErrDisabled {
-		t.Errorf("Remove on nil manager = %v, want ErrDisabled", err)
-	}
-	if _, err := mgr.List(ctx); err != ErrDisabled {
-		t.Errorf("List on nil manager = %v, want ErrDisabled", err)
-	}
-}
-
-func TestNewManagerEmptyImageDisables(t *testing.T) {
+func TestNewManagerEmptyImageErrors(t *testing.T) {
 	mgr, err := NewManager(context.Background(), "", nil)
-	if err != nil {
-		t.Fatalf("NewManager(\"\"): %v", err)
+	if err == nil {
+		t.Fatal("NewManager(\"\") = nil error, want an error (sandbox is mandatory)")
 	}
 	if mgr != nil {
-		t.Fatalf("NewManager(\"\") = %v, want nil (disabled)", mgr)
+		t.Fatalf("NewManager(\"\") = %v, want nil manager alongside the error", mgr)
 	}
 }


### PR DESCRIPTION
## Summary
- Mission shell/verify_cmd execution always routes through sandboxd now — removed the in-process exec.CommandContext fallback that ran when MISSION_SANDBOX_IMAGE was unset. That fallback let a plan's verify_cmd assumptions (python3, node) silently diverge from what a sandboxed run actually provides, and it never surfaced the mismatch until a mission got stuck mid-run.
- sandboxd fails closed at boot if no image is configured, instead of coming up degraded and reporting "not_configured" per-request.
- MISSION_SANDBOX_IMAGE is no longer a separate, driftable env value: release compose derives it from `TIMOTHY_VERSION` (same tag as every other service image — this was the root cause of a real homelab mission failure this session, where the sandbox tag was frozen at an old release while everything else moved on). Local dev hardcodes the `make sandbox-image` tag directly in compose, matching every other locally-built image.
- `install.sh` always pulls the sandbox image now (reading `TIMOTHY_VERSION` back from `.env`, so a manual upgrade that only bumps that one value still pulls the matching sandbox tag). `make up` depends on `make sandbox-image` so a fresh clone's first run doesn't crash-loop sandboxd.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go vet -tags integration ./...` all clean
- [x] `go test -race ./...` — full repo, all packages pass
- [x] `make test-integration` against live stack — passes (bar the pre-existing, unrelated `TestGoldenRecallAt5` local-environment flake)
- [x] `make canary` (research mission) — PASS
- [x] `make canary-coding` (coding mission, exercises sandboxed shell/verify_cmd end-to-end) — PASS
- [x] Verified both `deploy/docker-compose.yml` and `deploy/release/docker-compose.yml` render correctly via `docker compose config`, confirming `MISSION_SANDBOX_IMAGE` resolves to the right tag in both local and release modes