### PR TITLE
feat(web): show live word count under mission goal field

### DIFF
--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -203,6 +203,10 @@ export function MissionForm({
   const routes = useRoutes()
   const enabledRoutes = routes?.filter((r) => r.enabled) ?? []
   const [goal, setGoal] = useState('')
+  const goalWordCount = useMemo(
+    () => (goal.trim() === '' ? 0 : goal.trim().split(/\s+/).length),
+    [goal],
+  )
   // attachments, like goal, is never seeded from initial — a follow-up
   // carries the parent's outcome digest as prompt context, not its
   // documents; each new mission attaches its own.
@@ -601,6 +605,9 @@ export function MissionForm({
           autoFocus
           className="min-h-60 resize-y text-base"
         />
+        <p className="text-right text-xs text-muted-foreground">
+          {goalWordCount} {goalWordCount === 1 ? 'word' : 'words'}
+        </p>
 
         {goal.trim() !== '' && (
           <button type="button" onClick={toggleKind} disabled={repeat && kind === 'general'}>


### PR DESCRIPTION
## Summary
- Adds a live word count below the mission goal textarea in MissionForm.

## Test plan
- [x] make build web via docker (npm run build + lint, 0 errors)
- [x] verified in local UI at :3300 after rebuild

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789116419&installation_model_id=431401&pr_number=227&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F227&signature=2371c371ae0aad617289715a8ac795343ac5c2c3133c95b087bf6ff3569edfa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->