### PR TITLE
build: inject version and sha into local web builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,13 @@ GO_IMAGE   := golang:1.26.5
 LINT_IMAGE := golangci/golangci-lint:v2.12.2
 COMPOSE    := docker compose -f deploy/docker-compose.yml
 
+# Local web builds get the same version/sha the release pipeline
+# injects, so the sidebar never falls back to package.json's stale
+# version and an "unknown" sha. -dev marks an image as locally built;
+# ?= lets an explicit environment override win (the release path).
+export GIT_SHA     ?= $(shell git rev-parse --short HEAD 2>/dev/null)
+export APP_VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null)-dev
+
 # Go toolchain runs containerized: no host Go install required, same
 # version everywhere. Named volumes cache modules and builds.
 GO_RUN := docker run --rm -v $(CURDIR):/src -w /src \

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -273,6 +273,7 @@ services:
       context: ../web
       args:
         GIT_SHA: ${GIT_SHA:-}
+        APP_VERSION: ${APP_VERSION:-}
       # HugeIcons Pro registry auth for npm ci, passed as a BuildKit
       # secret (name-only ref; the value lives in deploy/.env, never in
       # the repo or an image layer).


### PR DESCRIPTION
## Why

Local web builds showed `0.1.0-alpha.8` and sha `unknown` in the sidebar: compose passed neither `APP_VERSION` nor `GIT_SHA`, so vite fell back to package.json's stale version field, and the in-image `git rev-parse` fallback can't work — the web build context has no `.git`.

## What

- Makefile exports `GIT_SHA` (`git rev-parse --short HEAD`) and `APP_VERSION` (`git describe --tags --abbrev=0` + `-dev` suffix) for every compose invocation; `?=` lets an explicit environment override win.
- compose web build passes `APP_VERSION` through (GIT_SHA already was, just always empty).

## Verification

`make web` then grep of the served bundle: `0.1.0-alpha.25-dev` and the current sha both embedded. `make build test vet lint` green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788994666&installation_model_id=431401&pr_number=225&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F225&signature=bce93e8b910a302132bfbfc71a974f1b16489102b6d4ed0026affc7d6f8cb0e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->