### PR TITLE
feat: credentials directory with reuse picker

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -457,7 +457,7 @@ func main() {
 	api.Register(app.Server, svc, store, broker,
 		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, usageDecorator.Decorate, app.Log), flags, fxStore,
 		agentReg, conns, goog, secrets, agent, missionStore, missionDriver, missionNotifier,
-		missionWorkspace, resolveSecret, routeForRole, chat.ClassifyOverGateway(gwc), gwc.ResolveRoute, chat.TitleOverGateway(gwc), ledgerAgg.TopModelByMission, missionHub, attachmentStore, &http.Client{}, whisperURL, token, app.Log)
+		missionWorkspace, resolveSecret, routeForRole, chat.ClassifyOverGateway(gwc), gwc.ResolveRoute, chat.TitleOverGateway(gwc), ledgerAgg.TopModelByMission, missionHub, attachmentStore, &http.Client{}, whisperURL, token, app.Log, gwc)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)

--- a/internal/brain/api/admin.go
+++ b/internal/brain/api/admin.go
@@ -1,9 +1,12 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
+	"github.com/SumonMSelim/timothy/internal/brain/connectors"
+	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
 	"github.com/SumonMSelim/timothy/internal/brain/settings"
 )
 
@@ -96,4 +99,148 @@ func (a *API) registerSettings(handle func(pattern string, h http.Handler), flag
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})))
+}
+
+// GatewaySecrets is the slice of gwclient.Client the credentials
+// directory needs — an interface at point of use so tests can fake the
+// gateway round trip without a live one. *gwclient.Client satisfies it.
+type GatewaySecrets interface {
+	ListSecrets(ctx context.Context) ([]gwclient.SecretRef, error)
+	DeleteSecret(ctx context.Context, refName string) (status int, err error)
+}
+
+// connectorLister is the slice of connectors.Store the directory
+// needs — *connectors.Store satisfies it.
+type connectorLister interface {
+	List(ctx context.Context) ([]connectors.Connector, error)
+}
+
+// secretRefEntry is the credentials panel's per-ref shape: the
+// gateway's directory metadata plus every referent (provider or
+// connector) across both services, merged here because neither service
+// alone can see both tables. Never a value.
+type secretRefEntry struct {
+	RefName      string          `json:"name"`
+	CreatedAt    any             `json:"created_at,omitempty"`
+	UpdatedAt    any             `json:"updated_at,omitempty"`
+	ReferencedBy []referenceInfo `json:"referenced_by"`
+}
+
+type referenceInfo struct {
+	Kind string `json:"kind"` // "provider" | "connector"
+	Name string `json:"name"`
+}
+
+// registerSecrets mounts brain's own credentials-directory endpoints.
+// GET assembles the gateway's per-ref provider referents with brain's
+// own connector referents (two independent DBs, no new cross-service
+// dependency — see admin_test.go for the design note). DELETE checks
+// connector references itself before forwarding to the gateway, which
+// independently refuses on provider references — each service stays
+// authoritative for the referents it owns. nil gw or conns leaves the
+// surface unmounted.
+func (a *API) registerSecrets(handle func(pattern string, h http.Handler), gw GatewaySecrets, conns connectorLister) {
+	if gw == nil || conns == nil {
+		return
+	}
+	h := &secretsAPI{gw: gw, connectors: conns}
+	handle("GET /v1/admin/secrets", a.auth(http.HandlerFunc(h.list)))
+	handle("DELETE /v1/admin/secrets/{ref_name}", a.auth(http.HandlerFunc(h.delete)))
+}
+
+type secretsAPI struct {
+	gw         GatewaySecrets
+	connectors connectorLister
+}
+
+// connectorRefs maps every stored secret ref name to the connector
+// names referencing it: each row's credential_ref, plus — for a github
+// connector with commit signing enabled — the derived
+// connectors.SigningKeyRefSuffix ref its private signing key lives
+// under, so the signing key never looks orphaned in the panel or
+// becomes deletable while the connector still signs with it.
+func connectorRefs(ctx context.Context, store connectorLister) (map[string][]string, error) {
+	rows, err := store.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string][]string{}
+	for _, c := range rows {
+		if c.CredentialRef == "" {
+			continue
+		}
+		out[c.CredentialRef] = append(out[c.CredentialRef], c.Name)
+		if c.Kind == "github" {
+			var cfg connectors.GitHubConfig
+			if json.Unmarshal(c.Config, &cfg) == nil && (cfg.SignCommits || cfg.SigningPublicKey != "") {
+				ref := connectors.SigningKeyRefSuffix(c.CredentialRef)
+				out[ref] = append(out[ref], c.Name)
+			}
+		}
+	}
+	return out, nil
+}
+
+func (h *secretsAPI) list(w http.ResponseWriter, r *http.Request) {
+	refs, err := h.gw.ListSecrets(r.Context())
+	if err != nil {
+		jsonError(w, http.StatusBadGateway, "gateway_unreachable", err.Error())
+		return
+	}
+	byConnector, err := connectorRefs(r.Context(), h.connectors)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "connectors_failed", err.Error())
+		return
+	}
+
+	out := make([]secretRefEntry, len(refs))
+	for i, ref := range refs {
+		var referents []referenceInfo
+		for _, name := range ref.ReferencedBy {
+			referents = append(referents, referenceInfo{Kind: "provider", Name: name})
+		}
+		for _, name := range byConnector[ref.RefName] {
+			referents = append(referents, referenceInfo{Kind: "connector", Name: name})
+		}
+		out[i] = secretRefEntry{
+			RefName: ref.RefName, CreatedAt: ref.CreatedAt, UpdatedAt: ref.UpdatedAt,
+			ReferencedBy: referents,
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"secrets": out})
+}
+
+// delete refuses (409) while any connector still names ref_name as its
+// credential_ref, without ever asking the gateway — a connector-only
+// reference is brain's own domain. Otherwise it forwards to the
+// gateway, which independently refuses on provider references.
+func (h *secretsAPI) delete(w http.ResponseWriter, r *http.Request) {
+	refName := r.PathValue("ref_name")
+	byConnector, err := connectorRefs(r.Context(), h.connectors)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "connectors_failed", err.Error())
+		return
+	}
+	if names := byConnector[refName]; len(names) > 0 {
+		jsonError(w, http.StatusConflict, "in_use",
+			refName+" is referenced by connector(s) "+joinNames(names))
+		return
+	}
+	status, err := h.gw.DeleteSecret(r.Context(), refName)
+	if err != nil {
+		if status == 0 {
+			status = http.StatusBadGateway
+		}
+		jsonError(w, status, "delete_failed", err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func joinNames(names []string) string {
+	out := names[0]
+	for _, n := range names[1:] {
+		out += ", " + n
+	}
+	return out
 }

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -91,7 +91,7 @@ var memoryRoutePatterns = []string{
 // proxy to the gateway's internal control plane, conns the local
 // connector control plane (nil leaves any of them unmounted).
 // whisperURL empty leaves /v1/transcribe unmounted (WHISPER_URL unset).
-func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, secrets *secretstore.Store, toolset Toolset, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, token string, log *slog.Logger) {
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, secrets *secretstore.Store, toolset Toolset, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, token string, log *slog.Logger, gwSecrets GatewaySecrets) {
 	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log, flags: flags, rates: rates}
 	if memories != nil {
 		for _, pattern := range memoryRoutePatterns {
@@ -99,6 +99,15 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 		}
 	}
 	a.registerAdmin(srv.Handle, admin)
+	// conns is a *connectors.Manager: boxing a nil pointer straight into
+	// the connectorLister interface would make registerSecrets' nil
+	// check fail (non-nil interface holding a nil pointer), so the
+	// conversion happens here, guarded.
+	var connLister connectorLister
+	if conns != nil {
+		connLister = conns.Store()
+	}
+	a.registerSecrets(srv.Handle, gwSecrets, connLister)
 	a.registerSettings(srv.Handle, flags, whisperURL)
 	a.registerAgents(srv.Handle, agentReg)
 	a.registerConnectors(srv.Handle, conns, goog, secrets)

--- a/internal/brain/api/secrets_test.go
+++ b/internal/brain/api/secrets_test.go
@@ -1,0 +1,215 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/connectors"
+	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+)
+
+// fakeGatewaySecrets stubs the gateway round trip so the credentials
+// directory's merge logic can be tested without a live gateway.
+type fakeGatewaySecrets struct {
+	refs       []gwclient.SecretRef
+	listErr    error
+	deleteErr  error
+	deleteCode int
+	deletedRef string
+}
+
+func (f *fakeGatewaySecrets) ListSecrets(context.Context) ([]gwclient.SecretRef, error) {
+	return f.refs, f.listErr
+}
+
+func (f *fakeGatewaySecrets) DeleteSecret(_ context.Context, refName string) (int, error) {
+	f.deletedRef = refName
+	if f.deleteErr != nil {
+		return f.deleteCode, f.deleteErr
+	}
+	return http.StatusNoContent, nil
+}
+
+// fakeConnectorLister stubs connectors.Store's List for the same
+// reason — no DB needed to test the merge/guard logic.
+type fakeConnectorLister struct {
+	rows []connectors.Connector
+	err  error
+}
+
+func (f *fakeConnectorLister) List(context.Context) ([]connectors.Connector, error) {
+	return f.rows, f.err
+}
+
+func TestListSecretsMergesProviderAndConnectorReferents(t *testing.T) {
+	t.Parallel()
+	a := &API{token: "tok", log: discard()}
+	gw := &fakeGatewaySecrets{refs: []gwclient.SecretRef{
+		{RefName: "GITHUB_PAT", ReferencedBy: []string{"github-provider"}},
+		{RefName: "GITHUB_PAT_SIGNING_KEY"},
+		{RefName: "ORPHAN_KEY"},
+	}}
+	conns := &fakeConnectorLister{rows: []connectors.Connector{
+		{Name: "github-mcp", CredentialRef: "GITHUB_PAT"},
+		{Name: "github-signed", Kind: "github", CredentialRef: "GITHUB_PAT", Config: json.RawMessage(`{"sign_commits":true,"signing_public_key":"ssh-ed25519 AAAA"}`)},
+		{Name: "no-cred", CredentialRef: ""},
+	}}
+	m := http.NewServeMux()
+	a.registerSecrets(m.Handle, gw, conns)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/secrets", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var body struct {
+		Secrets []secretRefEntry `json:"secrets"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Secrets) != 3 {
+		t.Fatalf("secrets = %+v, want 3 entries", body.Secrets)
+	}
+	byName := map[string]secretRefEntry{}
+	for _, s := range body.Secrets {
+		byName[s.RefName] = s
+	}
+	got := byName["GITHUB_PAT"].ReferencedBy
+	if len(got) != 3 {
+		t.Fatalf("GITHUB_PAT referenced_by = %+v, want provider + 2 connectors", got)
+	}
+	want := map[referenceInfo]bool{
+		{Kind: "provider", Name: "github-provider"}: true,
+		{Kind: "connector", Name: "github-mcp"}:     true,
+		{Kind: "connector", Name: "github-signed"}:  true,
+	}
+	for _, r := range got {
+		if !want[r] {
+			t.Fatalf("unexpected referent %+v in %+v", r, got)
+		}
+	}
+	signKey := byName["GITHUB_PAT_SIGNING_KEY"].ReferencedBy
+	if len(signKey) != 1 || signKey[0] != (referenceInfo{Kind: "connector", Name: "github-signed"}) {
+		t.Fatalf("GITHUB_PAT_SIGNING_KEY referenced_by = %+v, want the signing connector (derived ref must never look orphaned)", signKey)
+	}
+	if len(byName["ORPHAN_KEY"].ReferencedBy) != 0 {
+		t.Fatalf("ORPHAN_KEY referenced_by = %+v, want empty", byName["ORPHAN_KEY"].ReferencedBy)
+	}
+}
+
+func TestListSecretsPropagatesGatewayFailure(t *testing.T) {
+	t.Parallel()
+	a := &API{token: "tok", log: discard()}
+	gw := &fakeGatewaySecrets{listErr: errors.New("gateway down")}
+	conns := &fakeConnectorLister{}
+	m := http.NewServeMux()
+	a.registerSecrets(m.Handle, gw, conns)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/secrets", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
+	}
+}
+
+func TestDeleteSecretRefusesWhenConnectorReferencesIt(t *testing.T) {
+	t.Parallel()
+	a := &API{token: "tok", log: discard()}
+	gw := &fakeGatewaySecrets{}
+	conns := &fakeConnectorLister{rows: []connectors.Connector{
+		{Name: "github-mcp", CredentialRef: "GITHUB_PAT"},
+	}}
+	m := http.NewServeMux()
+	a.registerSecrets(m.Handle, gw, conns)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/admin/secrets/GITHUB_PAT", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", w.Code)
+	}
+	if gw.deletedRef != "" {
+		t.Fatalf("gateway DeleteSecret called with %q, want never called (connector guard must short-circuit)", gw.deletedRef)
+	}
+	var body struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Message == "" {
+		t.Fatal("error message empty, want it to list the referencing connector")
+	}
+}
+
+func TestDeleteSecretForwardsOrphanedRefToGateway(t *testing.T) {
+	t.Parallel()
+	a := &API{token: "tok", log: discard()}
+	gw := &fakeGatewaySecrets{}
+	conns := &fakeConnectorLister{}
+	m := http.NewServeMux()
+	a.registerSecrets(m.Handle, gw, conns)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/admin/secrets/ORPHAN_KEY", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", w.Code)
+	}
+	if gw.deletedRef != "ORPHAN_KEY" {
+		t.Fatalf("gateway DeleteSecret called with %q, want ORPHAN_KEY", gw.deletedRef)
+	}
+}
+
+// TestDeleteSecretPropagatesGatewayInUseRefusal covers the other half
+// of the split guard: a provider-only reference is invisible to
+// brain's connector check, so the gateway's own 409 must still surface
+// unchanged.
+func TestDeleteSecretPropagatesGatewayInUseRefusal(t *testing.T) {
+	t.Parallel()
+	a := &API{token: "tok", log: discard()}
+	gw := &fakeGatewaySecrets{deleteErr: errors.New("SOME_KEY is referenced by provider(s) [openai]: in use"), deleteCode: http.StatusConflict}
+	conns := &fakeConnectorLister{}
+	m := http.NewServeMux()
+	a.registerSecrets(m.Handle, gw, conns)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/admin/secrets/SOME_KEY", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 from the gateway's own refusal", w.Code)
+	}
+}
+
+func TestRegisterSecretsUnmountedWithoutGatewayOrConnectors(t *testing.T) {
+	t.Parallel()
+	a := &API{token: "tok", log: discard()}
+	m := http.NewServeMux()
+	a.registerSecrets(m.Handle, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/secrets", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (route unmounted)", w.Code)
+	}
+}

--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -250,6 +251,73 @@ func (c *Client) ResolveRoute(ctx context.Context, name, harness string) (*Resol
 	c.resolved[cacheKey] = resolveCacheEntry{route: &out, exp: time.Now().Add(resolveTTL)}
 	c.mu.Unlock()
 	return &out, nil
+}
+
+// SecretRef mirrors the gateway admin's SecretRef: a stored secret's
+// directory metadata plus the provider names that reference it. Never
+// a value.
+type SecretRef struct {
+	RefName      string    `json:"ref_name"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	ReferencedBy []string  `json:"referenced_by_providers"`
+}
+
+// ListSecrets fetches the gateway's secrets directory (names,
+// timestamps, provider referents) — never a value. Brain's own
+// /v1/admin/secrets handler merges connector referents into this
+// before serving it to the UI.
+func (c *Client) ListSecrets(ctx context.Context) ([]SecretRef, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/internal/admin/secrets", nil)
+	if err != nil {
+		return nil, fmt.Errorf("gwclient: request: %w", err)
+	}
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("gwclient: gateway unreachable: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("gwclient: gateway http %d: %s", resp.StatusCode, string(msg))
+	}
+	var out struct {
+		Secrets []SecretRef `json:"secrets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("gwclient: decode secrets: %w", err)
+	}
+	return out.Secrets, nil
+}
+
+// DeleteSecret proxies the delete to the gateway, which refuses (in
+// use) while any provider still names refName as its credential_ref.
+// Brain's own handler checks connector references first so a
+// connector-only refusal never round-trips to the gateway at all. On
+// failure it returns the gateway's own status code so the caller can
+// preserve a 409 (in use) rather than flattening every failure to 500.
+func (c *Client) DeleteSecret(ctx context.Context, refName string) (status int, err error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodDelete,
+		c.baseURL+"/internal/admin/secrets/"+url.PathEscape(refName), nil)
+	if err != nil {
+		return 0, fmt.Errorf("gwclient: request: %w", err)
+	}
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return 0, fmt.Errorf("gwclient: gateway unreachable: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNoContent {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		var body struct {
+			Message string `json:"message"`
+		}
+		if err := json.Unmarshal(raw, &body); err == nil && body.Message != "" {
+			return resp.StatusCode, errors.New(body.Message)
+		}
+		return resp.StatusCode, fmt.Errorf("gwclient: gateway http %d: %s", resp.StatusCode, string(raw))
+	}
+	return http.StatusNoContent, nil
 }
 
 // Embed returns one vector per input text via the gateway's

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -88,14 +88,99 @@ func (a *Admin) SetSecret(ctx context.Context, refName, value string) error {
 	return nil
 }
 
-// DeleteSecret removes a stored secret value.
+// DeleteSecret removes a stored secret value. Refused while an enabled
+// provider still names refName as its credential_ref — the values a
+// credential unlocks (chat completions) must never start failing
+// silently because its directory entry vanished out from under it.
 func (a *Admin) DeleteSecret(ctx context.Context, refName string) error {
+	providers, err := a.providersReferencing(ctx, refName)
+	if err != nil {
+		return err
+	}
+	if len(providers) > 0 {
+		return fmt.Errorf("%s is referenced by provider(s) %v: %w", refName, providers, ErrInUse)
+	}
 	if err := a.secrets.Delete(ctx, refName); err != nil {
 		return err
 	}
 	a.audit(ctx, "delete", "secret", refName, map[string]bool{"configured": true}, nil)
 	a.reload(ctx)
 	return nil
+}
+
+// providersReferencing returns the names of every provider row whose
+// credential_ref matches refName, regardless of enabled state — a
+// disabled provider still owns the credential and a delete would strand
+// it, so DeleteSecret refuses on any match, not just enabled ones.
+func (a *Admin) providersReferencing(ctx context.Context, refName string) ([]string, error) {
+	db, err := a.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("admin secrets: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT name FROM providers WHERE credential_ref = $1 ORDER BY name`, refName)
+	if err != nil {
+		return nil, fmt.Errorf("admin secrets: referenced by: %w", err)
+	}
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("admin secrets: referenced by: %w", err)
+		}
+		names = append(names, name)
+	}
+	return names, rows.Err()
+}
+
+// SecretRef is one stored secret's directory entry: name and
+// timestamps, plus the providers that name it as credential_ref. Values
+// are never included — ListSecrets exists so the UI can show what
+// exists and what would break on delete, nothing more.
+type SecretRef struct {
+	RefName      string    `json:"ref_name"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	ReferencedBy []string  `json:"referenced_by_providers"`
+}
+
+// ListSecrets returns every stored secret's directory metadata with the
+// providers (by name) that reference it. Connector references are
+// brain's own domain (D-057-style split) — the caller (brain's proxy)
+// merges those in; this only ever reports what the gateway's own
+// tables know about.
+func (a *Admin) ListSecrets(ctx context.Context) ([]SecretRef, error) {
+	refs, err := a.secrets.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	db, err := a.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("admin secrets: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT credential_ref, name FROM providers WHERE credential_ref <> '' ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("admin secrets: referenced by: %w", err)
+	}
+	defer rows.Close()
+	byRef := map[string][]string{}
+	for rows.Next() {
+		var ref, name string
+		if err := rows.Scan(&ref, &name); err != nil {
+			return nil, fmt.Errorf("admin secrets: referenced by: %w", err)
+		}
+		byRef[ref] = append(byRef[ref], name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("admin secrets: referenced by: %w", err)
+	}
+
+	out := make([]SecretRef, len(refs))
+	for i, r := range refs {
+		out[i] = SecretRef{RefName: r.RefName, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+			ReferencedBy: byRef[r.RefName]}
+	}
+	return out, nil
 }
 
 // SetSecretValue stores value under refName through the store-wide

--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -817,6 +817,95 @@ func TestCreateExcludeFromBootstrapSkipsFixedRoutes(t *testing.T) {
 	}
 }
 
+// TestListSecretsReportsProviderReferents pins ListSecrets' contract:
+// every stored ref comes back with timestamps and the names of every
+// provider whose credential_ref matches it, an orphaned ref reports an
+// empty (never nil, for a clean UI render) referenced_by.
+func TestListSecretsReportsProviderReferents(t *testing.T) {
+	adm, _, _ := testAdmin(t)
+	ctx := t.Context()
+
+	ref := adminMarker + "listed"
+	if err := adm.SetSecret(ctx, ref, "sk-live-value"); err != nil {
+		t.Fatalf("SetSecret: %v", err)
+	}
+	orphan := adminMarker + "orphan"
+	if err := adm.SetSecret(ctx, orphan, "sk-live-value-2"); err != nil {
+		t.Fatalf("SetSecret orphan: %v", err)
+	}
+	id, err := adm.Create(ctx, Provider{
+		Name: adminMarker + "listing-provider", Kind: "api", Driver: "openaicompat",
+		BaseURL: "https://example.invalid/v1", DefaultModel: "m1", CredentialRef: ref,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Cleanup(func() { _ = adm.Delete(ctx, id) })
+
+	refs, err := adm.ListSecrets(ctx)
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+	byName := map[string]SecretRef{}
+	for _, r := range refs {
+		byName[r.RefName] = r
+	}
+	got, ok := byName[ref]
+	if !ok {
+		t.Fatalf("ListSecrets missing %s", ref)
+	}
+	if got.CreatedAt.IsZero() || got.UpdatedAt.IsZero() {
+		t.Fatalf("ref %s timestamps = %+v, want both set", ref, got)
+	}
+	if len(got.ReferencedBy) != 1 || got.ReferencedBy[0] != adminMarker+"listing-provider" {
+		t.Fatalf("ref %s referenced_by = %v, want [%s]", ref, got.ReferencedBy, adminMarker+"listing-provider")
+	}
+	orphanGot, ok := byName[orphan]
+	if !ok {
+		t.Fatalf("ListSecrets missing %s", orphan)
+	}
+	if len(orphanGot.ReferencedBy) != 0 {
+		t.Fatalf("orphan ref referenced_by = %v, want empty", orphanGot.ReferencedBy)
+	}
+}
+
+// TestDeleteSecretRefusesWhileProviderReferencesIt pins the guard added
+// to DeleteSecret: a provider naming refName as credential_ref blocks
+// the delete regardless of the provider's enabled state (a disabled
+// provider still owns the credential), and the row survives; deleting
+// the provider first lets the secret go.
+func TestDeleteSecretRefusesWhileProviderReferencesIt(t *testing.T) {
+	adm, _, _ := testAdmin(t)
+	ctx := t.Context()
+
+	ref := adminMarker + "guarded"
+	if err := adm.SetSecret(ctx, ref, "sk-live-value"); err != nil {
+		t.Fatalf("SetSecret: %v", err)
+	}
+	id, err := adm.Create(ctx, Provider{
+		Name: adminMarker + "guard-provider", Kind: "api", Driver: "openaicompat",
+		BaseURL: "https://example.invalid/v1", DefaultModel: "m1", CredentialRef: ref,
+		Enabled: false,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := adm.DeleteSecret(ctx, ref); err == nil || !strings.Contains(err.Error(), "referenced by provider") {
+		t.Fatalf("DeleteSecret while referenced = %v, want in-use refusal naming the provider", err)
+	}
+	if configured, _, err := adm.SecretStatus(ctx, ref); err != nil || !configured {
+		t.Fatalf("SecretStatus after refused delete: configured=%v err=%v, want still configured", configured, err)
+	}
+
+	if err := adm.Delete(ctx, id); err != nil {
+		t.Fatalf("Delete provider: %v", err)
+	}
+	if err := adm.DeleteSecret(ctx, ref); err != nil {
+		t.Fatalf("DeleteSecret after provider removed: %v", err)
+	}
+}
+
 func TestSecretExternalBackendConfig(t *testing.T) {
 	adm, _, _ := testAdmin(t)
 	ctx := t.Context()

--- a/internal/gateway/api/admin.go
+++ b/internal/gateway/api/admin.go
@@ -28,6 +28,7 @@ func RegisterAdmin(srv *httpserver.Server, adm *admin.Admin) {
 	srv.Handle("DELETE /internal/admin/routes/{name}", http.HandlerFunc(h.deleteRoute))
 	srv.Handle("PUT /internal/admin/routes/{name}/role", http.HandlerFunc(h.setRouteRole))
 	srv.Handle("PATCH /internal/admin/usage/budget", http.HandlerFunc(h.patchBudget))
+	srv.Handle("GET /internal/admin/secrets", http.HandlerFunc(h.listSecrets))
 	srv.Handle("PUT /internal/admin/secrets/{ref_name}", http.HandlerFunc(h.setSecret))
 	srv.Handle("DELETE /internal/admin/secrets/{ref_name}", http.HandlerFunc(h.deleteSecret))
 	srv.Handle("GET /internal/admin/secrets/{ref_name}", http.HandlerFunc(h.getSecretStatus))
@@ -263,6 +264,17 @@ func (h *adminAPI) setSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// listSecrets serves the credentials directory: names, timestamps, and
+// which providers reference each one. Never a value.
+func (h *adminAPI) listSecrets(w http.ResponseWriter, r *http.Request) {
+	refs, err := h.adm.ListSecrets(r.Context())
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "admin_failed", err.Error())
+		return
+	}
+	writeJSON(w, map[string]any{"secrets": refs})
 }
 
 func (h *adminAPI) deleteSecret(w http.ResponseWriter, r *http.Request) {

--- a/internal/secretstore/secretstore.go
+++ b/internal/secretstore/secretstore.go
@@ -17,6 +17,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -111,6 +112,39 @@ func (s *Store) Status(ctx context.Context, refName string) (configured bool, ba
 		return false, "", err
 	}
 	return true, r.backend, nil
+}
+
+// Ref is one secrets-table row's directory metadata — name and
+// timestamps only, never the value or its backend_ref (which can leak
+// the external path an operator otherwise never sees).
+type Ref struct {
+	RefName   string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// List returns every stored ref's directory metadata, ordered by name,
+// for the credentials panel. Never resolves or exposes a value.
+func (s *Store) List(ctx context.Context) ([]Ref, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("secretstore: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT ref_name, created_at, updated_at FROM secrets ORDER BY ref_name`)
+	if err != nil {
+		return nil, fmt.Errorf("secretstore: list: %w", err)
+	}
+	defer rows.Close()
+
+	out := []Ref{}
+	for rows.Next() {
+		var r Ref
+		if err := rows.Scan(&r.RefName, &r.CreatedAt, &r.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("secretstore: list: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
 }
 
 // externalRef is the backend_ref every write-through secret gets in an

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -635,6 +635,31 @@ export async function deleteSecret(refName: string): Promise<void> {
   await request<void>(`/v1/admin/secrets/${encodeURIComponent(refName)}`, { method: 'DELETE' })
 }
 
+// SecretReference is one provider or connector naming a credential ref
+// as its credential_ref — the credentials panel's used-by chips.
+export interface SecretReference {
+  kind: 'provider' | 'connector'
+  name: string
+}
+
+// SecretRefEntry is one stored secret's directory entry: name,
+// timestamps (when the row has them), and every referent across both
+// providers and connectors. Never a value — the credentials panel is a
+// directory, not a vault viewer.
+export interface SecretRefEntry {
+  name: string
+  created_at?: string
+  updated_at?: string
+  referenced_by: SecretReference[]
+}
+
+// listSecretRefs lists every stored credential ref for the Credentials
+// tab and the "use existing" pickers on provider/connector forms.
+export async function listSecretRefs(): Promise<SecretRefEntry[]> {
+  const { secrets } = await request<{ secrets: SecretRefEntry[] }>('/v1/admin/secrets')
+  return secrets ?? []
+}
+
 export interface SecretStatus {
   configured: boolean
   backend: string

--- a/web/src/components/settings/ConnectorAdd.test.tsx
+++ b/web/src/components/settings/ConnectorAdd.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ConnectorAdd } from './ConnectorAdd'
+
+vi.mock('../../api/client', () => ({
+  connectorOAuthStart: vi.fn(),
+  createConnector: vi.fn(),
+  listSecretBackends: vi.fn(),
+  listSecretRefs: vi.fn(),
+  patchConnector: vi.fn(),
+  setSecret: vi.fn(),
+  testConnector: vi.fn(),
+}))
+
+import {
+  createConnector,
+  listSecretBackends,
+  listSecretRefs,
+  patchConnector,
+  setSecret,
+  testConnector,
+} from '../../api/client'
+
+function renderPage(presetId: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/settings/connectors/new/${presetId}`]}>
+      <Routes>
+        <Route path="/settings/connectors/new/:presetId" element={<ConnectorAdd />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  vi.clearAllMocks()
+  vi.mocked(listSecretBackends).mockResolvedValue([{ backend: 'db', configured: true, default: true }])
+  vi.mocked(listSecretRefs).mockResolvedValue([
+    { name: 'GITHUB_PAT', referenced_by: [{ kind: 'connector', name: 'github-account' }] },
+  ])
+})
+
+describe('ConnectorAdd existing-credential picker (github MCP token)', () => {
+  it('defaults to New credential with the paste field visible', async () => {
+    renderPage('github')
+    expect(await screen.findByPlaceholderText('ghp_… or github_pat_…')).toBeInTheDocument()
+  })
+
+  it('choosing an existing ref skips the token secret write and reuses it as credential_ref', async () => {
+    vi.mocked(createConnector).mockResolvedValue('conn-1')
+    vi.mocked(testConnector).mockResolvedValue({ ok: true })
+    vi.mocked(patchConnector).mockResolvedValue()
+    renderPage('github')
+
+    fireEvent.change(await screen.findByPlaceholderText('github-mcp'), { target: { value: 'github-mcp-2' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Use existing' }))
+    expect(screen.queryByPlaceholderText('ghp_… or github_pat_…')).not.toBeInTheDocument()
+
+    fireEvent.click(await screen.findByLabelText('existing credential'))
+    fireEvent.click(await screen.findByRole('option', { name: /GITHUB_PAT/ }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Test connection' }))
+    await waitFor(() => expect(createConnector).toHaveBeenCalled())
+    expect(setSecret).not.toHaveBeenCalled()
+    expect(vi.mocked(createConnector).mock.calls[0][0]).toMatchObject({ credential_ref: 'GITHUB_PAT' })
+  })
+})

--- a/web/src/components/settings/ConnectorAdd.tsx
+++ b/web/src/components/settings/ConnectorAdd.tsx
@@ -15,6 +15,7 @@ import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { ConnectorLogo } from './ConnectorLogo'
 import { connectorPresets } from './connectorPresets'
+import { CredentialModeToggle, ExistingCredentialSelect, type CredentialMode } from './CredentialRefPicker'
 import { Field } from './shared'
 import { useDefaultSecretBackend } from './useDefaultSecretBackend'
 import { errText, secretDestination } from './util'
@@ -53,6 +54,14 @@ export function ConnectorAdd() {
   // providers have. createdID tracks that row so a passing test's
   // Add just enables it rather than creating a second one.
   const [createdID, setCreatedID] = useState<string | null>(null)
+  // tokenCredMode/clientSecretCredMode: "new" pastes+stores a fresh
+  // secret (current behavior); "existing" reuses a stored ref instead
+  // — e.g. the same GitHub PAT already used by another connector, or
+  // the same Google OAuth client credentials across gmail/calendar.
+  const [tokenCredMode, setTokenCredMode] = useState<CredentialMode>('new')
+  const [existingTokenRef, setExistingTokenRef] = useState('')
+  const [clientSecretCredMode, setClientSecretCredMode] = useState<CredentialMode>('new')
+  const [existingClientSecretRef, setExistingClientSecretRef] = useState('')
 
   useEffect(() => {
     if (!preset) return
@@ -64,6 +73,10 @@ export function ConnectorAdd() {
     setBusy(false)
     setTest(null)
     setCreatedID(null)
+    setTokenCredMode('new')
+    setExistingTokenRef('')
+    setClientSecretCredMode('new')
+    setExistingClientSecretRef('')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [preset?.id])
 
@@ -79,6 +92,8 @@ export function ConnectorAdd() {
     setCreatedID(null)
   }
 
+  const usingExistingToken = tokenCredMode === 'existing'
+
   const runTest = async () => {
     if (!slug) {
       toast.error('Name required', { description: 'Give this connector a unique name before testing.' })
@@ -88,8 +103,12 @@ export function ConnectorAdd() {
       toast.error('Endpoint required', { description: 'An MCP endpoint is required to test this connector.' })
       return
     }
-    if (isGitHub && !token.trim()) {
+    if (isGitHub && !usingExistingToken && !token.trim()) {
       toast.error('Token required', { description: 'A personal access token is required to test this connector.' })
+      return
+    }
+    if (usingExistingToken && !existingTokenRef) {
+      toast.error('Credential required', { description: 'Choose an existing credential to reuse.' })
       return
     }
     setBusy(true)
@@ -97,14 +116,16 @@ export function ConnectorAdd() {
     try {
       // Suffix without stuttering: a name already ending in the flavor
       // word ("github", "github-mcp") gets the bare _PAT/_TOKEN suffix.
-      const tokenRef = isGitHub
-        ? refBase.endsWith('GITHUB')
-          ? `${refBase}_PAT`
-          : `${refBase}_GITHUB_PAT`
-        : refBase.endsWith('_MCP')
-          ? `${refBase}_TOKEN`
-          : `${refBase}_MCP_TOKEN`
-      if (token) await setSecret(tokenRef, token.trim())
+      const tokenRef = usingExistingToken
+        ? existingTokenRef
+        : isGitHub
+          ? refBase.endsWith('GITHUB')
+            ? `${refBase}_PAT`
+            : `${refBase}_GITHUB_PAT`
+          : refBase.endsWith('_MCP')
+            ? `${refBase}_TOKEN`
+            : `${refBase}_MCP_TOKEN`
+      if (!usingExistingToken && token) await setSecret(tokenRef, token.trim())
       const id = await createConnector(
         isGitHub
           ? { name: slug, kind: 'github', config: {}, credential_ref: tokenRef, enabled: false }
@@ -112,7 +133,7 @@ export function ConnectorAdd() {
               name: slug,
               kind: 'mcp',
               config: { endpoint: endpoint.trim() },
-              credential_ref: token ? tokenRef : '',
+              credential_ref: usingExistingToken || token ? tokenRef : '',
               enabled: false,
             },
       )
@@ -143,11 +164,13 @@ export function ConnectorAdd() {
     }
   }
 
+  const usingExistingClientSecret = clientSecretCredMode === 'existing'
+
   const submitGoogle = async () => {
     setBusy(true)
     try {
-      const secretRef = `${refBase}_GOOGLE_CLIENT_SECRET`
-      await setSecret(secretRef, clientSecret)
+      const secretRef = usingExistingClientSecret ? existingClientSecretRef : `${refBase}_GOOGLE_CLIENT_SECRET`
+      if (!usingExistingClientSecret) await setSecret(secretRef, clientSecret)
       const id = await createConnector({
         name: slug,
         kind: 'google',
@@ -166,8 +189,13 @@ export function ConnectorAdd() {
     }
   }
 
-  const canTest = slug !== '' && (isGitHub ? token.trim() !== '' : endpoint.trim() !== '')
-  const canSubmitGoogle = slug !== '' && clientID.trim() !== '' && clientSecret !== ''
+  const canTest =
+    slug !== '' &&
+    (isGitHub ? (usingExistingToken ? existingTokenRef !== '' : token.trim() !== '') : endpoint.trim() !== '')
+  const canSubmitGoogle =
+    slug !== '' &&
+    clientID.trim() !== '' &&
+    (usingExistingClientSecret ? existingClientSecretRef !== '' : clientSecret !== '')
 
   return (
     <div className="mt-6 w-full space-y-6">
@@ -211,16 +239,27 @@ export function ConnectorAdd() {
                   className="mt-1.5 h-10"
                 />
               </Field>
-              <Field label="OAuth client secret">
-                <Input
-                  type="password"
-                  value={clientSecret}
-                  onChange={(e) => setClientSecret(e.target.value)}
-                  placeholder="GOCSPX-…"
-                  className="mt-1.5 h-10"
-                  autoComplete="off"
-                />
-              </Field>
+              <div>
+                <div className="mb-1.5 flex items-center justify-between">
+                  <span className="text-sm font-medium text-foreground">OAuth client secret</span>
+                  <CredentialModeToggle mode={clientSecretCredMode} onChange={setClientSecretCredMode} />
+                </div>
+                {clientSecretCredMode === 'existing' ? (
+                  <ExistingCredentialSelect
+                    value={existingClientSecretRef}
+                    onChange={setExistingClientSecretRef}
+                  />
+                ) : (
+                  <Input
+                    type="password"
+                    value={clientSecret}
+                    onChange={(e) => setClientSecret(e.target.value)}
+                    placeholder="GOCSPX-…"
+                    className="h-10"
+                    autoComplete="off"
+                  />
+                )}
+              </div>
             </div>
             <p className="text-sm text-muted-foreground">
               From a Google Cloud OAuth client (Web application). Add{' '}
@@ -259,48 +298,66 @@ export function ConnectorAdd() {
               </>
             )}
             <div>
-              <Field
-                label={
-                  isGitHub ? 'Personal access token' : preset.id === 'custom-mcp' ? 'Bearer token (optional)' : 'Bearer token'
-                }
-              >
-                <Input
-                  type="password"
-                  value={token}
-                  onChange={(e) => {
-                    setToken(e.target.value)
+              <div className="mb-1.5 flex items-center justify-between">
+                <span className="text-sm font-medium text-foreground">
+                  {isGitHub ? 'Personal access token' : preset.id === 'custom-mcp' ? 'Bearer token (optional)' : 'Bearer token'}
+                </span>
+                <CredentialModeToggle
+                  mode={tokenCredMode}
+                  onChange={(m) => {
+                    setTokenCredMode(m)
                     invalidate()
                   }}
-                  placeholder={preset.tokenPlaceholder ?? 'token'}
-                  className="mt-1.5 h-10"
-                  autoComplete="off"
                 />
-              </Field>
-              <p className="mt-1.5 text-sm text-muted-foreground">
-                {preset.tokenHint}
-                {preset.tokenURL && (
-                  <>
-                    {' '}
-                    <a
-                      href={preset.tokenURL}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="font-medium text-primary underline underline-offset-2 hover:no-underline"
-                    >
-                      Create one on GitHub →
-                    </a>
-                  </>
-                )}
-                {!preset.tokenURL && (
-                  <>
-                    {' '}
-                    {secretDestination(
-                      defaultBackend,
-                      isGitHub ? `${refBase}_GITHUB_PAT` : `${refBase}_MCP_TOKEN`,
+              </div>
+              {tokenCredMode === 'existing' ? (
+                <ExistingCredentialSelect
+                  value={existingTokenRef}
+                  onChange={(v) => {
+                    setExistingTokenRef(v)
+                    invalidate()
+                  }}
+                />
+              ) : (
+                <>
+                  <Input
+                    type="password"
+                    value={token}
+                    onChange={(e) => {
+                      setToken(e.target.value)
+                      invalidate()
+                    }}
+                    placeholder={preset.tokenPlaceholder ?? 'token'}
+                    className="h-10"
+                    autoComplete="off"
+                  />
+                  <p className="mt-1.5 text-sm text-muted-foreground">
+                    {preset.tokenHint}
+                    {preset.tokenURL && (
+                      <>
+                        {' '}
+                        <a
+                          href={preset.tokenURL}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+                        >
+                          Create one on GitHub →
+                        </a>
+                      </>
                     )}
-                  </>
-                )}
-              </p>
+                    {!preset.tokenURL && (
+                      <>
+                        {' '}
+                        {secretDestination(
+                          defaultBackend,
+                          isGitHub ? `${refBase}_GITHUB_PAT` : `${refBase}_MCP_TOKEN`,
+                        )}
+                      </>
+                    )}
+                  </p>
+                </>
+              )}
             </div>
 
             <div

--- a/web/src/components/settings/CredentialRefPicker.tsx
+++ b/web/src/components/settings/CredentialRefPicker.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react'
+import { listSecretRefs, type SecretRefEntry } from '../../api/client'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { Field } from './shared'
+
+export type CredentialMode = 'new' | 'existing'
+
+// referentLabel renders a ref's used-by hint for the option label — no
+// type-classification of secrets, just what already references it.
+function referentLabel(ref: SecretRefEntry): string {
+  if (ref.referenced_by.length === 0) return ref.name
+  return `${ref.name} (used by ${ref.referenced_by.map((r) => r.name).join(', ')})`
+}
+
+// ModeToggle is the segmented "New credential" / "Use existing"
+// control shared by every form offering credential reuse.
+export function CredentialModeToggle({
+  mode,
+  onChange,
+}: {
+  mode: CredentialMode
+  onChange: (mode: CredentialMode) => void
+}) {
+  return (
+    <div className="inline-flex rounded-lg border border-border p-0.5 text-sm">
+      {(['new', 'existing'] as const).map((m) => (
+        <button
+          key={m}
+          type="button"
+          onClick={() => onChange(m)}
+          className={`rounded-md px-2.5 py-1 font-medium transition ${
+            mode === m ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'
+          }`}
+        >
+          {m === 'new' ? 'New credential' : 'Use existing'}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// ExistingCredentialSelect lists every stored ref (fetched fresh on
+// mount) for a "Use existing" picker. Choosing one is the caller's
+// responsibility to wire into credential_ref; this component only
+// lists and reports the choice.
+export function ExistingCredentialSelect({
+  value,
+  onChange,
+  placeholder = 'choose a stored credential',
+}: {
+  value: string
+  onChange: (refName: string) => void
+  placeholder?: string
+}) {
+  const [refs, setRefs] = useState<SecretRefEntry[]>([])
+  useEffect(() => {
+    listSecretRefs().then(setRefs, () => undefined)
+  }, [])
+
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className="mt-1.5 h-10 w-full" aria-label="existing credential">
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {refs.map((r) => (
+          <SelectItem key={r.name} value={r.name}>
+            {referentLabel(r)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+// CredentialRefField pairs the mode toggle with either the caller's own
+// "new credential" fields (children) or the existing-ref picker —
+// choosing existing sets credential_ref to that name; the caller skips
+// its own secret PUT on submit whenever mode is "existing".
+export function CredentialRefField({
+  label,
+  mode,
+  onModeChange,
+  existingRef,
+  onExistingRefChange,
+  children,
+}: {
+  label: string
+  mode: CredentialMode
+  onModeChange: (mode: CredentialMode) => void
+  existingRef: string
+  onExistingRefChange: (refName: string) => void
+  children: React.ReactNode
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-foreground">{label}</span>
+        <CredentialModeToggle mode={mode} onChange={onModeChange} />
+      </div>
+      {mode === 'existing' ? (
+        <Field label="Existing credential">
+          <ExistingCredentialSelect value={existingRef} onChange={onExistingRefChange} />
+        </Field>
+      ) : (
+        children
+      )}
+    </div>
+  )
+}

--- a/web/src/components/settings/CredentialsTab.test.tsx
+++ b/web/src/components/settings/CredentialsTab.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SecretRefEntry } from '../../api/client'
+import { CredentialsTab } from './CredentialsTab'
+
+vi.mock('../../api/client', () => ({
+  deleteSecret: vi.fn(),
+  listSecretRefs: vi.fn(),
+}))
+
+import { deleteSecret, listSecretRefs } from '../../api/client'
+
+const referenced: SecretRefEntry = {
+  name: 'GITHUB_PAT',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+  referenced_by: [
+    { kind: 'connector', name: 'github-mcp' },
+    { kind: 'provider', name: 'github-provider' },
+  ],
+}
+
+const orphaned: SecretRefEntry = {
+  name: 'OLD_KEY',
+  referenced_by: [],
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('CredentialsTab', () => {
+  it('renders every stored ref with its used-by chips and no delete button when referenced', async () => {
+    vi.mocked(listSecretRefs).mockResolvedValue([referenced])
+    render(<CredentialsTab />)
+
+    expect(await screen.findByText('GITHUB_PAT')).toBeInTheDocument()
+    expect(screen.getByText(/connector: github-mcp/)).toBeInTheDocument()
+    expect(screen.getByText(/provider: github-provider/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Delete GITHUB_PAT' })).not.toBeInTheDocument()
+  })
+
+  it('shows an empty state when nothing is stored', async () => {
+    vi.mocked(listSecretRefs).mockResolvedValue([])
+    render(<CredentialsTab />)
+
+    expect(await screen.findByText('No credentials stored yet.')).toBeInTheDocument()
+  })
+
+  it('marks an unreferenced ref as orphaned and offers a delete button', async () => {
+    vi.mocked(listSecretRefs).mockResolvedValue([orphaned])
+    render(<CredentialsTab />)
+
+    expect(await screen.findByText('OLD_KEY')).toBeInTheDocument()
+    expect(screen.getByText('orphaned')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete OLD_KEY' })).toBeInTheDocument()
+  })
+
+  it('requires confirmation before deleting, and refreshes the list after', async () => {
+    vi.mocked(listSecretRefs).mockResolvedValueOnce([orphaned]).mockResolvedValueOnce([])
+    vi.mocked(deleteSecret).mockResolvedValue()
+    render(<CredentialsTab />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete OLD_KEY' }))
+    expect(await screen.findByText('Delete OLD_KEY?')).toBeInTheDocument()
+    expect(screen.getByText(/This cannot be undone/)).toBeInTheDocument()
+    expect(deleteSecret).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(deleteSecret).toHaveBeenCalledWith('OLD_KEY'))
+    await waitFor(() => expect(screen.getByText('No credentials stored yet.')).toBeInTheDocument())
+  })
+
+  it('cancelling the confirm dialog never calls deleteSecret', async () => {
+    vi.mocked(listSecretRefs).mockResolvedValue([orphaned])
+    render(<CredentialsTab />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete OLD_KEY' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+
+    expect(deleteSecret).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/settings/CredentialsTab.tsx
+++ b/web/src/components/settings/CredentialsTab.tsx
@@ -1,0 +1,138 @@
+import { Delete02Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { deleteSecret, listSecretRefs, type SecretRefEntry } from '../../api/client'
+import { Button } from '../ui/button'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog'
+import { errText } from './util'
+
+// CredentialsTab is a read-only directory of every stored secret ref:
+// name, used-by chips, and timestamps when the row has them. There is
+// no reveal/show-value affordance anywhere — this lists what exists
+// and what references it, never a value. Delete is only offered for
+// orphaned refs; a referenced ref's delete button is replaced by its
+// used-by chips explaining why.
+export function CredentialsTab() {
+  const [refs, setRefs] = useState<SecretRefEntry[]>([])
+  const [loaded, setLoaded] = useState(false)
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const refresh = useCallback(() => {
+    listSecretRefs()
+      .then((rows) => {
+        setRefs(rows)
+        setLoaded(true)
+      })
+      .catch((err: unknown) => toast.error('Could not load credentials', { description: errText(err) }))
+  }, [])
+  useEffect(refresh, [refresh])
+
+  const remove = async (name: string) => {
+    setBusy(true)
+    try {
+      await deleteSecret(name)
+      toast.success('Credential removed', { description: `${name} is gone from the store.` })
+      setPendingDelete(null)
+      refresh()
+    } catch (err) {
+      toast.error('Could not remove credential', { description: errText(err) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="mt-6 space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Every credential Timothy has stored, by reference name. Values are never shown here —
+        this is a directory, not a vault viewer. A credential in use by a provider or connector
+        can&apos;t be deleted until nothing references it.
+      </p>
+      {loaded && refs.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border p-10 text-center text-sm text-muted-foreground">
+          No credentials stored yet.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-4 py-2 text-left font-medium">Reference</th>
+                <th className="px-4 py-2 text-left font-medium">Used by</th>
+                <th className="px-4 py-2 text-left font-medium">Created</th>
+                <th className="px-4 py-2 text-left font-medium">Updated</th>
+                <th className="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {refs.map((r) => (
+                <tr key={r.name}>
+                  <td className="px-4 py-2 font-mono text-xs">{r.name}</td>
+                  <td className="px-4 py-2">
+                    {r.referenced_by.length === 0 ? (
+                      <span className="text-xs text-muted-foreground">orphaned</span>
+                    ) : (
+                      <div className="flex flex-wrap gap-1">
+                        {r.referenced_by.map((ref) => (
+                          <span
+                            key={`${ref.kind}-${ref.name}`}
+                            className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground"
+                          >
+                            {ref.kind}: {ref.name}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-4 py-2 text-xs text-muted-foreground">
+                    {r.created_at ? new Date(r.created_at).toLocaleDateString() : '—'}
+                  </td>
+                  <td className="px-4 py-2 text-xs text-muted-foreground">
+                    {r.updated_at ? new Date(r.updated_at).toLocaleDateString() : '—'}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    {r.referenced_by.length === 0 && (
+                      <button
+                        type="button"
+                        aria-label={`Delete ${r.name}`}
+                        onClick={() => setPendingDelete(r.name)}
+                        className="text-muted-foreground hover:text-red-500"
+                      >
+                        <HugeiconsIcon icon={Delete02Icon} className="size-4" />
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <Dialog open={pendingDelete != null} onOpenChange={(open) => !open && setPendingDelete(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete {pendingDelete}?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            This cannot be undone. The stored value is removed permanently.
+          </p>
+          <DialogFooter>
+            <Button variant="outline" disabled={busy} onClick={() => setPendingDelete(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={busy}
+              onClick={() => pendingDelete && void remove(pendingDelete)}
+            >
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/web/src/components/settings/ProviderAdd.test.tsx
+++ b/web/src/components/settings/ProviderAdd.test.tsx
@@ -8,11 +8,19 @@ vi.mock('../../api/client', () => ({
   createProvider: vi.fn(),
   listProviders: vi.fn(),
   listSecretBackends: vi.fn(),
+  listSecretRefs: vi.fn(),
   setSecret: vi.fn(),
   validateProvider: vi.fn(),
 }))
 
-import { createProvider, listProviders, listSecretBackends, setSecret, validateProvider } from '../../api/client'
+import {
+  createProvider,
+  listProviders,
+  listSecretBackends,
+  listSecretRefs,
+  setSecret,
+  validateProvider,
+} from '../../api/client'
 
 // Both openaicompat, but different endpoints — models declared on one
 // must never suggest for the other.
@@ -48,6 +56,7 @@ beforeEach(() => {
   vi.mocked(listSecretBackends).mockResolvedValue([
     { backend: 'db', configured: true, default: true },
   ])
+  vi.mocked(listSecretRefs).mockResolvedValue([])
 })
 
 describe('ProviderAdd model suggestions', () => {
@@ -80,6 +89,55 @@ describe('ProviderAdd key hint links', () => {
   it('renders no link for a preset without a keyURL', async () => {
     renderPage('ollama')
     expect(screen.queryByRole('link', { name: /Open Ollama/ })).not.toBeInTheDocument()
+  })
+})
+
+describe('ProviderAdd existing-credential picker', () => {
+  beforeEach(() => {
+    vi.mocked(validateProvider).mockResolvedValue({ ok: true, latency_ms: 12, model: 'glm-5.2' })
+    vi.mocked(setSecret).mockResolvedValue()
+    vi.mocked(createProvider).mockResolvedValue('p-new')
+    vi.mocked(listSecretRefs).mockResolvedValue([
+      { name: 'ZAI_API_KEY', referenced_by: [{ kind: 'provider', name: 'GLM (Z.ai)' }] },
+    ])
+  })
+
+  it('defaults to New credential with the paste field visible', async () => {
+    renderPage('glm')
+    expect(await screen.findByLabelText('API key')).toBeInTheDocument()
+    expect(screen.queryByLabelText('existing credential')).not.toBeInTheDocument()
+  })
+
+  it('switching to Use existing swaps in the ref picker and lists stored refs', async () => {
+    renderPage('glm')
+    await screen.findByLabelText('API key')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use existing' }))
+
+    expect(screen.queryByLabelText('API key')).not.toBeInTheDocument()
+    const select = await screen.findByLabelText('existing credential')
+    expect(select).toBeInTheDocument()
+    fireEvent.click(select)
+    expect(await screen.findByRole('option', { name: /ZAI_API_KEY/ })).toBeInTheDocument()
+  })
+
+  it('choosing an existing ref sets credential_ref and skips the secret write on submit', async () => {
+    renderPage('glm')
+    await screen.findByLabelText('API key')
+    fireEvent.click(screen.getByRole('button', { name: 'Use existing' }))
+
+    fireEvent.click(await screen.findByLabelText('existing credential'))
+    fireEvent.click(await screen.findByRole('option', { name: /ZAI_API_KEY/ }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Test connection' }))
+    await waitFor(() => expect(validateProvider).toHaveBeenCalled())
+    expect(setSecret).not.toHaveBeenCalled()
+    expect(vi.mocked(validateProvider).mock.calls[0][0]).toMatchObject({ credential_ref: 'ZAI_API_KEY' })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Add provider' }))
+    await waitFor(() => expect(createProvider).toHaveBeenCalled())
+    expect(setSecret).not.toHaveBeenCalled()
+    expect(vi.mocked(createProvider).mock.calls[0][0]).toMatchObject({ credential_ref: 'ZAI_API_KEY' })
   })
 })
 

--- a/web/src/components/settings/ProviderAdd.tsx
+++ b/web/src/components/settings/ProviderAdd.tsx
@@ -8,6 +8,7 @@ import type { AdminProvider, TestResult } from '../../api/types'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { CredentialModeToggle, ExistingCredentialSelect, type CredentialMode } from './CredentialRefPicker'
 import { ModelInput, type ModelSuggestion } from './ModelInput'
 import { modelCatalog } from './modelCatalog'
 import { bedrockRegions, providerPresets, type ProviderPreset } from './presets'
@@ -58,6 +59,11 @@ export function ProviderAdd() {
   const [tested, setTested] = useState(false)
   const [existing, setExisting] = useState<AdminProvider[]>([])
   const [anthropicAuth, setAnthropicAuth] = useState<AnthropicAuthMode>('api_key')
+  // credMode picks between typing a new secret (default) and reusing a
+  // stored ref — only offered for the plain (non-bedrock-split,
+  // non-CLI) API key flow, the common reuse case (e.g. the same
+  // OpenAI-compatible key across two provider rows).
+  const [credMode, setCredMode] = useState<CredentialMode>('new')
 
   useEffect(() => {
     listProviders().then(setExisting, () => undefined)
@@ -80,6 +86,7 @@ export function ProviderAdd() {
     setTest(null)
     setTested(false)
     setAnthropicAuth('api_key')
+    setCredMode('new')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [preset?.id])
 
@@ -135,7 +142,12 @@ export function ProviderAdd() {
       access_key_id: stripPaste(accessKeyId.trim()),
       secret_access_key: stripPaste(secretAccessKey.trim()),
     })
-  const hasKey = bedrockSplit ? !!(accessKeyId.trim() && secretAccessKey.trim()) : !!key.trim()
+  const usingExistingCred = !isCli && !bedrockSplit && credMode === 'existing'
+  const hasKey = usingExistingCred
+    ? !!ref.trim()
+    : bedrockSplit
+      ? !!(accessKeyId.trim() && secretAccessKey.trim())
+      : !!key.trim()
 
   // Any edit invalidates a previous test — the config it validated no
   // longer matches what's on screen.
@@ -201,7 +213,7 @@ export function ProviderAdd() {
       )
       return
     }
-    if (isAnthropic && anthropicAuth === 'api_key' && stripPaste(key).startsWith('sk-ant-oat')) {
+    if (!usingExistingCred && isAnthropic && anthropicAuth === 'api_key' && stripPaste(key).startsWith('sk-ant-oat')) {
       setKeyError('This looks like a subscription token — use "Subscription token" instead.')
       return
     }
@@ -213,7 +225,7 @@ export function ProviderAdd() {
     setBusy(true)
     setTest(null)
     try {
-      if (wantsKey && hasKey) {
+      if (wantsKey && hasKey && !usingExistingCred) {
         if (!ref.trim()) throw new Error('a credential reference name is required to store the key')
         await setSecret(ref.trim(), bedrockSplit ? bedrockKeyJSON() : stripPaste(key))
       }
@@ -464,48 +476,72 @@ export function ProviderAdd() {
         )}
         {!isCli && wantsKey && !bedrockSplit && (
           <div>
-            <Field label={preset.id === 'custom' ? 'API key (optional)' : 'API key'}>
-              <Input
-                type="password"
-                value={key}
-                onChange={(e) => {
-                  setKey(e.target.value)
+            <div className="mb-1.5 flex items-center justify-between">
+              <span className="text-sm font-medium text-foreground">
+                {preset.id === 'custom' ? 'API key (optional)' : 'API key'}
+              </span>
+              <CredentialModeToggle
+                mode={credMode}
+                onChange={(m) => {
+                  setCredMode(m)
                   invalidate()
                 }}
-                placeholder={preset.keyPlaceholder ?? 'paste key'}
-                className="mt-1.5 h-10"
-                autoComplete="off"
-                aria-invalid={keyError != null}
               />
-            </Field>
-            {keyError && (
-              <p className="mt-1.5 flex items-center gap-1.5 text-sm font-medium text-destructive">
-                <HugeiconsIcon icon={AlertCircleIcon} className="size-4 shrink-0" />
-                {keyError}
-              </p>
-            )}
-            {!keyError && (
-              <div className="mt-1.5 space-y-1 text-sm text-muted-foreground">
-                {preset.keyHint && (
-                  <p>
-                    {preset.keyHint}
-                    {preset.keyURL && (
-                      <>
-                        {' '}
-                        <a
-                          href={preset.keyURL}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="font-medium text-primary underline underline-offset-2 hover:no-underline"
-                        >
-                          Open {preset.name} →
-                        </a>
-                      </>
-                    )}
+            </div>
+            {credMode === 'existing' ? (
+              <ExistingCredentialSelect
+                value={ref}
+                onChange={(v) => {
+                  setRef(v)
+                  setRefEdited(true)
+                  invalidate()
+                }}
+              />
+            ) : (
+              <>
+                <Input
+                  type="password"
+                  value={key}
+                  onChange={(e) => {
+                    setKey(e.target.value)
+                    invalidate()
+                  }}
+                  placeholder={preset.keyPlaceholder ?? 'paste key'}
+                  aria-label={preset.id === 'custom' ? 'API key (optional)' : 'API key'}
+                  className="h-10"
+                  autoComplete="off"
+                  aria-invalid={keyError != null}
+                />
+                {keyError && (
+                  <p className="mt-1.5 flex items-center gap-1.5 text-sm font-medium text-destructive">
+                    <HugeiconsIcon icon={AlertCircleIcon} className="size-4 shrink-0" />
+                    {keyError}
                   </p>
                 )}
-                <p>{secretDestination(defaultBackend, ref)}</p>
-              </div>
+                {!keyError && (
+                  <div className="mt-1.5 space-y-1 text-sm text-muted-foreground">
+                    {preset.keyHint && (
+                      <p>
+                        {preset.keyHint}
+                        {preset.keyURL && (
+                          <>
+                            {' '}
+                            <a
+                              href={preset.keyURL}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="font-medium text-primary underline underline-offset-2 hover:no-underline"
+                            >
+                              Open {preset.name} →
+                            </a>
+                          </>
+                        )}
+                      </p>
+                    )}
+                    <p>{secretDestination(defaultBackend, ref)}</p>
+                  </div>
+                )}
+              </>
             )}
           </div>
         )}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes, useLocation, Link } from 'react-router'
 import { AgentsTab } from '../components/settings/AgentsTab'
 import { ConnectorsTab } from '../components/settings/ConnectorsTab'
+import { CredentialsTab } from '../components/settings/CredentialsTab'
 import { FeaturesTab } from '../components/settings/FeaturesTab'
 import { ProvidersTab } from '../components/settings/ProvidersTab'
 import { RoutesTab } from '../components/settings/RoutesTab'
@@ -17,6 +18,7 @@ const tabs = [
   { key: 'agents', label: 'Agents', render: AgentsTab },
   { key: 'routes', label: 'Routing', render: RoutesTab },
   { key: 'secrets', label: 'Secrets', render: SecretsTab },
+  { key: 'credentials', label: 'Credentials', render: CredentialsTab },
   { key: 'features', label: 'Features', render: FeaturesTab },
 ] as const
 


### PR DESCRIPTION
- `GET /v1/admin/secrets`: ref names + created/updated + `referenced_by` (provider/connector), never values. Gateway computes provider referents (owns both tables); brain adds connector referents from its own store — incl. the derived `<ref>_SIGNING_KEY` of signing-enabled github connectors, so a signing key never looks orphaned — merged in brain's handler. No new cross-service coupling.
- `DELETE /v1/admin/secrets/{ref}`: split guard — brain 409s on connector references without touching the gateway; gateway independently 409s on provider references; only true orphans delete.
- Web: read-only Credentials tab (used-by chips, orphan-only delete with confirm); provider + connector forms gain a New/Use-existing segmented picker — existing mode skips the secret PUT and reuses the chosen ref (Google: client-secret ref reusable, OAuth grants stay per-connection).
- Registered as literal mux patterns beside the existing byte-for-byte `{ref_name}` proxy (more-specific-pattern precedent).

Gates: Go + web green, 583 web tests. Rebased over #206 (signing-key refs accounted for).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788843073&installation_model_id=431401&pr_number=208&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F208&signature=f6d3151d3966f0b2c0f6370cf1d3304501cb272b826660147c8d59b2d43ab469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->