### PR TITLE
ci(release): skip unchanged image rebuilds + mission UI fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,55 @@ jobs:
   # on main that already went green through ci-ok. Re-running build/
   # vet/test/lint against the same commit here would only slow the
   # release down for no new signal.
+
+  # Decides which of the 8 images actually need a rebuild for this
+  # tag. Diffs against the previous release tag (not the previous
+  # commit): a service skipped across several no-op releases in a row
+  # must still be compared against the last tag that actually built
+  # it, or a real change could be missed. First-ever release (no
+  # previous tag) marks everything changed.
+  diff:
+    runs-on: ubuntu-latest
+    outputs:
+      brain: ${{ steps.diff.outputs.brain }}
+      gateway: ${{ steps.diff.outputs.gateway }}
+      memoryd: ${{ steps.diff.outputs.memoryd }}
+      sandboxd: ${{ steps.diff.outputs.sandboxd }}
+      web: ${{ steps.diff.outputs.web }}
+      markitdown: ${{ steps.diff.outputs.markitdown }}
+      whisper: ${{ steps.diff.outputs.whisper }}
+      sandbox: ${{ steps.diff.outputs.sandbox }}
+      prev_tag: ${{ steps.prev.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - id: prev
+        run: |
+          prev=$(git tag --sort=-v:refname | grep -v "^${GITHUB_REF_NAME}$" | head -1)
+          echo "tag=$prev" >> "$GITHUB_OUTPUT"
+      - id: diff
+        run: |
+          if [ -z "${{ steps.prev.outputs.tag }}" ]; then
+            echo "no previous release tag; building everything"
+            for name in brain gateway memoryd sandboxd web markitdown whisper sandbox; do
+              echo "$name=true" >> "$GITHUB_OUTPUT"
+            done
+            exit 0
+          fi
+          files=$(git diff --name-only "${{ steps.prev.outputs.tag }}" "$GITHUB_SHA")
+          changed() { echo "$files" | grep -qE "$1"; }
+          go_pattern='^(go\.mod|go\.sum|migrations/|internal/|cmd/|deploy/Dockerfile)'
+          for name in brain gateway memoryd sandboxd; do
+            changed "$go_pattern" && echo "$name=true" >> "$GITHUB_OUTPUT" || echo "$name=false" >> "$GITHUB_OUTPUT"
+          done
+          changed '^web/' && echo "web=true" >> "$GITHUB_OUTPUT" || echo "web=false" >> "$GITHUB_OUTPUT"
+          changed '^markitdown-svc/' && echo "markitdown=true" >> "$GITHUB_OUTPUT" || echo "markitdown=false" >> "$GITHUB_OUTPUT"
+          changed '^whisper-svc/' && echo "whisper=true" >> "$GITHUB_OUTPUT" || echo "whisper=false" >> "$GITHUB_OUTPUT"
+          changed '^deploy/sandbox\.Dockerfile$' && echo "sandbox=true" >> "$GITHUB_OUTPUT" || echo "sandbox=false" >> "$GITHUB_OUTPUT"
+
   images:
+    needs: diff
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -65,11 +113,15 @@ jobs:
             dockerfile: deploy/sandbox.Dockerfile
     steps:
       - uses: actions/checkout@v7
+        if: fromJSON(needs.diff.outputs[matrix.name])
       - id: version
         run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
       - id: sha
         run: echo "short=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-qemu-action@v3
+        if: fromJSON(needs.diff.outputs[matrix.name])
+      # Always set up buildx: the copy-forward step below (unchanged
+      # images) also needs it for `docker buildx imagetools create`.
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -77,6 +129,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
+        if: fromJSON(needs.diff.outputs[matrix.name])
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
@@ -101,6 +154,18 @@ jobs:
           tags: ghcr.io/${{ github.repository_owner }}/timothy-${{ matrix.name }}:${{ steps.version.outputs.value }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+      # Unchanged image: no rebuild, just point the new version tag at
+      # the previous release's manifest list. Keeps every tag pinned
+      # to a real image (no floating tags) without paying for a
+      # redundant multi-arch build.
+      - name: Copy forward unchanged image
+        if: needs.diff.outputs.prev_tag != '' && !fromJSON(needs.diff.outputs[matrix.name])
+        run: |
+          prev_version="${{ needs.diff.outputs.prev_tag }}"
+          prev_version="${prev_version#v}"
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository_owner }}/timothy-${{ matrix.name }}:${{ steps.version.outputs.value }} \
+            ghcr.io/${{ github.repository_owner }}/timothy-${{ matrix.name }}:${prev_version}
 
   release:
     needs: images

--- a/web/src/components/missions/ProgressSection.test.tsx
+++ b/web/src/components/missions/ProgressSection.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ProgressSection } from './ProgressSection'
+
+describe('ProgressSection', () => {
+  it('shows a placeholder when there are no notes', () => {
+    render(<ProgressSection notes={[]} />)
+    expect(screen.getByText('No progress notes yet.')).toBeInTheDocument()
+  })
+
+  it('renders each note in its own container with markdown applied', () => {
+    render(
+      <ProgressSection
+        notes={[
+          { at: '2026-01-01T00:00:00Z', note: '**bold** and a [link](https://example.com)' },
+          { at: '2026-01-02T00:00:00Z', note: 'plain text' },
+        ]}
+      />,
+    )
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(2)
+    expect(items[0].querySelector('strong')).toHaveTextContent('bold')
+    expect(items[0].querySelector('a')).toHaveAttribute('href', 'https://example.com')
+    expect(items[1]).toHaveTextContent('plain text')
+  })
+})

--- a/web/src/components/missions/ProgressSection.tsx
+++ b/web/src/components/missions/ProgressSection.tsx
@@ -1,3 +1,5 @@
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import type { ProgressNote } from '../../api/types'
 
 export function ProgressSection({ notes }: { notes: ProgressNote[] }) {
@@ -7,9 +9,13 @@ export function ProgressSection({ notes }: { notes: ProgressNote[] }) {
   return (
     <ul className="space-y-2">
       {notes.map((n, i) => (
-        <li key={i} className="text-sm">
-          <span className="mr-2 text-xs text-muted-foreground">{new Date(n.at).toLocaleString()}</span>
-          {n.note}
+        <li key={i} className="rounded-lg border border-border bg-muted/30">
+          <div className="border-b border-border px-3 py-1.5 text-xs text-muted-foreground">
+            {new Date(n.at).toLocaleString()}
+          </div>
+          <div className="prose prose-sm max-h-64 max-w-none overflow-y-auto p-3 dark:prose-invert">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{n.note}</ReactMarkdown>
+          </div>
         </li>
       ))}
     </ul>

--- a/web/src/components/missions/ResultSection.test.tsx
+++ b/web/src/components/missions/ResultSection.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ResultSection } from './ResultSection'
+
+describe('ResultSection', () => {
+  it('renders the evidence text as markdown', () => {
+    render(<ResultSection evidence={'**bold** and a [link](https://example.com)'} />)
+    expect(screen.getByRole('strong')).toHaveTextContent('bold')
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://example.com')
+  })
+})

--- a/web/src/components/missions/ResultSection.tsx
+++ b/web/src/components/missions/ResultSection.tsx
@@ -1,0 +1,12 @@
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+export function ResultSection({ evidence }: { evidence: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-muted/30">
+      <div className="prose prose-sm max-w-none p-3 dark:prose-invert">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{evidence}</ReactMarkdown>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -14,9 +14,9 @@ function event(payload: unknown): MissionEvent {
 }
 
 describe('mission.unit_verified rendering', () => {
-  it('names the unit when the payload carries an index', () => {
-    expect(renderEvent(event({ unit: 0, passed: true }))).toBe('Unit 0 verification: passed')
-    expect(renderEvent(event({ unit: 2, passed: false }))).toBe('Unit 2 verification: failed')
+  it('names the unit 1-indexed when the payload carries a 0-indexed index', () => {
+    expect(renderEvent(event({ unit: 0, passed: true }))).toBe('Unit 1 verification: passed')
+    expect(renderEvent(event({ unit: 2, passed: false }))).toBe('Unit 3 verification: failed')
   })
 
   it('omits the unit index when the payload has none, rather than showing "Unit ?"', () => {

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -28,7 +28,7 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
   },
   'mission.unit_verified': (p) => {
     const { unit, passed } = asRecord(p)
-    const label = unit != null ? `Unit ${String(unit)} verification` : 'Unit verification'
+    const label = typeof unit === 'number' ? `Unit ${unit + 1} verification` : 'Unit verification'
     return `${label}: ${passed ? 'passed' : 'failed'}`
   },
   'mission.review_verdict': (p) => {

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -19,6 +19,7 @@ import { PermissionBanner } from '../components/missions/PermissionBanner'
 import { PlanSection } from '../components/missions/PlanSection'
 import { ProgressSection } from '../components/missions/ProgressSection'
 import { PushBranchDialog } from '../components/missions/PushBranchDialog'
+import { ResultSection } from '../components/missions/ResultSection'
 import { TimelineSection } from '../components/missions/TimelineSection'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
@@ -53,11 +54,20 @@ export function MissionDetail() {
   const [pushOpen, setPushOpen] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
 
+  const refreshSeq = useRef(0)
+
   const refresh = useCallback(() => {
     if (!id) return
-    getMission(id).then(setMission, () => undefined)
-    missionEvents(id).then(setEvents, () => undefined)
-    missionUsage(id).then(setUsage, () => undefined)
+    const seq = ++refreshSeq.current
+    getMission(id).then((m) => {
+      if (seq === refreshSeq.current) setMission(m)
+    }, () => undefined)
+    missionEvents(id).then((e) => {
+      if (seq === refreshSeq.current) setEvents(e)
+    }, () => undefined)
+    missionUsage(id).then((u) => {
+      if (seq === refreshSeq.current) setUsage(u)
+    }, () => undefined)
   }, [id])
 
   const pendingPermission = mission?.pending_permission
@@ -208,9 +218,11 @@ export function MissionDetail() {
               <span className="capitalize">{mission.kind}</span>
               <span>{mission.phase}</span>
               <span>{mission.status.replace(/_/g, ' ')}</span>
-              <span>
-                iteration {mission.iteration}/{mission.max_iterations}
-              </span>
+              {!terminalPhases.has(mission.phase) && (
+                <span>
+                  iteration {mission.iteration + 1}/{mission.max_iterations}
+                </span>
+              )}
               {mission.budget_usd != null && <span>budget ${mission.budget_usd}</span>}
             </div>
             {mission.branch && (
@@ -330,9 +342,7 @@ export function MissionDetail() {
       {terminalPhases.has(mission.phase) && mission.last_evidence && (
         <section>
           <h2 className="mb-2 text-sm font-semibold tracking-tight">Result</h2>
-          <div className="rounded-lg border border-border bg-muted/50 p-3">
-            <p className="text-sm whitespace-pre-wrap">{mission.last_evidence}</p>
-          </div>
+          <ResultSection evidence={mission.last_evidence} />
         </section>
       )}
 


### PR DESCRIPTION
## Summary
- Release CI rebuilds all 8 multi-arch images unconditionally every tag; a new `diff` job now compares against the previous release tag and copy-forwards unchanged images via `docker buildx imagetools create` instead of rebuilding or using a floating tag.
- Mission progress notes and the result section were raw text; now rendered as markdown in scrollable, bordered cards.
- Fixes iteration always showing `0/N` on a running mission, and a stale-response race in `refresh()` where an out-of-order fetch could clobber newer state after a permission decision.

## Test plan
- [x] `npm run build && npm run lint && npm test` — 397 passing
- [ ] Cut a release tag with only Go changes, confirm web/markitdown/whisper/sandbox images are copy-forwarded, not rebuilt
- [ ] Confirm every image tag still resolves to a real, pullable manifest for both changed and unchanged legs