### PR TITLE
test: deflake askgate serialization test

### DIFF
--- a/internal/brain/loop/askgate_test.go
+++ b/internal/brain/loop/askgate_test.go
@@ -2,6 +2,7 @@ package loop
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 )
@@ -60,8 +61,11 @@ func TestAskGateSerializesConcurrentWaiters(t *testing.T) {
 	var order []int
 	orderCh := make(chan int, n)
 	start := make(chan struct{})
+	var wg sync.WaitGroup
 	for i := 0; i < n; i++ {
+		wg.Add(1)
 		go func(i int) {
+			defer wg.Done()
 			<-start
 			release, ok := g.lock(t.Context(), key)
 			if !ok {
@@ -87,6 +91,10 @@ func TestAskGateSerializesConcurrentWaiters(t *testing.T) {
 	if len(order) != n {
 		t.Fatalf("completed = %d, want %d", len(order), n)
 	}
+
+	// The orderCh send happens before release() — wait for the
+	// goroutines themselves, or the last release races the assertion.
+	wg.Wait()
 
 	g.mu.Lock()
 	left := len(g.entries)


### PR DESCRIPTION
## Summary
`TestAskGateSerializesConcurrentWaiters` sends to `orderCh` before `release()`, so asserting `entries == 0` after draining the channel races the last goroutine's release — flaked on PR #197's CI. Fix: WaitGroup on the goroutines before the assertion.

## Testing
- `go test -race -count=10 -run TestAskGate ./internal/brain/loop/` green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788837877&installation_model_id=431401&pr_number=200&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F200&signature=86d2684781fe100a82239b7f52224792172e8eee7a7b4ffc0dde9393964a9e8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->