### PR TITLE
fix: mission turns see builtins only, never connector tools

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -959,6 +959,12 @@ func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, wor
 	perms := tools.NewPermissions(db, workspace)
 	broker := loop.NewPermBroker()
 	agent := loop.NewAgent(gwc, constrained, perms, outputs, tools.NewAudit(db), store, broker, defs, log)
+	// Mission-driven turns (Request.BuiltinsOnly) get this compiled-in
+	// set only — never connector tools or the chat-only mission tools
+	// registered later in main(), since neither exists yet at this
+	// point. This snapshot never changes at runtime, unlike the shared
+	// registry SwapTools maintains.
+	agent.SetBaseTools(constrained, defs)
 	// Shell dumps grow fast; offload them sooner than the default so a
 	// long command output never bloats the context (D-019).
 	agent.SetOffloadThreshold("shell", 4<<10)

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -103,6 +103,14 @@ type Agent struct {
 	exec   Executor
 	defs   []provider.ToolDef
 
+	// baseExec/baseDefs is the compiled-in-builtins-only surface a
+	// Request.BuiltinsOnly turn resolves to instead of exec/defs: set
+	// once at startup (buildAgent compiles it before any connector or
+	// chat-only mission tool exists) and never swapped afterward, so no
+	// lock is needed reading it alongside toolMu below.
+	baseExec Executor
+	baseDefs []provider.ToolDef
+
 	// forceRouteBySuffix maps a tool name SUFFIX to a resolver for the
 	// route its output must be processed under — e.g. a route chained
 	// only to a local/trusted provider, for tools whose results carry
@@ -159,10 +167,22 @@ func (a *Agent) SwapTools(exec Executor, defs []provider.ToolDef) {
 	a.exec, a.defs = exec, defs
 }
 
-func (a *Agent) toolset() (Executor, []provider.ToolDef) {
+func (a *Agent) toolset(builtinsOnly bool) (Executor, []provider.ToolDef) {
+	if builtinsOnly {
+		return a.baseExec, a.baseDefs
+	}
 	a.toolMu.RLock()
 	defer a.toolMu.RUnlock()
 	return a.exec, a.defs
+}
+
+// SetBaseTools registers the compiled-in-builtins-only tool surface a
+// Request.BuiltinsOnly turn (mission-driven: explore/plan/worker/
+// reviewer) resolves to, instead of the full shared registry
+// (connector tools + chat-only mission tools). Startup-time only —
+// unlike SwapTools' surface, this snapshot never changes at runtime.
+func (a *Agent) SetBaseTools(exec Executor, defs []provider.ToolDef) {
+	a.baseExec, a.baseDefs = exec, defs
 }
 
 // Tools returns the live tool surface (builtins + connector tools,
@@ -170,7 +190,7 @@ func (a *Agent) toolset() (Executor, []provider.ToolDef) {
 // available, like an agent's tools-allowlist picker, without executing
 // anything.
 func (a *Agent) Tools() []provider.ToolDef {
-	_, defs := a.toolset()
+	_, defs := a.toolset(false)
 	return defs
 }
 
@@ -230,6 +250,19 @@ type Request struct {
 	Messages  []provider.Message
 	MissionID string // ledger tag: set when this turn serves a mission, not chat
 
+	// BuiltinsOnly restricts the turn's base tool surface to compiled-in
+	// builtins (calculator, shell, web_search, ...), excluding connector
+	// tools (e.g. a write-capable GitHub MCP token) and the chat-only
+	// mission tools (missions/mission_push). Set by every mission-driven
+	// request (explore/plan/worker/reviewer) — a mission worker must
+	// never side-channel a connector write around the worktree/human-
+	// consented push pipeline, and mission_push is nonsensical inside a
+	// mission turn. Deliberately independent of MissionID (a ledger
+	// attribution tag only) so tool-surface scoping stays an explicit,
+	// intentional choice at each call site rather than inferred.
+	// ExtraTools still layer on top as normal.
+	BuiltinsOnly bool
+
 	// ExtraTools are tool defs available ONLY for this turn, on top of
 	// the agent's shared base set — e.g. the missions package's
 	// mission_status/review_verdict sentinel calls, which chat sessions
@@ -288,7 +321,7 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 		a.waitToolsReady(ctx)
 	}
 
-	exec, defs := a.toolset()
+	exec, defs := a.toolset(req.BuiltinsOnly)
 	defs = filterDefs(defs, req.ToolAllow)
 	if len(req.ExtraTools) > 0 {
 		var extraDefs []provider.ToolDef

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -966,6 +966,140 @@ func TestSwapToolsChangesSurfaceForNewTurns(t *testing.T) {
 	}
 }
 
+// TestRequestBuiltinsOnlySeesBaseToolsNotConnectorTools confirms a
+// mission-driven turn (Request.BuiltinsOnly) resolves to the
+// SetBaseTools snapshot instead of the shared registry SwapTools
+// maintains — a connector tool (or a chat-only mission tool) present
+// in the shared registry must never be offered to a builtins-only
+// turn, closing the side-channel a mission worker could otherwise use
+// to bypass the worktree/human-consented push pipeline.
+func TestRequestBuiltinsOnlySeesBaseToolsNotConnectorTools(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		finalStep("done"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	// Base tools: just "echo" (testAgent's default).
+	baseReg := tools.NewRegistry()
+	if err := baseReg.Register(&tools.Tool{
+		Name: "echo", Description: "echoes",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+		Execute:     func(context.Context, json.RawMessage) (string, error) { return "", nil },
+	}); err != nil {
+		t.Fatal(err)
+	}
+	baseConstrained, err := tools.NewConstrained(baseReg, testToolCalls())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.SetBaseTools(registryExec{baseConstrained}, []provider.ToolDef{{Name: "echo", Description: "echoes", InputSchema: json.RawMessage(`{"type":"object"}`)}})
+
+	// Full/shared registry: adds a connector tool on top via SwapTools.
+	fullReg := tools.NewRegistry()
+	for _, tool := range []*tools.Tool{
+		{Name: "echo", Description: "echoes", InputSchema: json.RawMessage(`{"type":"object"}`),
+			Execute: func(context.Context, json.RawMessage) (string, error) { return "", nil }},
+		{Name: "github_create_issue", Description: "creates an issue", InputSchema: json.RawMessage(`{"type":"object"}`),
+			Execute: func(context.Context, json.RawMessage) (string, error) { return "", nil }},
+	} {
+		if err := fullReg.Register(tool); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fullConstrained, err := tools.NewConstrained(fullReg, testToolCalls())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.SwapTools(registryExec{fullConstrained}, []provider.ToolDef{
+		{Name: "echo", Description: "echoes", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		{Name: "github_create_issue", Description: "creates an issue", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	})
+
+	ch, err := a.Start(t.Context(), Request{
+		SessionID: "s1", Route: "default", BuiltinsOnly: true,
+		Messages: []provider.Message{{Role: "user", Content: "go"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	for _, d := range gw.requests[0].Tools {
+		if d.Name == "github_create_issue" {
+			t.Fatalf("connector tool leaked into a BuiltinsOnly request's tool defs: %+v", gw.requests[0].Tools)
+		}
+	}
+	if len(gw.requests[0].Tools) != 1 || gw.requests[0].Tools[0].Name != "echo" {
+		t.Fatalf("BuiltinsOnly request tools = %+v, want only echo", gw.requests[0].Tools)
+	}
+}
+
+// TestRequestWithoutBuiltinsOnlySeesFullSurfaceAfterSwap is
+// TestSwapToolsChangesSurfaceForNewTurns's counterpart: a plain
+// (unflagged, chat-shaped) turn keeps seeing the full shared registry
+// — including connector tools — across a SwapTools/reload cycle, even
+// after SetBaseTools has been called for the mission-only surface.
+func TestRequestWithoutBuiltinsOnlySeesFullSurfaceAfterSwap(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		finalStep("done"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	baseReg := tools.NewRegistry()
+	if err := baseReg.Register(&tools.Tool{
+		Name: "echo", Description: "echoes", InputSchema: json.RawMessage(`{"type":"object"}`),
+		Execute: func(context.Context, json.RawMessage) (string, error) { return "", nil },
+	}); err != nil {
+		t.Fatal(err)
+	}
+	baseConstrained, err := tools.NewConstrained(baseReg, testToolCalls())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.SetBaseTools(registryExec{baseConstrained}, []provider.ToolDef{{Name: "echo", Description: "echoes", InputSchema: json.RawMessage(`{"type":"object"}`)}})
+
+	fullReg := tools.NewRegistry()
+	for _, tool := range []*tools.Tool{
+		{Name: "echo", Description: "echoes", InputSchema: json.RawMessage(`{"type":"object"}`),
+			Execute: func(context.Context, json.RawMessage) (string, error) { return "", nil }},
+		{Name: "github_create_issue", Description: "creates an issue", InputSchema: json.RawMessage(`{"type":"object"}`),
+			Execute: func(context.Context, json.RawMessage) (string, error) { return "", nil }},
+	} {
+		if err := fullReg.Register(tool); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fullConstrained, err := tools.NewConstrained(fullReg, testToolCalls())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a.SwapTools(registryExec{fullConstrained}, []provider.ToolDef{
+		{Name: "echo", Description: "echoes", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		{Name: "github_create_issue", Description: "creates an issue", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	})
+
+	ch, err := a.Start(t.Context(), Request{
+		SessionID: "s1", Route: "default",
+		Messages: []provider.Message{{Role: "user", Content: "go"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	var sawConnector bool
+	for _, d := range gw.requests[0].Tools {
+		if d.Name == "github_create_issue" {
+			sawConnector = true
+		}
+	}
+	if !sawConnector {
+		t.Fatalf("connector tool missing from an unflagged request after SwapTools: %+v", gw.requests[0].Tools)
+	}
+}
+
 // TestForceRouteSwitchesRouteAfterMatchingToolAndStaysSticky pins the
 // sensitive-tool-output routing mechanism: a tool whose name ends with
 // a registered suffix (connector tools are namespaced

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -392,13 +392,14 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 	system, user := packet.Render()
 	extra := append([]*tools.Tool{MissionStatusTool()}, r.missionTools(m)...)
 	req := loop.Request{
-		SessionID:  m.SessionID,
-		Route:      workerRoute(m),
-		Agent:      "mission-worker",
-		MissionID:  m.ID,
-		System:     system,
-		Messages:   []provider.Message{{Role: "user", Content: user}},
-		ExtraTools: extra,
+		SessionID:    m.SessionID,
+		Route:        workerRoute(m),
+		Agent:        "mission-worker",
+		MissionID:    m.ID,
+		System:       system,
+		Messages:     []provider.Message{{Role: "user", Content: user}},
+		ExtraTools:   extra,
+		BuiltinsOnly: true,
 		// Schedule-fired missions have nobody watching: asks fail fast
 		// with feedback instead of parking (D-039). UI-created missions
 		// (ScheduleID empty) keep the park-and-answer flow.
@@ -488,14 +489,15 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 		extra = append(extra, shell)
 	}
 	req := loop.Request{
-		SessionID:  m.SessionID,
-		Route:      m.Route,
-		Agent:      "mission-explorer",
-		MissionID:  m.ID,
-		System:     system,
-		Messages:   []provider.Message{{Role: "user", Content: user}},
-		ExtraTools: extra,
-		Unattended: m.ScheduleID != "",
+		SessionID:    m.SessionID,
+		Route:        m.Route,
+		Agent:        "mission-explorer",
+		MissionID:    m.ID,
+		System:       system,
+		Messages:     []provider.Message{{Role: "user", Content: user}},
+		ExtraTools:   extra,
+		BuiltinsOnly: true,
+		Unattended:   m.ScheduleID != "",
 	}
 
 	text, args, err := r.runTurn(ctx, req, exploreNotesToolName)
@@ -566,14 +568,15 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 
 	extra := append([]*tools.Tool{ReviewVerdictTool()}, r.missionTools(m)...)
 	req := loop.Request{
-		SessionID:  m.SessionID,
-		Route:      m.ReviewRoute,
-		Agent:      "mission-reviewer",
-		MissionID:  m.ID,
-		System:     system,
-		Messages:   messages,
-		ExtraTools: extra,
-		Unattended: m.ScheduleID != "",
+		SessionID:    m.SessionID,
+		Route:        m.ReviewRoute,
+		Agent:        "mission-reviewer",
+		MissionID:    m.ID,
+		System:       system,
+		Messages:     messages,
+		ExtraTools:   extra,
+		BuiltinsOnly: true,
+		Unattended:   m.ScheduleID != "",
 	}
 	text, args, err := r.runTurn(ctx, req, reviewVerdictToolName)
 	if err != nil {
@@ -698,9 +701,10 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 		// it), so the turn's only tool is submit_plan — a planner that
 		// reaches for shell parked a live canary on the permission gate
 		// for ten minutes trying to do the worker's job in plan phase.
-		ToolAllow:  []string{planToolName},
-		ExtraTools: []*tools.Tool{PlanTool()},
-		Unattended: m.ScheduleID != "",
+		ToolAllow:    []string{planToolName},
+		ExtraTools:   []*tools.Tool{PlanTool()},
+		BuiltinsOnly: true,
+		Unattended:   m.ScheduleID != "",
 	}
 	text, args, err := r.runTurn(ctx, req, planToolName)
 	if err != nil {

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -1094,3 +1094,56 @@ func TestRunTurnNilErrErrorEvent(t *testing.T) {
 		t.Fatalf("err = %v, want generic provider stream error", err)
 	}
 }
+
+// TestMissionRunnerRequestsAreBuiltinsOnly guards the security fix:
+// every loop.Request the native runner builds — worker, explorer,
+// reviewer, planner — must set BuiltinsOnly, so a mission turn's base
+// tool surface never includes connector tools (e.g. a write-capable
+// GitHub MCP token) or the chat-only mission/mission_push tools. A
+// missed phase here would silently reopen the side-channel the fix
+// closes.
+func TestMissionRunnerRequestsAreBuiltinsOnly(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ok"}`)},
+	}}
+	r := newTestRunner(agent)
+	if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if !agent.requests[len(agent.requests)-1].BuiltinsOnly {
+		t.Fatal("RunWorker's request must set BuiltinsOnly")
+	}
+
+	agent = &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(exploreNotesToolName, `{"findings":"none"}`)},
+	}}
+	r = newTestRunner(agent)
+	if _, err := r.ExploreSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err != nil {
+		t.Fatalf("ExploreSession: %v", err)
+	}
+	if !agent.requests[len(agent.requests)-1].BuiltinsOnly {
+		t.Fatal("ExploreSession's request must set BuiltinsOnly")
+	}
+
+	agent = &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(reviewVerdictToolName, `{"decision":"approve"}`)},
+	}}
+	r = newTestRunner(agent)
+	if _, _, err := r.RunReview(context.Background(), Mission{ID: "m1", ReviewRoute: "default"}, ReviewPacket{Goal: "goal"}, nil); err != nil {
+		t.Fatalf("RunReview: %v", err)
+	}
+	if !agent.requests[len(agent.requests)-1].BuiltinsOnly {
+		t.Fatal("RunReview's request must set BuiltinsOnly")
+	}
+
+	agent = &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, `{"units":[{"title":"do it","verify_cmd":"true"}]}`)},
+	}}
+	r = newTestRunner(agent)
+	if _, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, ""); err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if !agent.requests[len(agent.requests)-1].BuiltinsOnly {
+		t.Fatal("PlanSession's request must set BuiltinsOnly")
+	}
+}


### PR DESCRIPTION
## Summary
Mission turns previously saw the full chat registry — including write-capable connector tools (GitHub MCP) and the chat-only `missions`/`mission_push` tools. That allowed a mission worker to side-channel GitHub writes around the worktree → human-consented push/PR pipeline. Safety invariants are Go code, not prompts: requests now carry `BuiltinsOnly`; the loop holds an immutable startup snapshot of compiled-in builtins and flagged turns resolve it instead of the swappable registry. Mission ExtraTools unchanged; chat unchanged (full surface, reload-safe).

## Testing
- Loop tests: flagged turn never sees connector tools after a SwapTools cycle; unflagged turn keeps the full surface
- Mission runner test: all four phases' requests carry the flag
- make build test vet lint green; full `go test -race ./...` green
- make canary PASS on the rebuilt stack (88s)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788836742&installation_model_id=431401&pr_number=199&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F199&signature=0fc42a4aaaf7f367a11bb6d6b3be50fdfc61e494f9a648689ee7d780a758fb24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->