### PR TITLE
docs: add code of conduct, contributing guide, security policy, pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+*Issue #, if available:*
+
+*Description of changes (what and why):*
+
+## Checklist
+
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (subject ≤ 72 chars, body explains why)
+- [ ] Tests added or updated for changed logic
+- [ ] `make build test vet lint` passes
+- [ ] Web changes: `npm run build && npm run lint && npm test` passes (in the Node container)
+- [ ] Harness changes (`internal/brain/missions/`, executors): `make canary` passes against a rebuilt brain
+- [ ] No secrets, credentials, or personal data in code, tests, or fixtures
+
+By submitting this pull request, I confirm my contribution is made under the terms of the [AGPL-3.0 license](../LICENSE).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+This project has adopted the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+In short: be respectful, be constructive, and assume good faith. Harassment, personal attacks, and discriminatory behavior are not tolerated anywhere in this project's spaces — issues, pull requests, discussions, or commits.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainer at [sumonmselim@gmail.com](mailto:sumonmselim@gmail.com). All reports are reviewed and handled confidentially.
+
+For the full text, enforcement guidelines, and FAQ, see the [Contributor Covenant website](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing Guidelines
+
+Thank you for your interest in contributing to Timothy. Whether it's a bug report, a new feature, a correction, or additional documentation, feedback and contributions are welcome.
+
+Please read this document before submitting an issue or pull request.
+
+## Security issue notifications
+
+If you discover a potential security issue, please follow the process in [SECURITY.md](SECURITY.md). Do **not** create a public GitHub issue for security problems.
+
+## Reporting bugs / requesting features
+
+Use the [GitHub issue tracker](https://github.com/timothy-agent/timothy/issues). Before filing, check open and recently closed issues to avoid duplicates. Useful details:
+
+- Reproducible steps or a test case
+- The release tag or commit you're running (`TIMOTHY_VERSION` in your `.env`, or `git rev-parse HEAD`)
+- Relevant service logs (`make logs` or `docker compose logs <service>`), with any secrets removed
+- Anything unusual about your environment or deployment
+
+## Development setup
+
+Everything runs in Docker — no host Go or Node toolchain required. See the [README](README.md) for the full build-from-source guide. The short version:
+
+```sh
+cp deploy/env.example deploy/.env   # set POSTGRES_PASSWORD
+make up                             # start the stack
+make build test vet lint            # the canonical pre-commit gates
+```
+
+Web checks run in a Node container:
+
+```sh
+docker run --rm -v "$PWD/web":/app -w /app node:24.18.0-alpine \
+  sh -c "npm run build && npm run lint && npm test"
+```
+
+Integration tests (`make test-integration`) and the mission regression gate (`make canary`) need the compose stack up.
+
+## Contributing via pull requests
+
+Before sending a pull request:
+
+1. Work against the latest `main`.
+2. Check open and recently merged PRs for overlap.
+3. For significant changes, open an issue first to discuss the approach — this avoids wasted work.
+
+When submitting:
+
+1. Fork the repository and create a branch named `<type>/<short-description>` (e.g. `feat/mission-labels`, `fix/route-cache`).
+2. Keep the change focused. Unrelated reformatting or refactoring makes review harder.
+3. Follow [Conventional Commits](https://www.conventionalcommits.org/): `<type>[scope]: <description>` with a subject ≤ 72 chars, lowercase, no trailing period. The body explains **why**, not what.
+4. Add or update tests for any logic you add or change. Table-driven tests are the house style for Go.
+5. Make sure `make build test vet lint` and the web checks pass locally.
+6. If your change touches the missions harness (anything under `internal/brain/missions/` or the executor path), run `make canary` against a rebuilt brain.
+7. Fill in the pull request template and stay involved in the review conversation.
+
+### Project invariants
+
+A few rules are enforced in review and are not up for relaxation — see [CLAUDE.md](CLAUDE.md) for the full list. Highlights:
+
+- Append-only stores stay append-only (`session_events`, `mission_events`, `memories`).
+- Safety invariants (allowlists, ceilings, permission gates) live in Go code, never in a prompt.
+- Secrets are referenced by name (`credential_ref`) only — raw values never appear in the database, API responses, logs, or frontend.
+- Unknown prices are recorded as NULL, never guessed.
+- No speculative abstractions: no interface with one implementation, no config nothing reads.
+- Never edit an already-applied migration (except during the pre-release window, per maintainer direction).
+
+## Finding contributions to work on
+
+Issues labeled `help wanted` or `good first issue` are the best starting points. Documentation improvements are always welcome.
+
+## Code of Conduct
+
+This project has adopted a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold it.
+
+## Licensing
+
+Timothy is licensed under [AGPL-3.0](LICENSE). By submitting a pull request, you agree that your contribution is licensed under the same terms.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+Timothy is a self-hosted assistant that holds provider API keys, OAuth grants, and personal data, and runs model-directed code in sandboxes — security reports are taken seriously.
+
+## Reporting a vulnerability
+
+Please do **not** open a public GitHub issue for security problems.
+
+Instead, use one of:
+
+- **GitHub private vulnerability reporting** (preferred): [Report a vulnerability](https://github.com/timothy-agent/timothy/security/advisories/new) — creates a private advisory only maintainers can see.
+- **Email**: [sumonmselim@gmail.com](mailto:sumonmselim@gmail.com) with a description, reproduction steps, and impact assessment.
+
+You can expect an acknowledgment within a few days. Please practice coordinated disclosure: give us a reasonable window to ship a fix before any public write-up.
+
+## Supported versions
+
+Timothy is in alpha. Only the **latest release** receives security fixes; there are no backports. If you're running an older tag, upgrade first and check whether the issue reproduces.
+
+## Scope notes
+
+Things that are **by design** in the current single-operator posture (still worth reporting if you find a way to escalate beyond them):
+
+- Timothy is designed to be operated by a single trusted user; there is no multi-user privilege boundary inside one instance.
+- Mission sandboxes run model-authored code with network egress; isolation boundaries between a mission and its own workspace contents are documented as accepted risks (`D-0XX` markers in code).
+
+Things we especially want to hear about:
+
+- Secret material (API keys, tokens, signing keys) leaking into logs, API responses, the database in plaintext, or the frontend
+- Sandbox escape to the host or to another mission's workspace
+- Authentication bypass on the public API
+- SSRF/injection reachable through connector or tool inputs


### PR DESCRIPTION
Community-health files modeled on the AWS `.github` policy-repo pattern, tailored to this repo:

- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 adoption, maintainer contact
- `CONTRIBUTING.md` — issue guidance, docker-only dev setup, PR flow with the repo's actual gates (conventional commits, table-driven tests, `make canary` for harness changes), project invariants, AGPL licensing note
- `SECURITY.md` — GitHub private vulnerability reporting (preferred) + email, latest-release-only support, honest single-operator scope notes plus the escalations we most want reported
- `.github/PULL_REQUEST_TEMPLATE.md` — issue ref, description, CI-mirroring checklist, AGPL confirmation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788844073&installation_model_id=431401&pr_number=210&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F210&signature=9121ca92375691b9501a53e33092498984673797ba18f1214dbad204ceae78a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->