### PR TITLE
feat: derive sandbox variant images, pull missing on demand

### DIFF
--- a/internal/brain/sandboxclient/sandboxclient.go
+++ b/internal/brain/sandboxclient/sandboxclient.go
@@ -45,7 +45,7 @@ type execRequest struct {
 	TimeoutSeconds int               `json:"timeout_seconds"`
 	Env            map[string]string `json:"env,omitempty"`
 	// Environment selects the mission's sandbox image (D-05x) — a key
-	// into sandboxd's own environmentImages allowlist, never a
+	// into sandboxd's own environmentKeys allowlist, never a
 	// free-form image string. Only matters on the mission's first exec
 	// (image is fixed once its container is created).
 	Environment string `json:"environment,omitempty"`

--- a/internal/sandboxd/api.go
+++ b/internal/sandboxd/api.go
@@ -154,7 +154,7 @@ type execRequest struct {
 	TimeoutSeconds int               `json:"timeout_seconds"`
 	Env            map[string]string `json:"env,omitempty"`
 	// Environment selects the mission's sandbox image (D-05x) — a key
-	// into manager.go's environmentImages allowlist, never a free-form
+	// into manager.go's environmentKeys allowlist, never a free-form
 	// image string. "" and "base" both mean the configured base image.
 	// Only matters on a mission's first exec (image is fixed once its
 	// container is created); a later exec sends whatever the mission
@@ -165,7 +165,7 @@ type execRequest struct {
 }
 
 // validExecEnvironment rejects any environment key outside
-// manager.go's environmentImages allowlist (plus the "" and "base"
+// manager.go's environmentKeys allowlist (plus the "" and "base"
 // aliases for the base image) — same shape as validExecEnv's D-053
 // allowlist check, checked before the exec ever reaches Docker so an
 // unrecognized key is a clean 400, not a mid-stream infra error.
@@ -174,7 +174,7 @@ func validExecEnvironment(environment string) bool {
 	case "", "base":
 		return true
 	default:
-		return environmentImages[environment] != ""
+		return environmentKeys[environment]
 	}
 }
 

--- a/internal/sandboxd/api_test.go
+++ b/internal/sandboxd/api_test.go
@@ -167,7 +167,7 @@ func TestHandleExecUnknownEnvNameRejected(t *testing.T) {
 }
 
 // TestHandleExecUnknownEnvironmentRejected confirms an environment key
-// outside manager.go's environmentImages allowlist (D-05x) 400s before
+// outside manager.go's environmentKeys allowlist (D-05x) 400s before
 // ever reaching the daemon — mirrors D-053's env-var allowlist gate.
 func TestHandleExecUnknownEnvironmentRejected(t *testing.T) {
 	t.Parallel()

--- a/internal/sandboxd/manager.go
+++ b/internal/sandboxd/manager.go
@@ -16,6 +16,7 @@ import (
 	"log/slog"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -91,45 +92,73 @@ const (
 // string-matching the error text.
 var ErrTimeout = errors.New("sandbox: command timed out")
 
-// environmentImages is the D-05x allowlist mapping a mission's
-// "environment" key to the sandbox image tag it runs — the ONLY way an
-// image is ever chosen; a request carries the key, never a free-form
-// image string (mirrors internal/brain/missions.Environments, which
-// the API validates create/schedule requests against before this is
-// ever reached). "" and "base" both resolve to the operator-configured
-// base image (MISSION_SANDBOX_IMAGE) — "" is Manager's zero-value
-// default for back-compat with a caller that predates the environment
-// axis, "base" is the operator's explicit escape hatch out of
-// auto-detection. Every other key names a variant image built FROM
-// that base (deploy/sandbox-<key>.Dockerfile, `make sandbox-image`).
-var environmentImages = map[string]string{
-	"go":     "timothy-sandbox-go:latest",
-	"node":   "timothy-sandbox-node:latest",
-	"python": "timothy-sandbox-python:latest",
-	"java":   "timothy-sandbox-java:latest",
-	"php":    "timothy-sandbox-php:latest",
+// environmentKeys is the D-05x allowlist of a mission's "environment"
+// key — the ONLY way an image is ever chosen; a request carries the
+// key, never a free-form image string (mirrors
+// internal/brain/missions.Environments, which the API validates
+// create/schedule requests against before this is ever reached). ""
+// and "base" both resolve to the operator-configured base image
+// (MISSION_SANDBOX_IMAGE) — "" is Manager's zero-value default for
+// back-compat with a caller that predates the environment axis, "base"
+// is the operator's explicit escape hatch out of auto-detection. Every
+// other key derives a variant image ref from the base ref (imageFor):
+// the base repository name gets "-<key>" appended, same tag —
+// timothy-sandbox:latest -> timothy-sandbox-go:latest (local `make
+// sandbox-image` convention) and
+// ghcr.io/timothy-agent/timothy-sandbox:0.1.0-alpha.21 ->
+// ghcr.io/timothy-agent/timothy-sandbox-go:0.1.0-alpha.21 (release
+// convention: deploy/sandbox-<key>.Dockerfile + release.yml publish
+// exactly these names).
+var environmentKeys = map[string]bool{
+	"go":     true,
+	"node":   true,
+	"python": true,
+	"java":   true,
+	"php":    true,
 }
 
 // ErrUnknownEnvironment reports an environment key outside
-// environmentImages (and not "" or "base") — never silently falls back
+// environmentKeys (and not "" or "base") — never silently falls back
 // to the base image, so a typo'd or stale key fails loudly instead of
 // running a mission's coding work in the wrong toolchain.
 var ErrUnknownEnvironment = errors.New("sandbox: unknown environment")
 
-// imageFor resolves environment to an image tag via environmentImages
-// only — see D-05x. baseImage is the operator-configured
-// MISSION_SANDBOX_IMAGE (back-compat default, and "base"'s explicit
-// target).
+// imageFor derives environment's image ref from baseImage — see
+// D-05x. baseImage is the operator-configured MISSION_SANDBOX_IMAGE
+// (back-compat default, and "base"'s explicit target). Digest refs
+// (baseImage containing "@") cannot be derived from and are rejected
+// for any variant environment.
 func imageFor(baseImage, environment string) (string, error) {
 	switch environment {
 	case "", "base":
 		return baseImage, nil
 	default:
-		if img, ok := environmentImages[environment]; ok {
-			return img, nil
+		if !environmentKeys[environment] {
+			return "", fmt.Errorf("%w: %q", ErrUnknownEnvironment, environment)
 		}
-		return "", fmt.Errorf("%w: %q", ErrUnknownEnvironment, environment)
+		if strings.Contains(baseImage, "@") {
+			return "", fmt.Errorf("sandbox: variant environments require a tagged image ref, got digest %q", baseImage)
+		}
+		repo, tag := splitImageRef(baseImage)
+		variant := repo + "-" + environment
+		if tag == "" {
+			return variant, nil
+		}
+		return variant + ":" + tag, nil
 	}
+}
+
+// splitImageRef splits an image ref into repository and tag. The tag
+// separator is the last ":" occurring after the last "/", so a
+// registry-with-port ref (e.g. localhost:5000/timothy-sandbox) is never
+// split at the port colon. No tag present -> tag is "".
+func splitImageRef(image string) (repo, tag string) {
+	slash := strings.LastIndex(image, "/")
+	colon := strings.LastIndex(image, ":")
+	if colon <= slash {
+		return image, ""
+	}
+	return image[:colon], image[colon+1:]
 }
 
 // Manager creates, reuses, and tears down one Docker container per
@@ -240,10 +269,9 @@ func (m *Manager) Ping(ctx context.Context) error {
 // would otherwise see every mission shell call fail opaquely instead
 // of a clear boot-time health signal. Variant images (go/node/...) are
 // not checked here: an operator who never runs a mission in that
-// environment need not have built it, and a missing variant fails
-// loudly at ensureContainer time instead (ErrUnknownEnvironment is for
-// an unrecognized key, not a missing image — Docker's own pull/create
-// error covers the latter).
+// environment need not have it locally yet, and createContainer pulls
+// a missing variant on demand instead (ErrUnknownEnvironment is for an
+// unrecognized key, not a missing image).
 func (m *Manager) CheckImage(ctx context.Context) error {
 	_, err := m.cli.ImageInspect(ctx, m.baseImage)
 	return err
@@ -370,13 +398,34 @@ func (m *Manager) createContainer(ctx context.Context, missionID, name, environm
 		NetworkMode:   "bridge",
 		RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyDisabled},
 	}
-	resp, err := m.cli.ContainerCreate(ctx, client.ContainerCreateOptions{
+	createOpts := client.ContainerCreateOptions{
 		Config:     cfg,
 		HostConfig: hostCfg,
 		Name:       name,
-	})
+	}
+	resp, err := m.cli.ContainerCreate(ctx, createOpts)
 	if err != nil {
-		return "", fmt.Errorf("sandbox: create container %s: %w", name, err)
+		if !errdefs.IsNotFound(err) {
+			return "", fmt.Errorf("sandbox: create container %s: %w", name, err)
+		}
+		// Image not pulled locally yet (variant images especially are
+		// built/pushed at release time, not baked into every deployment) —
+		// pull it once and retry create exactly once.
+		if m.log != nil {
+			m.log.Info("sandbox: pulling image", "image", image, "mission", missionID)
+		}
+		pull, pullErr := m.cli.ImagePull(ctx, image, client.ImagePullOptions{})
+		if pullErr != nil {
+			return "", fmt.Errorf("sandbox: pull image %s: %w", image, pullErr)
+		}
+		waitErr := pull.Wait(ctx)
+		if waitErr != nil {
+			return "", fmt.Errorf("sandbox: pull image %s: %w", image, waitErr)
+		}
+		resp, err = m.cli.ContainerCreate(ctx, createOpts)
+		if err != nil {
+			return "", fmt.Errorf("sandbox: create container %s: %w", name, err)
+		}
 	}
 	if _, err := m.cli.ContainerStart(ctx, resp.ID, client.ContainerStartOptions{}); err != nil {
 		return "", fmt.Errorf("sandbox: start container %s: %w", name, err)

--- a/internal/sandboxd/manager_test.go
+++ b/internal/sandboxd/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -346,46 +347,71 @@ func TestCreateContainerOmitsStateMountWhenAbsent(t *testing.T) {
 	}
 }
 
-// TestImageFor covers D-05x's environment->image resolution: the
-// allowlist in environmentImages is the ONLY source of a variant image
-// tag; "" and "base" both resolve to the operator-configured base
-// image; anything else unrecognized is a loud error, never a silent
-// fallback.
+// TestImageFor covers D-05x's environment->image derivation: "" and
+// "base" both resolve to the operator-configured base image; every
+// other allowlisted key derives a variant ref from the base ref
+// (repository + "-<key>", same tag); a digest base or an unrecognized
+// key is a loud error, never a silent fallback.
 func TestImageFor(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
+		name        string
+		baseImage   string
 		environment string
 		want        string
 		wantErr     bool
 	}{
-		{environment: "", want: "timothy-sandbox-base:latest"},
-		{environment: "base", want: "timothy-sandbox-base:latest"},
-		{environment: "go", want: "timothy-sandbox-go:latest"},
-		{environment: "node", want: "timothy-sandbox-node:latest"},
-		{environment: "python", want: "timothy-sandbox-python:latest"},
-		{environment: "java", want: "timothy-sandbox-java:latest"},
-		{environment: "php", want: "timothy-sandbox-php:latest"},
-		{environment: "ruby", wantErr: true},
-		{environment: "timothy-sandbox-go:latest", wantErr: true}, // an image string, not a key
+		{name: "empty", baseImage: "timothy-sandbox:latest", environment: "", want: "timothy-sandbox:latest"},
+		{name: "base", baseImage: "timothy-sandbox:latest", environment: "base", want: "timothy-sandbox:latest"},
+		{name: "go", baseImage: "timothy-sandbox:latest", environment: "go", want: "timothy-sandbox-go:latest"},
+		{name: "node", baseImage: "timothy-sandbox:latest", environment: "node", want: "timothy-sandbox-node:latest"},
+		{name: "python", baseImage: "timothy-sandbox:latest", environment: "python", want: "timothy-sandbox-python:latest"},
+		{name: "java", baseImage: "timothy-sandbox:latest", environment: "java", want: "timothy-sandbox-java:latest"},
+		{name: "php", baseImage: "timothy-sandbox:latest", environment: "php", want: "timothy-sandbox-php:latest"},
+		{
+			name:        "ghcr versioned",
+			baseImage:   "ghcr.io/timothy-agent/timothy-sandbox:0.1.0-alpha.21",
+			environment: "go",
+			want:        "ghcr.io/timothy-agent/timothy-sandbox-go:0.1.0-alpha.21",
+		},
+		{
+			name:        "registry with port",
+			baseImage:   "localhost:5000/timothy-sandbox:v1",
+			environment: "go",
+			want:        "localhost:5000/timothy-sandbox-go:v1",
+		},
+		{
+			name:        "untagged base",
+			baseImage:   "timothy-sandbox",
+			environment: "go",
+			want:        "timothy-sandbox-go",
+		},
+		{
+			name:        "digest base rejected",
+			baseImage:   "x@sha256:abc",
+			environment: "go",
+			wantErr:     true,
+		},
+		{name: "unknown env", baseImage: "timothy-sandbox:latest", environment: "ruby", wantErr: true},
 	}
 	for _, tc := range cases {
-		t.Run(tc.environment, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := imageFor("timothy-sandbox-base:latest", tc.environment)
+			got, err := imageFor(tc.baseImage, tc.environment)
 			if tc.wantErr {
 				if err == nil {
-					t.Fatalf("imageFor(%q) = %q, nil, want an error", tc.environment, got)
+					t.Fatalf("imageFor(%q, %q) = %q, nil, want an error", tc.baseImage, tc.environment, got)
 				}
-				if !errors.Is(err, ErrUnknownEnvironment) {
-					t.Errorf("imageFor(%q) error = %v, want ErrUnknownEnvironment", tc.environment, err)
+				if tc.environment == "ruby" && !errors.Is(err, ErrUnknownEnvironment) {
+					t.Errorf("imageFor(%q, %q) error = %v, want ErrUnknownEnvironment", tc.baseImage, tc.environment, err)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("imageFor(%q): %v", tc.environment, err)
+				t.Fatalf("imageFor(%q, %q): %v", tc.baseImage, tc.environment, err)
 			}
 			if got != tc.want {
-				t.Errorf("imageFor(%q) = %q, want %q", tc.environment, got, tc.want)
+				t.Errorf("imageFor(%q, %q) = %q, want %q", tc.baseImage, tc.environment, got, tc.want)
 			}
 		})
 	}
@@ -398,5 +424,77 @@ func TestNewManagerEmptyImageErrors(t *testing.T) {
 	}
 	if mgr != nil {
 		t.Fatalf("NewManager(\"\") = %v, want nil manager alongside the error", mgr)
+	}
+}
+
+// TestEnsureContainerPullsMissingImage confirms a create that 404s for
+// a missing image triggers exactly one ImagePull, then a retried create
+// that succeeds.
+func TestEnsureContainerPullsMissingImage(t *testing.T) {
+	var createCalls, pullCalls int
+	cli := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1.51/containers/timothy-sandbox-m1/json":
+			http.Error(w, "no such container", http.StatusNotFound)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1.51/containers/create":
+			createCalls++
+			if createCalls == 1 {
+				http.Error(w, "No such image: img:latest", http.StatusNotFound)
+				return
+			}
+			writeJSON(t, w, http.StatusCreated, container.CreateResponse{ID: "new1"})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1.51/images/create":
+			pullCalls++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"Pull complete"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1.51/containers/new1/start":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected call: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	mgr := newTestManager(cli)
+	mgr.workspaceMount = mount.Mount{Type: mount.TypeVolume, Source: "timothy_workspace", Target: workspaceMountPath}
+
+	id, err := mgr.ensureContainer(context.Background(), "m1", "")
+	if err != nil {
+		t.Fatalf("ensureContainer: %v", err)
+	}
+	if id != "new1" {
+		t.Fatalf("id = %q, want new1", id)
+	}
+	if pullCalls != 1 {
+		t.Fatalf("pullCalls = %d, want exactly 1", pullCalls)
+	}
+	if createCalls != 2 {
+		t.Fatalf("createCalls = %d, want exactly 2 (initial 404 + retry)", createCalls)
+	}
+}
+
+// TestEnsureContainerPullFailureNamesImage confirms a pull that itself
+// fails surfaces an error naming the image, not a generic infra error.
+func TestEnsureContainerPullFailureNamesImage(t *testing.T) {
+	cli := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1.51/containers/timothy-sandbox-m1/json":
+			http.Error(w, "no such container", http.StatusNotFound)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1.51/containers/create":
+			http.Error(w, "No such image: img:latest", http.StatusNotFound)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1.51/images/create":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"errorDetail":{"message":"manifest unknown"}}`))
+		default:
+			t.Fatalf("unexpected call: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	mgr := newTestManager(cli)
+	mgr.workspaceMount = mount.Mount{Type: mount.TypeVolume, Source: "timothy_workspace", Target: workspaceMountPath}
+
+	_, err := mgr.ensureContainer(context.Background(), "m1", "")
+	if err == nil {
+		t.Fatal("ensureContainer: want error when pull fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "img") {
+		t.Errorf("error = %q, want it to name the image", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary
- Replace the hardcoded variant image map (`timothy-sandbox-<k>:latest`) with derivation from `MISSION_SANDBOX_IMAGE`: repository gets `-<key>` appended, tag preserved — `ghcr.io/timothy-agent/timothy-sandbox:0.1.0-alpha.21` → `ghcr.io/timothy-agent/timothy-sandbox-go:0.1.0-alpha.21`, matching exactly what release.yml publishes. Local `make sandbox-image` convention (`timothy-sandbox:latest` → `timothy-sandbox-go:latest`) unchanged.
- Environment allowlist stays Go code (`environmentKeys`); unknown key still fails loudly with `ErrUnknownEnvironment`. Digest base refs rejected for variants. Registry-with-port refs split correctly (tag = last `:` after last `/`).
- `createContainer` pulls a missing image on demand (NotFound → `ImagePull` + drain → retry create once). SSE headers flush before ensure, so long pulls survive client/server timeouts.

## Why
Registry deployments had to manually pull and retag every sandbox variant per release; the missed step at alpha.20 paused a mission on `No such image`. This makes the configured base image the single source of truth — next deploy needs no sandbox image handling at all.

## Testing
- `make build test vet lint` green; `go test -race ./internal/sandboxd/...` green (derivation table incl. port/untagged/digest cases; two fake-daemon pull tests: pull-then-retry, pull failure names image).
- `make canary` PASS (done/done, 107s).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788790935&installation_model_id=431401&pr_number=191&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F191&signature=f27279b1889435aa1c8af53e7c630d2c6c45d16d7a8ffa8bf3b7559e599add45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->