### PR TITLE
ci: copy forward sandbox images when family unchanged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,9 +180,15 @@ jobs:
   # timothy-sandbox) rather than renaming it — nothing outside this
   # workflow needs to change to keep pulling the base under its
   # original name.
+  #
+  # Unlike service images, the family's copy-forward lives inside this
+  # same job (per-step ifs) rather than a matrix conditional: the
+  # release compose pins MISSION_SANDBOX_IMAGE to the release version
+  # and sandboxd derives variant refs from it, so every release MUST
+  # have all six sandbox tags — a skipped job would leave them
+  # dangling and break the first mission of each environment.
   sandbox-images:
     needs: diff
-    if: needs.diff.outputs.sandbox == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       packages: write
@@ -193,14 +199,27 @@ jobs:
       - id: sha
         run: echo "short=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-qemu-action@v4
+        if: fromJSON(needs.diff.outputs.sandbox)
       - name: Setup Blacksmith Builder
+        if: fromJSON(needs.diff.outputs.sandbox)
         uses: useblacksmith/setup-docker-builder@v1
       - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Copy forward unchanged family
+        if: needs.diff.outputs.prev_tag != '' && !fromJSON(needs.diff.outputs.sandbox)
+        run: |
+          prev_version="${{ needs.diff.outputs.prev_tag }}"
+          prev_version="${prev_version#v}"
+          for name in sandbox sandbox-base sandbox-go sandbox-node sandbox-python sandbox-java sandbox-php; do
+            docker buildx imagetools create \
+              --tag ghcr.io/${{ github.repository_owner }}/timothy-$name:${{ steps.version.outputs.value }} \
+              ghcr.io/${{ github.repository_owner }}/timothy-$name:${prev_version}
+          done
       - name: Build and push base
+        if: fromJSON(needs.diff.outputs.sandbox)
         uses: useblacksmith/build-push-action@v2
         with:
           context: .
@@ -214,6 +233,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/timothy-sandbox:${{ steps.version.outputs.value }}
             ghcr.io/${{ github.repository_owner }}/timothy-sandbox-base:${{ steps.version.outputs.value }}
       - name: Build and push variants
+        if: fromJSON(needs.diff.outputs.sandbox)
         run: |
           for lang in go node python java php; do
             docker buildx build \
@@ -229,12 +249,7 @@ jobs:
 
   release:
     needs: [images, sandbox-images]
-    # sandbox-images is conditionally skipped (no sandbox-*.Dockerfile
-    # change this release) — the default success() treats a skipped
-    # need as not-success and would skip this job too, so it's spelled
-    # out explicitly: images must succeed, sandbox-images must succeed
-    # or be skipped.
-    if: needs.images.result == 'success' && (needs.sandbox-images.result == 'success' || needs.sandbox-images.result == 'skipped')
+    if: needs.images.result == 'success' && needs.sandbox-images.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write


### PR DESCRIPTION
Release compose pins MISSION_SANDBOX_IMAGE to the release version and
sandboxd derives variant refs from it, so every release must have all
six sandbox tags. Skipping the job when no sandbox Dockerfile changed
left them dangling at the new version.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788791602&installation_model_id=431401&pr_number=192&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F192&signature=784a19830e7e42918f08639a35adc5940ae2c6cc4e47ad2ed491c2266128768d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->