### PR TITLE
test: sweep hidden sessions when deleting fixture missions

### DIFF
--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -46,7 +46,16 @@ func testMissionStore(t *testing.T) *missions.Store {
 	t.Cleanup(func() {
 		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer ccancel()
-		_, _ = db.Exec(cctx, "DELETE FROM missions WHERE goal LIKE $1 || '%'", "itest-api-mission ")
+		// Delete the missions plus any hidden sessions they provisioned,
+		// which would otherwise linger as empty chats in the session list.
+		_, _ = db.Exec(cctx, `WITH gone AS (
+			DELETE FROM missions WHERE goal LIKE $1 || '%' RETURNING session_id
+		), ids AS (SELECT session_id FROM gone WHERE session_id IS NOT NULL),
+		g AS (DELETE FROM session_grants WHERE session_id IN (SELECT session_id FROM ids)),
+		a AS (DELETE FROM tool_audit WHERE session_id IN (SELECT session_id FROM ids)),
+		o AS (DELETE FROM tool_outputs WHERE session_id IN (SELECT session_id FROM ids)),
+		e AS (DELETE FROM session_events WHERE session_id IN (SELECT session_id FROM ids))
+		DELETE FROM sessions WHERE id IN (SELECT session_id FROM ids)`, "itest-api-mission ")
 	})
 	return store
 }

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -78,11 +78,25 @@ type execer interface {
 // rows are also swept by the slug form.
 func sweep(ctx context.Context, db execer) {
 	slug := strings.TrimSpace(marker)
-	_, _ = db.Exec(ctx, `DELETE FROM missions WHERE schedule_id IN (
+	_, _ = db.Exec(ctx, sweepMissionsSQL(`schedule_id IN (
 		SELECT id FROM schedules WHERE name LIKE $1 || '%' OR name LIKE $2 || '%'
-	)`, marker, slug)
+	)`), marker, slug)
 	_, _ = db.Exec(ctx, "DELETE FROM schedules WHERE name LIKE $1 || '%' OR name LIKE $2 || '%'", marker, slug)
-	_, _ = db.Exec(ctx, "DELETE FROM missions WHERE goal LIKE $1 || '%'", marker)
+	_, _ = db.Exec(ctx, sweepMissionsSQL("goal LIKE $1 || '%'"), marker)
+}
+
+// sweepMissionsSQL deletes missions matching filter along with the
+// hidden sessions they provisioned, which would otherwise linger as
+// empty chats in the session list.
+func sweepMissionsSQL(filter string) string {
+	return `WITH gone AS (
+		DELETE FROM missions WHERE ` + filter + ` RETURNING session_id
+	), ids AS (SELECT session_id FROM gone WHERE session_id IS NOT NULL),
+	g AS (DELETE FROM session_grants WHERE session_id IN (SELECT session_id FROM ids)),
+	a AS (DELETE FROM tool_audit WHERE session_id IN (SELECT session_id FROM ids)),
+	o AS (DELETE FROM tool_outputs WHERE session_id IN (SELECT session_id FROM ids)),
+	e AS (DELETE FROM session_events WHERE session_id IN (SELECT session_id FROM ids))
+	DELETE FROM sessions WHERE id IN (SELECT session_id FROM ids)`
 }
 
 func TestMissionCRUD(t *testing.T) {


### PR DESCRIPTION
## Summary
Missions integration fixtures provision a hidden untitled session (`ensureProvisioned`), but test cleanup deleted only the mission rows. The orphaned sessions lost their mission link and showed up in the chat sidebar as empty chats — 8 accumulated from local integration runs.

Cleanup now deletes the provisioned sessions (grants, audit, outputs, events, session row) together with the missions, in both `internal/brain/missions` sweep and the `internal/brain/api` missions fixture.

## Testing
- `go test -race -count=1 -tags integration ./internal/brain/missions/ ./internal/brain/api/ ./internal/brain/session/` green.
- Orphan count after run: 0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788662092&installation_model_id=431401&pr_number=188&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F188&signature=dd900bd0627788eba4b522a3afd48f1b01362ca3d037ec6a5b2fb5436a2826ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->