### PR TITLE
feat: source-language selection for mic dictation, whisper large-v3 default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
             context: whisper-svc
             dockerfile: whisper-svc/Dockerfile
             build-args: |
-              WHISPER_MODEL=small
+              WHISPER_MODEL=large-v3
           - name: sandbox
             context: .
             dockerfile: deploy/sandbox.Dockerfile

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -61,13 +61,18 @@ services:
     build:
       context: ../whisper-svc
       args:
-        WHISPER_MODEL: ${WHISPER_MODEL:-small}
+        WHISPER_MODEL: ${WHISPER_MODEL:-large-v3}
     environment:
-      WHISPER_MODEL: ${WHISPER_MODEL:-small}
+      WHISPER_MODEL: ${WHISPER_MODEL:-large-v3}
     # internal-only: no published ports, no auth; brain is the sole
     # caller, same trust boundary as searxng/markitdown. No user-facing
-    # knob in deploy/env.example — WHISPER_MODEL defaults to "small"
-    # here and is only worth changing per-deployment, not per-user.
+    # knob in deploy/env.example — WHISPER_MODEL defaults to
+    # "large-v3": smaller models (tried up to "medium") misidentify
+    # some languages entirely (e.g. Bangla decoded as Hindi even with
+    # the language explicitly forced), not just lower accuracy within
+    # the right language. Slower per clip and a bigger image, but
+    # dictation is not latency-sensitive the way live transcription
+    # would be.
 
   # Local models: run Ollama natively on the host (Metal/CUDA — a
   # containerized runner gets CPU only and can't serve big models) and

--- a/deploy/release/docker-compose.yml
+++ b/deploy/release/docker-compose.yml
@@ -59,10 +59,10 @@ services:
     <<: *service
     image: ghcr.io/timothy-agent/timothy-whisper:${TIMOTHY_VERSION:?set TIMOTHY_VERSION in .env}
     environment:
-      # The published image bakes model "small" at build time;
+      # The published image bakes model "large-v3" at build time;
       # overriding this requires rebuilding the image, not just
       # changing the value here.
-      WHISPER_MODEL: small
+      WHISPER_MODEL: large-v3
     # internal-only: no published ports, no auth; brain is the sole
     # caller, same trust boundary as searxng/markitdown.
 

--- a/internal/brain/api/transcribe.go
+++ b/internal/brain/api/transcribe.go
@@ -28,7 +28,7 @@ func (a *API) registerTranscribe(handle func(pattern string, h http.Handler), cl
 			jsonError(w, http.StatusBadRequest, "bad_request", "empty request body")
 			return
 		}
-		text, err := whisper.Transcribe(r.Context(), client, whisperURL, raw)
+		text, err := whisper.Transcribe(r.Context(), client, whisperURL, raw, r.URL.Query().Get("language"))
 		if err != nil {
 			jsonError(w, http.StatusBadGateway, "transcribe_failed", err.Error())
 			return

--- a/internal/brain/api/transcribe_test.go
+++ b/internal/brain/api/transcribe_test.go
@@ -75,6 +75,32 @@ func TestRegisterTranscribe(t *testing.T) {
 		}
 	})
 
+	t.Run("forwards the language query param to the sidecar", func(t *testing.T) {
+		var gotQuery string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"text": "hello"}`))
+		}))
+		defer srv.Close()
+
+		a, _, _ := testAPI(t, "tok", nil)
+		m := http.NewServeMux()
+		a.registerTranscribe(m.Handle, srv.Client(), srv.URL)
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/transcribe?language=bn", strings.NewReader("audio"))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("code = %d body=%s", w.Code, w.Body.String())
+		}
+		if gotQuery != "language=bn" {
+			t.Fatalf("sidecar query = %q, want language=bn", gotQuery)
+		}
+	})
+
 	t.Run("rejects an empty body", func(t *testing.T) {
 		a, _, _ := testAPI(t, "tok", nil)
 		m := http.NewServeMux()

--- a/internal/platform/whisper/whisper.go
+++ b/internal/platform/whisper/whisper.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"time"
 )
 
@@ -21,11 +22,17 @@ const transcribeTimeout = 120 * time.Second
 // Transcribe posts raw audio bytes to the whisper sidecar and returns
 // the transcribed text. baseURL empty means the sidecar isn't
 // configured — callers fall back to whatever they'd otherwise do.
-func Transcribe(ctx context.Context, client *http.Client, baseURL string, raw []byte) (string, error) {
+// language is an optional ISO 639-1 code (e.g. "bn"); empty lets the
+// sidecar auto-detect.
+func Transcribe(ctx context.Context, client *http.Client, baseURL string, raw []byte, language string) (string, error) {
 	if baseURL == "" {
 		return "", fmt.Errorf("whisper is not configured")
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/transcribe", bytes.NewReader(raw))
+	url := baseURL + "/transcribe"
+	if language != "" {
+		url += "?language=" + neturl.QueryEscape(language)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(raw))
 	if err != nil {
 		return "", fmt.Errorf("build request: %w", err)
 	}

--- a/internal/platform/whisper/whisper_test.go
+++ b/internal/platform/whisper/whisper_test.go
@@ -20,7 +20,7 @@ func TestTranscribe(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		out, err := Transcribe(context.Background(), srv.Client(), srv.URL, []byte("fake audio bytes"))
+		out, err := Transcribe(context.Background(), srv.Client(), srv.URL, []byte("fake audio bytes"), "")
 		if err != nil {
 			t.Fatalf("Transcribe: %v", err)
 		}
@@ -29,8 +29,42 @@ func TestTranscribe(t *testing.T) {
 		}
 	})
 
+	t.Run("passes the language as a query param when set", func(t *testing.T) {
+		var gotQuery string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"text": "hello"}`))
+		}))
+		defer srv.Close()
+
+		if _, err := Transcribe(context.Background(), srv.Client(), srv.URL, []byte("x"), "bn"); err != nil {
+			t.Fatalf("Transcribe: %v", err)
+		}
+		if gotQuery != "language=bn" {
+			t.Fatalf("query = %q, want language=bn", gotQuery)
+		}
+	})
+
+	t.Run("omits the query param when language is empty", func(t *testing.T) {
+		var gotQuery string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"text": "hello"}`))
+		}))
+		defer srv.Close()
+
+		if _, err := Transcribe(context.Background(), srv.Client(), srv.URL, []byte("x"), ""); err != nil {
+			t.Fatalf("Transcribe: %v", err)
+		}
+		if gotQuery != "" {
+			t.Fatalf("query = %q, want empty", gotQuery)
+		}
+	})
+
 	t.Run("unconfigured base URL errors without a request", func(t *testing.T) {
-		if _, err := Transcribe(context.Background(), nil, "", []byte("x")); err == nil {
+		if _, err := Transcribe(context.Background(), nil, "", []byte("x"), ""); err == nil {
 			t.Fatal("empty baseURL accepted")
 		}
 	})
@@ -41,7 +75,7 @@ func TestTranscribe(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, err := Transcribe(context.Background(), srv.Client(), srv.URL, []byte("x"))
+		_, err := Transcribe(context.Background(), srv.Client(), srv.URL, []byte("x"), "")
 		if err == nil || !strings.Contains(err.Error(), "422") {
 			t.Fatalf("err = %v, want http 422 surfaced", err)
 		}
@@ -58,7 +92,7 @@ func TestTranscribe(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		if _, err := Transcribe(ctx, srv.Client(), srv.URL, []byte("x")); err == nil {
+		if _, err := Transcribe(ctx, srv.Client(), srv.URL, []byte("x"), ""); err == nil {
 			t.Fatal("canceled context accepted")
 		}
 	})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -331,9 +331,11 @@ export async function deleteSession(id: string): Promise<void> {
 // transcribe posts a recorded audio clip (from the mic button) to
 // brain's local speech-to-text proxy and returns the transcript.
 // Raw bytes, not JSON — the body IS the audio, so this bypasses
-// request()'s JSON content type.
-export async function transcribe(blob: Blob): Promise<string> {
-  const res = await fetch('/v1/transcribe', {
+// request()'s JSON content type. language is an optional ISO 639-1
+// code (e.g. "bn"); omitted lets the sidecar auto-detect.
+export async function transcribe(blob: Blob, language?: string): Promise<string> {
+  const url = language ? `/v1/transcribe?language=${encodeURIComponent(language)}` : '/v1/transcribe'
+  const res = await fetch(url, {
     method: 'POST',
     headers: { Authorization: `Bearer ${getToken()}` },
     body: blob,

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -46,6 +46,7 @@ const getUserMedia = vi.fn().mockResolvedValue(fakeStream)
 
 beforeEach(() => {
   vi.clearAllMocks()
+  localStorage.clear()
   FakeMediaRecorder.instances = []
   vi.stubGlobal('MediaRecorder', FakeMediaRecorder)
   Object.defineProperty(navigator, 'mediaDevices', {
@@ -112,6 +113,24 @@ describe('Composer mic button', () => {
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('transcribe failed (502)'))
     expect(onDraft).not.toHaveBeenCalled()
+  })
+
+  it('passes the selected source language to transcribe and persists it', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.transcribe).mockResolvedValue('হ্যালো')
+    render(<Composer {...baseProps()} />)
+
+    const trigger = screen.getByRole('button', { name: 'Speech input language' })
+    fireEvent.pointerDown(trigger, { button: 0, pointerId: 1 })
+    fireEvent.click(trigger)
+    fireEvent.click(await screen.findByText('Bangla'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Record voice input' }))
+    await waitFor(() => expect(FakeMediaRecorder.instances).toHaveLength(1))
+    fireEvent.click(screen.getByRole('button', { name: 'Stop recording' }))
+
+    await waitFor(() => expect(client.transcribe).toHaveBeenCalledWith(expect.anything(), 'bn'))
+    expect(localStorage.getItem('timothy.transcribeLanguage')).toBe('bn')
   })
 
   it('toasts when the microphone permission is denied', async () => {

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -1,11 +1,13 @@
 import {
   Attachment02Icon,
+  ArrowDown01Icon,
   ArrowUp01Icon,
   Cancel01Icon,
   Loading03Icon,
   Mic01Icon,
   Pdf02Icon,
   StopIcon,
+  Tick02Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import type { ClipboardEvent, DragEvent } from 'react'
@@ -13,7 +15,18 @@ import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { transcribe, uploadAttachment } from '../api/client'
 import { skillLabels } from '../lib/skills'
+import {
+  getTranscribeLanguage,
+  setTranscribeLanguage,
+  TRANSCRIBE_LANGUAGES,
+} from '../lib/transcribeLanguage'
 import { AgentRoutePicker } from './AgentRoutePicker'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from './ui/dropdown-menu'
 
 // PendingAttachment is one upload in flight or done, owned by the
 // page (same pattern as `draft`) so the send flow can read and clear
@@ -90,6 +103,7 @@ export function Composer({
   draftRef.current = draft
   const [recording, setRecording] = useState(false)
   const [transcribing, setTranscribing] = useState(false)
+  const [transcribeLanguage, setTranscribeLanguageState] = useState(getTranscribeLanguage)
 
   // Auto-grow up to a cap, then scroll inside. Runs on every draft
   // change so programmatic clears (post-send) shrink it back.
@@ -143,7 +157,7 @@ export function Composer({
   async function transcribeBlob(blob: Blob) {
     setTranscribing(true)
     try {
-      const text = await transcribe(blob)
+      const text = await transcribe(blob, transcribeLanguage)
       const cur = draftRef.current
       if (text) onDraft(cur ? `${cur} ${text}` : text)
     } catch (err) {
@@ -345,6 +359,47 @@ export function Composer({
               className={transcribing ? 'size-4 animate-spin' : 'size-4'}
             />
           </button>
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              aria-label="Speech input language"
+              disabled={disabled || recording || transcribing}
+              className="flex h-8 items-center gap-1 rounded-full px-2 text-xs text-zinc-500 transition hover:bg-zinc-100 disabled:text-zinc-300 dark:text-zinc-400 dark:hover:bg-zinc-700/50 dark:disabled:text-zinc-600"
+            >
+              <span>
+                {TRANSCRIBE_LANGUAGES.find((l) => l.code === transcribeLanguage)?.label ?? 'Auto'}
+              </span>
+              <HugeiconsIcon icon={ArrowDown01Icon} className="size-3 opacity-60" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-48 p-1.5">
+              <DropdownMenuItem
+                onSelect={() => {
+                  setTranscribeLanguageState('')
+                  setTranscribeLanguage('')
+                }}
+                data-selected={transcribeLanguage === '' || undefined}
+                className="justify-between rounded-lg px-2.5 py-1.5 data-selected:bg-zinc-100 dark:data-selected:bg-zinc-800"
+              >
+                <span className="text-sm">Auto-detect</span>
+                {transcribeLanguage === '' && <HugeiconsIcon icon={Tick02Icon} className="size-4" />}
+              </DropdownMenuItem>
+              {TRANSCRIBE_LANGUAGES.map((l) => (
+                <DropdownMenuItem
+                  key={l.code}
+                  onSelect={() => {
+                    setTranscribeLanguageState(l.code)
+                    setTranscribeLanguage(l.code)
+                  }}
+                  data-selected={transcribeLanguage === l.code || undefined}
+                  className="justify-between rounded-lg px-2.5 py-1.5 data-selected:bg-zinc-100 dark:data-selected:bg-zinc-800"
+                >
+                  <span className="text-sm">{l.label}</span>
+                  {transcribeLanguage === l.code && (
+                    <HugeiconsIcon icon={Tick02Icon} className="size-4" />
+                  )}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
         {streaming && onStop ? (
           <button

--- a/web/src/lib/transcribeLanguage.ts
+++ b/web/src/lib/transcribeLanguage.ts
@@ -1,0 +1,29 @@
+const key = 'timothy.transcribeLanguage'
+
+// getTranscribeLanguage/setTranscribeLanguage mirror sound.ts's
+// localStorage get/set pattern. Empty string means auto-detect, the
+// default — whisper's own language guess is wrong often enough for
+// some languages that a sticky override is worth persisting.
+export function getTranscribeLanguage(): string {
+  return localStorage.getItem(key) ?? ''
+}
+
+export function setTranscribeLanguage(language: string) {
+  localStorage.setItem(key, language)
+}
+
+// A short curated list, not an exhaustive ISO 639-1 table — whisper
+// supports far more, but the mic button needs a pickable list, not a
+// search box.
+export const TRANSCRIBE_LANGUAGES: { code: string; label: string }[] = [
+  { code: 'en', label: 'English' },
+  { code: 'bn', label: 'Bangla' },
+  { code: 'hi', label: 'Hindi' },
+  { code: 'es', label: 'Spanish' },
+  { code: 'fr', label: 'French' },
+  { code: 'de', label: 'German' },
+  { code: 'ar', label: 'Arabic' },
+  { code: 'zh', label: 'Chinese' },
+  { code: 'ja', label: 'Japanese' },
+  { code: 'ru', label: 'Russian' },
+]

--- a/web/src/lib/transcribeLanguage.ts
+++ b/web/src/lib/transcribeLanguage.ts
@@ -22,6 +22,7 @@ export const TRANSCRIBE_LANGUAGES: { code: string; label: string }[] = [
   { code: 'es', label: 'Spanish' },
   { code: 'fr', label: 'French' },
   { code: 'de', label: 'German' },
+  { code: 'nl', label: 'Dutch' },
   { code: 'ar', label: 'Arabic' },
   { code: 'zh', label: 'Chinese' },
   { code: 'ja', label: 'Japanese' },

--- a/whisper-svc/Dockerfile
+++ b/whisper-svc/Dockerfile
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # HF_HOME lives outside /root so the model cached at build time stays
 # readable at runtime, where the service runs as nobody.
 ENV HF_HOME=/models
-ARG WHISPER_MODEL=small
+ARG WHISPER_MODEL=large-v3
 RUN python -c "from faster_whisper import WhisperModel; WhisperModel('${WHISPER_MODEL}', device='cpu', compute_type='int8')" \
     && chmod -R a+rX /models
 

--- a/whisper-svc/main.py
+++ b/whisper-svc/main.py
@@ -21,20 +21,25 @@ def health():
 
 
 @app.post("/transcribe")
-async def transcribe(request: Request):
+async def transcribe(request: Request, language: str | None = None):
     """Transcribes the request body (raw audio bytes) to text.
 
     Accepts whatever container format the browser recorded (webm/opus
     from MediaRecorder, also wav/ogg/mp3) — faster-whisper decodes via
     PyAV, which bundles its own ffmpeg libs, so no separate ffmpeg
     binary is needed in the image.
+
+    `language` is an optional ISO 639-1 code (e.g. "bn", "en"). Omitted
+    or empty falls back to faster-whisper's own auto-detection, which
+    can mis-guess on short clips or languages the model handles less
+    reliably.
     """
     body = await request.body()
     if not body:
         raise HTTPException(status_code=400, detail="empty request body")
 
     try:
-        segments, _ = model.transcribe(io.BytesIO(body))
+        segments, _ = model.transcribe(io.BytesIO(body), language=language or None)
         text = "".join(segment.text for segment in segments).strip()
     except Exception as exc:  # faster-whisper/PyAV raise assorted decode errors
         raise HTTPException(status_code=422, detail=f"transcription failed: {exc}") from exc


### PR DESCRIPTION
## Summary
- Mic dictation always auto-detected the spoken language; add an optional source-language hint (picker next to the mic button) threaded through brain's `/v1/transcribe` to whisper-svc's faster-whisper call. Persists in localStorage, defaults to auto-detect.
- Bumped the default `WHISPER_MODEL` to `large-v3`: tested against real Bangla speech, both `small` and `medium` decoded it as Hindi even with `language=bn` forced (a language-identity miss, not just lower accuracy). `large-v3` gets it right. Dictation isn't latency-sensitive, so the slower CPU decode is worth it.
- Added Dutch to the language picker's curated list.

## Test plan
- [x] `go build/vet/test -race` — all green
- [x] `npm run build && npm run lint && npm test` — 398 passing
- [x] Manually tested Bangla dictation end-to-end against a locally rebuilt stack (small/medium → wrong language; large-v3 → correct)