### PR TITLE
feat: blocked-question answers, schedule carryover, gateway snapshot robustness

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -327,12 +328,52 @@ func (h *missionAPI) events(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"events": events})
 }
 
+// resumeAnswerCap bounds the answer text carried into the progress note
+// and the mission.answered event payload — same cap as other bounded
+// event-payload fields in this package (e.g. push_failed's reason).
+const resumeAnswerCap = 500
+
+// resume handles POST /v1/missions/{id}/resume. An optional JSON body
+// {"answer": "..."} carries the human's reply to a worker's blocked
+// question: it's appended as a progress note (so the next worker
+// session's packet renders it, same as any other progress note) and as
+// a mission.answered event, BEFORE the resume signal — so the worker
+// that runs next already has the answer in its packet. An empty or
+// absent body (or one with an empty/missing answer) resumes exactly as
+// before this existed; only malformed JSON is rejected.
 func (h *missionAPI) resume(w http.ResponseWriter, r *http.Request) {
-	if err := h.driver.Signal(r.Context(), r.PathValue("id"), missions.InputResume); err != nil {
+	var body struct {
+		Answer string `json:"answer"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+		jsonError(w, http.StatusBadRequest, "bad_request", "body must be JSON with an optional answer field")
+		return
+	}
+	id := r.PathValue("id")
+	if body.Answer != "" {
+		answer := missions.NeutralizeSlot(truncateAnswer(body.Answer, resumeAnswerCap))
+		if err := h.store.AppendProgress(r.Context(), id, "Answer to your question: "+answer); err != nil {
+			h.log.Warn("mission: record answer progress note failed", "mission_id", id, "error", err)
+		}
+		if err := h.store.AppendEvent(r.Context(), id, "mission.answered", map[string]any{"answer": answer}); err != nil {
+			h.log.Warn("mission: record mission.answered event failed", "mission_id", id, "error", err)
+		}
+	}
+	if err := h.driver.Signal(r.Context(), id, missions.InputResume); err != nil {
 		failMission(w, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// truncateAnswer caps an answer at n runes-as-bytes, matching the
+// truncate helper's shape elsewhere in this codebase (missions.truncate
+// is unexported to this package).
+func truncateAnswer(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
 }
 
 func (h *missionAPI) cancel(w http.ResponseWriter, r *http.Request) {

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -1,0 +1,168 @@
+//go:build integration
+
+package api
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+	"github.com/SumonMSelim/timothy/internal/platform/migrate"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+	"github.com/SumonMSelim/timothy/migrations"
+)
+
+// testMissionStore mirrors internal/brain/missions' own testStore
+// helper — a real Postgres-backed *missions.Store, migrated, with
+// itest-prefixed fixtures swept on cleanup.
+func testMissionStore(t *testing.T) *missions.Store {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	store := missions.NewStore(pool, log)
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer ccancel()
+		_, _ = db.Exec(cctx, "DELETE FROM missions WHERE goal LIKE $1 || '%'", "itest-api-mission ")
+	})
+	return store
+}
+
+// TestMissionsResumeWithAnswerReachesWorker confirms POST
+// .../resume with {"answer": "..."} appends a progress note and a
+// mission.answered event BEFORE signaling resume — the progress note is
+// what the next worker session's packet actually renders (WorkPacket.Render
+// in packet.go reads m.Progress verbatim, no packet changes needed for
+// the answer to reach the worker).
+func TestMissionsResumeWithAnswerReachesWorker(t *testing.T) {
+	store := testMissionStore(t)
+	ctx := context.Background()
+
+	id, err := store.Create(ctx, missions.Mission{Goal: "itest-api-mission answer test", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Park it in waiting_for_input, same shape a real worker_blocked
+	// transition leaves behind, so Signal(InputResume) has something
+	// legal to resume from.
+	if err := store.ApplyTransition(ctx, id, missions.Transition{
+		Next: missions.StepState{Phase: missions.PhaseExecute, Status: missions.StatusWaitingForInput},
+	}); err != nil {
+		t.Fatalf("ApplyTransition: %v", err)
+	}
+
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/resume", strings.NewReader(`{"answer":"the deploy target is staging"}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("resume with answer = %d, want 204", w.Code)
+	}
+
+	got, err := store.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != missions.StatusIdle {
+		t.Fatalf("status after resume = %q, want idle", got.Status)
+	}
+	if len(got.Progress) != 1 || !strings.Contains(got.Progress[0].Note, "Answer to your question: the deploy target is staging") {
+		t.Fatalf("progress = %+v, want one note containing the answer", got.Progress)
+	}
+
+	events, err := store.Events(ctx, id)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	var sawAnswered, sawResumed bool
+	for _, e := range events {
+		switch e.Kind {
+		case "mission.answered":
+			sawAnswered = true
+			if !strings.Contains(string(e.Payload), "the deploy target is staging") {
+				t.Fatalf("mission.answered payload = %s, want the answer", e.Payload)
+			}
+		case "mission.resumed":
+			sawResumed = true
+		}
+		// The answer must be recorded before the resume — same
+		// invariant the state machine's own event ordering already
+		// relies on elsewhere.
+		if e.Kind == "mission.resumed" && sawAnswered == false {
+			t.Fatal("mission.resumed appeared before mission.answered")
+		}
+	}
+	if !sawAnswered || !sawResumed {
+		t.Fatalf("events = %+v, want both mission.answered and mission.resumed", events)
+	}
+}
+
+// TestMissionsResumeWithoutAnswerLeavesProgressUntouched confirms the
+// pause-case resume (no body) still works and writes no progress note —
+// resume without an answer must stay legal.
+func TestMissionsResumeWithoutAnswerLeavesProgressUntouched(t *testing.T) {
+	store := testMissionStore(t)
+	ctx := context.Background()
+
+	id, err := store.Create(ctx, missions.Mission{Goal: "itest-api-mission no answer", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.ApplyTransition(ctx, id, missions.Transition{
+		Next: missions.StepState{Phase: missions.PhaseExecute, Status: missions.StatusPaused, PauseReason: missions.PauseInfra},
+	}); err != nil {
+		t.Fatalf("ApplyTransition: %v", err)
+	}
+
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/resume", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("resume without a body = %d, want 204", w.Code)
+	}
+
+	got, err := store.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != missions.StatusIdle {
+		t.Fatalf("status after resume = %q, want idle", got.Status)
+	}
+	if len(got.Progress) != 0 {
+		t.Fatalf("progress = %+v, want none (no answer given)", got.Progress)
+	}
+}

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -194,6 +195,61 @@ func TestMissionsClassifyEndpoint(t *testing.T) {
 
 	if code, _ := call(`{"goal":""}`); code != http.StatusBadRequest {
 		t.Fatalf("classify with an empty goal = %d, want 400", code)
+	}
+}
+
+// TestMissionsResumeMalformedBodyRejected confirms a resume request
+// with a body that isn't valid JSON 400s before ever reaching the store
+// or driver — a degraded pool would surface as 500 (failMission's
+// default) if the request passed body parsing, so a 400 here proves it
+// didn't.
+func TestMissionsResumeMalformedBodyRejected(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/v1/missions/abc/resume", strings.NewReader(`{not json`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("resume with malformed JSON body = %d, want 400", w.Code)
+	}
+}
+
+// TestMissionsResumeEmptyBodyUnchanged confirms an absent body (nil,
+// matching the pre-answer-feature client) and an empty JSON object both
+// still reach the driver's Signal call exactly as before this feature
+// existed — proven by both hitting the same degraded-pool failure a
+// resume with no answer always hit.
+func TestMissionsResumeEmptyBodyUnchanged(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil)
+
+	call := func(body io.Reader) int {
+		req := httptest.NewRequest("POST", "/v1/missions/abc/resume", body)
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w.Code
+	}
+	if code := call(nil); code != http.StatusBadRequest {
+		t.Fatalf("resume with no body = %d, want 400 from the degraded driver (reached Signal)", code)
+	}
+	if code := call(strings.NewReader(`{}`)); code != http.StatusBadRequest {
+		t.Fatalf("resume with empty JSON body = %d, want 400 from the degraded driver (reached Signal)", code)
+	}
+	if code := call(strings.NewReader(`{"answer":""}`)); code != http.StatusBadRequest {
+		t.Fatalf("resume with empty answer = %d, want 400 from the degraded driver (reached Signal, no answer appended)", code)
 	}
 }
 

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -105,7 +105,7 @@ func (p *StorePermissionParker) OnPermissionCleared(ctx context.Context, mission
 // a failed append logs and never aborts the turn it's reporting on.
 func (p *StorePermissionParker) OnPermissionDenied(ctx context.Context, missionID, tool, digest string) {
 	if err := p.Store.AppendEvent(ctx, missionID, "mission.permission_denied", map[string]any{
-		"tool": tool, "digest": digest,
+		"tool": tool, "detail": digest,
 	}); err != nil {
 		p.Log.Error("mission: record permission denied failed", "mission_id", missionID, "error", err)
 	}

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -38,6 +38,16 @@ type Schedule struct {
 	LastRun         *time.Time      `json:"last_run,omitempty"`
 	CreatedAt       time.Time       `json:"created_at"`
 	UpdatedAt       time.Time       `json:"updated_at"`
+	// PendingFire carries forward a fire that was due but skipped
+	// because a mission from this schedule was still active (fireOne's
+	// dedup) — cleared the moment it actually fires.
+	PendingFire bool `json:"pending_fire"`
+	// LastSkippedAt/SkipReason record the most recent skip (either
+	// "backfill_grace" or "active_mission"), cleared on any successful
+	// fire — nil/empty means the schedule's last due boundary fired
+	// (or it has never been due).
+	LastSkippedAt *time.Time `json:"last_skipped_at,omitempty"`
+	SkipReason    string     `json:"skip_reason,omitempty"`
 }
 
 // MissionTemplate is applied verbatim as a new mission's initial
@@ -187,7 +197,7 @@ func (s *Scheduler) tick(ctx context.Context, now time.Time) error {
 		return tx.Commit(ctx) // another instance already owns this tick
 	}
 
-	rows, err := tx.Query(ctx, `SELECT id, name, cron, mission_template, enabled, expires_at, last_run, created_at, updated_at
+	rows, err := tx.Query(ctx, `SELECT id, name, cron, mission_template, enabled, expires_at, last_run, created_at, updated_at, pending_fire
 		FROM schedules WHERE enabled AND (expires_at IS NULL OR expires_at > now())`)
 	if err != nil {
 		return fmt.Errorf("scheduler: query schedules: %w", err)
@@ -196,7 +206,7 @@ func (s *Scheduler) tick(ctx context.Context, now time.Time) error {
 	for rows.Next() {
 		var sc Schedule
 		var templateJSON []byte
-		if err := rows.Scan(&sc.ID, &sc.Name, &sc.Cron, &templateJSON, &sc.Enabled, &sc.ExpiresAt, &sc.LastRun, &sc.CreatedAt, &sc.UpdatedAt); err != nil {
+		if err := rows.Scan(&sc.ID, &sc.Name, &sc.Cron, &templateJSON, &sc.Enabled, &sc.ExpiresAt, &sc.LastRun, &sc.CreatedAt, &sc.UpdatedAt, &sc.PendingFire); err != nil {
 			rows.Close()
 			return fmt.Errorf("scheduler: scan schedule: %w", err)
 		}
@@ -216,9 +226,10 @@ func (s *Scheduler) tick(ctx context.Context, now time.Time) error {
 	return tx.Commit(ctx)
 }
 
-// fireOne evaluates and, if due, fires one schedule — inside the same
-// transaction tick holds, so last_run and any created mission commit
-// atomically together.
+// fireOne evaluates and, if due (or carrying a pending fire from an
+// earlier dedup skip), fires one schedule at most once — inside the
+// same transaction tick holds, so last_run/pending_fire/skip fields and
+// any created mission commit atomically together.
 func (s *Scheduler) fireOne(ctx context.Context, tx pgx.Tx, sc Schedule, now time.Time) error {
 	// A never-run schedule anchors on its own creation, not "now" —
 	// otherwise Next(now) is always in the future and it could never
@@ -232,31 +243,102 @@ func (s *Scheduler) fireOne(ctx context.Context, tx pgx.Tx, sc Schedule, now tim
 	if err != nil {
 		return err
 	}
+
+	// Backfill skip: past misfireGrace, never fires for this boundary —
+	// still advance last_run (so the NEXT boundary computes from now,
+	// not the stale anchor) and record why, but pending_fire is
+	// untouched (a stale pending fire from an EARLIER dedup skip must
+	// still get its own chance below, not be silently dropped by this
+	// unrelated late boundary).
+	if dec == decisionBackfillSkip {
+		if err := s.markSkipped(ctx, tx, sc, now, "backfill_grace"); err != nil {
+			return err
+		}
+		return s.tryFirePending(ctx, tx, sc, now)
+	}
 	if dec == decisionSkip {
+		return s.tryFirePending(ctx, tx, sc, now)
+	}
+
+	// dec == decisionFire: due this tick. Whether or not a pending fire
+	// from an earlier tick is also carried, only ONE mission fires —
+	// firing the current due boundary also satisfies whatever was
+	// pending, so pending_fire clears here rather than firing twice.
+	active, err := s.activeMissionExists(ctx, tx, sc.ID)
+	if err != nil {
+		return err
+	}
+	if active {
+		// Live-queue dedup: a mission from THIS schedule still active
+		// means firing again would pile up parallel runs of the same
+		// job — skip firing, carry it forward as pending, but still
+		// advance last_run so the next boundary computes from now.
+		if _, err := tx.Exec(ctx, `UPDATE schedules SET
+				last_run = $2, pending_fire = true, last_skipped_at = $2, skip_reason = $3, updated_at = now()
+			WHERE id = $1`, sc.ID, now, "active_mission"); err != nil {
+			return fmt.Errorf("advance last_run (dedup skip): %w", err)
+		}
+		s.log.Info("scheduler: skipped firing, a mission from this schedule is still active", "schedule_id", sc.ID)
 		return nil
 	}
-
-	// Live-queue dedup: a mission from THIS schedule still active means
-	// firing again would pile up parallel runs of the same job — skip
-	// firing, but still advance last_run so the next boundary computes
-	// from now, not from the stale anchor.
-	if dec == decisionFire {
-		var activeCount int
-		if err := tx.QueryRow(ctx, `SELECT count(*) FROM missions
-			WHERE schedule_id = $1 AND phase NOT IN ('done', 'failed')`, sc.ID).Scan(&activeCount); err != nil {
-			return fmt.Errorf("check active missions: %w", err)
-		}
-		if activeCount == 0 {
-			if err := s.createFromTemplate(ctx, tx, sc); err != nil {
-				return fmt.Errorf("create mission: %w", err)
-			}
-		} else {
-			s.log.Info("scheduler: skipped firing, a mission from this schedule is still active", "schedule_id", sc.ID)
-		}
+	if err := s.createFromTemplate(ctx, tx, sc); err != nil {
+		return fmt.Errorf("create mission: %w", err)
 	}
-
-	if _, err := tx.Exec(ctx, `UPDATE schedules SET last_run = $2, updated_at = now() WHERE id = $1`, sc.ID, now); err != nil {
+	if _, err := tx.Exec(ctx, `UPDATE schedules SET
+			last_run = $2, pending_fire = false, last_skipped_at = NULL, skip_reason = '', updated_at = now()
+		WHERE id = $1`, sc.ID, now); err != nil {
 		return fmt.Errorf("advance last_run: %w", err)
+	}
+	return nil
+}
+
+// tryFirePending fires a carried-forward pending fire when no mission
+// from this schedule is currently active — the other half of the dedup
+// skip's carryover: the tick that skipped set pending_fire, and every
+// SUBSEQUENT tick (not just the one right after) checks it here until
+// the active mission finally clears. A no-op when pending_fire is
+// false, or when a mission is still active.
+func (s *Scheduler) tryFirePending(ctx context.Context, tx pgx.Tx, sc Schedule, now time.Time) error {
+	if !sc.PendingFire {
+		return nil
+	}
+	active, err := s.activeMissionExists(ctx, tx, sc.ID)
+	if err != nil {
+		return err
+	}
+	if active {
+		return nil
+	}
+	if err := s.createFromTemplate(ctx, tx, sc); err != nil {
+		return fmt.Errorf("create mission (pending fire): %w", err)
+	}
+	if _, err := tx.Exec(ctx, `UPDATE schedules SET
+			pending_fire = false, last_skipped_at = NULL, skip_reason = '', updated_at = now()
+		WHERE id = $1`, sc.ID); err != nil {
+		return fmt.Errorf("clear pending_fire: %w", err)
+	}
+	return nil
+}
+
+// activeMissionExists reports whether a mission from schedule id is
+// still in a non-terminal phase.
+func (s *Scheduler) activeMissionExists(ctx context.Context, tx pgx.Tx, scheduleID string) (bool, error) {
+	var activeCount int
+	if err := tx.QueryRow(ctx, `SELECT count(*) FROM missions
+		WHERE schedule_id = $1 AND phase NOT IN ('done', 'failed')`, scheduleID).Scan(&activeCount); err != nil {
+		return false, fmt.Errorf("check active missions: %w", err)
+	}
+	return activeCount > 0, nil
+}
+
+// markSkipped records a backfill-grace skip's reason/time — last_run
+// still advances so the next boundary computes from now, not the stale
+// anchor (same rule the pre-existing backfill-skip path always followed).
+func (s *Scheduler) markSkipped(ctx context.Context, tx pgx.Tx, sc Schedule, now time.Time, reason string) error {
+	if _, err := tx.Exec(ctx, `UPDATE schedules SET
+			last_run = $2, last_skipped_at = $2, skip_reason = $3, updated_at = now()
+		WHERE id = $1`, sc.ID, now, reason); err != nil {
+		return fmt.Errorf("advance last_run (backfill skip): %w", err)
 	}
 	return nil
 }

--- a/internal/brain/missions/scheduler_integration_test.go
+++ b/internal/brain/missions/scheduler_integration_test.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func createTestSchedule(t *testing.T, store *Store, name, cronExpr string) string {
@@ -113,5 +115,184 @@ func TestSchedulerLiveQueueDedup(t *testing.T) {
 	}
 	if lastRun == nil {
 		t.Fatal("last_run was not advanced despite the dedup skip")
+	}
+}
+
+// scheduleFlags reads pending_fire/last_skipped_at/skip_reason for
+// assertions below.
+func scheduleFlags(t *testing.T, ctx context.Context, db *pgxpool.Pool, id string) (pendingFire bool, lastSkippedAt *time.Time, skipReason string) {
+	t.Helper()
+	if err := db.QueryRow(ctx, `SELECT pending_fire, last_skipped_at, skip_reason FROM schedules WHERE id = $1`, id).
+		Scan(&pendingFire, &lastSkippedAt, &skipReason); err != nil {
+		t.Fatalf("read schedule flags: %v", err)
+	}
+	return
+}
+
+// TestSchedulerDedupSkipSetsPendingFireAndRecordsReason confirms a live-
+// queue dedup skip (a mission from this schedule still active) carries
+// the missed fire forward via pending_fire, and records the skip.
+func TestSchedulerDedupSkipSetsPendingFireAndRecordsReason(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	id := createTestSchedule(t, store, marker+"dedup-pending", "* * * * *")
+	db, _ := store.db.Get()
+	past := time.Now().Add(-2 * time.Minute)
+	if _, err := db.Exec(ctx, "UPDATE schedules SET created_at = $2 WHERE id = $1", id, past); err != nil {
+		t.Fatalf("backdate schedule: %v", err)
+	}
+
+	missionID, err := store.Create(ctx, Mission{Goal: marker + "active blocker", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := db.Exec(ctx, "UPDATE missions SET schedule_id = $2 WHERE id = $1", missionID, id); err != nil {
+		t.Fatalf("attach schedule: %v", err)
+	}
+
+	sched := NewScheduler(store.db, store, nil, nil, nil, store.log)
+	if err := sched.tick(ctx, time.Now()); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	pending, skippedAt, reason := scheduleFlags(t, ctx, db, id)
+	if !pending {
+		t.Fatal("pending_fire = false, want true after a dedup skip")
+	}
+	if skippedAt == nil || reason != "active_mission" {
+		t.Fatalf("last_skipped_at=%v skip_reason=%q, want a timestamp and active_mission", skippedAt, reason)
+	}
+}
+
+// TestSchedulerPendingFireResolvesOnceMissionClears confirms a schedule
+// carrying pending_fire from an earlier dedup skip fires on the NEXT
+// tick once the blocking mission is no longer active, and clears both
+// pending_fire and the skip fields.
+func TestSchedulerPendingFireResolvesOnceMissionClears(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	id := createTestSchedule(t, store, marker+"pending-resolves", "* * * * *")
+	db, _ := store.db.Get()
+	past := time.Now().Add(-2 * time.Minute)
+	if _, err := db.Exec(ctx, "UPDATE schedules SET created_at = $2 WHERE id = $1", id, past); err != nil {
+		t.Fatalf("backdate schedule: %v", err)
+	}
+
+	missionID, err := store.Create(ctx, Mission{Goal: marker + "temporarily active", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := db.Exec(ctx, "UPDATE missions SET schedule_id = $2 WHERE id = $1", missionID, id); err != nil {
+		t.Fatalf("attach schedule: %v", err)
+	}
+
+	sched := NewScheduler(store.db, store, nil, nil, nil, store.log)
+	// First tick: due, but the mission above is active -> dedup skip,
+	// pending_fire set.
+	if err := sched.tick(ctx, time.Now()); err != nil {
+		t.Fatalf("tick 1: %v", err)
+	}
+	if pending, _, _ := scheduleFlags(t, ctx, db, id); !pending {
+		t.Fatal("pending_fire not set after first tick's dedup skip")
+	}
+
+	// The blocking mission finishes.
+	if _, err := db.Exec(ctx, "UPDATE missions SET phase = 'done' WHERE id = $1", missionID); err != nil {
+		t.Fatalf("complete blocking mission: %v", err)
+	}
+
+	// Second tick: cron isn't newly due (last_run just advanced a moment
+	// ago), but the pending fire must still resolve.
+	if err := sched.tick(ctx, time.Now()); err != nil {
+		t.Fatalf("tick 2: %v", err)
+	}
+
+	pending, skippedAt, reason := scheduleFlags(t, ctx, db, id)
+	if pending {
+		t.Fatal("pending_fire still true after the blocking mission cleared")
+	}
+	if skippedAt != nil || reason != "" {
+		t.Fatalf("last_skipped_at=%v skip_reason=%q, want both cleared after the pending fire resolved", skippedAt, reason)
+	}
+
+	var missionCount int
+	if err := db.QueryRow(ctx, `SELECT count(*) FROM missions WHERE schedule_id = $1`, id).Scan(&missionCount); err != nil {
+		t.Fatalf("count missions: %v", err)
+	}
+	if missionCount != 2 {
+		t.Fatalf("mission count = %d, want 2 (the original active one plus the resolved pending fire)", missionCount)
+	}
+}
+
+// TestSchedulerDueAndPendingFiresOnce confirms a schedule that is BOTH
+// newly due (its cron boundary passed again) AND still carrying an
+// earlier pending_fire only spawns one mission for the tick, not two.
+func TestSchedulerDueAndPendingFiresOnce(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	id := createTestSchedule(t, store, marker+"due-and-pending", "* * * * *")
+	db, _ := store.db.Get()
+	past := time.Now().Add(-2 * time.Minute)
+	if _, err := db.Exec(ctx, `UPDATE schedules SET created_at = $2, pending_fire = true,
+			last_skipped_at = $2, skip_reason = 'active_mission' WHERE id = $1`, id, past); err != nil {
+		t.Fatalf("seed pending schedule: %v", err)
+	}
+
+	sched := NewScheduler(store.db, store, nil, nil, nil, store.log)
+	if err := sched.tick(ctx, time.Now()); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	var missionCount int
+	if err := db.QueryRow(ctx, `SELECT count(*) FROM missions WHERE schedule_id = $1`, id).Scan(&missionCount); err != nil {
+		t.Fatalf("count missions: %v", err)
+	}
+	if missionCount != 1 {
+		t.Fatalf("mission count = %d, want exactly 1 (due + pending fires once)", missionCount)
+	}
+	pending, skippedAt, reason := scheduleFlags(t, ctx, db, id)
+	if pending || skippedAt != nil || reason != "" {
+		t.Fatalf("pending_fire=%v last_skipped_at=%v skip_reason=%q, want all cleared after firing", pending, skippedAt, reason)
+	}
+}
+
+// TestSchedulerBackfillSkipRecordsReason confirms a schedule whose due
+// boundary is past misfireGrace still skips firing, but now records
+// last_skipped_at/skip_reason="backfill_grace" instead of leaving no
+// trace.
+func TestSchedulerBackfillSkipRecordsReason(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	id := createTestSchedule(t, store, marker+"backfill", "0 9 * * *")
+	db, _ := store.db.Get()
+	// Anchor far enough in the past that "now" is well beyond
+	// misfireGrace past the next boundary.
+	past := time.Now().Add(-48 * time.Hour)
+	if _, err := db.Exec(ctx, "UPDATE schedules SET created_at = $2 WHERE id = $1", id, past); err != nil {
+		t.Fatalf("backdate schedule: %v", err)
+	}
+
+	sched := NewScheduler(store.db, store, nil, nil, nil, store.log)
+	if err := sched.tick(ctx, time.Now()); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	var missionCount int
+	if err := db.QueryRow(ctx, `SELECT count(*) FROM missions WHERE schedule_id = $1`, id).Scan(&missionCount); err != nil {
+		t.Fatalf("count missions: %v", err)
+	}
+	if missionCount != 0 {
+		t.Fatalf("mission count = %d, want 0 (backfill grace skip never fires)", missionCount)
+	}
+	pending, skippedAt, reason := scheduleFlags(t, ctx, db, id)
+	if pending {
+		t.Fatal("pending_fire = true, want false (a backfill skip is not a dedup skip)")
+	}
+	if skippedAt == nil || reason != "backfill_grace" {
+		t.Fatalf("last_skipped_at=%v skip_reason=%q, want a timestamp and backfill_grace", skippedAt, reason)
 	}
 }

--- a/internal/brain/missions/schedules.go
+++ b/internal/brain/missions/schedules.go
@@ -53,12 +53,13 @@ func NextRun(cronExpr string, now time.Time) time.Time {
 	return schedule.Next(now)
 }
 
-const scheduleColumns = `id, name, cron, mission_template, enabled, expires_at, last_run, created_at, updated_at`
+const scheduleColumns = `id, name, cron, mission_template, enabled, expires_at, last_run, created_at, updated_at, pending_fire, last_skipped_at, skip_reason`
 
 func scanSchedule(row pgx.Row) (Schedule, error) {
 	var sc Schedule
 	var templateJSON []byte
-	if err := row.Scan(&sc.ID, &sc.Name, &sc.Cron, &templateJSON, &sc.Enabled, &sc.ExpiresAt, &sc.LastRun, &sc.CreatedAt, &sc.UpdatedAt); err != nil {
+	if err := row.Scan(&sc.ID, &sc.Name, &sc.Cron, &templateJSON, &sc.Enabled, &sc.ExpiresAt, &sc.LastRun, &sc.CreatedAt, &sc.UpdatedAt,
+		&sc.PendingFire, &sc.LastSkippedAt, &sc.SkipReason); err != nil {
 		return Schedule{}, err
 	}
 	_ = json.Unmarshal(templateJSON, &sc.MissionTemplate)

--- a/internal/gateway/admin/admin_routes_test.go
+++ b/internal/gateway/admin/admin_routes_test.go
@@ -23,10 +23,7 @@ func routesSnapshot(t *testing.T, strategy string) *router.Snapshot {
 		{ProviderID: "p3", Model: "m"},
 		{ProviderID: "p2", Model: "small"},
 	}}}
-	snap, err := router.BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := router.BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
 	return snap
 }
 
@@ -97,10 +94,7 @@ func TestResolvedForRouteSkipsAllUnusable(t *testing.T) {
 	routeRows := []router.RouteRow{{Name: "r", Enabled: true, Chain: []router.ChainEntry{
 		{ProviderID: "p1", Model: "m"},
 	}}}
-	snap, err := router.BuildSnapshot(provRows, routeRows, func(string) string { return "" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := router.BuildSnapshot(provRows, routeRows, func(string) string { return "" })
 
 	resolved, serving := resolvedForRoute(snap, "r")
 	if len(resolved) != 1 || resolved[0].Usable {

--- a/internal/gateway/api/api_test.go
+++ b/internal/gateway/api/api_test.go
@@ -162,10 +162,7 @@ func snapshotFor(t *testing.T, firstURL, secondURL string) *router.Snapshot {
 			{ProviderID: "p1", Model: "m1"},
 		}, Enabled: true},
 	}
-	snap, err := router.BuildSnapshot(rows, routes, func(string) string { return "" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := router.BuildSnapshot(rows, routes, func(string) string { return "" })
 	return snap
 }
 
@@ -503,10 +500,7 @@ func TestStreamVisionRouteMissingFallsBackToDefault(t *testing.T) {
 		{Name: "default", Role: "default", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: true},
 		// no "vision" route row at all.
 	}
-	snap, err := router.BuildSnapshot(rows, routes, func(string) string { return "" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := router.BuildSnapshot(rows, routes, func(string) string { return "" })
 	a, rec := newAPI(snap)
 
 	w := postJSON(t, a.handleStream, fmt.Sprintf(`{"route":"vision","messages":%s}`, visionMessages))
@@ -549,10 +543,7 @@ func TestStreamVisionRouteDisabledFallsBackToDefault(t *testing.T) {
 		{Name: "default", Role: "default", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: true},
 		{Name: "vision", Role: "vision", Capability: "vision", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: false},
 	}
-	snap, err := router.BuildSnapshot(rows, routes, func(string) string { return "" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := router.BuildSnapshot(rows, routes, func(string) string { return "" })
 	a, rec := newAPI(snap)
 
 	w := postJSON(t, a.handleStream, fmt.Sprintf(`{"route":"vision","messages":%s}`, visionMessages))
@@ -584,10 +575,7 @@ func TestStreamVisionRoutePresentNoFallback(t *testing.T) {
 		{Name: "vision", Role: "vision", Capability: "vision", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "vm"}}, Enabled: true},
 		{Name: "default", Role: "default", Chain: []router.ChainEntry{{ProviderID: "p2", Model: "dm"}}, Enabled: true},
 	}
-	snap, err := router.BuildSnapshot(rows, routes, func(string) string { return "" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := router.BuildSnapshot(rows, routes, func(string) string { return "" })
 	a, rec := newAPI(snap)
 
 	w := postJSON(t, a.handleStream, fmt.Sprintf(`{"route":"vision","messages":%s}`, visionMessages))
@@ -626,10 +614,7 @@ func TestStreamVisionCapabilityExhaustedNoFallback(t *testing.T) {
 	routes := []router.RouteRow{
 		{Name: "vision", Role: "vision", Capability: "vision", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: true},
 	}
-	snap, err := router.BuildSnapshot(rows, routes, func(string) string { return "" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := router.BuildSnapshot(rows, routes, func(string) string { return "" })
 	a, rec := newAPI(snap)
 
 	w := postJSON(t, a.handleStream, fmt.Sprintf(`{"route":"vision","messages":%s}`, visionMessages))
@@ -700,10 +685,7 @@ func TestEmbedSkipsIncapableDriverAtResolve(t *testing.T) {
 			{ProviderID: "p0", Model: "m0"}, {ProviderID: "p1", Model: "m1"},
 		}, Enabled: true},
 	}
-	snap, err := router.BuildSnapshot(rows, routes, func(string) string { return "" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := router.BuildSnapshot(rows, routes, func(string) string { return "" })
 	a, rec := newAPI(snap)
 
 	w := postJSON(t, a.handleEmbed, `{"texts":["a","b"]}`)
@@ -728,10 +710,7 @@ func TestProvidersListingNeverLeaksSecrets(t *testing.T) {
 		CredentialRef: "ONE_KEY", Enabled: true,
 		Models: []router.ModelInfo{{ID: "m1"}},
 	}}
-	snap, err := router.BuildSnapshot(rows, nil, func(string) string { return secret })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := router.BuildSnapshot(rows, nil, func(string) string { return secret })
 	a, _ := newAPI(snap)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/providers", nil)

--- a/internal/gateway/provider/registry.go
+++ b/internal/gateway/provider/registry.go
@@ -33,6 +33,13 @@ type Registry struct {
 	providers map[string]Provider
 }
 
+// NewRegistry returns an empty registry — router.BuildSnapshot builds
+// providers one at a time (per-provider degradation) and adds each
+// survivor via Add.
+func NewRegistry() *Registry {
+	return &Registry{providers: make(map[string]Provider)}
+}
+
 // Build constructs providers from configs. lookup resolves a
 // credential reference to its secret value (os.Getenv in production,
 // a fake in tests). A ref that resolves empty still builds the
@@ -102,6 +109,13 @@ func Build(cfgs []Config, lookup func(string) string) (*Registry, error) {
 func (r *Registry) Get(name string) (Provider, bool) {
 	p, ok := r.providers[name]
 	return p, ok
+}
+
+// Add inserts a single built provider, overwriting any existing entry
+// of the same name — router.BuildSnapshot builds providers one at a
+// time for per-provider degradation and merges the survivors here.
+func (r *Registry) Add(name string, p Provider) {
+	r.providers[name] = p
 }
 
 // Names returns all provider names (unordered).

--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -101,7 +101,8 @@ type Snapshot struct {
 	roleRoute  map[string]string       // role -> route name (all routes, not just enabled)
 	stats      map[string]ModelStats   // "provider/model" -> recent ledger stats
 	registry   *provider.Registry
-	healthy    map[string]bool // by name: credential ref resolved
+	healthy    map[string]bool   // by name: credential ref resolved and driver built
+	unhealthy  map[string]string // by name: reason, set whenever healthy[name] is false
 }
 
 // ModelStats are time-decayed aggregates from the recent cost ledger,
@@ -142,10 +143,26 @@ func (e *NoRouteError) Error() string {
 	return msg
 }
 
+// BuildWarning reports one provider row that could not be built into a
+// usable driver — a malformed config never takes down the whole
+// snapshot; the row stays in Providers()/rows for admin visibility,
+// just unhealthy and absent from the registry.
+type BuildWarning struct {
+	Provider string
+	Err      error
+}
+
 // BuildSnapshot assembles a snapshot from table rows. lookup resolves
 // credential references; a ref that resolves empty marks the provider
-// unhealthy (skipped by routing) without failing the build.
-func BuildSnapshot(provRows []ProviderRow, routeRows []RouteRow, lookup func(string) string) (*Snapshot, error) {
+// unhealthy (skipped by routing) without failing the build. Rows whose
+// driver fails to build are excluded from the registry; disabled rows
+// stay in the registry (admin probes need them) but are marked
+// unhealthy. Neither is removed from rows/byName — admin views still
+// list them. providers.name is DB-unique, so
+// duplicate rows can't reach BuildSnapshot; a bad or disabled provider
+// is reported via the returned warnings — BuildSnapshot itself never
+// fails.
+func BuildSnapshot(provRows []ProviderRow, routeRows []RouteRow, lookup func(string) string) (*Snapshot, []BuildWarning) {
 	s := &Snapshot{
 		rows:       make(map[string]ProviderRow, len(provRows)),
 		byName:     make(map[string]ProviderRow, len(provRows)),
@@ -154,18 +171,35 @@ func BuildSnapshot(provRows []ProviderRow, routeRows []RouteRow, lookup func(str
 		capability: map[string]string{},
 		roleRoute:  map[string]string{},
 		healthy:    make(map[string]bool, len(provRows)),
+		unhealthy:  map[string]string{},
+		registry:   provider.NewRegistry(),
 	}
 
-	cfgs := make([]provider.Config, 0, len(provRows))
+	var warnings []BuildWarning
 	for _, row := range provRows {
 		s.rows[row.ID] = row
 		s.byName[row.Name] = row
+		// Disabled rows are still built into the registry so the admin
+		// connection probe can reach them (create → test → enable); they
+		// stay unhealthy and routing rejects them on row.Enabled.
+		switch {
+		case !row.Enabled:
+			s.unhealthy[row.Name] = "disabled"
 		// credential_ref names an env var for API-key drivers; bedrock now
 		// requires the same ref to resolve in the secret store as static
 		// keys (D-047, profile/SSO mode removed) — so an unresolved ref
 		// marks every driver unhealthy alike.
-		s.healthy[row.Name] = row.CredentialRef == "" || lookup(row.CredentialRef) != ""
-		cfgs = append(cfgs, provider.Config{
+		case row.CredentialRef != "" && lookup(row.CredentialRef) == "":
+			s.unhealthy[row.Name] = fmt.Sprintf("credential %s unresolved", row.CredentialRef)
+		default:
+			s.healthy[row.Name] = true
+		}
+
+		// Built one provider at a time: a single bad driver name or
+		// invalid config must not take down every other route's
+		// providers, so provider.Build's all-or-nothing error is
+		// contained to this one row.
+		reg, err := provider.Build([]provider.Config{{
 			Name:            row.Name,
 			Kind:            provider.Kind(row.Kind),
 			Driver:          row.Driver,
@@ -175,14 +209,16 @@ func BuildSnapshot(provRows []ProviderRow, routeRows []RouteRow, lookup func(str
 			Region:          row.Region,
 			ReasoningEffort: row.ReasoningEffort,
 			Timeout:         row.Timeout,
-		})
+		}}, lookup)
+		if err != nil {
+			warnings = append(warnings, BuildWarning{Provider: row.Name, Err: err})
+			s.healthy[row.Name] = false
+			s.unhealthy[row.Name] = err.Error()
+			continue
+		}
+		p, _ := reg.Get(row.Name)
+		s.registry.Add(row.Name, p)
 	}
-
-	reg, err := provider.Build(cfgs, lookup)
-	if err != nil {
-		return nil, err
-	}
-	s.registry = reg
 
 	for _, r := range routeRows {
 		s.capability[r.Name] = r.Capability
@@ -194,7 +230,7 @@ func BuildSnapshot(provRows []ProviderRow, routeRows []RouteRow, lookup func(str
 			s.strategy[r.Name] = r.Strategy
 		}
 	}
-	return s, nil
+	return s, warnings
 }
 
 // RouteForRole returns the name of the route currently bound to role
@@ -314,7 +350,7 @@ func (s *Snapshot) entryGate(row ProviderRow, model string, required []provider.
 	case !row.Enabled:
 		return nil, row.Name, "disabled"
 	case !s.healthy[row.Name]:
-		return nil, row.Name, fmt.Sprintf("unhealthy: credential %s unresolved", row.CredentialRef)
+		return nil, row.Name, fmt.Sprintf("unhealthy: %s", s.unhealthy[row.Name])
 	case !inRegistry:
 		return nil, row.Name, "not in registry"
 	}

--- a/internal/gateway/router/router_test.go
+++ b/internal/gateway/router/router_test.go
@@ -49,10 +49,7 @@ func testSnapshot(t *testing.T, lookups map[string]string) *Snapshot {
 			{ProviderID: "p2", Model: "embed-b"},
 		}, Enabled: true},
 	}
-	snap, err := BuildSnapshot(provRows, routeRows, func(ref string) string { return lookups[ref] })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := BuildSnapshot(provRows, routeRows, func(ref string) string { return lookups[ref] })
 	return snap
 }
 
@@ -214,10 +211,7 @@ func TestResolveModelLevelCapabilities(t *testing.T) {
 			{ProviderID: "p1", Model: "titan-embed"},
 		}, Enabled: true},
 	}
-	snap, err := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
 
 	attempts, err := snap.Resolve("coding", "", Sticky{})
 	if err != nil {
@@ -247,12 +241,9 @@ func TestResolveModelCapabilityExhaustionNamesModel(t *testing.T) {
 	routeRows := []RouteRow{{Name: "coding", Chain: []ChainEntry{
 		{ProviderID: "p1", Model: "titan-embed"},
 	}, Enabled: true}}
-	snap, err := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
 
-	_, err = snap.Resolve("coding", "", Sticky{})
+	_, err := snap.Resolve("coding", "", Sticky{})
 	if err == nil || !strings.Contains(err.Error(), "bedrock/titan-embed (lacks chat capability") {
 		t.Fatalf("err = %v, want model-naming capability reason", err)
 	}
@@ -276,10 +267,7 @@ func TestResolveVisionRejectsModelDeclaringOnlyChat(t *testing.T) {
 		{ProviderID: "p1", Model: "haiku"},
 		{ProviderID: "p1", Model: "sonnet"},
 	}, Enabled: true}}
-	snap, err := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
 
 	attempts, err := snap.Resolve("coding", "", Sticky{}, provider.CapVision)
 	if err != nil {
@@ -325,12 +313,9 @@ func TestResolveVisionExhaustionMentionsVision(t *testing.T) {
 	routeRows := []RouteRow{{Name: "coding", Chain: []ChainEntry{
 		{ProviderID: "p1", Model: "haiku"},
 	}, Enabled: true}}
-	snap, err := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
 
-	_, err = snap.Resolve("coding", "", Sticky{}, provider.CapVision)
+	_, err := snap.Resolve("coding", "", Sticky{}, provider.CapVision)
 	if err == nil || !strings.Contains(err.Error(), "lacks vision capability") {
 		t.Fatalf("err = %v, want a reason mentioning vision", err)
 	}
@@ -377,11 +362,117 @@ func TestRoutesListing(t *testing.T) {
 	}
 }
 
-// TestBedrockUnresolvedCredentialRefFailsBuild covers D-048: AWS
+// TestDisabledProviderSkippedByRouting covers the disabled-provider
+// contract: a disabled row is still built into the registry (the admin
+// connection probe reaches providers before they are enabled), stays
+// unhealthy, keeps its place in rows/byName for admin visibility, and
+// a chain entry pointing at it is skipped by routing.
+func TestDisabledProviderSkippedByRouting(t *testing.T) {
+	t.Parallel()
+	snap := testSnapshot(t, allKeys())
+
+	if _, ok := snap.Provider("disabled-one"); !ok {
+		t.Fatal("disabled provider missing from the registry")
+	}
+	rows, healthy := snap.Providers()
+	found := false
+	for _, r := range rows {
+		if r.Name == "disabled-one" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("disabled provider missing from Providers() rows")
+	}
+	if healthy["disabled-one"] {
+		t.Fatal("disabled provider reported healthy")
+	}
+
+	attempts, err := snap.Resolve("mini", "", Sticky{})
+	var nre *NoRouteError
+	if !errors.As(err, &nre) || attempts != nil {
+		t.Fatalf("Resolve(mini) = %+v, %v, want NoRouteError skipping the disabled entry", attempts, err)
+	}
+	if !strings.Contains(err.Error(), "disabled-one (disabled") {
+		t.Fatalf("err = %v, want a disabled skip reason", err)
+	}
+}
+
+// TestBuildSnapshotOneInvalidProviderAmongTwo covers the second
+// defect: a single misconfigured provider row (here, openaicompat
+// missing its required base_url) must not take down routing for every
+// other provider. The bad row surfaces as a BuildWarning and stays
+// unhealthy; the good row keeps serving.
+func TestBuildSnapshotOneInvalidProviderAmongTwo(t *testing.T) {
+	t.Parallel()
+	provRows := []ProviderRow{
+		{ID: "p1", Name: "bad", Kind: "api", Driver: "openaicompat", // no BaseURL: Build errors
+			DefaultModel: "m", CredentialRef: "K", Enabled: true,
+			Models: []ModelInfo{{ID: "m"}}},
+		{ID: "p2", Name: "good", Kind: "api", Driver: "openaicompat",
+			BaseURL: "https://good.example/v1", DefaultModel: "m", CredentialRef: "K", Enabled: true,
+			Models: []ModelInfo{{ID: "m"}}},
+	}
+	routeRows := []RouteRow{{Name: "r", Enabled: true, Chain: []ChainEntry{
+		{ProviderID: "p1", Model: "m"},
+		{ProviderID: "p2", Model: "m"},
+	}}}
+	snap, warnings := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
+	if len(warnings) != 1 || warnings[0].Provider != "bad" || !strings.Contains(warnings[0].Err.Error(), "requires base_url") {
+		t.Fatalf("warnings = %+v, want one warning naming bad's base_url requirement", warnings)
+	}
+	if _, ok := snap.Provider("bad"); ok {
+		t.Fatal("invalid provider built into the registry")
+	}
+	if _, ok := snap.Provider("good"); !ok {
+		t.Fatal("valid provider missing from the registry")
+	}
+
+	attempts, err := snap.Resolve("r", "", Sticky{})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := attemptNames(attempts); got != "good/m" {
+		t.Fatalf("attempts = %s, want good/m only", got)
+	}
+}
+
+// TestBuildSnapshotAllProvidersInvalidStillBuilds covers the same
+// defect at its extreme: every provider row fails to build. The
+// snapshot must still build (an empty registry is a valid degraded
+// state), and Resolve falls through to the existing, well-handled
+// no-usable-provider path rather than any build-time failure.
+func TestBuildSnapshotAllProvidersInvalidStillBuilds(t *testing.T) {
+	t.Parallel()
+	provRows := []ProviderRow{
+		{ID: "p1", Name: "bad1", Kind: "api", Driver: "openaicompat", // no BaseURL
+			DefaultModel: "m", CredentialRef: "K", Enabled: true, Models: []ModelInfo{{ID: "m"}}},
+		{ID: "p2", Name: "bad2", Kind: "api", Driver: "openaicompat", // no BaseURL
+			DefaultModel: "m", CredentialRef: "K", Enabled: true, Models: []ModelInfo{{ID: "m"}}},
+	}
+	routeRows := []RouteRow{{Name: "r", Enabled: true, Chain: []ChainEntry{
+		{ProviderID: "p1", Model: "m"},
+		{ProviderID: "p2", Model: "m"},
+	}}}
+	snap, warnings := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
+	if len(warnings) != 2 {
+		t.Fatalf("warnings = %+v, want two", warnings)
+	}
+
+	_, err := snap.Resolve("r", "", Sticky{})
+	var nre *NoRouteError
+	if !errors.As(err, &nre) {
+		t.Fatalf("err = %v, want the existing NoRouteError path", err)
+	}
+}
+
+// TestBedrockUnresolvedCredentialRefDegradesNotFails covers D-048: AWS
 // profile/SSO mode is gone, so a bedrock row whose credential_ref does
-// not resolve in the secret store is a hard BuildSnapshot error, not a
-// degraded-but-usable provider.
-func TestBedrockUnresolvedCredentialRefFailsBuild(t *testing.T) {
+// not resolve in the secret store fails to build its own driver — but
+// per-provider degradation means BuildSnapshot itself never fails: the
+// row surfaces as a warning and stays unhealthy rather than taking
+// down the whole snapshot.
+func TestBedrockUnresolvedCredentialRefDegradesNotFails(t *testing.T) {
 	t.Parallel()
 	provRows := []ProviderRow{{
 		ID: "p1", Name: "bedrock", Kind: "api", Driver: "bedrock",
@@ -392,9 +483,13 @@ func TestBedrockUnresolvedCredentialRefFailsBuild(t *testing.T) {
 	routeRows := []RouteRow{{Name: "embedding", Chain: []ChainEntry{
 		{ProviderID: "p1", Model: "titan-embed"},
 	}, Enabled: true}}
-	_, err := BuildSnapshot(provRows, routeRows, func(string) string { return "" })
-	if err == nil || !strings.Contains(err.Error(), "bedrock requires static keys in the secret store") {
-		t.Fatalf("BuildSnapshot err = %v, want a clear static-keys-required message", err)
+	snap, warnings := BuildSnapshot(provRows, routeRows, func(string) string { return "" })
+	if len(warnings) != 1 || warnings[0].Provider != "bedrock" ||
+		!strings.Contains(warnings[0].Err.Error(), "bedrock requires static keys in the secret store") {
+		t.Fatalf("warnings = %+v, want one bedrock static-keys-required warning", warnings)
+	}
+	if _, err := snap.Resolve("embedding", "", Sticky{}); err == nil || !strings.Contains(err.Error(), "unhealthy") {
+		t.Fatalf("Resolve err = %v, want unhealthy skip", err)
 	}
 }
 
@@ -415,15 +510,12 @@ func TestBedrockResolvingCredentialRefPassesStaticCredentialsThrough(t *testing.
 	routeRows := []RouteRow{{Name: "chat", Chain: []ChainEntry{
 		{ProviderID: "p1", Model: "us.amazon.nova-pro-v1:0"},
 	}, Enabled: true}}
-	snap, err := BuildSnapshot(provRows, routeRows, func(ref string) string {
+	snap, _ := BuildSnapshot(provRows, routeRows, func(ref string) string {
 		if ref == "bedrock-static" {
 			return secretJSON
 		}
 		return ""
 	})
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
 
 	attempts, err := snap.Resolve("chat", "", Sticky{})
 	if err != nil {
@@ -458,15 +550,12 @@ func TestBedrockOptionsRegionThreadsToProvider(t *testing.T) {
 	routeRows := []RouteRow{{Name: "chat", Chain: []ChainEntry{
 		{ProviderID: "p1", Model: "us.amazon.nova-pro-v1:0"},
 	}, Enabled: true}}
-	snap, err := BuildSnapshot(provRows, routeRows, func(ref string) string {
+	snap, _ := BuildSnapshot(provRows, routeRows, func(ref string) string {
 		if ref == "bedrock-static" {
 			return secretJSON
 		}
 		return ""
 	})
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
 
 	attempts, err := snap.Resolve("chat", "", Sticky{})
 	if err != nil {
@@ -492,10 +581,7 @@ func TestScoredStrategyReordersChain(t *testing.T) {
 		{ProviderID: "p1", Model: "big"},
 		{ProviderID: "p2", Model: "small"},
 	}}}
-	snap, err := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
 
 	attempts, err := snap.Resolve("r", "", Sticky{})
 	if err != nil {
@@ -597,10 +683,7 @@ func TestResolveDetailScoredMatchesResolve(t *testing.T) {
 		{ProviderID: "p1", Model: "big"},
 		{ProviderID: "p2", Model: "small"},
 	}}}
-	snap, err := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
 
 	detail := snap.ResolveDetail("r")
 	attempts, err := snap.Resolve("r", "", Sticky{})
@@ -646,10 +729,7 @@ func TestResolveDetailNeutralAndFloor(t *testing.T) {
 		{ProviderID: "p1", Model: "m1"},
 		{ProviderID: "p2", Model: "m2"},
 	}}}
-	snap, err := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
 	snap.SetStats(map[string]ModelStats{
 		"flaky/m2": {Uptime: 0.01, LatencyMS: 100, TokensPerS: 10},
 	})
@@ -716,10 +796,7 @@ func TestResolveDetailSingleEntryScored(t *testing.T) {
 	routeRows := []RouteRow{{Name: "r", Strategy: "price", Enabled: true, Chain: []ChainEntry{
 		{ProviderID: "p1", Model: "m"},
 	}}}
-	snap, err := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
-	if err != nil {
-		t.Fatalf("BuildSnapshot: %v", err)
-	}
+	snap, _ := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
 
 	d := snap.ResolveDetail("r")
 	if len(d) != 1 || !d[0].Scored {

--- a/internal/gateway/router/store.go
+++ b/internal/gateway/router/store.go
@@ -152,9 +152,9 @@ func (s *Store) Load(ctx context.Context) error {
 		return fmt.Errorf("router: route rows: %w", err)
 	}
 
-	snap, err := BuildSnapshot(provRows, routes, s.lookup)
-	if err != nil {
-		return fmt.Errorf("router: build snapshot: %w", err)
+	snap, warnings := BuildSnapshot(provRows, routes, s.lookup)
+	for _, w := range warnings {
+		s.log.Warn("router: provider failed to build; marked unhealthy", "provider", w.Provider, "error", w.Err)
 	}
 	// Ledger stats feed scored strategies; a failure only degrades
 	// scoring to declared prices, never the snapshot itself.

--- a/migrations/0010_missions.sql
+++ b/migrations/0010_missions.sql
@@ -124,7 +124,17 @@ CREATE TABLE IF NOT EXISTS schedules (
     expires_at        timestamptz,
     last_run          timestamptz,
     created_at        timestamptz NOT NULL DEFAULT now(),
-    updated_at        timestamptz NOT NULL DEFAULT now()
+    updated_at        timestamptz NOT NULL DEFAULT now(),
+    -- A due fire skipped because a mission from this schedule was still
+    -- active is not lost: pending_fire carries it forward so the next
+    -- tick with no active mission fires it, instead of the schedule
+    -- silently missing that boundary forever (scheduler.go's fireOne).
+    pending_fire      boolean NOT NULL DEFAULT false,
+    -- Records the most recent skip (backfill grace or active-mission
+    -- dedup) for the schedules API to surface; cleared on any
+    -- successful fire.
+    last_skipped_at   timestamptz,
+    skip_reason       text NOT NULL DEFAULT ''
 );
 
 -- Deferred FK: a mission may name the schedule that spawned it. NOT

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -619,4 +619,7 @@ export interface Schedule {
   next_run?: string
   created_at: string
   updated_at: string
+  pending_fire: boolean
+  last_skipped_at?: string
+  skip_reason?: string
 }

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -44,6 +44,7 @@ const schedule: Schedule = {
   next_run: '2026-07-27T08:00:00Z',
   created_at: '2026-07-01T00:00:00Z',
   updated_at: '2026-07-01T00:00:00Z',
+  pending_fire: false,
 }
 
 afterEach(() => {

--- a/web/src/components/missions/RecurringSchedules.test.tsx
+++ b/web/src/components/missions/RecurringSchedules.test.tsx
@@ -23,6 +23,7 @@ const schedule: Schedule = {
   next_run: '2026-07-27T08:00:00Z',
   created_at: '2026-07-01T00:00:00Z',
   updated_at: '2026-07-01T00:00:00Z',
+  pending_fire: false,
 }
 
 function renderList() {

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -610,6 +610,7 @@ describe('MissionDetail', () => {
         next_run: '2026-01-02T07:00:00Z',
         created_at: '2026-01-01T00:00:00Z',
         updated_at: '2026-01-01T00:00:00Z',
+        pending_fire: false,
       },
     ])
     renderPage()


### PR DESCRIPTION
## Summary
- Mission resume accepts an optional answer body: it lands in progress notes plus a `mission.answered` event, so a worker blocked on a question receives the reply on its next turn with zero packet changes.
- Deduped schedule fires carry over via `pending_fire` instead of being dropped; skip bookkeeping via `last_skipped_at` / `skip_reason`; carried fire runs as soon as no active mission blocks it.
- `mission.permission_denied` payload key `digest` renamed to `detail`.
- Gateway `BuildSnapshot` never fails wholesale: per-row provider build, malformed configs become logged warnings + unhealthy rows. Disabled providers stay in the registry so the admin connection probe works before enabling; routing still rejects them.

## Testing
- `make build test vet lint` green.
- `make test-integration`: only pre-existing ledger flake (`TestBudgetStatusIgnoresOtherCurrencySpend`, zero diff there).
- Canary PASS (163s).
- Live gateway rebuild: 4 providers / 9 routes loaded, no warnings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788661028&installation_model_id=431401&pr_number=187&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F187&signature=e55529094c74febbce5496a224e0010983c0da22f1633b3c98e8eb831306129f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->