### PR TITLE
fix: brain boot panic from duplicate secrets delete route

### DIFF
--- a/internal/brain/api/admin.go
+++ b/internal/brain/api/admin.go
@@ -30,7 +30,10 @@ var adminRoutePatterns = []string{
 	"DELETE /v1/admin/routes/{name}",
 	"PUT /v1/admin/routes/{name}/role",
 	"PUT /v1/admin/secrets/{ref_name}",
-	"DELETE /v1/admin/secrets/{ref_name}",
+	// DELETE /v1/admin/secrets/{ref_name} is deliberately NOT proxied:
+	// registerSecrets serves it locally (connector-reference guard
+	// before forwarding), and net/http's ServeMux panics on a duplicate
+	// pattern — the two registrations must never coexist.
 	"GET /v1/admin/secrets/{ref_name}",
 	"GET /v1/admin/secret-backends",
 	"PUT /v1/admin/secret-backends/default",
@@ -137,10 +140,13 @@ type referenceInfo struct {
 // dependency — see admin_test.go for the design note). DELETE checks
 // connector references itself before forwarding to the gateway, which
 // independently refuses on provider references — each service stays
-// authoritative for the referents it owns. nil gw or conns leaves the
-// surface unmounted.
+// authoritative for the referents it owns. nil gw leaves the surface
+// unmounted; nil conns (connectors disabled — no master key) still
+// mounts it, minus the connector-reference guard, because DELETE has
+// no proxied fallback (see adminRoutePatterns) and the gateway's own
+// provider guard still applies.
 func (a *API) registerSecrets(handle func(pattern string, h http.Handler), gw GatewaySecrets, conns connectorLister) {
-	if gw == nil || conns == nil {
+	if gw == nil {
 		return
 	}
 	h := &secretsAPI{gw: gw, connectors: conns}
@@ -160,6 +166,9 @@ type secretsAPI struct {
 // under, so the signing key never looks orphaned in the panel or
 // becomes deletable while the connector still signs with it.
 func connectorRefs(ctx context.Context, store connectorLister) (map[string][]string, error) {
+	if store == nil {
+		return map[string][]string{}, nil
+	}
 	rows, err := store.List(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/brain/api/secrets_test.go
+++ b/internal/brain/api/secrets_test.go
@@ -198,6 +198,42 @@ func TestDeleteSecretPropagatesGatewayInUseRefusal(t *testing.T) {
 	}
 }
 
+// TestSecretsRoutesCoexistWithAdminProxy pins the boot path that once
+// panicked: registerAdmin's proxied patterns and registerSecrets'
+// local ones share the /v1/admin/secrets namespace, and net/http's
+// ServeMux panics on any duplicate — both must register side by side.
+func TestSecretsRoutesCoexistWithAdminProxy(t *testing.T) {
+	t.Parallel()
+	a := &API{token: "tok", log: discard()}
+	m := http.NewServeMux()
+	a.registerAdmin(m.Handle, http.NotFoundHandler())
+	a.registerSecrets(m.Handle, &fakeGatewaySecrets{}, &fakeConnectorLister{})
+}
+
+// TestRegisterSecretsMountsWithoutConnectors pins that a nil connector
+// lister (connectors disabled) still serves DELETE — it has no proxied
+// fallback, so unmounting it here would remove secret deletion
+// entirely; only the connector-reference guard drops out.
+func TestRegisterSecretsMountsWithoutConnectors(t *testing.T) {
+	t.Parallel()
+	a := &API{token: "tok", log: discard()}
+	gw := &fakeGatewaySecrets{}
+	m := http.NewServeMux()
+	a.registerSecrets(m.Handle, gw, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/admin/secrets/SOME_KEY", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204 (delete must survive disabled connectors)", w.Code)
+	}
+	if gw.deletedRef != "SOME_KEY" {
+		t.Fatalf("gateway DeleteSecret called with %q, want SOME_KEY", gw.deletedRef)
+	}
+}
+
 func TestRegisterSecretsUnmountedWithoutGatewayOrConnectors(t *testing.T) {
 	t.Parallel()
 	a := &API{token: "tok", log: discard()}


### PR DESCRIPTION
#208 left `DELETE /v1/admin/secrets/{ref_name}` registered twice — once by the new local credentials handler, once by the admin proxy's pattern list — and `net/http.ServeMux` panics on duplicate patterns, so brain crash-looped at boot (CI stayed green: each surface was unit-tested on its own fresh mux).

- Drop the proxied DELETE from `adminRoutePatterns` (local handler subsumes it: connector guard, then forwards to the gateway's provider guard)
- Mount the secrets surface even when connectors are disabled — DELETE has no proxied fallback anymore; only the connector guard drops out
- `TestSecretsRoutesCoexistWithAdminProxy` registers both surfaces on one mux, the way boot does, so a future duplicate panics in CI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788843981&installation_model_id=431401&pr_number=209&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F209&signature=ac7bec879252a669ffa43d6dfff394d9670d7baf2cfd4b8e13513c11fa59df81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->