### PR TITLE
feat: add knowledge documents from a URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ PostgreSQL database + React web UI, run via Docker Compose
 
 ## Commands
 
-The Go toolchain runs containerized (`golang:1.26.5`); no host Go.
+The Go toolchain runs containerized (`golang:1.26.6`); no host Go.
 
 ```sh
 make build test vet lint     # canonical pre-commit verify — run before every commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ PostgreSQL database + React web UI, run via Docker Compose
 
 ## Commands
 
-The Go toolchain runs containerized (`golang:1.26.5`); no host Go.
+The Go toolchain runs containerized (`golang:1.26.6`); no host Go.
 
 ```sh
 make build test vet lint     # canonical pre-commit verify
@@ -41,7 +41,7 @@ Single Go test:
 ```sh
 docker run --rm -v "$PWD":/src -w /src \
   -v timothy-go-mod:/go/pkg/mod -v timothy-go-cache:/root/.cache/go-build \
-  -e GOFLAGS=-buildvcs=false golang:1.26.5 \
+  -e GOFLAGS=-buildvcs=false golang:1.26.6 \
   go test -race -run TestName ./internal/brain/missions/
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_IMAGE   := golang:1.26.5
+GO_IMAGE   := golang:1.26.6
 LINT_IMAGE := golangci/golangci-lint:v2.12.2
 COMPOSE    := docker compose -f deploy/docker-compose.yml
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.26.5 AS build
+FROM golang:1.26.6 AS build
 WORKDIR /src
 
 COPY go.mod go.sum ./

--- a/deploy/sandbox-go.Dockerfile
+++ b/deploy/sandbox-go.Dockerfile
@@ -4,7 +4,7 @@
 # toolchain to the base mission sandbox — missions writing Go need
 # `go build`/`go test` for their verify_cmd.
 ARG SANDBOX_BASE=timothy-sandbox-base:latest
-FROM golang:1.26.5 AS go-dist
+FROM golang:1.26.6 AS go-dist
 
 FROM ${SANDBOX_BASE}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SumonMSelim/timothy
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.5

--- a/internal/brain/api/kb.go
+++ b/internal/brain/api/kb.go
@@ -4,14 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
+	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/SumonMSelim/timothy/internal/brain/kb"
 	"github.com/SumonMSelim/timothy/internal/platform/markitdown"
+	"github.com/SumonMSelim/timothy/internal/platform/netguard"
 )
 
 // maxKBUploadBytes caps a single knowledge-base document upload.
@@ -38,13 +43,19 @@ func (a *API) registerKB(handle func(pattern string, h http.Handler), store *kb.
 	if store == nil {
 		return
 	}
-	h := &kbAPI{store: store, ingest: ingest, markitdownURL: markitdownURL, markitdownHTTP: &http.Client{}, log: a.log}
+	h := &kbAPI{
+		store: store, ingest: ingest, markitdownURL: markitdownURL,
+		markitdownHTTP: &http.Client{},
+		fetchHTTP: &http.Client{Timeout: kbURLFetchTimeout, Transport: kbFetchTransport},
+		log: a.log,
+	}
 	handle("GET /v1/admin/kb/collections", a.auth(http.HandlerFunc(h.listCollections)))
 	handle("POST /v1/admin/kb/collections", a.auth(http.HandlerFunc(h.createCollection)))
 	handle("GET /v1/admin/kb/collections/{id}", a.auth(http.HandlerFunc(h.getCollection)))
 	handle("DELETE /v1/admin/kb/collections/{id}", a.auth(http.HandlerFunc(h.deleteCollection)))
 	handle("GET /v1/admin/kb/collections/{id}/documents", a.auth(http.HandlerFunc(h.listDocuments)))
 	handle("POST /v1/admin/kb/collections/{id}/documents", a.auth(http.HandlerFunc(h.uploadDocument)))
+	handle("POST /v1/admin/kb/collections/{id}/documents/url", a.auth(http.HandlerFunc(h.addDocumentFromURL)))
 	handle("DELETE /v1/admin/kb/documents/{id}", a.auth(http.HandlerFunc(h.deleteDocument)))
 	handle("POST /v1/admin/kb/documents/{id}/reingest", a.auth(http.HandlerFunc(h.reingestDocument)))
 }
@@ -54,7 +65,11 @@ type kbAPI struct {
 	ingest         kbIngester
 	markitdownURL  string
 	markitdownHTTP *http.Client
-	log            *slog.Logger
+	// fetchHTTP fetches user-supplied URLs; production wires it through
+	// netguard.Dial so only public addresses are dialed (SSRF), tests
+	// substitute an unguarded client.
+	fetchHTTP *http.Client
+	log       *slog.Logger
 }
 
 func failKB(w http.ResponseWriter, err error) {
@@ -193,7 +208,7 @@ func (h *kbAPI) uploadDocument(w http.ResponseWriter, r *http.Request) {
 	markdownText = strings.ToValidUTF8(strings.ReplaceAll(markdownText, "\x00", ""), "�")
 
 	title := strings.TrimSuffix(header.Filename, filepath.Ext(header.Filename))
-	docID, err := h.store.CreateDocument(r.Context(), collectionID, title, header.Filename, markdownText, int64(len(raw)))
+	docID, err := h.store.CreateDocument(r.Context(), collectionID, title, "file", header.Filename, markdownText, int64(len(raw)))
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
 		return
@@ -206,6 +221,150 @@ func (h *kbAPI) uploadDocument(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, sanitizeDocument(doc))
+}
+
+// kbURLFetchTimeout bounds one whole URL fetch (dial through read).
+const kbURLFetchTimeout = 30 * time.Second
+
+// kbFetchTransport dials user-supplied URLs through netguard so only
+// public addresses are reached (SSRF). A var, not inline, so tests can
+// point it at an unguarded transport; production never reassigns it.
+var kbFetchTransport http.RoundTripper = &http.Transport{DialContext: netguard.Dial, ForceAttemptHTTP2: true}
+
+type kbURLRequest struct {
+	URL   string `json:"url"`
+	Title string `json:"title"`
+}
+
+// addDocumentFromURL fetches a user-supplied URL (public addresses
+// only — the client dials through netguard), converts the response to
+// markdown the same way upload does (HTML/PDF via markitdown, plain
+// text and markdown taken as-is), creates a pending document row with
+// the URL as source_ref, then fires the same background ingest.
+func (h *kbAPI) addDocumentFromURL(w http.ResponseWriter, r *http.Request) {
+	collectionID := r.PathValue("id")
+	if _, err := h.store.GetCollection(r.Context(), collectionID); err != nil {
+		failKB(w, err)
+		return
+	}
+
+	var req kbURLRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	u, err := url.Parse(strings.TrimSpace(req.URL))
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "url must be a full http:// or https:// URL")
+		return
+	}
+	// Never forward embedded credentials (and never leak them on a
+	// redirect to another host).
+	u.User = nil
+
+	body, contentType, err := h.fetchURL(r.Context(), u)
+	if err != nil {
+		jsonError(w, http.StatusBadGateway, "fetch_failed", err.Error())
+		return
+	}
+
+	markdownText, err := h.convertFetched(r.Context(), u, body, contentType)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, "conversion_failed", err.Error())
+		return
+	}
+	// Same sanitation as upload: converted output can carry NUL bytes
+	// or invalid UTF-8, which Postgres text columns reject (22021).
+	markdownText = strings.ToValidUTF8(strings.ReplaceAll(markdownText, "\x00", ""), "�")
+	if strings.TrimSpace(markdownText) == "" {
+		jsonError(w, http.StatusBadRequest, "conversion_failed", "page had no extractable text")
+		return
+	}
+
+	title := strings.TrimSpace(req.Title)
+	if title == "" {
+		title = titleFromURL(u)
+	}
+	docID, err := h.store.CreateDocument(r.Context(), collectionID, title, "url", u.String(), markdownText, int64(len(body)))
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
+		return
+	}
+	h.startIngest(docID, title)
+
+	doc, err := h.store.GetDocument(r.Context(), docID)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, sanitizeDocument(doc))
+}
+
+// fetchURL GETs u, capping the body at maxKBUploadBytes, and returns
+// the bytes plus the response Content-Type.
+func (h *kbAPI) fetchURL(ctx context.Context, u *url.URL) ([]byte, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("User-Agent", "timothy/1.0 (+self-hosted assistant)")
+	req.Header.Set("Accept", "text/html, application/pdf;q=0.9, text/plain;q=0.9, text/markdown;q=0.9, */*;q=0.1")
+
+	resp, err := h.fetchHTTP.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, "", fmt.Errorf("http %d fetching %s", resp.StatusCode, u.Host)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxKBUploadBytes+1))
+	if err != nil {
+		return nil, "", fmt.Errorf("read body: %w", err)
+	}
+	if len(body) > maxKBUploadBytes {
+		return nil, "", fmt.Errorf("response exceeds the 32MiB limit")
+	}
+	return body, resp.Header.Get("Content-Type"), nil
+}
+
+// convertFetched turns a fetched body into markdown by content type:
+// HTML and PDF through markitdown (required, same as upload), plain
+// text and markdown as-is. Anything else is unsupported.
+func (h *kbAPI) convertFetched(ctx context.Context, u *url.URL, body []byte, contentType string) (string, error) {
+	if contentType == "" {
+		contentType = http.DetectContentType(body)
+	}
+	switch {
+	case strings.Contains(contentType, "text/html"), strings.Contains(contentType, "application/pdf"):
+		if h.markitdownURL == "" {
+			return "", fmt.Errorf("document conversion requires the markitdown sidecar (MARKITDOWN_URL)")
+		}
+		name := "page.html"
+		if strings.Contains(contentType, "application/pdf") {
+			name = "page.pdf"
+		}
+		md, err := markitdown.Convert(ctx, h.markitdownHTTP, h.markitdownURL, name, contentType, body)
+		if err != nil {
+			return "", err
+		}
+		return markitdown.TruncateMarkdown(md), nil
+	case strings.Contains(contentType, "text/markdown"), strings.Contains(contentType, "text/plain"):
+		return string(body), nil
+	default:
+		return "", fmt.Errorf("unsupported content type %q at %s: only html, pdf, markdown, and plain text", contentType, u.Host)
+	}
+}
+
+// titleFromURL derives a document title from the URL: the last
+// non-empty path segment without its extension, else the host.
+func titleFromURL(u *url.URL) string {
+	seg := path.Base(strings.TrimRight(u.Path, "/"))
+	seg = strings.TrimSuffix(seg, path.Ext(seg))
+	if seg != "" && seg != "." && seg != "/" {
+		return seg
+	}
+	return u.Host
 }
 
 // startIngest fires the status->ingesting->memoryd->terminal sequence

--- a/internal/brain/api/kb_integration_test.go
+++ b/internal/brain/api/kb_integration_test.go
@@ -270,6 +270,127 @@ func TestKBDocumentUploadRejectsUnsupportedType(t *testing.T) {
 	}
 }
 
+func TestKBDocumentFromURLIngestsFetchedMarkdown(t *testing.T) {
+	store := testKBStore(t)
+	ingester := &fakeIngester{}
+
+	page := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+		_, _ = w.Write([]byte("# Fetched\nbody from the web"))
+	}))
+	defer page.Close()
+
+	// httptest listens on loopback, which the production netguard
+	// transport refuses — swap in an unguarded one for this test.
+	saved := kbFetchTransport
+	kbFetchTransport = http.DefaultTransport
+	defer func() { kbFetchTransport = saved }()
+
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, ingester, "")
+
+	collID, err := store.CreateCollection(context.Background(), "itest-url", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/v1/admin/kb/collections/"+collID+"/documents/url",
+		strings.NewReader(`{"url":"`+page.URL+`/guides/rag-primer.md","title":""}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d body %s", w.Code, w.Body)
+	}
+	if strings.Contains(w.Body.String(), "body from the web") {
+		t.Fatal("response must not include markdown")
+	}
+
+	var doc struct {
+		ID        string `json:"id"`
+		Title     string `json:"title"`
+		SourceRef string `json:"source_ref"`
+	}
+	if err := decodeBody(t, w.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.Title != "rag-primer" {
+		t.Fatalf("title = %q, want derived rag-primer", doc.Title)
+	}
+	if doc.SourceRef != page.URL+"/guides/rag-primer.md" {
+		t.Fatalf("source_ref = %q, want the fetched URL", doc.SourceRef)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if ingester.callCount() > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	final, err := store.GetDocument(context.Background(), doc.ID)
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if final.Markdown != "# Fetched\nbody from the web" {
+		t.Fatalf("stored markdown = %q", final.Markdown)
+	}
+	if got := ingester.callCount(); got != 1 {
+		t.Fatalf("ingester calls = %d, want 1", got)
+	}
+}
+
+func TestKBDocumentFromURLRejectsBadURL(t *testing.T) {
+	store := testKBStore(t)
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "")
+
+	collID, err := store.CreateCollection(context.Background(), "itest-url-bad", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	for _, raw := range []string{`{"url":"ftp://example.com/x"}`, `{"url":"not a url"}`, `{"url":""}`} {
+		req := httptest.NewRequest("POST", "/v1/admin/kb/collections/"+collID+"/documents/url", strings.NewReader(raw))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("body %s: status = %d, want 400", raw, w.Code)
+		}
+	}
+}
+
+func TestKBDocumentFromURLBlocksLocalAddresses(t *testing.T) {
+	store := testKBStore(t)
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	// Real guarded transport: the loopback httptest server must be
+	// refused at dial time.
+	a.registerKB(m.Handle, store, &fakeIngester{}, "")
+
+	page := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("secret internal page"))
+	}))
+	defer page.Close()
+
+	collID, err := store.CreateCollection(context.Background(), "itest-url-ssrf", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/v1/admin/kb/collections/"+collID+"/documents/url",
+		strings.NewReader(`{"url":"`+page.URL+`"}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusBadGateway || !strings.Contains(w.Body.String(), "blocked address") {
+		t.Fatalf("status = %d body %s, want 502 blocked address", w.Code, w.Body)
+	}
+}
+
 func TestKBDocumentReingestFailureSetsFailedStatus(t *testing.T) {
 	store := testKBStore(t)
 	ingester := &fakeIngester{err: errors.New("memoryd unreachable")}
@@ -281,7 +402,7 @@ func TestKBDocumentReingestFailureSetsFailedStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
-	docID, err := store.CreateDocument(context.Background(), collID, "Doc", "doc.md", "content", 7)
+	docID, err := store.CreateDocument(context.Background(), collID, "Doc", "file", "doc.md", "content", 7)
 	if err != nil {
 		t.Fatalf("CreateDocument: %v", err)
 	}

--- a/internal/brain/api/kb_url_test.go
+++ b/internal/brain/api/kb_url_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestTitleFromURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"path segment without extension", "https://example.com/docs/getting-started.html", "getting-started"},
+		{"trailing slash", "https://example.com/blog/rag-deep-dive/", "rag-deep-dive"},
+		{"root path falls back to host", "https://example.com/", "example.com"},
+		{"empty path falls back to host", "https://example.com", "example.com"},
+		{"pdf name", "https://example.com/papers/attention.pdf", "attention"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			u, err := url.Parse(tc.url)
+			if err != nil {
+				t.Fatalf("parse %s: %v", tc.url, err)
+			}
+			if got := titleFromURL(u); got != tc.want {
+				t.Fatalf("titleFromURL(%s) = %q, want %q", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConvertFetched(t *testing.T) {
+	t.Parallel()
+	markitdown := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"markdown":"# Converted"}`))
+	}))
+	t.Cleanup(markitdown.Close)
+
+	u, _ := url.Parse("https://example.com/page")
+	tests := []struct {
+		name          string
+		markitdownURL string
+		contentType   string
+		body          string
+		want          string
+		wantErr       string
+	}{
+		{"markdown passthrough", "", "text/markdown; charset=utf-8", "# Raw", "# Raw", ""},
+		{"plain text passthrough", "", "text/plain", "hello", "hello", ""},
+		{"html converts via markitdown", markitdown.URL, "text/html; charset=utf-8", "<h1>x</h1>", "# Converted", ""},
+		{"pdf converts via markitdown", markitdown.URL, "application/pdf", "%PDF-", "# Converted", ""},
+		{"html without markitdown errors", "", "text/html", "<h1>x</h1>", "", "markitdown sidecar"},
+		{"unsupported type", "", "image/png", "\x89PNG", "", "unsupported content type"},
+		{"missing content type sniffs html", markitdown.URL, "", "<!DOCTYPE html><html><body>x</body></html>", "# Converted", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := &kbAPI{markitdownURL: tc.markitdownURL, markitdownHTTP: &http.Client{}}
+			got, err := h.convertFetched(context.Background(), u, []byte(tc.body), tc.contentType)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("convertFetched: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("markdown = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/brain/kb/kb.go
+++ b/internal/brain/kb/kb.go
@@ -193,10 +193,11 @@ func (s *Store) GetDocument(ctx context.Context, id string) (Document, error) {
 }
 
 // CreateDocument inserts a pending document row: markdown is the
-// markitdown conversion done once at upload time (or the raw file for
-// .md/.txt, which skip conversion); sourceRef names the uploaded
-// filename.
-func (s *Store) CreateDocument(ctx context.Context, collectionID, title, sourceRef, markdown string, bytes int64) (string, error) {
+// markitdown conversion done once at upload/fetch time (or the raw
+// content for markdown/plain text, which skip conversion); sourceType
+// is 'file' or 'url'; sourceRef names the uploaded filename or the
+// fetched URL.
+func (s *Store) CreateDocument(ctx context.Context, collectionID, title, sourceType, sourceRef, markdown string, bytes int64) (string, error) {
 	db, err := s.db.Get()
 	if err != nil {
 		return "", fmt.Errorf("kb documents create: %w", err)
@@ -204,8 +205,8 @@ func (s *Store) CreateDocument(ctx context.Context, collectionID, title, sourceR
 	var id string
 	err = db.QueryRow(ctx, `INSERT INTO kb_documents
 		(collection_id, title, source_type, source_ref, markdown, status, bytes)
-		VALUES ($1, $2, 'file', $3, $4, 'pending', $5) RETURNING id`,
-		collectionID, title, sourceRef, markdown, bytes).Scan(&id)
+		VALUES ($1, $2, $3, $4, $5, 'pending', $6) RETURNING id`,
+		collectionID, title, sourceType, sourceRef, markdown, bytes).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("kb documents create: %w", err)
 	}

--- a/internal/brain/tools/builtin/webfetch.go
+++ b/internal/brain/tools/builtin/webfetch.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
 	"github.com/SumonMSelim/timothy/internal/platform/markitdown"
+	"github.com/SumonMSelim/timothy/internal/platform/netguard"
 )
 
 const (
@@ -49,7 +49,7 @@ func WebFetch(cfg WebFetchConfig) *tools.Tool {
 	client := &http.Client{
 		Timeout: webFetchTimeout,
 		Transport: &http.Transport{
-			DialContext:       guardedDial,
+			DialContext:       netguard.Dial,
 			ForceAttemptHTTP2: true,
 		},
 	}
@@ -177,62 +177,6 @@ func fetchReadable(ctx context.Context, client *http.Client, markitdownURL, rawU
 		return "", fmt.Errorf("page had no extractable text")
 	}
 	return text, nil
-}
-
-// guardedDial resolves the host, refuses non-public addresses, and
-// dials the vetted IP directly.
-func guardedDial(ctx context.Context, network, addr string) (net.Conn, error) {
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return nil, fmt.Errorf("split host: %w", err)
-	}
-	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
-	if err != nil {
-		return nil, fmt.Errorf("resolve %s: %w", host, err)
-	}
-	dialer := &net.Dialer{Timeout: 10 * time.Second}
-	var lastErr error
-	for _, ip := range ips {
-		if reason := blockedIP(ip.IP); reason != "" {
-			lastErr = fmt.Errorf("blocked address: %s resolves to %s (%s)", host, ip.IP, reason)
-			continue
-		}
-		conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.IP.String(), port))
-		if err == nil {
-			return conn, nil
-		}
-		lastErr = err
-	}
-	if lastErr == nil {
-		lastErr = fmt.Errorf("no addresses for %s", host)
-	}
-	return nil, lastErr
-}
-
-var cgnatNet = &net.IPNet{IP: net.IPv4(100, 64, 0, 0), Mask: net.CIDRMask(10, 32)}
-
-// blockedIP returns a non-empty reason when the address must not be
-// dialed: anything that isn't plain public unicast. Covers loopback,
-// RFC 1918 + IPv6 ULA, link-local (169.254.0.0/16 — cloud metadata
-// endpoints live there), CGNAT, unspecified, and multicast.
-func blockedIP(ip net.IP) string {
-	switch {
-	case ip.IsLoopback():
-		return "loopback"
-	case ip.IsPrivate():
-		return "private range"
-	case ip.IsLinkLocalUnicast(), ip.IsLinkLocalMulticast():
-		return "link-local"
-	case ip.IsUnspecified():
-		return "unspecified"
-	case ip.IsMulticast():
-		return "multicast"
-	case cgnatNet.Contains(ip):
-		return "carrier-grade NAT range"
-	case !ip.IsGlobalUnicast():
-		return "not global unicast"
-	}
-	return ""
 }
 
 // extractHTMLText walks the DOM collecting text nodes, skipping

--- a/internal/brain/tools/builtin/webfetch_test.go
+++ b/internal/brain/tools/builtin/webfetch_test.go
@@ -3,45 +3,12 @@ package builtin
 import (
 	"context"
 	"encoding/json"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 )
-
-func TestBlockedIP(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		ip      string
-		blocked bool
-	}{
-		{ip: "127.0.0.1", blocked: true},
-		{ip: "::1", blocked: true},
-		{ip: "10.1.2.3", blocked: true},
-		{ip: "172.16.0.1", blocked: true},
-		{ip: "192.168.1.1", blocked: true},
-		{ip: "169.254.169.254", blocked: true}, // cloud metadata
-		{ip: "100.64.0.1", blocked: true},      // CGNAT
-		{ip: "0.0.0.0", blocked: true},
-		{ip: "224.0.0.1", blocked: true},
-		{ip: "fd00::1", blocked: true}, // IPv6 ULA
-		{ip: "fe80::1", blocked: true}, // IPv6 link-local
-		{ip: "8.8.8.8", blocked: false},
-		{ip: "1.1.1.1", blocked: false},
-		{ip: "2606:4700:4700::1111", blocked: false},
-	}
-	for _, tc := range tests {
-		t.Run(tc.ip, func(t *testing.T) {
-			t.Parallel()
-			reason := blockedIP(net.ParseIP(tc.ip))
-			if (reason != "") != tc.blocked {
-				t.Fatalf("blockedIP(%s) = %q, want blocked=%v", tc.ip, reason, tc.blocked)
-			}
-		})
-	}
-}
 
 func TestWebFetchRefusesLocalAddresses(t *testing.T) {
 	t.Parallel()

--- a/internal/platform/netguard/netguard.go
+++ b/internal/platform/netguard/netguard.go
@@ -1,0 +1,69 @@
+// Package netguard provides an SSRF-safe dialer for fetching
+// model- or user-supplied URLs: the host is resolved here and only
+// vetted public unicast addresses are dialed, so a DNS answer can't
+// change between check and connect, and redirects re-enter the guard
+// on every hop.
+package netguard
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+)
+
+// Dial resolves the host, refuses non-public addresses, and dials the
+// vetted IP directly. Suitable as an http.Transport DialContext.
+func Dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("split host: %w", err)
+	}
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s: %w", host, err)
+	}
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	var lastErr error
+	for _, ip := range ips {
+		if reason := BlockedIP(ip.IP); reason != "" {
+			lastErr = fmt.Errorf("blocked address: %s resolves to %s (%s)", host, ip.IP, reason)
+			continue
+		}
+		conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.IP.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no addresses for %s", host)
+	}
+	return nil, lastErr
+}
+
+var cgnatNet = &net.IPNet{IP: net.IPv4(100, 64, 0, 0), Mask: net.CIDRMask(10, 32)}
+
+// BlockedIP returns a non-empty reason when the address must not be
+// dialed: anything that isn't plain public unicast. Covers loopback,
+// RFC 1918 + IPv6 ULA, link-local (169.254.0.0/16 — cloud metadata
+// endpoints live there), CGNAT, unspecified, and multicast.
+func BlockedIP(ip net.IP) string {
+	switch {
+	case ip.IsLoopback():
+		return "loopback"
+	case ip.IsPrivate():
+		return "private range"
+	case ip.IsLinkLocalUnicast(), ip.IsLinkLocalMulticast():
+		return "link-local"
+	case ip.IsUnspecified():
+		return "unspecified"
+	case ip.IsMulticast():
+		return "multicast"
+	case cgnatNet.Contains(ip):
+		return "carrier-grade NAT range"
+	case !ip.IsGlobalUnicast():
+		return "not global unicast"
+	}
+	return ""
+}

--- a/internal/platform/netguard/netguard_test.go
+++ b/internal/platform/netguard/netguard_test.go
@@ -1,0 +1,38 @@
+package netguard
+
+import (
+	"net"
+	"testing"
+)
+
+func TestBlockedIP(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		ip      string
+		blocked bool
+	}{
+		{ip: "127.0.0.1", blocked: true},
+		{ip: "::1", blocked: true},
+		{ip: "10.1.2.3", blocked: true},
+		{ip: "172.16.0.1", blocked: true},
+		{ip: "192.168.1.1", blocked: true},
+		{ip: "169.254.169.254", blocked: true}, // cloud metadata
+		{ip: "100.64.0.1", blocked: true},      // CGNAT
+		{ip: "0.0.0.0", blocked: true},
+		{ip: "224.0.0.1", blocked: true},
+		{ip: "fd00::1", blocked: true}, // IPv6 ULA
+		{ip: "fe80::1", blocked: true}, // IPv6 link-local
+		{ip: "8.8.8.8", blocked: false},
+		{ip: "1.1.1.1", blocked: false},
+		{ip: "2606:4700:4700::1111", blocked: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.ip, func(t *testing.T) {
+			t.Parallel()
+			reason := BlockedIP(net.ParseIP(tc.ip))
+			if (reason != "") != tc.blocked {
+				t.Fatalf("BlockedIP(%s) = %q, want blocked=%v", tc.ip, reason, tc.blocked)
+			}
+		})
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -830,6 +830,15 @@ export async function deleteKbDocument(id: string): Promise<void> {
   await request<void>(`/v1/admin/kb/documents/${id}`, { method: 'DELETE' })
 }
 
+// addKbDocumentFromUrl asks brain to fetch a public URL, convert it to
+// markdown, and ingest it into the collection.
+export async function addKbDocumentFromUrl(collectionId: string, url: string): Promise<KbDocument> {
+  return request<KbDocument>(`/v1/admin/kb/collections/${collectionId}/documents/url`, {
+    method: 'POST',
+    body: JSON.stringify({ url }),
+  })
+}
+
 export async function reingestKbDocument(id: string): Promise<void> {
   await request<void>(`/v1/admin/kb/documents/${id}/reingest`, { method: 'POST' })
 }

--- a/web/src/components/settings/KnowledgeCollectionDetail.tsx
+++ b/web/src/components/settings/KnowledgeCollectionDetail.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, Navigate, useNavigate, useParams } from 'react-router'
 import { toast } from 'sonner'
 import {
+  addKbDocumentFromUrl,
   deleteKbCollection,
   deleteKbDocument,
   getKbCollection,
@@ -74,6 +75,8 @@ export function KnowledgeCollectionDetail() {
   const [confirmDeleteCollection, setConfirmDeleteCollection] = useState(false)
   const [confirmDeleteDoc, setConfirmDeleteDoc] = useState<KbDocument | null>(null)
   const [uploading, setUploading] = useState<Record<string, boolean>>({})
+  const [url, setUrl] = useState('')
+  const [addingUrl, setAddingUrl] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
   const refresh = useCallback(() => {
@@ -119,6 +122,20 @@ export function KnowledgeCollectionDetail() {
           return next
         })
       }
+    }
+  }
+
+  const addUrl = async () => {
+    if (!id || !url.trim() || addingUrl) return
+    setAddingUrl(true)
+    try {
+      const doc = await addKbDocumentFromUrl(id, url.trim())
+      setDocuments((prev) => [doc, ...prev])
+      setUrl('')
+    } catch (err) {
+      toast.error('Could not add URL', { description: errText(err) })
+    } finally {
+      setAddingUrl(false)
     }
   }
 
@@ -218,6 +235,29 @@ export function KnowledgeCollectionDetail() {
           </p>
         )}
       </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          void addUrl()
+        }}
+        className="flex items-center gap-2"
+      >
+        <input
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://example.com/article — add a page or PDF by URL"
+          className="h-9 w-full rounded-md border border-border bg-transparent px-3 text-sm outline-none placeholder:text-muted-foreground focus:border-ring"
+        />
+        <Button type="submit" variant="outline" disabled={!url.trim() || addingUrl}>
+          {addingUrl ? (
+            <HugeiconsIcon icon={Loading03Icon} className="animate-spin" />
+          ) : (
+            'Add URL'
+          )}
+        </Button>
+      </form>
 
       {documents.length === 0 ? (
         <p className="text-sm text-muted-foreground">No documents yet.</p>


### PR DESCRIPTION
## What

- New `POST /v1/admin/kb/collections/{id}/documents/url`: fetches a user-supplied URL, converts HTML/PDF via markitdown (markdown/plain text pass through), sanitizes NUL/invalid UTF-8, creates the document with `source_type: url` and the URL as `source_ref`, then runs the existing background ingest.
- Collection page gains a URL input next to the file drop zone.
- `CreateDocument` gains a `sourceType` parameter (was hardcoded `'file'`).

## Security

URL fetches dial through the new `internal/platform/netguard` package — the SSRF guard extracted from `web_fetch` (resolve-then-dial, refuses loopback/private/link-local/CGNAT, re-applied on every redirect hop). Both consumers now share one implementation and test suite.

## Testing

- Unit: `titleFromURL`, `convertFetched` (fake markitdown), netguard blocked-IP table.
- Integration: fetch-and-ingest happy path, bad-URL 400s, loopback URL refused with `blocked address` through the real guarded transport.
- Live: ingested a real HTML page end to end (52 chunks, ready) and verified kb_search retrieval grounds answers in it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789337617&installation_model_id=431401&pr_number=241&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F241&signature=bace5611349eba871110c6824ed3f23986c903e6c4faf903dc9cb4c221c8e421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->