### PR TITLE
test(ledger): isolate budget currency test from live spend

### DIFF
--- a/internal/gateway/ledger/budget_integration_test.go
+++ b/internal/gateway/ledger/budget_integration_test.go
@@ -136,7 +136,10 @@ func TestBudgetRoundTripAndStatus(t *testing.T) {
 // TestBudgetStatusIgnoresOtherCurrencySpend confirms a budget in one
 // currency never gets checked against spend recorded in another —
 // comparing across currencies would need a guessed FX rate, which
-// this codebase never does.
+// this codebase never does. The budget is denominated in XTS (the ISO
+// 4217 code reserved for testing) rather than USD: the test runs
+// against the live ledger, and a USD budget would count real same-day
+// spend (canary missions, title calls) as contamination.
 func TestBudgetStatusIgnoresOtherCurrencySpend(t *testing.T) {
 	dsn := os.Getenv("DATABASE_URL")
 	if dsn == "" {
@@ -172,8 +175,8 @@ func TestBudgetStatusIgnoresOtherCurrencySpend(t *testing.T) {
 		}
 	}()
 
-	// A USD day budget with a huge headroom; all the spend below is EUR.
-	if err := s.Set(ctx, "day", &BudgetLimit{Amount: 1e9, Currency: "USD"}); err != nil {
+	// An XTS day budget with a huge headroom; all the spend below is EUR.
+	if err := s.Set(ctx, "day", &BudgetLimit{Amount: 1e9, Currency: "XTS"}); err != nil {
 		t.Fatalf("set day: %v", err)
 	}
 
@@ -194,7 +197,7 @@ func TestBudgetStatusIgnoresOtherCurrencySpend(t *testing.T) {
 	if err != nil {
 		t.Fatalf("status: %v", err)
 	}
-	if status.Day.Currency != "USD" || status.Day.Spend != 0 || status.Day.Over {
-		t.Fatalf("day = %+v, want USD currency, zero spend, not over (EUR spend must not count)", status.Day)
+	if status.Day.Currency != "XTS" || status.Day.Spend != 0 || status.Day.Over {
+		t.Fatalf("day = %+v, want XTS currency, zero spend, not over (EUR spend must not count)", status.Day)
 	}
 }


### PR DESCRIPTION
## Why

`TestBudgetStatusIgnoresOtherCurrencySpend` asserted zero USD day-spend against the live ledger, failing deterministically any day the stack spent real money (canary missions, title generation). Surfaced while verifying #220.

## What

The test budget is now denominated in XTS (the ISO 4217 code reserved for testing) instead of USD. Real spend is never XTS-denominated, so it cannot contaminate the window, and the semantic under test — spend in one currency never counts against a budget in another — is unchanged.

## Verification

`go test -race -count=3 -tags integration -run TestBudgetStatus ./internal/gateway/ledger/` against a live DB carrying real same-day USD spend: passes (failed deterministically before).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788985806&installation_model_id=431401&pr_number=221&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F221&signature=c257847aa673ce2d8b05a5282c44773cbcfc888a2d715300c3d1b385caba90bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->