### PR TITLE
fix: human connector test errors with reconnect action

### DIFF
--- a/internal/brain/connectors/github.go
+++ b/internal/brain/connectors/github.go
@@ -266,7 +266,7 @@ func fetchGitHubRepo(ctx context.Context, client *http.Client, token, owner, rep
 }
 
 // createGitHubPR issues POST /repos/{owner}/{repo}/pulls. The error
-// returned on a non-201 response embeds the response body verbatim so
+// returned on a non-201 response embeds GitHub's parsed message(s) so
 // CreatePR's own already-exists check (githubPRAlreadyExistsMarker) can
 // match against it.
 func createGitHubPR(ctx context.Context, client *http.Client, token, owner, repo, title, head, base, body string) (GitHubPR, error) {
@@ -431,12 +431,37 @@ func githubRequest(ctx context.Context, client *http.Client, token, path string)
 	return resp, nil
 }
 
+// githubErrorBody is the subset of GitHub's error response this
+// package reads: {"message": "..."} on virtually every non-2xx reply,
+// plus the per-field "errors[].message" a 422 validation failure adds
+// (e.g. CreatePR's already-exists detail, see
+// githubPRAlreadyExistsMarker).
+type githubErrorBody struct {
+	Message string `json:"message"`
+	Errors  []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
 // githubStatusError reports a non-200 GitHub response without ever
-// including the request (and thus the token).
+// including the request (and thus the token) or the raw response
+// body: 401 gets a fixed reconnect-oriented message, other statuses
+// keep the status code plus GitHub's parsed message field(s), if any.
 func githubStatusError(resp *http.Response) error {
-	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
 	if resp.StatusCode == http.StatusUnauthorized {
-		return fmt.Errorf("github: bad or expired token (401): %s", snippet)
+		return fmt.Errorf("GitHub token invalid or expired — replace the PAT")
 	}
-	return fmt.Errorf("github: status %d: %s", resp.StatusCode, snippet)
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var e githubErrorBody
+	_ = json.Unmarshal(body, &e)
+	msg := e.Message
+	for _, sub := range e.Errors {
+		if sub.Message != "" {
+			msg += ": " + sub.Message
+		}
+	}
+	if msg != "" {
+		return fmt.Errorf("github: status %d: %s", resp.StatusCode, msg)
+	}
+	return fmt.Errorf("github: status %d", resp.StatusCode)
 }

--- a/internal/brain/connectors/github_test.go
+++ b/internal/brain/connectors/github_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -95,7 +96,7 @@ func TestFetchGitHubIdentity(t *testing.T) {
 					_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
 				}
 			},
-			wantErr: "401",
+			wantErr: "invalid or expired",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -113,6 +114,60 @@ func TestFetchGitHubIdentity(t *testing.T) {
 			}
 			if got != tc.want {
 				t.Fatalf("identity = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGitHubStatusErrorMapping pins the "status + short reason, no raw
+// JSON body" discipline: 401 always gets the fixed reconnect message
+// (never the raw body), other statuses keep GitHub's parsed message
+// field(s), and no raw JSON structure ever leaks into the error text.
+func TestGitHubStatusErrorMapping(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{
+			name:   "401 bad or expired token",
+			status: http.StatusUnauthorized,
+			body:   `{"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}`,
+			want:   "GitHub token invalid or expired — replace the PAT",
+		},
+		{
+			name:   "403 forbidden keeps github's message",
+			status: http.StatusForbidden,
+			body:   `{"message":"Resource not accessible by personal access token","documentation_url":"https://docs.github.com/rest"}`,
+			want:   "github: status 403: Resource not accessible by personal access token",
+		},
+		{
+			name:   "404 not found keeps github's message",
+			status: http.StatusNotFound,
+			body:   `{"message":"Not Found","documentation_url":"https://docs.github.com/rest"}`,
+			want:   "github: status 404: Not Found",
+		},
+		{
+			name:   "500 with no parseable message",
+			status: http.StatusInternalServerError,
+			body:   `not json at all`,
+			want:   "github: status 500",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resp := &http.Response{
+				StatusCode: tc.status,
+				Body:       io.NopCloser(strings.NewReader(tc.body)),
+			}
+			err := githubStatusError(resp)
+			if err.Error() != tc.want {
+				t.Fatalf("githubStatusError = %q, want %q", err.Error(), tc.want)
+			}
+			if strings.Contains(err.Error(), "documentation_url") {
+				t.Fatalf("githubStatusError leaked raw JSON: %q", err.Error())
 			}
 		})
 	}

--- a/internal/brain/connectors/google.go
+++ b/internal/brain/connectors/google.go
@@ -205,8 +205,7 @@ func (g *Google) exchange(ctx context.Context, cfg GoogleConfig, form url.Values
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
-		return tokenBundle{}, fmt.Errorf("token endpoint status %d: %s", resp.StatusCode, snippet)
+		return tokenBundle{}, googleTokenError(resp)
 	}
 	var out struct {
 		AccessToken  string `json:"access_token"`
@@ -221,6 +220,32 @@ func (g *Google) exchange(ctx context.Context, cfg GoogleConfig, form url.Values
 		RefreshToken: out.RefreshToken,
 		Expiry:       time.Now().Add(time.Duration(out.ExpiresIn) * time.Second),
 	}, nil
+}
+
+// googleOAuthErrorBody is the token endpoint's error shape
+// (https://www.rfc-editor.org/rfc/rfc6749#section-5.2).
+type googleOAuthErrorBody struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// googleTokenError maps a non-200 token endpoint response to a human
+// message, never surfacing the raw JSON body. invalid_grant (expired
+// or revoked refresh token — Google's testing-mode apps hit this
+// roughly weekly) gets the reconnect-oriented message; other errors
+// keep the status and Google's error code, nothing more.
+func googleTokenError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var e googleOAuthErrorBody
+	_ = json.Unmarshal(body, &e)
+	if e.Error == "invalid_grant" {
+		return fmt.Errorf("Google authorization expired or was revoked — reconnect to re-authorize. " +
+			"(Testing-mode OAuth apps expire grants roughly weekly.)")
+	}
+	if e.Error != "" {
+		return fmt.Errorf("Google authorization failed (status %d, error %q) — reconnect to re-authorize", resp.StatusCode, e.Error)
+	}
+	return fmt.Errorf("Google authorization failed (status %d)", resp.StatusCode)
 }
 
 func (g *Google) storeBundle(ctx context.Context, ref string, b tokenBundle) error {

--- a/internal/brain/connectors/google_test.go
+++ b/internal/brain/connectors/google_test.go
@@ -547,6 +547,62 @@ func TestCalendarToolsRoundTrip(t *testing.T) {
 	}
 }
 
+// TestGoogleTokenErrorMapping pins the "typed, human message, no raw
+// JSON body" discipline for the OAuth token endpoint's error
+// responses: invalid_grant (expired or revoked refresh token — the
+// case Google's testing-mode apps hit weekly) gets the reconnect-
+// oriented message, other oauth errors keep the status and Google's
+// error code without ever leaking the raw JSON body.
+func TestGoogleTokenErrorMapping(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{
+			name:   "invalid_grant expired refresh token",
+			status: http.StatusBadRequest,
+			body:   `{"error":"invalid_grant","error_description":"Token has been expired or revoked."}`,
+			want:   "Google authorization expired or was revoked — reconnect to re-authorize. (Testing-mode OAuth apps expire grants roughly weekly.)",
+		},
+		{
+			name:   "invalid_grant revoked",
+			status: http.StatusBadRequest,
+			body:   `{"error":"invalid_grant","error_description":"Token has been revoked."}`,
+			want:   "Google authorization expired or was revoked — reconnect to re-authorize. (Testing-mode OAuth apps expire grants roughly weekly.)",
+		},
+		{
+			name:   "other oauth error keeps status and code",
+			status: http.StatusBadRequest,
+			body:   `{"error":"invalid_client","error_description":"The OAuth client was not found."}`,
+			want:   `Google authorization failed (status 400, error "invalid_client") — reconnect to re-authorize`,
+		},
+		{
+			name:   "generic 500 with no parseable error",
+			status: http.StatusInternalServerError,
+			body:   `<html>Internal Server Error</html>`,
+			want:   "Google authorization failed (status 500)",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resp := &http.Response{
+				StatusCode: tc.status,
+				Body:       io.NopCloser(strings.NewReader(tc.body)),
+			}
+			err := googleTokenError(resp)
+			if err.Error() != tc.want {
+				t.Fatalf("googleTokenError = %q, want %q", err.Error(), tc.want)
+			}
+			if strings.Contains(err.Error(), "error_description") {
+				t.Fatalf("googleTokenError leaked raw JSON: %q", err.Error())
+			}
+		})
+	}
+}
+
 func TestGoogleSourceTestRefreshesToken(t *testing.T) {
 	t.Parallel()
 	f := &fakeGoogle{}

--- a/internal/brain/connectors/mcp.go
+++ b/internal/brain/connectors/mcp.go
@@ -189,8 +189,7 @@ func (s *mcpSource) rpc(ctx context.Context, method string, params, result any) 
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
-		return fmt.Errorf("%s: status %d: %s", method, resp.StatusCode, snippet)
+		return fmt.Errorf("%s: %w", method, mcpStatusError(resp))
 	}
 	if sid := resp.Header.Get("Mcp-Session-Id"); sid != "" {
 		s.sessionID = sid
@@ -231,6 +230,39 @@ func (s *mcpSource) rpc(ctx context.Context, method string, params, result any) 
 		}
 	}
 	return nil
+}
+
+// mcpErrorBody is the shape an MCP server's non-2xx body may carry;
+// {"message"} and {"error"} both appear across servers in practice.
+type mcpErrorBody struct {
+	Message string `json:"message"`
+	Error   string `json:"error"`
+}
+
+// mcpStatusError reports a non-2xx transport response: status code
+// plus a short reason, never a raw JSON (or arbitrary HTML/text)
+// body. A JSON error body's message/error field is used verbatim if
+// present; otherwise a short truncated snippet stands in, since a
+// server's error shape is not standardized like Google's or GitHub's.
+func mcpStatusError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var e mcpErrorBody
+	if json.Unmarshal(body, &e) == nil {
+		if e.Message != "" {
+			return fmt.Errorf("status %d: %s", resp.StatusCode, e.Message)
+		}
+		if e.Error != "" {
+			return fmt.Errorf("status %d: %s", resp.StatusCode, e.Error)
+		}
+	}
+	snippet := strings.TrimSpace(string(body))
+	if len(snippet) > 120 {
+		snippet = snippet[:120] + "…"
+	}
+	if snippet == "" {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return fmt.Errorf("status %d: %s", resp.StatusCode, snippet)
 }
 
 // notify posts a JSON-RPC notification (no id, no response body

--- a/internal/brain/connectors/mcp_test.go
+++ b/internal/brain/connectors/mcp_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -190,6 +191,60 @@ func TestMCPBuildFailures(t *testing.T) {
 	}, func(context.Context, string) (string, error) { return "wrong", nil })
 	if err == nil || !strings.Contains(err.Error(), "401") {
 		t.Fatalf("bad token build = %v, want 401", err)
+	}
+}
+
+// TestMCPStatusErrorNeverLeaksRawJSON pins the "status + short reason,
+// no raw body" discipline shared with the Google/GitHub error mapping:
+// a JSON error body's message/error field is used verbatim, and a
+// non-JSON body is truncated rather than dumped whole.
+func TestMCPStatusErrorNeverLeaksRawJSON(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{
+			name:   "message field",
+			status: http.StatusForbidden,
+			body:   `{"message":"insufficient scope","extra":{"deeply":{"nested":"junk"}}}`,
+			want:   "status 403: insufficient scope",
+		},
+		{
+			name:   "error field",
+			status: http.StatusInternalServerError,
+			body:   `{"error":"internal failure","trace":"huge stack trace blob"}`,
+			want:   "status 500: internal failure",
+		},
+		{
+			name:   "non-json body truncated",
+			status: http.StatusBadGateway,
+			body:   strings.Repeat("x", 500),
+			want:   "status 502: " + strings.Repeat("x", 120) + "…",
+		},
+		{
+			name:   "empty body",
+			status: http.StatusServiceUnavailable,
+			body:   "",
+			want:   "status 503",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resp := &http.Response{
+				StatusCode: tc.status,
+				Body:       io.NopCloser(strings.NewReader(tc.body)),
+			}
+			err := mcpStatusError(resp)
+			if err.Error() != tc.want {
+				t.Fatalf("mcpStatusError = %q, want %q", err.Error(), tc.want)
+			}
+			if strings.Contains(err.Error(), "extra") || strings.Contains(err.Error(), "trace") {
+				t.Fatalf("mcpStatusError leaked raw JSON fields: %q", err.Error())
+			}
+		})
 	}
 }
 

--- a/web/src/components/settings/ConnectorEdit.tsx
+++ b/web/src/components/settings/ConnectorEdit.tsx
@@ -174,10 +174,22 @@ export function ConnectorEdit() {
                   ? `Failed: ${test.error}`
                   : 'Not tested yet.'}
           </span>
-          <Button size="sm" variant="test" disabled={testing} onClick={() => void runTest()}>
-            {testing ? 'Testing…' : 'Test connection'}
-          </Button>
+          {test && !test.ok && connector.kind === 'google' ? (
+            <Button size="sm" variant="outline" disabled={oauthBusy} onClick={() => void reconnectGoogle()}>
+              {oauthBusy ? 'Redirecting…' : 'Reconnect'}
+            </Button>
+          ) : (
+            <Button size="sm" variant="test" disabled={testing} onClick={() => void runTest()}>
+              {testing ? 'Testing…' : 'Test connection'}
+            </Button>
+          )}
         </div>
+
+        {test && !test.ok && connector.kind === 'github' && (
+          <p className="-mt-3 text-sm text-muted-foreground">
+            Paste a new personal access token below to replace it.
+          </p>
+        )}
 
         {connector.kind === 'google' ? (
           <div className="space-y-3">

--- a/web/src/components/settings/ConnectorsTab.test.tsx
+++ b/web/src/components/settings/ConnectorsTab.test.tsx
@@ -102,6 +102,48 @@ describe('Connectors tab', () => {
     )
   })
 
+  it('renders a Reconnect button and the failure message for a failed google test', async () => {
+    vi.mocked(testConnector).mockResolvedValue({
+      ok: false,
+      error: 'Google authorization expired or was revoked — reconnect to re-authorize. (Testing-mode OAuth apps expire grants roughly weekly.)',
+    })
+    vi.mocked(connectorOAuthStart).mockResolvedValue('https://accounts.google.com/o/oauth2/v2/auth?x=2')
+
+    renderTab(`/settings/connectors/${calendarConnector.id}`)
+    fireEvent.click(await screen.findByRole('button', { name: 'Test connection' }))
+
+    expect(await screen.findByText(/Failed: Google authorization expired or was revoked/)).toBeTruthy()
+    const reconnect = screen.getByRole('button', { name: 'Reconnect' })
+    fireEvent.click(reconnect)
+
+    await waitFor(() =>
+      expect(assign).toHaveBeenCalledWith('https://accounts.google.com/o/oauth2/v2/auth?x=2'),
+    )
+    expect(connectorOAuthStart).toHaveBeenCalledWith(calendarConnector.id)
+  })
+
+  it('keeps the plain Test connection button for a non-google connector test failure', async () => {
+    const githubConnector: AdminConnector = {
+      id: 'gh1',
+      name: 'personal-gh',
+      kind: 'github',
+      config: {},
+      credential_ref: 'PERSONAL_GH_GITHUB_PAT',
+      enabled: true,
+      sensitive: false,
+    }
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(testConnector).mockResolvedValue({ ok: false, error: 'GitHub token invalid or expired — replace the PAT' })
+
+    renderTab(`/settings/connectors/${githubConnector.id}`)
+    fireEvent.click(await screen.findByRole('button', { name: 'Test connection' }))
+
+    expect(await screen.findByText(/Failed: GitHub token invalid or expired/)).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Reconnect' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Test connection' })).toBeTruthy()
+    expect(screen.getByText(/Paste a new personal access token below/)).toBeTruthy()
+  })
+
   it('shows the OAuth outcome banners from the callback redirect', async () => {
     renderTab('/settings/connectors?oauth_connected=personal')
     expect(await screen.findByText(/Google account connected to “personal”/)).toBeTruthy()


### PR DESCRIPTION
## Summary
- Google token failures map to human messages: `invalid_grant` → "authorization expired or was revoked — reconnect to re-authorize (testing-mode apps expire ~weekly)"; other OAuth errors keep status + error code, never the raw body
- GitHub 401 → "token invalid or expired — replace the PAT"; other statuses keep GitHub's parsed `message` (PR-already-exists detection preserved), no raw dumps
- MCP transport errors: JSON message field or a 120-char snippet, never the raw body
- Web: failed google test renders an inline **Reconnect** button (existing oauth/start flow); failed github test hints at the PAT rotation field

## Testing
- Table tests for all three mappers asserting no raw JSON leaks
- Web tests: Reconnect wiring, github hint, other kinds unchanged
- make build test vet lint green; web 569/569

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788836297&installation_model_id=431401&pr_number=198&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F198&signature=5b5dbf5e5f586e4419a51fb1fb9503e2b62ca4a183848c54ff2afb0b5f804bca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->