### PR TITLE
feat: responses-api capability probe and mission form polish

### DIFF
--- a/internal/brain/api/admin.go
+++ b/internal/brain/api/admin.go
@@ -138,6 +138,13 @@ type secretRefEntry struct {
 type referenceInfo struct {
 	Kind string `json:"kind"` // "provider" | "connector"
 	Name string `json:"name"`
+	// Role distinguishes what the ref is used for, so the frontend can
+	// refuse manual picks of machine-managed refs: "credential" (a
+	// normal manually-set secret), "oauth_tokens" (a google connector's
+	// machine-written token bundle — never a valid manual pick),
+	// "signing_key" (a github connector's derived signing key), or
+	// "client_secret" (a google connector's OAuth client secret).
+	Role string `json:"role"`
 }
 
 // registerSecrets mounts brain's own credentials-directory endpoints.
@@ -170,26 +177,41 @@ type secretsAPI struct {
 // connector with commit signing enabled — the derived
 // connectors.SigningKeyRefSuffix ref its private signing key lives
 // under, so the signing key never looks orphaned in the panel or
-// becomes deletable while the connector still signs with it.
-func connectorRefs(ctx context.Context, store connectorLister) (map[string][]string, error) {
+// becomes deletable while the connector still signs with it. A google
+// connector's config.client_secret_ref counts the same way: it is
+// resolved on every OAuth token refresh, so deleting it would break
+// the connector at the next refresh.
+func connectorRefs(ctx context.Context, store connectorLister) (map[string][]referenceInfo, error) {
 	if store == nil {
-		return map[string][]string{}, nil
+		return map[string][]referenceInfo{}, nil
 	}
 	rows, err := store.List(ctx)
 	if err != nil {
 		return nil, err
 	}
-	out := map[string][]string{}
+	out := map[string][]referenceInfo{}
 	for _, c := range rows {
 		if c.CredentialRef == "" {
 			continue
 		}
-		out[c.CredentialRef] = append(out[c.CredentialRef], c.Name)
+		// A google connector's credential_ref is the machine-written
+		// OAuth token bundle, never a valid manual pick.
+		credRole := "credential"
+		if c.Kind == "google" {
+			credRole = "oauth_tokens"
+		}
+		out[c.CredentialRef] = append(out[c.CredentialRef], referenceInfo{Kind: "connector", Name: c.Name, Role: credRole})
 		if c.Kind == "github" {
 			var cfg connectors.GitHubConfig
 			if json.Unmarshal(c.Config, &cfg) == nil && (cfg.SignCommits || cfg.SigningPublicKey != "") {
 				ref := connectors.SigningKeyRefSuffix(c.CredentialRef)
-				out[ref] = append(out[ref], c.Name)
+				out[ref] = append(out[ref], referenceInfo{Kind: "connector", Name: c.Name, Role: "signing_key"})
+			}
+		}
+		if c.Kind == "google" {
+			var cfg connectors.GoogleConfig
+			if json.Unmarshal(c.Config, &cfg) == nil && cfg.ClientSecretRef != "" {
+				out[cfg.ClientSecretRef] = append(out[cfg.ClientSecretRef], referenceInfo{Kind: "connector", Name: c.Name, Role: "client_secret"})
 			}
 		}
 	}
@@ -214,11 +236,9 @@ func (h *secretsAPI) list(w http.ResponseWriter, r *http.Request) {
 		// referenced_by unconditionally.
 		referents := []referenceInfo{}
 		for _, name := range ref.ReferencedBy {
-			referents = append(referents, referenceInfo{Kind: "provider", Name: name})
+			referents = append(referents, referenceInfo{Kind: "provider", Name: name, Role: "credential"})
 		}
-		for _, name := range byConnector[ref.RefName] {
-			referents = append(referents, referenceInfo{Kind: "connector", Name: name})
-		}
+		referents = append(referents, byConnector[ref.RefName]...)
 		out[i] = secretRefEntry{
 			RefName: ref.RefName, CreatedAt: ref.CreatedAt, UpdatedAt: ref.UpdatedAt,
 			ReferencedBy: referents,
@@ -238,7 +258,11 @@ func (h *secretsAPI) delete(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusInternalServerError, "connectors_failed", err.Error())
 		return
 	}
-	if names := byConnector[refName]; len(names) > 0 {
+	if refs := byConnector[refName]; len(refs) > 0 {
+		names := make([]string, len(refs))
+		for i, ref := range refs {
+			names[i] = ref.Name
+		}
 		jsonError(w, http.StatusConflict, "in_use",
 			refName+" is referenced by connector(s) "+joinNames(names))
 		return

--- a/internal/brain/api/admin.go
+++ b/internal/brain/api/admin.go
@@ -198,7 +198,7 @@ func connectorRefs(ctx context.Context, store connectorLister) (map[string][]ref
 		// OAuth token bundle, never a valid manual pick.
 		credRole := "credential"
 		if c.Kind == "google" {
-			credRole = "oauth_tokens"
+			credRole = "oauth_tokens" //nolint:gosec // G101: role label, not a credential value.
 		}
 		out[c.CredentialRef] = append(out[c.CredentialRef], referenceInfo{Kind: "connector", Name: c.Name, Role: credRole})
 		if c.Kind == "github" {

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -748,7 +748,16 @@ func (h *missionAPI) executorOptions(w http.ResponseWriter, r *http.Request) {
 		case resolved == nil || len(resolved.Entries) == 0:
 			opt.Reason = "route has no chain entries"
 		default:
+			// No entry usable: surface the first entry's own skip_reason
+			// (e.g. the responses-probe gate's "endpoint does not serve
+			// /v1/responses…") so the MissionForm tooltip stays
+			// actionable instead of falling back to a generic string —
+			// only when that reason is itself empty does the generic
+			// string apply.
 			opt.Reason = "no usable provider for this route"
+			if resolved.Entries[0].SkipReason != "" {
+				opt.Reason = resolved.Entries[0].SkipReason
+			}
 			for _, e := range resolved.Entries {
 				if e.Usable {
 					opt.Usable, opt.ProviderName, opt.Model, opt.Reason = true, e.ProviderName, e.Model, ""

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/SumonMSelim/timothy/internal/brain/attachments"
 	"github.com/SumonMSelim/timothy/internal/brain/connectors"
+	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
 	"github.com/SumonMSelim/timothy/internal/gateway/ledger"
 	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
@@ -670,6 +671,78 @@ func TestMissionsDecorateTopModels(t *testing.T) {
 
 	if out := h.decorateTopModels(context.Background(), nil); len(out) != 0 {
 		t.Fatalf("decorateTopModels(nil) = %+v, want empty slice", out)
+	}
+}
+
+// TestMissionsExecutorOptionsSurfacesSkipReason: when resolve succeeds
+// but no chain entry is usable, the option's reason must be the first
+// entry's own skip_reason when it's non-empty (e.g. the gateway's
+// responses-probe gate, "endpoint does not serve /v1/responses…") —
+// dropping it in favor of the generic "no usable provider for this
+// route" string would silently strip the actionable detail from the
+// MissionForm tooltip. An entry with no skip_reason of its own still
+// falls back to the generic string, and a route with zero entries
+// keeps its own distinct reason untouched.
+func TestMissionsExecutorOptionsSurfacesSkipReason(t *testing.T) {
+	t.Parallel()
+
+	h := &missionAPI{log: discard(), resolveExecutorOptions: func(_ context.Context, route, harness string) (*gwclient.ResolvedRoute, error) {
+		switch harness {
+		case "codex-cli":
+			return &gwclient.ResolvedRoute{Route: route, Entries: []gwclient.ResolvedRouteEntry{
+				{ProviderName: "zai", Model: "glm-4.7", Usable: false,
+					SkipReason: "endpoint does not serve /v1/responses — run Test connection on the provider to re-probe"},
+			}}, nil
+		case "opencode":
+			return &gwclient.ResolvedRoute{Route: route, Entries: []gwclient.ResolvedRouteEntry{
+				{ProviderName: "zai", Model: "glm-4.7", Usable: false},
+			}}, nil
+		default:
+			return &gwclient.ResolvedRoute{Route: route, Entries: nil}, nil
+		}
+	}}
+
+	req := httptest.NewRequest("GET", "/v1/missions/executor-options?route=coding", nil)
+	w := httptest.NewRecorder()
+	h.executorOptions(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var body struct {
+		Options []executorOption `json:"options"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byHarness := map[string]executorOption{}
+	for _, o := range body.Options {
+		byHarness[o.Harness] = o
+	}
+
+	codex, ok := byHarness["codex-cli"]
+	if !ok {
+		t.Fatal("codex-cli option missing (executor.Registered() should include it)")
+	}
+	wantReason := "endpoint does not serve /v1/responses — run Test connection on the provider to re-probe"
+	if codex.Usable || codex.Reason != wantReason {
+		t.Fatalf("codex-cli option = %+v, want unusable with the entry's own skip_reason %q", codex, wantReason)
+	}
+
+	opencode, ok := byHarness["opencode"]
+	if !ok {
+		t.Fatal("opencode option missing (executor.Registered() should include it)")
+	}
+	if opencode.Usable || opencode.Reason != "no usable provider for this route" {
+		t.Fatalf("opencode option = %+v, want the generic reason (entry carries no skip_reason)", opencode)
+	}
+
+	for harness, opt := range byHarness {
+		if harness == "codex-cli" || harness == "opencode" {
+			continue
+		}
+		if opt.Usable || opt.Reason != "route has no chain entries" {
+			t.Fatalf("%s option = %+v, want the no-entries reason untouched", harness, opt)
+		}
 	}
 }
 

--- a/internal/brain/api/secrets_test.go
+++ b/internal/brain/api/secrets_test.go
@@ -88,9 +88,9 @@ func TestListSecretsMergesProviderAndConnectorReferents(t *testing.T) {
 		t.Fatalf("GITHUB_PAT referenced_by = %+v, want provider + 2 connectors", got)
 	}
 	want := map[referenceInfo]bool{
-		{Kind: "provider", Name: "github-provider"}: true,
-		{Kind: "connector", Name: "github-mcp"}:     true,
-		{Kind: "connector", Name: "github-signed"}:  true,
+		{Kind: "provider", Name: "github-provider", Role: "credential"}: true,
+		{Kind: "connector", Name: "github-mcp", Role: "credential"}:     true,
+		{Kind: "connector", Name: "github-signed", Role: "credential"}:  true,
 	}
 	for _, r := range got {
 		if !want[r] {
@@ -98,8 +98,8 @@ func TestListSecretsMergesProviderAndConnectorReferents(t *testing.T) {
 		}
 	}
 	signKey := byName["GITHUB_PAT_SIGNING_KEY"].ReferencedBy
-	if len(signKey) != 1 || signKey[0] != (referenceInfo{Kind: "connector", Name: "github-signed"}) {
-		t.Fatalf("GITHUB_PAT_SIGNING_KEY referenced_by = %+v, want the signing connector (derived ref must never look orphaned)", signKey)
+	if len(signKey) != 1 || signKey[0] != (referenceInfo{Kind: "connector", Name: "github-signed", Role: "signing_key"}) {
+		t.Fatalf("GITHUB_PAT_SIGNING_KEY referenced_by = %+v, want the signing connector with role signing_key (derived ref must never look orphaned)", signKey)
 	}
 	if len(byName["ORPHAN_KEY"].ReferencedBy) != 0 {
 		t.Fatalf("ORPHAN_KEY referenced_by = %+v, want empty", byName["ORPHAN_KEY"].ReferencedBy)
@@ -127,6 +127,72 @@ func TestListSecretsPropagatesGatewayFailure(t *testing.T) {
 
 	if w.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502", w.Code)
+	}
+}
+
+func TestListSecretsCountsGoogleClientSecretRef(t *testing.T) {
+	t.Parallel()
+	a := &API{token: "tok", log: discard()}
+	gw := &fakeGatewaySecrets{refs: []gwclient.SecretRef{
+		{RefName: "GMAIL_GOOGLE_OAUTH"},
+		{RefName: "GMAIL_GOOGLE_CLIENT_SECRET"},
+	}}
+	conns := &fakeConnectorLister{rows: []connectors.Connector{
+		{Name: "gmail", Kind: "google", CredentialRef: "GMAIL_GOOGLE_OAUTH",
+			Config: json.RawMessage(`{"client_id":"x.apps.googleusercontent.com","client_secret_ref":"GMAIL_GOOGLE_CLIENT_SECRET"}`)},
+	}}
+	m := http.NewServeMux()
+	a.registerSecrets(m.Handle, gw, conns)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/secrets", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var body struct {
+		Secrets []secretRefEntry `json:"secrets"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byName := map[string]secretRefEntry{}
+	for _, s := range body.Secrets {
+		byName[s.RefName] = s
+	}
+	got := byName["GMAIL_GOOGLE_CLIENT_SECRET"].ReferencedBy
+	if len(got) != 1 || got[0] != (referenceInfo{Kind: "connector", Name: "gmail", Role: "client_secret"}) {
+		t.Fatalf("GMAIL_GOOGLE_CLIENT_SECRET referenced_by = %+v, want the google connector with role client_secret (client secret is resolved on every token refresh, must never look orphaned)", got)
+	}
+	oauth := byName["GMAIL_GOOGLE_OAUTH"].ReferencedBy
+	if len(oauth) != 1 || oauth[0] != (referenceInfo{Kind: "connector", Name: "gmail", Role: "oauth_tokens"}) {
+		t.Fatalf("GMAIL_GOOGLE_OAUTH referenced_by = %+v, want the google connector with role oauth_tokens (machine-managed token bundle, never a manual pick)", oauth)
+	}
+}
+
+func TestDeleteSecretRefusesGoogleClientSecretRef(t *testing.T) {
+	t.Parallel()
+	a := &API{token: "tok", log: discard()}
+	gw := &fakeGatewaySecrets{}
+	conns := &fakeConnectorLister{rows: []connectors.Connector{
+		{Name: "gmail", Kind: "google", CredentialRef: "GMAIL_GOOGLE_OAUTH",
+			Config: json.RawMessage(`{"client_secret_ref":"GMAIL_GOOGLE_CLIENT_SECRET"}`)},
+	}}
+	m := http.NewServeMux()
+	a.registerSecrets(m.Handle, gw, conns)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/admin/secrets/GMAIL_GOOGLE_CLIENT_SECRET", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", w.Code)
+	}
+	if gw.deletedRef != "" {
+		t.Fatalf("gateway DeleteSecret called with %q, want never called", gw.deletedRef)
 	}
 }
 

--- a/internal/brain/api/secrets_test.go
+++ b/internal/brain/api/secrets_test.go
@@ -138,6 +138,7 @@ func TestListSecretsCountsGoogleClientSecretRef(t *testing.T) {
 		{RefName: "GMAIL_GOOGLE_CLIENT_SECRET"},
 	}}
 	conns := &fakeConnectorLister{rows: []connectors.Connector{
+		//nolint:gosec // G101: fixture ref names, not credential values.
 		{Name: "gmail", Kind: "google", CredentialRef: "GMAIL_GOOGLE_OAUTH",
 			Config: json.RawMessage(`{"client_id":"x.apps.googleusercontent.com","client_secret_ref":"GMAIL_GOOGLE_CLIENT_SECRET"}`)},
 	}}
@@ -177,6 +178,7 @@ func TestDeleteSecretRefusesGoogleClientSecretRef(t *testing.T) {
 	a := &API{token: "tok", log: discard()}
 	gw := &fakeGatewaySecrets{}
 	conns := &fakeConnectorLister{rows: []connectors.Connector{
+		//nolint:gosec // G101: fixture ref names, not credential values.
 		{Name: "gmail", Kind: "google", CredentialRef: "GMAIL_GOOGLE_OAUTH",
 			Config: json.RawMessage(`{"client_secret_ref":"GMAIL_GOOGLE_CLIENT_SECRET"}`)},
 	}}

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -5,13 +5,17 @@
 package admin
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"regexp"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -365,6 +369,9 @@ func validateProvider(p Provider) error {
 	if err := validateLitellmProvider(p.Options); err != nil {
 		return err
 	}
+	if err := validateOpenAIResponses(p.Options); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -392,6 +399,11 @@ var harnessDrivers = map[string]map[string]bool{
 // anthropic_base_url must point at an Anthropic-compatible endpoint.
 // Never called for kind='cli' rows — those are inherently
 // wire-compatible (D-051, see validateProvider's "cli" case).
+// Deliberately does NOT check options.openai_responses (codex-cli's
+// stricter requirement, router.harnessNeedsResponses): that flag is
+// runtime-probed by Admin.Test, never known at write time, so a
+// wire-compatible openaicompat row always validates here regardless of
+// whether its endpoint actually serves /responses.
 func validateHarnessWireFormat(harness, driver string, opts map[string]string) error {
 	accepted, known := harnessDrivers[harness]
 	if !known {
@@ -444,6 +456,21 @@ func parseRequestTimeout(opts map[string]string) (time.Duration, error) {
 		return 0, fmt.Errorf("options.request_timeout %q: %w", raw, err)
 	}
 	return d, nil
+}
+
+// validateOpenAIResponses checks options.openai_responses, when
+// present, is exactly "true" or "false" — the two literals the
+// responses probe (Admin.Test) ever writes. Absent means unknown,
+// never guessed; an operator should never hand-write anything else here.
+func validateOpenAIResponses(opts map[string]string) error {
+	raw, ok := opts["openai_responses"]
+	if !ok || raw == "" {
+		return nil
+	}
+	if raw != "true" && raw != "false" {
+		return fmt.Errorf("options.openai_responses %q must be \"true\" or \"false\"", raw)
+	}
+	return nil
 }
 
 // List returns every provider row, config order by name.
@@ -603,6 +630,9 @@ func (a *Admin) Patch(ctx context.Context, id string, patch ProviderPatch) error
 			return err
 		}
 		if err := validateLitellmProvider(*patch.Options); err != nil {
+			return err
+		}
+		if err := validateOpenAIResponses(*patch.Options); err != nil {
 			return err
 		}
 	}
@@ -1059,6 +1089,13 @@ type TestResult struct {
 	LatencyMS int64  `json:"latency_ms"`
 	Model     string `json:"model"`
 	Detail    string `json:"detail,omitempty"`
+	// ResponsesOK is whether the endpoint serves POST /responses (the
+	// OpenAI Responses API codex-cli requires) — nil when unprobed or
+	// the probe outcome was ambiguous (never guessed), set only for an
+	// openaicompat provider with a base_url. Never affects OK: a
+	// provider without /responses is still a perfectly good chat
+	// provider for every harness/route that doesn't need it.
+	ResponsesOK *bool `json:"responses_ok,omitempty"`
 }
 
 // Test runs a one-token completion against the provider and books it
@@ -1084,9 +1121,54 @@ func (a *Admin) Test(ctx context.Context, id, model string) (TestResult, error) 
 		return TestResult{}, fmt.Errorf("provider %s has no default model; pass one", p.Name)
 	}
 
-	res := a.probe(ctx, drv, p.Name, model, snap.Prices(p.Name, model), probeTimeout(p.Options))
+	timeout := probeTimeout(p.Options)
+	res := a.probe(ctx, drv, p.Name, model, snap.Prices(p.Name, model), timeout)
+	if res.OK && p.Driver == "openaicompat" && p.BaseURL != "" {
+		res.ResponsesOK = a.probeResponses(ctx, p.BaseURL, p.CredentialRef, model, timeout)
+		if res.ResponsesOK != nil {
+			if err := a.setOpenAIResponses(ctx, id, *res.ResponsesOK); err != nil {
+				a.log.Warn("persist openai_responses probe result failed", "provider", id, "error", err)
+			}
+		}
+	}
 	a.audit(ctx, "test", "provider", id, nil, res)
 	return res, nil
+}
+
+// setOpenAIResponses merges options.openai_responses into the provider
+// row's existing options (never clobbering other keys) and reloads the
+// serving snapshot, mirroring Patch's own read-modify-write-then-reload
+// shape but scoped to this one key.
+func (a *Admin) setOpenAIResponses(ctx context.Context, id string, ok bool) error {
+	db, err := a.db.Get()
+	if err != nil {
+		return fmt.Errorf("admin set openai_responses: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("admin set openai_responses: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	before, err := a.getForUpdate(ctx, tx, id)
+	if err != nil {
+		return err
+	}
+	opts := map[string]string{}
+	for k, v := range before.Options {
+		opts[k] = v
+	}
+	opts["openai_responses"] = strconv.FormatBool(ok)
+
+	if _, err := tx.Exec(ctx, `UPDATE providers SET options = $2, updated_at = now() WHERE id = $1`,
+		id, jsonOr(opts, "{}")); err != nil {
+		return fmt.Errorf("admin set openai_responses: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("admin set openai_responses: %w", err)
+	}
+	a.reload(ctx)
+	return nil
 }
 
 // Validate runs the same one-token probe as Test against a provider
@@ -1125,7 +1207,13 @@ func (a *Admin) Validate(ctx context.Context, p Provider, model string) (TestRes
 	}
 	drv, _ := reg.Get(p.Name)
 
-	res := a.probe(ctx, drv, p.Name, model, nil, probeTimeout(p.Options))
+	probeTO := probeTimeout(p.Options)
+	res := a.probe(ctx, drv, p.Name, model, nil, probeTO)
+	if res.OK && p.Driver == "openaicompat" && p.BaseURL != "" {
+		// Report-only: Validate probes an unsaved config, so there is
+		// nothing to persist the result onto.
+		res.ResponsesOK = a.probeResponses(ctx, p.BaseURL, p.CredentialRef, model, probeTO)
+	}
 	a.audit(ctx, "validate", "provider", p.Name, nil, res)
 	return res, nil
 }
@@ -1228,6 +1316,63 @@ func (a *Admin) probe(ctx context.Context, drv provider.Provider, providerName, 
 	entry.LatencyMS = res.LatencyMS
 	a.rec.Record(ctx, entry)
 	return res
+}
+
+// responsesProbeBody is the minimal OpenAI Responses API request the
+// capability probe sends: max_output_tokens' floor is 16 (the API
+// rejects anything lower), so this is the smallest legal request that
+// still exercises the endpoint.
+type responsesProbeBody struct {
+	Model           string `json:"model"`
+	Input           string `json:"input"`
+	MaxOutputTokens int    `json:"max_output_tokens"`
+}
+
+// probeResponses checks whether baseURL serves POST /responses — the
+// OpenAI Responses API wire codex-cli requires (D-051 follow-up: the
+// Z.ai coding-plan endpoint 404s /responses despite chatting fine over
+// /chat/completions, so the static openaicompat wire check alone can't
+// tell missions codex-cli will actually work there). Only ever called
+// after the chat probe already succeeded, and never affects
+// TestResult.OK — a provider without /responses is still a perfectly
+// good chat provider. Result is deliberately tri-state: 2xx is a
+// confirmed true, 404/405 (route not found/not allowed — the
+// unambiguous "this endpoint doesn't have /responses" signals) is a
+// confirmed false, anything else (network error, timeout, 401/403/429,
+// 5xx) is nil — an ambiguous signal must never be recorded as a
+// definite no. No ledger entry: this is capability detection, not
+// spend, and cost is unknown either way (never guessed) even if the
+// response happens to carry a usage field.
+func (a *Admin) probeResponses(ctx context.Context, baseURL, credentialRef, model string, timeout time.Duration) *bool {
+	body, err := json.Marshal(responsesProbeBody{Model: model, Input: "ping", MaxOutputTokens: 16})
+	if err != nil {
+		return nil
+	}
+	tctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(tctx, http.MethodPost, strings.TrimSuffix(baseURL, "/")+"/responses", bytes.NewReader(body))
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if credentialRef != "" {
+		req.Header.Set("Authorization", "Bearer "+a.credentialLookup()(credentialRef))
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		v := true
+		return &v
+	case resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed:
+		v := false
+		return &v
+	default:
+		return nil
+	}
 }
 
 // Sentinel errors the HTTP layer maps onto status codes.

--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -5,6 +5,7 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -1078,4 +1079,152 @@ func TestCatalogPricesResolvesByProviderRow(t *testing.T) {
 	if priced[1].Price != nil {
 		t.Fatalf("unknown provider priced = %+v, want nil", priced[1].Price)
 	}
+}
+
+// TestTestPersistsOpenAIResponsesOnDefiniteResult is the real incident
+// this probe exists for (Z.ai's coding-plan endpoint 404s /responses
+// while chatting fine over /chat/completions): Test's chat probe
+// succeeds, the /responses probe returns a definite 404 → false, Test
+// persists options.openai_responses=false onto the provider row and
+// reloads the snapshot, and TestResult.OK stays true throughout — a
+// provider without /responses is still a perfectly good chat provider.
+func TestTestPersistsOpenAIResponsesOnDefiniteResult(t *testing.T) {
+	adm, store, _ := testAdmin(t)
+	ctx := t.Context()
+
+	var responsesHit bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/chat/completions":
+			oaiWriteSSE(w, `{"choices":[{"delta":{"content":"pong"}}]}`)
+			oaiWriteSSE(w, `{"choices":[{"delta":{},"finish_reason":"stop"}]}`)
+			oaiWriteSSE(w, "[DONE]")
+		case "/responses":
+			responsesHit = true
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	name := adminMarker + "responses-probe"
+	id, err := adm.Create(ctx, Provider{
+		Name: name, Kind: "api", Driver: "openaicompat",
+		BaseURL: srv.URL, CredentialRef: adminMarker + "responses-probe-key", DefaultModel: "m1",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	res, err := adm.Test(ctx, id, "")
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("Test.OK = false, want true (chat probe succeeded): %+v", res)
+	}
+	if !responsesHit {
+		t.Fatal("responses probe never hit /responses")
+	}
+	if res.ResponsesOK == nil || *res.ResponsesOK {
+		t.Fatalf("ResponsesOK = %v, want false (404)", res.ResponsesOK)
+	}
+
+	list, err := adm.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var found bool
+	for _, p := range list {
+		if p.ID != id {
+			continue
+		}
+		found = true
+		if p.Options["openai_responses"] != "false" {
+			t.Fatalf("persisted options.openai_responses = %q, want \"false\"", p.Options["openai_responses"])
+		}
+	}
+	if !found {
+		t.Fatal("provider not found after Test")
+	}
+
+	waitSnapshot(t, store, name)
+	rows, _ := store.Snapshot().Providers()
+	var row *router.ProviderRow
+	for i := range rows {
+		if rows[i].Name == name {
+			row = &rows[i]
+		}
+	}
+	if row == nil {
+		t.Fatal("provider row missing from snapshot after reload")
+	}
+	if row.OpenAIResponses == nil || *row.OpenAIResponses {
+		t.Fatalf("snapshot row OpenAIResponses = %v, want false", row.OpenAIResponses)
+	}
+}
+
+// TestValidateNeverPersistsOpenAIResponses: Validate probes an unsaved
+// config (the create-time preview) and must only report the result,
+// never write it anywhere — there's no provider row yet to write onto.
+func TestValidateNeverPersistsOpenAIResponses(t *testing.T) {
+	adm, _, _ := testAdmin(t)
+	ctx := t.Context()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/chat/completions":
+			oaiWriteSSE(w, `{"choices":[{"delta":{"content":"pong"}}]}`)
+			oaiWriteSSE(w, `{"choices":[{"delta":{},"finish_reason":"stop"}]}`)
+			oaiWriteSSE(w, "[DONE]")
+		case "/responses":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	ref := adminMarker + "validate-responses-key"
+	if err := adm.SetSecret(ctx, ref, "sk-test"); err != nil {
+		t.Fatalf("SetSecret: %v", err)
+	}
+	t.Cleanup(func() { _ = adm.DeleteSecret(context.Background(), ref) })
+
+	res, err := adm.Validate(ctx, Provider{
+		Name: adminMarker + "validate-unsaved", Kind: "api", Driver: "openaicompat",
+		BaseURL: srv.URL, CredentialRef: ref,
+	}, "m1")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("Validate.OK = false, want true: %+v", res)
+	}
+	if res.ResponsesOK == nil || !*res.ResponsesOK {
+		t.Fatalf("ResponsesOK = %v, want true (2xx)", res.ResponsesOK)
+	}
+
+	// Nothing was ever created, so there is nothing in the providers
+	// table this could have written onto — confirm no stray row exists
+	// under either name Validate touched.
+	list, err := adm.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, p := range list {
+		if strings.HasPrefix(p.Name, adminMarker+"validate") {
+			t.Fatalf("Validate must never persist a provider row, found: %+v", p)
+		}
+	}
+}
+
+// oaiWriteSSE writes one OpenAI-compat chat/completions SSE chunk,
+// mirroring the provider package's own oaiWrite test helper (unexported
+// there, so duplicated here for this package's Stream-driving probes).
+func oaiWriteSSE(w http.ResponseWriter, data string) {
+	_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+	w.(http.Flusher).Flush()
 }

--- a/internal/gateway/admin/admin_options_test.go
+++ b/internal/gateway/admin/admin_options_test.go
@@ -1,6 +1,8 @@
 package admin
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -72,6 +74,37 @@ func TestValidateLitellmProvider(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatalf("validateLitellmProvider: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateOpenAIResponses(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		opts    map[string]string
+		wantErr string
+	}{
+		{name: "absent is valid", opts: map[string]string{}},
+		{name: "nil map is valid", opts: nil},
+		{name: "empty string is valid (unset)", opts: map[string]string{"openai_responses": ""}},
+		{name: "true is valid", opts: map[string]string{"openai_responses": "true"}},
+		{name: "false is valid", opts: map[string]string{"openai_responses": "false"}},
+		{name: "arbitrary value rejected", opts: map[string]string{"openai_responses": "yes"}, wantErr: "openai_responses"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateOpenAIResponses(tt.opts)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateOpenAIResponses: %v", err)
 			}
 		})
 	}
@@ -182,6 +215,60 @@ func TestValidateHarnessWireFormat(t *testing.T) {
 		})
 	}
 }
+
+// TestProbeResponsesClassification covers the responses-capability
+// probe's tri-state classification (real incident: Z.ai's coding-plan
+// endpoint 404s /responses while chatting fine over /chat/completions —
+// 404/405 are the only unambiguous "no" signals; everything else stays
+// unknown rather than guessing).
+func TestProbeResponsesClassification(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		status int
+		fail   bool // simulate a network error / no server at all
+		want   *bool
+	}{
+		{name: "2xx is a definite yes", status: http.StatusOK, want: boolPtrAdmin(true)},
+		{name: "201 is still a definite yes", status: http.StatusCreated, want: boolPtrAdmin(true)},
+		{name: "404 is a definite no", status: http.StatusNotFound, want: boolPtrAdmin(false)},
+		{name: "405 is a definite no", status: http.StatusMethodNotAllowed, want: boolPtrAdmin(false)},
+		{name: "401 is unknown", status: http.StatusUnauthorized, want: nil},
+		{name: "403 is unknown", status: http.StatusForbidden, want: nil},
+		{name: "429 is unknown", status: http.StatusTooManyRequests, want: nil},
+		{name: "500 is unknown", status: http.StatusInternalServerError, want: nil},
+		{name: "network failure is unknown", fail: true, want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			a := &Admin{}
+			baseURL := "http://127.0.0.1:1" // unreachable, used only for the fail case
+			if !tt.fail {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path != "/responses" {
+						t.Errorf("path = %q, want /responses", r.URL.Path)
+					}
+					w.WriteHeader(tt.status)
+				}))
+				defer srv.Close()
+				baseURL = srv.URL
+			}
+			got := a.probeResponses(t.Context(), baseURL, "", "m1", 2*time.Second)
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("probeResponses = %v, want nil", *got)
+				}
+				return
+			}
+			if got == nil || *got != *tt.want {
+				t.Fatalf("probeResponses = %v, want %v", got, *tt.want)
+			}
+		})
+	}
+}
+
+func boolPtrAdmin(b bool) *bool { return &b }
 
 func TestProbeTimeout(t *testing.T) {
 	t.Parallel()

--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -69,6 +69,12 @@ type ProviderRow struct {
 	// (e.g. a subscription-auth row with no chat driver at all). Ignored
 	// by every chat-serving driver.
 	AnthropicBaseURL string
+	// OpenAIResponses comes from options.openai_responses — whether this
+	// row's endpoint serves POST /v1/responses, set by Admin.Test's probe
+	// (never guessed): nil is unknown (never probed, or the probe result
+	// was ambiguous), true/false is a definite probe result. Only checked
+	// for harnesses in harnessNeedsResponses (codex-cli).
+	OpenAIResponses *bool
 }
 
 // ChainEntry is one step of a route chain. Harness selection moved to
@@ -104,6 +110,14 @@ var harnessDrivers = map[string]map[string]bool{
 	"codex-cli":  {"openaicompat": true},
 	"opencode":   {"openaicompat": true},
 }
+
+// harnessNeedsResponses names harnesses that speak the OpenAI Responses
+// API (POST /responses) exclusively — codex 0.147.0 has no chat/
+// completions fallback, so a wire-compatible (openaicompat) provider
+// whose endpoint doesn't actually serve /responses still fails at
+// spawn time (the real Z.ai incident this gate exists for). Checked by
+// executorUsable against the row's probed OpenAIResponses flag.
+var harnessNeedsResponses = map[string]bool{"codex-cli": true}
 
 // RouteRow mirrors one routes table row. Strategy picks the chain
 // order at resolve time: "ordered" keeps the written priority; "auto",
@@ -682,6 +696,12 @@ func executorUsable(row ProviderRow, harness string) (bool, string) {
 	}
 	if row.CredentialRef == "" {
 		return false, "credential_ref is required"
+	}
+	// A known-false probe means the endpoint answered and rejected
+	// /responses (404/405) — an unknown result (nil, never probed or an
+	// ambiguous probe outcome) stays usable rather than guessing.
+	if harnessNeedsResponses[harness] && row.OpenAIResponses != nil && !*row.OpenAIResponses {
+		return false, "endpoint does not serve /v1/responses — run Test connection on the provider to re-probe"
 	}
 	return true, ""
 }

--- a/internal/gateway/router/router_test.go
+++ b/internal/gateway/router/router_test.go
@@ -1221,3 +1221,81 @@ func TestResolveRouteCarriesPrices(t *testing.T) {
 		t.Fatalf("unpriced entry Prices = %+v, want nil", entries[1].Prices)
 	}
 }
+
+// TestExecutorUsableOpenAIResponsesGate covers the responses capability
+// probe gate (real incident: Z.ai's coding-plan endpoint 404s /responses
+// while its driver is openaicompat, so the static wire check alone said
+// "usable" and codex-cli failed at spawn time). Only codex-cli
+// (harnessNeedsResponses) is gated; nil (never probed, or an ambiguous
+// probe outcome) and true both stay usable — only a definite false
+// flips it.
+func TestExecutorUsableOpenAIResponsesGate(t *testing.T) {
+	t.Parallel()
+	trueVal, falseVal := true, false
+	base := ProviderRow{Kind: "api", Driver: "openaicompat", CredentialRef: "K", Enabled: true}
+
+	tests := []struct {
+		name       string
+		harness    string
+		responses  *bool
+		wantUsable bool
+		wantReason string
+	}{
+		{name: "codex-cli unknown flag stays usable", harness: "codex-cli", responses: nil, wantUsable: true},
+		{name: "codex-cli true flag stays usable", harness: "codex-cli", responses: &trueVal, wantUsable: true},
+		{name: "codex-cli false flag is unusable", harness: "codex-cli", responses: &falseVal, wantUsable: false, wantReason: "does not serve /v1/responses"},
+		{name: "opencode unaffected by false flag", harness: "opencode", responses: &falseVal, wantUsable: true},
+		{name: "pi unaffected by false flag", harness: "pi", responses: &falseVal, wantUsable: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			row := base
+			row.OpenAIResponses = tt.responses
+			usable, reason := executorUsable(row, tt.harness)
+			if usable != tt.wantUsable {
+				t.Fatalf("usable = %v, reason = %q, want usable=%v", usable, reason, tt.wantUsable)
+			}
+			if tt.wantReason != "" && !strings.Contains(reason, tt.wantReason) {
+				t.Fatalf("reason = %q, want containing %q", reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestResolveRouteOpenAIResponsesGate is the same gate exercised through
+// ResolveRoute, confirming the wire-incompatible check still wins when
+// both would otherwise fire (order matters: a provider whose driver
+// can't even speak the harness's wire should report that reason, not
+// the responses one).
+func TestResolveRouteOpenAIResponsesGate(t *testing.T) {
+	t.Parallel()
+	falseVal := false
+	provRows := []ProviderRow{
+		{ID: "p1", Name: "zai-coding-plan", Kind: "api", Driver: "openaicompat",
+			CredentialRef: "Z_KEY", Enabled: true, OpenAIResponses: &falseVal},
+	}
+	routeRows := []RouteRow{
+		{Name: "coding-exec", Enabled: true, Chain: []ChainEntry{
+			{ProviderID: "p1", Model: "glm-4.7"},
+		}},
+	}
+	snap, _ := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" })
+
+	entries, ok := snap.ResolveRoute("coding-exec", "codex-cli")
+	if !ok || len(entries) != 1 {
+		t.Fatalf("ResolveRoute = %+v, ok=%v", entries, ok)
+	}
+	if entries[0].Usable || !strings.Contains(entries[0].SkipReason, "does not serve /v1/responses") {
+		t.Fatalf("entry = %+v, want unusable with the responses-probe reason", entries[0])
+	}
+
+	// opencode speaks the same wire but doesn't need /responses.
+	entries, ok = snap.ResolveRoute("coding-exec", "opencode")
+	if !ok || len(entries) != 1 {
+		t.Fatalf("ResolveRoute = %+v, ok=%v", entries, ok)
+	}
+	if !entries[0].Usable || entries[0].SkipReason != "" {
+		t.Fatalf("entry = %+v, want usable (opencode doesn't need /responses)", entries[0])
+	}
+}

--- a/internal/gateway/router/store.go
+++ b/internal/gateway/router/store.go
@@ -169,19 +169,24 @@ func (s *Store) Load(ctx context.Context) error {
 }
 
 // applyProviderOptions decodes a providers row's options jsonb into row.
-// Only reasoning_effort, request_timeout, and region are recognized
-// today (D-040, D-041, D-048); unknown keys are ignored silently. An
-// unparseable request_timeout fails the load outright — config honesty,
-// never a silent fallback to the driver default. region gets no such
+// Only reasoning_effort, request_timeout, region, anthropic_base_url,
+// and openai_responses are recognized today (D-040, D-041, D-048,
+// D-051); unknown keys are ignored silently. An unparseable
+// request_timeout fails the load outright — config honesty, never a
+// silent fallback to the driver default. region gets no such
 // validation beyond being present: AWS region ids change over time, so
 // the gateway never hardcodes a valid set — an unknown region simply
-// fails at the AWS SDK when used.
+// fails at the AWS SDK when used. openai_responses is tri-state
+// ("true"/"false"/absent); absent leaves row.OpenAIResponses nil
+// (unknown), anything else fails the load — Admin.Test/Patch are the
+// only writers and only ever write those two literals.
 func applyProviderOptions(row *ProviderRow, optionsJSON []byte) error {
 	var opts struct {
 		ReasoningEffort  string `json:"reasoning_effort"`
 		RequestTimeout   string `json:"request_timeout"`
 		Region           string `json:"region"`
 		AnthropicBaseURL string `json:"anthropic_base_url"`
+		OpenAIResponses  string `json:"openai_responses"`
 	}
 	if err := json.Unmarshal(optionsJSON, &opts); err != nil {
 		return err
@@ -195,6 +200,18 @@ func applyProviderOptions(row *ProviderRow, optionsJSON []byte) error {
 			return fmt.Errorf("request_timeout %q: %w", opts.RequestTimeout, err)
 		}
 		row.Timeout = d
+	}
+	switch opts.OpenAIResponses {
+	case "":
+		// absent = unknown, row.OpenAIResponses stays nil.
+	case "true":
+		v := true
+		row.OpenAIResponses = &v
+	case "false":
+		v := false
+		row.OpenAIResponses = &v
+	default:
+		return fmt.Errorf("openai_responses %q must be \"true\" or \"false\"", opts.OpenAIResponses)
 	}
 	return nil
 }

--- a/internal/gateway/router/store_test.go
+++ b/internal/gateway/router/store_test.go
@@ -51,3 +51,50 @@ func TestApplyProviderOptionsReasoningEffort(t *testing.T) {
 		t.Fatalf("ReasoningEffort = %q, want none", row.ReasoningEffort)
 	}
 }
+
+// TestApplyProviderOptionsOpenAIResponses covers the tri-state
+// openai_responses flag (D-051 follow-up): absent must leave
+// OpenAIResponses nil (unknown, never guessed), "true"/"false" set a
+// definite *bool, and anything else fails the load outright — the only
+// writers (Admin.Test/Patch) never write anything but those two literals.
+func TestApplyProviderOptionsOpenAIResponses(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		options string
+		want    *bool
+		wantErr string
+	}{
+		{name: "absent leaves nil", options: `{}`, want: nil},
+		{name: "true sets true", options: `{"openai_responses": "true"}`, want: boolPtr(true)},
+		{name: "false sets false", options: `{"openai_responses": "false"}`, want: boolPtr(false)},
+		{name: "invalid value errors", options: `{"openai_responses": "yes"}`, wantErr: "openai_responses"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var row ProviderRow
+			err := applyProviderOptions(&row, []byte(tt.options))
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("applyProviderOptions: %v", err)
+			}
+			if tt.want == nil {
+				if row.OpenAIResponses != nil {
+					t.Fatalf("OpenAIResponses = %v, want nil", *row.OpenAIResponses)
+				}
+				return
+			}
+			if row.OpenAIResponses == nil || *row.OpenAIResponses != *tt.want {
+				t.Fatalf("OpenAIResponses = %v, want %v", row.OpenAIResponses, *tt.want)
+			}
+		})
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -777,6 +777,7 @@ export async function deleteSecret(refName: string): Promise<void> {
 export interface SecretReference {
   kind: 'provider' | 'connector'
   name: string
+  role: 'credential' | 'oauth_tokens' | 'signing_key' | 'client_secret'
 }
 
 // SecretRefEntry is one stored secret's directory entry: name,

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -567,6 +567,10 @@ export interface TestResult {
   latency_ms: number
   model: string
   detail?: string
+  // responses_ok: whether the endpoint serves POST /responses (the
+  // OpenAI Responses API codex-cli requires) — absent when unprobed or
+  // the probe outcome was ambiguous, never affects ok.
+  responses_ok?: boolean
 }
 
 // AvailableModel is one model reported by a provider's own listing

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -1,8 +1,8 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { AdminConnector, AdminRoute, GitHubRepo, Mission, Schedule } from '../../api/types'
-import { MissionForm } from './MissionForm'
+import type { AdminAgent, AdminConnector, AdminRoute, GitHubRepo, Mission, Schedule } from '../../api/types'
+import { defaultRouteLabel, MissionForm } from './MissionForm'
 
 vi.mock('../../api/client', () => ({
   classifyMission: vi.fn(),
@@ -66,6 +66,58 @@ const schedule: Schedule = {
   pending_fire: false,
 }
 
+function makeAgent(overrides: Partial<AdminAgent> = {}): AdminAgent {
+  return {
+    id: 'a1',
+    name: 'agent',
+    description: '',
+    prompt_overlay: '',
+    route: '',
+    skills: [],
+    tools: [],
+    memory: false,
+    is_default: false,
+    enabled: true,
+    ...overrides,
+  }
+}
+
+describe('defaultRouteLabel', () => {
+  it("uses the agent's own route when the agent has one", () => {
+    const agent = makeAgent({ route: 'careful' })
+    expect(defaultRouteLabel('general', agent, routes)).toBe('Default (careful)')
+    // Takes priority even for coding with a "coding" route present.
+    expect(
+      defaultRouteLabel('coding', agent, [...routes, { name: 'coding', strategy: 'ordered', enabled: true, chain: [] }]),
+    ).toBe('Default (careful)')
+  })
+
+  it('falls back to a route literally named "coding" for coding missions when no agent route is set', () => {
+    const codingRoutes: AdminRoute[] = [
+      ...routes,
+      { name: 'coding', strategy: 'ordered', enabled: true, chain: [] },
+    ]
+    expect(defaultRouteLabel('coding', undefined, codingRoutes)).toBe('Default (coding)')
+    expect(defaultRouteLabel('coding', makeAgent({ route: '' }), codingRoutes)).toBe('Default (coding)')
+  })
+
+  it('falls back to the route carrying the "default" role otherwise', () => {
+    const withDefaultRole: AdminRoute[] = [
+      { name: 'default', strategy: 'ordered', enabled: true, chain: [], role: 'default' },
+      { name: 'careful', strategy: 'ordered', enabled: true, chain: [] },
+    ]
+    expect(defaultRouteLabel('general', undefined, withDefaultRole)).toBe('Default (default)')
+    // Also applies to a coding mission when no "coding"-named route exists.
+    expect(defaultRouteLabel('coding', undefined, withDefaultRole)).toBe('Default (default)')
+  })
+
+  it('falls back to plain "Default" when nothing resolves', () => {
+    expect(defaultRouteLabel('general', undefined, routes)).toBe('Default')
+    expect(defaultRouteLabel('coding', undefined, routes)).toBe('Default')
+    expect(defaultRouteLabel('general', undefined, null)).toBe('Default')
+  })
+})
+
 afterEach(() => {
   cleanup()
   vi.useRealTimers()
@@ -120,7 +172,6 @@ describe('MissionForm — create mode, one-off mission', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Research something new' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Show advanced options' }))
     fireEvent.click(screen.getByLabelText(/Auto-approve safe tool calls/))
     fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
 
@@ -779,7 +830,7 @@ describe('MissionForm — create mode, repeat on schedule', () => {
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
     fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
-    fireEvent.click(screen.getByRole('combobox'))
+    fireEvent.click(screen.getAllByRole('combobox')[0])
     fireEvent.click(await screen.findByText('Custom'))
     fireEvent.change(screen.getByLabelText('Cron expression'), { target: { value: 'bad cron' } })
 

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -15,7 +15,14 @@ import {
   patchSchedule,
   testConnector,
 } from '../../api/client'
-import type { AdminAgent, AdminConnector, GitHubIdentity, GitHubRepo, Schedule } from '../../api/types'
+import type {
+  AdminAgent,
+  AdminConnector,
+  AdminRoute,
+  GitHubIdentity,
+  GitHubRepo,
+  Schedule,
+} from '../../api/types'
 import { useAgents, useRoutes } from '../AgentPicker'
 import { slugify } from '../settings/AgentForm'
 import { cronPresets, type CronPresetValue, presetFor } from '../../lib/schedules'
@@ -74,16 +81,17 @@ const kindCopy: Record<Kind, string> = {
   general: 'General · scratch workspace',
 }
 
-// A schedule's mission_template carries route/review_route/budget as
-// explicit undefined when unset (see types.ts) — "non-default" means
-// any of them, or a non-default agent, actually has a value.
+// A schedule's mission_template carries route/review_route as explicit
+// undefined when unset (see types.ts) — "non-default" means any of
+// them, or a non-default agent, actually has a value. Budget and
+// auto-approve are always visible now, so they never force the
+// advanced section open.
 function hasNonDefaults(t: Schedule['mission_template']): boolean {
   return !!(
     t.agent_id ||
     t.route ||
     t.review_route ||
     t.plan_route ||
-    t.budget_amount != null ||
     t.harness ||
     t.environment ||
     t.branch_pattern ||
@@ -96,6 +104,27 @@ function hasNonDefaults(t: Schedule['mission_template']): boolean {
 // Select and the route/reviewRoute/escalationRoute state (which stay ''
 // to match the API's own empty-means-default semantics).
 const ROUTE_DEFAULT = '__default__'
+
+// defaultRouteLabel mirrors the server's own empty-route resolution
+// (internal/brain/api/missions.go's CreateMission handler +
+// missions.DefaultCodingRoute) so the Route select's "Default" option
+// tells the operator where it actually resolves, in the same order the
+// server tries:
+//  1. the picked agent's own route, if it has one
+//  2. for a coding mission, a route literally named "coding" if one exists
+//  3. whichever route carries the "default" role
+//  4. otherwise just "Default"
+export function defaultRouteLabel(
+  kind: Kind,
+  agent: AdminAgent | undefined,
+  routes: AdminRoute[] | null,
+): string {
+  if (agent?.route) return `Default (${agent.route})`
+  if (kind === 'coding' && routes?.some((r) => r.name === 'coding')) return 'Default (coding)'
+  const defaultRoleRoute = routes?.find((r) => r.role === 'default')
+  if (defaultRoleRoute) return `Default (${defaultRoleRoute.name})`
+  return 'Default'
+}
 
 // Sentinel for the executor Select's "apply the settings default"
 // choice — wire value stays '' (omit harness from the create payload)
@@ -1043,6 +1072,49 @@ export function MissionForm({
           </div>
         )}
 
+        <div className="space-y-1.5">
+          <Label htmlFor="mission-budget">Budget</Label>
+          <div className="flex gap-2">
+            <Input
+              id="mission-budget"
+              type="number"
+              value={budget}
+              onChange={(e) => setBudget(e.target.value)}
+              placeholder="No limit"
+              className="flex-1"
+            />
+            <Select value={budgetCurrency} onValueChange={setBudgetCurrency}>
+              <SelectTrigger className="w-24" aria-label="Budget currency">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CURRENCIES.map((c) => (
+                  <SelectItem key={c} value={c}>
+                    {c}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <label htmlFor="mission-auto-approve" className="flex items-start gap-2 text-sm">
+          <input
+            id="mission-auto-approve"
+            type="checkbox"
+            checked={autoApproveSafe}
+            onChange={(e) => setAutoApproveSafe(e.target.checked)}
+            className="mt-0.5"
+          />
+          <span>
+            Auto-approve safe tool calls
+            <span className="block text-xs text-muted-foreground">
+              Runs unattended without pausing for approval on routine commands. Destructive
+              or unrecognized commands still always ask.
+            </span>
+          </span>
+        </label>
+
         <Collapsible open={showAdvanced} onOpenChange={setShowAdvanced}>
           <CollapsibleTrigger className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground">
             {showAdvanced ? 'Hide advanced options' : 'Show advanced options'}
@@ -1067,7 +1139,9 @@ export function MissionForm({
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value={ROUTE_DEFAULT}>Default</SelectItem>
+                      <SelectItem value={ROUTE_DEFAULT}>
+                        {defaultRouteLabel(kind, agents.find((a) => a.id === agentID), routes)}
+                      </SelectItem>
                       {enabledRoutes.map((r) => (
                         <SelectItem key={r.name} value={r.name}>
                           {r.name}
@@ -1095,7 +1169,7 @@ export function MissionForm({
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value={ROUTE_DEFAULT}>Default</SelectItem>
+                      <SelectItem value={ROUTE_DEFAULT}>Default (same as plan/execute route)</SelectItem>
                       {enabledRoutes.map((r) => (
                         <SelectItem key={r.name} value={r.name}>
                           {r.name}
@@ -1198,31 +1272,6 @@ export function MissionForm({
                   </Select>
                 </div>
               )}
-              <div className="space-y-1.5">
-                <Label htmlFor="mission-budget">Budget</Label>
-                <div className="flex gap-2">
-                  <Input
-                    id="mission-budget"
-                    type="number"
-                    value={budget}
-                    onChange={(e) => setBudget(e.target.value)}
-                    placeholder="No limit"
-                    className="flex-1"
-                  />
-                  <Select value={budgetCurrency} onValueChange={setBudgetCurrency}>
-                    <SelectTrigger className="w-24" aria-label="Budget currency">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {CURRENCIES.map((c) => (
-                        <SelectItem key={c} value={c}>
-                          {c}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
               {repeat && (
                 <div className="space-y-1.5">
                   <Label htmlFor="mission-max-iterations">Max iterations</Label>
@@ -1235,25 +1284,6 @@ export function MissionForm({
                   />
                 </div>
               )}
-              <label
-                htmlFor="mission-auto-approve"
-                className="flex items-start gap-2 text-sm sm:col-span-2"
-              >
-                <input
-                  id="mission-auto-approve"
-                  type="checkbox"
-                  checked={autoApproveSafe}
-                  onChange={(e) => setAutoApproveSafe(e.target.checked)}
-                  className="mt-0.5"
-                />
-                <span>
-                  Auto-approve safe tool calls
-                  <span className="block text-xs text-muted-foreground">
-                    Runs unattended without pausing for approval on routine commands. Destructive
-                    or unrecognized commands still always ask.
-                  </span>
-                </span>
-              </label>
             </div>
           </CollapsibleContent>
         </Collapsible>

--- a/web/src/components/settings/ConnectorAdd.test.tsx
+++ b/web/src/components/settings/ConnectorAdd.test.tsx
@@ -38,7 +38,11 @@ beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(listSecretBackends).mockResolvedValue([{ backend: 'db', configured: true, default: true }])
   vi.mocked(listSecretRefs).mockResolvedValue([
-    { name: 'GITHUB_PAT', referenced_by: [{ kind: 'connector', name: 'github-account' }] },
+    { name: 'GITHUB_PAT', referenced_by: [{ kind: 'connector', name: 'github-account', role: 'credential' }] },
+    {
+      name: 'GMAIL_GOOGLE_OAUTH',
+      referenced_by: [{ kind: 'connector', name: 'gmail', role: 'oauth_tokens' }],
+    },
   ])
 })
 
@@ -65,5 +69,14 @@ describe('ConnectorAdd existing-credential picker (github MCP token)', () => {
     await waitFor(() => expect(createConnector).toHaveBeenCalled())
     expect(setSecret).not.toHaveBeenCalled()
     expect(vi.mocked(createConnector).mock.calls[0][0]).toMatchObject({ credential_ref: 'GITHUB_PAT' })
+  })
+
+  it('disables an OAuth token bundle ref with a managed-by-connector label', async () => {
+    renderPage('github')
+    fireEvent.click(screen.getByRole('button', { name: 'Use existing' }))
+
+    fireEvent.click(await screen.findByLabelText('existing credential'))
+    const option = await screen.findByRole('option', { name: /GMAIL_GOOGLE_OAUTH.*OAuth tokens \(managed by connector\)/ })
+    expect(option).toHaveAttribute('aria-disabled', 'true')
   })
 })

--- a/web/src/components/settings/CredentialRefPicker.tsx
+++ b/web/src/components/settings/CredentialRefPicker.tsx
@@ -13,6 +13,16 @@ function referentLabel(ref: SecretRefEntry): string {
   return `${ref.name} (used by ${refs.map((r) => r.name).join(', ')})`
 }
 
+// managedRoleSuffix flags a ref as machine-managed, never a valid
+// manual pick: a google connector's OAuth token bundle, or a github
+// connector's derived signing key.
+function managedRoleSuffix(ref: SecretRefEntry): string | null {
+  const refs = ref.referenced_by ?? []
+  if (refs.some((r) => r.role === 'oauth_tokens')) return ' — OAuth tokens (managed by connector)'
+  if (refs.some((r) => r.role === 'signing_key')) return ' — signing key (managed)'
+  return null
+}
+
 // ModeToggle is the segmented "New credential" / "Use existing"
 // control shared by every form offering credential reuse.
 export function CredentialModeToggle({
@@ -64,11 +74,15 @@ export function ExistingCredentialSelect({
         <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent>
-        {refs.map((r) => (
-          <SelectItem key={r.name} value={r.name}>
-            {referentLabel(r)}
-          </SelectItem>
-        ))}
+        {refs.map((r) => {
+          const managedSuffix = managedRoleSuffix(r)
+          return (
+            <SelectItem key={r.name} value={r.name} disabled={managedSuffix !== null}>
+              {referentLabel(r)}
+              {managedSuffix}
+            </SelectItem>
+          )
+        })}
       </SelectContent>
     </Select>
   )

--- a/web/src/components/settings/CredentialsTab.test.tsx
+++ b/web/src/components/settings/CredentialsTab.test.tsx
@@ -15,8 +15,8 @@ const referenced: SecretRefEntry = {
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-02T00:00:00Z',
   referenced_by: [
-    { kind: 'connector', name: 'github-mcp' },
-    { kind: 'provider', name: 'github-provider' },
+    { kind: 'connector', name: 'github-mcp', role: 'credential' },
+    { kind: 'provider', name: 'github-provider', role: 'credential' },
   ],
 }
 

--- a/web/src/components/settings/ProviderAdd.test.tsx
+++ b/web/src/components/settings/ProviderAdd.test.tsx
@@ -230,7 +230,7 @@ describe('ProviderAdd existing-credential picker', () => {
     vi.mocked(setSecret).mockResolvedValue()
     vi.mocked(createProvider).mockResolvedValue('p-new')
     vi.mocked(listSecretRefs).mockResolvedValue([
-      { name: 'ZAI_API_KEY', referenced_by: [{ kind: 'provider', name: 'GLM (Z.ai)' }] },
+      { name: 'ZAI_API_KEY', referenced_by: [{ kind: 'provider', name: 'GLM (Z.ai)', role: 'credential' }] },
     ])
   })
 

--- a/web/src/components/settings/ProviderAdd.tsx
+++ b/web/src/components/settings/ProviderAdd.tsx
@@ -14,7 +14,7 @@ import { bedrockRegions, providerPresets, type ProviderPreset } from './presets'
 import { ProviderLogo } from './ProviderLogo'
 import { Field } from './shared'
 import { useDefaultSecretBackend } from './useDefaultSecretBackend'
-import { errText, isTimothyAuthDetail, isTimothyAuthError, probeFailureText, secretDestination, stripPaste } from './util'
+import { errText, isTimothyAuthDetail, isTimothyAuthError, probeFailureText, responsesSuffix, secretDestination, stripPaste } from './util'
 
 // refFor derives a credential ref for a named provider instance: the
 // preset's conventional storage-key name, or one from the user's name.
@@ -696,7 +696,7 @@ export function ProviderAdd() {
               {busy
                 ? `Sending test completion to ${model.trim() || '…'}…`
                 : tested
-                  ? `OK, ${test?.model} answered in ${test?.latency_ms} ms.`
+                  ? `OK, ${test?.model} answered in ${test?.latency_ms} ms.${test ? responsesSuffix(test) : ''}`
                   : test && !test.ok
                     ? probeFailureText(test)
                     : 'Not tested yet, run a test before adding.'}

--- a/web/src/components/settings/ProviderEdit.tsx
+++ b/web/src/components/settings/ProviderEdit.tsx
@@ -31,7 +31,7 @@ import { bedrockRegions, matchPreset } from './presets'
 import { ProviderLogo } from './ProviderLogo'
 import { Field, Toggle } from './shared'
 import { useDefaultSecretBackend } from './useDefaultSecretBackend'
-import { backendLabel, errText, isTimothyAuthDetail, isTimothyAuthError, probeFailureText, secretDestination, stripPaste } from './util'
+import { backendLabel, errText, isTimothyAuthDetail, isTimothyAuthError, probeFailureText, responsesSuffix, secretDestination, stripPaste } from './util'
 
 // ProviderEdit is a provider's own page for the controls too heavy for
 // its summary card: rotating the stored key, and declaring which
@@ -282,7 +282,7 @@ function CredentialSection({
             {testing
               ? 'Testing connection…'
               : test?.ok
-                ? `OK, ${test.model} answered in ${test.latency_ms} ms.`
+                ? `OK, ${test.model} answered in ${test.latency_ms} ms.${responsesSuffix(test)}`
                 : test && !test.ok
                   ? probeFailureText(test)
                   : 'Not tested yet.'}

--- a/web/src/components/settings/ProvidersList.tsx
+++ b/web/src/components/settings/ProvidersList.tsx
@@ -15,7 +15,7 @@ import { Button } from '../ui/button'
 import { matchPreset, providerPresets } from './presets'
 import { ProviderLogo } from './ProviderLogo'
 import { Toggle } from './shared'
-import { errText, humanizeProbeDetail, isTimothyAuthDetail, isTimothyAuthError, timothyAuthErrorMessage } from './util'
+import { errText, humanizeProbeDetail, isTimothyAuthDetail, isTimothyAuthError, responsesSuffix, timothyAuthErrorMessage } from './util'
 
 export function ProvidersList() {
   const [providers, setProviders] = useState<AdminProvider[]>([])
@@ -169,7 +169,7 @@ function ProviderCard({
           className={`rounded-lg border p-2 text-xs ${test.ok ? 'border-good/30 bg-good-soft text-good' : 'border-destructive/30 bg-destructive/5 text-destructive'}`}
         >
           {test.ok
-            ? `OK, ${test.latency_ms} ms`
+            ? `OK, ${test.latency_ms} ms${responsesSuffix(test)}`
             : isTimothyAuthDetail(test.detail)
               ? timothyAuthErrorMessage
               : `Failed: ${humanizeProbeDetail(test.detail ?? '')}`}

--- a/web/src/components/settings/util.test.ts
+++ b/web/src/components/settings/util.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { humanizeProbeDetail, probeFailureText } from './util'
+import { humanizeProbeDetail, probeFailureText, responsesSuffix } from './util'
 
 describe('humanizeProbeDetail', () => {
   it('extracts the message from an OpenAI-shaped JSON body', () => {
@@ -27,5 +27,19 @@ describe('probeFailureText', () => {
         detail: 'http 401: {"error":{"code":"401","message":"token expired or incorrect"}}',
       }),
     ).toBe('Failed after 1694 ms: Provider rejected the API key — token expired or incorrect')
+  })
+})
+
+describe('responsesSuffix', () => {
+  it('renders yes when the endpoint serves /responses', () => {
+    expect(responsesSuffix({ responses_ok: true })).toBe(' · responses API: yes')
+  })
+
+  it('renders no on a confirmed miss (the Z.ai coding-plan case)', () => {
+    expect(responsesSuffix({ responses_ok: false })).toBe(' · responses API: no')
+  })
+
+  it('renders nothing when the probe is unprobed or ambiguous', () => {
+    expect(responsesSuffix({})).toBe('')
   })
 })

--- a/web/src/components/settings/util.ts
+++ b/web/src/components/settings/util.ts
@@ -41,6 +41,14 @@ export function probeFailureText(test: { latency_ms: number; detail?: string }):
   return `Failed after ${test.latency_ms} ms: ${humanizeProbeDetail(test.detail ?? '')}`
 }
 
+// responsesSuffix appends the responses-API capability probe result to
+// a passing test's success line — absent (unprobed or ambiguous) adds
+// nothing.
+export function responsesSuffix(test: { responses_ok?: boolean }): string {
+  if (test.responses_ok === undefined) return ''
+  return ` · responses API: ${test.responses_ok ? 'yes' : 'no'}`
+}
+
 function pickJsonMessage(v: unknown): string | undefined {
   if (typeof v === 'string' && v.trim()) return v.trim()
   if (typeof v !== 'object' || v === null) return undefined


### PR DESCRIPTION
## What

**Responses-API capability probe** — codex-cli requires \`/v1/responses\`; the static wire gate can't see that Z.ai's coding-plan endpoint 404s it (chats fine over chat/completions), so codex×GLM missions passed validation and died at spawn.
- Test connection additionally probes \`{base_url}/responses\` on openaicompat rows: 2xx → true, 404/405 → false, ambiguous (401/429/5xx/timeout) → unknown, never guessed. Definite results persist as tri-state \`options.openai_responses\`; Validate reports but never persists. Chat-probe \`ok\` unaffected; no ledger entry (capability detection, not spend).
- \`executorUsable\` greys codex-cli only on known-false, with an actionable reason the mission-form tooltip now surfaces (brain passes the first entry's skip_reason through). Unknown never blocks.
- Test banners show \`responses API: yes/no\`.
- Live-verified: GLM probes false and its routes grey codex-cli; OpenAI/Ollama probe true.

**Credentials fixes**
- A google connector's \`config.client_secret_ref\` now counts as a referent (it's resolved on every token refresh) — no longer shows orphaned, DELETE refuses 409 while the connector lives.
- Secret referents carry a \`role\` (\`credential\` / \`oauth_tokens\` / \`signing_key\` / \`client_secret\`); the shared credential picker disables machine-managed refs with an explanatory label — picking a token bundle as a client secret (real incident) is no longer possible.

**Mission form polish**
- Budget + Auto-approve safe tool calls moved out of the advanced section (per-mission control knobs); routes and git strategy stay advanced.
- Route select's "Default" now names its actual resolution (agent route / \`coding\` route / default-role route), Review route default labeled "same as plan/execute route".

## Verification
Full Go suite (-race, vet, integration-tag vet), integration tests, web build+lint+705 tests, \`make canary\` PASS, plus live checks against configured providers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789693858&installation_model_id=431401&pr_number=251&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F251&signature=467385b6d853d9b20ae105fb205b23934f8faf6cd72bd747f19e796a4f76389c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->