### PR TITLE
fix(sandboxd): drop all capabilities and block privilege escalation in mission sandboxes

### DIFF
--- a/internal/sandboxd/manager.go
+++ b/internal/sandboxd/manager.go
@@ -421,6 +421,12 @@ func (m *Manager) createContainer(ctx context.Context, missionID, name, environm
 		// brain/gateway/sshd when the host itself is under memory
 		// pressure.
 		OomScoreAdj: sandboxOomScoreAdj,
+		// Capabilities only matter to root, and the container runs uid
+		// 65534, but CapDrop closes NET_RAW on the bridge and
+		// no-new-privileges blocks any setuid escalation path; missions
+		// need neither (pip/npm/git run unprivileged).
+		CapDrop:     []string{"ALL"},
+		SecurityOpt: []string{"no-new-privileges"},
 		// Default bridge: internet access (a coding mission may need
 		// `pip install`/`npm install`), but NOT the compose-internal
 		// "timothy" network — no route to postgres/gateway/memoryd.

--- a/internal/sandboxd/manager_test.go
+++ b/internal/sandboxd/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -631,6 +632,12 @@ func TestCreateContainerHardensResources(t *testing.T) {
 	}
 	if gotHostConfig.OomScoreAdj != sandboxOomScoreAdj {
 		t.Errorf("OomScoreAdj = %d, want %d", gotHostConfig.OomScoreAdj, sandboxOomScoreAdj)
+	}
+	if !slices.Equal(gotHostConfig.CapDrop, []string{"ALL"}) {
+		t.Errorf("CapDrop = %v, want [ALL]", gotHostConfig.CapDrop)
+	}
+	if !slices.Contains(gotHostConfig.SecurityOpt, "no-new-privileges") {
+		t.Errorf("SecurityOpt = %v, want to contain no-new-privileges", gotHostConfig.SecurityOpt)
 	}
 }
 


### PR DESCRIPTION
## Why

Mission sandbox containers run model-authored commands as uid 65534, but the container itself kept Docker's default capability set and permitted privilege escalation via setuid binaries. Neither is needed by any mission workflow.

## What

Two fields on the sandbox `HostConfig` in `internal/sandboxd/manager.go`:

- `CapDrop: ["ALL"]` — closes NET_RAW (raw-socket spoofing from the bridge network) and every other default capability a setuid binary could regain.
- `SecurityOpt: ["no-new-privileges"]` — removes the setuid/setgid escalation path entirely.

pip, npm, and git all run unprivileged; missions see no behavior change.

Out of scope, noted for a future slice: network egress control (sandboxes currently have full bridge internet for `pip install`/`npm install`).

## Verification

- `go test -race ./internal/sandboxd/` green, with new assertions on `CapDrop`/`SecurityOpt` in `TestCreateContainerHardensResources`.
- `make build vet lint` clean.
- `make canary` PASS against a rebuilt sandboxd: golden mission completed unattended inside a hardened container (3 turns, unit verified, review skipped).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789032360&installation_model_id=431401&pr_number=226&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F226&signature=a30e5b8e18435cac8a91cf6987ab41088c0214afad42f719caf6dfbb65e5a443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->