### PR TITLE
feat: migrate stored credentials between secret backends

### DIFF
--- a/internal/brain/api/admin.go
+++ b/internal/brain/api/admin.go
@@ -41,6 +41,8 @@ var adminRoutePatterns = []string{
 	// before forwarding), and net/http's ServeMux panics on a duplicate
 	// pattern — the two registrations must never coexist.
 	"GET /v1/admin/secrets/{ref_name}",
+	"POST /v1/admin/secrets/{ref_name}/migrate",
+	"POST /v1/admin/secrets/migrate",
 	"GET /v1/admin/secret-backends",
 	"PUT /v1/admin/secret-backends/default",
 	"GET /v1/admin/secret-backends/{backend}",
@@ -130,6 +132,7 @@ type connectorLister interface {
 // alone can see both tables. Never a value.
 type secretRefEntry struct {
 	RefName      string          `json:"name"`
+	Backend      string          `json:"backend"`
 	CreatedAt    any             `json:"created_at,omitempty"`
 	UpdatedAt    any             `json:"updated_at,omitempty"`
 	ReferencedBy []referenceInfo `json:"referenced_by"`
@@ -240,7 +243,7 @@ func (h *secretsAPI) list(w http.ResponseWriter, r *http.Request) {
 		}
 		referents = append(referents, byConnector[ref.RefName]...)
 		out[i] = secretRefEntry{
-			RefName: ref.RefName, CreatedAt: ref.CreatedAt, UpdatedAt: ref.UpdatedAt,
+			RefName: ref.RefName, Backend: ref.Backend, CreatedAt: ref.CreatedAt, UpdatedAt: ref.UpdatedAt,
 			ReferencedBy: referents,
 		}
 	}

--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -264,6 +264,7 @@ func (c *Client) ResolveRoute(ctx context.Context, name, harness string) (*Resol
 // a value.
 type SecretRef struct {
 	RefName      string    `json:"ref_name"`
+	Backend      string    `json:"backend"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 	ReferencedBy []string  `json:"referenced_by_providers"`

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -145,12 +145,83 @@ func (a *Admin) providersReferencing(ctx context.Context, refName string) ([]str
 	return names, rows.Err()
 }
 
+// validSecretBackends is the known backend set, mirroring
+// secretstore's own (unexported) validExternalBackend plus "db" — the
+// gateway package validates independently since Migrate's target
+// backend needs checking before other work (List, per-ref loop), not
+// just at the secretstore call site.
+var validSecretBackends = map[string]bool{"db": true, "vault": true, "asm": true}
+
+// MigrateSecret moves refName's stored value onto targetBackend,
+// wiping its old storage. Audited with backend names only — never the
+// value, which never leaves secretstore.Migrate's own transaction of
+// external calls.
+func (a *Admin) MigrateSecret(ctx context.Context, refName, targetBackend string) error {
+	if refName == "" {
+		return fmt.Errorf("ref name is required")
+	}
+	if !validSecretBackends[targetBackend] {
+		return fmt.Errorf("unknown backend %q", targetBackend)
+	}
+	if err := a.secrets.Migrate(ctx, refName, targetBackend); err != nil {
+		return err
+	}
+	a.audit(ctx, "migrate", "secret", refName, nil, map[string]string{"backend": targetBackend})
+	a.reload(ctx)
+	return nil
+}
+
+// SecretMigrationResult is one ref's outcome from a bulk migration:
+// exactly one of migrated/skipped is true, or error is set. A partial
+// failure never aborts the rest of the batch.
+type SecretMigrationResult struct {
+	Name     string `json:"name"`
+	Migrated bool   `json:"migrated"`
+	Skipped  bool   `json:"skipped"`
+	Error    string `json:"error,omitempty"`
+}
+
+// MigrateAllSecrets moves every stored ref not already on targetBackend
+// there, one at a time — a single ref's failure (unreachable backend,
+// bad ref name) is recorded and the batch continues, so one bad ref
+// never blocks migrating the rest.
+func (a *Admin) MigrateAllSecrets(ctx context.Context, targetBackend string) ([]SecretMigrationResult, error) {
+	if !validSecretBackends[targetBackend] {
+		return nil, fmt.Errorf("unknown backend %q", targetBackend)
+	}
+	refs, err := a.secrets.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SecretMigrationResult, 0, len(refs))
+	for _, r := range refs {
+		configured, backend, err := a.secrets.Status(ctx, r.RefName)
+		if err != nil {
+			out = append(out, SecretMigrationResult{Name: r.RefName, Error: err.Error()})
+			continue
+		}
+		if !configured || backend == targetBackend {
+			out = append(out, SecretMigrationResult{Name: r.RefName, Skipped: true})
+			continue
+		}
+		if err := a.secrets.Migrate(ctx, r.RefName, targetBackend); err != nil {
+			out = append(out, SecretMigrationResult{Name: r.RefName, Error: err.Error()})
+			continue
+		}
+		a.audit(ctx, "migrate", "secret", r.RefName, nil, map[string]string{"backend": targetBackend})
+		out = append(out, SecretMigrationResult{Name: r.RefName, Migrated: true})
+	}
+	a.reload(ctx)
+	return out, nil
+}
+
 // SecretRef is one stored secret's directory entry: name and
 // timestamps, plus the providers that name it as credential_ref. Values
 // are never included — ListSecrets exists so the UI can show what
 // exists and what would break on delete, nothing more.
 type SecretRef struct {
 	RefName      string    `json:"ref_name"`
+	Backend      string    `json:"backend"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 	ReferencedBy []string  `json:"referenced_by_providers"`
@@ -189,7 +260,7 @@ func (a *Admin) ListSecrets(ctx context.Context) ([]SecretRef, error) {
 
 	out := make([]SecretRef, len(refs))
 	for i, r := range refs {
-		out[i] = SecretRef{RefName: r.RefName, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+		out[i] = SecretRef{RefName: r.RefName, Backend: r.Backend, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
 			ReferencedBy: byRef[r.RefName]}
 	}
 	return out, nil

--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -1031,6 +1031,188 @@ func TestSecretValueWriteThrough(t *testing.T) {
 	}
 }
 
+// TestMigrateSecretAuditsHasNoValue drives MigrateSecret db->vault
+// against a fake KV v2 server and checks the audit row records only
+// the backend name, never the secret value.
+func TestMigrateSecretAuditsHasNoValue(t *testing.T) {
+	adm, _, pool := testAdmin(t)
+	ctx := t.Context()
+	db, _ := pool.Get()
+	ref := adminMarker + "migrate-one"
+
+	var wroteValue string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/auth/token/lookup-self":
+			w.Write([]byte(`{}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/kv/data/timothy/"+ref:
+			var body struct {
+				Data struct {
+					Value string `json:"value"`
+				} `json:"data"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			wroteValue = body.Data.Value
+			w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	origCfg, err := adm.SecretBackendConfig(ctx, "vault")
+	if err != nil {
+		t.Fatalf("SecretBackendConfig (orig): %v", err)
+	}
+	origDefault, err := adm.secrets.DefaultBackend(ctx)
+	if err != nil {
+		t.Fatalf("DefaultBackend (orig): %v", err)
+	}
+	defer func() {
+		if string(origCfg) != "{}" {
+			if err := adm.SetSecretBackendConfig(ctx, "vault", origCfg); err != nil {
+				t.Errorf("restore vault config: %v", err)
+			}
+		} else if err := adm.DeleteSecretBackendConfig(ctx, "vault"); err != nil {
+			t.Errorf("remove test vault config: %v", err)
+		}
+		if err := adm.SetDefaultSecretBackend(ctx, origDefault); err != nil {
+			t.Errorf("restore default backend: %v", err)
+		}
+	}()
+
+	if err := adm.SetSecretBackendConfig(ctx, "vault",
+		[]byte(`{"address":"`+srv.URL+`","mount":"kv","token_ref":"`+ref+`_TOKEN"}`)); err != nil {
+		t.Fatalf("SetSecretBackendConfig: %v", err)
+	}
+	if err := adm.SetSecret(ctx, ref+"_TOKEN", "vault-tok"); err != nil {
+		t.Fatalf("SetSecret token: %v", err)
+	}
+
+	// Set the ref itself through built-in storage (default still "db"
+	// at this point), then migrate it onto vault explicitly.
+	if err := adm.SetSecret(ctx, ref, "sk-secret-value"); err != nil {
+		t.Fatalf("SetSecret: %v", err)
+	}
+
+	if err := adm.MigrateSecret(ctx, ref, "vault"); err != nil {
+		t.Fatalf("MigrateSecret: %v", err)
+	}
+	if wroteValue != "sk-secret-value" {
+		t.Fatalf("vault received value %q, want sk-secret-value", wroteValue)
+	}
+	if configured, backend, err := adm.SecretStatus(ctx, ref); err != nil || !configured || backend != "vault" {
+		t.Fatalf("SecretStatus after migrate: configured=%v backend=%q err=%v", configured, backend, err)
+	}
+
+	var before, after []byte
+	if err := db.QueryRow(ctx, `SELECT before, after FROM admin_audit
+		WHERE entity = 'secret' AND entity_id = $1 AND action = 'migrate'
+		ORDER BY ts DESC LIMIT 1`, ref).Scan(&before, &after); err != nil {
+		t.Fatalf("audit query: %v", err)
+	}
+	if strings.Contains(string(before), "sk-secret-value") || strings.Contains(string(after), "sk-secret-value") {
+		t.Fatalf("audit row leaked the secret value: before=%s after=%s", before, after)
+	}
+	var afterBody map[string]string
+	if err := json.Unmarshal(after, &afterBody); err != nil {
+		t.Fatalf("audit after %s: %v", after, err)
+	}
+	if afterBody["backend"] != "vault" {
+		t.Fatalf("audit after = %v, want backend=vault", afterBody)
+	}
+
+	// Idempotent: migrating again to the same backend is a no-op.
+	if err := adm.MigrateSecret(ctx, ref, "vault"); err != nil {
+		t.Fatalf("MigrateSecret (idempotent): %v", err)
+	}
+
+	// Unknown target is rejected.
+	if err := adm.MigrateSecret(ctx, ref, "nope"); err == nil {
+		t.Fatal("MigrateSecret with unknown backend accepted")
+	}
+}
+
+// TestMigrateAllSecretsBulkPartialFailure drives the bulk endpoint
+// against two refs: one already on the target backend (skipped), one
+// db-backed that migrates cleanly, and asserts a failure on one ref
+// (unconfigured asm) never aborts the rest of the batch.
+func TestMigrateAllSecretsBulkPartialFailure(t *testing.T) {
+	adm, _, _ := testAdmin(t)
+	ctx := t.Context()
+	refOK := adminMarker + "migrate-all-ok"
+	refSkip := adminMarker + "migrate-all-skip"
+
+	origVaultCfg, err := adm.SecretBackendConfig(ctx, "vault")
+	if err != nil {
+		t.Fatalf("SecretBackendConfig (orig): %v", err)
+	}
+	defer func() {
+		if string(origVaultCfg) != "{}" {
+			if err := adm.SetSecretBackendConfig(ctx, "vault", origVaultCfg); err != nil {
+				t.Errorf("restore vault config: %v", err)
+			}
+		} else if err := adm.DeleteSecretBackendConfig(ctx, "vault"); err != nil {
+			t.Errorf("remove test vault config: %v", err)
+		}
+	}()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/auth/token/lookup-self":
+			w.Write([]byte(`{}`))
+		case r.Method == http.MethodPost:
+			w.Write([]byte(`{}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	if err := adm.SetSecretBackendConfig(ctx, "vault",
+		[]byte(`{"address":"`+srv.URL+`","mount":"kv","token_ref":"`+refOK+`_TOKEN"}`)); err != nil {
+		t.Fatalf("SetSecretBackendConfig: %v", err)
+	}
+	if err := adm.SetSecret(ctx, refOK+"_TOKEN", "vault-tok"); err != nil {
+		t.Fatalf("SetSecret token: %v", err)
+	}
+
+	// refOK: db-backed, migrates cleanly to vault.
+	if err := adm.SetSecret(ctx, refOK, "sk-a"); err != nil {
+		t.Fatalf("SetSecret refOK: %v", err)
+	}
+	// refSkip: migrate it onto vault up front so the bulk call sees it
+	// already there and skips it.
+	if err := adm.MigrateSecret(ctx, refSkip, "vault"); err == nil {
+		t.Fatal("expected refSkip to not exist yet")
+	}
+	if err := adm.SetSecret(ctx, refSkip, "sk-b"); err != nil {
+		t.Fatalf("SetSecret refSkip: %v", err)
+	}
+	if err := adm.MigrateSecret(ctx, refSkip, "vault"); err != nil {
+		t.Fatalf("pre-migrate refSkip: %v", err)
+	}
+
+	results, err := adm.MigrateAllSecrets(ctx, "vault")
+	if err != nil {
+		t.Fatalf("MigrateAllSecrets: %v", err)
+	}
+	byName := map[string]SecretMigrationResult{}
+	for _, r := range results {
+		byName[r.Name] = r
+	}
+	if !byName[refOK].Migrated {
+		t.Fatalf("refOK result = %+v, want migrated", byName[refOK])
+	}
+	if !byName[refSkip].Skipped {
+		t.Fatalf("refSkip result = %+v, want skipped (already on vault)", byName[refSkip])
+	}
+
+	// An unknown target backend fails validation before touching any ref.
+	if _, err := adm.MigrateAllSecrets(ctx, "nope"); err == nil {
+		t.Fatal("MigrateAllSecrets with unknown backend accepted")
+	}
+}
+
 // TestCatalogPricesResolvesByProviderRow is CatalogPrices' end-to-end
 // coverage of the DB half resolvePricedModel's unit tests fake out: a
 // real provider row (options.litellm_provider="zai", the repro's

--- a/internal/gateway/api/admin.go
+++ b/internal/gateway/api/admin.go
@@ -33,6 +33,8 @@ func RegisterAdmin(srv *httpserver.Server, adm *admin.Admin) {
 	srv.Handle("PUT /internal/admin/secrets/{ref_name}", http.HandlerFunc(h.setSecret))
 	srv.Handle("DELETE /internal/admin/secrets/{ref_name}", http.HandlerFunc(h.deleteSecret))
 	srv.Handle("GET /internal/admin/secrets/{ref_name}", http.HandlerFunc(h.getSecretStatus))
+	srv.Handle("POST /internal/admin/secrets/{ref_name}/migrate", http.HandlerFunc(h.migrateSecret))
+	srv.Handle("POST /internal/admin/secrets/migrate", http.HandlerFunc(h.migrateAllSecrets))
 	srv.Handle("GET /internal/admin/secret-backends", http.HandlerFunc(h.listSecretBackends))
 	srv.Handle("PUT /internal/admin/secret-backends/default", http.HandlerFunc(h.putDefaultSecretBackend))
 	srv.Handle("GET /internal/admin/secret-backends/{backend}", http.HandlerFunc(h.getSecretBackend))
@@ -299,6 +301,44 @@ func (h *adminAPI) getSecretStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, map[string]any{"configured": configured, "backend": backend})
+}
+
+// migrateSecret moves one ref's stored value onto {"backend": ...},
+// wiping its old storage. Registered as a literal .../{ref_name}/migrate
+// suffix, so it never collides with the bulk .../secrets/migrate route
+// (net/http's ServeMux picks the more specific pattern regardless of
+// registration order).
+func (h *adminAPI) migrateSecret(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Backend string `json:"backend"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if err := h.adm.MigrateSecret(r.Context(), r.PathValue("ref_name"), body.Backend); err != nil {
+		fail(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// migrateAllSecrets moves every ref not already on {"backend": ...}
+// there; per-ref failures land in the response, never abort the batch.
+func (h *adminAPI) migrateAllSecrets(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Backend string `json:"backend"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	results, err := h.adm.MigrateAllSecrets(r.Context(), body.Backend)
+	if err != nil {
+		fail(w, err)
+		return
+	}
+	writeJSON(w, map[string]any{"results": results})
 }
 
 func (h *adminAPI) listSecretBackends(w http.ResponseWriter, r *http.Request) {

--- a/internal/secretstore/secretstore.go
+++ b/internal/secretstore/secretstore.go
@@ -119,6 +119,7 @@ func (s *Store) Status(ctx context.Context, refName string) (configured bool, ba
 // the external path an operator otherwise never sees).
 type Ref struct {
 	RefName   string
+	Backend   string
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
@@ -130,7 +131,7 @@ func (s *Store) List(ctx context.Context) ([]Ref, error) {
 	if err != nil {
 		return nil, fmt.Errorf("secretstore: %w", err)
 	}
-	rows, err := db.Query(ctx, `SELECT ref_name, created_at, updated_at FROM secrets ORDER BY ref_name`)
+	rows, err := db.Query(ctx, `SELECT ref_name, backend, created_at, updated_at FROM secrets ORDER BY ref_name`)
 	if err != nil {
 		return nil, fmt.Errorf("secretstore: list: %w", err)
 	}
@@ -139,7 +140,7 @@ func (s *Store) List(ctx context.Context) ([]Ref, error) {
 	out := []Ref{}
 	for rows.Next() {
 		var r Ref
-		if err := rows.Scan(&r.RefName, &r.CreatedAt, &r.UpdatedAt); err != nil {
+		if err := rows.Scan(&r.RefName, &r.Backend, &r.CreatedAt, &r.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("secretstore: list: %w", err)
 		}
 		out = append(out, r)
@@ -238,6 +239,91 @@ func (s *Store) upsertRef(ctx context.Context, refName, backend, backendRef stri
 		refName, backend, backendRef)
 	if err != nil {
 		return fmt.Errorf("secretstore: set %s: %w", refName, err)
+	}
+	return nil
+}
+
+// Migrate moves refName's stored value onto targetBackend, replacing
+// its current backend entirely. Idempotent no-op when refName already
+// lives on targetBackend. Ordering matters for crash safety: the new
+// home is written FIRST, the row's backend column flipped SECOND, and
+// only then is the old storage wiped — a crash between any two steps
+// leaves the value readable at its new home (a stray old-backend copy
+// is merely wasteful, never lost) rather than gone. The whole thing
+// cannot be one DB transaction since external writes (vault/asm HTTP
+// calls) aren't transactional with Postgres; the ordering above is the
+// substitute safety net. Deleting the old copy is best-effort, silent
+// (like Delete's own external cleanup) — a leftover external secret is
+// orphaned but harmless once the row no longer points at it, and never
+// fails the migration itself.
+func (s *Store) Migrate(ctx context.Context, refName, targetBackend string) error {
+	if targetBackend != "db" {
+		if err := validExternalBackend(targetBackend); err != nil {
+			return err
+		}
+	}
+	r, err := s.row(ctx, refName)
+	if err != nil {
+		return err
+	}
+	if r.backend == targetBackend {
+		return nil
+	}
+
+	value, err := s.Resolve(ctx, refName)
+	if err != nil {
+		return fmt.Errorf("secretstore: migrate %s: resolve current value: %w", refName, err)
+	}
+
+	// Step 1: write the value into its new home. Nothing about refName's
+	// row changes yet, so a crash here just leaves the old copy in place
+	// with the row still pointing at it — safe, retryable.
+	switch targetBackend {
+	case "db":
+		if err := s.SetDB(ctx, refName, value); err != nil {
+			return fmt.Errorf("secretstore: migrate %s: write db: %w", refName, err)
+		}
+	case "vault":
+		if err := validExternalRefName(refName); err != nil {
+			return err
+		}
+		if err := s.writeVault(ctx, externalRef(refName), value); err != nil {
+			return fmt.Errorf("secretstore: migrate %s: write vault: %w", refName, err)
+		}
+	case "asm":
+		if err := validExternalRefName(refName); err != nil {
+			return err
+		}
+		if err := s.writeASM(ctx, externalRef(refName), value); err != nil {
+			return fmt.Errorf("secretstore: migrate %s: write asm: %w", refName, err)
+		}
+	}
+
+	// Step 2: flip the row to point at the new home. SetDB/upsertRef
+	// already did this as part of step 1 for "db"; external targets need
+	// it done explicitly since writeVault/writeASM only touch the
+	// external system, not the row.
+	if targetBackend != "db" {
+		backendRef := externalRef(refName)
+		if targetBackend == "vault" {
+			backendRef += "#value"
+		}
+		if err := s.upsertRef(ctx, refName, targetBackend, backendRef); err != nil {
+			return fmt.Errorf("secretstore: migrate %s: point row at %s: %w", refName, targetBackend, err)
+		}
+	}
+
+	// Step 3: wipe the old home now that nothing points at it. Best
+	// effort, silently — the row is already correct either way (same as
+	// Delete's own external cleanup, which has nowhere to log either), so
+	// a leftover external secret never fails Migrate. A db old home needs
+	// no separate wipe here: upsertRef (step 2, for an external target)
+	// already cleared ciphertext/nonce as part of the same statement.
+	switch r.backend {
+	case "vault":
+		_ = s.deleteVault(ctx, externalRef(refName))
+	case "asm":
+		_ = s.deleteASM(ctx, externalRef(refName))
 	}
 	return nil
 }

--- a/internal/secretstore/secretstore_integration_test.go
+++ b/internal/secretstore/secretstore_integration_test.go
@@ -305,3 +305,255 @@ func TestDefaultBackendLifecycle(t *testing.T) {
 		t.Fatalf("DefaultBackend after delete = %q, %v; want db", got, err)
 	}
 }
+
+// fakeVaultKV serves a minimal KV v2 mount for TestMigrate*: same
+// shape as TestVaultWriteThrough's inline fake, factored out so both
+// migrate directions can share one server.
+func fakeVaultKV(t *testing.T) (*httptest.Server, map[string]string) {
+	t.Helper()
+	kv := map[string]string{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Vault-Token") != "vault-tok" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		switch {
+		case r.URL.Path == "/v1/auth/token/lookup-self":
+			w.Write([]byte(`{}`))
+		case strings.HasPrefix(r.URL.Path, "/v1/kv/data/"):
+			path := strings.TrimPrefix(r.URL.Path, "/v1/kv/data/")
+			switch r.Method {
+			case http.MethodPost:
+				var body struct {
+					Data struct {
+						Value string `json:"value"`
+					} `json:"data"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				kv[path] = body.Data.Value
+				w.Write([]byte(`{}`))
+			case http.MethodGet:
+				val, ok := kv[path]
+				if !ok {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				_, _ = w.Write([]byte(`{"data":{"data":{"value":` + strconv.Quote(val) + `}}}`))
+			default:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}
+		case strings.HasPrefix(r.URL.Path, "/v1/kv/metadata/") && r.Method == http.MethodDelete:
+			delete(kv, strings.TrimPrefix(r.URL.Path, "/v1/kv/metadata/"))
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	return srv, kv
+}
+
+// setUpVaultDefault points s at a fake vault mount and makes it the
+// store-wide default, returning a restore func for the caller to defer
+// (mirrors TestVaultWriteThrough's own save/restore dance since the
+// backend config table is shared state).
+func setUpVaultDefault(t *testing.T, s *Store, srv *httptest.Server, tokenRef string) func() {
+	t.Helper()
+	ctx := t.Context()
+	origCfg, err := s.GetBackendConfig(ctx, "vault")
+	if err != nil {
+		t.Fatalf("GetBackendConfig: %v", err)
+	}
+	origDefault, err := s.DefaultBackend(ctx)
+	if err != nil {
+		t.Fatalf("DefaultBackend: %v", err)
+	}
+	cfg := `{"address":"` + srv.URL + `","mount":"kv","token_ref":"` + tokenRef + `"}`
+	if _, err := s.SetBackendConfig(ctx, "vault", []byte(cfg)); err != nil {
+		t.Fatalf("SetBackendConfig: %v", err)
+	}
+	if err := s.SetDB(ctx, tokenRef, "vault-tok"); err != nil {
+		t.Fatalf("SetDB token: %v", err)
+	}
+	if err := s.SetDefaultBackend(ctx, "vault"); err != nil {
+		t.Fatalf("SetDefaultBackend: %v", err)
+	}
+	return func() {
+		if string(origCfg) != "{}" {
+			if _, err := s.SetBackendConfig(ctx, "vault", origCfg); err != nil {
+				t.Errorf("restore vault config: %v", err)
+			}
+		} else if err := s.DeleteBackendConfig(ctx, "vault"); err != nil {
+			t.Errorf("delete vault config: %v", err)
+		}
+		if err := s.SetDefaultBackend(ctx, origDefault); err != nil {
+			t.Errorf("restore default backend: %v", err)
+		}
+	}
+}
+
+// TestMigrateDBToVault drives Migrate's db->external direction: the
+// value written under backend='db' must resolve identically after
+// Migrate, live in the fake vault mount, and the db ciphertext/nonce
+// must be gone (cleared by upsertRef in step 2).
+func TestMigrateDBToVault(t *testing.T) {
+	s := integrationStore(t)
+	ctx := t.Context()
+	ref := "TEST_MIGRATE_DBVAULT_" + t.Name()
+	tokenRef := ref + "_TOKEN"
+
+	srv, kv := fakeVaultKV(t)
+	defer srv.Close()
+	restore := setUpVaultDefault(t, s, srv, tokenRef)
+	defer restore()
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer func() {
+		_, _ = db.Exec(ctx, `DELETE FROM secrets WHERE ref_name IN ($1, $2)`, ref, tokenRef)
+	}()
+
+	// Set through db explicitly (SetDB, not Set — the default is vault
+	// by now), so the starting point is a real db-backed row.
+	if err := s.SetDB(ctx, ref, "sk-orig"); err != nil {
+		t.Fatalf("SetDB: %v", err)
+	}
+
+	if err := s.Migrate(ctx, ref, "vault"); err != nil {
+		t.Fatalf("Migrate db->vault: %v", err)
+	}
+	if kv["timothy/"+ref] != "sk-orig" {
+		t.Fatalf("vault mount holds %q, want sk-orig", kv["timothy/"+ref])
+	}
+	if configured, backend, err := s.Status(ctx, ref); err != nil || !configured || backend != "vault" {
+		t.Fatalf("Status after migrate: configured=%v backend=%q err=%v", configured, backend, err)
+	}
+	got, err := s.Resolve(ctx, ref)
+	if err != nil || got != "sk-orig" {
+		t.Fatalf("Resolve after migrate = (%q, %v), want (sk-orig, nil)", got, err)
+	}
+	var ciphertext []byte
+	if err := db.QueryRow(ctx, `SELECT ciphertext FROM secrets WHERE ref_name = $1`, ref).Scan(&ciphertext); err != nil {
+		t.Fatalf("query ciphertext: %v", err)
+	}
+	if ciphertext != nil {
+		t.Error("db ciphertext survived a migrate to vault")
+	}
+
+	// Idempotent: migrating again to the same backend is a no-op, not
+	// a second write.
+	if err := s.Migrate(ctx, ref, "vault"); err != nil {
+		t.Fatalf("Migrate (idempotent): %v", err)
+	}
+}
+
+// TestMigrateVaultToDB drives Migrate's external->db direction and
+// confirms the old vault copy is deleted (step 3's cleanup).
+func TestMigrateVaultToDB(t *testing.T) {
+	s := integrationStore(t)
+	ctx := t.Context()
+	ref := "TEST_MIGRATE_VAULTDB_" + t.Name()
+	tokenRef := ref + "_TOKEN"
+
+	srv, kv := fakeVaultKV(t)
+	defer srv.Close()
+	restore := setUpVaultDefault(t, s, srv, tokenRef)
+	defer restore()
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer func() {
+		_, _ = db.Exec(ctx, `DELETE FROM secrets WHERE ref_name IN ($1, $2)`, ref, tokenRef)
+	}()
+
+	// Set through the (now vault) default so the starting point is a
+	// real vault-backed row.
+	if err := s.Set(ctx, ref, "sk-vault"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	if err := s.Migrate(ctx, ref, "db"); err != nil {
+		t.Fatalf("Migrate vault->db: %v", err)
+	}
+	if configured, backend, err := s.Status(ctx, ref); err != nil || !configured || backend != "db" {
+		t.Fatalf("Status after migrate: configured=%v backend=%q err=%v", configured, backend, err)
+	}
+	got, err := s.Resolve(ctx, ref)
+	if err != nil || got != "sk-vault" {
+		t.Fatalf("Resolve after migrate = (%q, %v), want (sk-vault, nil)", got, err)
+	}
+	if _, ok := kv["timothy/"+ref]; ok {
+		t.Error("Migrate vault->db left the old vault copy behind")
+	}
+}
+
+// TestMigrateUnknownTargetErrors pins that Migrate rejects a target
+// backend name outside {db, vault, asm} before touching the row.
+func TestMigrateUnknownTargetErrors(t *testing.T) {
+	s := integrationStore(t)
+	ctx := t.Context()
+	ref := "TEST_MIGRATE_UNKNOWN_" + t.Name()
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer func() {
+		_, _ = db.Exec(ctx, `DELETE FROM secrets WHERE ref_name = $1`, ref)
+	}()
+
+	if err := s.SetDB(ctx, ref, "sk-x"); err != nil {
+		t.Fatalf("SetDB: %v", err)
+	}
+	if err := s.Migrate(ctx, ref, "nope"); err == nil {
+		t.Fatal("unknown target backend accepted")
+	}
+	if configured, backend, err := s.Status(ctx, ref); err != nil || !configured || backend != "db" {
+		t.Fatalf("row changed after a rejected migrate: configured=%v backend=%q err=%v", configured, backend, err)
+	}
+}
+
+// TestMigrateUnconfiguredTargetErrors pins that Migrate refuses a known
+// but unconfigured external backend (no vault/asm connection config
+// saved) — the write in step 1 fails cleanly (vaultConfig/asmClient
+// error), leaving the row on its original backend.
+func TestMigrateUnconfiguredTargetErrors(t *testing.T) {
+	s := integrationStore(t)
+	ctx := t.Context()
+	ref := "TEST_MIGRATE_NOCFG_" + t.Name()
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	origCfg, err := s.GetBackendConfig(ctx, "vault")
+	if err != nil {
+		t.Fatalf("GetBackendConfig: %v", err)
+	}
+	defer func() {
+		_, _ = db.Exec(ctx, `DELETE FROM secrets WHERE ref_name = $1`, ref)
+		if string(origCfg) != "{}" {
+			if _, err := s.SetBackendConfig(ctx, "vault", origCfg); err != nil {
+				t.Errorf("restore vault config: %v", err)
+			}
+		} else if err := s.DeleteBackendConfig(ctx, "vault"); err != nil {
+			t.Errorf("delete vault config: %v", err)
+		}
+	}()
+	if err := s.DeleteBackendConfig(ctx, "vault"); err != nil {
+		t.Fatalf("DeleteBackendConfig: %v", err)
+	}
+
+	if err := s.SetDB(ctx, ref, "sk-x"); err != nil {
+		t.Fatalf("SetDB: %v", err)
+	}
+	if err := s.Migrate(ctx, ref, "vault"); err == nil {
+		t.Fatal("unconfigured vault target accepted")
+	}
+	if configured, backend, err := s.Status(ctx, ref); err != nil || !configured || backend != "db" {
+		t.Fatalf("row changed after a rejected migrate: configured=%v backend=%q err=%v", configured, backend, err)
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -772,6 +772,33 @@ export async function deleteSecret(refName: string): Promise<void> {
   await request<void>(`/v1/admin/secrets/${encodeURIComponent(refName)}`, { method: 'DELETE' })
 }
 
+// migrateSecret moves one stored ref's value onto backend, wiping its
+// old storage — used to re-home a credential after Vault/ASM is set up.
+export async function migrateSecret(refName: string, backend: string): Promise<void> {
+  await request<void>(`/v1/admin/secrets/${encodeURIComponent(refName)}/migrate`, {
+    method: 'POST',
+    body: JSON.stringify({ backend }),
+  })
+}
+
+export interface SecretMigrationResult {
+  name: string
+  migrated: boolean
+  skipped: boolean
+  error?: string
+}
+
+// migrateAllSecrets moves every stored ref not already on backend
+// there; a per-ref failure lands in its result entry, never aborts the
+// rest of the batch.
+export async function migrateAllSecrets(backend: string): Promise<SecretMigrationResult[]> {
+  const { results } = await request<{ results: SecretMigrationResult[] }>('/v1/admin/secrets/migrate', {
+    method: 'POST',
+    body: JSON.stringify({ backend }),
+  })
+  return results ?? []
+}
+
 // SecretReference is one provider or connector naming a credential ref
 // as its credential_ref — the credentials panel's used-by chips.
 export interface SecretReference {
@@ -786,6 +813,7 @@ export interface SecretReference {
 // directory, not a vault viewer.
 export interface SecretRefEntry {
   name: string
+  backend: string
   created_at?: string
   updated_at?: string
   referenced_by: SecretReference[]

--- a/web/src/components/settings/ConnectorAdd.test.tsx
+++ b/web/src/components/settings/ConnectorAdd.test.tsx
@@ -38,9 +38,14 @@ beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(listSecretBackends).mockResolvedValue([{ backend: 'db', configured: true, default: true }])
   vi.mocked(listSecretRefs).mockResolvedValue([
-    { name: 'GITHUB_PAT', referenced_by: [{ kind: 'connector', name: 'github-account', role: 'credential' }] },
+    {
+      name: 'GITHUB_PAT',
+      backend: 'db',
+      referenced_by: [{ kind: 'connector', name: 'github-account', role: 'credential' }],
+    },
     {
       name: 'GMAIL_GOOGLE_OAUTH',
+      backend: 'db',
       referenced_by: [{ kind: 'connector', name: 'gmail', role: 'oauth_tokens' }],
     },
   ])

--- a/web/src/components/settings/CredentialsTab.test.tsx
+++ b/web/src/components/settings/CredentialsTab.test.tsx
@@ -6,12 +6,18 @@ import { CredentialsTab } from './CredentialsTab'
 vi.mock('../../api/client', () => ({
   deleteSecret: vi.fn(),
   listSecretRefs: vi.fn(),
+  migrateAllSecrets: vi.fn(),
+}))
+vi.mock('./useDefaultSecretBackend', () => ({
+  useDefaultSecretBackend: vi.fn(() => 'db'),
 }))
 
-import { deleteSecret, listSecretRefs } from '../../api/client'
+import { deleteSecret, listSecretRefs, migrateAllSecrets } from '../../api/client'
+import { useDefaultSecretBackend } from './useDefaultSecretBackend'
 
 const referenced: SecretRefEntry = {
   name: 'GITHUB_PAT',
+  backend: 'db',
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-02T00:00:00Z',
   referenced_by: [
@@ -22,12 +28,14 @@ const referenced: SecretRefEntry = {
 
 const orphaned: SecretRefEntry = {
   name: 'OLD_KEY',
+  backend: 'db',
   referenced_by: [],
 }
 
 afterEach(cleanup)
 beforeEach(() => {
   vi.clearAllMocks()
+  vi.mocked(useDefaultSecretBackend).mockReturnValue('db')
 })
 
 describe('CredentialsTab', () => {
@@ -80,5 +88,35 @@ describe('CredentialsTab', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
 
     expect(deleteSecret).not.toHaveBeenCalled()
+  })
+
+  it('hides the migrate-all button when the default backend is db', async () => {
+    vi.mocked(useDefaultSecretBackend).mockReturnValue('db')
+    vi.mocked(listSecretRefs).mockResolvedValue([{ ...orphaned, backend: 'vault' }])
+    render(<CredentialsTab />)
+
+    await screen.findByText('OLD_KEY')
+    expect(screen.queryByRole('button', { name: /Migrate all to/ })).not.toBeInTheDocument()
+  })
+
+  it('hides the migrate-all button when every ref is already on the default backend', async () => {
+    vi.mocked(useDefaultSecretBackend).mockReturnValue('vault')
+    vi.mocked(listSecretRefs).mockResolvedValue([{ ...orphaned, backend: 'vault' }])
+    render(<CredentialsTab />)
+
+    await screen.findByText('OLD_KEY')
+    expect(screen.queryByRole('button', { name: /Migrate all to/ })).not.toBeInTheDocument()
+  })
+
+  it('shows migrate-all when the default backend is external and a ref lives elsewhere', async () => {
+    vi.mocked(useDefaultSecretBackend).mockReturnValue('vault')
+    vi.mocked(listSecretRefs).mockResolvedValue([{ ...orphaned, backend: 'db' }])
+    vi.mocked(migrateAllSecrets).mockResolvedValue([{ name: 'OLD_KEY', migrated: true, skipped: false }])
+    render(<CredentialsTab />)
+
+    const button = await screen.findByRole('button', { name: 'Migrate all to Vault' })
+    fireEvent.click(button)
+
+    await waitFor(() => expect(migrateAllSecrets).toHaveBeenCalledWith('vault'))
   })
 })

--- a/web/src/components/settings/CredentialsTab.tsx
+++ b/web/src/components/settings/CredentialsTab.tsx
@@ -2,10 +2,17 @@ import { Delete02Icon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { deleteSecret, listSecretRefs, type SecretRefEntry } from '../../api/client'
+import { deleteSecret, listSecretRefs, migrateAllSecrets, type SecretRefEntry } from '../../api/client'
 import { Button } from '../ui/button'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog'
+import { useDefaultSecretBackend } from './useDefaultSecretBackend'
 import { errText } from './util'
+
+const BACKEND_LABEL: Record<string, string> = {
+  db: 'Timothy storage',
+  vault: 'Vault',
+  asm: 'AWS Secrets Manager',
+}
 
 // CredentialsTab is a read-only directory of every stored secret ref:
 // name, used-by chips, and timestamps when the row has them. There is
@@ -18,6 +25,8 @@ export function CredentialsTab() {
   const [loaded, setLoaded] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
+  const [migrating, setMigrating] = useState(false)
+  const defaultBackend = useDefaultSecretBackend()
 
   const refresh = useCallback(() => {
     listSecretRefs()
@@ -43,6 +52,35 @@ export function CredentialsTab() {
     }
   }
 
+  // Migrate all: only offered once an external backend is the default
+  // (moving everything back to "db" isn't this button's job) and at
+  // least one ref still lives elsewhere.
+  const elsewhereCount = refs.filter((r) => r.backend !== defaultBackend).length
+  const showMigrateAll = defaultBackend !== 'db' && elsewhereCount > 0
+
+  const migrateAll = async () => {
+    setMigrating(true)
+    try {
+      const results = await migrateAllSecrets(defaultBackend)
+      const migrated = results.filter((r) => r.migrated).length
+      const failed = results.filter((r) => r.error)
+      if (failed.length > 0) {
+        toast.error(`Migrated ${migrated}, ${failed.length} failed`, {
+          description: failed.map((f) => `${f.name}: ${f.error}`).join('; '),
+        })
+      } else {
+        toast.success(`Migrated ${migrated} credential${migrated === 1 ? '' : 's'}`, {
+          description: `Now stored in ${BACKEND_LABEL[defaultBackend] ?? defaultBackend}.`,
+        })
+      }
+      refresh()
+    } catch (err) {
+      toast.error('Could not migrate credentials', { description: errText(err) })
+    } finally {
+      setMigrating(false)
+    }
+  }
+
   return (
     <div className="mt-6 space-y-4">
       <p className="text-sm text-muted-foreground">
@@ -50,6 +88,17 @@ export function CredentialsTab() {
         this is a directory, not a vault viewer. A credential in use by a provider or connector
         can&apos;t be deleted until nothing references it.
       </p>
+      {showMigrateAll && (
+        <div className="flex items-center gap-3 rounded-xl border border-border p-4">
+          <div className="min-w-0 flex-1 text-sm">
+            {elsewhereCount} credential{elsewhereCount === 1 ? '' : 's'} not yet in{' '}
+            {BACKEND_LABEL[defaultBackend] ?? defaultBackend}.
+          </div>
+          <Button size="sm" disabled={migrating} onClick={() => void migrateAll()}>
+            Migrate all to {BACKEND_LABEL[defaultBackend] ?? defaultBackend}
+          </Button>
+        </div>
+      )}
       {loaded && refs.length === 0 ? (
         <div className="rounded-xl border border-dashed border-border p-10 text-center text-sm text-muted-foreground">
           No credentials stored yet.

--- a/web/src/components/settings/ProviderAdd.test.tsx
+++ b/web/src/components/settings/ProviderAdd.test.tsx
@@ -230,7 +230,11 @@ describe('ProviderAdd existing-credential picker', () => {
     vi.mocked(setSecret).mockResolvedValue()
     vi.mocked(createProvider).mockResolvedValue('p-new')
     vi.mocked(listSecretRefs).mockResolvedValue([
-      { name: 'ZAI_API_KEY', referenced_by: [{ kind: 'provider', name: 'GLM (Z.ai)', role: 'credential' }] },
+      {
+        name: 'ZAI_API_KEY',
+        backend: 'db',
+        referenced_by: [{ kind: 'provider', name: 'GLM (Z.ai)', role: 'credential' }],
+      },
     ])
   })
 


### PR DESCRIPTION
## What

Secrets have a per-ref backend (db/vault/asm) but no way to move an existing ref — the API never returns values, so only the server can re-home them. This adds:

- \`secretstore.Migrate(ref, target)\`: resolve via the row's own backend → write through the target (same addressing as a fresh Set) → flip the backend column → wipe old storage last. Crash between steps leaves a harmless duplicate, never a loss. Idempotent on same-backend; clear error on unconfigured targets.
- Gateway admin: \`POST /internal/admin/secrets/{ref}/migrate\` + bulk \`POST /internal/admin/secrets/migrate\` (per-ref results, one failure never aborts the batch). Audit action "migrate" carries backend names only — never values. Brain proxies both.
- \`ListSecrets\` now reports each ref's backend end-to-end; credentials panel shows it and offers "Migrate all to <backend>" when the default backend is external.

## Verification
Full Go suite + integration tests (secretstore against fake Vault KV v2 httptest incl. db→vault, vault→db, idempotency, unconfigured-target, ciphertext-wipe and external-delete assertions; admin audit-has-no-values + bulk partial failure), \`make lint\` 0 issues, web build+lint+708 tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789696503&installation_model_id=431401&pr_number=252&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F252&signature=152164f9f8a38e42d8712048fd6e09722ef6b76e1e9cb52ba0ccd895e548449f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->