### PR TITLE
feat: memory-aware mission admission, sandbox hardening, whisper opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Alpha releases with prebuilt images are available on the [Releases page](https:/
 - **Multi-provider chat**: Anthropic, Amazon Bedrock, and any OpenAI-compatible API behind one gateway; providers, models, and per-task routing are database configuration, editable at runtime from the settings panel with hot reload.
 - **Sessions that survive**: every conversation is an append-only event log; kill a container mid-stream and the session resumes and replays exactly.
 - **Tools, permissions, skills**: the agent loop executes tools behind a constraint/permission chain (destructive actions require explicit approval in the UI); skill packs load lazily by task.
-- **Missions**: long-running agent tasks with a pure state machine, harness-owned verification (artifacts must exist before any model claim counts), per-mission sandboxes, budgets, and LLM review; recurring missions fire from cron schedules.
+- **Missions**: long-running agent tasks with a pure state machine, harness-owned verification (artifacts must exist before any model claim counts), per-mission sandboxes, budgets, and LLM review; recurring missions fire from cron schedules. Coding missions auto-detect their language environment (Go, Node, Python, Java, PHP) and run in a matching per-language sandbox image, pulled on demand.
+- **Delegated coding harness**: a coding mission can hand its execution to headless Claude Code running inside the mission sandbox — against an Anthropic subscription, or any provider with an Anthropic-compatible endpoint (GLM, local Ollama) — while Timothy keeps verification, review, budgets, and the event timeline; it falls back to the native loop (recorded in the timeline) whenever the harness is unavailable.
+- **Memory-aware scheduling**: before starting a mission, sandboxd checks whether the host can actually afford another sandbox; if not, the mission queues idle and is retried automatically as resources free up.
 - **Long-term memory**: staged fact extraction with a confirmation queue, hybrid pgvector retrieval (vector + text + entity, RRF-fused) under a strict token budget.
 - **Cost accounting**: every request lands in a ledger with honest pricing (unknown price is recorded as null, never guessed); usage dashboard, spend budgets with alerts, Prometheus metrics on every service.
 - **Privacy floor**: tools whose output carries sensitive data (raw email) pin the rest of their turn, and every downstream side-call (memory extraction, compaction), to a dedicated route you can chain to a local model.
@@ -39,7 +41,7 @@ Go microservices behind a single public API, one PostgreSQL database, React web 
 | `web`        | React + Tailwind interface: chat, missions, usage, settings                                 |
 | `searxng`    | Internal metasearch backend for the web_search tool                                          |
 | `markitdown` | Internal Python sidecar: file→markdown conversion                                           |
-| `whisper`    | Internal Python sidecar: local speech-to-text for the web mic button                        |
+| `whisper`    | Internal Python sidecar: local speech-to-text for the web mic button (opt-in, off by default) |
 
 Plus Postgres (18 + pgvector), internal only, no host port. Migrations are embedded in each Go binary and applied automatically at startup; there's no separate migrate command. Every Go service exposes `GET /health` and `GET /metrics`.
 
@@ -78,7 +80,18 @@ The fastest way to run Timothy: no Go/Node toolchain, no build step, just Docker
 
 3. Open the printed link: the web UI signs in automatically from the token in the URL.
 
-To upgrade later: bump `TIMOTHY_VERSION` in `.env`, run `docker compose pull && docker compose up -d`, then `docker pull ghcr.io/timothy-agent/timothy-sandbox:$TIMOTHY_VERSION` (the per-mission sandbox image sandboxd pulls via the Docker socket, outside compose's own pull) — or just re-run `install.sh`, which does all three (it leaves an existing `.env` untouched and only refreshes `docker-compose.yml`, the searxng config, and the sandbox image).
+To upgrade later, in this order:
+
+1. Download the new release's `docker-compose.yml` (it changes between releases; the old one may reference services or settings the new images don't expect):
+
+   ```sh
+   curl -fsSLo docker-compose.yml "https://github.com/timothy-agent/timothy/releases/download/<new-tag>/docker-compose.yml"
+   ```
+
+2. Set `TIMOTHY_VERSION` in `.env` to the new tag (without the `v` prefix).
+3. `docker compose pull && docker compose up -d`
+
+Or bump `TIMOTHY_VERSION` in `.env` and re-run the new release's `install.sh`, which handles the rest (it leaves an existing `.env` untouched, refreshes `docker-compose.yml` and the searxng config, and pre-pulls the mission sandbox image). Sandbox images (base and the per-language variants) are otherwise pulled on demand by sandboxd the first time a mission needs them.
 
 The rest of this README covers building and running from source instead.
 
@@ -108,7 +121,7 @@ Prerequisites:
    make sandbox-image
    ```
 
-   Skip this and leave `MISSION_SANDBOX_IMAGE` empty in `.env` if you don't need missions isolated in their own container; mission shell commands then run in-process instead.
+   This builds the base image plus the per-language variants (`timothy-sandbox-{go,node,python,java,php}:latest`) that coding missions run in; sandboxd derives a variant's image name from `MISSION_SANDBOX_IMAGE`, so the local names must stay in this convention. Skip this and leave `MISSION_SANDBOX_IMAGE` empty in `.env` if you don't need missions isolated in their own container; mission shell commands then run in-process instead.
 
 3. (Linux only) Set `DOCKER_SOCK_GID` so `sandboxd` can use the Docker socket:
 
@@ -129,27 +142,6 @@ Prerequisites:
 5. First login. There's no login page: the web UI auto-opens a settings dialog asking for an API token the first time it can't find one. Paste the `TIMOTHY_API_TOKEN` value from `deploy/.env`. It's stored in your browser's `localStorage`.
 
 6. Add a provider. A fresh install has zero LLM providers and no routing configured, so Timothy can't answer anything until you do this. Go to **Settings → Providers**, pick a preset tile (OpenAI, Anthropic, Bedrock, GLM, Grok, Ollama, or a custom OpenAI-compatible endpoint), fill in the form, and run the connection test before adding it. The API key you enter is encrypted into the secret store (default backend `db`, encrypted with `TIMOTHY_MASTER_KEY`); the database only ever holds a reference to it, never the raw value, and it never appears in `.env`, logs, or API responses. Creating your first provider automatically bootstraps the 4 routes Timothy needs to work (`default`, `summarize`, `embedding`, `vision`); routes are otherwise fully user-managed (create, edit chain/strategy, delete) from **Settings → Routing**.
-
-## Optional: local models
-
-Run Ollama natively on the host, not in a container: a containerized Ollama only gets CPU, while a host install can use Metal or CUDA. Then add a provider with the **Ollama** preset; it prefills the base URL `http://host.docker.internal:11434/v1`. On Linux, `host.docker.internal` may need a `host-gateway` entry in your Docker config to resolve.
-
-## Optional: Google connectors (Gmail, Calendar)
-
-1. Create an OAuth client in Google Cloud Console, type **Web application**.
-2. Set `TIMOTHY_PUBLIC_URL` in `.env` to the URL your *browser* uses to reach Timothy (e.g. `http://localhost:3300`). This must match what you register with Google, or the OAuth callback fails.
-3. Add `<TIMOTHY_PUBLIC_URL>/v1/connectors/oauth/callback` to the OAuth client's authorized redirect URIs.
-4. In the UI: **Settings → Connectors**, pick the Gmail or Calendar tile, paste the client ID and client secret, and complete the consent flow. Scopes requested: `gmail.modify`, `calendar`.
-
-While the Google OAuth app is in "Testing" mode (the default for a new Cloud project), refresh tokens expire roughly every 7 days; when a connector stops working, reconnect it from Settings, or publish the OAuth app to avoid the expiry.
-
-## Optional: GitHub connector
-
-Configured as an MCP preset in **Settings → Connectors**: paste a GitHub personal access token into the Bearer token field.
-
-## Optional: Amazon Bedrock
-
-Create an IAM user scoped to `bedrock:InvokeModel*` only, generate an access key, and enter the access key ID and secret access key into their own fields on the Bedrock provider in **Settings → Providers**. Pick a region from the dropdown; no `~/.aws`, no SSO, nothing to run on the host.
 
 ## Operating the stack
 

--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -247,7 +247,7 @@ func main() {
 	}
 	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, fxStore, gwc, secrets, app.Log)
 	if missionDriver != nil {
-		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, app.Log)
+		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, app.Log)
 	}
 	app.AddCheck("sandbox", func() httpserver.Check {
 		if err := missionSandbox.Health(ctx); err != nil {
@@ -458,8 +458,9 @@ func buildConnectors(db *pgpool.Pool, secrets *secretstore.Store, log *slog.Logg
 }
 
 // missionWorkSlotMax bounds how many missions may be status='working'
-// at once — a conservative default until this needs to be a runtime
-// setting.
+// at once — the absolute ceiling; in practice the D-056 memory
+// admission gate (sandboxd's /capacity) binds first, since a host tight
+// on memory denies well before 4 concurrent missions.
 const missionWorkSlotMax = 4
 
 // missionAgentResolver adapts agentReg.ResolveByID to scheduler.go's
@@ -535,6 +536,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	perms := tools.NewPermissions(db, toolWorkspaceRoot)
 	driver := missions.NewDriver(store, runner, workspace, notifier, sessions, perms, sandboxMgr.Exec, sandboxMgr, log)
 	driver.SetFXRates(fxStore)
+	driver.SetCapacityGate(sandboxMgr)
 	resolveAgent := missionAgentResolver(agentReg)
 	driver.SetAgentResolver(resolveAgent)
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -58,6 +58,7 @@ services:
 
   whisper:
     <<: *service
+    profiles: [whisper]
     build:
       context: ../whisper-svc
       args:
@@ -73,6 +74,9 @@ services:
     # the right language. Slower per clip and a bigger image, but
     # dictation is not latency-sensitive the way live transcription
     # would be.
+    # Off by default: the model holds ~3 GiB RSS at idle. Enable with
+    # COMPOSE_PROFILES=whisper and WHISPER_URL=http://whisper:8001 in
+    # .env.
 
   # Local models: run Ollama natively on the host (Metal/CUDA — a
   # containerized runner gets CPU only and can't serve big models) and
@@ -122,8 +126,10 @@ services:
       # markdown/text; compose-internal only.
       MARKITDOWN_URL: http://markitdown:8000
       # Local speech-to-text for the web mic button; compose-internal
-      # only, audio never leaves the box.
-      WHISPER_URL: http://whisper:8001
+      # only, audio never leaves the box. Empty by default (feature
+      # off) since whisper itself defaults off — see its service
+      # comment.
+      WHISPER_URL: ${WHISPER_URL:-}
       # sandboxd's internal address — mission shell/verify_cmd execution
       # always runs there; brain never touches the Docker socket
       # directly.
@@ -142,8 +148,6 @@ services:
       searxng:
         condition: service_started
       markitdown:
-        condition: service_started
-      whisper:
         condition: service_started
       sandboxd:
         condition: service_started

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -46,3 +46,8 @@ HUGEICONS_TOKEN=
 # works. Linux hosts: run `stat -c '%g' /var/run/docker.sock` and set
 # it here if it isn't 0.
 DOCKER_SOCK_GID=0
+
+# --- Speech-to-text (optional) ---
+# Local speech-to-text for the web mic button (~3 GiB RAM). Enable both:
+# COMPOSE_PROFILES=whisper
+# WHISPER_URL=http://whisper:8001

--- a/deploy/release/docker-compose.yml
+++ b/deploy/release/docker-compose.yml
@@ -57,6 +57,7 @@ services:
 
   whisper:
     <<: *service
+    profiles: [whisper]
     image: ghcr.io/timothy-agent/timothy-whisper:${TIMOTHY_VERSION:?set TIMOTHY_VERSION in .env}
     environment:
       # The published image bakes model "large-v3" at build time;
@@ -65,6 +66,9 @@ services:
       WHISPER_MODEL: large-v3
     # internal-only: no published ports, no auth; brain is the sole
     # caller, same trust boundary as searxng/markitdown.
+    # Off by default: the model holds ~3 GiB RSS at idle. Enable with
+    # COMPOSE_PROFILES=whisper and WHISPER_URL=http://whisper:8001 in
+    # .env.
 
   # Local models: run Ollama natively on the host (Metal/CUDA — a
   # containerized runner gets CPU only and can't serve big models) and
@@ -104,8 +108,10 @@ services:
       # markdown/text; compose-internal only.
       MARKITDOWN_URL: http://markitdown:8000
       # Local speech-to-text for the web mic button; compose-internal
-      # only, audio never leaves the box.
-      WHISPER_URL: http://whisper:8001
+      # only, audio never leaves the box. Empty by default (feature
+      # off) since whisper itself defaults off — see its service
+      # comment.
+      WHISPER_URL: ${WHISPER_URL:-}
       # sandboxd's internal address — mission shell/verify_cmd execution
       # always runs there; brain never touches the Docker socket
       # directly.
@@ -124,8 +130,6 @@ services:
       searxng:
         condition: service_started
       markitdown:
-        condition: service_started
-      whisper:
         condition: service_started
       sandboxd:
         condition: service_started

--- a/deploy/release/env.example
+++ b/deploy/release/env.example
@@ -38,3 +38,8 @@ TIMOTHY_PUBLIC_URL=http://localhost:3300
 # works. Linux hosts: run `stat -c '%g' /var/run/docker.sock` and set
 # it here if it isn't 0.
 DOCKER_SOCK_GID=0
+
+# --- Speech-to-text (optional) ---
+# Local speech-to-text for the web mic button (~3 GiB RAM). Enable both:
+# COMPOSE_PROFILES=whisper
+# WHISPER_URL=http://whisper:8001

--- a/internal/brain/api/admin.go
+++ b/internal/brain/api/admin.go
@@ -50,14 +50,18 @@ func (a *API) registerAdmin(handle func(pattern string, h http.Handler), admin h
 
 // registerSettings mounts brain's own feature switches — served
 // locally, not proxied: the gateway has no business knowing them.
-func (a *API) registerSettings(handle func(pattern string, h http.Handler), flags *settings.Store) {
+// whisperURL derives the read-only transcribe_enabled flag; it isn't a
+// stored setting and PATCH rejects it like any other unknown key.
+func (a *API) registerSettings(handle func(pattern string, h http.Handler), flags *settings.Store, whisperURL string) {
 	if flags == nil {
 		return
 	}
 	handle("GET /v1/admin/settings", a.auth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		s := flags.All(r.Context())
+		s["transcribe_enabled"] = whisperURL != ""
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"settings": flags.All(r.Context()),
+			"settings": s,
 			"values":   flags.AllValues(r.Context()),
 		})
 	})))

--- a/internal/brain/api/admin_test.go
+++ b/internal/brain/api/admin_test.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/settings"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+// degradedSettings builds a Store over a pool with no DSN, i.e.
+// permanently degraded — All/AllValues fall back to their built-in
+// defaults without ever touching a database, which is all these tests
+// need from the settings switches.
+func degradedSettings(t *testing.T) *settings.Store {
+	t.Helper()
+	pool := pgpool.New(t.Context(), "", discard())
+	return settings.New(pool, discard())
+}
+
+func TestGetSettingsReportsTranscribeEnabled(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		whisperURL string
+		want       bool
+	}{
+		{"configured", "http://whisper:9000", true},
+		{"unset", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a := &API{token: "tok", log: discard(), flags: degradedSettings(t)}
+			m := http.NewServeMux()
+			a.registerSettings(m.Handle, a.flags, tc.whisperURL)
+
+			req := httptest.NewRequest(http.MethodGet, "/v1/admin/settings", nil)
+			req.Header.Set("Authorization", "Bearer tok")
+			w := httptest.NewRecorder()
+			m.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", w.Code)
+			}
+			var body struct {
+				Settings map[string]bool `json:"settings"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if got := body.Settings["transcribe_enabled"]; got != tc.want {
+				t.Fatalf("transcribe_enabled = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPatchSettingsRejectsTranscribeEnabled(t *testing.T) {
+	t.Parallel()
+	a := &API{token: "tok", log: discard(), flags: degradedSettings(t)}
+	m := http.NewServeMux()
+	a.registerSettings(m.Handle, a.flags, "http://whisper:9000")
+
+	req := httptest.NewRequest(http.MethodPatch, "/v1/admin/settings", strings.NewReader(`{"transcribe_enabled": false}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+
+	// The derived flag stays untouched by the rejected write.
+	getReq := httptest.NewRequest(http.MethodGet, "/v1/admin/settings", nil)
+	getReq.Header.Set("Authorization", "Bearer tok")
+	getW := httptest.NewRecorder()
+	m.ServeHTTP(getW, getReq)
+	var body struct {
+		Settings map[string]bool `json:"settings"`
+	}
+	if err := json.Unmarshal(getW.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.Settings["transcribe_enabled"] {
+		t.Fatalf("transcribe_enabled = %v, want true after rejected patch", body.Settings["transcribe_enabled"])
+	}
+}

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -97,7 +97,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 		}
 	}
 	a.registerAdmin(srv.Handle, admin)
-	a.registerSettings(srv.Handle, flags)
+	a.registerSettings(srv.Handle, flags, whisperURL)
 	a.registerAgents(srv.Handle, agentReg)
 	a.registerConnectors(srv.Handle, conns, goog)
 	a.registerTools(srv.Handle, toolset)

--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -177,7 +177,11 @@ func (r *delegatedRunner) RunReview(ctx context.Context, m Mission, packet Revie
 // route on the executor axis, walking the first usable, non-cooled
 // entry into the delegated protocol. An unknown harness, a resolve
 // failure, or no usable entry at all falls back to native.RunWorker
-// unchanged — today's behavior is always the floor.
+// unchanged — today's behavior is always the floor — but a mission
+// that explicitly asked for a harness must not fall back silently: an
+// executor.skipped event is recorded first (see recordSkipped) so the
+// mission's own history shows the requested harness was never actually
+// used.
 func (r *delegatedRunner) RunWorker(ctx context.Context, m Mission, packet WorkPacket) (WorkerVerdict, string, error) {
 	if m.Harness == "" {
 		return r.native.RunWorker(ctx, m, packet)
@@ -185,6 +189,7 @@ func (r *delegatedRunner) RunWorker(ctx context.Context, m Mission, packet WorkP
 	adapter, ok := executor.Lookup(m.Harness)
 	if !ok {
 		r.log.Warn("delegated runner: unknown harness; falling back to native", "mission_id", m.ID, "harness", m.Harness)
+		r.recordSkipped(ctx, m.ID, m.Harness, "unknown_harness", nil)
 		return r.native.RunWorker(ctx, m, packet)
 	}
 
@@ -192,29 +197,60 @@ func (r *delegatedRunner) RunWorker(ctx context.Context, m Mission, packet WorkP
 	if err != nil || route == nil {
 		if err != nil {
 			r.log.Warn("delegated runner: route resolve failed; falling back to native", "mission_id", m.ID, "error", err)
+			r.recordSkipped(ctx, m.ID, m.Harness, "resolve_failed", map[string]any{"error": truncate(err.Error(), 2000)})
+		} else {
+			r.recordSkipped(ctx, m.ID, m.Harness, "resolve_failed", map[string]any{"error": "resolved route was nil without an error"})
 		}
 		return r.native.RunWorker(ctx, m, packet)
 	}
 
-	for _, entry := range route.Entries {
+	var skipReasons []string
+	var cooledEntry *gwclient.ResolvedRouteEntry
+	var cooledUntil time.Time
+	for i, entry := range route.Entries {
 		if !entry.Usable {
+			skipReasons = append(skipReasons, entry.SkipReason)
 			continue
 		}
-		if r.cooledDown(m.Harness, entry) {
+		if exp, cooled := r.cooledUntil(m.Harness, entry); cooled {
+			if cooledEntry == nil {
+				cooledEntry = &route.Entries[i]
+				cooledUntil = exp
+			}
 			continue
 		}
 		return r.runDelegated(ctx, m, packet, entry, adapter)
 	}
+
+	if cooledEntry != nil {
+		r.log.Warn("delegated runner: every usable entry cooled down; falling back to native", "mission_id", m.ID, "harness", m.Harness)
+		r.recordSkipped(ctx, m.ID, m.Harness, "cooldown", map[string]any{
+			"until": cooledUntil.UTC().Format(time.RFC3339), "provider": cooledEntry.ProviderName, "model": cooledEntry.Model,
+		})
+	} else {
+		r.log.Warn("delegated runner: no usable route entry; falling back to native", "mission_id", m.ID, "harness", m.Harness)
+		r.recordSkipped(ctx, m.ID, m.Harness, "no_usable_entry", map[string]any{"skip_reasons": boundStrings(skipReasons, 5)})
+	}
 	return r.native.RunWorker(ctx, m, packet)
 }
 
-// cooledDown reports whether entry is in its post-failure cooldown
-// window.
-func (r *delegatedRunner) cooledDown(harness string, entry gwclient.ResolvedRouteEntry) bool {
+// boundStrings caps a []string to at most n elements — skip_reasons is
+// operator-facing context, not a field anything keys logic on.
+func boundStrings(s []string, n int) []string {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}
+
+// cooledUntil reports whether entry is in its post-failure cooldown
+// window, and if so, when it expires — RunWorker's walk needs the
+// expiry to report a cooldown reason's "until" field.
+func (r *delegatedRunner) cooledUntil(harness string, entry gwclient.ResolvedRouteEntry) (time.Time, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	exp, ok := r.cooldown[cooldownKey{entry.ProviderID, entry.Model, harness}]
-	return ok && time.Now().Before(exp)
+	return exp, ok && time.Now().Before(exp)
 }
 
 // coolDown marks entry unusable for cooldownTTL — set on transport
@@ -837,6 +873,19 @@ func (r *delegatedRunner) recordDied(ctx context.Context, missionID, reason stri
 // recordAuthFailed writes executor.auth_failed.
 func (r *delegatedRunner) recordAuthFailed(ctx context.Context, missionID, harness string) {
 	r.recordEventForce(ctx, missionID, "executor.auth_failed", map[string]any{"harness": harness})
+}
+
+// recordSkipped writes executor.skipped — the one persisted record that
+// a mission explicitly requesting harness ran native instead, and why.
+// extra carries the reason-specific fields (error/until+provider+model/
+// skip_reasons); nil for unknown_harness, which needs nothing beyond
+// harness+reason.
+func (r *delegatedRunner) recordSkipped(ctx context.Context, missionID, harness, reason string, extra map[string]any) {
+	payload := map[string]any{"harness": harness, "reason": reason}
+	for k, v := range extra {
+		payload[k] = v
+	}
+	r.recordEventForce(ctx, missionID, "executor.skipped", payload)
 }
 
 // recordEvent appends one executor.* event, respecting maxExecutorEvents

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -731,6 +731,62 @@ func TestDelegatedRunWorker_CooldownSkipsToNativeFallback(t *testing.T) {
 	if sandbox.launches != 1 {
 		t.Fatalf("sandbox launches = %d, want 1 (second call must not retry the cooled-down entry)", sandbox.launches)
 	}
+	if events.count("executor.skipped") != 1 {
+		t.Fatalf("executor.skipped count = %d, want 1", events.count("executor.skipped"))
+	}
+	skipped, _ := events.last("executor.skipped")
+	var skippedPayload map[string]any
+	_ = json.Unmarshal(skipped.Payload, &skippedPayload)
+	if skippedPayload["reason"] != "cooldown" {
+		t.Fatalf("executor.skipped reason = %v, want cooldown", skippedPayload["reason"])
+	}
+	if skippedPayload["harness"] != m.Harness {
+		t.Fatalf("executor.skipped harness = %v, want %q", skippedPayload["harness"], m.Harness)
+	}
+	if skippedPayload["provider"] != failing.ProviderName || skippedPayload["model"] != failing.Model {
+		t.Fatalf("executor.skipped provider/model = %v/%v, want %v/%v", skippedPayload["provider"], skippedPayload["model"], failing.ProviderName, failing.Model)
+	}
+	if _, ok := skippedPayload["until"].(string); !ok {
+		t.Fatalf("executor.skipped until = %v, want an RFC3339 string", skippedPayload["until"])
+	}
+}
+
+// TestDelegatedRunWorker_Dispatch_NoUsableEntryFallsBackToNative covers
+// the route-had-entries-but-none-Usable case, distinct from cooldown:
+// no entry was ever usable in the first place, so there is nothing to
+// cool down.
+func TestDelegatedRunWorker_Dispatch_NoUsableEntryFallsBackToNative(t *testing.T) {
+	native := &fakeNative{verdict: WorkerVerdict{Outcome: "done"}}
+	sandbox := newFakeSandbox()
+	events := &fakeEventSink{}
+	unusable := gwclient.ResolvedRouteEntry{
+		ProviderID: "prov-1", ProviderName: "anthropic", Driver: "anthropic",
+		Model: "claude-haiku-4-5-20251001", Usable: false, SkipReason: "no credential configured",
+	}
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{unusable}}
+
+	r := newTestDelegatedRunner(native, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+
+	if _, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if native.callCount() != 1 {
+		t.Fatalf("native call count = %d, want 1", native.callCount())
+	}
+	if events.count("executor.skipped") != 1 {
+		t.Fatalf("executor.skipped count = %d, want 1", events.count("executor.skipped"))
+	}
+	skipped, _ := events.last("executor.skipped")
+	var skippedPayload map[string]any
+	_ = json.Unmarshal(skipped.Payload, &skippedPayload)
+	if skippedPayload["reason"] != "no_usable_entry" {
+		t.Fatalf("executor.skipped reason = %v, want no_usable_entry", skippedPayload["reason"])
+	}
+	reasons, ok := skippedPayload["skip_reasons"].([]any)
+	if !ok || len(reasons) != 1 || reasons[0] != "no credential configured" {
+		t.Fatalf("executor.skipped skip_reasons = %v, want [%q]", skippedPayload["skip_reasons"], "no credential configured")
+	}
 }
 
 // --- scenario 7: api-key mode ---------------------------------------------
@@ -1060,8 +1116,9 @@ func TestDelegatedRunWorker_Dispatch_EmptyHarnessSkipsResolve(t *testing.T) {
 func TestDelegatedRunWorker_Dispatch_UnknownHarnessFallsBackToNative(t *testing.T) {
 	native := &fakeNative{verdict: WorkerVerdict{Outcome: "done"}}
 	sandbox := newFakeSandbox()
+	events := &fakeEventSink{}
 
-	r := newTestDelegatedRunner(native, scriptedResolver(nil, nil), scriptedCred("", nil), sandbox, nil, nil, &fakeLedger{})
+	r := newTestDelegatedRunner(native, scriptedResolver(nil, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
 	m := testMission("m1", t.TempDir())
 	m.Harness = "codex-cli-unregistered"
 
@@ -1071,13 +1128,26 @@ func TestDelegatedRunWorker_Dispatch_UnknownHarnessFallsBackToNative(t *testing.
 	if native.callCount() != 1 {
 		t.Fatalf("native call count = %d, want 1", native.callCount())
 	}
+	if events.count("executor.skipped") != 1 {
+		t.Fatalf("executor.skipped count = %d, want 1", events.count("executor.skipped"))
+	}
+	skipped, _ := events.last("executor.skipped")
+	var skippedPayload map[string]any
+	_ = json.Unmarshal(skipped.Payload, &skippedPayload)
+	if skippedPayload["reason"] != "unknown_harness" {
+		t.Fatalf("executor.skipped reason = %v, want unknown_harness", skippedPayload["reason"])
+	}
+	if skippedPayload["harness"] != m.Harness {
+		t.Fatalf("executor.skipped harness = %v, want %q", skippedPayload["harness"], m.Harness)
+	}
 }
 
 func TestDelegatedRunWorker_Dispatch_ResolveErrorFallsBackToNative(t *testing.T) {
 	native := &fakeNative{verdict: WorkerVerdict{Outcome: "done"}}
 	sandbox := newFakeSandbox()
+	events := &fakeEventSink{}
 
-	r := newTestDelegatedRunner(native, scriptedResolver(nil, fmt.Errorf("gateway unreachable")), scriptedCred("", nil), sandbox, nil, nil, &fakeLedger{})
+	r := newTestDelegatedRunner(native, scriptedResolver(nil, fmt.Errorf("gateway unreachable")), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
 	m := testMission("m1", t.TempDir())
 
 	if _, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"}); err != nil {
@@ -1085,6 +1155,18 @@ func TestDelegatedRunWorker_Dispatch_ResolveErrorFallsBackToNative(t *testing.T)
 	}
 	if native.callCount() != 1 {
 		t.Fatalf("native call count = %d, want 1", native.callCount())
+	}
+	if events.count("executor.skipped") != 1 {
+		t.Fatalf("executor.skipped count = %d, want 1", events.count("executor.skipped"))
+	}
+	skipped, _ := events.last("executor.skipped")
+	var skippedPayload map[string]any
+	_ = json.Unmarshal(skipped.Payload, &skippedPayload)
+	if skippedPayload["reason"] != "resolve_failed" {
+		t.Fatalf("executor.skipped reason = %v, want resolve_failed", skippedPayload["reason"])
+	}
+	if errStr, _ := skippedPayload["error"].(string); errStr == "" {
+		t.Fatalf("executor.skipped error = %q, want a non-empty error string", errStr)
 	}
 }
 

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -129,6 +129,11 @@ type Driver struct {
 	// behavior.
 	fxRates fxRateSource
 
+	// capacity backs the D-056 admission gate (see SetCapacityGate /
+	// Advance) — nil-safe: unset means every idle->working transition is
+	// admitted, same as before this existed.
+	capacity capacityChecker
+
 	// gatekeepers holds each mission's in-progress reviewer session
 	// state, keyed by mission id, for the "delta recheck" resume on
 	// rework. Process-local by design: lost on restart is acceptable —
@@ -177,6 +182,13 @@ func (d *Driver) SetAgentResolver(resolve AgentResolver) {
 // optional cross-cutting dependency.
 func (d *Driver) SetFXRates(store fxRateSource) {
 	d.fxRates = store
+}
+
+// SetCapacityGate wires the D-056 admission gate Advance consults before
+// flipping a mission idle->working — a setter (not a NewDriver
+// parameter) for the same reason SetFXRates is.
+func (d *Driver) SetCapacityGate(gate capacityChecker) {
+	d.capacity = gate
 }
 
 // removeSandbox best-effort tears down a mission's sandbox container in
@@ -332,6 +344,20 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 	}
 	if m.Phase.Terminal() || m.Status == StatusPaused || m.Status == StatusWaitingForInput {
 		return false, nil
+	}
+	// D-056: admission applies only to idle->working, never to a mission
+	// already mid-flight (Drive's own loop calling Advance again finds
+	// m.Status == StatusWorking here, past this check) — a memory-tight
+	// host must queue NEW work, not stall work already in progress.
+	// canContinue=false stops just THIS Drive call; the mission's row is
+	// untouched (still status='idle'), so the periodic work-slot sweep
+	// retries it in workSlotSweepInterval exactly like a mission that
+	// never got an immediate Drive at all.
+	if m.Status == StatusIdle {
+		if admit, reason := admitWork(ctx, d.capacity, d.log); !admit {
+			d.log.Info("driver: capacity denied, mission stays idle", "mission_id", id, "reason", reason)
+			return false, nil
+		}
 	}
 	// A mission that reached the store without going through Create
 	// (scheduler.go's createFromTemplate inserts a bare row directly) has

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -1466,3 +1466,105 @@ func TestDriverModelFloorPausesImmediately(t *testing.T) {
 		t.Fatalf("mission after below-floor turn = %s/%s, want paused/infra immediately", m.Status, m.PauseReason)
 	}
 }
+
+// TestDriverAdvanceDeniesIdleToWorkingOnCapacity covers D-056's driver-
+// path gate: an idle mission whose capacity gate denies must not run
+// its turn at all (the runner is never called) and canContinue=false so
+// this Drive call stops with the mission still idle for the periodic
+// sweep to retry.
+func TestDriverAdvanceDeniesIdleToWorkingOnCapacity(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusIdle, MaxIterations: 8,
+		SessionID: "already-provisioned", Workspace: "/already/provisioned",
+	})
+	runner := &scriptedRunner{exploreNotes: []string{"explored"}}
+	d := testDriver(store, runner)
+	d.SetCapacityGate(fakeCapacityChecker{admit: false, reason: "mem_available 900MB < floor 1024 + per-sandbox 768"})
+
+	cont, err := d.Advance(context.Background(), "m1")
+	if err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if cont {
+		t.Fatal("Advance = canContinue true, want false when capacity denies")
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Status != StatusIdle || m.Phase != PhaseExplore {
+		t.Fatalf("mission after capacity denial = %s/%s, want idle/explore untouched (phase run must not happen)", m.Status, m.Phase)
+	}
+}
+
+// TestDriverAdvanceCapacityGateErrorAdmitsOpen confirms a gate that
+// itself errors (sandboxd unreachable) does not block the turn — a dead
+// gate must never freeze the mission queue.
+func TestDriverAdvanceCapacityGateErrorAdmitsOpen(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusIdle, MaxIterations: 8})
+	runner := &scriptedRunner{exploreNotes: []string{"explored"}}
+	d := testDriver(store, runner)
+	d.SetCapacityGate(fakeCapacityChecker{err: fmt.Errorf("sandboxd unreachable")})
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhasePlan {
+		t.Fatalf("mission.Phase = %s, want plan (turn ran despite the gate erroring)", m.Phase)
+	}
+}
+
+// TestDriverAdvanceCapacityGateAdmitsRunsTurn confirms a gate that
+// admits lets the idle mission's turn run normally.
+func TestDriverAdvanceCapacityGateAdmitsRunsTurn(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusIdle, MaxIterations: 8})
+	runner := &scriptedRunner{exploreNotes: []string{"explored"}}
+	d := testDriver(store, runner)
+	d.SetCapacityGate(fakeCapacityChecker{admit: true})
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhasePlan {
+		t.Fatalf("mission.Phase = %s, want plan (turn ran when the gate admits)", m.Phase)
+	}
+}
+
+// TestDriverAdvanceNilCapacityGateRunsTurn confirms the default (no gate
+// wired) behaves exactly as before this existed — every idle mission's
+// turn runs unconditionally.
+func TestDriverAdvanceNilCapacityGateRunsTurn(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusIdle, MaxIterations: 8})
+	runner := &scriptedRunner{exploreNotes: []string{"explored"}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhasePlan {
+		t.Fatalf("mission.Phase = %s, want plan (nil gate never blocks)", m.Phase)
+	}
+}
+
+// TestDriverAdvanceCapacityGateIgnoredWhenAlreadyWorking confirms
+// admission applies only to idle->working: a mission already working
+// must keep advancing even when the gate denies.
+func TestDriverAdvanceCapacityGateIgnoredWhenAlreadyWorking(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8})
+	runner := &scriptedRunner{exploreNotes: []string{"explored"}}
+	d := testDriver(store, runner)
+	d.SetCapacityGate(fakeCapacityChecker{admit: false, reason: "denied"})
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhasePlan {
+		t.Fatalf("mission.Phase = %s, want plan (a denial must not stall a mission already working)", m.Phase)
+	}
+}

--- a/internal/brain/missions/executor/claude.go
+++ b/internal/brain/missions/executor/claude.go
@@ -93,7 +93,10 @@ func (claudeAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 		argv = append(argv, "--append-system-prompt", spec.SystemAppend)
 	}
 
-	env := map[string]string{"NO_COLOR": "1"}
+	// nodeMaxOldSpaceMB (D-056) bounds the CLI's node heap: unbounded,
+	// node sizes its heap from cgroup limits, and a long run's transcript
+	// heap balloons toward the sandbox's 2 GiB cap.
+	env := map[string]string{"NO_COLOR": "1", "NODE_OPTIONS": "--max-old-space-size=768"}
 	if spec.AuthMode == AuthAPIKey {
 		env["ANTHROPIC_API_KEY"] = spec.APIKey
 	}

--- a/internal/brain/missions/executor/claude_test.go
+++ b/internal/brain/missions/executor/claude_test.go
@@ -257,6 +257,9 @@ func TestClaudeAdapter_BuildInvocation(t *testing.T) {
 				if inv.Env["NO_COLOR"] != "1" {
 					t.Error("NO_COLOR must always be set")
 				}
+				if inv.Env["NODE_OPTIONS"] != "--max-old-space-size=768" {
+					t.Errorf("NODE_OPTIONS = %q, want --max-old-space-size=768 (D-056, bounds the CLI's node heap)", inv.Env["NODE_OPTIONS"])
+				}
 			},
 		},
 		{

--- a/internal/brain/missions/sweep.go
+++ b/internal/brain/missions/sweep.go
@@ -39,15 +39,42 @@ type sandboxSweeper interface {
 	Sweep(ctx context.Context, isTerminal func(missionID string) bool) error
 }
 
+// capacityChecker is the narrow slice of sandboxclient.Client's
+// admission gate (D-056) the sweep needs — kept as an interface for the
+// same reason sandboxSweeper is: no compile-time dependency on Docker
+// from this package.
+type capacityChecker interface {
+	Capacity(ctx context.Context) (admit bool, reason string, err error)
+}
+
+// admitWork reports whether the host can afford claiming another work
+// slot right now (D-056). A nil gate always admits (tests, and any
+// sandbox-less setup that never wired sandboxclient in). A gate that
+// itself errors also admits, logged at WARN: a dead sandboxd must not
+// freeze the mission queue — a mission that actually needs the sandbox
+// will fail loudly at exec time anyway, so failing this check open costs
+// nothing a live gate wouldn't also risk.
+func admitWork(ctx context.Context, gate capacityChecker, log *slog.Logger) (admit bool, reason string) {
+	if gate == nil {
+		return true, ""
+	}
+	admit, reason, err := gate.Capacity(ctx)
+	if err != nil {
+		log.Warn("work slot sweep: capacity check failed, admitting open", "error", err)
+		return true, ""
+	}
+	return admit, reason
+}
+
 // RecoverAndSweep runs the boot-time recovery pass once (re-Drives any
 // mission left status='working' from a prior process's crash), then
 // runs the periodic work-slot sweep until ctx is done — which now also
 // sweeps orphaned sandbox containers on the same tick (see
 // runWorkSlotSweep). This is the one entry point cmd/brain/main.go
 // needs — it owns the Driver, which carries its own Store reference.
-func RecoverAndSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, log *slog.Logger) {
+func RecoverAndSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, log *slog.Logger) {
 	recoverWorking(ctx, d, store, log)
-	runWorkSlotSweep(ctx, d, store, maxConcurrent, sandbox, log)
+	runWorkSlotSweep(ctx, d, store, maxConcurrent, sandbox, capacity, log)
 }
 
 // sweepOrphanSandboxes runs on every runWorkSlotSweep tick (previously
@@ -117,7 +144,7 @@ func recoverWorking(ctx context.Context, d *Driver, store *Store, log *slog.Logg
 // re-Drives any 'working' mission stale past staleWorkingAfter — all on
 // the same tick. Runs until ctx is done — this call blocks, so
 // RecoverAndSweep's caller runs it in its own goroutine.
-func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, log *slog.Logger) {
+func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, log *slog.Logger) {
 	ticker := time.NewTicker(workSlotSweepInterval)
 	defer ticker.Stop()
 	for {
@@ -127,6 +154,14 @@ func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurren
 		case <-ticker.C:
 			sweepOrphanSandboxes(ctx, store, sandbox, log)
 			reDriveStaleWorking(ctx, d, store, log)
+			// D-056: skip the claim entirely this tick if the host can't
+			// afford another working mission — the mission stays idle,
+			// and this same sweep retries it in workSlotSweepInterval; that
+			// retry IS the queue, no separate parking state needed.
+			if admit, reason := admitWork(ctx, capacity, log); !admit {
+				log.Info("work slot sweep: capacity denied, leaving missions idle", "reason", reason)
+				continue
+			}
 			id, ok, err := store.ClaimWorkSlot(ctx, maxConcurrent)
 			if err != nil {
 				log.Error("work slot sweep: claim failed", "error", err)

--- a/internal/brain/missions/sweep_test.go
+++ b/internal/brain/missions/sweep_test.go
@@ -1,0 +1,66 @@
+package missions
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// fakeCapacityChecker scripts one Capacity call per test case.
+type fakeCapacityChecker struct {
+	admit  bool
+	reason string
+	err    error
+}
+
+func (f fakeCapacityChecker) Capacity(ctx context.Context) (bool, string, error) {
+	return f.admit, f.reason, f.err
+}
+
+// TestAdmitWork covers D-056's three gate outcomes: nil gate always
+// admits (tests, sandbox-less setups), a gate error also admits (fails
+// open so a dead sandboxd never freezes the mission queue), and a live
+// gate's own admit/reason pass through unchanged.
+func TestAdmitWork(t *testing.T) {
+	t.Parallel()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	cases := []struct {
+		name       string
+		gate       capacityChecker
+		wantAdmit  bool
+		wantReason string
+	}{
+		{name: "nil gate admits", gate: nil, wantAdmit: true},
+		{
+			name:      "gate error admits open",
+			gate:      fakeCapacityChecker{err: errors.New("sandboxd unreachable")},
+			wantAdmit: true,
+		},
+		{
+			name:       "gate denies",
+			gate:       fakeCapacityChecker{admit: false, reason: "mem_available 900MB < floor 1024 + per-sandbox 768"},
+			wantAdmit:  false,
+			wantReason: "mem_available 900MB < floor 1024 + per-sandbox 768",
+		},
+		{
+			name:      "gate admits",
+			gate:      fakeCapacityChecker{admit: true},
+			wantAdmit: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			admit, reason := admitWork(context.Background(), tc.gate, log)
+			if admit != tc.wantAdmit {
+				t.Errorf("admit = %v, want %v", admit, tc.wantAdmit)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
+			}
+		})
+	}
+}

--- a/internal/brain/sandboxclient/sandboxclient.go
+++ b/internal/brain/sandboxclient/sandboxclient.go
@@ -215,6 +215,40 @@ func (c *Client) list(ctx context.Context) ([]string, error) {
 	return out.MissionIDs, nil
 }
 
+// capacityTimeout bounds the /capacity call (D-056) — it's a single
+// local read (/proc/meminfo + a container list), so 5s is already
+// generous; a hung sandboxd must not stall the admission gate's caller.
+const capacityTimeout = 5 * time.Second
+
+// Capacity asks sandboxd whether the host can afford one more working
+// mission (D-056) — brain's admission gate consults this before flipping
+// a mission idle->working.
+func (c *Client) Capacity(ctx context.Context) (admit bool, reason string, err error) {
+	cctx, cancel := context.WithTimeout(ctx, capacityTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(cctx, http.MethodGet, c.baseURL+"/capacity", nil)
+	if err != nil {
+		return false, "", fmt.Errorf("sandboxclient: request: %w", err)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return false, "", fmt.Errorf("sandboxclient: sandboxd unreachable: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return false, "", fmt.Errorf("sandboxclient: sandboxd http %d: %s", resp.StatusCode, string(msg))
+	}
+	var body struct {
+		Admit  bool   `json:"admit"`
+		Reason string `json:"reason"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return false, "", fmt.Errorf("sandboxclient: decode capacity: %w", err)
+	}
+	return body.Admit, body.Reason, nil
+}
+
 // Health reports whether sandboxd itself is reachable — the sandbox
 // health check surfaced through brain's own /health.
 func (c *Client) Health(ctx context.Context) error {

--- a/internal/brain/sandboxclient/sandboxclient_test.go
+++ b/internal/brain/sandboxclient/sandboxclient_test.go
@@ -217,3 +217,56 @@ func TestHealthOK(t *testing.T) {
 		t.Fatalf("Health: %v", err)
 	}
 }
+
+func TestCapacityAdmitted(t *testing.T) {
+	t.Parallel()
+	c := sandboxdStub(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/capacity" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"admit":true,"mem_available_mb":4096,"running_sandboxes":1}`))
+	})
+
+	admit, reason, err := c.Capacity(t.Context())
+	if err != nil {
+		t.Fatalf("Capacity: %v", err)
+	}
+	if !admit {
+		t.Error("admit = false, want true")
+	}
+	if reason != "" {
+		t.Errorf("reason = %q, want empty when admitted", reason)
+	}
+}
+
+func TestCapacityDenied(t *testing.T) {
+	t.Parallel()
+	c := sandboxdStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"admit":false,"mem_available_mb":900,"running_sandboxes":3,"reason":"mem_available 900MB < floor 1024 + per-sandbox 768"}`))
+	})
+
+	admit, reason, err := c.Capacity(t.Context())
+	if err != nil {
+		t.Fatalf("Capacity: %v", err)
+	}
+	if admit {
+		t.Error("admit = true, want false")
+	}
+	if reason == "" {
+		t.Error("reason = empty, want the denial reason surfaced")
+	}
+}
+
+func TestCapacityNon200IsError(t *testing.T) {
+	t.Parallel()
+	c := sandboxdStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"infra","message":"read meminfo failed"}`, http.StatusBadGateway)
+	})
+
+	if _, _, err := c.Capacity(t.Context()); err == nil {
+		t.Fatal("Capacity: want an error for a non-200 sandboxd response, got nil")
+	}
+}

--- a/internal/sandboxd/api.go
+++ b/internal/sandboxd/api.go
@@ -61,6 +61,10 @@ var execEnvAllowlist = map[string]bool{
 	"CLAUDE_CODE_OAUTH_TOKEN": true,
 	"NO_COLOR":                true,
 	"TERM":                    true,
+	// NODE_OPTIONS (D-056): bounds the claude CLI's node heap so a long
+	// run's transcript doesn't balloon toward the sandbox's 2 GiB cap —
+	// set unconditionally by the claude adapter, not a credential.
+	"NODE_OPTIONS": true,
 }
 
 // execEnvMaxValueLen bounds a single env value — generous for a token
@@ -121,6 +125,7 @@ func Register(s *httpserver.Server, mgr *Manager, cfg Config, log *slog.Logger) 
 	s.Handle("POST /v1/sandboxes/{missionID}/exec", http.HandlerFunc(a.handleExec))
 	s.Handle("DELETE /v1/sandboxes/{missionID}", http.HandlerFunc(a.handleRemove))
 	s.Handle("GET /v1/sandboxes", http.HandlerFunc(a.handleList))
+	s.Handle("GET /capacity", http.HandlerFunc(a.handleCapacity))
 }
 
 func jsonError(w http.ResponseWriter, status int, code, msg string) {
@@ -346,4 +351,25 @@ func (a *API) handleList(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(listResponse{MissionIDs: ids})
+}
+
+type capacityResponse struct {
+	Admit            bool   `json:"admit"`
+	MemAvailableMB   int    `json:"mem_available_mb"`
+	RunningSandboxes int    `json:"running_sandboxes"`
+	Reason           string `json:"reason,omitempty"`
+}
+
+// handleCapacity reports whether the host can afford one more working
+// mission (D-056) — brain's admission gate consults this before flipping
+// a mission idle->working.
+func (a *API) handleCapacity(w http.ResponseWriter, r *http.Request) {
+	report, err := a.mgr.Capacity(r.Context())
+	if err != nil {
+		a.log.Warn("sandbox capacity failed", "error", err)
+		jsonError(w, http.StatusBadGateway, "infra", err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(capacityResponse(report))
 }

--- a/internal/sandboxd/api_test.go
+++ b/internal/sandboxd/api_test.go
@@ -112,6 +112,7 @@ func TestValidExecEnv(t *testing.T) {
 				"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat-test",
 				"NO_COLOR":                "1",
 				"TERM":                    "xterm",
+				"NODE_OPTIONS":            "--max-old-space-size=768",
 			},
 			wantOK: true,
 		},
@@ -439,5 +440,37 @@ func TestHandleListLabelFiltering(t *testing.T) {
 	}
 	if len(out.MissionIDs) != 1 || out.MissionIDs[0] != validUUID {
 		t.Fatalf("mission_ids = %v, want [%s] (empty/missing labels skipped)", out.MissionIDs, validUUID)
+	}
+}
+
+// TestHandleCapacity confirms the /capacity route reports Manager's
+// Capacity result as JSON (D-056) — brain's admission gate reads this.
+func TestHandleCapacity(t *testing.T) {
+	t.Parallel()
+	cli := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/containers/json") {
+			writeJSON(t, w, http.StatusOK, []container.Summary{
+				{ID: "c1", Labels: map[string]string{missionLabel: validUUID}},
+			})
+			return
+		}
+		t.Fatalf("unexpected call: %s %s", r.Method, r.URL.Path)
+	})
+	mgr := newTestManager(cli)
+
+	rec := httptest.NewRecorder()
+	testAPI(mgr).handleCapacity(rec, httptest.NewRequest(http.MethodGet, "/capacity", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var out capacityResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.RunningSandboxes != 1 {
+		t.Fatalf("running_sandboxes = %d, want 1", out.RunningSandboxes)
+	}
+	if out.MemAvailableMB <= 0 {
+		t.Fatalf("mem_available_mb = %d, want > 0 from a real /proc/meminfo", out.MemAvailableMB)
 	}
 }

--- a/internal/sandboxd/manager.go
+++ b/internal/sandboxd/manager.go
@@ -9,6 +9,7 @@
 package sandboxd
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -57,6 +58,19 @@ const (
 	sandboxMemoryBytes = 2 << 30 // 2 GiB
 	sandboxNanoCPUs    = 2_000_000_000
 	sandboxPidsLimit   = 256
+
+	// sandboxMemoryReservationBytes is the soft limit (D-056):
+	// MemorySwap == sandboxMemoryBytes below caps a container's total
+	// memory+swap usage at the same 2 GiB ceiling, so a sandbox can
+	// never push the host into swap; MemoryReservation is the kernel's
+	// earlier, softer signal — under host memory pressure it reclaims a
+	// sandbox's page cache before the 2 GiB hard cap is ever reached.
+	sandboxMemoryReservationBytes = 256 << 20 // 256 MiB
+
+	// sandboxOomScoreAdj (D-056) biases the kernel's OOM killer toward
+	// sacrificing a sandbox container's processes before brain, gateway,
+	// or sshd under host memory pressure.
+	sandboxOomScoreAdj = 500
 
 	// execGraceKill is how long `timeout` waits after SIGTERM before
 	// SIGKILL — matches shell.go's cmd.WaitDelay intent (give a process a
@@ -187,6 +201,12 @@ type Manager struct {
 
 	mu    sync.Mutex
 	locks map[string]*sync.Mutex // per-mission ensureContainer lock
+
+	// pullMu (D-056) serializes ImagePull across missions — concurrent
+	// layer decompression for two different variant images spikes
+	// hundreds of MB each; serializing trades pull latency for bounded
+	// memory during the pull.
+	pullMu sync.Mutex
 }
 
 // NewManager connects to the Docker daemon and resolves the shared
@@ -388,10 +408,19 @@ func (m *Manager) createContainer(ctx context.Context, missionID, name, environm
 		// zombies against PidsLimit over a long mission.
 		Init: &initTrue,
 		Resources: container.Resources{
-			Memory:    memBytes,
-			NanoCPUs:  nanoCPUs,
-			PidsLimit: &pids,
+			Memory: memBytes,
+			// MemorySwap == Memory (D-056): swap is included in, not
+			// added on top of, the 2 GiB cap — a sandbox can never push
+			// the host into swap no matter how it misbehaves.
+			MemorySwap:        memBytes,
+			MemoryReservation: sandboxMemoryReservationBytes,
+			NanoCPUs:          nanoCPUs,
+			PidsLimit:         &pids,
 		},
+		// OomScoreAdj (D-056): the kernel sacrifices sandboxes before
+		// brain/gateway/sshd when the host itself is under memory
+		// pressure.
+		OomScoreAdj: sandboxOomScoreAdj,
 		// Default bridge: internet access (a coding mission may need
 		// `pip install`/`npm install`), but NOT the compose-internal
 		// "timothy" network — no route to postgres/gateway/memoryd.
@@ -410,17 +439,12 @@ func (m *Manager) createContainer(ctx context.Context, missionID, name, environm
 		}
 		// Image not pulled locally yet (variant images especially are
 		// built/pushed at release time, not baked into every deployment) —
-		// pull it once and retry create exactly once.
-		if m.log != nil {
-			m.log.Info("sandbox: pulling image", "image", image, "mission", missionID)
-		}
-		pull, pullErr := m.cli.ImagePull(ctx, image, client.ImagePullOptions{})
-		if pullErr != nil {
-			return "", fmt.Errorf("sandbox: pull image %s: %w", image, pullErr)
-		}
-		waitErr := pull.Wait(ctx)
-		if waitErr != nil {
-			return "", fmt.Errorf("sandbox: pull image %s: %w", image, waitErr)
+		// pull it once and retry create exactly once. pullMu (D-056)
+		// serializes this across concurrent missions: two different
+		// variant images decompressing layers at once spikes hundreds of
+		// MB each, and this trades pull latency for bounded memory.
+		if err := m.pullImage(ctx, image, missionID); err != nil {
+			return "", err
 		}
 		resp, err = m.cli.ContainerCreate(ctx, createOpts)
 		if err != nil {
@@ -431,6 +455,31 @@ func (m *Manager) createContainer(ctx context.Context, missionID, name, environm
 		return "", fmt.Errorf("sandbox: start container %s: %w", name, err)
 	}
 	return resp.ID, nil
+}
+
+// pullImage pulls image, serialized against every other pull via pullMu
+// (D-056). Re-checks with ImageInspect after acquiring the lock: the
+// image may have arrived while this call waited on a sibling mission's
+// pull, and re-pulling it would be a wasted decompression pass.
+func (m *Manager) pullImage(ctx context.Context, image, missionID string) error {
+	m.pullMu.Lock()
+	defer m.pullMu.Unlock()
+
+	if _, err := m.cli.ImageInspect(ctx, image); err == nil {
+		return nil
+	}
+
+	if m.log != nil {
+		m.log.Info("sandbox: pulling image", "image", image, "mission", missionID)
+	}
+	pull, pullErr := m.cli.ImagePull(ctx, image, client.ImagePullOptions{})
+	if pullErr != nil {
+		return fmt.Errorf("sandbox: pull image %s: %w", image, pullErr)
+	}
+	if waitErr := pull.Wait(ctx); waitErr != nil {
+		return fmt.Errorf("sandbox: pull image %s: %w", image, waitErr)
+	}
+	return nil
 }
 
 // Exec runs command in missionID's sandbox container (environment
@@ -595,4 +644,86 @@ func (m *Manager) List(ctx context.Context) ([]string, error) {
 		}
 	}
 	return ids, nil
+}
+
+// hostMemoryFloorMB / perSandboxEstimateMB (D-056) are the two halves of
+// the admission rule: floor is the headroom the host and its own
+// services (brain, gateway, sshd, ...) must keep; estimate is one
+// active sandbox's typical working set INCLUDING a claude CLI run —
+// deliberately below sandboxMemoryBytes's 2 GiB hard cap, which is a
+// ceiling a runaway container may hit, not what a normal one actually
+// uses. Admission compares against MemAvailable (not free), the kernel's
+// own estimate of what can be handed to a new workload without swapping.
+const (
+	hostMemoryFloorMB    = 1024
+	perSandboxEstimateMB = 768
+)
+
+// CapacityReport is sandboxd's answer to "can this host afford another
+// working mission" — brain's admission gate (missions/sweep.go,
+// driver.go) consults it before flipping a mission idle->working, so a
+// host already tight on memory queues new work instead of swap-thrashing
+// under one more sandbox plus its claude CLI process.
+type CapacityReport struct {
+	Admit            bool
+	MemAvailableMB   int
+	RunningSandboxes int
+	Reason           string // empty when Admit is true
+}
+
+// Capacity reports whether the host can afford one more working
+// mission. MemAvailableMB reads /proc/meminfo — sandboxd's own container
+// runs with no memory limit, so this is the HOST's view of available
+// memory, not sandboxd's cgroup. RunningSandboxes reuses List, the same
+// live-container count api.go's ensure-time cap uses.
+func (m *Manager) Capacity(ctx context.Context) (CapacityReport, error) {
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return CapacityReport{}, fmt.Errorf("sandbox: capacity: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	availMB, err := parseMemAvailable(f)
+	if err != nil {
+		return CapacityReport{}, fmt.Errorf("sandbox: capacity: %w", err)
+	}
+
+	ids, err := m.List(ctx)
+	if err != nil {
+		return CapacityReport{}, fmt.Errorf("sandbox: capacity: %w", err)
+	}
+
+	report := CapacityReport{MemAvailableMB: availMB, RunningSandboxes: len(ids)}
+	if availMB >= hostMemoryFloorMB+perSandboxEstimateMB {
+		report.Admit = true
+		return report, nil
+	}
+	report.Reason = fmt.Sprintf("mem_available %dMB < floor %d + per-sandbox %d", availMB, hostMemoryFloorMB, perSandboxEstimateMB)
+	return report, nil
+}
+
+// parseMemAvailable reads the "MemAvailable:" line from a /proc/meminfo
+// stream and returns it in MB (the file reports kB) — split out from
+// Capacity so the parsing logic is table-testable without a real
+// /proc/meminfo.
+func parseMemAvailable(r io.Reader) (int, error) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "MemAvailable:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return 0, fmt.Errorf("sandbox: malformed MemAvailable line %q", line)
+		}
+		kb, err := strconv.Atoi(fields[1])
+		if err != nil {
+			return 0, fmt.Errorf("sandbox: parse MemAvailable value %q: %w", fields[1], err)
+		}
+		return kb / 1024, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("sandbox: read meminfo: %w", err)
+	}
+	return 0, fmt.Errorf("sandbox: no MemAvailable line in meminfo")
 }

--- a/internal/sandboxd/manager_test.go
+++ b/internal/sandboxd/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
@@ -436,6 +437,9 @@ func TestEnsureContainerPullsMissingImage(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1.51/containers/timothy-sandbox-m1/json":
 			http.Error(w, "no such container", http.StatusNotFound)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1.51/images/"):
+			// pullImage's ImageInspect re-check (D-056): not present yet.
+			http.Error(w, "no such image", http.StatusNotFound)
 		case r.Method == http.MethodPost && r.URL.Path == "/v1.51/containers/create":
 			createCalls++
 			if createCalls == 1 {
@@ -478,6 +482,8 @@ func TestEnsureContainerPullFailureNamesImage(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1.51/containers/timothy-sandbox-m1/json":
 			http.Error(w, "no such container", http.StatusNotFound)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1.51/images/"):
+			http.Error(w, "no such image", http.StatusNotFound)
 		case r.Method == http.MethodPost && r.URL.Path == "/v1.51/containers/create":
 			http.Error(w, "No such image: img:latest", http.StatusNotFound)
 		case r.Method == http.MethodPost && r.URL.Path == "/v1.51/images/create":
@@ -496,5 +502,217 @@ func TestEnsureContainerPullFailureNamesImage(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "img") {
 		t.Errorf("error = %q, want it to name the image", err.Error())
+	}
+}
+
+// TestEnsureContainerConcurrentPullsDoNotOverlap covers D-056's pullMu:
+// two missions racing a create for the SAME missing image must not
+// trigger two overlapping ImagePull calls — the second caller's
+// ImageInspect (after acquiring pullMu) must find the image the first
+// caller already pulled.
+func TestEnsureContainerConcurrentPullsDoNotOverlap(t *testing.T) {
+	var mu sync.Mutex
+	pullCalls := 0
+	pullInFlight := false
+	imagePresent := false
+
+	cli := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1.51/containers/") && strings.HasSuffix(r.URL.Path, "/json"):
+			http.Error(w, "no such container", http.StatusNotFound)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1.51/images/"):
+			mu.Lock()
+			present := imagePresent
+			mu.Unlock()
+			if present {
+				writeJSON(t, w, http.StatusOK, container.InspectResponse{})
+				return
+			}
+			http.Error(w, "no such image", http.StatusNotFound)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1.51/images/create":
+			mu.Lock()
+			if pullInFlight {
+				mu.Unlock()
+				t.Errorf("overlapping ImagePull calls: pullMu did not serialize")
+				return
+			}
+			pullInFlight = true
+			pullCalls++
+			mu.Unlock()
+
+			time.Sleep(20 * time.Millisecond) // widen the window a missing lock would race in
+
+			mu.Lock()
+			imagePresent = true
+			pullInFlight = false
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"Pull complete"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1.51/containers/create":
+			mu.Lock()
+			present := imagePresent
+			mu.Unlock()
+			if !present {
+				http.Error(w, "No such image: img:latest", http.StatusNotFound)
+				return
+			}
+			writeJSON(t, w, http.StatusCreated, container.CreateResponse{ID: "new-" + r.RemoteAddr})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/start"):
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected call: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	mgr := newTestManager(cli)
+	mgr.workspaceMount = mount.Mount{Type: mount.TypeVolume, Source: "timothy_workspace", Target: workspaceMountPath}
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := range 2 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := mgr.createContainer(context.Background(), "m1", "timothy-sandbox-m1", "")
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("createContainer[%d]: %v", i, err)
+		}
+	}
+	if pullCalls != 1 {
+		t.Fatalf("pullCalls = %d, want exactly 1 (second caller's ImageInspect after pullMu should find it already pulled)", pullCalls)
+	}
+}
+
+// TestCreateContainerHardensResources covers D-056: MemorySwap caps at
+// the same 2 GiB the memory limit does (so swap can never let a sandbox
+// exceed it), MemoryReservation is the soft-limit floor, and
+// OomScoreAdj biases the kernel to sacrifice a sandbox before brain.
+func TestCreateContainerHardensResources(t *testing.T) {
+	var gotHostConfig container.HostConfig
+	cli := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1.51/containers/create":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read create body: %v", err)
+			}
+			var cfg struct {
+				HostConfig container.HostConfig
+			}
+			if err := json.Unmarshal(body, &cfg); err != nil {
+				t.Fatalf("unmarshal create body: %v", err)
+			}
+			gotHostConfig = cfg.HostConfig
+			writeJSON(t, w, http.StatusCreated, container.CreateResponse{ID: "new1"})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1.51/containers/new1/start":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected call: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	mgr := newTestManager(cli)
+	mgr.workspaceMount = mount.Mount{Type: mount.TypeVolume, Source: "timothy_workspace", Target: workspaceMountPath}
+
+	if _, err := mgr.createContainer(context.Background(), "m1", "timothy-sandbox-m1", ""); err != nil {
+		t.Fatalf("createContainer: %v", err)
+	}
+	if gotHostConfig.MemorySwap != sandboxMemoryBytes {
+		t.Errorf("MemorySwap = %d, want %d (== Memory, swap included not additive)", gotHostConfig.MemorySwap, sandboxMemoryBytes)
+	}
+	if gotHostConfig.MemoryReservation != sandboxMemoryReservationBytes {
+		t.Errorf("MemoryReservation = %d, want %d", gotHostConfig.MemoryReservation, sandboxMemoryReservationBytes)
+	}
+	if gotHostConfig.OomScoreAdj != sandboxOomScoreAdj {
+		t.Errorf("OomScoreAdj = %d, want %d", gotHostConfig.OomScoreAdj, sandboxOomScoreAdj)
+	}
+}
+
+// TestManagerCapacityReadsRealMeminfo confirms Capacity reads the
+// process's real /proc/meminfo (the host view sandboxd's own
+// memory-unlimited container sees) and folds in List's live container
+// count — it can't script MemAvailable itself, so it only asserts the
+// report is internally consistent with whatever this test process's
+// actual /proc/meminfo and container list report.
+func TestManagerCapacityReadsRealMeminfo(t *testing.T) {
+	cli := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, http.StatusOK, []container.Summary{})
+	})
+	mgr := newTestManager(cli)
+
+	report, err := mgr.Capacity(context.Background())
+	if err != nil {
+		t.Fatalf("Capacity: %v", err)
+	}
+	if report.MemAvailableMB <= 0 {
+		t.Errorf("MemAvailableMB = %d, want > 0 from a real /proc/meminfo", report.MemAvailableMB)
+	}
+	if report.RunningSandboxes != 0 {
+		t.Errorf("RunningSandboxes = %d, want 0 (fake daemon reported none)", report.RunningSandboxes)
+	}
+	wantAdmit := report.MemAvailableMB >= hostMemoryFloorMB+perSandboxEstimateMB
+	if report.Admit != wantAdmit {
+		t.Errorf("Admit = %v, want %v for MemAvailableMB=%d", report.Admit, wantAdmit, report.MemAvailableMB)
+	}
+	if !report.Admit && report.Reason == "" {
+		t.Error("Admit = false, want a non-empty Reason")
+	}
+}
+
+// TestParseMemAvailable covers normal /proc/meminfo shape, a missing
+// MemAvailable line (error, never a guessed 0), and outright garbage.
+func TestParseMemAvailable(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "normal",
+			input: "MemTotal:        8000000 kB\n" +
+				"MemFree:         1000000 kB\n" +
+				"MemAvailable:    3145728 kB\n" +
+				"Buffers:          200000 kB\n",
+			want: 3072, // 3145728 kB / 1024
+		},
+		{
+			name:    "missing line",
+			input:   "MemTotal:        8000000 kB\nMemFree:         1000000 kB\n",
+			wantErr: true,
+		},
+		{
+			name:    "garbage value",
+			input:   "MemAvailable:    notanumber kB\n",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			input:   "",
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseMemAvailable(strings.NewReader(tc.input))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseMemAvailable(%q) = %d, nil, want an error", tc.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseMemAvailable(%q): %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseMemAvailable(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
 	}
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -812,6 +812,9 @@ export async function setRouteRole(name: string, role: string): Promise<void> {
 }
 
 export interface AdminSettings {
+  // Feature switches, plus the read-only derived transcribe_enabled
+  // key (true when WHISPER_URL is configured server-side) — the
+  // Composer mic button hides itself when it's false.
   settings: Record<string, boolean>
   // Typed runtime settings; empty string means the built-in default.
   values: Record<string, string>

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -664,6 +664,16 @@ export interface ExecutorAuthFailedPayload {
   harness: string
 }
 
+export interface ExecutorSkippedPayload {
+  harness: string
+  reason: 'unknown_harness' | 'resolve_failed' | 'no_usable_entry' | 'cooldown'
+  error?: string
+  until?: string
+  provider?: string
+  model?: string
+  skip_reasons?: string[]
+}
+
 // MissionFile is one entry of a mission workspace's file listing
 // (GET /v1/missions/:id/files). Declared marks files named in the
 // mission's plan artifacts, not the full tree.

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -7,6 +7,7 @@ vi.mock('../api/client', () => ({
   listRoutes: vi.fn().mockResolvedValue([]),
   transcribe: vi.fn(),
   uploadAttachment: vi.fn(),
+  getSettings: vi.fn().mockResolvedValue({ settings: { transcribe_enabled: true }, values: {} }),
 }))
 
 vi.mock('sonner', () => ({
@@ -61,9 +62,32 @@ afterEach(() => {
 })
 
 describe('Composer mic button', () => {
-  it('renders a mic button', () => {
+  it('renders a mic button', async () => {
     render(<Composer {...baseProps()} />)
-    expect(screen.getByRole('button', { name: 'Record voice input' })).toBeTruthy()
+    expect(await screen.findByRole('button', { name: 'Record voice input' })).toBeTruthy()
+  })
+
+  it('hides the mic button while the settings fetch is unresolved', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.getSettings).mockReturnValueOnce(new Promise(() => {}))
+    render(<Composer {...baseProps()} />)
+    expect(screen.queryByRole('button', { name: 'Record voice input' })).toBeNull()
+  })
+
+  it('hides the mic button when transcription is disabled', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.getSettings).mockResolvedValueOnce({
+      settings: { transcribe_enabled: false },
+      values: {},
+    })
+    render(<Composer {...baseProps()} />)
+    await waitFor(() => expect(client.getSettings).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: 'Record voice input' })).toBeNull()
+  })
+
+  it('shows the mic button when transcription is enabled', async () => {
+    render(<Composer {...baseProps()} />)
+    expect(await screen.findByRole('button', { name: 'Record voice input' })).toBeTruthy()
   })
 
   it('records, stops, transcribes, and appends the text to the draft', async () => {
@@ -72,7 +96,7 @@ describe('Composer mic button', () => {
     const onDraft = vi.fn()
     render(<Composer {...baseProps()} onDraft={onDraft} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Record voice input' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Record voice input' }))
     await waitFor(() => expect(getUserMedia).toHaveBeenCalledWith({ audio: true }))
     await waitFor(() => expect(FakeMediaRecorder.instances).toHaveLength(1))
     const recorder = FakeMediaRecorder.instances[0]
@@ -93,7 +117,7 @@ describe('Composer mic button', () => {
     const onDraft = vi.fn()
     render(<Composer {...baseProps()} draft="hello" onDraft={onDraft} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Record voice input' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Record voice input' }))
     await waitFor(() => expect(FakeMediaRecorder.instances).toHaveLength(1))
     fireEvent.click(screen.getByRole('button', { name: 'Stop recording' }))
 
@@ -107,7 +131,7 @@ describe('Composer mic button', () => {
     const onDraft = vi.fn()
     render(<Composer {...baseProps()} draft="untouched" onDraft={onDraft} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Record voice input' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Record voice input' }))
     await waitFor(() => expect(FakeMediaRecorder.instances).toHaveLength(1))
     fireEvent.click(screen.getByRole('button', { name: 'Stop recording' }))
 
@@ -120,12 +144,12 @@ describe('Composer mic button', () => {
     vi.mocked(client.transcribe).mockResolvedValue('হ্যালো')
     render(<Composer {...baseProps()} />)
 
-    const trigger = screen.getByRole('button', { name: 'Speech input language' })
+    const trigger = await screen.findByRole('button', { name: 'Speech input language' })
     fireEvent.pointerDown(trigger, { button: 0, pointerId: 1 })
     fireEvent.click(trigger)
     fireEvent.click(await screen.findByText('Bangla'))
 
-    fireEvent.click(screen.getByRole('button', { name: 'Record voice input' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Record voice input' }))
     await waitFor(() => expect(FakeMediaRecorder.instances).toHaveLength(1))
     fireEvent.click(screen.getByRole('button', { name: 'Stop recording' }))
 
@@ -138,7 +162,7 @@ describe('Composer mic button', () => {
     getUserMedia.mockRejectedValueOnce(new Error('denied'))
     render(<Composer {...baseProps()} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Record voice input' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Record voice input' }))
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith('Microphone permission was denied'),
     )
@@ -150,7 +174,7 @@ describe('Composer mic button', () => {
     Object.defineProperty(navigator, 'mediaDevices', { value: undefined, configurable: true })
     render(<Composer {...baseProps()} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Record voice input' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Record voice input' }))
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith(
         'Microphone input is not available in this browser or context',

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -13,7 +13,7 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import type { ClipboardEvent, DragEvent } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { transcribe, uploadAttachment } from '../api/client'
+import { getSettings, transcribe, uploadAttachment } from '../api/client'
 import { skillLabels } from '../lib/skills'
 import {
   getTranscribeLanguage,
@@ -104,6 +104,16 @@ export function Composer({
   const [recording, setRecording] = useState(false)
   const [transcribing, setTranscribing] = useState(false)
   const [transcribeLanguage, setTranscribeLanguageState] = useState(getTranscribeLanguage)
+  // Default hidden: a mic that 404s because WHISPER_URL is unset is
+  // worse than one that appears a beat late once the settings fetch
+  // resolves.
+  const [transcribeEnabled, setTranscribeEnabled] = useState(false)
+
+  useEffect(() => {
+    getSettings()
+      .then((s) => setTranscribeEnabled(s.settings.transcribe_enabled ?? false))
+      .catch(() => setTranscribeEnabled(false))
+  }, [])
 
   // Auto-grow up to a cap, then scroll inside. Runs on every draft
   // change so programmatic clears (post-send) shrink it back.
@@ -342,64 +352,71 @@ export function Composer({
               </button>
             </>
           )}
-          <button
-            type="button"
-            onClick={recording ? stopRecording : startRecording}
-            aria-label={recording ? 'Stop recording' : 'Record voice input'}
-            aria-pressed={recording}
-            disabled={disabled || transcribing}
-            className={
-              recording
-                ? 'flex size-8 shrink-0 animate-pulse items-center justify-center rounded-full bg-red-600 text-white transition hover:bg-red-500'
-                : 'flex size-8 shrink-0 items-center justify-center rounded-full text-zinc-500 transition hover:bg-zinc-100 disabled:text-zinc-300 dark:text-zinc-400 dark:hover:bg-zinc-700/50 dark:disabled:text-zinc-600'
-            }
-          >
-            <HugeiconsIcon
-              icon={transcribing ? Loading03Icon : Mic01Icon}
-              className={transcribing ? 'size-4 animate-spin' : 'size-4'}
-            />
-          </button>
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              aria-label="Speech input language"
-              disabled={disabled || recording || transcribing}
-              className="flex h-8 items-center gap-1 rounded-full px-2 text-xs text-zinc-500 transition hover:bg-zinc-100 disabled:text-zinc-300 dark:text-zinc-400 dark:hover:bg-zinc-700/50 dark:disabled:text-zinc-600"
-            >
-              <span>
-                {TRANSCRIBE_LANGUAGES.find((l) => l.code === transcribeLanguage)?.label ?? 'Auto'}
-              </span>
-              <HugeiconsIcon icon={ArrowDown01Icon} className="size-3 opacity-60" />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-48 p-1.5">
-              <DropdownMenuItem
-                onSelect={() => {
-                  setTranscribeLanguageState('')
-                  setTranscribeLanguage('')
-                }}
-                data-selected={transcribeLanguage === '' || undefined}
-                className="justify-between rounded-lg px-2.5 py-1.5 data-selected:bg-zinc-100 dark:data-selected:bg-zinc-800"
+          {transcribeEnabled && (
+            <>
+              <button
+                type="button"
+                onClick={recording ? stopRecording : startRecording}
+                aria-label={recording ? 'Stop recording' : 'Record voice input'}
+                aria-pressed={recording}
+                disabled={disabled || transcribing}
+                className={
+                  recording
+                    ? 'flex size-8 shrink-0 animate-pulse items-center justify-center rounded-full bg-red-600 text-white transition hover:bg-red-500'
+                    : 'flex size-8 shrink-0 items-center justify-center rounded-full text-zinc-500 transition hover:bg-zinc-100 disabled:text-zinc-300 dark:text-zinc-400 dark:hover:bg-zinc-700/50 dark:disabled:text-zinc-600'
+                }
               >
-                <span className="text-sm">Auto-detect</span>
-                {transcribeLanguage === '' && <HugeiconsIcon icon={Tick02Icon} className="size-4" />}
-              </DropdownMenuItem>
-              {TRANSCRIBE_LANGUAGES.map((l) => (
-                <DropdownMenuItem
-                  key={l.code}
-                  onSelect={() => {
-                    setTranscribeLanguageState(l.code)
-                    setTranscribeLanguage(l.code)
-                  }}
-                  data-selected={transcribeLanguage === l.code || undefined}
-                  className="justify-between rounded-lg px-2.5 py-1.5 data-selected:bg-zinc-100 dark:data-selected:bg-zinc-800"
+                <HugeiconsIcon
+                  icon={transcribing ? Loading03Icon : Mic01Icon}
+                  className={transcribing ? 'size-4 animate-spin' : 'size-4'}
+                />
+              </button>
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  aria-label="Speech input language"
+                  disabled={disabled || recording || transcribing}
+                  className="flex h-8 items-center gap-1 rounded-full px-2 text-xs text-zinc-500 transition hover:bg-zinc-100 disabled:text-zinc-300 dark:text-zinc-400 dark:hover:bg-zinc-700/50 dark:disabled:text-zinc-600"
                 >
-                  <span className="text-sm">{l.label}</span>
-                  {transcribeLanguage === l.code && (
-                    <HugeiconsIcon icon={Tick02Icon} className="size-4" />
-                  )}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+                  <span>
+                    {TRANSCRIBE_LANGUAGES.find((l) => l.code === transcribeLanguage)?.label ??
+                      'Auto'}
+                  </span>
+                  <HugeiconsIcon icon={ArrowDown01Icon} className="size-3 opacity-60" />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-48 p-1.5">
+                  <DropdownMenuItem
+                    onSelect={() => {
+                      setTranscribeLanguageState('')
+                      setTranscribeLanguage('')
+                    }}
+                    data-selected={transcribeLanguage === '' || undefined}
+                    className="justify-between rounded-lg px-2.5 py-1.5 data-selected:bg-zinc-100 dark:data-selected:bg-zinc-800"
+                  >
+                    <span className="text-sm">Auto-detect</span>
+                    {transcribeLanguage === '' && (
+                      <HugeiconsIcon icon={Tick02Icon} className="size-4" />
+                    )}
+                  </DropdownMenuItem>
+                  {TRANSCRIBE_LANGUAGES.map((l) => (
+                    <DropdownMenuItem
+                      key={l.code}
+                      onSelect={() => {
+                        setTranscribeLanguageState(l.code)
+                        setTranscribeLanguage(l.code)
+                      }}
+                      data-selected={transcribeLanguage === l.code || undefined}
+                      className="justify-between rounded-lg px-2.5 py-1.5 data-selected:bg-zinc-100 dark:data-selected:bg-zinc-800"
+                    >
+                      <span className="text-sm">{l.label}</span>
+                      {transcribeLanguage === l.code && (
+                        <HugeiconsIcon icon={Tick02Icon} className="size-4" />
+                      )}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </>
+          )}
         </div>
         {streaming && onStop ? (
           <button

--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -151,6 +151,54 @@ describe('executor lifecycle event rendering', () => {
     render(<div>{renderEvent(event({ harness: 'claude-cli' }, 'executor.auth_failed'))}</div>)
     expect(screen.getByText(/re-run the harness login/)).toBeInTheDocument()
   })
+
+  it('renders executor.skipped with the resolve_failed error', () => {
+    render(
+      <div>
+        {renderEvent(
+          event({ harness: 'claude-cli', reason: 'resolve_failed', error: 'gateway unreachable' }, 'executor.skipped'),
+        )}
+      </div>,
+    )
+    expect(screen.getByText(/Harness skipped: resolve_failed/)).toBeInTheDocument()
+    expect(screen.getByText(/gateway unreachable/)).toBeInTheDocument()
+  })
+
+  it('renders executor.skipped with the cooldown provider/model/until', () => {
+    render(
+      <div>
+        {renderEvent(
+          event(
+            {
+              harness: 'claude-cli',
+              reason: 'cooldown',
+              until: '2026-01-01T00:10:00Z',
+              provider: 'anthropic',
+              model: 'claude-haiku-4-5-20251001',
+            },
+            'executor.skipped',
+          ),
+        )}
+      </div>,
+    )
+    expect(screen.getByText(/Harness skipped: cooldown/)).toBeInTheDocument()
+    expect(screen.getByText(/anthropic\/claude-haiku-4-5-20251001 until 2026-01-01T00:10:00Z/)).toBeInTheDocument()
+  })
+
+  it('renders executor.skipped with the no_usable_entry skip reasons', () => {
+    render(
+      <div>
+        {renderEvent(
+          event(
+            { harness: 'claude-cli', reason: 'no_usable_entry', skip_reasons: ['no credential configured'] },
+            'executor.skipped',
+          ),
+        )}
+      </div>,
+    )
+    expect(screen.getByText(/Harness skipped: no_usable_entry/)).toBeInTheDocument()
+    expect(screen.getByText(/no credential configured/)).toBeInTheDocument()
+  })
 })
 
 describe('unknown event kind fallback', () => {

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -4,6 +4,7 @@ import type {
   ExecutorDiedPayload,
   ExecutorIdleKilledPayload,
   ExecutorResultPayload,
+  ExecutorSkippedPayload,
   ExecutorSpawnedPayload,
   MissionEvent,
 } from '../../api/types'
@@ -123,6 +124,19 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
   'executor.auth_failed': (p) => {
     const { harness } = p as ExecutorAuthFailedPayload
     return <span className="text-red-400">{harness} auth failed — re-run the harness login</span>
+  },
+  'executor.skipped': (p) => {
+    const { reason, error, until, provider, model, skip_reasons } = p as ExecutorSkippedPayload
+    return (
+      <span className="text-amber-400">
+        Harness skipped: {reason}
+        {reason === 'resolve_failed' && error ? ` — ${truncateForDisplay(error)}` : ''}
+        {reason === 'cooldown' && until ? ` — ${provider}/${model} until ${until}` : ''}
+        {reason === 'no_usable_entry' && skip_reasons && skip_reasons.length > 0
+          ? ` — ${skip_reasons.join(', ')}`
+          : ''}
+      </span>
+    )
   },
 }
 

--- a/web/src/pages/Chat.test.tsx
+++ b/web/src/pages/Chat.test.tsx
@@ -24,6 +24,7 @@ vi.mock('../api/client', () => ({
   answerPermission: vi.fn(),
   listRoutes: vi.fn(),
   listAgents: vi.fn(),
+  getSettings: vi.fn().mockResolvedValue({ settings: { transcribe_enabled: false }, values: {} }),
 }))
 
 vi.mock('../lib/events', () => ({ subscribeEvents: vi.fn() }))

--- a/web/src/pages/Home.test.tsx
+++ b/web/src/pages/Home.test.tsx
@@ -8,6 +8,7 @@ vi.mock('../api/client', () => ({
   listAgents: vi.fn(),
   listMemories: vi.fn(),
   listRoutes: vi.fn(),
+  getSettings: vi.fn().mockResolvedValue({ settings: { transcribe_enabled: false }, values: {} }),
 }))
 
 import type { AdminRoute } from '../api/types'


### PR DESCRIPTION
## Summary
- **Dynamic admission (D-056)**: sandboxd exposes `GET /capacity` (host MemAvailable from /proc/meminfo vs 1 GiB floor + 768 MB per-sandbox estimate); brain consults it at both idle→working seams (Driver.Advance create-path and the 30s work-slot sweep). Denied missions stay idle and the sweep retries — the queue is the existing sweep. Nil gate / sandboxd error fail open; `missionWorkSlotMax=4` stays as absolute ceiling.
- **Sandbox hardening**: `MemorySwap=Memory` (no host swap), `MemoryReservation` 256 MiB, `OomScoreAdj +500`, image pulls serialized behind a mutex with inspect-recheck.
- **CLI heap bound**: `NODE_OPTIONS=--max-old-space-size=768` injected into claude CLI runs via the D-053 allowlist.
- **Whisper opt-in, default off**: compose `profiles: [whisper]`, brain `WHISPER_URL` defaults empty (graceful: transcribe endpoint unregistered); UI mic gated on derived read-only `transcribe_enabled` setting (default hidden until settings resolve). Frees ~2.8 GiB on small hosts.
- **executor.skipped event**: every silent harness→native fallback now records why (unknown_harness / resolve_failed / cooldown with until / no_usable_entry with skip_reasons) + WARN logs; rendered in the mission timeline.
- README: what-works-today refresh, corrected upgrade steps (compose refresh + tag bump first), optional sections removed.

## Why
4 GB homelab wedged (swap thrash, hard reset) under 4 concurrent missions + idle whisper holding 2.8 GiB; post-mortem also found harness fallbacks leaving zero evidence.

## Testing
- `make build test vet lint` green; race tests green (sandboxd, missions, sandboxclient, executor) incl. pull-serialization concurrency test.
- Web 520/520, tsc + oxlint clean.
- Compose config valid with whisper profile off/on.
- `make canary` PASS (3×). Live capacity probe: `{"admit":true,"mem_available_mb":5688,"running_sandboxes":0}`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788806094&installation_model_id=431401&pr_number=193&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F193&signature=d75544617994731b23b496329a63a3e5a15b270c7ec7083cf5dffd5ef46d0e6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->