### PR TITLE
feat: configurable git branch pattern and commit style for missions

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -604,6 +604,8 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	driver := missions.NewDriver(store, runner, workspace, notifier, sessions, perms, sandboxMgr.Exec, sandboxMgr, log)
 	driver.SetFXRates(fxStore)
 	driver.SetCapacityGate(sandboxMgr)
+	driver.SetGitBranchPattern(flags.GitBranchPattern)
+	driver.SetGitCommitStyle(flags.GitCommitStyle)
 	resolveAgent := missionAgentResolver(agentReg)
 	driver.SetAgentResolver(resolveAgent)
 	if conns != nil && secrets != nil {
@@ -624,19 +626,19 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 		// operator's fixed identity. Best-effort at the driver layer
 		// (SetCloneIdentityResolver's caller already treats a resolve
 		// error as WARN-and-fall-back, never a provisioning failure).
-		driver.SetCloneIdentityResolver(func(ctx context.Context, connectorID string) (string, string, error) {
+		driver.SetCloneIdentityResolver(func(ctx context.Context, connectorID string) (string, string, string, error) {
 			identity, err := conns.TestIdentity(ctx, connectorID)
 			if err != nil {
-				return "", "", err
+				return "", "", "", err
 			}
 			if identity == nil {
-				return "", "", fmt.Errorf("connector %s has no identity to resolve", connectorID)
+				return "", "", "", fmt.Errorf("connector %s has no identity to resolve", connectorID)
 			}
 			name := identity.Name
 			if name == "" {
 				name = identity.Login
 			}
-			return name, identity.Email, nil
+			return name, identity.Email, identity.Login, nil
 		})
 	}
 	if conns != nil && secrets != nil {

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -277,6 +277,13 @@ type createMissionRequest struct {
 	// mission) and kind=coding — a model never decides this, only the
 	// human choosing it here.
 	OnComplete string `json:"on_complete"`
+	// BranchPattern/CommitStyle override the settings-configured git
+	// strategy defaults for this mission alone; "" (the default) applies
+	// the settings default at provisioning/commit time. Validated the
+	// same way settings.Store.SetValue validates the global default —
+	// only known placeholders/styles, never model-decided.
+	BranchPattern string `json:"branch_pattern"`
+	CommitStyle   string `json:"commit_style"`
 }
 
 // create validates the request, resolves route/review_route/budget
@@ -371,6 +378,16 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "bad_request", `on_complete must be "", "push", or "push_pr"`)
 		return
 	}
+	if req.BranchPattern != "" {
+		if err := missions.ValidateBranchPattern(req.BranchPattern); err != nil {
+			jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+	}
+	if err := missions.ValidateCommitStyle(req.CommitStyle); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
 	// Resolve even with an empty AgentID: ResolveByID("") falls back to
 	// the default agent, same as chat sessions that don't pick one — a
 	// mission created without an explicit agent still needs a real
@@ -426,6 +443,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		MaxIterations: req.MaxIterations, BudgetAmount: req.BudgetAmount, BudgetCurrency: budgetCurrency,
 		AutoApproveSafe: autoApproveSafe, PromptOverlay: promptOverlay, Harness: req.Harness, Environment: req.Environment,
 		RepoURL: req.RepoURL, ConnectorID: req.ConnectorID, OnComplete: req.OnComplete,
+		BranchPattern: req.BranchPattern, CommitStyle: req.CommitStyle,
 	}
 	id, err := h.driver.Create(r.Context(), m)
 	if err != nil {

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -277,6 +277,47 @@ func TestMissionsCreateValidatesOnComplete(t *testing.T) {
 	}
 }
 
+// TestMissionsCreateValidatesGitStrategy covers create()'s
+// branch_pattern/commit_style gate: an invalid pattern/style is
+// rejected outright (a distinct error body, before Driver.Create is
+// ever reached), while a valid one passes validation and reaches the
+// (degraded) store — same generic 400 failMission maps every
+// unrecognized store error to, mirroring
+// TestMissionsCreateValidatesHarness's shape.
+func TestMissionsCreateValidatesGitStrategy(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+
+	post := func(body string) (int, string) {
+		m := mux(a)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		b, _ := io.ReadAll(w.Result().Body)
+		return w.Code, string(b)
+	}
+
+	if code, body := post(`{"goal":"g","kind":"coding","branch_pattern":"{unknown}/{slug}"}`); code != 400 || !strings.Contains(body, "unknown placeholder") {
+		t.Fatalf("unknown placeholder: code=%d body=%q, want 400 with an unknown-placeholder message", code, body)
+	}
+	if code, body := post(`{"goal":"g","kind":"coding","branch_pattern":"../{slug}"}`); code != 400 || !strings.Contains(body, "branch pattern") {
+		t.Fatalf("traversal pattern: code=%d body=%q, want 400 with a branch-pattern message", code, body)
+	}
+	if code, body := post(`{"goal":"g","kind":"coding","commit_style":"loud"}`); code != 400 || !strings.Contains(body, "commit style") {
+		t.Fatalf("unknown commit style: code=%d body=%q, want 400 with a commit-style message", code, body)
+	}
+	// Valid values pass validation and reach the degraded store —
+	// failMission's generic 400, not a git-strategy-specific message.
+	if code, body := post(`{"goal":"g","kind":"coding","branch_pattern":"{type}/{login}/{slug}","commit_style":"plain"}`); code != 400 || strings.Contains(body, "branch pattern") || strings.Contains(body, "commit style") {
+		t.Fatalf("valid git strategy fields: code=%d body=%q, want a generic 400 (passed validation)", code, body)
+	}
+}
+
 // TestClassifyKind exercises classifyKind's parsing and its bias to
 // "coding" for anything short of an unambiguous "general" reply —
 // nil classify, a classify error, and a garbage reply must all land on

--- a/internal/brain/missions/branchtemplate.go
+++ b/internal/brain/missions/branchtemplate.go
@@ -1,0 +1,126 @@
+package missions
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// DefaultBranchPattern is the built-in branch template — the exact
+// shape Provision always used before this existed ("<type>/<slug>").
+const DefaultBranchPattern = "{type}/{slug}"
+
+// maxBranchLen caps an expanded branch pattern the same as maxSlugLen
+// bounded the old fixed "<type>/<slug>" shape: type (<=7 chars) + "/" +
+// slug (<=40 chars) never exceeded ~50 chars, so a template with more
+// placeholders (login, date) gets a generous but still bounded cap.
+const maxBranchLen = 200
+
+// branchRefPattern is the charset a fully-expanded branch name must
+// satisfy — a conservative subset of what git actually allows,
+// intentionally excluding "~^:?*[\" and control/space characters that
+// are technically legal in some git ref forms but never desirable in a
+// generated branch name.
+var branchRefPattern = regexp.MustCompile(`^[A-Za-z0-9._/-]+$`)
+
+// branchPlaceholder matches any {word} token so ValidateBranchPattern
+// can reject unknown placeholders before one ever reaches expansion.
+var branchPlaceholder = regexp.MustCompile(`\{[a-z]+\}`)
+
+// knownBranchPlaceholders is the exhaustive set ExpandBranchPattern
+// understands. {type} is the CommitType heuristic, {slug} the existing
+// Slug, {login} the mission connection's GitHub login (empty for a
+// non-github mission), {date} the mission's creation date (YYYYMMDD).
+var knownBranchPlaceholders = map[string]bool{
+	"{type}": true, "{slug}": true, "{login}": true, "{date}": true,
+}
+
+// ValidateBranchPattern rejects a template that could produce an unsafe
+// or malformed branch name, checked against dummy placeholder values so
+// the same rules apply whether {login} ends up empty or not. Rules:
+// only known placeholders, and after expansion — a valid git ref
+// fragment (charset [A-Za-z0-9._/-], no "..", no leading/trailing
+// slash, within maxBranchLen).
+func ValidateBranchPattern(pattern string) error {
+	if pattern == "" {
+		return fmt.Errorf("branch pattern must not be empty")
+	}
+	for _, m := range branchPlaceholder.FindAllString(pattern, -1) {
+		if !knownBranchPlaceholders[m] {
+			return fmt.Errorf("branch pattern: unknown placeholder %q", m)
+		}
+	}
+	// Two probes: {login} present and {login} empty — collapseSlashes'
+	// behavior differs between the two, and both must independently
+	// produce a valid ref.
+	for _, login := range []string{"octocat", ""} {
+		expanded := ExpandBranchPattern(pattern, "feat", "example-slug", login, "20260101")
+		if err := validateExpandedRef(expanded); err != nil {
+			return fmt.Errorf("branch pattern: %w (example expansion %q)", err, expanded)
+		}
+	}
+	return nil
+}
+
+// validateExpandedRef checks one already-expanded branch name against
+// the git-ref-fragment safety rules ValidateBranchPattern enforces.
+func validateExpandedRef(ref string) error {
+	if ref == "" {
+		return fmt.Errorf("expands to an empty branch name")
+	}
+	if len(ref) > maxBranchLen {
+		return fmt.Errorf("expands to a branch name longer than %d chars", maxBranchLen)
+	}
+	if !branchRefPattern.MatchString(ref) {
+		return fmt.Errorf("expands to %q, outside the allowed charset [A-Za-z0-9._/-]", ref)
+	}
+	if strings.Contains(ref, "..") {
+		return fmt.Errorf("expands to %q, containing \"..\"", ref)
+	}
+	if strings.HasPrefix(ref, "/") || strings.HasSuffix(ref, "/") {
+		return fmt.Errorf("expands to %q, with a leading or trailing slash", ref)
+	}
+	return nil
+}
+
+// ExpandBranchPattern substitutes {type}/{slug}/{login}/{date} into
+// pattern, then collapses any run of slashes the substitution produced
+// (an empty {login} is the common cause — "feat//my-slug" would
+// otherwise be left in the branch name) and trims any leading/trailing
+// slash left behind.
+func ExpandBranchPattern(pattern, typ, slug, login, date string) string {
+	r := strings.NewReplacer(
+		"{type}", typ,
+		"{slug}", slug,
+		"{login}", login,
+		"{date}", date,
+	)
+	expanded := r.Replace(pattern)
+	return collapseSlashes(expanded)
+}
+
+// slashRun collapses "//", "///", etc. down to a single "/".
+var slashRun = regexp.MustCompile(`/{2,}`)
+
+func collapseSlashes(s string) string {
+	s = slashRun.ReplaceAllString(s, "/")
+	return strings.Trim(s, "/")
+}
+
+// Commit styles: "conventional" (default, "<type>: <subject>") or
+// "plain" (the unit title as-is, still length/body-preserving).
+const (
+	CommitStyleConventional = "conventional"
+	CommitStylePlain        = "plain"
+)
+
+// ValidateCommitStyle rejects anything besides the known styles; empty
+// is valid and means "use the effective default."
+func ValidateCommitStyle(style string) error {
+	switch style {
+	case "", CommitStyleConventional, CommitStylePlain:
+		return nil
+	default:
+		return fmt.Errorf("commit style: unknown value %q", style)
+	}
+}

--- a/internal/brain/missions/branchtemplate_test.go
+++ b/internal/brain/missions/branchtemplate_test.go
@@ -1,0 +1,113 @@
+package missions
+
+import "testing"
+
+func TestValidateBranchPattern(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern string
+		wantErr bool
+	}{
+		{"default pattern", DefaultBranchPattern, false},
+		{"empty", "", true},
+		{"unknown placeholder", "{oops}/{slug}", true},
+		{"login placeholder", "{type}/{login}/{slug}", false},
+		{"date placeholder", "{date}-{slug}", false},
+		{"all placeholders", "{type}/{login}/{date}/{slug}", false},
+		{"leading traversal", "../{slug}", true},
+		{"embedded traversal", "{type}/../{slug}", true},
+		{"leading slash literal", "/{type}/{slug}", false}, // collapses to type/slug
+		{"disallowed char space", "{type} /{slug}", true},
+		{"disallowed char tilde", "{type}~/{slug}", true},
+		{"disallowed char caret", "{type}^/{slug}", true},
+		{"disallowed char colon", "{type}:{slug}", true},
+		{"disallowed char question mark", "{type}?/{slug}", true},
+		{"disallowed char asterisk", "{type}*/{slug}", true},
+		{"disallowed char bracket", "{type}[x]/{slug}", true},
+		{"disallowed char backslash", `{type}\{slug}`, true},
+		{"no placeholders, plain literal", "always-this-branch", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateBranchPattern(tc.pattern)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateBranchPattern(%q) error = %v, wantErr %v", tc.pattern, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestExpandBranchPattern(t *testing.T) {
+	cases := []struct {
+		name                   string
+		pattern                string
+		typ, slug, login, date string
+		want                   string
+	}{
+		{
+			"default shape",
+			DefaultBranchPattern,
+			"feat", "add-dark-mode", "", "20260101",
+			"feat/add-dark-mode",
+		},
+		{
+			"login present",
+			"{type}/{login}/{slug}",
+			"fix", "login-bug", "octocat", "20260101",
+			"fix/octocat/login-bug",
+		},
+		{
+			"login empty collapses the double slash",
+			"{type}/{login}/{slug}",
+			"fix", "login-bug", "", "20260101",
+			"fix/login-bug",
+		},
+		{
+			"login empty at the start collapses leading slash",
+			"{login}/{type}/{slug}",
+			"fix", "login-bug", "", "20260101",
+			"fix/login-bug",
+		},
+		{
+			"date placeholder substitutes",
+			"{date}-{type}-{slug}",
+			"chore", "bump-deps", "", "20260315",
+			"20260315-chore-bump-deps",
+		},
+		{
+			"every placeholder used",
+			"{login}/{date}/{type}/{slug}",
+			"docs", "readme-update", "octocat", "20260315",
+			"octocat/20260315/docs/readme-update",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExpandBranchPattern(tc.pattern, tc.typ, tc.slug, tc.login, tc.date)
+			if got != tc.want {
+				t.Fatalf("ExpandBranchPattern(%q, ...) = %q, want %q", tc.pattern, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateCommitStyle(t *testing.T) {
+	cases := []struct {
+		style   string
+		wantErr bool
+	}{
+		{"", false},
+		{CommitStyleConventional, false},
+		{CommitStylePlain, false},
+		{"loud", true},
+		{"CONVENTIONAL", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.style, func(t *testing.T) {
+			err := ValidateCommitStyle(tc.style)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateCommitStyle(%q) error = %v, wantErr %v", tc.style, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -150,6 +150,21 @@ type Driver struct {
 	// identity), never fails provisioning.
 	resolveCloneIdentity CloneIdentityResolver
 
+	// gitBranchPattern resolves the settings-configured default branch
+	// pattern (see SetGitBranchPattern) — consulted by ensureProvisioned
+	// only when the mission's own BranchPattern is empty (mission
+	// override > settings > worktree.go's DefaultBranchPattern). nil-safe:
+	// unset falls straight through to Provision's own DefaultBranchPattern
+	// fallback, same as before this setting existed.
+	gitBranchPattern func(ctx context.Context) string
+
+	// gitCommitStyle resolves the settings-configured default commit
+	// style (see SetGitCommitStyle) — consulted by runExecute only when
+	// the mission's own CommitStyle is empty (mission override > settings
+	// > CommitStyleConventional). nil-safe: unset falls straight through
+	// to CommitMessage's own conventional-style default.
+	gitCommitStyle func(ctx context.Context) string
+
 	// completer runs a mission's recorded on_complete choice
 	// (push/push_pr) once it reaches phase=done (see SetCompleter,
 	// fireOnComplete) — nil-safe: unset (no connectors/secrets wired)
@@ -236,16 +251,31 @@ func (d *Driver) SetCloneTokenResolver(resolve CloneTokenResolver) {
 }
 
 // CloneIdentityResolver resolves a mission's connector_id to the
-// commit identity (name, email) ensureProvisioned's clone is authored
-// as — the identity counterpart of CloneTokenResolver, resolved fresh
-// at provisioning time (never persisted on the mission row).
-type CloneIdentityResolver func(ctx context.Context, connectorID string) (name, email string, err error)
+// commit identity (name, email, GitHub login) ensureProvisioned's clone
+// is authored as — the identity counterpart of CloneTokenResolver,
+// resolved fresh at provisioning time (never persisted on the mission
+// row). login backs the {login} branch-pattern placeholder.
+type CloneIdentityResolver func(ctx context.Context, connectorID string) (name, email, login string, err error)
 
 // SetCloneIdentityResolver wires the resolver ensureProvisioned uses to
 // set a repo_url mission's clone local git identity — a setter (not a
 // NewDriver parameter) for the same reason SetAgentResolver is.
 func (d *Driver) SetCloneIdentityResolver(resolve CloneIdentityResolver) {
 	d.resolveCloneIdentity = resolve
+}
+
+// SetGitBranchPattern wires the live settings getter ensureProvisioned
+// falls back to when a mission's own BranchPattern is empty — a setter
+// (not a NewDriver parameter) for the same reason SetAgentResolver is.
+func (d *Driver) SetGitBranchPattern(get func(ctx context.Context) string) {
+	d.gitBranchPattern = get
+}
+
+// SetGitCommitStyle wires the live settings getter runExecute falls
+// back to when a mission's own CommitStyle is empty — a setter for the
+// same reason SetGitBranchPattern is.
+func (d *Driver) SetGitCommitStyle(get func(ctx context.Context) string) {
+	d.gitCommitStyle = get
 }
 
 // SetCompleter wires the Completer the driver's auto-fire-on-done hook
@@ -380,15 +410,19 @@ func (d *Driver) ensureProvisioned(ctx context.Context, m Mission) (Mission, err
 			// back to the fixed commitName/commitEmail (worktree.go's
 			// CommitUnit).
 			if d.resolveCloneIdentity != nil {
-				name, email, err := d.resolveCloneIdentity(ctx, m.ConnectorID)
+				name, email, login, err := d.resolveCloneIdentity(ctx, m.ConnectorID)
 				if err != nil {
 					d.log.Warn("driver: resolve clone identity failed; commits fall back to fixed identity", "mission_id", m.ID, "error", err)
 				} else {
-					connIdentity = &GitIdentity{Name: name, Email: email}
+					connIdentity = &GitIdentity{Name: name, Email: email, Login: login}
 				}
 			}
 		}
-		workspace, worktree, branch, baseCommit, err := d.workspace.Provision(ctx, m.ID, m.Goal, m.Kind, m.RepoURL, token, connIdentity)
+		branchPattern := m.BranchPattern
+		if branchPattern == "" && d.gitBranchPattern != nil {
+			branchPattern = d.gitBranchPattern(ctx)
+		}
+		workspace, worktree, branch, baseCommit, err := d.workspace.Provision(ctx, m.ID, m.Goal, m.Kind, m.RepoURL, token, connIdentity, branchPattern)
 		if err != nil {
 			return m, fmt.Errorf("provision: %w", err)
 		}
@@ -881,6 +915,18 @@ func restorePassedUnits(spec *Spec, prior Spec) {
 	}
 }
 
+// effectiveCommitStyle resolves the precedence mission override >
+// settings default > CommitMessage's own conventional-style default.
+func (d *Driver) effectiveCommitStyle(ctx context.Context, m Mission) string {
+	if m.CommitStyle != "" {
+		return m.CommitStyle
+	}
+	if d.gitCommitStyle != nil {
+		return d.gitCommitStyle(ctx)
+	}
+	return ""
+}
+
 func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 	packet, err := d.packet(ctx, m)
 	if err != nil {
@@ -909,7 +955,7 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 				unitTitle = unit.Title
 			}
 			body := "mission " + m.ID + " iteration " + fmt.Sprint(m.Iteration)
-			msg := CommitMessage(unitTitle, m.Goal, body)
+			msg := CommitMessage(unitTitle, m.Goal, body, d.effectiveCommitStyle(ctx, m))
 			if err := d.workspace.CommitUnit(ctx, m.Worktree, msg); err != nil {
 				d.log.Warn("driver: commit unit failed", "mission_id", m.ID, "error", err)
 			}

--- a/internal/brain/missions/driver_integration_test.go
+++ b/internal/brain/missions/driver_integration_test.go
@@ -32,7 +32,7 @@ func TestDriverEndToEndCodingMission(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	ws, wt, branch, base, err := workspace.Provision(ctx, id, marker+"e2e coding", "coding", "", "", nil)
+	ws, wt, branch, base, err := workspace.Provision(ctx, id, marker+"e2e coding", "coding", "", "", nil, "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -1151,6 +1151,103 @@ func TestDriverAdvanceLazilyProvisionsBareMission(t *testing.T) {
 	}
 }
 
+// TestDriverProvisionUsesMissionBranchPatternOverSettings confirms the
+// precedence order ensureProvisioned resolves: a mission's own
+// BranchPattern wins over the settings-configured default.
+func TestDriverProvisionUsesMissionBranchPatternOverSettings(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Goal: "Fix the login bug", Kind: "coding", BranchPattern: "custom/{slug}",
+		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8,
+	})
+	sessions := &fakeSessionCreator{}
+	wsRoot := t.TempDir()
+	workspace := NewWorkspace(wsRoot, nil, slog.Default())
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
+	d := NewDriver(store, runner, workspace, nil, sessions, &fakeGranter{}, nil, nil, slog.Default())
+	d.SetGitBranchPattern(func(context.Context) string { return "settings/{slug}" })
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if got, want := m.Branch, "custom/fix-the-login-bug"; got != want {
+		t.Fatalf("Branch = %q, want %q (mission override should win over settings)", got, want)
+	}
+}
+
+// TestDriverProvisionFallsBackToSettingsBranchPattern confirms the
+// settings default applies when the mission itself carries no override.
+func TestDriverProvisionFallsBackToSettingsBranchPattern(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Goal: "Fix the login bug", Kind: "coding",
+		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8,
+	})
+	sessions := &fakeSessionCreator{}
+	wsRoot := t.TempDir()
+	workspace := NewWorkspace(wsRoot, nil, slog.Default())
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
+	d := NewDriver(store, runner, workspace, nil, sessions, &fakeGranter{}, nil, nil, slog.Default())
+	d.SetGitBranchPattern(func(context.Context) string { return "settings/{slug}" })
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if got, want := m.Branch, "settings/fix-the-login-bug"; got != want {
+		t.Fatalf("Branch = %q, want %q (settings default should apply)", got, want)
+	}
+}
+
+// TestDriverProvisionFallsBackToDefaultBranchPattern confirms
+// DefaultBranchPattern applies when neither the mission nor settings
+// carry an override — the original "<type>/<slug>" behavior.
+func TestDriverProvisionFallsBackToDefaultBranchPattern(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Goal: "Fix the login bug", Kind: "coding",
+		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8,
+	})
+	sessions := &fakeSessionCreator{}
+	wsRoot := t.TempDir()
+	workspace := NewWorkspace(wsRoot, nil, slog.Default())
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
+	d := NewDriver(store, runner, workspace, nil, sessions, &fakeGranter{}, nil, nil, slog.Default())
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if got, want := m.Branch, "fix/fix-the-login-bug"; got != want {
+		t.Fatalf("Branch = %q, want %q (default pattern should apply)", got, want)
+	}
+}
+
+// TestDriverEffectiveCommitStylePrecedence confirms mission override >
+// settings default > CommitMessage's own conventional default.
+func TestDriverEffectiveCommitStylePrecedence(t *testing.T) {
+	cases := []struct {
+		name          string
+		missionStyle  string
+		settingsStyle func(context.Context) string
+		want          string
+	}{
+		{"mission override wins", CommitStylePlain, func(context.Context) string { return CommitStyleConventional }, CommitStylePlain},
+		{"settings default applies", "", func(context.Context) string { return CommitStylePlain }, CommitStylePlain},
+		{"no override, no settings: conventional default", "", nil, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &Driver{gitCommitStyle: tc.settingsStyle, log: slog.Default()}
+			got := d.effectiveCommitStyle(context.Background(), Mission{CommitStyle: tc.missionStyle})
+			if got != tc.want {
+				t.Fatalf("effectiveCommitStyle = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestDriverAdvanceSkipsProvisioningWhenAlreadyProvisioned confirms
 // ensureProvisioned is a no-op (no new session, no re-grant) once a
 // mission already has both — the ordinary case for every mission

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -21,26 +21,26 @@ type Mission struct {
 	// Store.SetNameIfEmpty. Scheduler-fired missions get the schedule's
 	// own name directly, no LLM call. Empty means generation hasn't
 	// landed yet; the UI falls back to a truncated Goal.
-	Name string `json:"name,omitempty"`
-	Kind string `json:"kind"` // coding | general
+	Name    string `json:"name,omitempty"`
+	Kind    string `json:"kind"` // coding | general
 	AgentID string `json:"agent_id,omitempty"`
 	// PromptOverlay is a snapshot of the creating agent's overlay text
 	// at create time — see 0010_missions.sql for why this isn't a live
 	// agent lookup.
-	PromptOverlay string         `json:"prompt_overlay,omitempty"`
-	Phase         Phase          `json:"phase"`
-	Status        Status         `json:"status"`
+	PromptOverlay string `json:"prompt_overlay,omitempty"`
+	Phase         Phase  `json:"phase"`
+	Status        Status `json:"status"`
 	// FailureReason is derived (no column) from this mission's latest
 	// mission.failed event's payload.reason — "cancelled" or
 	// "max_iterations" (statemachine.go) — set only by Store.List/Get for
 	// a phase=failed mission. Empty for every other mission.
-	FailureReason string `json:"failure_reason,omitempty"`
-	PauseReason   PauseReason    `json:"pause_reason,omitempty"`
-	PauseMessage  string         `json:"pause_message,omitempty"`
-	Workspace     string         `json:"workspace,omitempty"`
-	Worktree      string         `json:"worktree,omitempty"`
-	Branch        string         `json:"branch,omitempty"`
-	BaseCommit    string         `json:"base_commit,omitempty"`
+	FailureReason string      `json:"failure_reason,omitempty"`
+	PauseReason   PauseReason `json:"pause_reason,omitempty"`
+	PauseMessage  string      `json:"pause_message,omitempty"`
+	Workspace     string      `json:"workspace,omitempty"`
+	Worktree      string      `json:"worktree,omitempty"`
+	Branch        string      `json:"branch,omitempty"`
+	BaseCommit    string      `json:"base_commit,omitempty"`
 	// RepoURL is the GitHub repo this coding mission was cloned from
 	// (https clone URL) — empty means the self-init'd empty repo
 	// Workspace.Provision otherwise creates. ConnectorID names the
@@ -48,6 +48,14 @@ type Mission struct {
 	// token itself is never stored, only resolved fresh at provisioning.
 	RepoURL     string `json:"repo_url,omitempty"`
 	ConnectorID string `json:"connector_id,omitempty"`
+	// BranchPattern/CommitStyle are this mission's own override of the
+	// settings-configured git strategy defaults (git_branch_pattern/
+	// git_commit_style), snapshotted at create time: "" means "use the
+	// settings default," resolved fresh at provisioning/commit time
+	// (driver.go), never baked in here. See branchtemplate.go for the
+	// template placeholders and style values.
+	BranchPattern string `json:"branch_pattern,omitempty"`
+	CommitStyle   string `json:"commit_style,omitempty"`
 	// OnComplete is the operator's consent-at-create choice for what
 	// happens when this mission reaches phase=done: "" (default) does
 	// nothing, "push" pushes the branch, "push_pr" pushes then opens a
@@ -55,9 +63,9 @@ type Mission struct {
 	// validation); the harness (driver.go) executes it automatically on
 	// the done transition using the SAME push/PR code path the manual
 	// push/pr endpoints use.
-	OnComplete string `json:"on_complete,omitempty"`
-	Spec          Spec           `json:"spec"`
-	Progress      []ProgressNote `json:"progress"`
+	OnComplete string         `json:"on_complete,omitempty"`
+	Spec       Spec           `json:"spec"`
+	Progress   []ProgressNote `json:"progress"`
 	// LastEvidence is the most recent worker mission_status call's
 	// evidence text — carried from execute into review so a
 	// general mission (whose baseline diff is always empty,

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -49,7 +49,8 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 	escalation_route, prompt_overlay,
 	pending_permission, pending_permission_tool, pending_permission_args,
 	pending_permission_danger, pending_permission_rationale, auto_approve_safe, last_evidence,
-	explore_notes, replan_used, schedule_id, session_id, harness, environment, repo_url, connector_id, on_complete, created_at, updated_at`
+	explore_notes, replan_used, schedule_id, session_id, harness, environment, repo_url, connector_id, on_complete,
+	branch_pattern, commit_style, created_at, updated_at`
 
 // scanMissionWithFailureReason is scanMission plus one extra trailing
 // column: the mission's latest mission.failed event's payload.reason
@@ -72,7 +73,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&pendingPermission, &m.PendingPermissionTool, &m.PendingPermissionArgs,
 		&m.PendingPermissionDanger, &m.PendingPermissionRationale, &m.AutoApproveSafe, &m.LastEvidence,
 		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
-		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.CreatedAt, &m.UpdatedAt,
+		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &m.CreatedAt, &m.UpdatedAt,
 		&failureReason); err != nil {
 		return Mission{}, err
 	}
@@ -141,7 +142,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&pendingPermission, &m.PendingPermissionTool, &m.PendingPermissionArgs,
 		&m.PendingPermissionDanger, &m.PendingPermissionRationale, &m.AutoApproveSafe, &m.LastEvidence,
 		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
-		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.CreatedAt, &m.UpdatedAt); err != nil {
+		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &m.CreatedAt, &m.UpdatedAt); err != nil {
 		return Mission{}, err
 	}
 	if agentID != nil {
@@ -198,9 +199,9 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 		budgetCurrency = "USD"
 	}
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, escalation_route, prompt_overlay, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, NULLIF($13, '')::uuid, $14, $15, $16, $17, $18, $19) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 8), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.EscalationRoute, m.PromptOverlay, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, escalation_route, prompt_overlay, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, NULLIF($13, '')::uuid, $14, $15, $16, $17, $18, $19, $20, $21) RETURNING id`,
+		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 8), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.EscalationRoute, m.PromptOverlay, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -287,6 +287,45 @@ func TestMissionOnCompleteRoundTrips(t *testing.T) {
 	}
 }
 
+// TestMissionGitStrategyRoundTrips covers branch_pattern/commit_style:
+// first-class columns snapshotted at create time, same shape as Harness
+// above — "" (use the settings default) is the default when a mission
+// omits them.
+func TestMissionGitStrategyRoundTrips(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{
+		Goal: marker + "git-strategy", Kind: "coding", Route: "default",
+		BranchPattern: "{type}/{login}/{slug}", CommitStyle: "plain",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.BranchPattern != "{type}/{login}/{slug}" {
+		t.Fatalf("BranchPattern = %q, want {type}/{login}/{slug}", m.BranchPattern)
+	}
+	if m.CommitStyle != "plain" {
+		t.Fatalf("CommitStyle = %q, want plain", m.CommitStyle)
+	}
+
+	id2, err := s.Create(ctx, Mission{Goal: marker + "no-git-strategy", Kind: "general", Route: "default"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	m2, err := s.Get(ctx, id2)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m2.BranchPattern != "" || m2.CommitStyle != "" {
+		t.Fatalf("BranchPattern/CommitStyle = %q/%q, want empty when not set", m2.BranchPattern, m2.CommitStyle)
+	}
+}
+
 func TestMissionNameRoundTrips(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()

--- a/internal/brain/missions/worktree.go
+++ b/internal/brain/missions/worktree.go
@@ -62,7 +62,12 @@ func NewWorkspace(root string, identity func(context.Context) (name, email strin
 // operator's fixed identity; nil (no connector, or identity resolve
 // failed) leaves the clone with no local identity override, falling
 // back to the fixed commitName/commitEmail same as before this existed.
-func (w *Workspace) Provision(ctx context.Context, missionID, goal, kind, repoURL, token string, connIdentity *GitIdentity) (workspace, worktree, branch, baseCommit string, err error) {
+// branchPattern is the already-resolved effective template (mission
+// override > settings > DefaultBranchPattern, resolved by the caller);
+// empty falls back to DefaultBranchPattern here so every existing call
+// site (tests, any caller not yet passing one) keeps the original
+// "<type>/<slug>" shape.
+func (w *Workspace) Provision(ctx context.Context, missionID, goal, kind, repoURL, token string, connIdentity *GitIdentity, branchPattern string) (workspace, worktree, branch, baseCommit string, err error) {
 	workspace = filepath.Join(w.root, missionID)
 	if err := os.MkdirAll(workspace, 0o750); err != nil {
 		return "", "", "", "", fmt.Errorf("worktree: provision: mkdir %s: %w", workspace, err)
@@ -72,7 +77,14 @@ func (w *Workspace) Provision(ctx context.Context, missionID, goal, kind, repoUR
 		return workspace, "", "", "", nil
 	}
 
-	branch = CommitType(goal) + "/" + Slug(goal, missionID)
+	if branchPattern == "" {
+		branchPattern = DefaultBranchPattern
+	}
+	login := ""
+	if connIdentity != nil {
+		login = connIdentity.Login
+	}
+	branch = ExpandBranchPattern(branchPattern, CommitType(goal), Slug(goal, missionID), login, branchDate())
 	worktree = filepath.Join(workspace, "wt")
 
 	if repoURL != "" {
@@ -87,12 +99,20 @@ func (w *Workspace) Provision(ctx context.Context, missionID, goal, kind, repoUR
 	return workspace, worktree, branch, baseCommit, nil
 }
 
-// GitIdentity is a resolved commit author (name, email) — a
-// connection's identity, threaded from CloneIdentityResolver through
-// Provision to cloneRepo's local git config.
+// GitIdentity is a resolved commit author (name, email), plus the
+// connection's GitHub login — threaded from CloneIdentityResolver
+// through Provision to cloneRepo's local git config (Name/Email) and to
+// the {login} branch-pattern placeholder (Login).
 type GitIdentity struct {
 	Name  string
 	Email string
+	Login string
+}
+
+// branchDate is the mission-creation date substituted for the {date}
+// branch-pattern placeholder, formatted YYYYMMDD.
+func branchDate() string {
+	return time.Now().UTC().Format("20060102")
 }
 
 // cloneRepo clones repoURL's default branch into dir, authenticated
@@ -270,21 +290,26 @@ func CommitType(text string) string {
 // commit subjects stay at or under 72 chars.
 const maxCommitSubjectLen = 72
 
-// CommitMessage builds a Conventional Commits message for a unit
-// commit: "<type>: <title>" as the subject (type from unitTitle via
-// CommitType, falling back to goal when unitTitle is empty), body
-// unchanged (whatever the caller already put there, e.g. mission
-// id/iteration). The subject is lowercased and trimmed to
-// maxCommitSubjectLen, trailing punctuation removed.
-func CommitMessage(unitTitle, goal, body string) string {
+// CommitMessage builds a unit commit message in the given style
+// (empty defaults to CommitStyleConventional, same as every call site
+// before commit styles existed): "conventional" produces "<type>:
+// <title>" as the subject (type from unitTitle via CommitType, falling
+// back to goal when unitTitle is empty); "plain" uses the title as-is,
+// no type prefix. Both styles lowercase-and-trim the same way,
+// trimming to maxCommitSubjectLen with trailing punctuation removed;
+// body is unchanged (whatever the caller already put there, e.g.
+// mission id/iteration).
+func CommitMessage(unitTitle, goal, body, style string) string {
 	title := unitTitle
 	if title == "" {
 		title = goal
 	}
-	typ := CommitType(title)
 	subject := strings.ToLower(strings.TrimSpace(title))
 	subject = strings.TrimRight(subject, ".")
-	prefix := typ + ": "
+	prefix := ""
+	if style != CommitStylePlain {
+		prefix = CommitType(title) + ": "
+	}
 	if max := maxCommitSubjectLen - len(prefix); len(subject) > max {
 		subject = strings.TrimRight(subject[:max], " .")
 	}

--- a/internal/brain/missions/worktree_integration_test.go
+++ b/internal/brain/missions/worktree_integration_test.go
@@ -19,7 +19,7 @@ func TestProvisionNonCodingMission(t *testing.T) {
 	w := newTestWorkspace(t)
 	ctx := context.Background()
 
-	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-2", "Do something", "general", "", "", nil)
+	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-2", "Do something", "general", "", "", nil, "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}

--- a/internal/brain/missions/worktree_test.go
+++ b/internal/brain/missions/worktree_test.go
@@ -45,39 +45,54 @@ func TestCommitType(t *testing.T) {
 
 func TestCommitMessage(t *testing.T) {
 	cases := []struct {
-		name, unitTitle, goal, body, want string
+		name, unitTitle, goal, body, style, want string
 	}{
 		{
 			"unit title used when present",
-			"Fix the broken login flow", "Some other goal", "body text",
+			"Fix the broken login flow", "Some other goal", "body text", "",
 			"fix: fix the broken login flow\n\nbody text",
 		},
 		{
 			"falls back to goal when no unit title",
-			"", "Refactor the auth module", "body text",
+			"", "Refactor the auth module", "body text", "",
 			"refactor: refactor the auth module\n\nbody text",
 		},
 		{
 			"no body omits the blank separator",
-			"Add tests for parser", "goal", "",
+			"Add tests for parser", "goal", "", "",
 			"test: add tests for parser",
 		},
 		{
 			"trailing period trimmed",
-			"Add dark mode.", "goal", "",
+			"Add dark mode.", "goal", "", "",
 			"feat: add dark mode",
 		},
 		{
 			"long title trimmed to 72 chars",
-			strings.Repeat("a", 100), "goal", "",
+			strings.Repeat("a", 100), "goal", "", "",
 			"feat: " + strings.Repeat("a", 66),
+		},
+		{
+			"empty style defaults to conventional",
+			"Fix the broken login flow", "goal", "", CommitStyleConventional,
+			"fix: fix the broken login flow",
+		},
+		{
+			"plain style omits the type prefix",
+			"Fix the broken login flow", "goal", "body text", CommitStylePlain,
+			"fix the broken login flow\n\nbody text",
+		},
+		{
+			"plain style still trims to 72 chars",
+			strings.Repeat("a", 100), "goal", "", CommitStylePlain,
+			strings.Repeat("a", 72),
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := CommitMessage(tc.unitTitle, tc.goal, tc.body)
+			got := CommitMessage(tc.unitTitle, tc.goal, tc.body, tc.style)
 			if got != tc.want {
-				t.Fatalf("CommitMessage(%q, %q, %q) = %q, want %q", tc.unitTitle, tc.goal, tc.body, got, tc.want)
+				t.Fatalf("CommitMessage(%q, %q, %q, %q) = %q, want %q", tc.unitTitle, tc.goal, tc.body, tc.style, got, tc.want)
 			}
 			subject := strings.SplitN(got, "\n", 2)[0]
 			if len(subject) > maxCommitSubjectLen {
@@ -148,7 +163,7 @@ func TestProvisionCodingMissionSelfInitsRepo(t *testing.T) {
 	w := newTestWorkspace(t)
 	ctx := context.Background()
 
-	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-self", "Fix the login bug", "coding", "", "", nil)
+	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-self", "Fix the login bug", "coding", "", "", nil, "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -202,7 +217,7 @@ func TestProvisionSelfInitRollbackAndCommitUnit(t *testing.T) {
 	w := newTestWorkspace(t)
 	ctx := context.Background()
 
-	_, worktree, _, _, err := w.Provision(ctx, "mission-self-2", "Add a feature", "coding", "", "", nil)
+	_, worktree, _, _, err := w.Provision(ctx, "mission-self-2", "Add a feature", "coding", "", "", nil, "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -260,7 +275,7 @@ func TestProvisionClonesRepo(t *testing.T) {
 	gitRun(t, seed, "remote", "add", "origin", bare)
 	gitRun(t, seed, "push", "-q", "origin", "main")
 
-	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-clone", "Fix the login bug", "coding", bare, "dummy-token", nil)
+	workspace, worktree, branch, baseCommit, err := w.Provision(ctx, "mission-clone", "Fix the login bug", "coding", bare, "dummy-token", nil, "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -312,7 +327,7 @@ func TestProvisionClonesRepoWithConnIdentity(t *testing.T) {
 	gitRun(t, seed, "push", "-q", "origin", "main")
 
 	identity := &GitIdentity{Name: "conn-bot", Email: "conn-bot@example.com"}
-	_, worktree, _, _, err := w.Provision(ctx, "mission-conn-identity", "Fix the login bug", "coding", bare, "dummy-token", identity)
+	_, worktree, _, _, err := w.Provision(ctx, "mission-conn-identity", "Fix the login bug", "coding", bare, "dummy-token", identity, "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -372,7 +387,7 @@ func TestTeardownRemovesSelfInitRepo(t *testing.T) {
 	w := newTestWorkspace(t)
 	ctx := context.Background()
 
-	workspace, worktree, _, _, err := w.Provision(ctx, "mission-self-3", "Teardown test", "coding", "", "", nil)
+	workspace, worktree, _, _, err := w.Provision(ctx, "mission-self-3", "Teardown test", "coding", "", "", nil, "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
 	"github.com/SumonMSelim/timothy/internal/brain/missions/executor"
 	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
 )
@@ -58,13 +59,26 @@ const (
 	// request defaults to when it doesn't specify one (D-051); "" (the
 	// default) means native. Never applies to kind=general missions.
 	ValueCodingExecutor = "coding_executor"
+	// ValueGitBranchPattern is the default branch-name template a coding
+	// mission's Provision expands (missions/branchtemplate.go); ""
+	// defers to missions.DefaultBranchPattern ("{type}/{slug}"), the
+	// original behavior. A mission's own branch_pattern column
+	// overrides this per create request.
+	ValueGitBranchPattern = "git_branch_pattern"
+	// ValueGitCommitStyle is the default commit-message style
+	// ("conventional" or "plain") a mission's unit commits use; "" defers
+	// to missions.CommitStyleConventional, the original behavior. A
+	// mission's own commit_style column overrides this per create
+	// request.
+	ValueGitCommitStyle = "git_commit_style"
 )
 
 var knownValueKeys = map[string]bool{
 	ValueTokenBudget: true, ValueSkillsAllowlist: true,
 	ValueGitAuthorName: true, ValueGitAuthorEmail: true,
 	ValueSensitiveToolRoute: true, ValueDefaultCurrency: true,
-	ValueCodingExecutor: true,
+	ValueCodingExecutor:   true,
+	ValueGitBranchPattern: true, ValueGitCommitStyle: true,
 }
 
 // allowedCurrencies is the flat, fixed list of ISO 4217 codes the
@@ -158,6 +172,18 @@ func (s *Store) DefaultCurrency(ctx context.Context) string {
 // mission's create request, "" (native) when unset.
 func (s *Store) CodingExecutor(ctx context.Context) string {
 	return s.Value(ctx, ValueCodingExecutor)
+}
+
+// GitBranchPattern returns the configured default branch-name template,
+// "" (missions.DefaultBranchPattern) when unset.
+func (s *Store) GitBranchPattern(ctx context.Context) string {
+	return s.Value(ctx, ValueGitBranchPattern)
+}
+
+// GitCommitStyle returns the configured default commit-message style,
+// "" (missions.CommitStyleConventional) when unset.
+func (s *Store) GitCommitStyle(ctx context.Context) string {
+	return s.Value(ctx, ValueGitCommitStyle)
 }
 
 // SkillAllowed reports whether the allowlist admits a pack name;
@@ -267,6 +293,16 @@ func (s *Store) SetValue(ctx context.Context, key, value string) error {
 			value = ""
 		} else if _, ok := executor.Lookup(value); !ok {
 			return fmt.Errorf("%s: unknown harness %q", key, value)
+		}
+	}
+	if key == ValueGitBranchPattern && value != "" {
+		if err := missions.ValidateBranchPattern(value); err != nil {
+			return fmt.Errorf("%s: %w", key, err)
+		}
+	}
+	if key == ValueGitCommitStyle && value != "" {
+		if err := missions.ValidateCommitStyle(value); err != nil {
+			return fmt.Errorf("%s: %w", key, err)
 		}
 	}
 	return s.write(ctx, key, s.Value(ctx, key), value)

--- a/internal/brain/settings/settings_integration_test.go
+++ b/internal/brain/settings/settings_integration_test.go
@@ -234,3 +234,38 @@ func TestCodingExecutorSetting(t *testing.T) {
 		t.Fatalf("CodingExecutor after native = %q, want empty (native normalizes to \"\")", got)
 	}
 }
+
+func TestGitStrategySettings(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	if got := s.GitBranchPattern(ctx); got != "" {
+		t.Fatalf("GitBranchPattern default = %q, want empty (built-in default)", got)
+	}
+	if got := s.GitCommitStyle(ctx); got != "" {
+		t.Fatalf("GitCommitStyle default = %q, want empty (built-in default)", got)
+	}
+
+	if err := s.SetValue(ctx, ValueGitBranchPattern, "{type}/{login}/{slug}"); err != nil {
+		t.Fatalf("SetValue branch pattern: %v", err)
+	}
+	if got := s.GitBranchPattern(ctx); got != "{type}/{login}/{slug}" {
+		t.Fatalf("GitBranchPattern after set = %q", got)
+	}
+	if err := s.SetValue(ctx, ValueGitBranchPattern, "{unknown}/{slug}"); err == nil {
+		t.Fatal("unknown placeholder accepted")
+	}
+	if err := s.SetValue(ctx, ValueGitBranchPattern, "../{slug}"); err == nil {
+		t.Fatal("traversal pattern accepted")
+	}
+
+	if err := s.SetValue(ctx, ValueGitCommitStyle, "plain"); err != nil {
+		t.Fatalf("SetValue commit style: %v", err)
+	}
+	if got := s.GitCommitStyle(ctx); got != "plain" {
+		t.Fatalf("GitCommitStyle after set = %q, want plain", got)
+	}
+	if err := s.SetValue(ctx, ValueGitCommitStyle, "loud"); err == nil {
+		t.Fatal("unknown commit style accepted")
+	}
+}

--- a/migrations/0010_missions.sql
+++ b/migrations/0010_missions.sql
@@ -128,7 +128,16 @@ CREATE TABLE IF NOT EXISTS missions (
     -- the harness only ever executes a choice a human already made.
     -- Requires repo_url+connector_id and kind='coding', same guards as
     -- the manual push/pr endpoints.
-    on_complete           text NOT NULL DEFAULT ''
+    on_complete           text NOT NULL DEFAULT '',
+    -- This mission's own override of the settings-configured git
+    -- strategy defaults (settings.ValueGitBranchPattern/
+    -- ValueGitCommitStyle): '' (the default) means "use the settings
+    -- default," resolved fresh at provisioning/commit time
+    -- (internal/brain/missions/driver.go), never baked in here.
+    -- branch_pattern is a validated template (internal/brain/missions/
+    -- branchtemplate.go); commit_style is 'conventional' or 'plain'.
+    branch_pattern        text NOT NULL DEFAULT '',
+    commit_style          text NOT NULL DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS missions_status_idx ON missions (status);

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -902,6 +902,12 @@ export interface CreateMissionInput {
   // then opens a pull request. Requires repo_url + connector_id and
   // kind === 'coding'.
   on_complete?: '' | 'push' | 'push_pr'
+  // branch_pattern/commit_style override the settings-configured git
+  // strategy defaults for this mission alone; omit (or "") applies the
+  // settings default. See FeaturesTab's git strategy cards for the
+  // placeholder/style reference.
+  branch_pattern?: string
+  commit_style?: string
 }
 
 // ExecutorOption is one registered harness's usability on a given

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -607,6 +607,11 @@ export interface Mission {
   // turns run under (D-051): "" or absent is native in-process
   // dispatch, "claude-cli"/"pi" name a registered executor.
   harness?: string
+  // branch_pattern/commit_style are this mission's own override of the
+  // settings-configured git strategy defaults; "" or absent means the
+  // settings default applied at provisioning/commit time.
+  branch_pattern?: string
+  commit_style?: string
   // top_model/top_model_provider are decorated onto the list/get
   // response from the cost ledger's top-served-model-per-mission
   // lookup (internal/brain/api/missions.go's decorateTopModels) — the
@@ -788,6 +793,8 @@ export interface MissionTemplate {
   auto_approve_safe?: boolean
   harness?: string
   environment?: string
+  branch_pattern?: string
+  commit_style?: string
 }
 
 // Schedule is a recurring cron trigger that fires mission_template

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -303,6 +303,67 @@ describe('MissionForm — environment select', () => {
   })
 })
 
+describe('MissionForm — git strategy overrides', () => {
+  it('shows branch pattern and commit style in Advanced for a coding mission', async () => {
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(await screen.findByText('General · scratch workspace'))
+    fireEvent.click(screen.getByRole('button', { name: 'Show advanced options' }))
+
+    expect(screen.getByLabelText('Branch pattern')).toBeInTheDocument()
+    expect(screen.getByLabelText('Commit style')).toBeInTheDocument()
+    expect(screen.getByLabelText('Commit style')).toHaveTextContent('Default (from settings)')
+  })
+
+  it('omits branch pattern and commit style for a general mission', async () => {
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    expect(await screen.findByText('General · scratch workspace')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Show advanced options' }))
+
+    expect(screen.queryByLabelText('Branch pattern')).toBeNull()
+    expect(screen.queryByLabelText('Commit style')).toBeNull()
+  })
+
+  it('submits a typed branch pattern and picked commit style for a coding mission', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm8' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(await screen.findByText('General · scratch workspace'))
+    fireEvent.click(screen.getByRole('button', { name: 'Show advanced options' }))
+    fireEvent.change(screen.getByLabelText('Branch pattern'), {
+      target: { value: '{type}/{login}/{slug}' },
+    })
+    fireEvent.click(screen.getByLabelText('Commit style'))
+    fireEvent.click(await screen.findByText('Plain'))
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(
+        expect.objectContaining({ branch_pattern: '{type}/{login}/{slug}', commit_style: 'plain' }),
+      ),
+    )
+  })
+
+  it('omits branch pattern and commit style from the create payload when left on defaults', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm9' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(await screen.findByText('General · scratch workspace'))
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(
+        expect.objectContaining({ branch_pattern: undefined, commit_style: undefined }),
+      ),
+    )
+  })
+})
+
 const githubConnector: AdminConnector = {
   id: 'c1',
   name: 'personal-gh',

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -64,7 +64,9 @@ function hasNonDefaults(t: Schedule['mission_template']): boolean {
     t.review_route ||
     t.budget_amount != null ||
     t.harness ||
-    t.environment
+    t.environment ||
+    t.branch_pattern ||
+    t.commit_style
   )
 }
 
@@ -103,6 +105,17 @@ const environmentChoices: { value: string; label: string }[] = [
   { value: 'python', label: 'Python' },
   { value: 'java', label: 'Java' },
   { value: 'php', label: 'PHP' },
+]
+
+// Sentinel for the commit-style Select's "apply the settings default"
+// choice — wire value stays '' (omit commit_style from the create
+// payload) to match the API's own empty-means-default semantics.
+const COMMIT_STYLE_DEFAULT = '__default__'
+
+const commitStyleChoices: { value: string; label: string }[] = [
+  { value: COMMIT_STYLE_DEFAULT, label: 'Default (from settings)' },
+  { value: 'conventional', label: 'Conventional' },
+  { value: 'plain', label: 'Plain' },
 ]
 
 // expiresAt is stored as the wire-compatible 'YYYY-MM-DDTHH:mm' string the
@@ -175,6 +188,8 @@ export function MissionForm({
   const [autoApproveSafe, setAutoApproveSafe] = useState(true)
   const [harness, setHarness] = useState('')
   const [environment, setEnvironment] = useState('')
+  const [branchPattern, setBranchPattern] = useState('')
+  const [commitStyle, setCommitStyle] = useState('')
   const [executorOptions, setExecutorOptions] = useState<ExecutorOption[] | null>(null)
   const [busy, setBusy] = useState(false)
 
@@ -315,6 +330,8 @@ export function MissionForm({
     setBudgetCurrency(schedule.mission_template.budget_currency || 'USD')
     setHarness(schedule.mission_template.harness ?? '')
     setEnvironment(schedule.mission_template.environment ?? '')
+    setBranchPattern(schedule.mission_template.branch_pattern ?? '')
+    setCommitStyle(schedule.mission_template.commit_style ?? '')
     setExpiresAt(schedule.expires_at ? schedule.expires_at.slice(0, 16) : '')
     setCronError(null)
   }, [mode, schedule])
@@ -424,6 +441,8 @@ export function MissionForm({
       auto_approve_safe: autoApproveSafe,
       harness: kind === 'coding' ? harness || undefined : undefined,
       environment: kind === 'coding' ? environment || undefined : undefined,
+      branch_pattern: kind === 'coding' ? branchPattern.trim() || undefined : undefined,
+      commit_style: kind === 'coding' ? commitStyle || undefined : undefined,
       repo_url: repoURL,
       connector_id: repoURL ? connectorID : undefined,
       on_complete: repoURL && onComplete ? onComplete : undefined,
@@ -448,6 +467,8 @@ export function MissionForm({
         auto_approve_safe: autoApproveSafe,
         harness: kind === 'coding' ? harness || undefined : undefined,
         environment: kind === 'coding' ? environment || undefined : undefined,
+        branch_pattern: kind === 'coding' ? branchPattern.trim() || undefined : undefined,
+        commit_style: kind === 'coding' ? commitStyle || undefined : undefined,
       },
       expires_at: expiresAt ? new Date(expiresAt).toISOString() : undefined,
     })
@@ -473,6 +494,12 @@ export function MissionForm({
         harness: schedule.mission_template.kind === 'coding' ? harness || undefined : undefined,
         environment:
           schedule.mission_template.kind === 'coding' ? environment || undefined : undefined,
+        branch_pattern:
+          schedule.mission_template.kind === 'coding'
+            ? branchPattern.trim() || undefined
+            : undefined,
+        commit_style:
+          schedule.mission_template.kind === 'coding' ? commitStyle || undefined : undefined,
       },
       expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
     })
@@ -1044,6 +1071,37 @@ export function MissionForm({
                       </SelectContent>
                     </Select>
                   )}
+                </div>
+              )}
+              {kind === 'coding' && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="mission-branch-pattern">Branch pattern</Label>
+                  <Input
+                    id="mission-branch-pattern"
+                    value={branchPattern}
+                    onChange={(e) => setBranchPattern(e.target.value)}
+                    placeholder="Default (from settings)"
+                  />
+                </div>
+              )}
+              {kind === 'coding' && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="mission-commit-style">Commit style</Label>
+                  <Select
+                    value={commitStyle || COMMIT_STYLE_DEFAULT}
+                    onValueChange={(v) => setCommitStyle(v === COMMIT_STYLE_DEFAULT ? '' : v)}
+                  >
+                    <SelectTrigger id="mission-commit-style" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {commitStyleChoices.map((c) => (
+                        <SelectItem key={c.value} value={c.value}>
+                          {c.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
               )}
               <div className="space-y-1.5">

--- a/web/src/components/settings/FeaturesTab.tsx
+++ b/web/src/components/settings/FeaturesTab.tsx
@@ -71,6 +71,8 @@ export function FeaturesTab() {
       {values && <SensitiveRouteCard values={values} onError={setError} onSaved={refresh} />}
       {values && <DefaultCurrencyCard values={values} onError={setError} onSaved={refresh} />}
       {values && <DefaultCodingExecutorCard values={values} onError={setError} onSaved={refresh} />}
+      {values && <GitBranchPatternCard values={values} onError={setError} onSaved={refresh} />}
+      {values && <GitCommitStyleCard values={values} onError={setError} onSaved={refresh} />}
       <NotificationSoundCard />
     </div>
   )
@@ -212,6 +214,114 @@ function DefaultCodingExecutorCard({
       </div>
       <p className="mt-2 text-xs text-muted-foreground">
         New coding missions delegate to this harness unless overridden at creation time.
+      </p>
+    </div>
+  )
+}
+
+// GitBranchPatternCard picks the default branch-name template new
+// coding missions expand at provisioning time — mirrors
+// DefaultCurrencyCard's shape, a free-text input since the template
+// language (placeholders) isn't a fixed choice list.
+function GitBranchPatternCard({
+  values,
+  onError,
+  onSaved,
+}: {
+  values: Record<string, string>
+  onError: (msg: string) => void
+  onSaved: () => void
+}) {
+  const [pattern, setPattern] = useState(values.git_branch_pattern ?? '')
+  const [saved, setSaved] = useState(false)
+
+  const save = () => {
+    setSaved(false)
+    patchSettingValues({ git_branch_pattern: pattern.trim() })
+      .then(() => {
+        setSaved(true)
+        onSaved()
+      })
+      .catch((err: unknown) => onError(errText(err)))
+  }
+
+  return (
+    <div className="rounded-xl border border-border p-4">
+      <div className="text-sm font-medium">Default branch pattern</div>
+      <div className="mt-3 flex flex-wrap items-end gap-3">
+        <label className="grid gap-1 text-xs text-muted-foreground">
+          Pattern
+          <Input
+            value={pattern}
+            onChange={(e) => setPattern(e.target.value)}
+            placeholder="{type}/{slug}"
+            className="w-72"
+            aria-label="Default branch pattern"
+          />
+        </label>
+        <Button onClick={save}>Save</Button>
+        {saved && <span className="text-xs text-muted-foreground">Saved.</span>}
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Placeholders: <code>{'{type}'}</code> (fix/feat/docs/…), <code>{'{slug}'}</code> (from the
+        goal), <code>{'{login}'}</code> (GitHub login, empty for non-github missions),{' '}
+        <code>{'{date}'}</code> (YYYYMMDD). Empty uses <code>{'{type}/{slug}'}</code>.
+      </p>
+    </div>
+  )
+}
+
+const COMMIT_STYLE_DEFAULT = '__default__'
+
+// GitCommitStyleCard picks the default commit-message style new
+// missions' unit commits use — mirrors DefaultCodingExecutorCard's
+// shape, a fixed choice list.
+function GitCommitStyleCard({
+  values,
+  onError,
+  onSaved,
+}: {
+  values: Record<string, string>
+  onError: (msg: string) => void
+  onSaved: () => void
+}) {
+  const [style, setStyle] = useState(values.git_commit_style ?? '')
+  const [saved, setSaved] = useState(false)
+
+  const save = () => {
+    setSaved(false)
+    patchSettingValues({ git_commit_style: style })
+      .then(() => {
+        setSaved(true)
+        onSaved()
+      })
+      .catch((err: unknown) => onError(errText(err)))
+  }
+
+  return (
+    <div className="rounded-xl border border-border p-4">
+      <div className="text-sm font-medium">Default commit style</div>
+      <div className="mt-3 flex flex-wrap items-end gap-3">
+        <div className="grid gap-1 text-xs text-muted-foreground">
+          <span>Style</span>
+          <Select
+            value={style || COMMIT_STYLE_DEFAULT}
+            onValueChange={(v) => setStyle(v === COMMIT_STYLE_DEFAULT ? '' : v)}
+          >
+            <SelectTrigger className="h-10 w-56" aria-label="Default commit style">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={COMMIT_STYLE_DEFAULT}>Conventional (default)</SelectItem>
+              <SelectItem value="plain">Plain</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <Button onClick={save}>Save</Button>
+        {saved && <span className="text-xs text-muted-foreground">Saved.</span>}
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Conventional: <code>type: subject</code>. Plain: the unit title as-is, no type prefix.
       </p>
     </div>
   )


### PR DESCRIPTION
Global settings (`git_branch_pattern`, `git_commit_style`) plus per-mission overrides in the coding Advanced section. Branch templates support `{type}` `{slug}` `{login}` `{date}` with Go-side validation (charset, no `..`, length cap, empty-`{login}` collapse). Commit style: conventional (default) or plain. Precedence: mission override > settings > built-in default; empty everywhere = exact previous behavior.

- `branchtemplate.go`: validate/expand, probed with both empty and present `{login}`
- `Provision`/`CommitMessage` gain resolved-strategy params; `CloneIdentityResolver` now carries GitHub login
- Migration 0010 edited in place (pre-release rule): `branch_pattern`, `commit_style` columns
- Settings cards + MissionForm Advanced fields; omitted from payload when default

Canary PASS on rebuilt brain.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788839541&installation_model_id=431401&pr_number=202&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F202&signature=a157c6ad2819ac24861512cca028a84e6f49ccbc1670781169cab291fc846c91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->