### PR TITLE
feat: kb url ingest quality and knowledge qol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Timothy
 
 [![CI](https://github.com/timothy-agent/timothy/actions/workflows/ci.yml/badge.svg)](https://github.com/timothy-agent/timothy/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/timothy-agent/timothy/graph/badge.svg?token=TTV3A14CFX)](https://codecov.io/gh/timothy-agent/timothy)
 [![Release](https://img.shields.io/github/v/release/timothy-agent/timothy?include_prereleases&sort=semver&label=release)](https://github.com/timothy-agent/timothy/releases/latest)
 [![Go](https://img.shields.io/badge/Go-1.26-00ADD8?logo=go&logoColor=white)](https://go.dev)
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)](https://react.dev)

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -32,7 +32,6 @@ func staticBudget(n int) func(context.Context) int {
 	return func(context.Context) int { return n }
 }
 
-
 // memDir is an in-memory Directory + chat.SessionLog.
 type memDir struct {
 	mu         sync.Mutex

--- a/internal/brain/api/kb.go
+++ b/internal/brain/api/kb.go
@@ -46,8 +46,8 @@ func (a *API) registerKB(handle func(pattern string, h http.Handler), store *kb.
 	h := &kbAPI{
 		store: store, ingest: ingest, markitdownURL: markitdownURL,
 		markitdownHTTP: &http.Client{},
-		fetchHTTP: &http.Client{Timeout: kbURLFetchTimeout, Transport: kbFetchTransport},
-		log: a.log,
+		fetchHTTP:      &http.Client{Timeout: kbURLFetchTimeout, Transport: kbFetchTransport},
+		log:            a.log,
 	}
 	handle("GET /v1/admin/kb/collections", a.auth(http.HandlerFunc(h.listCollections)))
 	handle("POST /v1/admin/kb/collections", a.auth(http.HandlerFunc(h.createCollection)))
@@ -350,6 +350,8 @@ func (h *kbAPI) convertFetched(ctx context.Context, u *url.URL, body []byte, con
 		name := "page.html"
 		if strings.Contains(contentType, "application/pdf") {
 			name = "page.pdf"
+		} else {
+			body = stripHTMLChrome(body)
 		}
 		md, err := markitdown.Convert(ctx, h.markitdownHTTP, h.markitdownURL, name, contentType, body)
 		if err != nil {

--- a/internal/brain/api/kb_html.go
+++ b/internal/brain/api/kb_html.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"bytes"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// kbChromeTags are stripped unconditionally (never carry article
+// content), except <header>/<footer> which need the sectioning-parent
+// check in isPageChrome below.
+var kbChromeTags = map[string]bool{
+	"script": true, "style": true, "noscript": true, "template": true,
+	"iframe": true, "nav": true, "aside": true,
+}
+
+// kbChromeRoles are ARIA landmark roles that mark page navigation/
+// boilerplate rather than article content.
+var kbChromeRoles = map[string]bool{
+	"navigation": true, "banner": true, "contentinfo": true, "complementary": true,
+}
+
+// kbSectioningTags bound how far up the tree a <header>/<footer> looks
+// for its nearest sectioning ancestor (HTML5 allows nested headers
+// inside <article>/<section>, which are content, not page chrome).
+var kbSectioningTags = map[string]bool{
+	"article": true, "section": true, "aside": true, "body": true,
+}
+
+// stripHTMLChrome removes navigation/boilerplate elements from a page
+// before it goes to markitdown: script/style/nav/header/footer/etc.,
+// plus ARIA landmarks and aria-hidden nodes. Best-effort — a parse
+// failure or an all-chrome page returns the input unchanged rather
+// than starving the ingest of any text at all.
+func stripHTMLChrome(body []byte) []byte {
+	doc, err := html.Parse(bytes.NewReader(body))
+	if err != nil {
+		return body
+	}
+	stripChromeNodes(doc)
+	isolateMain(doc)
+
+	var buf bytes.Buffer
+	if err := html.Render(&buf, doc); err != nil {
+		return body
+	}
+	stripped := buf.Bytes()
+	if strings.TrimSpace(textContent(doc)) == "" {
+		return body
+	}
+	return stripped
+}
+
+// stripChromeNodes walks the tree removing chrome elements. Recurses
+// depth-first so a removed node's children never get separately
+// visited.
+func stripChromeNodes(n *html.Node) {
+	child := n.FirstChild
+	for child != nil {
+		next := child.NextSibling
+		if child.Type == html.ElementNode && isChrome(child) {
+			n.RemoveChild(child)
+		} else {
+			stripChromeNodes(child)
+		}
+		child = next
+	}
+}
+
+func isChrome(n *html.Node) bool {
+	if kbChromeTags[n.Data] {
+		return true
+	}
+	if n.Data == "header" || n.Data == "footer" {
+		return isPageChrome(n)
+	}
+	for _, attr := range n.Attr {
+		switch attr.Key {
+		case "role":
+			if kbChromeRoles[strings.ToLower(strings.TrimSpace(attr.Val))] {
+				return true
+			}
+		case "aria-hidden":
+			if strings.EqualFold(strings.TrimSpace(attr.Val), "true") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isolateMain replaces <body>'s children with the page's single
+// <main> element when there is exactly one with text in it —
+// non-semantic chrome siblings (progress bars, hint overlays) go with
+// everything else outside it. Zero or multiple <main>s leaves the
+// body untouched.
+func isolateMain(doc *html.Node) {
+	body := findElement(doc, "body")
+	if body == nil {
+		return
+	}
+	mains := collectElements(body, "main")
+	if len(mains) != 1 || strings.TrimSpace(textContent(mains[0])) == "" {
+		return
+	}
+	main := mains[0]
+	main.Parent.RemoveChild(main)
+	for body.FirstChild != nil {
+		body.RemoveChild(body.FirstChild)
+	}
+	body.AppendChild(main)
+}
+
+func findElement(n *html.Node, tag string) *html.Node {
+	if n.Type == html.ElementNode && n.Data == tag {
+		return n
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if found := findElement(c, tag); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func collectElements(n *html.Node, tag string) []*html.Node {
+	var out []*html.Node
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && c.Data == tag {
+			out = append(out, c)
+			continue
+		}
+		out = append(out, collectElements(c, tag)...)
+	}
+	return out
+}
+
+// isPageChrome reports whether header/footer n's nearest sectioning
+// ancestor is <body> (page-level chrome) rather than <article>/
+// <section>/<aside> (in-content heading/footer, kept).
+func isPageChrome(n *html.Node) bool {
+	for p := n.Parent; p != nil; p = p.Parent {
+		if p.Type == html.ElementNode && kbSectioningTags[p.Data] {
+			return p.Data == "body"
+		}
+	}
+	return true
+}
+
+// textContent concatenates all text nodes under n.
+func textContent(n *html.Node) string {
+	if n.Type == html.TextNode {
+		return n.Data
+	}
+	var sb strings.Builder
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		sb.WriteString(textContent(c))
+	}
+	return sb.String()
+}

--- a/internal/brain/api/kb_html_test.go
+++ b/internal/brain/api/kb_html_test.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStripHTMLChrome(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		input       string
+		wantAbsent  []string
+		wantPresent []string
+	}{
+		{
+			name: "nav/header/footer/script junk stripped around main article",
+			input: `<html><body>
+				<header>Site Logo <nav>Home | About</nav></header>
+				<script>trackClick();</script>
+				<style>.x{color:red}</style>
+				<nav>Home | About | Contact</nav>
+				<main><article><h1>Article Title</h1><p>The real content lives here.</p></article></main>
+				<footer>Copyright 2026 · All rights reserved</footer>
+			</body></html>`,
+			wantAbsent:  []string{"Home | About", "trackClick", "color:red", "Copyright 2026", "Site Logo"},
+			wantPresent: []string{"Article Title", "The real content lives here"},
+		},
+		{
+			name: "nested header inside article survives",
+			input: `<html><body>
+				<header>Page Nav</header>
+				<main><article><header><h2>Section Heading</h2></header><p>Body text.</p></article></main>
+			</body></html>`,
+			wantAbsent:  []string{"Page Nav"},
+			wantPresent: []string{"Section Heading", "Body text"},
+		},
+		{
+			name: "everything inside nav falls back to original",
+			input: `<html><body>
+				<nav><p>Only content is inside this nav element.</p></nav>
+			</body></html>`,
+			wantPresent: []string{"Only content is inside this nav element"},
+		},
+		{
+			name: "role navigation div stripped",
+			input: `<html><body>
+				<div role="navigation">Menu | Links | Here</div>
+				<main><p>Kept paragraph text.</p></main>
+			</body></html>`,
+			wantAbsent:  []string{"Menu | Links | Here"},
+			wantPresent: []string{"Kept paragraph text"},
+		},
+		{
+			name: "aria-hidden true stripped",
+			input: `<html><body>
+				<div aria-hidden="true">Decorative hidden text</div>
+				<main><p>Visible paragraph.</p></main>
+			</body></html>`,
+			wantAbsent:  []string{"Decorative hidden text"},
+			wantPresent: []string{"Visible paragraph"},
+		},
+		{
+			name: "single main isolates content from non-semantic chrome siblings",
+			input: `<html><body>
+				<div class="progress"></div>
+				<div class="hint">←/→ · space · f fullscreen · Home/End</div>
+				<div class="corner">Day 1 · Last updated 2026-06-19</div>
+				<main class="deck"><section><h1>Slide Title</h1><p>Slide body text.</p></section></main>
+			</body></html>`,
+			wantAbsent:  []string{"fullscreen", "Last updated"},
+			wantPresent: []string{"Slide Title", "Slide body text"},
+		},
+		{
+			name: "two mains leave body untouched",
+			input: `<html><body>
+				<div class="hint">keyboard hints here</div>
+				<main><p>First main.</p></main>
+				<main><p>Second main.</p></main>
+			</body></html>`,
+			wantPresent: []string{"keyboard hints here", "First main", "Second main"},
+		},
+		{
+			name: "empty main leaves body untouched",
+			input: `<html><body>
+				<p>Real text outside.</p>
+				<main></main>
+			</body></html>`,
+			wantPresent: []string{"Real text outside"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := string(stripHTMLChrome([]byte(tc.input)))
+			for _, s := range tc.wantAbsent {
+				if strings.Contains(got, s) {
+					t.Errorf("stripHTMLChrome output still contains %q\ngot: %s", s, got)
+				}
+			}
+			for _, s := range tc.wantPresent {
+				if !strings.Contains(got, s) {
+					t.Errorf("stripHTMLChrome output missing %q\ngot: %s", s, got)
+				}
+			}
+		})
+	}
+}
+
+// TestStripHTMLChromeMalformedReturnsUnchanged pins the best-effort
+// fallback: a parse the html package can't handle at all (none are
+// known to actually error, since it tolerates malformed markup by
+// design) must never panic, and byte-identical input on any bail-out
+// path.
+func TestStripHTMLChromeMalformedReturnsUnchanged(t *testing.T) {
+	t.Parallel()
+	tests := []string{
+		"",
+		"<<<not really html at all>>>",
+		"<div><span>unclosed tags all the way down<p><b>",
+		"plain text, no tags whatsoever",
+	}
+	for _, in := range tests {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("stripHTMLChrome panicked on %q: %v", in, r)
+				}
+			}()
+			_ = stripHTMLChrome([]byte(in))
+		}()
+	}
+}

--- a/internal/brain/api/kb_integration_test.go
+++ b/internal/brain/api/kb_integration_test.go
@@ -134,6 +134,23 @@ func TestKBCollectionsCRUD(t *testing.T) {
 		t.Fatalf("list status = %d body %s", w.Code, w.Body)
 	}
 
+	// A failed document counts toward failed_count but not the base
+	// doc/chunk story — GetCollection picks it up via collectionColumns.
+	docID, err := store.CreateDocument(context.Background(), created.ID, "Doc", "file", "doc.md", "content", 7)
+	if err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+	if err := store.SetFailed(context.Background(), docID, "boom"); err != nil {
+		t.Fatalf("SetFailed: %v", err)
+	}
+	got, err := store.GetCollection(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	if got.FailedCount != 1 {
+		t.Fatalf("FailedCount = %d, want 1", got.FailedCount)
+	}
+
 	del := httptest.NewRequest("DELETE", "/v1/admin/kb/collections/"+created.ID, nil)
 	del.Header.Set("Authorization", "Bearer tok")
 	w = httptest.NewRecorder()

--- a/internal/brain/kb/kb.go
+++ b/internal/brain/kb/kb.go
@@ -29,6 +29,7 @@ type Collection struct {
 	Description string    `json:"description"`
 	DocCount    int       `json:"doc_count"`
 	ChunkCount  int       `json:"chunk_count"`
+	FailedCount int       `json:"failed_count"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
 }
@@ -67,11 +68,12 @@ func New(db *pgpool.Pool) *Store {
 
 const collectionColumns = `c.id, c.name, c.description, c.created_at, c.updated_at,
 	(SELECT count(*) FROM kb_documents d WHERE d.collection_id = c.id),
-	(SELECT coalesce(sum(d.chunk_count), 0) FROM kb_documents d WHERE d.collection_id = c.id)`
+	(SELECT coalesce(sum(d.chunk_count), 0) FROM kb_documents d WHERE d.collection_id = c.id),
+	(SELECT count(*) FROM kb_documents d WHERE d.collection_id = c.id AND d.status = 'failed')`
 
 func scanCollection(row pgx.Row) (Collection, error) {
 	var c Collection
-	err := row.Scan(&c.ID, &c.Name, &c.Description, &c.CreatedAt, &c.UpdatedAt, &c.DocCount, &c.ChunkCount)
+	err := row.Scan(&c.ID, &c.Name, &c.Description, &c.CreatedAt, &c.UpdatedAt, &c.DocCount, &c.ChunkCount, &c.FailedCount)
 	return c, err
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -549,6 +549,9 @@ export interface KbCollection {
   description: string
   doc_count: number
   chunk_count: number
+  // failed_count is how many documents in this collection are in the
+  // 'failed' ingestion state.
+  failed_count: number
   created_at: string
   updated_at: string
 }

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -413,8 +413,8 @@ describe('Composer knowledge mentions', () => {
   it('shows a filtered popup, selects on Enter, strips the token, and stops intercepting Enter', async () => {
     const client = await import('../api/client')
     vi.mocked(client.listKbCollections).mockResolvedValue([
-      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, created_at: '', updated_at: '' },
-      { id: '2', name: 'billing', description: '', doc_count: 0, chunk_count: 0, created_at: '', updated_at: '' },
+      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+      { id: '2', name: 'billing', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
     ])
     const onSend = vi.fn()
     render(<StatefulComposer onSend={onSend} />)
@@ -439,7 +439,7 @@ describe('Composer knowledge mentions', () => {
   it('closes the popup on Escape and lets Enter send', async () => {
     const client = await import('../api/client')
     vi.mocked(client.listKbCollections).mockResolvedValue([
-      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, created_at: '', updated_at: '' },
+      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
     ])
     const onSend = vi.fn()
     render(<StatefulComposer onSend={onSend} />)
@@ -474,7 +474,7 @@ describe('Composer knowledge mentions', () => {
     vi.mocked(client.listKbCollections)
       .mockRejectedValueOnce(new Error('network error'))
       .mockResolvedValueOnce([
-        { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, created_at: '', updated_at: '' },
+        { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
       ])
     const onSend = vi.fn()
     render(<StatefulComposer onSend={onSend} />)
@@ -493,8 +493,8 @@ describe('Composer knowledge mentions', () => {
   it('cycles the highlighted option with ArrowDown/ArrowUp, wrapping at both ends', async () => {
     const client = await import('../api/client')
     vi.mocked(client.listKbCollections).mockResolvedValue([
-      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, created_at: '', updated_at: '' },
-      { id: '2', name: 'billing', description: '', doc_count: 0, chunk_count: 0, created_at: '', updated_at: '' },
+      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+      { id: '2', name: 'billing', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
     ])
     const onSend = vi.fn()
     render(<StatefulComposer onSend={onSend} />)
@@ -523,8 +523,8 @@ describe('Composer knowledge mentions', () => {
   it('selects the clicked popup option, adding a chip and stripping the token', async () => {
     const client = await import('../api/client')
     vi.mocked(client.listKbCollections).mockResolvedValue([
-      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, created_at: '', updated_at: '' },
-      { id: '2', name: 'billing', description: '', doc_count: 0, chunk_count: 0, created_at: '', updated_at: '' },
+      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+      { id: '2', name: 'billing', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
     ])
     const onSend = vi.fn()
     render(<StatefulComposer onSend={onSend} />)
@@ -543,7 +543,7 @@ describe('Composer knowledge mentions', () => {
   it('selects the highlighted option on Tab, same as Enter', async () => {
     const client = await import('../api/client')
     vi.mocked(client.listKbCollections).mockResolvedValue([
-      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, created_at: '', updated_at: '' },
+      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
     ])
     const onSend = vi.fn()
     render(<StatefulComposer onSend={onSend} />)
@@ -577,8 +577,8 @@ describe('Composer agent-bound knowledge chips', () => {
   it('excludes agent-bound names from the mention popup', async () => {
     const client = await import('../api/client')
     vi.mocked(client.listKbCollections).mockResolvedValue([
-      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, created_at: '', updated_at: '' },
-      { id: '2', name: 'runbooks', description: '', doc_count: 0, chunk_count: 0, created_at: '', updated_at: '' },
+      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+      { id: '2', name: 'runbooks', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
     ])
     function StatefulWithAgentKnowledge() {
       const [draft, setDraft] = useState('')

--- a/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
@@ -67,6 +67,25 @@ function StatusBadge({ doc }: { doc: KbDocument }) {
 // document in the collection reaches a terminal state.
 const pollMs = 3000
 
+// parseUrls splits pasted/typed text on whitespace into unique, valid
+// http(s) URLs, preserving first-seen order.
+function parseUrls(text: string): string[] {
+  const seen = new Set<string>()
+  const urls: string[] = []
+  for (const token of text.split(/\s+/)) {
+    if (!token || seen.has(token)) continue
+    try {
+      const parsed = new URL(token)
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') continue
+    } catch {
+      continue
+    }
+    seen.add(token)
+    urls.push(token)
+  }
+  return urls
+}
+
 export function KnowledgeCollectionDetail() {
   const { id } = useParams()
   const navigate = useNavigate()
@@ -76,7 +95,7 @@ export function KnowledgeCollectionDetail() {
   const [confirmDeleteDoc, setConfirmDeleteDoc] = useState<KbDocument | null>(null)
   const [uploading, setUploading] = useState<Record<string, boolean>>({})
   const [url, setUrl] = useState('')
-  const [addingUrl, setAddingUrl] = useState(false)
+  const [urlProgress, setUrlProgress] = useState<{ done: number; total: number } | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
   const refresh = useCallback(() => {
@@ -126,16 +145,24 @@ export function KnowledgeCollectionDetail() {
   }
 
   const addUrl = async () => {
-    if (!id || !url.trim() || addingUrl) return
-    setAddingUrl(true)
-    try {
-      const doc = await addKbDocumentFromUrl(id, url.trim())
-      setDocuments((prev) => [doc, ...prev])
-      setUrl('')
-    } catch (err) {
-      toast.error('Could not add URL', { description: errText(err) })
-    } finally {
-      setAddingUrl(false)
+    if (!id || urlProgress) return
+    const urls = parseUrls(url)
+    if (urls.length === 0) return
+    setUrlProgress({ done: 0, total: urls.length })
+    const failed: string[] = []
+    for (const [i, u] of urls.entries()) {
+      try {
+        await addKbDocumentFromUrl(id, u)
+      } catch {
+        failed.push(u)
+      }
+      setUrlProgress({ done: i + 1, total: urls.length })
+    }
+    setUrlProgress(null)
+    setUrl('')
+    refresh()
+    if (failed.length > 0) {
+      toast.error(`${failed.length} of ${urls.length} failed: ${failed[0]}${failed.length > 1 ? '…' : ''}`)
     }
   }
 
@@ -241,18 +268,31 @@ export function KnowledgeCollectionDetail() {
           e.preventDefault()
           void addUrl()
         }}
-        className="flex items-center gap-2"
+        className="flex items-end gap-2"
       >
-        <input
-          type="url"
+        <textarea
+          rows={1}
           value={url}
-          onChange={(e) => setUrl(e.target.value)}
-          placeholder="https://example.com/article — add a page or PDF by URL"
-          className="h-9 w-full rounded-md border border-border bg-transparent px-3 text-sm outline-none placeholder:text-muted-foreground focus:border-ring"
+          onChange={(e) => {
+            setUrl(e.target.value)
+            e.target.style.height = 'auto'
+            e.target.style.height = `${e.target.scrollHeight}px`
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              void addUrl()
+            }
+          }}
+          placeholder="https://example.com/article — add a page or PDF by URL (paste several to bulk-add)"
+          className="max-h-40 min-h-9 w-full resize-none rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-ring"
         />
-        <Button type="submit" variant="outline" disabled={!url.trim() || addingUrl}>
-          {addingUrl ? (
-            <HugeiconsIcon icon={Loading03Icon} className="animate-spin" />
+        <Button type="submit" variant="outline" disabled={parseUrls(url).length === 0 || !!urlProgress}>
+          {urlProgress ? (
+            <>
+              <HugeiconsIcon icon={Loading03Icon} className="animate-spin" />
+              adding {urlProgress.done}/{urlProgress.total}…
+            </>
           ) : (
             'Add URL'
           )}

--- a/web/src/components/knowledge/KnowledgeCollectionsList.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionsList.tsx
@@ -73,6 +73,12 @@ export function KnowledgeCollectionsList() {
               <p className="mt-auto text-xs text-muted-foreground">
                 {c.doc_count} doc{c.doc_count === 1 ? '' : 's'} · {c.chunk_count} chunk
                 {c.chunk_count === 1 ? '' : 's'} · updated {relativeTime(c.updated_at)}
+                {c.failed_count > 0 && (
+                  <span className="text-red-600 dark:text-red-400">
+                    {' '}
+                    · {c.failed_count} failed
+                  </span>
+                )}
               </p>
             </button>
           ))}

--- a/web/src/components/settings/KnowledgePicker.test.tsx
+++ b/web/src/components/settings/KnowledgePicker.test.tsx
@@ -16,6 +16,7 @@ const collections: KbCollection[] = [
     description: 'Product documentation.',
     doc_count: 1,
     chunk_count: 5,
+    failed_count: 0,
     created_at: '2026-08-01T00:00:00Z',
     updated_at: '2026-08-01T00:00:00Z',
   },

--- a/web/src/pages/Home.test.tsx
+++ b/web/src/pages/Home.test.tsx
@@ -143,7 +143,7 @@ describe('Home', () => {
 
   it('carries picked #mention chips into the chat intent on send', async () => {
     vi.mocked(listKbCollections).mockResolvedValue([
-      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, created_at: '', updated_at: '' },
+      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
     ])
     renderHome()
     const input = screen.getByLabelText('Message') as HTMLTextAreaElement

--- a/web/src/pages/Knowledge.test.tsx
+++ b/web/src/pages/Knowledge.test.tsx
@@ -1,8 +1,13 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
+import { toast } from 'sonner'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { KbCollection, KbDocument } from '../api/types'
 import { Knowledge } from './Knowledge'
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
 
 vi.mock('../api/client', () => ({
   listKbCollections: vi.fn(),
@@ -13,9 +18,11 @@ vi.mock('../api/client', () => ({
   uploadKbDocument: vi.fn(),
   deleteKbDocument: vi.fn(),
   reingestKbDocument: vi.fn(),
+  addKbDocumentFromUrl: vi.fn(),
 }))
 
 import {
+  addKbDocumentFromUrl,
   createKbCollection,
   deleteKbDocument,
   getKbCollection,
@@ -31,6 +38,7 @@ const productDocs: KbCollection = {
   description: 'Product documentation for support agents.',
   doc_count: 2,
   chunk_count: 40,
+  failed_count: 0,
   created_at: '2026-08-01T00:00:00Z',
   updated_at: '2026-08-10T00:00:00Z',
 }
@@ -86,6 +94,19 @@ describe('Knowledge page', () => {
     expect(await screen.findByText('Collections · 1')).toBeTruthy()
     expect(screen.getByText('product-docs')).toBeTruthy()
     expect(screen.getByText(/2 docs · 40 chunks/)).toBeTruthy()
+  })
+
+  it('shows a failed-docs badge on the card when failed_count > 0', async () => {
+    vi.mocked(listKbCollections).mockResolvedValue([{ ...productDocs, failed_count: 3 }])
+    renderPage()
+    expect(await screen.findByText(/2 docs · 40 chunks/)).toBeTruthy()
+    expect(screen.getByText(/3 failed/)).toBeTruthy()
+  })
+
+  it('shows no failed-docs badge when failed_count is 0', async () => {
+    renderPage()
+    expect(await screen.findByText(/2 docs · 40 chunks/)).toBeTruthy()
+    expect(screen.queryByText(/failed/)).toBeNull()
   })
 
   it('shows an empty state with an explainer and create button', async () => {
@@ -147,6 +168,66 @@ describe('Knowledge page', () => {
 
       await waitFor(() => expect(uploadKbDocument).toHaveBeenCalledWith('c1', file))
       expect(await screen.findByText('new.md')).toBeTruthy()
+    })
+
+    it('adds a single URL via the input, unchanged from prior behavior', async () => {
+      const added: KbDocument = { ...readyDoc, id: 'd4', title: 'article', status: 'pending' }
+      vi.mocked(addKbDocumentFromUrl).mockResolvedValue(added)
+
+      renderPage('/knowledge/c1')
+      await screen.findByText('onboarding.pdf')
+
+      const input = screen.getByPlaceholderText(/add a page or PDF by URL/)
+      fireEvent.change(input, { target: { value: 'https://example.com/a' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Add URL' }))
+
+      await waitFor(() =>
+        expect(addKbDocumentFromUrl).toHaveBeenCalledWith('c1', 'https://example.com/a'),
+      )
+      expect(addKbDocumentFromUrl).toHaveBeenCalledTimes(1)
+    })
+
+    it('submits multiple pasted URLs sequentially, in order, with progress text', async () => {
+      vi.mocked(addKbDocumentFromUrl).mockResolvedValue(readyDoc)
+
+      renderPage('/knowledge/c1')
+      await screen.findByText('onboarding.pdf')
+
+      const input = screen.getByPlaceholderText(/add a page or PDF by URL/)
+      fireEvent.change(input, {
+        target: { value: 'https://example.com/a\nhttps://example.com/b https://example.com/c' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: 'Add URL' }))
+
+      await waitFor(() => expect(addKbDocumentFromUrl).toHaveBeenCalledTimes(3))
+      expect(addKbDocumentFromUrl).toHaveBeenNthCalledWith(1, 'c1', 'https://example.com/a')
+      expect(addKbDocumentFromUrl).toHaveBeenNthCalledWith(2, 'c1', 'https://example.com/b')
+      expect(addKbDocumentFromUrl).toHaveBeenNthCalledWith(3, 'c1', 'https://example.com/c')
+    })
+
+    it('keeps submitting remaining URLs after one fails, and toasts a summary', async () => {
+      vi.mocked(addKbDocumentFromUrl).mockImplementation((_id, url) =>
+        url === 'https://example.com/bad'
+          ? Promise.reject(new Error('fetch failed'))
+          : Promise.resolve(readyDoc),
+      )
+
+      renderPage('/knowledge/c1')
+      await screen.findByText('onboarding.pdf')
+
+      const input = screen.getByPlaceholderText(/add a page or PDF by URL/)
+      fireEvent.change(input, {
+        target: {
+          value: 'https://example.com/a https://example.com/bad https://example.com/c',
+        },
+      })
+      fireEvent.click(screen.getByRole('button', { name: 'Add URL' }))
+
+      await waitFor(() => expect(addKbDocumentFromUrl).toHaveBeenCalledTimes(3))
+      expect(addKbDocumentFromUrl).toHaveBeenNthCalledWith(3, 'c1', 'https://example.com/c')
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith('1 of 3 failed: https://example.com/bad'),
+      )
     })
 
     it('re-ingests a failed document', async () => {


### PR DESCRIPTION
## What

- **HTML chrome stripping at URL ingest**: pages fetched for the knowledge base go through a pre-markitdown cleanup — `script`/`style`/`noscript`/`template`/`iframe`/`nav`/`aside` removed, page-level `header`/`footer` (nearest sectioning ancestor is `body`) removed, ARIA landmark roles (`navigation`, `banner`, `contentinfo`, `complementary`) and `aria-hidden="true"` nodes removed. When a page has exactly one non-empty `<main>`, only it is kept, so non-semantic chrome siblings (progress bars, keyboard-hint overlays, corner labels) drop as well. Best-effort: parse failure or an all-chrome page falls back to the original body rather than starving the ingest.
- **Failed-document badge**: collections list shows "· N failed" when a collection has failed docs; `failed_count` added to the collections API.
- **Bulk URL import**: the collection URL input accepts multiple whitespace-separated URLs, ingests them sequentially with "adding N/M…" progress and a failure summary toast.
- Codecov badge in README.

## Why

First chunks of URL-ingested docs started with "←/→ · space · f fullscreen" nav junk, hurting retrieval. Failed docs were invisible until opening a collection. Adding many course pages one URL at a time was tedious.

## Verified

- `make build test vet lint` — 0 issues; table-driven tests for the stripper (chrome removal, nested-header survival, single-main isolation, multi/empty-main no-op, malformed-input fallback).
- Web: build clean, lint 0 errors, full test run green.
- Live: re-ingested course pages; `<main>`-structured page now chunks with zero chrome text (verified in kb_chunks).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789500955&installation_model_id=431401&pr_number=245&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F245&signature=aa4f95a93838b43580b0fefc6320d52daa1364717d37025625a4847978c052ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->