### PR TITLE
feat: mission steering notes, reliable title generation

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -56,6 +56,7 @@ func (a *API) registerMissions(handle func(pattern string, h http.Handler), stor
 	handle("DELETE /v1/missions/{id}", a.auth(http.HandlerFunc(h.delete)))
 	handle("GET /v1/missions/{id}/events", a.auth(http.HandlerFunc(h.events)))
 	handle("POST /v1/missions/{id}/resume", a.auth(http.HandlerFunc(h.resume)))
+	handle("POST /v1/missions/{id}/note", a.auth(http.HandlerFunc(h.note)))
 	handle("POST /v1/missions/{id}/cancel", a.auth(http.HandlerFunc(h.cancel)))
 	handle("POST /v1/missions/{id}/permission", a.auth(http.HandlerFunc(h.permission)))
 	handle("GET /v1/missions/{id}/files", a.auth(http.HandlerFunc(h.files)))
@@ -611,6 +612,39 @@ func (h *missionAPI) cancel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// note handles POST /v1/missions/{id}/note: operator guidance injected
+// into a running mission via the existing progress-note pipeline — no
+// state transition, no driver signal. The next worker turn's packet
+// renders it like any other progress note (Render, packet.go), so
+// steering takes effect on its own without waking the mission early.
+func (h *missionAPI) note(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Text string `json:"text"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Text == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "body must be JSON with a non-empty text field")
+		return
+	}
+	id := r.PathValue("id")
+	m, err := h.store.Get(r.Context(), id)
+	if err != nil {
+		failMission(w, err)
+		return
+	}
+	if m.Phase.Terminal() {
+		jsonError(w, http.StatusConflict, "already_finished", missions.ErrTerminal.Error())
+		return
+	}
+	note := missions.NeutralizeSlot(truncateAnswer(body.Text, resumeAnswerCap))
+	if err := h.store.AppendEvent(r.Context(), id, "mission.steered", map[string]any{"note": note}); err != nil {
+		h.log.Warn("mission: record mission.steered event failed", "mission_id", id, "error", err)
+	}
+	if err := h.store.AppendProgress(r.Context(), id, "Operator note: "+note); err != nil {
+		h.log.Warn("mission: record operator note progress failed", "mission_id", id, "error", err)
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }
 
 // permission answers a mission's pending_permission — the SAME

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -203,6 +203,139 @@ func TestMissionsResumeWithoutAnswerLeavesProgressUntouched(t *testing.T) {
 	}
 }
 
+// TestMissionsNoteAppendsEventAndProgressWithoutPhaseChange confirms
+// POST .../note appends a mission.steered event and an "Operator
+// note: ..." progress note, sanitized/truncated the same way resume's
+// answer is, and leaves phase/status untouched — the note rides the
+// next worker turn's own packet, no driver signal involved.
+func TestMissionsNoteAppendsEventAndProgressWithoutPhaseChange(t *testing.T) {
+	store := testMissionStore(t)
+	ctx := context.Background()
+
+	id, err := store.Create(ctx, missions.Mission{Goal: "itest-api-mission note test", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.ApplyTransition(ctx, id, missions.Transition{
+		Next: missions.StepState{Phase: missions.PhaseExecute, Status: missions.StatusIdle},
+	}); err != nil {
+		t.Fatalf("ApplyTransition: %v", err)
+	}
+
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":"focus on the staging config next"}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("note = %d, want 200: %s", w.Code, w.Body.String())
+	}
+
+	got, err := store.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Phase != missions.PhaseExecute || got.Status != missions.StatusIdle {
+		t.Fatalf("phase/status after note = %s/%s, want unchanged execute/idle", got.Phase, got.Status)
+	}
+	if len(got.Progress) != 1 || !strings.Contains(got.Progress[0].Note, "Operator note: focus on the staging config next") {
+		t.Fatalf("progress = %+v, want one operator note", got.Progress)
+	}
+
+	events, err := store.Events(ctx, id)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	var sawSteered bool
+	for _, e := range events {
+		if e.Kind == "mission.steered" {
+			sawSteered = true
+			if !strings.Contains(string(e.Payload), "focus on the staging config next") {
+				t.Fatalf("mission.steered payload = %s, want the note", e.Payload)
+			}
+		}
+	}
+	if !sawSteered {
+		t.Fatalf("events = %+v, want mission.steered", events)
+	}
+}
+
+// TestMissionsNoteUnknownMission confirms an unknown mission id 404s
+// before any store write is attempted.
+func TestMissionsNoteUnknownMission(t *testing.T) {
+	store := testMissionStore(t)
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/v1/missions/00000000-0000-0000-0000-000000000000/note", strings.NewReader(`{"text":"hello"}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("note on unknown mission = %d, want 404: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestMissionsNoteEmptyTextRejected confirms an empty/missing text
+// field 400s.
+func TestMissionsNoteEmptyTextRejected(t *testing.T) {
+	store := testMissionStore(t)
+	ctx := context.Background()
+	id, err := store.Create(ctx, missions.Mission{Goal: "itest-api-mission note empty test", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":""}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("note with empty text = %d, want 400: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestMissionsNoteTerminalMissionRejected confirms a done/failed
+// mission refuses the note with 409 already_finished rather than
+// silently writing to a mission nothing will ever read again.
+func TestMissionsNoteTerminalMissionRejected(t *testing.T) {
+	store := testMissionStore(t)
+	ctx := context.Background()
+	id, err := store.Create(ctx, missions.Mission{Goal: "itest-api-mission note terminal test", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.ApplyTransition(ctx, id, missions.Transition{
+		Next: missions.StepState{Phase: missions.PhaseDone, Status: missions.StatusIdle},
+	}); err != nil {
+		t.Fatalf("ApplyTransition: %v", err)
+	}
+
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":"too late"}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("note on terminal mission = %d, want 409: %s", w.Code, w.Body.String())
+	}
+}
+
 // TestMissionsCreateResponseCarriesDetectedEnvironment confirms the
 // POST /v1/missions response reflects the row create() actually
 // persisted — the create() handler resolves an omitted coding

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -319,6 +319,40 @@ func TestMissionsResumeEmptyBodyUnchanged(t *testing.T) {
 	}
 }
 
+// TestMissionsNoteMalformedOrEmptyBodyRejected confirms note's text
+// validation happens before ever reaching the store — a degraded pool
+// would surface as 500 (failMission's default) once past validation,
+// so a 400 here proves the handler rejected the request first.
+func TestMissionsNoteMalformedOrEmptyBodyRejected(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	call := func(body io.Reader) int {
+		req := httptest.NewRequest("POST", "/v1/missions/abc/note", body)
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w.Code
+	}
+	if code := call(strings.NewReader(`{not json`)); code != http.StatusBadRequest {
+		t.Fatalf("note with malformed JSON body = %d, want 400", code)
+	}
+	if code := call(nil); code != http.StatusBadRequest {
+		t.Fatalf("note with no body = %d, want 400", code)
+	}
+	if code := call(strings.NewReader(`{}`)); code != http.StatusBadRequest {
+		t.Fatalf("note with empty JSON body = %d, want 400", code)
+	}
+	if code := call(strings.NewReader(`{"text":""}`)); code != http.StatusBadRequest {
+		t.Fatalf("note with empty text = %d, want 400", code)
+	}
+}
+
 // TestMissionsDecorateTopModels covers decorateTopModels's three
 // degrade paths (nil seam, seam error, no rows) plus the happy path,
 // all against a fake topModels func — no store/ledger involved, since

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -421,26 +421,71 @@ func ClassifyOverGateway(gw Gateway) agents.Classify {
 	}
 }
 
-// TitleOverGateway mirrors autoTitle's mechanism (same "default" role
-// route, same system prompt, same MaxTokens headroom, same rune-safe
-// truncation) as a standalone one-shot call — for callers outside chat
-// (missions naming a mission from its goal) that want a short display
-// name generated the identical way a session's title is, without the
-// session/reply/sensitive-route ceremony a live chat turn carries.
-// Returns "" (never an error) on any failure — best-effort, exactly
-// like autoTitle's own logged-and-dropped failure path; the caller
-// decides what "no name yet" means for its own fallback rendering.
+// titleChatterPrefixes are stock openers a model reaches for when it
+// answers or comments on the request instead of naming it — rejected
+// case-insensitively, but only as whole leading words: "Okta setup"
+// must not trip on "ok".
+var titleChatterPrefixes = []string{
+	"i'll", "i will", "i can", "i would", "sure", "okay", "ok",
+	"let me", "here is", "here's", "certainly", "of course",
+}
+
+// validTitle rejects anything that isn't a short, plain name: empty,
+// over 8 words, over 60 chars, carrying a newline/backtick/code fence,
+// or opening with a chatter prefix — the shape of a model answering or
+// commenting on the request instead of naming it.
+func validTitle(s string) bool {
+	if s == "" || len(s) > 60 {
+		return false
+	}
+	if strings.ContainsAny(s, "\n`") {
+		return false
+	}
+	if len(strings.Fields(s)) > 8 {
+		return false
+	}
+	lower := strings.ToLower(s)
+	for _, p := range titleChatterPrefixes {
+		if lower == p || (strings.HasPrefix(lower, p) && !isWordChar(lower[len(p)])) {
+			return false
+		}
+	}
+	return true
+}
+
+// isWordChar reports whether b continues a word — used to bound a
+// chatter-prefix match at a word boundary.
+func isWordChar(b byte) bool {
+	return b >= 'a' && b <= 'z' || b >= '0' && b <= '9' || b == '\''
+}
+
+// TitleOverGateway mirrors autoTitle's mechanism (same system-prompt/
+// MaxTokens-headroom/rune-safe-truncation shape) as a standalone
+// one-shot call — for callers outside chat (missions naming a mission
+// from its goal) that want a short display name generated the same
+// way a session's title is, without the session/reply/sensitive-route
+// ceremony a live chat turn carries. Titles are summarize-class work
+// (D-049): routed by the "summarize" role, falling back to "default"
+// when unbound, rather than burning the default chain's big model. A
+// rejected reply (validTitle) retries once with the same params;
+// still-invalid or any gateway failure returns "" (never an error) —
+// best-effort, exactly like autoTitle's own logged-and-dropped failure
+// path; the caller decides what "no name yet" means for its own
+// fallback rendering.
 func TitleOverGateway(gw Gateway) func(ctx context.Context, input string) string {
 	return func(ctx context.Context, input string) string {
 		ctx, cancel := context.WithTimeout(ctx, titleTimeout)
 		defer cancel()
 
-		const titleSystem = `Produce a title for this conversation: at most 6 words, plain text, no quotes, no trailing punctuation. Reply with only the title.`
-		route, ok, err := gw.RouteForRole(ctx, "default")
+		const titleSystem = `Produce a title for this conversation: at most 6 words, plain text, no quotes, no trailing punctuation. Do not perform, answer, or comment on the request — output only a short name for it. Reply with only the title.`
+		route, ok, err := gw.RouteForRole(ctx, "summarize")
 		if err != nil || !ok {
-			return ""
+			route, ok, err = gw.RouteForRole(ctx, "default")
+			if err != nil || !ok {
+				return ""
+			}
 		}
-		events, err := gw.Stream(ctx, gwclient.StreamRequest{
+		req := gwclient.StreamRequest{
 			Route:    route,
 			Purpose:  "title",
 			System:   titleSystem,
@@ -449,21 +494,24 @@ func TitleOverGateway(gw Gateway) func(ctx context.Context, input string) string
 			// the first answer token; a tight cap truncates the stream
 			// mid-reasoning and yields an empty title.
 			MaxTokens: 1000,
-		})
-		if err != nil {
-			return ""
 		}
-		var b strings.Builder
-		for ev := range events {
-			if ev.Type == stream.EventChunk {
-				b.WriteString(ev.Text)
+		for attempt := 0; attempt < 2; attempt++ {
+			events, err := gw.Stream(ctx, req)
+			if err != nil {
+				return ""
+			}
+			var b strings.Builder
+			for ev := range events {
+				if ev.Type == stream.EventChunk {
+					b.WriteString(ev.Text)
+				}
+			}
+			title := strings.TrimSpace(strings.Trim(strings.TrimSpace(b.String()), `"'`))
+			if validTitle(title) {
+				return truncateRunes(title, 80)
 			}
 		}
-		title := strings.TrimSpace(strings.Trim(strings.TrimSpace(b.String()), `"'`))
-		if title == "" {
-			return ""
-		}
-		return truncateRunes(title, 80)
+		return ""
 	}
 }
 

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -1580,12 +1580,13 @@ func TestAutoTitleUsesDefaultRouteNotClassifyRoute(t *testing.T) {
 	t.Fatal("no title request recorded")
 }
 
-// TestTitleOverGatewayUsesDefaultRoleAndTrimsQuotes mirrors
-// TestAutoTitleUsesDefaultRouteNotClassifyRoute for the standalone
+// TestTitleOverGatewayUsesSummarizeRoleAndTrimsQuotes mirrors
+// TestClassifyOverGatewayResolvesSummarizeRole for the standalone
 // TitleOverGateway constructor (missions naming reuses this instead of
 // autoTitle directly, since a mission has no session/reply at create
-// time) — same "default" role, same quote/whitespace trimming.
-func TestTitleOverGatewayUsesDefaultRoleAndTrimsQuotes(t *testing.T) {
+// time) — titles are summarize-class work (D-049), same quote/
+// whitespace trimming.
+func TestTitleOverGatewayUsesSummarizeRoleAndTrimsQuotes(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGW{events: okEvents(`"Parse Logs Utility"`)}
 	name := TitleOverGateway(gw)(context.Background(), "write a Go CLI that parses logs")
@@ -1598,11 +1599,35 @@ func TestTitleOverGatewayUsesDefaultRoleAndTrimsQuotes(t *testing.T) {
 	if len(gw.requests) != 1 {
 		t.Fatalf("requests = %d, want 1", len(gw.requests))
 	}
-	if gw.requests[0].Route != "default" {
-		t.Fatalf("route = %q, want default", gw.requests[0].Route)
+	if gw.requests[0].Route != "summarize" {
+		t.Fatalf("route = %q, want summarize", gw.requests[0].Route)
 	}
 	if gw.requests[0].Purpose != "title" {
 		t.Fatalf("purpose = %q, want title", gw.requests[0].Purpose)
+	}
+}
+
+// TestTitleOverGatewayFallsBackToDefaultRoleWhenSummarizeUnbound
+// confirms an unbound "summarize" role falls back to "default" rather
+// than giving up — a fresh install may not have seeded a summarize
+// role yet.
+func TestTitleOverGatewayFallsBackToDefaultRoleWhenSummarizeUnbound(t *testing.T) {
+	t.Parallel()
+	gw := &roleGW{
+		fakeGW: fakeGW{events: okEvents("Parse Logs Utility")},
+		routeForRole: func(_ context.Context, role string) (string, bool, error) {
+			if role == "summarize" {
+				return "", false, nil
+			}
+			return role, true, nil
+		},
+	}
+	name := TitleOverGateway(gw)(context.Background(), "write a Go CLI that parses logs")
+	if name != "Parse Logs Utility" {
+		t.Fatalf("name = %q, want Parse Logs Utility", name)
+	}
+	if got := gw.lastRequest().Route; got != "default" {
+		t.Fatalf("route = %q, want default (fallback from unbound summarize)", got)
 	}
 }
 
@@ -1616,6 +1641,115 @@ func TestTitleOverGatewayEmptyOnGatewayError(t *testing.T) {
 	name := TitleOverGateway(gw)(context.Background(), "a goal")
 	if name != "" {
 		t.Fatalf("name = %q, want empty on gateway error", name)
+	}
+}
+
+// TestValidTitle table-tests each rejection class and a set of
+// accepted titles, including a 6-word and a unicode one.
+func TestValidTitle(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty", "", false},
+		{"too many words", "one two three four five six seven eight nine", false},
+		{"too long", strings.Repeat("a", 61), false},
+		{"newline", "Parse Logs\nUtility", false},
+		{"backtick", "Parse `Logs` Utility", false},
+		{"chatter i'll", "I'll create a log parser", false},
+		{"chatter i will", "I will build this now", false},
+		{"chatter i can", "I can do that for you", false},
+		{"chatter i would", "I would suggest a CLI", false},
+		{"chatter sure", "Sure, here's a title", false},
+		{"chatter okay", "Okay let's name this", false},
+		{"chatter ok", "Ok here is a name", false},
+		{"chatter let me", "Let me name this for you", false},
+		{"chatter here is", "Here is your title", false},
+		{"chatter here's", "Here's a good name", false},
+		{"chatter certainly", "Certainly, a title follows", false},
+		{"chatter of course", "Of course, here's a name", false},
+		{"chatter case-insensitive", "SURE thing, a title", false},
+		{"bare chatter word", "Ok", false},
+		{"normal short", "Parse Logs Utility", true},
+		{"six words", "Build A Go Log Parser Tool", true},
+		{"unicode", "Résumé Parser Für Verträge", true},
+		{"prefix inside word ok", "Okta Integration Setup", true},
+		{"prefix inside word sure", "Surefire Deploy Checklist", true},
+		{"prefix inside word here", "Heredoc Quoting Fix", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := validTitle(tc.in); got != tc.want {
+				t.Fatalf("validTitle(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// titleScriptedGW returns one canned reply per Stream call, in
+// order — for proving TitleOverGateway's one-retry contract, which
+// fakeGW's always-identical-events shape can't exercise.
+type titleScriptedGW struct {
+	fakeGW
+	replies []string
+}
+
+func (g *titleScriptedGW) Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error) {
+	g.mu.Lock()
+	i := len(g.requests)
+	g.requests = append(g.requests, req)
+	reply := g.replies[min(i, len(g.replies)-1)]
+	g.mu.Unlock()
+	return okEventsChan(reply), nil
+}
+
+func okEventsChan(text string) <-chan stream.StreamEvent {
+	ch := make(chan stream.StreamEvent, len(okEvents(text)))
+	for _, ev := range okEvents(text) {
+		ch <- ev
+	}
+	close(ch)
+	return ch
+}
+
+// TestTitleOverGatewayRetriesOnceOnChatterThenSucceeds confirms a
+// first reply that answers/comments on the request instead of naming
+// it is rejected and retried once with the same params, returning the
+// second reply once it's valid.
+func TestTitleOverGatewayRetriesOnceOnChatterThenSucceeds(t *testing.T) {
+	t.Parallel()
+	gw := &titleScriptedGW{replies: []string{"I'll create a log parser for you", "Parse Logs Utility"}}
+	name := TitleOverGateway(gw)(context.Background(), "write a Go CLI that parses logs")
+	if name != "Parse Logs Utility" {
+		t.Fatalf("name = %q, want Parse Logs Utility", name)
+	}
+	gw.mu.Lock()
+	defer gw.mu.Unlock()
+	if len(gw.requests) != 2 {
+		t.Fatalf("requests = %d, want 2 (one retry)", len(gw.requests))
+	}
+	if gw.requests[0].Route != gw.requests[1].Route || gw.requests[0].Purpose != gw.requests[1].Purpose {
+		t.Fatalf("retry params changed: %+v vs %+v", gw.requests[0], gw.requests[1])
+	}
+}
+
+// TestTitleOverGatewayEmptyWhenBothAttemptsInvalid confirms two
+// consecutive chatter replies exhaust the retry and return "" rather
+// than a chatter string.
+func TestTitleOverGatewayEmptyWhenBothAttemptsInvalid(t *testing.T) {
+	t.Parallel()
+	gw := &titleScriptedGW{replies: []string{"I'll create a log parser", "Sure, here's a title for that"}}
+	name := TitleOverGateway(gw)(context.Background(), "write a Go CLI that parses logs")
+	if name != "" {
+		t.Fatalf("name = %q, want empty after both attempts invalid", name)
+	}
+	gw.mu.Lock()
+	defer gw.mu.Unlock()
+	if len(gw.requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(gw.requests))
 	}
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -941,6 +941,16 @@ export async function cancelMission(id: string): Promise<void> {
   await request<void>(`/v1/missions/${id}/cancel`, { method: 'POST' })
 }
 
+// sendMissionNote injects operator guidance into a running mission via
+// the progress-note pipeline — no state transition, picked up by the
+// next worker turn's own packet.
+export async function sendMissionNote(id: string, text: string): Promise<void> {
+  await request<void>(`/v1/missions/${id}/note`, {
+    method: 'POST',
+    body: JSON.stringify({ text }),
+  })
+}
+
 export async function deleteMission(id: string): Promise<void> {
   await request<void>(`/v1/missions/${id}`, { method: 'DELETE' })
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -689,6 +689,12 @@ export interface ExecutorSkippedPayload {
   skip_reasons?: string[]
 }
 
+// MissionSteeredPayload is mission.steered's payload — operator
+// guidance injected into a running mission via POST .../note.
+export interface MissionSteeredPayload {
+  note: string
+}
+
 // MissionFile is one entry of a mission workspace's file listing
 // (GET /v1/missions/:id/files). Declared marks files named in the
 // mission's plan artifacts, not the full tree.

--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -120,6 +120,15 @@ describe('executor.result rendering', () => {
   })
 })
 
+describe('mission.steered rendering', () => {
+  it('renders the operator note as an amber row', () => {
+    render(<div>{renderEvent(event({ note: 'focus on staging next' }, 'mission.steered'))}</div>)
+    const row = screen.getByText(/Operator note: focus on staging next/)
+    expect(row).toBeInTheDocument()
+    expect(row).toHaveClass('text-amber-400')
+  })
+})
+
 describe('executor lifecycle event rendering', () => {
   it('renders executor.spawned with harness, provider/model, and auth mode', () => {
     render(

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -7,6 +7,7 @@ import type {
   ExecutorSkippedPayload,
   ExecutorSpawnedPayload,
   MissionEvent,
+  MissionSteeredPayload,
 } from '../../api/types'
 import { formatDuration } from '../../lib/format'
 
@@ -74,6 +75,10 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
     return detail ? `${base}: ${String(detail)}` : base
   },
   'mission.resumed': () => 'Resumed',
+  'mission.steered': (p) => {
+    const { note } = p as MissionSteeredPayload
+    return <span className="text-amber-400">Operator note: {note}</span>
+  },
   'mission.recovery': () => 'Recovered after a restart',
   'mission.violation': () => 'Policy violation detected',
   'mission.done': () => 'Mission completed',

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../api/client', () => ({
   missionEvents: vi.fn(),
   missionUsage: vi.fn(),
   resumeMission: vi.fn(),
+  sendMissionNote: vi.fn(),
   cancelMission: vi.fn(),
   deleteMission: vi.fn(),
   answerMissionPermission: vi.fn(),
@@ -32,6 +33,7 @@ import {
   missionEvents,
   missionUsage,
   resumeMission,
+  sendMissionNote,
 } from '../api/client'
 import { playAlertSound } from '../lib/alertSound'
 import { subscribeEvents } from '../lib/events'
@@ -649,6 +651,23 @@ describe('MissionDetail', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Resume' }))
     await waitFor(() => expect(resumeMission).toHaveBeenCalledWith('m1'))
+  })
+
+  it('sends a note for a working mission and clears the input on success', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    const input = screen.getByPlaceholderText('Send a note to steer this mission…')
+    fireEvent.change(input, { target: { value: 'focus on staging next' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send note' }))
+    await waitFor(() => expect(sendMissionNote).toHaveBeenCalledWith('m1', 'focus on staging next'))
+    await waitFor(() => expect(input).toHaveValue(''))
+  })
+
+  it('hides the note affordance once the mission is terminal', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, phase: 'done', status: 'idle' })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(screen.queryByPlaceholderText('Send a note to steer this mission…')).toBeNull()
   })
 
   it('surfaces the most recent mission.paused event detail while paused', async () => {

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -12,6 +12,7 @@ import {
   missionEvents,
   missionUsage,
   resumeMission,
+  sendMissionNote,
 } from '../api/client'
 import type { Mission, MissionEvent, MissionUsage, Schedule } from '../api/types'
 import { ArtifactsSection } from '../components/missions/ArtifactsSection'
@@ -23,6 +24,7 @@ import { GoalSection } from '../components/missions/GoalSection'
 import { ResultSection } from '../components/missions/ResultSection'
 import { TimelineSection } from '../components/missions/TimelineSection'
 import { Button } from '../components/ui/button'
+import { Input } from '../components/ui/input'
 import {
   Dialog,
   DialogContent,
@@ -160,6 +162,8 @@ export function MissionDetail() {
   const [schedule, setSchedule] = useState<Schedule | null>(null)
   const [busy, setBusy] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const [noteText, setNoteText] = useState('')
+  const [sendingNote, setSendingNote] = useState(false)
   // answeredPermission tracks the pending_permission id the user just
   // decided on, so the card stops being actionable immediately — the
   // decision POST resolves the broker right away, but
@@ -286,6 +290,21 @@ export function MissionDetail() {
     }
   }
 
+  const sendNote = async () => {
+    const text = noteText.trim()
+    if (!text) return
+    setSendingNote(true)
+    try {
+      await sendMissionNote(id, text)
+      setNoteText('')
+      toast.success('Note sent')
+    } catch (err) {
+      toast.error('Could not send note', { description: errText(err) })
+    } finally {
+      setSendingNote(false)
+    }
+  }
+
   const cancel = async () => {
     setBusy(true)
     try {
@@ -404,6 +423,24 @@ export function MissionDetail() {
             )}
             {pauseDetail && (
               <p className="mt-2 text-sm text-amber-700 dark:text-amber-400">{pauseDetail}</p>
+            )}
+            {!terminalPhases.has(mission.phase) && (
+              <div className="mt-3 flex max-w-md gap-2">
+                <Input
+                  placeholder="Send a note to steer this mission…"
+                  value={noteText}
+                  onChange={(e) => setNoteText(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && void sendNote()}
+                  disabled={sendingNote}
+                />
+                <Button
+                  variant="outline"
+                  disabled={sendingNote || !noteText.trim()}
+                  onClick={() => void sendNote()}
+                >
+                  Send note
+                </Button>
+              </div>
             )}
           </div>
           <div className="flex shrink-0 gap-2">


### PR DESCRIPTION
## Summary
- **Steering notes**: `POST /v1/missions/{id}/note {"text"}` → `mission.steered` event + `Operator note:` progress note; worker packets already render progress, so the note reaches the next worker turn with zero state-machine changes. Same cap + `NeutralizeSlot` as blocked-question answers; 400 empty, 404 unknown, 409 terminal. Mission detail gets a send-note box (hidden when terminal) and an amber timeline renderer.
- **Title hardening** (chat titles + mission names, same function): route via `summarize` role (fallback `default`), prompt forbids answering the request, `validTitle` rejects chatter (word-boundary prefixes — "Okta Integration Setup" stays valid — plus length/word caps, newline/backtick), one retry then "" so callers fall back to truncated goal.

## Notes
- Reviewer packets carry no progress notes and replan folds only the last 3 — a note is guaranteed to reach the next **worker** turn; steering review rounds directly would be a separate change.

## Testing
- `make build test vet lint` green; integration suite green (note tests against live Postgres; pre-existing unrelated `TestBudgetStatusIgnoresOtherCurrencySpend` flake)
- Web build/lint/533 tests green
- Live smoke: note on running mission → event + progress in timeline; note after cancel → 409 `already_finished`
- `make canary` PASS

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788822246&installation_model_id=431401&pr_number=196&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F196&signature=bcfe5f9c0399355b7fc54dd8d777bc97a879823f6c9777f4fc7c130a709ca03c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->