### PR TITLE
feat: github connection for missions - clone, push, pr, auto-deploy

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -54,6 +55,35 @@ const defaultTokenBudget = 60_000
 // (session.SensitiveTools, chat/memoryd/compactor) both key off this
 // same list, so a tool added here is covered everywhere at once.
 var sensitiveToolSuffixes = []string{"gmail_read", "gmail_read_attachment"}
+
+// builtinToolSet guards the compiled-in tool slice buildAgent
+// returns: the connector reload goroutine reads it (via
+// conns.SetOnReload's closure) on its own timer, concurrently with
+// main()'s later append of the mission tools once missionStore is
+// built — a plain slice variable shared across those two goroutines
+// would race on that append. add appends under lock and returns the
+// current snapshot for the caller to pass straight to swapAgentTools.
+type builtinToolSet struct {
+	mu    sync.Mutex
+	tools []*tools.Tool
+}
+
+func newBuiltinToolSet(initial []*tools.Tool) *builtinToolSet {
+	return &builtinToolSet{tools: initial}
+}
+
+func (b *builtinToolSet) add(t ...*tools.Tool) []*tools.Tool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.tools = append(b.tools, t...)
+	return append([]*tools.Tool(nil), b.tools...)
+}
+
+func (b *builtinToolSet) snapshot() []*tools.Tool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]*tools.Tool(nil), b.tools...)
+}
 
 const (
 	serviceName = "brain"
@@ -174,11 +204,12 @@ func main() {
 	fxStore := fxrates.NewStore(app.DB)
 	go fxrates.NewFetcher(fxStore, settings.AllowedCurrencies(), app.Log).Run(ctx)
 
-	agent, broker, outputs, builtinSet, chatPerms, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, markitdownURL, packs, flags.SkillAllowed, mc.Add, app.Log, toolCalls, sensitiveRoute, fxStore)
+	agent, broker, outputs, builtins, chatPerms, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, markitdownURL, packs, flags.SkillAllowed, mc.Add, app.Log, toolCalls, sensitiveRoute, fxStore)
 	if buildErr != nil {
 		fmt.Fprintln(os.Stderr, buildErr)
 		os.Exit(1)
 	}
+	builtinSet := newBuiltinToolSet(builtins)
 	go runOutputGC(ctx, outputs, app.Log)
 
 	secrets, err := buildSecretStore(app.DB, app.Log)
@@ -193,11 +224,12 @@ func main() {
 	conns, goog := buildConnectors(app.DB, secrets, app.Log)
 	if conns != nil {
 		conns.RegisterBuilder("mcp", connectors.MCPBuilder(nil))
+		conns.RegisterBuilder("github", connectors.GitHubBuilder(nil))
 		if goog != nil {
 			conns.RegisterBuilder("google", goog.Builder())
 		}
 		conns.SetOnReload(func(context.Context) {
-			swapAgentTools(agent, builtinSet, conns, app.Log, toolCalls)
+			swapAgentTools(agent, builtinSet.snapshot(), conns, app.Log, toolCalls)
 		})
 		go runConnectorReload(ctx, conns, app.Log)
 		app.AddCheck("connectors", func() httpserver.Check {
@@ -245,9 +277,41 @@ func main() {
 		}
 		return name
 	}
-	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, fxStore, gwc, secrets, app.Log)
+	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, fxStore, gwc, secrets, conns, app.Log)
 	if missionDriver != nil {
 		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, app.Log)
+	}
+	// Chat-facing mission tools (D-0xx: "is mission X done?" / "push
+	// mission X"): registered here, not inside buildAgent, since both
+	// need missionStore (built above, after buildAgent) and mission_push
+	// additionally needs conns+secrets for its push token resolver.
+	// missionStore nil (WORKSPACES unset) means neither tool is
+	// registered at all, matching the nil-gating pattern buildMissions
+	// itself already uses. A recompile+swap applies them to the live
+	// agent immediately rather than waiting for the next connector
+	// reload (which may never come if no connectors are configured).
+	if missionStore != nil {
+		missionAdapter := missionToolStore{missionStore}
+		newTools := []*tools.Tool{builtin.Missions(missionAdapter, missionAdapter)}
+		if conns != nil && secrets != nil {
+			resolvePushToken := func(ctx context.Context, connectorID string) (string, error) {
+				c, err := conns.Store().Get(ctx, connectorID)
+				if err != nil {
+					return "", fmt.Errorf("resolve connector %s: %w", connectorID, err)
+				}
+				return secrets.Resolve(ctx, c.CredentialRef)
+			}
+			completer := missionCompleterAdapter{missionStore, missions.NewCompleter(missionWorkspace, missionStore, nil, connsPRSource{conns})}
+			newTools = append(newTools, builtin.MissionPush(missionAdapter, completer, resolvePushToken))
+		}
+		current := builtinSet.add(newTools...)
+		if conns != nil {
+			swapAgentTools(agent, current, conns, app.Log, toolCalls)
+		} else if constrained, defs, err := compileToolset(current, nil, app.Log, toolCalls); err != nil {
+			app.Log.Warn("mission tool registration failed; agent keeps its previous tool surface", "error", err)
+		} else {
+			agent.SwapTools(constrained, defs)
+		}
 	}
 	app.AddCheck("sandbox", func() httpserver.Check {
 		if err := missionSandbox.Health(ctx); err != nil {
@@ -494,7 +558,7 @@ func missionAgentResolver(agentReg *agents.Store) missions.AgentResolver {
 // time) so an agent edited after the fact still applies. The hub
 // lives inside the same gate as everything else here — no missions,
 // no push events either.
-func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, agentReg *agents.Store, routeForRole func(context.Context, string) string, fxStore *fxrates.Store, gwc *gwclient.Client, secrets *secretstore.Store, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace, *missions.Hub) {
+func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, agentReg *agents.Store, routeForRole func(context.Context, string) string, fxStore *fxrates.Store, gwc *gwclient.Client, secrets *secretstore.Store, conns *connectors.Manager, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace, *missions.Hub) {
 	root := os.Getenv("WORKSPACES")
 	if root == "" {
 		log.Info("WORKSPACES not set; missions disabled")
@@ -542,6 +606,59 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	driver.SetCapacityGate(sandboxMgr)
 	resolveAgent := missionAgentResolver(agentReg)
 	driver.SetAgentResolver(resolveAgent)
+	if conns != nil && secrets != nil {
+		// A repo_url mission's clone token: resolve connector_id straight
+		// to its credential_ref's secret value, same as resolveSecret does
+		// for the push endpoint — no need to build a full connector
+		// Source just to read one credential.
+		driver.SetCloneTokenResolver(func(ctx context.Context, connectorID string) (string, error) {
+			c, err := conns.Store().Get(ctx, connectorID)
+			if err != nil {
+				return "", fmt.Errorf("resolve connector %s: %w", connectorID, err)
+			}
+			return secrets.Resolve(ctx, c.CredentialRef)
+		})
+		// A repo_url mission's clone commit identity: reuse the same
+		// TestIdentity path Settings' connector test button calls, so
+		// commits inside the clone are authored as the connection, not the
+		// operator's fixed identity. Best-effort at the driver layer
+		// (SetCloneIdentityResolver's caller already treats a resolve
+		// error as WARN-and-fall-back, never a provisioning failure).
+		driver.SetCloneIdentityResolver(func(ctx context.Context, connectorID string) (string, string, error) {
+			identity, err := conns.TestIdentity(ctx, connectorID)
+			if err != nil {
+				return "", "", err
+			}
+			if identity == nil {
+				return "", "", fmt.Errorf("connector %s has no identity to resolve", connectorID)
+			}
+			name := identity.Name
+			if name == "" {
+				name = identity.Login
+			}
+			return name, identity.Email, nil
+		})
+	}
+	if conns != nil && secrets != nil {
+		// The auto-fire-on-done hook's push token: resolve connector_id
+		// straight to its credential_ref's secret value, same as the
+		// clone token resolver above and the push endpoint's own
+		// resolvePushToken — the on_complete path never has an explicit
+		// credential_ref override, only ever the mission's own connector.
+		resolvePushToken := func(ctx context.Context, connectorID string) (string, error) {
+			c, err := conns.Store().Get(ctx, connectorID)
+			if err != nil {
+				return "", fmt.Errorf("resolve connector %s: %w", connectorID, err)
+			}
+			return secrets.Resolve(ctx, c.CredentialRef)
+		}
+		driver.SetCompleter(missions.NewCompleter(workspace, store, resolvePushToken, connsPRSource{conns}))
+		driver.SetPushFailedNotifier(func(ctx context.Context, missionID, message string) {
+			if err := notifier.NotifyMessage(ctx, missionID, "push_failed", message); err != nil {
+				log.Warn("driver: on_complete push_failed notification failed", "mission_id", missionID, "error", err)
+			}
+		})
+	}
 
 	schedulerEnabled := func(ctx context.Context) bool { return flags.Enabled(ctx, settings.KeyScheduler) }
 	// routeExists backs DefaultCodingRoute's preference check for a
@@ -555,6 +672,123 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	scheduler := missions.NewScheduler(db, store, resolveAgent, schedulerEnabled, routeForRole, routeExists, flags.CodingExecutor, log)
 	go scheduler.Run(ctx)
 	return store, driver, notifier, workspace, hub
+}
+
+// connsPRSource adapts *connectors.Manager to missions.PRSource for the
+// driver's on_complete auto-fire hook — missions has no compile-time
+// dependency on the connectors package, same reasoning as
+// CloneTokenResolver's closure-based wiring above.
+type connsPRSource struct {
+	conns *connectors.Manager
+}
+
+func (c connsPRSource) DefaultBranch(ctx context.Context, connectorID, owner, repo string) (string, error) {
+	repoInfo, err := c.conns.GetRepo(ctx, connectorID, owner, repo)
+	if err != nil {
+		return "", err
+	}
+	return repoInfo.DefaultBranch, nil
+}
+
+func (c connsPRSource) CreatePR(ctx context.Context, connectorID, owner, repo, title, head, base, body string) (string, int, error) {
+	created, err := c.conns.CreatePR(ctx, connectorID, owner, repo, title, head, base, body)
+	if err != nil {
+		return "", 0, err
+	}
+	return created.HTMLURL, created.Number, nil
+}
+
+// toMissionRecord adapts a missions.Mission into the builtin package's
+// own MissionRecord shape — see MissionRecord's doc comment for why
+// builtin can't import missions.Mission directly. NotPushable is
+// precomputed here since missions.NotPushable also lives in the
+// missions package.
+func toMissionRecord(m missions.Mission) builtin.MissionRecord {
+	passed := 0
+	for _, u := range m.Spec.Units {
+		if u.Passes {
+			passed++
+		}
+	}
+	return builtin.MissionRecord{
+		ID: m.ID, Name: m.Name, Goal: m.Goal, Kind: m.Kind,
+		Phase: string(m.Phase), Status: string(m.Status), Iteration: m.Iteration,
+		Harness: m.Harness, RepoURL: m.RepoURL, Branch: m.Branch, ConnectorID: m.ConnectorID,
+		CreatedAt: m.CreatedAt, UpdatedAt: m.UpdatedAt,
+		UnitsPassed: passed, UnitsTotal: len(m.Spec.Units),
+		PauseReason: string(m.PauseReason), PauseMessage: m.PauseMessage,
+		OnComplete:        m.OnComplete,
+		NotPushableReason: missions.NotPushable(m),
+	}
+}
+
+// missionToolStore adapts *missions.Store to the builtin package's
+// missions/mission_push tool interfaces (missionLister,
+// missionEventReader) — a thin translation layer since builtin cannot
+// import missions.Mission/missions.Event directly (import cycle, see
+// MissionRecord's doc comment).
+type missionToolStore struct {
+	store *missions.Store
+}
+
+func (a missionToolStore) ListMissions(ctx context.Context, limit int) ([]builtin.MissionRecord, error) {
+	all, err := a.store.List(ctx, missions.ListFilter{Limit: limit})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]builtin.MissionRecord, len(all))
+	for i, m := range all {
+		out[i] = toMissionRecord(m)
+	}
+	return out, nil
+}
+
+func (a missionToolStore) GetMission(ctx context.Context, id string) (builtin.MissionRecord, error) {
+	m, err := a.store.Get(ctx, id)
+	if err != nil {
+		return builtin.MissionRecord{}, err
+	}
+	return toMissionRecord(m), nil
+}
+
+func (a missionToolStore) MissionEvents(ctx context.Context, id string) ([]builtin.MissionEvent, error) {
+	evs, err := a.store.Events(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]builtin.MissionEvent, len(evs))
+	for i, e := range evs {
+		out[i] = builtin.MissionEvent{Kind: e.Kind, Payload: e.Payload}
+	}
+	return out, nil
+}
+
+// missionCompleterAdapter adapts *missions.Completer to the builtin
+// package's missionCompleter interface — mission_push's push/PR calls
+// go through the exact same Completer the button/auto-fire paths use.
+// It re-Gets the mission by id from the real store before calling
+// Completer, so Completer always acts on the authoritative
+// missions.Mission (worktree, full spec for PRBody, ...) rather than a
+// partial copy shuttled through builtin.MissionRecord.
+type missionCompleterAdapter struct {
+	store     *missions.Store
+	completer *missions.Completer
+}
+
+func (a missionCompleterAdapter) PushMissionBranch(ctx context.Context, id, token string) (string, error) {
+	m, err := a.store.Get(ctx, id)
+	if err != nil {
+		return "", fmt.Errorf("no mission found with id %q", id)
+	}
+	return a.completer.PushBranch(ctx, m, token)
+}
+
+func (a missionCompleterAdapter) OpenMissionPR(ctx context.Context, id, token string) (string, int, error) {
+	m, err := a.store.Get(ctx, id)
+	if err != nil {
+		return "", 0, fmt.Errorf("no mission found with id %q", id)
+	}
+	return a.completer.OpenPR(ctx, m, token)
 }
 
 // credResolveTimeout bounds one credential_ref resolution the delegated

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -106,7 +106,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	if flags != nil {
 		codingExecutorDefault = flags.CodingExecutor
 	}
-	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret, routeForRole, missionClassify, codingExecutorDefault, resolveExecutorOptions, nameMission, topModels)
+	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret, routeForRole, missionClassify, codingExecutorDefault, resolveExecutorOptions, nameMission, topModels, conns)
 	a.registerSchedules(srv.Handle, missionStore)
 	a.registerEvents(srv.Handle, hub)
 	a.registerTranscribe(srv.Handle, whisperClient, whisperURL)

--- a/internal/brain/api/connectors.go
+++ b/internal/brain/api/connectors.go
@@ -23,6 +23,8 @@ func (a *API) registerConnectors(handle func(pattern string, h http.Handler), mg
 	handle("PATCH /v1/admin/connectors/{id}", a.auth(http.HandlerFunc(h.patch)))
 	handle("DELETE /v1/admin/connectors/{id}", a.auth(http.HandlerFunc(h.delete)))
 	handle("POST /v1/admin/connectors/{id}/test", a.auth(http.HandlerFunc(h.test)))
+	handle("GET /v1/admin/connectors/{id}/repos", a.auth(http.HandlerFunc(h.listRepos)))
+	handle("POST /v1/admin/connectors/{id}/repos", a.auth(http.HandlerFunc(h.createRepo)))
 	if goog != nil {
 		handle("POST /v1/admin/connectors/{id}/oauth/start", a.auth(http.HandlerFunc(h.oauthStart)))
 		// The callback is Google redirecting the user's browser — no
@@ -114,6 +116,48 @@ func (h *connectorAPI) patch(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// listRepos serves GET /v1/admin/connectors/{id}/repos: every repo the
+// connector's PAT can see, for the mission-create repo picker.
+// Non-github-kind (or unbuildable) connectors 400/422 via failConnector
+// (ErrUnsupported maps to 422 there — kept as 400 here since a picker
+// asking a non-github connector for repos is caller error, not an
+// infra condition).
+func (h *connectorAPI) listRepos(w http.ResponseWriter, r *http.Request) {
+	repos, err := h.mgr.ListRepos(r.Context(), r.PathValue("id"))
+	if err != nil {
+		failConnector(w, err)
+		return
+	}
+	if repos == nil {
+		repos = []connectors.GitHubRepo{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"repos": repos})
+}
+
+// createRepo serves POST /v1/admin/connectors/{id}/repos body
+// {"name","private"}: creates a new repo through the connector's PAT,
+// auto-initialized so it has a default branch to clone.
+func (h *connectorAPI) createRepo(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name    string `json:"name"`
+		Private bool   `json:"private"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if req.Name == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "name is required")
+		return
+	}
+	repo, err := h.mgr.CreateRepo(r.Context(), r.PathValue("id"), req.Name, req.Private)
+	if err != nil {
+		failConnector(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, repo)
+}
+
 func (h *connectorAPI) delete(w http.ResponseWriter, r *http.Request) {
 	if err := h.mgr.Store().Delete(r.Context(), r.PathValue("id")); err != nil {
 		failConnector(w, err)
@@ -124,12 +168,19 @@ func (h *connectorAPI) delete(w http.ResponseWriter, r *http.Request) {
 
 // test mirrors the provider test endpoint's shape: 200 with {ok,
 // error} for probe outcomes so the UI renders failures inline; HTTP
-// errors only for unknown ids and unbuildable kinds.
+// errors only for unknown ids and unbuildable kinds. A successful
+// github-kind test also carries the resolved identity (D-057): the
+// connector has no tools to prove itself with, so identity is the
+// evidence a working PAT was configured.
 func (h *connectorAPI) test(w http.ResponseWriter, r *http.Request) {
-	err := h.mgr.Test(r.Context(), r.PathValue("id"))
+	identity, err := h.mgr.TestIdentity(r.Context(), r.PathValue("id"))
 	switch {
 	case err == nil:
-		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+		out := map[string]any{"ok": true}
+		if identity != nil {
+			out["identity"] = identity
+		}
+		writeJSON(w, http.StatusOK, out)
 	case errors.Is(err, connectors.ErrNotFound), errors.Is(err, connectors.ErrUnsupported):
 		failConnector(w, err)
 	default:

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -8,13 +8,13 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/SumonMSelim/timothy/internal/brain/agents"
+	"github.com/SumonMSelim/timothy/internal/brain/connectors"
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
 	"github.com/SumonMSelim/timothy/internal/brain/missions/executor"
@@ -43,11 +43,11 @@ import (
 // provider/model per mission id from the cost ledger (D-05x's
 // ledger.Aggregator.TopModelByMission) for the list response's
 // top_model decoration — nil (no ledger wiring) omits the field.
-func (a *API) registerMissions(handle func(pattern string, h http.Handler), store *missions.Store, driver *missions.Driver, notifier *missions.Notifier, agentReg *agents.Store, workspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, classify agents.Classify, codingExecutorDefault func(context.Context) string, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error)) {
+func (a *API) registerMissions(handle func(pattern string, h http.Handler), store *missions.Store, driver *missions.Driver, notifier *missions.Notifier, agentReg *agents.Store, workspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, classify agents.Classify, codingExecutorDefault func(context.Context) string, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), conns *connectors.Manager) {
 	if store == nil {
 		return
 	}
-	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, workspace: workspace, resolveSecret: resolveSecret, routeForRole: routeForRole, classify: classify, codingExecutorDefault: codingExecutorDefault, resolveExecutorOptions: resolveExecutorOptions, nameMission: nameMission, topModels: topModels, perms: a.perms, dir: a.dir, log: a.log}
+	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, workspace: workspace, resolveSecret: resolveSecret, routeForRole: routeForRole, classify: classify, codingExecutorDefault: codingExecutorDefault, resolveExecutorOptions: resolveExecutorOptions, nameMission: nameMission, topModels: topModels, conns: conns, perms: a.perms, dir: a.dir, log: a.log}
 	handle("GET /v1/missions", a.auth(http.HandlerFunc(h.list)))
 	handle("POST /v1/missions", a.auth(http.HandlerFunc(h.create)))
 	handle("POST /v1/missions/classify", a.auth(http.HandlerFunc(h.classifyGoal)))
@@ -63,6 +63,7 @@ func (a *API) registerMissions(handle func(pattern string, h http.Handler), stor
 	handle("GET /v1/missions/{id}/files/{path...}", a.auth(http.HandlerFunc(h.download)))
 	handle("GET /v1/missions/{id}/archive", a.auth(http.HandlerFunc(h.archive)))
 	handle("POST /v1/missions/{id}/push", a.auth(http.HandlerFunc(h.push)))
+	handle("POST /v1/missions/{id}/pr", a.auth(http.HandlerFunc(h.pr)))
 	handle("GET /v1/notifications", a.auth(http.HandlerFunc(h.notifications)))
 	handle("POST /v1/notifications/{id}/read", a.auth(http.HandlerFunc(h.markRead)))
 }
@@ -102,6 +103,12 @@ type missionAPI struct {
 	// from the cost ledger; nil (no ledger wiring) omits top_model/
 	// top_model_provider from list/get responses entirely.
 	topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error)
+	// conns is the connector control plane: create() validates
+	// connector_id names an enabled github-kind connector before
+	// accepting repo_url. nil (no secret store, connectors disabled)
+	// makes repo_url mission creation unavailable, same 400 shape as any
+	// other rejected connector_id.
+	conns *connectors.Manager
 	// perms answers a mission's pending_permission — the same
 	// PermissionResolver chat sessions use (A.perms), never a
 	// mission-specific broker.
@@ -255,6 +262,21 @@ type createMissionRequest struct {
 	// unattended, so auto-approving DangerSafe shell calls is the
 	// sensible default; destructive commands always ask regardless.
 	AutoApproveSafe *bool `json:"auto_approve_safe"`
+	// RepoURL is a GitHub repo's https clone URL: when set, the mission
+	// clones it instead of self-initializing an empty repo. Mutually
+	// exclusive with a future repo_path option and coding-only, same as
+	// Harness/Environment. Requires ConnectorID — v1 has no anonymous
+	// clone path.
+	RepoURL string `json:"repo_url"`
+	// ConnectorID names a github-kind connectors row whose PAT
+	// authenticates the clone; only meaningful alongside RepoURL.
+	ConnectorID string `json:"connector_id"`
+	// OnComplete is the operator's consent-at-create choice for what
+	// happens when this mission reaches done: "" (default), "push", or
+	// "push_pr". Requires RepoURL+ConnectorID (a github-connection
+	// mission) and kind=coding — a model never decides this, only the
+	// human choosing it here.
+	OnComplete string `json:"on_complete"`
 }
 
 // create validates the request, resolves route/review_route/budget
@@ -313,6 +335,42 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		// explicit request; "" stays "" (base) when nothing matches.
 		req.Environment, _ = missions.DetectEnvironment("", req.Goal)
 	}
+	switch {
+	case req.RepoURL != "" && req.Kind != "coding":
+		jsonError(w, http.StatusBadRequest, "bad_request", "repo_url is only valid for kind=coding missions")
+		return
+	case req.RepoURL != "" && req.ConnectorID == "":
+		jsonError(w, http.StatusBadRequest, "bad_request", "connector_id is required with repo_url")
+		return
+	case req.RepoURL == "" && req.ConnectorID != "":
+		jsonError(w, http.StatusBadRequest, "bad_request", "connector_id is only valid alongside repo_url")
+		return
+	case req.RepoURL != "":
+		if h.conns == nil {
+			jsonError(w, http.StatusBadRequest, "bad_request", "connectors are not enabled")
+			return
+		}
+		c, err := h.conns.Store().Get(r.Context(), req.ConnectorID)
+		if err != nil {
+			jsonError(w, http.StatusBadRequest, "bad_request", "unknown connector_id")
+			return
+		}
+		if c.Kind != "github" {
+			jsonError(w, http.StatusBadRequest, "bad_request", "connector_id must name a github-kind connector")
+			return
+		}
+	}
+	switch req.OnComplete {
+	case "":
+	case "push", "push_pr":
+		if req.Kind != "coding" || req.RepoURL == "" || req.ConnectorID == "" {
+			jsonError(w, http.StatusBadRequest, "bad_request", "on_complete requires repo_url and connector_id on a kind=coding mission")
+			return
+		}
+	default:
+		jsonError(w, http.StatusBadRequest, "bad_request", `on_complete must be "", "push", or "push_pr"`)
+		return
+	}
 	// Resolve even with an empty AgentID: ResolveByID("") falls back to
 	// the default agent, same as chat sessions that don't pick one — a
 	// mission created without an explicit agent still needs a real
@@ -367,6 +425,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		Route: req.Route, ReviewRoute: req.ReviewRoute, EscalationRoute: req.EscalationRoute,
 		MaxIterations: req.MaxIterations, BudgetAmount: req.BudgetAmount, BudgetCurrency: budgetCurrency,
 		AutoApproveSafe: autoApproveSafe, PromptOverlay: promptOverlay, Harness: req.Harness, Environment: req.Environment,
+		RepoURL: req.RepoURL, ConnectorID: req.ConnectorID, OnComplete: req.OnComplete,
 	}
 	id, err := h.driver.Create(r.Context(), m)
 	if err != nil {
@@ -787,74 +846,231 @@ func (h *missionAPI) archive(w http.ResponseWriter, r *http.Request) {
 // check, not a secret-store lookup.
 var pushRefPattern = regexp.MustCompile(`^[A-Za-z0-9_./-]{1,128}$`)
 
-// push pushes the mission's branch to its worktree's origin remote,
-// authenticated with the resolved credential_ref. Guards (kind,
-// branch, worktree presence) are Go code, never a prompt — only coding
-// missions with a live worktree are ever pushable.
+// pushTokenError is the sentinel resolvePushToken returns on any
+// resolution failure, carrying the exact HTTP status/code/message the
+// caller should surface — push and pr share this one resolution path,
+// so both endpoints report identical errors for identical causes.
+type pushTokenError struct {
+	status  int
+	code    string
+	message string
+}
+
+func (e *pushTokenError) Error() string { return e.message }
+
+// resolvePushToken resolves the token that authenticates a push:
+// credentialRef (from the request body) when non-empty always wins —
+// an explicit override — otherwise, a github-connection mission (m has
+// a connector_id) resolves the connector's own PAT; a mission with
+// neither is a 400, not a fall-through to "no credential configured".
+func (h *missionAPI) resolvePushToken(ctx context.Context, m missions.Mission, credentialRef string) (string, error) {
+	if credentialRef != "" {
+		if !pushRefPattern.MatchString(credentialRef) {
+			return "", &pushTokenError{http.StatusBadRequest, "bad_request", "credential_ref must match ^[A-Za-z0-9_./-]{1,128}$"}
+		}
+		if h.resolveSecret == nil {
+			return "", &pushTokenError{http.StatusNotFound, "not_found", "secret store not configured"}
+		}
+		token, err := h.resolveSecret(ctx, credentialRef)
+		if err != nil {
+			if errors.Is(err, secretstore.ErrNotFound) {
+				return "", &pushTokenError{http.StatusNotFound, "secret_not_found", "no secret configured for that credential_ref"}
+			}
+			return "", &pushTokenError{http.StatusBadGateway, "push_failed", "failed to resolve credential"}
+		}
+		return token, nil
+	}
+	if m.ConnectorID == "" {
+		return "", &pushTokenError{http.StatusBadRequest, "bad_request", "credential_ref is required and must match ^[A-Za-z0-9_./-]{1,128}$"}
+	}
+	if h.conns == nil {
+		return "", &pushTokenError{http.StatusBadRequest, "bad_request", "connectors are not enabled"}
+	}
+	c, err := h.conns.Store().Get(ctx, m.ConnectorID)
+	if err != nil {
+		return "", &pushTokenError{http.StatusBadRequest, "bad_request", "unknown connector_id"}
+	}
+	if c.Kind != "github" {
+		return "", &pushTokenError{http.StatusBadRequest, "bad_request", "connector_id must name a github-kind connector"}
+	}
+	if !c.Enabled {
+		return "", &pushTokenError{http.StatusBadRequest, "bad_request", "connector is disabled"}
+	}
+	if h.resolveSecret == nil {
+		return "", &pushTokenError{http.StatusNotFound, "not_found", "secret store not configured"}
+	}
+	token, err := h.resolveSecret(ctx, c.CredentialRef)
+	if err != nil {
+		return "", &pushTokenError{http.StatusBadGateway, "push_failed", "failed to resolve connector credential"}
+	}
+	return token, nil
+}
+
+// pushMissionBranch pushes m's branch to its worktree's origin remote
+// with token, recording mission.pushed/mission.push_failed either way —
+// missions.Completer.PushBranch does the actual push and event
+// recording, the SAME code the driver's auto-fire-on-done hook calls,
+// so a manual push and an auto-fired push can never diverge in what
+// they do or which events land on the Timeline. Event-record failures
+// here are logged, never turned into a failed response — the push
+// itself already succeeded or failed on its own terms.
+func (h *missionAPI) pushMissionBranch(ctx context.Context, m missions.Mission, token string) (host string, err error) {
+	host, err = h.completer().PushBranch(ctx, m, token)
+	if err != nil && !errors.Is(err, missions.ErrRemoteUnsupported) && !errors.Is(err, missions.ErrPushRejected) {
+		h.log.Warn("mission: push failed", "mission_id", m.ID, "error", err)
+	}
+	return host, err
+}
+
+// completer builds a missions.Completer wired to this handler's own
+// workspace/store — cheap, stateless besides those two pointers, so a
+// fresh one per call is simplest; the driver holds its own long-lived
+// Completer for the auto-fire path.
+func (h *missionAPI) completer() *missions.Completer {
+	return missions.NewCompleter(h.workspace, h.store, nil, h.prSource())
+}
+
+// prSource adapts h.conns (nil-safe) to missions.PRSource.
+func (h *missionAPI) prSource() missions.PRSource {
+	if h.conns == nil {
+		return nil
+	}
+	return connsPRSource{h.conns}
+}
+
+// connsPRSource adapts *connectors.Manager to missions.PRSource — the
+// PR endpoint's own adapter; the driver's SetPRSource wiring in
+// cmd/brain/main.go builds an equivalent one.
+type connsPRSource struct {
+	conns *connectors.Manager
+}
+
+func (c connsPRSource) DefaultBranch(ctx context.Context, connectorID, owner, repo string) (string, error) {
+	repoInfo, err := c.conns.GetRepo(ctx, connectorID, owner, repo)
+	if err != nil {
+		return "", err
+	}
+	return repoInfo.DefaultBranch, nil
+}
+
+func (c connsPRSource) CreatePR(ctx context.Context, connectorID, owner, repo, title, head, base, body string) (string, int, error) {
+	created, err := c.conns.CreatePR(ctx, connectorID, owner, repo, title, head, base, body)
+	if err != nil {
+		return "", 0, err
+	}
+	return created.HTMLURL, created.Number, nil
+}
+
+// pushStatusCode maps a Push error to the HTTP status/code pair the
+// push/pr endpoints both report — shared so a rejected/unsupported
+// remote reads identically from either entry point.
+func pushStatusCode(err error) (status int, code string) {
+	switch {
+	case errors.Is(err, missions.ErrRemoteUnsupported):
+		return http.StatusBadRequest, "remote_unsupported"
+	case errors.Is(err, missions.ErrPushRejected):
+		return http.StatusConflict, "push_rejected"
+	default:
+		return http.StatusBadGateway, "push_failed"
+	}
+}
+
+// push pushes the mission's branch to its worktree's origin remote.
+// credential_ref in the body is optional for a github-connection
+// mission (absent resolves the connector's own PAT); required
+// otherwise. Guards (kind, branch, worktree presence) are Go code,
+// never a prompt — only coding missions with a live worktree are ever
+// pushable.
 func (h *missionAPI) push(w http.ResponseWriter, r *http.Request) {
 	m, err := h.store.Get(r.Context(), r.PathValue("id"))
 	if err != nil {
 		failMission(w, err)
 		return
 	}
-	if m.Kind != "coding" {
-		jsonError(w, http.StatusBadRequest, "not_pushable", "only coding missions can be pushed")
-		return
-	}
-	if m.Branch == "" {
-		jsonError(w, http.StatusBadRequest, "not_pushable", "mission has no branch")
-		return
-	}
-	if _, err := os.Stat(m.Worktree); err != nil {
-		jsonError(w, http.StatusBadRequest, "not_pushable", "mission worktree is not available")
+	if reason := missions.NotPushable(m); reason != "" {
+		jsonError(w, http.StatusBadRequest, "not_pushable", reason)
 		return
 	}
 	var req struct {
 		CredentialRef string `json:"credential_ref"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
-	if !pushRefPattern.MatchString(req.CredentialRef) {
-		jsonError(w, http.StatusBadRequest, "bad_request", "credential_ref is required and must match ^[A-Za-z0-9_./-]{1,128}$")
-		return
-	}
-	if h.resolveSecret == nil {
-		jsonError(w, http.StatusNotFound, "not_found", "secret store not configured")
-		return
-	}
-	token, err := h.resolveSecret(r.Context(), req.CredentialRef)
+	token, err := h.resolvePushToken(r.Context(), m, req.CredentialRef)
 	if err != nil {
-		if errors.Is(err, secretstore.ErrNotFound) {
-			jsonError(w, http.StatusNotFound, "secret_not_found", "no secret configured for that credential_ref")
+		var te *pushTokenError
+		if errors.As(err, &te) {
+			jsonError(w, te.status, te.code, te.message)
 			return
 		}
-		jsonError(w, http.StatusBadGateway, "push_failed", "failed to resolve credential")
+		jsonError(w, http.StatusBadGateway, "push_failed", err.Error())
 		return
 	}
-	host, pushErr := h.workspace.Push(r.Context(), m.Worktree, m.Branch, token)
+	host, pushErr := h.pushMissionBranch(r.Context(), m, token)
 	if pushErr != nil {
-		reason := "push failed"
-		status, code := http.StatusBadGateway, "push_failed"
-		switch {
-		case errors.Is(pushErr, missions.ErrRemoteUnsupported):
-			status, code = http.StatusBadRequest, "remote_unsupported"
-			reason = "remote unsupported"
-		case errors.Is(pushErr, missions.ErrPushRejected):
-			status, code = http.StatusConflict, "push_rejected"
-			reason = "push rejected"
-		}
-		if err := h.store.AppendEvent(r.Context(), m.ID, "mission.push_failed", map[string]any{"reason": reason}); err != nil {
-			h.log.Warn("mission: record push_failed event failed", "mission_id", m.ID, "error", err)
-		}
+		status, code := pushStatusCode(pushErr)
 		jsonError(w, status, code, pushErr.Error())
 		return
 	}
-	if err := h.store.AppendEvent(r.Context(), m.ID, "mission.pushed", map[string]any{"branch": m.Branch, "remote_host": host}); err != nil {
-		h.log.Warn("mission: record pushed event failed", "mission_id", m.ID, "error", err)
-	}
 	writeJSON(w, http.StatusOK, map[string]string{"branch": m.Branch, "remote_host": host})
+}
+
+// pr handles POST /v1/missions/{id}/pr: github-connection missions
+// only (400 otherwise). missions.Completer.OpenPR does the actual push,
+// default-branch lookup, PR create, and mission.pr_opened event
+// recording — the SAME code the driver's auto-fire-on-done hook calls
+// for on_complete="push_pr", so a manual PR and an auto-fired one can
+// never diverge. A re-call that finds the existing PR (CreatePR's
+// already-exists path) still appends a SECOND mission.pr_opened event,
+// tolerated as a harmless duplicate (the Timeline shows one extra
+// identical row) rather than adding a "did we already record this PR"
+// lookup.
+func (h *missionAPI) pr(w http.ResponseWriter, r *http.Request) {
+	m, err := h.store.Get(r.Context(), r.PathValue("id"))
+	if err != nil {
+		failMission(w, err)
+		return
+	}
+	if m.ConnectorID == "" || m.RepoURL == "" {
+		jsonError(w, http.StatusBadRequest, "not_pr_able", "only github-connection missions can open a pull request")
+		return
+	}
+	if reason := missions.NotPushable(m); reason != "" {
+		jsonError(w, http.StatusBadRequest, "not_pushable", reason)
+		return
+	}
+	if h.conns == nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", "connectors are not enabled")
+		return
+	}
+	if _, _, ok := missions.ParseGitHubRepoURL(m.RepoURL); !ok {
+		jsonError(w, http.StatusBadRequest, "bad_request", "mission repo_url is not a recognizable github https clone URL")
+		return
+	}
+
+	token, err := h.resolvePushToken(r.Context(), m, "")
+	if err != nil {
+		var te *pushTokenError
+		if errors.As(err, &te) {
+			jsonError(w, te.status, te.code, te.message)
+			return
+		}
+		jsonError(w, http.StatusBadGateway, "push_failed", err.Error())
+		return
+	}
+	url, number, err := h.completer().OpenPR(r.Context(), m, token)
+	if err != nil {
+		if errors.Is(err, missions.ErrRemoteUnsupported) || errors.Is(err, missions.ErrPushRejected) {
+			status, code := pushStatusCode(err)
+			jsonError(w, status, code, err.Error())
+			return
+		}
+		jsonError(w, http.StatusBadGateway, "pr_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"url": url, "number": number})
 }
 
 func (h *missionAPI) notifications(w http.ResponseWriter, r *http.Request) {

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -9,13 +9,17 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/cgi"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/SumonMSelim/timothy/internal/brain/connectors"
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
 	"github.com/SumonMSelim/timothy/internal/platform/migrate"
 	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
 	"github.com/SumonMSelim/timothy/migrations"
@@ -113,7 +117,7 @@ func TestMissionsResumeWithAnswerReachesWorker(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/resume", strings.NewReader(`{"answer":"the deploy target is staging"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -181,7 +185,7 @@ func TestMissionsResumeWithoutAnswerLeavesProgressUntouched(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/resume", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -225,7 +229,7 @@ func TestMissionsNoteAppendsEventAndProgressWithoutPhaseChange(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":"focus on the staging config next"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -271,7 +275,7 @@ func TestMissionsNoteUnknownMission(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/00000000-0000-0000-0000-000000000000/note", strings.NewReader(`{"text":"hello"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -295,7 +299,7 @@ func TestMissionsNoteEmptyTextRejected(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":""}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -325,7 +329,7 @@ func TestMissionsNoteTerminalMissionRejected(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":"too late"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -349,7 +353,7 @@ func TestMissionsCreateResponseCarriesDetectedEnvironment(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	body := `{"goal":"itest-api-mission write a Go CLI that parses logs","kind":"coding"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -393,7 +397,7 @@ func TestMissionsCreateGeneratesNameAsync(t *testing.T) {
 	nameMission := func(ctx context.Context, goal string) string {
 		return "Parse Logs Utility"
 	}
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil)
 
 	body := `{"goal":"itest-api-mission write a Go CLI that parses logs","kind":"general"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -441,7 +445,7 @@ func TestMissionsCreateNameFallsBackToEmptyOnGenerationFailure(t *testing.T) {
 		defer close(done)
 		return "" // simulates a gateway/timeout failure, same as TitleOverGateway
 	}
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil)
 
 	body := `{"goal":"itest-api-mission a goal whose naming will fail","kind":"general"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -467,5 +471,516 @@ func TestMissionsCreateNameFallsBackToEmptyOnGenerationFailure(t *testing.T) {
 	}
 	if got.Name != "" {
 		t.Fatalf("stored name = %q, want empty on generation failure", got.Name)
+	}
+}
+
+// --- push/pr with a github-connection mission ---
+
+// requireGitForAPI mirrors missions.requireGit (unexported to that
+// package) — these tests exercise real git clones/pushes, same as
+// worktree_test.go's coverage, just from the API layer down.
+func requireGitForAPI(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found on PATH; skipping")
+	}
+}
+
+func gitRunAPI(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...) //nolint:gosec // fixed test-fixture subcommands
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+	return string(out)
+}
+
+// gitHTTPBackendTLSServer stands up a real https:// git remote backed
+// by git-http-backend (CGI) over an httptest TLS server — validateRemote
+// (push.go) requires a genuine https:// scheme, so a local bare repo's
+// plain filesystem path (the trick push_test.go/worktree_test.go use
+// for rawPush, which bypasses validateRemote) can't stand in here; this
+// gives Workspace.Push a real https origin to push against without any
+// network access. Callers must set GIT_SSL_NO_VERIFY=1 in the pushing
+// process's env (the server's cert is self-signed) — see
+// requireGitSSLNoVerify.
+func gitHTTPBackendTLSServer(t *testing.T, reposRoot string) *httptest.Server {
+	t.Helper()
+	handler := &cgi.Handler{
+		Path: "/usr/lib/git-core/git-http-backend",
+		Env:  []string{"GIT_HTTP_EXPORT_ALL=1", "GIT_PROJECT_ROOT=" + reposRoot},
+		Dir:  reposRoot,
+	}
+	srv := httptest.NewTLSServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// requireGitSSLNoVerify sets GIT_SSL_NO_VERIFY=1 in the test process's
+// own environment for the test's duration — rawPush/cloneRepo build
+// cmd.Env from os.Environ(), so this propagates to every git subprocess
+// they spawn, letting them trust gitHTTPBackendTLSServer's self-signed
+// cert without touching production code (which never sets this itself).
+func requireGitSSLNoVerify(t *testing.T) {
+	t.Helper()
+	t.Setenv("GIT_SSL_NO_VERIFY", "1")
+}
+
+// seedBareRepoWithMissionBranch builds a bare repo served over a real
+// local https server (gitHTTPBackendTLSServer), then clones it into a
+// mission worktree already checked out on branch — mirroring what
+// Workspace.Provision would have produced for a real repo_url mission,
+// without going through Provision itself (these tests fabricate the
+// mission row directly via store.Create + SetProvisioned, so no
+// connector token/identity resolution needs to run at provision time).
+func seedBareRepoWithMissionBranch(t *testing.T) (repoURL, worktree, branch string) {
+	t.Helper()
+	requireGitSSLNoVerify(t)
+
+	reposRoot := t.TempDir()
+	bareName := "repo.git"
+	bare := reposRoot + "/" + bareName
+	gitRunAPI(t, reposRoot, "init", "-q", "--bare", "-b", "main", bareName)
+	// git-http-backend's default receive-pack refuses non-fast-forward
+	// pushes only; it's disabled from serving at all unless the repo
+	// opts in (GIT_HTTP_EXPORT_ALL above covers the read side, but a
+	// push additionally needs http.receivepack on).
+	gitRunAPI(t, bare, "config", "http.receivepack", "true")
+
+	srv := gitHTTPBackendTLSServer(t, reposRoot)
+	repoURL = srv.URL + "/" + bareName
+
+	seed := t.TempDir()
+	gitRunAPI(t, seed, "init", "-q", "-b", "main")
+	if err := os.WriteFile(seed+"/README.md", []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRunAPI(t, seed, "add", "README.md")
+	gitRunAPI(t, seed, "-c", "user.name=test", "-c", "user.email=test@test", "commit", "-q", "-m", "seed")
+	gitRunAPI(t, seed, "remote", "add", "origin", repoURL)
+	gitRunAPI(t, seed, "push", "-q", "origin", "main")
+
+	worktree = t.TempDir() + "/wt"
+	gitRunAPI(t, t.TempDir(), "clone", "-q", repoURL, worktree)
+	branch = "mission/itest-pr-test"
+	gitRunAPI(t, worktree, "checkout", "-q", "-b", branch)
+	// A local change to push — an empty diff from origin/main would
+	// still push fine, but a real file makes the test's intent obvious.
+	if err := os.WriteFile(worktree+"/change.txt", []byte("mission work"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRunAPI(t, worktree, "add", "change.txt")
+	gitRunAPI(t, worktree, "-c", "user.name=test", "-c", "user.email=test@test", "commit", "-q", "-m", "mission work")
+	return repoURL, worktree, branch
+}
+
+// fakeGitHubSource is a connectors.Source implementing the repoSource
+// capability (GetRepo/CreatePR, ListRepos/CreateRepo unused here) by
+// hand — used instead of connectors.GitHubBuilder + a real HTTP fake
+// server, since githubAPIBase (the base URL GitHubBuilder's requests
+// hit) is unexported to the connectors package and this test lives in
+// api. GetRepo/CreatePR themselves are already covered against the
+// real wire format in internal/brain/connectors/github_test.go; this
+// fake only needs to prove the API layer calls through to them
+// correctly.
+type fakeGitHubSource struct {
+	getRepoFn  func(ctx context.Context, owner, repo string) (connectors.GitHubRepo, error)
+	createPRFn func(ctx context.Context, owner, repo, title, head, base, body string) (connectors.GitHubPR, error)
+}
+
+func (f *fakeGitHubSource) Tools() []*tools.Tool       { return nil }
+func (f *fakeGitHubSource) Test(context.Context) error { return nil }
+func (f *fakeGitHubSource) Close() error               { return nil }
+func (f *fakeGitHubSource) ListRepos(context.Context) ([]connectors.GitHubRepo, error) {
+	return nil, errors.New("not implemented in fakeGitHubSource")
+}
+func (f *fakeGitHubSource) CreateRepo(context.Context, string, bool) (connectors.GitHubRepo, error) {
+	return connectors.GitHubRepo{}, errors.New("not implemented in fakeGitHubSource")
+}
+func (f *fakeGitHubSource) GetRepo(ctx context.Context, owner, repo string) (connectors.GitHubRepo, error) {
+	return f.getRepoFn(ctx, owner, repo)
+}
+func (f *fakeGitHubSource) CreatePR(ctx context.Context, owner, repo, title, head, base, body string) (connectors.GitHubPR, error) {
+	return f.createPRFn(ctx, owner, repo, title, head, base, body)
+}
+
+// testConnectorsManager builds a real *connectors.Manager backed by the
+// same test Postgres pool, with the github builder returning src for
+// every build — enough to exercise the API layer's connector-resolution
+// and PR-flow wiring without touching real GitHub HTTP.
+func testConnectorsManager(t *testing.T, src connectors.Source) *connectors.Manager {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	// context.Background(), not t.Context(): the pool's manage/watch
+	// loop (pgpool.go) closes the underlying connection the moment its
+	// context is Done, and t.Context() cancels at test end BEFORE
+	// t.Cleanup callbacks run — a cleanup that still needs this pool
+	// (createGitHubConnectorRow's own delete) would race the pool
+	// tearing itself down. The pool has no other lifetime owner here, so
+	// tying it to Background is safe: it's simply dropped (never
+	// explicitly closed) once the test process is done with it.
+	pool := pgpool.New(context.Background(), dsn, discard())
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	store := connectors.NewStore(pool, discard())
+	resolve := func(context.Context, string) (string, error) { return "fake-pat-token", nil }
+	mgr := connectors.NewManager(store, resolve, discard())
+	mgr.RegisterBuilder("github", func(context.Context, connectors.Connector, connectors.Resolve) (connectors.Source, error) {
+		return src, nil
+	})
+	return mgr
+}
+
+// createGitHubConnectorRow inserts a real github-kind connector row
+// against the test Postgres, cleaned up on test end.
+func createGitHubConnectorRow(t *testing.T, mgr *connectors.Manager) string {
+	t.Helper()
+	id, err := mgr.Store().Create(t.Context(), connectors.Connector{
+		Name: "itest-api-pr-gh", Kind: "github", CredentialRef: "GH_PAT", Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("create connector: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := mgr.Store().Delete(context.Background(), id); err != nil {
+			t.Logf("cleanup: delete connector %s: %v", id, err)
+		}
+	})
+	return id
+}
+
+// createGitHubConnectionMission fabricates a mission row with
+// connector_id/repo_url set and SetProvisioned pointed at worktree —
+// the shape Driver.ensureProvisioned would have produced for a real
+// repo_url mission, without actually running provisioning (these tests
+// only exercise push/pr, not clone/authorship, which worktree_test.go
+// already covers).
+func createGitHubConnectionMission(t *testing.T, store *missions.Store, connectorID, repoURL, worktree, branch string) string {
+	t.Helper()
+	id, err := store.Create(t.Context(), missions.Mission{
+		Goal: "itest-api-mission pr flow", Kind: "coding", RepoURL: repoURL, ConnectorID: connectorID,
+	})
+	if err != nil {
+		t.Fatalf("create mission: %v", err)
+	}
+	if err := store.SetProvisioned(t.Context(), id, worktree+"/..", worktree, branch, "deadbeef"); err != nil {
+		t.Fatalf("SetProvisioned: %v", err)
+	}
+	return id
+}
+
+// TestMissionsPushResolvesConnectorToken proves POST .../push with no
+// credential_ref in the body resolves the mission's connector's PAT
+// instead — the connector-resolution path SetCloneTokenResolver's
+// sibling wires at the push endpoint.
+func TestMissionsPushResolvesConnectorToken(t *testing.T) {
+	requireGitForAPI(t)
+	store := testMissionStore(t)
+	// push never builds a repoSource (only Store().Get for the
+	// credential_ref) — an empty fakeGitHubSource is a safe stand-in;
+	// getRepoFn/createPRFn would only be invoked if the endpoint
+	// unexpectedly tried to build one.
+	mgr := testConnectorsManager(t, &fakeGitHubSource{})
+	connID := createGitHubConnectorRow(t, mgr)
+	repoURL, worktree, branch := seedBareRepoWithMissionBranch(t)
+
+	id := createGitHubConnectionMission(t, store, connID, repoURL, worktree, branch)
+	workspace := missions.NewWorkspace(t.TempDir(), nil, discard())
+	var resolvedRef string
+	resolveSecret := func(_ context.Context, ref string) (string, error) {
+		resolvedRef = ref
+		return "dummy-token", nil
+	}
+
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr)
+
+	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/push", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("push with no credential_ref on a github-connection mission = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if resolvedRef != "GH_PAT" {
+		t.Fatalf("resolveSecret ref = %q, want the connector's own credential_ref GH_PAT", resolvedRef)
+	}
+}
+
+// TestMissionsPushConnectorTable covers the connector-resolution error
+// paths: a missing connector_id, a disabled connector, and a
+// non-github-kind connector each report a clear 400 rather than
+// silently falling through to "credential_ref is required".
+func TestMissionsPushConnectorTable(t *testing.T) {
+	requireGitForAPI(t)
+	store := testMissionStore(t)
+
+	cases := []struct {
+		name       string
+		setupConns func(t *testing.T) (*connectors.Manager, string) // returns (mgr, connectorID)
+	}{
+		{
+			name: "connector missing",
+			setupConns: func(t *testing.T) (*connectors.Manager, string) {
+				mgr := testConnectorsManager(t, &fakeGitHubSource{})
+				return mgr, "00000000-0000-0000-0000-000000000000"
+			},
+		},
+		{
+			name: "connector disabled",
+			setupConns: func(t *testing.T) (*connectors.Manager, string) {
+				mgr := testConnectorsManager(t, &fakeGitHubSource{})
+				id, err := mgr.Store().Create(t.Context(), connectors.Connector{
+					Name: "itest-api-pr-disabled", Kind: "github", CredentialRef: "GH_PAT", Enabled: false,
+				})
+				if err != nil {
+					t.Fatalf("create connector: %v", err)
+				}
+				t.Cleanup(func() { _ = mgr.Store().Delete(context.Background(), id) })
+				return mgr, id
+			},
+		},
+		{
+			name: "connector not github kind",
+			setupConns: func(t *testing.T) (*connectors.Manager, string) {
+				mgr := testConnectorsManager(t, &fakeGitHubSource{})
+				id, err := mgr.Store().Create(t.Context(), connectors.Connector{
+					Name: "itest-api-pr-mcp", Kind: "mcp", CredentialRef: "", Enabled: true,
+				})
+				if err != nil {
+					t.Fatalf("create connector: %v", err)
+				}
+				t.Cleanup(func() { _ = mgr.Store().Delete(context.Background(), id) })
+				return mgr, id
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr, connID := tc.setupConns(t)
+			bare, worktree, branch := seedBareRepoWithMissionBranch(t)
+			id := createGitHubConnectionMission(t, store, connID, bare, worktree, branch)
+			workspace := missions.NewWorkspace(t.TempDir(), nil, discard())
+
+			a := &API{token: "tok", log: discard()}
+			m := mux(a)
+			a.registerMissions(m.Handle, store, nil, nil, nil, workspace, nil, nil, nil, nil, nil, nil, nil, mgr)
+
+			req := httptest.NewRequest("POST", "/v1/missions/"+id+"/push", strings.NewReader(`{}`))
+			req.Header.Set("Authorization", "Bearer tok")
+			w := httptest.NewRecorder()
+			m.ServeHTTP(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("push with %s = %d, want 400: %s", tc.name, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestMissionsPushExplicitCredentialRefOverridesConnector proves an
+// explicit credential_ref in the body still wins even on a
+// github-connection mission — the override path.
+func TestMissionsPushExplicitCredentialRefOverridesConnector(t *testing.T) {
+	requireGitForAPI(t)
+	store := testMissionStore(t)
+	// push never builds a repoSource on the explicit-ref path either.
+	mgr := testConnectorsManager(t, &fakeGitHubSource{})
+	connID := createGitHubConnectorRow(t, mgr)
+	bare, worktree, branch := seedBareRepoWithMissionBranch(t)
+	id := createGitHubConnectionMission(t, store, connID, bare, worktree, branch)
+	workspace := missions.NewWorkspace(t.TempDir(), nil, discard())
+
+	var gotRef string
+	resolveSecret := func(_ context.Context, ref string) (string, error) {
+		gotRef = ref
+		return "dummy-token", nil
+	}
+
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr)
+
+	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/push", strings.NewReader(`{"credential_ref":"explicit-ref"}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("push with explicit credential_ref = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if gotRef != "explicit-ref" {
+		t.Fatalf("resolveSecret ref = %q, want the explicit override", gotRef)
+	}
+}
+
+// TestMissionsPRHappyPath exercises POST .../pr end to end: push, then
+// GetRepo (default_branch), then CreatePR, recording mission.pr_opened.
+// GetRepo/CreatePR's own wire-format correctness (including the
+// already-exists retry) is covered directly against a fake GitHub
+// server in internal/brain/connectors/github_test.go; this test proves
+// the API layer's push-then-lookup-then-create sequencing and event
+// recording.
+func TestMissionsPRHappyPath(t *testing.T) {
+	requireGitForAPI(t)
+	store := testMissionStore(t)
+	var sawPRCreate bool
+	mgr := testConnectorsManager(t, &fakeGitHubSource{
+		getRepoFn: func(_ context.Context, owner, repo string) (connectors.GitHubRepo, error) {
+			if owner != "octocat" || repo != "hello-world" {
+				t.Fatalf("GetRepo(%q, %q), want octocat/hello-world", owner, repo)
+			}
+			return connectors.GitHubRepo{FullName: "octocat/hello-world", DefaultBranch: "main"}, nil
+		},
+		createPRFn: func(_ context.Context, owner, repo, title, head, base, body string) (connectors.GitHubPR, error) {
+			sawPRCreate = true
+			if base != "main" {
+				t.Fatalf("CreatePR base = %q, want main (the repo's default branch)", base)
+			}
+			return connectors.GitHubPR{Number: 9, HTMLURL: "https://github.com/octocat/hello-world/pull/9", State: "open"}, nil
+		},
+	})
+	connID := createGitHubConnectorRow(t, mgr)
+	// worktree's real origin (from seedBareRepoWithMissionBranch) is the
+	// local https test server — the actual push target. repo_url is set
+	// to a realistic github.com shape instead: the pr endpoint parses
+	// owner/repo from THAT field (mission.RepoURL), never from the
+	// worktree's origin remote, exactly like a real github-connection
+	// mission would.
+	_, worktree, branch := seedBareRepoWithMissionBranch(t)
+	id := createGitHubConnectionMission(t, store, connID, "https://github.com/octocat/hello-world.git", worktree, branch)
+
+	workspace := missions.NewWorkspace(t.TempDir(), nil, discard())
+	resolveSecret := func(context.Context, string) (string, error) { return "dummy-token", nil }
+
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr)
+
+	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/pr", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("pr = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if !sawPRCreate {
+		t.Fatal("PR create endpoint was never called")
+	}
+	var resp struct {
+		URL    string `json:"url"`
+		Number int    `json:"number"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Number != 9 {
+		t.Fatalf("response = %+v, want number 9", resp)
+	}
+
+	events, err := store.Events(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	var sawEvent bool
+	for _, e := range events {
+		if e.Kind == "mission.pr_opened" {
+			sawEvent = true
+			var payload struct {
+				URL    string `json:"url"`
+				Number int    `json:"number"`
+			}
+			if err := json.Unmarshal(e.Payload, &payload); err != nil {
+				t.Fatalf("decode mission.pr_opened payload: %v", err)
+			}
+			if payload.Number != 9 {
+				t.Fatalf("mission.pr_opened payload = %+v, want number 9", payload)
+			}
+		}
+	}
+	if !sawEvent {
+		t.Fatal("mission.pr_opened event was not recorded")
+	}
+}
+
+// TestMissionsPRAlreadyExistsReturnsExisting proves the pr endpoint
+// surfaces whatever CreatePR returns even when it internally resolved
+// an "already exists" conflict to the existing PR (the retry logic
+// itself is connectors.githubSource.CreatePR's — see
+// TestManagerCreatePRAlreadyExists in the connectors package for that
+// wire-level behavior) — the re-call/idempotent path a repeated "Push
+// & open PR" click takes.
+func TestMissionsPRAlreadyExistsReturnsExisting(t *testing.T) {
+	requireGitForAPI(t)
+	store := testMissionStore(t)
+	mgr := testConnectorsManager(t, &fakeGitHubSource{
+		getRepoFn: func(context.Context, string, string) (connectors.GitHubRepo, error) {
+			return connectors.GitHubRepo{FullName: "octocat/hello-world", DefaultBranch: "main"}, nil
+		},
+		createPRFn: func(context.Context, string, string, string, string, string, string) (connectors.GitHubPR, error) {
+			// Simulates CreatePR having already resolved a 422
+			// already-exists conflict to the existing open PR.
+			return connectors.GitHubPR{Number: 55, HTMLURL: "https://github.com/octocat/hello-world/pull/55", State: "open"}, nil
+		},
+	})
+	connID := createGitHubConnectorRow(t, mgr)
+	_, worktree, branch := seedBareRepoWithMissionBranch(t)
+	id := createGitHubConnectionMission(t, store, connID, "https://github.com/octocat/hello-world.git", worktree, branch)
+
+	workspace := missions.NewWorkspace(t.TempDir(), nil, discard())
+	resolveSecret := func(context.Context, string) (string, error) { return "dummy-token", nil }
+
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr)
+
+	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/pr", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("pr (already exists) = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Number int `json:"number"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Number != 55 {
+		t.Fatalf("response = %+v, want the existing PR number 55", resp)
+	}
+}
+
+// TestMissionsPRRejectsNonGitHubConnectionMission proves the pr
+// endpoint 400s a real mission row that has neither connector_id nor
+// repo_url — the gate exercised against an actual store this time
+// (TestPRRejectsNonGitHubConnectionMission in missions_test.go only
+// proves the route reaches the store).
+func TestMissionsPRRejectsNonGitHubConnectionMission(t *testing.T) {
+	store := testMissionStore(t)
+	id, err := store.Create(t.Context(), missions.Mission{Goal: "itest-api-mission non-github pr", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/pr", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("pr on a non-github-connection mission = %d, want 400: %s", w.Code, w.Body.String())
 	}
 }

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SumonMSelim/timothy/internal/brain/connectors"
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
 	"github.com/SumonMSelim/timothy/internal/gateway/ledger"
 	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
@@ -18,7 +19,7 @@ func TestMissionsEndpointsUnmountedWhenStoreNil(t *testing.T) {
 	t.Parallel()
 	a, _, _ := testAPI(t, "tok", nil)
 	m := mux(a)
-	a.registerMissions(m.Handle, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	for _, req := range []struct{ method, path string }{
 		{"GET", "/v1/missions"},
@@ -33,6 +34,7 @@ func TestMissionsEndpointsUnmountedWhenStoreNil(t *testing.T) {
 		{"GET", "/v1/missions/abc/files/foo.txt"},
 		{"GET", "/v1/missions/abc/archive"},
 		{"POST", "/v1/missions/abc/push"},
+		{"POST", "/v1/missions/abc/pr"},
 		{"GET", "/v1/notifications"},
 		{"POST", "/v1/notifications/abc/read"},
 	} {
@@ -56,7 +58,7 @@ func TestMissionsListFilterValidation(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	call := func(path string) int {
 		req := httptest.NewRequest("GET", path, nil)
@@ -104,7 +106,7 @@ func TestMissionsDeleteReachesStore(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("DELETE", "/v1/missions/abc", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -134,7 +136,7 @@ func TestMissionsCreateValidatesHarness(t *testing.T) {
 
 	post := func(codingExecutorDefault func(context.Context) string, body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, codingExecutorDefault, nil, nil, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, codingExecutorDefault, nil, nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -177,6 +179,101 @@ func TestMissionsCreateValidatesHarness(t *testing.T) {
 	}
 	if generalCalled {
 		t.Fatal("codingExecutorDefault seam invoked for a kind=general request")
+	}
+}
+
+// TestMissionsCreateValidatesRepoURL covers repo_url/connector_id's
+// create() gate: repo_url is coding-only, requires connector_id,
+// connector_id is only valid alongside repo_url, and an unknown
+// connector_id 400s before Driver.Create is ever reached — mirrors
+// TestMissionsCreateValidatesHarness's shape (a degraded store makes
+// the "passed validation" cases 400 too, via failMission's generic
+// mapping, so they're distinguished by not asserting a specific error
+// message here, only that outright-rejected shapes 400 for a DIFFERENT,
+// earlier reason: this test only needs to prove the reject cases fire
+// before any store/connector call, which a nil conns/degraded store
+// setup already demonstrates for the connector_id lookup case).
+func TestMissionsCreateValidatesRepoURL(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	connStore := connectors.NewStore(pool, discard())
+	conns := connectors.NewManager(connStore, nil, discard())
+
+	post := func(body string) int {
+		m := mux(a)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns)
+		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := post(`{"goal":"g","kind":"general","repo_url":"https://github.com/o/r","connector_id":"1"}`); code != 400 {
+		t.Fatalf("repo_url on kind=general = %d, want 400", code)
+	}
+	if code := post(`{"goal":"g","kind":"coding","repo_url":"https://github.com/o/r"}`); code != 400 {
+		t.Fatalf("repo_url without connector_id = %d, want 400", code)
+	}
+	if code := post(`{"goal":"g","kind":"coding","connector_id":"1"}`); code != 400 {
+		t.Fatalf("connector_id without repo_url = %d, want 400", code)
+	}
+	// connector_id names no real row against a degraded connectors
+	// store — the same "unknown connector_id" 400 an unresolvable id
+	// would get against a live store.
+	if code := post(`{"goal":"g","kind":"coding","repo_url":"https://github.com/o/r","connector_id":"nope"}`); code != 400 {
+		t.Fatalf("unknown connector_id = %d, want 400", code)
+	}
+	// No conns wired at all: repo_url is rejected outright rather than
+	// panicking on a nil manager.
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(`{"goal":"g","kind":"coding","repo_url":"https://github.com/o/r","connector_id":"1"}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != 400 {
+		t.Fatalf("repo_url with no conns wired = %d, want 400", w.Code)
+	}
+}
+
+// TestMissionsCreateValidatesOnComplete covers on_complete's create()
+// gate: an unknown value is rejected outright, and "push"/"push_pr"
+// both require a github-connection coding mission (repo_url +
+// connector_id) — mirrors TestMissionsCreateValidatesRepoURL's shape.
+func TestMissionsCreateValidatesOnComplete(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	connStore := connectors.NewStore(pool, discard())
+	conns := connectors.NewManager(connStore, nil, discard())
+
+	post := func(body string) int {
+		m := mux(a)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns)
+		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := post(`{"goal":"g","kind":"coding","repo_url":"https://github.com/o/r","connector_id":"1","on_complete":"bogus"}`); code != 400 {
+		t.Fatalf("unknown on_complete = %d, want 400", code)
+	}
+	if code := post(`{"goal":"g","kind":"coding","on_complete":"push"}`); code != 400 {
+		t.Fatalf("on_complete=push without repo_url/connector_id = %d, want 400", code)
+	}
+	if code := post(`{"goal":"g","kind":"coding","on_complete":"push_pr"}`); code != 400 {
+		t.Fatalf("on_complete=push_pr without repo_url/connector_id = %d, want 400", code)
+	}
+	if code := post(`{"goal":"g","kind":"general","repo_url":"https://github.com/o/r","connector_id":"1","on_complete":"push"}`); code != 400 {
+		t.Fatalf("on_complete=push on kind=general = %d, want 400", code)
 	}
 }
 
@@ -243,7 +340,7 @@ func TestMissionsClassifyEndpoint(t *testing.T) {
 	a, _, _ := testAPI(t, "tok", nil)
 	classify := func(context.Context, string) (string, error) { return "general", nil }
 	m := mux(a)
-	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil)
 
 	call := func(body string) (int, string) {
 		req := httptest.NewRequest("POST", "/v1/missions/classify", strings.NewReader(body))
@@ -276,7 +373,7 @@ func TestMissionsResumeMalformedBodyRejected(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/abc/resume", strings.NewReader(`{not json`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -299,7 +396,7 @@ func TestMissionsResumeEmptyBodyUnchanged(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	call := func(body io.Reader) int {
 		req := httptest.NewRequest("POST", "/v1/missions/abc/resume", body)
@@ -330,7 +427,7 @@ func TestMissionsNoteMalformedOrEmptyBodyRejected(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	call := func(body io.Reader) int {
 		req := httptest.NewRequest("POST", "/v1/missions/abc/note", body)
@@ -405,7 +502,7 @@ func TestMissionsCreateKindOptional(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	call := func(body string) (int, string) {
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -429,5 +526,32 @@ func TestMissionsCreateKindOptional(t *testing.T) {
 	}
 	if code, body := call(`{"goal":"do something","kind":"bogus"}`); code != http.StatusBadRequest || !strings.Contains(body, "kind must be") {
 		t.Fatalf("create with an invalid kind = %d %s, want 400 from kind validation", code, body)
+	}
+}
+
+// TestPRRejectsNonGitHubConnectionMission covers the pr endpoint's own
+// gate (missing connector_id/repo_url) before it ever reaches the
+// store's degraded pool, mirroring TestMissionsCreateValidatesRepoURL's
+// pattern of asserting the specific rejection reason.
+func TestPRRejectsNonGitHubConnectionMission(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	m := mux(a)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	// Against a degraded pool, store.Get itself fails before the
+	// connector_id/repo_url gate is ever reached — this test only
+	// proves the route exists and reaches the store (400, not 404),
+	// same reasoning as TestMissionsDeleteReachesStore. The gate's own
+	// behavior (400 not_pr_able for a non-github-connection mission) is
+	// covered against a real mission row in the integration suite.
+	req := httptest.NewRequest("POST", "/v1/missions/abc/pr", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("POST pr against a degraded store = %d, want 400 (reached the store, generic failure)", w.Code)
 	}
 }

--- a/internal/brain/connectors/connectors.go
+++ b/internal/brain/connectors/connectors.go
@@ -20,8 +20,11 @@ import (
 
 // kinds whitelists what the manager can actually build. google
 // arrives with the OAuth phase; the panel shows it once a builder
-// registers.
-var kinds = map[string]bool{"mcp": true, "google": true}
+// registers. github is identity/credential-only (D-057): it serves no
+// chat tools in this slice, existing purely so mission flows (clone,
+// push, PR) and Settings can resolve a GitHub identity from a PAT; the
+// MCP-based GitHub connector keeps serving GitHub chat tools.
+var kinds = map[string]bool{"mcp": true, "google": true, "github": true}
 
 // credentialRefPattern matches the gateway's: names and paths only,
 // never anything that could be a pasted secret.

--- a/internal/brain/connectors/github.go
+++ b/internal/brain/connectors/github.go
@@ -1,0 +1,442 @@
+package connectors
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// GitHubConfig is the connectors.config shape for kind='github'. Auth
+// is entirely the connector's credential_ref (a PAT in the secret
+// store) — config carries nothing today, kept as a struct so a future
+// slice (e.g. a default org/repo) has somewhere to land.
+type GitHubConfig struct{}
+
+// githubAPIBase is a var, not a const, so tests can point it at a fake
+// server; production never reassigns it.
+var githubAPIBase = "https://api.github.com"
+
+const (
+	githubAPIVersion = "2022-11-28"
+
+	githubCallTimeout = 10 * time.Second
+)
+
+// GitHubIdentity is what Test resolves and reports: enough to confirm
+// which account a PAT authenticates as and what it can commit as.
+type GitHubIdentity struct {
+	Login  string `json:"login"`
+	Name   string `json:"name"`
+	Email  string `json:"email"`  // resolved commit email, see resolveEmail
+	Scopes string `json:"scopes"` // "fine-grained token" when the classic scopes header is absent
+}
+
+// GitHubRepo is the wire shape of one repo a connector's PAT can see or
+// create — the fields mission creation's repo picker/create-new flow
+// needs, nothing more.
+type GitHubRepo struct {
+	FullName      string `json:"full_name"`
+	Private       bool   `json:"private"`
+	DefaultBranch string `json:"default_branch"`
+	HTMLURL       string `json:"html_url"`
+	CloneURL      string `json:"clone_url"`
+	PushedAt      string `json:"pushed_at"`
+}
+
+// githubRepoPerPage is the max GitHub allows per page; githubRepoMaxRepos
+// bounds how many pages ListRepos follows so a PAT with an enormous
+// number of repos can't make mission creation's repo list hang.
+const (
+	githubRepoPerPage  = 100
+	githubRepoMaxRepos = 300
+)
+
+// GitHubBuilder returns the Builder for kind='github'. The source
+// serves zero tools by design: identity/credential connector only,
+// chat tools stay on the MCP-based GitHub connector.
+func GitHubBuilder(client *http.Client) Builder {
+	if client == nil {
+		client = &http.Client{}
+	}
+	return func(_ context.Context, c Connector, resolve Resolve) (Source, error) {
+		if c.CredentialRef == "" {
+			return nil, fmt.Errorf("github %s: credential_ref is required (a GitHub PAT)", c.Name)
+		}
+		return &githubSource{name: c.Name, credentialRef: c.CredentialRef, resolve: resolve, client: client}, nil
+	}
+}
+
+// githubSource is a built github-kind connector: no tools, Test
+// resolves the PAT and confirms it authenticates against the GitHub API.
+type githubSource struct {
+	name          string
+	credentialRef string
+	resolve       Resolve
+	client        *http.Client
+}
+
+// Tools is empty: identity/credential connector, no chat tools.
+func (s *githubSource) Tools() []*tools.Tool { return nil }
+
+func (s *githubSource) Test(ctx context.Context) error {
+	token, err := s.resolve(ctx, s.credentialRef)
+	if err != nil {
+		return fmt.Errorf("resolve credential_ref %q: %w", s.credentialRef, err)
+	}
+	_, err = fetchGitHubIdentity(ctx, s.client, token)
+	return err
+}
+
+// Identity resolves and returns the connector's GitHub identity — the
+// richer counterpart to Test, called by the test endpoint to report
+// login/name/email/scopes alongside the pass/fail.
+func (s *githubSource) Identity(ctx context.Context) (GitHubIdentity, error) {
+	token, err := s.resolve(ctx, s.credentialRef)
+	if err != nil {
+		return GitHubIdentity{}, fmt.Errorf("resolve credential_ref %q: %w", s.credentialRef, err)
+	}
+	return fetchGitHubIdentity(ctx, s.client, token)
+}
+
+func (s *githubSource) Close() error { return nil }
+
+// ListRepos resolves the connector's PAT and returns every repo it can
+// see (owner, collaborator, or org member), most recently pushed
+// first, following pagination up to githubRepoMaxRepos.
+func (s *githubSource) ListRepos(ctx context.Context) ([]GitHubRepo, error) {
+	token, err := s.resolve(ctx, s.credentialRef)
+	if err != nil {
+		return nil, fmt.Errorf("resolve credential_ref %q: %w", s.credentialRef, err)
+	}
+	return fetchGitHubRepos(ctx, s.client, token)
+}
+
+// CreateRepo resolves the connector's PAT and creates a new repo owned
+// by whichever account the PAT authenticates as, with auto_init so it
+// has a default branch to clone.
+func (s *githubSource) CreateRepo(ctx context.Context, name string, private bool) (GitHubRepo, error) {
+	token, err := s.resolve(ctx, s.credentialRef)
+	if err != nil {
+		return GitHubRepo{}, fmt.Errorf("resolve credential_ref %q: %w", s.credentialRef, err)
+	}
+	return createGitHubRepo(ctx, s.client, token, name, private)
+}
+
+// fetchGitHubRepos pages through GET /user/repos, capped at
+// githubRepoMaxRepos so a PAT with an enormous number of repos can't
+// make this hang.
+func fetchGitHubRepos(ctx context.Context, client *http.Client, token string) ([]GitHubRepo, error) {
+	var out []GitHubRepo
+	for page := 1; len(out) < githubRepoMaxRepos; page++ {
+		path := fmt.Sprintf("/user/repos?affiliation=owner,collaborator,organization_member&sort=pushed&per_page=%d&page=%d", githubRepoPerPage, page)
+		resp, err := githubRequest(ctx, client, token, path)
+		if err != nil {
+			return nil, err
+		}
+		var repos []GitHubRepo
+		err = func() error {
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				return githubStatusError(resp)
+			}
+			return json.NewDecoder(resp.Body).Decode(&repos)
+		}()
+		if err != nil {
+			return nil, fmt.Errorf("list repos: %w", err)
+		}
+		out = append(out, repos...)
+		if len(repos) < githubRepoPerPage {
+			break
+		}
+	}
+	if len(out) > githubRepoMaxRepos {
+		out = out[:githubRepoMaxRepos]
+	}
+	return out, nil
+}
+
+// createGitHubRepo issues POST /user/repos. auto_init is always true so
+// the new repo has a default branch to clone into a mission workspace.
+func createGitHubRepo(ctx context.Context, client *http.Client, token, name string, private bool) (GitHubRepo, error) {
+	body, err := json.Marshal(map[string]any{"name": name, "private": private, "auto_init": true})
+	if err != nil {
+		return GitHubRepo{}, fmt.Errorf("create repo: encode request: %w", err)
+	}
+	cctx, cancel := context.WithTimeout(ctx, githubCallTimeout)
+	req, err := http.NewRequestWithContext(cctx, http.MethodPost, githubAPIBase+"/user/repos", bytes.NewReader(body))
+	if err != nil {
+		cancel()
+		return GitHubRepo{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
+	resp, err := client.Do(req)
+	if err != nil {
+		cancel()
+		return GitHubRepo{}, err
+	}
+	defer cancel()
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		return GitHubRepo{}, fmt.Errorf("create repo: %w", githubStatusError(resp))
+	}
+	var repo GitHubRepo
+	if err := json.NewDecoder(resp.Body).Decode(&repo); err != nil {
+		return GitHubRepo{}, fmt.Errorf("create repo: decode response: %w", err)
+	}
+	return repo, nil
+}
+
+// GitHubPR is the wire shape of one pull request the PR-create flow
+// needs: enough for POST /v1/missions/{id}/pr's {url, number} response
+// and to detect/return an already-open PR for the same head.
+type GitHubPR struct {
+	Number  int    `json:"number"`
+	HTMLURL string `json:"html_url"`
+	State   string `json:"state"`
+}
+
+// githubPRAlreadyExistsMarker is the distinctive substring GitHub's 422
+// response carries when a PR for the given head/base already exists —
+// the signal CreatePR uses to fetch and return the existing PR instead
+// of erroring.
+const githubPRAlreadyExistsMarker = "A pull request already exists for"
+
+// GetRepo resolves the connector's PAT and returns owner/repo's
+// metadata (default_branch is all the PR flow needs from it).
+func (s *githubSource) GetRepo(ctx context.Context, owner, repo string) (GitHubRepo, error) {
+	token, err := s.resolve(ctx, s.credentialRef)
+	if err != nil {
+		return GitHubRepo{}, fmt.Errorf("resolve credential_ref %q: %w", s.credentialRef, err)
+	}
+	return fetchGitHubRepo(ctx, s.client, token, owner, repo)
+}
+
+// CreatePR opens a pull request head -> base with title/body. If GitHub
+// reports one already exists for this head (422,
+// githubPRAlreadyExistsMarker), the existing open PR is fetched and
+// returned instead of erroring — idempotent re-calls (e.g. a re-push
+// through the same endpoint) never fail on this.
+func (s *githubSource) CreatePR(ctx context.Context, owner, repo, title, head, base, body string) (GitHubPR, error) {
+	token, err := s.resolve(ctx, s.credentialRef)
+	if err != nil {
+		return GitHubPR{}, fmt.Errorf("resolve credential_ref %q: %w", s.credentialRef, err)
+	}
+	pr, err := createGitHubPR(ctx, s.client, token, owner, repo, title, head, base, body)
+	if err == nil {
+		return pr, nil
+	}
+	if !strings.Contains(err.Error(), githubPRAlreadyExistsMarker) {
+		return GitHubPR{}, err
+	}
+	existing, findErr := findOpenGitHubPR(ctx, s.client, token, owner, repo, head)
+	if findErr != nil {
+		return GitHubPR{}, fmt.Errorf("create pr: %w (and could not fetch existing: %v)", err, findErr)
+	}
+	if existing == nil {
+		return GitHubPR{}, fmt.Errorf("create pr: %w (github reported one exists, but none was found open for head %s)", err, head)
+	}
+	return *existing, nil
+}
+
+// fetchGitHubRepo calls GET /repos/{owner}/{repo}.
+func fetchGitHubRepo(ctx context.Context, client *http.Client, token, owner, repo string) (GitHubRepo, error) {
+	resp, err := githubRequest(ctx, client, token, fmt.Sprintf("/repos/%s/%s", owner, repo))
+	if err != nil {
+		return GitHubRepo{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return GitHubRepo{}, fmt.Errorf("get repo: %w", githubStatusError(resp))
+	}
+	var r GitHubRepo
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return GitHubRepo{}, fmt.Errorf("get repo: decode response: %w", err)
+	}
+	return r, nil
+}
+
+// createGitHubPR issues POST /repos/{owner}/{repo}/pulls. The error
+// returned on a non-201 response embeds the response body verbatim so
+// CreatePR's own already-exists check (githubPRAlreadyExistsMarker) can
+// match against it.
+func createGitHubPR(ctx context.Context, client *http.Client, token, owner, repo, title, head, base, body string) (GitHubPR, error) {
+	reqBody, err := json.Marshal(map[string]any{"title": title, "head": head, "base": base, "body": body})
+	if err != nil {
+		return GitHubPR{}, fmt.Errorf("create pr: encode request: %w", err)
+	}
+	cctx, cancel := context.WithTimeout(ctx, githubCallTimeout)
+	path := fmt.Sprintf("/repos/%s/%s/pulls", owner, repo)
+	req, err := http.NewRequestWithContext(cctx, http.MethodPost, githubAPIBase+path, bytes.NewReader(reqBody))
+	if err != nil {
+		cancel()
+		return GitHubPR{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
+	resp, err := client.Do(req)
+	if err != nil {
+		cancel()
+		return GitHubPR{}, err
+	}
+	defer cancel()
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		return GitHubPR{}, fmt.Errorf("create pr: %w", githubStatusError(resp))
+	}
+	var pr GitHubPR
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return GitHubPR{}, fmt.Errorf("create pr: decode response: %w", err)
+	}
+	return pr, nil
+}
+
+// findOpenGitHubPR looks up the open PR for owner/repo whose head is
+// "<owner>:<branch>" (GitHub's head filter form) — used when
+// createGitHubPR reports one already exists, so CreatePR can return it
+// instead of erroring. Returns (nil, nil) if none is found open.
+func findOpenGitHubPR(ctx context.Context, client *http.Client, token, owner, repo, head string) (*GitHubPR, error) {
+	path := fmt.Sprintf("/repos/%s/%s/pulls?state=open&head=%s:%s", owner, repo, owner, head)
+	resp, err := githubRequest(ctx, client, token, path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, githubStatusError(resp)
+	}
+	var prs []GitHubPR
+	if err := json.NewDecoder(resp.Body).Decode(&prs); err != nil {
+		return nil, fmt.Errorf("decode pulls list: %w", err)
+	}
+	if len(prs) == 0 {
+		return nil, nil
+	}
+	return &prs[0], nil
+}
+
+// githubUser is the subset of GET /user this package reads.
+type githubUser struct {
+	Login string `json:"login"`
+	Name  string `json:"name"`
+	ID    int64  `json:"id"`
+	Email string `json:"email"`
+}
+
+// githubEmail is one entry of GET /user/emails.
+type githubEmail struct {
+	Email    string `json:"email"`
+	Primary  bool   `json:"primary"`
+	Verified bool   `json:"verified"`
+}
+
+// fetchGitHubIdentity resolves the account a PAT authenticates as and
+// its commit email, plus token scope metadata. Never logs the token.
+func fetchGitHubIdentity(ctx context.Context, client *http.Client, token string) (GitHubIdentity, error) {
+	user, scopesHeader, err := githubGetUser(ctx, client, token)
+	if err != nil {
+		return GitHubIdentity{}, err
+	}
+	email, err := resolveEmail(ctx, client, token, user)
+	if err != nil {
+		return GitHubIdentity{}, err
+	}
+	scopes := scopesHeader
+	if scopes == "" {
+		scopes = "fine-grained token"
+	}
+	return GitHubIdentity{Login: user.Login, Name: user.Name, Email: email, Scopes: scopes}, nil
+}
+
+// githubGetUser calls GET /user and returns the decoded body plus the
+// classic PAT's X-OAuth-Scopes header verbatim (empty for fine-grained
+// tokens, which don't set it).
+func githubGetUser(ctx context.Context, client *http.Client, token string) (githubUser, string, error) {
+	resp, err := githubRequest(ctx, client, token, "/user")
+	if err != nil {
+		return githubUser{}, "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return githubUser{}, "", githubStatusError(resp)
+	}
+	var user githubUser
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return githubUser{}, "", fmt.Errorf("decode /user: %w", err)
+	}
+	return user, resp.Header.Get("X-OAuth-Scopes"), nil
+}
+
+// resolveEmail finds the commit email for user: the primary+verified
+// entry from /user/emails, tolerating a fine-grained PAT without the
+// Email permission (403/404) by falling back to /user's public email,
+// then GitHub's stable noreply address.
+func resolveEmail(ctx context.Context, client *http.Client, token string, user githubUser) (string, error) {
+	resp, err := githubRequest(ctx, client, token, "/user/emails")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusOK {
+		var emails []githubEmail
+		if err := json.NewDecoder(resp.Body).Decode(&emails); err != nil {
+			return "", fmt.Errorf("decode /user/emails: %w", err)
+		}
+		for _, e := range emails {
+			if e.Primary && e.Verified {
+				return e.Email, nil
+			}
+		}
+	} else if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusNotFound {
+		return "", githubStatusError(resp)
+	}
+
+	if user.Email != "" {
+		return user.Email, nil
+	}
+	return fmt.Sprintf("%d+%s@users.noreply.github.com", user.ID, user.Login), nil
+}
+
+// githubRequest issues one authenticated GitHub API GET. The token
+// never appears in an error: only the status code and a short body
+// snippet are surfaced.
+func githubRequest(ctx context.Context, client *http.Client, token, path string) (*http.Response, error) {
+	cctx, cancel := context.WithTimeout(ctx, githubCallTimeout)
+	req, err := http.NewRequestWithContext(cctx, http.MethodGet, githubAPIBase+path, nil)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
+	resp, err := client.Do(req)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	resp.Body = &cancelBody{ReadCloser: resp.Body, cancel: cancel}
+	return resp, nil
+}
+
+// githubStatusError reports a non-200 GitHub response without ever
+// including the request (and thus the token).
+func githubStatusError(resp *http.Response) error {
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("github: bad or expired token (401): %s", snippet)
+	}
+	return fmt.Errorf("github: status %d: %s", resp.StatusCode, snippet)
+}

--- a/internal/brain/connectors/github_test.go
+++ b/internal/brain/connectors/github_test.go
@@ -1,0 +1,457 @@
+package connectors
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// githubFakeServer serves /user and /user/emails with configurable
+// bodies/status/headers, mirroring the seam google_test.go uses for
+// its OAuth endpoints, and points githubAPIBase at it for the test's
+// duration.
+func githubFakeServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	prev := githubAPIBase
+	githubAPIBase = srv.URL
+	t.Cleanup(func() { githubAPIBase = prev })
+	return srv
+}
+
+// TestFetchGitHubIdentity and its siblings below mutate the shared
+// githubAPIBase var, so none of them run t.Parallel().
+func TestFetchGitHubIdentity(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		handler http.HandlerFunc
+		want    GitHubIdentity
+		wantErr string
+	}{
+		{
+			name: "public email on /user, classic PAT scopes",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/user":
+					w.Header().Set("X-OAuth-Scopes", "repo, read:org")
+					_, _ = w.Write([]byte(`{"login":"octocat","name":"The Octocat","id":1,"email":"octocat@github.com"}`))
+				case "/user/emails":
+					_, _ = w.Write([]byte(`[{"email":"octocat@github.com","primary":true,"verified":true}]`))
+				}
+			},
+			want: GitHubIdentity{Login: "octocat", Name: "The Octocat", Email: "octocat@github.com", Scopes: "repo, read:org"},
+		},
+		{
+			name: "primary verified email from /user/emails wins over /user's",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/user":
+					_, _ = w.Write([]byte(`{"login":"octocat","name":"The Octocat","id":1,"email":""}`))
+				case "/user/emails":
+					_, _ = w.Write([]byte(`[
+						{"email":"unverified@x.com","primary":true,"verified":false},
+						{"email":"secondary@x.com","primary":false,"verified":true},
+						{"email":"primary@x.com","primary":true,"verified":true}
+					]`))
+				}
+			},
+			want: GitHubIdentity{Login: "octocat", Name: "The Octocat", Email: "primary@x.com", Scopes: "fine-grained token"},
+		},
+		{
+			name: "fine-grained PAT without Email permission falls back to noreply",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/user":
+					_, _ = w.Write([]byte(`{"login":"octocat","name":"The Octocat","id":583231,"email":""}`))
+				case "/user/emails":
+					w.WriteHeader(http.StatusForbidden)
+					_, _ = w.Write([]byte(`{"message":"Resource not accessible by personal access token"}`))
+				}
+			},
+			want: GitHubIdentity{Login: "octocat", Name: "The Octocat", Email: "583231+octocat@users.noreply.github.com", Scopes: "fine-grained token"},
+		},
+		{
+			name: "emails 404 falls back the same way as 403",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/user":
+					_, _ = w.Write([]byte(`{"login":"octocat","name":"","id":1,"email":""}`))
+				case "/user/emails":
+					w.WriteHeader(http.StatusNotFound)
+				}
+			},
+			want: GitHubIdentity{Login: "octocat", Name: "", Email: "1+octocat@users.noreply.github.com", Scopes: "fine-grained token"},
+		},
+		{
+			name: "bad token 401 on /user",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/user" {
+					w.WriteHeader(http.StatusUnauthorized)
+					_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+				}
+			},
+			wantErr: "401",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := githubFakeServer(t, tc.handler)
+
+			got, err := fetchGitHubIdentity(t.Context(), srv.Client(), "test-token")
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want it to contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("fetchGitHubIdentity: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("identity = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFetchGitHubIdentityNeverLogsToken(t *testing.T) {
+	srv := githubFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer secret-pat" {
+			t.Errorf("Authorization = %q", auth)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	_, err := fetchGitHubIdentity(t.Context(), srv.Client(), "secret-pat")
+	if err == nil || strings.Contains(err.Error(), "secret-pat") {
+		t.Fatalf("err = %v, must never contain the token", err)
+	}
+}
+
+func TestGitHubBuilderRequiresCredentialRef(t *testing.T) {
+	t.Parallel()
+	b := GitHubBuilder(nil)
+	_, err := b(t.Context(), Connector{Name: "gh", Kind: "github"}, func(_ context.Context, _ string) (string, error) { return "", nil })
+	if err == nil {
+		t.Fatal("missing credential_ref accepted")
+	}
+}
+
+func TestGitHubSourceServesNoTools(t *testing.T) {
+	t.Parallel()
+	b := GitHubBuilder(nil)
+	src, err := b(t.Context(), Connector{Name: "gh", Kind: "github", CredentialRef: "GH_PAT"},
+		func(_ context.Context, _ string) (string, error) { return "tok", nil })
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if got := src.Tools(); len(got) != 0 {
+		t.Fatalf("Tools() = %v, want none: github is identity-only in this slice", got)
+	}
+}
+
+func TestValidateAcceptsGitHubKind(t *testing.T) {
+	t.Parallel()
+	c := Connector{Name: "personal-gh", Kind: "github", CredentialRef: "GH_PAT", Config: json.RawMessage(`{}`)}
+	if err := validate(c); err != nil {
+		t.Fatalf("valid github connector rejected: %v", err)
+	}
+}
+
+// TestManagerTestIdentityReturnsGitHubIdentity exercises the seam the
+// API's test endpoint uses: a github-kind Test resolving to an
+// identity payload instead of just ok/error.
+func TestManagerTestIdentityReturnsGitHubIdentity(t *testing.T) {
+	srv := githubFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/user":
+			w.Header().Set("X-OAuth-Scopes", "repo")
+			_, _ = w.Write([]byte(`{"login":"octocat","name":"The Octocat","id":1,"email":"octocat@github.com"}`))
+		case "/user/emails":
+			_, _ = w.Write([]byte(`[{"email":"octocat@github.com","primary":true,"verified":true}]`))
+		}
+	})
+
+	m := testManager(fakeRows{rows: []Connector{
+		{ID: "1", Name: "personal-gh", Kind: "github", CredentialRef: "GH_PAT"},
+	}})
+	m.resolve = func(context.Context, string) (string, error) { return "tok", nil }
+	m.RegisterBuilder("github", GitHubBuilder(srv.Client()))
+
+	identity, err := m.TestIdentity(t.Context(), "1")
+	if err != nil {
+		t.Fatalf("TestIdentity: %v", err)
+	}
+	if identity == nil || identity.Login != "octocat" || identity.Email != "octocat@github.com" || identity.Scopes != "repo" {
+		t.Fatalf("identity = %+v", identity)
+	}
+}
+
+// TestManagerTestIdentityMCPHasNoIdentity pins that kinds without an
+// identity concept keep the plain ok/error contract: identity is nil,
+// not an error.
+func TestManagerTestIdentityMCPHasNoIdentity(t *testing.T) {
+	m := testManager(fakeRows{rows: []Connector{
+		{ID: "1", Name: "grafana", Kind: "mcp"},
+	}})
+	m.RegisterBuilder("mcp", func(context.Context, Connector, Resolve) (Source, error) {
+		return &fakeSource{}, nil
+	})
+
+	identity, err := m.TestIdentity(t.Context(), "1")
+	if err != nil {
+		t.Fatalf("TestIdentity: %v", err)
+	}
+	if identity != nil {
+		t.Fatalf("identity = %+v, want nil for a non-identity kind", identity)
+	}
+}
+
+// TestFetchGitHubReposPaginates proves ListRepos follows GET
+// /user/repos pagination (a full page implies there may be more) and
+// stops once a short page comes back.
+func TestFetchGitHubReposPaginates(t *testing.T) {
+	page1 := make([]GitHubRepo, githubRepoPerPage)
+	for i := range page1 {
+		page1[i] = GitHubRepo{FullName: "org/repo1"}
+	}
+	page2 := []GitHubRepo{{FullName: "org/repo2"}}
+
+	var gotPages []string
+	srv := githubFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/user/repos" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		gotPages = append(gotPages, r.URL.Query().Get("page"))
+		switch r.URL.Query().Get("page") {
+		case "1":
+			_ = json.NewEncoder(w).Encode(page1)
+		case "2":
+			_ = json.NewEncoder(w).Encode(page2)
+		default:
+			t.Fatalf("unexpected page %q", r.URL.Query().Get("page"))
+		}
+	})
+
+	repos, err := fetchGitHubRepos(t.Context(), srv.Client(), "test-token")
+	if err != nil {
+		t.Fatalf("fetchGitHubRepos: %v", err)
+	}
+	if len(repos) != githubRepoPerPage+1 {
+		t.Fatalf("len(repos) = %d, want %d", len(repos), githubRepoPerPage+1)
+	}
+	if len(gotPages) != 2 {
+		t.Fatalf("pages fetched = %v, want 2 pages", gotPages)
+	}
+}
+
+// TestFetchGitHubReposCapsAtMax proves ListRepos stops paging once it
+// has githubRepoMaxRepos, even if the remote claims more full pages —
+// an enormous PAT-visible repo count must not hang the request.
+func TestFetchGitHubReposCapsAtMax(t *testing.T) {
+	fullPage := make([]GitHubRepo, githubRepoPerPage)
+	srv := githubFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(fullPage)
+	})
+
+	repos, err := fetchGitHubRepos(t.Context(), srv.Client(), "test-token")
+	if err != nil {
+		t.Fatalf("fetchGitHubRepos: %v", err)
+	}
+	if len(repos) != githubRepoMaxRepos {
+		t.Fatalf("len(repos) = %d, want capped at %d", len(repos), githubRepoMaxRepos)
+	}
+}
+
+func TestCreateGitHubRepo(t *testing.T) {
+	srv := githubFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/user/repos" || r.Method != http.MethodPost {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		var body struct {
+			Name     string `json:"name"`
+			Private  bool   `json:"private"`
+			AutoInit bool   `json:"auto_init"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if body.Name != "new-repo" || !body.Private || !body.AutoInit {
+			t.Fatalf("unexpected request body: %+v", body)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(GitHubRepo{FullName: "octocat/new-repo", Private: true, DefaultBranch: "main"})
+	})
+
+	repo, err := createGitHubRepo(t.Context(), srv.Client(), "test-token", "new-repo", true)
+	if err != nil {
+		t.Fatalf("createGitHubRepo: %v", err)
+	}
+	if repo.FullName != "octocat/new-repo" || repo.DefaultBranch != "main" {
+		t.Fatalf("repo = %+v", repo)
+	}
+}
+
+// TestManagerListReposNonGitHubKind pins that the ListRepos capability
+// gate rejects a kind with no repo concept (mcp) with ErrUnsupported.
+func TestManagerListReposNonGitHubKind(t *testing.T) {
+	m := testManager(fakeRows{rows: []Connector{
+		{ID: "1", Name: "grafana", Kind: "mcp"},
+	}})
+	m.RegisterBuilder("mcp", func(context.Context, Connector, Resolve) (Source, error) {
+		return &fakeSource{}, nil
+	})
+
+	if _, err := m.ListRepos(t.Context(), "1"); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("ListRepos on mcp connector = %v, want ErrUnsupported", err)
+	}
+}
+
+// TestManagerListReposAndCreateRepo exercises the full seam the API's
+// repo endpoints use: a github-kind connector's ListRepos/CreateRepo
+// both build fresh and close the ephemeral source.
+func TestManagerListReposAndCreateRepo(t *testing.T) {
+	srv := githubFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/user/repos" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode([]GitHubRepo{{FullName: "octocat/hello-world"}})
+		case r.URL.Path == "/user/repos" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(GitHubRepo{FullName: "octocat/brand-new"})
+		}
+	})
+
+	m := testManager(fakeRows{rows: []Connector{
+		{ID: "1", Name: "personal-gh", Kind: "github", CredentialRef: "GH_PAT"},
+	}})
+	m.resolve = func(context.Context, string) (string, error) { return "tok", nil }
+	m.RegisterBuilder("github", GitHubBuilder(srv.Client()))
+
+	repos, err := m.ListRepos(t.Context(), "1")
+	if err != nil {
+		t.Fatalf("ListRepos: %v", err)
+	}
+	if len(repos) != 1 || repos[0].FullName != "octocat/hello-world" {
+		t.Fatalf("repos = %+v", repos)
+	}
+
+	repo, err := m.CreateRepo(t.Context(), "1", "brand-new", false)
+	if err != nil {
+		t.Fatalf("CreateRepo: %v", err)
+	}
+	if repo.FullName != "octocat/brand-new" {
+		t.Fatalf("repo = %+v", repo)
+	}
+}
+
+// TestFetchGitHubRepo proves GET /repos/{owner}/{repo} decodes into
+// GitHubRepo — the PR flow's default_branch lookup.
+func TestFetchGitHubRepo(t *testing.T) {
+	srv := githubFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/octocat/hello-world" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(GitHubRepo{FullName: "octocat/hello-world", DefaultBranch: "main"})
+	})
+
+	repo, err := fetchGitHubRepo(t.Context(), srv.Client(), "test-token", "octocat", "hello-world")
+	if err != nil {
+		t.Fatalf("fetchGitHubRepo: %v", err)
+	}
+	if repo.DefaultBranch != "main" {
+		t.Fatalf("repo = %+v", repo)
+	}
+}
+
+// TestCreateGitHubPR proves POST /repos/{owner}/{repo}/pulls sends the
+// expected body and decodes the created PR.
+func TestCreateGitHubPR(t *testing.T) {
+	srv := githubFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/octocat/hello-world/pulls" || r.Method != http.MethodPost {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		var body struct {
+			Title string `json:"title"`
+			Head  string `json:"head"`
+			Base  string `json:"base"`
+			Body  string `json:"body"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if body.Title != "Fix bug" || body.Head != "mission/fix-bug" || body.Base != "main" {
+			t.Fatalf("unexpected request body: %+v", body)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(GitHubPR{Number: 42, HTMLURL: "https://github.com/octocat/hello-world/pull/42", State: "open"})
+	})
+
+	pr, err := createGitHubPR(t.Context(), srv.Client(), "test-token", "octocat", "hello-world", "Fix bug", "mission/fix-bug", "main", "body text")
+	if err != nil {
+		t.Fatalf("createGitHubPR: %v", err)
+	}
+	if pr.Number != 42 || pr.HTMLURL != "https://github.com/octocat/hello-world/pull/42" {
+		t.Fatalf("pr = %+v", pr)
+	}
+}
+
+// TestManagerCreatePRAlreadyExists proves CreatePR fetches and returns
+// the existing open PR when GitHub's 422 reports one already exists for
+// the head — the idempotent re-call path a re-push through the same
+// endpoint takes.
+func TestManagerCreatePRAlreadyExists(t *testing.T) {
+	srv := githubFakeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/repos/octocat/hello-world/pulls" && r.Method == http.MethodPost:
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"message": "Validation Failed",
+				"errors": []map[string]any{
+					{"message": "A pull request already exists for octocat:mission/fix-bug."},
+				},
+			})
+		case r.URL.Path == "/repos/octocat/hello-world/pulls" && r.Method == http.MethodGet:
+			if r.URL.Query().Get("state") != "open" {
+				t.Fatalf("expected state=open, got %q", r.URL.RawQuery)
+			}
+			_ = json.NewEncoder(w).Encode([]GitHubPR{
+				{Number: 7, HTMLURL: "https://github.com/octocat/hello-world/pull/7", State: "open"},
+			})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	m := testManager(fakeRows{rows: []Connector{
+		{ID: "1", Name: "personal-gh", Kind: "github", CredentialRef: "GH_PAT"},
+	}})
+	m.resolve = func(context.Context, string) (string, error) { return "tok", nil }
+	m.RegisterBuilder("github", GitHubBuilder(srv.Client()))
+
+	pr, err := m.CreatePR(t.Context(), "1", "octocat", "hello-world", "Fix bug", "mission/fix-bug", "main", "body")
+	if err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	if pr.Number != 7 {
+		t.Fatalf("pr = %+v, want the existing open PR #7", pr)
+	}
+}
+
+// TestManagerGetRepoNonGitHubKind pins that GetRepo also gates on the
+// repoSource capability, mirroring TestManagerListReposNonGitHubKind.
+func TestManagerGetRepoNonGitHubKind(t *testing.T) {
+	m := testManager(fakeRows{rows: []Connector{
+		{ID: "1", Name: "grafana", Kind: "mcp"},
+	}})
+	m.RegisterBuilder("mcp", func(context.Context, Connector, Resolve) (Source, error) {
+		return &fakeSource{}, nil
+	})
+
+	if _, err := m.GetRepo(t.Context(), "1", "o", "r"); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("GetRepo on mcp connector = %v, want ErrUnsupported", err)
+	}
+}

--- a/internal/brain/connectors/manager.go
+++ b/internal/brain/connectors/manager.go
@@ -224,24 +224,133 @@ func (m *Manager) SensitiveNames(ctx context.Context) ([]string, error) {
 // connectivity check, so a connector can be verified before it is
 // switched on. The ephemeral source is closed either way.
 func (m *Manager) Test(ctx context.Context, id string) error {
+	_, err := m.TestIdentity(ctx, id)
+	return err
+}
+
+// identifier is the optional Source capability that reports who a
+// credential authenticates as (github-kind today). Type-asserted so
+// kinds without an identity concept (mcp, google) are untouched.
+type identifier interface {
+	Identity(ctx context.Context) (GitHubIdentity, error)
+}
+
+// TestIdentity is Test plus, for a kind that can report one (github),
+// the resolved identity — the evidence a working credential was
+// configured, since the connector serves no tools to prove itself
+// with otherwise. identity is nil for kinds with no identity concept.
+func (m *Manager) TestIdentity(ctx context.Context, id string) (*GitHubIdentity, error) {
 	c, err := m.rows.Get(ctx, id)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	b, ok := m.builders[c.Kind]
 	if !ok {
-		return fmt.Errorf("connector kind %s has no builder yet: %w", c.Kind, ErrUnsupported)
+		return nil, fmt.Errorf("connector kind %s has no builder yet: %w", c.Kind, ErrUnsupported)
 	}
 	tctx, cancel := context.WithTimeout(ctx, testTimeout)
 	defer cancel()
 	src, err := b(tctx, c, m.resolve)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer func() {
 		if err := src.Close(); err != nil {
 			m.log.Warn("connector close failed", "connector", c.Name, "error", err)
 		}
 	}()
-	return src.Test(tctx)
+
+	idr, ok := src.(identifier)
+	if !ok {
+		return nil, src.Test(tctx)
+	}
+	identity, err := idr.Identity(tctx)
+	if err != nil {
+		return nil, err
+	}
+	return &identity, nil
+}
+
+// repoSource is the optional Source capability that lists/creates
+// GitHub repos and opens pull requests (github-kind today).
+// Type-asserted so kinds without a repo concept (mcp, google) are
+// untouched, mirroring identifier.
+type repoSource interface {
+	ListRepos(ctx context.Context) ([]GitHubRepo, error)
+	CreateRepo(ctx context.Context, name string, private bool) (GitHubRepo, error)
+	GetRepo(ctx context.Context, owner, repo string) (GitHubRepo, error)
+	CreatePR(ctx context.Context, owner, repo, title, head, base, body string) (GitHubPR, error)
+}
+
+// buildRepoSource resolves connector id, builds it fresh (same shape as
+// TestIdentity), and returns it asserted to repoSource — ErrUnsupported
+// for an unknown kind or a kind with no repo concept.
+func (m *Manager) buildRepoSource(ctx context.Context, id string) (repoSource, func(), error) {
+	c, err := m.rows.Get(ctx, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	b, ok := m.builders[c.Kind]
+	if !ok {
+		return nil, nil, fmt.Errorf("connector kind %s has no builder yet: %w", c.Kind, ErrUnsupported)
+	}
+	tctx, cancel := context.WithTimeout(ctx, testTimeout)
+	src, err := b(tctx, c, m.resolve)
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+	closeFn := func() {
+		cancel()
+		if err := src.Close(); err != nil {
+			m.log.Warn("connector close failed", "connector", c.Name, "error", err)
+		}
+	}
+	rs, ok := src.(repoSource)
+	if !ok {
+		closeFn()
+		return nil, nil, fmt.Errorf("connector kind %s has no repos to list: %w", c.Kind, ErrUnsupported)
+	}
+	return rs, closeFn, nil
+}
+
+// ListRepos lists every repo the connector's credential can see.
+func (m *Manager) ListRepos(ctx context.Context, id string) ([]GitHubRepo, error) {
+	rs, closeFn, err := m.buildRepoSource(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	defer closeFn()
+	return rs.ListRepos(ctx)
+}
+
+// CreateRepo creates a new repo through the connector's credential.
+func (m *Manager) CreateRepo(ctx context.Context, id, name string, private bool) (GitHubRepo, error) {
+	rs, closeFn, err := m.buildRepoSource(ctx, id)
+	if err != nil {
+		return GitHubRepo{}, err
+	}
+	defer closeFn()
+	return rs.CreateRepo(ctx, name, private)
+}
+
+// GetRepo resolves owner/repo's metadata through the connector's
+// credential — the PR flow's default_branch lookup.
+func (m *Manager) GetRepo(ctx context.Context, id, owner, repo string) (GitHubRepo, error) {
+	rs, closeFn, err := m.buildRepoSource(ctx, id)
+	if err != nil {
+		return GitHubRepo{}, err
+	}
+	defer closeFn()
+	return rs.GetRepo(ctx, owner, repo)
+}
+
+// CreatePR opens a pull request through the connector's credential.
+func (m *Manager) CreatePR(ctx context.Context, id, owner, repo, title, head, base, body string) (GitHubPR, error) {
+	rs, closeFn, err := m.buildRepoSource(ctx, id)
+	if err != nil {
+		return GitHubPR{}, err
+	}
+	defer closeFn()
+	return rs.CreatePR(ctx, owner, repo, title, head, base, body)
 }

--- a/internal/brain/missions/complete.go
+++ b/internal/brain/missions/complete.go
@@ -1,0 +1,230 @@
+package missions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+)
+
+// PushTokenResolver resolves a github-connection mission's own PAT from
+// its connector_id — the auto-fire path (RunOnComplete) never has an
+// explicit credential_ref override, unlike the manual push/pr API
+// endpoints, so this is exactly api/missions.go's resolvePushToken minus
+// the credential_ref-override branch. Passed into NewCompleter; the
+// driver's own Completer is wired in via Driver.SetCompleter, same
+// setter pattern as Driver.SetCloneTokenResolver.
+type PushTokenResolver func(ctx context.Context, connectorID string) (string, error)
+
+// PRSource is the narrow slice of a GitHub connector's repo operations
+// OpenPR needs — a local interface (missions has no compile-time
+// dependency on the connectors package) satisfied by a small adapter
+// cmd/brain/main.go wires, same pattern as CloneTokenResolver.
+type PRSource interface {
+	// DefaultBranch resolves owner/repo's default branch through
+	// connectorID's credential.
+	DefaultBranch(ctx context.Context, connectorID, owner, repo string) (string, error)
+	// CreatePR opens (or fetches the existing) pull request through
+	// connectorID's credential.
+	CreatePR(ctx context.Context, connectorID, owner, repo, title, head, base, body string) (prURL string, prNumber int, err error)
+}
+
+// githubRepoPattern matches the owner/repo path segment of a GitHub
+// https clone URL (with or without .git suffix) — the shape
+// ParseGitHubRepoURL extracts from mission.RepoURL.
+var githubRepoPattern = regexp.MustCompile(`^https://[^/]+/([^/]+)/([^/]+?)(?:\.git)?/?$`)
+
+// ParseGitHubRepoURL extracts owner/repo from repoURL (mission.RepoURL,
+// always an https clone URL per validateRemote's own gate at push
+// time) — ok is false for anything that doesn't match the expected
+// shape.
+func ParseGitHubRepoURL(repoURL string) (owner, repo string, ok bool) {
+	m := githubRepoPattern.FindStringSubmatch(repoURL)
+	if m == nil {
+		return "", "", false
+	}
+	return m[1], m[2], true
+}
+
+// eventAppender is the narrow slice of *Store Completer needs — kept as
+// an interface so tests can fake it without a real Postgres pool, same
+// reasoning as driverStore.
+type eventAppender interface {
+	AppendEvent(ctx context.Context, id, kind string, payload map[string]any) error
+}
+
+// branchPusher is the narrow slice of *Workspace Completer needs — kept
+// as an interface so tests can fake the push (exercising the https-only
+// validation is push_test.go's job, not this package's) without a real
+// https origin.
+type branchPusher interface {
+	Push(ctx context.Context, worktree, branch, token string) (string, error)
+}
+
+// Completer runs the push/push+PR action a mission's on_complete field
+// requests when it reaches done — the driver's auto-fire hook. It
+// shares PushBranch/OpenPR's actual push-and-record-event logic with
+// the manual push/pr API endpoints (internal/brain/api/missions.go
+// calls the same two methods), so neither path can diverge in what
+// "push" or "PR" means or which events land on the Timeline.
+type Completer struct {
+	workspace    branchPusher
+	store        eventAppender
+	resolveToken PushTokenResolver
+	pr           PRSource
+}
+
+// NewCompleter builds a Completer. resolveToken/pr may be nil (no
+// secret store / no connectors wired) — RunOnComplete reports a plain
+// error in that case rather than a panic; workspace/store are always
+// present since missions itself requires both to run at all.
+func NewCompleter(workspace *Workspace, store eventAppender, resolveToken PushTokenResolver, pr PRSource) *Completer {
+	return &Completer{workspace: workspace, store: store, resolveToken: resolveToken, pr: pr}
+}
+
+// NotPushable reports the shared kind/branch/worktree guards push and
+// pr both require — Go code, never a prompt: only a coding mission
+// with a live worktree is ever pushable. Shared by the manual push/pr
+// API handlers and the driver's auto-fire-on-done hook so neither can
+// diverge on what counts as pushable.
+func NotPushable(m Mission) string {
+	switch {
+	case m.Kind != "coding":
+		return "only coding missions can be pushed"
+	case m.Branch == "":
+		return "mission has no branch"
+	default:
+		if _, err := os.Stat(m.Worktree); err != nil {
+			return "mission worktree is not available"
+		}
+	}
+	return ""
+}
+
+// PushBranch pushes m's branch to its worktree's origin remote with
+// token, recording mission.pushed/mission.push_failed either way — the
+// shared event-recording shape both the manual push endpoint and the
+// driver's auto-fire hook use, so the Timeline reads identically
+// regardless of which one fired.
+func (c *Completer) PushBranch(ctx context.Context, m Mission, token string) (host string, err error) {
+	host, pushErr := c.workspace.Push(ctx, m.Worktree, m.Branch, token)
+	if pushErr != nil {
+		reason := "push failed"
+		switch {
+		case errors.Is(pushErr, ErrRemoteUnsupported):
+			reason = "remote unsupported"
+		case errors.Is(pushErr, ErrPushRejected):
+			reason = "push rejected"
+		}
+		if err := c.store.AppendEvent(ctx, m.ID, "mission.push_failed", map[string]any{"reason": reason}); err != nil {
+			return "", fmt.Errorf("push: record push_failed: %w", err)
+		}
+		return "", pushErr
+	}
+	if err := c.store.AppendEvent(ctx, m.ID, "mission.pushed", map[string]any{"branch": m.Branch, "remote_host": host}); err != nil {
+		return host, fmt.Errorf("push: record pushed: %w", err)
+	}
+	return host, nil
+}
+
+// PRBody composes the pull request's markdown body: goal, unit list
+// with pass state, and a short harness-verification line.
+func PRBody(m Mission) string {
+	body := m.Goal + "\n\n"
+	if len(m.Spec.Units) > 0 {
+		body += "## Units\n\n"
+		for _, u := range m.Spec.Units {
+			mark := "[ ]"
+			if u.Passes {
+				mark = "[x]"
+			}
+			body += fmt.Sprintf("- %s %s\n", mark, u.Title)
+		}
+		body += "\n"
+	}
+	body += "_Verified by Timothy's mission harness (declared artifacts + verify_cmd, checked by the harness itself, never claimed by the model)._\n"
+	return body
+}
+
+// PRTitleGoalCap bounds a fallback PR title built from the goal when
+// the mission has no generated display name yet.
+const PRTitleGoalCap = 72
+
+// PRTitle prefers the mission's generated display name, falling back
+// to a truncated goal.
+func PRTitle(m Mission) string {
+	if m.Name != "" {
+		return m.Name
+	}
+	if len(m.Goal) <= PRTitleGoalCap {
+		return m.Goal
+	}
+	return m.Goal[:PRTitleGoalCap] + "…"
+}
+
+// OpenPR pushes the branch (idempotent re-push, same code path
+// PushBranch above uses) then opens (or fetches the existing) pull
+// request via pr, recording mission.pr_opened. github-connection
+// missions only — callers check m.ConnectorID/m.RepoURL first.
+func (c *Completer) OpenPR(ctx context.Context, m Mission, token string) (url string, number int, err error) {
+	owner, repo, ok := ParseGitHubRepoURL(m.RepoURL)
+	if !ok {
+		return "", 0, fmt.Errorf("pr: mission repo_url is not a recognizable github https clone URL")
+	}
+	if c.pr == nil {
+		return "", 0, fmt.Errorf("pr: connectors are not enabled")
+	}
+	if _, err := c.PushBranch(ctx, m, token); err != nil {
+		return "", 0, err
+	}
+	base, err := c.pr.DefaultBranch(ctx, m.ConnectorID, owner, repo)
+	if err != nil {
+		return "", 0, fmt.Errorf("pr: look up repo default branch: %w", err)
+	}
+	if base == "" {
+		return "", 0, fmt.Errorf("pr: repo has no default branch")
+	}
+	url, number, err = c.pr.CreatePR(ctx, m.ConnectorID, owner, repo, PRTitle(m), m.Branch, base, PRBody(m))
+	if err != nil {
+		return "", 0, fmt.Errorf("pr: %w", err)
+	}
+	if err := c.store.AppendEvent(ctx, m.ID, "mission.pr_opened", map[string]any{"url": url, "number": number}); err != nil {
+		return url, number, fmt.Errorf("pr: record pr_opened: %w", err)
+	}
+	return url, number, nil
+}
+
+// RunOnComplete executes m's recorded on_complete choice ("push" or
+// "push_pr") — called by the driver exactly once, right after the
+// mission's own ApplyTransition into phase=done succeeds. Failure never
+// un-dones a verified mission: it appends mission.push_failed (already
+// scrubbed of the token by PushBranch/OpenPR's error paths) and returns
+// the error for the caller to fire a notification; the mission row
+// itself is untouched either way. No retry loop — one attempt, the
+// manual push/pr endpoints remain available for the operator.
+func (c *Completer) RunOnComplete(ctx context.Context, m Mission) error {
+	if m.OnComplete == "" {
+		return nil
+	}
+	if reason := NotPushable(m); reason != "" {
+		return fmt.Errorf("on_complete: %s", reason)
+	}
+	if c.resolveToken == nil {
+		return fmt.Errorf("on_complete: connectors are not enabled")
+	}
+	token, err := c.resolveToken(ctx, m.ConnectorID)
+	if err != nil {
+		return fmt.Errorf("on_complete: resolve token: %w", err)
+	}
+	switch m.OnComplete {
+	case "push":
+		_, err := c.PushBranch(ctx, m, token)
+		return err
+	case "push_pr":
+		_, _, err := c.OpenPR(ctx, m, token)
+		return err
+	default:
+		return fmt.Errorf("on_complete: unknown value %q", m.OnComplete)
+	}
+}

--- a/internal/brain/missions/complete_test.go
+++ b/internal/brain/missions/complete_test.go
@@ -1,0 +1,272 @@
+package missions
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestParseGitHubRepoURL covers the owner/repo extraction OpenPR needs
+// from mission.RepoURL (always an https clone URL) — with and without
+// the .git suffix, and a malformed shape reporting ok=false.
+func TestParseGitHubRepoURL(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		url    string
+		owner  string
+		repo   string
+		wantOK bool
+	}{
+		{"with .git suffix", "https://github.com/octocat/hello-world.git", "octocat", "hello-world", true},
+		{"without .git suffix", "https://github.com/octocat/hello-world", "octocat", "hello-world", true},
+		{"trailing slash", "https://github.com/octocat/hello-world/", "octocat", "hello-world", true},
+		{"malformed, no repo segment", "https://github.com/octocat", "", "", false},
+		{"not a URL", "not-a-url", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			owner, repo, ok := ParseGitHubRepoURL(tc.url)
+			if ok != tc.wantOK || owner != tc.owner || repo != tc.repo {
+				t.Fatalf("ParseGitHubRepoURL(%q) = (%q, %q, %v), want (%q, %q, %v)", tc.url, owner, repo, ok, tc.owner, tc.repo, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestPRTitleFallsBackToTruncatedGoal covers PRTitle's name-vs-goal
+// precedence and the truncation cap for a long goal with no name yet.
+func TestPRTitleFallsBackToTruncatedGoal(t *testing.T) {
+	t.Parallel()
+	named := Mission{Name: "Fix Login Bug", Goal: "fix the login bug that logs everyone out"}
+	if got := PRTitle(named); got != "Fix Login Bug" {
+		t.Fatalf("PRTitle with a name = %q, want the name", got)
+	}
+	short := Mission{Goal: "fix the login bug"}
+	if got := PRTitle(short); got != "fix the login bug" {
+		t.Fatalf("PRTitle with a short goal and no name = %q, want the goal verbatim", got)
+	}
+	long := Mission{Goal: strings.Repeat("a", 100)}
+	got := PRTitle(long)
+	if len(got) != PRTitleGoalCap+len("…") || !strings.HasSuffix(got, "…") {
+		t.Fatalf("PRTitle with a long goal and no name = %q (len %d), want truncated to %d chars + ellipsis", got, len(got), PRTitleGoalCap)
+	}
+}
+
+// TestNotPushableGuards covers the shared kind/branch/worktree gate
+// both push and pr require, without touching a store or workspace.
+func TestNotPushableGuards(t *testing.T) {
+	t.Parallel()
+	if reason := NotPushable(Mission{Kind: "general"}); reason == "" {
+		t.Fatal("general mission should not be pushable")
+	}
+	if reason := NotPushable(Mission{Kind: "coding"}); reason == "" {
+		t.Fatal("coding mission with no branch should not be pushable")
+	}
+	if reason := NotPushable(Mission{Kind: "coding", Branch: "mission/x", Worktree: "/does/not/exist"}); reason == "" {
+		t.Fatal("coding mission with a missing worktree should not be pushable")
+	}
+}
+
+// fakeEventAppender records every AppendEvent call for assertion,
+// standing in for *Store without a real Postgres pool.
+type fakeEventAppender struct {
+	mu     sync.Mutex
+	events []Event
+	err    error
+}
+
+func (f *fakeEventAppender) AppendEvent(ctx context.Context, id, kind string, payload map[string]any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return f.err
+	}
+	f.events = append(f.events, Event{MissionID: id, Kind: kind})
+	return nil
+}
+
+func (f *fakeEventAppender) kinds() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.events))
+	for i, e := range f.events {
+		out[i] = e.Kind
+	}
+	return out
+}
+
+// fakePRSource scripts PRSource for RunOnComplete's push_pr path
+// without a real GitHub connector.
+type fakePRSource struct {
+	defaultBranch string
+	defaultErr    error
+	prURL         string
+	prNumber      int
+	createErr     error
+	createCalls   int
+}
+
+func (f *fakePRSource) DefaultBranch(ctx context.Context, connectorID, owner, repo string) (string, error) {
+	return f.defaultBranch, f.defaultErr
+}
+
+func (f *fakePRSource) CreatePR(ctx context.Context, connectorID, owner, repo, title, head, base, body string) (string, int, error) {
+	f.createCalls++
+	if f.createErr != nil {
+		return "", 0, f.createErr
+	}
+	return f.prURL, f.prNumber, nil
+}
+
+// fakeBranchPusher scripts branchPusher — the https-only remote
+// validation Workspace.Push itself enforces is push_test.go's own
+// coverage; Completer's job (proven here) is what it does with a push
+// that succeeds or fails, not git plumbing.
+type fakeBranchPusher struct {
+	host      string
+	err       error
+	pushCalls int
+}
+
+func (f *fakeBranchPusher) Push(ctx context.Context, worktree, branch, token string) (string, error) {
+	f.pushCalls++
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.host, nil
+}
+
+// pushableMission is a coding mission with the guards NotPushable
+// requires already satisfied (worktree present, branch set) — t.TempDir()
+// stands in for a real worktree since fakeBranchPusher never touches
+// the filesystem.
+func pushableMission(t *testing.T) Mission {
+	t.Helper()
+	return Mission{ID: "m1", Kind: "coding", Worktree: t.TempDir(), Branch: "mission/x", RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1"}
+}
+
+// TestCompleterRunOnCompletePush proves on_complete="push" pushes the
+// branch and records exactly one mission.pushed event — the same event
+// the manual push endpoint records.
+func TestCompleterRunOnCompletePush(t *testing.T) {
+	t.Parallel()
+	m := pushableMission(t)
+	m.OnComplete = "push"
+	store := &fakeEventAppender{}
+	pusher := &fakeBranchPusher{host: "github.com"}
+	resolveToken := func(ctx context.Context, connectorID string) (string, error) { return "dummy-token", nil }
+	c := &Completer{workspace: pusher, store: store, resolveToken: resolveToken}
+
+	if err := c.RunOnComplete(context.Background(), m); err != nil {
+		t.Fatalf("RunOnComplete: %v", err)
+	}
+	if pusher.pushCalls != 1 {
+		t.Fatalf("Push called %d times, want exactly 1", pusher.pushCalls)
+	}
+	if kinds := store.kinds(); len(kinds) != 1 || kinds[0] != "mission.pushed" {
+		t.Fatalf("events = %v, want exactly one mission.pushed", kinds)
+	}
+}
+
+// TestCompleterRunOnCompletePushPR proves on_complete="push_pr" pushes
+// then opens a PR, recording both mission.pushed and mission.pr_opened
+// — exactly once each.
+func TestCompleterRunOnCompletePushPR(t *testing.T) {
+	t.Parallel()
+	m := pushableMission(t)
+	m.OnComplete = "push_pr"
+	store := &fakeEventAppender{}
+	pusher := &fakeBranchPusher{host: "github.com"}
+	resolveToken := func(ctx context.Context, connectorID string) (string, error) { return "dummy-token", nil }
+	pr := &fakePRSource{defaultBranch: "main", prURL: "https://github.com/octo/repo/pull/1", prNumber: 1}
+	c := &Completer{workspace: pusher, store: store, resolveToken: resolveToken, pr: pr}
+
+	if err := c.RunOnComplete(context.Background(), m); err != nil {
+		t.Fatalf("RunOnComplete: %v", err)
+	}
+	if pusher.pushCalls != 1 {
+		t.Fatalf("Push called %d times, want exactly 1", pusher.pushCalls)
+	}
+	kinds := store.kinds()
+	if len(kinds) != 2 || kinds[0] != "mission.pushed" || kinds[1] != "mission.pr_opened" {
+		t.Fatalf("events = %v, want [mission.pushed mission.pr_opened]", kinds)
+	}
+	if pr.createCalls != 1 {
+		t.Fatalf("CreatePR called %d times, want exactly 1", pr.createCalls)
+	}
+}
+
+// TestCompleterRunOnCompletePushFailureNoPR proves a push failure during
+// push_pr stops before ever calling CreatePR — a failed push must never
+// still open a PR against whatever was last pushed.
+func TestCompleterRunOnCompletePushFailureNoPR(t *testing.T) {
+	t.Parallel()
+	m := pushableMission(t)
+	m.OnComplete = "push_pr"
+	store := &fakeEventAppender{}
+	pusher := &fakeBranchPusher{err: ErrPushRejected}
+	resolveToken := func(ctx context.Context, connectorID string) (string, error) { return "dummy-token", nil }
+	pr := &fakePRSource{defaultBranch: "main"}
+	c := &Completer{workspace: pusher, store: store, resolveToken: resolveToken, pr: pr}
+
+	if err := c.RunOnComplete(context.Background(), m); err == nil {
+		t.Fatal("RunOnComplete should surface the push failure")
+	}
+	if pr.createCalls != 0 {
+		t.Fatalf("CreatePR called %d times, want 0 (push failed first)", pr.createCalls)
+	}
+	if kinds := store.kinds(); len(kinds) != 1 || kinds[0] != "mission.push_failed" {
+		t.Fatalf("events = %v, want exactly one mission.push_failed", kinds)
+	}
+}
+
+// TestCompleterRunOnCompleteEmptyIsNoop proves a mission with no
+// on_complete choice does nothing — no push, no event, no error.
+func TestCompleterRunOnCompleteEmptyIsNoop(t *testing.T) {
+	t.Parallel()
+	store := &fakeEventAppender{}
+	c := NewCompleter(nil, store, nil, nil)
+	if err := c.RunOnComplete(context.Background(), Mission{OnComplete: ""}); err != nil {
+		t.Fatalf("RunOnComplete with empty on_complete: %v", err)
+	}
+	if len(store.kinds()) != 0 {
+		t.Fatalf("events = %v, want none", store.kinds())
+	}
+}
+
+// TestCompleterRunOnCompletePushFailureRecordsEvent proves a push
+// failure (unpushable mission) reports an error and records no
+// mission.pushed event — the mission itself is never touched, only the
+// caller (fireOnComplete) learns of the failure.
+func TestCompleterRunOnCompletePushFailureRecordsEvent(t *testing.T) {
+	t.Parallel()
+	store := &fakeEventAppender{}
+	c := NewCompleter(nil, store, nil, nil)
+	m := Mission{Kind: "general", OnComplete: "push"} // NotPushable rejects kind != coding
+	err := c.RunOnComplete(context.Background(), m)
+	if err == nil {
+		t.Fatal("RunOnComplete should fail for an unpushable mission")
+	}
+	if len(store.kinds()) != 0 {
+		t.Fatalf("events = %v, want none (NotPushable fails before any push attempt)", store.kinds())
+	}
+}
+
+// TestCompleterRunOnCompleteNoResolverFails proves a nil token resolver
+// (connectors/secrets not wired) fails cleanly rather than panicking.
+func TestCompleterRunOnCompleteNoResolverFails(t *testing.T) {
+	t.Parallel()
+	m := pushableMission(t)
+	m.OnComplete = "push"
+	store := &fakeEventAppender{}
+	c := NewCompleter(nil, store, nil, nil)
+	if err := c.RunOnComplete(context.Background(), m); err == nil {
+		t.Fatal("RunOnComplete with no token resolver should fail")
+	}
+	if len(store.kinds()) != 0 {
+		t.Fatalf("events = %v, want none", store.kinds())
+	}
+}
+

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -29,7 +29,7 @@ const driveTimeBound = 4 * time.Hour
 // every successful ApplyTransition; notify.go's Notifier satisfies it
 // (added in M3). nil is valid — M2 has no notifications wired yet.
 type notifier interface {
-	OnTransition(ctx context.Context, missionID string, before, after Status) error
+	OnTransition(ctx context.Context, m Mission, before, after Status, reason string) error
 }
 
 // sessionCreator opens the hidden, non-chat-facing session every
@@ -134,6 +134,35 @@ type Driver struct {
 	// admitted, same as before this existed.
 	capacity capacityChecker
 
+	// resolveCloneToken resolves a github-kind connector_id to the PAT
+	// that authenticates ensureProvisioned's clone (see SetCloneTokenResolver)
+	// — nil-safe: unset means a mission with repo_url set fails
+	// provisioning (surfaced as an infra pause, same as any other
+	// provisioning error), since there would be no way to authenticate
+	// the clone.
+	resolveCloneToken CloneTokenResolver
+
+	// resolveCloneIdentity resolves a github-kind connector_id to the
+	// commit identity (name, email) ensureProvisioned sets as the
+	// clone's local git config (see SetCloneIdentityResolver) — nil-safe:
+	// unset, or a resolve error, just leaves the clone with no local
+	// identity override (commits fall back to the operator's fixed
+	// identity), never fails provisioning.
+	resolveCloneIdentity CloneIdentityResolver
+
+	// completer runs a mission's recorded on_complete choice
+	// (push/push_pr) once it reaches phase=done (see SetCompleter,
+	// fireOnComplete) — nil-safe: unset (no connectors/secrets wired)
+	// just means the auto-fire hook never runs, same as a mission whose
+	// on_complete is "".
+	completer *Completer
+
+	// notifyPushFailed fires a best-effort notification when the
+	// auto-fire hook's push/PR attempt fails (see SetPushFailedNotifier)
+	// — nil-safe: unset just skips the notification, the mission.push_failed
+	// event (Completer.PushBranch's own append) is still recorded either way.
+	notifyPushFailed func(ctx context.Context, missionID, message string)
+
 	// gatekeepers holds each mission's in-progress reviewer session
 	// state, keyed by mission id, for the "delta recheck" resume on
 	// rework. Process-local by design: lost on restart is acceptable —
@@ -189,6 +218,76 @@ func (d *Driver) SetFXRates(store fxRateSource) {
 // parameter) for the same reason SetFXRates is.
 func (d *Driver) SetCapacityGate(gate capacityChecker) {
 	d.capacity = gate
+}
+
+// CloneTokenResolver resolves a mission's connector_id to the PAT that
+// authenticates ensureProvisioned's clone — api/missions.go validates
+// connector_id names a github-kind connector at create time; this
+// resolves the connector's credential_ref fresh at provisioning time,
+// the same "never persist the token" discipline push.go's credential_ref
+// resolution already follows.
+type CloneTokenResolver func(ctx context.Context, connectorID string) (string, error)
+
+// SetCloneTokenResolver wires the resolver ensureProvisioned uses to
+// authenticate a repo_url mission's clone — a setter (not a NewDriver
+// parameter) for the same reason SetAgentResolver is.
+func (d *Driver) SetCloneTokenResolver(resolve CloneTokenResolver) {
+	d.resolveCloneToken = resolve
+}
+
+// CloneIdentityResolver resolves a mission's connector_id to the
+// commit identity (name, email) ensureProvisioned's clone is authored
+// as — the identity counterpart of CloneTokenResolver, resolved fresh
+// at provisioning time (never persisted on the mission row).
+type CloneIdentityResolver func(ctx context.Context, connectorID string) (name, email string, err error)
+
+// SetCloneIdentityResolver wires the resolver ensureProvisioned uses to
+// set a repo_url mission's clone local git identity — a setter (not a
+// NewDriver parameter) for the same reason SetAgentResolver is.
+func (d *Driver) SetCloneIdentityResolver(resolve CloneIdentityResolver) {
+	d.resolveCloneIdentity = resolve
+}
+
+// SetCompleter wires the Completer the driver's auto-fire-on-done hook
+// (fireOnComplete) runs a mission's on_complete choice through — a
+// setter (not a NewDriver parameter) for the same reason SetAgentResolver
+// is: cmd/brain/main.go builds it after the Driver, once connectors/
+// secrets are available.
+func (d *Driver) SetCompleter(c *Completer) {
+	d.completer = c
+}
+
+// SetPushFailedNotifier wires the best-effort notification fired when
+// the auto-fire hook's push/PR attempt fails — a setter for the same
+// reason SetCompleter is.
+func (d *Driver) SetPushFailedNotifier(notify func(ctx context.Context, missionID, message string)) {
+	d.notifyPushFailed = notify
+}
+
+// fireOnComplete runs a mission's recorded on_complete choice
+// (push/push_pr) exactly once, right after its own ApplyTransition into
+// phase=done succeeds — the SAME Completer code the manual push/pr API
+// endpoints use, so an auto-fired push/PR can never diverge from what a
+// human clicking the button gets. Failure never un-dones the mission:
+// Completer.RunOnComplete already appended mission.push_failed (via
+// PushBranch/OpenPR's own error path); this only additionally fires a
+// best-effort notification so the operator hears about it, mirroring
+// notify.go's own best-effort webhook fan-out. No retry — one attempt,
+// the manual push/pr endpoints remain available.
+func (d *Driver) fireOnComplete(ctx context.Context, id string, m Mission) {
+	if d.completer == nil || m.OnComplete == "" {
+		return
+	}
+	// Detached from ctx: the mission is already terminal, so this must
+	// not be cancelled by a request winding down (same reasoning as
+	// removeSandbox).
+	rctx := context.Background()
+	if err := d.completer.RunOnComplete(rctx, m); err != nil {
+		d.log.Error("driver: on_complete auto-fire failed", "mission_id", id, "on_complete", m.OnComplete, "error", err)
+		if d.notifyPushFailed != nil {
+			d.notifyPushFailed(rctx, id, fmt.Sprintf("mission %s: automatic %s failed: %s", id, m.OnComplete, err.Error()))
+		}
+	}
 }
 
 // removeSandbox best-effort tears down a mission's sandbox container in
@@ -265,7 +364,31 @@ func (d *Driver) ensureProvisioned(ctx context.Context, m Mission) (Mission, err
 		d.grantSessionDefaults(ctx, m)
 	}
 	if d.workspace != nil && m.Workspace == "" && m.Worktree == "" {
-		workspace, worktree, branch, baseCommit, err := d.workspace.Provision(ctx, m.ID, m.Goal, m.Kind)
+		var token string
+		var connIdentity *GitIdentity
+		if m.RepoURL != "" {
+			if d.resolveCloneToken == nil {
+				return m, fmt.Errorf("provision: mission has repo_url but no clone token resolver is configured")
+			}
+			t, err := d.resolveCloneToken(ctx, m.ConnectorID)
+			if err != nil {
+				return m, fmt.Errorf("provision: resolve clone token: %w", err)
+			}
+			token = t
+			// Identity resolve failure never fails provisioning: it just
+			// leaves the clone with no local identity override, falling
+			// back to the fixed commitName/commitEmail (worktree.go's
+			// CommitUnit).
+			if d.resolveCloneIdentity != nil {
+				name, email, err := d.resolveCloneIdentity(ctx, m.ConnectorID)
+				if err != nil {
+					d.log.Warn("driver: resolve clone identity failed; commits fall back to fixed identity", "mission_id", m.ID, "error", err)
+				} else {
+					connIdentity = &GitIdentity{Name: name, Email: email}
+				}
+			}
+		}
+		workspace, worktree, branch, baseCommit, err := d.workspace.Provision(ctx, m.ID, m.Goal, m.Kind, m.RepoURL, token, connIdentity)
 		if err != nil {
 			return m, fmt.Errorf("provision: %w", err)
 		}
@@ -454,8 +577,15 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 		delete(d.gatekeepers, id)
 		d.removeSandbox(id)
 	}
+	if t.Next.Phase == PhaseDone {
+		// m is the pre-transition snapshot (re-fetched above, before this
+		// round's ApplyTransition) — RepoURL/ConnectorID/OnComplete/
+		// Branch/Worktree never change after create, so it's safe to
+		// reuse here rather than a third Get.
+		d.fireOnComplete(ctx, id, m)
+	}
 	if d.notify != nil {
-		if err := d.notify.OnTransition(ctx, id, before, t.Next.Status); err != nil {
+		if err := d.notify.OnTransition(ctx, m, before, t.Next.Status, failedReason(t.Events)); err != nil {
 			d.log.Warn("driver: notify failed", "mission_id", id, "error", err)
 		}
 	}
@@ -530,7 +660,7 @@ func (d *Driver) Signal(ctx context.Context, id string, input Input) error {
 		d.removeSandbox(id)
 	}
 	if d.notify != nil {
-		if err := d.notify.OnTransition(ctx, id, before, t.Next.Status); err != nil {
+		if err := d.notify.OnTransition(ctx, m, before, t.Next.Status, failedReason(t.Events)); err != nil {
 			d.log.Warn("driver: notify failed", "mission_id", id, "error", err)
 		}
 	}
@@ -774,7 +904,13 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 	switch verdict.Outcome {
 	case "done":
 		if m.Worktree != "" {
-			if err := d.workspace.CommitUnit(ctx, m.Worktree, "mission "+m.ID+" iteration "+fmt.Sprint(m.Iteration)); err != nil {
+			var unitTitle string
+			if unit, _ := currentUnit(m.Spec); unit != nil {
+				unitTitle = unit.Title
+			}
+			body := "mission " + m.ID + " iteration " + fmt.Sprint(m.Iteration)
+			msg := CommitMessage(unitTitle, m.Goal, body)
+			if err := d.workspace.CommitUnit(ctx, m.Worktree, msg); err != nil {
 				d.log.Warn("driver: commit unit failed", "mission_id", m.ID, "error", err)
 			}
 		}
@@ -1127,6 +1263,22 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return s[:n] + "…"
+}
+
+// failedReason pulls payload["reason"] off a transition's mission.failed
+// event, if any — the notifier's cheapest source for distinguishing
+// "cancelled" from an ordinary failure, since Step already built this
+// event this same round rather than requiring a second store query.
+func failedReason(events []EventDraft) string {
+	for _, ev := range events {
+		if ev.Kind != "mission.failed" {
+			continue
+		}
+		if reason, ok := ev.Payload["reason"].(string); ok {
+			return reason
+		}
+	}
+	return ""
 }
 
 // gitLogSince returns a capped, one-line-per-commit log of everything

--- a/internal/brain/missions/driver_integration_test.go
+++ b/internal/brain/missions/driver_integration_test.go
@@ -32,7 +32,7 @@ func TestDriverEndToEndCodingMission(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	ws, wt, branch, base, err := workspace.Provision(ctx, id, marker+"e2e coding", "coding")
+	ws, wt, branch, base, err := workspace.Provision(ctx, id, marker+"e2e coding", "coding", "", "", nil)
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -314,6 +314,125 @@ func TestDriverHappyPathToDone(t *testing.T) {
 	}
 }
 
+// codingWorktree inits a real git repo with one commit — coding
+// missions run BaselineDiff/CommitUnit against a real worktree even
+// with a scripted Runner, so on_complete tests (which need Kind=coding
+// for NotPushable to accept them) need a real git dir, not merely a
+// TempDir. Returns the dir and its HEAD commit hash for BaseCommit.
+func codingWorktree(t *testing.T) (dir, baseCommit string) {
+	t.Helper()
+	requireGitForPush(t)
+	dir = t.TempDir()
+	gitRun(t, dir, "init", "-q")
+	if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte("seed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, dir, "add", "seed.txt")
+	gitRun(t, dir, "-c", "user.name=test", "-c", "user.email=test@test", "commit", "-q", "-m", "seed")
+	return dir, strings.TrimSpace(gitRun(t, dir, "rev-parse", "HEAD"))
+}
+
+// TestDriverFiresOnCompletePushPROnDone proves a coding mission with
+// on_complete="push_pr" fires exactly one push and one PR create the
+// moment it reaches phase=done — the SAME Completer the manual push/pr
+// API endpoints use, wired via Driver.SetCompleter.
+func TestDriverFiresOnCompletePushPROnDone(t *testing.T) {
+	store := newFakeStore()
+	dir, base := codingWorktree(t)
+	store.put("m1", Mission{
+		ID: "m1", Kind: "coding", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8,
+		Worktree: dir, BaseCommit: base, Branch: "mission/x", RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1",
+		OnComplete: "push_pr",
+	})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit", VerifyCmd: ""}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := NewDriver(store, runner, NewWorkspace("", nil, log), nil, nil, nil, fakeSandboxExec, nil, log)
+	pusher := &fakeBranchPusher{host: "github.com"}
+	pr := &fakePRSource{defaultBranch: "main", prURL: "https://github.com/octo/repo/pull/1", prNumber: 1}
+	d.SetCompleter(&Completer{workspace: pusher, store: store, resolveToken: func(ctx context.Context, connectorID string) (string, error) {
+		return "dummy-token", nil
+	}, pr: pr})
+
+	// explore -> plan -> execute -> review -> done: 4 Advance calls.
+	driveN(t, d, "m1", 4)
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseDone {
+		t.Fatalf("mission phase = %q, want done", m.Phase)
+	}
+	if pusher.pushCalls != 1 {
+		t.Fatalf("Push called %d times, want exactly 1", pusher.pushCalls)
+	}
+	if pr.createCalls != 1 {
+		t.Fatalf("CreatePR called %d times, want exactly 1", pr.createCalls)
+	}
+	events := store.events["m1"]
+	var pushed, prOpened int
+	for _, e := range events {
+		switch e.Kind {
+		case "mission.pushed":
+			pushed++
+		case "mission.pr_opened":
+			prOpened++
+		}
+	}
+	if pushed != 1 || prOpened != 1 {
+		t.Fatalf("events pushed=%d pr_opened=%d, want exactly 1 each", pushed, prOpened)
+	}
+}
+
+// TestDriverOnCompleteFailureLeavesMissionDoneAndNotifies proves a
+// failed auto-fire (push rejected) never un-dones the mission — it
+// stays phase=done — and fires the wired push-failed notifier exactly
+// once.
+func TestDriverOnCompleteFailureLeavesMissionDoneAndNotifies(t *testing.T) {
+	store := newFakeStore()
+	dir, base := codingWorktree(t)
+	store.put("m1", Mission{
+		ID: "m1", Kind: "coding", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8,
+		Worktree: dir, BaseCommit: base, Branch: "mission/x", RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1",
+		OnComplete: "push",
+	})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit", VerifyCmd: ""}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := NewDriver(store, runner, NewWorkspace("", nil, log), nil, nil, nil, fakeSandboxExec, nil, log)
+	pusher := &fakeBranchPusher{err: ErrPushRejected}
+	d.SetCompleter(&Completer{workspace: pusher, store: store, resolveToken: func(ctx context.Context, connectorID string) (string, error) {
+		return "dummy-token", nil
+	}})
+	var notified []string
+	d.SetPushFailedNotifier(func(ctx context.Context, missionID, message string) {
+		notified = append(notified, message)
+	})
+
+	driveN(t, d, "m1", 4)
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseDone || m.Status != StatusDone {
+		t.Fatalf("mission after failed auto-fire = %+v, want it to stay done/done", m)
+	}
+	if len(notified) != 1 {
+		t.Fatalf("push-failed notifications = %d, want exactly 1", len(notified))
+	}
+	var pushFailed int
+	for _, e := range store.events["m1"] {
+		if e.Kind == "mission.push_failed" {
+			pushFailed++
+		}
+	}
+	if pushFailed != 1 {
+		t.Fatalf("mission.push_failed events = %d, want exactly 1", pushFailed)
+	}
+}
+
 // TestDriverExploreStoresNotesAndAdvances confirms the explore phase
 // stores ExploreSession's findings on the mission, emits
 // mission.explore_complete, and advances to plan.
@@ -1654,5 +1773,26 @@ func TestDriverAdvanceDiscardsTurnOnConcurrentTerminal(t *testing.T) {
 			t.Fatalf("sandboxRemove.Remove calls = %v, want exactly one call for m1", remover.calls())
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestFailedReason(t *testing.T) {
+	cases := []struct {
+		name   string
+		events []EventDraft
+		want   string
+	}{
+		{"no events", nil, ""},
+		{"no mission.failed event", []EventDraft{{Kind: "mission.progress"}}, ""},
+		{"cancelled", []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "cancelled"}}}, "cancelled"},
+		{"max_iterations", []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "max_iterations", "detail": "x"}}}, "max_iterations"},
+		{"missing reason key", []EventDraft{{Kind: "mission.failed", Payload: map[string]any{}}}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := failedReason(tc.events); got != tc.want {
+				t.Fatalf("failedReason(%+v) = %q, want %q", tc.events, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -41,6 +41,21 @@ type Mission struct {
 	Worktree      string         `json:"worktree,omitempty"`
 	Branch        string         `json:"branch,omitempty"`
 	BaseCommit    string         `json:"base_commit,omitempty"`
+	// RepoURL is the GitHub repo this coding mission was cloned from
+	// (https clone URL) — empty means the self-init'd empty repo
+	// Workspace.Provision otherwise creates. ConnectorID names the
+	// github-kind connectors row whose PAT authenticated the clone; the
+	// token itself is never stored, only resolved fresh at provisioning.
+	RepoURL     string `json:"repo_url,omitempty"`
+	ConnectorID string `json:"connector_id,omitempty"`
+	// OnComplete is the operator's consent-at-create choice for what
+	// happens when this mission reaches phase=done: "" (default) does
+	// nothing, "push" pushes the branch, "push_pr" pushes then opens a
+	// pull request. Only ever set at create time (api/missions.go's
+	// validation); the harness (driver.go) executes it automatically on
+	// the done transition using the SAME push/PR code path the manual
+	// push/pr endpoints use.
+	OnComplete string `json:"on_complete,omitempty"`
 	Spec          Spec           `json:"spec"`
 	Progress      []ProgressNote `json:"progress"`
 	// LastEvidence is the most recent worker mission_status call's

--- a/internal/brain/missions/notify.go
+++ b/internal/brain/missions/notify.go
@@ -55,21 +55,49 @@ func isActionableTransition(before, after Status) (kind string, ok bool) {
 	}
 }
 
+// composeMessage builds the operator-facing notification text for an
+// actionable transition: the mission's display title (PRTitle's own
+// name-vs-truncated-goal fallback, reused here so the two surfaces
+// never diverge) plus wording keyed on kind, with "failed" replaced by
+// "cancelled" when reason is the cancel state machine's own marker
+// (see statemachine.go's InputCancel branch, the only place that
+// reason is set).
+func composeMessage(kind, title, reason string) string {
+	switch kind {
+	case string(StatusDone):
+		return fmt.Sprintf("Mission - %s is done", title)
+	case string(StatusError):
+		if reason == "cancelled" {
+			return fmt.Sprintf("Mission - %s is cancelled", title)
+		}
+		return fmt.Sprintf("Mission - %s is failed", title)
+	case string(StatusPaused):
+		return fmt.Sprintf("Mission - %s is paused, needs your intervention.", title)
+	case string(StatusWaitingForInput):
+		return fmt.Sprintf("Mission - %s is waiting for your input.", title)
+	default:
+		return fmt.Sprintf("Mission - %s is now %s", title, kind)
+	}
+}
+
 // OnTransition is called by Driver after ApplyTransition succeeds, with
-// the before/after Status. Durable channel: a notifications row is
-// always written for a qualifying transition. Best-effort fan-out:
-// webhook POST of a generic JSON payload; failure only logs, never
-// blocks or loses the notification.
-func (n *Notifier) OnTransition(ctx context.Context, missionID string, before, after Status) error {
+// the mission (for its title), the before/after Status, and — only
+// populated on a transition into StatusError — the mission.failed
+// event's reason (e.g. "cancelled"), read from the same Transition.Events
+// the driver already has in hand rather than a second query. Durable
+// channel: a notifications row is always written for a qualifying
+// transition. Best-effort fan-out: webhook POST of a generic JSON
+// payload; failure only logs, never blocks or loses the notification.
+func (n *Notifier) OnTransition(ctx context.Context, m Mission, before, after Status, reason string) error {
 	kind, ok := isActionableTransition(before, after)
 	if !ok {
 		return nil
 	}
-	message := fmt.Sprintf("mission %s is now %s", missionID, kind)
-	if err := n.sendOncePerMission(ctx, missionID, kind, message); err != nil {
+	message := composeMessage(kind, PRTitle(m), reason)
+	if err := n.sendOncePerMission(ctx, m.ID, kind, message); err != nil {
 		return fmt.Errorf("notify: %w", err)
 	}
-	n.fanOut(ctx, missionID, kind, message)
+	n.fanOut(ctx, m.ID, kind, message)
 	return nil
 }
 
@@ -132,6 +160,19 @@ func (n *Notifier) fanOut(ctx context.Context, missionID, kind, message string) 
 	if resp.StatusCode >= 300 {
 		n.log.Warn("notify: webhook returned non-2xx", "status", resp.StatusCode)
 	}
+}
+
+// NotifyMessage fires a notification for an event OnTransition's own
+// before/after Status classification doesn't cover — used by the
+// driver's on_complete auto-fire hook (fireOnComplete) to surface a
+// failed automatic push/PR, the same durable-inbox-row-plus-best-effort-
+// webhook shape OnTransition itself uses.
+func (n *Notifier) NotifyMessage(ctx context.Context, missionID, kind, message string) error {
+	if err := n.sendOncePerMission(ctx, missionID, kind, message); err != nil {
+		return fmt.Errorf("notify: %w", err)
+	}
+	n.fanOut(ctx, missionID, kind, message)
+	return nil
 }
 
 // ClearMission marks unread rows read once the mission advances past

--- a/internal/brain/missions/notify_integration_test.go
+++ b/internal/brain/missions/notify_integration_test.go
@@ -17,12 +17,13 @@ func TestOnTransitionWritesNotificationOnActionableTransition(t *testing.T) {
 	ctx := context.Background()
 	n := testNotifier(t, store)
 
-	id, err := store.Create(ctx, Mission{Goal: marker + "notify-1", Kind: "general"})
+	goal := marker + "notify-1"
+	id, err := store.Create(ctx, Mission{Goal: goal, Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 
-	if err := n.OnTransition(ctx, id, StatusWorking, StatusPaused); err != nil {
+	if err := n.OnTransition(ctx, Mission{ID: id, Goal: goal}, StatusWorking, StatusPaused, ""); err != nil {
 		t.Fatalf("OnTransition: %v", err)
 	}
 	notes, err := n.List(ctx)
@@ -48,11 +49,12 @@ func TestOnTransitionSilentOnNonActionable(t *testing.T) {
 	ctx := context.Background()
 	n := testNotifier(t, store)
 
-	id, err := store.Create(ctx, Mission{Goal: marker + "notify-2", Kind: "general"})
+	goal := marker + "notify-2"
+	id, err := store.Create(ctx, Mission{Goal: goal, Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if err := n.OnTransition(ctx, id, StatusIdle, StatusWorking); err != nil {
+	if err := n.OnTransition(ctx, Mission{ID: id, Goal: goal}, StatusIdle, StatusWorking, ""); err != nil {
 		t.Fatalf("OnTransition: %v", err)
 	}
 	notes, err := n.List(ctx)
@@ -71,7 +73,8 @@ func TestSendOncePerMissionDedupes(t *testing.T) {
 	ctx := context.Background()
 	n := testNotifier(t, store)
 
-	id, err := store.Create(ctx, Mission{Goal: marker + "notify-3", Kind: "general"})
+	goal := marker + "notify-3"
+	id, err := store.Create(ctx, Mission{Goal: goal, Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -79,7 +82,7 @@ func TestSendOncePerMissionDedupes(t *testing.T) {
 	// A worker re-asking permission every command still produces
 	// exactly ONE inbox row, not one per re-ask.
 	for i := 0; i < 3; i++ {
-		if err := n.OnTransition(ctx, id, StatusWorking, StatusWaitingForInput); err != nil {
+		if err := n.OnTransition(ctx, Mission{ID: id, Goal: goal}, StatusWorking, StatusWaitingForInput, ""); err != nil {
 			t.Fatalf("OnTransition[%d]: %v", i, err)
 		}
 	}
@@ -103,11 +106,12 @@ func TestClearMissionMarksUnreadRowsRead(t *testing.T) {
 	ctx := context.Background()
 	n := testNotifier(t, store)
 
-	id, err := store.Create(ctx, Mission{Goal: marker + "notify-4", Kind: "general"})
+	goal := marker + "notify-4"
+	id, err := store.Create(ctx, Mission{Goal: goal, Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if err := n.OnTransition(ctx, id, StatusWorking, StatusPaused); err != nil {
+	if err := n.OnTransition(ctx, Mission{ID: id, Goal: goal}, StatusWorking, StatusPaused, ""); err != nil {
 		t.Fatalf("OnTransition: %v", err)
 	}
 	if err := n.ClearMission(ctx, id); err != nil {
@@ -126,7 +130,7 @@ func TestClearMissionMarksUnreadRowsRead(t *testing.T) {
 	// A NEW notification for the same mission after clearing is not
 	// suppressed by the dedup logic (the prior one is read, so the
 	// NOT EXISTS ... AND NOT read guard doesn't see it).
-	if err := n.OnTransition(ctx, id, StatusWorking, StatusDone); err != nil {
+	if err := n.OnTransition(ctx, Mission{ID: id, Goal: goal}, StatusWorking, StatusDone, ""); err != nil {
 		t.Fatalf("OnTransition after clear: %v", err)
 	}
 	notes, err = n.List(ctx)
@@ -149,11 +153,12 @@ func TestMarkRead(t *testing.T) {
 	ctx := context.Background()
 	n := testNotifier(t, store)
 
-	id, err := store.Create(ctx, Mission{Goal: marker + "notify-5", Kind: "general"})
+	goal := marker + "notify-5"
+	id, err := store.Create(ctx, Mission{Goal: goal, Kind: "general"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if err := n.OnTransition(ctx, id, StatusWorking, StatusError); err != nil {
+	if err := n.OnTransition(ctx, Mission{ID: id, Goal: goal}, StatusWorking, StatusError, ""); err != nil {
 		t.Fatalf("OnTransition: %v", err)
 	}
 	notes, err := n.List(ctx)

--- a/internal/brain/missions/notify_test.go
+++ b/internal/brain/missions/notify_test.go
@@ -2,6 +2,30 @@ package missions
 
 import "testing"
 
+func TestComposeMessage(t *testing.T) {
+	cases := []struct {
+		name        string
+		kind, title string
+		reason      string
+		want        string
+	}{
+		{"done", "done", "Fix the login bug", "", "Mission - Fix the login bug is done"},
+		{"failed", "error", "Fix the login bug", "max_iterations", "Mission - Fix the login bug is failed"},
+		{"failed no reason", "error", "Fix the login bug", "", "Mission - Fix the login bug is failed"},
+		{"cancelled", "error", "Fix the login bug", "cancelled", "Mission - Fix the login bug is cancelled"},
+		{"paused", "paused", "Fix the login bug", "", "Mission - Fix the login bug is paused, needs your intervention."},
+		{"waiting_for_input", "waiting_for_input", "Fix the login bug", "", "Mission - Fix the login bug is waiting for your input."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := composeMessage(tc.kind, tc.title, tc.reason)
+			if got != tc.want {
+				t.Fatalf("composeMessage(%q, %q, %q) = %q, want %q", tc.kind, tc.title, tc.reason, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsActionableTransition(t *testing.T) {
 	cases := []struct {
 		name          string

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -49,7 +49,7 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 	escalation_route, prompt_overlay,
 	pending_permission, pending_permission_tool, pending_permission_args,
 	pending_permission_danger, pending_permission_rationale, auto_approve_safe, last_evidence,
-	explore_notes, replan_used, schedule_id, session_id, harness, environment, created_at, updated_at`
+	explore_notes, replan_used, schedule_id, session_id, harness, environment, repo_url, connector_id, on_complete, created_at, updated_at`
 
 // scanMissionWithFailureReason is scanMission plus one extra trailing
 // column: the mission's latest mission.failed event's payload.reason
@@ -71,7 +71,8 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&m.EscalationRoute, &m.PromptOverlay,
 		&pendingPermission, &m.PendingPermissionTool, &m.PendingPermissionArgs,
 		&m.PendingPermissionDanger, &m.PendingPermissionRationale, &m.AutoApproveSafe, &m.LastEvidence,
-		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment, &m.CreatedAt, &m.UpdatedAt,
+		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
+		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.CreatedAt, &m.UpdatedAt,
 		&failureReason); err != nil {
 		return Mission{}, err
 	}
@@ -139,7 +140,8 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&m.EscalationRoute, &m.PromptOverlay,
 		&pendingPermission, &m.PendingPermissionTool, &m.PendingPermissionArgs,
 		&m.PendingPermissionDanger, &m.PendingPermissionRationale, &m.AutoApproveSafe, &m.LastEvidence,
-		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment, &m.CreatedAt, &m.UpdatedAt); err != nil {
+		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
+		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.CreatedAt, &m.UpdatedAt); err != nil {
 		return Mission{}, err
 	}
 	if agentID != nil {
@@ -196,9 +198,9 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 		budgetCurrency = "USD"
 	}
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, escalation_route, prompt_overlay, spec, session_id, auto_approve_safe, harness, environment)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, NULLIF($13, '')::uuid, $14, $15, $16) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 8), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.EscalationRoute, m.PromptOverlay, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, escalation_route, prompt_overlay, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, NULLIF($13, '')::uuid, $14, $15, $16, $17, $18, $19) RETURNING id`,
+		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 8), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.EscalationRoute, m.PromptOverlay, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -252,6 +252,41 @@ func TestMissionHarnessRoundTrips(t *testing.T) {
 	}
 }
 
+// TestMissionOnCompleteRoundTrips covers on_complete: a first-class
+// column snapshotted at create time, same shape as Harness above — ""
+// (do nothing) is the default when a mission omits it.
+func TestMissionOnCompleteRoundTrips(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{
+		Goal: marker + "on-complete", Kind: "coding", Route: "default",
+		RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1", OnComplete: "push_pr",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.OnComplete != "push_pr" {
+		t.Fatalf("OnComplete = %q, want push_pr", m.OnComplete)
+	}
+
+	id2, err := s.Create(ctx, Mission{Goal: marker + "no-on-complete", Kind: "general", Route: "default"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	m2, err := s.Get(ctx, id2)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m2.OnComplete != "" {
+		t.Fatalf("OnComplete = %q, want empty when not set", m2.OnComplete)
+	}
+}
+
 func TestMissionNameRoundTrips(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()

--- a/internal/brain/missions/worktree.go
+++ b/internal/brain/missions/worktree.go
@@ -19,6 +19,9 @@ const (
 	baseCommitTimeout = 1 * time.Second
 	rollbackTimeout   = 30 * time.Second
 	gitOpTimeout      = 30 * time.Second
+	// cloneTimeout is longer than gitOpTimeout: a real clone crosses the
+	// network and can be a lot bigger than one local git op.
+	cloneTimeout = 120 * time.Second
 
 	unavailableCommit = "(unavailable)"
 
@@ -51,8 +54,15 @@ func NewWorkspace(root string, identity func(context.Context) (name, email strin
 // wholly inside its own workspace dir. The base commit is captured
 // with a tight timeout (degrades to the sentinel "(unavailable)"
 // rather than blocking). Non-coding missions get a plain directory, no
-// git.
-func (w *Workspace) Provision(ctx context.Context, missionID, goal, kind string) (workspace, worktree, branch, baseCommit string, err error) {
+// git. repoURL non-empty clones that repo instead of self-initializing
+// an empty one (see cloneRepo); token authenticates the clone and is
+// required whenever repoURL is set. connIdentity, when non-nil, is the
+// connection's resolved (name, email) — set as this clone's LOCAL git
+// config so its commits are authored as the connection, never the
+// operator's fixed identity; nil (no connector, or identity resolve
+// failed) leaves the clone with no local identity override, falling
+// back to the fixed commitName/commitEmail same as before this existed.
+func (w *Workspace) Provision(ctx context.Context, missionID, goal, kind, repoURL, token string, connIdentity *GitIdentity) (workspace, worktree, branch, baseCommit string, err error) {
 	workspace = filepath.Join(w.root, missionID)
 	if err := os.MkdirAll(workspace, 0o750); err != nil {
 		return "", "", "", "", fmt.Errorf("worktree: provision: mkdir %s: %w", workspace, err)
@@ -62,15 +72,82 @@ func (w *Workspace) Provision(ctx context.Context, missionID, goal, kind string)
 		return workspace, "", "", "", nil
 	}
 
-	branch = "mission/" + Slug(goal, missionID)
+	branch = CommitType(goal) + "/" + Slug(goal, missionID)
 	worktree = filepath.Join(workspace, "wt")
 
-	if err := w.initSelfRepo(ctx, worktree, branch, missionID); err != nil {
+	if repoURL != "" {
+		if err := w.cloneRepo(ctx, worktree, branch, repoURL, token, connIdentity); err != nil {
+			return "", "", "", "", err
+		}
+	} else if err := w.initSelfRepo(ctx, worktree, branch, missionID); err != nil {
 		return "", "", "", "", err
 	}
 
 	baseCommit = w.captureBaseCommit(ctx, worktree)
 	return workspace, worktree, branch, baseCommit, nil
+}
+
+// GitIdentity is a resolved commit author (name, email) — a
+// connection's identity, threaded from CloneIdentityResolver through
+// Provision to cloneRepo's local git config.
+type GitIdentity struct {
+	Name  string
+	Email string
+}
+
+// cloneRepo clones repoURL's default branch into dir, authenticated
+// via the same ephemeral credential-helper pattern push.go's rawPush
+// uses (username x-access-token, password from an env var, never
+// argv/disk), then creates and checks out the mission's own branch on
+// top of the cloned default branch — mission commits land on
+// "<type>/<slug>" (see CommitType), the same branch shape a self-init'd mission uses,
+// never directly on the repo's default branch. connIdentity, when
+// non-nil, is written as the clone's LOCAL (not global) git config
+// right after — CommitUnit/initSelfRepo read this back so every commit
+// in this worktree is authored as the connection, no token involved.
+func (w *Workspace) cloneRepo(ctx context.Context, dir, branch, repoURL, token string, connIdentity *GitIdentity) error {
+	cctx, cancel := context.WithTimeout(ctx, cloneTimeout)
+	defer cancel()
+	helper := `!f() { echo "username=x-access-token"; echo "password=$GIT_CLONE_TOKEN"; }; f`
+	cmd := exec.CommandContext(cctx, "git", //nolint:gosec // repoURL/dir are validated https origins/harness-controlled paths; token travels via env, never argv
+		"-c", "credential.helper=",
+		"-c", "credential.helper="+helper,
+		"clone", "-q", "--single-branch", repoURL, dir)
+	cmd.Env = append(os.Environ(), "GIT_CLONE_TOKEN="+token, "GIT_TERMINAL_PROMPT=0")
+	out, err := cmd.CombinedOutput()
+	scrubbed := strings.ReplaceAll(string(out), token, "***")
+	if err != nil {
+		return fmt.Errorf("worktree: clone: %w: %s", err, scrubbed)
+	}
+	if out, err := runGit(cctx, dir, "checkout", "-q", "-b", branch); err != nil {
+		return fmt.Errorf("worktree: clone: create mission branch: %w: %s", err, out)
+	}
+	if connIdentity != nil {
+		if err := setLocalIdentity(cctx, dir, connIdentity.Name, connIdentity.Email); err != nil {
+			// Never fails provisioning: a clone with no local identity just
+			// falls back to the fixed commitName/commitEmail, same as any
+			// other mission.
+			w.log.Warn("worktree: clone identity config failed; commits fall back to fixed identity", "dir", dir, "error", err)
+		}
+	}
+	return nil
+}
+
+// setLocalIdentity writes user.name/user.email into dir's LOCAL git
+// config (never --global) — scoped to this one clone, never touching
+// the container's shared git config.
+func setLocalIdentity(ctx context.Context, dir, name, email string) error {
+	if name != "" {
+		if out, err := runGit(ctx, dir, "config", "--local", "user.name", name); err != nil {
+			return fmt.Errorf("set user.name: %w: %s", err, out)
+		}
+	}
+	if email != "" {
+		if out, err := runGit(ctx, dir, "config", "--local", "user.email", email); err != nil {
+			return fmt.Errorf("set user.email: %w: %s", err, out)
+		}
+	}
+	return nil
 }
 
 // initSelfRepo creates a brand-new git repo at dir on branch, with one
@@ -159,6 +236,65 @@ func Slug(goal, id string) string {
 	return s
 }
 
+// commitTypeKeywords maps a Conventional Commits type to the keywords
+// that select it — checked in order, first match wins, so more
+// specific types (fix, docs, test, refactor, chore) are tried before
+// the "feat" default.
+var commitTypeKeywords = []struct {
+	typ      string
+	keywords []string
+}{
+	{"fix", []string{"fix", "bug", "broken"}},
+	{"docs", []string{"doc", "readme", "comment"}},
+	{"test", []string{"test"}},
+	{"refactor", []string{"refactor", "rename", "cleanup"}},
+	{"chore", []string{"chore", "bump", "upgrade", "dependency"}},
+}
+
+// CommitType derives a Conventional Commits type from text (a mission
+// goal or unit title) via a small deterministic keyword heuristic — no
+// LLM call. Falls back to "feat" when nothing matches.
+func CommitType(text string) string {
+	lower := strings.ToLower(text)
+	for _, ct := range commitTypeKeywords {
+		for _, kw := range ct.keywords {
+			if strings.Contains(lower, kw) {
+				return ct.typ
+			}
+		}
+	}
+	return "feat"
+}
+
+// maxCommitSubjectLen matches the repo convention (root CLAUDE.md):
+// commit subjects stay at or under 72 chars.
+const maxCommitSubjectLen = 72
+
+// CommitMessage builds a Conventional Commits message for a unit
+// commit: "<type>: <title>" as the subject (type from unitTitle via
+// CommitType, falling back to goal when unitTitle is empty), body
+// unchanged (whatever the caller already put there, e.g. mission
+// id/iteration). The subject is lowercased and trimmed to
+// maxCommitSubjectLen, trailing punctuation removed.
+func CommitMessage(unitTitle, goal, body string) string {
+	title := unitTitle
+	if title == "" {
+		title = goal
+	}
+	typ := CommitType(title)
+	subject := strings.ToLower(strings.TrimSpace(title))
+	subject = strings.TrimRight(subject, ".")
+	prefix := typ + ": "
+	if max := maxCommitSubjectLen - len(prefix); len(subject) > max {
+		subject = strings.TrimRight(subject[:max], " .")
+	}
+	msg := prefix + subject
+	if body != "" {
+		msg += "\n\n" + body
+	}
+	return msg
+}
+
 // Rollback discards uncommitted work: `git checkout -- .` + `git clean
 // -fd` for coding missions, no-op otherwise.
 func (w *Workspace) Rollback(ctx context.Context, worktree, kind string) error {
@@ -176,9 +312,12 @@ func (w *Workspace) Rollback(ctx context.Context, worktree, kind string) error {
 	return nil
 }
 
-// CommitUnit commits the worktree's current changes, authored under
-// the operator's configured git identity when set (per-field fallback
-// to commitName/commitEmail otherwise), independent of host git config.
+// CommitUnit commits the worktree's current changes. A github-
+// connection mission's clone carries a LOCAL user.name/user.email (set
+// once at Provision time, see cloneRepo/setLocalIdentity) — that takes
+// priority so commits are authored as the connection; otherwise falls
+// back to the operator's configured git identity when set, then
+// commitName/commitEmail, independent of host git config.
 func (w *Workspace) CommitUnit(ctx context.Context, worktree, message string) error {
 	cctx, cancel := context.WithTimeout(ctx, gitOpTimeout)
 	defer cancel()
@@ -196,6 +335,14 @@ func (w *Workspace) CommitUnit(ctx context.Context, worktree, message string) er
 			}
 		}
 	}
+	if ln, le, ok := localIdentity(cctx, worktree); ok {
+		if ln != "" {
+			name = ln
+		}
+		if le != "" {
+			email = le
+		}
+	}
 	cmd := exec.CommandContext(cctx, "git", //nolint:gosec // name/email may be operator-supplied but travel as -c key=value args, never shell-interpolated; message is driver-built from mission id/iteration, not user input
 		"-c", "user.name="+name, "-c", "user.email="+email,
 		"commit", "-m", message, "--allow-empty")
@@ -204,6 +351,27 @@ func (w *Workspace) CommitUnit(ctx context.Context, worktree, message string) er
 		return fmt.Errorf("worktree: commit: %w: %s", err, string(out))
 	}
 	return nil
+}
+
+// localIdentity reads worktree's LOCAL (not global) user.name/
+// user.email, as set by setLocalIdentity at clone time for a
+// github-connection mission. ok is false when neither key is set
+// locally (a self-init'd or non-connector mission) — never an error,
+// since "no local identity" is the normal case.
+func localIdentity(ctx context.Context, worktree string) (name, email string, ok bool) {
+	name, nameOK := gitConfigLocal(ctx, worktree, "user.name")
+	email, emailOK := gitConfigLocal(ctx, worktree, "user.email")
+	return name, email, nameOK || emailOK
+}
+
+func gitConfigLocal(ctx context.Context, worktree, key string) (string, bool) {
+	cmd := exec.CommandContext(ctx, "git", "config", "--local", "--get", key) //nolint:gosec // key is always a fixed literal ("user.name"/"user.email"), never user input
+	cmd.Dir = worktree
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(out)), true
 }
 
 // Teardown removes the workspace. Every coding mission's repo lives

--- a/internal/brain/missions/worktree_integration_test.go
+++ b/internal/brain/missions/worktree_integration_test.go
@@ -19,7 +19,7 @@ func TestProvisionNonCodingMission(t *testing.T) {
 	w := newTestWorkspace(t)
 	ctx := context.Background()
 
-	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-2", "Do something", "general")
+	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-2", "Do something", "general", "", "", nil)
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}

--- a/internal/brain/missions/worktree_test.go
+++ b/internal/brain/missions/worktree_test.go
@@ -7,8 +7,85 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestCommitType(t *testing.T) {
+	cases := []struct {
+		name, text, want string
+	}{
+		{"fix keyword", "Fix the login bug", "fix"},
+		{"bug keyword", "there's a bug in checkout", "fix"},
+		{"broken keyword", "the build is broken", "fix"},
+		{"doc keyword", "Update the doc for setup", "docs"},
+		{"readme keyword", "Update README", "docs"},
+		{"comment keyword", "Add comments to parser", "docs"},
+		{"test keyword", "Add tests for the parser", "test"},
+		{"refactor keyword", "Refactor the auth module", "refactor"},
+		{"rename keyword", "Rename the package", "refactor"},
+		{"cleanup keyword", "Cleanup dead code", "refactor"},
+		{"chore keyword", "Chore: repo housekeeping", "chore"},
+		{"bump keyword", "Bump dependency versions", "chore"},
+		{"upgrade keyword", "Upgrade dependency", "chore"},
+		{"dependency keyword", "Update dependency pins", "chore"},
+		{"default feat", "Add dark mode toggle", "feat"},
+		{"empty text defaults to feat", "", "feat"},
+		{"fix checked before feat-like phrasing", "Fix: add new feature", "fix"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CommitType(tc.text)
+			if got != tc.want {
+				t.Fatalf("CommitType(%q) = %q, want %q", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCommitMessage(t *testing.T) {
+	cases := []struct {
+		name, unitTitle, goal, body, want string
+	}{
+		{
+			"unit title used when present",
+			"Fix the broken login flow", "Some other goal", "body text",
+			"fix: fix the broken login flow\n\nbody text",
+		},
+		{
+			"falls back to goal when no unit title",
+			"", "Refactor the auth module", "body text",
+			"refactor: refactor the auth module\n\nbody text",
+		},
+		{
+			"no body omits the blank separator",
+			"Add tests for parser", "goal", "",
+			"test: add tests for parser",
+		},
+		{
+			"trailing period trimmed",
+			"Add dark mode.", "goal", "",
+			"feat: add dark mode",
+		},
+		{
+			"long title trimmed to 72 chars",
+			strings.Repeat("a", 100), "goal", "",
+			"feat: " + strings.Repeat("a", 66),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CommitMessage(tc.unitTitle, tc.goal, tc.body)
+			if got != tc.want {
+				t.Fatalf("CommitMessage(%q, %q, %q) = %q, want %q", tc.unitTitle, tc.goal, tc.body, got, tc.want)
+			}
+			subject := strings.SplitN(got, "\n", 2)[0]
+			if len(subject) > maxCommitSubjectLen {
+				t.Fatalf("subject %q exceeds %d chars", subject, maxCommitSubjectLen)
+			}
+		})
+	}
+}
 
 func TestSlug(t *testing.T) {
 	cases := []struct {
@@ -71,12 +148,12 @@ func TestProvisionCodingMissionSelfInitsRepo(t *testing.T) {
 	w := newTestWorkspace(t)
 	ctx := context.Background()
 
-	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-self", "Fix the login bug", "coding")
+	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-self", "Fix the login bug", "coding", "", "", nil)
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
-	if branch != "mission/fix-the-login-bug" {
-		t.Fatalf("branch = %q, want mission/fix-the-login-bug", branch)
+	if branch != "fix/fix-the-login-bug" {
+		t.Fatalf("branch = %q, want fix/fix-the-login-bug", branch)
 	}
 	if baseCommit == "" || baseCommit == unavailableCommit {
 		t.Fatalf("baseCommit = %q, want a real commit hash", baseCommit)
@@ -125,7 +202,7 @@ func TestProvisionSelfInitRollbackAndCommitUnit(t *testing.T) {
 	w := newTestWorkspace(t)
 	ctx := context.Background()
 
-	_, worktree, _, _, err := w.Provision(ctx, "mission-self-2", "Add a feature", "coding")
+	_, worktree, _, _, err := w.Provision(ctx, "mission-self-2", "Add a feature", "coding", "", "", nil)
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -160,6 +237,133 @@ func TestProvisionSelfInitRollbackAndCommitUnit(t *testing.T) {
 	}
 }
 
+// TestProvisionClonesRepo proves a repoURL mission clones the given
+// repo's default branch and checks out its own mission branch on top,
+// rather than self-initializing an empty repo. The "remote" is a local
+// bare repo (a plain filesystem path git accepts as an origin), which
+// exercises the same clone/credential-helper code path a real https
+// origin would, just without a network round trip.
+func TestProvisionClonesRepo(t *testing.T) {
+	requireGit(t)
+	w := newTestWorkspace(t)
+	ctx := context.Background()
+
+	bare := t.TempDir()
+	gitRun(t, bare, "init", "-q", "--bare", "-b", "main")
+	seed := t.TempDir()
+	gitRun(t, seed, "init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, seed, "add", "README.md")
+	gitRun(t, seed, "-c", "user.name=test", "-c", "user.email=test@test", "commit", "-q", "-m", "seed")
+	gitRun(t, seed, "remote", "add", "origin", bare)
+	gitRun(t, seed, "push", "-q", "origin", "main")
+
+	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-clone", "Fix the login bug", "coding", bare, "dummy-token", nil)
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if branch != "fix/fix-the-login-bug" {
+		t.Fatalf("branch = %q, want fix/fix-the-login-bug", branch)
+	}
+	if baseCommit == "" || baseCommit == unavailableCommit {
+		t.Fatalf("baseCommit = %q, want a real commit hash", baseCommit)
+	}
+	if _, err := os.Stat(filepath.Join(worktree, "README.md")); err != nil {
+		t.Fatalf("cloned repo's README.md missing: %v", err)
+	}
+
+	cmd := exec.Command("git", "branch", "--show-current")
+	cmd.Dir = worktree
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git branch --show-current: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != branch {
+		t.Fatalf("current branch = %q, want %q", got, branch)
+	}
+	if _, err := os.Stat(workspace); err != nil {
+		t.Fatalf("workspace directory missing: %v", err)
+	}
+}
+
+// TestProvisionClonesRepoWithConnIdentity proves a connection's
+// resolved identity (connIdentity) lands as the clone's LOCAL git
+// config and that a subsequent CommitUnit authors its commit as that
+// identity, not the fixed commitName/commitEmail or any operator
+// default — the authorship mechanics driver.go's ensureProvisioned
+// wires (SetCloneIdentityResolver).
+func TestProvisionClonesRepoWithConnIdentity(t *testing.T) {
+	requireGit(t)
+	w := newTestWorkspace(t)
+	ctx := context.Background()
+
+	bare := t.TempDir()
+	gitRun(t, bare, "init", "-q", "--bare", "-b", "main")
+	seed := t.TempDir()
+	gitRun(t, seed, "init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, seed, "add", "README.md")
+	gitRun(t, seed, "-c", "user.name=test", "-c", "user.email=test@test", "commit", "-q", "-m", "seed")
+	gitRun(t, seed, "remote", "add", "origin", bare)
+	gitRun(t, seed, "push", "-q", "origin", "main")
+
+	identity := &GitIdentity{Name: "conn-bot", Email: "conn-bot@example.com"}
+	_, worktree, _, _, err := w.Provision(ctx, "mission-conn-identity", "Fix the login bug", "coding", bare, "dummy-token", identity)
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	name, ok := gitConfigLocal(ctx, worktree, "user.name")
+	if !ok || name != identity.Name {
+		t.Fatalf("local user.name = %q (ok=%v), want %q", name, ok, identity.Name)
+	}
+	email, ok := gitConfigLocal(ctx, worktree, "user.email")
+	if !ok || email != identity.Email {
+		t.Fatalf("local user.email = %q (ok=%v), want %q", email, ok, identity.Email)
+	}
+
+	if err := os.WriteFile(filepath.Join(worktree, "new.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.CommitUnit(ctx, worktree, "conn identity commit"); err != nil {
+		t.Fatalf("CommitUnit: %v", err)
+	}
+
+	cmd := exec.Command("git", "log", "-1", "--format=%an <%ae>")
+	cmd.Dir = worktree
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	got := strings.TrimSpace(string(out))
+	want := identity.Name + " <" + identity.Email + ">"
+	if got != want {
+		t.Fatalf("commit author = %q, want %q", got, want)
+	}
+}
+
+// TestCloneRepoScrubsTokenFromError mirrors push_test.go's
+// TestRawPushScrubsTokenFromError: a clone against a nonexistent remote
+// fails fast (no network touched), proving the error path never leaks
+// the literal token string.
+func TestCloneRepoScrubsTokenFromError(t *testing.T) {
+	requireGit(t)
+	w := newTestWorkspace(t)
+	dir := filepath.Join(t.TempDir(), "wt")
+	const token = "super-secret-clone-token"
+	err := w.cloneRepo(context.Background(), dir, "mission/x", "/does/not/exist", token, nil)
+	if err == nil {
+		t.Fatal("cloneRepo against a nonexistent remote should fail")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("error contains the raw token: %v", err)
+	}
+}
+
 // TestTeardownRemovesSelfInitRepo proves Teardown removes a coding
 // mission's self-init'd workspace outright — there is no separate
 // main-repo checkout to leave behind, so this is a plain os.RemoveAll.
@@ -168,7 +372,7 @@ func TestTeardownRemovesSelfInitRepo(t *testing.T) {
 	w := newTestWorkspace(t)
 	ctx := context.Background()
 
-	workspace, worktree, _, _, err := w.Provision(ctx, "mission-self-3", "Teardown test", "coding")
+	workspace, worktree, _, _, err := w.Provision(ctx, "mission-self-3", "Teardown test", "coding", "", "", nil)
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}

--- a/internal/brain/tools/builtin/missions.go
+++ b/internal/brain/tools/builtin/missions.go
@@ -1,0 +1,370 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// MissionRecord is the missions tool's own view of a missions.Mission
+// — kept as a local struct (not an import of internal/brain/missions)
+// because missions itself imports this package (runner.go's
+// builtin.Shell/WriteFile); missions.Mission would create an import
+// cycle. cmd/brain/main.go, which imports both packages, adapts real
+// missions.Mission values into this shape.
+type MissionRecord struct {
+	ID           string
+	Name         string
+	Goal         string
+	Kind         string
+	Phase        string
+	Status       string
+	Iteration    int
+	Harness      string
+	RepoURL      string
+	Branch       string
+	ConnectorID  string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	UnitsPassed  int
+	UnitsTotal   int
+	PauseReason  string
+	PauseMessage string
+	OnComplete   string
+	// NotPushableReason is missions.NotPushable(m) precomputed by the
+	// adapter (that check lives in missions, same import-cycle reason
+	// as the rest of this type) — empty means pushable.
+	NotPushableReason string
+}
+
+// MissionEvent is the missions tool's own view of a missions.Event —
+// same import-cycle reasoning as MissionRecord; only the fields
+// finding the latest PR url needs.
+type MissionEvent struct {
+	Kind    string
+	Payload json.RawMessage
+}
+
+// missionLister is the narrow slice of missions access the missions
+// and mission_push tools need — List and Get, kept as an interface so
+// tests fake it without a real Postgres pool.
+type missionLister interface {
+	ListMissions(ctx context.Context, limit int) ([]MissionRecord, error)
+	GetMission(ctx context.Context, id string) (MissionRecord, error)
+}
+
+// missionEventReader is the narrow slice of missions access the
+// missions tool needs to find a mission's latest PR URL, if any.
+type missionEventReader interface {
+	MissionEvents(ctx context.Context, id string) ([]MissionEvent, error)
+}
+
+const (
+	missionsListDefaultLimit = 10
+	missionsListMaxLimit     = 50
+)
+
+type missionsArgs struct {
+	Query string `json:"query"`
+	ID    string `json:"id"`
+	Limit int    `json:"limit"`
+}
+
+// missionPROpenedPayload is the shape of a mission.pr_opened event's
+// payload (see missions.Completer.OpenPR).
+type missionPROpenedPayload struct {
+	URL string `json:"url"`
+}
+
+// missionSnapshot is the compact JSON shape returned for a single
+// mission — the model reads this, so field names stay short and only
+// non-empty/non-zero fields worth reporting are included.
+type missionSnapshot struct {
+	ID           string `json:"id"`
+	Name         string `json:"name,omitempty"`
+	Goal         string `json:"goal"`
+	Kind         string `json:"kind"`
+	Phase        string `json:"phase"`
+	Status       string `json:"status"`
+	Iteration    int    `json:"iteration"`
+	Harness      string `json:"harness,omitempty"`
+	RepoURL      string `json:"repo_url,omitempty"`
+	Branch       string `json:"branch,omitempty"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
+	UnitsPassed  int    `json:"units_passed"`
+	UnitsTotal   int    `json:"units_total"`
+	PauseReason  string `json:"pause_reason,omitempty"`
+	PauseMessage string `json:"pause_message,omitempty"`
+	PRURL        string `json:"pr_url,omitempty"`
+	OnComplete   string `json:"on_complete,omitempty"`
+}
+
+// missionListItem is the compact shape for the list-mode result.
+type missionListItem struct {
+	ID        string `json:"id"`
+	Name      string `json:"name,omitempty"`
+	Phase     string `json:"phase"`
+	Status    string `json:"status"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+func toMissionListItem(m MissionRecord) missionListItem {
+	name := m.Name
+	if name == "" {
+		name = m.Goal
+	}
+	return missionListItem{
+		ID: m.ID, Name: name, Phase: m.Phase, Status: m.Status,
+		UpdatedAt: m.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+}
+
+func toMissionSnapshot(ctx context.Context, events missionEventReader, m MissionRecord) missionSnapshot {
+	snap := missionSnapshot{
+		ID: m.ID, Name: m.Name, Goal: m.Goal, Kind: m.Kind,
+		Phase: m.Phase, Status: m.Status, Iteration: m.Iteration,
+		Harness: m.Harness, RepoURL: m.RepoURL, Branch: m.Branch,
+		CreatedAt:   m.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:   m.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		UnitsPassed: m.UnitsPassed, UnitsTotal: m.UnitsTotal,
+		PauseReason: m.PauseReason, PauseMessage: m.PauseMessage,
+		OnComplete: m.OnComplete,
+	}
+	if events != nil {
+		if evs, err := events.MissionEvents(ctx, m.ID); err == nil {
+			for i := len(evs) - 1; i >= 0; i-- {
+				if evs[i].Kind != "mission.pr_opened" {
+					continue
+				}
+				var p missionPROpenedPayload
+				if err := json.Unmarshal(evs[i].Payload, &p); err == nil {
+					snap.PRURL = p.URL
+				}
+				break
+			}
+		}
+	}
+	return snap
+}
+
+// findMission resolves id or a query substring match against
+// name/goal to exactly one mission — ambiguous or absent matches
+// return a descriptive error rather than guessing.
+func findMission(ctx context.Context, store missionLister, id, query string) (MissionRecord, error) {
+	if id != "" {
+		m, err := store.GetMission(ctx, id)
+		if err != nil {
+			return MissionRecord{}, fmt.Errorf("no mission found with id %q", id)
+		}
+		return m, nil
+	}
+	all, err := store.ListMissions(ctx, 0)
+	if err != nil {
+		return MissionRecord{}, fmt.Errorf("list missions: %w", err)
+	}
+	q := strings.ToLower(strings.TrimSpace(query))
+	var matches []MissionRecord
+	for _, m := range all {
+		if strings.Contains(strings.ToLower(m.Name), q) || strings.Contains(strings.ToLower(m.Goal), q) {
+			matches = append(matches, m)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return MissionRecord{}, fmt.Errorf("no mission matches %q", query)
+	case 1:
+		return matches[0], nil
+	default:
+		var b strings.Builder
+		fmt.Fprintf(&b, "%q matches %d missions, be more specific or use id:\n", query, len(matches))
+		for _, m := range matches {
+			fmt.Fprintf(&b, "- %s: %s\n", m.ID, toMissionListItem(m).Name)
+		}
+		return MissionRecord{}, fmt.Errorf("%s", b.String())
+	}
+}
+
+// Missions is a read-only, permission-exempt tool: pure reads over
+// the missions store, no side effects. Answers "is mission X done?"
+// and similar status questions from real harness data (never the
+// worker/reviewer's own claims — same D-0xx discipline as the harness
+// itself). Registered only when store/events are non-nil (missions
+// engine wired, see cmd/brain/main.go's WORKSPACES gate).
+func Missions(store missionLister, events missionEventReader) *tools.Tool {
+	return &tools.Tool{
+		Name: "missions",
+		Description: `Reads mission status: answers "is mission X done?", "what's the status of my last mission?", and similar questions from the harness's own records — never the worker/reviewer's claims.
+
+Arguments (all optional):
+- id (string): exact mission id — returns that mission's full status snapshot.
+- query (string): a name/goal substring to find a mission by; must
+  match exactly one mission, otherwise you get the list of candidates
+  to disambiguate with id.
+- limit (int): with neither id nor query, lists recent missions
+  (default 10, max 50) with id/name/phase/status/updated_at.
+
+A snapshot includes: id, name, goal, kind, phase, status, iteration,
+harness, repo_url, branch, created/updated timestamps, unit pass
+counts, pause reason/message if paused, the latest PR url if one was
+opened, and the on_complete setting.
+
+Example: {"query": "invoice pdf export"} → that mission's snapshot, or
+a disambiguation list if more than one mission matches.
+Example: {} → the 10 most recently updated missions.`,
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"id": {"type": "string", "description": "Exact mission id"},
+				"query": {"type": "string", "description": "Name/goal substring to find a mission by"},
+				"limit": {"type": "integer", "description": "Max missions to list when neither id nor query is given (default 10, max 50)"}
+			},
+			"additionalProperties": false
+		}`),
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
+			var args missionsArgs
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return "", fmt.Errorf("invalid arguments: %w", err)
+			}
+			if args.ID != "" || args.Query != "" {
+				m, err := findMission(ctx, store, args.ID, args.Query)
+				if err != nil {
+					return "", err
+				}
+				snap := toMissionSnapshot(ctx, events, m)
+				out, err := json.Marshal(snap)
+				if err != nil {
+					return "", fmt.Errorf("encode mission snapshot: %w", err)
+				}
+				return string(out), nil
+			}
+			limit := args.Limit
+			if limit <= 0 {
+				limit = missionsListDefaultLimit
+			}
+			if limit > missionsListMaxLimit {
+				limit = missionsListMaxLimit
+			}
+			all, err := store.ListMissions(ctx, limit)
+			if err != nil {
+				return "", fmt.Errorf("list missions: %w", err)
+			}
+			items := make([]missionListItem, 0, len(all))
+			for _, m := range all {
+				items = append(items, toMissionListItem(m))
+			}
+			out, err := json.Marshal(items)
+			if err != nil {
+				return "", fmt.Errorf("encode mission list: %w", err)
+			}
+			return string(out), nil
+		},
+	}
+}
+
+// missionCompleter is the narrow slice of *missions.Completer the
+// mission_push tool needs — pushing (and optionally opening a PR)
+// through the SAME code path the button/auto-fire paths use, so a
+// chat-triggered push can never diverge in behavior. Takes the
+// mission id rather than a MissionRecord: the adapter (main.go) re-Gets
+// the mission from the real store itself, so Completer always acts on
+// the authoritative missions.Mission (worktree, spec, etc.) rather
+// than a partial copy shuttled through this package's own struct.
+type missionCompleter interface {
+	PushMissionBranch(ctx context.Context, id, token string) (host string, err error)
+	OpenMissionPR(ctx context.Context, id, token string) (url string, number int, err error)
+}
+
+// missionTokenResolver resolves a mission's own push token from its
+// connector_id — same resolver shape as missions.PushTokenResolver,
+// restated here so this file has no import-cycle-inducing dependency
+// beyond what missionCompleter already requires.
+type missionTokenResolver func(ctx context.Context, connectorID string) (string, error)
+
+type missionPushArgs struct {
+	ID     string `json:"id"`
+	OpenPR bool   `json:"open_pr"`
+}
+
+// MissionPush is permission-GATED — it is deliberately left out of
+// Permissions' exempt map (see internal/brain/tools/permissions.go)
+// and never appears in any allowlist grant a chat session's model
+// could pre-authorize itself into, so every call parks on an explicit
+// human approval, matching the "pushes stay human" invariant.
+//
+// NOTE (slice R): mission worker turns currently see the same base
+// tool registry chat sessions do (a known gap slice R will close by
+// restricting mission turns to their own tool set) — until then this
+// tool is technically reachable from a mission's own turns too, not
+// just chat. Do not "fix" that here; it's explicitly out of scope for
+// this slice.
+func MissionPush(store missionLister, completer missionCompleter, resolveToken missionTokenResolver) *tools.Tool {
+	return &tools.Tool{
+		Name: "mission_push",
+		Description: `Pushes a mission's branch to GitHub, optionally opening a pull request. Requires explicit human approval every time — this tool is never auto-approved.
+
+Only a github-connection coding mission with a completed worktree can
+be pushed (same guard the push/PR buttons in the UI use). The approval
+prompt shows the mission's goal and target repo so the human sees
+exactly what is about to be pushed where.
+
+Arguments:
+- id (string, required): the mission id to push.
+- open_pr (bool, optional): also open a pull request after pushing
+  (default false: push only).
+
+Example: {"id": "3fa1...", "open_pr": true} → pushes the branch, opens
+a PR, returns the PR url.`,
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"id": {"type": "string", "description": "Mission id to push"},
+				"open_pr": {"type": "boolean", "description": "Also open a pull request after pushing (default false)"}
+			},
+			"required": ["id"],
+			"additionalProperties": false
+		}`),
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
+			var args missionPushArgs
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return "", fmt.Errorf("invalid arguments: %w", err)
+			}
+			if strings.TrimSpace(args.ID) == "" {
+				return "", fmt.Errorf("id is required")
+			}
+			m, err := store.GetMission(ctx, args.ID)
+			if err != nil {
+				return "", fmt.Errorf("no mission found with id %q", args.ID)
+			}
+			if m.ConnectorID == "" || m.RepoURL == "" {
+				return "", fmt.Errorf("mission %s is not a github-connection mission", args.ID)
+			}
+			if m.NotPushableReason != "" {
+				return "", fmt.Errorf("mission %s is not pushable: %s", args.ID, m.NotPushableReason)
+			}
+			if resolveToken == nil {
+				return "", fmt.Errorf("push: connectors are not enabled")
+			}
+			token, err := resolveToken(ctx, m.ConnectorID)
+			if err != nil {
+				return "", fmt.Errorf("resolve push token: %w", err)
+			}
+			if args.OpenPR {
+				url, number, err := completer.OpenMissionPR(ctx, args.ID, token)
+				if err != nil {
+					return "", fmt.Errorf("open pr: %w", err)
+				}
+				return fmt.Sprintf("pushed %s and opened pull request #%d: %s", m.Branch, number, url), nil
+			}
+			host, err := completer.PushMissionBranch(ctx, args.ID, token)
+			if err != nil {
+				return "", fmt.Errorf("push: %w", err)
+			}
+			return fmt.Sprintf("pushed %s to %s", m.Branch, host), nil
+		},
+	}
+}

--- a/internal/brain/tools/builtin/missions_test.go
+++ b/internal/brain/tools/builtin/missions_test.go
@@ -1,0 +1,382 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeMissionStore is an in-memory missionLister + missionEventReader
+// stand-in — no Postgres pool, table-tests Execute against scripted
+// mission rows.
+type fakeMissionStore struct {
+	byID      map[string]MissionRecord
+	listOrder []string
+	events    map[string][]MissionEvent
+	listErr   error
+	getErr    error
+}
+
+func newFakeMissionStore() *fakeMissionStore {
+	return &fakeMissionStore{byID: map[string]MissionRecord{}, events: map[string][]MissionEvent{}}
+}
+
+func (f *fakeMissionStore) add(m MissionRecord) {
+	f.byID[m.ID] = m
+	f.listOrder = append(f.listOrder, m.ID)
+}
+
+func (f *fakeMissionStore) ListMissions(ctx context.Context, limit int) ([]MissionRecord, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := make([]MissionRecord, 0, len(f.listOrder))
+	for _, id := range f.listOrder {
+		out = append(out, f.byID[id])
+	}
+	if limit > 0 && limit < len(out) {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (f *fakeMissionStore) GetMission(ctx context.Context, id string) (MissionRecord, error) {
+	if f.getErr != nil {
+		return MissionRecord{}, f.getErr
+	}
+	m, ok := f.byID[id]
+	if !ok {
+		return MissionRecord{}, errors.New("not found")
+	}
+	return m, nil
+}
+
+func (f *fakeMissionStore) MissionEvents(ctx context.Context, id string) ([]MissionEvent, error) {
+	return f.events[id], nil
+}
+
+func mustMarshal(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// TestMissionsToolByID proves an id lookup returns that mission's full
+// snapshot, including the latest mission.pr_opened event's url.
+func TestMissionsToolByID(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	store.add(MissionRecord{
+		ID: "m1", Name: "Fix login bug", Goal: "fix the login bug", Kind: "coding",
+		Phase: "done", Status: "idle", Iteration: 3, RepoURL: "https://github.com/o/r.git",
+		Branch: "mission/m1", CreatedAt: now, UpdatedAt: now, UnitsPassed: 2, UnitsTotal: 2,
+	})
+	store.events["m1"] = []MissionEvent{
+		{Kind: "mission.pr_opened", Payload: mustMarshal(t, map[string]any{"url": "https://github.com/o/r/pull/1", "number": 1})},
+	}
+
+	tool := Missions(store, store)
+	out, err := tool.Execute(context.Background(), mustMarshal(t, map[string]string{"id": "m1"}))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var snap missionSnapshot
+	if err := json.Unmarshal([]byte(out), &snap); err != nil {
+		t.Fatalf("unmarshal snapshot: %v (out=%s)", err, out)
+	}
+	if snap.ID != "m1" || snap.Phase != "done" || snap.UnitsPassed != 2 {
+		t.Fatalf("snapshot = %+v", snap)
+	}
+	if snap.PRURL != "https://github.com/o/r/pull/1" {
+		t.Fatalf("PRURL = %q, want the pr_opened event's url", snap.PRURL)
+	}
+}
+
+// TestMissionsToolByQueryUnique proves a query substring matching
+// exactly one mission's name/goal resolves to that mission.
+func TestMissionsToolByQueryUnique(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	store.add(MissionRecord{ID: "m1", Name: "Invoice PDF export", Goal: "export invoices as pdf"})
+	store.add(MissionRecord{ID: "m2", Name: "Unrelated mission", Goal: "something else"})
+
+	tool := Missions(store, store)
+	out, err := tool.Execute(context.Background(), mustMarshal(t, map[string]string{"query": "invoice"}))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var snap missionSnapshot
+	if err := json.Unmarshal([]byte(out), &snap); err != nil {
+		t.Fatalf("unmarshal: %v (out=%s)", err, out)
+	}
+	if snap.ID != "m1" {
+		t.Fatalf("resolved to %q, want m1", snap.ID)
+	}
+}
+
+// TestMissionsToolByQueryAmbiguous proves a query matching more than
+// one mission returns a disambiguation list, not a guess.
+func TestMissionsToolByQueryAmbiguous(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	store.add(MissionRecord{ID: "m1", Name: "Export invoices", Goal: "export invoices as pdf"})
+	store.add(MissionRecord{ID: "m2", Name: "Export contacts", Goal: "export contacts as csv"})
+
+	tool := Missions(store, store)
+	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]string{"query": "export"}))
+	if err == nil {
+		t.Fatal("expected an ambiguous-match error")
+	}
+	if !strings.Contains(err.Error(), "m1") || !strings.Contains(err.Error(), "m2") {
+		t.Fatalf("error %q should list both candidate ids", err.Error())
+	}
+}
+
+// TestMissionsToolListMode proves the no-id/no-query path lists
+// missions with the default limit applied.
+func TestMissionsToolListMode(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	for i := 0; i < 3; i++ {
+		store.add(MissionRecord{ID: string(rune('a' + i)), Name: "mission", Phase: "execute", Status: "working"})
+	}
+	tool := Missions(store, store)
+	out, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{}))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var items []missionListItem
+	if err := json.Unmarshal([]byte(out), &items); err != nil {
+		t.Fatalf("unmarshal list: %v (out=%s)", err, out)
+	}
+	if len(items) != 3 {
+		t.Fatalf("list = %d items, want 3", len(items))
+	}
+}
+
+// TestMissionsToolListModeCapsLimit proves an over-large limit is
+// capped, not passed straight to the store.
+func TestMissionsToolListModeCapsLimit(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	var gotLimit int
+	capping := missionLimitCapture{fakeMissionStore: store, capture: &gotLimit}
+	tool := Missions(capping, store)
+	if _, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"limit": 500})); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotLimit != missionsListMaxLimit {
+		t.Fatalf("limit passed to store = %d, want capped to %d", gotLimit, missionsListMaxLimit)
+	}
+}
+
+// missionLimitCapture wraps fakeMissionStore to record the limit
+// ListMissions receives, proving the tool's own cap logic runs before
+// the store call.
+type missionLimitCapture struct {
+	*fakeMissionStore
+	capture *int
+}
+
+func (c missionLimitCapture) ListMissions(ctx context.Context, limit int) ([]MissionRecord, error) {
+	*c.capture = limit
+	return c.fakeMissionStore.ListMissions(ctx, limit)
+}
+
+// TestMissionsToolUnknownID proves an unknown id returns a clear
+// error rather than a zero-value snapshot.
+func TestMissionsToolUnknownID(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	tool := Missions(store, store)
+	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]string{"id": "does-not-exist"}))
+	if err == nil {
+		t.Fatal("expected an error for an unknown mission id")
+	}
+	if !strings.Contains(err.Error(), "does-not-exist") {
+		t.Fatalf("error %q should name the id", err.Error())
+	}
+}
+
+// fakeMissionCompleter scripts missionCompleter for mission_push's
+// table tests.
+type fakeMissionCompleter struct {
+	pushHost    string
+	pushErr     error
+	prURL       string
+	prNumber    int
+	prErr       error
+	pushCalls   int
+	openPRCalls int
+}
+
+func (f *fakeMissionCompleter) PushMissionBranch(ctx context.Context, id, token string) (string, error) {
+	f.pushCalls++
+	if f.pushErr != nil {
+		return "", f.pushErr
+	}
+	return f.pushHost, nil
+}
+
+func (f *fakeMissionCompleter) OpenMissionPR(ctx context.Context, id, token string) (string, int, error) {
+	f.openPRCalls++
+	if f.prErr != nil {
+		return "", 0, f.prErr
+	}
+	return f.prURL, f.prNumber, nil
+}
+
+func pushableRecord() MissionRecord {
+	return MissionRecord{ID: "m1", Goal: "fix the bug", Kind: "coding", Branch: "mission/m1",
+		RepoURL: "https://github.com/o/r.git", ConnectorID: "conn1"}
+}
+
+// TestMissionPushHappyPath proves a pushable mission pushes through
+// the completer and reports the host.
+func TestMissionPushHappyPath(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	store.add(pushableRecord())
+	completer := &fakeMissionCompleter{pushHost: "github.com"}
+	resolve := func(ctx context.Context, connectorID string) (string, error) { return "tok", nil }
+
+	tool := MissionPush(store, completer, resolve)
+	out, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"id": "m1"}))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "github.com") {
+		t.Fatalf("out = %q, want it to mention the pushed host", out)
+	}
+	if completer.pushCalls != 1 || completer.openPRCalls != 0 {
+		t.Fatalf("pushCalls=%d openPRCalls=%d, want push only", completer.pushCalls, completer.openPRCalls)
+	}
+}
+
+// TestMissionPushOpenPR proves open_pr:true opens a PR instead of a
+// plain push, reporting the PR url.
+func TestMissionPushOpenPR(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	store.add(pushableRecord())
+	completer := &fakeMissionCompleter{prURL: "https://github.com/o/r/pull/2", prNumber: 2}
+	resolve := func(ctx context.Context, connectorID string) (string, error) { return "tok", nil }
+
+	tool := MissionPush(store, completer, resolve)
+	out, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"id": "m1", "open_pr": true}))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "https://github.com/o/r/pull/2") {
+		t.Fatalf("out = %q, want the PR url", out)
+	}
+	if completer.openPRCalls != 1 || completer.pushCalls != 0 {
+		t.Fatalf("openPRCalls=%d pushCalls=%d, want open_pr only", completer.openPRCalls, completer.pushCalls)
+	}
+}
+
+// TestMissionPushNotPushable proves a mission NotPushable flags
+// (precomputed onto the record) is refused before ever calling the
+// completer.
+func TestMissionPushNotPushable(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	rec := pushableRecord()
+	rec.NotPushableReason = "mission has no branch"
+	store.add(rec)
+	completer := &fakeMissionCompleter{}
+	resolve := func(ctx context.Context, connectorID string) (string, error) { return "tok", nil }
+
+	tool := MissionPush(store, completer, resolve)
+	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"id": "m1"}))
+	if err == nil {
+		t.Fatal("expected a not-pushable error")
+	}
+	if !strings.Contains(err.Error(), "mission has no branch") {
+		t.Fatalf("error %q should carry the NotPushable reason", err.Error())
+	}
+	if completer.pushCalls != 0 {
+		t.Fatalf("completer called %d times, want 0", completer.pushCalls)
+	}
+}
+
+// TestMissionPushNonGitHubMission proves a mission with no
+// connector_id/repo_url (never cloned from GitHub) is refused before
+// calling the completer.
+func TestMissionPushNonGitHubMission(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	store.add(MissionRecord{ID: "m1", Kind: "coding", Branch: "mission/m1"})
+	completer := &fakeMissionCompleter{}
+	resolve := func(ctx context.Context, connectorID string) (string, error) { return "tok", nil }
+
+	tool := MissionPush(store, completer, resolve)
+	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"id": "m1"}))
+	if err == nil {
+		t.Fatal("expected a not-a-github-mission error")
+	}
+	if completer.pushCalls != 0 {
+		t.Fatalf("completer called %d times, want 0", completer.pushCalls)
+	}
+}
+
+// TestMissionPushCompleterError proves a completer failure surfaces
+// as the tool's own error.
+func TestMissionPushCompleterError(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	store.add(pushableRecord())
+	completer := &fakeMissionCompleter{pushErr: errors.New("push rejected by remote")}
+	resolve := func(ctx context.Context, connectorID string) (string, error) { return "tok", nil }
+
+	tool := MissionPush(store, completer, resolve)
+	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"id": "m1"}))
+	if err == nil {
+		t.Fatal("expected the completer's push error to surface")
+	}
+	if !strings.Contains(err.Error(), "push rejected by remote") {
+		t.Fatalf("error %q should wrap the completer's error", err.Error())
+	}
+}
+
+// TestMissionPushUnknownID proves an unknown mission id is refused
+// before any token resolution or completer call.
+func TestMissionPushUnknownID(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	completer := &fakeMissionCompleter{}
+	resolveCalls := 0
+	resolve := func(ctx context.Context, connectorID string) (string, error) {
+		resolveCalls++
+		return "tok", nil
+	}
+
+	tool := MissionPush(store, completer, resolve)
+	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"id": "nope"}))
+	if err == nil {
+		t.Fatal("expected an unknown-mission error")
+	}
+	if resolveCalls != 0 || completer.pushCalls != 0 {
+		t.Fatalf("resolveCalls=%d pushCalls=%d, want neither called", resolveCalls, completer.pushCalls)
+	}
+}
+
+// TestMissionPushRequiresID proves a missing id is rejected before
+// touching the store at all.
+func TestMissionPushRequiresID(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	completer := &fakeMissionCompleter{}
+	tool := MissionPush(store, completer, nil)
+	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{}))
+	if err == nil {
+		t.Fatal("expected an id-required error")
+	}
+}

--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -89,6 +89,11 @@ func NewPermissions(db *pgpool.Pool, workspaceRoot string) *Permissions {
 			// there is nothing for a prompt to guard that the tool
 			// doesn't already enforce harder.
 			"write_file": true,
+			// missions is a pure read over the missions store (status
+			// snapshot / list) — zero side effects, same reasoning as
+			// web_search. mission_push is deliberately NOT here: it must
+			// always ask (see MissionPush's doc comment).
+			"missions": true,
 		},
 	}
 }

--- a/internal/brain/tools/permissions_integration_test.go
+++ b/internal/brain/tools/permissions_integration_test.go
@@ -59,6 +59,23 @@ func TestResolveNoGrantAsks(t *testing.T) {
 	}
 }
 
+// TestResolveMissionPushAsksWithoutGrant proves mission_push (unlike
+// missions, which is exempt) always falls through to "no standing
+// grant" and asks — it is deliberately absent from Permissions.exempt
+// (see NewPermissions) so a chat session's model can never talk its
+// way into an auto-approved push.
+func TestResolveMissionPushAsksWithoutGrant(t *testing.T) {
+	p, sid := integrationPermissions(t)
+
+	res, err := p.Resolve(t.Context(), sid, "mission_push", json.RawMessage(`{"id":"m1"}`))
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Decision != DecisionAsk {
+		t.Fatalf("res = %+v, want ask", res)
+	}
+}
+
 func TestResolveSessionGrantAllows(t *testing.T) {
 	p, sid := integrationPermissions(t)
 

--- a/internal/brain/tools/permissions_test.go
+++ b/internal/brain/tools/permissions_test.go
@@ -190,6 +190,22 @@ func TestResolveShortCircuits(t *testing.T) {
 		}
 	})
 
+	// missions is a pure read (status snapshot/list) and exempt, same
+	// reasoning as web_search; mission_push must never be exempt (see
+	// TestResolveMissionPushAsksWithoutGrant, the integration
+	// counterpart proving its full no-grant path) — this only pins the
+	// exempt-map membership the short-circuit above depends on.
+	t.Run("missions tool exempt", func(t *testing.T) {
+		t.Parallel()
+		res, err := p.Resolve(ctx, "s1", "missions", json.RawMessage(`{}`))
+		if err != nil {
+			t.Fatalf("Resolve(missions): %v", err)
+		}
+		if res.Decision != DecisionAllow {
+			t.Fatalf("Resolve(missions) = %+v, want allow", res)
+		}
+	})
+
 	t.Run("destructive forces ask", func(t *testing.T) {
 		t.Parallel()
 		res, err := p.Resolve(ctx, "s1", "shell", json.RawMessage(`{"command":"rm -rf build/"}`))

--- a/migrations/0008_connectors.sql
+++ b/migrations/0008_connectors.sql
@@ -6,7 +6,7 @@
 CREATE TABLE IF NOT EXISTS connectors (
     id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     name           text UNIQUE NOT NULL,
-    kind           text NOT NULL CHECK (kind IN ('mcp', 'google')),
+    kind           text NOT NULL CHECK (kind IN ('mcp', 'google', 'github')),
     -- kind-specific settings: mcp → {transport, endpoint, headers},
     -- google → {scopes}. OAuth tokens NEVER live here; they go to the
     -- secrets table under credential_ref.

--- a/migrations/0010_missions.sql
+++ b/migrations/0010_missions.sql
@@ -108,7 +108,27 @@ CREATE TABLE IF NOT EXISTS missions (
     -- own name directly, no LLM call. Empty means generation hasn't
     -- landed yet (or a scheduler mission predates this column); the UI
     -- falls back to a truncated goal. Never re-summarized once set.
-    name                  text NOT NULL DEFAULT ''
+    name                  text NOT NULL DEFAULT '',
+    -- A coding mission can clone an existing GitHub repo instead of
+    -- self-initializing an empty one (Workspace.Provision): repo_url is
+    -- the repo's https clone URL, connector_id names the github-kind
+    -- connectors row whose PAT authenticates the clone. Both empty
+    -- (the default) is the existing self-init behavior; repo_url
+    -- without a connector_id is rejected at create time (api/missions.go)
+    -- -- v1 has no anonymous-clone path. The clone auth token itself is
+    -- never persisted here or anywhere else: it's resolved fresh from
+    -- connector_id's credential_ref at provisioning time only.
+    repo_url              text NOT NULL DEFAULT '',
+    connector_id          text NOT NULL DEFAULT '',
+    -- Consent-at-create for the mission's auto-completion action: ''
+    -- (default) does nothing when the mission reaches done; 'push'
+    -- pushes the branch; 'push_pr' pushes then opens a pull request.
+    -- Chosen by the operator at create time (api/missions.go), never
+    -- decided by the model -- keeps the pushes-stay-human invariant:
+    -- the harness only ever executes a choice a human already made.
+    -- Requires repo_url+connector_id and kind='coding', same guards as
+    -- the manual push/pr endpoints.
+    on_complete           text NOT NULL DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS missions_status_idx ON missions (status);

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -9,7 +9,9 @@ import {
   listMissionFiles,
   listProviders,
   listSessions,
+  openMissionPR,
   patchBudget,
+  pushMission,
   usageBudget,
 } from './client'
 import type { ChatEvent } from './types'
@@ -315,5 +317,47 @@ describe('mission artifacts and push', () => {
     expect(err.status).toBe(404)
     expect(err.code).toBe('no_workspace')
     expect(err.message).toBe('no workspace')
+  })
+
+  it('pushMission posts an empty body when credentialRef is omitted', async () => {
+    vi.stubGlobal('localStorage', { getItem: () => 'tok', setItem: () => {} })
+    const body = { branch: 'mission/x', remote_host: 'github.com' }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify(body), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const r = await pushMission('m1')
+
+    expect(fetchMock.mock.calls[0][0]).toBe('/v1/missions/m1/push')
+    expect(fetchMock.mock.calls[0][1]?.body).toBe('{}')
+    expect(r).toEqual(body)
+  })
+
+  it('pushMission posts credential_ref when provided', async () => {
+    vi.stubGlobal('localStorage', { getItem: () => 'tok', setItem: () => {} })
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ branch: 'b', remote_host: 'h' }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await pushMission('m1', 'my-ref')
+
+    expect(fetchMock.mock.calls[0][1]?.body).toBe(JSON.stringify({ credential_ref: 'my-ref' }))
+  })
+
+  it('openMissionPR posts to the pr endpoint and returns url/number', async () => {
+    vi.stubGlobal('localStorage', { getItem: () => 'tok', setItem: () => {} })
+    const body = { url: 'https://github.com/octocat/hello-world/pull/9', number: 9 }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify(body), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const r = await openMissionPR('m1')
+
+    expect(fetchMock.mock.calls[0][0]).toBe('/v1/missions/m1/pr')
+    expect(fetchMock.mock.calls[0][1]?.method).toBe('POST')
+    expect(r).toEqual(body)
   })
 })

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -12,6 +12,8 @@ import type {
   ChatEvent,
   ChatRequest,
   EntityGraphData,
+  GitHubIdentity,
+  GitHubRepo,
   GroupTotal,
   LatencyRow,
   MemoryItem,
@@ -762,9 +764,33 @@ export async function deleteConnector(id: string): Promise<void> {
   await request<void>(`/v1/admin/connectors/${id}`, { method: 'DELETE' })
 }
 
-export async function testConnector(id: string): Promise<{ ok: boolean; error?: string }> {
-  return request<{ ok: boolean; error?: string }>(`/v1/admin/connectors/${id}/test`, {
+export async function testConnector(
+  id: string,
+): Promise<{ ok: boolean; error?: string; identity?: GitHubIdentity }> {
+  return request<{ ok: boolean; error?: string; identity?: GitHubIdentity }>(
+    `/v1/admin/connectors/${id}/test`,
+    { method: 'POST' },
+  )
+}
+
+// listConnectorRepos lists every repo a github-kind connector's PAT
+// can see (owner, collaborator, or org member), most recently pushed
+// first — the mission create form's repo picker.
+export async function listConnectorRepos(id: string): Promise<GitHubRepo[]> {
+  const { repos } = await request<{ repos: GitHubRepo[] }>(`/v1/admin/connectors/${id}/repos`)
+  return repos ?? []
+}
+
+// createConnectorRepo creates a new repo through a github-kind
+// connector's PAT, auto-initialized so it has a default branch to
+// clone into a mission workspace.
+export async function createConnectorRepo(
+  id: string,
+  input: { name: string; private: boolean },
+): Promise<GitHubRepo> {
+  return request<GitHubRepo>(`/v1/admin/connectors/${id}/repos`, {
     method: 'POST',
+    body: JSON.stringify(input),
   })
 }
 
@@ -864,6 +890,18 @@ export interface CreateMissionInput {
   // markers, then a goal-keyword heuristic, falling back to base).
   // Only valid when kind === 'coding'.
   environment?: string
+  // repo_url is a GitHub repo's https clone URL: when set, the mission
+  // clones it instead of self-initializing an empty repo. Requires
+  // connector_id (a github-kind connector's PAT authenticates the
+  // clone) and is only valid when kind === 'coding'.
+  repo_url?: string
+  connector_id?: string
+  // on_complete is the operator's consent-at-create choice for what the
+  // harness does automatically once this mission reaches done: omit
+  // (or "") does nothing, "push" pushes the branch, "push_pr" pushes
+  // then opens a pull request. Requires repo_url + connector_id and
+  // kind === 'coding'.
+  on_complete?: '' | 'push' | 'push_pr'
 }
 
 // ExecutorOption is one registered harness's usability on a given
@@ -963,6 +1001,27 @@ export async function answerMissionPermission(
     method: 'POST',
     body: JSON.stringify({ decision }),
   })
+}
+
+// pushMission pushes the mission's branch to its worktree's origin
+// remote. credentialRef is optional: omitted (undefined) resolves a
+// github-connection mission's connector PAT server-side; passing one
+// always overrides.
+export async function pushMission(
+  id: string,
+  credentialRef?: string,
+): Promise<{ branch: string; remote_host: string }> {
+  return request<{ branch: string; remote_host: string }>(`/v1/missions/${id}/push`, {
+    method: 'POST',
+    body: JSON.stringify(credentialRef ? { credential_ref: credentialRef } : {}),
+  })
+}
+
+// openMissionPR pushes (idempotent re-push) then opens a pull request
+// for a github-connection mission — or returns the existing open PR
+// for the same head if GitHub reports one already exists.
+export async function openMissionPR(id: string): Promise<{ url: string; number: number }> {
+  return request<{ url: string; number: number }>(`/v1/missions/${id}/pr`, { method: 'POST' })
 }
 
 export async function listNotifications(): Promise<Notification[]> {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -563,6 +563,17 @@ export interface Mission {
   worktree?: string
   branch?: string
   base_commit?: string
+  // repo_url is the GitHub repo this coding mission was cloned from
+  // (https clone URL) — absent means the self-init'd empty repo.
+  // connector_id names the github-kind connector whose PAT
+  // authenticated the clone; only present alongside repo_url.
+  repo_url?: string
+  connector_id?: string
+  // on_complete is the operator's consent-at-create choice for what the
+  // harness does automatically when this mission reaches done: '' does
+  // nothing, 'push' pushes the branch, 'push_pr' pushes then opens a
+  // pull request. Only ever set at create time, never by the model.
+  on_complete?: '' | 'push' | 'push_pr'
   // explore_notes is set once, at the end of the explore phase
   // (driver.go's runExplore) — absent/empty for a mission created
   // before the explore phase existed, or one that hasn't reached it
@@ -695,6 +706,14 @@ export interface MissionSteeredPayload {
   note: string
 }
 
+// MissionPROpenedPayload is mission.pr_opened's payload — recorded by
+// POST .../pr once a pull request is opened (or an existing one for
+// the same head is found instead).
+export interface MissionPROpenedPayload {
+  url: string
+  number: number
+}
+
 // MissionFile is one entry of a mission workspace's file listing
 // (GET /v1/missions/:id/files). Declared marks files named in the
 // mission's plan artifacts, not the full tree.
@@ -715,12 +734,15 @@ export interface Notification {
 }
 
 // AdminConnector is one third-party integration the agent can call as
-// tools (MCP server or Google account). config is kind-specific; the
-// credential_ref names where its secret/tokens live.
+// tools (MCP server or Google account), or — for kind 'github' — an
+// identity/credential connector with no tools of its own (mission
+// flows and Settings resolve a GitHub identity from its PAT; chat
+// tools stay on the MCP-based GitHub connector). config is
+// kind-specific; the credential_ref names where its secret/tokens live.
 export interface AdminConnector {
   id: string
   name: string
-  kind: 'mcp' | 'google'
+  kind: 'mcp' | 'google' | 'github'
   config: Record<string, unknown>
   credential_ref: string
   enabled: boolean
@@ -728,6 +750,27 @@ export interface AdminConnector {
   // privacy-floor route (session.SensitiveTools), same as gmail_read
   // is pinned today — additive, connector-wide, no code change needed.
   sensitive: boolean
+}
+
+// GitHubIdentity is what a github-kind connector's test resolves:
+// which account its PAT authenticates as.
+export interface GitHubIdentity {
+  login: string
+  name: string
+  email: string
+  scopes: string
+}
+
+// GitHubRepo is one repo a github-kind connector's PAT can see or
+// create (GET/POST /v1/admin/connectors/:id/repos) — the mission
+// create form's repo picker/create-new flow.
+export interface GitHubRepo {
+  full_name: string
+  private: boolean
+  default_branch: string
+  html_url: string
+  clone_url: string
+  pushed_at: string
 }
 
 // MissionTemplate is the frozen mission-creation payload a schedule

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { AdminRoute, Mission, Schedule } from '../../api/types'
+import type { AdminConnector, AdminRoute, GitHubRepo, Mission, Schedule } from '../../api/types'
 import { MissionForm } from './MissionForm'
 
 vi.mock('../../api/client', () => ({
@@ -10,20 +11,34 @@ vi.mock('../../api/client', () => ({
   patchSchedule: vi.fn(),
   listAgents: vi.fn(),
   listRoutes: vi.fn(),
+  listConnectors: vi.fn(),
+  listConnectorRepos: vi.fn(),
+  createConnectorRepo: vi.fn(),
   getSettings: vi.fn(),
   getMissionExecutorOptions: vi.fn(),
+  testConnector: vi.fn().mockResolvedValue({ ok: true }),
 }))
 
 import {
   classifyMission,
+  createConnectorRepo,
   createMission,
   createSchedule,
   getMissionExecutorOptions,
   getSettings,
   listAgents,
+  listConnectorRepos,
+  listConnectors,
   listRoutes,
   patchSchedule,
 } from '../../api/client'
+
+// renderForm wraps MissionForm in a MemoryRouter — the repository
+// section's "no connectors" hint links to Settings → Connectors, which
+// needs router context even when that section never renders.
+function renderForm(el: React.ReactElement) {
+  return render(<MemoryRouter>{el}</MemoryRouter>)
+}
 
 const routes: AdminRoute[] = [
   { name: 'default', strategy: 'ordered', enabled: true, chain: [] },
@@ -61,13 +76,14 @@ beforeEach(() => {
   vi.mocked(getSettings).mockResolvedValue({ settings: {}, values: {} })
   vi.mocked(classifyMission).mockResolvedValue({ kind: 'general' })
   vi.mocked(getMissionExecutorOptions).mockResolvedValue([])
+  vi.mocked(listConnectors).mockResolvedValue([])
 })
 
 describe('MissionForm — create mode, one-off mission', () => {
   it('submits a general mission with the entered goal', async () => {
     vi.mocked(createMission).mockResolvedValue({ id: 'm2' } as Mission)
     const onDone = vi.fn()
-    render(<MissionForm mode="create" onDone={onDone} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={onDone} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Research something new' } })
     fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
@@ -86,7 +102,7 @@ describe('MissionForm — create mode, one-off mission', () => {
 
   it('preserves multi-line markdown in the goal on submit, trimming only leading/trailing whitespace', async () => {
     vi.mocked(createMission).mockResolvedValue({ id: 'm2' } as Mission)
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     const markdownGoal = '## Plan\n\n- step one\n- step two\n\nDo it **carefully**.'
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: `  ${markdownGoal}  ` } })
@@ -99,7 +115,7 @@ describe('MissionForm — create mode, one-off mission', () => {
 
   it('sends auto_approve_safe: false when the toggle is unchecked', async () => {
     vi.mocked(createMission).mockResolvedValue({ id: 'm2' } as Mission)
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Research something new' } })
     fireEvent.click(screen.getByRole('button', { name: 'Show advanced options' }))
@@ -114,7 +130,7 @@ describe('MissionForm — create mode, one-off mission', () => {
   })
 
   it('disables submit until a goal is entered', () => {
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     const createButton = screen.getByRole('button', { name: 'Create mission' }) as HTMLButtonElement
     expect(createButton.disabled).toBe(true)
@@ -125,7 +141,7 @@ describe('MissionForm — create mode, one-off mission', () => {
 
   it('calls onCancel when Cancel is clicked', () => {
     const onCancel = vi.fn()
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={onCancel} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={onCancel} />)
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
     expect(onCancel).toHaveBeenCalled()
   })
@@ -141,7 +157,7 @@ describe('MissionForm — kind chip', () => {
 
   it('shows a detecting state then the classified kind after the debounce', async () => {
     vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding' })
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Fix a bug in the repo' } })
     expect(screen.getByText('Detecting…')).toBeInTheDocument()
@@ -155,7 +171,7 @@ describe('MissionForm — kind chip', () => {
   })
 
   it('debounces repeated goal edits into a single classify call', async () => {
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     const goalInput = screen.getByLabelText('Goal')
     fireEvent.change(goalInput, { target: { value: 'Fix a' } })
@@ -170,7 +186,7 @@ describe('MissionForm — kind chip', () => {
   it('submits the mission with the classified kind', async () => {
     vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding' })
     vi.mocked(createMission).mockResolvedValue({ id: 'm3' } as Mission)
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Fix a bug' } })
     await vi.advanceTimersByTimeAsync(600)
@@ -182,7 +198,7 @@ describe('MissionForm — kind chip', () => {
   })
 
   it('clicking the chip toggles kind and locks it against further auto-detect', async () => {
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Fix a bug' } })
     await vi.advanceTimersByTimeAsync(600)
@@ -205,7 +221,7 @@ describe('MissionForm — kind chip', () => {
 
 describe('MissionForm — harness select placement', () => {
   it('shows the harness select in the main form body for a coding mission, without expanding Advanced', async () => {
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
     fireEvent.click(await screen.findByText('General · scratch workspace'))
@@ -216,7 +232,7 @@ describe('MissionForm — harness select placement', () => {
   })
 
   it('omits the harness select for a general mission', async () => {
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
     expect(await screen.findByText('General · scratch workspace')).toBeInTheDocument()
@@ -225,7 +241,7 @@ describe('MissionForm — harness select placement', () => {
 
   it('submits the picked harness for a coding mission', async () => {
     vi.mocked(createMission).mockResolvedValue({ id: 'm5' } as Mission)
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
     fireEvent.click(await screen.findByText('General · scratch workspace'))
@@ -241,7 +257,7 @@ describe('MissionForm — harness select placement', () => {
 
 describe('MissionForm — environment select', () => {
   it('shows the environment select for a coding mission, defaulted to Auto-detect', async () => {
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
     fireEvent.click(await screen.findByText('General · scratch workspace'))
@@ -251,7 +267,7 @@ describe('MissionForm — environment select', () => {
   })
 
   it('omits the environment select for a general mission', async () => {
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
     expect(await screen.findByText('General · scratch workspace')).toBeInTheDocument()
@@ -260,7 +276,7 @@ describe('MissionForm — environment select', () => {
 
   it('submits the picked environment for a coding mission, and omits it when left on Auto-detect', async () => {
     vi.mocked(createMission).mockResolvedValue({ id: 'm6' } as Mission)
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
     fireEvent.click(await screen.findByText('General · scratch workspace'))
@@ -275,7 +291,7 @@ describe('MissionForm — environment select', () => {
 
   it('omits environment from the create payload when left on Auto-detect', async () => {
     vi.mocked(createMission).mockResolvedValue({ id: 'm7' } as Mission)
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
     fireEvent.click(await screen.findByText('General · scratch workspace'))
@@ -287,11 +303,263 @@ describe('MissionForm — environment select', () => {
   })
 })
 
+const githubConnector: AdminConnector = {
+  id: 'c1',
+  name: 'personal-gh',
+  kind: 'github',
+  config: {},
+  credential_ref: 'GH_PAT',
+  enabled: true,
+  sensitive: false,
+}
+
+const repos: GitHubRepo[] = [
+  {
+    full_name: 'octocat/hello-world',
+    private: false,
+    default_branch: 'main',
+    html_url: 'https://github.com/octocat/hello-world',
+    clone_url: 'https://github.com/octocat/hello-world.git',
+    pushed_at: '2026-08-01T00:00:00Z',
+  },
+  {
+    full_name: 'octocat/secret-project',
+    private: true,
+    default_branch: 'main',
+    html_url: 'https://github.com/octocat/secret-project',
+    clone_url: 'https://github.com/octocat/secret-project.git',
+    pushed_at: '2026-07-01T00:00:00Z',
+  },
+]
+
+// Drives the goal + coding-kind selection every repository-section test
+// needs before the section itself renders.
+async function toCodingMission() {
+  fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+  fireEvent.click(await screen.findByText('General · scratch workspace'))
+  expect(screen.getByText('Coding · branches from repo')).toBeInTheDocument()
+}
+
+describe('MissionForm — repository source', () => {
+  it('defaults to None and omits repo_url/connector_id from the create payload', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm8' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMission()
+    expect(screen.getByRole('button', { name: 'None' })).toHaveAttribute('aria-pressed', 'true')
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(
+        expect.objectContaining({ repo_url: undefined, connector_id: undefined }),
+      ),
+    )
+  })
+
+  it('hides the repository section for a general mission', async () => {
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    expect(await screen.findByText('General · scratch workspace')).toBeInTheDocument()
+    expect(screen.queryByText('Repository')).toBeNull()
+  })
+
+  it('shows a hint linking to Settings → Connectors when no github connector exists', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([])
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMission()
+    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }))
+
+    expect(await screen.findByText(/No GitHub connectors configured yet/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Add one in Settings/ })).toHaveAttribute(
+      'href',
+      '/settings/connectors',
+    )
+  })
+
+  it('lists connector repos, filters them, and submits the picked clone_url + connector_id', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(listConnectorRepos).mockResolvedValue(repos)
+    vi.mocked(createMission).mockResolvedValue({ id: 'm9' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMission()
+    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }))
+    fireEvent.click(await screen.findByLabelText('Connector'))
+    fireEvent.click(await screen.findByText('personal-gh'))
+
+    await waitFor(() => expect(listConnectorRepos).toHaveBeenCalledWith('c1'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Choose a repository' }))
+    expect(await screen.findByText('octocat/hello-world')).toBeInTheDocument()
+    expect(screen.getByText('octocat/secret-project')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('Filter repositories…'), {
+      target: { value: 'secret' },
+    })
+    expect(screen.queryByText('octocat/hello-world')).toBeNull()
+    fireEvent.click(screen.getByText('octocat/secret-project'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          repo_url: 'https://github.com/octocat/secret-project.git',
+          connector_id: 'c1',
+        }),
+      ),
+    )
+    expect(createConnectorRepo).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a repo list load error inline', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(listConnectorRepos).mockRejectedValue(new Error('bad credentials'))
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMission()
+    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }))
+    fireEvent.click(await screen.findByLabelText('Connector'))
+    fireEvent.click(await screen.findByText('personal-gh'))
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Choose a repository' }))
+    expect(await screen.findByText(/Could not load repos: bad credentials/)).toBeInTheDocument()
+  })
+
+  it('new-repository flow: creates the repo first, then submits its clone_url', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(listConnectorRepos).mockResolvedValue(repos)
+    vi.mocked(createConnectorRepo).mockResolvedValue({
+      full_name: 'octocat/brand-new',
+      private: true,
+      default_branch: 'main',
+      html_url: 'https://github.com/octocat/brand-new',
+      clone_url: 'https://github.com/octocat/brand-new.git',
+      pushed_at: '2026-08-05T00:00:00Z',
+    })
+    vi.mocked(createMission).mockResolvedValue({ id: 'm10' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMission()
+    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }))
+    fireEvent.click(await screen.findByLabelText('Connector'))
+    fireEvent.click(await screen.findByText('personal-gh'))
+
+    fireEvent.click(await screen.findByLabelText('New repository'))
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'brand-new' } })
+    // Private defaults on; leave it checked.
+    expect((screen.getByLabelText('Private') as HTMLInputElement).checked).toBe(true)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createConnectorRepo).toHaveBeenCalledWith('c1', { name: 'brand-new', private: true }),
+    )
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          repo_url: 'https://github.com/octocat/brand-new.git',
+          connector_id: 'c1',
+        }),
+      ),
+    )
+  })
+
+  it('disables submit for the GitHub source until a connector and repo (or new-repo name) are chosen', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(listConnectorRepos).mockResolvedValue(repos)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMission()
+    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }))
+
+    const submit = screen.getByRole('button', { name: 'Create mission' }) as HTMLButtonElement
+    expect(submit.disabled).toBe(true)
+
+    fireEvent.click(await screen.findByLabelText('Connector'))
+    fireEvent.click(await screen.findByText('personal-gh'))
+    expect(submit.disabled).toBe(true)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Choose a repository' }))
+    fireEvent.click(await screen.findByText('octocat/hello-world'))
+    expect(submit.disabled).toBe(false)
+  })
+})
+
+describe('MissionForm — deployment (on_complete)', () => {
+  it('hides the Deployment section until a repo (or new-repo name) is chosen', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(listConnectorRepos).mockResolvedValue(repos)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMission()
+    expect(screen.queryByText('Deployment')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }))
+    expect(screen.queryByText('Deployment')).toBeNull()
+
+    fireEvent.click(await screen.findByLabelText('Connector'))
+    fireEvent.click(await screen.findByText('personal-gh'))
+    expect(screen.queryByText('Deployment')).toBeNull()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Choose a repository' }))
+    fireEvent.click(await screen.findByText('octocat/hello-world'))
+    expect(await screen.findByText('Deployment')).toBeInTheDocument()
+  })
+
+  it('hides the Deployment section for the None repo source', async () => {
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    await toCodingMission()
+    expect(screen.queryByText('Deployment')).toBeNull()
+  })
+
+  it('defaults to Nothing and omits on_complete from the create payload', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(listConnectorRepos).mockResolvedValue(repos)
+    vi.mocked(createMission).mockResolvedValue({ id: 'm11' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMission()
+    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }))
+    fireEvent.click(await screen.findByLabelText('Connector'))
+    fireEvent.click(await screen.findByText('personal-gh'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Choose a repository' }))
+    fireEvent.click(await screen.findByText('octocat/hello-world'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ on_complete: undefined })),
+    )
+  })
+
+  it('submits on_complete="push_pr" when Push and open a PR is chosen', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(listConnectorRepos).mockResolvedValue(repos)
+    vi.mocked(createMission).mockResolvedValue({ id: 'm12' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMission()
+    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }))
+    fireEvent.click(await screen.findByLabelText('Connector'))
+    fireEvent.click(await screen.findByText('personal-gh'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Choose a repository' }))
+    fireEvent.click(await screen.findByText('octocat/hello-world'))
+
+    fireEvent.click(await screen.findByLabelText('Deployment'))
+    fireEvent.click(await screen.findByText('Push and open a PR when done'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ on_complete: 'push_pr' })),
+    )
+  })
+})
+
 describe('MissionForm — create mode, repeat on schedule', () => {
   it('submits a schedule with the slugified default name, preset cron, and general kind', async () => {
     vi.mocked(createSchedule).mockResolvedValue({ id: 'sc1' })
     const onDone = vi.fn()
-    render(<MissionForm mode="create" onDone={onDone} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={onDone} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), {
       target: { value: 'Check the news every morning' },
@@ -320,7 +588,7 @@ describe('MissionForm — create mode, repeat on schedule', () => {
     vi.useFakeTimers()
     vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding' })
     vi.mocked(createSchedule).mockResolvedValue({ id: 'sc1' })
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
     await vi.advanceTimersByTimeAsync(600)
@@ -344,7 +612,7 @@ describe('MissionForm — create mode, repeat on schedule', () => {
 
   it('disables the chip toggle while repeating (coding unavailable)', async () => {
     vi.useFakeTimers()
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
     fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
@@ -359,7 +627,7 @@ describe('MissionForm — create mode, repeat on schedule', () => {
   })
 
   it('blocks submit on a malformed custom cron shape', async () => {
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
     fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
@@ -389,7 +657,7 @@ describe('MissionForm — create mode, repeat on schedule', () => {
       },
     ])
     vi.mocked(createSchedule).mockResolvedValue({ id: 'sc1' })
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(await screen.findByLabelText('Goal'), { target: { value: 'g' } })
     fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
@@ -403,7 +671,7 @@ describe('MissionForm — create mode, repeat on schedule', () => {
   })
 
   it('renders route selects fed from the live routes list, excluding disabled routes', async () => {
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(await screen.findByLabelText('Goal'), { target: { value: 'g' } })
     fireEvent.click(screen.getByRole('button', { name: 'Show advanced options' }))
@@ -416,7 +684,7 @@ describe('MissionForm — create mode, repeat on schedule', () => {
 
   it('submits the picked route and review route', async () => {
     vi.mocked(createMission).mockResolvedValue({ id: 'm4' } as Mission)
-    render(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Fix a bug' } })
     fireEvent.click(screen.getByRole('button', { name: 'Show advanced options' }))
@@ -434,7 +702,7 @@ describe('MissionForm — create mode, repeat on schedule', () => {
 
 describe('MissionForm — edit mode', () => {
   it('prefills from the schedule, chip locked to the template kind', async () => {
-    render(<MissionForm mode="edit" schedule={schedule} onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="edit" schedule={schedule} onDone={vi.fn()} onCancel={vi.fn()} />)
 
     expect(await screen.findByDisplayValue('weekly-digest')).toBeTruthy()
     expect(screen.getByDisplayValue('Summarize the week')).toBeTruthy()
@@ -445,7 +713,7 @@ describe('MissionForm — edit mode', () => {
   })
 
   it('auto-expands Advanced when the schedule has a non-default review route', async () => {
-    render(<MissionForm mode="edit" schedule={schedule} onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="edit" schedule={schedule} onDone={vi.fn()} onCancel={vi.fn()} />)
 
     await screen.findByDisplayValue('weekly-digest')
     expect(screen.getByLabelText('Review route')).toBeInTheDocument()
@@ -454,7 +722,7 @@ describe('MissionForm — edit mode', () => {
   it('preserves the schedule kind in the patch payload and never shows Run once', async () => {
     vi.mocked(patchSchedule).mockResolvedValue(schedule)
     const onDone = vi.fn()
-    render(<MissionForm mode="edit" schedule={schedule} onDone={onDone} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="edit" schedule={schedule} onDone={onDone} onCancel={vi.fn()} />)
 
     expect(screen.queryByRole('button', { name: 'Run once' })).toBeNull()
 
@@ -475,7 +743,7 @@ describe('MissionForm — edit mode', () => {
 
   it('picks a new expiry date from the calendar and submits it', async () => {
     vi.mocked(patchSchedule).mockResolvedValue(schedule)
-    render(<MissionForm mode="edit" schedule={schedule} onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="edit" schedule={schedule} onDone={vi.fn()} onCancel={vi.fn()} />)
 
     await screen.findByDisplayValue('weekly-digest')
     fireEvent.click(screen.getByLabelText('Expires'))
@@ -494,7 +762,7 @@ describe('MissionForm — edit mode', () => {
 
   it('clears the expiry back to never', async () => {
     vi.mocked(patchSchedule).mockResolvedValue(schedule)
-    render(<MissionForm mode="edit" schedule={schedule} onDone={vi.fn()} onCancel={vi.fn()} />)
+    renderForm(<MissionForm mode="edit" schedule={schedule} onDone={vi.fn()} onCancel={vi.fn()} />)
 
     await screen.findByDisplayValue('weekly-digest')
     fireEvent.click(screen.getByLabelText('Expires'))

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -1,15 +1,20 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router'
 import { toast } from 'sonner'
 import {
   classifyMission,
+  createConnectorRepo,
   createMission,
   createSchedule,
   type ExecutorOption,
   getMissionExecutorOptions,
   getSettings,
+  listConnectorRepos,
+  listConnectors,
   patchSchedule,
+  testConnector,
 } from '../../api/client'
-import type { AdminAgent, Schedule } from '../../api/types'
+import type { AdminAgent, AdminConnector, GitHubIdentity, GitHubRepo, Schedule } from '../../api/types'
 import { useAgents, useRoutes } from '../AgentPicker'
 import { slugify } from '../settings/AgentForm'
 import { cronPresets, type CronPresetValue, presetFor } from '../../lib/schedules'
@@ -18,6 +23,7 @@ import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { Calendar } from '../ui/calendar'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible'
+import { Command, CommandEmpty, CommandInput, CommandItem, CommandList } from '../ui/command'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
@@ -26,7 +32,22 @@ import { Textarea } from '../ui/textarea'
 import { errText } from '../settings/util'
 import { envIcon } from '../icons/EnvIcons'
 
+type RepoSource = 'none' | 'github'
+
 type Kind = 'coding' | 'general'
+
+type OnComplete = '' | 'push' | 'push_pr'
+
+// Sentinel for the Deployment Select — Radix Select.Item rejects an
+// empty string value, so the "do nothing" choice (the wire value '')
+// is represented by this sentinel on the Select itself.
+const ON_COMPLETE_NONE = '__none__'
+
+const onCompleteChoices: { value: string; label: string }[] = [
+  { value: ON_COMPLETE_NONE, label: 'Nothing' },
+  { value: 'push', label: 'Push branch when done' },
+  { value: 'push_pr', label: 'Push and open a PR when done' },
+]
 
 const kindCopy: Record<Kind, string> = {
   coding: 'Coding · branches from repo',
@@ -156,6 +177,76 @@ export function MissionForm({
   const [environment, setEnvironment] = useState('')
   const [executorOptions, setExecutorOptions] = useState<ExecutorOption[] | null>(null)
   const [busy, setBusy] = useState(false)
+
+  // Repository source: 'none' self-initializes an empty repo (the
+  // existing coding-mission default); 'github' clones an existing repo
+  // (or a brand-new one) through a github-kind connector.
+  const [repoSource, setRepoSource] = useState<RepoSource>('none')
+  const [githubConnectors, setGithubConnectors] = useState<AdminConnector[] | null>(null)
+  const [connectorID, setConnectorID] = useState('')
+  const [repos, setRepos] = useState<GitHubRepo[] | null>(null)
+  const [reposLoading, setReposLoading] = useState(false)
+  const [reposError, setReposError] = useState<string | null>(null)
+  const [repoQuery, setRepoQuery] = useState('')
+  const [selectedRepo, setSelectedRepo] = useState<GitHubRepo | null>(null)
+  const [connIdentity, setConnIdentity] = useState<GitHubIdentity | null>(null)
+  const [repoPickerOpen, setRepoPickerOpen] = useState(false)
+  const [newRepo, setNewRepo] = useState(false)
+  const [newRepoName, setNewRepoName] = useState('')
+  const [newRepoPrivate, setNewRepoPrivate] = useState(true)
+
+  // Consent-at-create for the mission's auto-completion action —
+  // resets whenever the GitHub source is unpicked, since on_complete is
+  // only ever valid alongside repo_url/connector_id.
+  const [onComplete, setOnComplete] = useState<OnComplete>('')
+  useEffect(() => {
+    if (repoSource !== 'github') setOnComplete('')
+  }, [repoSource])
+
+  // Fetch github-kind connectors once the operator picks the GitHub
+  // source — most missions never touch this, so it's not loaded
+  // upfront with agents/routes.
+  useEffect(() => {
+    if (repoSource !== 'github' || githubConnectors !== null) return
+    listConnectors()
+      .then((all) => setGithubConnectors(all.filter((c) => c.kind === 'github' && c.enabled)))
+      .catch(() => setGithubConnectors([]))
+  }, [repoSource, githubConnectors])
+
+  // Fetch the connector's repo list whenever it changes — best-effort,
+  // an error surfaces inline rather than blocking the form.
+  useEffect(() => {
+    if (repoSource !== 'github' || !connectorID) {
+      setRepos(null)
+      return
+    }
+    setReposLoading(true)
+    setReposError(null)
+    listConnectorRepos(connectorID)
+      .then(setRepos)
+      .catch((err) => setReposError(errText(err)))
+      .finally(() => setReposLoading(false))
+  }, [repoSource, connectorID])
+
+  // Resolve the connection's GitHub identity so the Deployment section
+  // can say who commits and PRs will be authored as — best-effort, an
+  // unresolved identity just hides the line.
+  useEffect(() => {
+    if (repoSource !== 'github' || !connectorID) {
+      setConnIdentity(null)
+      return
+    }
+    testConnector(connectorID)
+      .then((res) => setConnIdentity(res.identity ?? null))
+      .catch(() => setConnIdentity(null))
+  }, [repoSource, connectorID])
+
+  const filteredRepos = useMemo(() => {
+    if (!repos) return []
+    const q = repoQuery.trim().toLowerCase()
+    if (!q) return repos
+    return repos.filter((r) => r.full_name.toLowerCase().includes(q))
+  }, [repos, repoQuery])
 
   // Live executor pairing/usability preview: coding-only, refetched
   // whenever the kind flips to coding or the route selection changes.
@@ -299,12 +390,28 @@ export function MissionForm({
     setCronError(null)
   }
 
+  // A GitHub source is only meaningful once it can actually resolve to
+  // a clone URL: an existing repo picked, or a new-repo name typed.
+  const githubSourceReady =
+    repoSource !== 'github' ||
+    !!connectorID && (newRepo ? newRepoName.trim() !== '' : !!selectedRepo)
+
   const canSubmit =
     mode === 'edit'
       ? scheduleName.trim() !== '' && goal.trim() !== '' && validCronShape(cron)
-      : goal.trim() !== '' && (!repeat || validCronShape(cron))
+      : goal.trim() !== '' && (!repeat || validCronShape(cron)) && githubSourceReady
 
   const submitMission = async () => {
+    let repoURL: string | undefined
+    if (kind === 'coding' && repoSource === 'github' && connectorID) {
+      const repo = newRepo
+        ? await createConnectorRepo(connectorID, {
+            name: newRepoName.trim(),
+            private: newRepoPrivate,
+          })
+        : selectedRepo
+      repoURL = repo?.clone_url
+    }
     const { id } = await createMission({
       goal: goal.trim(),
       kind,
@@ -317,6 +424,9 @@ export function MissionForm({
       auto_approve_safe: autoApproveSafe,
       harness: kind === 'coding' ? harness || undefined : undefined,
       environment: kind === 'coding' ? environment || undefined : undefined,
+      repo_url: repoURL,
+      connector_id: repoURL ? connectorID : undefined,
+      on_complete: repoURL && onComplete ? onComplete : undefined,
     })
     toast.success('Mission created')
     onDone({ kind: 'mission', id })
@@ -429,6 +539,211 @@ export function MissionForm({
           </p>
         )}
       </section>
+
+      {kind === 'coding' && mode === 'create' && !repeat && (
+        <section className="space-y-3">
+          <div>
+            <h2 className="text-sm font-semibold">Repository</h2>
+            <p className="text-sm text-muted-foreground">
+              Work in a fresh scratch repo, or clone an existing GitHub repo.
+            </p>
+          </div>
+
+          <div className="inline-flex rounded-lg bg-muted p-1 text-sm">
+            <button
+              type="button"
+              onClick={() => setRepoSource('none')}
+              aria-pressed={repoSource === 'none'}
+              className={`rounded-md px-3 py-1.5 font-medium transition ${
+                repoSource === 'none' ? 'bg-background shadow-sm' : 'text-muted-foreground'
+              }`}
+            >
+              None
+            </button>
+            <button
+              type="button"
+              onClick={() => setRepoSource('github')}
+              aria-pressed={repoSource === 'github'}
+              className={`rounded-md px-3 py-1.5 font-medium transition ${
+                repoSource === 'github' ? 'bg-background shadow-sm' : 'text-muted-foreground'
+              }`}
+            >
+              GitHub
+            </button>
+          </div>
+
+          {repoSource === 'github' && (
+            <div className="space-y-3 rounded-lg border border-border p-4">
+              {githubConnectors === null ? (
+                <p className="text-sm text-muted-foreground">Loading connectors…</p>
+              ) : githubConnectors.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No GitHub connectors configured yet.{' '}
+                  <Link to="/settings/connectors" className="underline underline-offset-2">
+                    Add one in Settings → Connectors
+                  </Link>
+                  .
+                </p>
+              ) : (
+                <>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="mission-connector">Connector</Label>
+                    <Select
+                      value={connectorID}
+                      onValueChange={(v) => {
+                        setConnectorID(v)
+                        setSelectedRepo(null)
+                        setRepoQuery('')
+                      }}
+                    >
+                      <SelectTrigger id="mission-connector" className="w-full">
+                        <SelectValue placeholder="Choose a connector" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {githubConnectors.map((c) => (
+                          <SelectItem key={c.id} value={c.id}>
+                            {c.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  {connectorID && !newRepo && (
+                    <div className="space-y-1.5">
+                      <Label>Repository</Label>
+                      <Popover open={repoPickerOpen} onOpenChange={setRepoPickerOpen}>
+                        <PopoverTrigger asChild>
+                          <Button
+                            variant="outline"
+                            className="w-full justify-start font-normal"
+                            disabled={reposLoading}
+                          >
+                            {reposLoading
+                              ? 'Loading repos…'
+                              : (selectedRepo?.full_name ?? 'Choose a repository')}
+                          </Button>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-(--radix-popover-trigger-width) p-0">
+                          <Command shouldFilter={false}>
+                            <CommandInput
+                              placeholder="Filter repositories…"
+                              value={repoQuery}
+                              onValueChange={setRepoQuery}
+                            />
+                            <CommandList>
+                              <CommandEmpty>
+                                {reposError ? `Could not load repos: ${reposError}` : 'No matches.'}
+                              </CommandEmpty>
+                              {filteredRepos.map((r) => (
+                                <CommandItem
+                                  key={r.full_name}
+                                  value={r.full_name}
+                                  onSelect={() => {
+                                    setSelectedRepo(r)
+                                    setRepoPickerOpen(false)
+                                  }}
+                                >
+                                  <span className="truncate">{r.full_name}</span>
+                                  {r.private && (
+                                    <Badge variant="outline" className="ml-auto shrink-0">
+                                      Private
+                                    </Badge>
+                                  )}
+                                </CommandItem>
+                              ))}
+                            </CommandList>
+                          </Command>
+                        </PopoverContent>
+                      </Popover>
+                    </div>
+                  )}
+
+                  {connectorID && (
+                    <label
+                      htmlFor="mission-new-repo"
+                      className="flex items-center gap-2 text-sm"
+                    >
+                      <input
+                        id="mission-new-repo"
+                        type="checkbox"
+                        checked={newRepo}
+                        onChange={(e) => {
+                          setNewRepo(e.target.checked)
+                          setSelectedRepo(null)
+                        }}
+                      />
+                      New repository
+                    </label>
+                  )}
+
+                  {connectorID && newRepo && (
+                    <div className="grid gap-3 sm:grid-cols-[1fr_auto]">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="mission-new-repo-name">Name</Label>
+                        <Input
+                          id="mission-new-repo-name"
+                          value={newRepoName}
+                          onChange={(e) => setNewRepoName(e.target.value)}
+                          placeholder="my-new-repo"
+                        />
+                      </div>
+                      <label
+                        htmlFor="mission-new-repo-private"
+                        className="flex items-end gap-2 pb-2 text-sm"
+                      >
+                        <input
+                          id="mission-new-repo-private"
+                          type="checkbox"
+                          checked={newRepoPrivate}
+                          onChange={(e) => setNewRepoPrivate(e.target.checked)}
+                        />
+                        Private
+                      </label>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+
+          {repoSource === 'github' && githubSourceReady && (
+            <div className="space-y-1.5">
+              <Label htmlFor="mission-on-complete">Deployment</Label>
+              <Select
+                value={onComplete || ON_COMPLETE_NONE}
+                onValueChange={(v) =>
+                  setOnComplete(v === ON_COMPLETE_NONE ? '' : (v as OnComplete))
+                }
+              >
+                <SelectTrigger id="mission-on-complete" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {onCompleteChoices.map((c) => (
+                    <SelectItem key={c.value} value={c.value}>
+                      {c.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                What happens automatically when the mission finishes. A human always chooses this
+                up front — the model never decides.
+              </p>
+              {connIdentity && (
+                <p className="text-xs text-muted-foreground">
+                  Commits and pull requests will be authored as{' '}
+                  <span className="font-medium text-foreground">
+                    {connIdentity.name || connIdentity.login}
+                  </span>{' '}
+                  ({connIdentity.email})
+                </p>
+              )}
+            </div>
+          )}
+        </section>
+      )}
 
       <section className="space-y-3">
         <div>

--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -25,6 +25,40 @@ describe('mission.unit_verified rendering', () => {
   })
 })
 
+describe('mission.pushed rendering', () => {
+  it('names the branch and remote host', () => {
+    expect(renderEvent(event({ branch: 'mission/x', remote_host: 'github.com' }, 'mission.pushed'))).toBe(
+      'Pushed mission/x to github.com',
+    )
+  })
+})
+
+describe('mission.push_failed rendering', () => {
+  it('names the failure reason', () => {
+    expect(renderEvent(event({ reason: 'push rejected' }, 'mission.push_failed'))).toBe(
+      'Push failed: push rejected',
+    )
+  })
+
+  it('falls back to "unknown reason" when the payload has none', () => {
+    expect(renderEvent(event({}, 'mission.push_failed'))).toBe('Push failed: unknown reason')
+  })
+})
+
+describe('mission.pr_opened rendering', () => {
+  it('renders a link to the PR number', () => {
+    render(
+      <div>
+        {renderEvent(
+          event({ url: 'https://github.com/octocat/hello-world/pull/9', number: 9 }, 'mission.pr_opened'),
+        )}
+      </div>,
+    )
+    const link = screen.getByRole('link', { name: '#9' })
+    expect(link).toHaveAttribute('href', 'https://github.com/octocat/hello-world/pull/9')
+  })
+})
+
 describe('executor.result rendering', () => {
   const resultPayload = (cost_usd: number | null, cost_usd_billed = false) => ({
     status: 'ok',

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -7,6 +7,7 @@ import type {
   ExecutorSkippedPayload,
   ExecutorSpawnedPayload,
   MissionEvent,
+  MissionPROpenedPayload,
   MissionSteeredPayload,
 } from '../../api/types'
 import { formatDuration } from '../../lib/format'
@@ -97,6 +98,17 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
   'mission.push_failed': (p) => {
     const { reason } = asRecord(p)
     return `Push failed: ${String(reason ?? 'unknown reason')}`
+  },
+  'mission.pr_opened': (p) => {
+    const { url, number } = p as MissionPROpenedPayload
+    return (
+      <span>
+        Pull request opened:{' '}
+        <a href={url} target="_blank" rel="noreferrer" className="underline underline-offset-2 hover:text-foreground">
+          #{number}
+        </a>
+      </span>
+    )
   },
   'executor.spawned': (p) => {
     const { harness, provider, model, auth_mode } = p as ExecutorSpawnedPayload

--- a/web/src/components/settings/ConnectorAdd.tsx
+++ b/web/src/components/settings/ConnectorAdd.tsx
@@ -10,6 +10,7 @@ import {
   setSecret,
   testConnector,
 } from '../../api/client'
+import type { GitHubIdentity } from '../../api/types'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { ConnectorLogo } from './ConnectorLogo'
@@ -27,11 +28,11 @@ function slugify(v: string): string {
     .replace(/^-+|-+$/g, '')
 }
 
-// ConnectorAdd is preset-aware and its own page: MCP presets are
-// created, tested, and enabled in one go with Add gated on a passing
-// test (same contract as adding a provider); Google presets take the
-// OAuth client and hand off to Google's consent screen instead — there
-// is no unsaved test to run before that redirect.
+// ConnectorAdd is preset-aware and its own page: MCP and github presets
+// are created, tested, and enabled in one go with Add gated on a
+// passing test (same contract as adding a provider); Google presets
+// take the OAuth client and hand off to Google's consent screen
+// instead — there is no unsaved test to run before that redirect.
 export function ConnectorAdd() {
   const { presetId } = useParams()
   const navigate = useNavigate()
@@ -44,9 +45,11 @@ export function ConnectorAdd() {
   const [clientID, setClientID] = useState('')
   const [clientSecret, setClientSecret] = useState('')
   const [busy, setBusy] = useState(false)
-  const [test, setTest] = useState<{ ok: boolean; error?: string } | null>(null)
+  const [test, setTest] = useState<{ ok: boolean; error?: string; identity?: GitHubIdentity } | null>(
+    null,
+  )
   // The connector row is created (disabled) as part of testing an MCP
-  // preset — there's no unsaved-config validate endpoint like
+  // or github preset — there's no unsaved-config validate endpoint like
   // providers have. createdID tracks that row so a passing test's
   // Add just enables it rather than creating a second one.
   const [createdID, setCreatedID] = useState<string | null>(null)
@@ -66,6 +69,7 @@ export function ConnectorAdd() {
 
   if (!preset) return <Navigate to="/settings/connectors" replace />
   const isGoogle = preset.kind === 'google'
+  const isGitHub = preset.kind === 'github'
   const slug = slugify(name)
   const refBase = slug.toUpperCase().replace(/-/g, '_')
   const tested = test?.ok === true
@@ -80,22 +84,38 @@ export function ConnectorAdd() {
       toast.error('Name required', { description: 'Give this connector a unique name before testing.' })
       return
     }
-    if (!endpoint.trim()) {
+    if (!isGitHub && !endpoint.trim()) {
       toast.error('Endpoint required', { description: 'An MCP endpoint is required to test this connector.' })
+      return
+    }
+    if (isGitHub && !token.trim()) {
+      toast.error('Token required', { description: 'A personal access token is required to test this connector.' })
       return
     }
     setBusy(true)
     setTest(null)
     try {
-      const tokenRef = `${refBase}_MCP_TOKEN`
+      // Suffix without stuttering: a name already ending in the flavor
+      // word ("github", "github-mcp") gets the bare _PAT/_TOKEN suffix.
+      const tokenRef = isGitHub
+        ? refBase.endsWith('GITHUB')
+          ? `${refBase}_PAT`
+          : `${refBase}_GITHUB_PAT`
+        : refBase.endsWith('_MCP')
+          ? `${refBase}_TOKEN`
+          : `${refBase}_MCP_TOKEN`
       if (token) await setSecret(tokenRef, token.trim())
-      const id = await createConnector({
-        name: slug,
-        kind: 'mcp',
-        config: { endpoint: endpoint.trim() },
-        credential_ref: token ? tokenRef : '',
-        enabled: false,
-      })
+      const id = await createConnector(
+        isGitHub
+          ? { name: slug, kind: 'github', config: {}, credential_ref: tokenRef, enabled: false }
+          : {
+              name: slug,
+              kind: 'mcp',
+              config: { endpoint: endpoint.trim() },
+              credential_ref: token ? tokenRef : '',
+              enabled: false,
+            },
+      )
       setCreatedID(id)
       setTest(await testConnector(id))
     } catch (err) {
@@ -110,7 +130,11 @@ export function ConnectorAdd() {
     setBusy(true)
     try {
       await patchConnector(createdID, { enabled: true })
-      toast.success('Connector added', { description: `${slug} is connected and tools are servable.` })
+      toast.success('Connector added', {
+        description: isGitHub
+          ? `${slug} is connected; its identity is ready for mission use.`
+          : `${slug} is connected and tools are servable.`,
+      })
       navigate('/settings/connectors')
     } catch (err) {
       toast.error('Could not enable connector', { description: errText(err) })
@@ -142,7 +166,7 @@ export function ConnectorAdd() {
     }
   }
 
-  const canTest = slug !== '' && endpoint.trim() !== ''
+  const canTest = slug !== '' && (isGitHub ? token.trim() !== '' : endpoint.trim() !== '')
   const canSubmitGoogle = slug !== '' && clientID.trim() !== '' && clientSecret !== ''
 
   return (
@@ -216,22 +240,30 @@ export function ConnectorAdd() {
           </>
         ) : (
           <>
-            <Field label="Endpoint">
-              <Input
-                value={endpoint}
-                onChange={(e) => {
-                  setEndpoint(e.target.value)
-                  invalidate()
-                }}
-                placeholder="https://…/mcp"
-                className="mt-1.5 h-10"
-              />
-            </Field>
-            {preset.endpointHint && (
-              <p className="-mt-3 text-sm text-muted-foreground">{preset.endpointHint}</p>
+            {!isGitHub && (
+              <>
+                <Field label="Endpoint">
+                  <Input
+                    value={endpoint}
+                    onChange={(e) => {
+                      setEndpoint(e.target.value)
+                      invalidate()
+                    }}
+                    placeholder="https://…/mcp"
+                    className="mt-1.5 h-10"
+                  />
+                </Field>
+                {preset.endpointHint && (
+                  <p className="-mt-3 text-sm text-muted-foreground">{preset.endpointHint}</p>
+                )}
+              </>
             )}
             <div>
-              <Field label={preset.id === 'custom-mcp' ? 'Bearer token (optional)' : 'Bearer token'}>
+              <Field
+                label={
+                  isGitHub ? 'Personal access token' : preset.id === 'custom-mcp' ? 'Bearer token (optional)' : 'Bearer token'
+                }
+              >
                 <Input
                   type="password"
                   value={token}
@@ -245,8 +277,29 @@ export function ConnectorAdd() {
                 />
               </Field>
               <p className="mt-1.5 text-sm text-muted-foreground">
-                {preset.tokenHint ? `${preset.tokenHint} ` : ''}
-                {secretDestination(defaultBackend, `${refBase}_MCP_TOKEN`)}
+                {preset.tokenHint}
+                {preset.tokenURL && (
+                  <>
+                    {' '}
+                    <a
+                      href={preset.tokenURL}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+                    >
+                      Create one on GitHub →
+                    </a>
+                  </>
+                )}
+                {!preset.tokenURL && (
+                  <>
+                    {' '}
+                    {secretDestination(
+                      defaultBackend,
+                      isGitHub ? `${refBase}_GITHUB_PAT` : `${refBase}_MCP_TOKEN`,
+                    )}
+                  </>
+                )}
               </p>
             </div>
 
@@ -264,7 +317,9 @@ export function ConnectorAdd() {
                 {busy
                   ? 'Testing connection…'
                   : tested
-                    ? 'Connection OK, tools are servable.'
+                    ? isGitHub && test?.identity
+                      ? `Connected as ${test.identity.login} (${test.identity.email}), ${test.identity.scopes}.`
+                      : 'Connection OK, tools are servable.'
                     : test && !test.ok
                       ? `Connection failed: ${test.error}. The connector was saved disabled, fix and retry.`
                       : 'Not tested yet, run a test before adding.'}

--- a/web/src/components/settings/ConnectorEdit.tsx
+++ b/web/src/components/settings/ConnectorEdit.tsx
@@ -11,7 +11,7 @@ import {
   setSecret,
   testConnector,
 } from '../../api/client'
-import type { AdminConnector } from '../../api/types'
+import type { AdminConnector, GitHubIdentity } from '../../api/types'
 import { Button } from '../ui/button'
 import {
   Dialog,
@@ -32,7 +32,9 @@ export function ConnectorEdit() {
 
   const [connector, setConnector] = useState<AdminConnector | null | undefined>(undefined)
   const [confirmDelete, setConfirmDelete] = useState(false)
-  const [test, setTest] = useState<{ ok: boolean; error?: string } | null>(null)
+  const [test, setTest] = useState<{ ok: boolean; error?: string; identity?: GitHubIdentity } | null>(
+    null,
+  )
   const [testing, setTesting] = useState(false)
   const [token, setToken] = useState('')
   const [savingToken, setSavingToken] = useState(false)
@@ -74,7 +76,8 @@ export function ConnectorEdit() {
     if (!connector || !token) return
     setSavingToken(true)
     try {
-      const ref = connector.credential_ref || `${connector.name.toUpperCase().replace(/-/g, '_')}_MCP_TOKEN`
+      const suffix = connector.kind === 'github' ? '_GITHUB_PAT' : '_MCP_TOKEN'
+      const ref = connector.credential_ref || `${connector.name.toUpperCase().replace(/-/g, '_')}${suffix}`
       await setSecret(ref, token.trim())
       if (!connector.credential_ref) await patchConnector(connector.id, { credential_ref: ref })
       setToken('')
@@ -164,7 +167,9 @@ export function ConnectorEdit() {
             {testing
               ? 'Testing connection…'
               : test?.ok
-                ? 'Connection OK, tools are servable.'
+                ? connector.kind === 'github' && test.identity
+                  ? `Connected as ${test.identity.login} (${test.identity.email}), ${test.identity.scopes}.`
+                  : 'Connection OK, tools are servable.'
                 : test && !test.ok
                   ? `Failed: ${test.error}`
                   : 'Not tested yet.'}
@@ -186,9 +191,15 @@ export function ConnectorEdit() {
         ) : (
           <div className="space-y-3">
             <p className="text-sm text-muted-foreground">
-              Endpoint: <span className="font-mono">{String(connector.config.endpoint ?? '')}</span>
+              {connector.kind === 'github' ? (
+                'Identity for mission clone/push/PR use, no chat tools.'
+              ) : (
+                <>
+                  Endpoint: <span className="font-mono">{String(connector.config.endpoint ?? '')}</span>
+                </>
+              )}
             </p>
-            <Field label="Rotate bearer token">
+            <Field label={connector.kind === 'github' ? 'Rotate personal access token' : 'Rotate bearer token'}>
               <div className="mt-1.5 flex gap-2">
                 <Input
                   type="password"

--- a/web/src/components/settings/ConnectorsList.tsx
+++ b/web/src/components/settings/ConnectorsList.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router'
 import { toast } from 'sonner'
 import { listConnectors, patchConnector, testConnector } from '../../api/client'
-import type { AdminConnector } from '../../api/types'
+import type { AdminConnector, GitHubIdentity } from '../../api/types'
 import { Button } from '../ui/button'
 import { ConnectorLogo } from './ConnectorLogo'
 import { connectorPresets, unknownPreset } from './connectorPresets'
@@ -110,7 +110,9 @@ function ConnectorCard({
 }) {
   const preset = connectorPresets.find((p) => matchesPreset(connector, p)) ?? unknownPreset
   const [testing, setTesting] = useState(false)
-  const [test, setTest] = useState<{ ok: boolean; error?: string } | null>(null)
+  const [test, setTest] = useState<{ ok: boolean; error?: string; identity?: GitHubIdentity } | null>(
+    null,
+  )
 
   const toggle = (enabled: boolean) => {
     patchConnector(connector.id, { enabled }).then(onChanged, (err: unknown) =>
@@ -151,14 +153,20 @@ function ConnectorCard({
       <div className="truncate text-xs text-muted-foreground">
         {connector.kind === 'mcp'
           ? String(connector.config.endpoint ?? '')
-          : (connector.config.scopes as string[] | undefined)?.map((s) => s.split('/').pop()).join(', ')}
+          : connector.kind === 'google'
+            ? (connector.config.scopes as string[] | undefined)?.map((s) => s.split('/').pop()).join(', ')
+            : 'Identity for mission use, no chat tools'}
       </div>
 
       {test && (
         <div
           className={`rounded-lg border p-2 text-xs ${test.ok ? 'border-good/30 bg-good-soft text-good' : 'border-destructive/30 bg-destructive/5 text-destructive'}`}
         >
-          {test.ok ? 'Connection OK' : `Failed: ${test.error}`}
+          {test.ok
+            ? test.identity
+              ? `Connected as ${test.identity.login} (${test.identity.email})`
+              : 'Connection OK'
+            : `Failed: ${test.error}`}
         </div>
       )}
 
@@ -174,12 +182,16 @@ function ConnectorCard({
   )
 }
 
-function matchesPreset(c: AdminConnector, p: { kind: 'mcp' | 'google'; scopes?: string[]; endpoint?: string }) {
+function matchesPreset(
+  c: AdminConnector,
+  p: { kind: 'mcp' | 'google' | 'github'; scopes?: string[]; endpoint?: string },
+) {
   if (p.kind !== c.kind) return false
   if (c.kind === 'google') {
     const scopes = JSON.stringify(c.config.scopes ?? '')
     return p.scopes?.every((s) => scopes.includes(s)) ?? false
   }
+  if (c.kind === 'github') return true
   const endpoint = String(c.config.endpoint ?? '')
   return !!p.endpoint && endpoint.startsWith(p.endpoint)
 }

--- a/web/src/components/settings/ConnectorsTab.test.tsx
+++ b/web/src/components/settings/ConnectorsTab.test.tsx
@@ -64,8 +64,16 @@ describe('Connectors tab', () => {
     renderTab()
     expect(await screen.findByText('Your connectors · 1')).toBeTruthy()
     expect(screen.getByText('calendar')).toBeTruthy()
-    for (const name of ['Gmail', 'Google Calendar', 'GitHub']) {
-      expect(screen.getByRole('button', { name: new RegExp(name) })).toBeTruthy()
+    // Accessible names concatenate the tile's title and description
+    // (e.g. "GmailRead, search, and send email"), so match the title as
+    // a strict prefix up to where its description begins.
+    for (const [name, description] of [
+      ['Gmail', 'Read'],
+      ['Google Calendar', 'List'],
+      ['GitHub MCP', 'Issues'],
+      ['GitHub', 'Identity'],
+    ]) {
+      expect(screen.getByRole('button', { name: new RegExp(`^${name}${description}`) })).toBeTruthy()
     }
   })
 
@@ -110,7 +118,7 @@ describe('Connectors tab', () => {
     vi.mocked(patchConnector).mockResolvedValue()
 
     renderTab()
-    fireEvent.click(await screen.findByRole('button', { name: /GitHub/ }))
+    fireEvent.click(await screen.findByRole('button', { name: /^GitHub MCPIssues/ }))
     fireEvent.change(await screen.findByPlaceholderText('ghp_… or github_pat_…'), {
       target: { value: 'ghp_abc' },
     })
@@ -123,7 +131,7 @@ describe('Connectors tab', () => {
     await waitFor(() => expect(patchConnector).toHaveBeenCalledWith('c2', { enabled: true }))
     expect(setSecret).toHaveBeenCalledWith('GITHUB_MCP_TOKEN', 'ghp_abc')
     expect(createConnector).toHaveBeenCalledWith({
-      name: 'github',
+      name: 'github-mcp',
       kind: 'mcp',
       config: { endpoint: 'https://api.githubcopilot.com/mcp/' },
       credential_ref: 'GITHUB_MCP_TOKEN',
@@ -137,7 +145,7 @@ describe('Connectors tab', () => {
     vi.mocked(testConnector).mockResolvedValue({ ok: false, error: 'status 401' })
 
     renderTab()
-    fireEvent.click(await screen.findByRole('button', { name: /GitHub/ }))
+    fireEvent.click(await screen.findByRole('button', { name: /^GitHub MCPIssues/ }))
     fireEvent.change(await screen.findByPlaceholderText('ghp_… or github_pat_…'), {
       target: { value: 'bad-token' },
     })
@@ -147,7 +155,7 @@ describe('Connectors tab', () => {
     expect(patchConnector).not.toHaveBeenCalled()
     expect((screen.getByRole('button', { name: 'Add connector' }) as HTMLButtonElement).disabled).toBe(true)
     expect(createConnector).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'github', enabled: false }),
+      expect.objectContaining({ name: 'github-mcp', enabled: false }),
     )
   })
 

--- a/web/src/components/settings/connectorPresets.ts
+++ b/web/src/components/settings/connectorPresets.ts
@@ -4,15 +4,18 @@
 export interface ConnectorPreset {
   id: string
   name: string
-  kind: 'mcp' | 'google'
+  kind: 'mcp' | 'google' | 'github'
   description: string
   logo?: string
   brandColor: string
   // mcp: default endpoint ('' = user must enter one)
   endpoint?: string
   endpointHint?: string
+  // mcp, github: PAT/bearer token input copy
   tokenPlaceholder?: string
   tokenHint?: string
+  // github: link rendered after tokenHint (e.g. "Create one on GitHub")
+  tokenURL?: string
   // google: OAuth scopes this preset requests
   scopes?: string[]
 }
@@ -41,7 +44,7 @@ export const connectorPresets: ConnectorPreset[] = [
   },
   {
     id: 'github',
-    name: 'GitHub',
+    name: 'GitHub MCP',
     kind: 'mcp',
     description: 'Issues, PRs, code, via MCP',
     logo: 'github',
@@ -49,6 +52,18 @@ export const connectorPresets: ConnectorPreset[] = [
     endpoint: 'https://api.githubcopilot.com/mcp/',
     tokenPlaceholder: 'ghp_… or github_pat_…',
     tokenHint: 'A personal access token; fine-grained tokens work. github.com/settings/tokens',
+  },
+  {
+    id: 'github-account',
+    name: 'GitHub',
+    kind: 'github',
+    description: 'Identity for mission clone/push/PR, no chat tools',
+    logo: 'github',
+    brandColor: '#24292F',
+    tokenPlaceholder: 'ghp_… or github_pat_…',
+    tokenHint:
+      'Fine-grained personal access token — grant Contents (read and write) and Pull requests on the repositories Timothy may work with.',
+    tokenURL: 'https://github.com/settings/personal-access-tokens/new',
   },
 ]
 

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -21,6 +21,8 @@ vi.mock('../api/client', () => ({
   listSchedules: vi.fn(),
   downloadMissionFile: vi.fn(),
   downloadMissionArchive: vi.fn(),
+  pushMission: vi.fn(),
+  openMissionPR: vi.fn(),
 }))
 
 import {
@@ -32,6 +34,8 @@ import {
   listSchedules,
   missionEvents,
   missionUsage,
+  openMissionPR,
+  pushMission,
   resumeMission,
   sendMissionNote,
 } from '../api/client'
@@ -415,6 +419,29 @@ describe('MissionDetail environment pill', () => {
   })
 })
 
+describe('MissionDetail on_complete badge', () => {
+  it('shows the auto-push badge when on_complete is push', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, on_complete: 'push' })
+    renderPage()
+    expect(await screen.findByText('auto-push')).toBeTruthy()
+    expect(screen.queryByText('auto-PR')).toBeNull()
+  })
+
+  it('shows the auto-PR badge when on_complete is push_pr', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, on_complete: 'push_pr' })
+    renderPage()
+    expect(await screen.findByText('auto-PR')).toBeTruthy()
+    expect(screen.queryByText('auto-push')).toBeNull()
+  })
+
+  it('omits both badges when on_complete is empty', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(screen.queryByText('auto-push')).toBeNull()
+    expect(screen.queryByText('auto-PR')).toBeNull()
+  })
+})
+
 describe('MissionDetail', () => {
   it('renders mission header, plan, and progress', async () => {
     renderPage()
@@ -427,6 +454,25 @@ describe('MissionDetail', () => {
     renderPage()
     await screen.findByText('Fix the login bug')
     expect(screen.queryByText(/Allow/)).toBeNull()
+  })
+
+  it('shows a linked GitHub origin beside the branch when repo_url is set', async () => {
+    vi.mocked(getMission).mockResolvedValue({
+      ...baseMission,
+      repo_url: 'https://github.com/octocat/hello-world.git',
+    })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+
+    const link = screen.getByRole('link', { name: 'octocat/hello-world' })
+    expect(link).toHaveAttribute('href', 'https://github.com/octocat/hello-world')
+    expect(link).toHaveAttribute('target', '_blank')
+  })
+
+  it('omits the GitHub origin link when repo_url is not set', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(screen.queryByRole('link', { name: /octocat/ })).toBeNull()
   })
 
   it('shows the generated name in the header instead of the goal when set', async () => {
@@ -731,14 +777,14 @@ describe('MissionDetail', () => {
   it('hides delete for a non-terminal mission', async () => {
     renderPage()
     await screen.findByText('Fix the login bug')
-    expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Delete mission' })).toBeNull()
   })
 
   it('shows delete for a done mission and deletes on confirm', async () => {
     vi.mocked(getMission).mockResolvedValue({ ...baseMission, phase: 'done', status: 'done' })
     renderPage()
     await screen.findByText('Fix the login bug')
-    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete mission' }))
     const dialog = await screen.findByRole('dialog')
     fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
     await waitFor(() => expect(deleteMission).toHaveBeenCalledWith('m1'))
@@ -822,5 +868,101 @@ describe('MissionDetail', () => {
     renderPage()
     await screen.findByText('Fix the login bug')
     expect(screen.queryByText(/Recurring ·/)).toBeNull()
+  })
+})
+
+describe('MissionDetail push/PR (github-connection missions)', () => {
+  it('shows Push branch and Push & open PR only for a mission with connector_id', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, connector_id: 'conn-1' })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(screen.getByRole('button', { name: 'Push branch' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Push & open PR' })).toBeTruthy()
+  })
+
+  it('omits the push/PR buttons for a mission without connector_id', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(screen.queryByRole('button', { name: 'Push branch' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Push & open PR' })).toBeNull()
+  })
+
+  it('pushes the branch on click', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, connector_id: 'conn-1' })
+    vi.mocked(pushMission).mockResolvedValue({ branch: 'mission/fix-login', remote_host: 'github.com' })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Push branch' }))
+    await waitFor(() => expect(pushMission).toHaveBeenCalledWith('m1'))
+  })
+
+  it('opens a PR on click and shows the resulting chip immediately', async () => {
+    vi.mocked(getMission).mockResolvedValue({
+      ...baseMission,
+      connector_id: 'conn-1',
+      repo_url: 'https://github.com/octocat/hello-world.git',
+    })
+    vi.mocked(openMissionPR).mockResolvedValue({
+      url: 'https://github.com/octocat/hello-world/pull/9',
+      number: 9,
+    })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Push & open PR' }))
+    await waitFor(() => expect(openMissionPR).toHaveBeenCalledWith('m1'))
+
+    const link = await screen.findByRole('link', { name: 'PR #9' })
+    expect(link).toHaveAttribute('href', 'https://github.com/octocat/hello-world/pull/9')
+  })
+
+  it('renders the PR chip from a prior mission.pr_opened event on load, with no click needed', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, connector_id: 'conn-1' })
+    vi.mocked(missionEvents).mockResolvedValue([
+      ...events,
+      {
+        mission_id: 'm1',
+        seq: 5,
+        kind: 'mission.pr_opened',
+        payload: { url: 'https://github.com/octocat/hello-world/pull/12', number: 12 },
+        provenance: 'live',
+        created_at: '2026-01-01T00:04:00Z',
+      },
+    ])
+    renderPage()
+    const link = await screen.findByRole('link', { name: 'PR #12' })
+    expect(link).toHaveAttribute('href', 'https://github.com/octocat/hello-world/pull/12')
+  })
+
+  it('shows an error toast when the push fails', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, connector_id: 'conn-1' })
+    vi.mocked(pushMission).mockRejectedValue(new Error('push failed'))
+    renderPage()
+    await screen.findByText('Fix the login bug')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Push branch' }))
+    await waitFor(() => expect(pushMission).toHaveBeenCalled())
+    expect(screen.getByRole('button', { name: 'Push branch' })).not.toBeDisabled()
+  })
+
+  it('hides Push & open PR once a PR exists, keeping the push button and the PR chip', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, connector_id: 'conn-1' })
+    vi.mocked(missionEvents).mockResolvedValue([
+      ...events,
+      {
+        mission_id: 'm1',
+        seq: 5,
+        kind: 'mission.pr_opened',
+        payload: { url: 'https://github.com/octocat/hello-world/pull/12', number: 12 },
+        provenance: 'live',
+        created_at: '2026-01-01T00:04:00Z',
+      },
+    ])
+    renderPage()
+    await screen.findByRole('link', { name: 'PR #12' })
+
+    expect(screen.getByRole('button', { name: 'Push branch' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Push & open PR' })).toBeNull()
   })
 })

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -1,4 +1,9 @@
-import { ArrowLeft01Icon } from '@hugeicons-pro/core-stroke-rounded'
+import {
+  ArrowLeft01Icon,
+  CloudUploadIcon,
+  Delete02Icon,
+  GitPullRequestCreateIcon,
+} from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router'
@@ -11,10 +16,12 @@ import {
   listSchedules,
   missionEvents,
   missionUsage,
+  openMissionPR,
+  pushMission,
   resumeMission,
   sendMissionNote,
 } from '../api/client'
-import type { Mission, MissionEvent, MissionUsage, Schedule } from '../api/types'
+import type { Mission, MissionEvent, MissionPROpenedPayload, MissionUsage, Schedule } from '../api/types'
 import { ArtifactsSection } from '../components/missions/ArtifactsSection'
 import { PermissionBanner } from '../components/missions/PermissionBanner'
 import { PlanSection } from '../components/missions/PlanSection'
@@ -64,6 +71,17 @@ function formatDate(v?: string): string {
   return new Date(v).toLocaleString()
 }
 
+// githubFullName/githubHTMLURL derive the display label and browsable
+// link straight from repo_url's https clone URL — the mission row only
+// stores the clone URL, never a separate html_url.
+function githubFullName(repoURL: string): string {
+  return repoURL.replace(/^https?:\/\/[^/]+\//, '').replace(/\.git$/, '')
+}
+
+function githubHTMLURL(repoURL: string): string {
+  return repoURL.replace(/\.git$/, '')
+}
+
 // turnStats derives the detail view's Turns/Processing figures purely
 // from the mission.turn events the page already fetches — one event
 // per phase run (driver.go's Advance), so counting them is an honest
@@ -85,6 +103,19 @@ function turnStats(events: MissionEvent[]): { turns: number; processingMs: numbe
 
 const resumableStatuses = new Set(['paused', 'waiting_for_input'])
 const terminalPhases = new Set(['done', 'failed'])
+
+// latestPROpened finds the most recent mission.pr_opened event so the
+// PR chip persists across reloads — the timeline is the durable record
+// of a PR having been opened, the immediate POST response is only the
+// optimistic first paint.
+function latestPROpened(events: MissionEvent[]): MissionPROpenedPayload | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i].kind === 'mission.pr_opened') {
+      return events[i].payload as MissionPROpenedPayload
+    }
+  }
+  return null
+}
 
 // latestExecutorProgress finds the most recent executor.progress event
 // so the phase header can show a lightweight live indicator — these
@@ -164,6 +195,14 @@ export function MissionDetail() {
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [noteText, setNoteText] = useState('')
   const [sendingNote, setSendingNote] = useState(false)
+  const [pushing, setPushing] = useState(false)
+  const [openingPR, setOpeningPR] = useState(false)
+  // prInfo is the immediate response from a successful "Push & open PR"
+  // click — shown right away, before the mission.pr_opened event has
+  // necessarily made it into the fetched timeline (refresh() below is
+  // fire-and-forget). latestPROpened(events) is the durable source once
+  // the timeline catches up or the page reloads.
+  const [prInfo, setPRInfo] = useState<MissionPROpenedPayload | null>(null)
   // answeredPermission tracks the pending_permission id the user just
   // decided on, so the card stops being actionable immediately — the
   // decision POST resolves the broker right away, but
@@ -245,6 +284,14 @@ export function MissionDetail() {
 
   const canResume = resumableStatuses.has(mission.status)
   const canCancel = !terminalPhases.has(mission.phase)
+  // isGitHubConnection: a coding mission cloned through a connector —
+  // gets the two-button push affordance; every other mission keeps the
+  // existing single push flow (currently: none rendered — see slice 3
+  // notes). prChip prefers the optimistic click response over the
+  // timeline so it appears the instant the PR is opened, falling back
+  // to the durable mission.pr_opened event on reload/cross-tab.
+  const isGitHubConnection = !!mission.connector_id
+  const prChip = prInfo ?? latestPROpened(events)
 
   const { turns, processingMs } = turnStats(events)
   const executorActivity = terminalPhases.has(mission.phase) ? null : latestExecutorProgress(events)
@@ -315,6 +362,33 @@ export function MissionDetail() {
       toast.error('Could not cancel mission', { description: errText(err) })
     } finally {
       setBusy(false)
+    }
+  }
+
+  const push = async () => {
+    setPushing(true)
+    try {
+      const { branch, remote_host } = await pushMission(id)
+      toast.success(`Pushed ${branch} to ${remote_host}`)
+      refresh()
+    } catch (err) {
+      toast.error('Could not push branch', { description: errText(err) })
+    } finally {
+      setPushing(false)
+    }
+  }
+
+  const openPR = async () => {
+    setOpeningPR(true)
+    try {
+      const pr = await openMissionPR(id)
+      setPRInfo(pr)
+      toast.success(`Pull request #${pr.number} opened`)
+      refresh()
+    } catch (err) {
+      toast.error('Could not open pull request', { description: errText(err) })
+    } finally {
+      setOpeningPR(false)
     }
   }
 
@@ -414,6 +488,32 @@ export function MissionDetail() {
             {mission.branch && (
               <p className="mt-1 text-xs text-muted-foreground">
                 {mission.branch} @ {mission.base_commit?.slice(0, 8)}
+                {mission.repo_url && (
+                  <>
+                    {' · '}
+                    <a
+                      href={githubHTMLURL(mission.repo_url)}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="underline underline-offset-2 hover:text-foreground"
+                    >
+                      {githubFullName(mission.repo_url)}
+                    </a>
+                  </>
+                )}
+                {prChip && (
+                  <>
+                    {' · '}
+                    <a
+                      href={prChip.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="underline underline-offset-2 hover:text-foreground"
+                    >
+                      PR #{prChip.number}
+                    </a>
+                  </>
+                )}
               </p>
             )}
             {schedule && (
@@ -443,23 +543,70 @@ export function MissionDetail() {
               </div>
             )}
           </div>
-          <div className="flex shrink-0 gap-2">
-            {canResume && (
-              <Button variant="outline" disabled={busy} onClick={() => void resume()}>
-                Resume
-              </Button>
-            )}
-            {canCancel && (
-              <Button variant="destructive" disabled={busy} onClick={() => void cancel()}>
-                Cancel
-              </Button>
-            )}
-            {terminalPhases.has(mission.phase) && (
-              <Button variant="destructive" disabled={busy} onClick={() => setConfirmDelete(true)}>
-                Delete
-              </Button>
-            )}
-          </div>
+          <TooltipProvider>
+            <div className="flex shrink-0 gap-2">
+              {isGitHubConnection && mission.branch && (
+                <>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        aria-label="Push branch"
+                        disabled={pushing}
+                        onClick={() => void push()}
+                      >
+                        <HugeiconsIcon icon={CloudUploadIcon} />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Push branch to GitHub</TooltipContent>
+                  </Tooltip>
+                  {!prChip && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          aria-label="Push & open PR"
+                          disabled={openingPR}
+                          onClick={() => void openPR()}
+                        >
+                          <HugeiconsIcon icon={GitPullRequestCreateIcon} />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Push and open a pull request</TooltipContent>
+                    </Tooltip>
+                  )}
+                </>
+              )}
+              {canResume && (
+                <Button variant="outline" disabled={busy} onClick={() => void resume()}>
+                  Resume
+                </Button>
+              )}
+              {canCancel && (
+                <Button variant="destructive" disabled={busy} onClick={() => void cancel()}>
+                  Cancel
+                </Button>
+              )}
+              {terminalPhases.has(mission.phase) && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="destructive"
+                      size="icon"
+                      aria-label="Delete mission"
+                      disabled={busy}
+                      onClick={() => setConfirmDelete(true)}
+                    >
+                      <HugeiconsIcon icon={Delete02Icon} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Delete mission</TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+          </TooltipProvider>
         </div>
         <div className="mt-3 flex flex-wrap items-center gap-1.5">
           {usage &&
@@ -498,6 +645,19 @@ export function MissionDetail() {
                 </Badge>
               )
             })()}
+          {mission.on_complete === 'push' && (
+            <Badge variant="secondary" title="This mission pushes its branch automatically when it finishes">
+              auto-push
+            </Badge>
+          )}
+          {mission.on_complete === 'push_pr' && (
+            <Badge
+              variant="secondary"
+              title="This mission pushes its branch and opens a pull request automatically when it finishes"
+            >
+              auto-PR
+            </Badge>
+          )}
           {usage && usage.requests > 0 && (
             <Badge variant="secondary">
               {compact(usage.input_tokens)}→{compact(usage.output_tokens)} tok

--- a/web/src/pages/Missions.test.tsx
+++ b/web/src/pages/Missions.test.tsx
@@ -79,18 +79,21 @@ describe('Missions board', () => {
     expect(screen.getByText('working')).toBeTruthy()
   })
 
-  it('shows an unread notification strip', async () => {
+  it('shows an unread notification strip, colored amber for paused', async () => {
     const note: Notification = {
       id: 'n1',
       mission_id: 'm1',
       kind: 'paused',
-      message: 'mission m1 is now paused',
+      message: 'Mission - Fix the login bug is paused, needs your intervention.',
       read: false,
       created_at: '2026-01-01T00:00:00Z',
     }
     vi.mocked(listNotifications).mockResolvedValue([note])
     renderPage()
-    expect(await screen.findByText('mission m1 is now paused')).toBeTruthy()
+    const banner = await screen.findByText(
+      'Mission - Fix the login bug is paused, needs your intervention.',
+    )
+    expect(banner.closest('div')).toHaveClass('border-amber-200')
   })
 
   it('does not show read notifications', async () => {
@@ -98,14 +101,76 @@ describe('Missions board', () => {
       id: 'n1',
       mission_id: 'm1',
       kind: 'done',
-      message: 'mission m1 is now done',
+      message: 'Mission - Fix the login bug is done',
       read: true,
       created_at: '2026-01-01T00:00:00Z',
     }
     vi.mocked(listNotifications).mockResolvedValue([note])
     renderPage()
     await waitFor(() => expect(listNotifications).toHaveBeenCalled())
-    expect(screen.queryByText('mission m1 is now done')).toBeNull()
+    expect(screen.queryByText('Mission - Fix the login bug is done')).toBeNull()
+  })
+
+  it('colors a done notification green', async () => {
+    const note: Notification = {
+      id: 'n1',
+      mission_id: 'm1',
+      kind: 'done',
+      message: 'Mission - Fix the login bug is done',
+      read: false,
+      created_at: '2026-01-01T00:00:00Z',
+    }
+    vi.mocked(listNotifications).mockResolvedValue([note])
+    renderPage()
+    const banner = await screen.findByText('Mission - Fix the login bug is done')
+    expect(banner.closest('div')).toHaveClass('border-green-200')
+  })
+
+  it('colors an error notification red', async () => {
+    const note: Notification = {
+      id: 'n1',
+      mission_id: 'm1',
+      kind: 'error',
+      message: 'Mission - Fix the login bug is failed',
+      read: false,
+      created_at: '2026-01-01T00:00:00Z',
+    }
+    vi.mocked(listNotifications).mockResolvedValue([note])
+    renderPage()
+    const banner = await screen.findByText('Mission - Fix the login bug is failed')
+    expect(banner.closest('div')).toHaveClass('border-red-200')
+  })
+
+  it('colors a cancelled (error kind) notification red', async () => {
+    const note: Notification = {
+      id: 'n1',
+      mission_id: 'm1',
+      kind: 'error',
+      message: 'Mission - Fix the login bug is cancelled',
+      read: false,
+      created_at: '2026-01-01T00:00:00Z',
+    }
+    vi.mocked(listNotifications).mockResolvedValue([note])
+    renderPage()
+    const banner = await screen.findByText('Mission - Fix the login bug is cancelled')
+    expect(banner.closest('div')).toHaveClass('border-red-200')
+  })
+
+  it('colors a waiting_for_input notification amber', async () => {
+    const note: Notification = {
+      id: 'n1',
+      mission_id: 'm1',
+      kind: 'waiting_for_input',
+      message: 'Mission - Fix the login bug is waiting for your input.',
+      read: false,
+      created_at: '2026-01-01T00:00:00Z',
+    }
+    vi.mocked(listNotifications).mockResolvedValue([note])
+    renderPage()
+    const banner = await screen.findByText(
+      'Mission - Fix the login bug is waiting for your input.',
+    )
+    expect(banner.closest('div')).toHaveClass('border-amber-200')
   })
 
   it('navigates to the new mission page', async () => {

--- a/web/src/pages/Missions.tsx
+++ b/web/src/pages/Missions.tsx
@@ -9,6 +9,33 @@ import { RecurringSchedules } from '../components/missions/RecurringSchedules'
 import { Button } from '../components/ui/button'
 import { subscribeEvents } from '../lib/events'
 
+// notificationSeverityClasses colors the banner by notification kind —
+// same green/amber/red convention MissionCard's statusColor uses for
+// mission status chips. Any kind not listed here (unanticipated future
+// kind) falls back to the existing amber styling.
+const notificationSeverityClasses: Record<string, string> = {
+  done: 'border-green-200 bg-green-50 text-green-900 dark:border-green-900 dark:bg-green-950 dark:text-green-200',
+  error:
+    'border-red-200 bg-red-50 text-red-900 dark:border-red-900 dark:bg-red-950 dark:text-red-200',
+  paused:
+    'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200',
+  waiting_for_input:
+    'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200',
+}
+
+const notificationDismissClasses: Record<string, string> = {
+  done: 'text-green-700 hover:text-green-900 dark:text-green-400 dark:hover:text-green-200',
+  error: 'text-red-700 hover:text-red-900 dark:text-red-400 dark:hover:text-red-200',
+  paused: 'text-amber-700 hover:text-amber-900 dark:text-amber-400 dark:hover:text-amber-200',
+  waiting_for_input:
+    'text-amber-700 hover:text-amber-900 dark:text-amber-400 dark:hover:text-amber-200',
+}
+
+const defaultSeverityClasses =
+  'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200'
+const defaultDismissClasses =
+  'text-amber-700 hover:text-amber-900 dark:text-amber-400 dark:hover:text-amber-200'
+
 export function Missions() {
   const navigate = useNavigate()
   const [missions, setMissions] = useState<Mission[]>([])
@@ -54,7 +81,7 @@ export function Missions() {
           {unread.map((n) => (
             <div
               key={n.id}
-              className="flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200"
+              className={`flex items-center justify-between gap-3 rounded-lg border px-3 py-2 text-sm ${notificationSeverityClasses[n.kind] ?? defaultSeverityClasses}`}
             >
               <button
                 type="button"
@@ -67,7 +94,7 @@ export function Missions() {
               <button
                 type="button"
                 onClick={() => dismiss(n.id)}
-                className="shrink-0 text-amber-700 hover:text-amber-900 dark:text-amber-400 dark:hover:text-amber-200"
+                className={`shrink-0 ${notificationDismissClasses[n.kind] ?? defaultDismissClasses}`}
                 aria-label="Dismiss"
               >
                 <HugeiconsIcon icon={CancelCircleIcon} className="size-4" />


### PR DESCRIPTION
## Summary
First-class GitHub integration for missions through a new `github` connector kind (PAT + identity; chat tools stay on the MCP connector):
- **Repo picker + clone**: mission create lists/creates repos through the connection; provisioning clones via an ephemeral credential helper (token never in git config/argv/errors, scrub-tested)
- **Push + PR**: manual icon buttons and a consent-at-create **Deployment** section (auto push / push+PR on done via a shared `Completer` — manual and auto paths are the same code; failure keeps the mission done + notifies). Commits authored as the connection identity, disclosed in the form
- **Chat tools**: `missions` (read-only, exempt) + `mission_push` (always asks — pushes stay human)
- **Conventional git**: branches `<type>/<slug>` + conventional unit commits via a deterministic keyword heuristic
- **Notifications**: mission title + severity banners (done green, failed/cancelled red, paused amber)
- Fixed a real data race (connector reload vs post-boot tool registration)

## Migrations
0008/0010 edited in place (pre-release rule): connectors kind CHECK gains 'github'; missions gain `repo_url`, `connector_id`, `on_complete`. Existing DBs need matching ALTERs (applied to local dev; homelab pending at next deploy).

## Testing
- make build test vet lint green; -race suites green; integration suites green (pre-existing shared-DB budget flake aside)
- Web 567/567 tests, build + lint clean
- make canary PASS on the rebuilt stack
- Live end-to-end on a real repo: clone → conventional branch/commits authored as the operator → push → PR https://github.com/SumonMSelim/cursor-cart/pull/2

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788835292&installation_model_id=431401&pr_number=197&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F197&signature=9b21507edd742ff96021af628cd69fdd3e02589fece89749f9417ea2e9cefbb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->