### PR TITLE
fix(migrations): seed general agent on the default route

### DIFF
--- a/migrations/0009_agents.sql
+++ b/migrations/0009_agents.sql
@@ -32,8 +32,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS agents_one_default
 
 -- Seed exactly one agent: 'general', because exactly one default
 -- agent must exist. Every other agent is created by the operator in
--- the UI. Route is '' (the server default route) — routing is the
--- operator's routing table, not a seed opinion. Skills/tools are
+-- the UI. Route is 'default' (seeded in 0002_gateway.sql, guaranteed
+-- to exist by migration order). Skills/tools are
 -- opt-in only (empty means none): the seed allowlists every shipped
 -- skill pack — an allowlist entry costs one index line per turn, the
 -- body loads only on demand — and a minimal tool surface, since every
@@ -51,7 +51,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS agents_one_default
 -- if any default agent already exists, this seed must not attempt to
 -- set is_default=true.
 INSERT INTO agents (name, description, prompt_overlay, route, skills, tools, is_default)
-SELECT 'general', 'Everyday questions and tasks on a strong all-round chain.', '', '',
+SELECT 'general', 'Everyday questions and tasks on a strong all-round chain.', '', 'default',
     '["research-brief", "deep-research", "coding", "email-research"]',
     '["current_time", "convert_time", "calculate", "currency_convert", "web_search", "web_fetch", "remember", "missions", "mission_push", "gmail_search", "gmail_read", "calendar_list_events"]',
     NOT EXISTS (SELECT 1 FROM agents WHERE is_default)


### PR DESCRIPTION
## Why
The seeded `general` agent had route `''`, relying on server-side fallback to the default route. Explicit is better: a fresh install should show which route the default agent rides.

## What
- `migrations/0009_agents.sql`: seed `route = 'default'` (seeded by 0002_gateway.sql, guaranteed by migration order); comment updated.

## Verification
- Live DB already aligned (`general` → `default`), stack healthy.
- Pre-release migration edited in place per convention, no new ALTER.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789156928&installation_model_id=431401&pr_number=230&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F230&signature=96270cb85f7fa7e26e7a30de0647913c8dca728e635751ff56c88608a237904f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->