### PR TITLE
ci: skip web image build on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,15 +178,20 @@ jobs:
     # whose steps all skip still reports "success" (skipped steps
     # aren't a failure), so ci-ok's blanket check on `images` needs no
     # path-awareness of its own.
+    # The web leg additionally skips on fork PRs: its build needs the
+    # HUGEICONS_TOKEN secret, and GitHub withholds secrets from
+    # fork-triggered runs — the empty token fails npm auth (broke PR
+    # #248). Same-repo pushes and PRs still build it, and the release
+    # workflow builds it again at tag time, so nothing ships unbuilt.
     runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       matrix:
         service: [brain, gateway, memoryd, sandboxd, web]
     steps:
       - uses: actions/checkout@v7
-        if: (matrix.service == 'web' && needs.changes.outputs.web == 'true') || (matrix.service != 'web' && needs.changes.outputs.go == 'true')
+        if: (matrix.service == 'web' && needs.changes.outputs.web == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) || (matrix.service != 'web' && needs.changes.outputs.go == 'true')
       - name: Build image
-        if: (matrix.service == 'web' && needs.changes.outputs.web == 'true') || (matrix.service != 'web' && needs.changes.outputs.go == 'true')
+        if: (matrix.service == 'web' && needs.changes.outputs.web == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) || (matrix.service != 'web' && needs.changes.outputs.go == 'true')
         env:
           # Web only: HugeIcons Pro registry auth, passed as a BuildKit
           # secret so it never lands in an image layer.
@@ -202,7 +207,7 @@ jobs:
               -t timothy-${{ matrix.service }}:ci .
           fi
       - name: Scan image
-        if: (matrix.service == 'web' && needs.changes.outputs.web == 'true') || (matrix.service != 'web' && needs.changes.outputs.go == 'true')
+        if: (matrix.service == 'web' && needs.changes.outputs.web == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) || (matrix.service != 'web' && needs.changes.outputs.go == 'true')
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: timothy-${{ matrix.service }}:ci


### PR DESCRIPTION
The `images (web)` leg needs the `HUGEICONS_TOKEN` secret; GitHub withholds secrets from fork-triggered workflow runs, so any external PR touching `web/` fails on npm E401 (bit PR #248, which needed an admin bypass to merge).

This guards the web leg's steps with `github.event.pull_request.head.repo.full_name == github.repository` — fork PRs skip only the web image build+scan; the Go image legs, the full test suite, and the web test job still run for them. The web image is still built on every same-repo push/PR and again by the release workflow at tag time.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789687572&installation_model_id=431401&pr_number=250&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F250&signature=c2c18d9a5fb373aff7e4d19b3b8868a438a815de1247214153ce99b32ba652e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->