### PR TITLE
feat: research agent upgrades — search controls, citation verification, deep-research skill, research canary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GO_RUN := docker run --rm -v $(CURDIR):/src -w /src \
 	-e GOFLAGS=-buildvcs=false $(GO_IMAGE)
 
 .PHONY: build test test-integration test-live vet lint tidy skills-validate up down logs \
-	brain gateway memoryd web markitdown sandboxd dev canary canary-coding canary-executor sandbox-image
+	brain gateway memoryd web markitdown sandboxd dev canary canary-coding canary-research canary-executor sandbox-image
 
 build:
 	$(GO_RUN) go build ./...
@@ -105,6 +105,15 @@ canary:
 # without it.
 canary-coding:
 	./scripts/canary-coding.sh
+
+# Same gate for research work: the goal requires current web
+# information and a cited markdown report, so it exercises
+# web_search/web_fetch and the citations check that the trivial
+# lookup goals in canary-mission.sh never touch. Needs the stack up.
+# Optional LLM judge: set CANARY_JUDGE_ROUTE to a route different from
+# whatever wrote the report; unset means deterministic checks only.
+canary-research:
+	./scripts/canary-research.sh
 
 # Regression gate for the delegated-executor (D-052) path: pins a
 # canary-executor route to a single claude-cli chain entry, no

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -1043,7 +1043,7 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 		if err := d.store.SetLastEvidence(ctx, m.ID, verdict.Evidence); err != nil {
 			d.log.Warn("driver: record evidence failed", "mission_id", m.ID, "error", err)
 		}
-		if in, ok := d.trySkipReview(ctx, m); ok {
+		if in, ok := d.trySkipReview(ctx, m, verdict.SeenURLs); ok {
 			return in, nil
 		}
 		return StepInput{Input: InputPhaseComplete}, nil
@@ -1079,7 +1079,7 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 // Coding missions always review: a diff can be wrong in ways
 // existence checks can't see. Units with no declared artifacts always
 // review too — there is no harness evidence to stand on.
-func (d *Driver) trySkipReview(ctx context.Context, m Mission) (StepInput, bool) {
+func (d *Driver) trySkipReview(ctx context.Context, m Mission, seenURLs []string) (StepInput, bool) {
 	if m.Kind == "coding" {
 		return StepInput{}, false
 	}
@@ -1087,7 +1087,7 @@ func (d *Driver) trySkipReview(ctx context.Context, m Mission) (StepInput, bool)
 	if unit == nil || len(unit.Artifacts) == 0 {
 		return StepInput{}, false
 	}
-	if err := d.verifyCurrentUnit(ctx, m); err != nil {
+	if err := d.verifyCurrentUnit(ctx, m, seenURLs); err != nil {
 		var vf *verifyFailure
 		if errors.As(err, &vf) {
 			note := fmt.Sprintf("Verification failed for unit %d before review: %s", vf.unit+1, vf.excerpt)
@@ -1229,7 +1229,7 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 
 	if verdict.Approved {
 		var vf *verifyFailure
-		if err := d.verifyCurrentUnit(ctx, m); err != nil {
+		if err := d.verifyCurrentUnit(ctx, m, nil); err != nil {
 			if errors.As(err, &vf) {
 				// The reviewer approved, but the harness's own verify_cmd
 				// disagrees — real evidence the approval didn't hold up
@@ -1292,10 +1292,18 @@ func (e *verifyFailure) Error() string {
 // verifyCurrentUnit runs the harness's own checks for the plan's
 // current (first unverified) unit and marks it passed — only this
 // harness-run evidence may flip a unit's Passes flag, never model
-// output. Declared artifacts are checked first (exists, non-empty):
-// a tautological verify_cmd cannot pass a unit whose artifact was
-// never written.
-func (d *Driver) verifyCurrentUnit(ctx context.Context, m Mission) error {
+// output. Declared artifacts are checked first (exists, non-empty),
+// then (general missions only, D-059) that every URL cited in those
+// artifacts was actually seen by the worker via web_fetch/web_search
+// this turn — a tautological verify_cmd cannot pass a unit whose
+// artifact was never written, or whose citations were invented.
+// seenURLs is only ever populated by the caller right after the
+// worker turn that produced it (runExecute); it is empty on the later
+// runReview call, which is fine — for a general mission trySkipReview
+// already ran this exact check with the real evidence, and runReview
+// only reaches this path for coding missions (out of scope) or the
+// rare infra-failure fallback.
+func (d *Driver) verifyCurrentUnit(ctx context.Context, m Mission, seenURLs []string) error {
 	for i, u := range m.Spec.Units {
 		if u.Passes {
 			continue
@@ -1318,6 +1326,17 @@ func (d *Driver) verifyCurrentUnit(ctx context.Context, m Mission) error {
 				d.log.Warn("driver: record verify failed", "mission_id", m.ID, "error", err)
 			}
 			return &verifyFailure{unit: i, excerpt: excerpt}
+		}
+		if m.Kind == "general" {
+			if problems := CheckCitations(workRoot, u.Artifacts, seenURLs); len(problems) > 0 {
+				excerpt := "citation check failed:\n" + strings.Join(problems, "\n")
+				if err := d.store.AppendEvent(ctx, m.ID, "mission.unit_verified", map[string]any{
+					"unit": i, "passed": false, "check": "citations", "problems": problems,
+				}); err != nil {
+					d.log.Warn("driver: record verify failed", "mission_id", m.ID, "error", err)
+				}
+				return &verifyFailure{unit: i, excerpt: excerpt}
+			}
 		}
 		if u.VerifyCmd == "" {
 			return d.markUnitPassed(ctx, m, i)

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -1449,6 +1449,68 @@ func TestDriverArtifactCheckBlocksTautologicalDone(t *testing.T) {
 	}
 }
 
+// TestDriverCitationCheckBlocksInvokedCitation: a general mission's
+// worker writes an artifact citing a URL it never actually fetched or
+// searched — the harness's own CheckCitations must catch this and
+// send the unit back to execute, same failure path CheckArtifacts
+// uses, never letting the invented citation stand.
+func TestDriverCitationCheckBlocksInvokedCitation(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "report.md"), []byte("source: [docs](https://example.com/invented)"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking,
+		MaxIterations: 8, Workspace: root,
+		Spec: Spec{Units: []PlanUnit{{Title: "write report", Artifacts: []string{"report.md"}}}},
+	})
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote it", SeenURLs: []string{"https://example.com/other"}}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseExecute || m.Spec.Units[0].Passes {
+		t.Fatalf("mission = phase %s passes %v, want back in execute with the unit NOT passed", m.Phase, m.Spec.Units[0].Passes)
+	}
+	if len(m.Progress) == 0 || !strings.Contains(m.Progress[len(m.Progress)-1].Note, "citation check failed") {
+		t.Fatalf("progress = %+v, want a note explaining the citation failure", m.Progress)
+	}
+}
+
+// TestDriverCitationCheckSkippedForCodingMission: coding missions cite
+// source, not the web (D-059) — an invented URL in a coding mission's
+// artifact must not block it, since the citations check never runs
+// for Kind == "coding". The scriptedRunner has a review verdict
+// scripted since coding missions always review.
+func TestDriverCitationCheckSkippedForCodingMission(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "report.md"), []byte("source: [docs](https://example.com/invented)"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "coding", Phase: PhaseExecute, Status: StatusWorking,
+		MaxIterations: 8, Workspace: root,
+		Spec: Spec{Units: []PlanUnit{{Title: "write report", Artifacts: []string{"report.md"}}}},
+	})
+	runner := &scriptedRunner{
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner)
+
+	driveN(t, d, "m1", 2)
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseDone || m.Status != StatusDone {
+		t.Fatalf("mission = %+v, want done/done — citation check must not run for a coding mission", m)
+	}
+}
+
 // TestDriverRegressionFlipsUnitAndRetriesInsteadOfAdvancing reproduces
 // the fix: a unit that already passed can silently break while a LATER
 // unit's work is happening. Unit 0's artifact ("a.md") passed

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -281,10 +282,10 @@ func (r *nativeRunner) belowFloor(model string) bool {
 // full assistant text. It does not itself decide what a missing
 // sentinel means — that's the caller's job (worker vs review have
 // different enforcement/parsing needs).
-func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTool string) (text string, sentinelArgs json.RawMessage, err error) {
+func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTool string) (text string, sentinelArgs json.RawMessage, seenURLs []string, err error) {
 	events, err := r.agent.Start(ctx, req)
 	if err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 	var b strings.Builder
 	// parked tracks in-flight parks by CallID, not a single flag — a
@@ -307,6 +308,9 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 		case stream.EventToolEnd:
 			if ev.ToolCall != nil && ev.ToolCall.Name == sentinelTool {
 				sentinelArgs = ev.ToolCall.Input
+			}
+			if ev.ToolCall != nil && ev.ToolCall.Name == "web_fetch" {
+				seenURLs = append(seenURLs, webFetchArgURL(ev.ToolCall.Input)...)
 			}
 		case stream.EventPermissionRequest:
 			if r.parker != nil && ev.Permission != nil {
@@ -331,6 +335,9 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if ev.ToolResult != nil && ev.ToolResult.Status == "denied" && r.parker != nil {
 				r.parker.OnPermissionDenied(ctx, req.MissionID, ev.ToolResult.Name, ev.ToolResult.Digest)
 			}
+			if ev.ToolResult != nil && ev.ToolResult.Status == "ok" && ev.ToolResult.Name == "web_search" {
+				seenURLs = append(seenURLs, webSearchResultURLs(ev.ToolResult.Digest)...)
+			}
 		case stream.EventDone:
 			sawTerminal = true
 			if ev.Meta != nil {
@@ -345,7 +352,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if len(parked) > 0 && r.parker != nil {
 				r.parker.OnPermissionCleared(ctx, req.MissionID)
 			}
-			return b.String(), sentinelArgs, fmt.Errorf("mission runner: incomplete stream: %s", ev.Text)
+			return b.String(), sentinelArgs, seenURLs, fmt.Errorf("mission runner: incomplete stream: %s", ev.Text)
 		case stream.EventError:
 			if len(parked) > 0 && r.parker != nil {
 				r.parker.OnPermissionCleared(ctx, req.MissionID)
@@ -354,19 +361,62 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if ev.Err != nil {
 				msg = ev.Err.Message
 			}
-			return b.String(), sentinelArgs, fmt.Errorf("mission runner: %s", msg)
+			return b.String(), sentinelArgs, seenURLs, fmt.Errorf("mission runner: %s", msg)
 		}
 	}
 	if !sawTerminal {
 		if len(parked) > 0 && r.parker != nil {
 			r.parker.OnPermissionCleared(ctx, req.MissionID)
 		}
-		return b.String(), sentinelArgs, fmt.Errorf("mission runner: stream ended without a terminal event")
+		return b.String(), sentinelArgs, seenURLs, fmt.Errorf("mission runner: stream ended without a terminal event")
 	}
 	if servedModel != "" && r.belowFloor(servedModel) {
-		return b.String(), sentinelArgs, fmt.Errorf("%w: %s", ErrModelFloor, servedModel)
+		return b.String(), sentinelArgs, seenURLs, fmt.Errorf("%w: %s", ErrModelFloor, servedModel)
 	}
-	return b.String(), sentinelArgs, nil
+	return b.String(), sentinelArgs, seenURLs, nil
+}
+
+// webFetchArgURL extracts the url arg from a web_fetch call's raw
+// input — the exact field name webfetch.go's webFetchArgs decodes
+// (D-059). A malformed input yields nothing rather than an error: this
+// is best-effort evidence collection, not argument validation (the
+// tool's own Execute already rejected a bad call before this point).
+func webFetchArgURL(input json.RawMessage) []string {
+	var args struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil || args.URL == "" {
+		return nil
+	}
+	return []string{args.URL}
+}
+
+// webSearchResultURLs pulls result URLs out of web_search's rendered
+// output — websearch.go's runSearch emits one blank-line-separated
+// entry per result as "N. title\nurl\nsnippet" (D-059). Line 2 of each
+// three-line group is the URL; anything not matching that shape (the
+// "no results found" sentinel, a truncated tail) is skipped rather
+// than guessed at. Best-effort only: the digest is capped (and big
+// results offload to a stub), so URLs past the cap are lost. That is
+// deliberate lenience on top of the reliable contract — cite what you
+// web_fetch, whose args are never truncated.
+var webSearchResultHeader = regexp.MustCompile(`^\d+\.\s`)
+
+func webSearchResultURLs(digest string) []string {
+	lines := strings.Split(digest, "\n")
+	var urls []string
+	for i := 0; i+1 < len(lines); i++ {
+		// A result's first line is "N. title" — only its second line
+		// (the URL) is collected.
+		if !webSearchResultHeader.MatchString(lines[i]) {
+			continue
+		}
+		candidate := strings.TrimSpace(lines[i+1])
+		if strings.HasPrefix(candidate, "http://") || strings.HasPrefix(candidate, "https://") {
+			urls = append(urls, candidate)
+		}
+	}
+	return urls
 }
 
 // workerRoute picks the route a worker turn runs on. With an
@@ -427,11 +477,12 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		Unattended: m.ScheduleID != "",
 	}
 
-	text, args, err := r.runTurn(ctx, req, missionStatusToolName)
+	text, args, seenURLs, err := r.runTurn(ctx, req, missionStatusToolName)
 	if err != nil {
 		return WorkerVerdict{}, text, err
 	}
 	if v, ok := r.tryParseVerdict(args); ok {
+		v.SeenURLs = seenURLs
 		return v, text, nil
 	}
 
@@ -441,11 +492,13 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		provider.Message{Role: "assistant", Content: text},
 		provider.Message{Role: "user", Content: "[system] You must end your turn with exactly one mission_status tool call: done, retry, or blocked."},
 	)
-	recoverText, recoverArgs, err := r.runTurn(ctx, recoverReq, missionStatusToolName)
+	recoverText, recoverArgs, recoverSeenURLs, err := r.runTurn(ctx, recoverReq, missionStatusToolName)
+	seenURLs = append(seenURLs, recoverSeenURLs...)
 	if err != nil {
 		return WorkerVerdict{}, text + "\n" + recoverText, err
 	}
 	if v, ok := r.tryParseVerdict(recoverArgs); ok {
+		v.SeenURLs = seenURLs
 		return v, text + "\n" + recoverText, nil
 	}
 
@@ -462,6 +515,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 	if raw, ok := extractTextSentinel(combined, missionStatusToolName); ok {
 		if v, ok := r.tryParseVerdict(raw); ok {
 			r.log.Warn("mission worker expressed mission_status as text, not a tool call", "mission_id", m.ID)
+			v.SeenURLs = seenURLs
 			return v, combined, nil
 		}
 	}
@@ -525,7 +579,7 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 		Unattended:   m.ScheduleID != "",
 	}
 
-	text, args, err := r.runTurn(ctx, req, exploreNotesToolName)
+	text, args, _, err := r.runTurn(ctx, req, exploreNotesToolName)
 	if err != nil {
 		return "", err
 	}
@@ -539,7 +593,7 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 		provider.Message{Role: "assistant", Content: text},
 		provider.Message{Role: "user", Content: "[system] You must end your turn with exactly one explore_notes tool call containing your findings."},
 	)
-	recoverText, recoverArgs, err := r.runTurn(ctx, recoverReq, exploreNotesToolName)
+	recoverText, recoverArgs, _, err := r.runTurn(ctx, recoverReq, exploreNotesToolName)
 	if err != nil {
 		return "", err
 	}
@@ -603,7 +657,7 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 		BuiltinsOnly: true,
 		Unattended:   m.ScheduleID != "",
 	}
-	text, args, err := r.runTurn(ctx, req, reviewVerdictToolName)
+	text, args, _, err := r.runTurn(ctx, req, reviewVerdictToolName)
 	if err != nil {
 		return ReviewVerdict{}, nil, err
 	}
@@ -617,7 +671,7 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 			provider.Message{Role: "assistant", Content: text},
 			provider.Message{Role: "user", Content: "[system] You must end your turn with exactly one review_verdict tool call: approve or rework."},
 		)
-		recoverText, recoverArgs, err := r.runTurn(ctx, recoverReq, reviewVerdictToolName)
+		recoverText, recoverArgs, _, err := r.runTurn(ctx, recoverReq, reviewVerdictToolName)
 		if err != nil {
 			return ReviewVerdict{}, nil, err
 		}
@@ -735,7 +789,7 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 		BuiltinsOnly: true,
 		Unattended:   m.ScheduleID != "",
 	}
-	text, args, err := r.runTurn(ctx, req, planToolName)
+	text, args, _, err := r.runTurn(ctx, req, planToolName)
 	if err != nil {
 		return Spec{}, err
 	}
@@ -761,7 +815,7 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 		provider.Message{Role: "assistant", Content: text},
 		provider.Message{Role: "user", Content: "[system] Your last turn did not produce a usable plan: " + recoverReason + ". You must end this turn with exactly one submit_plan tool call."},
 	)
-	recoverText, recoverArgs, err := r.runTurn(ctx, recoverReq, planToolName)
+	recoverText, recoverArgs, _, err := r.runTurn(ctx, recoverReq, planToolName)
 	if err != nil {
 		return Spec{}, err
 	}

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -1240,7 +1240,7 @@ func TestRunTurnBareCloseIsError(t *testing.T) {
 		textEvent("partial work"),
 	}}}
 	r := newTestRunner(agent)
-	text, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName)
+	text, _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName)
 	if err == nil || !strings.Contains(err.Error(), "without a terminal event") {
 		t.Fatalf("err = %v, want no-terminal error", err)
 	}
@@ -1258,7 +1258,7 @@ func TestRunTurnIncompleteIsError(t *testing.T) {
 		{Type: stream.EventIncomplete, Text: "stream ended without a terminal event"},
 	}}}
 	r := newTestRunner(agent)
-	if _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "incomplete stream") {
+	if _, _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "incomplete stream") {
 		t.Fatalf("err = %v, want incomplete-stream error", err)
 	}
 }
@@ -1271,7 +1271,7 @@ func TestRunTurnNilErrErrorEvent(t *testing.T) {
 		{Type: stream.EventError},
 	}}}
 	r := newTestRunner(agent)
-	if _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "provider stream error") {
+	if _, _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "provider stream error") {
 		t.Fatalf("err = %v, want generic provider stream error", err)
 	}
 }
@@ -1326,5 +1326,98 @@ func TestMissionRunnerRequestsAreBuiltinsOnly(t *testing.T) {
 	}
 	if !agent.requests[len(agent.requests)-1].BuiltinsOnly {
 		t.Fatal("PlanSession's request must set BuiltinsOnly")
+	}
+}
+
+// okToolResultEvent is toolResultEvent's ok-status counterpart with a
+// name and digest — web_search's rendered results ride the digest,
+// never a separate raw-result field (D-059).
+func okToolResultEvent(id, name, digest string) stream.StreamEvent {
+	return stream.StreamEvent{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{
+		ID: id, Name: name, Status: "ok", Digest: digest,
+	}}
+}
+
+func TestWebFetchArgURL(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"valid url arg", `{"url":"https://example.com/docs"}`, []string{"https://example.com/docs"}},
+		{"empty url", `{"url":""}`, nil},
+		{"malformed json", `not json`, nil},
+		{"missing url field", `{}`, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := webFetchArgURL(json.RawMessage(tc.input))
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("webFetchArgURL(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWebSearchResultURLs(t *testing.T) {
+	cases := []struct {
+		name   string
+		digest string
+		want   []string
+	}{
+		{
+			name:   "single result",
+			digest: "1. Example Docs\nhttps://example.com/docs\nsnippet text",
+			want:   []string{"https://example.com/docs"},
+		},
+		{
+			name:   "multiple results blank-line separated",
+			digest: "1. First\nhttps://a.example/x\nsnippet one\n\n2. Second\nhttps://b.example/y\nsnippet two",
+			want:   []string{"https://a.example/x", "https://b.example/y"},
+		},
+		{
+			name:   "no results found sentinel yields nothing",
+			digest: "no results found",
+			want:   nil,
+		},
+		{
+			name:   "truncated tail with no url line yields nothing extra",
+			digest: "1. Only",
+			want:   nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := webSearchResultURLs(tc.digest)
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("webSearchResultURLs(%q) = %v, want %v", tc.digest, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRunWorkerCollectsSeenURLsFromWebFetchAndWebSearch is the
+// end-to-end wiring check (D-059): a worker turn that calls web_fetch
+// and web_search must surface both URLs on the returned verdict, so
+// the driver's citations check has real harness evidence to compare
+// against — never the model's own claim.
+func TestRunWorkerCollectsSeenURLsFromWebFetchAndWebSearch(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{
+			toolEndEvent("web_fetch", `{"url":"https://example.com/fetched"}`),
+			okToolResultEvent("call-1", "web_fetch", "fetched content"),
+			toolEndEvent("web_search", `{"query":"golang release notes"}`),
+			okToolResultEvent("call-2", "web_search", "1. Release notes\nhttps://example.com/searched\nsnippet"),
+			toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"researched"}`),
+		},
+	}}
+	r := newTestRunner(agent)
+	v, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	want := []string{"https://example.com/fetched", "https://example.com/searched"}
+	if !slices.Equal(v.SeenURLs, want) {
+		t.Fatalf("RunWorker verdict SeenURLs = %v, want %v", v.SeenURLs, want)
 	}
 }

--- a/internal/brain/missions/sentinel.go
+++ b/internal/brain/missions/sentinel.go
@@ -161,6 +161,12 @@ type WorkerVerdict struct {
 	// of burning to max_iterations on a model that never learns to call
 	// the tool.
 	Forced bool
+	// SeenURLs is every URL the worker actually observed this turn via
+	// web_fetch/web_search (D-059) — nativeRunner's own runTurn evidence,
+	// never model-reported. Empty for the delegated (CLI harness) path,
+	// which has no stream to observe; citations verification is native-
+	// runner-only for now.
+	SeenURLs []string
 }
 
 // parseWorkerVerdict decodes a mission_status tool call's arguments.

--- a/internal/brain/missions/verify.go
+++ b/internal/brain/missions/verify.go
@@ -6,8 +6,11 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -122,6 +125,100 @@ func CheckArtifacts(workRoot string, artifacts []string) []string {
 			problems = append(problems, fmt.Sprintf("%s: is a directory, expected a file", rel))
 		case info.Size() == 0:
 			problems = append(problems, fmt.Sprintf("%s: exists but is empty", rel))
+		}
+	}
+	return problems
+}
+
+// citedURLPattern matches both markdown links ([text](http...)) and
+// bare http(s) URLs. Markdown link targets are captured first so a
+// bare-URL scan doesn't also pick up the same URL again from inside
+// the parens (D-059).
+var citedURLPattern = regexp.MustCompile(`\[[^\]]*\]\((https?://[^\s)]+)\)|(https?://[^\s)\]]+)`)
+
+// ExtractCitedURLs pulls every http(s) URL cited in text — markdown
+// link targets and bare URLs alike — in first-seen order, deduplicated.
+func ExtractCitedURLs(text string) []string {
+	matches := citedURLPattern.FindAllStringSubmatch(text, -1)
+	seen := make(map[string]bool, len(matches))
+	var urls []string
+	for _, m := range matches {
+		u := m[1]
+		if u == "" {
+			u = m[2]
+		}
+		if u == "" || seen[u] {
+			continue
+		}
+		seen[u] = true
+		urls = append(urls, u)
+	}
+	return urls
+}
+
+// NormalizeURL canonicalizes a URL for citation comparison: lowercase
+// scheme+host, fragment stripped, one trailing slash collapsed. Query
+// strings are left exactly as given — a query difference means a
+// different resource, not the same one differently written. An
+// unparseable URL normalizes to its trimmed original so it still
+// compares (and fails) predictably rather than vanishing silently.
+func NormalizeURL(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return strings.TrimSpace(raw)
+	}
+	u.Scheme = strings.ToLower(u.Scheme)
+	u.Host = strings.ToLower(u.Host)
+	u.Fragment = ""
+	u.Path = strings.TrimSuffix(u.Path, "/")
+	return u.String()
+}
+
+// CheckCitations verifies every http(s) URL cited in a unit's declared
+// artifacts was actually seen by the worker this turn — via web_fetch's
+// url arg or a web_search result URL — never merely claimed. Scoped to
+// "general" missions only (D-059): coding missions cite source, not
+// the web. seenURLs empty and the artifact cites nothing passes
+// trivially; seenURLs empty with citations present fails everything,
+// since no web tool call at all cannot have produced any of them.
+func CheckCitations(workRoot string, artifacts, seenURLs []string) []string {
+	allowed := make(map[string]bool, len(seenURLs))
+	for _, u := range seenURLs {
+		allowed[NormalizeURL(u)] = true
+	}
+
+	var problems []string
+	for _, a := range artifacts {
+		rel := strings.TrimSpace(a)
+		if rel == "" {
+			continue
+		}
+		cleaned := filepath.Clean(rel)
+		if filepath.IsAbs(rel) || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+			continue // reported by CheckArtifacts; not this check's job
+		}
+		abs := filepath.Join(workRoot, cleaned)
+		if err := tools.WithinRoot(workRoot, abs); err != nil {
+			continue
+		}
+		content, err := os.ReadFile(abs) // #nosec G304 -- cleaned and WithinRoot-vetted above
+		if err != nil {
+			continue // missing/unreadable artifact is CheckArtifacts' problem
+		}
+
+		var unknown []string
+		seenUnknown := map[string]bool{}
+		for _, cited := range ExtractCitedURLs(string(content)) {
+			norm := NormalizeURL(cited)
+			if allowed[norm] || seenUnknown[norm] {
+				continue
+			}
+			seenUnknown[norm] = true
+			unknown = append(unknown, cited)
+		}
+		if len(unknown) > 0 {
+			sort.Strings(unknown)
+			problems = append(problems, fmt.Sprintf("%s: cited URL(s) never seen via web_fetch/web_search this turn: %s — fetch a source with web_fetch before citing it", rel, strings.Join(unknown, ", ")))
 		}
 	}
 	return problems

--- a/internal/brain/missions/verify_test.go
+++ b/internal/brain/missions/verify_test.go
@@ -142,3 +142,126 @@ func TestTailBufferBoundsMemoryKeepsEnd(t *testing.T) {
 		t.Fatalf("tailBuffer content = %q, want %q (the last 5 bytes)", got, want)
 	}
 }
+
+func TestExtractCitedURLs(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{"markdown link", "see [the docs](https://example.com/docs) for more", []string{"https://example.com/docs"}},
+		{"bare url", "fetched from https://example.com/api/v1 directly", []string{"https://example.com/api/v1"}},
+		{"mixed markdown and bare", "[a](https://a.example/x) and also https://b.example/y", []string{"https://a.example/x", "https://b.example/y"}},
+		{"no urls", "just plain text, no citations here", nil},
+		{"duplicate collapses to one", "https://example.com/x and again https://example.com/x", []string{"https://example.com/x"}},
+		{"http scheme included", "http://example.com/plain", []string{"http://example.com/plain"}},
+		{"non-http scheme ignored", "see ftp://example.com/file", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractCitedURLs(tc.text)
+			if !equalStrings(got, tc.want) {
+				t.Fatalf("ExtractCitedURLs(%q) = %v, want %v", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"trailing slash stripped", "https://example.com/docs/", "https://example.com/docs"},
+		{"fragment stripped", "https://example.com/docs#section-2", "https://example.com/docs"},
+		{"scheme and host lowercased", "HTTPS://Example.COM/Docs", "https://example.com/Docs"},
+		{"query preserved exactly", "https://example.com/search?q=Foo", "https://example.com/search?q=Foo"},
+		{"no trailing slash unchanged", "https://example.com/docs", "https://example.com/docs"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeURL(tc.in); got != tc.want {
+				t.Fatalf("NormalizeURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckCitations(t *testing.T) {
+	writeArtifact := func(t *testing.T, root, name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cases := []struct {
+		name      string
+		content   string
+		seenURLs  []string
+		wantProbs int
+	}{
+		{
+			name:      "cited url was fetched",
+			content:   "source: [docs](https://example.com/docs)",
+			seenURLs:  []string{"https://example.com/docs"},
+			wantProbs: 0,
+		},
+		{
+			name:      "invented citation fails",
+			content:   "source: [docs](https://example.com/invented)",
+			seenURLs:  []string{"https://example.com/other"},
+			wantProbs: 1,
+		},
+		{
+			name:      "bare url matched against search result",
+			content:   "see https://example.com/api for details",
+			seenURLs:  []string{"https://example.com/api"},
+			wantProbs: 0,
+		},
+		{
+			name:      "trailing slash and fragment normalize equal",
+			content:   "[ref](https://example.com/docs/#intro)",
+			seenURLs:  []string{"https://example.com/docs"},
+			wantProbs: 0,
+		},
+		{
+			name:      "no links in artifact passes trivially",
+			content:   "no citations here, just prose",
+			seenURLs:  nil,
+			wantProbs: 0,
+		},
+		{
+			name:      "no web calls at all but links present fails",
+			content:   "[ref](https://example.com/docs)",
+			seenURLs:  nil,
+			wantProbs: 1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeArtifact(t, root, "report.md", tc.content)
+			problems := CheckCitations(root, []string{"report.md"}, tc.seenURLs)
+			if len(problems) != tc.wantProbs {
+				t.Fatalf("CheckCitations = %v, want %d problem(s)", problems, tc.wantProbs)
+			}
+		})
+	}
+}
+
+// equalStrings compares two string slices where nil and empty are
+// treated the same (ExtractCitedURLs returns nil, not an empty slice,
+// when nothing matches).
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/brain/tools/builtin/websearch.go
+++ b/internal/brain/tools/builtin/websearch.go
@@ -14,13 +14,22 @@ import (
 )
 
 const (
-	webSearchTimeout   = 15 * time.Second
-	webSearchMaxBody   = 2 << 20 // bytes read off the wire
-	webSearchMaxResult = 10
+	webSearchTimeout       = 15 * time.Second
+	webSearchMaxBody       = 2 << 20 // bytes read off the wire
+	webSearchDefaultResult = 10
+	webSearchMaxResult     = 20
+)
+
+var (
+	webSearchTimeRanges = map[string]bool{"day": true, "week": true, "month": true, "year": true}
+	webSearchCategories = map[string]bool{"general": true, "news": true, "science": true, "it": true}
 )
 
 type webSearchArgs struct {
-	Query string `json:"query"`
+	Query     string `json:"query"`
+	TimeRange string `json:"time_range"`
+	Category  string `json:"category"`
+	Count     *int   `json:"count"`
 }
 
 // searxResult is the subset of SearXNG's JSON response this tool uses.
@@ -58,6 +67,15 @@ retry the search hoping for a different kind of result.
 
 Arguments:
 - query (string, required): the search query.
+- time_range (string, optional): "day", "week", "month", or "year" —
+  restricts results to that recency. Example: {"query": "AI news",
+  "time_range": "week"}.
+- category (string, optional): "general" (default), "news",
+  "science", or "it" — narrows results to that domain. Example:
+  {"query": "quantum computing breakthrough", "category": "science"}.
+- count (integer, optional): how many results to return, 1-20,
+  default 10. Example: {"query": "golang 1.26 release notes",
+  "count": 5}.
 
 Example: {"query": "Amazon Bedrock Nova Lite pricing"} → a numbered
 list of results with title, URL, and snippet.`,
@@ -67,6 +85,22 @@ list of results with title, URL, and snippet.`,
 				"query": {
 					"type": "string",
 					"description": "The search query"
+				},
+				"time_range": {
+					"type": "string",
+					"enum": ["day", "week", "month", "year"],
+					"description": "Restrict results to this recency window."
+				},
+				"category": {
+					"type": "string",
+					"enum": ["general", "news", "science", "it"],
+					"description": "Narrow results to this domain; defaults to general."
+				},
+				"count": {
+					"type": "integer",
+					"minimum": 1,
+					"maximum": 20,
+					"description": "Number of results to return; defaults to 10."
 				}
 			},
 			"required": ["query"],
@@ -80,13 +114,32 @@ list of results with title, URL, and snippet.`,
 			if strings.TrimSpace(args.Query) == "" {
 				return "", fmt.Errorf("query must not be empty")
 			}
-			return runSearch(ctx, client, endpoint, args.Query)
+			if args.TimeRange != "" && !webSearchTimeRanges[args.TimeRange] {
+				return "", fmt.Errorf("time_range must be one of day, week, month, year, got %q", args.TimeRange)
+			}
+			if args.Category != "" && !webSearchCategories[args.Category] {
+				return "", fmt.Errorf("category must be one of general, news, science, it, got %q", args.Category)
+			}
+			count := webSearchDefaultResult
+			if args.Count != nil {
+				count = *args.Count
+				if count < 1 || count > webSearchMaxResult {
+					return "", fmt.Errorf("count must be between 1 and %d, got %d", webSearchMaxResult, count)
+				}
+			}
+			return runSearch(ctx, client, endpoint, args.Query, args.TimeRange, args.Category, count)
 		},
 	}
 }
 
-func runSearch(ctx context.Context, client *http.Client, endpoint, query string) (string, error) {
+func runSearch(ctx context.Context, client *http.Client, endpoint, query, timeRange, category string, count int) (string, error) {
 	q := url.Values{"q": {query}, "format": {"json"}}
+	if timeRange != "" {
+		q.Set("time_range", timeRange)
+	}
+	if category != "" {
+		q.Set("categories", category)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"?"+q.Encode(), nil)
 	if err != nil {
 		return "", fmt.Errorf("build request: %w", err)
@@ -118,8 +171,8 @@ func runSearch(ctx context.Context, client *http.Client, endpoint, query string)
 
 	var b strings.Builder
 	n := len(parsed.Results)
-	if n > webSearchMaxResult {
-		n = webSearchMaxResult
+	if n > count {
+		n = count
 	}
 	for i := 0; i < n; i++ {
 		r := parsed.Results[i]

--- a/internal/brain/tools/builtin/websearch_test.go
+++ b/internal/brain/tools/builtin/websearch_test.go
@@ -104,7 +104,129 @@ func TestWebSearchCapsResultCount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if strings.Count(out, "https://example.com") != webSearchMaxResult {
-		t.Fatalf("result count = %d, want %d", strings.Count(out, "https://example.com"), webSearchMaxResult)
+	if strings.Count(out, "https://example.com") != webSearchDefaultResult {
+		t.Fatalf("result count = %d, want %d", strings.Count(out, "https://example.com"), webSearchDefaultResult)
+	}
+}
+
+func TestWebSearchCountControlsRenderedResults(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		var b strings.Builder
+		b.WriteString(`{"results":[`)
+		for i := 0; i < 25; i++ {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			b.WriteString(`{"title":"r","url":"https://example.com","content":"c"}`)
+		}
+		b.WriteString(`]}`)
+		_, _ = w.Write([]byte(b.String()))
+	}))
+	defer srv.Close()
+
+	tool := WebSearch(srv.URL)
+	args, _ := json.Marshal(map[string]any{"query": "x", "count": 3})
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := strings.Count(out, "https://example.com"); got != 3 {
+		t.Fatalf("result count = %d, want 3", got)
+	}
+}
+
+func TestWebSearchCountValidation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		count   int
+		wantErr bool
+	}{
+		{"min valid", 1, false},
+		{"max valid", 20, false},
+		{"zero rejected", 0, true},
+		{"negative rejected", -1, true},
+		{"over max rejected", 21, true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"results":[{"title":"r","url":"https://example.com","content":"c"}]}`))
+			}))
+			defer srv.Close()
+
+			tool := WebSearch(srv.URL)
+			args, _ := json.Marshal(map[string]any{"query": "x", "count": tt.count})
+			_, err := tool.Execute(context.Background(), args)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected an error for out-of-range count")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	}
+}
+
+func TestWebSearchTimeRangeAndCategoryParams(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("time_range"); got != "week" {
+			t.Errorf("time_range = %q, want week", got)
+		}
+		if got := r.URL.Query().Get("categories"); got != "news" {
+			t.Errorf("categories = %q, want news", got)
+		}
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer srv.Close()
+
+	tool := WebSearch(srv.URL)
+	args, _ := json.Marshal(map[string]string{"query": "x", "time_range": "week", "category": "news"})
+	if _, err := tool.Execute(context.Background(), args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+}
+
+func TestWebSearchOmitsOptionalParamsWhenAbsent(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Has("time_range") {
+			t.Errorf("time_range should be absent, got %q", r.URL.Query().Get("time_range"))
+		}
+		if r.URL.Query().Has("categories") {
+			t.Errorf("categories should be absent, got %q", r.URL.Query().Get("categories"))
+		}
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer srv.Close()
+
+	tool := WebSearch(srv.URL)
+	args, _ := json.Marshal(map[string]string{"query": "x"})
+	if _, err := tool.Execute(context.Background(), args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+}
+
+func TestWebSearchRejectsInvalidTimeRange(t *testing.T) {
+	t.Parallel()
+	tool := WebSearch("http://unused")
+	args, _ := json.Marshal(map[string]string{"query": "x", "time_range": "decade"})
+	_, err := tool.Execute(context.Background(), args)
+	if err == nil {
+		t.Fatal("expected an error for an invalid time_range")
+	}
+}
+
+func TestWebSearchRejectsInvalidCategory(t *testing.T) {
+	t.Parallel()
+	tool := WebSearch("http://unused")
+	args, _ := json.Marshal(map[string]string{"query": "x", "category": "sports"})
+	_, err := tool.Execute(context.Background(), args)
+	if err == nil {
+		t.Fatal("expected an error for an invalid category")
 	}
 }

--- a/scripts/canary-research.sh
+++ b/scripts/canary-research.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# Research-mission canary: runs one golden research mission end-to-end
+# against the live stack and asserts the harness contract holds for
+# work that needs live web information — done within a research-sized
+# iteration budget, zero human permission parks, every unit
+# harness-verified (citations included) by the time the mission
+# finishes. canary-mission.sh's trivial lookup goals never touch
+# web_search/web_fetch or the citations check; this one exists to catch
+# regressions in that path specifically. Run after any change to the
+# research/citation-checking machinery (make canary-research).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASE_URL="${CANARY_BASE_URL:-http://localhost:${BRAIN_PORT:-8300}}"
+TIMEOUT_SECS="${CANARY_TIMEOUT:-1200}"
+
+# A different goal every run: repeating one fixed goal would let
+# provider prompt caches, model memorization, and leftover artifacts
+# from prior runs flatter the result — a pass must mean the harness
+# worked NOW, on work it hasn't seen before. Each goal requires current
+# web information (not resolvable from training data alone) and a
+# cited markdown report, so a correct answer forces web_search/
+# web_fetch use and exercises CheckCitations.
+GOALS=(
+  "Research the current stable versions and release dates of the three most-used JavaScript runtimes (Node.js, Deno, Bun) and write a cited markdown report."
+  "Research the current status of the HTTP/3 and QUIC standards (RFC numbers, adoption by major browsers and CDNs) and write a cited markdown report."
+  "Research the latest publicly disclosed critical CVEs affecting the OpenSSH server and write a cited markdown report on remediation."
+  "Research the current pricing pages of AWS S3, Google Cloud Storage, and Azure Blob Storage for standard storage tiers and write a cited markdown report comparing them."
+  "Research the current LTS release schedule and end-of-life dates for PostgreSQL and write a cited markdown report."
+  "Research the current stable version and license terms of Docker Engine and Docker Desktop and write a cited markdown report."
+  "Research the current W3C standardization status of WebGPU and its browser support matrix and write a cited markdown report."
+  "Research the most recent security advisories published for the Redis project and write a cited markdown report on their impact and fixes."
+  "Research the current pricing and rate limits of the OpenAI and Anthropic public APIs and write a cited markdown report comparing them."
+  "Research the latest stable release of Kubernetes and its deprecation notices for the current minor version and write a cited markdown report."
+)
+GOAL="${GOALS[$((RANDOM % ${#GOALS[@]}))]}"
+
+# The API token stays in the shell environment only — sourced here,
+# never printed.
+if [[ -z "${TIMOTHY_API_TOKEN:-}" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${REPO_ROOT}/deploy/.env"
+  set +a
+fi
+if [[ -z "${TIMOTHY_API_TOKEN:-}" ]]; then
+  echo "canary-research: TIMOTHY_API_TOKEN not set and deploy/.env did not provide it" >&2
+  exit 2
+fi
+
+auth=(-H "Authorization: Bearer ${TIMOTHY_API_TOKEN}" -H "Content-Type: application/json")
+
+echo "canary-research: creating mission against ${BASE_URL}"
+create_resp="$(curl -sf "${auth[@]}" -X POST "${BASE_URL}/v1/missions" \
+  -d "{\"goal\": \"${GOAL}\", \"kind\": \"general\"}")"
+id="$(echo "${create_resp}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+echo "canary-research: mission ${id}"
+
+start=$(date +%s)
+phase=""
+status=""
+m=""
+while :; do
+  now=$(date +%s)
+  if (( now - start > TIMEOUT_SECS )); then
+    echo "canary-research: FAIL — timed out after ${TIMEOUT_SECS}s (phase=${phase} status=${status})" >&2
+    exit 1
+  fi
+  m="$(curl -sf "${auth[@]}" "${BASE_URL}/v1/missions/${id}")"
+  phase="$(echo "${m}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["phase"])')"
+  status="$(echo "${m}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])')"
+  pending="$(echo "${m}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("pending_permission_tool") or "")')"
+  echo "canary-research: ${phase}/${status} (t+$((now - start))s)${pending:+ [PARKED on ${pending}]}"
+  case "${phase}/${status}" in
+    done/*) break ;;
+    failed/*)
+      echo "canary-research: FAIL — mission failed" >&2
+      curl -sf "${auth[@]}" "${BASE_URL}/v1/missions/${id}/events" | python3 -m json.tool | tail -40 >&2
+      exit 1 ;;
+  esac
+  if [[ "${status}" == "paused" || "${status}" == "waiting_for_input" ]]; then
+    echo "canary-research: FAIL — mission parked (${status}); a canary must run unattended" >&2
+    exit 1
+  fi
+  sleep 5
+done
+
+events="$(curl -sf "${auth[@]}" "${BASE_URL}/v1/missions/${id}/events")"
+CANARY_EVENTS="${events}" python3 <<'PY'
+import json, os, sys
+events = json.loads(os.environ["CANARY_EVENTS"])["events"]
+kinds = {}
+for e in events:
+    kinds[e["kind"]] = kinds.get(e["kind"], 0) + 1
+
+parks = kinds.get("mission.permission_requested", 0)
+turns = [e for e in events if e["kind"] == "mission.turn"]
+total_ms = sum((e.get("payload") or {}).get("duration_ms", 0) for e in turns)
+
+# mission.unit_verified fires once per check (artifacts/citations/
+# verify_cmd/review) per unit, in order — retries on a failed check
+# (e.g. an uncited URL) are allowed mid-run, but the LAST verified
+# event recorded for each unit must be passed:true, or "done" was
+# claimed without the harness ever proving it for that unit.
+verified = [e for e in events if e["kind"] == "mission.unit_verified"]
+last_by_unit = {}
+for e in verified:
+    unit = (e.get("payload") or {}).get("unit")
+    last_by_unit[unit] = e
+
+print(f"canary-research: event counts: {json.dumps(kinds, sort_keys=True)}")
+print(f"canary-research: {len(turns)} model turns, {total_ms/1000:.0f}s total model time")
+
+failures = []
+if parks > 0:
+    failures.append(f"{parks} permission park(s) — canary must run unattended")
+if not verified:
+    failures.append("no harness-verified unit — done was claimed, never proven")
+unresolved = [u for u, e in last_by_unit.items() if not (e.get("payload") or {}).get("passed")]
+if unresolved:
+    failures.append(f"unit(s) {unresolved} never reached a passing final check")
+# Research is heavier than the trivial general canary: gathering
+# sources, writing, and citation-retry turns legitimately take more
+# turns than a one-shot lookup, but an unbounded loop still means the
+# harness is not right-sized for this workload.
+if len(turns) > 16:
+    failures.append(f"{len(turns)} turns for a research mission — loop is not right-sized")
+if failures:
+    print("canary-research: FAIL — " + "; ".join(failures), file=sys.stderr)
+    sys.exit(1)
+print("canary-research: deterministic checks PASS")
+PY
+
+# Cleanup runs on every PASS exit, including judge-skip paths — only a
+# FAIL leaves the mission in place for debugging. Tolerated as
+# best-effort: a cleanup failure must never flip a PASS to a FAIL.
+cleanup_mission() {
+  if curl -sf -X DELETE "${auth[@]}" "${BASE_URL}/v1/missions/${id}"; then
+    echo "canary-research: cleaned up mission ${id}"
+  else
+    echo "canary-research: WARNING — cleanup of mission ${id} failed (non-fatal)" >&2
+  fi
+}
+
+# --- Best-effort LLM judge -------------------------------------------
+#
+# Runs only after every deterministic check above has passed. The
+# judge must never run on the same route/model that wrote the report —
+# a model grading its own work is not an independent check — so it is
+# gated on a separate CANARY_JUDGE_ROUTE env var the operator points at
+# a different route. No route configured, no report retrievable, or
+# any judge-path failure degrades to a warning and exit 0: the
+# deterministic checks are the real gate, the judge is a bonus signal.
+if [[ -z "${CANARY_JUDGE_ROUTE:-}" ]]; then
+  echo "canary-research: judge skipped — CANARY_JUDGE_ROUTE not set" >&2
+  cleanup_mission
+  echo "canary-research: PASS"
+  exit 0
+fi
+
+# The mission's declared artifact path(s) come from its own plan, not
+# a guessed filename — Spec.Units[].artifacts is what CheckArtifacts
+# and CheckCitations already verified against.
+report_path="$(echo "${m}" | python3 -c '
+import json, sys
+m = json.load(sys.stdin)
+for u in (m.get("spec") or {}).get("units", []):
+    for a in u.get("artifacts") or []:
+        print(a)
+        raise SystemExit
+')"
+if [[ -z "${report_path}" ]]; then
+  echo "canary-research: judge skipped — mission spec declared no artifact path" >&2
+  cleanup_mission
+  echo "canary-research: PASS"
+  exit 0
+fi
+
+report="$(curl -sf "${auth[@]}" "${BASE_URL}/v1/missions/${id}/files/${report_path}" || true)"
+if [[ -z "${report}" ]]; then
+  echo "canary-research: judge skipped — could not fetch report at ${report_path} via /v1/missions/{id}/files/{path}" >&2
+  cleanup_mission
+  echo "canary-research: PASS"
+  exit 0
+fi
+
+echo "canary-research: judging report (${#report} bytes) on route ${CANARY_JUDGE_ROUTE}"
+
+judge_prompt="$(cat <<PROMPT
+Judge the following research report against this goal: "${GOAL}"
+
+Respond with STRICT JSON only, no prose, no markdown fences:
+{"label": "pass"|"fail", "critique": "<1-3 sentences>"}
+
+Judge on:
+- The report actually answers the stated goal.
+- Every factual claim carries an inline citation.
+- A "## Sources" section is present with real URLs.
+- No hype or unsupported superlatives.
+
+Report:
+${report}
+PROMPT
+)"
+
+# /v1/chat is SSE-only (there is no synchronous completion endpoint in
+# this codebase) and the gateway's own /v1/stream is internal-only —
+# unreachable from this host script — so /v1/chat on brain, with an
+# explicit route override, is the only reachable one-shot path. A
+# session auto-creates and is thrown away; no session bootstrapping is
+# needed beyond that. curl -N disables buffering so SSE lines arrive as
+# they stream instead of only after the connection closes.
+judge_body="$(python3 -c '
+import json, sys
+print(json.dumps({"message": sys.argv[1], "route": sys.argv[2]}))
+' "${judge_prompt}" "${CANARY_JUDGE_ROUTE}")"
+
+judge_sse="$(curl -sf -N "${auth[@]}" -X POST "${BASE_URL}/v1/chat" -d "${judge_body}" || true)"
+if [[ -z "${judge_sse}" ]]; then
+  echo "canary-research: judge skipped — /v1/chat request failed or returned nothing" >&2
+  cleanup_mission
+  echo "canary-research: PASS"
+  exit 0
+fi
+
+judge_verdict="$(CANARY_JUDGE_SSE="${judge_sse}" python3 <<'PY' || true
+import json, os, re
+
+sse = os.environ["CANARY_JUDGE_SSE"]
+text = ""
+for line in sse.splitlines():
+    line = line.strip()
+    if not line.startswith("data:"):
+        continue
+    payload = line[len("data:"):].strip()
+    if not payload:
+        continue
+    try:
+        event = json.loads(payload)
+    except json.JSONDecodeError:
+        continue
+    if isinstance(event, dict) and "text" in event and isinstance(event["text"], str):
+        text += event["text"]
+
+# Model output may wrap the JSON in prose or fences despite the
+# instruction — pull out the first {...} object rather than requiring
+# an exact match.
+match = re.search(r"\{.*\}", text, re.DOTALL)
+if not match:
+    raise SystemExit(1)
+verdict = json.loads(match.group(0))
+label = str(verdict.get("label", "")).strip().lower()
+critique = str(verdict.get("critique", "")).strip()
+if label not in ("pass", "fail"):
+    raise SystemExit(1)
+print(json.dumps({"label": label, "critique": critique}))
+PY
+)"
+
+if [[ -z "${judge_verdict}" ]]; then
+  echo "canary-research: judge skipped — could not parse a verdict from the judge's response" >&2
+  cleanup_mission
+  echo "canary-research: PASS"
+  exit 0
+fi
+
+judge_label="$(echo "${judge_verdict}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["label"])')"
+judge_critique="$(echo "${judge_verdict}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["critique"])')"
+
+if [[ "${judge_label}" != "pass" ]]; then
+  echo "canary-research: FAIL — judge verdict: fail — ${judge_critique}" >&2
+  exit 1
+fi
+echo "canary-research: judge verdict: pass — ${judge_critique}"
+cleanup_mission
+echo "canary-research: PASS"

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -29,10 +29,11 @@ description: Decomposes a complex research question into independent sub-questio
   aggregator repeating it.
 - Label inference explicitly: "Inference: ..." for anything reasoned from
   sources rather than stated by one. Never blur the line between the two.
-- Never cite a URL you did not fetch or see in a search result this turn.
-  The harness checks cited URLs against ones actually retrieved and fails
-  the unit on a mismatch, so an invented or remembered URL is not a
-  shortcut, it is a failed unit.
+- Cite only URLs you fetched with web_fetch this unit. A search snippet
+  is a lead, not a source: fetch the page before citing it. The harness
+  checks cited URLs against ones actually retrieved and fails the unit on
+  a mismatch, so an invented or remembered URL is not a shortcut, it is a
+  failed unit.
 - Stop searching a sub-question once it has an answer backed by adequate
   sources. If a query line goes nowhere, note the dead end in one line and
   try a different angle, don't repeat the same query hoping for a
@@ -54,7 +55,7 @@ description: Decomposes a complex research question into independent sub-questio
 | Excuse | Rebuttal |
 |---|---|
 | "These sub-questions all touch the same topic, I'll merge them" | Same topic doesn't mean same unit; independence is about whether one needs the other's answer. |
-| "I already found this in a search result snippet, no need to list it" | A snippet you read is a source you saw; put it in the Sources section or don't cite it. |
+| "The snippet already told me, no need to fetch the page" | A snippet is a lead, not a source; fetch the page, confirm the claim, then cite it. |
 | "The synthesis can just re-search to fill a gap" | Synthesis reads findings files only; a gap found at synthesis time means a findings unit was incomplete, not a license to search again. |
 | "One source is fine, this fact is obviously true" | Obviousness is not verification; decision-driving claims still need two independent sources. |
 | "Close enough to the URL I remember" | The harness matches cited URLs against fetched ones exactly; a remembered or reconstructed URL fails the unit. |
@@ -63,8 +64,8 @@ description: Decomposes a complex research question into independent sub-questio
 
 - A sub-question depends on another sub-question's answer but got its own
   parallel unit anyway.
-- A findings file cites a URL that never appears in that unit's search or
-  fetch results.
+- A findings file cites a URL that was never fetched with web_fetch in
+  that unit.
 - The synthesis unit is making a web_search or fetch call.
 - report.md contains a claim with no traceable source in any findings
   file's Sources section.

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: deep-research
+description: Decomposes a complex research question into independent sub-questions, researches each in its own unit, then synthesizes a cited report. Use when a question needs multiple independent angles of investigation. Never use when a single search answers the question.
+---
+
+# Deep research discipline
+
+## Rules
+
+- Decompose the goal into 2-4 independent sub-questions during explore. A
+  sub-question is independent only if it can be researched without knowing
+  the answer to another one; questions that depend on each other's results
+  stay together in one unit, they do not get split for the sake of
+  splitting.
+- Scout each sub-question with 1-2 web_search calls before locking the plan:
+  confirm it is actually answerable and roughly how much material exists.
+  This is reconnaissance, not the research itself.
+- One plan unit per sub-question. Each unit declares exactly one artifact,
+  `findings-<slug>.md`, created with write_file. Each findings file has:
+  the answer to that sub-question, key facts with an inline citation and
+  date on each, and a closing `## Sources` section listing only URLs
+  fetched or seen in that unit.
+- Close every findings file with `## Sources`: numbered list, one line
+  each, `1. [Title](URL)`. No dates or notes on that line. A source in the
+  list that the body never cites is not a citation.
+- Two independent sources for any fact the report will treat as a
+  decision-driving claim; one source is enough for background color.
+  Prefer the primary source (the vendor, the filing, the paper) over an
+  aggregator repeating it.
+- Label inference explicitly: "Inference: ..." for anything reasoned from
+  sources rather than stated by one. Never blur the line between the two.
+- Never cite a URL you did not fetch or see in a search result this turn.
+  The harness checks cited URLs against ones actually retrieved and fails
+  the unit on a mismatch, so an invented or remembered URL is not a
+  shortcut, it is a failed unit.
+- Stop searching a sub-question once it has an answer backed by adequate
+  sources. If a query line goes nowhere, note the dead end in one line and
+  try a different angle, don't repeat the same query hoping for a
+  different result.
+- The final unit is synthesis only: read every findings-*.md file, do not
+  run new web_search calls. Write `report.md` with write_file: a section
+  per sub-question plus an overview, every claim citing a source drawn
+  from a findings file's Sources section, closing with one consolidated
+  `## Sources` list merged from all findings files.
+- Verify each research unit's artifact with a verify_cmd that greps the
+  findings file for a `## Sources` heading and at least one `https://`
+  URL. Verify the synthesis unit's verify_cmd checks report.md exists and
+  contains a `## Sources` heading.
+- Conflicting sources get reported as a conflict in both the findings file
+  and, if load-bearing, the report. Do not silently pick a side.
+
+## Anti-rationalization
+
+| Excuse | Rebuttal |
+|---|---|
+| "These sub-questions all touch the same topic, I'll merge them" | Same topic doesn't mean same unit; independence is about whether one needs the other's answer. |
+| "I already found this in a search result snippet, no need to list it" | A snippet you read is a source you saw; put it in the Sources section or don't cite it. |
+| "The synthesis can just re-search to fill a gap" | Synthesis reads findings files only; a gap found at synthesis time means a findings unit was incomplete, not a license to search again. |
+| "One source is fine, this fact is obviously true" | Obviousness is not verification; decision-driving claims still need two independent sources. |
+| "Close enough to the URL I remember" | The harness matches cited URLs against fetched ones exactly; a remembered or reconstructed URL fails the unit. |
+
+## Red flags: stop and re-check
+
+- A sub-question depends on another sub-question's answer but got its own
+  parallel unit anyway.
+- A findings file cites a URL that never appears in that unit's search or
+  fetch results.
+- The synthesis unit is making a web_search or fetch call.
+- report.md contains a claim with no traceable source in any findings
+  file's Sources section.
+- Every source in a findings file's Sources list is the same domain.
+
+## Evidence required
+
+- Each findings-<slug>.md: answer, cited facts with dates, `## Sources`
+  listing only URLs actually retrieved that unit.
+- report.md: every claim traceable to a findings file's Sources section,
+  closing with a consolidated `## Sources` list.
+- Conflicts between sources surfaced explicitly, never silently resolved.


### PR DESCRIPTION
## Why

Research output quality depended entirely on prompt discipline: web_search had no recency/domain controls, nothing verified that cited URLs were ever actually read, multi-angle research had no mission shape, and no CI gate exercised the web-research path at all.

## What

- \`web_search\` gains optional \`time_range\`/\`category\` enums and \`count\` (1-20, default 10), mapped to SearXNG params.
- \`CheckCitations\` (D-059): harness-verified citations for general missions — every http(s) URL cited in a declared artifact must have been observed by the runner as a web_fetch arg or web_search result during the worker turn. Runs between CheckArtifacts and verify_cmd, same failure/feedback path. Reliable contract is fetch-before-cite (stream digests are capped); native runner only.
- \`skills/deep-research\`: decompose into independent sub-questions, one findings unit each, synthesis unit cites only from findings files.
- \`make canary-research\`: e2e gate on a web-research goal pool — asserts every unit's final harness check passed, zero parks, ≤16 turns; optional binary LLM judge behind CANARY_JUDGE_ROUTE (must differ from the writer route), degrades to warning.

## Verification

- \`make build test vet lint\` green.
- \`make canary\` PASS on rebuilt brain (3 turns) — no regression on the general path.
- \`make canary-research\` PASS (439s, 6 turns): one mid-run citation/verify retry then all three harness checks passed, review skipped on harness evidence, judge-skip path cleans up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789136301&installation_model_id=431401&pr_number=228&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F228&signature=51e3eb4d666c494b13ba5de2960a389ca9f698315c15285d8f312a0385b00757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->