### PR TITLE
fix: self-init mission git repos and harden worker sentinel handling

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -130,7 +130,6 @@ type createMissionRequest struct {
 	EscalationRoute string   `json:"escalation_route"`
 	MaxIterations   int      `json:"max_iterations"`
 	BudgetUSD       *float64 `json:"budget_usd"`
-	RepoPath        string   `json:"repo_path"`
 	// AutoApproveSafe defaults true (a pointer so an omitted field is
 	// distinguishable from an explicit false) — missions run for hours
 	// unattended, so auto-approving DangerSafe shell calls is the
@@ -158,11 +157,6 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "bad_request", `kind must be "coding", "research", or "scheduled"`)
 		return
 	}
-	if req.Kind == "coding" && req.RepoPath == "" {
-		jsonError(w, http.StatusBadRequest, "bad_request", "repo_path is required for coding missions")
-		return
-	}
-
 	// Resolve even with an empty AgentID: ResolveByID("") falls back to
 	// the default agent, same as chat sessions that don't pick one — a
 	// mission created without an explicit agent still needs a real
@@ -210,7 +204,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		MaxIterations: req.MaxIterations, BudgetUSD: req.BudgetUSD,
 		AutoApproveSafe: autoApproveSafe, PromptOverlay: promptOverlay,
 	}
-	id, err := h.driver.Create(r.Context(), m, req.RepoPath)
+	id, err := h.driver.Create(r.Context(), m)
 	if err != nil {
 		failMission(w, err)
 		return

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -180,13 +180,13 @@ func (d *Driver) removeSandbox(id string) {
 // off the first Drive in a background goroutine — callers (the API's
 // create handler) get the new id back immediately without waiting on
 // the mission to actually run.
-func (d *Driver) Create(ctx context.Context, m Mission, repoPath string) (string, error) {
+func (d *Driver) Create(ctx context.Context, m Mission) (string, error) {
 	id, err := d.store.Create(ctx, m)
 	if err != nil {
 		return "", fmt.Errorf("driver: create: %w", err)
 	}
 	m.ID = id
-	if _, err := d.ensureProvisioned(ctx, m, repoPath); err != nil {
+	if _, err := d.ensureProvisioned(ctx, m); err != nil {
 		return "", fmt.Errorf("driver: create: %w", err)
 	}
 	go func() { //nolint:gosec // G118: deliberate — the mission must outlive the HTTP request that created it, driveTimeBound is Drive's own cap
@@ -213,7 +213,7 @@ func (d *Driver) Create(ctx context.Context, m Mission, repoPath string) (string
 // provisioning halves below — same shape as Create always had, plus
 // the new ApprovalAllowlist grants (via resolveAgent) once a session
 // exists, whichever half of ensureProvisioned actually created it.
-func (d *Driver) ensureProvisioned(ctx context.Context, m Mission, repoPath string) (Mission, error) {
+func (d *Driver) ensureProvisioned(ctx context.Context, m Mission) (Mission, error) {
 	if m.SessionID == "" && d.sessions != nil {
 		sessionID, err := d.sessions.Create(ctx, "")
 		if err != nil {
@@ -226,7 +226,7 @@ func (d *Driver) ensureProvisioned(ctx context.Context, m Mission, repoPath stri
 		d.grantSessionDefaults(ctx, m)
 	}
 	if d.workspace != nil && m.Workspace == "" && m.Worktree == "" {
-		workspace, worktree, branch, baseCommit, err := d.workspace.Provision(ctx, m.ID, m.Goal, m.Kind, repoPath)
+		workspace, worktree, branch, baseCommit, err := d.workspace.Provision(ctx, m.ID, m.Goal, m.Kind)
 		if err != nil {
 			return m, fmt.Errorf("provision: %w", err)
 		}
@@ -313,10 +313,21 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 	// no shell/write_file tools (runner.go's missionTools returns nil for
 	// an empty WorkRoot).
 	if m.SessionID == "" || (m.Workspace == "" && m.Worktree == "") {
-		m, err = d.ensureProvisioned(ctx, m, "")
-		if err != nil {
-			return false, fmt.Errorf("driver advance: ensure provisioned: %w", err)
+		provisioned, provErr := d.ensureProvisioned(ctx, m)
+		if provErr != nil {
+			// Returning the error here would leave the mission idle for
+			// the work-slot sweep to retry ensureProvisioned every 30s
+			// forever. Pause it as an infra failure instead, same path a
+			// phase-run error takes below.
+			d.log.Error("driver: provisioning failed", "mission_id", id, "error", provErr)
+			in := StepInput{Input: InputReviewInfraFailure, Reason: "provisioning failed: " + provErr.Error()}
+			t := Step(toStepState(m), in, d.cfg)
+			if err := d.store.ApplyTransition(ctx, id, t); err != nil {
+				return false, fmt.Errorf("driver advance: apply transition after provisioning failure: %w", err)
+			}
+			return false, nil
 		}
+		m = provisioned
 	}
 
 	before := m.Status
@@ -564,7 +575,18 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 				d.log.Warn("driver: rollback failed", "mission_id", m.ID, "error", err)
 			}
 		}
-		return StepInput{Input: InputWorkerRetry, Reason: truncate(verdict.Analysis, 500)}, nil
+		in := StepInput{Input: InputWorkerRetry, Reason: truncate(verdict.Analysis, 500)}
+		if verdict.Forced {
+			// Neither a tool call nor a text-form sentinel (runner.go's
+			// extractTextSentinel) could be read from this turn — a
+			// distinct, stable fingerprint (rather than none at all) so
+			// the stall brake (stepWorkerRetry, StallRounds consecutive
+			// identical fingerprints) pauses the mission after repeated
+			// sentinel-less turns instead of grinding to max_iterations on
+			// a model that never learns to end its turn correctly.
+			in.GapFingerprint = "no_sentinel"
+		}
+		return in, nil
 	}
 }
 

--- a/internal/brain/missions/driver_integration_test.go
+++ b/internal/brain/missions/driver_integration_test.go
@@ -24,7 +24,6 @@ func TestDriverEndToEndCodingMission(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
 
-	repo := scratchRepo(t)
 	wsRoot := t.TempDir()
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	workspace := NewWorkspace(wsRoot, nil, log)
@@ -33,7 +32,7 @@ func TestDriverEndToEndCodingMission(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	ws, wt, branch, base, err := workspace.Provision(ctx, id, marker+"e2e coding", "coding", repo)
+	ws, wt, branch, base, err := workspace.Provision(ctx, id, marker+"e2e coding", "coding")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -510,7 +510,7 @@ func TestDriverCreateGrantsShellAutoApproveWhenEnabled(t *testing.T) {
 	granter := &fakeGranter{}
 	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, nil, nil, slog.Default())
 
-	id, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: true}, "")
+	id, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: true})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -532,7 +532,7 @@ func TestDriverCreateSkipsGrantWhenAutoApproveDisabled(t *testing.T) {
 	granter := &fakeGranter{}
 	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, nil, nil, slog.Default())
 
-	if _, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: false}, ""); err != nil {
+	if _, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: false}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	if len(granter.calls) != 0 {
@@ -558,7 +558,7 @@ func TestDriverCreateGrantsApprovalAllowlist(t *testing.T) {
 	id, err := d.Create(context.Background(), Mission{
 		Goal: "test", Kind: "research", AgentID: "briefing-agent",
 		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: false,
-	}, "")
+	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -593,7 +593,7 @@ func TestDriverCreateSkipsAllowlistGrantWhenAgentUnresolved(t *testing.T) {
 	if _, err := d.Create(context.Background(), Mission{
 		Goal: "test", Kind: "research", AutoApproveSafe: false,
 		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8,
-	}, ""); err != nil {
+	}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	if len(granter.calls) != 0 {
@@ -668,6 +668,49 @@ func TestDriverAdvanceSkipsProvisioningWhenAlreadyProvisioned(t *testing.T) {
 	}
 	if sessions.n != 0 {
 		t.Fatalf("sessions.Create was called %d times, want 0 for an already-provisioned mission", sessions.n)
+	}
+}
+
+// TestDriverAdvancePausesInsteadOfErroringOnProvisioningFailure
+// reproduces the hardening around mission provisioning: before, a
+// mission whose workspace can't be created left Advance returning an
+// error and the mission idle — exactly the state the work-slot sweep
+// retries ensureProvisioned against every 30s, forever. Now Advance
+// must pause the mission as an infra failure instead, so the sweep
+// leaves it alone.
+func TestDriverAdvancePausesInsteadOfErroringOnProvisioningFailure(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Goal: "test", Kind: "coding",
+		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8,
+	})
+	// wsRoot is a file, not a directory: Workspace.Provision's
+	// os.MkdirAll(workspace, ...) underneath it fails, giving
+	// ensureProvisioned a real error to propagate without needing git
+	// or any other external dependency.
+	wsRoot := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(wsRoot, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	workspace := NewWorkspace(wsRoot, nil, slog.Default())
+	granter := &fakeGranter{}
+	sessions := &fakeSessionCreator{}
+	runner := &scriptedRunner{}
+	d := NewDriver(store, runner, workspace, nil, sessions, granter, nil, nil, slog.Default())
+
+	canContinue, err := d.Advance(context.Background(), "m1")
+	if err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if canContinue {
+		t.Fatal("Advance reported it can continue after a provisioning failure")
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Status != StatusPaused {
+		t.Fatalf("mission status = %q, want paused", m.Status)
+	}
+	if m.PauseReason != PauseInfra {
+		t.Fatalf("mission pause reason = %q, want %q", m.PauseReason, PauseInfra)
 	}
 }
 
@@ -801,6 +844,38 @@ func TestDriverEscalatesRepeatedRework(t *testing.T) {
 	}
 	if _, ok := d.gatekeepers["m1"]; ok {
 		t.Fatal("gatekeeper state survived a repeated identical rework — must be dropped for fresh-eyes review")
+	}
+}
+
+// TestDriverForcedRetriesStallInsteadOfBurningIterations reproduces the
+// real observed failure: a worker whose turns never yield a sentinel
+// (no tool call, no text-form fallback either) used to burn every
+// remaining iteration on identical forced retries because
+// InputWorkerRetry carried no GapFingerprint at all — the stall brake
+// never had two identical fingerprints to compare. runner.go now sets
+// WorkerVerdict.Forced on that path, and driver.go's runExecute maps it
+// to a stable "no_sentinel" GapFingerprint, so two consecutive forced
+// retries now pause the mission (no_progress) well short of
+// MaxIterations instead of grinding through the whole budget.
+func TestDriverForcedRetriesStallInsteadOfBurningIterations(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 12})
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{
+		{Outcome: "retry", Analysis: "the worker did not report a status; treated as a failed attempt", Forced: true},
+	}}
+	d := testDriver(store, runner)
+
+	// Two forced retries must be enough to stall-pause (StallRounds=2),
+	// nowhere near MaxIterations=12 — driveN would otherwise burn all 12
+	// exactly like the real incident this guards against.
+	driveN(t, d, "m1", 2)
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Status != StatusPaused || m.PauseReason != PauseNoProgress {
+		t.Fatalf("mission after 2 consecutive Forced retries = %s/%s (iteration %d), want paused/no_progress", m.Status, m.PauseReason, m.Iteration)
+	}
+	if m.Iteration >= m.MaxIterations {
+		t.Fatalf("mission burned to max_iterations (%d) instead of stalling on the fingerprint", m.Iteration)
 	}
 }
 

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -402,15 +402,31 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		return v, text + "\n" + recoverText, nil
 	}
 
+	// Neither turn produced a tool call: before giving up, check whether
+	// the model expressed the sentinel as TEXT instead — observed on
+	// non-frontier models (GLM-5.2's XML-ish self-closing tag, qwen3:30b's
+	// bare "mission_status" token followed by a JSON object). A text-form
+	// verdict is trust-equivalent to the tool-call form: both are the
+	// model's own self-report, and the harness's own verify_cmd/
+	// CheckArtifacts evidence — never model output — is what actually
+	// gates a unit's Passes flag. This is strictly a fallback: the
+	// tool-call path above always wins when it succeeds.
+	combined := text + "\n" + recoverText
+	if raw, ok := extractTextSentinel(combined, missionStatusToolName); ok {
+		if v, ok := r.tryParseVerdict(raw); ok {
+			r.log.Warn("mission worker expressed mission_status as text, not a tool call", "mission_id", m.ID)
+			return v, combined, nil
+		}
+	}
+
 	// Still missing: bail detection informs the log, but either way this
 	// is a forced retry — detection accuracy never gates the outcome.
-	combined := text + "\n" + recoverText
 	if detectBail(combined) {
 		r.log.Warn("mission worker bailed without a sentinel call", "mission_id", m.ID)
 	} else {
 		r.log.Warn("mission worker ended without a sentinel call", "mission_id", m.ID)
 	}
-	return WorkerVerdict{Outcome: "retry", Analysis: "the worker did not report a status; treated as a failed attempt"}, combined, nil
+	return WorkerVerdict{Outcome: "retry", Analysis: "the worker did not report a status; treated as a failed attempt", Forced: true}, combined, nil
 }
 
 func (r *nativeRunner) tryParseVerdict(args json.RawMessage) (WorkerVerdict, bool) {
@@ -470,9 +486,26 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 			return ReviewVerdict{}, nil, err
 		}
 		if len(recoverArgs) == 0 {
-			return ReviewVerdict{}, nil, fmt.Errorf("mission runner: reviewer ended without a review_verdict call")
+			// Neither turn produced a review_verdict tool call: before
+			// failing the round, check for a text-form verdict — observed
+			// on qwen3:30b reviewers that write prose analysis and never
+			// call the tool. Trust-equivalent to the tool-call form (see
+			// RunWorker's identical fallback above): the harness's own
+			// artifact/diff evidence, not the reviewer's self-report,
+			// decides whether a unit actually holds up. A text-form rework
+			// with no parseable findings is acceptable — GapFingerprint of
+			// empty findings is empty, which the state machine already
+			// tolerates.
+			combined := text + "\n" + recoverText
+			if raw, ok := extractTextSentinel(combined, reviewVerdictToolName); ok {
+				r.log.Warn("mission reviewer expressed review_verdict as text, not a tool call", "mission_id", m.ID)
+				text, args = combined, raw
+			} else {
+				return ReviewVerdict{}, nil, fmt.Errorf("mission runner: reviewer ended without a review_verdict call")
+			}
+		} else {
+			text, args = text+"\n"+recoverText, recoverArgs
 		}
-		text, args = text+"\n"+recoverText, recoverArgs
 	}
 	verdict, err := parseReviewVerdict(args)
 	if err != nil {

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -166,8 +166,59 @@ func TestRunWorkerForcedRetryWhenSentinelNeverArrives(t *testing.T) {
 	if v.Outcome != "retry" {
 		t.Fatalf("RunWorker verdict when sentinel never arrives = %+v, want forced retry", v)
 	}
+	if !v.Forced {
+		t.Fatalf("RunWorker verdict when sentinel never arrives = %+v, want Forced=true", v)
+	}
 	if agent.call != 2 {
 		t.Fatalf("expected exactly two turns (original + one recovery, then give up), got %d", agent.call)
+	}
+}
+
+// TestRunWorkerFallsBackToXMLTextSentinel covers the observed GLM-5.2
+// failure: the worker never calls mission_status as a tool, but ends
+// its turn with the XML-ish self-closing tag form. The runner must
+// recover the verdict from text instead of forcing a retry.
+func TestRunWorkerFallsBackToXMLTextSentinel(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{textEvent(`All files have been created. <mission_status outcome="done" evidence="All files have been created and tests pass."/>`)},
+	}}
+	r := newTestRunner(agent)
+	v, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if v.Outcome != "done" || v.Evidence != "All files have been created and tests pass." {
+		t.Fatalf("RunWorker verdict via XML text fallback = %+v", v)
+	}
+	if v.Forced {
+		t.Fatal("a successfully-recovered text-form sentinel must not be marked Forced")
+	}
+	// The XML form arrived on the FIRST turn (no tool call at all), so the
+	// runner still needs its one recovery re-run before falling back to
+	// text extraction — that ladder order is unchanged by this fix.
+	if agent.call != 2 {
+		t.Fatalf("expected two turns (original + one recovery) before the text fallback kicks in, got %d", agent.call)
+	}
+}
+
+// TestRunWorkerFallsBackToTokenJSONTextSentinel covers the observed
+// qwen3:30b failure: a bare "mission_status" line followed by a JSON
+// object, never a tool call.
+func TestRunWorkerFallsBackToTokenJSONTextSentinel(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{textEvent("no sentinel here")},
+		{textEvent("mission_status\n{\"outcome\": \"retry\", \"analysis\": \"hit an error, will retry\"}")},
+	}}
+	r := newTestRunner(agent)
+	v, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if v.Outcome != "retry" || v.Analysis != "hit an error, will retry" {
+		t.Fatalf("RunWorker verdict via token+JSON text fallback = %+v", v)
+	}
+	if v.Forced {
+		t.Fatal("a successfully-recovered text-form sentinel must not be marked Forced")
 	}
 }
 
@@ -284,6 +335,47 @@ func TestRunReviewRecoversWhenVerdictMissingThenPresent(t *testing.T) {
 	}
 	if agent.call != 2 {
 		t.Fatalf("expected exactly two turns (original + one recovery), got %d", agent.call)
+	}
+}
+
+// TestRunReviewFallsBackToTextSentinel covers the observed qwen3:30b
+// reviewer failure: prose review, never a review_verdict tool call —
+// the runner must recover the verdict from a text-form sentinel in the
+// recovery turn instead of erroring the round out.
+func TestRunReviewFallsBackToTextSentinel(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{textEvent("Looking at this closely, I think it holds up.")}, // no tool call
+		{textEvent(`Confirmed. <review_verdict decision="approve"/>`)}, // recovery: still text-only
+	}}
+	r := newTestRunner(agent)
+	v, _, err := r.RunReview(context.Background(), Mission{ID: "m1", ReviewRoute: "default"}, ReviewPacket{Diff: "diff"}, nil)
+	if err != nil {
+		t.Fatalf("RunReview: %v", err)
+	}
+	if !v.Approved {
+		t.Fatalf("RunReview verdict via text fallback = %+v, want approved", v)
+	}
+}
+
+// TestRunReviewFallsBackToTokenJSONTextSentinel mirrors the XML case
+// for the token+JSON text form, on a rework decision — findings are
+// empty in the text form (acceptable: GapFingerprint of empty findings
+// is empty, which the state machine already tolerates).
+func TestRunReviewFallsBackToTokenJSONTextSentinel(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{textEvent("still analyzing")},
+		{textEvent("review_verdict\n{\"decision\": \"rework\"}")},
+	}}
+	r := newTestRunner(agent)
+	v, _, err := r.RunReview(context.Background(), Mission{ID: "m1", ReviewRoute: "default"}, ReviewPacket{Diff: "diff"}, nil)
+	if err != nil {
+		t.Fatalf("RunReview: %v", err)
+	}
+	if v.Approved {
+		t.Fatalf("RunReview verdict via token+JSON text fallback = %+v, want rework", v)
+	}
+	if len(v.Findings) != 0 {
+		t.Fatalf("RunReview findings = %+v, want empty (text form carries no structured findings)", v.Findings)
 	}
 }
 

--- a/internal/brain/missions/sentinel.go
+++ b/internal/brain/missions/sentinel.go
@@ -3,6 +3,7 @@ package missions
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -106,6 +107,15 @@ type WorkerVerdict struct {
 	Evidence string
 	Analysis string
 	Question string
+	// Forced marks a verdict the runner fabricated because NEITHER a
+	// tool call NOR a text-form sentinel (extractTextSentinel) could be
+	// found after the recovery re-run — set true ONLY on that path
+	// (runner.go's RunWorker). The driver fingerprints this case
+	// distinctly (GapFingerprint "no_sentinel") so the stall brake
+	// pauses after StallRounds consecutive sentinel-less turns instead
+	// of burning to max_iterations on a model that never learns to call
+	// the tool.
+	Forced bool
 }
 
 // parseWorkerVerdict decodes a mission_status tool call's arguments.
@@ -115,6 +125,135 @@ func parseWorkerVerdict(args json.RawMessage) (WorkerVerdict, error) {
 		return WorkerVerdict{}, err
 	}
 	return v, nil
+}
+
+// sentinelAttrs lists the known attribute/field names extractTextSentinel
+// will pull out of a text-form sentinel, per tool — anything else in
+// the tag or JSON object is ignored rather than round-tripped, since
+// the only fields WorkerVerdict/ReviewVerdict-parsing code ever reads
+// are these.
+var sentinelAttrs = map[string][]string{
+	missionStatusToolName: {"outcome", "evidence", "analysis", "question"},
+	reviewVerdictToolName: {"decision"},
+}
+
+// sentinelDiscriminator names the field whose value is validated
+// against sentinelDiscriminatorValues before a text-form match is
+// trusted — the same field the tool's own JSON schema marks required.
+var sentinelDiscriminator = map[string]string{
+	missionStatusToolName: "outcome",
+	reviewVerdictToolName: "decision",
+}
+
+var sentinelDiscriminatorValues = map[string]map[string]bool{
+	missionStatusToolName: {"done": true, "retry": true, "blocked": true},
+	reviewVerdictToolName: {"approve": true, "rework": true},
+}
+
+// xmlTagPattern matches an XML-ish sentinel tag: <toolName attr="val"
+// attr2='val2' ... /> or <toolName ...>, attribute values in either
+// quote style, attributes in any order. %s is the exact tool name —
+// callers build one pattern per tool so an unrelated tag never matches.
+const xmlTagPatternFmt = `<%s\b((?:\s+[a-zA-Z_][a-zA-Z0-9_]*\s*=\s*(?:"[^"]*"|'[^']*'))*)\s*/?>`
+
+// attrPattern pulls one name="value" or name='value' pair out of a
+// matched tag's attribute string.
+var attrPattern = regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*(?:"([^"]*)"|'([^']*)')`)
+
+// extractTextSentinel scans model text for a text-form end-of-turn
+// sentinel when the tool call itself never arrived — observed on
+// non-frontier models (GLM-5.2, qwen3:30b) that express the same
+// intent as prose instead of a structured call. Two forms are
+// recognized:
+//
+//  1. An XML-ish tag named exactly toolName, self-closing or not, with
+//     known attributes: `<mission_status outcome="done" .../>`.
+//  2. The tool name as a bare token followed by a JSON object (or a
+//     ```json fenced one) whose fields are read directly, e.g.
+//     `mission_status\n{"outcome":"done",...}`.
+//
+// When a form matches more than once, the LAST valid occurrence wins —
+// models sometimes repeat or revise the tag within one reply, and the
+// final one is the turn's actual verdict. Returns ok=false when
+// nothing recognizable — carrying the required discriminator field
+// with a valid enum value — is found.
+//
+// Trust note: a text-form sentinel is trust-equivalent to the tool-call
+// form — both are the model's own self-report of its own turn, neither
+// is verified here. The harness's own evidence (CheckArtifacts,
+// verify_cmd, RunVerify) is what actually gates a unit's Passes flag;
+// this function only saves a turn from being misread as "said nothing"
+// when it in fact reported an outcome in the wrong shape.
+func extractTextSentinel(text, toolName string) (json.RawMessage, bool) {
+	knownAttrs := sentinelAttrs[toolName]
+	discriminator := sentinelDiscriminator[toolName]
+	validValues := sentinelDiscriminatorValues[toolName]
+	if discriminator == "" || len(knownAttrs) == 0 {
+		return nil, false
+	}
+
+	var best map[string]string
+	bestPos := -1
+
+	// Form 1: XML-ish tag.
+	tagPattern := regexp.MustCompile(fmt.Sprintf(xmlTagPatternFmt, regexp.QuoteMeta(toolName)))
+	for _, m := range tagPattern.FindAllStringSubmatchIndex(text, -1) {
+		attrsText := text[m[2]:m[3]]
+		fields := map[string]string{}
+		for _, am := range attrPattern.FindAllStringSubmatch(attrsText, -1) {
+			name := am[1]
+			val := am[2]
+			if am[3] != "" {
+				val = am[3]
+			}
+			fields[name] = val
+		}
+		if v, ok := fields[discriminator]; ok && validValues[v] && m[0] > bestPos {
+			best, bestPos = fields, m[0]
+		}
+	}
+
+	// Form 2: bare token followed by a JSON object, or a ```json fenced
+	// one — position-compared against form 1 so whichever form's match
+	// starts LATER in the text wins overall (models sometimes repeat or
+	// revise the sentinel; the final occurrence is the turn's actual
+	// verdict, regardless of which form it's expressed in).
+	tokenPattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(toolName) + `\b\s*:?\s*(?:` + "```(?:json)?" + `)?\s*`)
+	for _, loc := range tokenPattern.FindAllStringIndex(text, -1) {
+		rest := text[loc[1]:]
+		start := strings.IndexByte(rest, '{')
+		if start == -1 || (start > 0 && strings.TrimSpace(rest[:start]) != "") {
+			continue
+		}
+		dec := json.NewDecoder(strings.NewReader(rest[start:]))
+		var obj map[string]any
+		if err := dec.Decode(&obj); err != nil {
+			continue
+		}
+		v, ok := obj[discriminator].(string)
+		if !ok || !validValues[v] {
+			continue
+		}
+		if loc[0] <= bestPos {
+			continue
+		}
+		fields := map[string]string{}
+		for _, attr := range knownAttrs {
+			if s, ok := obj[attr].(string); ok {
+				fields[attr] = s
+			}
+		}
+		best, bestPos = fields, loc[0]
+	}
+
+	if best == nil {
+		return nil, false
+	}
+	raw, err := json.Marshal(best)
+	if err != nil {
+		return nil, false
+	}
+	return json.RawMessage(raw), true
 }
 
 // bailPatterns are the known-weak stopgap layer for detecting a

--- a/internal/brain/missions/sentinel_test.go
+++ b/internal/brain/missions/sentinel_test.go
@@ -1,6 +1,7 @@
 package missions
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -78,5 +79,142 @@ func TestParseWorkerVerdict(t *testing.T) {
 	}
 	if v.Outcome != "done" || v.Evidence != "tests pass" {
 		t.Fatalf("parseWorkerVerdict = %+v", v)
+	}
+}
+
+// TestExtractTextSentinel covers the observed real-world failure
+// shapes: GLM-5.2 workers emitting an XML-ish self-closing tag,
+// qwen3:30b workers emitting a bare tool-name token followed by a JSON
+// object, and negative cases that must not match.
+func TestExtractTextSentinel(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		toolName string
+		wantOK   bool
+		want     map[string]string
+	}{
+		{
+			name:     "XML self-closing double-quoted",
+			text:     `Work complete. <mission_status outcome="done" evidence="All files have been created and tests pass."/>`,
+			toolName: missionStatusToolName,
+			wantOK:   true,
+			want:     map[string]string{"outcome": "done", "evidence": "All files have been created and tests pass."},
+		},
+		{
+			name:     "XML self-closing single-quoted",
+			text:     `<mission_status outcome='retry' analysis='hit a timeout'/>`,
+			toolName: missionStatusToolName,
+			wantOK:   true,
+			want:     map[string]string{"outcome": "retry", "analysis": "hit a timeout"},
+		},
+		{
+			name:     "XML attributes in reversed order",
+			text:     `<mission_status evidence="wrote summary.md" outcome="done"/>`,
+			toolName: missionStatusToolName,
+			wantOK:   true,
+			want:     map[string]string{"outcome": "done", "evidence": "wrote summary.md"},
+		},
+		{
+			name:     "XML non-self-closing open tag",
+			text:     `<mission_status outcome="blocked" question="which region?">`,
+			toolName: missionStatusToolName,
+			wantOK:   true,
+			want:     map[string]string{"outcome": "blocked", "question": "which region?"},
+		},
+		{
+			name: "repeated XML tag: last one wins",
+			text: `<mission_status outcome="retry" analysis="first attempt"/>` +
+				"\nActually, let me reconsider.\n" +
+				`<mission_status outcome="done" evidence="fixed it"/>`,
+			toolName: missionStatusToolName,
+			wantOK:   true,
+			want:     map[string]string{"outcome": "done", "evidence": "fixed it"},
+		},
+		{
+			name:     "token followed by JSON object",
+			text:     "mission_status\n{\"outcome\": \"done\", \"evidence\": \"all good\"}",
+			toolName: missionStatusToolName,
+			wantOK:   true,
+			want:     map[string]string{"outcome": "done", "evidence": "all good"},
+		},
+		{
+			name:     "token colon then JSON object",
+			text:     `mission_status: {"outcome": "retry", "analysis": "need another pass"}`,
+			toolName: missionStatusToolName,
+			wantOK:   true,
+			want:     map[string]string{"outcome": "retry", "analysis": "need another pass"},
+		},
+		{
+			name:     "fenced json object after token",
+			text:     "mission_status\n```json\n{\"outcome\": \"done\", \"evidence\": \"shipped\"}\n```",
+			toolName: missionStatusToolName,
+			wantOK:   true,
+			want:     map[string]string{"outcome": "done", "evidence": "shipped"},
+		},
+		{
+			name:     "review_verdict XML form",
+			text:     `<review_verdict decision="approve"/>`,
+			toolName: reviewVerdictToolName,
+			wantOK:   true,
+			want:     map[string]string{"decision": "approve"},
+		},
+		{
+			name:     "review_verdict token+JSON form",
+			text:     "review_verdict\n{\"decision\": \"rework\"}",
+			toolName: reviewVerdictToolName,
+			wantOK:   true,
+			want:     map[string]string{"decision": "rework"},
+		},
+		{
+			name:     "tool name mentioned in prose, no parseable payload",
+			text:     "I considered calling mission_status but decided to keep working instead.",
+			toolName: missionStatusToolName,
+			wantOK:   false,
+		},
+		{
+			name:     "JSON object missing the discriminator field",
+			text:     "mission_status\n{\"evidence\": \"did stuff\"}",
+			toolName: missionStatusToolName,
+			wantOK:   false,
+		},
+		{
+			name:     "XML tag with wrong enum value",
+			text:     `<mission_status outcome="finished"/>`,
+			toolName: missionStatusToolName,
+			wantOK:   false,
+		},
+		{
+			name:     "JSON object with wrong enum value",
+			text:     "mission_status\n{\"outcome\": \"success\"}",
+			toolName: missionStatusToolName,
+			wantOK:   false,
+		},
+		{
+			name:     "empty text",
+			text:     "",
+			toolName: missionStatusToolName,
+			wantOK:   false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, ok := extractTextSentinel(tc.text, tc.toolName)
+			if ok != tc.wantOK {
+				t.Fatalf("extractTextSentinel(%q) ok = %v, want %v (raw=%s)", tc.text, ok, tc.wantOK, raw)
+			}
+			if !ok {
+				return
+			}
+			var got map[string]string
+			if err := json.Unmarshal(raw, &got); err != nil {
+				t.Fatalf("extractTextSentinel returned unparseable JSON %s: %v", raw, err)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Fatalf("extractTextSentinel(%q)[%q] = %q, want %q (full: %+v)", tc.text, k, got[k], v, got)
+				}
+			}
+		})
 	}
 }

--- a/internal/brain/missions/worktree.go
+++ b/internal/brain/missions/worktree.go
@@ -44,12 +44,15 @@ func NewWorkspace(root string, identity func(context.Context) (name, email strin
 	return &Workspace{root: root, identity: identity, log: log}
 }
 
-// Provision creates the mission's directory. Coding missions run `git
-// worktree add -b mission/<slug> <dir>` against repoPath and capture
-// the base commit with a tight timeout (degrades to the sentinel
-// "(unavailable)" rather than blocking). Non-coding missions get a
-// plain directory, no git.
-func (w *Workspace) Provision(ctx context.Context, missionID, goal, kind, repoPath string) (workspace, worktree, branch, baseCommit string, err error) {
+// Provision creates the mission's directory. Coding missions get their
+// own fresh git repo self-initialized inside the workspace (see
+// initSelfRepo) — the brain container has no pre-existing repo to work
+// against on a real deployment, so every coding mission's repo lives
+// wholly inside its own workspace dir. The base commit is captured
+// with a tight timeout (degrades to the sentinel "(unavailable)"
+// rather than blocking). Non-coding missions get a plain directory, no
+// git.
+func (w *Workspace) Provision(ctx context.Context, missionID, goal, kind string) (workspace, worktree, branch, baseCommit string, err error) {
 	workspace = filepath.Join(w.root, missionID)
 	if err := os.MkdirAll(workspace, 0o750); err != nil {
 		return "", "", "", "", fmt.Errorf("worktree: provision: mkdir %s: %w", workspace, err)
@@ -61,16 +64,57 @@ func (w *Workspace) Provision(ctx context.Context, missionID, goal, kind, repoPa
 
 	branch = "mission/" + Slug(goal, missionID)
 	worktree = filepath.Join(workspace, "wt")
-	gctx, cancel := context.WithTimeout(ctx, gitOpTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(gctx, "git", "worktree", "add", "-b", branch, worktree) //nolint:gosec // branch is Slug()-derived (alphanumeric+hyphen only), not raw user input
-	cmd.Dir = repoPath
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", "", "", "", fmt.Errorf("worktree: git worktree add: %w: %s", err, string(out))
+
+	if err := w.initSelfRepo(ctx, worktree, branch, missionID); err != nil {
+		return "", "", "", "", err
 	}
 
 	baseCommit = w.captureBaseCommit(ctx, worktree)
 	return workspace, worktree, branch, baseCommit, nil
+}
+
+// initSelfRepo creates a brand-new git repo at dir on branch, with one
+// initial commit as the base for BaselineDiff/git log. The initial
+// commit tracks a placeholder file rather than being truly empty:
+// `git checkout -- .` (Rollback's discard step, run after every
+// worker/reviewer turn) fails with "pathspec '.' did not match any
+// file(s)" against a commit with zero tracked content, so the repo
+// needs at least one tracked file from the start. `git init -b`
+// requires git >= 2.28, which the brain image's alpine base satisfies.
+func (w *Workspace) initSelfRepo(ctx context.Context, dir, branch, missionID string) error {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("worktree: init self repo: mkdir %s: %w", dir, err)
+	}
+	gctx, cancel := context.WithTimeout(ctx, gitOpTimeout)
+	defer cancel()
+	if out, err := runGit(gctx, dir, "init", "-q", "-b", branch); err != nil {
+		return fmt.Errorf("worktree: git init: %w: %s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".gitkeep"), []byte(""), 0o600); err != nil {
+		return fmt.Errorf("worktree: init self repo: write .gitkeep: %w", err)
+	}
+	if out, err := runGit(gctx, dir, "add", ".gitkeep"); err != nil {
+		return fmt.Errorf("worktree: git init: add .gitkeep: %w: %s", err, out)
+	}
+	name, email := commitName, commitEmail
+	if w.identity != nil {
+		if n, e := w.identity(ctx); n != "" || e != "" {
+			if n != "" {
+				name = n
+			}
+			if e != "" {
+				email = e
+			}
+		}
+	}
+	cmd := exec.CommandContext(gctx, "git", //nolint:gosec // name/email travel as -c key=value args, never shell-interpolated; message is driver-built from the mission id
+		"-c", "user.name="+name, "-c", "user.email="+email,
+		"commit", "-m", "mission "+missionID+" initial")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("worktree: git init: initial commit: %w: %s", err, string(out))
+	}
+	return nil
 }
 
 // captureBaseCommit reads HEAD under a tight timeout — provisioning
@@ -162,21 +206,11 @@ func (w *Workspace) CommitUnit(ctx context.Context, worktree, message string) er
 	return nil
 }
 
-// Teardown removes the workspace. Coding missions: `git worktree
-// remove --force` (the branch itself survives, only the checkout
-// goes). Other kinds: os.RemoveAll.
+// Teardown removes the workspace. Every coding mission's repo lives
+// wholly inside its own workspace dir (see Provision) — there is no
+// separate source repo to leave a branch behind in, so this is a plain
+// os.RemoveAll for every kind.
 func (w *Workspace) Teardown(ctx context.Context, workspace, worktree, kind string) error {
-	if kind == "coding" && worktree != "" {
-		cctx, cancel := context.WithTimeout(ctx, gitOpTimeout)
-		defer cancel()
-		// git worktree remove must run from the main repo, not the
-		// worktree being removed — but it also works from any directory
-		// git can resolve the worktree path from, so run it unanchored.
-		cmd := exec.CommandContext(cctx, "git", "worktree", "remove", "--force", worktree) //nolint:gosec // worktree is a path this package created under its own workspace root, not user input
-		if out, err := cmd.CombinedOutput(); err != nil {
-			w.log.Warn("worktree: remove failed, falling back to rmdir", "worktree", worktree, "error", err, "output", string(out))
-		}
-	}
 	if err := os.RemoveAll(workspace); err != nil {
 		return fmt.Errorf("worktree: teardown: rmdir %s: %w", workspace, err)
 	}

--- a/internal/brain/missions/worktree_integration_test.go
+++ b/internal/brain/missions/worktree_integration_test.go
@@ -4,8 +4,6 @@ package missions
 
 import (
 	"context"
-	"io"
-	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,75 +11,15 @@ import (
 	"time"
 )
 
-func requireGit(t *testing.T) {
-	t.Helper()
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not found on PATH; skipping worktree integration test")
-	}
-}
-
-// scratchRepo creates a throwaway git repo with one commit, returning
-// its path.
-func scratchRepo(t *testing.T) string {
-	t.Helper()
-	dir := t.TempDir()
-	run := func(args ...string) {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v: %s", args, err, out)
-		}
-	}
-	run("init", "-q")
-	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("scratch repo\n"), 0o644); err != nil {
-		t.Fatalf("write README: %v", err)
-	}
-	run("add", "README.md")
-	run("-c", "user.name=test", "-c", "user.email=test@localhost", "commit", "-m", "initial")
-	return dir
-}
-
-func testWorkspace(t *testing.T) *Workspace {
-	t.Helper()
-	root := t.TempDir()
-	log := slog.New(slog.NewTextHandler(io.Discard, nil))
-	return NewWorkspace(root, nil, log)
-}
-
-func TestProvisionCodingMission(t *testing.T) {
-	requireGit(t)
-	w := testWorkspace(t)
-	repo := scratchRepo(t)
-	ctx := context.Background()
-
-	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-1", "Fix the login bug", "coding", repo)
-	if err != nil {
-		t.Fatalf("Provision: %v", err)
-	}
-	if workspace == "" || worktree == "" || branch != "mission/fix-the-login-bug" {
-		t.Fatalf("Provision = workspace=%q worktree=%q branch=%q, unexpected shape", workspace, worktree, branch)
-	}
-	if baseCommit == "" || baseCommit == unavailableCommit {
-		t.Fatalf("baseCommit = %q, want a real commit hash", baseCommit)
-	}
-	if _, err := os.Stat(worktree); err != nil {
-		t.Fatalf("worktree directory missing: %v", err)
-	}
-
-	// The branch actually exists in the source repo.
-	cmd := exec.Command("git", "branch", "--list", branch)
-	cmd.Dir = repo
-	out, err := cmd.Output()
-	if err != nil || len(out) == 0 {
-		t.Fatalf("git branch --list %s: out=%q err=%v", branch, out, err)
-	}
-}
+// requireGit and newTestWorkspace are defined once in worktree_test.go
+// (no build tag, so always compiled alongside this integration file)
+// and reused here.
 
 func TestProvisionNonCodingMission(t *testing.T) {
-	w := testWorkspace(t)
+	w := newTestWorkspace(t)
 	ctx := context.Background()
 
-	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-2", "Research something", "research", "")
+	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-2", "Research something", "research")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -101,8 +39,21 @@ func TestProvisionNonCodingMission(t *testing.T) {
 // — simulated via a context that's already expired.
 func TestCaptureBaseCommitDegradesOnTimeout(t *testing.T) {
 	requireGit(t)
-	w := testWorkspace(t)
-	repo := scratchRepo(t)
+	w := newTestWorkspace(t)
+	repo := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("scratch repo\n"), 0o600); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	run("add", "README.md")
+	run("-c", "user.name=test", "-c", "user.email=test@localhost", "commit", "-m", "initial")
 
 	expired, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 	defer cancel()
@@ -114,56 +65,8 @@ func TestCaptureBaseCommitDegradesOnTimeout(t *testing.T) {
 	}
 }
 
-func TestRollbackDiscardsUncommittedWork(t *testing.T) {
-	requireGit(t)
-	w := testWorkspace(t)
-	repo := scratchRepo(t)
-	ctx := context.Background()
-
-	_, worktree, _, _, err := w.Provision(ctx, "mission-3", "Rollback test", "coding", repo)
-	if err != nil {
-		t.Fatalf("Provision: %v", err)
-	}
-
-	dirty := filepath.Join(worktree, "scratch.txt")
-	if err := os.WriteFile(dirty, []byte("uncommitted"), 0o644); err != nil {
-		t.Fatalf("write dirty file: %v", err)
-	}
-	if err := w.Rollback(ctx, worktree, "coding"); err != nil {
-		t.Fatalf("Rollback: %v", err)
-	}
-	if _, err := os.Stat(dirty); !os.IsNotExist(err) {
-		t.Fatalf("dirty file survived rollback: err=%v", err)
-	}
-}
-
-func TestTeardownRemovesWorktreeButKeepsBranch(t *testing.T) {
-	requireGit(t)
-	w := testWorkspace(t)
-	repo := scratchRepo(t)
-	ctx := context.Background()
-
-	workspace, worktree, branch, _, err := w.Provision(ctx, "mission-4", "Teardown test", "coding", repo)
-	if err != nil {
-		t.Fatalf("Provision: %v", err)
-	}
-	if err := w.Teardown(ctx, workspace, worktree, "coding"); err != nil {
-		t.Fatalf("Teardown: %v", err)
-	}
-	if _, err := os.Stat(workspace); !os.IsNotExist(err) {
-		t.Fatalf("workspace survived teardown: err=%v", err)
-	}
-
-	cmd := exec.Command("git", "branch", "--list", branch)
-	cmd.Dir = repo
-	out, err := cmd.Output()
-	if err != nil || len(out) == 0 {
-		t.Fatalf("branch %s did not survive teardown: out=%q err=%v", branch, out, err)
-	}
-}
-
 func TestVerifyWorkspaceCatchesSymlinkSwap(t *testing.T) {
-	w := testWorkspace(t)
+	w := newTestWorkspace(t)
 	root := t.TempDir()
 	real := filepath.Join(root, "real")
 	other := filepath.Join(root, "other")

--- a/internal/brain/missions/worktree_test.go
+++ b/internal/brain/missions/worktree_test.go
@@ -1,6 +1,14 @@
 package missions
 
-import "testing"
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
 
 func TestSlug(t *testing.T) {
 	cases := []struct {
@@ -34,5 +42,140 @@ func TestSlug(t *testing.T) {
 				t.Fatal("Slug returned empty string")
 			}
 		})
+	}
+}
+
+// requireGit skips a test rather than failing it when git isn't on
+// PATH — mirrors worktree_integration_test.go's requireGit, duplicated
+// here since these tests (self-init needs no Docker/Postgres) live
+// outside the integration build tag.
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found on PATH; skipping")
+	}
+}
+
+func newTestWorkspace(t *testing.T) *Workspace {
+	t.Helper()
+	root := t.TempDir()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewWorkspace(root, nil, log)
+}
+
+// TestProvisionCodingMissionSelfInitsRepo covers the fix's core case:
+// a coding mission always self-initializes its own git repo inside
+// its workspace — no repo needs to pre-exist in the container.
+func TestProvisionCodingMissionSelfInitsRepo(t *testing.T) {
+	requireGit(t)
+	w := newTestWorkspace(t)
+	ctx := context.Background()
+
+	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-self", "Fix the login bug", "coding")
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if branch != "mission/fix-the-login-bug" {
+		t.Fatalf("branch = %q, want mission/fix-the-login-bug", branch)
+	}
+	if baseCommit == "" || baseCommit == unavailableCommit {
+		t.Fatalf("baseCommit = %q, want a real commit hash", baseCommit)
+	}
+	if _, err := os.Stat(worktree); err != nil {
+		t.Fatalf("worktree directory missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(worktree, ".git")); err != nil {
+		t.Fatalf("worktree has no .git: %v", err)
+	}
+
+	// HEAD actually resolves and matches the reported baseCommit.
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = worktree
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD: %v", err)
+	}
+	if got := string(out); got[:len(got)-1] != baseCommit {
+		t.Fatalf("HEAD = %q, want baseCommit %q", got, baseCommit)
+	}
+
+	// The checked-out branch is the one Provision reported.
+	cmd = exec.Command("git", "branch", "--show-current")
+	cmd.Dir = worktree
+	out, err = cmd.Output()
+	if err != nil {
+		t.Fatalf("git branch --show-current: %v", err)
+	}
+	if got := string(out); got[:len(got)-1] != branch {
+		t.Fatalf("current branch = %q, want %q", got, branch)
+	}
+
+	if _, err := os.Stat(workspace); err != nil {
+		t.Fatalf("workspace directory missing: %v", err)
+	}
+}
+
+// TestProvisionSelfInitRollbackAndCommitUnit proves the self-init'd
+// repo is a real working git repo, not just a directory that happens
+// to satisfy Provision's return shape: Rollback and CommitUnit (the
+// harness machinery every coding mission relies on) both work against
+// it.
+func TestProvisionSelfInitRollbackAndCommitUnit(t *testing.T) {
+	requireGit(t)
+	w := newTestWorkspace(t)
+	ctx := context.Background()
+
+	_, worktree, _, _, err := w.Provision(ctx, "mission-self-2", "Add a feature", "coding")
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	scratch := filepath.Join(worktree, "scratch.txt")
+	if err := os.WriteFile(scratch, []byte("uncommitted"), 0o600); err != nil {
+		t.Fatalf("write scratch file: %v", err)
+	}
+	if err := w.Rollback(ctx, worktree, "coding"); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if _, err := os.Stat(scratch); !os.IsNotExist(err) {
+		t.Fatalf("scratch file survived rollback: err=%v", err)
+	}
+
+	committed := filepath.Join(worktree, "unit1.txt")
+	if err := os.WriteFile(committed, []byte("unit 1 output"), 0o600); err != nil {
+		t.Fatalf("write unit file: %v", err)
+	}
+	if err := w.CommitUnit(ctx, worktree, "unit 1"); err != nil {
+		t.Fatalf("CommitUnit: %v", err)
+	}
+
+	cmd := exec.Command("git", "log", "--oneline")
+	cmd.Dir = worktree
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("git log is empty after CommitUnit")
+	}
+}
+
+// TestTeardownRemovesSelfInitRepo proves Teardown removes a coding
+// mission's self-init'd workspace outright — there is no separate
+// main-repo checkout to leave behind, so this is a plain os.RemoveAll.
+func TestTeardownRemovesSelfInitRepo(t *testing.T) {
+	requireGit(t)
+	w := newTestWorkspace(t)
+	ctx := context.Background()
+
+	workspace, worktree, _, _, err := w.Provision(ctx, "mission-self-3", "Teardown test", "coding")
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if err := w.Teardown(ctx, workspace, worktree, "coding"); err != nil {
+		t.Fatalf("Teardown: %v", err)
+	}
+	if _, err := os.Stat(workspace); !os.IsNotExist(err) {
+		t.Fatalf("workspace survived teardown: err=%v", err)
 	}
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -842,7 +842,6 @@ export interface CreateMissionInput {
   escalation_route?: string
   max_iterations?: number
   budget_usd?: number
-  repo_path?: string
   auto_approve_safe?: boolean
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -530,8 +530,7 @@ export interface AdminConnector {
 
 // MissionTemplate is the frozen mission-creation payload a schedule
 // fires at each tick (internal/brain/missions.MissionTemplate) — same
-// shape as CreateMissionInput, minus repo_path (out of scope for
-// scheduled missions in v1).
+// shape as CreateMissionInput.
 export interface MissionTemplate {
   goal: string
   kind: 'coding' | 'research'

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -83,17 +83,20 @@ describe('MissionForm — create mode, one-off mission', () => {
     expect(createButton.disabled).toBe(false)
   })
 
-  it('requires a repo path before submitting a coding mission', () => {
+  it('allows submitting a coding mission with just a goal', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm3' })
     render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Fix a bug' } })
     fireEvent.click(screen.getByRole('button', { name: /^Coding /i }))
 
     const createButton = screen.getByRole('button', { name: 'Create mission' }) as HTMLButtonElement
-    expect(createButton.disabled).toBe(true)
-
-    fireEvent.change(screen.getByLabelText('Repository path'), { target: { value: '/workspace/repo' } })
     expect(createButton.disabled).toBe(false)
+
+    fireEvent.click(createButton)
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ kind: 'coding' })),
+    )
   })
 
   it('calls onCancel when Cancel is clicked', () => {
@@ -148,7 +151,6 @@ describe('MissionForm — create mode, repeat on schedule', () => {
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
     fireEvent.click(screen.getByRole('button', { name: /^Coding /i }))
-    fireEvent.change(screen.getByLabelText('Repository path'), { target: { value: '/workspace/repo' } })
     fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
     fireEvent.click(screen.getByRole('button', { name: 'Create schedule' }))
 

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -46,7 +46,6 @@ export function MissionForm({
   const [goal, setGoal] = useState('')
   const [kind, setKind] = useState<(typeof kinds)[number]['value']>('research')
   const [agentID, setAgentID] = useState('')
-  const [repoPath, setRepoPath] = useState('')
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [route, setRoute] = useState('')
   const [reviewRoute, setReviewRoute] = useState('')
@@ -119,9 +118,7 @@ export function MissionForm({
   const canSubmit =
     mode === 'edit'
       ? scheduleName.trim() !== '' && goal.trim() !== '' && validCronShape(cron)
-      : goal.trim() !== '' &&
-        (kind !== 'coding' || repoPath.trim() !== '') &&
-        (!repeat || validCronShape(cron))
+      : goal.trim() !== '' && (!repeat || validCronShape(cron))
 
   const submitMission = async () => {
     const { id } = await createMission({
@@ -132,7 +129,6 @@ export function MissionForm({
       review_route: reviewRoute || undefined,
       escalation_route: escalationRoute || undefined,
       budget_usd: budget ? Number(budget) : undefined,
-      repo_path: kind === 'coding' ? repoPath.trim() : undefined,
       auto_approve_safe: autoApproveSafe,
     })
     toast.success('Mission created')
@@ -251,18 +247,6 @@ export function MissionForm({
             Coding missions aren't supported on a recurring schedule yet: each fire has no
             repository to work in.
           </p>
-        )}
-
-        {kind === 'coding' && !repeat && mode === 'create' && (
-          <div className="space-y-1.5">
-            <Label htmlFor="mission-repo">Repository path</Label>
-            <Input
-              id="mission-repo"
-              value={repoPath}
-              onChange={(e) => setRepoPath(e.target.value)}
-              placeholder="/workspace/my-repo"
-            />
-          </div>
         )}
       </section>
 


### PR DESCRIPTION
## Why

Two failure classes found while testing coding missions on a real deployment (timothy.mol.la) and locally:

1. **repo_path was unusable and unrecoverable.** Coding missions required a git repo path inside the brain container, but deployments mount no host repositories — `git worktree add` failed every time. Worse, repo_path was never persisted, so the work-slot sweep retried provisioning with an empty path every 30s forever (observed live: two missions error-looping indefinitely).
2. **Non-frontier models emit sentinels as text.** GLM-5.2 wrote `<mission_status .../>` as literal XML; qwen3:30b wrote the tool name + JSON as prose, and its reviewer never called `review_verdict` at all. Forced retries carried no gap fingerprint, so one live mission burned all 12 iterations on identical failures the stall brake never saw.

## What

- Coding missions **self-initialize their own git repo** in the mission workspace (`git init`, mission branch, initial commit). Rollback, per-unit commits, baseline-diff review, and git-log packets all keep working. `repo_path` removed from API and UI.
- **Provisioning failure now pauses the mission as infra** instead of leaving it idle for the sweep to hammer.
- **Text-form sentinel fallback** for `mission_status` and `review_verdict`: XML-tag and token+JSON forms parsed (last valid occurrence wins) before a turn is treated as verdict-less. Trust-equivalent to the tool-call form — harness CheckArtifacts/verify_cmd still solely gate unit passes.
- **Sentinel-less forced retries carry a `no_sentinel` fingerprint**, so the stall brake pauses after 2 rounds instead of grinding to max_iterations.

## Testing

- `make build test vet lint` clean; web build/lint/test clean (398 tests).
- `make canary` PASS (twice, before and after the sentinel fixes).
- Live coding missions: GLM-5.2 route — done, 3/3 units harness-verified, review clean. Nova Pro route — done, 3/3 verified. qwen3:30b — worker turn green end-to-end; reviewer text-verdict path covered by unit tests.

## Notes

- Mission branch push (`push.go`) reads `origin`, which self-init repos don't have — returns a clean error until Git integration lands (deliberately deferred).
- `Teardown` simplifies to plain `os.RemoveAll` (no external worktrees to detach).