### PR TITLE
feat: explore phase, goal-first mission creation, kind coding|general

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ down:
 logs:
 	$(COMPOSE) logs -f
 
-# Golden-mission regression gate: runs one research mission end-to-end
+# Golden-mission regression gate: runs one explore mission end-to-end
 # against the live stack and asserts it completes unattended (no parks,
 # harness-verified artifacts, bounded turns). Needs the stack up.
 canary:

--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -388,7 +388,7 @@ func main() {
 	api.Register(app.Server, svc, store, broker,
 		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, usageDecorator.Decorate, app.Log), flags, fxStore,
 		agentReg, conns, goog, agent, missionStore, missionDriver, missionNotifier,
-		missionWorkspace, resolveSecret, routeForRole, missionHub, attachmentStore, &http.Client{}, whisperURL, token, app.Log)
+		missionWorkspace, resolveSecret, routeForRole, chat.ClassifyOverGateway(gwc), missionHub, attachmentStore, &http.Client{}, whisperURL, token, app.Log)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -88,7 +88,7 @@ var memoryRoutePatterns = []string{
 // proxy to the gateway's internal control plane, conns the local
 // connector control plane (nil leaves any of them unmounted).
 // whisperURL empty leaves /v1/transcribe unmounted (WHISPER_URL unset).
-func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, toolset Toolset, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, token string, log *slog.Logger) {
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, toolset Toolset, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, token string, log *slog.Logger) {
 	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log, flags: flags, rates: rates}
 	if memories != nil {
 		for _, pattern := range memoryRoutePatterns {
@@ -100,7 +100,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	a.registerAgents(srv.Handle, agentReg)
 	a.registerConnectors(srv.Handle, conns, goog)
 	a.registerTools(srv.Handle, toolset)
-	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret, routeForRole)
+	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret, routeForRole, missionClassify)
 	a.registerSchedules(srv.Handle, missionStore)
 	a.registerEvents(srv.Handle, hub)
 	a.registerTranscribe(srv.Handle, whisperClient, whisperURL)

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/SumonMSelim/timothy/internal/brain/agents"
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
@@ -26,13 +27,14 @@ import (
 // route bound to the "default" system role (D-049) — an agent's empty
 // route means "the default chain," but the gateway's /v1/stream
 // requires a real, non-empty route name.
-func (a *API) registerMissions(handle func(pattern string, h http.Handler), store *missions.Store, driver *missions.Driver, notifier *missions.Notifier, agentReg *agents.Store, workspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string) {
+func (a *API) registerMissions(handle func(pattern string, h http.Handler), store *missions.Store, driver *missions.Driver, notifier *missions.Notifier, agentReg *agents.Store, workspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, classify agents.Classify) {
 	if store == nil {
 		return
 	}
-	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, workspace: workspace, resolveSecret: resolveSecret, routeForRole: routeForRole, perms: a.perms, dir: a.dir, log: a.log}
+	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, workspace: workspace, resolveSecret: resolveSecret, routeForRole: routeForRole, classify: classify, perms: a.perms, dir: a.dir, log: a.log}
 	handle("GET /v1/missions", a.auth(http.HandlerFunc(h.list)))
 	handle("POST /v1/missions", a.auth(http.HandlerFunc(h.create)))
+	handle("POST /v1/missions/classify", a.auth(http.HandlerFunc(h.classifyGoal)))
 	handle("GET /v1/missions/{id}", a.auth(http.HandlerFunc(h.get)))
 	handle("DELETE /v1/missions/{id}", a.auth(http.HandlerFunc(h.delete)))
 	handle("GET /v1/missions/{id}/events", a.auth(http.HandlerFunc(h.events)))
@@ -62,6 +64,11 @@ type missionAPI struct {
 	// for missions); nil or an unbound role fall back to "" and the
 	// gateway's own no_route error, same as an unconfigured route.
 	routeForRole func(context.Context, string) string
+	// classify resolves an omitted create request's kind from its goal
+	// (classifyKind below) and backs the /v1/missions/classify preview
+	// endpoint; nil (no gateway wiring) makes every omitted kind default
+	// straight to "coding", same as any classify error.
+	classify agents.Classify
 	// perms answers a mission's pending_permission — the same
 	// PermissionResolver chat sessions use (A.perms), never a
 	// mission-specific broker.
@@ -119,7 +126,12 @@ func (h *missionAPI) list(w http.ResponseWriter, r *http.Request) {
 }
 
 type createMissionRequest struct {
-	Goal        string `json:"goal"`
+	Goal string `json:"goal"`
+	// Kind is optional: an empty value is classified from Goal (see
+	// classifyKind) rather than rejected — the web UI's chip preview
+	// resolves it before submit, but any other caller (a script, a
+	// future integration) can still just send a goal and let the
+	// server decide.
 	Kind        string `json:"kind"`
 	AgentID     string `json:"agent_id"`
 	Route       string `json:"route"`
@@ -158,9 +170,11 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	switch req.Kind {
-	case "coding", "research", "scheduled":
+	case "":
+		req.Kind = classifyKind(r.Context(), h.classify, req.Goal)
+	case "coding", "general":
 	default:
-		jsonError(w, http.StatusBadRequest, "bad_request", `kind must be "coding", "research", or "scheduled"`)
+		jsonError(w, http.StatusBadRequest, "bad_request", `kind must be "coding" or "general"`)
 		return
 	}
 	// Resolve even with an empty AgentID: ResolveByID("") falls back to
@@ -220,6 +234,52 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, map[string]string{"id": id})
+}
+
+// classifyKind decides how a mission's work happens when the create
+// request omits kind. Biased hard toward "coding" on anything short of
+// an unambiguous "general" reply: a coding goal misread as general
+// loses branch/diff/rollback safety (the worse failure), while a
+// general goal misread as coding only wastes an empty worktree — so
+// every ambiguous or failed classification lands on the cheap side of
+// the error. nil classify (no gateway wiring) takes the same default.
+func classifyKind(ctx context.Context, classify agents.Classify, goal string) string {
+	if classify == nil {
+		return "coding"
+	}
+	prompt := "Decide how this mission's work happens. Answer with exactly one word.\n" +
+		"coding — the goal requires creating or modifying code, scripts, or configuration in a project/repository.\n" +
+		"general — everything else (documents, analysis, data gathering, operations).\n\n" +
+		"Goal: " + goal
+	reply, err := classify(ctx, prompt)
+	if err != nil {
+		return "coding"
+	}
+	reply = strings.ToLower(reply)
+	// "general" wins only when "coding" is absent from the reply.
+	if strings.Contains(reply, "general") && !strings.Contains(reply, "coding") {
+		return "general"
+	}
+	return "coding"
+}
+
+// classifyGoal serves POST /v1/missions/classify: the same
+// classification create() falls back to when kind is omitted, exposed
+// standalone so the web UI's chip preview can show a mission's inferred
+// kind before submit without actually creating anything.
+func (h *missionAPI) classifyGoal(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Goal string `json:"goal"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if req.Goal == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "goal is required")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"kind": classifyKind(r.Context(), h.classify, req.Goal)})
 }
 
 func (h *missionAPI) get(w http.ResponseWriter, r *http.Request) {

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -2,7 +2,10 @@ package api
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
@@ -13,7 +16,7 @@ func TestMissionsEndpointsUnmountedWhenStoreNil(t *testing.T) {
 	t.Parallel()
 	a, _, _ := testAPI(t, "tok", nil)
 	m := mux(a)
-	a.registerMissions(m.Handle, nil, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	for _, req := range []struct{ method, path string }{
 		{"GET", "/v1/missions"},
@@ -51,7 +54,7 @@ func TestMissionsListFilterValidation(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil)
 
 	call := func(path string) int {
 		req := httptest.NewRequest("GET", path, nil)
@@ -99,7 +102,7 @@ func TestMissionsDeleteReachesStore(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("DELETE", "/v1/missions/abc", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -107,5 +110,128 @@ func TestMissionsDeleteReachesStore(t *testing.T) {
 	m.ServeHTTP(w, req)
 	if w.Code != 400 {
 		t.Fatalf("DELETE against a degraded store = %d, want 400 (reached the store, generic failure)", w.Code)
+	}
+}
+
+// TestClassifyKind exercises classifyKind's parsing and its bias to
+// "coding" for anything short of an unambiguous "general" reply —
+// nil classify, a classify error, and a garbage reply must all land on
+// the cheap side of the error (see classifyKind's doc comment).
+func TestClassifyKind(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		classify func(ctx context.Context, prompt string) (string, error)
+		want     string
+	}{
+		{"nil classify defaults to coding", nil, "coding"},
+		{
+			"unambiguous general reply", func(context.Context, string) (string, error) {
+				return "General", nil
+			}, "general",
+		},
+		{
+			"unambiguous coding reply", func(context.Context, string) (string, error) {
+				return "coding", nil
+			}, "coding",
+		},
+		{
+			"garbage reply defaults to coding", func(context.Context, string) (string, error) {
+				return "banana", nil
+			}, "coding",
+		},
+		{
+			"reply mentioning both words defaults to coding", func(context.Context, string) (string, error) {
+				return "coding, not general", nil
+			}, "coding",
+		},
+		{
+			"empty reply defaults to coding", func(context.Context, string) (string, error) {
+				return "", nil
+			}, "coding",
+		},
+		{
+			"classify error defaults to coding", func(context.Context, string) (string, error) {
+				return "", errors.New("gateway down")
+			}, "coding",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyKind(context.Background(), tc.classify, "some goal")
+			if got != tc.want {
+				t.Fatalf("classifyKind() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMissionsClassifyEndpoint covers POST /v1/missions/classify: the
+// happy path returning the classifier's verdict, and the empty-goal
+// 400 — this endpoint has no store/driver dependency, so it can be
+// tested end to end without Postgres.
+func TestMissionsClassifyEndpoint(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	classify := func(context.Context, string) (string, error) { return "general", nil }
+	m := mux(a)
+	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, classify)
+
+	call := func(body string) (int, string) {
+		req := httptest.NewRequest("POST", "/v1/missions/classify", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w.Code, w.Body.String()
+	}
+
+	if code, body := call(`{"goal":"write a report on Q3 sales"}`); code != http.StatusOK {
+		t.Fatalf("classify with a goal = %d %s, want 200", code, body)
+	} else if !strings.Contains(body, `"kind":"general"`) {
+		t.Fatalf("classify body = %s, want kind general", body)
+	}
+
+	if code, _ := call(`{"goal":""}`); code != http.StatusBadRequest {
+		t.Fatalf("classify with an empty goal = %d, want 400", code)
+	}
+}
+
+// TestMissionsCreateKindOptional confirms an omitted kind no longer
+// 400s: it reaches classifyKind (defaulting to "coding" with no
+// classify wired) and then the degraded store, which 500s — proving
+// validation accepted the empty kind rather than rejecting it. An
+// explicit kind is still validated and honored exactly as before.
+func TestMissionsCreateKindOptional(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil)
+
+	call := func(body string) (int, string) {
+		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w.Code, w.Body.String()
+	}
+
+	// failMission's default branch maps any unrecognized driver error
+	// (here, the degraded pool's connection failure) to 400 — the SAME
+	// status an invalid kind gets, so the assertion that matters is
+	// which body comes back, not the status code alone: a body without
+	// "kind must be" proves the request passed kind validation and
+	// failed downstream instead.
+	if code, body := call(`{"goal":"do something"}`); code != http.StatusBadRequest || strings.Contains(body, "kind must be") {
+		t.Fatalf("create with omitted kind = %d %s, want 400 from the degraded driver, not kind validation", code, body)
+	}
+	if code, body := call(`{"goal":"do something","kind":"general"}`); code != http.StatusBadRequest || strings.Contains(body, "kind must be") {
+		t.Fatalf("create with explicit kind = %d %s, want 400 from the degraded driver, not kind validation", code, body)
+	}
+	if code, body := call(`{"goal":"do something","kind":"bogus"}`); code != http.StatusBadRequest || !strings.Contains(body, "kind must be") {
+		t.Fatalf("create with an invalid kind = %d %s, want 400 from kind validation", code, body)
 	}
 }

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -400,11 +400,13 @@ func ClassifyOverGateway(gw Gateway) agents.Classify {
 			return "", fmt.Errorf("chat: classify: summarize role is unbound")
 		}
 		events, err := gw.Stream(ctx, gwclient.StreamRequest{
-			Route:     route,
-			Purpose:   "agent_dispatch",
-			System:    "Answer with only what is requested — no prose, no explanation.",
-			Messages:  []provider.Message{{Role: "user", Content: prompt}},
-			MaxTokens: 20,
+			Route:    route,
+			Purpose:  "agent_dispatch",
+			System:   "Answer with only what is requested — no prose, no explanation.",
+			Messages: []provider.Message{{Role: "user", Content: prompt}},
+			// MaxTokens includes a thinking model's reasoning tokens; 512
+			// leaves room to think before the one-word answer.
+			MaxTokens: 512,
 		})
 		if err != nil {
 			return "", err

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -73,6 +73,7 @@ type driverStore interface {
 	SetSession(ctx context.Context, id, sessionID string) error
 	SetProvisioned(ctx context.Context, id, workspace, worktree, branch, baseCommit string) error
 	SetLastEvidence(ctx context.Context, id, evidence string) error
+	SetExploreNotes(ctx context.Context, id, notes string) error
 	AppendProgress(ctx context.Context, id, note string) error
 	Spend(ctx context.Context, missionID string) (MissionSpend, error)
 }
@@ -590,8 +591,8 @@ func isLastUnit(spec Spec) bool {
 // review verdict, planner output).
 func (d *Driver) runPhase(ctx context.Context, m Mission) (StepInput, error) {
 	switch m.Phase {
-	case PhaseResearch:
-		return d.runResearch(ctx, m)
+	case PhaseExplore:
+		return d.runExplore(ctx, m)
 	case PhasePlan:
 		return d.runPlan(ctx, m)
 	case PhaseExecute:
@@ -603,16 +604,33 @@ func (d *Driver) runPhase(ctx context.Context, m Mission) (StepInput, error) {
 	}
 }
 
-// runResearch is a placeholder single-turn phase in Phase 1: it
-// completes immediately, carrying no findings forward beyond what the
-// plan phase's own packet re-derives from the goal. A real research
-// loop (multi-turn, tool-using) is out of scope for this milestone.
-func (d *Driver) runResearch(ctx context.Context, m Mission) (StepInput, error) {
+// exploreNotesCap bounds how much of the explore turn's findings get
+// stored and fed into the plan phase's prompt — the findings feed
+// straight into the planner's prompt, and unbounded notes would blow
+// out that turn's context.
+const exploreNotesCap = 8000
+
+// runExplore runs one explore turn: a tool-using session that
+// explores the goal before planning commits to a shape. The findings
+// are stored on the mission (SetExploreNotes) so the plan phase's own
+// (separate) Advance call reads them back via a fresh Get.
+func (d *Driver) runExplore(ctx context.Context, m Mission) (StepInput, error) {
+	notes, err := d.runner.ExploreSession(ctx, m)
+	if err != nil {
+		return StepInput{}, err
+	}
+	notes = truncate(notes, exploreNotesCap)
+	if err := d.store.SetExploreNotes(ctx, m.ID, notes); err != nil {
+		return StepInput{}, fmt.Errorf("driver: store explore notes: %w", err)
+	}
+	if err := d.store.AppendEvent(ctx, m.ID, "mission.explore_complete", map[string]any{"chars": len(notes)}); err != nil {
+		d.log.Warn("driver: record explore complete failed", "mission_id", m.ID, "error", err)
+	}
 	return StepInput{Input: InputPhaseComplete}, nil
 }
 
 func (d *Driver) runPlan(ctx context.Context, m Mission) (StepInput, error) {
-	spec, err := d.runner.PlanSession(ctx, m, "")
+	spec, err := d.runner.PlanSession(ctx, m, m.ExploreNotes)
 	if err != nil {
 		return StepInput{}, err
 	}

--- a/internal/brain/missions/driver_integration_test.go
+++ b/internal/brain/missions/driver_integration_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // TestDriverEndToEndCodingMission is M2's exit criterion: one mission
-// driven fully through research -> plan -> execute -> review -> done
+// driven fully through explore -> plan -> execute -> review -> done
 // against a real Postgres Store and a real git Workspace, with a
 // SCRIPTED FAKE Runner standing in for the model (no live model call,
 // no gateway dependency).
@@ -70,7 +70,7 @@ func TestDriverEndToEndCodingMission(t *testing.T) {
 		t.Fatalf("git commit: %v: %s", err, out)
 	}
 
-	// research -> plan -> execute -> review -> done: drive to
+	// explore -> plan -> execute -> review -> done: drive to
 	// completion (bounded, so a design bug can't hang the test suite).
 	for i := 0; i < 10; i++ {
 		cont, err := d.Advance(ctx, id)
@@ -124,7 +124,7 @@ func TestDriverLazilyProvisionsBareSchedulerStyleMission(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	id, err := store.Create(ctx, Mission{
-		Goal: marker + "lazy provisioning", Kind: "research", Route: "default", ReviewRoute: "default",
+		Goal: marker + "lazy provisioning", Kind: "general", Route: "default", ReviewRoute: "default",
 		AutoApproveSafe: true,
 	})
 	if err != nil {

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -138,6 +138,15 @@ func (f *fakeStore) SetLastEvidence(ctx context.Context, id, evidence string) er
 	return nil
 }
 
+func (f *fakeStore) SetExploreNotes(ctx context.Context, id, notes string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	m := f.missions[id]
+	m.ExploreNotes = notes
+	f.missions[id] = m
+	return nil
+}
+
 func (f *fakeStore) AppendProgress(ctx context.Context, id, note string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -169,6 +178,15 @@ type scriptedRunner struct {
 	reviewIdx      int
 	plans          []Spec
 	planIdx        int
+	// planExploreNotes records the exploreNotes argument PlanSession
+	// was called with, one entry per call — lets a test assert the plan
+	// phase actually received what the explore phase stored.
+	planExploreNotes []string
+	// exploreNotes scripts ExploreSession's return, one entry consumed
+	// per call (same one-behind-repeat pattern as plans/workerVerdicts).
+	exploreNotes []string
+	exploreIdx   int
+	exploreErr   error
 }
 
 func (r *scriptedRunner) RunWorker(ctx context.Context, m Mission, packet WorkPacket) (WorkerVerdict, string, error) {
@@ -194,12 +212,27 @@ func (r *scriptedRunner) RunReview(ctx context.Context, m Mission, packet Review
 	return v, &GatekeeperState{}, nil
 }
 
-func (r *scriptedRunner) PlanSession(ctx context.Context, m Mission, researchNotes string) (Spec, error) {
+func (r *scriptedRunner) PlanSession(ctx context.Context, m Mission, exploreNotes string) (Spec, error) {
+	r.planExploreNotes = append(r.planExploreNotes, exploreNotes)
 	s := r.plans[r.planIdx]
 	if r.planIdx < len(r.plans)-1 {
 		r.planIdx++
 	}
 	return s, nil
+}
+
+func (r *scriptedRunner) ExploreSession(ctx context.Context, m Mission) (string, error) {
+	if r.exploreErr != nil {
+		return "", r.exploreErr
+	}
+	if len(r.exploreNotes) == 0 {
+		return "", nil
+	}
+	notes := r.exploreNotes[r.exploreIdx]
+	if r.exploreIdx < len(r.exploreNotes)-1 {
+		r.exploreIdx++
+	}
+	return notes, nil
 }
 
 // fakeSandboxExec runs command via /bin/sh -c directly in workdir —
@@ -253,7 +286,7 @@ func driveN(t *testing.T, d *Driver, id string, n int) {
 
 func TestDriverHappyPathToDone(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseResearch, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit", VerifyCmd: ""}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -261,7 +294,7 @@ func TestDriverHappyPathToDone(t *testing.T) {
 	}
 	d := testDriver(store, runner)
 
-	// research -> plan -> execute -> review -> done: 4 Advance calls.
+	// explore -> plan -> execute -> review -> done: 4 Advance calls.
 	driveN(t, d, "m1", 4)
 
 	m, _ := store.Get(context.Background(), "m1")
@@ -273,6 +306,114 @@ func TestDriverHappyPathToDone(t *testing.T) {
 	}
 }
 
+// TestDriverExploreStoresNotesAndAdvances confirms the explore phase
+// stores ExploreSession's findings on the mission, emits
+// mission.explore_complete, and advances to plan.
+func TestDriverExploreStoresNotesAndAdvances(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8})
+	runner := &scriptedRunner{
+		exploreNotes: []string{"no prior implementation exists; goal is self-contained"},
+		plans:         []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+	}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhasePlan {
+		t.Fatalf("mission phase after explore = %q, want plan", m.Phase)
+	}
+	if m.ExploreNotes != "no prior implementation exists; goal is self-contained" {
+		t.Fatalf("mission.ExploreNotes = %q, want the explore findings persisted", m.ExploreNotes)
+	}
+	events := store.events["m1"]
+	found := false
+	for _, ev := range events {
+		if ev.Kind == "mission.explore_complete" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("events = %+v, want a mission.explore_complete event", events)
+	}
+}
+
+// TestDriverExploreTruncatesLongNotes confirms exploreNotesCap bounds
+// what gets stored — the findings feed straight into the plan phase's
+// prompt, so unbounded notes would blow out that turn's context.
+func TestDriverExploreTruncatesLongNotes(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8})
+	long := strings.Repeat("x", exploreNotesCap+500)
+	runner := &scriptedRunner{
+		exploreNotes: []string{long},
+		plans:         []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+	}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if len(m.ExploreNotes) > exploreNotesCap+len("…") {
+		t.Fatalf("mission.ExploreNotes length = %d, want capped near %d", len(m.ExploreNotes), exploreNotesCap)
+	}
+}
+
+// TestDriverExploreErrorRoutesToWorkerFailed confirms an ExploreSession
+// error (infra/stream failure, not a missing-sentinel degrade — that
+// path never returns an error) maps to InputWorkerFailed, the same
+// backoff/pause machinery a worker/plan infra failure already takes —
+// explore has no phase-specific error input of its own.
+func TestDriverExploreErrorRoutesToWorkerFailed(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8})
+	runner := &scriptedRunner{exploreErr: fmt.Errorf("gateway unreachable")}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseExplore {
+		t.Fatalf("mission phase after explore error = %q, want it to stay in explore (retry-eligible)", m.Phase)
+	}
+	if m.ConsecutiveFailures == 0 {
+		t.Fatalf("mission.ConsecutiveFailures = %d, want the failure counted", m.ConsecutiveFailures)
+	}
+}
+
+// TestDriverPlanReceivesStoredExploreNotes confirms runPlan reads
+// m.ExploreNotes from the FRESH Get at the top of the plan phase's own
+// Advance call (a separate call from the explore phase's), not some
+// stale in-memory value from the explore turn.
+func TestDriverPlanReceivesStoredExploreNotes(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8})
+	runner := &scriptedRunner{
+		exploreNotes: []string{"found a reusable config loader in internal/platform/config"},
+		plans:         []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+	}
+	d := testDriver(store, runner)
+
+	// First Advance: explore phase.
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance[explore]: %v", err)
+	}
+	// Second Advance: plan phase, a SEPARATE call with its own fresh Get.
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance[plan]: %v", err)
+	}
+	if len(runner.planExploreNotes) != 1 {
+		t.Fatalf("PlanSession call count = %d, want exactly one", len(runner.planExploreNotes))
+	}
+	if runner.planExploreNotes[0] != "found a reusable config loader in internal/platform/config" {
+		t.Fatalf("PlanSession exploreNotes arg = %q, want the notes stored by the explore phase", runner.planExploreNotes[0])
+	}
+}
+
 // TestDriverExecuteRecordsHandoffOverRawText confirms that when the
 // worker's mission_status call carries a handoff note, the harness
 // records THAT as the progress note for the next session, not the
@@ -281,7 +422,7 @@ func TestDriverHappyPathToDone(t *testing.T) {
 // summary.
 func TestDriverExecuteRecordsHandoffOverRawText(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "hit a wall", Handoff: "half the migration is done; finish the token refresh path next"}},
 		workerText:     "raw turn text nobody should see in progress",
@@ -305,7 +446,7 @@ func TestDriverExecuteRecordsHandoffOverRawText(t *testing.T) {
 // handoff: the raw turn text is still what gets recorded.
 func TestDriverExecuteRecordsRawTextWithoutHandoff(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "hit a wall"}},
 		workerText:     "raw turn text",
@@ -326,7 +467,7 @@ func TestDriverExecuteRecordsRawTextWithoutHandoff(t *testing.T) {
 
 func TestDriverBackoffPauseAfterThreeFailures(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{workerErr: fmt.Errorf("gateway unavailable")}
 	d := testDriver(store, runner)
 
@@ -344,7 +485,7 @@ func TestDriverBackoffPauseAfterThreeFailures(t *testing.T) {
 // triggers the backoff brake, unlike a Runner-level failure.
 func TestDriverWorkerRetryDoesNotCountTowardBackoff(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "still working on it"}}}
 	d := testDriver(store, runner)
 
@@ -362,7 +503,7 @@ func TestDriverWorkerRetryDoesNotCountTowardBackoff(t *testing.T) {
 func TestDriverStallPauseOnIdenticalFindingsTwice(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "research", Phase: PhaseReview, Status: StatusWorking, MaxIterations: 8,
+		ID: "m1", Kind: "general", Phase: PhaseReview, Status: StatusWorking, MaxIterations: 8,
 		Spec: Spec{Units: []PlanUnit{{Title: "u1"}}},
 	})
 	sameFindings := []Finding{{Title: "missing validation", File: "x.go"}}
@@ -400,7 +541,7 @@ func TestDriverStallPauseOnIdenticalFindingsTwice(t *testing.T) {
 func TestDriverBudgetPause(t *testing.T) {
 	store := newFakeStore()
 	budget := 1.0
-	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "USD"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "USD"})
 	store.spend["m1"] = MissionSpend{ByCurrency: map[string]float64{"USD": 1.5}}
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done"}}}
 	d := testDriver(store, runner)
@@ -422,7 +563,7 @@ func TestDriverBudgetPause(t *testing.T) {
 func TestDriverBudgetPauseMixedCurrency(t *testing.T) {
 	store := newFakeStore()
 	budget := 100.0
-	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "USD"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "USD"})
 	store.spend["m1"] = MissionSpend{ByCurrency: map[string]float64{"EUR": 0.01}}
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done"}}}
 	d := testDriver(store, runner)
@@ -444,7 +585,7 @@ func TestDriverBudgetPauseMixedCurrency(t *testing.T) {
 func TestDriverBudgetConvertsOtherCurrencySpendWhenRateAvailable(t *testing.T) {
 	store := newFakeStore()
 	budget := 10.0
-	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "EUR"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "EUR"})
 	// 8 USD spend; 1 USD = 0.86 EUR -> 6.88 EUR, under the 10 EUR budget.
 	store.spend["m1"] = MissionSpend{ByCurrency: map[string]float64{"USD": 8}}
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done"}}}
@@ -467,7 +608,7 @@ func TestDriverBudgetConvertsOtherCurrencySpendWhenRateAvailable(t *testing.T) {
 func TestDriverBudgetPausesWhenConvertedSpendReachesLimit(t *testing.T) {
 	store := newFakeStore()
 	budget := 5.0
-	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "EUR"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "EUR"})
 	// 8 USD spend; 1 USD = 0.86 EUR -> 6.88 EUR, over the 5 EUR budget.
 	store.spend["m1"] = MissionSpend{ByCurrency: map[string]float64{"USD": 8}}
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done"}}}
@@ -491,7 +632,7 @@ func TestDriverBudgetPausesWhenConvertedSpendReachesLimit(t *testing.T) {
 func TestDriverBudgetPauseMixedCurrencyWhenRateMissing(t *testing.T) {
 	store := newFakeStore()
 	budget := 100.0
-	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "EUR"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, BudgetAmount: &budget, BudgetCurrency: "EUR"})
 	store.spend["m1"] = MissionSpend{ByCurrency: map[string]float64{"USD": 1}}
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done"}}}
 	d := testDriver(store, runner)
@@ -517,7 +658,7 @@ func TestDriverBudgetPauseMixedCurrencyWhenRateMissing(t *testing.T) {
 func TestDriverGatekeeperCleanupOnTerminal(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "research", Phase: PhaseReview, Status: StatusWorking, MaxIterations: 8,
+		ID: "m1", Kind: "general", Phase: PhaseReview, Status: StatusWorking, MaxIterations: 8,
 		Spec: Spec{Units: []PlanUnit{{Title: "only unit"}}},
 	})
 	d := testDriver(store, &scriptedRunner{reviewVerdicts: []ReviewVerdict{{Approved: true}}})
@@ -562,8 +703,12 @@ func (r *blockingRunner) RunReview(ctx context.Context, m Mission, packet Review
 	return r.reviewV, &GatekeeperState{}, nil
 }
 
-func (r *blockingRunner) PlanSession(ctx context.Context, m Mission, researchNotes string) (Spec, error) {
+func (r *blockingRunner) PlanSession(ctx context.Context, m Mission, exploreNotes string) (Spec, error) {
 	return r.planSpec, nil
+}
+
+func (r *blockingRunner) ExploreSession(ctx context.Context, m Mission) (string, error) {
+	return "", nil
 }
 
 // TestDriverDriveIsSerializedPerMission reproduces a real bug: the
@@ -577,7 +722,7 @@ func (r *blockingRunner) PlanSession(ctx context.Context, m Mission, researchNot
 func TestDriverDriveIsSerializedPerMission(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8,
+		ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8,
 		Spec: Spec{Units: []PlanUnit{{Title: "only unit"}}},
 	})
 	runner := &blockingRunner{
@@ -623,7 +768,7 @@ func TestDriverDriveIsSerializedPerMission(t *testing.T) {
 func TestDriverReviewApprovalContradictedByVerifyRoutesToRework(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "research", Phase: PhaseReview, Status: StatusWorking, MaxIterations: 8,
+		ID: "m1", Kind: "general", Phase: PhaseReview, Status: StatusWorking, MaxIterations: 8,
 		Spec: Spec{Units: []PlanUnit{{Title: "write summary.md", VerifyCmd: "test -f /nonexistent-verify-target"}}},
 	})
 	d := testDriver(store, &scriptedRunner{reviewVerdicts: []ReviewVerdict{{Approved: true}}})
@@ -651,7 +796,7 @@ func TestDriverReviewApprovalContradictedByVerifyRoutesToRework(t *testing.T) {
 
 func TestDriverBlockedParksForInput(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "which env?"}}}
 	d := testDriver(store, runner)
 
@@ -693,7 +838,7 @@ func TestDriverCreateGrantsShellAutoApproveWhenEnabled(t *testing.T) {
 	granter := &fakeGranter{}
 	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, nil, nil, slog.Default())
 
-	id, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: true})
+	id, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: true})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -715,7 +860,7 @@ func TestDriverCreateSkipsGrantWhenAutoApproveDisabled(t *testing.T) {
 	granter := &fakeGranter{}
 	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, nil, nil, slog.Default())
 
-	if _, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: false}); err != nil {
+	if _, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: false}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	if len(granter.calls) != 0 {
@@ -739,7 +884,7 @@ func TestDriverCreateGrantsApprovalAllowlist(t *testing.T) {
 	})
 
 	id, err := d.Create(context.Background(), Mission{
-		Goal: "test", Kind: "research", AgentID: "briefing-agent",
+		Goal: "test", Kind: "general", AgentID: "briefing-agent",
 		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: false,
 	})
 	if err != nil {
@@ -774,7 +919,7 @@ func TestDriverCreateSkipsAllowlistGrantWhenAgentUnresolved(t *testing.T) {
 	})
 
 	if _, err := d.Create(context.Background(), Mission{
-		Goal: "test", Kind: "research", AutoApproveSafe: false,
+		Goal: "test", Kind: "general", AutoApproveSafe: false,
 		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8,
 	}); err != nil {
 		t.Fatalf("Create: %v", err)
@@ -795,7 +940,7 @@ func TestDriverAdvanceLazilyProvisionsBareMission(t *testing.T) {
 	// A bare row, exactly as createFromTemplate leaves it: no
 	// SessionID, no Workspace/Worktree.
 	store.put("m1", Mission{
-		ID: "m1", Goal: "scheduled run", Kind: "research",
+		ID: "m1", Goal: "scheduled run", Kind: "general",
 		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: true,
 	})
 	granter := &fakeGranter{}
@@ -835,7 +980,7 @@ func TestDriverAdvanceLazilyProvisionsBareMission(t *testing.T) {
 func TestDriverAdvanceSkipsProvisioningWhenAlreadyProvisioned(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking,
+		ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking,
 		MaxIterations: 8, SessionID: "already-provisioned-session", Workspace: "/already/provisioned",
 	})
 	granter := &fakeGranter{}
@@ -910,7 +1055,7 @@ func TestDriverSkipsReviewWhenHarnessChecksPass(t *testing.T) {
 	}
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking,
+		ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking,
 		MaxIterations: 8, Workspace: root,
 		Spec: Spec{Units: []PlanUnit{{Title: "write summary", Artifacts: []string{"summary.md"}}}},
 	})
@@ -931,7 +1076,7 @@ func TestDriverSkipsReviewWhenHarnessChecksPass(t *testing.T) {
 func TestDriverArtifactCheckBlocksTautologicalDone(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking,
+		ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking,
 		MaxIterations: 8, Workspace: t.TempDir(),
 		Spec: Spec{Units: []PlanUnit{{Title: "write summary", Artifacts: []string{"summary.md"}, VerifyCmd: "echo done"}}},
 	})
@@ -1014,7 +1159,7 @@ func TestDriverEscalatesRepeatedRework(t *testing.T) {
 	fp := GapFingerprint(findings)
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "research", Phase: PhaseReview, Status: StatusWorking,
+		ID: "m1", Kind: "general", Phase: PhaseReview, Status: StatusWorking,
 		MaxIterations: 8, Workspace: t.TempDir(), LastGapFingerprint: fp, StallCount: 1,
 		Spec: Spec{Units: []PlanUnit{{Title: "write summary"}}},
 	})
@@ -1042,7 +1187,7 @@ func TestDriverEscalatesRepeatedRework(t *testing.T) {
 // MaxIterations instead of grinding through the whole budget.
 func TestDriverForcedRetriesStallInsteadOfBurningIterations(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 12})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 12})
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{
 		{Outcome: "retry", Analysis: "the worker did not report a status; treated as a failed attempt", Forced: true},
 	}}
@@ -1067,7 +1212,7 @@ func TestDriverForcedRetriesStallInsteadOfBurningIterations(t *testing.T) {
 // worker_failed rounds toward backoff.
 func TestDriverModelFloorPausesImmediately(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "research", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{workerErr: fmt.Errorf("%w: amazon.nova-lite-v1:0", ErrModelFloor)}
 	d := testDriver(store, runner)
 

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -1,6 +1,6 @@
 // Package missions implements Phase 1 of the mission engine: an
 // agent-driven, long-running unit of work that walks a fixed phase
-// pipeline (research -> plan -> execute -> review -> done|failed)
+// pipeline (explore -> plan -> execute -> review -> done|failed)
 // under a pure state machine, executed by native (in-process) model
 // turns via loop.Agent. Delegated CLI executors (claude/codex
 // subprocess shelling) are explicitly out of scope for this phase.
@@ -16,7 +16,7 @@ import (
 type Mission struct {
 	ID      string `json:"id"`
 	Goal    string `json:"goal"`
-	Kind    string `json:"kind"` // coding | research | scheduled
+	Kind    string `json:"kind"` // coding | general
 	AgentID string `json:"agent_id,omitempty"`
 	// PromptOverlay is a snapshot of the creating agent's overlay text
 	// at create time — see 0010_missions.sql for why this isn't a live
@@ -34,10 +34,13 @@ type Mission struct {
 	Progress      []ProgressNote `json:"progress"`
 	// LastEvidence is the most recent worker mission_status call's
 	// evidence text — carried from execute into review so a
-	// research/scheduled mission (whose baseline diff is always empty,
+	// general mission (whose baseline diff is always empty,
 	// having touched no tracked files) still gives the reviewer
 	// something real to judge instead of nothing.
-	LastEvidence        string   `json:"last_evidence,omitempty"`
+	LastEvidence string `json:"last_evidence,omitempty"`
+	// ExploreNotes is the explore phase's findings, carried forward
+	// into the plan phase's prompt (see runner.go's PlanSession).
+	ExploreNotes        string   `json:"explore_notes,omitempty"`
 	Iteration           int      `json:"iteration"`
 	MaxIterations       int      `json:"max_iterations"`
 	ConsecutiveFailures int      `json:"consecutive_failures"`

--- a/internal/brain/missions/notify_integration_test.go
+++ b/internal/brain/missions/notify_integration_test.go
@@ -17,7 +17,7 @@ func TestOnTransitionWritesNotificationOnActionableTransition(t *testing.T) {
 	ctx := context.Background()
 	n := testNotifier(t, store)
 
-	id, err := store.Create(ctx, Mission{Goal: marker + "notify-1", Kind: "research"})
+	id, err := store.Create(ctx, Mission{Goal: marker + "notify-1", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestOnTransitionSilentOnNonActionable(t *testing.T) {
 	ctx := context.Background()
 	n := testNotifier(t, store)
 
-	id, err := store.Create(ctx, Mission{Goal: marker + "notify-2", Kind: "research"})
+	id, err := store.Create(ctx, Mission{Goal: marker + "notify-2", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestSendOncePerMissionDedupes(t *testing.T) {
 	ctx := context.Background()
 	n := testNotifier(t, store)
 
-	id, err := store.Create(ctx, Mission{Goal: marker + "notify-3", Kind: "research"})
+	id, err := store.Create(ctx, Mission{Goal: marker + "notify-3", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestClearMissionMarksUnreadRowsRead(t *testing.T) {
 	ctx := context.Background()
 	n := testNotifier(t, store)
 
-	id, err := store.Create(ctx, Mission{Goal: marker + "notify-4", Kind: "research"})
+	id, err := store.Create(ctx, Mission{Goal: marker + "notify-4", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestMarkRead(t *testing.T) {
 	ctx := context.Background()
 	n := testNotifier(t, store)
 
-	id, err := store.Create(ctx, Mission{Goal: marker + "notify-5", Kind: "research"})
+	id, err := store.Create(ctx, Mission{Goal: marker + "notify-5", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -53,8 +53,15 @@ type Runner interface {
 	RunReview(ctx context.Context, m Mission, packet ReviewPacket, gatekeeper *GatekeeperState) (ReviewVerdict, *GatekeeperState, error)
 
 	// PlanSession runs the planning turn that produces a Spec (the list
-	// of PlanUnits) from the mission's goal and research-phase findings.
-	PlanSession(ctx context.Context, m Mission, researchNotes string) (Spec, error)
+	// of PlanUnits) from the mission's goal and explore-phase findings.
+	PlanSession(ctx context.Context, m Mission, exploreNotes string) (Spec, error)
+
+	// ExploreSession runs the explore turn: a tool-using session that
+	// explores the workspace and (via base tools) the web, ending with an
+	// explore_notes sentinel call. Exploration is advisory — a turn that
+	// never produces the sentinel degrades to the raw turn text rather
+	// than failing the phase.
+	ExploreSession(ctx context.Context, m Mission) (string, error)
 }
 
 // agentStream is the narrow slice of *loop.Agent nativeRunner actually
@@ -177,6 +184,24 @@ func NewNativeRunnerWithFloor(agent *loop.Agent, parker parkNotifier, floorDeny 
 const sandboxShellMaxTimeout = 15 * time.Minute
 
 func (r *nativeRunner) missionTools(m Mission) []*tools.Tool {
+	shell := r.missionShell(m)
+	if shell == nil {
+		return nil
+	}
+	return []*tools.Tool{
+		shell,
+		builtin.WriteFile(builtin.WriteFileConfig{Root: m.WorkRoot()}),
+	}
+}
+
+// missionShell builds the turn-scoped shell tool rooted in the
+// mission's own directory, routed through the mission's sandbox
+// container — shared by missionTools (worker/reviewer, paired with
+// write_file) and ExploreSession (shell only, read-only exploration:
+// the execute phase does the actual work, so explore never gets
+// write_file). Returns nil when the mission has no work root yet
+// (WorkRoot's Workspace/Worktree both empty).
+func (r *nativeRunner) missionShell(m Mission) *tools.Tool {
 	root := m.WorkRoot()
 	if root == "" {
 		return nil
@@ -206,10 +231,7 @@ func (r *nativeRunner) missionTools(m Mission) []*tools.Tool {
 			return result, nil
 		},
 	}
-	return []*tools.Tool{
-		builtin.Shell(shellCfg),
-		builtin.WriteFile(builtin.WriteFileConfig{Root: root}),
-	}
+	return builtin.Shell(shellCfg)
 }
 
 // shellOutputCap mirrors builtin.Shell's own output cap — the sandbox
@@ -440,6 +462,81 @@ func (r *nativeRunner) tryParseVerdict(args json.RawMessage) (WorkerVerdict, boo
 	return v, true
 }
 
+// ExploreSession runs the mission's explore turn: explore the goal
+// before planning commits to a shape. Unlike RunWorker's sentinel
+// ladder, a missing explore_notes call never fails the phase — the
+// findings are advisory input to the planner, not a gate on progress,
+// so the ladder's last resort is the raw turn text rather than a forced
+// failure.
+func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, error) {
+	system := "You are exploring one mission before it is planned. Investigate the goal: explore the workspace with shell (read-only — do not create or modify files; the execute phase does the actual work), and use web search/fetch tools if available and relevant to the goal. If the goal is self-contained and needs no exploration, say so briefly. End your turn with exactly one explore_notes tool call whose findings field contains everything the planner needs: what exists, what's relevant, constraints, gotchas, unknowns." + execEnvironmentNote()
+	user := "Goal: " + NeutralizeSlot(m.Goal)
+
+	extra := []*tools.Tool{ExploreNotesTool()}
+	if shell := r.missionShell(m); shell != nil {
+		extra = append(extra, shell)
+	}
+	req := loop.Request{
+		SessionID:  m.SessionID,
+		Route:      m.Route,
+		Agent:      "mission-explorer",
+		MissionID:  m.ID,
+		System:     system,
+		Messages:   []provider.Message{{Role: "user", Content: user}},
+		ExtraTools: extra,
+		Unattended: m.ScheduleID != "",
+	}
+
+	text, args, err := r.runTurn(ctx, req, exploreNotesToolName)
+	if err != nil {
+		return "", err
+	}
+	if notes, ok := tryParseFindings(args); ok {
+		return notes, nil
+	}
+
+	// One recovery re-run, same ladder shape as RunWorker/PlanSession.
+	recoverReq := req
+	recoverReq.Messages = append(append([]provider.Message{}, req.Messages...),
+		provider.Message{Role: "assistant", Content: text},
+		provider.Message{Role: "user", Content: "[system] You must end your turn with exactly one explore_notes tool call containing your findings."},
+	)
+	recoverText, recoverArgs, err := r.runTurn(ctx, recoverReq, exploreNotesToolName)
+	if err != nil {
+		return "", err
+	}
+	if notes, ok := tryParseFindings(recoverArgs); ok {
+		return notes, nil
+	}
+
+	// Neither turn produced a tool call: check for a text-form sentinel
+	// before giving up on structured output entirely.
+	combined := text + "\n" + recoverText
+	if raw, ok := extractTextSentinel(combined, exploreNotesToolName); ok {
+		if notes, ok := tryParseFindings(raw); ok {
+			return notes, nil
+		}
+	}
+
+	// Advisory phase: never a forced failure. The raw turn text is still
+	// useful context for the planner even with no structured findings.
+	r.log.Warn("mission explore ended without an explore_notes call; using raw turn text", "mission_id", m.ID)
+	return strings.TrimSpace(combined), nil
+}
+
+// tryParseFindings reports whether args decodes to a non-empty findings
+// string.
+func tryParseFindings(args json.RawMessage) (string, bool) {
+	if len(args) == 0 {
+		return "", false
+	}
+	findings, err := parseExploreFindings(args)
+	if err != nil || findings == "" {
+		return "", false
+	}
+	return findings, true
+}
+
 // RunReview judges the packet: the mission's goal and plan, the
 // harness-read artifact contents (never the worker's description of
 // them), the baseline diff when one exists, and the worker's evidence
@@ -566,17 +663,17 @@ func renderReviewContent(p ReviewPacket) string {
 }
 
 // PlanSession runs the planning turn that produces a Spec from the
-// mission's goal and research-phase findings. The plan is forced
+// mission's goal and explore-phase findings. The plan is forced
 // through the submit_plan tool call (mirroring RunWorker/RunReview's
 // sentinel ladder) rather than asked for as bare JSON prose — a model
 // free to preface its reply with prose was the root cause of a real
 // stuck mission (5 straight "invalid plan JSON" failures, identical
 // each retry since nothing told the model what went wrong).
-func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, researchNotes string) (Spec, error) {
+func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes string) (Spec, error) {
 	system := "You are planning one mission. Break the goal into the SMALLEST ordered list of verifiable units that achieves it — one unit is correct for a simple goal; never pad the plan. artifacts lists the workspace-relative file(s) the unit must produce — the harness itself checks each exists and is non-empty, so name the real deliverables. verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory — it must be a real POSIX shell command (using binaries like grep, test, wc — NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Never use command substitution ($(...) or backticks) in verify_cmd — write the direct command instead. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. End your turn with exactly one submit_plan tool call." + r.execEnvironmentNote()
 	user := "Goal: " + NeutralizeSlot(m.Goal)
-	if researchNotes != "" {
-		user += "\n\nResearch findings:\n" + NeutralizeSlot(researchNotes)
+	if exploreNotes != "" {
+		user += "\n\nExploration findings:\n" + NeutralizeSlot(exploreNotes)
 	}
 	req := loop.Request{
 		SessionID: m.SessionID,

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -344,7 +344,7 @@ func TestRunReviewRecoversWhenVerdictMissingThenPresent(t *testing.T) {
 // recovery turn instead of erroring the round out.
 func TestRunReviewFallsBackToTextSentinel(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{textEvent("Looking at this closely, I think it holds up.")}, // no tool call
+		{textEvent("Looking at this closely, I think it holds up.")},   // no tool call
 		{textEvent(`Confirmed. <review_verdict decision="approve"/>`)}, // recovery: still text-only
 	}}
 	r := newTestRunner(agent)
@@ -928,6 +928,132 @@ func TestRunWorkerReportsPermissionDenied(t *testing.T) {
 // infra error — previously it returned a clean empty verdict, which
 // the caller read as a missing sentinel and burned a recovery re-run
 // plus a forced retry for one silent infra failure.
+// TestExploreSessionSentinelPresent mirrors TestRunWorkerSentinelPresent:
+// an explore_notes call on the first turn is trusted directly, no
+// recovery needed.
+func TestExploreSessionSentinelPresent(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{textEvent("looked around"), toolEndEvent(exploreNotesToolName, `{"findings":"no prior implementation; goal is self-contained"}`)},
+	}}
+	r := newTestRunner(agent)
+	notes, err := r.ExploreSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"})
+	if err != nil {
+		t.Fatalf("ExploreSession: %v", err)
+	}
+	if notes != "no prior implementation; goal is self-contained" {
+		t.Fatalf("ExploreSession notes = %q", notes)
+	}
+	if agent.call != 1 {
+		t.Fatalf("expected exactly one turn when the sentinel is present, got %d", agent.call)
+	}
+}
+
+// TestExploreSessionRecoversWhenSentinelMissingThenPresent mirrors
+// RunWorker's recovery ladder: a missing sentinel on the first turn
+// gets one recovery re-run before the sentinel is trusted.
+func TestExploreSessionRecoversWhenSentinelMissingThenPresent(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{textEvent("still exploring")}, // no sentinel
+		{textEvent("done exploring"), toolEndEvent(exploreNotesToolName, `{"findings":"found a reusable config loader"}`)},
+	}}
+	r := newTestRunner(agent)
+	notes, err := r.ExploreSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"})
+	if err != nil {
+		t.Fatalf("ExploreSession: %v", err)
+	}
+	if notes != "found a reusable config loader" {
+		t.Fatalf("ExploreSession notes = %q", notes)
+	}
+	if agent.call != 2 {
+		t.Fatalf("expected exactly two turns (original + one recovery), got %d", agent.call)
+	}
+}
+
+// TestExploreSessionFallsBackToTextSentinel covers a explore turn
+// that expresses explore_notes as text (XML-ish tag), never as a tool
+// call — same fallback RunWorker/RunReview already rely on.
+func TestExploreSessionFallsBackToTextSentinel(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{textEvent("no tool call here")},
+		{textEvent(`Done. <explore_notes findings="the goal needs no exploration; it is self-contained"/>`)},
+	}}
+	r := newTestRunner(agent)
+	notes, err := r.ExploreSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"})
+	if err != nil {
+		t.Fatalf("ExploreSession: %v", err)
+	}
+	if notes != "the goal needs no exploration; it is self-contained" {
+		t.Fatalf("ExploreSession notes via text fallback = %q", notes)
+	}
+}
+
+// TestExploreSessionFallsBackToRawText is the advisory-phase contract:
+// when NEITHER turn produces an explore_notes call in any form, the raw
+// turn text becomes the notes — never an error, since explore findings
+// are advisory input to the planner, not a gate on mission progress.
+func TestExploreSessionFallsBackToRawText(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{textEvent("Looked at the workspace, nothing notable.")},
+		{textEvent("Confirmed, nothing else to add.")},
+	}}
+	r := newTestRunner(agent)
+	notes, err := r.ExploreSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"})
+	if err != nil {
+		t.Fatalf("ExploreSession: %v", err)
+	}
+	want := "Looked at the workspace, nothing notable.\nConfirmed, nothing else to add."
+	if notes != want {
+		t.Fatalf("ExploreSession fallback notes = %q, want %q", notes, want)
+	}
+	if agent.call != 2 {
+		t.Fatalf("expected exactly two turns (original + one recovery), got %d", agent.call)
+	}
+}
+
+// TestExploreSessionStreamErrorPropagates confirms an infra-level
+// stream error (not a missing sentinel) is a real error, distinct from
+// the advisory "no sentinel, use raw text" fallback path.
+func TestExploreSessionStreamErrorPropagates(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{{
+		{Type: stream.EventError, Err: &stream.StreamError{Message: "connection lost"}},
+	}}}
+	r := newTestRunner(agent)
+	if _, err := r.ExploreSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err == nil {
+		t.Fatal("ExploreSession: expected the stream error to propagate")
+	}
+}
+
+// TestExploreSessionGetsShellButNotWriteFile confirms the explore
+// turn's ExtraTools include a mission-scoped shell (for read-only
+// exploration) but never write_file — the execute phase does the
+// actual work, explore must not create or modify files.
+func TestExploreSessionGetsShellButNotWriteFile(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(exploreNotesToolName, `{"findings":"nothing notable"}`)},
+	}}
+	r := newTestRunner(agent)
+	m := Mission{ID: "m1", Route: "default", Goal: "test", Workspace: "/workspace/missions/m1"}
+	if _, err := r.ExploreSession(context.Background(), m); err != nil {
+		t.Fatalf("ExploreSession: %v", err)
+	}
+	var names []string
+	for _, tool := range agent.requests[0].ExtraTools {
+		names = append(names, tool.Name)
+	}
+	if !slices.Contains(names, "shell") {
+		t.Fatalf("explore ExtraTools = %v, want a mission-scoped shell", names)
+	}
+	if slices.Contains(names, "write_file") {
+		t.Fatalf("explore ExtraTools = %v, must not include write_file", names)
+	}
+	if !slices.Contains(names, exploreNotesToolName) {
+		t.Fatalf("explore ExtraTools = %v, want the explore_notes sentinel", names)
+	}
+	if agent.requests[0].ToolAllow != nil {
+		t.Fatalf("explore ToolAllow = %v, want nil so base tools (web_search/web_fetch) stay available", agent.requests[0].ToolAllow)
+	}
+}
+
 func TestRunTurnBareCloseIsError(t *testing.T) {
 	agent := &scriptedAgent{rawClose: true, batches: [][]stream.StreamEvent{{
 		textEvent("partial work"),

--- a/internal/brain/missions/scheduler_integration_test.go
+++ b/internal/brain/missions/scheduler_integration_test.go
@@ -17,7 +17,7 @@ func createTestSchedule(t *testing.T, store *Store, name, cronExpr string) strin
 	}
 	var id string
 	err = db.QueryRow(context.Background(), `INSERT INTO schedules (name, cron, mission_template)
-		VALUES ($1, $2, $3) RETURNING id`, name, cronExpr, `{"goal":"`+marker+`scheduled run","kind":"research"}`).Scan(&id)
+		VALUES ($1, $2, $3) RETURNING id`, name, cronExpr, `{"goal":"`+marker+`scheduled run","kind":"general"}`).Scan(&id)
 	if err != nil {
 		t.Fatalf("create schedule: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestSchedulerLiveQueueDedup(t *testing.T) {
 	}
 
 	// Pre-seed an ACTIVE mission already tied to this schedule.
-	missionID, err := store.Create(ctx, Mission{Goal: marker + "already active", Kind: "research"})
+	missionID, err := store.Create(ctx, Mission{Goal: marker + "already active", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}

--- a/internal/brain/missions/schedules_integration_test.go
+++ b/internal/brain/missions/schedules_integration_test.go
@@ -21,7 +21,7 @@ func TestScheduleCRUD(t *testing.T) {
 
 	id, err := store.CreateSchedule(ctx, Schedule{
 		Name: name, Cron: "0 7 * * *",
-		MissionTemplate: MissionTemplate{Goal: marker + "check topics", Kind: "research"},
+		MissionTemplate: MissionTemplate{Goal: marker + "check topics", Kind: "general"},
 		Enabled:         true,
 	})
 	if err != nil {
@@ -100,12 +100,12 @@ func TestScheduleDeleteBlockedByReferencingMission(t *testing.T) {
 
 	id, err := store.CreateSchedule(ctx, Schedule{
 		Name: slugMarker + "-in-use", Cron: "0 7 * * *",
-		MissionTemplate: MissionTemplate{Goal: marker + "referenced", Kind: "research"},
+		MissionTemplate: MissionTemplate{Goal: marker + "referenced", Kind: "general"},
 	})
 	if err != nil {
 		t.Fatalf("CreateSchedule: %v", err)
 	}
-	missionID, err := store.Create(ctx, Mission{Goal: marker + "referencing mission", Kind: "research"})
+	missionID, err := store.Create(ctx, Mission{Goal: marker + "referencing mission", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create mission: %v", err)
 	}

--- a/internal/brain/missions/sentinel.go
+++ b/internal/brain/missions/sentinel.go
@@ -105,6 +105,46 @@ func PlanTool() *tools.Tool {
 	}
 }
 
+// exploreNotesToolName is the explore phase's end-of-turn sentinel
+// call — advisory, unlike mission_status: a turn that never produces
+// it degrades to the raw turn text rather than failing the phase (see
+// runner.go's ExploreSession).
+const exploreNotesToolName = "explore_notes"
+
+// ExploreNotesTool defines the explorer's one tool call —
+// registered per-turn via loop.Request.ExtraTools, never in the shared
+// agent tool surface.
+func ExploreNotesTool() *tools.Tool {
+	return &tools.Tool{
+		Name:        exploreNotesToolName,
+		Description: "Report your exploration findings. Call this exactly once, as your final action.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"findings": {
+					"type": "string",
+					"description": "Everything the planner needs: what exists, what's relevant, constraints, unknowns."
+				}
+			},
+			"required": ["findings"]
+		}`),
+		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
+			return "findings recorded", nil
+		},
+	}
+}
+
+// parseExploreFindings decodes an explore_notes tool call's arguments.
+func parseExploreFindings(args json.RawMessage) (string, error) {
+	var v struct {
+		Findings string `json:"findings"`
+	}
+	if err := json.Unmarshal(args, &v); err != nil {
+		return "", err
+	}
+	return v.Findings, nil
+}
+
 // WorkerVerdict is the parsed mission_status call.
 type WorkerVerdict struct {
 	Outcome  string // done | retry | blocked
@@ -140,6 +180,7 @@ func parseWorkerVerdict(args json.RawMessage) (WorkerVerdict, error) {
 var sentinelAttrs = map[string][]string{
 	missionStatusToolName: {"outcome", "evidence", "analysis", "question", "handoff"},
 	reviewVerdictToolName: {"decision"},
+	exploreNotesToolName:  {"findings"},
 }
 
 // sentinelDiscriminator names the field whose value is validated
@@ -148,8 +189,15 @@ var sentinelAttrs = map[string][]string{
 var sentinelDiscriminator = map[string]string{
 	missionStatusToolName: "outcome",
 	reviewVerdictToolName: "decision",
+	exploreNotesToolName:  "findings",
 }
 
+// sentinelDiscriminatorValues enumerates the valid values for a
+// discriminator field with a fixed enum (mission_status's outcome,
+// review_verdict's decision). explore_notes' discriminator (findings)
+// is free text, not an enum — its absence here means extractTextSentinel
+// falls back to a plain non-empty check for that tool instead of an
+// enum membership test.
 var sentinelDiscriminatorValues = map[string]map[string]bool{
 	missionStatusToolName: {"done": true, "retry": true, "blocked": true},
 	reviewVerdictToolName: {"approve": true, "rework": true},
@@ -192,9 +240,18 @@ var attrPattern = regexp.MustCompile(`([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*(?:"([^"]*)
 func extractTextSentinel(text, toolName string) (json.RawMessage, bool) {
 	knownAttrs := sentinelAttrs[toolName]
 	discriminator := sentinelDiscriminator[toolName]
-	validValues := sentinelDiscriminatorValues[toolName]
 	if discriminator == "" || len(knownAttrs) == 0 {
 		return nil, false
+	}
+	// A tool with no enum entry here (explore_notes) has a free-text
+	// discriminator: any non-empty value is valid, rather than membership
+	// in a fixed set.
+	validValues, hasEnum := sentinelDiscriminatorValues[toolName]
+	isValid := func(v string) bool {
+		if !hasEnum {
+			return v != ""
+		}
+		return validValues[v]
 	}
 
 	var best map[string]string
@@ -213,7 +270,7 @@ func extractTextSentinel(text, toolName string) (json.RawMessage, bool) {
 			}
 			fields[name] = val
 		}
-		if v, ok := fields[discriminator]; ok && validValues[v] && m[0] > bestPos {
+		if v, ok := fields[discriminator]; ok && isValid(v) && m[0] > bestPos {
 			best, bestPos = fields, m[0]
 		}
 	}
@@ -236,7 +293,7 @@ func extractTextSentinel(text, toolName string) (json.RawMessage, bool) {
 			continue
 		}
 		v, ok := obj[discriminator].(string)
-		if !ok || !validValues[v] {
+		if !ok || !isValid(v) {
 			continue
 		}
 		if loc[0] <= bestPos {

--- a/internal/brain/missions/sentinel_test.go
+++ b/internal/brain/missions/sentinel_test.go
@@ -92,6 +92,100 @@ func TestParseWorkerVerdictDecodesHandoff(t *testing.T) {
 	}
 }
 
+func TestParseExploreFindings(t *testing.T) {
+	findings, err := parseExploreFindings([]byte(`{"findings":"no prior implementation exists; goal is self-contained"}`))
+	if err != nil {
+		t.Fatalf("parseExploreFindings: %v", err)
+	}
+	if findings != "no prior implementation exists; goal is self-contained" {
+		t.Fatalf("parseExploreFindings = %q", findings)
+	}
+}
+
+// TestParseExploreFindingsCaseInsensitiveKey confirms encoding/json's
+// default case-insensitive field matching applies here too (same as
+// parseWorkerVerdict) — a model that emits "Findings" instead of
+// "findings" still decodes.
+func TestParseExploreFindingsCaseInsensitiveKey(t *testing.T) {
+	findings, err := parseExploreFindings([]byte(`{"Findings":"found an existing config loader to reuse"}`))
+	if err != nil {
+		t.Fatalf("parseExploreFindings: %v", err)
+	}
+	if findings != "found an existing config loader to reuse" {
+		t.Fatalf("parseExploreFindings = %q", findings)
+	}
+}
+
+func TestParseExploreFindingsEmpty(t *testing.T) {
+	findings, err := parseExploreFindings([]byte(`{"findings":""}`))
+	if err != nil {
+		t.Fatalf("parseExploreFindings: %v", err)
+	}
+	if findings != "" {
+		t.Fatalf("parseExploreFindings = %q, want empty", findings)
+	}
+}
+
+func TestParseExploreFindingsMalformed(t *testing.T) {
+	if _, err := parseExploreFindings([]byte(`not json`)); err == nil {
+		t.Fatal("parseExploreFindings accepted malformed JSON")
+	}
+}
+
+// TestExtractTextSentinelExploreNotes covers explore_notes' text-form
+// fallback — its discriminator (findings) is free text, not a fixed
+// enum, so a plain non-empty check gates validity instead of enum
+// membership.
+func TestExtractTextSentinelExploreNotes(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    string
+		wantOK  bool
+		wantVal string
+	}{
+		{
+			name:    "XML form",
+			text:    `<explore_notes findings="no existing implementation; goal is self-contained"/>`,
+			wantOK:  true,
+			wantVal: "no existing implementation; goal is self-contained",
+		},
+		{
+			name:    "token+JSON form",
+			text:    "explore_notes\n{\"findings\": \"found a reusable config loader in internal/platform/config\"}",
+			wantOK:  true,
+			wantVal: "found a reusable config loader in internal/platform/config",
+		},
+		{
+			name:   "empty findings value is not a match",
+			text:   `<explore_notes findings=""/>`,
+			wantOK: false,
+		},
+		{
+			name:   "no explore_notes mention at all",
+			text:   "I looked around but found nothing worth noting.",
+			wantOK: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, ok := extractTextSentinel(tc.text, exploreNotesToolName)
+			if ok != tc.wantOK {
+				t.Fatalf("extractTextSentinel(%q) ok = %v, want %v", tc.text, ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			findings, err := parseExploreFindings(raw)
+			if err != nil {
+				t.Fatalf("parseExploreFindings: %v", err)
+			}
+			if findings != tc.wantVal {
+				t.Fatalf("findings = %q, want %q", findings, tc.wantVal)
+			}
+		})
+	}
+}
+
 // TestExtractTextSentinel covers the observed real-world failure
 // shapes: GLM-5.2 workers emitting an XML-ish self-closing tag,
 // qwen3:30b workers emitting a bare tool-name token followed by a JSON

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -4,16 +4,16 @@ package missions
 type Phase string
 
 const (
-	PhaseResearch Phase = "research"
-	PhasePlan     Phase = "plan"
-	PhaseExecute  Phase = "execute"
-	PhaseReview   Phase = "review"
-	PhaseDone     Phase = "done"
-	PhaseFailed   Phase = "failed"
+	PhaseExplore Phase = "explore"
+	PhasePlan    Phase = "plan"
+	PhaseExecute Phase = "execute"
+	PhaseReview  Phase = "review"
+	PhaseDone    Phase = "done"
+	PhaseFailed  Phase = "failed"
 )
 
 // phaseOrder is the fixed pipeline a mission advances through.
-var phaseOrder = []Phase{PhaseResearch, PhasePlan, PhaseExecute, PhaseReview}
+var phaseOrder = []Phase{PhaseExplore, PhasePlan, PhaseExecute, PhaseReview}
 
 // Terminal reports whether phase ends the mission.
 func (p Phase) Terminal() bool {
@@ -39,7 +39,7 @@ func nextPhase(p Phase) (Phase, bool) {
 // fail to load it at all).
 func parsePhase(raw string) (Phase, bool) {
 	switch Phase(raw) {
-	case PhaseResearch, PhasePlan, PhaseExecute, PhaseReview, PhaseDone, PhaseFailed:
+	case PhaseExplore, PhasePlan, PhaseExecute, PhaseReview, PhaseDone, PhaseFailed:
 		return Phase(raw), true
 	default:
 		return "", false
@@ -278,7 +278,7 @@ func stepResume(s StepState) Transition {
 	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.resumed"}}}
 }
 
-// stepPhaseComplete advances research/plan to the next fixed phase.
+// stepPhaseComplete advances explore/plan to the next fixed phase.
 // execute's completion goes through review (a worker verdict of DONE
 // requests review, it doesn't itself complete the phase — the driver
 // routes DONE into a review round, whose outcome arrives as

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -86,8 +86,8 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhaseExecute, Status: StatusPaused, PauseReason: PauseMixedCurrency, Spent: 0, Budget: budget(100), MixedCurrencySpend: true},
 		},
 		{
-			name:  "phase_complete advances research to plan",
-			state: StepState{Phase: PhaseResearch, Status: StatusWorking, Iteration: 2, ConsecutiveFailures: 1},
+			name:  "phase_complete advances explore to plan",
+			state: StepState{Phase: PhaseExplore, Status: StatusWorking, Iteration: 2, ConsecutiveFailures: 1},
 			input: StepInput{Input: InputPhaseComplete},
 			cfg:   DefaultConfig,
 			want:  StepState{Phase: PhasePlan, Status: StatusIdle},
@@ -306,7 +306,7 @@ func TestStepMixedCurrencyPauseDetail(t *testing.T) {
 }
 
 func TestParsePhase(t *testing.T) {
-	valid := []Phase{PhaseResearch, PhasePlan, PhaseExecute, PhaseReview, PhaseDone, PhaseFailed}
+	valid := []Phase{PhaseExplore, PhasePlan, PhaseExecute, PhaseReview, PhaseDone, PhaseFailed}
 	for _, p := range valid {
 		if got, ok := parsePhase(string(p)); !ok || got != p {
 			t.Fatalf("parsePhase(%q) = %q, %v; want %q, true", p, got, ok, p)
@@ -339,7 +339,7 @@ func TestPhaseTerminal(t *testing.T) {
 			t.Fatalf("%q.Terminal() = false, want true", p)
 		}
 	}
-	nonTerminal := []Phase{PhaseResearch, PhasePlan, PhaseExecute, PhaseReview}
+	nonTerminal := []Phase{PhaseExplore, PhasePlan, PhaseExecute, PhaseReview}
 	for _, p := range nonTerminal {
 		if p.Terminal() {
 			t.Fatalf("%q.Terminal() = true, want false", p)

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -48,7 +48,7 @@ const missionColumns = `id, goal, kind, agent_id, phase, status, pause_reason, p
 	escalation_route, prompt_overlay,
 	pending_permission, pending_permission_tool, pending_permission_args,
 	pending_permission_danger, pending_permission_rationale, auto_approve_safe, last_evidence,
-	schedule_id, session_id, created_at, updated_at`
+	explore_notes, schedule_id, session_id, created_at, updated_at`
 
 func scanMission(row pgx.Row) (Mission, error) {
 	var (
@@ -64,7 +64,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&m.EscalationRoute, &m.PromptOverlay,
 		&pendingPermission, &m.PendingPermissionTool, &m.PendingPermissionArgs,
 		&m.PendingPermissionDanger, &m.PendingPermissionRationale, &m.AutoApproveSafe, &m.LastEvidence,
-		&scheduleID, &sessionID, &m.CreatedAt, &m.UpdatedAt); err != nil {
+		&m.ExploreNotes, &scheduleID, &sessionID, &m.CreatedAt, &m.UpdatedAt); err != nil {
 		return Mission{}, err
 	}
 	if agentID != nil {
@@ -105,7 +105,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 	return m, nil
 }
 
-// Create inserts a mission row in phase=research, status=idle.
+// Create inserts a mission row in phase=explore, status=idle.
 func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	db, err := s.db.Get()
 	if err != nil {
@@ -351,6 +351,21 @@ func (s *Store) SetLastEvidence(ctx context.Context, id, evidence string) error 
 	if _, err := db.Exec(ctx, `UPDATE missions SET last_evidence = $2, updated_at = now() WHERE id = $1`,
 		id, evidence); err != nil {
 		return fmt.Errorf("missions set last evidence: %w", err)
+	}
+	return nil
+}
+
+// SetExploreNotes stores the explore phase's findings for the
+// planner. Like SetLastEvidence it bypasses the state machine: written
+// mid-phase, not at an Advance boundary.
+func (s *Store) SetExploreNotes(ctx context.Context, id, notes string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("missions set explore notes: %w", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE missions SET explore_notes = $2, updated_at = now() WHERE id = $1`,
+		id, notes); err != nil {
+		return fmt.Errorf("missions set explore notes: %w", err)
 	}
 	return nil
 }

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -89,7 +89,7 @@ func TestMissionCRUD(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
 
-	id, err := s.Create(ctx, Mission{Goal: marker + "crud", Kind: "research", Route: "default"})
+	id, err := s.Create(ctx, Mission{Goal: marker + "crud", Kind: "general", Route: "default"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -97,8 +97,8 @@ func TestMissionCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if m.Phase != PhaseResearch || m.Status != StatusIdle || m.MaxIterations != 8 {
-		t.Fatalf("Get = %+v, want default research/idle/8", m)
+	if m.Phase != PhaseExplore || m.Status != StatusIdle || m.MaxIterations != 8 {
+		t.Fatalf("Get = %+v, want default explore/idle/8", m)
 	}
 
 	list, err := s.List(ctx, ListFilter{})
@@ -133,12 +133,12 @@ func TestMissionDelete(t *testing.T) {
 		t.Fatalf("Delete of a nonexistent id = %v, want ErrNotFound", err)
 	}
 
-	id, err := s.Create(ctx, Mission{Goal: marker + "delete-live", Kind: "research"})
+	id, err := s.Create(ctx, Mission{Goal: marker + "delete-live", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	if _, err := s.Delete(ctx, id); !errors.Is(err, ErrNotTerminal) {
-		t.Fatalf("Delete of a live (research/idle) mission = %v, want ErrNotTerminal", err)
+		t.Fatalf("Delete of a live (explore/idle) mission = %v, want ErrNotTerminal", err)
 	}
 
 	if err := s.AppendEvent(ctx, id, "mission.progress", map[string]any{"note": "hi"}); err != nil {
@@ -175,7 +175,7 @@ func TestMissionPromptOverlayRoundTrips(t *testing.T) {
 	ctx := t.Context()
 
 	id, err := s.Create(ctx, Mission{
-		Goal: marker + "overlay", Kind: "research", Route: "default",
+		Goal: marker + "overlay", Kind: "general", Route: "default",
 		PromptOverlay: "You are a careful senior engineer.",
 	})
 	if err != nil {
@@ -191,7 +191,7 @@ func TestMissionPromptOverlayRoundTrips(t *testing.T) {
 
 	// Absent means "no agent overlay" (the general agent, e.g.) — must
 	// stay empty, not some driver default.
-	id2, err := s.Create(ctx, Mission{Goal: marker + "no-overlay", Kind: "research", Route: "default"})
+	id2, err := s.Create(ctx, Mission{Goal: marker + "no-overlay", Kind: "general", Route: "default"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestSetAndClearPendingPermission(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
 
-	id, err := s.Create(ctx, Mission{Goal: marker + "permission", Kind: "research", Route: "default"})
+	id, err := s.Create(ctx, Mission{Goal: marker + "permission", Kind: "general", Route: "default"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -259,7 +259,7 @@ func TestAppendProgress(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
 
-	id, err := s.Create(ctx, Mission{Goal: marker + "progress", Kind: "research", Route: "default"})
+	id, err := s.Create(ctx, Mission{Goal: marker + "progress", Kind: "general", Route: "default"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -297,7 +297,7 @@ func TestApplyTransitionAndEvents(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
 
-	id, err := s.Create(ctx, Mission{Goal: marker + "transition", Kind: "research"})
+	id, err := s.Create(ctx, Mission{Goal: marker + "transition", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -336,7 +336,7 @@ func TestApplyTransitionClearsPendingPermissionOnTerminal(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
 
-	id, err := s.Create(ctx, Mission{Goal: marker + "cancel-parked", Kind: "research"})
+	id, err := s.Create(ctx, Mission{Goal: marker + "cancel-parked", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -380,7 +380,7 @@ func TestAppendEventSeqMonotonic(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
 
-	id, err := s.Create(ctx, Mission{Goal: marker + "seq", Kind: "research"})
+	id, err := s.Create(ctx, Mission{Goal: marker + "seq", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -490,7 +490,7 @@ func TestClaimWorkSlotConcurrencyCap(t *testing.T) {
 	}
 	ids := make([]string, total)
 	for i := range ids {
-		id, err := s.Create(ctx, Mission{Goal: marker + "slot", Kind: "research"})
+		id, err := s.Create(ctx, Mission{Goal: marker + "slot", Kind: "general"})
 		if err != nil {
 			t.Fatalf("Create[%d]: %v", i, err)
 		}
@@ -537,7 +537,7 @@ func TestReconcileTerminalIdempotency(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
 
-	id, err := s.Create(ctx, Mission{Goal: marker + "reconcile", Kind: "research"})
+	id, err := s.Create(ctx, Mission{Goal: marker + "reconcile", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -596,11 +596,11 @@ func TestRecoverWorking(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
 
-	idleID, err := s.Create(ctx, Mission{Goal: marker + "recover-idle", Kind: "research"})
+	idleID, err := s.Create(ctx, Mission{Goal: marker + "recover-idle", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create idle: %v", err)
 	}
-	workingID, err := s.Create(ctx, Mission{Goal: marker + "recover-working", Kind: "research"})
+	workingID, err := s.Create(ctx, Mission{Goal: marker + "recover-working", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create working: %v", err)
 	}
@@ -628,7 +628,7 @@ func TestRecoverStaleWorking(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
 
-	freshID, err := s.Create(ctx, Mission{Goal: marker + "stale-fresh", Kind: "research"})
+	freshID, err := s.Create(ctx, Mission{Goal: marker + "stale-fresh", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create fresh: %v", err)
 	}
@@ -636,7 +636,7 @@ func TestRecoverStaleWorking(t *testing.T) {
 		t.Fatalf("ApplyTransition fresh: %v", err)
 	}
 
-	staleID, err := s.Create(ctx, Mission{Goal: marker + "stale-old", Kind: "research"})
+	staleID, err := s.Create(ctx, Mission{Goal: marker + "stale-old", Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create stale: %v", err)
 	}

--- a/internal/brain/missions/worktree_integration_test.go
+++ b/internal/brain/missions/worktree_integration_test.go
@@ -19,7 +19,7 @@ func TestProvisionNonCodingMission(t *testing.T) {
 	w := newTestWorkspace(t)
 	ctx := context.Background()
 
-	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-2", "Research something", "research")
+	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-2", "Do something", "general")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}

--- a/internal/brain/session/store_integration_test.go
+++ b/internal/brain/session/store_integration_test.go
@@ -127,7 +127,7 @@ func TestDeleteRefusesMissionSession(t *testing.T) {
 
 	var missionID string
 	if err := db.QueryRow(ctx, `INSERT INTO missions (goal, kind, session_id)
-		VALUES ('itest-delete-guard', 'research', $1) RETURNING id`, id).Scan(&missionID); err != nil {
+		VALUES ('itest-delete-guard', 'general', $1) RETURNING id`, id).Scan(&missionID); err != nil {
 		t.Fatalf("seed mission: %v", err)
 	}
 	t.Cleanup(func() {
@@ -338,7 +338,7 @@ func TestListExcludesMissionSessions(t *testing.T) {
 	}
 	var missionID string
 	if err := db.QueryRow(ctx,
-		"INSERT INTO missions (goal, kind, session_id) VALUES ($1, 'research', $2) RETURNING id",
+		"INSERT INTO missions (goal, kind, session_id) VALUES ($1, 'general', $2) RETURNING id",
 		marker, missionSessionID).Scan(&missionID); err != nil {
 		t.Fatalf("insert mission: %v", err)
 	}

--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -82,7 +82,8 @@ func NewPermissions(db *pgpool.Pool, workspaceRoot string) *Permissions {
 			// protocol parked every mission's first turn for nothing.
 			"mission_status": true,
 			"review_verdict": true,
-			"submit_plan":    true,
+			"submit_plan":   true,
+			"explore_notes": true,
 			// write_file is root-confined by construction (relative
 			// paths only, .. rejected, root fixed at registration) —
 			// there is nothing for a prompt to guard that the tool

--- a/internal/brain/tools/permissions_test.go
+++ b/internal/brain/tools/permissions_test.go
@@ -170,7 +170,7 @@ func TestResolveShortCircuits(t *testing.T) {
 
 	t.Run("mission sentinel tools exempt", func(t *testing.T) {
 		t.Parallel()
-		for _, tool := range []string{"mission_status", "review_verdict", "submit_plan"} {
+		for _, tool := range []string{"mission_status", "review_verdict", "submit_plan", "explore_notes"} {
 			res, err := p.Resolve(ctx, "s1", tool, json.RawMessage(`{}`))
 			if err != nil {
 				t.Fatalf("Resolve(%s): %v", tool, err)

--- a/migrations/0010_missions.sql
+++ b/migrations/0010_missions.sql
@@ -11,9 +11,9 @@
 CREATE TABLE IF NOT EXISTS missions (
     id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     goal                  text NOT NULL,
-    kind                  text NOT NULL CHECK (kind IN ('coding', 'research', 'scheduled')),
+    kind                  text NOT NULL CHECK (kind IN ('coding', 'general')),
     agent_id              uuid REFERENCES agents(id),
-    phase                 text NOT NULL DEFAULT 'research',
+    phase                 text NOT NULL DEFAULT 'explore',
     status                text NOT NULL DEFAULT 'idle',
     pause_reason          text NOT NULL DEFAULT '',
     pause_message         text NOT NULL DEFAULT '',
@@ -73,13 +73,17 @@ CREATE TABLE IF NOT EXISTS missions (
     -- classified commands still always ask, unaffected by this column
     -- or any grant.
     auto_approve_safe     boolean NOT NULL DEFAULT true,
-    -- The reviewer judges the baseline git diff, but a research/
-    -- scheduled mission never touches tracked files -- its diff is
+    -- The reviewer judges the baseline git diff, but a general
+    -- mission never touches tracked files -- its diff is
     -- always empty, so the reviewer previously had zero evidence to
     -- judge and rejected every round. This carries the worker's own
     -- mission_status evidence text forward from execute to review,
     -- alongside (not instead of) the diff for coding missions.
-    last_evidence         text NOT NULL DEFAULT ''
+    last_evidence         text NOT NULL DEFAULT '',
+    -- The explore phase's findings, carried into the plan phase's
+    -- prompt (internal/brain/missions/driver.go's runPlan) so the
+    -- planner sees what exploration turned up, not just the bare goal.
+    explore_notes         text NOT NULL DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS missions_status_idx ON missions (status);

--- a/scripts/canary-coding.sh
+++ b/scripts/canary-coding.sh
@@ -4,8 +4,8 @@
 # the coding-specific harness contract — worktree provisioned, LLM
 # review actually ran (coding never skips review), harness-verified
 # artifact present in the worktree, zero human permission parks. The
-# research canary (canary-mission.sh) cannot catch regressions in the
-# git/worktree/review path; this one exists for exactly that.
+# general-mission canary (canary-mission.sh) cannot catch regressions in
+# the git/worktree/review path; this one exists for exactly that.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/canary-mission.sh
+++ b/scripts/canary-mission.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Canary mission: runs one golden research mission end-to-end against
+# Canary mission: runs one golden general mission end-to-end against
 # the live stack and asserts the harness contract holds — done within
 # the iteration budget, zero human permission parks, artifacts verified
 # by the harness. Run after every harness change (make canary) so
@@ -45,7 +45,7 @@ auth=(-H "Authorization: Bearer ${TIMOTHY_API_TOKEN}" -H "Content-Type: applicat
 
 echo "canary: creating mission against ${BASE_URL}"
 create_resp="$(curl -sf "${auth[@]}" -X POST "${BASE_URL}/v1/missions" \
-  -d "{\"goal\": \"${GOAL}\", \"kind\": \"research\"}")"
+  -d "{\"goal\": \"${GOAL}\", \"kind\": \"general\"}")"
 id="$(echo "${create_resp}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
 echo "canary: mission ${id}"
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,7 @@
         "lucide-react": "^1.27.0",
         "radix-ui": "^1.6.7",
         "react": "^19.2.8",
+        "react-day-picker": "^10.0.1",
         "react-dom": "^19.2.8",
         "react-markdown": "^10.1.0",
         "react-router": "^8.3.0",
@@ -662,6 +663,12 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+      "license": "MIT"
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.75.1",
@@ -5035,6 +5042,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debounce-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
@@ -8670,6 +8687,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-10.0.1.tgz",
+      "integrity": "sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "date-fns": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-dom": {

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "lucide-react": "^1.27.0",
     "radix-ui": "^1.6.7",
     "react": "^19.2.8",
+    "react-day-picker": "^10.0.1",
     "react-dom": "^19.2.8",
     "react-markdown": "^10.1.0",
     "react-router": "^8.3.0",

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -842,7 +842,7 @@ export async function patchSettingValues(changes: Record<string, string>): Promi
 
 export interface CreateMissionInput {
   goal: string
-  kind: 'coding' | 'research'
+  kind: 'coding' | 'general'
   agent_id?: string
   route?: string
   review_route?: string
@@ -872,6 +872,16 @@ export async function createMission(input: CreateMissionInput): Promise<{ id: st
   return request<{ id: string }>('/v1/missions', {
     method: 'POST',
     body: JSON.stringify(input),
+  })
+}
+
+// classifyMission previews the kind create() would infer for goal —
+// the same classifyKind logic the server falls back to when kind is
+// omitted, exposed standalone for the create form's live chip.
+export async function classifyMission(goal: string): Promise<{ kind: 'coding' | 'general' }> {
+  return request<{ kind: 'coding' | 'general' }>('/v1/missions/classify', {
+    method: 'POST',
+    body: JSON.stringify({ goal }),
   })
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -500,14 +500,14 @@ export interface ProgressNote {
 }
 
 // Mission is one long-running, agent-driven unit of work
-// (internal/brain/missions): research -> plan -> execute -> review
+// (internal/brain/missions): explore -> plan -> execute -> review
 // under a state machine.
 export interface Mission {
   id: string
   goal: string
-  kind: 'coding' | 'research'
+  kind: 'coding' | 'general'
   agent_id?: string
-  phase: 'research' | 'plan' | 'execute' | 'review' | 'done' | 'failed'
+  phase: 'explore' | 'plan' | 'execute' | 'review' | 'done' | 'failed'
   status: 'idle' | 'working' | 'waiting_for_input' | 'paused' | 'done' | 'error'
   pause_reason?: 'backoff' | 'no_progress' | 'infra' | 'budget' | 'mixed_currency' | ''
   pause_message?: string
@@ -515,6 +515,11 @@ export interface Mission {
   worktree?: string
   branch?: string
   base_commit?: string
+  // explore_notes is set once, at the end of the explore phase
+  // (driver.go's runExplore) — absent/empty for a mission created
+  // before the explore phase existed, or one that hasn't reached it
+  // yet.
+  explore_notes?: string
   spec: { units: PlanUnit[] }
   progress: ProgressNote[]
   iteration: number
@@ -589,7 +594,7 @@ export interface AdminConnector {
 // shape as CreateMissionInput.
 export interface MissionTemplate {
   goal: string
-  kind: 'coding' | 'research'
+  kind: 'coding' | 'general'
   agent_id?: string
   route?: string
   review_route?: string

--- a/web/src/components/AgentPicker.tsx
+++ b/web/src/components/AgentPicker.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
-import { listAgents } from '../api/client'
-import type { AdminAgent } from '../api/types'
+import { listAgents, listRoutes } from '../api/client'
+import type { AdminAgent, AdminRoute } from '../api/types'
 
 // Sentinel value meaning "let the system pick" (D-034 follow-up) —
 // matches the backend's autoAgentName. Not a real agent row: the
@@ -24,4 +24,22 @@ export function useAgents(): AdminAgent[] {
     )
   }, [])
   return agents
+}
+
+// Module-level cache: the picker renders in every composer; the route
+// list changes rarely and a stale list self-heals on the next mount.
+let cachedRoutes: AdminRoute[] | null = null
+
+export function useRoutes(): AdminRoute[] | null {
+  const [routes, setRoutes] = useState<AdminRoute[] | null>(cachedRoutes)
+  useEffect(() => {
+    listRoutes().then(
+      (list) => {
+        cachedRoutes = list
+        setRoutes(cachedRoutes)
+      },
+      () => undefined, // admin proxy may be unreachable — picker hides itself
+    )
+  }, [])
+  return routes
 }

--- a/web/src/components/AgentRoutePicker.tsx
+++ b/web/src/components/AgentRoutePicker.tsx
@@ -5,10 +5,7 @@ import {
   Tick02Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { useEffect, useState } from 'react'
-import { listRoutes } from '../api/client'
-import type { AdminRoute } from '../api/types'
-import { AUTO_AGENT, useAgents } from './AgentPicker'
+import { AUTO_AGENT, useAgents, useRoutes } from './AgentPicker'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -17,24 +14,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from './ui/dropdown-menu'
-
-// Module-level cache: the picker renders in every composer; the route
-// list changes rarely and a stale list self-heals on the next mount.
-let cachedRoutes: AdminRoute[] | null = null
-
-function useRoutes(): AdminRoute[] | null {
-  const [routes, setRoutes] = useState<AdminRoute[] | null>(cachedRoutes)
-  useEffect(() => {
-    listRoutes().then(
-      (list) => {
-        cachedRoutes = list
-        setRoutes(cachedRoutes)
-      },
-      () => undefined, // admin proxy may be unreachable — picker hides itself
-    )
-  }, [])
-  return routes
-}
 
 // AgentRoutePicker combines who serves the next message with which
 // model chain serves it (D-034) into one control: the agent carries

--- a/web/src/components/missions/ExploreSection.test.tsx
+++ b/web/src/components/missions/ExploreSection.test.tsx
@@ -1,0 +1,21 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ExploreSection } from './ExploreSection'
+
+afterEach(cleanup)
+
+describe('ExploreSection', () => {
+  it('starts collapsed, showing only the trigger', () => {
+    render(<ExploreSection notes="**bold** finding and a [link](https://example.com)" />)
+    expect(screen.getByText('Show exploration')).toBeInTheDocument()
+    expect(screen.queryByText('bold')).not.toBeInTheDocument()
+  })
+
+  it('reveals the notes as markdown once expanded', () => {
+    render(<ExploreSection notes="**bold** finding and a [link](https://example.com)" />)
+    fireEvent.click(screen.getByText('Show exploration'))
+
+    expect(screen.getByText('bold').tagName).toBe('STRONG')
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://example.com')
+  })
+})

--- a/web/src/components/missions/ExploreSection.tsx
+++ b/web/src/components/missions/ExploreSection.tsx
@@ -1,0 +1,24 @@
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible'
+
+// ExploreSection renders a mission's explore_notes (set once, at the
+// end of the explore phase — see driver.go's runExplore) as
+// collapsed-by-default markdown, the same rendering ResultSection uses
+// for last_evidence. The page only mounts this when notes is non-empty.
+export function ExploreSection({ notes }: { notes: string }) {
+  return (
+    <Collapsible>
+      <CollapsibleTrigger className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground">
+        Show exploration
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="mt-2 rounded-lg border border-border bg-muted/30">
+          <div className="prose prose-sm max-h-64 max-w-none overflow-y-auto p-3 dark:prose-invert">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{notes}</ReactMarkdown>
+          </div>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -1,17 +1,33 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Schedule } from '../../api/types'
+import type { AdminRoute, Schedule } from '../../api/types'
 import { MissionForm } from './MissionForm'
 
 vi.mock('../../api/client', () => ({
+  classifyMission: vi.fn(),
   createMission: vi.fn(),
   createSchedule: vi.fn(),
   patchSchedule: vi.fn(),
   listAgents: vi.fn(),
+  listRoutes: vi.fn(),
   getSettings: vi.fn(),
 }))
 
-import { createMission, createSchedule, getSettings, listAgents, patchSchedule } from '../../api/client'
+import {
+  classifyMission,
+  createMission,
+  createSchedule,
+  getSettings,
+  listAgents,
+  listRoutes,
+  patchSchedule,
+} from '../../api/client'
+
+const routes: AdminRoute[] = [
+  { name: 'default', strategy: 'ordered', enabled: true, chain: [] },
+  { name: 'careful', strategy: 'ordered', enabled: true, chain: [] },
+  { name: 'disabled-route', strategy: 'ordered', enabled: false, chain: [] },
+]
 
 const schedule: Schedule = {
   id: 's1',
@@ -19,7 +35,7 @@ const schedule: Schedule = {
   cron: '0 8 * * 1-5',
   mission_template: {
     goal: 'Summarize the week',
-    kind: 'research',
+    kind: 'general',
     auto_approve_safe: true,
     review_route: 'default',
   },
@@ -30,16 +46,21 @@ const schedule: Schedule = {
   updated_at: '2026-07-01T00:00:00Z',
 }
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
 beforeEach(() => {
   Element.prototype.scrollIntoView = vi.fn()
   vi.clearAllMocks()
   vi.mocked(listAgents).mockResolvedValue([])
+  vi.mocked(listRoutes).mockResolvedValue(routes)
   vi.mocked(getSettings).mockResolvedValue({ settings: {}, values: {} })
+  vi.mocked(classifyMission).mockResolvedValue({ kind: 'general' })
 })
 
 describe('MissionForm — create mode, one-off mission', () => {
-  it('submits a research mission with the entered goal', async () => {
+  it('submits a general mission with the entered goal', async () => {
     vi.mocked(createMission).mockResolvedValue({ id: 'm2' })
     const onDone = vi.fn()
     render(<MissionForm mode="create" onDone={onDone} onCancel={vi.fn()} />)
@@ -51,7 +72,7 @@ describe('MissionForm — create mode, one-off mission', () => {
       expect(createMission).toHaveBeenCalledWith(
         expect.objectContaining({
           goal: 'Research something new',
-          kind: 'research',
+          kind: 'general',
           auto_approve_safe: true,
         }),
       ),
@@ -85,22 +106,6 @@ describe('MissionForm — create mode, one-off mission', () => {
     expect(createButton.disabled).toBe(false)
   })
 
-  it('allows submitting a coding mission with just a goal', async () => {
-    vi.mocked(createMission).mockResolvedValue({ id: 'm3' })
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
-
-    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Fix a bug' } })
-    fireEvent.click(screen.getByRole('button', { name: /^Coding /i }))
-
-    const createButton = screen.getByRole('button', { name: 'Create mission' }) as HTMLButtonElement
-    expect(createButton.disabled).toBe(false)
-
-    fireEvent.click(createButton)
-    await waitFor(() =>
-      expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ kind: 'coding' })),
-    )
-  })
-
   it('calls onCancel when Cancel is clicked', () => {
     const onCancel = vi.fn()
     render(<MissionForm mode="create" onDone={vi.fn()} onCancel={onCancel} />)
@@ -109,8 +114,80 @@ describe('MissionForm — create mode, one-off mission', () => {
   })
 })
 
+describe('MissionForm — kind chip', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows a detecting state then the classified kind after the debounce', async () => {
+    vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding' })
+    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Fix a bug in the repo' } })
+    expect(screen.getByText('Detecting…')).toBeInTheDocument()
+    expect(classifyMission).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(600)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(classifyMission).toHaveBeenCalledWith('Fix a bug in the repo')
+    expect(screen.getByText('Coding · branches from repo')).toBeInTheDocument()
+  })
+
+  it('debounces repeated goal edits into a single classify call', async () => {
+    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    const goalInput = screen.getByLabelText('Goal')
+    fireEvent.change(goalInput, { target: { value: 'Fix a' } })
+    await vi.advanceTimersByTimeAsync(300)
+    fireEvent.change(goalInput, { target: { value: 'Fix a bug' } })
+    await vi.advanceTimersByTimeAsync(600)
+
+    expect(classifyMission).toHaveBeenCalledTimes(1)
+    expect(classifyMission).toHaveBeenCalledWith('Fix a bug')
+  })
+
+  it('submits the mission with the classified kind', async () => {
+    vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding' })
+    vi.mocked(createMission).mockResolvedValue({ id: 'm3' })
+    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Fix a bug' } })
+    await vi.advanceTimersByTimeAsync(600)
+    await vi.advanceTimersByTimeAsync(0)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+    await vi.advanceTimersByTimeAsync(0)
+    expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ kind: 'coding' }))
+  })
+
+  it('clicking the chip toggles kind and locks it against further auto-detect', async () => {
+    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Fix a bug' } })
+    await vi.advanceTimersByTimeAsync(600)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(screen.getByText('General · scratch workspace')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('General · scratch workspace'))
+    expect(screen.getByText('Coding · branches from repo')).toBeInTheDocument()
+
+    vi.mocked(classifyMission).mockClear()
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Fix a bug in the app' } })
+    await vi.advanceTimersByTimeAsync(600)
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Locked: the further edit above must not trigger a reclassify.
+    expect(classifyMission).not.toHaveBeenCalled()
+    expect(screen.getByText('Coding · branches from repo')).toBeInTheDocument()
+  })
+})
+
 describe('MissionForm — create mode, repeat on schedule', () => {
-  it('submits a schedule with the slugified default name, preset cron, and research kind', async () => {
+  it('submits a schedule with the slugified default name, preset cron, and general kind', async () => {
     vi.mocked(createSchedule).mockResolvedValue({ id: 'sc1' })
     const onDone = vi.fn()
     render(<MissionForm mode="create" onDone={onDone} onCancel={vi.fn()} />)
@@ -128,7 +205,7 @@ describe('MissionForm — create mode, repeat on schedule', () => {
           cron: '0 7 * * *',
           mission_template: expect.objectContaining({
             goal: 'Check the news every morning',
-            kind: 'research',
+            kind: 'general',
             auto_approve_safe: true,
           }),
         }),
@@ -138,31 +215,46 @@ describe('MissionForm — create mode, repeat on schedule', () => {
     expect(onDone).toHaveBeenCalledWith({ kind: 'schedule', id: 'sc1' })
   })
 
-  it('disables the Coding card while repeating', () => {
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
-
-    fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
-
-    const codingCard = screen.getByRole('button', { name: /^Coding /i }) as HTMLButtonElement
-    expect(codingCard.disabled).toBe(true)
-  })
-
-  it('flips kind back to research when repeat turns on with coding selected', async () => {
+  it('forces kind to general and locks it when repeat turns on with coding selected', async () => {
+    vi.useFakeTimers()
+    vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding' })
     vi.mocked(createSchedule).mockResolvedValue({ id: 'sc1' })
     render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
-    fireEvent.click(screen.getByRole('button', { name: /^Coding /i }))
+    await vi.advanceTimersByTimeAsync(600)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(screen.getByText('Coding · branches from repo')).toBeInTheDocument()
+
     fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
+    expect(screen.getByText('General · scratch workspace')).toBeInTheDocument()
+
+    vi.useRealTimers()
     fireEvent.click(screen.getByRole('button', { name: 'Create schedule' }))
 
     await waitFor(() =>
       expect(createSchedule).toHaveBeenCalledWith(
         expect.objectContaining({
-          mission_template: expect.objectContaining({ kind: 'research' }),
+          mission_template: expect.objectContaining({ kind: 'general' }),
         }),
       ),
     )
+  })
+
+  it('disables the chip toggle while repeating (coding unavailable)', async () => {
+    vi.useFakeTimers()
+    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
+    await vi.advanceTimersByTimeAsync(600)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(screen.getByText('General · scratch workspace')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('General · scratch workspace'))
+    // Still general: the chip toggle no-ops for coding while repeating.
+    expect(screen.getByText('General · scratch workspace')).toBeInTheDocument()
+    vi.useRealTimers()
   })
 
   it('blocks submit on a malformed custom cron shape', async () => {
@@ -204,20 +296,58 @@ describe('MissionForm — create mode, repeat on schedule', () => {
     // Combobox order while repeating: Runs (cron preset), then Agent.
     fireEvent.click(screen.getAllByRole('combobox')[1])
     fireEvent.click(await screen.findByText('briefing'))
-    fireEvent.click(screen.getByText('Show advanced options'))
+    fireEvent.click(screen.getByRole('button', { name: 'Show advanced options' }))
 
-    expect((screen.getByLabelText('Review route') as HTMLInputElement).value).toBe('careful')
+    expect(screen.getByLabelText('Review route')).toHaveTextContent('careful')
+  })
+
+  it('renders route selects fed from the live routes list, excluding disabled routes', async () => {
+    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(await screen.findByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Show advanced options' }))
+    await screen.findByLabelText('Review route')
+
+    fireEvent.click(screen.getByLabelText('Route'))
+    expect(await screen.findByText('careful')).toBeInTheDocument()
+    expect(screen.queryByText('disabled-route')).not.toBeInTheDocument()
+  })
+
+  it('submits the picked route and review route', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm4' })
+    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Fix a bug' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Show advanced options' }))
+    await screen.findByLabelText('Review route')
+
+    fireEvent.click(screen.getByLabelText('Route'))
+    fireEvent.click(await screen.findByText('careful'))
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ route: 'careful' })),
+    )
   })
 })
 
 describe('MissionForm — edit mode', () => {
-  it('prefills from the schedule', async () => {
+  it('prefills from the schedule, chip locked to the template kind', async () => {
     render(<MissionForm mode="edit" schedule={schedule} onDone={vi.fn()} onCancel={vi.fn()} />)
 
     expect(await screen.findByDisplayValue('weekly-digest')).toBeTruthy()
     expect(screen.getByDisplayValue('Summarize the week')).toBeTruthy()
     expect(screen.getByText('Weekdays, 8:00 AM')).toBeTruthy()
-    expect((screen.getByLabelText('Expires') as HTMLInputElement).value).toBe('2026-08-01T12:30')
+    expect(screen.getByLabelText('Expires')).toHaveTextContent('Aug 1, 2026, 12:30')
+    expect(screen.getByText('General · scratch workspace')).toBeInTheDocument()
+    expect(classifyMission).not.toHaveBeenCalled()
+  })
+
+  it('auto-expands Advanced when the schedule has a non-default review route', async () => {
+    render(<MissionForm mode="edit" schedule={schedule} onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await screen.findByDisplayValue('weekly-digest')
+    expect(screen.getByLabelText('Review route')).toBeInTheDocument()
   })
 
   it('preserves the schedule kind in the patch payload and never shows Run once', async () => {
@@ -235,10 +365,47 @@ describe('MissionForm — edit mode', () => {
         's1',
         expect.objectContaining({
           name: 'weekly-digest',
-          mission_template: expect.objectContaining({ kind: 'research' }),
+          mission_template: expect.objectContaining({ kind: 'general' }),
         }),
       ),
     )
     expect(onDone).toHaveBeenCalledWith({ kind: 'schedule', id: 's1' })
+  })
+
+  it('picks a new expiry date from the calendar and submits it', async () => {
+    vi.mocked(patchSchedule).mockResolvedValue(schedule)
+    render(<MissionForm mode="edit" schedule={schedule} onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await screen.findByDisplayValue('weekly-digest')
+    fireEvent.click(screen.getByLabelText('Expires'))
+    fireEvent.click(await screen.findByRole('button', { name: /August 15th, 2026/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save schedule' }))
+
+    await waitFor(() =>
+      expect(patchSchedule).toHaveBeenCalledWith(
+        's1',
+        expect.objectContaining({
+          expires_at: expect.stringContaining('-15T12:30'),
+        }),
+      ),
+    )
+  })
+
+  it('clears the expiry back to never', async () => {
+    vi.mocked(patchSchedule).mockResolvedValue(schedule)
+    render(<MissionForm mode="edit" schedule={schedule} onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await screen.findByDisplayValue('weekly-digest')
+    fireEvent.click(screen.getByLabelText('Expires'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Clear' }))
+    expect(screen.getByLabelText('Expires')).toHaveTextContent('Never')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save schedule' }))
+    await waitFor(() =>
+      expect(patchSchedule).toHaveBeenCalledWith(
+        's1',
+        expect.objectContaining({ expires_at: null }),
+      ),
+    )
   })
 })

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -1,30 +1,79 @@
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { createMission, createSchedule, getSettings, patchSchedule } from '../../api/client'
+import {
+  classifyMission,
+  createMission,
+  createSchedule,
+  getSettings,
+  patchSchedule,
+} from '../../api/client'
 import type { AdminAgent, Schedule } from '../../api/types'
-import { useAgents } from '../AgentPicker'
+import { useAgents, useRoutes } from '../AgentPicker'
 import { slugify } from '../settings/AgentForm'
 import { cronPresets, type CronPresetValue, presetFor } from '../../lib/schedules'
 import { CURRENCIES } from '../../lib/currencies'
+import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
+import { Calendar } from '../ui/calendar'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { Textarea } from '../ui/textarea'
 import { errText } from '../settings/util'
 
-const kinds = [
-  {
-    value: 'research',
-    label: 'Research',
-    description: 'Investigate, gather sources, write findings.',
-  },
-  {
-    value: 'coding',
-    label: 'Coding',
-    description: 'Work a repository: plan, edit, verify.',
-  },
-] as const
+type Kind = 'coding' | 'general'
+
+const kindCopy: Record<Kind, string> = {
+  coding: 'Coding · branches from repo',
+  general: 'General · scratch workspace',
+}
+
+// A schedule's mission_template carries route/review_route/budget as
+// explicit undefined when unset (see types.ts) — "non-default" means
+// any of them, or a non-default agent, actually has a value.
+function hasNonDefaults(t: Schedule['mission_template']): boolean {
+  return !!(t.agent_id || t.route || t.review_route || t.budget_amount != null)
+}
+
+// Radix Select.Item rejects an empty string value, so the "no route
+// chosen" state is represented by this sentinel on the wire between the
+// Select and the route/reviewRoute/escalationRoute state (which stay ''
+// to match the API's own empty-means-default semantics).
+const ROUTE_DEFAULT = '__default__'
+
+// expiresAt is stored as the wire-compatible 'YYYY-MM-DDTHH:mm' string the
+// API already expects; these split it into a Date (for the calendar) and a
+// 'HH:mm' string (for the time input) and back.
+function expiresAtToDate(v: string): Date | undefined {
+  if (!v) return undefined
+  const [datePart, timePart] = v.split('T')
+  const [y, m, d] = datePart.split('-').map(Number)
+  const [h, min] = (timePart ?? '00:00').split(':').map(Number)
+  return new Date(y, m - 1, d, h, min)
+}
+
+function expiresAtToTime(v: string): string {
+  return v.split('T')[1] ?? '00:00'
+}
+
+function dateAndTimeToExpiresAt(date: Date, time: string): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}T${time}`
+}
+
+function formatExpiresAt(v: string): string {
+  const date = expiresAtToDate(v)
+  if (!date) return 'Never'
+  return `${date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })}, ${expiresAtToTime(v)}`
+}
 
 // MissionForm is the shared form behind both the new-mission page and
 // the edit-schedule page. In 'create' mode it submits a one-off
@@ -44,8 +93,16 @@ export function MissionForm({
   onCancel: () => void
 }) {
   const agents = useAgents()
+  const routes = useRoutes()
+  const enabledRoutes = routes?.filter((r) => r.enabled) ?? []
   const [goal, setGoal] = useState('')
-  const [kind, setKind] = useState<(typeof kinds)[number]['value']>('research')
+  const [kind, setKind] = useState<Kind>('general')
+  // kindLocked freezes kind against further auto-classify calls once
+  // the user has explicitly chosen it (chip click, or the repeat-mode
+  // general override below) — cleared when the goal is emptied, which
+  // resets to auto-detect for whatever's typed next.
+  const [kindLocked, setKindLocked] = useState(false)
+  const [classifying, setClassifying] = useState(false)
   const [agentID, setAgentID] = useState('')
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [route, setRoute] = useState('')
@@ -90,9 +147,10 @@ export function MissionForm({
     setPreset(presetFor(schedule.cron))
     setGoal(schedule.mission_template.goal)
     setKind(schedule.mission_template.kind)
+    setKindLocked(true)
     setAgentID(schedule.mission_template.agent_id ?? '')
     setAutoApproveSafe(schedule.mission_template.auto_approve_safe ?? true)
-    setShowAdvanced(false)
+    setShowAdvanced(hasNonDefaults(schedule.mission_template))
     setRoute(schedule.mission_template.route ?? '')
     setReviewRoute(schedule.mission_template.review_route ?? '')
     setMaxIterations(
@@ -110,6 +168,42 @@ export function MissionForm({
     setCronError(null)
   }, [mode, schedule])
 
+  // Live kind inference: debounced 600ms after goal edits, skipped
+  // once the user has locked a manual choice or the goal is empty.
+  // Unlocking on an emptied goal happens in the textarea's onChange
+  // below (a direct user edit), not here — this effect also runs on
+  // mount/schedule-load with the PREVIOUS render's goal, and clearing
+  // the lock from here would race the schedule-seed effect's own
+  // setKindLocked(true) and stomp it back to false.
+  useEffect(() => {
+    if (goal.trim() === '' || kindLocked) return
+    setClassifying(true)
+    const t = setTimeout(() => {
+      classifyMission(goal.trim())
+        .then((r) => setKind(r.kind))
+        .catch(() => {
+          // Best-effort preview: a failed classify leaves whatever kind
+          // was already showing rather than blocking the form.
+        })
+        .finally(() => setClassifying(false))
+    }, 600)
+    return () => {
+      clearTimeout(t)
+      setClassifying(false)
+    }
+  }, [goal, kindLocked])
+
+  const onGoalChange = (v: string) => {
+    setGoal(v)
+    if (v.trim() === '') setKindLocked(false)
+  }
+
+  const toggleKind = () => {
+    if (repeat && kind === 'general') return // coding is unavailable while repeating
+    setKind((k) => (k === 'coding' ? 'general' : 'coding'))
+    setKindLocked(true)
+  }
+
   const pickAgent = (id: string) => {
     setAgentID(id)
     const agent = agents.find((a) => a.id === id)
@@ -123,6 +217,16 @@ export function MissionForm({
     setPreset(v)
     const found = cronPresets.find((p) => p.value === v)
     if (found?.cron) setCron(found.cron)
+  }
+
+  const pickExpiresDate = (date: Date | undefined) => {
+    if (!date) return
+    setExpiresAt(dateAndTimeToExpiresAt(date, expiresAtToTime(expiresAt) || '00:00'))
+  }
+
+  const pickExpiresTime = (time: string) => {
+    const date = expiresAtToDate(expiresAt) ?? new Date()
+    setExpiresAt(dateAndTimeToExpiresAt(date, time))
   }
 
   // A client-side 5-field shape check only — the server is the
@@ -225,7 +329,7 @@ export function MissionForm({
   const submitLabel = mode === 'edit' ? 'Save schedule' : repeat ? 'Create schedule' : 'Create mission'
 
   return (
-    <div className="space-y-8 pb-24">
+    <div className="space-y-8">
       <section className="space-y-3">
         <div>
           <h2 className="text-sm font-semibold">Goal</h2>
@@ -237,34 +341,20 @@ export function MissionForm({
           id="mission-goal"
           aria-label="Goal"
           value={goal}
-          onChange={(e) => setGoal(e.target.value)}
+          onChange={(e) => onGoalChange(e.target.value)}
           placeholder="What should this mission accomplish?"
-          rows={5}
+          rows={10}
           autoFocus
-          className="text-base"
+          className="min-h-60 text-base"
         />
 
-        <div className="grid gap-3 sm:grid-cols-2">
-          {kinds.map((k) => {
-            const disabled = repeat && k.value === 'coding'
-            const selected = kind === k.value
-            return (
-              <button
-                key={k.value}
-                type="button"
-                disabled={disabled}
-                onClick={() => setKind(k.value)}
-                aria-pressed={selected}
-                className={`rounded-lg border p-3 text-left transition disabled:cursor-not-allowed disabled:opacity-50 ${
-                  selected ? 'border-primary bg-accent' : 'border-border hover:bg-muted'
-                }`}
-              >
-                <span className="text-sm font-medium">{k.label}</span>
-                <p className="mt-0.5 text-xs text-muted-foreground">{k.description}</p>
-              </button>
-            )
-          })}
-        </div>
+        {goal.trim() !== '' && (
+          <button type="button" onClick={toggleKind} disabled={repeat && kind === 'general'}>
+            <Badge variant={classifying ? 'outline' : 'secondary'} className="cursor-pointer">
+              {classifying ? 'Detecting…' : kindCopy[kind]}
+            </Badge>
+          </button>
+        )}
         {repeat && (
           <p className="text-xs text-muted-foreground">
             Coding missions aren't supported on a recurring schedule yet: each fire has no
@@ -299,7 +389,10 @@ export function MissionForm({
               type="button"
               onClick={() => {
                 setRepeat(true)
-                if (kind === 'coding') setKind('research')
+                if (kind === 'coding') {
+                  setKind('general')
+                  setKindLocked(true)
+                }
               }}
               aria-pressed={repeat}
               className={`rounded-md px-3 py-1.5 font-medium transition ${
@@ -350,24 +443,34 @@ export function MissionForm({
             </div>
 
             <div className="space-y-1.5">
-              <Label htmlFor="mission-max-iterations">Max iterations</Label>
-              <Input
-                id="mission-max-iterations"
-                type="number"
-                value={maxIterations}
-                onChange={(e) => setMaxIterations(e.target.value)}
-                placeholder="Default"
-              />
-            </div>
-
-            <div className="space-y-1.5">
               <Label htmlFor="mission-expires">Expires</Label>
-              <Input
-                id="mission-expires"
-                type="datetime-local"
-                value={expiresAt}
-                onChange={(e) => setExpiresAt(e.target.value)}
-              />
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button id="mission-expires" variant="outline" className="w-full justify-start">
+                    {formatExpiresAt(expiresAt)}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0">
+                  <Calendar
+                    mode="single"
+                    selected={expiresAtToDate(expiresAt)}
+                    onSelect={pickExpiresDate}
+                  />
+                  <div className="flex items-center gap-2 border-t border-border p-2.5">
+                    <Input
+                      aria-label="Expires time"
+                      type="time"
+                      value={expiresAtToTime(expiresAt)}
+                      onChange={(e) => pickExpiresTime(e.target.value)}
+                      disabled={!expiresAt}
+                      className="flex-1"
+                    />
+                    <Button variant="outline" size="sm" onClick={() => setExpiresAt('')}>
+                      Clear
+                    </Button>
+                  </div>
+                </PopoverContent>
+              </Popover>
               <p className="text-xs text-muted-foreground">
                 Server time. The schedule stops firing after this moment. Empty means it never
                 expires.
@@ -401,102 +504,166 @@ export function MissionForm({
           </div>
         )}
 
-        <button
-          type="button"
-          onClick={() => setShowAdvanced((v) => !v)}
-          className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
-        >
-          {showAdvanced ? 'Hide advanced options' : 'Show advanced options'}
-        </button>
-
-        {showAdvanced && (
-          <div className="grid gap-4 rounded-lg border border-border p-4 sm:grid-cols-2">
-            <div className="space-y-1.5">
-              <Label htmlFor="mission-route">Route</Label>
-              <Input
-                id="mission-route"
-                value={route}
-                onChange={(e) => setRoute(e.target.value)}
-                placeholder="default"
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="mission-review-route">Review route</Label>
-              <Input
-                id="mission-review-route"
-                value={reviewRoute}
-                onChange={(e) => setReviewRoute(e.target.value)}
-                placeholder="default"
-              />
-            </div>
-            {mode === 'create' && !repeat && (
+        <Collapsible open={showAdvanced} onOpenChange={setShowAdvanced}>
+          <CollapsibleTrigger className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground">
+            {showAdvanced ? 'Hide advanced options' : 'Show advanced options'}
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="mt-3 grid gap-4 rounded-lg border border-border p-4 sm:grid-cols-2">
               <div className="space-y-1.5">
-                <Label htmlFor="mission-escalation-route">Escalation route</Label>
-                <Input
-                  id="mission-escalation-route"
-                  value={escalationRoute}
-                  onChange={(e) => setEscalationRoute(e.target.value)}
-                  placeholder="Off, set to switch route after a failed or reworked turn"
-                />
+                <Label htmlFor="mission-route">Route</Label>
+                {routes === null ? (
+                  <Input
+                    id="mission-route"
+                    value={route}
+                    onChange={(e) => setRoute(e.target.value)}
+                    placeholder="default"
+                  />
+                ) : (
+                  <Select
+                    value={route || ROUTE_DEFAULT}
+                    onValueChange={(v) => setRoute(v === ROUTE_DEFAULT ? '' : v)}
+                  >
+                    <SelectTrigger id="mission-route" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={ROUTE_DEFAULT}>Default</SelectItem>
+                      {enabledRoutes.map((r) => (
+                        <SelectItem key={r.name} value={r.name}>
+                          {r.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
               </div>
-            )}
-            <div className="space-y-1.5">
-              <Label htmlFor="mission-budget">Budget</Label>
-              <div className="flex gap-2">
-                <Input
-                  id="mission-budget"
-                  type="number"
-                  value={budget}
-                  onChange={(e) => setBudget(e.target.value)}
-                  placeholder="No limit"
-                  className="flex-1"
-                />
-                <Select value={budgetCurrency} onValueChange={setBudgetCurrency}>
-                  <SelectTrigger className="w-24" aria-label="Budget currency">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {CURRENCIES.map((c) => (
-                      <SelectItem key={c} value={c}>
-                        {c}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+              <div className="space-y-1.5">
+                <Label htmlFor="mission-review-route">Review route</Label>
+                {routes === null ? (
+                  <Input
+                    id="mission-review-route"
+                    value={reviewRoute}
+                    onChange={(e) => setReviewRoute(e.target.value)}
+                    placeholder="default"
+                  />
+                ) : (
+                  <Select
+                    value={reviewRoute || ROUTE_DEFAULT}
+                    onValueChange={(v) => setReviewRoute(v === ROUTE_DEFAULT ? '' : v)}
+                  >
+                    <SelectTrigger id="mission-review-route" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={ROUTE_DEFAULT}>Default</SelectItem>
+                      {enabledRoutes.map((r) => (
+                        <SelectItem key={r.name} value={r.name}>
+                          {r.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
               </div>
-            </div>
-            <label
-              htmlFor="mission-auto-approve"
-              className="flex items-start gap-2 text-sm sm:col-span-2"
-            >
-              <input
-                id="mission-auto-approve"
-                type="checkbox"
-                checked={autoApproveSafe}
-                onChange={(e) => setAutoApproveSafe(e.target.checked)}
-                className="mt-0.5"
-              />
-              <span>
-                Auto-approve safe tool calls
-                <span className="block text-xs text-muted-foreground">
-                  Runs unattended without pausing for approval on routine commands. Destructive or
-                  unrecognized commands still always ask.
+              {mode === 'create' && !repeat && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="mission-escalation-route">Escalation route</Label>
+                  {routes === null ? (
+                    <Input
+                      id="mission-escalation-route"
+                      value={escalationRoute}
+                      onChange={(e) => setEscalationRoute(e.target.value)}
+                      placeholder="Off, set to switch route after a failed or reworked turn"
+                    />
+                  ) : (
+                    <Select
+                      value={escalationRoute || ROUTE_DEFAULT}
+                      onValueChange={(v) => setEscalationRoute(v === ROUTE_DEFAULT ? '' : v)}
+                    >
+                      <SelectTrigger id="mission-escalation-route" className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value={ROUTE_DEFAULT}>Off</SelectItem>
+                        {enabledRoutes.map((r) => (
+                          <SelectItem key={r.name} value={r.name}>
+                            {r.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                </div>
+              )}
+              <div className="space-y-1.5">
+                <Label htmlFor="mission-budget">Budget</Label>
+                <div className="flex gap-2">
+                  <Input
+                    id="mission-budget"
+                    type="number"
+                    value={budget}
+                    onChange={(e) => setBudget(e.target.value)}
+                    placeholder="No limit"
+                    className="flex-1"
+                  />
+                  <Select value={budgetCurrency} onValueChange={setBudgetCurrency}>
+                    <SelectTrigger className="w-24" aria-label="Budget currency">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {CURRENCIES.map((c) => (
+                        <SelectItem key={c} value={c}>
+                          {c}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              {repeat && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="mission-max-iterations">Max iterations</Label>
+                  <Input
+                    id="mission-max-iterations"
+                    type="number"
+                    value={maxIterations}
+                    onChange={(e) => setMaxIterations(e.target.value)}
+                    placeholder="Default"
+                  />
+                </div>
+              )}
+              <label
+                htmlFor="mission-auto-approve"
+                className="flex items-start gap-2 text-sm sm:col-span-2"
+              >
+                <input
+                  id="mission-auto-approve"
+                  type="checkbox"
+                  checked={autoApproveSafe}
+                  onChange={(e) => setAutoApproveSafe(e.target.checked)}
+                  className="mt-0.5"
+                />
+                <span>
+                  Auto-approve safe tool calls
+                  <span className="block text-xs text-muted-foreground">
+                    Runs unattended without pausing for approval on routine commands. Destructive
+                    or unrecognized commands still always ask.
+                  </span>
                 </span>
-              </span>
-            </label>
-          </div>
-        )}
+              </label>
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
       </section>
 
-      <div className="fixed inset-x-0 bottom-0 border-t border-border bg-background/95 backdrop-blur">
-        <div className="mx-auto flex max-w-3xl justify-end gap-2 px-4 py-3">
-          <Button variant="outline" disabled={busy} onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button disabled={!canSubmit || busy} onClick={() => void submit()}>
-            {submitLabel}
-          </Button>
-        </div>
+      <div className="flex gap-2">
+        <Button variant="outline" disabled={busy} onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button disabled={!canSubmit || busy} onClick={() => void submit()}>
+          {submitLabel}
+        </Button>
       </div>
     </div>
   )

--- a/web/src/components/missions/RecurringSchedules.test.tsx
+++ b/web/src/components/missions/RecurringSchedules.test.tsx
@@ -18,7 +18,7 @@ const schedule: Schedule = {
   id: 's1',
   name: 'weekly-digest',
   cron: '0 8 * * 1-5',
-  mission_template: { goal: 'Summarize the week', kind: 'research', auto_approve_safe: true },
+  mission_template: { goal: 'Summarize the week', kind: 'general', auto_approve_safe: true },
   enabled: true,
   next_run: '2026-07-27T08:00:00Z',
   created_at: '2026-07-01T00:00:00Z',

--- a/web/src/components/settings/AgentEdit.test.tsx
+++ b/web/src/components/settings/AgentEdit.test.tsx
@@ -59,7 +59,13 @@ describe('AgentEdit', () => {
     // in useAgentForm, these stay blank/default forever.
     expect(await screen.findByDisplayValue(coder.description)).toBeTruthy()
     expect(screen.getByDisplayValue(coder.prompt_overlay)).toBeTruthy()
-    expect(screen.getByDisplayValue('coding-task')).toBeTruthy()
     expect(screen.getByRole('combobox', { name: 'agent route' })).toHaveTextContent('coding')
+  })
+
+  it('does not show a skills allowlist field', async () => {
+    renderEdit()
+
+    await screen.findByDisplayValue(coder.description)
+    expect(screen.queryByText('Skills allowlist')).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/settings/AgentForm.tsx
+++ b/web/src/components/settings/AgentForm.tsx
@@ -147,14 +147,6 @@ export function AgentForm({
           </div>
         </Field>
       </div>
-      <Field label="Skills allowlist" hint="comma-separated; empty = all">
-        <Input
-          value={fields.skillsText}
-          onChange={(e) => fields.setSkillsText(e.target.value)}
-          placeholder="coding-task, research-task"
-          className="mt-1.5 h-10"
-        />
-      </Field>
       <Field label="Tools allowlist" hint="pick from the live tool surface; empty = all">
         <ToolsPicker value={fields.tools} onChange={fields.setTools} />
       </Field>

--- a/web/src/components/ui/calendar.tsx
+++ b/web/src/components/ui/calendar.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import * as React from "react"
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react"
+import { DayPicker } from "react-day-picker"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: React.ComponentProps<typeof DayPicker>) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn("p-3", className)}
+      classNames={{
+        months: "flex flex-col sm:flex-row gap-2",
+        month: "flex flex-col gap-4",
+        month_caption: "flex justify-center pt-1 relative items-center w-full",
+        caption_label: "text-sm font-medium",
+        nav: "flex items-center justify-between absolute inset-x-0 top-0",
+        button_previous: cn(
+          buttonVariants({ variant: "outline", size: "icon-sm" }),
+          "size-7 bg-transparent p-0"
+        ),
+        button_next: cn(
+          buttonVariants({ variant: "outline", size: "icon-sm" }),
+          "size-7 bg-transparent p-0"
+        ),
+        month_grid: "w-full border-collapse space-y-1",
+        weekdays: "flex",
+        weekday: "text-muted-foreground rounded-md w-8 font-normal text-xs",
+        week: "flex w-full mt-2",
+        day: "text-center text-sm p-0 relative",
+        day_button: cn(
+          buttonVariants({ variant: "ghost" }),
+          "size-8 rounded-md p-0 font-normal aria-selected:opacity-100"
+        ),
+        range_end: "day-range-end",
+        selected:
+          "bg-brand text-brand-foreground hover:bg-brand hover:text-brand-foreground focus:bg-brand focus:text-brand-foreground",
+        today: "bg-muted text-foreground",
+        outside:
+          "day-outside text-muted-foreground aria-selected:text-muted-foreground",
+        disabled: "text-muted-foreground opacity-50",
+        hidden: "invisible",
+        ...classNames,
+      }}
+      components={{
+        Chevron: ({ orientation }) => {
+          const Icon = orientation === "left" ? ChevronLeftIcon : ChevronRightIcon
+          return <Icon className="size-4" />
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Calendar }

--- a/web/src/components/ui/collapsible.tsx
+++ b/web/src/components/ui/collapsible.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import { Collapsible as CollapsiblePrimitive } from "radix-ui"
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Trigger>) {
+  return (
+    <CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />
+  )
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Content>) {
+  return (
+    <CollapsiblePrimitive.Content data-slot="collapsible-content" {...props} />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -282,6 +282,29 @@ describe('MissionDetail', () => {
     expect(screen.queryByText(/Allow/)).toBeNull()
   })
 
+  it('omits the Explore section when explore_notes is absent', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(screen.queryByText('Explore')).toBeNull()
+  })
+
+  it('shows a collapsed Explore section above Plan when explore_notes is set', async () => {
+    vi.mocked(getMission).mockResolvedValue({
+      ...baseMission,
+      explore_notes: 'found **three** prior approaches',
+    })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+
+    const headings = screen.getAllByRole('heading', { level: 2 }).map((h) => h.textContent)
+    expect(headings.indexOf('Explore')).toBeGreaterThanOrEqual(0)
+    expect(headings.indexOf('Explore')).toBeLessThan(headings.indexOf('Plan'))
+    expect(screen.queryByText('three')).toBeNull()
+
+    fireEvent.click(screen.getByText('Show exploration'))
+    expect(screen.getByText('three').tagName).toBe('STRONG')
+  })
+
   it('shows the permission banner with tool detail when pending_permission is set', async () => {
     vi.mocked(getMission).mockResolvedValue({
       ...baseMission,
@@ -582,7 +605,7 @@ describe('MissionDetail', () => {
         id: 'sc1',
         name: 'daily-brief',
         cron: '0 7 * * *',
-        mission_template: { goal: 'brief', kind: 'research' },
+        mission_template: { goal: 'brief', kind: 'general' },
         enabled: true,
         next_run: '2026-01-02T07:00:00Z',
         created_at: '2026-01-01T00:00:00Z',

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -18,6 +18,7 @@ import { ArtifactsSection } from '../components/missions/ArtifactsSection'
 import { PermissionBanner } from '../components/missions/PermissionBanner'
 import { PlanSection } from '../components/missions/PlanSection'
 import { ProgressSection } from '../components/missions/ProgressSection'
+import { ExploreSection } from '../components/missions/ExploreSection'
 import { ResultSection } from '../components/missions/ResultSection'
 import { TimelineSection } from '../components/missions/TimelineSection'
 import { Button } from '../components/ui/button'
@@ -421,6 +422,13 @@ export function MissionDetail() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {mission.explore_notes && (
+        <section>
+          <h2 className="mb-2 text-sm font-semibold tracking-tight">Explore</h2>
+          <ExploreSection notes={mission.explore_notes} />
+        </section>
+      )}
 
       <section>
         <h2 className="mb-2 text-sm font-semibold tracking-tight">Plan</h2>

--- a/web/src/pages/Missions.test.tsx
+++ b/web/src/pages/Missions.test.tsx
@@ -34,7 +34,7 @@ function captureSubscribe() {
 const mission: Mission = {
   id: 'm1',
   goal: 'Fix the login bug',
-  kind: 'research',
+  kind: 'general',
   phase: 'execute',
   status: 'working',
   spec: { units: [] },


### PR DESCRIPTION
## Summary

- Real explore phase: tool-using pre-plan session (base tools + mission sandbox shell, no write_file) whose findings persist on the mission and feed the planner; advisory sentinel with recovery ladder and raw-text fallback
- Mission kind simplified to `coding|general`: the only behavioral fork is worktree vs plain folder; `scheduled` was dead; the research kind/phase name collision is gone (phase renamed explore)
- Kind auto-classified from the goal (optional on create, `POST /v1/missions/classify` for the form's live preview), biased to coding on ambiguity
- ClassifyOverGateway token cap 20 → 512: thinking models burned the whole cap in reasoning, breaking classification and chat auto-dispatch
- Goal-first mission form: classify chip replaces kind cards, agent/routes/budget in a collapsed Advanced section, route selects fed by the live route list, calendar+time Expires picker, exploration section on mission detail

## Testing

- make build vet lint test green (lint 0 issues, race on)
- web: 440 tests / 47 files green
- make canary PASS (three runs across the arc; caught a real permission-exemption bug)
- Live: explore mission researched web sources end-to-end, classify verified against coding/general/ambiguous goals

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788650231&installation_model_id=431401&pr_number=185&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F185&signature=45fbf47dbae80a1a06c61cc89f1d26ab5ad9a7fa623f20fc3500f172ee10ff3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->