### PR TITLE
docs: spell out branching, commit, and pr conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,11 +88,33 @@ via the existing `--env-file` Make targets.
 - No speculative abstractions: no interface with one implementation,
   no config nothing reads.
 
+## Git workflow
+
+- Never commit to `main`. Branch off an updated `main`:
+  `git checkout main && git pull && git checkout -b <type>/<short-description>`.
+- Branch names: `<type>/<short-description>`, kebab-case, matching the
+  commit type of the work (`feat/mission-follow-up`,
+  `fix/ledger-budget-test-isolation`, `docs/git-workflow`).
+- Commits are Conventional Commits:
+  `<type>[optional scope]: <short description>` with types
+  `feat|fix|docs|style|refactor|perf|test|chore|build|ci|revert`.
+  Subject ≤72 chars, lowercase, imperative, no trailing period. Body
+  explains WHY, not what. Breaking changes get a `BREAKING CHANGE:`
+  footer. No vague subjects ("fix stuff", "WIP", "update").
+- One logical change per commit; run
+  `make build test vet lint` (and the web suite when `web/` changed)
+  before committing. `make canary` before merging any harness change.
+- PRs: title = the conventional commit subject; body = Why / What /
+  Verification. Squash-merge to main; the squash subject keeps the
+  conventional format (history reads `type(scope): subject (#PR)`).
+  Delete the branch on merge. Stacked PRs name their base PR in the
+  body and are retargeted after it merges.
+- No AI/tool attribution anywhere: commits, PR bodies, comments.
+- Never force-push shared branches; resolve conflicts by merging
+  `main` into the branch (squash-merge discards branch history anyway).
+
 ## Conventions
 
-- Conventional Commits, subject ≤72 chars, lowercase, body explains
-  WHY. No AI/tool attribution anywhere: commits, PRs, comments.
-- Branches `feat/<short-description>`; never commit to main.
 - Go: wrap errors with `%w`; sentinel errors + `errors.Is`; interfaces
   at point of use, none for a single implementation; table-driven
   tests; integration tests behind `//go:build integration`; race


### PR DESCRIPTION
## Why

AGENTS.md named Conventional Commits but left branching strategy, squash-merge behavior, stacked-PR handling, and pre-commit gates implicit.

## What

New Git workflow section: branch naming (`<type>/<short-description>` off updated main), commit format and types, one-logical-change + verify gates (`make build test vet lint`, web suite, canary for harness changes), PR shape (conventional title, Why/What/Verification body, squash-merge, stacked-PR retargeting), no attribution, no force-push.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788994109&installation_model_id=431401&pr_number=224&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F224&signature=db26f8a74c7d58d39ddc457f614ad8cf2dd6f90ba9ce52db3b0e2e450cbe333a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->