### PR TITLE
feat: automations page and mission list filters

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -45,6 +45,23 @@ describe('Sidebar nav', () => {
     const labels = links.map((l) => l.textContent).filter((t) => t === 'Knowledge' || t === 'Memory')
     expect(labels).toEqual(['Knowledge', 'Memory'])
   })
+
+  it('lists Automations directly below Missions', async () => {
+    renderAt('/')
+    const links = await screen.findAllByRole('link')
+    const labels = links.map((l) => l.textContent).filter((t) => t === 'Missions' || t === 'Automations')
+    expect(labels).toEqual(['Missions', 'Automations'])
+  })
+})
+
+describe('Legacy edit schedule route', () => {
+  it('redirects /missions/schedules/:id/edit to /automations/:id/edit', async () => {
+    renderAt('/missions/schedules/s1/edit')
+    // No GET-by-id for schedules: the redirected EditSchedule page can't
+    // resolve 's1' against an empty (failed-fetch) schedule list, so it
+    // falls back to its own not-found copy — proof the route landed.
+    expect(await screen.findByText('Schedule not found.')).toBeTruthy()
+  })
 })
 
 describe('Settings sidebar submenu', () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import {
   Key01Icon,
   LibraryIcon,
   Moon02Icon,
+  RepeatIcon,
   RocketIcon,
   Search01Icon,
   Settings02Icon,
@@ -61,6 +62,8 @@ import { getNotificationSoundEnabled } from './lib/sound'
 import { getTheme, nextTheme, setTheme, type Theme } from './lib/theme'
 import { Chat } from './pages/Chat'
 import { Analytics } from './pages/Analytics'
+import { AutomationDetail } from './pages/AutomationDetail'
+import { Automations } from './pages/Automations'
 import { EditSchedule } from './pages/EditSchedule'
 import { Home } from './pages/Home'
 import { Knowledge } from './pages/Knowledge'
@@ -75,6 +78,7 @@ const nav = [
   { label: 'Home', href: '/', icon: Home01Icon },
   { label: 'Chat', href: '/chat', icon: BubbleChatIcon },
   { label: 'Missions', href: '/missions', icon: RocketIcon },
+  { label: 'Automations', href: '/automations', icon: RepeatIcon },
   { label: 'Knowledge', href: '/knowledge', icon: LibraryIcon },
   { label: 'Memory', href: '/memory', icon: Brain02Icon },
   { label: 'Analytics', href: '/analytics', icon: Analytics01Icon },
@@ -88,6 +92,7 @@ function isActive(pathname: string, href: string): boolean {
   if (href === '/') return pathname === '/'
   if (href === '/chat') return pathname === '/chat' || pathname.startsWith('/chat/')
   if (href === '/missions') return pathname === '/missions' || pathname.startsWith('/missions/')
+  if (href === '/automations') return pathname === '/automations' || pathname.startsWith('/automations/')
   if (href === '/knowledge') return pathname === '/knowledge' || pathname.startsWith('/knowledge/')
   if (href === '/settings') return pathname.startsWith('/settings')
   return pathname === href
@@ -338,6 +343,13 @@ function LegacySessionRedirect() {
   return <Navigate to={`/chat/${id}`} replace />
 }
 
+// LegacyEditScheduleRedirect keeps old /missions/schedules/{id}/edit
+// links working now that schedule editing lives under /automations.
+function LegacyEditScheduleRedirect() {
+  const { id } = useParams()
+  return <Navigate to={`/automations/${id}/edit`} replace />
+}
+
 function App() {
   const [tokenOpen, setTokenOpen] = useState(false)
   const [paletteOpen, setPaletteOpen] = useState(false)
@@ -470,8 +482,15 @@ function App() {
                 <Route path="/dashboard" element={<Navigate to="/analytics" replace />} />
                 <Route path="/missions" element={<Missions />} />
                 <Route path="/missions/new" element={<NewMission />} />
-                <Route path="/missions/schedules/:id/edit" element={<EditSchedule />} />
+                {/* Old bookmark: schedule editing lived under /missions before automations got their own page. */}
+                <Route
+                  path="/missions/schedules/:id/edit"
+                  element={<LegacyEditScheduleRedirect />}
+                />
                 <Route path="/missions/:id" element={<MissionDetail />} />
+                <Route path="/automations" element={<Automations />} />
+                <Route path="/automations/:id/edit" element={<EditSchedule />} />
+                <Route path="/automations/:id" element={<AutomationDetail />} />
                 <Route path="/knowledge/*" element={<Knowledge />} />
                 <Route path="/memory/knowledge/*" element={<KnowledgeRedirect />} />
                 <Route path="/memory/*" element={<Memory />} />

--- a/web/src/pages/AutomationDetail.test.tsx
+++ b/web/src/pages/AutomationDetail.test.tsx
@@ -1,0 +1,83 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mission, Schedule } from '../api/types'
+import { AutomationDetail } from './AutomationDetail'
+
+vi.mock('../api/client', () => ({
+  listSchedules: vi.fn(),
+  listMissions: vi.fn(),
+}))
+
+import { listMissions, listSchedules } from '../api/client'
+
+const schedule: Schedule = {
+  id: 's1',
+  name: 'weekly-digest',
+  cron: '0 8 * * 1-5',
+  mission_template: { goal: 'Summarize the week', kind: 'general', auto_approve_safe: true },
+  enabled: true,
+  next_run: '2026-07-27T08:00:00Z',
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+  pending_fire: false,
+}
+
+const firedMission: Mission = {
+  id: 'm1',
+  goal: 'Summarize the week',
+  kind: 'general',
+  phase: 'done',
+  status: 'done',
+  spec: { units: [] },
+  progress: [],
+  iteration: 1,
+  max_iterations: 8,
+  consecutive_failures: 0,
+  stall_count: 0,
+  route: 'default',
+  review_route: 'default',
+  auto_approve_safe: true,
+  schedule_id: 's1',
+  created_at: '2026-07-27T08:00:00Z',
+  updated_at: '2026-07-27T08:01:00Z',
+}
+
+function renderAt(id: string) {
+  const router = createMemoryRouter(
+    [{ path: '/automations/:id', element: <AutomationDetail /> }],
+    { initialEntries: [`/automations/${id}`] },
+  )
+  return render(<RouterProvider router={router} />)
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(listSchedules).mockResolvedValue([])
+  vi.mocked(listMissions).mockResolvedValue([])
+})
+
+describe('AutomationDetail', () => {
+  it('shows a not-found message for an unknown schedule', async () => {
+    renderAt('missing')
+    expect(await screen.findByText('Automation not found.')).toBeTruthy()
+  })
+
+  it('renders the schedule summary and fetches its mission history', async () => {
+    vi.mocked(listSchedules).mockResolvedValue([schedule])
+    vi.mocked(listMissions).mockResolvedValue([firedMission])
+    renderAt('s1')
+
+    expect(await screen.findByText('weekly-digest')).toBeTruthy()
+    expect(screen.getByText('Weekdays, 8:00 AM')).toBeTruthy()
+    expect((await screen.findAllByText('Summarize the week')).length).toBe(2)
+    expect(listMissions).toHaveBeenCalledWith({ scheduleId: 's1' })
+  })
+
+  it('shows an empty state when the schedule has never fired', async () => {
+    vi.mocked(listSchedules).mockResolvedValue([schedule])
+    renderAt('s1')
+    expect(await screen.findByText('No missions fired yet.')).toBeTruthy()
+  })
+})

--- a/web/src/pages/AutomationDetail.tsx
+++ b/web/src/pages/AutomationDetail.tsx
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router'
+import { listMissions, listSchedules } from '../api/client'
+import type { Mission, Schedule } from '../api/types'
+import { MissionCard } from '../components/missions/MissionCard'
+import { Button } from '../components/ui/button'
+import { describeCron } from '../lib/schedules'
+import { relativeTime } from '../lib/format'
+
+// AutomationDetail shows one schedule's summary plus the missions it
+// has fired — no GET-by-id for schedules, same as EditSchedule, so the
+// list (small) is searched for the one being viewed.
+export function AutomationDetail() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const [schedule, setSchedule] = useState<Schedule | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [missions, setMissions] = useState<Mission[]>([])
+
+  const refresh = useCallback(() => {
+    if (!id) return
+    listSchedules().then(
+      (rows) => {
+        setSchedule(rows.find((s) => s.id === id) ?? null)
+        setLoading(false)
+      },
+      () => setLoading(false),
+    )
+    listMissions({ scheduleId: id }).then(setMissions, () => undefined)
+  }, [id])
+
+  useEffect(refresh, [refresh])
+
+  if (!id) return null
+
+  if (loading) {
+    return (
+      <div className="mx-auto w-full max-w-full px-8 py-6">
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      </div>
+    )
+  }
+
+  if (!schedule) {
+    return (
+      <div className="mx-auto w-full max-w-full px-8 py-6">
+        <p className="text-sm text-muted-foreground">
+          Automation not found.{' '}
+          <Link to="/automations" className="underline underline-offset-2 hover:text-foreground">
+            Back to automations
+          </Link>
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-full px-8 py-6">
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="truncate text-xl font-semibold tracking-tight">{schedule.name}</h1>
+          <p className="line-clamp-1 text-sm text-muted-foreground">{schedule.mission_template.goal}</p>
+          <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+            <span>{describeCron(schedule.cron)}</span>
+            {schedule.next_run && <span>next {relativeTime(schedule.next_run)}</span>}
+            {schedule.last_run && <span>last {relativeTime(schedule.last_run)}</span>}
+            <span>{schedule.enabled ? 'enabled' : 'disabled'}</span>
+          </div>
+        </div>
+        <Button variant="outline" onClick={() => navigate(`/automations/${id}/edit`)}>
+          Edit
+        </Button>
+      </div>
+
+      <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {missions.map((m) => (
+          <MissionCard key={m.id} mission={m} />
+        ))}
+        {missions.length === 0 && (
+          <div className="col-span-full rounded-xl border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+            No missions fired yet.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/Automations.test.tsx
+++ b/web/src/pages/Automations.test.tsx
@@ -1,18 +1,16 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Schedule } from '../../api/types'
-import { RecurringSchedules } from './RecurringSchedules'
+import type { Schedule } from '../api/types'
+import { Automations } from './Automations'
 
-vi.mock('../../api/client', () => ({
+vi.mock('../api/client', () => ({
   listSchedules: vi.fn(),
-  createSchedule: vi.fn(),
   patchSchedule: vi.fn(),
   deleteSchedule: vi.fn(),
-  listAgents: vi.fn(),
 }))
 
-import { deleteSchedule, listAgents, listSchedules, patchSchedule } from '../../api/client'
+import { deleteSchedule, listSchedules, patchSchedule } from '../api/client'
 
 const schedule: Schedule = {
   id: 's1',
@@ -26,13 +24,14 @@ const schedule: Schedule = {
   pending_fire: false,
 }
 
-function renderList() {
+function renderPage() {
   const router = createMemoryRouter(
     [
-      { path: '/missions', element: <RecurringSchedules /> },
-      { path: '/missions/schedules/:id/edit', element: <div>edit schedule page</div> },
+      { path: '/automations', element: <Automations /> },
+      { path: '/automations/:id', element: <div>automation detail page</div> },
+      { path: '/automations/:id/edit', element: <div>edit automation page</div> },
     ],
-    { initialEntries: ['/missions'] },
+    { initialEntries: ['/automations'] },
   )
   const result = render(<RouterProvider router={router} />)
   return { router, ...result }
@@ -43,27 +42,25 @@ beforeEach(() => {
   Element.prototype.scrollIntoView = vi.fn()
   vi.clearAllMocks()
   vi.mocked(listSchedules).mockResolvedValue([])
-  vi.mocked(listAgents).mockResolvedValue([])
 })
 
-describe('RecurringSchedules', () => {
-  it('renders nothing when there are no schedules', async () => {
-    const { container } = renderList()
-    await waitFor(() => expect(listSchedules).toHaveBeenCalled())
-    expect(container).toBeEmptyDOMElement()
+describe('Automations page', () => {
+  it('shows an empty state with no schedules', async () => {
+    renderPage()
+    expect(await screen.findByText(/No automations yet/)).toBeTruthy()
   })
 
   it('lists schedules with cron description and next run', async () => {
     vi.mocked(listSchedules).mockResolvedValue([schedule])
-    renderList()
+    renderPage()
     expect(await screen.findByText('weekly-digest')).toBeTruthy()
     expect(screen.getByText('Weekdays, 8:00 AM')).toBeTruthy()
   })
 
-  it('toggles enabled optimistically', async () => {
+  it('toggles enabled and calls PATCH', async () => {
     vi.mocked(listSchedules).mockResolvedValue([schedule])
     vi.mocked(patchSchedule).mockResolvedValue({ ...schedule, enabled: false })
-    renderList()
+    renderPage()
     await screen.findByText('weekly-digest')
 
     fireEvent.click(screen.getByRole('switch', { name: 'weekly-digest enabled' }))
@@ -73,7 +70,7 @@ describe('RecurringSchedules', () => {
   it('deletes a schedule after confirming', async () => {
     vi.mocked(listSchedules).mockResolvedValue([schedule])
     vi.mocked(deleteSchedule).mockResolvedValue()
-    renderList()
+    renderPage()
     await screen.findByText('weekly-digest')
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete weekly-digest' }))
@@ -82,14 +79,23 @@ describe('RecurringSchedules', () => {
     await waitFor(() => expect(deleteSchedule).toHaveBeenCalledWith('s1'))
   })
 
-  it('navigates to the edit schedule page', async () => {
+  it('navigates to the automation detail page on card click', async () => {
     vi.mocked(listSchedules).mockResolvedValue([schedule])
-    const { router } = renderList()
+    const { router } = renderPage()
+    fireEvent.click(await screen.findByText('weekly-digest'))
+
+    await waitFor(() => expect(router.state.location.pathname).toBe('/automations/s1'))
+    expect(await screen.findByText('automation detail page')).toBeTruthy()
+  })
+
+  it('navigates to the edit automation page', async () => {
+    vi.mocked(listSchedules).mockResolvedValue([schedule])
+    const { router } = renderPage()
     await screen.findByText('weekly-digest')
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
 
-    await waitFor(() => expect(router.state.location.pathname).toBe('/missions/schedules/s1/edit'))
-    expect(await screen.findByText('edit schedule page')).toBeTruthy()
+    await waitFor(() => expect(router.state.location.pathname).toBe('/automations/s1/edit'))
+    expect(await screen.findByText('edit automation page')).toBeTruthy()
   })
 })

--- a/web/src/pages/Automations.tsx
+++ b/web/src/pages/Automations.tsx
@@ -1,32 +1,29 @@
 import { Delete02Icon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useCallback, useEffect, useState } from 'react'
-import { useNavigate } from 'react-router'
+import { Link, useNavigate } from 'react-router'
 import { toast } from 'sonner'
-import { deleteSchedule, patchSchedule, listSchedules } from '../../api/client'
-import type { Schedule } from '../../api/types'
-import { describeCron } from '../../lib/schedules'
-import { Button } from '../ui/button'
+import { deleteSchedule, patchSchedule, listSchedules } from '../api/client'
+import type { Schedule } from '../api/types'
+import { describeCron } from '../lib/schedules'
+import { relativeTime } from '../lib/format'
+import { Button } from '../components/ui/button'
 import {
   Dialog,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '../ui/dialog'
-import { Toggle } from '../settings/shared'
-import { errText } from '../settings/util'
+} from '../components/ui/dialog'
+import { Toggle } from '../components/settings/shared'
+import { errText } from '../components/settings/util'
 
-function formatDate(v?: string): string {
-  if (!v) return 'N/A'
-  return new Date(v).toLocaleString()
-}
-
-// RecurringSchedules lists the recurring missions created from the new
-// mission page's "Repeat on schedule" option — rendered on the
-// Missions page between the notifications strip and the mission grid,
-// only when at least one schedule exists.
-export function RecurringSchedules() {
+// Automations lists every recurring schedule as a card, folding in what
+// RecurringSchedules used to render inline on the Missions page — same
+// API calls (listSchedules/patchSchedule/deleteSchedule), moved here
+// since a schedule now has its own detail page (run history) to link
+// into.
+export function Automations() {
   const navigate = useNavigate()
   const [schedules, setSchedules] = useState<Schedule[]>([])
   const [confirmDelete, setConfirmDelete] = useState<Schedule | null>(null)
@@ -59,48 +56,55 @@ export function RecurringSchedules() {
     }
   }
 
-  if (schedules.length === 0) return null
-
   return (
-    <div className="mt-4 space-y-3">
-      <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-        Recurring · {schedules.length}
-      </h2>
-      <div className="space-y-3">
+    <div className="mx-auto w-full max-w-full px-8 py-6">
+      <div>
+        <h1 className="text-xl font-semibold tracking-tight">Automations</h1>
+        <p className="text-sm text-muted-foreground">Recurring missions that run on a schedule.</p>
+      </div>
+
+      <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {schedules.map((sc) => (
           <div
             key={sc.id}
-            className="flex items-center gap-4 rounded-xl border border-border bg-card p-4"
+            className="flex flex-col gap-2 rounded-xl border border-border bg-card p-4 shadow-sm transition hover:border-brand hover:shadow-md"
           >
-            <div className="min-w-0 flex-1">
+            <Link to={`/automations/${sc.id}`} className="min-w-0">
               <span className="truncate text-sm font-semibold">{sc.name}</span>
               <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
                 {sc.mission_template.goal}
               </p>
               <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
                 <span>{describeCron(sc.cron)}</span>
-                <span>next run {formatDate(sc.next_run)}</span>
-                {sc.last_run && <span>last run {formatDate(sc.last_run)}</span>}
+                {sc.next_run && <span>next {relativeTime(sc.next_run)}</span>}
+                {sc.last_run && <span>last {relativeTime(sc.last_run)}</span>}
               </div>
+            </Link>
+            <div className="flex items-center gap-2">
+              <Toggle on={sc.enabled} onChange={(v) => toggle(sc, v)} label={`${sc.name} enabled`} />
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => navigate(`/automations/${sc.id}/edit`)}
+              >
+                Edit
+              </Button>
+              <button
+                type="button"
+                aria-label={`Delete ${sc.name}`}
+                onClick={() => setConfirmDelete(sc)}
+                className="ml-auto text-muted-foreground hover:text-destructive"
+              >
+                <HugeiconsIcon icon={Delete02Icon} className="size-4" />
+              </button>
             </div>
-            <Toggle on={sc.enabled} onChange={(v) => toggle(sc, v)} label={`${sc.name} enabled`} />
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => navigate(`/missions/schedules/${sc.id}/edit`)}
-            >
-              Edit
-            </Button>
-            <button
-              type="button"
-              aria-label={`Delete ${sc.name}`}
-              onClick={() => setConfirmDelete(sc)}
-              className="text-muted-foreground hover:text-destructive"
-            >
-              <HugeiconsIcon icon={Delete02Icon} className="size-4" />
-            </button>
           </div>
         ))}
+        {schedules.length === 0 && (
+          <div className="col-span-full rounded-xl border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+            No automations yet. Create a mission and choose "Repeat on schedule" to add one.
+          </div>
+        )}
       </div>
 
       <Dialog open={confirmDelete !== null} onOpenChange={(o) => !o && setConfirmDelete(null)}>

--- a/web/src/pages/EditSchedule.tsx
+++ b/web/src/pages/EditSchedule.tsx
@@ -39,8 +39,8 @@ export function EditSchedule() {
       <div className="mx-auto w-full max-w-full px-8 py-6">
         <p className="text-sm text-muted-foreground">
           Schedule not found.{' '}
-          <Link to="/missions" className="underline underline-offset-2 hover:text-foreground">
-            Back to missions
+          <Link to="/automations" className="underline underline-offset-2 hover:text-foreground">
+            Back to automations
           </Link>
         </p>
       </div>
@@ -60,8 +60,8 @@ export function EditSchedule() {
         <MissionForm
           mode="edit"
           schedule={schedule}
-          onCancel={() => navigate('/missions')}
-          onDone={() => navigate('/missions')}
+          onCancel={() => navigate(`/automations/${id}`)}
+          onDone={() => navigate(`/automations/${id}`)}
         />
       </div>
     </div>

--- a/web/src/pages/Missions.test.tsx
+++ b/web/src/pages/Missions.test.tsx
@@ -9,13 +9,11 @@ vi.mock('../api/client', () => ({
   listMissions: vi.fn(),
   listNotifications: vi.fn(),
   markNotificationRead: vi.fn(),
-  listSchedules: vi.fn(),
-  listAgents: vi.fn(),
 }))
 
 vi.mock('../lib/events', () => ({ subscribeEvents: vi.fn() }))
 
-import { listAgents, listMissions, listNotifications, listSchedules } from '../api/client'
+import { listMissions, listNotifications } from '../api/client'
 import { subscribeEvents } from '../lib/events'
 
 // captureSubscribe grabs the onSignal/onReady callbacks subscribeEvents
@@ -64,12 +62,11 @@ function renderPage() {
 
 afterEach(cleanup)
 beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn()
   vi.clearAllMocks()
   vi.mocked(subscribeEvents).mockReturnValue(vi.fn())
   vi.mocked(listMissions).mockResolvedValue([mission])
   vi.mocked(listNotifications).mockResolvedValue([])
-  vi.mocked(listAgents).mockResolvedValue([])
-  vi.mocked(listSchedules).mockResolvedValue([])
 })
 
 describe('Missions board', () => {
@@ -220,5 +217,75 @@ describe('Missions board', () => {
     await screen.findByText('Fix the login bug')
     unmount()
     expect(sub.unsubscribe).toHaveBeenCalled()
+  })
+
+  describe('filters', () => {
+    const coding: Mission = {
+      ...mission,
+      id: 'm2',
+      goal: 'Refactor the payments module',
+      kind: 'coding',
+      harness: 'claude-cli',
+      top_model: 'claude-opus-4',
+      schedule_id: 's1',
+    }
+
+    it('narrows by kind', async () => {
+      vi.mocked(listMissions).mockResolvedValue([mission, coding])
+      renderPage()
+      await screen.findByText('Fix the login bug')
+      await screen.findByText('Refactor the payments module')
+
+      fireEvent.click(screen.getByRole('combobox', { name: 'Filter by kind' }))
+      fireEvent.click(await screen.findByRole('option', { name: 'Coding' }))
+
+      expect(screen.queryByText('Fix the login bug')).toBeNull()
+      expect(screen.getByText('Refactor the payments module')).toBeTruthy()
+      expect(screen.getByText('1 of 2')).toBeTruthy()
+    })
+
+    it('narrows by harness, showing Native for an unset harness', async () => {
+      vi.mocked(listMissions).mockResolvedValue([mission, coding])
+      renderPage()
+      await screen.findByText('Fix the login bug')
+
+      fireEvent.click(screen.getByRole('combobox', { name: 'Filter by harness' }))
+      fireEvent.click(await screen.findByRole('option', { name: 'Native' }))
+
+      expect(screen.getByText('Fix the login bug')).toBeTruthy()
+      expect(screen.queryByText('Refactor the payments module')).toBeNull()
+    })
+
+    it('narrows by model', async () => {
+      vi.mocked(listMissions).mockResolvedValue([mission, coding])
+      renderPage()
+      await screen.findByText('Fix the login bug')
+
+      fireEvent.click(screen.getByRole('combobox', { name: 'Filter by model' }))
+      fireEvent.click(await screen.findByRole('option', { name: 'claude-opus-4' }))
+
+      expect(screen.queryByText('Fix the login bug')).toBeNull()
+      expect(screen.getByText('Refactor the payments module')).toBeTruthy()
+    })
+
+    it('narrows by source: automated means schedule_id is set', async () => {
+      vi.mocked(listMissions).mockResolvedValue([mission, coding])
+      renderPage()
+      await screen.findByText('Fix the login bug')
+
+      fireEvent.click(screen.getByRole('combobox', { name: 'Filter by source' }))
+      fireEvent.click(await screen.findByRole('option', { name: 'Automated' }))
+
+      expect(screen.queryByText('Fix the login bug')).toBeNull()
+      expect(screen.getByText('Refactor the payments module')).toBeTruthy()
+    })
+
+    it('shows no count when no filter is active', async () => {
+      vi.mocked(listMissions).mockResolvedValue([mission, coding])
+      renderPage()
+      await screen.findByText('Fix the login bug')
+      expect(screen.queryByText('1 of 2')).toBeNull()
+      expect(screen.queryByText('2 of 2')).toBeNull()
+    })
   })
 })

--- a/web/src/pages/Missions.tsx
+++ b/web/src/pages/Missions.tsx
@@ -1,13 +1,29 @@
 import { BellIcon, CancelCircleIcon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { listMissions, listNotifications, markNotificationRead } from '../api/client'
 import type { Mission, Notification } from '../api/types'
 import { MissionCard } from '../components/missions/MissionCard'
-import { RecurringSchedules } from '../components/missions/RecurringSchedules'
 import { Button } from '../components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../components/ui/select'
 import { subscribeEvents } from '../lib/events'
+
+type KindFilter = 'all' | Mission['kind']
+type SourceFilter = 'all' | 'manual' | 'automated'
+
+// harnessLabel mirrors MissionCard's own "Native" fallback for an
+// unset harness — filter options must read the same as the cards
+// they're filtering.
+function harnessLabel(harness?: string): string {
+  return harness || 'Native'
+}
 
 // notificationSeverityClasses colors the banner by notification kind —
 // same green/amber/red convention MissionCard's statusColor uses for
@@ -40,6 +56,10 @@ export function Missions() {
   const navigate = useNavigate()
   const [missions, setMissions] = useState<Mission[]>([])
   const [notifications, setNotifications] = useState<Notification[]>([])
+  const [kindFilter, setKindFilter] = useState<KindFilter>('all')
+  const [harnessFilter, setHarnessFilter] = useState('all')
+  const [modelFilter, setModelFilter] = useState('all')
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>('all')
 
   const refresh = useCallback(() => {
     listMissions().then(setMissions, () => undefined)
@@ -63,6 +83,34 @@ export function Missions() {
   const dismiss = (id: string) => {
     markNotificationRead(id).then(refresh, () => undefined)
   }
+
+  // Distinct harness/model values present in the loaded missions only —
+  // a picker never offers a value nothing on the board actually has.
+  const harnessOptions = useMemo(
+    () => Array.from(new Set(missions.map((m) => harnessLabel(m.harness)))).sort(),
+    [missions],
+  )
+  const modelOptions = useMemo(
+    () =>
+      Array.from(new Set(missions.map((m) => m.top_model).filter((v): v is string => !!v))).sort(),
+    [missions],
+  )
+
+  const filtersActive =
+    kindFilter !== 'all' || harnessFilter !== 'all' || modelFilter !== 'all' || sourceFilter !== 'all'
+
+  const filteredMissions = useMemo(
+    () =>
+      missions.filter((m) => {
+        if (kindFilter !== 'all' && m.kind !== kindFilter) return false
+        if (harnessFilter !== 'all' && harnessLabel(m.harness) !== harnessFilter) return false
+        if (modelFilter !== 'all' && m.top_model !== modelFilter) return false
+        if (sourceFilter === 'manual' && m.schedule_id) return false
+        if (sourceFilter === 'automated' && !m.schedule_id) return false
+        return true
+      }),
+    [missions, kindFilter, harnessFilter, modelFilter, sourceFilter],
+  )
 
   return (
     <div className="mx-auto w-full max-w-full px-8 py-6">
@@ -104,15 +152,73 @@ export function Missions() {
         </div>
       )}
 
-      <RecurringSchedules />
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <Select value={kindFilter} onValueChange={(v) => setKindFilter(v as KindFilter)}>
+          <SelectTrigger size="sm" aria-label="Filter by kind">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All kinds</SelectItem>
+            <SelectItem value="coding">Coding</SelectItem>
+            <SelectItem value="general">General</SelectItem>
+          </SelectContent>
+        </Select>
 
-      <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {missions.map((m) => (
+        <Select value={harnessFilter} onValueChange={setHarnessFilter}>
+          <SelectTrigger size="sm" aria-label="Filter by harness">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All harnesses</SelectItem>
+            {harnessOptions.map((h) => (
+              <SelectItem key={h} value={h}>
+                {h}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={modelFilter} onValueChange={setModelFilter}>
+          <SelectTrigger size="sm" aria-label="Filter by model">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All models</SelectItem>
+            {modelOptions.map((m) => (
+              <SelectItem key={m} value={m}>
+                {m}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={sourceFilter} onValueChange={(v) => setSourceFilter(v as SourceFilter)}>
+          <SelectTrigger size="sm" aria-label="Filter by source">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All sources</SelectItem>
+            <SelectItem value="manual">Manual</SelectItem>
+            <SelectItem value="automated">Automated</SelectItem>
+          </SelectContent>
+        </Select>
+
+        {filtersActive && (
+          <span className="text-xs text-muted-foreground">
+            {filteredMissions.length} of {missions.length}
+          </span>
+        )}
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {filteredMissions.map((m) => (
           <MissionCard key={m.id} mission={m} />
         ))}
-        {missions.length === 0 && (
+        {filteredMissions.length === 0 && (
           <div className="col-span-full rounded-xl border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
-            No missions yet, create one to get started.
+            {missions.length === 0
+              ? 'No missions yet, create one to get started.'
+              : 'No missions match the current filters.'}
           </div>
         )}
       </div>

--- a/web/src/pages/NewMission.tsx
+++ b/web/src/pages/NewMission.tsx
@@ -73,7 +73,7 @@ export function NewMission() {
               if (result.kind === 'mission') {
                 navigate(`/missions/${result.id}`)
               } else {
-                navigate('/missions')
+                navigate('/automations')
               }
             }}
           />


### PR DESCRIPTION
Scheduled missions get their own surface: /automations lists every schedule as a card (human-readable cron, next run, enabled toggle, delete), /automations/:id shows the schedule plus its fired-mission history, and the edit form moves under /automations/:id/edit with the old path redirecting. Nav gains an Automations entry.

The missions board drops the schedules strip and gains a client-side filter bar — kind, harness, model, and source (manual vs automated via schedule_id) — so routine-fired runs stop drowning manual ones.

No backend changes: the schedule_id list filter and all mission fields already existed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789701335&installation_model_id=431401&pr_number=254&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F254&signature=dafd27de11c3f7be5e94534e785aa4dd9b3bf091d0de4a01f5ebec2ccc25084a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->