### PR TITLE
feat: harden knowledge base retrieval and ingestion

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -474,6 +475,14 @@ func main() {
 	// error, not a nil-gate, since MEMORYD_URL always resolves to a
 	// default).
 	kbStore := kb.New(app.DB)
+	// Ingest goroutines die with the process; fail anything a previous
+	// run left mid-ingest so the UI offers reingest instead of an
+	// eternal spinner.
+	if n, err := kbStore.SweepStale(ctx); err != nil {
+		app.Log.Warn("kb stale-ingest sweep failed", "error", err)
+	} else if n > 0 {
+		app.Log.Info("kb stale-ingest sweep", "documents_failed", n)
+	}
 	svc.SetKBSearch(func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error) {
 		hits, err := mc.KBSearch(ctx, query, collectionNames, mode, k)
 		if err != nil {
@@ -488,6 +497,7 @@ func main() {
 		}
 		return out, nil
 	})
+	svc.SetKBRead(kbReadFromStore(kbStore))
 
 	usageDecorator := api.NewUsageDecorator(flags, fxStore)
 	// ledgerAgg backs the mission list's top_model decoration (D-05x):
@@ -509,6 +519,25 @@ func main() {
 // so it's built once here rather than each caller decoding the master
 // key independently. A nil return (with an error to log) means an
 // unusable master key or init failure; callers nil-gate on it.
+// kbReadFromStore builds the kb_read backing lookup: the full stored
+// markdown straight from brain's own kb store — no memoryd round trip.
+// A document outside the caller's allowed collections reads as not
+// found (never "forbidden": the distinction would leak that the id
+// exists).
+func kbReadFromStore(kbStore *kb.Store) func(ctx context.Context, documentID string, collectionNames []string) (builtin.KBDocument, error) {
+	return func(ctx context.Context, documentID string, collectionNames []string) (builtin.KBDocument, error) {
+		doc, err := kbStore.GetDocument(ctx, documentID)
+		if err != nil {
+			return builtin.KBDocument{}, fmt.Errorf("document %s not found", documentID)
+		}
+		col, err := kbStore.GetCollection(ctx, doc.CollectionID)
+		if err != nil || !slices.Contains(collectionNames, col.Name) {
+			return builtin.KBDocument{}, fmt.Errorf("document %s not found", documentID)
+		}
+		return builtin.KBDocument{Title: doc.Title, SourceRef: doc.SourceRef, Markdown: doc.Markdown}, nil
+	}
+}
+
 func buildSecretStore(db *pgpool.Pool, log *slog.Logger) (*secretstore.Store, error) {
 	masterKey, err := secretstore.DecodeMasterKey(os.Getenv(secretstore.MasterKeyEnv))
 	if err != nil {
@@ -644,7 +673,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 		}
 		return out, nil
 	}
-	nativeRunner := missions.NewNativeRunnerWithFloor(agent, parker, floorDeny, sandboxMgr.Exec, kbSearch, log)
+	nativeRunner := missions.NewNativeRunnerWithFloor(agent, parker, floorDeny, sandboxMgr.Exec, kbSearch, kbReadFromStore(kb.New(db)), log)
 	// The delegated runner wraps native with D-051/D-052's CLI-executor
 	// dispatch — resolve a worker route's chain via the gateway, spawn a
 	// harness entry's CLI detached in the mission's own sandbox container,

--- a/cmd/skills-validate/main.go
+++ b/cmd/skills-validate/main.go
@@ -73,7 +73,7 @@ func embeddingCollisions(gatewayURL string, packs []skills.Skill) error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	vecs, err := gwclient.New(gatewayURL).Embed(ctx, texts, "skills-validate")
+	vecs, _, err := gwclient.New(gatewayURL).Embed(ctx, texts, "skills-validate")
 	if err != nil {
 		return fmt.Errorf("embedding check: %w", err)
 	}

--- a/internal/brain/api/kb_integration_test.go
+++ b/internal/brain/api/kb_integration_test.go
@@ -341,6 +341,44 @@ func TestKBDocumentFromURLIngestsFetchedMarkdown(t *testing.T) {
 	}
 }
 
+func TestKBSweepStaleFailsStuckDocuments(t *testing.T) {
+	store := testKBStore(t)
+	ctx := context.Background()
+
+	collID, err := store.CreateCollection(ctx, "itest-sweep", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	pendingID, err := store.CreateDocument(ctx, collID, "Stuck pending", "file", "a.md", "content", 7)
+	if err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+	ingestingID, err := store.CreateDocument(ctx, collID, "Stuck ingesting", "file", "b.md", "content", 7)
+	if err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+	if err := store.SetIngesting(ctx, ingestingID); err != nil {
+		t.Fatalf("SetIngesting: %v", err)
+	}
+
+	n, err := store.SweepStale(ctx)
+	if err != nil {
+		t.Fatalf("SweepStale: %v", err)
+	}
+	if n < 2 {
+		t.Fatalf("swept %d documents, want at least the 2 stuck ones", n)
+	}
+	for _, id := range []string{pendingID, ingestingID} {
+		doc, err := store.GetDocument(ctx, id)
+		if err != nil {
+			t.Fatalf("GetDocument: %v", err)
+		}
+		if doc.Status != "failed" || !strings.Contains(doc.Error, "interrupted") {
+			t.Fatalf("doc %s: status=%q error=%q, want failed/interrupted", id, doc.Status, doc.Error)
+		}
+	}
+}
+
 func TestKBDocumentFromURLRejectsBadURL(t *testing.T) {
 	store := testKBStore(t)
 	a := &API{token: "tok", log: discard()}

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -147,6 +147,7 @@ type Service struct {
 	markitdownURL  string                             // "": pdf attachments disabled (MARKITDOWN_URL unset)
 	markitdownHTTP *http.Client                       // shared client for the markitdown sidecar call
 	kbSearch       KBSearch                           // nil: kb_search never offered, regardless of agent config
+	kbRead         KBRead                             // nil: kb_read never offered, regardless of agent config
 	logger         *slog.Logger
 
 	grants Granter // nil: chat never seeds standing grants (today's behavior)
@@ -266,6 +267,28 @@ func (s *Service) kbSearchTool(profile agents.Agent) *tools.Tool {
 	collections := slices.Clone(profile.Knowledge)
 	return builtin.KBSearch(func(ctx context.Context, query, mode string, k int) ([]builtin.KBSearchHit, error) {
 		return s.kbSearch(ctx, query, collections, mode, k)
+	})
+}
+
+// KBRead loads one knowledge-base document scoped to collectionNames —
+// same contract as KBSearch: collectionNames travels on every call and
+// is the serving agent's own Knowledge list.
+type KBRead func(ctx context.Context, documentID string, collectionNames []string) (builtin.KBDocument, error)
+
+// SetKBRead wires the kb_read tool's backing lookup. Optional — same
+// nil contract as SetKBSearch.
+func (s *Service) SetKBRead(fn KBRead) { s.kbRead = fn }
+
+// kbReadTool builds this turn's kb_read ExtraTool, gated exactly like
+// kbSearchTool: no backend or empty Knowledge means the tool is not
+// offered.
+func (s *Service) kbReadTool(profile agents.Agent) *tools.Tool {
+	if s.kbRead == nil || len(profile.Knowledge) == 0 {
+		return nil
+	}
+	collections := slices.Clone(profile.Knowledge)
+	return builtin.KBRead(func(ctx context.Context, documentID string) (builtin.KBDocument, error) {
+		return s.kbRead(ctx, documentID, collections)
 	})
 }
 
@@ -1005,7 +1028,10 @@ func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, 
 
 	var extraTools []*tools.Tool
 	if t := s.kbSearchTool(profile); t != nil {
-		extraTools = []*tools.Tool{t}
+		extraTools = append(extraTools, t)
+	}
+	if t := s.kbReadTool(profile); t != nil {
+		extraTools = append(extraTools, t)
 	}
 	upstream, err := s.gw.Stream(turnCtx, gwclient.StreamRequest{
 		Route:      route,

--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -327,36 +327,38 @@ func (c *Client) DeleteSecret(ctx context.Context, refName string) (status int, 
 }
 
 // Embed returns one vector per input text via the gateway's
-// embedding route. purpose tags the ledger row.
-func (c *Client) Embed(ctx context.Context, texts []string, purpose string) ([][]float32, error) {
+// embedding route, plus the model that produced them (the gateway
+// reports the resolved provider model). purpose tags the ledger row.
+func (c *Client) Embed(ctx context.Context, texts []string, purpose string) ([][]float32, string, error) {
 	body, err := json.Marshal(map[string]any{"texts": texts, "purpose": purpose})
 	if err != nil {
-		return nil, fmt.Errorf("gwclient: marshal embed: %w", err)
+		return nil, "", fmt.Errorf("gwclient: marshal embed: %w", err)
 	}
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/embed", bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("gwclient: request: %w", err)
+		return nil, "", fmt.Errorf("gwclient: request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	resp, err := c.http.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("gwclient: gateway unreachable: %w", err)
+		return nil, "", fmt.Errorf("gwclient: gateway unreachable: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
-		return nil, fmt.Errorf("gwclient: gateway http %d: %s", resp.StatusCode, string(msg))
+		return nil, "", fmt.Errorf("gwclient: gateway http %d: %s", resp.StatusCode, string(msg))
 	}
 	var out struct {
 		Embeddings [][]float32 `json:"embeddings"`
+		Model      string      `json:"model"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return nil, fmt.Errorf("gwclient: decode embed: %w", err)
+		return nil, "", fmt.Errorf("gwclient: decode embed: %w", err)
 	}
 	if len(out.Embeddings) != len(texts) {
-		return nil, fmt.Errorf("gwclient: embed returned %d vectors for %d texts", len(out.Embeddings), len(texts))
+		return nil, "", fmt.Errorf("gwclient: embed returned %d vectors for %d texts", len(out.Embeddings), len(texts))
 	}
-	return out.Embeddings, nil
+	return out.Embeddings, out.Model, nil
 }
 
 // Stream posts the request and yields the gateway's normalized events.

--- a/internal/brain/kb/kb.go
+++ b/internal/brain/kb/kb.go
@@ -213,6 +213,26 @@ func (s *Store) CreateDocument(ctx context.Context, collectionID, title, sourceT
 	return id, nil
 }
 
+// SweepStale fails every document parked at pending/ingesting. Ingest
+// runs on a fire-and-forget goroutine (api's startIngest), so a brain
+// restart mid-ingest strands the row in a non-terminal status forever
+// — the UI polls a spinner that never resolves. Called once at boot,
+// before any new ingest can start; the stored markdown survives, so
+// reingest recovers the document.
+func (s *Store) SweepStale(ctx context.Context) (int64, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return 0, fmt.Errorf("kb sweep stale: %w", err)
+	}
+	tag, err := db.Exec(ctx, `UPDATE kb_documents
+		SET status = 'failed', error = 'ingestion interrupted by a restart — re-ingest to retry', updated_at = now()
+		WHERE status IN ('pending', 'ingesting')`)
+	if err != nil {
+		return 0, fmt.Errorf("kb sweep stale: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
 // SetIngesting flips a document to the ingesting phase right before
 // the memoryd call — the background goroutine's own status update,
 // distinct from memoryd's own ready/failed report (store.KBStore.

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -159,6 +159,10 @@ type nativeRunner struct {
 	// dependency's absence turns the feature off entirely" contract as
 	// chat.go's SetKBSearch).
 	kbSearch KBSearchFunc
+
+	// kbRead backs the per-turn kb_read ExtraTool — same nil contract
+	// as kbSearch.
+	kbRead KBReadFunc
 }
 
 // KBSearchFunc runs one kb_search call scoped to collectionNames — main
@@ -167,6 +171,10 @@ type nativeRunner struct {
 // own Knowledge snapshot), never bound once, since the same func serves
 // every mission.
 type KBSearchFunc func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error)
+
+// KBReadFunc loads one kb document scoped to collectionNames — same
+// travel-on-every-call contract as KBSearchFunc.
+type KBReadFunc func(ctx context.Context, documentID string, collectionNames []string) (builtin.KBDocument, error)
 
 // NewNativeRunner wraps a production *loop.Agent as a Runner. The
 // agent instance is expected to be brain's existing chat agent — a
@@ -183,8 +191,8 @@ func NewNativeRunner(agent *loop.Agent, parker parkNotifier, log *slog.Logger) R
 // route through it instead of brain's own process — and a kb_search
 // backend (nil disables kb_search on every mission turn, matching
 // SetKBSearch's nil-safe contract).
-func NewNativeRunnerWithFloor(agent *loop.Agent, parker parkNotifier, floorDeny []string, sandbox sandboxExec, kbSearch KBSearchFunc, log *slog.Logger) Runner {
-	return &nativeRunner{agent: agent, parker: parker, modelFloorDeny: floorDeny, sandbox: sandbox, kbSearch: kbSearch, log: log}
+func NewNativeRunnerWithFloor(agent *loop.Agent, parker parkNotifier, floorDeny []string, sandbox sandboxExec, kbSearch KBSearchFunc, kbRead KBReadFunc, log *slog.Logger) Runner {
+	return &nativeRunner{agent: agent, parker: parker, modelFloorDeny: floorDeny, sandbox: sandbox, kbSearch: kbSearch, kbRead: kbRead, log: log}
 }
 
 // kbSearchTool builds this turn's kb_search ExtraTool bound to m's own
@@ -207,6 +215,19 @@ func (r *nativeRunner) kbSearchTool(m Mission, sink *kbRefSink) *tools.Tool {
 			sink.record(hits)
 		}
 		return hits, err
+	})
+}
+
+// kbReadTool builds this turn's kb_read ExtraTool, gated exactly like
+// kbSearchTool: no backend, or an empty Knowledge snapshot, means the
+// tool is not offered.
+func (r *nativeRunner) kbReadTool(m Mission) *tools.Tool {
+	if r.kbRead == nil || len(m.Knowledge) == 0 {
+		return nil
+	}
+	collections := slices.Clone(m.Knowledge)
+	return builtin.KBRead(func(ctx context.Context, documentID string) (builtin.KBDocument, error) {
+		return r.kbRead(ctx, documentID, collections)
 	})
 }
 
@@ -528,6 +549,9 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 	if t := r.kbSearchTool(m, kbSeen); t != nil {
 		extra = append(extra, t)
 	}
+	if t := r.kbReadTool(m); t != nil {
+		extra = append(extra, t)
+	}
 	req := loop.Request{
 		SessionID:    m.SessionID,
 		Route:        workerRoute(m),
@@ -634,6 +658,9 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 		extra = append(extra, shell)
 	}
 	if t := r.kbSearchTool(m, nil); t != nil {
+		extra = append(extra, t)
+	}
+	if t := r.kbReadTool(m); t != nil {
 		extra = append(extra, t)
 	}
 	req := loop.Request{
@@ -843,6 +870,9 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 	user += renderAttachments(m.Attachments)
 	extra := []*tools.Tool{PlanTool()}
 	if t := r.kbSearchTool(m, nil); t != nil {
+		extra = append(extra, t)
+	}
+	if t := r.kbReadTool(m); t != nil {
 		extra = append(extra, t)
 	}
 	req := loop.Request{

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -1456,6 +1456,32 @@ func TestKBSearchToolRecordsRefsInSink(t *testing.T) {
 	}
 }
 
+// kbReadTool follows kbSearchTool's opt-in-only contract exactly: no
+// backend, or an empty Knowledge snapshot, keeps the tool off the
+// offered surface; with both present it serves the bound collections.
+func TestKBReadToolGating(t *testing.T) {
+	read := func(ctx context.Context, documentID string, collections []string) (builtin.KBDocument, error) {
+		if !slices.Equal(collections, []string{"docs"}) {
+			t.Fatalf("collections = %v, want the mission snapshot", collections)
+		}
+		return builtin.KBDocument{Title: "Runbook", Markdown: "content"}, nil
+	}
+	if tool := (&nativeRunner{log: slog.Default()}).kbReadTool(Mission{Knowledge: []string{"docs"}}); tool != nil {
+		t.Fatal("kbReadTool offered without a backend")
+	}
+	if tool := (&nativeRunner{log: slog.Default(), kbRead: read}).kbReadTool(Mission{}); tool != nil {
+		t.Fatal("kbReadTool offered with empty knowledge")
+	}
+	tool := (&nativeRunner{log: slog.Default(), kbRead: read}).kbReadTool(Mission{Knowledge: []string{"docs"}})
+	if tool == nil {
+		t.Fatal("kbReadTool = nil with backend and knowledge present")
+	}
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"ref":"kb://doc-1"}`))
+	if err != nil || !strings.Contains(out, "Runbook") {
+		t.Fatalf("Execute = %q, %v", out, err)
+	}
+}
+
 // TestRunWorkerSurfacesKBSinkRefsOnVerdict is the end-to-end wiring
 // check: refs recorded by the sink during the worker turn must reach
 // the verdict's SeenURLs alongside the digest-harvested web URLs.

--- a/internal/brain/tools/builtin/kbread.go
+++ b/internal/brain/tools/builtin/kbread.go
@@ -1,0 +1,86 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// KBDocument is one full document as kb_read returns it.
+type KBDocument struct {
+	Title     string
+	SourceRef string
+	Markdown  string
+}
+
+// KBReadFunc loads one document by id. main curries the store lookup
+// in with the calling agent's collection allowlist already bound —
+// a document outside the allowed collections reads as not found, and
+// collections are NEVER a model-controlled argument (D-060: enforced
+// in Go, not a prompt).
+type KBReadFunc func(ctx context.Context, documentID string) (KBDocument, error)
+
+type kbReadArgs struct {
+	Ref string `json:"ref"`
+}
+
+// KBRead lets the model read a knowledge-base document in full after
+// kb_search surfaced an excerpt from it. read is built per-agent,
+// per-turn with the collection set already bound — this constructor
+// never sees or accepts collection names itself.
+func KBRead(read KBReadFunc) *tools.Tool {
+	return &tools.Tool{
+		Name: "kb_read",
+		Description: `Reads a full knowledge-base document by its kb:// reference.
+
+Use after kb_search when the returned passages are not enough — to see
+a passage's surrounding context, or to read the whole document a hit
+came from. Only documents in this agent's knowledge base collections
+are readable.
+
+Arguments:
+- ref (string, required): the "kb://<document-id>" reference from a
+  kb_search result's "Source:" line (the bare document id also works).
+
+Returns the document's title, source reference, and full markdown
+content.`,
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"ref": {
+					"type": "string",
+					"description": "kb:// reference (or bare document id) from a kb_search result."
+				}
+			},
+			"required": ["ref"],
+			"additionalProperties": false
+		}`),
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
+			var args kbReadArgs
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return "", fmt.Errorf("kb_read: invalid arguments: %w", err)
+			}
+			id := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(args.Ref), "kb://"))
+			if id == "" {
+				return "", fmt.Errorf("kb_read: ref must be a kb:// reference or document id")
+			}
+			doc, err := read(ctx, id)
+			if err != nil {
+				return "", fmt.Errorf("kb_read: %w", err)
+			}
+			var b strings.Builder
+			b.WriteString(doc.Title)
+			if doc.SourceRef != "" {
+				b.WriteString(" (")
+				b.WriteString(doc.SourceRef)
+				b.WriteString(")")
+			}
+			b.WriteString("\n\n")
+			b.WriteString(doc.Markdown)
+			return b.String(), nil
+		},
+	}
+}

--- a/internal/brain/tools/builtin/kbread_test.go
+++ b/internal/brain/tools/builtin/kbread_test.go
@@ -1,0 +1,57 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestKBReadExecute(t *testing.T) {
+	t.Parallel()
+	docs := map[string]KBDocument{
+		"doc-1": {Title: "Runbook", SourceRef: "https://example.com/runbook", Markdown: "# Steps\n1. do the thing"},
+	}
+	tool := KBRead(func(_ context.Context, id string) (KBDocument, error) {
+		d, ok := docs[id]
+		if !ok {
+			return KBDocument{}, fmt.Errorf("document %s not found", id)
+		}
+		return d, nil
+	})
+
+	tests := []struct {
+		name    string
+		args    string
+		want    []string
+		wantErr string
+	}{
+		{"kb ref", `{"ref":"kb://doc-1"}`, []string{"Runbook", "https://example.com/runbook", "do the thing"}, ""},
+		{"bare id", `{"ref":"doc-1"}`, []string{"Runbook"}, ""},
+		{"whitespace tolerated", `{"ref":"  kb://doc-1  "}`, []string{"Runbook"}, ""},
+		{"unknown id", `{"ref":"kb://nope"}`, nil, "not found"},
+		{"empty ref", `{"ref":"  "}`, nil, "ref must be"},
+		{"bare scheme", `{"ref":"kb://"}`, nil, "ref must be"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := tool.Execute(context.Background(), json.RawMessage(tc.args))
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(out, w) {
+					t.Fatalf("output %q missing %q", out, w)
+				}
+			}
+		})
+	}
+}

--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -98,6 +98,9 @@ func NewPermissions(db *pgpool.Pool, workspaceRoot string) *Permissions {
 			// at construction (D-060), never model input — same reasoning
 			// as web_search/missions.
 			"kb_search": true,
+			// kb_read is the same pure read, one document at a time,
+			// with the collection allowlist bound the same way.
+			"kb_read": true,
 		},
 	}
 }

--- a/internal/memory/api/api.go
+++ b/internal/memory/api/api.go
@@ -31,7 +31,7 @@ type Searcher interface {
 
 // Embedder embeds the query text; *gwclient.Client satisfies it.
 type Embedder interface {
-	Embed(ctx context.Context, texts []string, purpose string) ([][]float32, error)
+	Embed(ctx context.Context, texts []string, purpose string) ([][]float32, string, error)
 }
 
 // API serves memoryd's routes.
@@ -123,7 +123,7 @@ func (a *API) handleRetrieve(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var embedding store.Vector
-	if vecs, err := a.embed.Embed(r.Context(), []string{req.Query}, "memory-retrieve"); err != nil {
+	if vecs, _, err := a.embed.Embed(r.Context(), []string{req.Query}, "memory-retrieve"); err != nil {
 		a.log.Warn("query embedding failed; vector leg skipped", "error", err)
 	} else {
 		embedding = vecs[0]

--- a/internal/memory/api/api_test.go
+++ b/internal/memory/api/api_test.go
@@ -116,15 +116,15 @@ func (f *fakeSearcher) MarkRetrieved(_ context.Context, ids []string) { f.marked
 
 type fakeEmbedder struct{ err error }
 
-func (f *fakeEmbedder) Embed(_ context.Context, texts []string, _ string) ([][]float32, error) {
+func (f *fakeEmbedder) Embed(_ context.Context, texts []string, _ string) ([][]float32, string, error) {
 	if f.err != nil {
-		return nil, f.err
+		return nil, "", f.err
 	}
 	out := make([][]float32, len(texts))
 	for i := range texts {
 		out[i] = []float32{1, 0}
 	}
-	return out, nil
+	return out, "fake-embed", nil
 }
 
 func postRetrieve(t *testing.T, a *API, body string) *httptest.ResponseRecorder {

--- a/internal/memory/api/kb.go
+++ b/internal/memory/api/kb.go
@@ -57,20 +57,28 @@ func (a *API) handleIngest(w http.ResponseWriter, r *http.Request) {
 	for i, p := range pieces {
 		texts[i] = p.Breadcrumb + "\n\n" + p.Content
 	}
-	const embedPurpose = "kb-ingest"
-	vecs, err := a.embed.Embed(r.Context(), texts, embedPurpose)
-	if err != nil {
-		a.log.Warn("kb ingest embedding failed", "document_id", req.DocumentID, "error", err)
-		a.reportKBFailed(r.Context(), req.DocumentID, fmt.Sprintf("embedding failed: %v", err))
-		jsonError(w, http.StatusBadGateway, "embedding_failed", err.Error())
-		return
+	// Embed in bounded batches: a large document's chunk set in one
+	// request can exceed a provider's per-call input limit.
+	var vecs [][]float32
+	var model string
+	for start := 0; start < len(texts); start += kbEmbedBatchSize {
+		end := min(start+kbEmbedBatchSize, len(texts))
+		batch, batchModel, err := a.embed.Embed(r.Context(), texts[start:end], "kb-ingest")
+		if err != nil {
+			a.log.Warn("kb ingest embedding failed", "document_id", req.DocumentID, "error", err)
+			a.reportKBFailed(r.Context(), req.DocumentID, fmt.Sprintf("embedding failed: %v", err))
+			jsonError(w, http.StatusBadGateway, "embedding_failed", err.Error())
+			return
+		}
+		vecs = append(vecs, batch...)
+		model = batchModel
 	}
 
 	chunks := make([]store.KBChunk, len(pieces))
 	for i, p := range pieces {
 		chunks[i] = store.KBChunk{
 			Seq: p.Seq, Breadcrumb: p.Breadcrumb, Content: p.Content,
-			Embedding: store.Vector(vecs[i]), EmbeddingModel: embedPurpose,
+			Embedding: store.Vector(vecs[i]), EmbeddingModel: model,
 		}
 	}
 	if err := a.kb.ReplaceChunks(r.Context(), req.DocumentID, chunks); err != nil {
@@ -119,6 +127,10 @@ type kbSearchHitJSON struct {
 const (
 	kbSearchDefaultK = 8
 	kbSearchMaxK     = 10
+
+	// kbEmbedBatchSize bounds how many chunk texts ride one gateway
+	// embed call during ingestion.
+	kbEmbedBatchSize = 16
 )
 
 // handleKBSearch runs hybrid/semantic/keyword retrieval scoped to the
@@ -159,7 +171,7 @@ func (a *API) handleKBSearch(w http.ResponseWriter, r *http.Request) {
 
 	var embedding store.Vector
 	if mode != store.KBSearchKeyword {
-		vecs, err := a.embed.Embed(r.Context(), []string{req.Query}, "kb-search")
+		vecs, _, err := a.embed.Embed(r.Context(), []string{req.Query}, "kb-search")
 		if err != nil {
 			a.log.Warn("kb search embedding failed; degrading to keyword-only", "error", err)
 			if mode == store.KBSearchSemantic {

--- a/internal/memory/api/kb_test.go
+++ b/internal/memory/api/kb_test.go
@@ -15,9 +15,10 @@ import (
 )
 
 type fakeKB struct {
-	replacedDocID string
-	replacedCount int
-	replaceErr    error
+	replacedDocID  string
+	replacedCount  int
+	replacedChunks []store.KBChunk
+	replaceErr     error
 
 	searchHits []store.KBSearchHit
 	searchErr  error
@@ -31,6 +32,7 @@ type fakeKB struct {
 func (f *fakeKB) ReplaceChunks(_ context.Context, documentID string, chunks []store.KBChunk) error {
 	f.replacedDocID = documentID
 	f.replacedCount = len(chunks)
+	f.replacedChunks = chunks
 	return f.replaceErr
 }
 
@@ -84,6 +86,60 @@ func TestIngestChunksEmbedsAndStores(t *testing.T) {
 	}
 	if docs.ingestedID != "doc-1" || docs.ingestedCount != kb.replacedCount {
 		t.Fatalf("status not reported ingested: %+v", docs)
+	}
+}
+
+// batchSizeEmbedder records how many texts each Embed call carried.
+type batchSizeEmbedder struct {
+	fakeEmbedder
+	batches []int
+}
+
+func (b *batchSizeEmbedder) Embed(ctx context.Context, texts []string, purpose string) ([][]float32, string, error) {
+	b.batches = append(b.batches, len(texts))
+	return b.fakeEmbedder.Embed(ctx, texts, purpose)
+}
+
+func TestIngestBatchesEmbeddingsAndRecordsModel(t *testing.T) {
+	t.Parallel()
+	// Enough sections to force multiple embed batches.
+	var md strings.Builder
+	for i := range kbEmbedBatchSize + 5 {
+		md.WriteString("## Section ")
+		md.WriteString(strings.Repeat("x", i+1))
+		md.WriteString("\ncontent for this section\n\n")
+	}
+	body, err := json.Marshal(map[string]string{"document_id": "doc-b", "title": "Doc", "markdown": md.String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kb := &fakeKB{}
+	embed := &batchSizeEmbedder{}
+	a := kbAPIFor(kb, &fakeDocStatus{}, embed)
+	rec := postJSON(t, a.handleIngest, "/v1/ingest-document", string(body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body %s", rec.Code, rec.Body)
+	}
+	if len(embed.batches) < 2 {
+		t.Fatalf("embed batches = %v, want the chunk set split across calls", embed.batches)
+	}
+	for _, n := range embed.batches {
+		if n > kbEmbedBatchSize {
+			t.Fatalf("batch of %d exceeds the %d cap", n, kbEmbedBatchSize)
+		}
+	}
+	total := 0
+	for _, n := range embed.batches {
+		total += n
+	}
+	if total != kb.replacedCount {
+		t.Fatalf("embedded %d texts for %d stored chunks", total, kb.replacedCount)
+	}
+	for _, c := range kb.replacedChunks {
+		if c.EmbeddingModel != "fake-embed" {
+			t.Fatalf("embedding_model = %q, want the model the embedder reported", c.EmbeddingModel)
+		}
 	}
 }
 

--- a/internal/memory/api/manage.go
+++ b/internal/memory/api/manage.go
@@ -97,7 +97,7 @@ func (a *API) handleAdd(w http.ResponseWriter, r *http.Request) {
 	}
 	// Best-effort embedding: a user memory without a vector still
 	// serves the text and entity legs.
-	if vecs, err := a.embed.Embed(r.Context(), []string{req.Content}, "memory-remember"); err != nil {
+	if vecs, _, err := a.embed.Embed(r.Context(), []string{req.Content}, "memory-remember"); err != nil {
 		a.log.Warn("remember embedding failed; stored without vector", "error", err)
 	} else {
 		m.Embedding = store.Vector(vecs[0])
@@ -164,7 +164,7 @@ func (a *API) confirmEdited(ctx context.Context, id, content string) error {
 		Confidence: 1, EntityRefs: orig.EntityRefs,
 		SourceSession: orig.SourceSession, SourceSeq: orig.SourceSeq,
 	}
-	if vecs, err := a.embed.Embed(ctx, []string{content}, "memory-remember"); err != nil {
+	if vecs, _, err := a.embed.Embed(ctx, []string{content}, "memory-remember"); err != nil {
 		a.log.Warn("edit embedding failed; stored without vector", "error", err)
 	} else {
 		m.Embedding = store.Vector(vecs[0])

--- a/internal/memory/extract/consolidate.go
+++ b/internal/memory/extract/consolidate.go
@@ -228,7 +228,7 @@ func (c *Consolidator) mergeGroup(ctx context.Context, ids []string) (reject str
 		return reason, nil
 	}
 
-	vecs, err := c.gw.Embed(ctx, []string{merged}, "memory-consolidate")
+	vecs, _, err := c.gw.Embed(ctx, []string{merged}, "memory-consolidate")
 	if err != nil {
 		return "", fmt.Errorf("embed merged fact: %w", err)
 	}

--- a/internal/memory/extract/extract.go
+++ b/internal/memory/extract/extract.go
@@ -24,7 +24,7 @@ import (
 // Gateway is the slice of the gateway client extraction needs.
 type Gateway interface {
 	Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error)
-	Embed(ctx context.Context, texts []string, purpose string) ([][]float32, error)
+	Embed(ctx context.Context, texts []string, purpose string) ([][]float32, string, error)
 }
 
 // Storer is the slice of the memory store extraction needs.
@@ -113,7 +113,7 @@ func (e *Extractor) Extract(ctx context.Context, req Request) ([]string, error) 
 	// store without vectors (text and entity legs still retrieve
 	// them) and near-dup detection skips. Mirrors retrieval's
 	// partial-recall-beats-none stance.
-	vecs, err := e.gw.Embed(ctx, texts, "memory-extract")
+	vecs, _, err := e.gw.Embed(ctx, texts, "memory-extract")
 	if err != nil {
 		e.log.Warn("embedding failed; storing facts without vectors", "error", err, "session_id", req.SessionID)
 		vecs = make([][]float32, len(facts))

--- a/internal/memory/extract/extract_test.go
+++ b/internal/memory/extract/extract_test.go
@@ -116,15 +116,15 @@ func (g *fakeGateway) Stream(ctx context.Context, req gwclient.StreamRequest) (<
 	return ch, nil
 }
 
-func (g *fakeGateway) Embed(_ context.Context, texts []string, _ string) ([][]float32, error) {
+func (g *fakeGateway) Embed(_ context.Context, texts []string, _ string) ([][]float32, string, error) {
 	if g.embeds != nil {
-		return g.embeds, nil
+		return g.embeds, "fake-embed", nil
 	}
 	out := make([][]float32, len(texts))
 	for i := range texts {
 		out[i] = []float32{1, 0, 0}
 	}
-	return out, nil
+	return out, "fake-embed", nil
 }
 
 // fakeStore records pipeline actions.
@@ -329,8 +329,8 @@ func TestExtractSurfacesLLMError(t *testing.T) {
 // embedlessGateway fails Embed but streams facts fine.
 type embedlessGateway struct{ fakeGateway }
 
-func (g *embedlessGateway) Embed(context.Context, []string, string) ([][]float32, error) {
-	return nil, fmt.Errorf("no route for task category embedding")
+func (g *embedlessGateway) Embed(context.Context, []string, string) ([][]float32, string, error) {
+	return nil, "", fmt.Errorf("no route for task category embedding")
 }
 
 func TestExtractDegradesWithoutEmbeddings(t *testing.T) {

--- a/internal/memory/store/kb.go
+++ b/internal/memory/store/kb.go
@@ -121,6 +121,15 @@ const (
 const legLimitLit = "30"
 const rrfKLit = "60"
 
+// minSimilarityLit is the vector leg's relevance floor (cosine
+// similarity): below it a chunk is noise, not a match. Nearest-neighbor
+// search always returns SOMETHING — without a floor an off-topic query
+// still fills k slots with whatever is least-far away, and the model
+// may cite it. Returning nothing beats confidently-irrelevant (same
+// principle as memories retrieval). The keyword leg needs no floor: a
+// tsquery either matches lexemes or returns nothing.
+const minSimilarityLit = "0.25"
+
 // KBSearch runs hybrid (vector + full-text, RRF-fused), semantic-only,
 // or keyword-only retrieval over kb_chunks, scoped to collectionNames
 // (required, non-empty — collection scoping is enforced here in SQL,
@@ -174,40 +183,59 @@ const (
 	// enforced (D-060: Go code, never a prompt).
 	kbProjection = `SELECT c.id, d.id, d.title, col.name, c.breadcrumb, c.content, d.source_ref`
 
+	// kbQueryCTEq1/q2 normalize the query's lexemes and OR them
+	// together — same rationale as memories retrieval's textSQL: a
+	// multi-topic question must match each chunk that answers PART of
+	// it, which websearch/plainto AND-semantics would return nothing
+	// for. Lexemes are quoted (with '' doubling) so none can break the
+	// tsquery syntax. Two variants because the query text is $1 in
+	// keyword mode and $2 in hybrid.
+	kbQueryCTEq1 = `SELECT to_tsquery('english',
+			string_agg('''' || replace(lexeme, '''', '''''') || '''', ' | ')) AS query
+		FROM unnest(tsvector_to_array(to_tsvector('english', $1))) AS lexeme`
+	kbQueryCTEq2 = `SELECT to_tsquery('english',
+			string_agg('''' || replace(lexeme, '''', '''''') || '''', ' | ')) AS query
+		FROM unnest(tsvector_to_array(to_tsvector('english', $2))) AS lexeme`
+
 	semanticSQL = kbProjection + `, 1 - (c.embedding <=> $1::vector) AS score
 		FROM kb_chunks c
 		JOIN kb_documents d ON d.id = c.document_id
 		JOIN kb_collections col ON col.id = d.collection_id
 		WHERE col.name = ANY($2) AND c.embedding IS NOT NULL
+		  AND 1 - (c.embedding <=> $1::vector) >= ` + minSimilarityLit + `
 		ORDER BY c.embedding <=> $1::vector
 		LIMIT $3`
 
-	keywordSQL = kbProjection + `, ts_rank(c.tsv, websearch_to_tsquery('english', $1)) AS score
+	keywordSQL = `WITH q AS (` + kbQueryCTEq1 + `)
+		` + kbProjection + `, ts_rank(c.tsv, q.query) AS score
 		FROM kb_chunks c
 		JOIN kb_documents d ON d.id = c.document_id
-		JOIN kb_collections col ON col.id = d.collection_id
-		WHERE col.name = ANY($2) AND c.tsv @@ websearch_to_tsquery('english', $1)
+		JOIN kb_collections col ON col.id = d.collection_id, q
+		WHERE col.name = ANY($2) AND c.tsv @@ q.query
 		ORDER BY score DESC
 		LIMIT $3`
 
 	// hybridSQL fuses a vector top-30 and an FTS top-30 leg via
 	// Reciprocal Rank Fusion (k=60), same fusion constant as the
-	// memories retrieval package. $1 embedding, $2 query, $3 collection
-	// names, $4 result count.
-	hybridSQL = `WITH vec AS (
+	// memories retrieval package. Each leg carries its own relevance
+	// gate (similarity floor / lexeme match), so an off-topic query
+	// yields an empty result instead of the k least-far chunks.
+	// $1 embedding, $2 query, $3 collection names, $4 result count.
+	hybridSQL = `WITH q AS (` + kbQueryCTEq2 + `), vec AS (
 			SELECT c.id, row_number() OVER (ORDER BY c.embedding <=> $1::vector) AS rank
 			FROM kb_chunks c
 			JOIN kb_documents d ON d.id = c.document_id
 			JOIN kb_collections col ON col.id = d.collection_id
 			WHERE col.name = ANY($3) AND c.embedding IS NOT NULL
+			  AND 1 - (c.embedding <=> $1::vector) >= ` + minSimilarityLit + `
 			ORDER BY c.embedding <=> $1::vector
 			LIMIT ` + legLimitLit + `
 		), fts AS (
-			SELECT c.id, row_number() OVER (ORDER BY ts_rank(c.tsv, websearch_to_tsquery('english', $2)) DESC) AS rank
+			SELECT c.id, row_number() OVER (ORDER BY ts_rank(c.tsv, q.query) DESC) AS rank
 			FROM kb_chunks c
 			JOIN kb_documents d ON d.id = c.document_id
-			JOIN kb_collections col ON col.id = d.collection_id
-			WHERE col.name = ANY($3) AND c.tsv @@ websearch_to_tsquery('english', $2)
+			JOIN kb_collections col ON col.id = d.collection_id, q
+			WHERE col.name = ANY($3) AND c.tsv @@ q.query
 			ORDER BY rank
 			LIMIT ` + legLimitLit + `
 		), fused AS (

--- a/internal/memory/store/kb_golden_integration_test.go
+++ b/internal/memory/store/kb_golden_integration_test.go
@@ -1,0 +1,221 @@
+//go:build integration
+
+package store
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/SumonMSelim/timothy/internal/platform/migrate"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+	"github.com/SumonMSelim/timothy/migrations"
+)
+
+// Golden retrieval eval for the knowledge base, mirroring the memories
+// eval (internal/memory/retrieval/golden_integration_test.go): basis
+// vectors stand in for real embeddings, so the vector leg discriminates
+// perfectly and the eval isolates the SQL, not the embedding model.
+
+const kbGoldenCollection = "itest-kbgolden"
+const kbGoldenOther = "itest-kbgolden-other"
+
+func kbBasis(dim int) Vector {
+	v := make(Vector, 1024)
+	v[dim] = 1
+	return v
+}
+
+// kbFixture is one chunk; queries reference fixtures by key.
+type kbFixture struct {
+	key     string
+	content string
+	dim     int
+}
+
+// Two groups, each reachable primarily through ONE leg: vector-group
+// queries paraphrase with no lexical overlap; keyword-group queries
+// share words while their embedding points at an unused dimension.
+var kbCorpus = []kbFixture{
+	{key: "v-loki", dim: 1, content: "Log aggregation runs in single-binary mode and listens on port 3100."},
+	{key: "v-tempo", dim: 2, content: "Distributed tracing storage retains spans for fourteen days."},
+	{key: "v-mimir", dim: 3, content: "Long-term metrics storage compacts blocks every two hours."},
+
+	{key: "t-alloy", dim: 20, content: "Grafana Alloy scrapes node exporters and forwards to the collector."},
+	{key: "t-otel", dim: 21, content: "The OpenTelemetry Collector fans out traces, logs, and metrics."},
+	{key: "t-dash", dim: 22, content: "Dashboards provision from JSON files under the provisioning directory."},
+}
+
+type kbGolden struct {
+	text string
+	dim  int
+	want string
+}
+
+var kbGoldens = []kbGolden{
+	// vector group — no lexical overlap
+	{text: "where do the logs go?", dim: 1, want: "v-loki"},
+	{text: "how long are request journeys kept?", dim: 2, want: "v-tempo"},
+	{text: "what happens to old measurements?", dim: 3, want: "v-mimir"},
+
+	// keyword group — shared words, useless embedding
+	{text: "grafana alloy node exporters", dim: 900, want: "t-alloy"},
+	{text: "opentelemetry collector fans out", dim: 901, want: "t-otel"},
+	{text: "dashboards provisioning JSON", dim: 902, want: "t-dash"},
+
+	// multi-topic: AND-semantics would return nothing; each chunk
+	// answering PART of the question must surface.
+	{text: "how does alloy scrape exporters and where do dashboards provision from?", dim: 903, want: "t-alloy"},
+	{text: "how does alloy scrape exporters and where do dashboards provision from?", dim: 904, want: "t-dash"},
+}
+
+func seedKBGolden(t *testing.T) *KBStore {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	_, _ = db.Exec(ctx, "DELETE FROM kb_collections WHERE name LIKE 'itest-kbgolden%'")
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer ccancel()
+		conn, err := pgx.Connect(cctx, dsn)
+		if err != nil {
+			t.Errorf("cleanup connect: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close(cctx) }()
+		_, _ = conn.Exec(cctx, "DELETE FROM kb_collections WHERE name LIKE 'itest-kbgolden%'")
+	})
+
+	seed := func(collection, title string, fixtures []kbFixture) {
+		var collID string
+		if err := db.QueryRow(ctx,
+			"INSERT INTO kb_collections (name) VALUES ($1) RETURNING id", collection).Scan(&collID); err != nil {
+			t.Fatalf("insert collection: %v", err)
+		}
+		var docID string
+		if err := db.QueryRow(ctx, `INSERT INTO kb_documents (collection_id, title, status)
+			VALUES ($1, $2, 'ready') RETURNING id`, collID, title).Scan(&docID); err != nil {
+			t.Fatalf("insert document: %v", err)
+		}
+		chunks := make([]KBChunk, len(fixtures))
+		for i, f := range fixtures {
+			chunks[i] = KBChunk{Seq: i, Content: f.content, Embedding: kbBasis(f.dim), EmbeddingModel: "itest"}
+		}
+		st := NewKBStore(pool)
+		if err := st.ReplaceChunks(ctx, docID, chunks); err != nil {
+			t.Fatalf("ReplaceChunks: %v", err)
+		}
+	}
+	seed(kbGoldenCollection, "golden", kbCorpus)
+	// A second collection holding the SAME content proves scoping: it
+	// must never leak into searches scoped to the golden collection.
+	seed(kbGoldenOther, "other", kbCorpus)
+	return NewKBStore(pool)
+}
+
+func kbHitKeys(t *testing.T, hits []KBSearchHit) map[string]bool {
+	t.Helper()
+	byContent := map[string]string{}
+	for _, f := range kbCorpus {
+		byContent[f.content] = f.key
+	}
+	got := map[string]bool{}
+	for _, h := range hits {
+		got[byContent[h.Content]] = true
+	}
+	return got
+}
+
+func TestKBGoldenRecall(t *testing.T) {
+	st := seedKBGolden(t)
+	hitCount := 0
+	for _, q := range kbGoldens {
+		hits, err := st.KBSearch(t.Context(), q.text, kbBasis(q.dim), []string{kbGoldenCollection}, KBSearchHybrid, 5)
+		if err != nil {
+			t.Fatalf("KBSearch %q: %v", q.text, err)
+		}
+		for _, h := range hits {
+			if h.Collection != kbGoldenCollection {
+				t.Fatalf("query %q leaked collection %q", q.text, h.Collection)
+			}
+		}
+		if kbHitKeys(t, hits)[q.want] {
+			hitCount++
+		} else {
+			t.Logf("miss: %q wanted %s", q.text, q.want)
+		}
+	}
+	recall := float64(hitCount) / float64(len(kbGoldens))
+	if recall < 1.0 {
+		t.Fatalf("recall@5 = %.2f, want 1.0 (basis vectors leave no excuse)", recall)
+	}
+}
+
+func TestKBGoldenOffTopicReturnsNothing(t *testing.T) {
+	st := seedKBGolden(t)
+	// No lexical overlap with any chunk (mind stemming: "filings"
+	// would match "files"), embedding on an unused axis: both legs
+	// must gate it out — returning nothing beats returning the k
+	// least-far chunks.
+	hits, err := st.KBSearch(t.Context(), "quarterly marmalade recipes for zebras", kbBasis(950), []string{kbGoldenCollection}, KBSearchHybrid, 5)
+	if err != nil {
+		t.Fatalf("KBSearch: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("off-topic query returned %d hits, want 0", len(hits))
+	}
+}
+
+func TestKBGoldenKeywordOnlyMultiTopic(t *testing.T) {
+	st := seedKBGolden(t)
+	hits, err := st.KBSearch(t.Context(),
+		"how does alloy scrape exporters and where do dashboards provision from?",
+		nil, []string{kbGoldenCollection}, KBSearchKeyword, 5)
+	if err != nil {
+		t.Fatalf("KBSearch: %v", err)
+	}
+	got := kbHitKeys(t, hits)
+	if !got["t-alloy"] || !got["t-dash"] {
+		t.Fatalf("multi-topic keyword search missed a partial answer: got %v", got)
+	}
+}
+
+func TestKBGoldenSemanticFloor(t *testing.T) {
+	st := seedKBGolden(t)
+	// On-axis query hits; orthogonal query (similarity 0) must not.
+	hits, err := st.KBSearch(t.Context(), "anything", kbBasis(1), []string{kbGoldenCollection}, KBSearchSemantic, 5)
+	if err != nil {
+		t.Fatalf("KBSearch: %v", err)
+	}
+	if got := kbHitKeys(t, hits); !got["v-loki"] || len(hits) != 1 {
+		t.Fatalf("semantic on-axis: got %d hits %v, want exactly v-loki", len(hits), got)
+	}
+	hits, err = st.KBSearch(t.Context(), "anything", kbBasis(999), []string{kbGoldenCollection}, KBSearchSemantic, 5)
+	if err != nil {
+		t.Fatalf("KBSearch: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("semantic orthogonal: got %d hits, want 0 (similarity floor)", len(hits))
+	}
+}


### PR DESCRIPTION
## Retrieval

- **Relevance floor**: vector legs (semantic + hybrid) require cosine similarity ≥ 0.25 — an off-topic query now returns nothing instead of the k least-far chunks. The keyword leg needs no floor (a tsquery either matches or doesn't).
- **OR-lexeme FTS**: keyword/hybrid FTS legs switch from `websearch_to_tsquery` (AND semantics — multi-topic questions returned zero FTS hits) to the OR'd quoted-lexeme form the memories retrieval leg already uses.
- **Golden retrieval eval**: new integration eval over seeded basis-vector fixtures (`kb_golden_integration_test.go`) gates recall, multi-topic behavior, the similarity floor, and collection scoping.

## Ingestion

- **Batched embeddings**: chunks embed in batches of 16 instead of one request per document.
- **Honest `embedding_model`**: `gwclient.Embed` now returns the model the gateway resolved; kb_chunks records that instead of the literal string `"kb-ingest"` — stale-embedding detection becomes possible when the route's model changes.
- **Boot-time stale sweep**: documents stranded at pending/ingesting by a restart flip to failed ("interrupted — re-ingest to retry") instead of spinning forever in the UI.

## kb_read

New permission-exempt builtin, offered exactly where kb_search is (agent Knowledge allowlist in chat, mission Knowledge snapshot on mission turns): fetches a full document's stored markdown by its `kb://` ref, scoped in Go — a document outside the allowed collections reads as not found. Observed need: models were routing around the 8-chunk limit via web_fetch of the source URL, which uploaded documents don't have.

## Testing

- `make build test vet lint`: 0 issues; `make test-integration`: all ok (twice).
- New: KB golden eval (4 tests), kb_read table test, runner gating test, batching/model unit test, sweep integration test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789340272&installation_model_id=431401&pr_number=242&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F242&signature=d63057ad40c1fe7ce358d476a3e3b08cf52e459268edeb32c7d8872904538b6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->