### PR TITLE
fix: offer pi in the default coding harness setting

### DIFF
--- a/web/src/components/settings/FeaturesTab.tsx
+++ b/web/src/components/settings/FeaturesTab.tsx
@@ -167,7 +167,7 @@ const CODING_EXECUTOR_NATIVE = '__native__'
 // DefaultCodingExecutorCard picks the delegated coding-CLI harness new
 // coding missions default to when the mission itself doesn't specify
 // one — mirrors DefaultCurrencyCard's shape, options are static since
-// there's currently one known harness (claude-cli) besides native.
+// the known harnesses (claude-cli, pi) besides native.
 function DefaultCodingExecutorCard({
   values,
   onError,
@@ -206,6 +206,7 @@ function DefaultCodingExecutorCard({
             <SelectContent>
               <SelectItem value={CODING_EXECUTOR_NATIVE}>Native</SelectItem>
               <SelectItem value="claude-cli">Claude Code</SelectItem>
+              <SelectItem value="pi">pi</SelectItem>
             </SelectContent>
           </Select>
         </div>


### PR DESCRIPTION
Settings → Default coding harness only offered Native and Claude Code; pi was missing even though MissionForm's per-mission harness select and the backend executor-registry validation both already know it. Adds the missing option (+ stale comment fix).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788842139&installation_model_id=431401&pr_number=207&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F207&signature=478b29366de435848483607ce5cc46cba238c906fdc31497a548f5493e10b40f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->