### PR TITLE
feat(web): move settings tabs to a sidebar submenu

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import App from './App'
+
+// App wires in a lot of background polling (sessions, pending memories,
+// pending permissions, the /v1/events stream) — none of it relevant to
+// the sidebar's Settings submenu, so every fetch is stubbed to fail
+// harmlessly rather than mocking each api/client call individually.
+beforeEach(() => {
+  localStorage.setItem('timothy.token', 'test-token')
+  vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('no network in tests')))
+  // jsdom has no matchMedia; the sidebar's mobile breakpoint hook and
+  // sonner's Toaster both call it on mount.
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+  vi.unstubAllGlobals()
+})
+
+function renderAt(initialEntry: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <App />
+    </MemoryRouter>,
+  )
+}
+
+describe('Settings sidebar submenu', () => {
+  it('starts expanded and highlights the active area on a settings route', async () => {
+    renderAt('/settings/secrets')
+    const providersLink = await screen.findByRole('link', { name: 'Providers' })
+    const secretsLink = screen.getByRole('link', { name: 'Secrets' })
+    expect(secretsLink.getAttribute('data-active')).toBe('true')
+    expect(providersLink.getAttribute('data-active')).toBe('false')
+  })
+
+  it('collapses and expands on click without navigating away', async () => {
+    renderAt('/settings/providers')
+    await screen.findByRole('link', { name: 'Providers' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
+    expect(screen.queryByRole('link', { name: 'Providers' })).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
+    expect(await screen.findByRole('link', { name: 'Providers' })).toBeTruthy()
+  })
+
+  it('is collapsed by default off a settings route', () => {
+    renderAt('/memory')
+    expect(screen.queryByRole('link', { name: 'Providers' })).toBeNull()
+  })
+})

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import {
   Analytics01Icon,
+  ArrowRight01Icon,
   Brain02Icon,
   BubbleChatIcon,
   GithubIcon,
@@ -42,10 +43,15 @@ import {
   SidebarMenuBadge,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
   SidebarProvider,
   SidebarTrigger,
+  useSidebar,
 } from './components/ui/sidebar'
 import { TooltipProvider } from './components/ui/tooltip'
+import { cn } from './lib/utils'
 import { useSessions } from './lib/sessions'
 import { usePendingMemories } from './lib/memory'
 import { playAlertSound, unlockAudio } from './lib/alertSound'
@@ -61,7 +67,7 @@ import { MissionDetail } from './pages/MissionDetail'
 import { Missions } from './pages/Missions'
 import { NewMission } from './pages/NewMission'
 import { Research } from './pages/Research'
-import { Settings } from './pages/Settings'
+import { Settings, settingsAreas } from './pages/Settings'
 
 const nav = [
   { label: 'Home', href: '/', icon: Home01Icon },
@@ -84,13 +90,14 @@ function isActive(pathname: string, href: string): boolean {
 }
 
 // breadcrumbFor turns the current path into the header's breadcrumb
-// trail — static per top-level page, with a "Settings / <tab>" split
+// trail — static per top-level page, with a "Settings / <area>" split
 // for the one section that has sub-pages.
 function breadcrumbFor(pathname: string): string[] {
   const match = nav.find((n) => isActive(pathname, n.href))
   if (pathname.startsWith('/settings/')) {
-    const tab = pathname.split('/')[2]
-    if (tab) return ['Settings', tab.charAt(0).toUpperCase() + tab.slice(1)]
+    const key = pathname.split('/')[2]
+    const area = settingsAreas.find((a) => a.key === key)
+    if (area) return ['Settings', area.label]
   }
   return [match?.label ?? 'Timothy']
 }
@@ -114,6 +121,20 @@ function AppSidebar({
   onToken: () => void
 }) {
   const { pathname } = useLocation()
+  const navigate = useNavigate()
+  const { state: sidebarState, isMobile } = useSidebar()
+  // Settings starts expanded whenever we're already on a settings
+  // route (deep link or in-app nav), and stays however the user last
+  // toggled it otherwise — same "sticky until touched" feel as the
+  // rest of the sidebar's collapse state.
+  const [settingsOpen, setSettingsOpen] = useState(() => pathname.startsWith('/settings'))
+  useEffect(() => {
+    if (pathname.startsWith('/settings')) setSettingsOpen(true)
+  }, [pathname])
+  // Icon-collapsed mode hides the submenu entirely (no room for it),
+  // so a click there jumps straight to the first area instead of
+  // toggling an invisible expand state.
+  const iconCollapsed = sidebarState === 'collapsed' && !isMobile
 
   return (
     <Sidebar collapsible="icon">
@@ -132,22 +153,62 @@ function AppSidebar({
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
-              {nav.map((item) => (
-                <SidebarMenuItem key={item.href}>
-                  <SidebarMenuButton asChild isActive={isActive(pathname, item.href)} tooltip={item.label}>
-                    <Link to={item.href}>
+              {nav.map((item) =>
+                item.href === '/settings' ? (
+                  <SidebarMenuItem key={item.href}>
+                    <SidebarMenuButton
+                      isActive={isActive(pathname, item.href)}
+                      tooltip={item.label}
+                      onClick={() =>
+                        iconCollapsed
+                          ? navigate(`/settings/${settingsAreas[0].key}`)
+                          : setSettingsOpen((open) => !open)
+                      }
+                    >
                       <HugeiconsIcon icon={item.icon} />
                       <span>{item.label}</span>
-                    </Link>
-                  </SidebarMenuButton>
-                  {item.href === '/memory' && pendingMemories > 0 && (
-                    <SidebarMenuBadge>{pendingMemories}</SidebarMenuBadge>
-                  )}
-                  {item.href === '/chat' && pendingPermissions > 0 && (
-                    <SidebarMenuBadge>{pendingPermissions}</SidebarMenuBadge>
-                  )}
-                </SidebarMenuItem>
-              ))}
+                      <HugeiconsIcon
+                        icon={ArrowRight01Icon}
+                        className={cn(
+                          'ml-auto size-3.5! transition-transform group-data-[collapsible=icon]:hidden',
+                          settingsOpen && 'rotate-90',
+                        )}
+                      />
+                    </SidebarMenuButton>
+                    {settingsOpen && (
+                      <SidebarMenuSub>
+                        {settingsAreas.map((area) => (
+                          <SidebarMenuSubItem key={area.key}>
+                            <SidebarMenuSubButton
+                              asChild
+                              isActive={pathname.startsWith(`/settings/${area.key}`)}
+                            >
+                              <Link to={`/settings/${area.key}`}>
+                                <span>{area.label}</span>
+                              </Link>
+                            </SidebarMenuSubButton>
+                          </SidebarMenuSubItem>
+                        ))}
+                      </SidebarMenuSub>
+                    )}
+                  </SidebarMenuItem>
+                ) : (
+                  <SidebarMenuItem key={item.href}>
+                    <SidebarMenuButton asChild isActive={isActive(pathname, item.href)} tooltip={item.label}>
+                      <Link to={item.href}>
+                        <HugeiconsIcon icon={item.icon} />
+                        <span>{item.label}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                    {item.href === '/memory' && pendingMemories > 0 && (
+                      <SidebarMenuBadge>{pendingMemories}</SidebarMenuBadge>
+                    )}
+                    {item.href === '/chat' && pendingPermissions > 0 && (
+                      <SidebarMenuBadge>{pendingPermissions}</SidebarMenuBadge>
+                    )}
+                  </SidebarMenuItem>
+                ),
+              )}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>

--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -106,16 +106,18 @@ beforeEach(() => {
   ])
 })
 
-describe('Settings tabs', () => {
-  it('routes to the active tab', async () => {
+describe('Settings pages', () => {
+  it('renders the area as its own page with a heading', async () => {
     renderPage('/settings/secrets')
     expect(await screen.findByText('HashiCorp Vault')).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Secrets' })).toBeTruthy()
     expect(screen.queryByText('Your providers')).toBeNull()
   })
 
-  it('defaults to Providers', async () => {
+  it('redirects /settings to providers', async () => {
     renderPage('/settings')
     expect(await screen.findByText('healthy')).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Providers' })).toBeTruthy()
   })
 })
 

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes, useLocation, Link } from 'react-router'
+import { Navigate, Route, Routes } from 'react-router'
 import { AgentsTab } from '../components/settings/AgentsTab'
 import { ConnectorsTab } from '../components/settings/ConnectorsTab'
 import { CredentialsTab } from '../components/settings/CredentialsTab'
@@ -6,57 +6,80 @@ import { FeaturesTab } from '../components/settings/FeaturesTab'
 import { ProvidersTab } from '../components/settings/ProvidersTab'
 import { RoutesTab } from '../components/settings/RoutesTab'
 import { SecretsTab } from '../components/settings/SecretsTab'
-import { cn } from '../lib/utils'
 
-// Sub-nav is a fixed tab list, one per settings area — each area is a
-// real route under /settings/*, not a query param, so a provider's
-// own add/edit page (their own screen, not a dialog) has somewhere to
-// live: /settings/providers/new.
-const tabs = [
-  { key: 'providers', label: 'Providers', render: ProvidersTab },
-  { key: 'connectors', label: 'Connectors', render: ConnectorsTab },
-  { key: 'agents', label: 'Agents', render: AgentsTab },
-  { key: 'routes', label: 'Routing', render: RoutesTab },
-  { key: 'secrets', label: 'Secrets', render: SecretsTab },
-  { key: 'credentials', label: 'Credentials', render: CredentialsTab },
-  { key: 'features', label: 'Features', render: FeaturesTab },
+// One area per settings page — each is a real route under
+// /settings/*, not a query param, so a provider's own add/edit page
+// (their own screen, not a dialog) has somewhere to live:
+// /settings/providers/new. The sidebar's Settings submenu (App.tsx)
+// links to these same keys, so they stay in lockstep.
+export const settingsAreas = [
+  {
+    key: 'providers',
+    label: 'Providers',
+    description: 'Connect and manage the LLM providers Timothy can route work to.',
+    render: ProvidersTab,
+  },
+  {
+    key: 'connectors',
+    label: 'Connectors',
+    description: 'External services Timothy can act on, like Google or MCP servers.',
+    render: ConnectorsTab,
+  },
+  {
+    key: 'agents',
+    label: 'Agents',
+    description: 'Prompt overlays, skills, and tools bundled per agent.',
+    render: AgentsTab,
+  },
+  {
+    key: 'routes',
+    label: 'Routing',
+    description: 'Task routes decide which provider chain handles a given job.',
+    render: RoutesTab,
+  },
+  {
+    key: 'secrets',
+    label: 'Secrets',
+    description: 'Where credentials live: Timothy storage, Vault, or AWS Secrets Manager.',
+    render: SecretsTab,
+  },
+  {
+    key: 'credentials',
+    label: 'Credentials',
+    description: 'API keys and tokens stored for providers and connectors.',
+    render: CredentialsTab,
+  },
+  {
+    key: 'features',
+    label: 'Features',
+    description: 'Feature switches and defaults: changes serve immediately, no restarts.',
+    render: FeaturesTab,
+  },
 ] as const
 
-export function Settings() {
-  const { pathname } = useLocation()
-  const active = tabs.find((t) => pathname.startsWith(`/settings/${t.key}`)) ?? tabs[0]
-
+// SettingsPage is the shared shell every settings area renders inside:
+// same container/heading style as other top-level pages (Memory,
+// Analytics), just the area's own component below it.
+function SettingsPage({ area }: { area: (typeof settingsAreas)[number] }) {
+  const Area = area.render
   return (
     <div className="h-full overflow-y-auto">
       <div className="mx-auto max-w-full px-8 py-8">
-        <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Providers, task allocation, and feature switches: changes serve immediately, no
-          restarts.
-        </p>
-        <div className="mt-5 flex gap-1 border-b border-border">
-          {tabs.map((t) => (
-            <Link
-              key={t.key}
-              to={`/settings/${t.key}`}
-              className={cn(
-                'px-3 py-2 text-sm font-medium',
-                active.key === t.key
-                  ? 'border-b-2 border-brand text-foreground'
-                  : 'text-muted-foreground hover:text-foreground',
-              )}
-            >
-              {t.label}
-            </Link>
-          ))}
-        </div>
-        <Routes>
-          <Route path="/" element={<Navigate to="providers" replace />} />
-          {tabs.map((t) => (
-            <Route key={t.key} path={`${t.key}/*`} element={<t.render />} />
-          ))}
-        </Routes>
+        <h1 className="text-2xl font-semibold tracking-tight">{area.label}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">{area.description}</p>
+        <Area />
       </div>
     </div>
+  )
+}
+
+export function Settings() {
+  return (
+    <Routes>
+      <Route path="/" element={<Navigate to="providers" replace />} />
+      {settingsAreas.map((area) => (
+        <Route key={area.key} path={`${area.key}/*`} element={<SettingsPage area={area} />} />
+      ))}
+    </Routes>
   )
 }


### PR DESCRIPTION
## What

The Settings tab strip is gone. Each settings area (Providers, Connectors, Agents, Routing, Secrets, Credentials, Features) is now its own page, reached through an expandable Settings entry in the left sidebar.

## Why

Seven areas outgrew a tab strip: the shared page buried each area under a generic heading, and the sidebar already had room for direct navigation.

## How

- `settingsAreas` in Settings.tsx carries key/label/description/component per area; the sidebar submenu and breadcrumb both read from it, so labels stay in lockstep.
- Each area renders in a shared page shell (h1 + muted description) matching Memory/Analytics.
- Sidebar uses the existing SidebarMenuSub primitives. The submenu auto-expands on any /settings/* route and stays as last toggled otherwise. In icon-collapsed mode a click on Settings navigates to Providers instead of toggling an invisible submenu.
- Route paths unchanged (`/settings/<key>/*`), `/settings` still redirects to providers, so deep links and in-app navigation (e.g. `/settings/providers/new`) keep working.

## Testing

- Updated Settings page tests to assert per-area headings.
- New App.test.tsx smoke tests: submenu expands + highlights active area on a settings route, toggles on click, starts collapsed elsewhere.
- Web build, lint, and all 595 tests pass; web container rebuilt and healthy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788849937&installation_model_id=431401&pr_number=216&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F216&signature=524109e2b94f2f73b863200a24b5b8d50cf47b759fcee5ce59958c1750182463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->