### PR TITLE
fix: kb stale-ingest sweep raced the db pool at boot

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -477,12 +477,22 @@ func main() {
 	kbStore := kb.New(app.DB)
 	// Ingest goroutines die with the process; fail anything a previous
 	// run left mid-ingest so the UI offers reingest instead of an
-	// eternal spinner.
-	if n, err := kbStore.SweepStale(ctx); err != nil {
-		app.Log.Warn("kb stale-ingest sweep failed", "error", err)
-	} else if n > 0 {
-		app.Log.Info("kb stale-ingest sweep", "documents_failed", n)
-	}
+	// eternal spinner. On its own goroutine behind WaitHealthy: at this
+	// point in boot the pool is still connecting (the connector load
+	// and mission recovery sweep hit the same window and retry).
+	go func() {
+		wctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		if err := app.DB.WaitHealthy(wctx); err != nil {
+			app.Log.Warn("kb stale-ingest sweep skipped: database not ready", "error", err)
+			return
+		}
+		if n, err := kbStore.SweepStale(wctx); err != nil {
+			app.Log.Warn("kb stale-ingest sweep failed", "error", err)
+		} else if n > 0 {
+			app.Log.Info("kb stale-ingest sweep", "documents_failed", n)
+		}
+	}()
 	svc.SetKBSearch(func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error) {
 		hits, err := mc.KBSearch(ctx, query, collectionNames, mode, k)
 		if err != nil {

--- a/internal/brain/api/kb_integration_test.go
+++ b/internal/brain/api/kb_integration_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/SumonMSelim/timothy/internal/brain/kb"
 	"github.com/SumonMSelim/timothy/internal/platform/migrate"
 	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
@@ -361,12 +363,35 @@ func TestKBSweepStaleFailsStuckDocuments(t *testing.T) {
 		t.Fatalf("SetIngesting: %v", err)
 	}
 
+	// Fresh rows sit inside the sweep's grace window (a boot sweep must
+	// not eat an upload that just started); nothing is swept yet.
 	n, err := store.SweepStale(ctx)
 	if err != nil {
 		t.Fatalf("SweepStale: %v", err)
 	}
-	if n < 2 {
-		t.Fatalf("swept %d documents, want at least the 2 stuck ones", n)
+	if n != 0 {
+		t.Fatalf("swept %d fresh documents, want 0 (grace window)", n)
+	}
+
+	// Backdate both past the grace window, as a restart-stranded row
+	// would be.
+	conn, err := pgx.Connect(ctx, os.Getenv("DATABASE_URL"))
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = conn.Close(ctx) }()
+	if _, err := conn.Exec(ctx,
+		`UPDATE kb_documents SET updated_at = now() - interval '5 minutes' WHERE id = ANY($1)`,
+		[]string{pendingID, ingestingID}); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	n, err = store.SweepStale(ctx)
+	if err != nil {
+		t.Fatalf("SweepStale: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("swept %d documents, want the 2 stuck ones", n)
 	}
 	for _, id := range []string{pendingID, ingestingID} {
 		doc, err := store.GetDocument(ctx, id)

--- a/internal/brain/kb/kb.go
+++ b/internal/brain/kb/kb.go
@@ -213,12 +213,14 @@ func (s *Store) CreateDocument(ctx context.Context, collectionID, title, sourceT
 	return id, nil
 }
 
-// SweepStale fails every document parked at pending/ingesting. Ingest
-// runs on a fire-and-forget goroutine (api's startIngest), so a brain
+// SweepStale fails documents parked at pending/ingesting. Ingest runs
+// on a fire-and-forget goroutine (api's startIngest), so a brain
 // restart mid-ingest strands the row in a non-terminal status forever
-// — the UI polls a spinner that never resolves. Called once at boot,
-// before any new ingest can start; the stored markdown survives, so
-// reingest recovers the document.
+// — the UI polls a spinner that never resolves. Called once at boot on
+// its own goroutine, which races the freshly started API server: the
+// 30-second grace window keeps a legitimately in-flight upload from
+// being swept. The stored markdown survives, so reingest recovers the
+// document.
 func (s *Store) SweepStale(ctx context.Context) (int64, error) {
 	db, err := s.db.Get()
 	if err != nil {
@@ -226,7 +228,8 @@ func (s *Store) SweepStale(ctx context.Context) (int64, error) {
 	}
 	tag, err := db.Exec(ctx, `UPDATE kb_documents
 		SET status = 'failed', error = 'ingestion interrupted by a restart — re-ingest to retry', updated_at = now()
-		WHERE status IN ('pending', 'ingesting')`)
+		WHERE status IN ('pending', 'ingesting')
+		  AND updated_at < now() - interval '30 seconds'`)
 	if err != nil {
 		return 0, fmt.Errorf("kb sweep stale: %w", err)
 	}


### PR DESCRIPTION
Observed live right after merging #242: brain logs showed `kb stale-ingest sweep failed: pgpool: database unavailable: connecting` — the sweep ran inline before the pool was warm and gave up, while connector load and mission recovery retry through the same window.

- Sweep now runs on its own goroutine behind `WaitHealthy` (30s budget).
- Since it now races the freshly started API server, `SweepStale` only fails rows idle longer than 30 seconds — a legitimately in-flight upload seconds after boot survives.
- Integration test asserts both: fresh rows survive the sweep, backdated rows are failed.

`go build ./... && go vet` clean; sweep integration test green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789415187&installation_model_id=431401&pr_number=243&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F243&signature=b62df8d6d2a3f9a484fe50f22fd9adae010946c5879a8b42f9993ecc93142ec9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->