### PR TITLE
fix: refuse migrating secret-backend bootstrap credentials off db

### DIFF
--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -1192,6 +1192,10 @@ func TestMigrateAllSecretsBulkPartialFailure(t *testing.T) {
 		t.Fatalf("pre-migrate refSkip: %v", err)
 	}
 
+	// refBootstrap: the vault backend's own token_ref, db-backed. The
+	// bulk migrate must record it as an error, never abort the batch.
+	refBootstrap := refOK + "_TOKEN"
+
 	results, err := adm.MigrateAllSecrets(ctx, "vault")
 	if err != nil {
 		t.Fatalf("MigrateAllSecrets: %v", err)
@@ -1205,6 +1209,13 @@ func TestMigrateAllSecretsBulkPartialFailure(t *testing.T) {
 	}
 	if !byName[refSkip].Skipped {
 		t.Fatalf("refSkip result = %+v, want skipped (already on vault)", byName[refSkip])
+	}
+	bootstrapResult := byName[refBootstrap]
+	if bootstrapResult.Migrated || bootstrapResult.Skipped || bootstrapResult.Error == "" {
+		t.Fatalf("refBootstrap result = %+v, want error only", bootstrapResult)
+	}
+	if !strings.Contains(bootstrapResult.Error, "bootstrap credential") {
+		t.Fatalf("refBootstrap error = %q, want it to mention bootstrap credential", bootstrapResult.Error)
 	}
 
 	// An unknown target backend fails validation before touching any ref.

--- a/internal/secretstore/secretstore.go
+++ b/internal/secretstore/secretstore.go
@@ -12,6 +12,7 @@ package secretstore
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -243,9 +244,62 @@ func (s *Store) upsertRef(ctx context.Context, refName, backend, backendRef stri
 	return nil
 }
 
+// bootstrapRefs collects the ref names every configured external
+// backend needs to log in with — vault's token/secret_id ref, asm's
+// static secret key ref — applying each config loader's own
+// defaulting for an empty ref field. Unconfigured backends contribute
+// nothing. These refs unlock the backend they name, so migrating one
+// of them into that same backend is a chicken-and-egg lockout: nothing
+// left in db can decrypt the login credential needed to resolve it.
+func (s *Store) bootstrapRefs(ctx context.Context) (map[string]bool, error) {
+	out := map[string]bool{}
+	vaultCfg, err := s.GetBackendConfig(ctx, "vault")
+	if err != nil {
+		return nil, err
+	}
+	if string(vaultCfg) != "{}" {
+		var v VaultConfig
+		if err := json.Unmarshal(vaultCfg, &v); err != nil {
+			return nil, fmt.Errorf("secretstore: vault config: %w", err)
+		}
+		tokenRef := v.TokenRef
+		if tokenRef == "" {
+			tokenRef = defaultVaultTokenRef
+		}
+		out[tokenRef] = true
+		if v.Auth == "approle" {
+			secretIDRef := v.SecretIDRef
+			if secretIDRef == "" {
+				secretIDRef = defaultVaultSecretIDRef
+			}
+			out[secretIDRef] = true
+		}
+	}
+	asmCfg, err := s.GetBackendConfig(ctx, "asm")
+	if err != nil {
+		return nil, err
+	}
+	if string(asmCfg) != "{}" {
+		var a ASMConfig
+		if err := json.Unmarshal(asmCfg, &a); err != nil {
+			return nil, fmt.Errorf("secretstore: asm config: %w", err)
+		}
+		if a.Auth == "keys" {
+			secretKeyRef := a.SecretKeyRef
+			if secretKeyRef == "" {
+				secretKeyRef = defaultASMSecretKeyRef
+			}
+			out[secretKeyRef] = true
+		}
+	}
+	return out, nil
+}
+
 // Migrate moves refName's stored value onto targetBackend, replacing
 // its current backend entirely. Idempotent no-op when refName already
-// lives on targetBackend. Ordering matters for crash safety: the new
+// lives on targetBackend. Refuses to move a backend bootstrap
+// credential (see bootstrapRefs) off db into the very backend it
+// unlocks. Ordering matters for crash safety: the new
 // home is written FIRST, the row's backend column flipped SECOND, and
 // only then is the old storage wiped — a crash between any two steps
 // leaves the value readable at its new home (a stray old-backend copy
@@ -260,6 +314,13 @@ func (s *Store) Migrate(ctx context.Context, refName, targetBackend string) erro
 	if targetBackend != "db" {
 		if err := validExternalBackend(targetBackend); err != nil {
 			return err
+		}
+		bootstrap, err := s.bootstrapRefs(ctx)
+		if err != nil {
+			return err
+		}
+		if bootstrap[refName] {
+			return fmt.Errorf("secretstore: %q is a backend bootstrap credential (vault/asm login secret) and must stay in built-in db storage", refName)
 		}
 	}
 	r, err := s.row(ctx, refName)

--- a/internal/secretstore/secretstore_integration_test.go
+++ b/internal/secretstore/secretstore_integration_test.go
@@ -557,3 +557,135 @@ func TestMigrateUnconfiguredTargetErrors(t *testing.T) {
 		t.Fatalf("row changed after a rejected migrate: configured=%v backend=%q err=%v", configured, backend, err)
 	}
 }
+
+// TestMigrateRefusesVaultTokenBootstrapRef pins the chicken-and-egg
+// fix: vault's own token_ref must never move into vault itself, since
+// resolving it afterward would need the token it no longer has in db.
+// Migrating it back to db (the recovery path) stays allowed.
+func TestMigrateRefusesVaultTokenBootstrapRef(t *testing.T) {
+	s := integrationStore(t)
+	ctx := t.Context()
+	tokenRef := "TEST_MIGRATE_BOOTSTRAP_TOKEN_" + t.Name()
+
+	srv, _ := fakeVaultKV(t)
+	defer srv.Close()
+	restore := setUpVaultDefault(t, s, srv, tokenRef)
+	defer restore()
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer func() {
+		_, _ = db.Exec(ctx, `DELETE FROM secrets WHERE ref_name = $1`, tokenRef)
+	}()
+
+	err = s.Migrate(ctx, tokenRef, "vault")
+	if err == nil {
+		t.Fatal("Migrate accepted moving the vault token_ref into vault")
+	}
+	if !strings.Contains(err.Error(), "bootstrap credential") {
+		t.Fatalf("error = %v, want it to mention bootstrap credential", err)
+	}
+	if configured, backend, err := s.Status(ctx, tokenRef); err != nil || !configured || backend != "db" {
+		t.Fatalf("row changed after a rejected migrate: configured=%v backend=%q err=%v", configured, backend, err)
+	}
+
+	// Recovery path: migrating the bootstrap ref back to db (its
+	// current backend) stays allowed as a no-op.
+	if err := s.Migrate(ctx, tokenRef, "db"); err != nil {
+		t.Fatalf("Migrate bootstrap ref to db (no-op): %v", err)
+	}
+}
+
+// TestMigrateRefusesVaultSecretIDBootstrapRef covers the exact
+// production incident: approle auth's secret_id_ref (defaulting to
+// VAULT_SECRET_ID) must also be refused into vault.
+func TestMigrateRefusesVaultSecretIDBootstrapRef(t *testing.T) {
+	s := integrationStore(t)
+	ctx := t.Context()
+	secretIDRef := "TEST_MIGRATE_BOOTSTRAP_SECRETID_" + t.Name()
+
+	srv, _ := fakeVaultKV(t)
+	defer srv.Close()
+
+	origCfg, err := s.GetBackendConfig(ctx, "vault")
+	if err != nil {
+		t.Fatalf("GetBackendConfig: %v", err)
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer func() {
+		_, _ = db.Exec(ctx, `DELETE FROM secrets WHERE ref_name = $1`, secretIDRef)
+		if string(origCfg) != "{}" {
+			if _, err := s.SetBackendConfig(ctx, "vault", origCfg); err != nil {
+				t.Errorf("restore vault config: %v", err)
+			}
+		} else if err := s.DeleteBackendConfig(ctx, "vault"); err != nil {
+			t.Errorf("delete vault config: %v", err)
+		}
+	}()
+
+	cfg := `{"address":"` + srv.URL + `","mount":"kv","auth":"approle","role_id":"role-x","secret_id_ref":"` + secretIDRef + `"}`
+	if _, err := s.SetBackendConfig(ctx, "vault", []byte(cfg)); err != nil {
+		t.Fatalf("SetBackendConfig: %v", err)
+	}
+	if err := s.SetDB(ctx, secretIDRef, "secret-id-x"); err != nil {
+		t.Fatalf("SetDB: %v", err)
+	}
+
+	err = s.Migrate(ctx, secretIDRef, "vault")
+	if err == nil {
+		t.Fatal("Migrate accepted moving the vault secret_id_ref into vault")
+	}
+	if !strings.Contains(err.Error(), "bootstrap credential") {
+		t.Fatalf("error = %v, want it to mention bootstrap credential", err)
+	}
+}
+
+// TestMigrateRefusesASMSecretKeyBootstrapRef covers asm's static-keys
+// auth: the secret_key_ref (defaulting to AWS_SECRET_ACCESS_KEY) must
+// be refused into asm. Only the asm backend config row is saved here
+// (no live AWS client) — bootstrapRefs reads stored config only, so it
+// picks the ref up without needing working AWS credentials.
+func TestMigrateRefusesASMSecretKeyBootstrapRef(t *testing.T) {
+	s := integrationStore(t)
+	ctx := t.Context()
+	secretKeyRef := "TEST_MIGRATE_BOOTSTRAP_ASMKEY_" + t.Name()
+
+	origCfg, err := s.GetBackendConfig(ctx, "asm")
+	if err != nil {
+		t.Fatalf("GetBackendConfig: %v", err)
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer func() {
+		_, _ = db.Exec(ctx, `DELETE FROM secrets WHERE ref_name = $1`, secretKeyRef)
+		if string(origCfg) != "{}" {
+			if _, err := s.SetBackendConfig(ctx, "asm", origCfg); err != nil {
+				t.Errorf("restore asm config: %v", err)
+			}
+		} else if err := s.DeleteBackendConfig(ctx, "asm"); err != nil {
+			t.Errorf("delete asm config: %v", err)
+		}
+	}()
+
+	cfg := `{"auth":"keys","access_key_id":"AKIAEXAMPLE","secret_key_ref":"` + secretKeyRef + `"}`
+	if _, err := s.SetBackendConfig(ctx, "asm", []byte(cfg)); err != nil {
+		t.Fatalf("SetBackendConfig: %v", err)
+	}
+	if err := s.SetDB(ctx, secretKeyRef, "secret-key-x"); err != nil {
+		t.Fatalf("SetDB: %v", err)
+	}
+
+	err = s.Migrate(ctx, secretKeyRef, "asm")
+	if err == nil {
+		t.Fatal("Migrate accepted moving the asm secret_key_ref into asm")
+	}
+	if !strings.Contains(err.Error(), "bootstrap credential") {
+		t.Fatalf("error = %v, want it to mention bootstrap credential", err)
+	}
+}


### PR DESCRIPTION
Migrate happily moved a backend's own login credential (vault approle secret_id, vault token, ASM static secret key) into the external backend it unlocks. Hit in production: VAULT_SECRET_ID got bulk-migrated into vault, after which approle login has nothing db-backed left to authenticate with and every vault-backed secret becomes unresolvable until a fresh secret_id is minted and re-pinned.

Migrate now collects each configured backend's bootstrap refs (with the config loaders' own defaulting) and refuses moving one anywhere but back to db — the recovery path stays open. Bulk migration reports the refusal as a per-ref error without aborting the batch.

Covered by integration tests for vault token_ref, approle secret_id_ref (the production repro), ASM secret_key_ref, and the bulk partial-failure case.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789699084&installation_model_id=431401&pr_number=253&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F253&signature=c394042fec9b58d11d8cd473c17ac9afed8138468334a7f0e66b7a69702bcab9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->