### PR TITLE
feat: verify regression gate, replan-on-stall, quoted-regex guard fix

### DIFF
--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -523,7 +523,7 @@ func (d *Driver) toStepState(ctx context.Context, m Mission) StepState {
 		ConsecutiveFailures: m.ConsecutiveFailures, LastGapFingerprint: m.LastGapFingerprint,
 		StallCount: m.StallCount, Spent: spent, Budget: m.BudgetAmount,
 		MixedCurrencySpend: mixed, RateAsOf: rateAsOf,
-		LastUnit: isLastUnit(m.Spec),
+		LastUnit: isLastUnit(m.Spec), ReplanUsed: m.ReplanUsed,
 	}
 }
 
@@ -630,17 +630,81 @@ func (d *Driver) runExplore(ctx context.Context, m Mission) (StepInput, error) {
 }
 
 func (d *Driver) runPlan(ctx context.Context, m Mission) (StepInput, error) {
-	spec, err := d.runner.PlanSession(ctx, m, m.ExploreNotes)
+	priorSpec := m.Spec
+	spec, err := d.runner.PlanSession(ctx, m, replanNotes(m))
 	if err != nil {
 		return StepInput{}, err
 	}
 	if err := d.store.AppendEvent(ctx, m.ID, "mission.plan_created", map[string]any{"units": len(spec.Units)}); err != nil {
 		return StepInput{}, fmt.Errorf("driver: record plan: %w", err)
 	}
+	if m.ReplanUsed {
+		// Carry forward prior harness evidence: a unit the new plan kept
+		// unchanged (same title, same verify_cmd) and that had already
+		// passed stays passed — the planner's own parseSpec forces every
+		// unit to passes=false, since it can't itself claim pre-verified.
+		restorePassedUnits(&spec, priorSpec)
+	}
 	if err := d.store.SetSpec(ctx, m.ID, spec); err != nil {
 		return StepInput{}, err
 	}
 	return StepInput{Input: InputPhaseComplete}, nil
+}
+
+// replanNotes extends the planner's exploreNotes input with what
+// stalled, on a replan only — first-time planning passes m.ExploreNotes
+// through unchanged. Folded into the existing exploreNotes string
+// argument (rather than a new Runner parameter) so PlanSession's
+// interface never has to change for this feature.
+func replanNotes(m Mission) string {
+	if !m.ReplanUsed || len(m.Spec.Units) == 0 {
+		return m.ExploreNotes
+	}
+	var b strings.Builder
+	b.WriteString(m.ExploreNotes)
+	b.WriteString("\n\nThe previous plan stalled and is being replanned. Current plan:\n")
+	for _, u := range m.Spec.Units {
+		status := "pending"
+		if u.Passes {
+			status = "verified"
+		}
+		fmt.Fprintf(&b, "- [%s] %s\n", status, u.Title)
+	}
+	if notes := recentProgressNotes(m.Progress, 3); notes != "" {
+		b.WriteString("\nRecent progress:\n")
+		b.WriteString(notes)
+	}
+	b.WriteString("\nKeep verified units unchanged, restructure or fix the rest.")
+	return b.String()
+}
+
+// recentProgressNotes renders the last n progress notes, oldest first.
+func recentProgressNotes(notes []ProgressNote, n int) string {
+	if len(notes) > n {
+		notes = notes[len(notes)-n:]
+	}
+	var b strings.Builder
+	for _, note := range notes {
+		fmt.Fprintf(&b, "- %s\n", note.Note)
+	}
+	return b.String()
+}
+
+// restorePassedUnits re-marks spec's units passed when a prior unit
+// with the exact same title and verify_cmd had already passed — harness
+// evidence a replan must not silently erase for work it didn't touch.
+func restorePassedUnits(spec *Spec, prior Spec) {
+	passed := make(map[string]bool, len(prior.Units))
+	for _, u := range prior.Units {
+		if u.Passes {
+			passed[u.Title+"\x00"+u.VerifyCmd] = true
+		}
+	}
+	for i := range spec.Units {
+		if passed[spec.Units[i].Title+"\x00"+spec.Units[i].VerifyCmd] {
+			spec.Units[i].Passes = true
+		}
+	}
 }
 
 func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
@@ -730,12 +794,75 @@ func (d *Driver) trySkipReview(ctx context.Context, m Mission) (StepInput, bool)
 		d.log.Warn("driver: pre-review verify errored; falling back to review", "mission_id", m.ID, "error", err)
 		return StepInput{}, false
 	}
+	if in, regressed := d.checkRegressions(ctx, m); regressed {
+		return in, true
+	}
 	if err := d.store.AppendEvent(ctx, m.ID, "mission.review_skipped", map[string]any{
 		"unit": idx, "reason": "artifacts and verify_cmd passed harness checks",
 	}); err != nil {
 		d.log.Warn("driver: record review skip failed", "mission_id", m.ID, "error", err)
 	}
 	return StepInput{Input: InputReviewApprove}, true
+}
+
+// checkRegressions re-verifies every unit that had ALREADY passed
+// (excluding whichever unit the caller just verified) after a unit's
+// own verify_cmd/CheckArtifacts just succeeded — a later unit's work
+// can silently break an earlier unit's artifacts, and passes today
+// only ever moves forward, never re-checked. Cheap and deterministic
+// (harness-side shell, same as verifyCurrentUnit), capped at the
+// spec's own unit count. Re-fetches the mission first: verifyCurrentUnit's
+// SetSpec write is not reflected in the caller's in-memory m.
+func (d *Driver) checkRegressions(ctx context.Context, m Mission) (StepInput, bool) {
+	fresh, err := d.store.Get(ctx, m.ID)
+	if err != nil {
+		d.log.Warn("driver: regression check reload failed", "mission_id", m.ID, "error", err)
+		return StepInput{}, false
+	}
+	workRoot := fresh.WorkRoot()
+	for i, u := range fresh.Spec.Units {
+		if !u.Passes {
+			continue
+		}
+		if problems := CheckArtifacts(workRoot, u.Artifacts); len(problems) > 0 {
+			return d.regressed(ctx, fresh, i, "artifacts", strings.Join(problems, "\n"))
+		}
+		if u.VerifyCmd == "" {
+			continue
+		}
+		res, err := d.runVerify(ctx, fresh.ID, workRoot, u.VerifyCmd)
+		if err != nil {
+			d.log.Warn("driver: regression re-verify errored", "mission_id", fresh.ID, "unit", i, "error", err)
+			continue
+		}
+		if !res.Passed {
+			return d.regressed(ctx, fresh, i, "verify_cmd", res.Excerpt)
+		}
+	}
+	return StepInput{}, false
+}
+
+// regressed flips a previously-passed unit back to unverified, records
+// mission.regression, and returns the same StepInput shape a failed
+// current-unit verify produces — the existing worker-retry/stall
+// machinery drives the fix with zero statemachine changes.
+func (d *Driver) regressed(ctx context.Context, m Mission, unit int, check, excerpt string) (StepInput, bool) {
+	units := make([]PlanUnit, len(m.Spec.Units))
+	copy(units, m.Spec.Units)
+	title := units[unit].Title
+	units[unit].Passes = false
+	if err := d.store.SetSpec(ctx, m.ID, Spec{Units: units}); err != nil {
+		d.log.Warn("driver: record regression spec write failed", "mission_id", m.ID, "error", err)
+	}
+	if err := d.store.AppendEvent(ctx, m.ID, "mission.regression", map[string]any{"unit": title, "check": check}); err != nil {
+		d.log.Warn("driver: record regression event failed", "mission_id", m.ID, "error", err)
+	}
+	note := fmt.Sprintf("Regression: unit %q, previously verified, now fails its %s check:\n%s", title, check, excerpt)
+	if err := d.recordProgress(ctx, m.ID, note); err != nil {
+		d.log.Warn("driver: record regression progress note failed", "mission_id", m.ID, "error", err)
+	}
+	fp := "regression:" + title
+	return StepInput{Input: InputWorkerRetry, Reason: truncate(note, 500), GapFingerprint: fp}, true
 }
 
 // currentUnit returns the plan's first unverified unit and its index,
@@ -816,6 +943,9 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 				return StepInput{Input: InputReviewRework, GapFingerprint: fp}, nil
 			}
 			return StepInput{Input: InputReviewInfraFailure}, err
+		}
+		if in, regressed := d.checkRegressions(ctx, m); regressed {
+			return in, nil
 		}
 		return StepInput{Input: InputReviewApprove}, nil
 	}

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -103,6 +103,7 @@ func (f *fakeStore) ApplyTransition(ctx context.Context, id string, t Transition
 	m.Phase, m.Status, m.PauseReason = t.Next.Phase, t.Next.Status, t.Next.PauseReason
 	m.Iteration, m.MaxIterations = t.Next.Iteration, t.Next.MaxIterations
 	m.ConsecutiveFailures, m.LastGapFingerprint, m.StallCount = t.Next.ConsecutiveFailures, t.Next.LastGapFingerprint, t.Next.StallCount
+	m.ReplanUsed = t.Next.ReplanUsed
 	f.missions[id] = m
 	for _, ev := range t.Events {
 		f.seq[id]++
@@ -314,7 +315,7 @@ func TestDriverExploreStoresNotesAndAdvances(t *testing.T) {
 	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{
 		exploreNotes: []string{"no prior implementation exists; goal is self-contained"},
-		plans:         []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		plans:        []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 	}
 	d := testDriver(store, runner)
 
@@ -349,7 +350,7 @@ func TestDriverExploreTruncatesLongNotes(t *testing.T) {
 	long := strings.Repeat("x", exploreNotesCap+500)
 	runner := &scriptedRunner{
 		exploreNotes: []string{long},
-		plans:         []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		plans:        []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 	}
 	d := testDriver(store, runner)
 
@@ -394,7 +395,7 @@ func TestDriverPlanReceivesStoredExploreNotes(t *testing.T) {
 	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{
 		exploreNotes: []string{"found a reusable config loader in internal/platform/config"},
-		plans:         []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		plans:        []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 	}
 	d := testDriver(store, runner)
 
@@ -502,8 +503,11 @@ func TestDriverWorkerRetryDoesNotCountTowardBackoff(t *testing.T) {
 
 func TestDriverStallPauseOnIdenticalFindingsTwice(t *testing.T) {
 	store := newFakeStore()
+	// ReplanUsed is pre-set true so the stall's first threshold hit
+	// pauses like it always did — the replan-on-first-stall behavior is
+	// covered separately by TestDriverReplanOnFirstStall.
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Phase: PhaseReview, Status: StatusWorking, MaxIterations: 8,
+		ID: "m1", Kind: "general", Phase: PhaseReview, Status: StatusWorking, MaxIterations: 8, ReplanUsed: true,
 		Spec: Spec{Units: []PlanUnit{{Title: "u1"}}},
 	})
 	sameFindings := []Finding{{Title: "missing validation", File: "x.go"}}
@@ -531,6 +535,55 @@ func TestDriverStallPauseOnIdenticalFindingsTwice(t *testing.T) {
 	m, _ = store.Get(context.Background(), "m1")
 	if m.Status != StatusPaused || m.PauseReason != PauseNoProgress {
 		t.Fatalf("mission after 2 identical-fingerprint reworks = %+v, want paused/no_progress", m)
+	}
+}
+
+// TestDriverReplanOnFirstStall confirms a mission's FIRST stall (two
+// identical-fingerprint reworks, ReplanUsed still false) goes back to
+// planning instead of pausing — the driver-level counterpart of
+// statemachine_test.go's pure Step assertion, exercised through real
+// Advance calls so the plan phase's own re-run (via runPlan) is covered
+// too.
+func TestDriverReplanOnFirstStall(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseReview, Status: StatusWorking, MaxIterations: 8,
+		Spec: Spec{Units: []PlanUnit{{Title: "u1"}}},
+	})
+	sameFindings := []Finding{{Title: "missing validation", File: "x.go"}}
+	runner := &scriptedRunner{
+		reviewVerdicts: []ReviewVerdict{{Approved: false, Findings: sameFindings}},
+		plans:          []Spec{{Units: []PlanUnit{{Title: "u1 replanned"}}}},
+	}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance 1: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	m.Phase = PhaseReview
+	store.put("m1", m)
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance 2: %v", err)
+	}
+	m, _ = store.Get(context.Background(), "m1")
+	if m.Status == StatusPaused {
+		t.Fatalf("mission after the FIRST stall = %+v, want a replan, not a pause", m)
+	}
+	if !m.ReplanUsed {
+		t.Fatal("ReplanUsed = false after a replan, want true")
+	}
+	if m.Phase != PhasePlan && m.Phase != PhaseExecute {
+		t.Fatalf("mission phase after replan = %q, want plan (or execute once the plan phase ran)", m.Phase)
+	}
+	found := false
+	for _, ev := range store.events["m1"] {
+		if ev.Kind == "mission.replan" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected a mission.replan event")
 	}
 }
 
@@ -1096,6 +1149,192 @@ func TestDriverArtifactCheckBlocksTautologicalDone(t *testing.T) {
 	}
 }
 
+// TestDriverRegressionFlipsUnitAndRetriesInsteadOfAdvancing reproduces
+// the fix: a unit that already passed can silently break while a LATER
+// unit's work is happening. Unit 0's artifact ("a.md") passed
+// previously; before the driver verifies unit 1, a.md gets deleted (as
+// if the worker's unit-1 changes broke it). The regression check must
+// catch this at the point unit 1's own verify succeeds, flip unit 0's
+// Passes back to false, emit mission.regression, and route back to
+// execute (worker_retry) instead of letting the mission advance to
+// review for unit 1.
+func TestDriverRegressionFlipsUnitAndRetriesInsteadOfAdvancing(t *testing.T) {
+	root := t.TempDir()
+	aPath := filepath.Join(root, "a.md")
+	if err := os.WriteFile(aPath, []byte("unit 0 content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "b.md"), []byte("unit 1 content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking,
+		MaxIterations: 8, Workspace: root,
+		Spec: Spec{Units: []PlanUnit{
+			{Title: "unit0", Artifacts: []string{"a.md"}, Passes: true},
+			{Title: "unit1", Artifacts: []string{"b.md"}},
+		}},
+	})
+	// Simulate unit 1's work having broken unit 0's artifact by the time
+	// the harness re-checks it: delete a.md right before the driver runs.
+	if err := os.Remove(aPath); err != nil {
+		t.Fatal(err)
+	}
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote b.md"}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseExecute {
+		t.Fatalf("mission phase = %q, want execute (regression routes back to work, not forward)", m.Phase)
+	}
+	if m.Spec.Units[0].Passes {
+		t.Fatal("unit 0's Passes was not flipped back to false after its artifact regressed")
+	}
+	found := false
+	for _, ev := range store.events["m1"] {
+		if ev.Kind == "mission.regression" {
+			found = true
+			if !strings.Contains(string(ev.Payload), `"unit":"unit0"`) || !strings.Contains(string(ev.Payload), `"check":"artifacts"`) {
+				t.Fatalf("mission.regression payload = %s, want unit=unit0 check=artifacts", ev.Payload)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected a mission.regression event")
+	}
+	if m.Iteration == 0 {
+		t.Fatal("a regression must cost an iteration via worker_retry, same as any other rework")
+	}
+}
+
+// TestDriverNoRegressionAdvancesNormally confirms the regression check
+// is a no-op — same phase progression as before this feature — when
+// every previously-passed unit still holds up.
+func TestDriverNoRegressionAdvancesNormally(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.md"), []byte("unit 0 content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "b.md"), []byte("unit 1 content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking,
+		MaxIterations: 8, Workspace: root,
+		Spec: Spec{Units: []PlanUnit{
+			{Title: "unit0", Artifacts: []string{"a.md"}, Passes: true},
+			{Title: "unit1", Artifacts: []string{"b.md"}},
+		}},
+	})
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote b.md"}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if !m.Spec.Units[1].Passes {
+		t.Fatal("unit 1 should have passed with no regression detected")
+	}
+	if !m.Spec.Units[0].Passes {
+		t.Fatal("unit 0 must remain passed when its artifact still holds up")
+	}
+	for _, ev := range store.events["m1"] {
+		if ev.Kind == "mission.regression" {
+			t.Fatal("no regression event expected when nothing regressed")
+		}
+	}
+}
+
+// TestDriverReplanPreservesMatchingPassedUnitsResetsOthers confirms
+// runPlan's restorePassedUnits: after a replan, a unit whose title and
+// verify_cmd are unchanged from a previously-passed unit is re-marked
+// passed (harness evidence carried forward); a unit the new plan
+// changed (or that is genuinely new) stays unverified, since
+// parseSpec's own zeroing is correct for anything actually different.
+func TestDriverReplanPreservesMatchingPassedUnitsResetsOthers(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhasePlan, Status: StatusIdle,
+		MaxIterations: 8, ReplanUsed: true,
+		Spec: Spec{Units: []PlanUnit{
+			{Title: "unit0", VerifyCmd: "test -f a.md", Passes: true},
+			{Title: "unit1", VerifyCmd: "test -f b.md", Passes: false},
+		}},
+	})
+	runner := &scriptedRunner{plans: []Spec{{Units: []PlanUnit{
+		{Title: "unit0", VerifyCmd: "test -f a.md"}, // unchanged: must be restored to passed
+		{Title: "unit1", VerifyCmd: "test -f c.md"}, // verify_cmd changed: must stay unverified
+	}}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if !m.Spec.Units[0].Passes {
+		t.Fatal("unit0 (title+verify_cmd unchanged) should have been restored to passed")
+	}
+	if m.Spec.Units[1].Passes {
+		t.Fatal("unit1 (verify_cmd changed) must stay unverified")
+	}
+}
+
+// TestDriverReplanPromptCarriesStallContext confirms runPlan feeds the
+// planner an augmented exploreNotes on a replan: current plan status
+// and recent progress, plus the "previous plan stalled" instruction —
+// not just the bare explore notes a first-time plan gets.
+func TestDriverReplanPromptCarriesStallContext(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhasePlan, Status: StatusIdle,
+		MaxIterations: 8, ReplanUsed: true, ExploreNotes: "original findings",
+		Progress: []ProgressNote{{Note: "tried approach A, failed"}},
+		Spec:     Spec{Units: []PlanUnit{{Title: "unit0", Passes: true}}},
+	})
+	runner := &scriptedRunner{plans: []Spec{{Units: []PlanUnit{{Title: "unit0"}}}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if len(runner.planExploreNotes) != 1 {
+		t.Fatalf("PlanSession call count = %d, want 1", len(runner.planExploreNotes))
+	}
+	got := runner.planExploreNotes[0]
+	for _, want := range []string{"original findings", "previous plan stalled", "tried approach A, failed", "unit0"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("replan prompt = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+// TestDriverFirstPlanDoesNotGetReplanNotes confirms a mission's very
+// first planning pass (ReplanUsed false) passes exploreNotes through
+// unchanged — no stall framing for a plan that never stalled.
+func TestDriverFirstPlanDoesNotGetReplanNotes(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhasePlan, Status: StatusIdle,
+		MaxIterations: 8, ExploreNotes: "original findings",
+	})
+	runner := &scriptedRunner{plans: []Spec{{Units: []PlanUnit{{Title: "unit0"}}}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if got := runner.planExploreNotes[0]; got != "original findings" {
+		t.Fatalf("first-plan exploreNotes = %q, want unchanged %q", got, "original findings")
+	}
+}
+
 // TestDriverCodingMissionsAlwaysReview: the skip gate must never apply
 // to coding missions — a diff can be wrong in ways existence checks
 // cannot see.
@@ -1187,7 +1426,10 @@ func TestDriverEscalatesRepeatedRework(t *testing.T) {
 // MaxIterations instead of grinding through the whole budget.
 func TestDriverForcedRetriesStallInsteadOfBurningIterations(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 12})
+	// ReplanUsed pre-set true: this test asserts the pause outcome
+	// specifically; the first-stall replan path is covered separately
+	// by TestDriverReplanOnFirstStall.
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 12, ReplanUsed: true})
 	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{
 		{Outcome: "retry", Analysis: "the worker did not report a status; treated as a failed attempt", Forced: true},
 	}}

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -40,16 +40,20 @@ type Mission struct {
 	LastEvidence string `json:"last_evidence,omitempty"`
 	// ExploreNotes is the explore phase's findings, carried forward
 	// into the plan phase's prompt (see runner.go's PlanSession).
-	ExploreNotes        string   `json:"explore_notes,omitempty"`
-	Iteration           int      `json:"iteration"`
-	MaxIterations       int      `json:"max_iterations"`
-	ConsecutiveFailures int      `json:"consecutive_failures"`
-	LastGapFingerprint  string   `json:"last_gap_fingerprint,omitempty"`
-	StallCount          int      `json:"stall_count"`
-	BudgetAmount        *float64 `json:"budget_amount,omitempty"`
-	BudgetCurrency      string   `json:"budget_currency,omitempty"`
-	Route               string   `json:"route"`
-	ReviewRoute         string   `json:"review_route"`
+	ExploreNotes        string `json:"explore_notes,omitempty"`
+	Iteration           int    `json:"iteration"`
+	MaxIterations       int    `json:"max_iterations"`
+	ConsecutiveFailures int    `json:"consecutive_failures"`
+	LastGapFingerprint  string `json:"last_gap_fingerprint,omitempty"`
+	StallCount          int    `json:"stall_count"`
+	// ReplanUsed reports whether this mission already spent its one
+	// automatic replan-on-stall attempt (statemachine.go's
+	// stepWorkerRetry/stepReviewRework).
+	ReplanUsed     bool     `json:"replan_used"`
+	BudgetAmount   *float64 `json:"budget_amount,omitempty"`
+	BudgetCurrency string   `json:"budget_currency,omitempty"`
+	Route          string   `json:"route"`
+	ReviewRoute    string   `json:"review_route"`
 	// EscalationRoute, when non-empty, is the route worker turns switch
 	// to after a worker failure or review rework — instead of burning
 	// iterations on a model that already proved too weak for the unit.

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -133,6 +133,11 @@ type StepState struct {
 	// last unit — PhaseReview's approve transition needs this to
 	// decide between advancing to execute (more units left) or done.
 	LastUnit bool
+	// ReplanUsed reports whether this mission already spent its one
+	// automatic replan-on-stall attempt (stepWorkerRetry/
+	// stepReviewRework) — a second stall pauses for a human same as
+	// before this feature existed.
+	ReplanUsed bool
 }
 
 // StepInput bundles the triggering Input with whatever data it
@@ -336,6 +341,9 @@ func stepWorkerRetry(s StepState, in StepInput, cfg Config) Transition {
 		}
 		s.LastGapFingerprint = in.GapFingerprint
 		if s.StallCount >= cfg.StallRounds {
+			if !s.ReplanUsed {
+				return replanTransition(s, in)
+			}
 			return Transition{
 				Next:   withPause(s, PauseNoProgress),
 				Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseNoProgress), "detail": in.Reason}}},
@@ -350,6 +358,19 @@ func stepWorkerRetry(s StepState, in StepInput, cfg Config) Transition {
 		}
 	}
 	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.retry", Payload: map[string]any{"cause": "worker_retry", "reason": in.Reason}}}}
+}
+
+// replanTransition sends a first-time stall back to planning instead of
+// pausing: spends the mission's one replan attempt and resets the
+// counters a fresh planning pass needs.
+func replanTransition(s StepState, in StepInput) Transition {
+	s.ReplanUsed = true
+	s.Phase = PhasePlan
+	s.Status = StatusIdle
+	s.StallCount = 0
+	s.LastGapFingerprint = ""
+	s.Iteration = 0
+	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.replan", Payload: map[string]any{"reason": in.Reason}}}}
 }
 
 // stepReviewApprove clears the stall counter (progress was made) and
@@ -382,6 +403,9 @@ func stepReviewRework(s StepState, in StepInput, cfg Config) Transition {
 	}
 	s.LastGapFingerprint = in.GapFingerprint
 	if s.StallCount >= cfg.StallRounds {
+		if !s.ReplanUsed {
+			return replanTransition(s, in)
+		}
 		return Transition{
 			Next:   withPause(s, PauseNoProgress),
 			Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseNoProgress), "detail": in.Reason}}},

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -170,11 +170,11 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, Iteration: 1, StallCount: 1, LastGapFingerprint: "verify_failed:unit_0"},
 		},
 		{
-			name:  "worker_retry with the SAME fingerprint twice pauses no_progress (stall)",
-			state: StepState{Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "verify_failed:unit_0"},
+			name:  "worker_retry with the SAME fingerprint twice pauses no_progress once replan is already used",
+			state: StepState{Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "verify_failed:unit_0", ReplanUsed: true},
 			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "verify_failed:unit_0"},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseExecute, Status: StatusPaused, PauseReason: PauseNoProgress, MaxIterations: 8, StallCount: 2, LastGapFingerprint: "verify_failed:unit_0"},
+			want:  StepState{Phase: PhaseExecute, Status: StatusPaused, PauseReason: PauseNoProgress, MaxIterations: 8, StallCount: 2, LastGapFingerprint: "verify_failed:unit_0", ReplanUsed: true},
 		},
 		{
 			name:  "worker_retry with a DIFFERENT fingerprint does not accumulate stall",
@@ -205,11 +205,11 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhaseExecute, Status: StatusIdle, MaxIterations: 8, Iteration: 1, StallCount: 1, LastGapFingerprint: "abc"},
 		},
 		{
-			name:  "review_rework with the SAME fingerprint twice pauses no_progress (stall)",
-			state: StepState{Phase: PhaseReview, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "abc"},
+			name:  "review_rework with the SAME fingerprint twice pauses no_progress once replan is already used",
+			state: StepState{Phase: PhaseReview, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "abc", ReplanUsed: true},
 			input: StepInput{Input: InputReviewRework, GapFingerprint: "abc"},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseReview, Status: StatusPaused, PauseReason: PauseNoProgress, MaxIterations: 8, StallCount: 2, LastGapFingerprint: "abc"},
+			want:  StepState{Phase: PhaseReview, Status: StatusPaused, PauseReason: PauseNoProgress, MaxIterations: 8, StallCount: 2, LastGapFingerprint: "abc", ReplanUsed: true},
 		},
 		{
 			name:  "review_rework with a DIFFERENT fingerprint does not accumulate stall",
@@ -224,6 +224,20 @@ func TestStep(t *testing.T) {
 			input: StepInput{Input: InputReviewRework, GapFingerprint: "abc"},
 			cfg:   Config{BackoffFailures: 10, StallRounds: 10},
 			want:  StepState{Phase: PhaseFailed, Status: StatusError, MaxIterations: 1, Iteration: 1, StallCount: 1, LastGapFingerprint: "abc"},
+		},
+		{
+			name:  "worker_retry stall with replan unused replans instead of pausing",
+			state: StepState{Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "verify_failed:unit_0"},
+			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "verify_failed:unit_0", Reason: "same failure again"},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhasePlan, Status: StatusIdle, MaxIterations: 8, ReplanUsed: true},
+		},
+		{
+			name:  "review_rework stall with replan unused replans instead of pausing",
+			state: StepState{Phase: PhaseReview, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "abc"},
+			input: StepInput{Input: InputReviewRework, GapFingerprint: "abc", Reason: "reviewer keeps rejecting"},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhasePlan, Status: StatusIdle, MaxIterations: 8, ReplanUsed: true},
 		},
 		{
 			name:  "review_infra_failure pauses with infra reason",
@@ -302,6 +316,36 @@ func TestStepMixedCurrencyPauseDetail(t *testing.T) {
 	detail, _ := got.Events[0].Payload["detail"].(string)
 	if detail == "" || detail == "budget reached" {
 		t.Fatalf("Events[0].Payload[detail] = %q, want a mixed-currency-specific message", detail)
+	}
+}
+
+// TestStepReplanEmitsReasonAndUsesReplanOnlyOnce confirms the stall
+// branch's replan path emits mission.replan carrying the stall reason,
+// and that a second identical stall (ReplanUsed already true) pauses
+// no_progress exactly as before this feature existed.
+func TestStepReplanEmitsReasonAndUsesReplanOnlyOnce(t *testing.T) {
+	first := Step(
+		StepState{Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "fp"},
+		StepInput{Input: InputWorkerRetry, GapFingerprint: "fp", Reason: "stuck"},
+		DefaultConfig,
+	)
+	if len(first.Events) != 1 || first.Events[0].Kind != "mission.replan" {
+		t.Fatalf("Events = %+v, want exactly one mission.replan event", first.Events)
+	}
+	if reason, _ := first.Events[0].Payload["reason"].(string); reason != "stuck" {
+		t.Fatalf("mission.replan payload reason = %q, want %q", reason, "stuck")
+	}
+	if !first.Next.ReplanUsed {
+		t.Fatal("ReplanUsed = false after the first stall, want true")
+	}
+
+	second := Step(
+		StepState{Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "fp", ReplanUsed: true},
+		StepInput{Input: InputWorkerRetry, GapFingerprint: "fp"},
+		DefaultConfig,
+	)
+	if second.Next.Status != StatusPaused || second.Next.PauseReason != PauseNoProgress {
+		t.Fatalf("second identical stall = %+v, want paused/no_progress", second.Next)
 	}
 }
 

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -48,7 +48,7 @@ const missionColumns = `id, goal, kind, agent_id, phase, status, pause_reason, p
 	escalation_route, prompt_overlay,
 	pending_permission, pending_permission_tool, pending_permission_args,
 	pending_permission_danger, pending_permission_rationale, auto_approve_safe, last_evidence,
-	explore_notes, schedule_id, session_id, created_at, updated_at`
+	explore_notes, replan_used, schedule_id, session_id, created_at, updated_at`
 
 func scanMission(row pgx.Row) (Mission, error) {
 	var (
@@ -64,7 +64,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&m.EscalationRoute, &m.PromptOverlay,
 		&pendingPermission, &m.PendingPermissionTool, &m.PendingPermissionArgs,
 		&m.PendingPermissionDanger, &m.PendingPermissionRationale, &m.AutoApproveSafe, &m.LastEvidence,
-		&m.ExploreNotes, &scheduleID, &sessionID, &m.CreatedAt, &m.UpdatedAt); err != nil {
+		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.CreatedAt, &m.UpdatedAt); err != nil {
 		return Mission{}, err
 	}
 	if agentID != nil {
@@ -426,7 +426,7 @@ func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) er
 	clearPending := t.Next.Phase.Terminal()
 	if _, err := tx.Exec(ctx, `UPDATE missions SET
 			phase = $2, status = $3, pause_reason = $4, pause_message = '', iteration = $5, max_iterations = $6,
-			consecutive_failures = $7, last_gap_fingerprint = $8, stall_count = $9, updated_at = now(),
+			consecutive_failures = $7, last_gap_fingerprint = $8, stall_count = $9, replan_used = $11, updated_at = now(),
 			pending_permission = CASE WHEN $10 THEN '' ELSE pending_permission END,
 			pending_permission_tool = CASE WHEN $10 THEN '' ELSE pending_permission_tool END,
 			pending_permission_args = CASE WHEN $10 THEN '' ELSE pending_permission_args END,
@@ -435,7 +435,7 @@ func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) er
 		WHERE id = $1`,
 		id, string(t.Next.Phase), string(t.Next.Status), string(t.Next.PauseReason),
 		t.Next.Iteration, t.Next.MaxIterations, t.Next.ConsecutiveFailures,
-		t.Next.LastGapFingerprint, t.Next.StallCount, clearPending,
+		t.Next.LastGapFingerprint, t.Next.StallCount, clearPending, t.Next.ReplanUsed,
 	); err != nil {
 		return fmt.Errorf("missions apply transition update: %w", err)
 	}

--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -383,7 +383,17 @@ func guardSubject(root, tool, subject string) string {
 		}
 	}
 	if root != "" {
-		for _, tok := range CommandTokens(subject) {
+		for _, qt := range commandTokensQuoted(subject) {
+			tok := qt.text
+			// A quoted token can't shell-expand (brace, glob-via-regex
+			// chars), so a regex/pattern argument like '/^#{1,6}/' or
+			// '/tmp/{a,b}' looks path-like but never resolves to a real
+			// path — skip it. Unquoted, the same text is still live
+			// shell syntax (e.g. /x/{a,b} brace-expands to real paths)
+			// and must stay checked.
+			if qt.quoted && strings.ContainsAny(tok, "^$[]{}\\+|") {
+				continue
+			}
 			// A parent-directory reference in any path-like token can
 			// climb out of the workspace once the shell resolves it —
 			// the lexical check below can't see where it lands, so a
@@ -417,18 +427,39 @@ func pathWithin(root, p string) bool {
 // absolute paths. It intentionally over-matches: a false hit returns
 // corrective feedback, and the model retries with workspace paths.
 func CommandTokens(command string) []string {
+	qts := commandTokensQuoted(command)
+	out := make([]string, 0, len(qts))
+	for _, qt := range qts {
+		out = append(out, qt.text)
+	}
+	return out
+}
+
+// quotedToken is a command token plus whether it was single- or
+// double-quoted in the original command — quoting suppresses shell
+// expansion, which guardSubject uses to tell a real path from a
+// pattern argument (see commandTokensQuoted).
+type quotedToken struct {
+	text   string
+	quoted bool
+}
+
+// commandTokensQuoted is CommandTokens plus per-token quoting info.
+func commandTokensQuoted(command string) []quotedToken {
 	// '=' splits too, so --output=/abs/path exposes its path part.
 	fields := strings.Fields(strings.ReplaceAll(command, "=", " "))
-	out := make([]string, 0, len(fields))
+	out := make([]quotedToken, 0, len(fields))
 	for _, f := range fields {
 		// Redirect/fd syntax (>, <, 2>) only ever prefixes a path, never
 		// trails it — trimming from both ends would also strip a
 		// literal "<tag>" down to "/tag", a false absolute-path hit.
 		f = strings.TrimLeft(f, "<>0123456789")
-		f = strings.Trim(f, `'";|&()`)
-		if f != "" {
-			out = append(out, f)
+		trimmed := strings.Trim(f, `'";|&()`)
+		if trimmed == "" {
+			continue
 		}
+		quoted := (strings.HasPrefix(f, "'") || strings.HasPrefix(f, `"`)) && trimmed != f
+		out = append(out, quotedToken{text: trimmed, quoted: quoted})
 	}
 	return out
 }

--- a/internal/brain/tools/permissions_test.go
+++ b/internal/brain/tools/permissions_test.go
@@ -39,6 +39,15 @@ func TestGuardSubject(t *testing.T) {
 		{name: "html closing tag", command: `echo "</head>" >> summary.md`},
 		{name: "html tag no quotes", command: "printf '<html>\\n</html>'"},
 		{name: "redirect outside workspace", command: "cat file 2>&1 >/etc/passwd", blocked: "outside the workspace"},
+
+		{name: "quoted regex leading slash", command: "awk '/^#{1,6}/ {print}' README.md"},
+		{name: "quoted regex alternation", command: "grep -E '^(foo|bar)$' /workspace/file"},
+		{name: "quoted sed pattern", command: "sed 's/^#//' notes.md"},
+		{name: "quoted secret path still denied", command: "cat '/etc/passwd'", blocked: "system dirs"},
+		{name: "quoted plain path still denied", command: "cat '/Users/someone/x'", blocked: "outside the workspace"},
+		{name: "quoted brace path exempt", command: "cat '/tmp/{a,b}'"},
+		{name: "unquoted brace path denied", command: "cat /tmp/{a,b}", blocked: "outside the workspace"},
+		{name: "quoted metachars relative redirect", command: `echo "^foo$" > out.md`},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/migrations/0010_missions.sql
+++ b/migrations/0010_missions.sql
@@ -83,7 +83,11 @@ CREATE TABLE IF NOT EXISTS missions (
     -- The explore phase's findings, carried into the plan phase's
     -- prompt (internal/brain/missions/driver.go's runPlan) so the
     -- planner sees what exploration turned up, not just the bare goal.
-    explore_notes         text NOT NULL DEFAULT ''
+    explore_notes         text NOT NULL DEFAULT '',
+    -- A mission gets exactly one automatic replan attempt on stall
+    -- (statemachine.go's stepWorkerRetry/stepReviewRework) before a
+    -- second identical stall pauses for a human, same as always.
+    replan_used           boolean NOT NULL DEFAULT false
 );
 
 CREATE INDEX IF NOT EXISTS missions_status_idx ON missions (status);


### PR DESCRIPTION
## Summary

- Regression gate: every unit pass re-verifies all previously-passed units (CheckArtifacts + verify_cmd); a regression flips the unit back, emits mission.regression, and rides the existing retry/stall machinery — no state-machine changes
- Replan-on-stall: first stall triggers one automatic replan (planner sees plan pass-status, recent progress, stall reason; verified unchanged units keep harness evidence) before the second stall pauses as before; replan_used column guards the loop
- guardSubject fix: quoted regex arguments (awk '/^#{1,6}/') no longer hard-denied as workspace escapes; unquoted expansion forms and the secrets guard unchanged

## Testing

- make build vet lint test green (lint 0 issues, race on)
- make canary PASS
- New table tests: regression flip/advance, replan transitions + one-shot guard, evidence carry-forward, 8 new guardSubject cases including the live failure

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788655596&installation_model_id=431401&pr_number=186&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F186&signature=43899ceb14e2b84aa1e221c7cae9f0d97d12eb0cfe80522e1a3665a53bb3e0e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->