### PR TITLE
fix: refuse writes to terminal missions, read host meminfo under lxc

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -204,6 +204,11 @@ services:
       #   docker run --rm -u 0 -v timothy_executor-claude-state:/s timothy-sandbox:latest chown 65534:65534 /s
       #   docker run --rm -it -v timothy_executor-claude-state:/home/sandbox/.claude timothy-sandbox:latest claude /login
       - executor-claude-state:/statevols/claude
+      # Host meminfo — under LXC, lxcfs serves the guest's real memory
+      # limit here, while this container's own /proc shows the
+      # hypervisor's (Capacity's admission gate would otherwise read a
+      # 32 GB host on a 4 GB guest). No-op bind on bare metal.
+      - /proc/meminfo:/host/meminfo:ro
       # The socket this service exists to hold instead of brain.
       # group_add grants its group inside the container; Docker
       # Desktop's socket is group 0 (root), Linux hosts typically use a

--- a/deploy/release/docker-compose.yml
+++ b/deploy/release/docker-compose.yml
@@ -156,6 +156,11 @@ services:
       # or writes mission files through this mount. A container's own
       # replicated mount is unaffected by the ro flag here.
       - workspace:/workspace:ro
+      # Host meminfo — under LXC, lxcfs serves the guest's real memory
+      # limit here, while this container's own /proc shows the
+      # hypervisor's (Capacity's admission gate would otherwise read a
+      # 32 GB host on a 4 GB guest). No-op bind on bare metal.
+      - /proc/meminfo:/host/meminfo:ro
       # The socket this service exists to hold instead of brain.
       # group_add grants its group inside the container; Docker
       # Desktop's socket is group 0 (root), Linux hosts typically use a

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -342,7 +342,8 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 	if err != nil {
 		return false, fmt.Errorf("driver advance: %w", err)
 	}
-	if m.Phase.Terminal() || m.Status == StatusPaused || m.Status == StatusWaitingForInput {
+	if m.Phase.Terminal() || m.Status == StatusPaused || m.Status == StatusWaitingForInput ||
+		m.Status == StatusDone || m.Status == StatusError {
 		return false, nil
 	}
 	// D-056: admission applies only to idle->working, never to a mission
@@ -435,6 +436,18 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 	state := d.toStepState(ctx, m)
 	t := Step(state, in, d.cfg)
 	if err := d.store.ApplyTransition(ctx, id, t); err != nil {
+		if errors.Is(err, ErrTerminal) {
+			// The mission reached a terminal state (e.g. cancel) while this
+			// turn was in flight — the turn's own transition arrived too
+			// late and must be discarded, not written over the terminal
+			// row. Cancel's own transition already tore down the sandbox;
+			// this is the belt for a turn that raced past that teardown and
+			// may have started a fresh container of its own.
+			d.log.Info("driver: mission reached terminal state mid-turn, discarding turn result", "mission_id", id)
+			delete(d.gatekeepers, id)
+			d.removeSandbox(id)
+			return false, nil
+		}
 		return false, fmt.Errorf("driver advance: apply transition: %w", err)
 	}
 	if t.Next.Phase.Terminal() {

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -29,6 +29,10 @@ type fakeStore struct {
 	// zero spend in every currency, matching a mission with no ledger
 	// rows yet.
 	spend map[string]MissionSpend
+	// applyTransitionErr, when set, makes ApplyTransition return this
+	// error instead of writing — scripts the real Store's terminal-row
+	// guard (ErrTerminal) without a Postgres pool.
+	applyTransitionErr error
 }
 
 func newFakeStore() *fakeStore {
@@ -99,6 +103,9 @@ func (f *fakeStore) Get(ctx context.Context, id string) (Mission, error) {
 func (f *fakeStore) ApplyTransition(ctx context.Context, id string, t Transition) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.applyTransitionErr != nil {
+		return f.applyTransitionErr
+	}
 	m := f.missions[id]
 	m.Phase, m.Status, m.PauseReason = t.Next.Phase, t.Next.Status, t.Next.PauseReason
 	m.Iteration, m.MaxIterations = t.Next.Iteration, t.Next.MaxIterations
@@ -1566,5 +1573,86 @@ func TestDriverAdvanceCapacityGateIgnoredWhenAlreadyWorking(t *testing.T) {
 	m, _ := store.Get(context.Background(), "m1")
 	if m.Phase != PhasePlan {
 		t.Fatalf("mission.Phase = %s, want plan (a denial must not stall a mission already working)", m.Phase)
+	}
+}
+
+// fakeSandboxRemover records Remove calls so a test can assert
+// terminal-transition cleanup ran without a real Docker socket.
+type fakeSandboxRemover struct {
+	mu      sync.Mutex
+	removed []string
+}
+
+func (f *fakeSandboxRemover) Remove(ctx context.Context, missionID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.removed = append(f.removed, missionID)
+	return nil
+}
+
+func (f *fakeSandboxRemover) calls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.removed...)
+}
+
+// TestDriverAdvanceStopsOnTerminalStatus is the cheap belt: a mission
+// whose Status already reads done/error (set by a concurrent cancel)
+// must not run another turn, even before the Store-level guard is
+// consulted.
+func TestDriverAdvanceStopsOnTerminalStatus(t *testing.T) {
+	for _, status := range []Status{StatusDone, StatusError} {
+		store := newFakeStore()
+		store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: status, MaxIterations: 8})
+		runner := &scriptedRunner{}
+		d := testDriver(store, runner)
+
+		cont, err := d.Advance(context.Background(), "m1")
+		if err != nil {
+			t.Fatalf("Advance (status=%s): %v", status, err)
+		}
+		if cont {
+			t.Fatalf("Advance (status=%s) canContinue = true, want false", status)
+		}
+	}
+}
+
+// TestDriverAdvanceDiscardsTurnOnConcurrentTerminal reproduces the
+// production bug: a cancel lands mid-turn (ApplyTransition's row-lock
+// guard now returns ErrTerminal for the turn's own late transition).
+// Advance must treat that as a clean stop — no error escalation — and
+// still tear down the sandbox, since the in-flight turn may have
+// recreated a container after cancel's own teardown ran.
+func TestDriverAdvanceDiscardsTurnOnConcurrentTerminal(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
+	store.applyTransitionErr = ErrTerminal
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done"}}}
+	remover := &fakeSandboxRemover{}
+	d := NewDriver(store, runner, nil, nil, nil, nil, fakeSandboxExec, remover, slog.Default())
+	d.gatekeepers["m1"] = &GatekeeperState{}
+
+	cont, err := d.Advance(context.Background(), "m1")
+	if err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if cont {
+		t.Fatal("Advance canContinue = true, want false (turn discarded on terminal race)")
+	}
+	if _, stillPresent := d.gatekeepers["m1"]; stillPresent {
+		t.Fatal("gatekeeper state was not cleaned up when the turn discarded on terminal race")
+	}
+	// removeSandbox fires the actual Remove call in a background
+	// goroutine (independent of the request's own ctx) — poll briefly
+	// rather than asserting immediately.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if calls := remover.calls(); len(calls) == 1 && calls[0] == "m1" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("sandboxRemove.Remove calls = %v, want exactly one call for m1", remover.calls())
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -515,6 +515,15 @@ func (s *Store) LastRunState(ctx context.Context, missionID string) (*runState, 
 // mission row to Next and appends its Events in order, all in one
 // txn. This is the ONLY way mission state changes after Create —
 // Driver never issues a bare UPDATE.
+//
+// Guards against a cancel (or any other terminal transition) landing
+// mid-turn: the row is locked FOR UPDATE and its CURRENT phase
+// re-checked before writing. A mission observed non-terminal at the
+// top of a Drive turn can be cancelled by a concurrent Signal before
+// that turn's own ApplyTransition runs; without this check the turn's
+// stale transition would overwrite the terminal row and resurrect the
+// mission. Once Terminal(), the row is a dead end — this returns
+// ErrTerminal and appends NO event, never a silent no-op write.
 func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) error {
 	db, err := s.db.Get()
 	if err != nil {
@@ -525,6 +534,17 @@ func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) er
 		return fmt.Errorf("missions apply transition begin: %w", err)
 	}
 	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+
+	var currentPhase string
+	if err := tx.QueryRow(ctx, `SELECT phase FROM missions WHERE id = $1 FOR UPDATE`, id).Scan(&currentPhase); err != nil {
+		if err == pgx.ErrNoRows {
+			return fmt.Errorf("mission %s: %w", id, ErrNotFound)
+		}
+		return fmt.Errorf("missions apply transition lock: %w", err)
+	}
+	if phase, ok := parsePhase(currentPhase); ok && phase.Terminal() {
+		return ErrTerminal
+	}
 
 	// pause_message is cleared unconditionally: the state machine's
 	// Transition never carries a message string (only scanMission's

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -486,6 +486,94 @@ func TestApplyTransitionClearsPendingPermissionOnTerminal(t *testing.T) {
 	}
 }
 
+// TestApplyTransitionRejectsWriteOnTerminalMission reproduces a real
+// bug: a mission cancelled (terminal phase persisted) while a Drive
+// loop's turn was in flight — the turn's own ApplyTransition,
+// operating on a stale pre-cancel snapshot, must not be allowed to
+// overwrite the terminal row and resurrect the mission.
+func TestApplyTransitionRejectsWriteOnTerminalMission(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{Goal: marker + "terminal-guard", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := s.ApplyTransition(ctx, id, Transition{
+		Next:   StepState{Phase: PhaseFailed, Status: StatusError, MaxIterations: 8},
+		Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "cancelled"}}},
+	}); err != nil {
+		t.Fatalf("ApplyTransition (cancel): %v", err)
+	}
+
+	// A stale in-flight turn's transition arrives after cancel already
+	// landed — must be rejected, not written over the terminal row.
+	err = s.ApplyTransition(ctx, id, Transition{
+		Next:   StepState{Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8},
+		Events: []EventDraft{{Kind: "mission.turn", Payload: map[string]any{"phase": "execute"}}},
+	})
+	if !errors.Is(err, ErrTerminal) {
+		t.Fatalf("ApplyTransition (stale turn) err = %v, want ErrTerminal", err)
+	}
+
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.Phase != PhaseFailed || m.Status != StatusError {
+		t.Fatalf("mission after rejected write: phase=%q status=%q, want failed/error unchanged", m.Phase, m.Status)
+	}
+
+	events, err := s.Events(ctx, id)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	if len(events) != 1 || events[0].Kind != "mission.failed" {
+		t.Fatalf("Events = %+v, want only the cancel's mission.failed event, no mission.turn", events)
+	}
+}
+
+// TestApplyTransitionCancelThenDoubleCancel exercises the two ends of
+// the cancel path around the new guard: a cancel applied to a live
+// mission still writes normally, and a second cancel on the
+// now-terminal mission is rejected rather than silently re-applying.
+func TestApplyTransitionCancelThenDoubleCancel(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{Goal: marker + "double-cancel", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cancelTransition := Transition{
+		Next:   StepState{Phase: PhaseFailed, Status: StatusError, MaxIterations: 8},
+		Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "cancelled"}}},
+	}
+	if err := s.ApplyTransition(ctx, id, cancelTransition); err != nil {
+		t.Fatalf("ApplyTransition (first cancel): %v", err)
+	}
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.Phase != PhaseFailed {
+		t.Fatalf("mission phase after first cancel = %q, want failed", m.Phase)
+	}
+
+	if err := s.ApplyTransition(ctx, id, cancelTransition); !errors.Is(err, ErrTerminal) {
+		t.Fatalf("ApplyTransition (second cancel) err = %v, want ErrTerminal", err)
+	}
+
+	events, err := s.Events(ctx, id)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("Events = %+v, want exactly one mission.failed from the first cancel", events)
+	}
+}
+
 // TestAppendEventSeqMonotonic drives concurrent appends to the SAME
 // mission and asserts seq is a gap-free 1..N sequence — the FOR UPDATE
 // lock on the mission row must serialize these, not merely avoid a

--- a/internal/sandboxd/manager.go
+++ b/internal/sandboxd/manager.go
@@ -671,13 +671,26 @@ type CapacityReport struct {
 	Reason           string // empty when Admit is true
 }
 
+// hostMeminfoPath is bind-mounted from the LXC guest's own host-side
+// /proc/meminfo (deploy/docker-compose.yml). Under LXC, a container's
+// raw /proc/meminfo is the hypervisor's kernel procfs — lxcfs only
+// masks /proc for processes running directly on the guest, not for
+// something bind-mounted straight through into a container — so
+// sandboxd's own /proc/meminfo reports the HYPERVISOR's memory (e.g.
+// 32 GB on a 4 GB guest). The guest's real, lxcfs-served view is only
+// reachable via this separately-mounted path; falls back to
+// /proc/meminfo when absent (bare-metal/non-LXC hosts, or the mount
+// missing).
+const hostMeminfoPath = "/host/meminfo"
+
 // Capacity reports whether the host can afford one more working
-// mission. MemAvailableMB reads /proc/meminfo — sandboxd's own container
-// runs with no memory limit, so this is the HOST's view of available
+// mission. MemAvailableMB reads /host/meminfo when present, else
+// /proc/meminfo (see hostMeminfoPath) — sandboxd's own container runs
+// with no memory limit, so this is the HOST's view of available
 // memory, not sandboxd's cgroup. RunningSandboxes reuses List, the same
 // live-container count api.go's ensure-time cap uses.
 func (m *Manager) Capacity(ctx context.Context) (CapacityReport, error) {
-	f, err := os.Open("/proc/meminfo")
+	f, err := openMeminfo(hostMeminfoPath, "/proc/meminfo")
 	if err != nil {
 		return CapacityReport{}, fmt.Errorf("sandbox: capacity: %w", err)
 	}
@@ -699,6 +712,17 @@ func (m *Manager) Capacity(ctx context.Context) (CapacityReport, error) {
 	}
 	report.Reason = fmt.Sprintf("mem_available %dMB < floor %d + per-sandbox %d", availMB, hostMemoryFloorMB, perSandboxEstimateMB)
 	return report, nil
+}
+
+// openMeminfo opens primary, falling back to fallback when primary
+// doesn't exist — split out from Capacity (params instead of the
+// hostMeminfoPath/proc constants directly) so the preference order is
+// table-testable against temp files without a real /host or /proc.
+func openMeminfo(primary, fallback string) (*os.File, error) {
+	if f, err := os.Open(primary); err == nil { //nolint:gosec // G304: fixed operator-controlled paths (hostMeminfoPath/proc), not user input.
+		return f, nil
+	}
+	return os.Open(fallback) //nolint:gosec // G304: fixed operator-controlled paths (hostMeminfoPath/proc), not user input.
 }
 
 // parseMemAvailable reads the "MemAvailable:" line from a /proc/meminfo

--- a/internal/sandboxd/manager_test.go
+++ b/internal/sandboxd/manager_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -661,6 +663,53 @@ func TestManagerCapacityReadsRealMeminfo(t *testing.T) {
 	if !report.Admit && report.Reason == "" {
 		t.Error("Admit = false, want a non-empty Reason")
 	}
+}
+
+// TestOpenMeminfo covers the LXC/lxcfs path preference: primary
+// (hostMeminfoPath's bind mount) wins when present, and a missing
+// primary falls back to the plain /proc/meminfo path — reproduces the
+// bug where sandboxd read the hypervisor's /proc/meminfo instead of
+// the guest's lxcfs-served one.
+func TestOpenMeminfo(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "host-meminfo")
+	fallback := filepath.Join(dir, "proc-meminfo")
+	if err := os.WriteFile(primary, []byte("MemAvailable: 1000 kB\n"), 0o600); err != nil {
+		t.Fatalf("write primary: %v", err)
+	}
+	if err := os.WriteFile(fallback, []byte("MemAvailable: 2000 kB\n"), 0o600); err != nil {
+		t.Fatalf("write fallback: %v", err)
+	}
+	missing := filepath.Join(dir, "does-not-exist")
+
+	t.Run("primary present", func(t *testing.T) {
+		f, err := openMeminfo(primary, fallback)
+		if err != nil {
+			t.Fatalf("openMeminfo: %v", err)
+		}
+		defer func() { _ = f.Close() }()
+		if f.Name() != primary {
+			t.Errorf("opened %q, want primary %q", f.Name(), primary)
+		}
+	})
+
+	t.Run("primary missing falls back", func(t *testing.T) {
+		f, err := openMeminfo(missing, fallback)
+		if err != nil {
+			t.Fatalf("openMeminfo: %v", err)
+		}
+		defer func() { _ = f.Close() }()
+		if f.Name() != fallback {
+			t.Errorf("opened %q, want fallback %q", f.Name(), fallback)
+		}
+	})
+
+	t.Run("both missing errors", func(t *testing.T) {
+		if _, err := openMeminfo(missing, filepath.Join(dir, "also-missing")); err == nil {
+			t.Error("openMeminfo with both paths missing = nil error, want an error")
+		}
+	})
 }
 
 // TestParseMemAvailable covers normal /proc/meminfo shape, a missing


### PR DESCRIPTION
## Summary
- **Terminal-state race**: a cancelled mission could be resurrected by an in-flight turn. `ApplyTransition` now locks the mission row `FOR UPDATE` and refuses any write once the phase is terminal (`ErrTerminal`, no event appended). `Advance` early-returns on done/error status. A turn completing after a concurrent cancel discards its result at INFO, cleans gatekeeper state, and best-effort removes the sandbox container. API cancel already maps `ErrTerminal` to 409.
- **LXC meminfo**: the D-056 capacity gate saw the hypervisor's memory (32 GB) instead of the guest's (8 GB) because Docker bind-mounts raw `/proc/meminfo`, bypassing lxcfs. sandboxd now reads `/host/meminfo` (new ro bind-mount in both compose files) with `/proc/meminfo` fallback.

## Why
Both found live on homelab after alpha.23: zombie mission recreated its sandbox 3× after cancel; capacity gate admitted everything because it saw 32 GB available on a 4 GB guest.

## Testing
- `make build test vet lint` green
- `go test -race ./internal/brain/missions/... ./internal/sandboxd/...` green
- Integration tests: terminal write rejected against real Postgres, cancel-then-double-cancel
- `make canary` PASS
- Live-verified: `/host/meminfo` mount present in sandboxd, capacity endpoint returns real guest numbers

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788813278&installation_model_id=431401&pr_number=194&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F194&signature=fe7a2faae93bf7c871545dd9cf540fccab0a7fd5c69647e52152b97ce2ad041e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->