### PR TITLE
feat: read-only connector tools in mission turns

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -629,6 +629,48 @@ func missionAgentResolver(agentReg *agents.Store) missions.AgentResolver {
 	}
 }
 
+// missionConnectorReadsResolver adapts agentReg + conns to
+// missions.ConnectorReadsResolver: an agent's Tools allowlist
+// intersected with every built connector's ReadOnly-marked, non-MCP
+// tools (connectors.Manager.ReadOnlyTools already excludes MCP and
+// non-read-only tools). tools.ToolMatches is the same suffix rule
+// filterDefs/matchGrant use, so an allowlist entry authored before any
+// connector name is known (e.g. "gmail_search") still matches the
+// namespaced tool at resolve time.
+func missionConnectorReadsResolver(agentReg *agents.Store, conns *connectors.Manager) missions.ConnectorReadsResolver {
+	return func(ctx context.Context, agentID string) []*tools.Tool {
+		a, ok := agentReg.ResolveByID(ctx, agentID)
+		if !ok {
+			return nil
+		}
+		return intersectReadOnlyConnectorTools(a.Tools, conns.ReadOnlyTools())
+	}
+}
+
+// intersectReadOnlyConnectorTools is missionConnectorReadsResolver's
+// pure matching step, split out so it's unit-testable without a real
+// agents.Store/connectors.Manager (both need a live Postgres pool):
+// every available (already ReadOnly-marked, non-MCP) tool whose name
+// tools.ToolMatches an entry in allow. Empty allow (agent has no Tools
+// at all) matches nothing, same as filterDefs' empty-allow-means-
+// everything convention does NOT apply here — an agent that has never
+// opted into any tool gets no connector reads either.
+func intersectReadOnlyConnectorTools(allow []string, available []*tools.Tool) []*tools.Tool {
+	if len(allow) == 0 {
+		return nil
+	}
+	var out []*tools.Tool
+	for _, t := range available {
+		for _, a := range allow {
+			if tools.ToolMatches(t.Name, a) {
+				out = append(out, t)
+				break
+			}
+		}
+	}
+	return out
+}
+
 // buildMissions wires the mission engine (Store, Driver, Notifier,
 // Scheduler, Hub). Gated on WORKSPACES: no workspace root configured
 // means missions stay entirely inert — no goroutines started, nothing
@@ -684,6 +726,9 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 		return out, nil
 	}
 	nativeRunner := missions.NewNativeRunnerWithFloor(agent, parker, floorDeny, sandboxMgr.Exec, kbSearch, kbReadFromStore(kb.New(db)), log)
+	if conns != nil {
+		nativeRunner.SetConnectorReads(missionConnectorReadsResolver(agentReg, conns))
+	}
 	// The delegated runner wraps native with D-051/D-052's CLI-executor
 	// dispatch — resolve a worker route's chain via the gateway, spawn a
 	// harness entry's CLI detached in the mission's own sandbox container,

--- a/cmd/brain/main_test.go
+++ b/cmd/brain/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// TestIntersectReadOnlyConnectorToolsMatchesAllowlist confirms the
+// resolver's matching step: only tools whose name matches an allow
+// entry (direct or connector-namespaced suffix, D-036) come through,
+// and an empty allowlist (agent opted into nothing) yields none.
+func TestIntersectReadOnlyConnectorToolsMatchesAllowlist(t *testing.T) {
+	available := []*tools.Tool{
+		{Name: "gmail_gmail_search", ReadOnly: true},
+		{Name: "google-calendar_calendar_list_events", ReadOnly: true},
+		{Name: "gmail_gmail_send"}, // not read-only; ReadOnlyTools would never hand this in, but the matcher must not care
+	}
+
+	got := intersectReadOnlyConnectorTools([]string{"gmail_search"}, available)
+	var names []string
+	for _, tl := range got {
+		names = append(names, tl.Name)
+	}
+	if !slices.Equal(names, []string{"gmail_gmail_search"}) {
+		t.Fatalf("intersect = %v, want [gmail_gmail_search]", names)
+	}
+
+	if got := intersectReadOnlyConnectorTools(nil, available); got != nil {
+		t.Fatalf("empty allowlist = %v, want nil", got)
+	}
+
+	got = intersectReadOnlyConnectorTools([]string{"calendar_list_events", "gmail_search"}, available)
+	names = nil
+	for _, tl := range got {
+		names = append(names, tl.Name)
+	}
+	slices.Sort(names)
+	want := []string{"gmail_gmail_search", "google-calendar_calendar_list_events"}
+	slices.Sort(want)
+	if !slices.Equal(names, want) {
+		t.Fatalf("intersect = %v, want %v", names, want)
+	}
+}

--- a/internal/brain/connectors/google_test.go
+++ b/internal/brain/connectors/google_test.go
@@ -455,6 +455,43 @@ func TestGoogleBuilderScopeGating(t *testing.T) {
 	}
 }
 
+// TestGoogleReadOnlyToolsPinned pins exactly which google tools carry
+// tools.Tool.ReadOnly — mission worker/explore turns layer these back
+// in despite BuiltinsOnly (see missions.ConnectorReadsResolver); a
+// future tool addition must decide this explicitly rather than
+// silently inheriting read-only exposure to missions.
+func TestGoogleReadOnlyToolsPinned(t *testing.T) {
+	t.Parallel()
+	f := &fakeGoogle{}
+	row := googleRow(bothScopes)
+	g, _ := testGoogle(t, f, row)
+	src, err := g.Builder()(t.Context(), row, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]bool{
+		"gmail_search":          true,
+		"gmail_read":            true,
+		"gmail_read_attachment": true,
+		"calendar_list_events":  true,
+	}
+	got := map[string]bool{}
+	for _, tl := range src.Tools() {
+		if tl.ReadOnly {
+			got[tl.Name] = true
+		}
+	}
+	if len(got) != len(want) {
+		t.Fatalf("read-only tools = %v, want %v", got, want)
+	}
+	for name := range want {
+		if !got[name] {
+			t.Errorf("expected %s to be marked ReadOnly", name)
+		}
+	}
+}
+
 func connectedSource(t *testing.T, f *fakeGoogle) (Source, *fakeSecrets) {
 	t.Helper()
 	row := googleRow(bothScopes)

--- a/internal/brain/connectors/google_tools.go
+++ b/internal/brain/connectors/google_tools.go
@@ -228,7 +228,8 @@ func htmlPart(parts []gmailPart) []byte {
 
 func (s *googleSource) gmailSearch() *tools.Tool {
 	return &tools.Tool{
-		Name: "gmail_search",
+		Name:     "gmail_search",
+		ReadOnly: true,
 		Description: `Search the connected Gmail account. query uses Gmail search syntax
 (from:, subject:, is:unread, newer_than:7d, after:YYYY/MM/DD, ...).
 Returns up to max_results (default 10) messages as id, date, from,
@@ -335,6 +336,7 @@ func findAttachment(parts []gmailPart, filename string) (string, bool) {
 func (s *googleSource) gmailRead() *tools.Tool {
 	return &tools.Tool{
 		Name:        "gmail_read",
+		ReadOnly:    true,
 		Description: "Read one email's full content by message id (from gmail_search). Returns headers and the body — plain text when available, otherwise the HTML body rendered to readable text (common for booking confirmations and receipts) — plus a list of attachment filenames, if any. Use gmail_read_attachment with the message id and a filename from that list to read an attachment's content.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"id":{"type":"string","description":"Gmail message id"}
@@ -381,6 +383,7 @@ func (s *googleSource) gmailRead() *tools.Tool {
 func (s *googleSource) gmailReadAttachment() *tools.Tool {
 	return &tools.Tool{
 		Name:        "gmail_read_attachment",
+		ReadOnly:    true,
 		Description: "Reads an attachment's content as markdown/text, given a message id and the attachment's filename (both from gmail_read's attachments list). Handles PDFs, Office documents, and other common formats.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"message_id":{"type":"string","description":"Gmail message id"},
@@ -464,6 +467,7 @@ func (s *googleSource) gmailSend() *tools.Tool {
 func (s *googleSource) calendarListEvents() *tools.Tool {
 	return &tools.Tool{
 		Name:        "calendar_list_events",
+		ReadOnly:    true,
 		Description: "List events from the connected Google Calendar (primary calendar). time_min/time_max are RFC3339 timestamps; both default to the next 7 days. Returns start, end, summary, and location per event.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"time_min":{"type":"string","description":"RFC3339, e.g. 2026-07-21T00:00:00Z"},

--- a/internal/brain/connectors/manager.go
+++ b/internal/brain/connectors/manager.go
@@ -163,6 +163,38 @@ func (m *Manager) Tools() []*tools.Tool {
 	return out
 }
 
+// ReadOnlyTools returns every built connector's ReadOnly-marked tools,
+// namespaced exactly like Tools — for mission turns, which must see
+// connector reads (gmail search, calendar list) despite BuiltinsOnly
+// but never connector writes (see missions.nativeRunner's connector
+// reads resolver). MCP sources are excluded unconditionally, marker or
+// not: a remote MCP server's tool can change behavior between builds,
+// and nothing here can verify a "read-only" claim actually holds —
+// unlike google's tool constructors, which are Timothy's own code.
+func (m *Manager) ReadOnlyTools() []*tools.Tool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var out []*tools.Tool
+	for name, src := range m.sources {
+		if _, isMCP := src.(*mcpSource); isMCP {
+			continue
+		}
+		for _, t := range src.Tools() {
+			if !t.ReadOnly {
+				continue
+			}
+			full := toolNameSanitizer.ReplaceAllString(name+"_"+t.Name, "_")
+			if len(full) > 128 {
+				full = full[:128]
+			}
+			clone := *t
+			clone.Name = full
+			out = append(out, &clone)
+		}
+	}
+	return out
+}
+
 // SetOnReload registers a hook that fires after every successful
 // Reload — the agent's tool set rebuilds from it. Startup-time only.
 func (m *Manager) SetOnReload(fn func(context.Context)) {

--- a/internal/brain/connectors/manager_test.go
+++ b/internal/brain/connectors/manager_test.go
@@ -96,6 +96,33 @@ func TestReloadSkipsFailedBuildAndClosesOld(t *testing.T) {
 	}
 }
 
+// TestReadOnlyToolsExcludesWritesAndMCP pins ReadOnlyTools' two-part
+// filter: only ReadOnly-marked tools, and never from an MCP source —
+// even one whose tool happens to carry ReadOnly, since a remote MCP
+// server's claim can't be verified (see ReadOnlyTools' doc comment).
+func TestReadOnlyToolsExcludesWritesAndMCP(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{})
+	m.sources = map[string]Source{
+		"gmail": &fakeSource{tools: []*tools.Tool{
+			{Name: "search", ReadOnly: true},
+			{Name: "send", ReadOnly: false},
+		}},
+		"remote": &mcpSource{name: "remote", toolList: []*tools.Tool{
+			{Name: "read", ReadOnly: true},
+		}},
+	}
+
+	got := map[string]bool{}
+	for _, t := range m.ReadOnlyTools() {
+		got[t.Name] = true
+	}
+	want := map[string]bool{"gmail_search": true}
+	if len(got) != len(want) || !got["gmail_search"] {
+		t.Fatalf("ReadOnlyTools = %v, want %v", got, want)
+	}
+}
+
 func TestReloadKeepsSetOnListError(t *testing.T) {
 	t.Parallel()
 	keep := &fakeSource{}

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -265,7 +265,11 @@ type Request struct {
 	// mission turn. Deliberately independent of MissionID (a ledger
 	// attribution tag only) so tool-surface scoping stays an explicit,
 	// intentional choice at each call site rather than inferred.
-	// ExtraTools still layer on top as normal.
+	// ExtraTools still layer on top as normal — missions.nativeRunner's
+	// worker/explore turns use exactly this to add back read-only
+	// connector tools (gmail/calendar reads) that scheduled general
+	// missions need, gated on the agent's Tools allowlist and never
+	// including MCP or write-capable tools (missions.ConnectorReadsResolver).
 	BuiltinsOnly bool
 
 	// ExtraTools are tool defs available ONLY for this turn, on top of

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -163,6 +163,45 @@ type nativeRunner struct {
 	// kbRead backs the per-turn kb_read ExtraTool — same nil contract
 	// as kbSearch.
 	kbRead KBReadFunc
+
+	// connectorReads resolves a mission's agent to the read-only
+	// connector tools (gmail/calendar reads) it may use on worker/explore
+	// turns (see SetConnectorReads) — nil-safe: unset means no connector
+	// reads are offered, same as before this existed.
+	connectorReads ConnectorReadsResolver
+}
+
+// ConnectorReadsResolver resolves an agent id to the read-only
+// connector tools a mission turn for that agent may use — the
+// intersection of the agent's Tools allowlist and every built
+// connector's ReadOnly-marked, non-MCP tools (see
+// connectors.Manager.ReadOnlyTools). Connector WRITES are never
+// included regardless of the allowlist: mission turns stay
+// BuiltinsOnly for the base surface, and this resolver only ever
+// layers reads on top via ExtraTools — a worker can never side-channel
+// a connector write around the worktree/human-consented push
+// pipeline. Resolved at DRIVE time (every RunWorker/ExploreSession
+// call), not cached on the mission, so an agent's allowlist or a
+// connector's enabled state edited mid-mission applies on the very
+// next turn. Being offered a read tool here is separate from being
+// pre-approved to call it without asking: these tools are not in
+// tools.Permissions' exempt set (same as chat), so an unattended,
+// schedule-fired mission (Unattended: true, D-039) still needs a
+// standing grant or the call fails fast instead of parking. That grant
+// already exists — driver.go's grantSessionDefaults seeds one from the
+// mission's agent's ApprovalAllowlist (a separate field from Tools) at
+// provisioning time, the same path a chat agent's connector-tool
+// grants take. An agent that wants its scheduled missions to actually
+// read gmail/calendar unattended must list the tool in BOTH Tools (to
+// be offered here) and ApprovalAllowlist (to be pre-approved).
+type ConnectorReadsResolver func(ctx context.Context, agentID string) []*tools.Tool
+
+// SetConnectorReads wires the resolver RunWorker/ExploreSession use to
+// layer read-only connector tools onto a mission turn — a setter (not
+// a NewNativeRunner parameter) because cmd/brain/main.go builds the
+// runner before the connectors.Manager it closes over.
+func (r *nativeRunner) SetConnectorReads(resolve ConnectorReadsResolver) {
+	r.connectorReads = resolve
 }
 
 // KBSearchFunc runs one kb_search call scoped to collectionNames — main
@@ -191,7 +230,11 @@ func NewNativeRunner(agent *loop.Agent, parker parkNotifier, log *slog.Logger) R
 // route through it instead of brain's own process — and a kb_search
 // backend (nil disables kb_search on every mission turn, matching
 // SetKBSearch's nil-safe contract).
-func NewNativeRunnerWithFloor(agent *loop.Agent, parker parkNotifier, floorDeny []string, sandbox sandboxExec, kbSearch KBSearchFunc, kbRead KBReadFunc, log *slog.Logger) Runner {
+// The return type is the unexported *nativeRunner, not Runner: callers
+// that need to wire SetConnectorReads (cmd/brain/main.go) must hold the
+// concrete type to call it, before handing the result on as a Runner
+// to buildDelegatedRunner.
+func NewNativeRunnerWithFloor(agent *loop.Agent, parker parkNotifier, floorDeny []string, sandbox sandboxExec, kbSearch KBSearchFunc, kbRead KBReadFunc, log *slog.Logger) *nativeRunner {
 	return &nativeRunner{agent: agent, parker: parker, modelFloorDeny: floorDeny, sandbox: sandbox, kbSearch: kbSearch, kbRead: kbRead, log: log}
 }
 
@@ -229,6 +272,18 @@ func (r *nativeRunner) kbReadTool(m Mission) *tools.Tool {
 	return builtin.KBRead(func(ctx context.Context, documentID string) (builtin.KBDocument, error) {
 		return r.kbRead(ctx, documentID, collections)
 	})
+}
+
+// connectorReadTools resolves m's read-only connector tools (nil
+// resolver or no agent id means none) — appended to worker/explore
+// ExtraTools so a scheduled mission (daily inbox digest, calendar
+// summary) can read gmail/calendar without the base connector surface
+// (which BuiltinsOnly excludes) ever reopening for a write.
+func (r *nativeRunner) connectorReadTools(ctx context.Context, m Mission) []*tools.Tool {
+	if r.connectorReads == nil {
+		return nil
+	}
+	return r.connectorReads(ctx, m.AgentID)
 }
 
 // kbRefSink accumulates the kb:// refs of documents kb_search actually
@@ -552,6 +607,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 	if t := r.kbReadTool(m); t != nil {
 		extra = append(extra, t)
 	}
+	extra = append(extra, r.connectorReadTools(ctx, m)...)
 	req := loop.Request{
 		SessionID:    m.SessionID,
 		Route:        workerRoute(m),
@@ -663,6 +719,7 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 	if t := r.kbReadTool(m); t != nil {
 		extra = append(extra, t)
 	}
+	extra = append(extra, r.connectorReadTools(ctx, m)...)
 	req := loop.Request{
 		SessionID:    m.SessionID,
 		Route:        oversightRoute(m),

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -909,6 +909,80 @@ func TestRunWorkerGetsMissionScopedShell(t *testing.T) {
 	}
 }
 
+// TestRunWorkerIncludesConnectorReadsWhenResolverSet confirms RunWorker
+// layers the connector reads resolver's tools into ExtraTools —
+// scheduled general missions (daily inbox digest) need gmail/calendar
+// reads despite BuiltinsOnly.
+func TestRunWorkerIncludesConnectorReadsWhenResolverSet(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ok"}`)},
+	}}
+	r := newTestRunner(agent)
+	var gotAgentID string
+	r.connectorReads = func(ctx context.Context, agentID string) []*tools.Tool {
+		gotAgentID = agentID
+		return []*tools.Tool{{Name: "gmail_gmail_search", ReadOnly: true}}
+	}
+	m := Mission{ID: "m1", AgentID: "a1", Route: "default", Workspace: "/workspace/missions/m1"}
+	if _, _, err := r.RunWorker(context.Background(), m, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if gotAgentID != "a1" {
+		t.Fatalf("connectorReads called with agentID %q, want a1", gotAgentID)
+	}
+	var names []string
+	for _, tool := range agent.requests[0].ExtraTools {
+		names = append(names, tool.Name)
+	}
+	if !slices.Contains(names, "gmail_gmail_search") {
+		t.Fatalf("worker ExtraTools = %v, want gmail_gmail_search", names)
+	}
+}
+
+// TestRunWorkerOmitsConnectorReadsWhenResolverUnset confirms unset
+// connectorReads (today's default) never adds connector tools —
+// nil-safe, same as before this existed.
+func TestRunWorkerOmitsConnectorReadsWhenResolverUnset(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ok"}`)},
+	}}
+	r := newTestRunner(agent)
+	m := Mission{ID: "m1", Route: "default", Workspace: "/workspace/missions/m1"}
+	if _, _, err := r.RunWorker(context.Background(), m, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	for _, tool := range agent.requests[0].ExtraTools {
+		if strings.Contains(tool.Name, "gmail") || strings.Contains(tool.Name, "calendar") {
+			t.Fatalf("worker ExtraTools = %v, want no connector tools", tool.Name)
+		}
+	}
+}
+
+// TestExploreSessionIncludesConnectorReadsWhenResolverSet mirrors
+// TestRunWorkerIncludesConnectorReadsWhenResolverSet for the explore
+// phase — scheduled missions may need connector reads before planning
+// too.
+func TestExploreSessionIncludesConnectorReadsWhenResolverSet(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(exploreNotesToolName, `{"findings":"ok"}`)},
+	}}
+	r := newTestRunner(agent)
+	r.connectorReads = func(ctx context.Context, agentID string) []*tools.Tool {
+		return []*tools.Tool{{Name: "google-calendar_calendar_list_events", ReadOnly: true}}
+	}
+	m := Mission{ID: "m1", AgentID: "a1", Route: "default"}
+	if _, err := r.ExploreSession(context.Background(), m); err != nil {
+		t.Fatalf("ExploreSession: %v", err)
+	}
+	var names []string
+	for _, tool := range agent.requests[0].ExtraTools {
+		names = append(names, tool.Name)
+	}
+	if !slices.Contains(names, "google-calendar_calendar_list_events") {
+		t.Fatalf("explore ExtraTools = %v, want google-calendar_calendar_list_events", names)
+	}
+}
+
 // shellExtraTool pulls the "shell" tool out of a mission's ExtraTools
 // list — helper for tests exercising missionTools' Runner wiring
 // directly, without going through a full RunWorker turn.

--- a/internal/brain/tools/tool.go
+++ b/internal/brain/tools/tool.go
@@ -20,4 +20,11 @@ type Tool struct {
 	Description string
 	InputSchema json.RawMessage
 	Execute     func(ctx context.Context, args json.RawMessage) (string, error)
+	// ReadOnly marks a tool as having no side effects — set only on
+	// connector tools a mission turn may see despite BuiltinsOnly (see
+	// loop.Request.BuiltinsOnly and missions.nativeRunner's connector
+	// reads resolver). Unset (false) everywhere else; setting it is a
+	// deliberate, per-tool decision, never inferred from a naming
+	// convention or a connector's kind.
+	ReadOnly bool
 }


### PR DESCRIPTION
Mission turns run BuiltinsOnly, which excludes every connector tool — including reads. That blocks the scheduled-automation use case entirely: a daily inbox digest or calendar summary mission has no gmail/calendar access and fails or fabricates.

Explore and worker turns now additionally receive connector tools that are both explicitly marked read-only and present in the mission agent's tools allowlist, layered via ExtraTools; the base surface stays builtins-only. The write side-channel exclusion is unchanged: send/create tools are never marked, and MCP tools are excluded unconditionally since a remote MCP tool's side effects can't be verified. The read-only set is pinned by test so any future tool addition must decide explicitly.

Unattended missions still require the standing session grant seeded from the agent's approval allowlist — no new auto-approval path.

Canary: PASS (golden mission, review-skip path, 6 turns).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789751146&installation_model_id=431401&pr_number=255&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F255&signature=e06500a50c4fdf5e166e2c0fe3d37248976854b5a4c507cebeeeee9ac7e5360a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->