### PR TITLE
fix: credential picker crash and google secret field layout

### DIFF
--- a/internal/brain/api/admin.go
+++ b/internal/brain/api/admin.go
@@ -204,7 +204,9 @@ func (h *secretsAPI) list(w http.ResponseWriter, r *http.Request) {
 
 	out := make([]secretRefEntry, len(refs))
 	for i, ref := range refs {
-		var referents []referenceInfo
+		// Always a JSON array, never null: the frontend indexes
+		// referenced_by unconditionally.
+		referents := []referenceInfo{}
 		for _, name := range ref.ReferencedBy {
 			referents = append(referents, referenceInfo{Kind: "provider", Name: name})
 		}

--- a/internal/brain/api/secrets_test.go
+++ b/internal/brain/api/secrets_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/SumonMSelim/timothy/internal/brain/connectors"
@@ -102,6 +103,12 @@ func TestListSecretsMergesProviderAndConnectorReferents(t *testing.T) {
 	}
 	if len(byName["ORPHAN_KEY"].ReferencedBy) != 0 {
 		t.Fatalf("ORPHAN_KEY referenced_by = %+v, want empty", byName["ORPHAN_KEY"].ReferencedBy)
+	}
+	// An orphaned ref must serialize referenced_by as [], never null —
+	// the frontend indexes it unconditionally, and null once crashed the
+	// credential picker.
+	if !strings.Contains(w.Body.String(), `"referenced_by":[]`) {
+		t.Fatalf("body = %s, want orphaned referenced_by serialized as []", w.Body.String())
 	}
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -657,7 +657,8 @@ export interface SecretRefEntry {
 // tab and the "use existing" pickers on provider/connector forms.
 export async function listSecretRefs(): Promise<SecretRefEntry[]> {
   const { secrets } = await request<{ secrets: SecretRefEntry[] }>('/v1/admin/secrets')
-  return secrets ?? []
+  // referenced_by is normalized here so no consumer ever sees null.
+  return (secrets ?? []).map((s) => ({ ...s, referenced_by: s.referenced_by ?? [] }))
 }
 
 export interface SecretStatus {

--- a/web/src/components/settings/ConnectorAdd.tsx
+++ b/web/src/components/settings/ConnectorAdd.tsx
@@ -230,36 +230,34 @@ export function ConnectorAdd() {
 
         {isGoogle ? (
           <>
-            <div className="grid gap-5 sm:grid-cols-2">
-              <Field label="OAuth client ID">
-                <Input
-                  value={clientID}
-                  onChange={(e) => setClientID(e.target.value)}
-                  placeholder="….apps.googleusercontent.com"
-                  className="mt-1.5 h-10"
-                />
-              </Field>
-              <div>
-                <div className="mb-1.5 flex items-center justify-between">
-                  <span className="text-sm font-medium text-foreground">OAuth client secret</span>
-                  <CredentialModeToggle mode={clientSecretCredMode} onChange={setClientSecretCredMode} />
-                </div>
-                {clientSecretCredMode === 'existing' ? (
-                  <ExistingCredentialSelect
-                    value={existingClientSecretRef}
-                    onChange={setExistingClientSecretRef}
-                  />
-                ) : (
-                  <Input
-                    type="password"
-                    value={clientSecret}
-                    onChange={(e) => setClientSecret(e.target.value)}
-                    placeholder="GOCSPX-…"
-                    className="h-10"
-                    autoComplete="off"
-                  />
-                )}
+            <Field label="OAuth client ID">
+              <Input
+                value={clientID}
+                onChange={(e) => setClientID(e.target.value)}
+                placeholder="….apps.googleusercontent.com"
+                className="mt-1.5 h-10"
+              />
+            </Field>
+            <div>
+              <div className="mb-1.5 flex items-center justify-between">
+                <span className="text-sm font-medium text-foreground">OAuth client secret</span>
+                <CredentialModeToggle mode={clientSecretCredMode} onChange={setClientSecretCredMode} />
               </div>
+              {clientSecretCredMode === 'existing' ? (
+                <ExistingCredentialSelect
+                  value={existingClientSecretRef}
+                  onChange={setExistingClientSecretRef}
+                />
+              ) : (
+                <Input
+                  type="password"
+                  value={clientSecret}
+                  onChange={(e) => setClientSecret(e.target.value)}
+                  placeholder="GOCSPX-…"
+                  className="h-10"
+                  autoComplete="off"
+                />
+              )}
             </div>
             <p className="text-sm text-muted-foreground">
               From a Google Cloud OAuth client (Web application). Add{' '}

--- a/web/src/components/settings/CredentialRefPicker.tsx
+++ b/web/src/components/settings/CredentialRefPicker.tsx
@@ -8,8 +8,9 @@ export type CredentialMode = 'new' | 'existing'
 // referentLabel renders a ref's used-by hint for the option label — no
 // type-classification of secrets, just what already references it.
 function referentLabel(ref: SecretRefEntry): string {
-  if (ref.referenced_by.length === 0) return ref.name
-  return `${ref.name} (used by ${ref.referenced_by.map((r) => r.name).join(', ')})`
+  const refs = ref.referenced_by ?? []
+  if (refs.length === 0) return ref.name
+  return `${ref.name} (used by ${refs.map((r) => r.name).join(', ')})`
 }
 
 // ModeToggle is the segmented "New credential" / "Use existing"


### PR DESCRIPTION
Two problems in #208's credential picker, both found in manual use:

- Clicking **Use existing** crashed the page: orphaned refs serialized `referenced_by: null` (nil Go slice) and `referentLabel` indexes it unconditionally. The handler now always emits `[]` (pinned by a raw-body test), and `listSecretRefs` normalizes as a second layer.
- The Google OAuth client-secret field sat in a two-column grid, so the New/Use-existing toggle crowded the label and squeezed the input. The secret field now takes its own full-width row below the client ID.

Verified on the live stack: endpoint emits `[]` for all three orphaned refs, brain healthy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788845000&installation_model_id=431401&pr_number=212&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F212&signature=6837011c93b88d9f2340c41f1d9cf24a35a45f63e5c24330566b4d198d061e89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->