### PR TITLE
feat: add knowledgebase with hybrid rag retrieval for chats and missions

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/connectors"
 	"github.com/SumonMSelim/timothy/internal/brain/fxrates"
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/brain/kb"
 	"github.com/SumonMSelim/timothy/internal/brain/loop"
 	"github.com/SumonMSelim/timothy/internal/brain/memclient"
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
@@ -278,7 +279,7 @@ func main() {
 		}
 		return name
 	}
-	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, fxStore, gwc, secrets, conns, app.Log)
+	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, fxStore, gwc, secrets, conns, mc, app.Log)
 	if missionDriver != nil {
 		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, app.Log)
 	}
@@ -467,6 +468,27 @@ func main() {
 		svc.SetMarkitdown(markitdownURL)
 	}
 
+	// kb_search: nil-safe wiring, same shape as memory retrieve/extract
+	// above — mc satisfies IngestDocument/KBSearch unconditionally, so
+	// this always wires (memoryd unreachable surfaces as a per-call
+	// error, not a nil-gate, since MEMORYD_URL always resolves to a
+	// default).
+	kbStore := kb.New(app.DB)
+	svc.SetKBSearch(func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error) {
+		hits, err := mc.KBSearch(ctx, query, collectionNames, mode, k)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]builtin.KBSearchHit, len(hits))
+		for i, h := range hits {
+			out[i] = builtin.KBSearchHit{
+				DocumentID: h.DocumentID, DocumentTitle: h.DocumentTitle, Breadcrumb: h.Breadcrumb,
+				Content: h.Content, SourceRef: h.SourceRef,
+			}
+		}
+		return out, nil
+	})
+
 	usageDecorator := api.NewUsageDecorator(flags, fxStore)
 	// ledgerAgg backs the mission list's top_model decoration (D-05x):
 	// same *pgpool.Pool the rest of brain shares, no separate wiring.
@@ -474,7 +496,7 @@ func main() {
 	api.Register(app.Server, svc, store, broker,
 		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, usageDecorator.Decorate, app.Log), flags, fxStore,
 		agentReg, conns, goog, secrets, agent, packs, missionStore, missionDriver, missionNotifier,
-		missionWorkspace, resolveSecret, routeForRole, chat.ClassifyOverGateway(gwc), gwc.ResolveRoute, chat.TitleOverGateway(gwc, app.Log), ledgerAgg.TopModelByMission, missionHub, attachmentStore, &http.Client{}, whisperURL, markitdownURL, token, app.Log, gwc)
+		missionWorkspace, resolveSecret, routeForRole, chat.ClassifyOverGateway(gwc), gwc.ResolveRoute, chat.TitleOverGateway(gwc, app.Log), ledgerAgg.TopModelByMission, missionHub, attachmentStore, &http.Client{}, whisperURL, markitdownURL, token, app.Log, gwc, kbStore, mc)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)
@@ -563,6 +585,7 @@ func missionAgentResolver(agentReg *agents.Store) missions.AgentResolver {
 		return missions.AgentDefaults{
 			Route: a.Route, ReviewRoute: a.ReviewRoute, PromptOverlay: a.PromptOverlay,
 			BudgetAmount: a.BudgetUSD, ApprovalAllowlist: a.ApprovalAllowlist,
+			Knowledge: a.Knowledge,
 		}, true
 	}
 }
@@ -576,7 +599,7 @@ func missionAgentResolver(agentReg *agents.Store) missions.AgentResolver {
 // time) so an agent edited after the fact still applies. The hub
 // lives inside the same gate as everything else here — no missions,
 // no push events either.
-func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, agentReg *agents.Store, routeForRole func(context.Context, string) string, fxStore *fxrates.Store, gwc *gwclient.Client, secrets *secretstore.Store, conns *connectors.Manager, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace, *missions.Hub) {
+func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, agentReg *agents.Store, routeForRole func(context.Context, string) string, fxStore *fxrates.Store, gwc *gwclient.Client, secrets *secretstore.Store, conns *connectors.Manager, mc *memclient.Client, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace, *missions.Hub) {
 	root := os.Getenv("WORKSPACES")
 	if root == "" {
 		log.Info("WORKSPACES not set; missions disabled")
@@ -603,7 +626,25 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	// sandboxMgr routes model-authored command execution (the
 	// worker/reviewer shell, verify_cmd) OUT of brain's own process,
 	// through sandboxd, into a per-mission Docker container.
-	nativeRunner := missions.NewNativeRunnerWithFloor(agent, parker, floorDeny, sandboxMgr.Exec, log)
+	// kb_search: nil-safe (mc is never nil, MEMORYD_URL always resolves
+	// to a default), same shape as chat's own SetKBSearch wiring — the
+	// mission's OWN Knowledge snapshot (never a live agent lookup)
+	// scopes collections per turn (missions.nativeRunner.kbSearchTool).
+	kbSearch := func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error) {
+		hits, err := mc.KBSearch(ctx, query, collectionNames, mode, k)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]builtin.KBSearchHit, len(hits))
+		for i, h := range hits {
+			out[i] = builtin.KBSearchHit{
+				DocumentID: h.DocumentID, DocumentTitle: h.DocumentTitle, Breadcrumb: h.Breadcrumb,
+				Content: h.Content, SourceRef: h.SourceRef,
+			}
+		}
+		return out, nil
+	}
+	nativeRunner := missions.NewNativeRunnerWithFloor(agent, parker, floorDeny, sandboxMgr.Exec, kbSearch, log)
 	// The delegated runner wraps native with D-051/D-052's CLI-executor
 	// dispatch — resolve a worker route's chain via the gateway, spawn a
 	// harness entry's CLI detached in the mission's own sandbox container,
@@ -951,13 +992,14 @@ func (r turnRouter) Stream(ctx context.Context, req gwclient.StreamRequest) (<-c
 		return r.gw.Stream(ctx, req)
 	}
 	return r.agent.Start(ctx, loop.Request{
-		SessionID: req.SessionID,
-		Route:     req.Route,
-		Agent:     req.Agent,
-		ToolAllow: req.ToolAllow,
-		ModelHint: req.ModelHint,
-		System:    req.System,
-		Messages:  req.Messages,
+		SessionID:  req.SessionID,
+		Route:      req.Route,
+		Agent:      req.Agent,
+		ToolAllow:  req.ToolAllow,
+		ExtraTools: req.ExtraTools,
+		ModelHint:  req.ModelHint,
+		System:     req.System,
+		Messages:   req.Messages,
 	})
 }
 

--- a/cmd/memoryd/main.go
+++ b/cmd/memoryd/main.go
@@ -62,7 +62,8 @@ func main() {
 		Archived: app.Metrics.NewCounter("memory_archived_total", "Stale episodic memories archived."),
 		Decayed:  app.Metrics.NewCounter("memory_decayed_total", "Stale semantic facts decayed and queued for reconfirmation."),
 	})
-	api.Register(app.Server, extractor, searcher, gwc, st, consolidator, app.Log)
+	kbStore := store.NewKBStore(app.DB)
+	api.Register(app.Server, extractor, searcher, gwc, st, consolidator, kbStore, kbStore, app.Log)
 	go consolidator.RunLoop(ctx, consolidateEvery)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/internal/brain/agents/agents.go
+++ b/internal/brain/agents/agents.go
@@ -47,6 +47,11 @@ type Agent struct {
 	ReviewRoute       string   `json:"review_route"`
 	BudgetUSD         *float64 `json:"budget_usd,omitempty"`
 	ApprovalAllowlist []string `json:"approval_allowlist"`
+	// Knowledge names the kb_collections this agent may search with
+	// kb_search (D-060) — empty means none (opt-in only, same as
+	// Skills/Tools). Collection scoping is enforced in Go at the tool
+	// call, never left to a prompt.
+	Knowledge []string `json:"knowledge"`
 }
 
 // namePattern mirrors connectors: a lowercase slug that survives in
@@ -86,21 +91,22 @@ func NewStore(db *pgpool.Pool, log *slog.Logger) *Store {
 	return &Store{db: db, log: log}
 }
 
-const agentColumns = `id, name, description, prompt_overlay, route, skills, tools, memory, is_default, enabled, review_route, budget_usd, approval_allowlist`
+const agentColumns = `id, name, description, prompt_overlay, route, skills, tools, memory, is_default, enabled, review_route, budget_usd, approval_allowlist, knowledge`
 
 func scanAgent(row pgx.Row) (Agent, error) {
 	var (
-		a                   Agent
-		skills, tools, appr []byte
+		a                              Agent
+		skills, tools, appr, knowledge []byte
 	)
 	if err := row.Scan(&a.ID, &a.Name, &a.Description, &a.PromptOverlay, &a.Route,
 		&skills, &tools, &a.Memory, &a.IsDefault, &a.Enabled,
-		&a.ReviewRoute, &a.BudgetUSD, &appr); err != nil {
+		&a.ReviewRoute, &a.BudgetUSD, &appr, &knowledge); err != nil {
 		return Agent{}, err
 	}
 	_ = json.Unmarshal(skills, &a.Skills)
 	_ = json.Unmarshal(tools, &a.Tools)
 	_ = json.Unmarshal(appr, &a.ApprovalAllowlist)
+	_ = json.Unmarshal(knowledge, &a.Knowledge)
 	if a.Skills == nil {
 		a.Skills = []string{}
 	}
@@ -109,6 +115,9 @@ func scanAgent(row pgx.Row) (Agent, error) {
 	}
 	if a.ApprovalAllowlist == nil {
 		a.ApprovalAllowlist = []string{}
+	}
+	if a.Knowledge == nil {
+		a.Knowledge = []string{}
 	}
 	return a, nil
 }
@@ -242,14 +251,14 @@ func (s *Store) Create(ctx context.Context, a Agent) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("agents create: %w", err)
 	}
-	skills, tools, appr := jsonArr(a.Skills), jsonArr(a.Tools), jsonArr(a.ApprovalAllowlist)
+	skills, tools, appr, knowledge := jsonArr(a.Skills), jsonArr(a.Tools), jsonArr(a.ApprovalAllowlist), jsonArr(a.Knowledge)
 	var id string
 	err = db.QueryRow(ctx, `INSERT INTO agents
 			(name, description, prompt_overlay, route, skills, tools, memory, enabled,
-			 review_route, budget_usd, approval_allowlist)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING id`,
+			 review_route, budget_usd, approval_allowlist, knowledge)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING id`,
 		a.Name, a.Description, a.PromptOverlay, a.Route, skills, tools, a.Memory, a.Enabled,
-		a.ReviewRoute, a.BudgetUSD, appr).Scan(&id)
+		a.ReviewRoute, a.BudgetUSD, appr, knowledge).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("agents create: %w", err)
 	}
@@ -271,6 +280,7 @@ type Patch struct {
 	ReviewRoute       *string   `json:"review_route"`
 	BudgetUSD         *float64  `json:"budget_usd"`
 	ApprovalAllowlist *[]string `json:"approval_allowlist"`
+	Knowledge         *[]string `json:"knowledge"`
 }
 
 func (s *Store) Patch(ctx context.Context, id string, p Patch) error {
@@ -323,13 +333,16 @@ func (s *Store) Patch(ctx context.Context, id string, p Patch) error {
 	if p.ApprovalAllowlist != nil {
 		after.ApprovalAllowlist = *p.ApprovalAllowlist
 	}
+	if p.Knowledge != nil {
+		after.Knowledge = *p.Knowledge
+	}
 	if _, err := tx.Exec(ctx, `UPDATE agents SET description = $2, prompt_overlay = $3,
 			route = $4, skills = $5, tools = $6, memory = $7, enabled = $8,
-			review_route = $9, budget_usd = $10, approval_allowlist = $11, updated_at = now()
+			review_route = $9, budget_usd = $10, approval_allowlist = $11, knowledge = $12, updated_at = now()
 		WHERE id = $1`,
 		id, after.Description, after.PromptOverlay, after.Route,
 		jsonArr(after.Skills), jsonArr(after.Tools), after.Memory, after.Enabled,
-		after.ReviewRoute, after.BudgetUSD, jsonArr(after.ApprovalAllowlist)); err != nil {
+		after.ReviewRoute, after.BudgetUSD, jsonArr(after.ApprovalAllowlist), jsonArr(after.Knowledge)); err != nil {
 		return fmt.Errorf("agents patch: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -22,6 +22,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/connectors"
 	"github.com/SumonMSelim/timothy/internal/brain/fxrates"
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/brain/kb"
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
 	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/brain/settings"
@@ -92,7 +93,7 @@ var memoryRoutePatterns = []string{
 // proxy to the gateway's internal control plane, conns the local
 // connector control plane (nil leaves any of them unmounted).
 // whisperURL empty leaves /v1/transcribe unmounted (WHISPER_URL unset).
-func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, secrets *secretstore.Store, toolset Toolset, packs []skills.Skill, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, markitdownURL string, token string, log *slog.Logger, gwSecrets GatewaySecrets) {
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, secrets *secretstore.Store, toolset Toolset, packs []skills.Skill, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, markitdownURL string, token string, log *slog.Logger, gwSecrets GatewaySecrets, kbStore *kb.Store, kbIngest kbIngester) {
 	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log, flags: flags, rates: rates}
 	if memories != nil {
 		for _, pattern := range memoryRoutePatterns {
@@ -114,6 +115,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	a.registerConnectors(srv.Handle, conns, goog, secrets)
 	a.registerTools(srv.Handle, toolset)
 	a.registerSkills(srv.Handle, packs)
+	a.registerKB(srv.Handle, kbStore, kbIngest, markitdownURL)
 	var codingExecutorDefault func(context.Context) string
 	if flags != nil {
 		codingExecutorDefault = flags.CodingExecutor

--- a/internal/brain/api/kb.go
+++ b/internal/brain/api/kb.go
@@ -1,0 +1,260 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/SumonMSelim/timothy/internal/brain/kb"
+	"github.com/SumonMSelim/timothy/internal/platform/markitdown"
+)
+
+// maxKBUploadBytes caps a single knowledge-base document upload.
+const maxKBUploadBytes = 32 << 20 // 32MiB
+
+// kbAllowedExt names the file extensions kb document upload accepts.
+// .md/.txt skip markitdown entirely (already markdown/plain text);
+// everything else converts through the sidecar.
+var kbAllowedExt = map[string]bool{
+	".pdf": true, ".md": true, ".txt": true, ".docx": true, ".html": true,
+}
+
+// kbIngester runs memoryd's ingest pipeline for one document; nil
+// disables background ingestion (memoryd unreachable is a runtime
+// error, not a nil-gate, but MEMORYD_URL is always configured — this
+// interface exists so tests can fake it).
+type kbIngester interface {
+	IngestDocument(ctx context.Context, documentID, title, markdown string) (int, error)
+}
+
+// registerKB mounts the knowledge-base admin surface (D-060). Nil
+// store leaves it unmounted, same nil-gate pattern as agents/skills.
+func (a *API) registerKB(handle func(pattern string, h http.Handler), store *kb.Store, ingest kbIngester, markitdownURL string) {
+	if store == nil {
+		return
+	}
+	h := &kbAPI{store: store, ingest: ingest, markitdownURL: markitdownURL, markitdownHTTP: &http.Client{}, log: a.log}
+	handle("GET /v1/admin/kb/collections", a.auth(http.HandlerFunc(h.listCollections)))
+	handle("POST /v1/admin/kb/collections", a.auth(http.HandlerFunc(h.createCollection)))
+	handle("GET /v1/admin/kb/collections/{id}", a.auth(http.HandlerFunc(h.getCollection)))
+	handle("DELETE /v1/admin/kb/collections/{id}", a.auth(http.HandlerFunc(h.deleteCollection)))
+	handle("GET /v1/admin/kb/collections/{id}/documents", a.auth(http.HandlerFunc(h.listDocuments)))
+	handle("POST /v1/admin/kb/collections/{id}/documents", a.auth(http.HandlerFunc(h.uploadDocument)))
+	handle("DELETE /v1/admin/kb/documents/{id}", a.auth(http.HandlerFunc(h.deleteDocument)))
+	handle("POST /v1/admin/kb/documents/{id}/reingest", a.auth(http.HandlerFunc(h.reingestDocument)))
+}
+
+type kbAPI struct {
+	store          *kb.Store
+	ingest         kbIngester
+	markitdownURL  string
+	markitdownHTTP *http.Client
+	log            *slog.Logger
+}
+
+func failKB(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, kb.ErrNotFound):
+		jsonError(w, http.StatusNotFound, "not_found", err.Error())
+	case errors.Is(err, kb.ErrInUse):
+		jsonError(w, http.StatusConflict, "in_use", err.Error())
+	default:
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+	}
+}
+
+// sanitizeDocument clears Markdown before a document ever reaches
+// writeJSON — the field stays populated in the struct (reingest reads
+// it back) but never rides the wire, mirroring sanitizeMission's
+// attachment-markdown strip in missions.go.
+func sanitizeDocument(d kb.Document) kb.Document {
+	d.Markdown = ""
+	return d
+}
+
+func (h *kbAPI) listCollections(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.store.ListCollections(r.Context())
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"collections": rows})
+}
+
+func (h *kbAPI) createCollection(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "name is required")
+		return
+	}
+	id, err := h.store.CreateCollection(r.Context(), req.Name, req.Description)
+	if err != nil {
+		failKB(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]string{"id": id})
+}
+
+func (h *kbAPI) getCollection(w http.ResponseWriter, r *http.Request) {
+	c, err := h.store.GetCollection(r.Context(), r.PathValue("id"))
+	if err != nil {
+		failKB(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, c)
+}
+
+func (h *kbAPI) deleteCollection(w http.ResponseWriter, r *http.Request) {
+	if err := h.store.DeleteCollection(r.Context(), r.PathValue("id")); err != nil {
+		failKB(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *kbAPI) listDocuments(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.store.ListDocuments(r.Context(), r.PathValue("id"))
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
+		return
+	}
+	out := make([]kb.Document, len(rows))
+	for i, d := range rows {
+		out[i] = sanitizeDocument(d)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"documents": out})
+}
+
+// uploadDocument accepts a single multipart file field "file", caps
+// its size at maxKBUploadBytes, converts it to markdown via markitdown
+// (skipped for .md/.txt, already markdown/plain text), creates a
+// pending document row, then fires the background ingest goroutine.
+func (h *kbAPI) uploadDocument(w http.ResponseWriter, r *http.Request) {
+	collectionID := r.PathValue("id")
+	if _, err := h.store.GetCollection(r.Context(), collectionID); err != nil {
+		failKB(w, err)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxKBUploadBytes)
+	if err := r.ParseMultipartForm(maxKBUploadBytes); err != nil { //nolint:gosec // G120: r.Body is already MaxBytesReader-capped above at the same limit
+		jsonError(w, http.StatusBadRequest, "too_large", "file exceeds the 32MiB limit")
+		return
+	}
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", "multipart field \"file\" is required")
+		return
+	}
+	defer func() { _ = file.Close() }()
+
+	ext := strings.ToLower(filepath.Ext(header.Filename))
+	if !kbAllowedExt[ext] {
+		jsonError(w, http.StatusBadRequest, "unsupported_type", "file must be .pdf, .md, .txt, .docx, or .html")
+		return
+	}
+
+	raw, err := io.ReadAll(file)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", "failed to read upload: "+err.Error())
+		return
+	}
+
+	var markdownText string
+	if ext == ".md" || ext == ".txt" {
+		markdownText = string(raw)
+	} else {
+		if h.markitdownURL == "" {
+			jsonError(w, http.StatusBadRequest, "bad_request", "document conversion requires the markitdown sidecar (MARKITDOWN_URL)")
+			return
+		}
+		md, err := markitdown.Convert(r.Context(), h.markitdownHTTP, h.markitdownURL, header.Filename, "", raw)
+		if err != nil {
+			jsonError(w, http.StatusBadGateway, "conversion_failed", err.Error())
+			return
+		}
+		markdownText = markitdown.TruncateMarkdown(md)
+	}
+
+	// Converted output can carry NUL bytes or invalid UTF-8 (seen in
+	// real PDFs); Postgres text columns reject both (SQLSTATE 22021).
+	markdownText = strings.ToValidUTF8(strings.ReplaceAll(markdownText, "\x00", ""), "�")
+
+	title := strings.TrimSuffix(header.Filename, filepath.Ext(header.Filename))
+	docID, err := h.store.CreateDocument(r.Context(), collectionID, title, header.Filename, markdownText, int64(len(raw)))
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
+		return
+	}
+	h.startIngest(docID, title)
+
+	doc, err := h.store.GetDocument(r.Context(), docID)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, sanitizeDocument(doc))
+}
+
+// startIngest fires the status->ingesting->memoryd->terminal sequence
+// in the background: upload/reingest both return as soon as the
+// document row exists, not once ingestion finishes.
+func (h *kbAPI) startIngest(docID, title string) {
+	go func() {
+		ctx := context.Background()
+		if err := h.store.SetIngesting(ctx, docID); err != nil {
+			h.log.Warn("kb ingest status update failed", "document_id", docID, "error", err)
+		}
+		doc, err := h.store.GetDocument(ctx, docID)
+		if err != nil {
+			h.log.Warn("kb ingest: document vanished before ingest", "document_id", docID, "error", err)
+			return
+		}
+		if h.ingest == nil {
+			_ = h.store.SetFailed(ctx, docID, "memoryd is not configured")
+			return
+		}
+		if _, err := h.ingest.IngestDocument(ctx, docID, title, doc.Markdown); err != nil {
+			h.log.Warn("kb ingest failed", "document_id", docID, "error", err)
+			_ = h.store.SetFailed(ctx, docID, err.Error())
+		}
+	}()
+}
+
+func (h *kbAPI) deleteDocument(w http.ResponseWriter, r *http.Request) {
+	if err := h.store.DeleteDocument(r.Context(), r.PathValue("id")); err != nil {
+		failKB(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// reingestDocument reuses the document's already-stored markdown (no
+// re-conversion) and re-runs the ingest pipeline, which deletes the
+// document's existing chunks before writing the new set.
+func (h *kbAPI) reingestDocument(w http.ResponseWriter, r *http.Request) {
+	docID := r.PathValue("id")
+	doc, err := h.store.GetDocument(r.Context(), docID)
+	if err != nil {
+		failKB(w, err)
+		return
+	}
+	if strings.TrimSpace(doc.Markdown) == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "document has no stored markdown to reingest")
+		return
+	}
+	h.startIngest(docID, doc.Title)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/brain/api/kb_integration_test.go
+++ b/internal/brain/api/kb_integration_test.go
@@ -1,0 +1,315 @@
+//go:build integration
+
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/kb"
+	"github.com/SumonMSelim/timothy/internal/platform/migrate"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+	"github.com/SumonMSelim/timothy/migrations"
+)
+
+// multipartFile builds a single-field multipart body for upload tests.
+func multipartFile(t *testing.T, field, filename string, content []byte) (*bytes.Buffer, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, err := mw.CreateFormFile(field, filename)
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := part.Write(content); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	return &buf, mw.FormDataContentType()
+}
+
+func decodeBody(t *testing.T, raw []byte, v any) error {
+	t.Helper()
+	return json.Unmarshal(raw, v)
+}
+
+// testKBStore mirrors testMissionStore (missions_integration_test.go):
+// a real Postgres-backed *kb.Store, migrated, with itest-prefixed
+// fixtures swept on cleanup.
+func testKBStore(t *testing.T) *kb.Store {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer ccancel()
+		_, _ = db.Exec(cctx, `DELETE FROM kb_collections WHERE name LIKE 'itest-%'`)
+	})
+	return kb.New(pool)
+}
+
+// fakeIngester never calls memoryd; tests only exercise brain's own
+// CRUD/upload surface, not the memoryd round trip (covered separately
+// in internal/memory/api). Ingestion runs on brain's own background
+// goroutine (kb.go's startIngest), so calls needs its own lock — the
+// test polls it from the main goroutine while the fake is invoked from
+// that background one.
+type fakeIngester struct {
+	err error
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (f *fakeIngester) IngestDocument(context.Context, string, string, string) (int, error) {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+	return 3, f.err
+}
+
+func (f *fakeIngester) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func TestKBCollectionsCRUD(t *testing.T) {
+	store := testKBStore(t)
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "")
+
+	create := httptest.NewRequest("POST", "/v1/admin/kb/collections", strings.NewReader(`{"name":"itest-docs","description":"test collection"}`))
+	create.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, create)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body %s", w.Code, w.Body)
+	}
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := decodeBody(t, w.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	list := httptest.NewRequest("GET", "/v1/admin/kb/collections", nil)
+	list.Header.Set("Authorization", "Bearer tok")
+	w = httptest.NewRecorder()
+	m.ServeHTTP(w, list)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "itest-docs") {
+		t.Fatalf("list status = %d body %s", w.Code, w.Body)
+	}
+
+	del := httptest.NewRequest("DELETE", "/v1/admin/kb/collections/"+created.ID, nil)
+	del.Header.Set("Authorization", "Bearer tok")
+	w = httptest.NewRecorder()
+	m.ServeHTTP(w, del)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d body %s", w.Code, w.Body)
+	}
+
+	if _, err := store.GetCollection(context.Background(), created.ID); err == nil {
+		t.Fatal("expected the collection to be gone after delete")
+	}
+}
+
+func TestKBDocumentUploadSkipsMarkitdownForMarkdown(t *testing.T) {
+	store := testKBStore(t)
+	ingester := &fakeIngester{}
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, ingester, "")
+
+	collID, err := store.CreateCollection(context.Background(), "itest-upload", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	body, contentType := multipartFile(t, "file", "notes.md", []byte("# Title\nsome content"))
+	req := httptest.NewRequest("POST", "/v1/admin/kb/collections/"+collID+"/documents", body)
+	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("Content-Type", contentType)
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("upload status = %d body %s", w.Code, w.Body)
+	}
+	if strings.Contains(w.Body.String(), "some content") {
+		t.Fatal("response must not include markdown")
+	}
+
+	var doc struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}
+	if err := decodeBody(t, w.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.Status != "pending" {
+		t.Fatalf("status = %q, want pending (background goroutine flips it later)", doc.Status)
+	}
+
+	// The real terminal flip (ingesting -> ready/failed) is memoryd's
+	// own report via SetIngested/SetFailed (internal/memory/store/kb.go)
+	// after a real ReplaceChunks — this fake ingester only stands in for
+	// the memclient round trip, so the document parks at "ingesting"
+	// here; poll for that and confirm the fake was actually reached with
+	// the stored markdown.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if ingester.callCount() > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	final, err := store.GetDocument(context.Background(), doc.ID)
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if final.Status != "ingesting" {
+		t.Fatalf("status = %q, want ingesting", final.Status)
+	}
+	if got := ingester.callCount(); got != 1 {
+		t.Fatalf("ingester calls = %d, want 1", got)
+	}
+	if final.Markdown != "# Title\nsome content" {
+		t.Fatalf("stored markdown = %q", final.Markdown)
+	}
+}
+
+func TestKBDocumentUploadStripsNULAndInvalidUTF8(t *testing.T) {
+	store := testKBStore(t)
+	ingester := &fakeIngester{}
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, ingester, "")
+
+	collID, err := store.CreateCollection(context.Background(), "itest-nul", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	// Real markitdown output has produced NUL bytes from PDFs; Postgres
+	// text columns reject 0x00 and invalid UTF-8 outright.
+	body, contentType := multipartFile(t, "file", "dirty.txt", []byte("clean\x00 text \xff here"))
+	req := httptest.NewRequest("POST", "/v1/admin/kb/collections/"+collID+"/documents", body)
+	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("Content-Type", contentType)
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("upload status = %d body %s", w.Code, w.Body)
+	}
+
+	var doc struct {
+		ID string `json:"id"`
+	}
+	if err := decodeBody(t, w.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	final, err := store.GetDocument(context.Background(), doc.ID)
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if final.Markdown != "clean text � here" {
+		t.Fatalf("stored markdown = %q, want NUL stripped and invalid UTF-8 replaced", final.Markdown)
+	}
+}
+
+func TestKBDocumentUploadRejectsUnsupportedType(t *testing.T) {
+	store := testKBStore(t)
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "")
+
+	collID, err := store.CreateCollection(context.Background(), "itest-upload-bad", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	body, contentType := multipartFile(t, "file", "archive.zip", []byte("PK\x03\x04"))
+	req := httptest.NewRequest("POST", "/v1/admin/kb/collections/"+collID+"/documents", body)
+	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("Content-Type", contentType)
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestKBDocumentReingestFailureSetsFailedStatus(t *testing.T) {
+	store := testKBStore(t)
+	ingester := &fakeIngester{err: errors.New("memoryd unreachable")}
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, ingester, "")
+
+	collID, err := store.CreateCollection(context.Background(), "itest-reingest", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	docID, err := store.CreateDocument(context.Background(), collID, "Doc", "doc.md", "content", 7)
+	if err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/v1/admin/kb/documents/"+docID+"/reingest", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("reingest status = %d body %s", w.Code, w.Body)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		got, err := store.GetDocument(context.Background(), docID)
+		if err != nil {
+			t.Fatalf("GetDocument: %v", err)
+		}
+		if got.Status == "failed" {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	final, err := store.GetDocument(context.Background(), docID)
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if final.Status != "failed" || !strings.Contains(final.Error, "memoryd unreachable") {
+		t.Fatalf("document = %+v, want failed with the ingester's error", final)
+	}
+}

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -495,6 +495,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 	// name: req.AgentID is the mission row's agent_id FK value (the
 	// picker sends a.id), unlike chat's session.agent which is a name.
 	var promptOverlay string
+	var knowledge []string
 	if h.agentReg != nil {
 		if a, ok := h.agentReg.ResolveByID(r.Context(), req.AgentID); ok {
 			if req.Route == "" {
@@ -507,6 +508,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 				req.BudgetAmount = a.BudgetUSD
 			}
 			promptOverlay = a.PromptOverlay
+			knowledge = a.Knowledge
 		}
 	}
 	// An agent's route (and this handler's own fallback) can still be
@@ -550,7 +552,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		Goal: req.Goal, Kind: req.Kind, AgentID: req.AgentID,
 		Route: req.Route, ReviewRoute: req.ReviewRoute, PlanRoute: req.PlanRoute, EscalationRoute: req.EscalationRoute,
 		MaxIterations: req.MaxIterations, BudgetAmount: req.BudgetAmount, BudgetCurrency: budgetCurrency,
-		AutoApproveSafe: autoApproveSafe, PromptOverlay: promptOverlay, Harness: req.Harness, Environment: req.Environment,
+		AutoApproveSafe: autoApproveSafe, PromptOverlay: promptOverlay, Knowledge: knowledge, Harness: req.Harness, Environment: req.Environment,
 		RepoURL: req.RepoURL, ConnectorID: req.ConnectorID, OnComplete: req.OnComplete,
 		BranchPattern: req.BranchPattern, CommitStyle: req.CommitStyle,
 		ParentMissionID: parentMissionID, ParentContext: parentContext,

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -25,6 +25,8 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
 	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/brain/skills"
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+	"github.com/SumonMSelim/timothy/internal/brain/tools/builtin"
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 	"github.com/SumonMSelim/timothy/internal/platform/markitdown"
@@ -144,6 +146,7 @@ type Service struct {
 	attachments    AttachmentStore                    // nil: attachments disabled (ATTACHMENTS_DIR unset)
 	markitdownURL  string                             // "": pdf attachments disabled (MARKITDOWN_URL unset)
 	markitdownHTTP *http.Client                       // shared client for the markitdown sidecar call
+	kbSearch       KBSearch                           // nil: kb_search never offered, regardless of agent config
 	logger         *slog.Logger
 
 	grants Granter // nil: chat never seeds standing grants (today's behavior)
@@ -234,6 +237,36 @@ func (s *Service) SetMarkitdown(url string) {
 	if s.markitdownHTTP == nil {
 		s.markitdownHTTP = &http.Client{}
 	}
+}
+
+// KBSearch runs one knowledge-base search scoped to collectionNames —
+// main curries memclient.Client.KBSearch in; collectionNames travels
+// on every call, never bound once, since the same func serves every
+// agent and each turn's collections are the SERVING agent's own
+// Knowledge list (D-060: enforced here in Go, never a prompt).
+type KBSearch func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error)
+
+// SetKBSearch wires the kb_search tool's backing search call. Optional
+// — nil means kb_search is never offered on any turn, regardless of an
+// agent's Knowledge list (same "the dependency's absence turns the
+// feature off entirely" contract as SetMemoryRetrieve/SetAttachments).
+func (s *Service) SetKBSearch(fn KBSearch) { s.kbSearch = fn }
+
+// kbSearchTool builds this turn's kb_search ExtraTool bound to
+// profile's Knowledge collections, or nil when kb_search must not be
+// offered: no backing search call wired, or the agent named no
+// collections (empty Knowledge = no kb_search, same opt-in-only
+// contract as Skills/Tools — this is the "exclude from the turn"
+// choice, matching load_skill's precedent of leaving a tool off the
+// offered surface entirely rather than having it answer with an error).
+func (s *Service) kbSearchTool(profile agents.Agent) *tools.Tool {
+	if s.kbSearch == nil || len(profile.Knowledge) == 0 {
+		return nil
+	}
+	collections := slices.Clone(profile.Knowledge)
+	return builtin.KBSearch(func(ctx context.Context, query, mode string, k int) ([]builtin.KBSearchHit, error) {
+		return s.kbSearch(ctx, query, collections, mode, k)
+	})
 }
 
 // SetAutoDispatch wires auto agent dispatch (D-034 follow-up): a
@@ -970,15 +1003,20 @@ func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, 
 		}
 	}
 
+	var extraTools []*tools.Tool
+	if t := s.kbSearchTool(profile); t != nil {
+		extraTools = []*tools.Tool{t}
+	}
 	upstream, err := s.gw.Stream(turnCtx, gwclient.StreamRequest{
-		Route:     route,
-		Agent:     profile.Name,
-		ToolAllow: resolveToolAllow(profile),
-		Purpose:   "chat",
-		ModelHint: modelHint,
-		System:    system,
-		Messages:  msgs,
-		SessionID: sessionID,
+		Route:      route,
+		Agent:      profile.Name,
+		ToolAllow:  resolveToolAllow(profile),
+		ExtraTools: extraTools,
+		Purpose:    "chat",
+		ModelHint:  modelHint,
+		System:     system,
+		Messages:   msgs,
+		SessionID:  sessionID,
 	})
 	if err != nil {
 		s.turnDone(sessionID)

--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/router"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
@@ -28,17 +29,22 @@ type StreamRequest struct {
 	// Agent attributes the call in the cost ledger. ToolAllow is
 	// loop-internal (never serialized): the serving agent's tool
 	// allowlist, empty = all tools.
-	Agent     string             `json:"agent,omitempty"`
-	ToolAllow []string           `json:"-"`
-	Purpose   string             `json:"purpose,omitempty"` // ledger tag: why this call happened
-	ModelHint string             `json:"model_hint,omitempty"`
-	System    string             `json:"system,omitempty"`
-	Messages  []provider.Message `json:"messages"`
-	Tools     []provider.ToolDef `json:"tools,omitempty"`
-	MaxTokens int                `json:"max_tokens,omitempty"`
-	Effort    string             `json:"effort,omitempty"` // D-020: "low" | "" (normal)
-	SessionID string             `json:"session_id,omitempty"`
-	MissionID string             `json:"mission_id,omitempty"` // ledger tag: the mission this turn serves
+	Agent     string   `json:"agent,omitempty"`
+	ToolAllow []string `json:"-"`
+	// ExtraTools are turn-only tool defs layered on top of the shared
+	// base set (loop.Request.ExtraTools) — chat's per-agent kb_search
+	// binding is the only caller today. Loop-internal, never
+	// serialized, same as ToolAllow.
+	ExtraTools []*tools.Tool      `json:"-"`
+	Purpose    string             `json:"purpose,omitempty"` // ledger tag: why this call happened
+	ModelHint  string             `json:"model_hint,omitempty"`
+	System     string             `json:"system,omitempty"`
+	Messages   []provider.Message `json:"messages"`
+	Tools      []provider.ToolDef `json:"tools,omitempty"`
+	MaxTokens  int                `json:"max_tokens,omitempty"`
+	Effort     string             `json:"effort,omitempty"` // D-020: "low" | "" (normal)
+	SessionID  string             `json:"session_id,omitempty"`
+	MissionID  string             `json:"mission_id,omitempty"` // ledger tag: the mission this turn serves
 }
 
 // windowsTTL matches the gateway's own config poll cadence: a fresher

--- a/internal/brain/kb/kb.go
+++ b/internal/brain/kb/kb.go
@@ -1,0 +1,259 @@
+// Package kb is brain's knowledge-base control plane (D-060):
+// collection and document CRUD, upload-time markitdown conversion, and
+// the background ingest handoff to memoryd. Chunk storage and search
+// live in memoryd (internal/memory/store, internal/memory/api) — this
+// package only owns kb_collections and kb_documents.
+package kb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+// ErrNotFound reports that no collection/document matched the given id.
+var ErrNotFound = errors.New("not found")
+
+// ErrInUse reports an operation blocked by a dependent row.
+var ErrInUse = errors.New("in use")
+
+// Collection is one named group of documents agents can search.
+type Collection struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	DocCount    int       `json:"doc_count"`
+	ChunkCount  int       `json:"chunk_count"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// Document is one ingested file within a collection. Markdown is
+// deliberately excluded from this struct's JSON — API handlers strip
+// it before serving (mirrors mission attachments, D-05x); it still
+// lives in the row for reingest to reuse without re-converting.
+type Document struct {
+	ID           string     `json:"id"`
+	CollectionID string     `json:"collection_id"`
+	Title        string     `json:"title"`
+	SourceType   string     `json:"source_type"`
+	SourceRef    string     `json:"source_ref"`
+	Status       string     `json:"status"`
+	Error        string     `json:"error"`
+	Bytes        int64      `json:"bytes"`
+	ChunkCount   int        `json:"chunk_count"`
+	IngestedAt   *time.Time `json:"ingested_at"`
+	CreatedAt    time.Time  `json:"created_at"`
+	// Markdown is the markitdown-converted document body — never
+	// serialized in API responses (handlers zero it before writeJSON);
+	// present here only so reingest can read it back without a
+	// separate query.
+	Markdown string `json:"-"`
+}
+
+// Store is the kb_collections/kb_documents CRUD.
+type Store struct {
+	db *pgpool.Pool
+}
+
+func New(db *pgpool.Pool) *Store {
+	return &Store{db: db}
+}
+
+const collectionColumns = `c.id, c.name, c.description, c.created_at, c.updated_at,
+	(SELECT count(*) FROM kb_documents d WHERE d.collection_id = c.id),
+	(SELECT coalesce(sum(d.chunk_count), 0) FROM kb_documents d WHERE d.collection_id = c.id)`
+
+func scanCollection(row pgx.Row) (Collection, error) {
+	var c Collection
+	err := row.Scan(&c.ID, &c.Name, &c.Description, &c.CreatedAt, &c.UpdatedAt, &c.DocCount, &c.ChunkCount)
+	return c, err
+}
+
+// ListCollections returns every collection, by name.
+func (s *Store) ListCollections(ctx context.Context) ([]Collection, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("kb collections list: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT `+collectionColumns+` FROM kb_collections c ORDER BY c.name`)
+	if err != nil {
+		return nil, fmt.Errorf("kb collections list: %w", err)
+	}
+	defer rows.Close()
+	out := []Collection{}
+	for rows.Next() {
+		c, err := scanCollection(rows)
+		if err != nil {
+			return nil, fmt.Errorf("kb collections list: %w", err)
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// GetCollection returns one collection by id.
+func (s *Store) GetCollection(ctx context.Context, id string) (Collection, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return Collection{}, fmt.Errorf("kb collection %s: %w", id, err)
+	}
+	c, err := scanCollection(db.QueryRow(ctx, `SELECT `+collectionColumns+` FROM kb_collections c WHERE c.id = $1`, id))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Collection{}, fmt.Errorf("collection %s: %w", id, ErrNotFound)
+	}
+	if err != nil {
+		return Collection{}, fmt.Errorf("kb collection %s: %w", id, err)
+	}
+	return c, nil
+}
+
+// CreateCollection inserts a new collection.
+func (s *Store) CreateCollection(ctx context.Context, name, description string) (string, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return "", fmt.Errorf("kb collections create: %w", err)
+	}
+	var id string
+	err = db.QueryRow(ctx, `INSERT INTO kb_collections (name, description) VALUES ($1, $2) RETURNING id`,
+		name, description).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("kb collections create: %w", err)
+	}
+	return id, nil
+}
+
+// DeleteCollection removes a collection; ON DELETE CASCADE takes its
+// documents and chunks with it.
+func (s *Store) DeleteCollection(ctx context.Context, id string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("kb collections delete: %w", err)
+	}
+	tag, err := db.Exec(ctx, `DELETE FROM kb_collections WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("kb collections delete: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("collection %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+const documentColumns = `id, collection_id, title, source_type, source_ref, status, error, bytes, chunk_count, ingested_at, created_at, markdown`
+
+func scanDocument(row pgx.Row) (Document, error) {
+	var d Document
+	err := row.Scan(&d.ID, &d.CollectionID, &d.Title, &d.SourceType, &d.SourceRef,
+		&d.Status, &d.Error, &d.Bytes, &d.ChunkCount, &d.IngestedAt, &d.CreatedAt, &d.Markdown)
+	return d, err
+}
+
+// ListDocuments returns every document in a collection, newest first.
+func (s *Store) ListDocuments(ctx context.Context, collectionID string) ([]Document, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("kb documents list: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT `+documentColumns+` FROM kb_documents WHERE collection_id = $1 ORDER BY created_at DESC`, collectionID)
+	if err != nil {
+		return nil, fmt.Errorf("kb documents list: %w", err)
+	}
+	defer rows.Close()
+	out := []Document{}
+	for rows.Next() {
+		d, err := scanDocument(rows)
+		if err != nil {
+			return nil, fmt.Errorf("kb documents list: %w", err)
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// GetDocument returns one document by id.
+func (s *Store) GetDocument(ctx context.Context, id string) (Document, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return Document{}, fmt.Errorf("kb document %s: %w", id, err)
+	}
+	d, err := scanDocument(db.QueryRow(ctx, `SELECT `+documentColumns+` FROM kb_documents WHERE id = $1`, id))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Document{}, fmt.Errorf("document %s: %w", id, ErrNotFound)
+	}
+	if err != nil {
+		return Document{}, fmt.Errorf("kb document %s: %w", id, err)
+	}
+	return d, nil
+}
+
+// CreateDocument inserts a pending document row: markdown is the
+// markitdown conversion done once at upload time (or the raw file for
+// .md/.txt, which skip conversion); sourceRef names the uploaded
+// filename.
+func (s *Store) CreateDocument(ctx context.Context, collectionID, title, sourceRef, markdown string, bytes int64) (string, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return "", fmt.Errorf("kb documents create: %w", err)
+	}
+	var id string
+	err = db.QueryRow(ctx, `INSERT INTO kb_documents
+		(collection_id, title, source_type, source_ref, markdown, status, bytes)
+		VALUES ($1, $2, 'file', $3, $4, 'pending', $5) RETURNING id`,
+		collectionID, title, sourceRef, markdown, bytes).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("kb documents create: %w", err)
+	}
+	return id, nil
+}
+
+// SetIngesting flips a document to the ingesting phase right before
+// the memoryd call — the background goroutine's own status update,
+// distinct from memoryd's own ready/failed report (store.KBStore.
+// SetIngested/SetFailed in internal/memory/store/kb.go).
+func (s *Store) SetIngesting(ctx context.Context, id string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("kb document %s ingesting: %w", id, err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE kb_documents SET status = 'ingesting', updated_at = now() WHERE id = $1`, id); err != nil {
+		return fmt.Errorf("kb document %s ingesting: %w", id, err)
+	}
+	return nil
+}
+
+// SetFailed marks a document failed — used when brain itself (not
+// memoryd) hits an error before the ingest call ever reaches memoryd,
+// e.g. memoryd unreachable.
+func (s *Store) SetFailed(ctx context.Context, id, errMsg string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("kb document %s failed: %w", id, err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE kb_documents SET status = 'failed', error = $2, updated_at = now() WHERE id = $1`, id, errMsg); err != nil {
+		return fmt.Errorf("kb document %s failed: %w", id, err)
+	}
+	return nil
+}
+
+// DeleteDocument removes a document; ON DELETE CASCADE takes its
+// chunks with it.
+func (s *Store) DeleteDocument(ctx context.Context, id string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("kb documents delete: %w", err)
+	}
+	tag, err := db.Exec(ctx, `DELETE FROM kb_documents WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("kb documents delete: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("document %s: %w", id, ErrNotFound)
+	}
+	return nil
+}

--- a/internal/brain/memclient/memclient.go
+++ b/internal/brain/memclient/memclient.go
@@ -131,6 +131,84 @@ func (c *Client) Retrieve(ctx context.Context, sessionID, query string) ([]Memor
 	return out.Memories, nil
 }
 
+// IngestDocument runs memoryd's synchronous chunk/embed/store pipeline
+// for one already-converted document and returns the chunk count.
+// Re-ingest is safe to call again: memoryd deletes the document's
+// existing chunks before writing the new set.
+func (c *Client) IngestDocument(ctx context.Context, documentID, title, markdown string) (int, error) {
+	body, err := json.Marshal(map[string]string{"document_id": documentID, "title": title, "markdown": markdown})
+	if err != nil {
+		return 0, fmt.Errorf("memclient: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/ingest-document", bytes.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("memclient: request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("memclient: memoryd unreachable: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return 0, fmt.Errorf("memclient: memoryd http %d: %s", resp.StatusCode, string(msg))
+	}
+	var out struct {
+		ChunkCount int `json:"chunk_count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return 0, fmt.Errorf("memclient: decode: %w", err)
+	}
+	return out.ChunkCount, nil
+}
+
+// KBChunkHit is one hybrid-retrieval result from the knowledge base.
+type KBChunkHit struct {
+	ChunkID       string  `json:"chunk_id"`
+	DocumentID    string  `json:"document_id"`
+	DocumentTitle string  `json:"document_title"`
+	Collection    string  `json:"collection"`
+	Breadcrumb    string  `json:"breadcrumb"`
+	Content       string  `json:"content"`
+	Score         float64 `json:"score"`
+	SourceRef     string  `json:"source_ref"`
+}
+
+// KBSearch asks memoryd for the top-k chunks matching query, scoped to
+// collectionNames (required, non-empty — this is the ONLY place a
+// caller can widen or narrow that scope; the tool that calls this must
+// bind names at construction, never take them from model input).
+func (c *Client) KBSearch(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]KBChunkHit, error) {
+	body, err := json.Marshal(map[string]any{
+		"query": query, "collection_names": collectionNames, "mode": mode, "k": k,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("memclient: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/kb-search", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("memclient: request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("memclient: memoryd unreachable: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("memclient: memoryd http %d: %s", resp.StatusCode, string(msg))
+	}
+	var out struct {
+		Results []KBChunkHit `json:"results"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("memclient: decode: %w", err)
+	}
+	return out.Results, nil
+}
+
 // RenderBlock fences retrieved memories as tagged DATA for the system
 // prompt tail. The preamble and the closing-tag escape are the
 // memory-poisoning defense (D-011): whatever a memory's content says,

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -28,7 +28,11 @@ type Mission struct {
 	// at create time — see 0010_missions.sql for why this isn't a live
 	// agent lookup.
 	PromptOverlay string `json:"prompt_overlay,omitempty"`
-	Phase         Phase  `json:"phase"`
+	// Knowledge is a snapshot of the creating agent's kb_collections
+	// allowlist at create time, same reasoning as PromptOverlay above.
+	// Empty means kb_search is never offered on this mission's turns.
+	Knowledge []string `json:"knowledge,omitempty"`
+	Phase     Phase    `json:"phase"`
 	Status        Status `json:"status"`
 	// FailureReason is derived (no column) from this mission's latest
 	// mission.failed event's payload.reason — "cancelled" or

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -8,8 +8,10 @@ import (
 	"io"
 	"log/slog"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/SumonMSelim/timothy/internal/brain/loop"
@@ -151,7 +153,20 @@ type nativeRunner struct {
 	// sandbox executes worker/reviewer shell commands in a per-mission
 	// Docker container instead of brain's own process.
 	sandbox sandboxExec
+	// kbSearch backs the per-turn kb_search ExtraTool (see kbSearchTool)
+	// — nil means kb_search is never offered on any mission turn,
+	// regardless of a mission's own Knowledge snapshot (same "the
+	// dependency's absence turns the feature off entirely" contract as
+	// chat.go's SetKBSearch).
+	kbSearch KBSearchFunc
 }
+
+// KBSearchFunc runs one kb_search call scoped to collectionNames — main
+// curries memclient.Client.KBSearch in, same shape as chat.go's
+// KBSearch type. collectionNames travels on every call (the mission's
+// own Knowledge snapshot), never bound once, since the same func serves
+// every mission.
+type KBSearchFunc func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error)
 
 // NewNativeRunner wraps a production *loop.Agent as a Runner. The
 // agent instance is expected to be brain's existing chat agent — a
@@ -163,11 +178,58 @@ func NewNativeRunner(agent *loop.Agent, parker parkNotifier, log *slog.Logger) R
 }
 
 // NewNativeRunnerWithFloor is NewNativeRunner plus a model floor deny
-// list (see nativeRunner.modelFloorDeny) and a sandbox exec backend
-// (a *sandbox.Manager.Exec closure) — worker and reviewer shell calls
-// route through it instead of brain's own process.
-func NewNativeRunnerWithFloor(agent *loop.Agent, parker parkNotifier, floorDeny []string, sandbox sandboxExec, log *slog.Logger) Runner {
-	return &nativeRunner{agent: agent, parker: parker, modelFloorDeny: floorDeny, sandbox: sandbox, log: log}
+// list (see nativeRunner.modelFloorDeny), a sandbox exec backend (a
+// *sandbox.Manager.Exec closure) — worker and reviewer shell calls
+// route through it instead of brain's own process — and a kb_search
+// backend (nil disables kb_search on every mission turn, matching
+// SetKBSearch's nil-safe contract).
+func NewNativeRunnerWithFloor(agent *loop.Agent, parker parkNotifier, floorDeny []string, sandbox sandboxExec, kbSearch KBSearchFunc, log *slog.Logger) Runner {
+	return &nativeRunner{agent: agent, parker: parker, modelFloorDeny: floorDeny, sandbox: sandbox, kbSearch: kbSearch, log: log}
+}
+
+// kbSearchTool builds this turn's kb_search ExtraTool bound to m's own
+// Knowledge snapshot, or nil when kb_search must not be offered: no
+// backend wired, or the mission's creating agent named no collections
+// (empty Knowledge = no kb_search, same opt-in-only contract as
+// chat.go's kbSearchTool, which this mirrors exactly). A non-nil sink
+// records every returned document at execution time — the harness's
+// citation evidence must come from here, not from the rendered tool
+// result: digests cap at digestCeiling and offload past 8KiB, so a
+// full kb_search result never survives into the digest text.
+func (r *nativeRunner) kbSearchTool(m Mission, sink *kbRefSink) *tools.Tool {
+	if r.kbSearch == nil || len(m.Knowledge) == 0 {
+		return nil
+	}
+	collections := slices.Clone(m.Knowledge)
+	return builtin.KBSearch(func(ctx context.Context, query, mode string, k int) ([]builtin.KBSearchHit, error) {
+		hits, err := r.kbSearch(ctx, query, collections, mode, k)
+		if err == nil && sink != nil {
+			sink.record(hits)
+		}
+		return hits, err
+	})
+}
+
+// kbRefSink accumulates the kb:// refs of documents kb_search actually
+// returned across a worker run's turns. Guarded because the loop may
+// execute tool calls concurrently within a turn.
+type kbRefSink struct {
+	mu   sync.Mutex
+	refs []string
+}
+
+func (s *kbRefSink) record(hits []builtin.KBSearchHit) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, h := range hits {
+		s.refs = append(s.refs, "kb://"+h.DocumentID)
+	}
+}
+
+func (s *kbRefSink) all() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.refs)
 }
 
 // missionTools builds the turn-scoped file tools rooted in the
@@ -461,7 +523,11 @@ func reviewRoute(m Mission) string {
 // retry, never a silent accept.
 func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPacket) (WorkerVerdict, string, error) {
 	system, user := packet.Render()
+	kbSeen := &kbRefSink{}
 	extra := append([]*tools.Tool{MissionStatusTool()}, r.missionTools(m)...)
+	if t := r.kbSearchTool(m, kbSeen); t != nil {
+		extra = append(extra, t)
+	}
 	req := loop.Request{
 		SessionID:    m.SessionID,
 		Route:        workerRoute(m),
@@ -482,7 +548,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		return WorkerVerdict{}, text, err
 	}
 	if v, ok := r.tryParseVerdict(args); ok {
-		v.SeenURLs = seenURLs
+		v.SeenURLs = append(seenURLs, kbSeen.all()...)
 		return v, text, nil
 	}
 
@@ -498,7 +564,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		return WorkerVerdict{}, text + "\n" + recoverText, err
 	}
 	if v, ok := r.tryParseVerdict(recoverArgs); ok {
-		v.SeenURLs = seenURLs
+		v.SeenURLs = append(seenURLs, kbSeen.all()...)
 		return v, text + "\n" + recoverText, nil
 	}
 
@@ -515,7 +581,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 	if raw, ok := extractTextSentinel(combined, missionStatusToolName); ok {
 		if v, ok := r.tryParseVerdict(raw); ok {
 			r.log.Warn("mission worker expressed mission_status as text, not a tool call", "mission_id", m.ID)
-			v.SeenURLs = seenURLs
+			v.SeenURLs = append(seenURLs, kbSeen.all()...)
 			return v, combined, nil
 		}
 	}
@@ -566,6 +632,9 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 	extra := []*tools.Tool{ExploreNotesTool()}
 	if shell := r.missionShell(m); shell != nil {
 		extra = append(extra, shell)
+	}
+	if t := r.kbSearchTool(m, nil); t != nil {
+		extra = append(extra, t)
 	}
 	req := loop.Request{
 		SessionID:    m.SessionID,
@@ -772,6 +841,10 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 		user += "\n\nPrevious mission outcome:\n" + NeutralizeSlot(m.ParentContext)
 	}
 	user += renderAttachments(m.Attachments)
+	extra := []*tools.Tool{PlanTool()}
+	if t := r.kbSearchTool(m, nil); t != nil {
+		extra = append(extra, t)
+	}
 	req := loop.Request{
 		SessionID: m.SessionID,
 		Route:     oversightRoute(m),
@@ -780,12 +853,13 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 		System:    system,
 		Messages:  []provider.Message{{Role: "user", Content: user}},
 		// The planner plans; it must not act. No base tool matches this
-		// allowlist (submit_plan arrives via ExtraTools, which bypass
-		// it), so the turn's only tool is submit_plan — a planner that
-		// reaches for shell parked a live canary on the permission gate
-		// for ten minutes trying to do the worker's job in plan phase.
+		// allowlist (submit_plan/kb_search arrive via ExtraTools, which
+		// bypass it, and kb_search is read-only — never "acting"), so
+		// the turn's only BASE tool is none — a planner that reaches for
+		// shell parked a live canary on the permission gate for ten
+		// minutes trying to do the worker's job in plan phase.
 		ToolAllow:    []string{planToolName},
-		ExtraTools:   []*tools.Tool{PlanTool()},
+		ExtraTools:   extra,
 		BuiltinsOnly: true,
 		Unattended:   m.ScheduleID != "",
 	}

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/SumonMSelim/timothy/internal/brain/loop"
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
+	"github.com/SumonMSelim/timothy/internal/brain/tools/builtin"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 )
 
@@ -1420,4 +1421,133 @@ func TestRunWorkerCollectsSeenURLsFromWebFetchAndWebSearch(t *testing.T) {
 	if !slices.Equal(v.SeenURLs, want) {
 		t.Fatalf("RunWorker verdict SeenURLs = %v, want %v", v.SeenURLs, want)
 	}
+}
+
+// TestKBSearchToolRecordsRefsInSink covers the execution-time harvest
+// (the digest is capped/offloaded past digestCeiling, so citation
+// evidence must be recorded when the tool RUNS, never parsed from the
+// rendered result): executing the worker's kb_search tool must land
+// every returned document's kb:// ref in the sink, and a nil sink
+// (explore/plan turns) must stay safe.
+func TestKBSearchToolRecordsRefsInSink(t *testing.T) {
+	r := &nativeRunner{log: slog.Default(), kbSearch: func(ctx context.Context, query string, collections []string, mode string, k int) ([]builtin.KBSearchHit, error) {
+		return []builtin.KBSearchHit{
+			{DocumentID: "aaaaaaaa-0000-0000-0000-000000000001", DocumentTitle: "Runbook", Content: "content"},
+			{DocumentID: "bbbbbbbb-0000-0000-0000-000000000002", DocumentTitle: "Guide", Content: "more"},
+		}, nil
+	}}
+	m := Mission{ID: "m1", Knowledge: []string{"docs"}}
+
+	sink := &kbRefSink{}
+	tool := r.kbSearchTool(m, sink)
+	if tool == nil {
+		t.Fatal("kbSearchTool = nil with backend and knowledge present")
+	}
+	if _, err := tool.Execute(context.Background(), json.RawMessage(`{"query":"deploy runbook"}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	want := []string{"kb://aaaaaaaa-0000-0000-0000-000000000001", "kb://bbbbbbbb-0000-0000-0000-000000000002"}
+	if got := sink.all(); !slices.Equal(got, want) {
+		t.Fatalf("sink refs = %v, want %v", got, want)
+	}
+
+	if _, err := r.kbSearchTool(m, nil).Execute(context.Background(), json.RawMessage(`{"query":"deploy runbook"}`)); err != nil {
+		t.Fatalf("Execute with nil sink: %v", err)
+	}
+}
+
+// TestRunWorkerSurfacesKBSinkRefsOnVerdict is the end-to-end wiring
+// check: refs recorded by the sink during the worker turn must reach
+// the verdict's SeenURLs alongside the digest-harvested web URLs.
+func TestRunWorkerSurfacesKBSinkRefsOnVerdict(t *testing.T) {
+	agent := &kbExecutingAgent{scriptedAgent: scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"researched"}`)},
+	}}}
+	r := newTestRunner(agent)
+	r.kbSearch = func(ctx context.Context, query string, collections []string, mode string, k int) ([]builtin.KBSearchHit, error) {
+		return []builtin.KBSearchHit{{DocumentID: "aaaaaaaa-0000-0000-0000-000000000001", DocumentTitle: "Runbook", Content: "content"}}, nil
+	}
+	v, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default", Knowledge: []string{"docs"}}, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	want := []string{"kb://aaaaaaaa-0000-0000-0000-000000000001"}
+	if !slices.Equal(v.SeenURLs, want) {
+		t.Fatalf("RunWorker verdict SeenURLs = %v, want %v", v.SeenURLs, want)
+	}
+}
+
+// kbExecutingAgent stands in for the loop actually running the offered
+// kb_search tool mid-turn: Start executes it for real (so the tool's
+// closure records into the worker's sink) before replaying the
+// scripted events.
+type kbExecutingAgent struct {
+	scriptedAgent
+}
+
+func (a *kbExecutingAgent) Start(ctx context.Context, req loop.Request) (<-chan stream.StreamEvent, error) {
+	for _, tool := range req.ExtraTools {
+		if tool.Name == "kb_search" {
+			if _, err := tool.Execute(ctx, json.RawMessage(`{"query":"q"}`)); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return a.scriptedAgent.Start(ctx, req)
+}
+
+// TestRunWorkerOffersKBSearchOnlyWhenMissionHasKnowledge covers
+// kbSearchTool's opt-in-only contract: no backend wired, or a mission
+// with an empty Knowledge snapshot, must never put kb_search on the
+// turn's offered tool surface (chat.go's kbSearchTool mirrors this
+// exactly on the chat side).
+func TestRunWorkerOffersKBSearchOnlyWhenMissionHasKnowledge(t *testing.T) {
+	hasKBSearch := func(req loop.Request) bool {
+		for _, tool := range req.ExtraTools {
+			if tool.Name == "kb_search" {
+				return true
+			}
+		}
+		return false
+	}
+	doneBatch := [][]stream.StreamEvent{{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ok"}`)}}
+
+	t.Run("no backend wired", func(t *testing.T) {
+		agent := &scriptedAgent{batches: doneBatch}
+		r := newTestRunner(agent)
+		if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default", Knowledge: []string{"docs"}}, WorkPacket{Goal: "test"}); err != nil {
+			t.Fatalf("RunWorker: %v", err)
+		}
+		if hasKBSearch(agent.requests[0]) {
+			t.Fatal("kb_search offered with no backend wired")
+		}
+	})
+
+	t.Run("empty mission knowledge", func(t *testing.T) {
+		agent := &scriptedAgent{batches: doneBatch}
+		r := newTestRunner(agent)
+		r.kbSearch = func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error) {
+			return nil, nil
+		}
+		if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"}); err != nil {
+			t.Fatalf("RunWorker: %v", err)
+		}
+		if hasKBSearch(agent.requests[0]) {
+			t.Fatal("kb_search offered with empty mission Knowledge")
+		}
+	})
+
+	t.Run("backend wired and knowledge set", func(t *testing.T) {
+		agent := &scriptedAgent{batches: doneBatch}
+		r := newTestRunner(agent)
+		r.kbSearch = func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error) {
+			return nil, nil
+		}
+		if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default", Knowledge: []string{"docs"}}, WorkPacket{Goal: "test"}); err != nil {
+			t.Fatalf("RunWorker: %v", err)
+		}
+		if !hasKBSearch(agent.requests[0]) {
+			t.Fatal("kb_search not offered despite backend wired and non-empty Knowledge")
+		}
+	})
 }

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -96,6 +96,10 @@ type AgentDefaults struct {
 	// explicit budget_currency, or "USD" if that's also empty).
 	BudgetAmount      *float64
 	ApprovalAllowlist []string
+	// Knowledge is the agent's kb_collections allowlist, snapshotted
+	// onto the mission the same way PromptOverlay is (see
+	// missions.Mission.Knowledge).
+	Knowledge []string
 }
 
 // AgentResolver resolves an agent id to its defaults at FIRE time, not
@@ -376,17 +380,24 @@ func (s *Scheduler) markSkipped(ctx context.Context, tx pgx.Tx, sc Schedule, now
 // lazily the first time Advance/Drive touches it (see driver.go's
 // ensureProvisioned).
 func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedule) error {
-	t, promptOverlay := resolveTemplateDefaults(ctx, sc.MissionTemplate, s.resolve, s.routeForRole, s.routeExists, s.codingExecutorDefault)
+	t, promptOverlay, knowledge := resolveTemplateDefaults(ctx, sc.MissionTemplate, s.resolve, s.routeForRole, s.routeExists, s.codingExecutorDefault)
 	spec, _ := json.Marshal(Spec{})
 	budgetCurrency := t.BudgetCurrency
 	if budgetCurrency == "" {
 		budgetCurrency = "USD"
 	}
-	_, err := tx.Exec(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, auto_approve_safe, spec, schedule_id, harness, environment)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
+	if knowledge == nil {
+		knowledge = []string{}
+	}
+	knowledgeJSON, err := json.Marshal(knowledge)
+	if err != nil {
+		return fmt.Errorf("marshal knowledge: %w", err)
+	}
+	_, err = tx.Exec(ctx, `INSERT INTO missions
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, knowledge, auto_approve_safe, spec, schedule_id, harness, environment)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
 		t.Goal, sc.Name, t.Kind, t.AgentID, orDefault(t.MaxIterations, 8), t.BudgetAmount, budgetCurrency, t.Route, t.ReviewRoute, t.PlanRoute,
-		promptOverlay, t.AutoApproveSafe, spec, sc.ID, t.Harness, t.Environment)
+		promptOverlay, knowledgeJSON, t.AutoApproveSafe, spec, sc.ID, t.Harness, t.Environment)
 	return err
 }
 
@@ -402,8 +413,9 @@ func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedu
 // (DefaultCodingRoute), and a coding template that omits harness gets
 // the settings default (D-051) — mirrors api/missions.go create()'s
 // own precedence so a scheduler-fired mission inherits it too.
-func resolveTemplateDefaults(ctx context.Context, t MissionTemplate, resolve AgentResolver, routeForRole func(context.Context, string) string, routeExists func(context.Context, string) bool, codingExecutorDefault func(context.Context) string) (MissionTemplate, string) {
+func resolveTemplateDefaults(ctx context.Context, t MissionTemplate, resolve AgentResolver, routeForRole func(context.Context, string) string, routeExists func(context.Context, string) bool, codingExecutorDefault func(context.Context) string) (MissionTemplate, string, []string) {
 	promptOverlay := ""
+	var knowledge []string
 	if resolve != nil {
 		if defaults, ok := resolve(ctx, t.AgentID); ok {
 			if t.Route == "" {
@@ -416,6 +428,7 @@ func resolveTemplateDefaults(ctx context.Context, t MissionTemplate, resolve Age
 				t.BudgetAmount = defaults.BudgetAmount
 			}
 			promptOverlay = defaults.PromptOverlay
+			knowledge = defaults.Knowledge
 		}
 	}
 	defaultRoute := ""
@@ -448,5 +461,5 @@ func resolveTemplateDefaults(ctx context.Context, t MissionTemplate, resolve Age
 	if t.Kind == "coding" && t.Environment == "" {
 		t.Environment, _ = DetectEnvironment("", t.Goal)
 	}
-	return t, promptOverlay
+	return t, promptOverlay, knowledge
 }

--- a/internal/brain/missions/scheduler_test.go
+++ b/internal/brain/missions/scheduler_test.go
@@ -2,6 +2,7 @@ package missions
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 )
@@ -102,6 +103,7 @@ func TestResolveTemplateDefaults(t *testing.T) {
 		wantBudget    *float64
 		wantOverlay   string
 		wantHarness   string
+		wantKnowledge []string
 	}{
 		{
 			name:       "nil resolver falls back to the default role's route",
@@ -156,6 +158,26 @@ func TestResolveTemplateDefaults(t *testing.T) {
 			wantReview:  "careful",
 			wantBudget:  &budget,
 			wantOverlay: "overlay text",
+		},
+		{
+			name:     "resolved agent's knowledge collections are returned",
+			template: MissionTemplate{Goal: "g", AgentID: "briefing"},
+			resolve: func(ctx context.Context, agentID string) (AgentDefaults, bool) {
+				return AgentDefaults{Route: "fast", ReviewRoute: "careful", Knowledge: []string{"docs", "runbooks"}}, true
+			},
+			wantRoute:     "fast",
+			wantReview:    "careful",
+			wantKnowledge: []string{"docs", "runbooks"},
+		},
+		{
+			name:     "unresolved agent id yields no knowledge",
+			template: MissionTemplate{Goal: "g", AgentID: "missing"},
+			resolve: func(ctx context.Context, agentID string) (AgentDefaults, bool) {
+				return AgentDefaults{}, false
+			},
+			wantRoute:     "default",
+			wantReview:    "default",
+			wantKnowledge: nil,
 		},
 		{
 			name:     "template's own non-empty fields are never overwritten",
@@ -227,7 +249,7 @@ func TestResolveTemplateDefaults(t *testing.T) {
 					return false
 				}
 			}
-			got, overlay := resolveTemplateDefaults(context.Background(), tc.template, tc.resolve, routeForRole, routeExists, tc.codingExec)
+			got, overlay, knowledge := resolveTemplateDefaults(context.Background(), tc.template, tc.resolve, routeForRole, routeExists, tc.codingExec)
 			if got.Route != tc.wantRoute {
 				t.Errorf("Route = %q, want %q", got.Route, tc.wantRoute)
 			}
@@ -247,6 +269,9 @@ func TestResolveTemplateDefaults(t *testing.T) {
 			}
 			if got.Harness != tc.wantHarness {
 				t.Errorf("Harness = %q, want %q", got.Harness, tc.wantHarness)
+			}
+			if !slices.Equal(knowledge, tc.wantKnowledge) {
+				t.Errorf("knowledge = %v, want %v", knowledge, tc.wantKnowledge)
 			}
 		})
 	}

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -46,7 +46,7 @@ func (s *Store) SetHub(hub *Hub) {
 const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_reason, pause_message,
 	workspace, worktree, branch, base_commit, spec, progress, iteration, max_iterations,
 	consecutive_failures, last_gap_fingerprint, stall_count, budget_amount, budget_currency, route, review_route,
-	plan_route, escalation_route, prompt_overlay,
+	plan_route, escalation_route, prompt_overlay, knowledge,
 	pending_permission, pending_permission_tool, pending_permission_args,
 	pending_permission_danger, pending_permission_rationale, auto_approve_safe, last_evidence,
 	explore_notes, replan_used, schedule_id, session_id, harness, environment, repo_url, connector_id, on_complete,
@@ -63,13 +63,13 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		agentID, scheduleID, sessionID, parentMission *string
 		phase, status                                 string
 		pendingPermission                             *string
-		spec, progress, attachmentsRaw                []byte
+		spec, progress, attachmentsRaw, knowledgeRaw  []byte
 		failureReason                                 *string
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
 		&m.ConsecutiveFailures, &m.LastGapFingerprint, &m.StallCount, &m.BudgetAmount, &m.BudgetCurrency, &m.Route, &m.ReviewRoute,
-		&m.PlanRoute, &m.EscalationRoute, &m.PromptOverlay,
+		&m.PlanRoute, &m.EscalationRoute, &m.PromptOverlay, &knowledgeRaw,
 		&pendingPermission, &m.PendingPermissionTool, &m.PendingPermissionArgs,
 		&m.PendingPermissionDanger, &m.PendingPermissionRationale, &m.AutoApproveSafe, &m.LastEvidence,
 		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
@@ -78,6 +78,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&failureReason); err != nil {
 		return Mission{}, err
 	}
+	_ = json.Unmarshal(knowledgeRaw, &m.Knowledge)
 	if agentID != nil {
 		m.AgentID = *agentID
 	}
@@ -138,12 +139,12 @@ func scanMission(row pgx.Row) (Mission, error) {
 		agentID, scheduleID, sessionID, parentMission *string
 		phase, status                                 string
 		pendingPermission                             *string
-		spec, progress, attachmentsRaw                []byte
+		spec, progress, attachmentsRaw, knowledgeRaw  []byte
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
 		&m.ConsecutiveFailures, &m.LastGapFingerprint, &m.StallCount, &m.BudgetAmount, &m.BudgetCurrency, &m.Route, &m.ReviewRoute,
-		&m.PlanRoute, &m.EscalationRoute, &m.PromptOverlay,
+		&m.PlanRoute, &m.EscalationRoute, &m.PromptOverlay, &knowledgeRaw,
 		&pendingPermission, &m.PendingPermissionTool, &m.PendingPermissionArgs,
 		&m.PendingPermissionDanger, &m.PendingPermissionRationale, &m.AutoApproveSafe, &m.LastEvidence,
 		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
@@ -151,6 +152,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&m.CreatedAt, &m.UpdatedAt); err != nil {
 		return Mission{}, err
 	}
+	_ = json.Unmarshal(knowledgeRaw, &m.Knowledge)
 	if agentID != nil {
 		m.AgentID = *agentID
 	}
@@ -213,15 +215,25 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("missions create attachments: %w", err)
 	}
+	// knowledge is NOT NULL; a nil slice marshals to "null", so a
+	// mission with no knowledge collections gets "[]" instead.
+	knowledge := m.Knowledge
+	if knowledge == nil {
+		knowledge = []string{}
+	}
+	knowledgeJSON, err := json.Marshal(knowledge)
+	if err != nil {
+		return "", fmt.Errorf("missions create knowledge: %w", err)
+	}
 	var id string
 	budgetCurrency := m.BudgetCurrency
 	if budgetCurrency == "" {
 		budgetCurrency = "USD"
 	}
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, prompt_overlay, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, attachments)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, NULLIF($14, '')::uuid, $15, $16, $17, $18, $19, $20, $21, $22, NULLIF($23, '')::uuid, $24, $25) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 8), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.PromptOverlay, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, attachmentsJSON,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, attachments)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NULLIF($15, '')::uuid, $16, $17, $18, $19, $20, $21, $22, $23, NULLIF($24, '')::uuid, $25, $26) RETURNING id`,
+		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 8), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, attachmentsJSON,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -309,6 +310,43 @@ func TestMissionPromptOverlayRoundTrips(t *testing.T) {
 	}
 	if m2.PromptOverlay != "" {
 		t.Fatalf("PromptOverlay = %q, want empty when not set", m2.PromptOverlay)
+	}
+}
+
+// TestMissionKnowledgeRoundTrips covers Knowledge: a snapshot of the
+// creating agent's kb_collections at create time, same shape as
+// PromptOverlay above.
+func TestMissionKnowledgeRoundTrips(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{
+		Goal: marker + "knowledge", Kind: "general", Route: "default",
+		Knowledge: []string{"docs", "runbooks"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !slices.Equal(m.Knowledge, []string{"docs", "runbooks"}) {
+		t.Fatalf("Knowledge = %v, want it to round-trip unchanged", m.Knowledge)
+	}
+
+	// Absent means "kb_search never offered" — must stay empty, not some
+	// driver default.
+	id2, err := s.Create(ctx, Mission{Goal: marker + "no-knowledge", Kind: "general", Route: "default"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	m2, err := s.Get(ctx, id2)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(m2.Knowledge) != 0 {
+		t.Fatalf("Knowledge = %v, want empty when not set", m2.Knowledge)
 	}
 }
 

--- a/internal/brain/missions/verify.go
+++ b/internal/brain/missions/verify.go
@@ -131,13 +131,15 @@ func CheckArtifacts(workRoot string, artifacts []string) []string {
 }
 
 // citedURLPattern matches both markdown links ([text](http...)) and
-// bare http(s) URLs. Markdown link targets are captured first so a
-// bare-URL scan doesn't also pick up the same URL again from inside
-// the parens (D-059).
-var citedURLPattern = regexp.MustCompile(`\[[^\]]*\]\((https?://[^\s)]+)\)|(https?://[^\s)\]]+)`)
+// bare http(s) URLs, plus kb://<document_id> refs (kbsearch.go's
+// formatKBHits "Source:" line) in either form. Markdown link targets
+// are captured first so a bare-ref scan doesn't also pick up the same
+// URL/ref again from inside the parens (D-059).
+var citedURLPattern = regexp.MustCompile(`\[[^\]]*\]\(((?:https?|kb)://[^\s)]+)\)|((?:https?|kb)://[^\s)\]]+)`)
 
-// ExtractCitedURLs pulls every http(s) URL cited in text — markdown
-// link targets and bare URLs alike — in first-seen order, deduplicated.
+// ExtractCitedURLs pulls every http(s) URL and kb:// reference cited in
+// text — markdown link targets and bare refs alike — in first-seen
+// order, deduplicated.
 func ExtractCitedURLs(text string) []string {
 	matches := citedURLPattern.FindAllStringSubmatch(text, -1)
 	seen := make(map[string]bool, len(matches))
@@ -147,7 +149,18 @@ func ExtractCitedURLs(text string) []string {
 		if u == "" {
 			u = m[2]
 		}
-		if u == "" || seen[u] {
+		if u == "" {
+			continue
+		}
+		// A bare kb:// ref is a bounded UUID, so anything past it —
+		// "kb://<id>;" at a clause boundary — is prose punctuation the
+		// bare-ref branch swallowed, never part of the ref.
+		if rest, ok := strings.CutPrefix(u, "kb://"); ok {
+			u = "kb://" + strings.TrimRightFunc(rest, func(r rune) bool {
+				return r != '-' && (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F')
+			})
+		}
+		if seen[u] {
 			continue
 		}
 		seen[u] = true
@@ -174,13 +187,15 @@ func NormalizeURL(raw string) string {
 	return u.String()
 }
 
-// CheckCitations verifies every http(s) URL cited in a unit's declared
-// artifacts was actually seen by the worker this turn — via web_fetch's
-// url arg or a web_search result URL — never merely claimed. Scoped to
+// CheckCitations verifies every http(s) URL and kb:// reference cited
+// in a unit's declared artifacts was actually seen by the worker this
+// turn — via web_fetch's url arg, a web_search result URL, or a
+// kb_search result's kb:// ref — never merely claimed. Scoped to
 // "general" missions only (D-059): coding missions cite source, not
-// the web. seenURLs empty and the artifact cites nothing passes
-// trivially; seenURLs empty with citations present fails everything,
-// since no web tool call at all cannot have produced any of them.
+// the web/knowledge base. seenURLs empty and the artifact cites
+// nothing passes trivially; seenURLs empty with citations present
+// fails everything, since no tool call at all cannot have produced any
+// of them.
 func CheckCitations(workRoot string, artifacts, seenURLs []string) []string {
 	allowed := make(map[string]bool, len(seenURLs))
 	for _, u := range seenURLs {
@@ -218,8 +233,52 @@ func CheckCitations(workRoot string, artifacts, seenURLs []string) []string {
 		}
 		if len(unknown) > 0 {
 			sort.Strings(unknown)
-			problems = append(problems, fmt.Sprintf("%s: cited URL(s) never seen via web_fetch/web_search this turn: %s — fetch a source with web_fetch before citing it", rel, strings.Join(unknown, ", ")))
+			problems = append(problems, fmt.Sprintf("%s: %s — %s", rel, unknownCitationSummary(unknown), unknownCitationFix(unknown)))
 		}
 	}
 	return problems
+}
+
+// unknownCitationSummary labels an unknown-citation list "URL(s)",
+// "kb reference(s)", or a mix — the failure message only names kb
+// refs when at least one is actually present, so a citations-web-only
+// unit's message never mentions a tool it had no reason to use.
+func unknownCitationSummary(unknown []string) string {
+	hasKB, hasURL := false, false
+	for _, u := range unknown {
+		if strings.HasPrefix(u, "kb://") {
+			hasKB = true
+		} else {
+			hasURL = true
+		}
+	}
+	switch {
+	case hasKB && hasURL:
+		return "cited URL(s)/kb reference(s) never seen this turn: " + strings.Join(unknown, ", ")
+	case hasKB:
+		return "cited kb reference(s) never seen via kb_search this turn: " + strings.Join(unknown, ", ")
+	default:
+		return "cited URL(s) never seen via web_fetch/web_search this turn: " + strings.Join(unknown, ", ")
+	}
+}
+
+// unknownCitationFix names the fix matching unknownCitationSummary's
+// scope.
+func unknownCitationFix(unknown []string) string {
+	hasKB, hasURL := false, false
+	for _, u := range unknown {
+		if strings.HasPrefix(u, "kb://") {
+			hasKB = true
+		} else {
+			hasURL = true
+		}
+	}
+	switch {
+	case hasKB && hasURL:
+		return "fetch a source with web_fetch, or search for it with kb_search, before citing it"
+	case hasKB:
+		return "search for it with kb_search before citing it"
+	default:
+		return "fetch a source with web_fetch before citing it"
+	}
 }

--- a/internal/brain/missions/verify_test.go
+++ b/internal/brain/missions/verify_test.go
@@ -156,6 +156,10 @@ func TestExtractCitedURLs(t *testing.T) {
 		{"duplicate collapses to one", "https://example.com/x and again https://example.com/x", []string{"https://example.com/x"}},
 		{"http scheme included", "http://example.com/plain", []string{"http://example.com/plain"}},
 		{"non-http scheme ignored", "see ftp://example.com/file", nil},
+		{"bare kb ref", "Source: kb://doc-123", []string{"kb://doc-123"}},
+		{"markdown kb link", "see [the doc](kb://doc-123) for more", []string{"kb://doc-123"}},
+		{"mixed kb ref and url", "kb://doc-123 and also https://example.com/x", []string{"kb://doc-123", "https://example.com/x"}},
+		{"bare kb ref sheds trailing punctuation", "cites kb://a1b2c3d4-0000-0000-0000-000000000001; and kb://a1b2c3d4-0000-0000-0000-000000000002.", []string{"kb://a1b2c3d4-0000-0000-0000-000000000001", "kb://a1b2c3d4-0000-0000-0000-000000000002"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -237,6 +241,24 @@ func TestCheckCitations(t *testing.T) {
 			content:   "[ref](https://example.com/docs)",
 			seenURLs:  nil,
 			wantProbs: 1,
+		},
+		{
+			name:      "cited kb ref was searched",
+			content:   "Source: kb://doc-123",
+			seenURLs:  []string{"kb://doc-123"},
+			wantProbs: 0,
+		},
+		{
+			name:      "invented kb ref fails",
+			content:   "Source: kb://doc-invented",
+			seenURLs:  []string{"kb://doc-other"},
+			wantProbs: 1,
+		},
+		{
+			name:      "kb ref and url both seen passes",
+			content:   "Source: kb://doc-123\nsee also [docs](https://example.com/docs)",
+			seenURLs:  []string{"kb://doc-123", "https://example.com/docs"},
+			wantProbs: 0,
 		},
 	}
 	for _, tc := range cases {

--- a/internal/brain/tools/builtin/kbsearch.go
+++ b/internal/brain/tools/builtin/kbsearch.go
@@ -1,0 +1,144 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+const (
+	kbSearchDefaultK = 8
+	kbSearchMaxK     = 10
+)
+
+var kbSearchModes = map[string]bool{"hybrid": true, "semantic": true, "keyword": true}
+
+// KBSearchHit is one retrieved chunk; memclient.KBChunkHit satisfies
+// this shape, passed in as a plain struct to keep this package free of
+// a memclient import.
+type KBSearchHit struct {
+	DocumentID    string
+	DocumentTitle string
+	Breadcrumb    string
+	Content       string
+	SourceRef     string
+}
+
+// KBSearchFunc runs one hybrid/semantic/keyword search scoped to
+// collections; main curries memclient.Client.KBSearch in with the
+// calling agent's collection allowlist already bound — collections are
+// NEVER a model-controlled argument (D-060: enforced in Go, not a
+// prompt).
+type KBSearchFunc func(ctx context.Context, query, mode string, k int) ([]KBSearchHit, error)
+
+type kbSearchArgs struct {
+	Query string `json:"query"`
+	Mode  string `json:"mode"`
+	K     *int   `json:"k"`
+}
+
+// KBSearch lets the model search one agent's allowed knowledge-base
+// collections. search is built per-agent, per-turn (see chat.go) with
+// the collection set already bound — this constructor never sees or
+// accepts collection names itself.
+func KBSearch(search KBSearchFunc) *tools.Tool {
+	return &tools.Tool{
+		Name: "kb_search",
+		Description: `Searches this agent's knowledge base collections and returns matching passages with their source.
+
+Use when the user asks about something that might be documented in the
+agent's configured knowledge base — internal docs, reference material,
+uploaded files — rather than general knowledge or long-term memory.
+
+Arguments:
+- query (string, required): what to search for.
+- mode (string, optional): "hybrid" (default, vector + keyword),
+  "semantic" (vector only), or "keyword" (full-text only).
+- k (integer, optional): how many passages to return, 1-10, default 8.
+
+Returns numbered passages, each with its document title, section
+breadcrumb, source reference, and content, plus a "Source:" line giving
+a stable kb:// reference — cite that reference when answering from a
+result.`,
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"query": {
+					"type": "string",
+					"description": "What to search for."
+				},
+				"mode": {
+					"type": "string",
+					"enum": ["hybrid", "semantic", "keyword"],
+					"description": "Retrieval mode; defaults to hybrid."
+				},
+				"k": {
+					"type": "integer",
+					"minimum": 1,
+					"maximum": 10,
+					"description": "Number of passages to return; defaults to 8."
+				}
+			},
+			"required": ["query"],
+			"additionalProperties": false
+		}`),
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
+			var args kbSearchArgs
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return "", fmt.Errorf("kb_search: invalid arguments: %w", err)
+			}
+			if strings.TrimSpace(args.Query) == "" {
+				return "", fmt.Errorf("kb_search: query must not be empty")
+			}
+			if args.Mode != "" && !kbSearchModes[args.Mode] {
+				return "", fmt.Errorf("kb_search: mode must be hybrid, semantic, or keyword, got %q", args.Mode)
+			}
+			k := kbSearchDefaultK
+			if args.K != nil {
+				k = *args.K
+				if k < 1 || k > kbSearchMaxK {
+					return "", fmt.Errorf("kb_search: k must be between 1 and %d, got %d", kbSearchMaxK, k)
+				}
+			}
+			hits, err := search(ctx, args.Query, args.Mode, k)
+			if err != nil {
+				return "", fmt.Errorf("kb_search: %w", err)
+			}
+			return formatKBHits(hits), nil
+		},
+	}
+}
+
+func formatKBHits(hits []KBSearchHit) string {
+	if len(hits) == 0 {
+		return "no matching passages found"
+	}
+	var b strings.Builder
+	for i, h := range hits {
+		b.WriteString(strconv.Itoa(i + 1))
+		b.WriteString(". ")
+		b.WriteString(h.DocumentTitle)
+		if h.Breadcrumb != "" {
+			b.WriteString(" — ")
+			b.WriteString(h.Breadcrumb)
+		}
+		if h.SourceRef != "" {
+			b.WriteString(" (")
+			b.WriteString(h.SourceRef)
+			b.WriteString(")")
+		}
+		b.WriteString("\n")
+		if h.DocumentID != "" {
+			b.WriteString("Source: kb://")
+			b.WriteString(h.DocumentID)
+			b.WriteString("\n")
+		}
+		b.WriteString(h.Content)
+		b.WriteString("\n\n")
+	}
+	return strings.TrimSpace(b.String())
+}

--- a/internal/brain/tools/builtin/kbsearch_test.go
+++ b/internal/brain/tools/builtin/kbsearch_test.go
@@ -1,0 +1,132 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeKBSearch struct {
+	hits     []KBSearchHit
+	err      error
+	sawQuery string
+	sawMode  string
+	sawK     int
+}
+
+func (f *fakeKBSearch) search(_ context.Context, query, mode string, k int) ([]KBSearchHit, error) {
+	f.sawQuery, f.sawMode, f.sawK = query, mode, k
+	return f.hits, f.err
+}
+
+func TestKBSearchFormatsHits(t *testing.T) {
+	t.Parallel()
+	fk := &fakeKBSearch{hits: []KBSearchHit{
+		{DocumentID: "doc-abc-123", DocumentTitle: "Runbook", Breadcrumb: "Runbook > Deploy", Content: "Run make deploy.", SourceRef: "runbook.md"},
+		{DocumentTitle: "FAQ", Content: "Ask ops."},
+	}}
+	tool := KBSearch(fk.search)
+	args, _ := json.Marshal(map[string]string{"query": "how to deploy"})
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	for _, want := range []string{"1. Runbook", "Runbook > Deploy", "runbook.md", "Source: kb://doc-abc-123", "Run make deploy.", "2. FAQ", "Ask ops."} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+	if fk.sawQuery != "how to deploy" || fk.sawK != kbSearchDefaultK {
+		t.Fatalf("query/k not passed through: query=%q k=%d", fk.sawQuery, fk.sawK)
+	}
+}
+
+// TestKBSearchOmitsSourceLineWithoutDocumentID covers a hit with no
+// DocumentID (a memclient response shape that predates this field, or
+// a genuinely missing id) — formatKBHits must not render a bare
+// "Source: kb://" ref with nothing after the scheme.
+func TestKBSearchOmitsSourceLineWithoutDocumentID(t *testing.T) {
+	t.Parallel()
+	fk := &fakeKBSearch{hits: []KBSearchHit{{DocumentTitle: "FAQ", Content: "Ask ops."}}}
+	tool := KBSearch(fk.search)
+	args, _ := json.Marshal(map[string]string{"query": "q"})
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(out, "Source: kb://") {
+		t.Fatalf("output has a Source line with no document id:\n%s", out)
+	}
+}
+
+func TestKBSearchNoResults(t *testing.T) {
+	t.Parallel()
+	fk := &fakeKBSearch{hits: nil}
+	tool := KBSearch(fk.search)
+	args, _ := json.Marshal(map[string]string{"query": "nothing"})
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out != "no matching passages found" {
+		t.Fatalf("out = %q", out)
+	}
+}
+
+func TestKBSearchRejectsEmptyQuery(t *testing.T) {
+	t.Parallel()
+	tool := KBSearch((&fakeKBSearch{}).search)
+	args, _ := json.Marshal(map[string]string{"query": "  "})
+	if _, err := tool.Execute(context.Background(), args); err == nil {
+		t.Fatal("expected an error for empty query")
+	}
+}
+
+func TestKBSearchRejectsInvalidMode(t *testing.T) {
+	t.Parallel()
+	tool := KBSearch((&fakeKBSearch{}).search)
+	args, _ := json.Marshal(map[string]string{"query": "x", "mode": "vibes"})
+	if _, err := tool.Execute(context.Background(), args); err == nil {
+		t.Fatal("expected an error for invalid mode")
+	}
+}
+
+func TestKBSearchRejectsKOutOfRange(t *testing.T) {
+	t.Parallel()
+	for _, k := range []int{0, 11, -1} {
+		k := k
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			tool := KBSearch((&fakeKBSearch{}).search)
+			args, _ := json.Marshal(map[string]any{"query": "x", "k": k})
+			if _, err := tool.Execute(context.Background(), args); err == nil {
+				t.Fatalf("k=%d: expected an error", k)
+			}
+		})
+	}
+}
+
+func TestKBSearchPassesModeAndK(t *testing.T) {
+	t.Parallel()
+	fk := &fakeKBSearch{}
+	tool := KBSearch(fk.search)
+	args, _ := json.Marshal(map[string]any{"query": "x", "mode": "keyword", "k": 3})
+	if _, err := tool.Execute(context.Background(), args); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fk.sawMode != "keyword" || fk.sawK != 3 {
+		t.Fatalf("mode/k = %q/%d, want keyword/3", fk.sawMode, fk.sawK)
+	}
+}
+
+func TestKBSearchPropagatesSearchError(t *testing.T) {
+	t.Parallel()
+	fk := &fakeKBSearch{err: errors.New("memoryd down")}
+	tool := KBSearch(fk.search)
+	args, _ := json.Marshal(map[string]string{"query": "x"})
+	if _, err := tool.Execute(context.Background(), args); err == nil {
+		t.Fatal("expected the search error to propagate")
+	}
+}

--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -82,8 +82,8 @@ func NewPermissions(db *pgpool.Pool, workspaceRoot string) *Permissions {
 			// protocol parked every mission's first turn for nothing.
 			"mission_status": true,
 			"review_verdict": true,
-			"submit_plan":   true,
-			"explore_notes": true,
+			"submit_plan":    true,
+			"explore_notes":  true,
 			// write_file is root-confined by construction (relative
 			// paths only, .. rejected, root fixed at registration) —
 			// there is nothing for a prompt to guard that the tool
@@ -94,6 +94,10 @@ func NewPermissions(db *pgpool.Pool, workspaceRoot string) *Permissions {
 			// web_search. mission_push is deliberately NOT here: it must
 			// always ask (see MissionPush's doc comment).
 			"missions": true,
+			// kb_search is a pure read scoped to collections bound in Go
+			// at construction (D-060), never model input — same reasoning
+			// as web_search/missions.
+			"kb_search": true,
 		},
 	}
 }

--- a/internal/memory/api/api.go
+++ b/internal/memory/api/api.go
@@ -41,12 +41,16 @@ type API struct {
 	embed       Embedder
 	store       Manager
 	consolidate ConsolidateRunner
+	kb          KBManager
+	kbDocs      DocumentStatusSetter
 	log         *slog.Logger
 }
 
-// Register mounts the routes.
-func Register(srv *httpserver.Server, ext Extractor, search Searcher, embed Embedder, st Manager, consolidate ConsolidateRunner, log *slog.Logger) {
-	a := &API{ext: ext, search: search, embed: embed, store: st, consolidate: consolidate, log: log}
+// Register mounts the routes. kb/kbDocs nil leaves /ingest-document and
+// /kb-search unmounted (WORKSPACES-style nil-gate, same as every other
+// optional surface).
+func Register(srv *httpserver.Server, ext Extractor, search Searcher, embed Embedder, st Manager, consolidate ConsolidateRunner, kb KBManager, kbDocs DocumentStatusSetter, log *slog.Logger) {
+	a := &API{ext: ext, search: search, embed: embed, store: st, consolidate: consolidate, kb: kb, kbDocs: kbDocs, log: log}
 	srv.Handle("POST /v1/extract", http.HandlerFunc(a.handleExtract))
 	srv.Handle("POST /v1/retrieve", http.HandlerFunc(a.handleRetrieve))
 	srv.Handle("GET /v1/memories", http.HandlerFunc(a.handleList))
@@ -56,6 +60,10 @@ func Register(srv *httpserver.Server, ext Extractor, search Searcher, embed Embe
 	srv.Handle("GET /v1/entities/graph", http.HandlerFunc(a.handleEntityGraph))
 	srv.Handle("GET /v1/entities/{id}/memories", http.HandlerFunc(a.handleEntityMemories))
 	srv.Handle("POST /v1/consolidate", http.HandlerFunc(a.handleConsolidate))
+	if kb != nil {
+		srv.Handle("POST /v1/ingest-document", http.HandlerFunc(a.handleIngest))
+		srv.Handle("POST /v1/kb-search", http.HandlerFunc(a.handleKBSearch))
+	}
 }
 
 // handleExtract runs extraction synchronously and returns the inserted

--- a/internal/memory/api/kb.go
+++ b/internal/memory/api/kb.go
@@ -1,0 +1,197 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/SumonMSelim/timothy/internal/memory/chunk"
+	"github.com/SumonMSelim/timothy/internal/memory/store"
+)
+
+// KBManager is the knowledge-base slice of the store; *store.KBStore
+// satisfies it. Nil leaves the KB routes unmounted.
+type KBManager interface {
+	ReplaceChunks(ctx context.Context, documentID string, chunks []store.KBChunk) error
+	KBSearch(ctx context.Context, query string, embedding store.Vector, collectionNames []string, mode store.KBSearchMode, k int) ([]store.KBSearchHit, error)
+}
+
+// DocumentStatusSetter reports ingestion outcomes back onto brain's
+// kb_documents row — memoryd only ever reports ready/failed here; it
+// does not own that table (internal/brain/kb does).
+type DocumentStatusSetter interface {
+	SetIngested(ctx context.Context, documentID string, chunkCount int) error
+	SetFailed(ctx context.Context, documentID string, errMsg string) error
+}
+
+type ingestRequest struct {
+	DocumentID string `json:"document_id"`
+	Title      string `json:"title"`
+	Markdown   string `json:"markdown"`
+}
+
+// handleIngest runs the synchronous ingestion pipeline: chunk, embed,
+// replace the document's existing chunks, report the outcome. Always
+// deletes-and-rewrites (ReplaceChunks) — a re-ingest is never additive.
+func (a *API) handleIngest(w http.ResponseWriter, r *http.Request) {
+	var req ingestRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if strings.TrimSpace(req.DocumentID) == "" || strings.TrimSpace(req.Markdown) == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "document_id and markdown are required")
+		return
+	}
+
+	pieces := chunk.Split(req.Title, req.Markdown)
+	if len(pieces) == 0 {
+		a.reportKBFailed(r.Context(), req.DocumentID, "document produced no chunks")
+		jsonError(w, http.StatusBadRequest, "empty_document", "document produced no chunks")
+		return
+	}
+
+	texts := make([]string, len(pieces))
+	for i, p := range pieces {
+		texts[i] = p.Breadcrumb + "\n\n" + p.Content
+	}
+	const embedPurpose = "kb-ingest"
+	vecs, err := a.embed.Embed(r.Context(), texts, embedPurpose)
+	if err != nil {
+		a.log.Warn("kb ingest embedding failed", "document_id", req.DocumentID, "error", err)
+		a.reportKBFailed(r.Context(), req.DocumentID, fmt.Sprintf("embedding failed: %v", err))
+		jsonError(w, http.StatusBadGateway, "embedding_failed", err.Error())
+		return
+	}
+
+	chunks := make([]store.KBChunk, len(pieces))
+	for i, p := range pieces {
+		chunks[i] = store.KBChunk{
+			Seq: p.Seq, Breadcrumb: p.Breadcrumb, Content: p.Content,
+			Embedding: store.Vector(vecs[i]), EmbeddingModel: embedPurpose,
+		}
+	}
+	if err := a.kb.ReplaceChunks(r.Context(), req.DocumentID, chunks); err != nil {
+		a.log.Warn("kb ingest store failed", "document_id", req.DocumentID, "error", err)
+		a.reportKBFailed(r.Context(), req.DocumentID, err.Error())
+		jsonError(w, http.StatusInternalServerError, "ingest_failed", err.Error())
+		return
+	}
+	if a.kbDocs != nil {
+		if err := a.kbDocs.SetIngested(r.Context(), req.DocumentID, len(chunks)); err != nil {
+			a.log.Warn("kb ingest status update failed", "document_id", req.DocumentID, "error", err)
+		}
+	}
+	a.log.Info("kb document ingested", "document_id", req.DocumentID, "chunks", len(chunks))
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"chunk_count": len(chunks)})
+}
+
+func (a *API) reportKBFailed(ctx context.Context, documentID, msg string) {
+	if a.kbDocs == nil {
+		return
+	}
+	if err := a.kbDocs.SetFailed(ctx, documentID, msg); err != nil {
+		a.log.Warn("kb ingest failure report failed", "document_id", documentID, "error", err)
+	}
+}
+
+type kbSearchRequest struct {
+	Query           string   `json:"query"`
+	CollectionNames []string `json:"collection_names"`
+	Mode            string   `json:"mode"`
+	K               int      `json:"k"`
+}
+
+type kbSearchHitJSON struct {
+	ChunkID       string  `json:"chunk_id"`
+	DocumentID    string  `json:"document_id"`
+	DocumentTitle string  `json:"document_title"`
+	Collection    string  `json:"collection"`
+	Breadcrumb    string  `json:"breadcrumb"`
+	Content       string  `json:"content"`
+	Score         float64 `json:"score"`
+	SourceRef     string  `json:"source_ref"`
+}
+
+const (
+	kbSearchDefaultK = 8
+	kbSearchMaxK     = 10
+)
+
+// handleKBSearch runs hybrid/semantic/keyword retrieval scoped to the
+// caller-provided collection names — collection_names is required and
+// non-empty; brain resolves it from the calling agent's Knowledge
+// allowlist before this call, but memoryd enforces the non-empty
+// requirement independently rather than trusting the caller.
+func (a *API) handleKBSearch(w http.ResponseWriter, r *http.Request) {
+	var req kbSearchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Query) == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "query is required")
+		return
+	}
+	if len(req.CollectionNames) == 0 {
+		jsonError(w, http.StatusBadRequest, "bad_request", "collection_names must be non-empty")
+		return
+	}
+	mode := store.KBSearchMode(req.Mode)
+	switch mode {
+	case "", store.KBSearchHybrid:
+		mode = store.KBSearchHybrid
+	case store.KBSearchSemantic, store.KBSearchKeyword:
+	default:
+		jsonError(w, http.StatusBadRequest, "bad_request", "mode must be hybrid, semantic, or keyword")
+		return
+	}
+	k := req.K
+	if k <= 0 {
+		k = kbSearchDefaultK
+	}
+	if k > kbSearchMaxK {
+		k = kbSearchMaxK
+	}
+
+	var embedding store.Vector
+	if mode != store.KBSearchKeyword {
+		vecs, err := a.embed.Embed(r.Context(), []string{req.Query}, "kb-search")
+		if err != nil {
+			a.log.Warn("kb search embedding failed; degrading to keyword-only", "error", err)
+			if mode == store.KBSearchSemantic {
+				jsonError(w, http.StatusBadGateway, "embedding_failed", err.Error())
+				return
+			}
+			mode = store.KBSearchKeyword
+		} else {
+			embedding = vecs[0]
+		}
+	}
+
+	hits, err := a.kb.KBSearch(r.Context(), req.Query, embedding, req.CollectionNames, mode, k)
+	if err != nil {
+		a.log.Warn("kb search failed", "error", err)
+		jsonError(w, http.StatusInternalServerError, "search_failed", err.Error())
+		return
+	}
+
+	out := make([]kbSearchHitJSON, len(hits))
+	var topScore float64
+	for i, hit := range hits {
+		out[i] = kbSearchHitJSON{
+			ChunkID: hit.ChunkID, DocumentID: hit.DocumentID, DocumentTitle: hit.DocumentTitle,
+			Collection: hit.Collection, Breadcrumb: hit.Breadcrumb, Content: hit.Content,
+			Score: hit.Score, SourceRef: hit.SourceRef,
+		}
+		if i == 0 {
+			topScore = hit.Score
+		}
+	}
+	a.log.Info("kb search", "mode", string(mode), "k", k, "top_score", topScore, "rows", len(out))
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"results": out})
+}

--- a/internal/memory/api/kb_test.go
+++ b/internal/memory/api/kb_test.go
@@ -1,0 +1,226 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/memory/store"
+)
+
+type fakeKB struct {
+	replacedDocID string
+	replacedCount int
+	replaceErr    error
+
+	searchHits []store.KBSearchHit
+	searchErr  error
+	sawQuery   string
+	sawNames   []string
+	sawMode    store.KBSearchMode
+	sawK       int
+	sawEmb     store.Vector
+}
+
+func (f *fakeKB) ReplaceChunks(_ context.Context, documentID string, chunks []store.KBChunk) error {
+	f.replacedDocID = documentID
+	f.replacedCount = len(chunks)
+	return f.replaceErr
+}
+
+func (f *fakeKB) KBSearch(_ context.Context, query string, embedding store.Vector, names []string, mode store.KBSearchMode, k int) ([]store.KBSearchHit, error) {
+	f.sawQuery, f.sawEmb, f.sawNames, f.sawMode, f.sawK = query, embedding, names, mode, k
+	return f.searchHits, f.searchErr
+}
+
+type fakeDocStatus struct {
+	ingestedID    string
+	ingestedCount int
+	failedID      string
+	failedMsg     string
+}
+
+func (f *fakeDocStatus) SetIngested(_ context.Context, documentID string, chunkCount int) error {
+	f.ingestedID, f.ingestedCount = documentID, chunkCount
+	return nil
+}
+
+func (f *fakeDocStatus) SetFailed(_ context.Context, documentID string, errMsg string) error {
+	f.failedID, f.failedMsg = documentID, errMsg
+	return nil
+}
+
+func kbAPIFor(kb KBManager, docs DocumentStatusSetter, embed Embedder) *API {
+	return &API{kb: kb, kbDocs: docs, embed: embed, log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+func postJSON(t *testing.T, handler http.HandlerFunc, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+	return rec
+}
+
+func TestIngestChunksEmbedsAndStores(t *testing.T) {
+	t.Parallel()
+	kb := &fakeKB{}
+	docs := &fakeDocStatus{}
+	a := kbAPIFor(kb, docs, &fakeEmbedder{})
+	body := `{"document_id":"doc-1","title":"Doc","markdown":"## Section\nsome content here"}`
+	rec := postJSON(t, a.handleIngest, "/v1/ingest-document", body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body %s", rec.Code, rec.Body)
+	}
+	if kb.replacedDocID != "doc-1" || kb.replacedCount == 0 {
+		t.Fatalf("chunks not stored: doc=%s count=%d", kb.replacedDocID, kb.replacedCount)
+	}
+	if docs.ingestedID != "doc-1" || docs.ingestedCount != kb.replacedCount {
+		t.Fatalf("status not reported ingested: %+v", docs)
+	}
+}
+
+func TestIngestValidation(t *testing.T) {
+	t.Parallel()
+	for name, body := range map[string]string{
+		"missing document_id": `{"markdown":"x"}`,
+		"missing markdown":    `{"document_id":"d1"}`,
+		"bad json":            `{`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			a := kbAPIFor(&fakeKB{}, &fakeDocStatus{}, &fakeEmbedder{})
+			rec := postJSON(t, a.handleIngest, "/v1/ingest-document", body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", rec.Code)
+			}
+		})
+	}
+}
+
+func TestIngestEmbeddingFailureReportsFailedStatus(t *testing.T) {
+	t.Parallel()
+	docs := &fakeDocStatus{}
+	a := kbAPIFor(&fakeKB{}, docs, &fakeEmbedder{err: errors.New("gateway down")})
+	rec := postJSON(t, a.handleIngest, "/v1/ingest-document", `{"document_id":"doc-2","markdown":"content"}`)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	if docs.failedID != "doc-2" {
+		t.Fatalf("failure not reported: %+v", docs)
+	}
+}
+
+func TestIngestStoreFailureReportsFailedStatus(t *testing.T) {
+	t.Parallel()
+	kb := &fakeKB{replaceErr: errors.New("db down")}
+	docs := &fakeDocStatus{}
+	a := kbAPIFor(kb, docs, &fakeEmbedder{})
+	rec := postJSON(t, a.handleIngest, "/v1/ingest-document", `{"document_id":"doc-3","markdown":"content"}`)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if docs.failedID != "doc-3" {
+		t.Fatalf("failure not reported: %+v", docs)
+	}
+}
+
+func TestKBSearchDefaultsToHybridAndEmbeds(t *testing.T) {
+	t.Parallel()
+	kb := &fakeKB{searchHits: []store.KBSearchHit{{ChunkID: "c1", Score: 0.9}}}
+	a := kbAPIFor(kb, nil, &fakeEmbedder{})
+	rec := postJSON(t, a.handleKBSearch, "/v1/kb-search", `{"query":"what is X","collection_names":["docs"]}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body %s", rec.Code, rec.Body)
+	}
+	if kb.sawMode != store.KBSearchHybrid {
+		t.Fatalf("mode = %s, want hybrid", kb.sawMode)
+	}
+	if len(kb.sawEmb) == 0 {
+		t.Fatal("hybrid mode must embed the query")
+	}
+	if kb.sawK != kbSearchDefaultK {
+		t.Fatalf("k = %d, want default %d", kb.sawK, kbSearchDefaultK)
+	}
+	var out struct {
+		Results []kbSearchHitJSON `json:"results"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Results) != 1 || out.Results[0].ChunkID != "c1" {
+		t.Fatalf("results = %+v", out.Results)
+	}
+}
+
+func TestKBSearchKeywordModeSkipsEmbedding(t *testing.T) {
+	t.Parallel()
+	kb := &fakeKB{}
+	embed := &fakeEmbedder{}
+	a := kbAPIFor(kb, nil, embed)
+	rec := postJSON(t, a.handleKBSearch, "/v1/kb-search", `{"query":"x","collection_names":["docs"],"mode":"keyword"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if kb.sawMode != store.KBSearchKeyword {
+		t.Fatalf("mode = %s, want keyword", kb.sawMode)
+	}
+	if kb.sawEmb != nil {
+		t.Fatal("keyword mode must not embed the query")
+	}
+}
+
+func TestKBSearchRequiresCollectionNames(t *testing.T) {
+	t.Parallel()
+	a := kbAPIFor(&fakeKB{}, nil, &fakeEmbedder{})
+	rec := postJSON(t, a.handleKBSearch, "/v1/kb-search", `{"query":"x","collection_names":[]}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestKBSearchKCapsAtMax(t *testing.T) {
+	t.Parallel()
+	kb := &fakeKB{}
+	a := kbAPIFor(kb, nil, &fakeEmbedder{})
+	rec := postJSON(t, a.handleKBSearch, "/v1/kb-search", `{"query":"x","collection_names":["docs"],"k":50}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if kb.sawK != kbSearchMaxK {
+		t.Fatalf("k = %d, want capped at %d", kb.sawK, kbSearchMaxK)
+	}
+}
+
+func TestKBSearchSemanticEmbeddingFailureIs502(t *testing.T) {
+	t.Parallel()
+	a := kbAPIFor(&fakeKB{}, nil, &fakeEmbedder{err: errors.New("no route")})
+	rec := postJSON(t, a.handleKBSearch, "/v1/kb-search", `{"query":"x","collection_names":["docs"],"mode":"semantic"}`)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+}
+
+func TestKBSearchHybridDegradesToKeywordOnEmbedFailure(t *testing.T) {
+	t.Parallel()
+	kb := &fakeKB{}
+	a := kbAPIFor(kb, nil, &fakeEmbedder{err: errors.New("no route")})
+	rec := postJSON(t, a.handleKBSearch, "/v1/kb-search", `{"query":"x","collection_names":["docs"]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (degraded)", rec.Code)
+	}
+	if kb.sawMode != store.KBSearchKeyword {
+		t.Fatalf("mode = %s, want degraded to keyword", kb.sawMode)
+	}
+}

--- a/internal/memory/chunk/chunk.go
+++ b/internal/memory/chunk/chunk.go
@@ -1,0 +1,234 @@
+// Package chunk splits a markdown document into embedding-sized
+// chunks for the knowledge base (D-060). Splits happen on heading
+// boundaries first, then on paragraph boundaries within an oversized
+// section; a code fence is never split. Each chunk carries a
+// breadcrumb (document title + heading path) prepended to the text
+// actually embedded, so a chunk retrieved out of context still reads
+// as "where it came from."
+package chunk
+
+import (
+	"strings"
+)
+
+const (
+	// targetTokens is the chunk size this package aims for.
+	targetTokens = 500
+	// maxTokens forces a section over this size to split further.
+	maxTokens = 600
+	// overlapRatio is how much of a split section's tail repeats at
+	// the head of the next chunk, so a fact spanning the cut isn't
+	// stranded in neither chunk.
+	overlapRatio = 0.15
+)
+
+// estimateTokens is a cheap chars/4 approximation — good enough to
+// size chunks, never used for billing.
+func estimateTokens(s string) int {
+	return len(s) / 4
+}
+
+// Chunk is one piece of a document, ready to embed and store.
+// Breadcrumb is kept separate from Content: callers embed
+// Breadcrumb+"\n\n"+Content but store them as distinct columns.
+type Chunk struct {
+	Seq        int
+	Breadcrumb string
+	Content    string
+}
+
+// heading is one parsed markdown heading line.
+type heading struct {
+	level int
+	text  string
+}
+
+// parseHeading returns the heading level and text if line is an ATX
+// heading ("# ", "## ", ...), or ok=false otherwise. Headings inside a
+// fenced code block are handled by the caller, not here.
+func parseHeading(line string) (heading, bool) {
+	trimmed := strings.TrimRight(line, " \t")
+	level := 0
+	for level < len(trimmed) && trimmed[level] == '#' {
+		level++
+	}
+	if level == 0 || level > 6 {
+		return heading{}, false
+	}
+	if level == len(trimmed) {
+		return heading{level: level, text: ""}, true
+	}
+	if trimmed[level] != ' ' && trimmed[level] != '\t' {
+		return heading{}, false
+	}
+	return heading{level: level, text: strings.TrimSpace(trimmed[level:])}, true
+}
+
+// section is one heading-delimited slice of the document, with the
+// heading path (title excluded) that leads to it.
+type section struct {
+	path []string
+	body string
+}
+
+// split walks the document line by line, tracking fence state so a
+// "#" inside a code block is never mistaken for a heading, and the
+// current heading path (one entry per active level).
+func split(markdown string) []section {
+	lines := strings.Split(markdown, "\n")
+	var sections []section
+	var path []string
+	var body strings.Builder
+	inFence := false
+
+	flush := func() {
+		if strings.TrimSpace(body.String()) != "" {
+			sections = append(sections, section{path: append([]string(nil), path...), body: body.String()})
+		}
+		body.Reset()
+	}
+
+	for _, line := range lines {
+		fenceLine := strings.HasPrefix(strings.TrimSpace(line), "```") || strings.HasPrefix(strings.TrimSpace(line), "~~~")
+		if fenceLine {
+			inFence = !inFence
+			body.WriteString(line)
+			body.WriteString("\n")
+			continue
+		}
+		if !inFence {
+			if h, ok := parseHeading(line); ok {
+				flush()
+				if h.level > len(path) {
+					for len(path) < h.level-1 {
+						path = append(path, "")
+					}
+					path = append(path, h.text)
+				} else {
+					path = append(path[:h.level-1], h.text)
+				}
+				continue
+			}
+		}
+		body.WriteString(line)
+		body.WriteString("\n")
+	}
+	flush()
+	return sections
+}
+
+// breadcrumb renders "Title > H2 > H3", skipping empty path entries
+// (a heading level jumped over, e.g. H1 then H3 directly).
+func breadcrumb(title string, path []string) string {
+	parts := []string{}
+	if title != "" {
+		parts = append(parts, title)
+	}
+	for _, p := range path {
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return strings.Join(parts, " > ")
+}
+
+// Split chunks markdown into embedding-sized pieces. title names the
+// document (the breadcrumb's first segment). A section within budget
+// becomes one chunk; an oversized section splits at paragraph
+// boundaries with overlap, never inside a code fence.
+func Split(title, markdown string) []Chunk {
+	var out []Chunk
+	for _, sec := range split(markdown) {
+		bc := breadcrumb(title, sec.path)
+		body := strings.TrimSpace(sec.body)
+		if body == "" {
+			continue
+		}
+		for _, piece := range splitOversized(body) {
+			out = append(out, Chunk{Breadcrumb: bc, Content: piece})
+		}
+	}
+	for i := range out {
+		out[i].Seq = i
+	}
+	return out
+}
+
+// paragraphs splits body on blank lines, keeping any fenced code block
+// intact as a single paragraph regardless of blank lines inside it.
+func paragraphs(body string) []string {
+	lines := strings.Split(body, "\n")
+	var out []string
+	var cur strings.Builder
+	inFence := false
+
+	flush := func() {
+		if s := strings.TrimSpace(cur.String()); s != "" {
+			out = append(out, s)
+		}
+		cur.Reset()
+	}
+
+	for _, line := range lines {
+		fenceLine := strings.HasPrefix(strings.TrimSpace(line), "```") || strings.HasPrefix(strings.TrimSpace(line), "~~~")
+		if fenceLine {
+			inFence = !inFence
+			cur.WriteString(line)
+			cur.WriteString("\n")
+			continue
+		}
+		if !inFence && strings.TrimSpace(line) == "" {
+			flush()
+			continue
+		}
+		cur.WriteString(line)
+		cur.WriteString("\n")
+	}
+	flush()
+	return out
+}
+
+// splitOversized returns body as-is when it fits maxTokens, else packs
+// its paragraphs into ~targetTokens pieces with a trailing-paragraph
+// overlap between consecutive pieces. A single paragraph bigger than
+// maxTokens (e.g. one huge code fence) is kept whole — never split
+// inside a fence.
+func splitOversized(body string) []string {
+	if estimateTokens(body) <= maxTokens {
+		return []string{body}
+	}
+
+	paras := paragraphs(body)
+	var pieces []string
+	var cur []string
+	curTokens := 0
+
+	pushPiece := func() {
+		if len(cur) == 0 {
+			return
+		}
+		pieces = append(pieces, strings.Join(cur, "\n\n"))
+	}
+
+	for _, p := range paras {
+		pt := estimateTokens(p)
+		if curTokens > 0 && curTokens+pt > targetTokens {
+			pushPiece()
+			// Overlap: carry the tail paragraphs of the just-closed
+			// piece into the next one, up to ~overlapRatio of target.
+			overlapBudget := int(float64(targetTokens) * overlapRatio)
+			var carry []string
+			carryTokens := 0
+			for i := len(cur) - 1; i >= 0 && carryTokens < overlapBudget; i-- {
+				carry = append([]string{cur[i]}, carry...)
+				carryTokens += estimateTokens(cur[i])
+			}
+			cur = carry
+			curTokens = carryTokens
+		}
+		cur = append(cur, p)
+		curTokens += pt
+	}
+	pushPiece()
+	return pieces
+}

--- a/internal/memory/chunk/chunk_test.go
+++ b/internal/memory/chunk/chunk_test.go
@@ -1,0 +1,147 @@
+package chunk
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSplitHeadingNesting(t *testing.T) {
+	t.Parallel()
+	md := "Intro text.\n\n" +
+		"## Section A\n" +
+		"A body.\n\n" +
+		"### Subsection A.1\n" +
+		"A1 body.\n\n" +
+		"## Section B\n" +
+		"B body.\n"
+
+	chunks := Split("Doc Title", md)
+	if len(chunks) != 4 {
+		t.Fatalf("got %d chunks, want 4: %+v", len(chunks), chunks)
+	}
+	want := []string{
+		"Doc Title",
+		"Doc Title > Section A",
+		"Doc Title > Section A > Subsection A.1",
+		"Doc Title > Section B",
+	}
+	for i, w := range want {
+		if chunks[i].Breadcrumb != w {
+			t.Errorf("chunk %d breadcrumb = %q, want %q", i, chunks[i].Breadcrumb, w)
+		}
+	}
+}
+
+func TestSplitSkipsHeadingLevelJump(t *testing.T) {
+	t.Parallel()
+	// H1 then H3 directly: the H2 slot must not leave a stray empty
+	// segment in the breadcrumb.
+	md := "# Title\nintro\n\n### Deep\nbody\n"
+	chunks := Split("Doc", md)
+	found := false
+	for _, c := range chunks {
+		if strings.Contains(c.Breadcrumb, "Deep") {
+			found = true
+			if strings.Contains(c.Breadcrumb, " >  > ") {
+				t.Errorf("breadcrumb has an empty segment: %q", c.Breadcrumb)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no chunk carried the Deep heading")
+	}
+}
+
+func TestSplitLongSectionOverlaps(t *testing.T) {
+	t.Parallel()
+	// Build a section well past maxTokens (600 tokens ≈ 2400 chars) out
+	// of many small paragraphs so it must split, and check consecutive
+	// pieces share at least one paragraph (the overlap).
+	var b strings.Builder
+	b.WriteString("## Big Section\n")
+	paras := make([]string, 40)
+	for i := range paras {
+		paras[i] = strings.Repeat("word", 20) + " para" + string(rune('a'+i%26))
+		b.WriteString(paras[i])
+		b.WriteString("\n\n")
+	}
+	chunks := Split("Doc", b.String())
+	if len(chunks) < 2 {
+		t.Fatalf("expected the oversized section to split into multiple chunks, got %d", len(chunks))
+	}
+	for i := 0; i < len(chunks)-1; i++ {
+		if chunks[i].Breadcrumb != chunks[i+1].Breadcrumb {
+			continue // different section, no overlap expected
+		}
+		tailOfCur := lastParagraph(chunks[i].Content)
+		if !strings.Contains(chunks[i+1].Content, tailOfCur) {
+			t.Errorf("chunk %d and %d (same section) share no overlap paragraph", i, i+1)
+		}
+	}
+}
+
+func lastParagraph(s string) string {
+	parts := strings.Split(strings.TrimSpace(s), "\n\n")
+	return parts[len(parts)-1]
+}
+
+func TestSplitKeepsCodeFenceIntact(t *testing.T) {
+	t.Parallel()
+	fence := "```go\nfunc main() {\n" + strings.Repeat("\tfmt.Println(\"line\")\n", 200) + "}\n```"
+	md := "## Code\n" + fence + "\n"
+	chunks := Split("Doc", md)
+	for _, c := range chunks {
+		openers := strings.Count(c.Content, "```")
+		if openers%2 != 0 {
+			t.Errorf("chunk has an unmatched code fence: %q", c.Content[:min(200, len(c.Content))])
+		}
+	}
+	// The fence must appear whole in at least one chunk.
+	joined := ""
+	for _, c := range chunks {
+		joined += c.Content
+	}
+	if !strings.Contains(joined, "func main()") || !strings.Contains(joined, "}\n```") {
+		t.Fatal("fence content lost across the split")
+	}
+}
+
+func TestSplitTinyDocument(t *testing.T) {
+	t.Parallel()
+	chunks := Split("Doc", "just one short line")
+	if len(chunks) != 1 {
+		t.Fatalf("got %d chunks, want 1", len(chunks))
+	}
+	if chunks[0].Breadcrumb != "Doc" {
+		t.Errorf("breadcrumb = %q, want %q", chunks[0].Breadcrumb, "Doc")
+	}
+	if chunks[0].Content != "just one short line" {
+		t.Errorf("content = %q", chunks[0].Content)
+	}
+}
+
+func TestSplitEmptyDocument(t *testing.T) {
+	t.Parallel()
+	chunks := Split("Doc", "")
+	if len(chunks) != 0 {
+		t.Fatalf("got %d chunks for empty doc, want 0", len(chunks))
+	}
+}
+
+func TestSplitSeqIsSequential(t *testing.T) {
+	t.Parallel()
+	md := "## A\nbody a\n\n## B\nbody b\n\n## C\nbody c\n"
+	chunks := Split("Doc", md)
+	for i, c := range chunks {
+		if c.Seq != i {
+			t.Errorf("chunk %d has Seq %d", i, c.Seq)
+		}
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/memory/store/kb.go
+++ b/internal/memory/store/kb.go
@@ -1,0 +1,225 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+// KBChunk is one chunk row ready to insert during ingestion.
+type KBChunk struct {
+	Seq            int
+	Breadcrumb     string
+	Content        string
+	Embedding      Vector
+	EmbeddingModel string
+}
+
+// KBStore persists knowledge-base chunks (D-060) and reports ingestion
+// outcomes onto brain's kb_documents row. Collection/document CRUD is
+// brain's own (internal/brain/kb) — memoryd only writes kb_chunks and
+// the narrow status/chunk_count/error columns ingestion owns, sharing
+// the one Postgres instance (D-060 doesn't split the database, just
+// the code that owns each table).
+type KBStore struct {
+	db *pgpool.Pool
+}
+
+func NewKBStore(db *pgpool.Pool) *KBStore {
+	return &KBStore{db: db}
+}
+
+// SetIngested marks a document ready after a successful ingest.
+func (s *KBStore) SetIngested(ctx context.Context, documentID string, chunkCount int) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("kb set ingested: %w", err)
+	}
+	_, err = db.Exec(ctx, `UPDATE kb_documents
+		SET status = 'ready', chunk_count = $2, error = '', ingested_at = now(), updated_at = now()
+		WHERE id = $1`, documentID, chunkCount)
+	if err != nil {
+		return fmt.Errorf("kb set ingested: %w", err)
+	}
+	return nil
+}
+
+// SetFailed marks a document failed with the given error message.
+func (s *KBStore) SetFailed(ctx context.Context, documentID string, errMsg string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("kb set failed: %w", err)
+	}
+	_, err = db.Exec(ctx, `UPDATE kb_documents
+		SET status = 'failed', error = $2, updated_at = now()
+		WHERE id = $1`, documentID, errMsg)
+	if err != nil {
+		return fmt.Errorf("kb set failed: %w", err)
+	}
+	return nil
+}
+
+// ReplaceChunks deletes every existing chunk for documentID and inserts
+// the new set in one transaction — re-ingest is delete-and-rewrite,
+// never an in-place update (KB documents are mutable reference data,
+// but a chunk's identity is only meaningful within one ingestion pass).
+func (s *KBStore) ReplaceChunks(ctx context.Context, documentID string, chunks []KBChunk) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("kb replace chunks: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("kb replace chunks begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+
+	if _, err := tx.Exec(ctx, `DELETE FROM kb_chunks WHERE document_id = $1`, documentID); err != nil {
+		return fmt.Errorf("kb replace chunks delete: %w", err)
+	}
+	for _, c := range chunks {
+		if _, err := tx.Exec(ctx, `INSERT INTO kb_chunks
+			(document_id, seq, breadcrumb, content, embedding, embedding_model)
+			VALUES ($1, $2, $3, $4, NULLIF($5, '')::vector, $6)`,
+			documentID, c.Seq, c.Breadcrumb, c.Content, c.Embedding.String(), c.EmbeddingModel); err != nil {
+			return fmt.Errorf("kb replace chunks insert: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("kb replace chunks commit: %w", err)
+	}
+	return nil
+}
+
+// KBSearchHit is one hybrid-retrieval result row.
+type KBSearchHit struct {
+	ChunkID       string
+	DocumentID    string
+	DocumentTitle string
+	Collection    string
+	Breadcrumb    string
+	Content       string
+	Score         float64
+	SourceRef     string
+}
+
+// KBSearchMode selects which leg(s) KBSearch runs.
+type KBSearchMode string
+
+const (
+	KBSearchHybrid   KBSearchMode = "hybrid"
+	KBSearchSemantic KBSearchMode = "semantic"
+	KBSearchKeyword  KBSearchMode = "keyword"
+)
+
+// legLimitLit/rrfKLit are string literals (not ints) so they concatenate
+// directly into the const SQL below — legLimit bounds each leg's
+// candidate set before RRF fusion, rrfK is the standard Reciprocal Rank
+// Fusion damping constant; both mirror the memories retrieval package's
+// own values (internal/memory/retrieval/search.go, fuse.go).
+const legLimitLit = "30"
+const rrfKLit = "60"
+
+// KBSearch runs hybrid (vector + full-text, RRF-fused), semantic-only,
+// or keyword-only retrieval over kb_chunks, scoped to collectionNames
+// (required, non-empty — collection scoping is enforced here in SQL,
+// never left to a prompt). embedding may be nil only when mode is
+// keyword; hybrid/semantic without an embedding return no results from
+// the vector leg (callers should not call semantic/hybrid without one).
+func (s *KBStore) KBSearch(ctx context.Context, query string, embedding Vector, collectionNames []string, mode KBSearchMode, k int) ([]KBSearchHit, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("kb search: %w", err)
+	}
+	if len(collectionNames) == 0 {
+		return nil, fmt.Errorf("kb search: collection_names is required")
+	}
+	if k <= 0 {
+		k = 8
+	}
+
+	var sql string
+	var args []any
+	switch mode {
+	case KBSearchSemantic:
+		sql, args = semanticSQL, []any{embedding.String(), collectionNames, k}
+	case KBSearchKeyword:
+		sql, args = keywordSQL, []any{query, collectionNames, k}
+	default:
+		sql, args = hybridSQL, []any{embedding.String(), query, collectionNames, k}
+	}
+
+	rows, err := db.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("kb search: %w", err)
+	}
+	defer rows.Close()
+
+	var out []KBSearchHit
+	for rows.Next() {
+		var h KBSearchHit
+		if err := rows.Scan(&h.ChunkID, &h.DocumentID, &h.DocumentTitle, &h.Collection,
+			&h.Breadcrumb, &h.Content, &h.SourceRef, &h.Score); err != nil {
+			return nil, fmt.Errorf("kb search: %w", err)
+		}
+		out = append(out, h)
+	}
+	return out, rows.Err()
+}
+
+const (
+	// kbProjection joins chunk -> document -> collection, scoped by
+	// collection name — the sole point collection access control is
+	// enforced (D-060: Go code, never a prompt).
+	kbProjection = `SELECT c.id, d.id, d.title, col.name, c.breadcrumb, c.content, d.source_ref`
+
+	semanticSQL = kbProjection + `, 1 - (c.embedding <=> $1::vector) AS score
+		FROM kb_chunks c
+		JOIN kb_documents d ON d.id = c.document_id
+		JOIN kb_collections col ON col.id = d.collection_id
+		WHERE col.name = ANY($2) AND c.embedding IS NOT NULL
+		ORDER BY c.embedding <=> $1::vector
+		LIMIT $3`
+
+	keywordSQL = kbProjection + `, ts_rank(c.tsv, websearch_to_tsquery('english', $1)) AS score
+		FROM kb_chunks c
+		JOIN kb_documents d ON d.id = c.document_id
+		JOIN kb_collections col ON col.id = d.collection_id
+		WHERE col.name = ANY($2) AND c.tsv @@ websearch_to_tsquery('english', $1)
+		ORDER BY score DESC
+		LIMIT $3`
+
+	// hybridSQL fuses a vector top-30 and an FTS top-30 leg via
+	// Reciprocal Rank Fusion (k=60), same fusion constant as the
+	// memories retrieval package. $1 embedding, $2 query, $3 collection
+	// names, $4 result count.
+	hybridSQL = `WITH vec AS (
+			SELECT c.id, row_number() OVER (ORDER BY c.embedding <=> $1::vector) AS rank
+			FROM kb_chunks c
+			JOIN kb_documents d ON d.id = c.document_id
+			JOIN kb_collections col ON col.id = d.collection_id
+			WHERE col.name = ANY($3) AND c.embedding IS NOT NULL
+			ORDER BY c.embedding <=> $1::vector
+			LIMIT ` + legLimitLit + `
+		), fts AS (
+			SELECT c.id, row_number() OVER (ORDER BY ts_rank(c.tsv, websearch_to_tsquery('english', $2)) DESC) AS rank
+			FROM kb_chunks c
+			JOIN kb_documents d ON d.id = c.document_id
+			JOIN kb_collections col ON col.id = d.collection_id
+			WHERE col.name = ANY($3) AND c.tsv @@ websearch_to_tsquery('english', $2)
+			ORDER BY rank
+			LIMIT ` + legLimitLit + `
+		), fused AS (
+			SELECT id, sum(1.0 / (` + rrfKLit + ` + rank)) AS score
+			FROM (SELECT id, rank FROM vec UNION ALL SELECT id, rank FROM fts) legs
+			GROUP BY id
+		)
+		` + kbProjection + `, fused.score
+		FROM fused
+		JOIN kb_chunks c ON c.id = fused.id
+		JOIN kb_documents d ON d.id = c.document_id
+		JOIN kb_collections col ON col.id = d.collection_id
+		ORDER BY fused.score DESC
+		LIMIT $4`
+)

--- a/migrations/0009_agents.sql
+++ b/migrations/0009_agents.sql
@@ -23,6 +23,10 @@ CREATE TABLE IF NOT EXISTS agents (
     review_route       text NOT NULL DEFAULT '',
     budget_usd         numeric(12,2),
     approval_allowlist jsonb NOT NULL DEFAULT '[]',
+    -- Knowledge collections (kb_collections.name) this agent may search
+    -- with kb_search (D-060) — empty means none, same opt-in semantics
+    -- as skills/tools: an agent must name a collection explicitly.
+    knowledge      jsonb NOT NULL DEFAULT '[]',
     created_at     timestamptz NOT NULL DEFAULT now(),
     updated_at     timestamptz NOT NULL DEFAULT now()
 );

--- a/migrations/0010_missions.sql
+++ b/migrations/0010_missions.sql
@@ -70,6 +70,13 @@ CREATE TABLE IF NOT EXISTS missions (
     -- agent lookup later without risking a surprise prompt change
     -- mid-mission if the agent row is edited while the mission runs.
     prompt_overlay        text NOT NULL DEFAULT '',
+    -- Knowledge snapshots the creating agent's kb_collections allowlist
+    -- at create time, same reasoning as prompt_overlay above — a
+    -- mission outlives the request that made it, so kb_search's
+    -- collection scoping can't re-resolve a live agent lookup later.
+    -- Empty array means kb_search is never offered on this mission's
+    -- turns, regardless of what the agent row says today.
+    knowledge             jsonb NOT NULL DEFAULT '[]',
     -- Harness snapshots the operator's execution-strategy choice for a
     -- coding mission's worker turns at create time, never re-read from
     -- settings at dispatch. "" is native; "claude-cli" (etc) names a

--- a/migrations/0012_knowledge.sql
+++ b/migrations/0012_knowledge.sql
@@ -1,0 +1,68 @@
+-- Knowledge base: named collections of ingested documents an agent can
+-- search with kb_search (D-060). Unlike memories, KB content is
+-- MUTABLE reference data — external documentation the operator curates,
+-- not something Timothy observed. Re-ingesting a document deletes its
+-- existing chunks and rewrites them; there is no supersede chain here.
+--
+-- D-060: KB is external memory, distinct from extracted long-term
+-- memory (D-011). When the two disagree, facts sourced from KB outrank
+-- extracted memories (a curated doc beats an inferred fact), but
+-- user-stated preferences from memory outrank KB (the user's own words
+-- beat any document). KB chunks are never written into the memories
+-- table — the two stores stay separate, resolved at use time, not
+-- merged at write time.
+
+CREATE TABLE IF NOT EXISTS kb_collections (
+    id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        text UNIQUE NOT NULL,
+    description text NOT NULL DEFAULT '',
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS kb_documents (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    collection_id uuid NOT NULL REFERENCES kb_collections (id) ON DELETE CASCADE,
+    title         text NOT NULL,
+    source_type   text NOT NULL DEFAULT 'file',
+    source_ref    text NOT NULL DEFAULT '',
+    content_hash  text NOT NULL DEFAULT '',
+    -- markdown is the markitdown conversion of the uploaded file,
+    -- persisted so a re-ingest never re-calls the sidecar (mirrors
+    -- mission attachments, D-05x); never served over the admin API.
+    markdown      text NOT NULL DEFAULT '',
+    status        text NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'ingesting', 'ready', 'failed')),
+    error         text NOT NULL DEFAULT '',
+    bytes         bigint NOT NULL DEFAULT 0,
+    chunk_count   int NOT NULL DEFAULT 0,
+    ingested_at   timestamptz,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS kb_documents_collection_idx ON kb_documents (collection_id);
+
+CREATE TABLE IF NOT EXISTS kb_chunks (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    document_id     uuid NOT NULL REFERENCES kb_documents (id) ON DELETE CASCADE,
+    seq             int NOT NULL,
+    breadcrumb      text NOT NULL DEFAULT '',
+    content         text NOT NULL,
+    -- Same dimension as memories.embedding (0005_memory.sql) — both
+    -- ride the gateway's one configured embedding model.
+    embedding       vector(1024),
+    embedding_model text NOT NULL DEFAULT '',
+    tsv             tsvector GENERATED ALWAYS AS (to_tsvector('english', content)) STORED,
+    metadata        jsonb NOT NULL DEFAULT '{}',
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (document_id, seq)
+);
+
+CREATE INDEX IF NOT EXISTS kb_chunks_embedding_hnsw
+    ON kb_chunks USING hnsw (embedding vector_cosine_ops)
+    WITH (m = 20, ef_construction = 200);
+
+CREATE INDEX IF NOT EXISTS kb_chunks_tsv_gin ON kb_chunks USING gin (tsv);
+
+CREATE INDEX IF NOT EXISTS kb_chunks_document_idx ON kb_chunks (document_id);

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -15,6 +15,8 @@ description: Decomposes a complex research question into independent sub-questio
 - Scout each sub-question with 1-2 web_search calls before locking the plan:
   confirm it is actually answerable and roughly how much material exists.
   This is reconnaissance, not the research itself.
+- If a kb_search tool is available, search the knowledge base before the
+  web and cite kb sources by their kb:// ref.
 - One plan unit per sub-question. Each unit declares exactly one artifact,
   `findings-<slug>.md`, created with write_file. Each findings file has:
   the answer to that sub-question, key facts with an inline citation and

--- a/skills/research-brief/SKILL.md
+++ b/skills/research-brief/SKILL.md
@@ -8,6 +8,7 @@ description: Source-grounded research with verification and citations. Use when 
 ## Rules
 
 - Retrieve before you write: every load-bearing claim needs a source you actually fetched this turn, not trained recall.
+- If a kb_search tool is available, search the knowledge base before the web and cite kb sources by their kb:// ref.
 - Two independent sources for any claim that drives a decision; one source for background color.
 - Record where each fact came from; a source mentioned only in the trailing list without ever being referenced in the body is not a citation, it is decoration.
 - Distinguish plainly between what a source states and what you infer from it; label inference as inference.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -16,6 +16,8 @@ import type {
   GitHubIdentity,
   GitHubRepo,
   GroupTotal,
+  KbCollection,
+  KbDocument,
   LatencyRow,
   MemoryItem,
   Mission,
@@ -767,6 +769,69 @@ export async function setDefaultAgent(id: string): Promise<void> {
 
 export async function deleteAgent(id: string): Promise<void> {
   await request<void>(`/v1/admin/agents/${id}`, { method: 'DELETE' })
+}
+
+// --- knowledge (RAG collections agents search with kb_search) ---
+
+export async function listKbCollections(): Promise<KbCollection[]> {
+  const { collections } = await request<{ collections: KbCollection[] }>('/v1/admin/kb/collections')
+  return collections ?? []
+}
+
+export async function getKbCollection(id: string): Promise<KbCollection> {
+  return request<KbCollection>(`/v1/admin/kb/collections/${id}`)
+}
+
+export async function createKbCollection(c: { name: string; description: string }): Promise<string> {
+  const { id } = await request<{ id: string }>('/v1/admin/kb/collections', {
+    method: 'POST',
+    body: JSON.stringify(c),
+  })
+  return id
+}
+
+export async function deleteKbCollection(id: string): Promise<void> {
+  await request<void>(`/v1/admin/kb/collections/${id}`, { method: 'DELETE' })
+}
+
+export async function listKbDocuments(collectionId: string): Promise<KbDocument[]> {
+  const { documents } = await request<{ documents: KbDocument[] }>(
+    `/v1/admin/kb/collections/${collectionId}/documents`,
+  )
+  return documents ?? []
+}
+
+// uploadKbDocument posts one file to a collection (multipart field
+// "file") — same bypass of request()'s JSON content type as
+// uploadAttachment, since the body is the file, not JSON.
+export async function uploadKbDocument(collectionId: string, file: File): Promise<KbDocument> {
+  const form = new FormData()
+  form.append('file', file)
+  const res = await fetch(`/v1/admin/kb/collections/${collectionId}/documents`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${getToken()}` },
+    body: form,
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    let message = body
+    try {
+      const parsed = JSON.parse(body) as { message?: string }
+      message = parsed.message ?? body
+    } catch {
+      // Non-JSON error body: keep the raw text.
+    }
+    throw new ChatError(res.status, message || `upload failed (${res.status})`)
+  }
+  return (await res.json()) as KbDocument
+}
+
+export async function deleteKbDocument(id: string): Promise<void> {
+  await request<void>(`/v1/admin/kb/documents/${id}`, { method: 'DELETE' })
+}
+
+export async function reingestKbDocument(id: string): Promise<void> {
+  await request<void>(`/v1/admin/kb/documents/${id}/reingest`, { method: 'POST' })
 }
 
 // --- connectors (integrations) ---

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -507,6 +507,10 @@ export interface AdminAgent {
   memory: boolean
   is_default: boolean
   enabled: boolean
+  // Knowledge collections this agent can search with kb_search.
+  // Optional: the backend doesn't send it yet, so callers default to
+  // [] when absent.
+  knowledge?: string[]
   // Mission-only fields (internal/brain/missions) — meaningless to a
   // chat-only agent, absent or at zero values for one. Optional here
   // since most call sites (chat agent picker etc.) never populate
@@ -530,6 +534,35 @@ export interface AdminTool {
 export interface AdminSkill {
   name: string
   description: string
+}
+
+// KbCollection is one document collection agents can search with
+// kb_search — a named group of ingested documents.
+export interface KbCollection {
+  id: string
+  name: string
+  description: string
+  doc_count: number
+  chunk_count: number
+  created_at: string
+  updated_at: string
+}
+
+// KbDocument is one ingested file within a collection. status tracks
+// the ingestion pipeline: pending (queued) -> ingesting (chunking +
+// embedding) -> ready | failed.
+export interface KbDocument {
+  id: string
+  collection_id: string
+  title: string
+  source_type: 'file' | 'notion' | 'wiki' | 'url'
+  source_ref: string
+  status: 'pending' | 'ingesting' | 'ready' | 'failed'
+  error: string
+  chunk_count: number
+  bytes: number
+  ingested_at: string | null
+  created_at: string
 }
 
 // PlanUnit is one item of a mission's plan. passes is flipped only by

--- a/web/src/components/settings/AgentAdd.tsx
+++ b/web/src/components/settings/AgentAdd.tsx
@@ -29,6 +29,7 @@ export function AgentAdd() {
         route: value.route,
         skills: value.skills,
         tools: value.tools,
+        knowledge: value.knowledge,
         memory: value.memory,
         enabled: true,
       })

--- a/web/src/components/settings/AgentEdit.test.tsx
+++ b/web/src/components/settings/AgentEdit.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AdminAgent, AdminRoute } from '../../api/types'
@@ -11,9 +11,10 @@ vi.mock('../../api/client', () => ({
   deleteAgent: vi.fn(),
   listTools: vi.fn(),
   listSkills: vi.fn(),
+  listKbCollections: vi.fn(),
 }))
 
-import { listAgents, listRoutes, listTools, listSkills } from '../../api/client'
+import { listAgents, listRoutes, listTools, listSkills, listKbCollections, patchAgent } from '../../api/client'
 
 afterEach(cleanup)
 
@@ -39,6 +40,7 @@ beforeEach(() => {
   vi.mocked(listRoutes).mockResolvedValue([codingRoute])
   vi.mocked(listTools).mockResolvedValue([])
   vi.mocked(listSkills).mockResolvedValue([])
+  vi.mocked(listKbCollections).mockResolvedValue([])
 })
 
 function renderEdit(id = 'a1') {
@@ -69,5 +71,27 @@ describe('AgentEdit', () => {
 
     await screen.findByDisplayValue(coder.description)
     expect(screen.getByText('Skills allowlist')).toBeInTheDocument()
+  })
+
+  it('shows a knowledge allowlist field', async () => {
+    renderEdit()
+
+    await screen.findByDisplayValue(coder.description)
+    expect(screen.getByText('Knowledge allowlist')).toBeInTheDocument()
+  })
+
+  it('includes knowledge in the save payload, defaulting to empty when the agent omits it', async () => {
+    vi.mocked(patchAgent).mockResolvedValue()
+    renderEdit()
+
+    await screen.findByDisplayValue(coder.description)
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(patchAgent).toHaveBeenCalledWith(
+        'a1',
+        expect.objectContaining({ knowledge: [] }),
+      ),
+    )
   })
 })

--- a/web/src/components/settings/AgentEdit.tsx
+++ b/web/src/components/settings/AgentEdit.tsx
@@ -51,6 +51,7 @@ export function AgentEdit() {
         route: value.route,
         skills: value.skills,
         tools: value.tools,
+        knowledge: value.knowledge,
         memory: value.memory,
       })
       toast.success('Agent saved')

--- a/web/src/components/settings/AgentForm.tsx
+++ b/web/src/components/settings/AgentForm.tsx
@@ -8,6 +8,7 @@ import {
   SelectValue,
 } from '../ui/select'
 import { Field, Toggle } from './shared'
+import { KnowledgePicker } from './KnowledgePicker'
 import { SkillsPicker } from './SkillsPicker'
 import { ToolsPicker } from './ToolsPicker'
 import type { AdminAgent, AdminRoute } from '../../api/types'
@@ -27,6 +28,7 @@ export interface AgentFormValue {
   route: string
   skills: string[]
   tools: string[]
+  knowledge: string[]
   memory: boolean
 }
 
@@ -37,6 +39,7 @@ export function useAgentForm(agent?: AdminAgent) {
   const [route, setRoute] = useState(agent?.route ?? '')
   const [skills, setSkills] = useState<string[]>(agent?.skills ?? [])
   const [tools, setTools] = useState<string[]>(agent?.tools ?? [])
+  const [knowledge, setKnowledge] = useState<string[]>(agent?.knowledge ?? [])
   const [memory, setMemory] = useState(agent?.memory ?? true)
 
   // Edit loads its agent asynchronously, after this hook has already
@@ -50,6 +53,7 @@ export function useAgentForm(agent?: AdminAgent) {
     setRoute(agent.route)
     setSkills(agent.skills)
     setTools(agent.tools)
+    setKnowledge(agent.knowledge ?? [])
     setMemory(agent.memory)
   }, [agent])
 
@@ -60,13 +64,31 @@ export function useAgentForm(agent?: AdminAgent) {
     route,
     skills,
     tools,
+    knowledge,
     memory,
   }
 
   return {
     value,
     canSubmit: agent ? true : slugify(name) !== '',
-    fields: { name, setName, description, setDescription, overlay, setOverlay, route, setRoute, skills, setSkills, tools, setTools, memory, setMemory },
+    fields: {
+      name,
+      setName,
+      description,
+      setDescription,
+      overlay,
+      setOverlay,
+      route,
+      setRoute,
+      skills,
+      setSkills,
+      tools,
+      setTools,
+      knowledge,
+      setKnowledge,
+      memory,
+      setMemory,
+    },
   }
 }
 
@@ -145,6 +167,9 @@ export function AgentForm({
       </Field>
       <Field label="Tools allowlist" hint="pick from the live tool surface; empty = none">
         <ToolsPicker value={fields.tools} onChange={fields.setTools} />
+      </Field>
+      <Field label="Knowledge allowlist" hint="collections this agent can search with kb_search; empty = none">
+        <KnowledgePicker value={fields.knowledge} onChange={fields.setKnowledge} />
       </Field>
     </div>
   )

--- a/web/src/components/settings/KnowledgeCollectionAdd.tsx
+++ b/web/src/components/settings/KnowledgeCollectionAdd.tsx
@@ -1,0 +1,80 @@
+import { ArrowLeft01Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useState } from 'react'
+import { Link, useNavigate } from 'react-router'
+import { toast } from 'sonner'
+import { createKbCollection } from '../../api/client'
+import { slugify } from './AgentForm'
+import { Field } from './shared'
+import { Input } from '../ui/input'
+import { Button } from '../ui/button'
+import { errText } from './util'
+
+export function KnowledgeCollectionAdd() {
+  const navigate = useNavigate()
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const submit = async () => {
+    setBusy(true)
+    try {
+      const id = await createKbCollection({ name: slugify(name), description: description.trim() })
+      toast.success('Collection created', { description: `${slugify(name)} is ready for documents.` })
+      navigate(`/settings/knowledge/${id}`)
+    } catch (err) {
+      toast.error('Could not create collection', { description: errText(err) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="mt-6 w-full space-y-6">
+      <Link
+        to="/settings/knowledge"
+        className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+      >
+        <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+        Knowledge
+      </Link>
+
+      <div className="border-b border-border pb-6">
+        <h1 className="text-xl font-semibold tracking-tight">New collection</h1>
+        <p className="text-sm text-muted-foreground">
+          A named group of documents agents can search with kb_search.
+        </p>
+      </div>
+
+      <div className="max-w-3xl">
+        <div className="grid gap-5">
+          <Field label="Name" hint="unique slug, immutable after creation">
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="product-docs, runbooks…"
+              className="mt-1.5 h-10"
+            />
+          </Field>
+          <Field label="Description" hint="what this collection covers">
+            <Input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What documents live here"
+              className="mt-1.5 h-10"
+            />
+          </Field>
+        </div>
+
+        <div className="flex gap-3 pt-6">
+          <Button variant="outline" disabled={busy} onClick={() => navigate('/settings/knowledge')}>
+            Cancel
+          </Button>
+          <Button disabled={slugify(name) === '' || busy} onClick={() => void submit()}>
+            Create collection
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/settings/KnowledgeCollectionDetail.tsx
+++ b/web/src/components/settings/KnowledgeCollectionDetail.tsx
@@ -1,0 +1,323 @@
+import {
+  ArrowLeft01Icon,
+  CancelCircleIcon,
+  CloudUploadIcon,
+  Delete02Icon,
+  File02Icon,
+  Loading03Icon,
+  ReloadIcon,
+  Tick02Icon,
+} from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, Navigate, useNavigate, useParams } from 'react-router'
+import { toast } from 'sonner'
+import {
+  deleteKbCollection,
+  deleteKbDocument,
+  getKbCollection,
+  listKbDocuments,
+  reingestKbDocument,
+  uploadKbDocument,
+} from '../../api/client'
+import type { KbCollection, KbDocument } from '../../api/types'
+import { humanBytes, relativeTime } from '../../lib/format'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+import { errText } from './util'
+
+const acceptExt = '.pdf,.md,.txt,.docx,.html'
+
+const statusStyle: Record<KbDocument['status'], string> = {
+  pending: 'bg-muted text-muted-foreground',
+  ingesting: 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300',
+  ready: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300',
+  failed: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300',
+}
+
+function StatusBadge({ doc }: { doc: KbDocument }) {
+  const icon =
+    doc.status === 'ingesting' ? (
+      <HugeiconsIcon icon={Loading03Icon} className="size-3 animate-spin" />
+    ) : doc.status === 'ready' ? (
+      <HugeiconsIcon icon={Tick02Icon} className="size-3" />
+    ) : doc.status === 'failed' ? (
+      <HugeiconsIcon icon={CancelCircleIcon} className="size-3" />
+    ) : null
+
+  return (
+    <span
+      title={doc.status === 'failed' ? doc.error : undefined}
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${statusStyle[doc.status]}`}
+    >
+      {icon}
+      {doc.status}
+    </span>
+  )
+}
+
+// pending/ingesting documents are polled every 3s until every
+// document in the collection reaches a terminal state.
+const pollMs = 3000
+
+export function KnowledgeCollectionDetail() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const [collection, setCollection] = useState<KbCollection | null | undefined>(undefined)
+  const [documents, setDocuments] = useState<KbDocument[]>([])
+  const [confirmDeleteCollection, setConfirmDeleteCollection] = useState(false)
+  const [confirmDeleteDoc, setConfirmDeleteDoc] = useState<KbDocument | null>(null)
+  const [uploading, setUploading] = useState<Record<string, boolean>>({})
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const refresh = useCallback(() => {
+    if (!id) return
+    Promise.all([getKbCollection(id), listKbDocuments(id)])
+      .then(([c, docs]) => {
+        setCollection(c)
+        setDocuments(docs)
+      })
+      .catch((err: unknown) => {
+        toast.error('Could not load collection', { description: errText(err) })
+        setCollection(null)
+      })
+  }, [id])
+  useEffect(refresh, [refresh])
+
+  const hasPending = documents.some((d) => d.status === 'pending' || d.status === 'ingesting')
+  useEffect(() => {
+    if (!hasPending || !id) return
+    const t = setInterval(() => {
+      listKbDocuments(id).then(setDocuments, () => undefined)
+    }, pollMs)
+    return () => clearInterval(t)
+  }, [hasPending, id])
+
+  if (collection === null) return <Navigate to="/settings/knowledge" replace />
+  if (collection === undefined) return null
+
+  async function uploadFiles(files: File[]) {
+    if (!id) return
+    for (const file of files) {
+      const key = crypto.randomUUID()
+      setUploading((prev) => ({ ...prev, [key]: true }))
+      try {
+        const doc = await uploadKbDocument(id, file)
+        setDocuments((prev) => [doc, ...prev])
+      } catch (err) {
+        toast.error(`${file.name}: upload failed`, { description: errText(err) })
+      } finally {
+        setUploading((prev) => {
+          const next = { ...prev }
+          delete next[key]
+          return next
+        })
+      }
+    }
+  }
+
+  const removeCollection = async () => {
+    if (!id) return
+    try {
+      await deleteKbCollection(id)
+      toast.success('Collection removed')
+      navigate('/settings/knowledge')
+    } catch (err) {
+      toast.error('Could not remove collection', { description: errText(err) })
+      setConfirmDeleteCollection(false)
+    }
+  }
+
+  const removeDoc = async () => {
+    if (!confirmDeleteDoc) return
+    try {
+      await deleteKbDocument(confirmDeleteDoc.id)
+      setDocuments((prev) => prev.filter((d) => d.id !== confirmDeleteDoc.id))
+      toast.success('Document removed')
+    } catch (err) {
+      toast.error('Could not remove document', { description: errText(err) })
+    } finally {
+      setConfirmDeleteDoc(null)
+    }
+  }
+
+  const reingest = async (doc: KbDocument) => {
+    try {
+      await reingestKbDocument(doc.id)
+      setDocuments((prev) =>
+        prev.map((d) => (d.id === doc.id ? { ...d, status: 'pending', error: '' } : d)),
+      )
+    } catch (err) {
+      toast.error('Could not re-ingest document', { description: errText(err) })
+    }
+  }
+
+  return (
+    <div className="mt-6 w-full space-y-6">
+      <Link
+        to="/settings/knowledge"
+        className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+      >
+        <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+        Knowledge
+      </Link>
+
+      <div className="flex items-center justify-between border-b border-border pb-6">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight">{collection.name}</h1>
+          {collection.description && (
+            <p className="text-sm text-muted-foreground">{collection.description}</p>
+          )}
+        </div>
+        <Button variant="destructive" onClick={() => setConfirmDeleteCollection(true)}>
+          <HugeiconsIcon icon={Delete02Icon} />
+          Delete collection
+        </Button>
+      </div>
+
+      <div
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={(e) => {
+          e.preventDefault()
+          const files = [...e.dataTransfer.files]
+          if (files.length > 0) void uploadFiles(files)
+        }}
+        className="flex flex-col items-center gap-2 rounded-xl border border-dashed border-border p-6 text-center"
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          accept={acceptExt}
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            const files = [...(e.target.files ?? [])]
+            e.target.value = ''
+            if (files.length > 0) void uploadFiles(files)
+          }}
+        />
+        <HugeiconsIcon icon={CloudUploadIcon} className="size-6 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">
+          Drag files here or{' '}
+          <button type="button" onClick={() => inputRef.current?.click()} className="text-brand underline">
+            browse
+          </button>
+          {' '}· {acceptExt}
+        </p>
+        {Object.keys(uploading).length > 0 && (
+          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <HugeiconsIcon icon={Loading03Icon} className="size-3 animate-spin" />
+            Uploading {Object.keys(uploading).length} file
+            {Object.keys(uploading).length === 1 ? '' : 's'}…
+          </p>
+        )}
+      </div>
+
+      {documents.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No documents yet.</p>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-border">
+          <table className="w-full text-sm">
+            <thead className="border-b border-border bg-muted/50 text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2">Title</th>
+                <th className="px-3 py-2">Source</th>
+                <th className="px-3 py-2">Status</th>
+                <th className="px-3 py-2">Chunks</th>
+                <th className="px-3 py-2">Size</th>
+                <th className="px-3 py-2">Ingested</th>
+                <th className="px-3 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {documents.map((doc) => (
+                <tr key={doc.id} className="border-b border-border last:border-0">
+                  <td className="flex items-center gap-2 px-3 py-2">
+                    <HugeiconsIcon icon={File02Icon} className="size-4 shrink-0 text-muted-foreground" />
+                    <span className="truncate">{doc.title}</span>
+                  </td>
+                  <td className="px-3 py-2">
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase text-muted-foreground">
+                      {doc.source_type}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2">
+                    <StatusBadge doc={doc} />
+                  </td>
+                  <td className="px-3 py-2">{doc.chunk_count}</td>
+                  <td className="px-3 py-2">{humanBytes(doc.bytes)}</td>
+                  <td className="px-3 py-2">{doc.ingested_at ? relativeTime(doc.ingested_at) : '—'}</td>
+                  <td className="px-3 py-2">
+                    <div className="flex items-center justify-end gap-2">
+                      <button
+                        type="button"
+                        aria-label={`Re-ingest ${doc.title}`}
+                        onClick={() => void reingest(doc)}
+                        className="text-muted-foreground hover:text-foreground"
+                      >
+                        <HugeiconsIcon icon={ReloadIcon} className="size-4" />
+                      </button>
+                      <button
+                        type="button"
+                        aria-label={`Delete ${doc.title}`}
+                        onClick={() => setConfirmDeleteDoc(doc)}
+                        className="text-muted-foreground hover:text-destructive"
+                      >
+                        <HugeiconsIcon icon={Delete02Icon} className="size-4" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <Dialog open={confirmDeleteCollection} onOpenChange={setConfirmDeleteCollection}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete {collection.name}?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Removes the collection and every document in it. Agents that searched it lose access
+            immediately.
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmDeleteCollection(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={() => void removeCollection()}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={confirmDeleteDoc !== null} onOpenChange={(o) => !o && setConfirmDeleteDoc(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete {confirmDeleteDoc?.title}?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Removes the document and its indexed chunks from the collection.
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmDeleteDoc(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={() => void removeDoc()}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/web/src/components/settings/KnowledgeCollectionsList.tsx
+++ b/web/src/components/settings/KnowledgeCollectionsList.tsx
@@ -1,0 +1,83 @@
+import { Add01Icon, LibraryIcon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router'
+import { toast } from 'sonner'
+import { listKbCollections } from '../../api/client'
+import type { KbCollection } from '../../api/types'
+import { relativeTime } from '../../lib/format'
+import { Button } from '../ui/button'
+import { errText } from './util'
+
+export function KnowledgeCollectionsList() {
+  const [collections, setCollections] = useState<KbCollection[]>([])
+  const navigate = useNavigate()
+
+  const refresh = useCallback(() => {
+    listKbCollections()
+      .then(setCollections)
+      .catch((err: unknown) => toast.error('Could not load collections', { description: errText(err) }))
+  }, [])
+  useEffect(refresh, [refresh])
+
+  return (
+    <div className="mt-6 space-y-6">
+      <p className="text-sm text-muted-foreground">
+        Collections group documents an agent can search with kb_search for grounded answers.
+        Upload files to a collection, then allow an agent to search it from the agent's own
+        settings.
+      </p>
+
+      <div className="flex items-center justify-between">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Collections · {collections.length}
+        </h2>
+        <Button onClick={() => navigate('/settings/knowledge/new')}>
+          <HugeiconsIcon icon={Add01Icon} />
+          New collection
+        </Button>
+      </div>
+
+      {collections.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border p-10 text-center">
+          <span className="flex size-10 items-center justify-center rounded-lg bg-brand-soft text-brand-soft-foreground">
+            <HugeiconsIcon icon={LibraryIcon} className="size-5" />
+          </span>
+          <p className="text-sm text-muted-foreground">
+            No collections yet. Create one and upload documents so agents can search them for
+            grounded answers.
+          </p>
+          <Button onClick={() => navigate('/settings/knowledge/new')}>
+            <HugeiconsIcon icon={Add01Icon} />
+            New collection
+          </Button>
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {collections.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              onClick={() => navigate(`/settings/knowledge/${c.id}`)}
+              className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 text-left shadow-sm transition hover:shadow-md"
+            >
+              <div className="flex items-center gap-3">
+                <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-brand-soft text-brand-soft-foreground">
+                  <HugeiconsIcon icon={LibraryIcon} className="size-4.5" />
+                </span>
+                <span className="min-w-0 flex-1 truncate text-sm font-semibold">{c.name}</span>
+              </div>
+              {c.description && (
+                <p className="line-clamp-2 text-sm text-muted-foreground">{c.description}</p>
+              )}
+              <p className="mt-auto text-xs text-muted-foreground">
+                {c.doc_count} doc{c.doc_count === 1 ? '' : 's'} · {c.chunk_count} chunk
+                {c.chunk_count === 1 ? '' : 's'} · updated {relativeTime(c.updated_at)}
+              </p>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/settings/KnowledgePicker.test.tsx
+++ b/web/src/components/settings/KnowledgePicker.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { KbCollection } from '../../api/types'
+import { KnowledgePicker } from './KnowledgePicker'
+
+vi.mock('../../api/client', () => ({
+  listKbCollections: vi.fn(),
+}))
+
+import { listKbCollections } from '../../api/client'
+
+const collections: KbCollection[] = [
+  {
+    id: 'c1',
+    name: 'product-docs',
+    description: 'Product documentation.',
+    doc_count: 1,
+    chunk_count: 5,
+    created_at: '2026-08-01T00:00:00Z',
+    updated_at: '2026-08-01T00:00:00Z',
+  },
+]
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  // jsdom lacks scrollIntoView; cmdk calls it when an item mounts.
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+describe('KnowledgePicker', () => {
+  it('shows "No knowledge" when nothing is selected', async () => {
+    vi.mocked(listKbCollections).mockResolvedValue(collections)
+    render(<KnowledgePicker value={[]} onChange={vi.fn()} />)
+    expect(await screen.findByText('No knowledge')).toBeTruthy()
+  })
+
+  it('selects a collection from the popover', async () => {
+    vi.mocked(listKbCollections).mockResolvedValue(collections)
+    const onChange = vi.fn()
+    render(<KnowledgePicker value={[]} onChange={onChange} />)
+
+    fireEvent.click(await screen.findByRole('combobox'))
+    fireEvent.click(await screen.findByText('product-docs'))
+
+    expect(onChange).toHaveBeenCalledWith(['product-docs'])
+  })
+
+  it('removes a selected collection via its chip', async () => {
+    vi.mocked(listKbCollections).mockResolvedValue(collections)
+    const onChange = vi.fn()
+    render(<KnowledgePicker value={['product-docs']} onChange={onChange} />)
+
+    fireEvent.click(await screen.findByLabelText('Remove product-docs'))
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+
+  it('falls back to free text when the collection list is empty', async () => {
+    vi.mocked(listKbCollections).mockResolvedValue([])
+    const onChange = vi.fn()
+    render(<KnowledgePicker value={[]} onChange={onChange} />)
+
+    const input = await screen.findByPlaceholderText('product-docs, runbooks')
+    fireEvent.change(input, { target: { value: 'a, b' } })
+    expect(onChange).toHaveBeenCalledWith(['a', 'b'])
+  })
+})

--- a/web/src/components/settings/KnowledgePicker.tsx
+++ b/web/src/components/settings/KnowledgePicker.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from 'react'
+import { ChevronDownIcon } from 'lucide-react'
+import { listKbCollections } from '../../api/client'
+import type { KbCollection } from '../../api/types'
+import { Button } from '../ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '../ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
+
+// Module-level cache: the picker can render in every agent form; the
+// collection surface changes rarely and a stale list self-heals on
+// the next mount.
+let cachedCollections: KbCollection[] | null = null
+
+function useKbCollections(): KbCollection[] {
+  const [collections, setCollections] = useState<KbCollection[]>(cachedCollections ?? [])
+  useEffect(() => {
+    listKbCollections().then(
+      (list) => {
+        cachedCollections = list
+        setCollections(list)
+      },
+      () => undefined,
+    )
+  }, [])
+  return collections
+}
+
+// KnowledgePicker lets an agent's knowledge allowlist be built from
+// the actual collections instead of typed blind — the exact
+// collection name is otherwise undiscoverable. Falls back to
+// comma-separated free text when the list is empty (the admin
+// endpoint failed to load, or a fresh install with no collections
+// yet), so the allowlist stays usable either way.
+export function KnowledgePicker({
+  value,
+  onChange,
+}: {
+  value: string[]
+  onChange: (v: string[]) => void
+}) {
+  const collections = useKbCollections()
+  const [open, setOpen] = useState(false)
+
+  const toggle = (name: string) => {
+    onChange(value.includes(name) ? value.filter((v) => v !== name) : [...value, name])
+  }
+
+  if (collections.length === 0) {
+    return (
+      <input
+        value={value.join(', ')}
+        onChange={(e) =>
+          onChange(
+            e.target.value
+              .split(',')
+              .map((s) => s.trim())
+              .filter(Boolean),
+          )
+        }
+        placeholder="product-docs, runbooks"
+        className="mt-1.5 flex h-10 w-full rounded-lg border border-input bg-transparent px-3 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+      />
+    )
+  }
+
+  return (
+    <div className="mt-1.5">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="h-10 w-full justify-between font-normal"
+          >
+            <span className="truncate text-left">
+              {value.length === 0 ? 'No knowledge' : `${value.length} selected`}
+            </span>
+            <ChevronDownIcon className="size-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[min(92vw,24rem)] p-0" align="start">
+          <Command>
+            <CommandInput placeholder="Search collections…" />
+            <CommandList>
+              <CommandEmpty>No collection matches.</CommandEmpty>
+              <CommandGroup>
+                {collections.map((c) => (
+                  <CommandItem
+                    key={c.name}
+                    value={c.name}
+                    data-checked={value.includes(c.name) || undefined}
+                    onSelect={() => toggle(c.name)}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="font-mono text-xs">{c.name}</div>
+                      {c.description && (
+                        <div className="truncate text-xs text-muted-foreground">
+                          {c.description}
+                        </div>
+                      )}
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      {value.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {value.map((name) => (
+            <button
+              key={name}
+              type="button"
+              onClick={() => toggle(name)}
+              className="rounded-full bg-muted px-2 py-0.5 font-mono text-xs text-muted-foreground transition hover:bg-destructive/10 hover:text-destructive"
+              aria-label={`Remove ${name}`}
+            >
+              {name} ×
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/settings/KnowledgeTab.test.tsx
+++ b/web/src/components/settings/KnowledgeTab.test.tsx
@@ -1,0 +1,173 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { KbCollection, KbDocument } from '../../api/types'
+import { KnowledgeTab } from './KnowledgeTab'
+
+vi.mock('../../api/client', () => ({
+  listKbCollections: vi.fn(),
+  getKbCollection: vi.fn(),
+  createKbCollection: vi.fn(),
+  deleteKbCollection: vi.fn(),
+  listKbDocuments: vi.fn(),
+  uploadKbDocument: vi.fn(),
+  deleteKbDocument: vi.fn(),
+  reingestKbDocument: vi.fn(),
+}))
+
+import {
+  createKbCollection,
+  deleteKbDocument,
+  getKbCollection,
+  listKbCollections,
+  listKbDocuments,
+  reingestKbDocument,
+  uploadKbDocument,
+} from '../../api/client'
+
+const productDocs: KbCollection = {
+  id: 'c1',
+  name: 'product-docs',
+  description: 'Product documentation for support agents.',
+  doc_count: 2,
+  chunk_count: 40,
+  created_at: '2026-08-01T00:00:00Z',
+  updated_at: '2026-08-10T00:00:00Z',
+}
+
+const readyDoc: KbDocument = {
+  id: 'd1',
+  collection_id: 'c1',
+  title: 'onboarding.pdf',
+  source_type: 'file',
+  source_ref: 'onboarding.pdf',
+  status: 'ready',
+  error: '',
+  chunk_count: 20,
+  bytes: 204_800,
+  ingested_at: '2026-08-10T00:00:00Z',
+  created_at: '2026-08-10T00:00:00Z',
+}
+
+const failedDoc: KbDocument = {
+  id: 'd2',
+  collection_id: 'c1',
+  title: 'broken.docx',
+  source_type: 'file',
+  source_ref: 'broken.docx',
+  status: 'failed',
+  error: 'unsupported encoding',
+  chunk_count: 0,
+  bytes: 1024,
+  ingested_at: null,
+  created_at: '2026-08-10T00:00:00Z',
+}
+
+function renderTab(entry = '/settings/knowledge') {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/settings/knowledge/*" element={<KnowledgeTab />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(listKbCollections).mockResolvedValue([productDocs])
+})
+
+describe('KnowledgeTab list', () => {
+  it('renders collections with doc and chunk counts', async () => {
+    renderTab()
+    expect(await screen.findByText('Collections · 1')).toBeTruthy()
+    expect(screen.getByText('product-docs')).toBeTruthy()
+    expect(screen.getByText(/2 docs · 40 chunks/)).toBeTruthy()
+  })
+
+  it('shows an empty state with an explainer and create button', async () => {
+    vi.mocked(listKbCollections).mockResolvedValue([])
+    renderTab()
+    expect(await screen.findByText(/No collections yet/)).toBeTruthy()
+    expect(screen.getAllByRole('button', { name: 'New collection' }).length).toBeGreaterThan(0)
+  })
+})
+
+describe('KnowledgeTab create', () => {
+  it('creates a collection and navigates to its detail page', async () => {
+    vi.mocked(createKbCollection).mockResolvedValue('c2')
+    vi.mocked(getKbCollection).mockResolvedValue({ ...productDocs, id: 'c2', name: 'runbooks' })
+    vi.mocked(listKbDocuments).mockResolvedValue([])
+
+    renderTab()
+    fireEvent.click(await screen.findByRole('button', { name: 'New collection' }))
+
+    fireEvent.change(await screen.findByPlaceholderText('product-docs, runbooks…'), {
+      target: { value: 'Runbooks' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Create collection' }))
+
+    await waitFor(() =>
+      expect(createKbCollection).toHaveBeenCalledWith({ name: 'runbooks', description: '' }),
+    )
+    expect(await screen.findByRole('heading', { name: 'runbooks' })).toBeTruthy()
+  })
+})
+
+describe('KnowledgeTab detail', () => {
+  beforeEach(() => {
+    vi.mocked(getKbCollection).mockResolvedValue(productDocs)
+    vi.mocked(listKbDocuments).mockResolvedValue([readyDoc, failedDoc])
+  })
+
+  it('renders documents with status badges', async () => {
+    renderTab('/settings/knowledge/c1')
+    expect(await screen.findByText('onboarding.pdf')).toBeTruthy()
+    expect(screen.getByText('ready')).toBeTruthy()
+    expect(screen.getByText('failed')).toBeTruthy()
+    expect(screen.getByText('broken.docx')).toBeTruthy()
+  })
+
+  it('shows the error as a tooltip on a failed document', async () => {
+    renderTab('/settings/knowledge/c1')
+    await screen.findByText('broken.docx')
+    expect(screen.getByText('failed').closest('span')).toHaveAttribute('title', 'unsupported encoding')
+  })
+
+  it('uploads a file via the input and adds it to the document list', async () => {
+    const uploaded: KbDocument = { ...readyDoc, id: 'd3', title: 'new.md', status: 'pending' }
+    vi.mocked(uploadKbDocument).mockResolvedValue(uploaded)
+
+    renderTab('/settings/knowledge/c1')
+    await screen.findByText('onboarding.pdf')
+
+    const file = new File(['# hi'], 'new.md', { type: 'text/markdown' })
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(input, { target: { files: [file] } })
+
+    await waitFor(() => expect(uploadKbDocument).toHaveBeenCalledWith('c1', file))
+    expect(await screen.findByText('new.md')).toBeTruthy()
+  })
+
+  it('re-ingests a failed document', async () => {
+    vi.mocked(reingestKbDocument).mockResolvedValue()
+    renderTab('/settings/knowledge/c1')
+    await screen.findByText('broken.docx')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Re-ingest broken.docx' }))
+    await waitFor(() => expect(reingestKbDocument).toHaveBeenCalledWith('d2'))
+  })
+
+  it('deletes a document after confirmation', async () => {
+    vi.mocked(deleteKbDocument).mockResolvedValue()
+    renderTab('/settings/knowledge/c1')
+    await screen.findByText('onboarding.pdf')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete onboarding.pdf' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(deleteKbDocument).toHaveBeenCalledWith('d1'))
+  })
+})

--- a/web/src/components/settings/KnowledgeTab.tsx
+++ b/web/src/components/settings/KnowledgeTab.tsx
@@ -1,0 +1,17 @@
+import { Route, Routes } from 'react-router'
+import { KnowledgeCollectionAdd } from './KnowledgeCollectionAdd'
+import { KnowledgeCollectionDetail } from './KnowledgeCollectionDetail'
+import { KnowledgeCollectionsList } from './KnowledgeCollectionsList'
+
+// KnowledgeTab is the route container for the knowledge area: a
+// collections list, a dedicated create screen, and a detail screen
+// for documents within one collection — mirrors AgentsTab.
+export function KnowledgeTab() {
+  return (
+    <Routes>
+      <Route path="/" element={<KnowledgeCollectionsList />} />
+      <Route path="new" element={<KnowledgeCollectionAdd />} />
+      <Route path=":id" element={<KnowledgeCollectionDetail />} />
+    </Routes>
+  )
+}

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { compact, formatDuration, missionDisplayName, money } from './format'
+import { compact, formatDuration, humanBytes, missionDisplayName, money, relativeTime } from './format'
 
 describe('compact', () => {
   it('leaves small numbers as-is', () => {
@@ -79,5 +79,40 @@ describe('money', () => {
 
   it('falls back to "CODE amount" for a currency code Intl rejects, without throwing', () => {
     expect(money(1.5, 'NOTACODE')).toBe('NOTACODE 1.50')
+  })
+})
+
+describe('humanBytes', () => {
+  it('renders sub-1024 byte counts as bytes', () => {
+    expect(humanBytes(512)).toBe('512 B')
+  })
+
+  it('renders kilobytes with one decimal', () => {
+    expect(humanBytes(2048)).toBe('2.0 KB')
+  })
+
+  it('renders megabytes and gigabytes', () => {
+    expect(humanBytes(5 * 1024 * 1024)).toBe('5.0 MB')
+    expect(humanBytes(2 * 1024 * 1024 * 1024)).toBe('2.0 GB')
+  })
+})
+
+describe('relativeTime', () => {
+  it('renders under a minute as "just now"', () => {
+    expect(relativeTime(new Date(Date.now() - 10_000).toISOString())).toBe('just now')
+  })
+
+  it('renders minutes and hours ago', () => {
+    expect(relativeTime(new Date(Date.now() - 5 * 60_000).toISOString())).toBe('5m ago')
+    expect(relativeTime(new Date(Date.now() - 3 * 3_600_000).toISOString())).toBe('3h ago')
+  })
+
+  it('renders days ago within a week', () => {
+    expect(relativeTime(new Date(Date.now() - 2 * 86_400_000).toISOString())).toBe('2d ago')
+  })
+
+  it('falls back to a locale date past a week', () => {
+    const old = new Date(Date.now() - 10 * 86_400_000)
+    expect(relativeTime(old.toISOString())).toBe(old.toLocaleDateString())
   })
 })

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -29,6 +29,36 @@ export function missionDisplayName(mission: { name?: string; goal: string }, n =
   return goal.length > n ? `${goal.slice(0, n)}…` : goal
 }
 
+// humanBytes renders a byte count in the largest unit that keeps it
+// readable (KB/MB/GB), one decimal past the first unit.
+export function humanBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  const units = ['KB', 'MB', 'GB', 'TB']
+  let v = bytes / 1024
+  let i = 0
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024
+    i++
+  }
+  return `${v.toFixed(1)} ${units[i]}`
+}
+
+// relativeTime renders an ISO timestamp as "just now" / "5m ago" /
+// "3h ago" / "2d ago", falling back to a locale date past a week —
+// document/collection rows update often enough that an absolute
+// timestamp is less scannable than a relative one.
+export function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime()
+  if (ms < 60_000) return 'just now'
+  const minutes = Math.floor(ms / 60_000)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d ago`
+  return new Date(iso).toLocaleDateString()
+}
+
 // money renders an amount in its billing currency's own symbol rather
 // than assuming "$"/USD — the ledger itself never converts (D-013):
 // this always renders the amount exactly as recorded. Precision keeps

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -3,6 +3,7 @@ import { AgentsTab } from '../components/settings/AgentsTab'
 import { ConnectorsTab } from '../components/settings/ConnectorsTab'
 import { CredentialsTab } from '../components/settings/CredentialsTab'
 import { FeaturesTab } from '../components/settings/FeaturesTab'
+import { KnowledgeTab } from '../components/settings/KnowledgeTab'
 import { ProvidersTab } from '../components/settings/ProvidersTab'
 import { RoutesTab } from '../components/settings/RoutesTab'
 import { SecretsTab } from '../components/settings/SecretsTab'
@@ -36,6 +37,12 @@ export const settingsAreas = [
     label: 'Routing',
     description: 'Task routes decide which provider chain handles a given job.',
     render: RoutesTab,
+  },
+  {
+    key: 'knowledge',
+    label: 'Knowledge',
+    description: 'Curate document collections agents can search for grounded answers.',
+    render: KnowledgeTab,
   },
   {
     key: 'secrets',


### PR DESCRIPTION
## Why
Agents needed grounded answers from curated documents — system-design articles, books, internal docs — not just web search and extracted memories. This adds a knowledgebase: document collections agents search on demand, with citations verifiable by the mission harness.

## What
**Schema** (`0012_knowledge.sql`): `kb_collections` / `kb_documents` / `kb_chunks` (vector(1024) + generated tsvector, HNSW + GIN). Mutable by design — re-ingest supersedes chunks. D-060: KB is external memory; facts from KB outrank extracted memories, preferences outrank KB, KB never writes into `memories`. `agents.knowledge` jsonb allowlist added to 0009 in place (empty = none, same opt-in contract as skills/tools).

**Ingestion** (brain → memoryd): multipart upload (pdf/docx/html/md/txt, 32MiB cap) → markitdown once at upload (markdown stored, stripped from API responses) → heading-aware chunker (~400–600 tokens, 15% overlap, code fences intact, breadcrumbs) → gateway embedding route → chunks with embedding model name recorded. NUL bytes / invalid UTF-8 sanitized (real PDFs produced both).

**Retrieval**: hybrid pgvector cosine + Postgres FTS fused with RRF in one SQL query, collection-scoped in Go, per-query score logging; `mode: hybrid|semantic|keyword` (keyword skips the embedding call).

**kb_search tool**: pure-read builtin, collections bound at construction — never a model-controlled param. Chat binds per turn from the agent profile; missions snapshot `knowledge` at create (like prompt_overlay) and offer the tool on explore/plan/worker turns.

**Harness citations**: tool results carry `Source: kb://<document_id>`; the runner records returned document IDs at execution time via a thread-safe sink (digest text is capped at 4KiB/offloaded past 8KiB — parsing it silently lost all evidence and failed every correct citation). `CheckCitations` verifies kb refs from the same seen-set as web URLs; bare-ref extraction sheds trailing punctuation.

**Web UI**: Settings → Knowledge (collections, drag-drop upload, per-document status with 3s polling, re-ingest/delete), KnowledgePicker on the agent form.

## Verification
- `make build test vet lint` green; web 623/623 tests, build + oxlint clean.
- Integration: KB CRUD/upload/reingest/NUL-sanitization + mission knowledge round-trip against live stack.
- `make canary` PASS post-harness-change (7 turns, done/done, review skipped on harness evidence).
- Live e2e: three real PDFs ingested (60 chunks); chat session answered cross-document synthesis with kb_search + correct citations; mission `run-20260813b` produced kb-brief.md with 15 kb:// citations, all harness-verified, done/done.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789220303&installation_model_id=431401&pr_number=232&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F232&signature=5cbdb366e1a757ac59c86cf633b1e32c971c8d027ecf5a951c400ba8e5f6d506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->