### PR TITLE
feat: extract memory once on mission done/failed

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -412,6 +412,23 @@ func main() {
 			app.Log.Warn("turn memory extraction failed", "session_id", sessionID, "error", err)
 		}
 	})
+	if missionDriver != nil {
+		// Same mc.Extract entry point chat's own MemoryExtract rides,
+		// fed the mission's curated digest instead of a chat turn's
+		// residue — missions/memory.go builds the digest, this closure
+		// only owns the flag gate, timeout, and error logging, exactly
+		// like chat's own wiring above.
+		missionDriver.SetMemoryExtract(func(ctx context.Context, sessionID string, seq int64, text, route string) {
+			if !flags.Enabled(ctx, settings.KeyMemoryExtraction) {
+				return
+			}
+			ectx, cancel := context.WithTimeout(context.WithoutCancel(ctx), extractBudget)
+			defer cancel()
+			if _, err := mc.Extract(ectx, sessionID, seq, text, route); err != nil {
+				app.Log.Warn("mission memory extraction failed", "session_id", sessionID, "error", err)
+			}
+		})
+	}
 	compactor.SetMemoryExtract(func(ctx context.Context, sessionID string, seq int64, text, route string) []string {
 		if !flags.Enabled(ctx, settings.KeyMemoryExtraction) {
 			return nil

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -69,6 +69,7 @@ type driverStore interface {
 	Get(ctx context.Context, id string) (Mission, error)
 	ApplyTransition(ctx context.Context, id string, t Transition) error
 	AppendEvent(ctx context.Context, id, kind string, payload map[string]any) error
+	Events(ctx context.Context, id string) ([]Event, error)
 	SetSpec(ctx context.Context, id string, spec Spec) error
 	SetSession(ctx context.Context, id, sessionID string) error
 	SetProvisioned(ctx context.Context, id, workspace, worktree, branch, baseCommit string) error
@@ -177,6 +178,11 @@ type Driver struct {
 	// — nil-safe: unset just skips the notification, the mission.push_failed
 	// event (Completer.PushBranch's own append) is still recorded either way.
 	notifyPushFailed func(ctx context.Context, missionID, message string)
+
+	// memory wires the memoryd extraction hook (see SetMemoryExtract) —
+	// nil-safe: unset skips extraction entirely, same as chat's own
+	// MemoryExtract field.
+	memory MemoryExtract
 
 	// gatekeepers holds each mission's in-progress reviewer session
 	// state, keyed by mission id, for the "delta recheck" resume on
@@ -306,6 +312,15 @@ func (d *Driver) SetCompleter(c *Completer) {
 // reason SetCompleter is.
 func (d *Driver) SetPushFailedNotifier(notify func(ctx context.Context, missionID, message string)) {
 	d.notifyPushFailed = notify
+}
+
+// SetMemoryExtract wires the memoryd extraction hook fired once a
+// mission reaches a terminal phase (see extractMissionMemory) — a
+// setter (not a NewDriver parameter) for the same reason SetCompleter
+// is. Optional — nil (today's default) leaves missions extracting
+// nothing into memory.
+func (d *Driver) SetMemoryExtract(fn MemoryExtract) {
+	d.memory = fn
 }
 
 // fireOnComplete runs a mission's recorded on_complete choice
@@ -624,6 +639,7 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 	if t.Next.Phase.Terminal() {
 		delete(d.gatekeepers, id)
 		d.removeSandbox(id)
+		d.extractMissionMemory(ctx, id, t.Next.Phase, failedReason(t.Events))
 	}
 	if t.Next.Phase == PhaseDone {
 		// m is the pre-transition snapshot (re-fetched above, before this
@@ -706,6 +722,7 @@ func (d *Driver) Signal(ctx context.Context, id string, input Input) error {
 	if t.Next.Phase.Terminal() {
 		delete(d.gatekeepers, id)
 		d.removeSandbox(id)
+		d.extractMissionMemory(ctx, id, t.Next.Phase, failedReason(t.Events))
 	}
 	if d.notify != nil {
 		if err := d.notify.OnTransition(ctx, m, before, t.Next.Status, failedReason(t.Events)); err != nil {

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -128,6 +128,14 @@ func (f *fakeStore) AppendEvent(ctx context.Context, id, kind string, payload ma
 	return nil
 }
 
+func (f *fakeStore) Events(ctx context.Context, id string) ([]Event, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]Event, len(f.events[id]))
+	copy(out, f.events[id])
+	return out, nil
+}
+
 func (f *fakeStore) SetSpec(ctx context.Context, id string, spec Spec) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/internal/brain/missions/memory.go
+++ b/internal/brain/missions/memory.go
@@ -1,0 +1,158 @@
+package missions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// memoryExtractedKind marks that a mission's one terminal extraction
+// pass has already fired — the append-only idempotency record
+// extractMissionMemory checks before running, since mission_events has
+// no other way to record "this already happened" (D-idempotent-event,
+// same pattern mission.review_skipped/mission.turn already use for
+// non-transition bookkeeping).
+const memoryExtractedKind = "mission.memory_extracted"
+
+// MemoryExtract posts one mission's curated digest to memoryd for
+// long-term memory extraction — the same signature and fire-and-forget
+// contract as chat.MemoryExtract (see chat.go), so cmd/brain/main.go
+// wires both through the identical mc.Extract call. seq is always 0: a
+// mission's extraction is not tied to any session_events sequence
+// number the way a chat turn's is, and memoryd's source_seq is opaque
+// bookkeeping it never dereferences into the missions log.
+type MemoryExtract func(ctx context.Context, sessionID string, seq int64, text string, route string)
+
+// alreadyExtracted reports whether events already carries a
+// mission.memory_extracted record — checked before every extraction
+// attempt so a re-drive (sweep.go's boot-time recovery, or a Signal
+// racing an Advance) can never fire the pass twice for the same
+// mission.
+func alreadyExtracted(events []Event) bool {
+	for _, ev := range events {
+		if ev.Kind == memoryExtractedKind {
+			return true
+		}
+	}
+	return false
+}
+
+// extractMissionMemory runs the mission's one terminal extraction pass:
+// called by Advance/Signal exactly when a transition's Next.Phase is
+// terminal (done or failed). Nil memory client, or a mission with no
+// hidden session, skips silently — matching the nil-gated dependency
+// pattern the rest of the driver's optional hooks use (fireOnComplete,
+// notify). Extraction failures can never fail or block the mission
+// transition: MemoryExtract's own contract (see its doc comment) is
+// fire-and-forget, so nothing here can return an error to the caller
+// even in principle.
+func (d *Driver) extractMissionMemory(ctx context.Context, id string, terminal Phase, failureReason string) {
+	if d.memory == nil {
+		return
+	}
+	m, err := d.store.Get(ctx, id)
+	if err != nil {
+		d.log.Warn("driver: memory extraction: reload mission failed", "mission_id", id, "error", err)
+		return
+	}
+	if m.SessionID == "" {
+		return
+	}
+	events, err := d.store.Events(ctx, id)
+	if err != nil {
+		d.log.Warn("driver: memory extraction: load events failed", "mission_id", id, "error", err)
+		return
+	}
+	if alreadyExtracted(events) {
+		return
+	}
+	digest := buildDigest(m, events, terminal, failureReason)
+	// The idempotency record must land BEFORE dispatch, not after: the
+	// extraction call itself is fire-and-forget (no completion signal
+	// this function can wait on), so appending after would leave the
+	// exact race window this guard exists to close — a re-drive landing
+	// between dispatch and a not-yet-appended event would fire a second
+	// pass. Marking the attempt (not "succeeded") is the same commitment
+	// AppendEvent's other bookkeeping-only callers make.
+	if err := d.store.AppendEvent(ctx, id, memoryExtractedKind, map[string]any{"terminal": string(terminal)}); err != nil {
+		d.log.Warn("driver: memory extraction: record event failed", "mission_id", id, "error", err)
+		return
+	}
+	go d.memory(context.Background(), m.SessionID, 0, digest, "") //nolint:gosec // G118: deliberate — the mission is already terminal, extraction must outlive whatever request/ctx observed that transition
+}
+
+// buildDigest assembles the curated extraction input: goal, title,
+// kind, explore notes, per-unit outcomes (title/status/verify evidence
+// summary only, never shell output), the review verdict (or
+// review_skipped), and the terminal state/failure reason. Deliberately
+// excludes anything resembling the raw transcript — build-log noise
+// (tool_execution payloads, mission.turn timings) never appears here.
+func buildDigest(m Mission, events []Event, terminal Phase, failureReason string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "mission goal: %s\n", m.Goal)
+	if m.Name != "" {
+		fmt.Fprintf(&b, "mission title: %s\n", m.Name)
+	}
+	fmt.Fprintf(&b, "mission kind: %s\n", m.Kind)
+	if m.ExploreNotes != "" {
+		b.WriteString("\nexplore notes:\n")
+		b.WriteString(m.ExploreNotes)
+		b.WriteString("\n")
+	}
+	if len(m.Spec.Units) > 0 {
+		b.WriteString("\nunits:\n")
+		for _, u := range m.Spec.Units {
+			status := "not verified"
+			if u.Passes {
+				status = "passed"
+			}
+			fmt.Fprintf(&b, "- %s: %s\n", u.Title, status)
+		}
+	}
+	if decision, findings, ok := lastReviewVerdict(events); ok {
+		fmt.Fprintf(&b, "\nreview verdict: %s\n", decision)
+		if findings != "" {
+			fmt.Fprintf(&b, "review findings: %s\n", findings)
+		}
+	} else if reviewSkipped(events) {
+		b.WriteString("\nreview: skipped (harness checks alone established the unit)\n")
+	}
+	fmt.Fprintf(&b, "\nterminal state: %s\n", terminal)
+	if terminal == PhaseFailed && failureReason != "" {
+		fmt.Fprintf(&b, "failure reason: %s\n", failureReason)
+	}
+	return b.String()
+}
+
+// lastReviewVerdict scans events for the most recent
+// mission.review_verdict, returning its decision/findings. ok=false
+// when review never ran this mission.
+func lastReviewVerdict(events []Event) (decision, findings string, ok bool) {
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].Kind != "mission.review_verdict" {
+			continue
+		}
+		var payload struct {
+			Decision string `json:"decision"`
+			Findings string `json:"findings"`
+		}
+		if err := json.Unmarshal(events[i].Payload, &payload); err != nil {
+			return "", "", false
+		}
+		return payload.Decision, payload.Findings, true
+	}
+	return "", "", false
+}
+
+// reviewSkipped reports whether any mission.review_skipped event fired
+// — the non-coding fast path that bypasses LLM review entirely on
+// harness evidence (driver.go's trySkipReview).
+func reviewSkipped(events []Event) bool {
+	for _, ev := range events {
+		if ev.Kind == "mission.review_skipped" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/brain/missions/memory_test.go
+++ b/internal/brain/missions/memory_test.go
@@ -1,0 +1,278 @@
+package missions
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestBuildDigest(t *testing.T) {
+	tests := []struct {
+		name          string
+		mission       Mission
+		events        []Event
+		terminal      Phase
+		failureReason string
+		wantContains  []string
+		wantExcludes  []string
+	}{
+		{
+			name: "goal explore units review done",
+			mission: Mission{
+				Goal: "add a widget", Name: "Widget mission", Kind: "coding",
+				ExploreNotes: "found the widget package",
+				Spec:         Spec{Units: []PlanUnit{{Title: "write widget.go", Passes: true}}},
+			},
+			events: []Event{
+				{Kind: "mission.turn", Payload: json.RawMessage(`{"phase":"execute","duration_ms":500}`)},
+				{Kind: "mission.review_verdict", Payload: json.RawMessage(`{"decision":"approved","findings":"looks good"}`)},
+			},
+			terminal: PhaseDone,
+			wantContains: []string{
+				"add a widget", "Widget mission", "coding",
+				"found the widget package",
+				"write widget.go: passed",
+				"review verdict: approved", "review findings: looks good",
+				"terminal state: done",
+			},
+			wantExcludes: []string{"duration_ms", "\"phase\":\"execute\""},
+		},
+		{
+			name: "review skipped",
+			mission: Mission{
+				Goal: "general task", Kind: "general",
+				Spec: Spec{Units: []PlanUnit{{Title: "only unit", Passes: true}}},
+			},
+			events: []Event{
+				{Kind: "mission.review_skipped", Payload: json.RawMessage(`{"unit":0,"reason":"artifacts and verify_cmd passed harness checks"}`)},
+			},
+			terminal:     PhaseDone,
+			wantContains: []string{"review: skipped"},
+			wantExcludes: []string{"review verdict:"},
+		},
+		{
+			name: "failed with reason",
+			mission: Mission{
+				Goal: "risky task", Kind: "coding",
+				Spec: Spec{Units: []PlanUnit{{Title: "unit one", Passes: false}}},
+			},
+			terminal:      PhaseFailed,
+			failureReason: "max_iterations",
+			wantContains:  []string{"terminal state: failed", "failure reason: max_iterations", "unit one: not verified"},
+		},
+		{
+			name:         "no raw transcript noise",
+			mission:      Mission{Goal: "quiet task", Kind: "general"},
+			events:       []Event{{Kind: "mission.turn", Payload: json.RawMessage(`{"ok":true,"input":"phase_complete"}`)}},
+			terminal:     PhaseDone,
+			wantExcludes: []string{"mission.turn", "\"ok\":true", "phase_complete"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			digest := buildDigest(tt.mission, tt.events, tt.terminal, tt.failureReason)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(digest, want) {
+					t.Errorf("digest missing %q\ngot:\n%s", want, digest)
+				}
+			}
+			for _, exclude := range tt.wantExcludes {
+				if strings.Contains(digest, exclude) {
+					t.Errorf("digest must not contain %q\ngot:\n%s", exclude, digest)
+				}
+			}
+		})
+	}
+}
+
+// recordingExtract is a MemoryExtract that records every call it
+// receives, synchronized so tests can assert on it after the driver's
+// dispatching goroutine has had a chance to run.
+type recordingExtract struct {
+	mu    sync.Mutex
+	calls []string // sessionID per call
+}
+
+func (r *recordingExtract) fn() MemoryExtract {
+	return func(ctx context.Context, sessionID string, seq int64, text, route string) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.calls = append(r.calls, sessionID)
+	}
+}
+
+func (r *recordingExtract) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
+}
+
+// waitForCalls polls count() until it reaches want or the deadline
+// passes — the extraction dispatch is `go d.memory(...)`, so tests
+// need a brief allowance for that goroutine to run.
+func waitForCalls(t *testing.T, r *recordingExtract, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if r.count() == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("extraction calls = %d, want %d", r.count(), want)
+}
+
+func TestDriverExtractsMemoryOnDone(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8, SessionID: "sess-1"})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner)
+	rec := &recordingExtract{}
+	d.SetMemoryExtract(rec.fn())
+
+	driveN(t, d, "m1", 4) // explore -> plan -> execute -> review -> done
+
+	waitForCalls(t, rec, 1)
+
+	events, _ := store.Events(context.Background(), "m1")
+	if !alreadyExtracted(events) {
+		t.Fatal("expected mission.memory_extracted event after done transition")
+	}
+}
+
+func TestDriverExtractsMemoryOnFailed(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 1, SessionID: "sess-1"})
+	runner := &scriptedRunner{
+		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "nope"}},
+	}
+	d := testDriver(store, runner)
+	rec := &recordingExtract{}
+	d.SetMemoryExtract(rec.fn())
+
+	// MaxIterations=1: the first retry immediately exhausts iterations
+	// and the state machine fails the mission (stepWorkerRetry).
+	driveN(t, d, "m1", 1)
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseFailed {
+		t.Fatalf("mission phase = %s, want failed", m.Phase)
+	}
+	waitForCalls(t, rec, 1)
+}
+
+func TestDriverDoesNotExtractOnNonTerminalTransitions(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8, SessionID: "sess-1"})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner)
+	rec := &recordingExtract{}
+	d.SetMemoryExtract(rec.fn())
+
+	// explore -> plan -> execute: 2 non-terminal Advance calls.
+	driveN(t, d, "m1", 2)
+
+	// Give any (wrongly) dispatched goroutine a chance to run before
+	// asserting zero.
+	time.Sleep(20 * time.Millisecond)
+	if got := rec.count(); got != 0 {
+		t.Fatalf("extraction calls after non-terminal transitions = %d, want 0", got)
+	}
+}
+
+func TestDriverExtractsMemoryOnceOnRedrive(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDone, Status: StatusDone, SessionID: "sess-1"})
+	// The mission is already terminal; simulate a re-drive (sweep/boot
+	// recovery) by calling extractMissionMemory directly a second time
+	// after the first has already recorded its idempotency event.
+	d := testDriver(store, &scriptedRunner{})
+	rec := &recordingExtract{}
+	d.SetMemoryExtract(rec.fn())
+
+	d.extractMissionMemory(context.Background(), "m1", PhaseDone, "")
+	waitForCalls(t, rec, 1)
+
+	d.extractMissionMemory(context.Background(), "m1", PhaseDone, "")
+	time.Sleep(20 * time.Millisecond)
+	if got := rec.count(); got != 1 {
+		t.Fatalf("extraction calls after re-drive = %d, want 1 (idempotency guard must suppress the second attempt)", got)
+	}
+}
+
+// TestDriverMemoryExtractionErrorDoesNotBlockTransition asserts the
+// mission transition completes regardless of what the wired
+// MemoryExtract does — its signature has no error return (see
+// MemoryExtract's doc comment), so a caller like main.go's wrapper
+// that fails to reach memoryd only ever logs; nothing propagates back
+// to the driver that could block or unwind the transition already
+// committed before extraction was even dispatched.
+func TestDriverMemoryExtractionErrorDoesNotBlockTransition(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8, SessionID: "sess-1"})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner)
+	rec := &recordingExtract{}
+	d.SetMemoryExtract(func(ctx context.Context, sessionID string, seq int64, text, route string) {
+		// Simulates main.go's wrapper swallowing a memoryd error: logged
+		// there, never surfaced here.
+		rec.fn()(ctx, sessionID, seq, text, route)
+	})
+
+	driveN(t, d, "m1", 4)
+	m, err := store.Get(context.Background(), "m1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Phase != PhaseDone {
+		t.Fatalf("mission phase = %s, want done despite extraction failure", m.Phase)
+	}
+	waitForCalls(t, rec, 1)
+}
+
+func TestDriverSkipsExtractionWhenNilClient(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8, SessionID: "sess-1"})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner) // no SetMemoryExtract call: d.memory stays nil
+
+	driveN(t, d, "m1", 4)
+
+	events, _ := store.Events(context.Background(), "m1")
+	if alreadyExtracted(events) {
+		t.Fatal("nil memory client must never record mission.memory_extracted")
+	}
+}
+
+func TestDriverSkipsExtractionWhenNoSession(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDone, Status: StatusDone, SessionID: ""})
+	d := testDriver(store, &scriptedRunner{})
+	rec := &recordingExtract{}
+	d.SetMemoryExtract(rec.fn())
+
+	d.extractMissionMemory(context.Background(), "m1", PhaseDone, "")
+	time.Sleep(20 * time.Millisecond)
+	if got := rec.count(); got != 0 {
+		t.Fatalf("extraction calls with no hidden session = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## What

Missions now feed the long-term memory pipeline: one extraction pass fires when a mission transitions to done or failed, over a curated digest, through the same memclient.Extract entry point chat uses. Extracted memories land in memoryd's staging queue for operator confirmation as usual.

## Why

Memory extraction was chat-only (chat.go); mission sessions are hidden, so hours of unattended mission work never produced a single memory.

## How

- Digest is curated, never the raw transcript: goal/title/kind, explore notes, per-unit pass/fail from harness evidence, review verdict (or review_skipped), terminal state and failure reason. No shell output, no mission.turn payloads.
- Seam: the existing terminal block in Driver.Advance/Signal where gatekeeper/sandbox teardown already runs after ApplyTransition.
- Idempotency: a mission.memory_extracted event is appended before dispatch and checked first, so re-drives and sweeps can't fire the pass twice.
- Nil client (memory disabled) or missing hidden session skips silently; extraction failure can never block the transition.
- Wiring in cmd/brain/main.go mirrors chat's: same settings flag gate, timeout, and mc.Extract call.

## Testing

- Table-driven digest tests plus driver-level: fires once on done, once on failed, zero on non-terminal, not twice on re-drive, error doesn't block, nil client skips.
- make build test vet lint green; canary PASS with mission.memory_extracted: 1 in event counts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788848552&installation_model_id=431401&pr_number=215&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F215&signature=6aa0bad514b003666d42a371d6a8f0a5a357f9bf686dd32c3f3d89228543f48e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->