### PR TITLE
feat: destinations for mission result delivery (email, webhook)

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/attachments"
 	"github.com/SumonMSelim/timothy/internal/brain/chat"
 	"github.com/SumonMSelim/timothy/internal/brain/connectors"
+	"github.com/SumonMSelim/timothy/internal/brain/destinations"
 	"github.com/SumonMSelim/timothy/internal/brain/fxrates"
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
 	"github.com/SumonMSelim/timothy/internal/brain/kb"
@@ -284,6 +285,10 @@ func main() {
 	if missionDriver != nil {
 		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, app.Log)
 	}
+	destinationStore, destinationDeliverer := buildDestinations(app.DB, conns, goog, flags, missionStore, app.Log)
+	if missionDriver != nil && destinationDeliverer != nil {
+		missionDriver.SetDestinationDeliver(destinationDeliverer.Deliver)
+	}
 	// Chat-facing mission tools (D-0xx: "is mission X done?" / "push
 	// mission X"): registered here, not inside buildAgent, since both
 	// need missionStore (built above, after buildAgent) and mission_push
@@ -513,10 +518,21 @@ func main() {
 	// ledgerAgg backs the mission list's top_model decoration (D-05x):
 	// same *pgpool.Pool the rest of brain shares, no separate wiring.
 	ledgerAgg := ledger.NewAggregator(app.DB)
+	// destinationTest is nil-boxed the same way connLister is inside
+	// Register itself: a nil *destinations.Deliverer passed straight as
+	// api's destinationTester interface would be a non-nil interface
+	// holding nil. interface{ Test(...) } here structurally matches
+	// api.destinationTester without naming that unexported type.
+	var destinationTest interface {
+		Test(ctx context.Context, id string) error
+	}
+	if destinationDeliverer != nil {
+		destinationTest = destinationDeliverer
+	}
 	api.Register(app.Server, svc, store, broker,
 		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, usageDecorator.Decorate, app.Log), flags, fxStore,
 		agentReg, conns, goog, secrets, agent, packs, missionStore, missionDriver, missionNotifier,
-		missionWorkspace, resolveSecret, routeForRole, chat.ClassifyOverGateway(gwc), gwc.ResolveRoute, chat.TitleOverGateway(gwc, app.Log), ledgerAgg.TopModelByMission, missionHub, attachmentStore, &http.Client{}, whisperURL, markitdownURL, token, app.Log, gwc, kbStore, mc)
+		missionWorkspace, resolveSecret, routeForRole, chat.ClassifyOverGateway(gwc), gwc.ResolveRoute, chat.TitleOverGateway(gwc, app.Log), ledgerAgg.TopModelByMission, missionHub, attachmentStore, &http.Client{}, whisperURL, markitdownURL, token, app.Log, gwc, kbStore, mc, destinationStore, destinationTest)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)
@@ -601,6 +617,53 @@ func buildConnectors(db *pgpool.Pool, secrets *secretstore.Store, log *slog.Logg
 		log.Warn("MARKITDOWN_URL not set; gmail_read falls back to a snippet for HTML-only mail, and gmail_read_attachment is unavailable")
 	}
 	return mgr, goog
+}
+
+// buildDestinations wires the destinations control plane (store +
+// adapters + Deliverer). missionStore nil (WORKSPACES unset) disables
+// it entirely — delivery has no meaning without missions. conns/goog
+// nil still builds the store (webhook destinations work without
+// connectors); an email destination's create/update then fails
+// validation with a clear error, same nil-gated shape as
+// api/missions.go's own repo_url-needs-connectors check.
+func buildDestinations(db *pgpool.Pool, conns *connectors.Manager, goog *connectors.Google, flags *settings.Store, missionStore *missions.Store, log *slog.Logger) (*destinations.Store, *destinations.Deliverer) {
+	if missionStore == nil {
+		return nil, nil
+	}
+	var connLookup destinationConnectorLookup
+	if conns != nil {
+		connLookup = destinationConnectorLookup{conns}
+	}
+	store := destinations.NewStore(db, connLookup, log)
+	// goog nil (no secret store) leaves Mail nil: EmailAdapter.Deliver
+	// then fails per-delivery with a clear error rather than a create-
+	// time block, matching how an email destination's create itself
+	// already requires an enabled google connector to exist.
+	var email *destinations.EmailAdapter
+	if goog != nil {
+		email = &destinations.EmailAdapter{Mail: goog}
+	}
+	webhook := &destinations.WebhookAdapter{}
+	deliverer := destinations.NewDeliverer(store, missionStore, email, webhook, flags.WebBaseURL, log)
+	return store, deliverer
+}
+
+// destinationConnectorLookup adapts *connectors.Manager to
+// destinations' own narrow Connector/connectorLookup shape — missions
+// has no compile-time dependency on the connectors package's own
+// Connector type, same reasoning as connsPRSource above. A zero value
+// (conns == nil) is never boxed here; buildDestinations only
+// constructs one when conns is non-nil.
+type destinationConnectorLookup struct {
+	conns *connectors.Manager
+}
+
+func (d destinationConnectorLookup) Get(ctx context.Context, id string) (destinations.Connector, error) {
+	c, err := d.conns.Store().Get(ctx, id)
+	if err != nil {
+		return destinations.Connector{}, err
+	}
+	return destinations.Connector{Kind: c.Kind, Enabled: c.Enabled}, nil
 }
 
 // missionWorkSlotMax bounds how many missions may be status='working'

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/attachments"
 	"github.com/SumonMSelim/timothy/internal/brain/chat"
 	"github.com/SumonMSelim/timothy/internal/brain/connectors"
+	"github.com/SumonMSelim/timothy/internal/brain/destinations"
 	"github.com/SumonMSelim/timothy/internal/brain/fxrates"
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
 	"github.com/SumonMSelim/timothy/internal/brain/kb"
@@ -99,7 +100,7 @@ var memoryRoutePatterns = []string{
 // proxy to the gateway's internal control plane, conns the local
 // connector control plane (nil leaves any of them unmounted).
 // whisperURL empty leaves /v1/transcribe unmounted (WHISPER_URL unset).
-func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, secrets *secretstore.Store, toolset Toolset, packs []skills.Skill, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, markitdownURL string, token string, log *slog.Logger, gwSecrets GatewaySecrets, kbStore *kb.Store, kbIngest kbIngester) {
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, secrets *secretstore.Store, toolset Toolset, packs []skills.Skill, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, markitdownURL string, token string, log *slog.Logger, gwSecrets GatewaySecrets, kbStore *kb.Store, kbIngest kbIngester, destinationStore *destinations.Store, destinationTest destinationTester) {
 	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log, flags: flags, rates: rates}
 	if kbStore != nil {
 		a.kbCollections = kbStore.ListCollections
@@ -136,8 +137,24 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	if attachmentStore != nil {
 		missionAttachments = attachmentStore
 	}
-	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret, routeForRole, missionClassify, codingExecutorDefault, resolveExecutorOptions, nameMission, topModels, conns, missionAttachments, markitdownURL)
+	// destinationLookupStore is *destinations.Store itself (EnabledByID)
+	// — nil-boxed the same way connLister is above so a nil
+	// destinationStore keeps registerMissions' create-time validation
+	// honest (rejects any non-empty destination_ids).
+	var destLookup destinationLookup
+	if destinationStore != nil {
+		destLookup = destinationStore
+	}
+	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret, routeForRole, missionClassify, codingExecutorDefault, resolveExecutorOptions, nameMission, topModels, conns, missionAttachments, markitdownURL, destLookup)
 	a.registerSchedules(srv.Handle, missionStore)
+	// destinationRefs is *missions.Store itself (ActiveMissionReferencesDestination) —
+	// nil-boxed the same way connLister is above so a nil missionStore
+	// keeps registerDestinations' refs check honest.
+	var destRefs destinationRefs
+	if missionStore != nil {
+		destRefs = missionStore
+	}
+	a.registerDestinations(srv.Handle, destinationStore, destRefs, destinationTest)
 	a.registerEvents(srv.Handle, hub)
 	a.registerTranscribe(srv.Handle, whisperClient, whisperURL)
 	a.registerAttachments(srv.Handle, attachmentStore)

--- a/internal/brain/api/destinations.go
+++ b/internal/brain/api/destinations.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/SumonMSelim/timothy/internal/brain/destinations"
+)
+
+// destinationRefs is the narrow slice of *missions.Store the delete
+// guard needs — an interface so this file doesn't force a hard
+// missions import dependency shape beyond what's already used
+// elsewhere in this package.
+type destinationRefs interface {
+	ActiveMissionReferencesDestination(ctx context.Context, destinationID string) (bool, error)
+}
+
+// destinationTester sends a canned test payload through a
+// destination's real adapter — destinations.Deliverer's own
+// deliverOne machinery isn't reused here since a test send must report
+// success/failure synchronously to the caller, not fire-and-forget;
+// see (a *destinationAPI).test.
+type destinationTester interface {
+	Test(ctx context.Context, id string) error
+}
+
+// registerDestinations mounts the destinations CRUD + test-send
+// surface — served locally like connectors, nil-gated on store (no
+// WORKSPACES/missions disables destinations too, since delivery has no
+// meaning without missions).
+func (a *API) registerDestinations(handle func(pattern string, h http.Handler), store *destinations.Store, refs destinationRefs, tester destinationTester) {
+	if store == nil {
+		return
+	}
+	h := &destinationAPI{store: store, refs: refs, tester: tester}
+	handle("GET /v1/admin/destinations", a.auth(http.HandlerFunc(h.list)))
+	handle("POST /v1/admin/destinations", a.auth(http.HandlerFunc(h.create)))
+	handle("PATCH /v1/admin/destinations/{id}", a.auth(http.HandlerFunc(h.patch)))
+	handle("DELETE /v1/admin/destinations/{id}", a.auth(http.HandlerFunc(h.delete)))
+	handle("POST /v1/admin/destinations/{id}/test", a.auth(http.HandlerFunc(h.test)))
+}
+
+type destinationAPI struct {
+	store  *destinations.Store
+	refs   destinationRefs
+	tester destinationTester
+}
+
+func failDestination(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, destinations.ErrNotFound):
+		jsonError(w, http.StatusNotFound, "not_found", err.Error())
+	case errors.Is(err, destinations.ErrReferenced):
+		jsonError(w, http.StatusConflict, "referenced", err.Error())
+	default:
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+	}
+}
+
+func (h *destinationAPI) list(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.store.List(r.Context())
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "destinations_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"destinations": rows})
+}
+
+func (h *destinationAPI) create(w http.ResponseWriter, r *http.Request) {
+	var d destinations.Destination
+	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	id, err := h.store.Create(r.Context(), d)
+	if err != nil {
+		failDestination(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"id": id})
+}
+
+func (h *destinationAPI) patch(w http.ResponseWriter, r *http.Request) {
+	var patch destinations.Patch
+	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if err := h.store.Patch(r.Context(), r.PathValue("id"), patch); err != nil {
+		failDestination(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// delete refuses with 409 while any non-terminal mission references
+// this destination — historical (terminal) mission references never
+// block deletion.
+func (h *destinationAPI) delete(w http.ResponseWriter, r *http.Request) {
+	if err := h.store.Delete(r.Context(), r.PathValue("id"), h.refs); err != nil {
+		failDestination(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// test sends a canned "Timothy test delivery" payload through the REAL
+// adapter and reports success/failure synchronously — mirrors the
+// connector/provider test endpoints' 200-with-{ok,error} shape so the
+// UI renders failures inline.
+func (h *destinationAPI) test(w http.ResponseWriter, r *http.Request) {
+	if h.tester == nil {
+		jsonError(w, http.StatusNotFound, "not_found", "destination test-send is not enabled")
+		return
+	}
+	if err := h.tester.Test(r.Context(), r.PathValue("id")); err != nil {
+		if errors.Is(err, destinations.ErrNotFound) {
+			failDestination(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": false, "error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}

--- a/internal/brain/api/destinations_test.go
+++ b/internal/brain/api/destinations_test.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/destinations"
+)
+
+func TestDestinationsEndpointsUnmountedWhenStoreNil(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	m := mux(a)
+	a.registerDestinations(m.Handle, nil, nil, nil)
+
+	for _, req := range []struct{ method, path string }{
+		{"GET", "/v1/admin/destinations"},
+		{"POST", "/v1/admin/destinations"},
+		{"PATCH", "/v1/admin/destinations/abc"},
+		{"DELETE", "/v1/admin/destinations/abc"},
+		{"POST", "/v1/admin/destinations/abc/test"},
+	} {
+		httpReq := httptest.NewRequest(req.method, req.path, nil)
+		httpReq.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, httpReq)
+		if w.Code != 404 {
+			t.Fatalf("%s %s with a nil destinations store = %d, want 404 (unmounted)", req.method, req.path, w.Code)
+		}
+	}
+}
+
+func TestFailDestination(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"not found", destinations.ErrNotFound, 404},
+		{"referenced", destinations.ErrReferenced, 409},
+		{"other", errors.New("bad config"), 400},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			failDestination(w, tt.err)
+			if w.Code != tt.want {
+				t.Fatalf("failDestination(%v) = %d, want %d", tt.err, w.Code, tt.want)
+			}
+		})
+	}
+}
+
+// fakeTester is a minimal destinationTester fake, exercising the test
+// handler's success/failure/not-found branches without a real Store.
+type fakeTester struct {
+	err error
+}
+
+func (f fakeTester) Test(context.Context, string) error { return f.err }
+
+func TestDestinationTestHandler(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	m := mux(a)
+
+	t.Run("nil tester 404s", func(t *testing.T) {
+		a.registerDestinations(m.Handle, nil, nil, nil)
+		// store is nil so the whole surface is unmounted; nothing to
+		// assert beyond the unmounted test above — covered there.
+	})
+
+	t.Run("success reports ok true", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h := &destinationAPI{tester: fakeTester{err: nil}}
+		req := httptest.NewRequest("POST", "/v1/admin/destinations/d1/test", nil)
+		req.SetPathValue("id", "d1")
+		h.test(w, req)
+		if w.Code != 200 {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+		if body := w.Body.String(); body != `{"ok":true}`+"\n" {
+			t.Fatalf("body = %q", body)
+		}
+	})
+
+	t.Run("adapter failure reports ok false with error", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h := &destinationAPI{tester: fakeTester{err: errors.New("smtp timeout")}}
+		req := httptest.NewRequest("POST", "/v1/admin/destinations/d1/test", nil)
+		req.SetPathValue("id", "d1")
+		h.test(w, req)
+		if w.Code != 200 {
+			t.Fatalf("status = %d, want 200", w.Code)
+		}
+		if body := w.Body.String(); body != `{"error":"smtp timeout","ok":false}`+"\n" {
+			t.Fatalf("body = %q", body)
+		}
+	})
+
+	t.Run("unknown destination 404s", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h := &destinationAPI{tester: fakeTester{err: destinations.ErrNotFound}}
+		req := httptest.NewRequest("POST", "/v1/admin/destinations/d1/test", nil)
+		req.SetPathValue("id", "d1")
+		h.test(w, req)
+		if w.Code != 404 {
+			t.Fatalf("status = %d, want 404", w.Code)
+		}
+	})
+
+	t.Run("no tester configured 404s", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h := &destinationAPI{}
+		req := httptest.NewRequest("POST", "/v1/admin/destinations/d1/test", nil)
+		req.SetPathValue("id", "d1")
+		h.test(w, req)
+		if w.Code != 404 {
+			t.Fatalf("status = %d, want 404", w.Code)
+		}
+	})
+}

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -64,11 +64,11 @@ type missionAttachmentStore interface {
 // (not *attachments.Store) so the caller's own nil-box guard (a nil
 // *attachments.Store boxed here would be a non-nil interface value)
 // happens once, at the call site — same shape as chat.Service.SetAttachments.
-func (a *API) registerMissions(handle func(pattern string, h http.Handler), store *missions.Store, driver *missions.Driver, notifier *missions.Notifier, agentReg *agents.Store, workspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, classify agents.Classify, codingExecutorDefault func(context.Context) string, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), conns *connectors.Manager, attachmentStore missionAttachmentStore, markitdownURL string) {
+func (a *API) registerMissions(handle func(pattern string, h http.Handler), store *missions.Store, driver *missions.Driver, notifier *missions.Notifier, agentReg *agents.Store, workspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, classify agents.Classify, codingExecutorDefault func(context.Context) string, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), conns *connectors.Manager, attachmentStore missionAttachmentStore, markitdownURL string, destinationLookupStore destinationLookup) {
 	if store == nil {
 		return
 	}
-	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, workspace: workspace, resolveSecret: resolveSecret, routeForRole: routeForRole, classify: classify, codingExecutorDefault: codingExecutorDefault, resolveExecutorOptions: resolveExecutorOptions, nameMission: nameMission, topModels: topModels, conns: conns, perms: a.perms, dir: a.dir, log: a.log, attachments: attachmentStore, markitdownURL: markitdownURL, markitdownHTTP: &http.Client{}}
+	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, workspace: workspace, resolveSecret: resolveSecret, routeForRole: routeForRole, classify: classify, codingExecutorDefault: codingExecutorDefault, resolveExecutorOptions: resolveExecutorOptions, nameMission: nameMission, topModels: topModels, conns: conns, perms: a.perms, dir: a.dir, log: a.log, attachments: attachmentStore, markitdownURL: markitdownURL, markitdownHTTP: &http.Client{}, destinations: destinationLookupStore}
 	handle("GET /v1/missions", a.auth(http.HandlerFunc(h.list)))
 	handle("POST /v1/missions", a.auth(http.HandlerFunc(h.create)))
 	handle("POST /v1/missions/classify", a.auth(http.HandlerFunc(h.classifyGoal)))
@@ -146,6 +146,20 @@ type missionAPI struct {
 	// rejects any attachment with a 400 naming the missing sidecar.
 	markitdownURL  string
 	markitdownHTTP *http.Client
+	// destinations resolves a create request's destination_ids against
+	// the operator-owned destinations table (D-061's exfiltration
+	// guard: an id must exist AND be enabled) — nil (destinations
+	// disabled) rejects any non-empty destination_ids.
+	destinations destinationLookup
+}
+
+// destinationLookup is the narrow slice of *destinations.Store the
+// mission create handler needs to validate destination_ids —
+// EnabledByID reports whether id names a real, enabled row (ok=false
+// covers both "unknown id" and "disabled", both rejected identically
+// by validateDestinationIDs below).
+type destinationLookup interface {
+	EnabledByID(ctx context.Context, id string) (ok bool, err error)
 }
 
 // routeExists reports whether name resolves to a real route via
@@ -162,6 +176,35 @@ func (h *missionAPI) routeExists(ctx context.Context, name string) bool {
 	}
 	_, err := h.resolveExecutorOptions(ctx, name, "")
 	return err == nil
+}
+
+// validateDestinationIDs rejects any id that doesn't name a real,
+// enabled destinations row — the exfiltration guard (D-061): a mission
+// create request only ever attaches operator-owned destinations, never
+// an arbitrary string the model might have supplied. Lists every
+// invalid id in one error, same spirit as an unknown-tool rejection
+// naming what's actually valid.
+func (h *missionAPI) validateDestinationIDs(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	if h.destinations == nil {
+		return fmt.Errorf("destinations are not enabled")
+	}
+	var invalid []string
+	for _, id := range ids {
+		ok, err := h.destinations.EnabledByID(ctx, id)
+		if err != nil {
+			return fmt.Errorf("destination_ids: %w", err)
+		}
+		if !ok {
+			invalid = append(invalid, id)
+		}
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("unknown or disabled destination id(s): %s", strings.Join(invalid, ", "))
+	}
+	return nil
 }
 
 func failMission(w http.ResponseWriter, err error) {
@@ -349,6 +392,12 @@ type createMissionRequest struct {
 	// to markdown once here (see resolveAttachments); images/audio are
 	// unsupported for missions.
 	Attachments []missionAttachmentInput `json:"attachments"`
+	// DestinationIDs names operator-created destinations (email,
+	// webhook) to deliver this mission's outcome digest to on the
+	// terminal done transition — every id is validated to exist AND be
+	// enabled at create time (see create() below); the model never
+	// supplies or addresses a destination (D-061).
+	DestinationIDs []string `json:"destination_ids"`
 }
 
 // missionAttachmentInput names one already-uploaded attachment to
@@ -461,6 +510,10 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
+	if err := h.validateDestinationIDs(r.Context(), req.DestinationIDs); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
 	var parentMissionID, parentContext string
 	if req.ParentMissionID != "" {
 		parent, err := h.store.Get(r.Context(), req.ParentMissionID)
@@ -556,7 +609,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		RepoURL: req.RepoURL, ConnectorID: req.ConnectorID, OnComplete: req.OnComplete,
 		BranchPattern: req.BranchPattern, CommitStyle: req.CommitStyle,
 		ParentMissionID: parentMissionID, ParentContext: parentContext,
-		Attachments: missionAtts,
+		Attachments: missionAtts, DestinationIDs: req.DestinationIDs,
 	}
 	id, err := h.driver.Create(r.Context(), m)
 	if err != nil {

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -119,7 +119,7 @@ func TestMissionsResumeWithAnswerReachesWorker(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/resume", strings.NewReader(`{"answer":"the deploy target is staging"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -187,7 +187,7 @@ func TestMissionsResumeWithoutAnswerLeavesProgressUntouched(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/resume", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -231,7 +231,7 @@ func TestMissionsNoteAppendsEventAndProgressWithoutPhaseChange(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":"focus on the staging config next"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -277,7 +277,7 @@ func TestMissionsNoteUnknownMission(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/00000000-0000-0000-0000-000000000000/note", strings.NewReader(`{"text":"hello"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -301,7 +301,7 @@ func TestMissionsNoteEmptyTextRejected(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":""}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -331,7 +331,7 @@ func TestMissionsNoteTerminalMissionRejected(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":"too late"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -355,7 +355,7 @@ func TestMissionsCreateResponseCarriesDetectedEnvironment(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	body := `{"goal":"itest-api-mission write a Go CLI that parses logs","kind":"coding"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -394,7 +394,7 @@ func TestMissionsCreateCarriesPlanRoute(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	body := `{"goal":"itest-api-mission plan route round trip","kind":"general","route":"mini","plan_route":"strong"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -433,7 +433,7 @@ func TestMissionsCreateFollowUp(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	post := func(body string) (int, []byte) {
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -498,7 +498,7 @@ func TestMissionsCreateFollowUpUnknownParent(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	body := `{"goal":"itest-api-mission follow-up unknown parent","kind":"general","parent_mission_id":"00000000-0000-0000-0000-000000000000"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -553,7 +553,7 @@ func TestMissionsCreateWithPDFAttachment(t *testing.T) {
 		defer md.Close()
 
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil)
 
 		code, body := post(m, `{"goal":"itest-api-mission with attachment","kind":"general","attachments":[{"id":"`+att.ID+`","name":"spec.pdf"}]}`)
 		if code != http.StatusCreated {
@@ -618,7 +618,7 @@ func TestMissionsCreateWithPDFAttachment(t *testing.T) {
 		defer md.Close()
 
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil)
 
 		code, body := post(m, `{"goal":"itest-api-mission with huge attachment","kind":"general","attachments":[{"id":"`+att.ID+`"}]}`)
 		if code != http.StatusCreated {
@@ -647,7 +647,7 @@ func TestMissionsCreateWithPDFAttachment(t *testing.T) {
 		defer md.Close()
 
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil)
 
 		code, body := post(m, `{"goal":"itest-api-mission markitdown failure","kind":"general","attachments":[{"id":"`+att.ID+`"}]}`)
 		if code != http.StatusInternalServerError {
@@ -672,7 +672,7 @@ func TestMissionsCreateGeneratesNameAsync(t *testing.T) {
 	nameMission := func(ctx context.Context, goal string) string {
 		return "Parse Logs Utility"
 	}
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "", nil)
 
 	body := `{"goal":"itest-api-mission write a Go CLI that parses logs","kind":"general"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -720,7 +720,7 @@ func TestMissionsCreateNameFallsBackToEmptyOnGenerationFailure(t *testing.T) {
 		defer close(done)
 		return "" // simulates a gateway/timeout failure, same as TitleOverGateway
 	}
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "", nil)
 
 	body := `{"goal":"itest-api-mission a goal whose naming will fail","kind":"general"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -977,7 +977,7 @@ func TestMissionsPushResolvesConnectorToken(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "")
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/push", strings.NewReader(`{}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1049,7 +1049,7 @@ func TestMissionsPushConnectorTable(t *testing.T) {
 
 			a := &API{token: "tok", log: discard()}
 			m := mux(a)
-			a.registerMissions(m.Handle, store, nil, nil, nil, workspace, nil, nil, nil, nil, nil, nil, nil, mgr, nil, "")
+			a.registerMissions(m.Handle, store, nil, nil, nil, workspace, nil, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil)
 
 			req := httptest.NewRequest("POST", "/v1/missions/"+id+"/push", strings.NewReader(`{}`))
 			req.Header.Set("Authorization", "Bearer tok")
@@ -1083,7 +1083,7 @@ func TestMissionsPushExplicitCredentialRefOverridesConnector(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "")
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/push", strings.NewReader(`{"credential_ref":"explicit-ref"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1138,7 +1138,7 @@ func TestMissionsPRHappyPath(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "")
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/pr", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1215,7 +1215,7 @@ func TestMissionsPRAlreadyExistsReturnsExisting(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "")
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/pr", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1249,7 +1249,7 @@ func TestMissionsPRRejectsNonGitHubConnectionMission(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/pr", nil)
 	req.Header.Set("Authorization", "Bearer tok")

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -23,7 +23,7 @@ func TestMissionsEndpointsUnmountedWhenStoreNil(t *testing.T) {
 	t.Parallel()
 	a, _, _ := testAPI(t, "tok", nil)
 	m := mux(a)
-	a.registerMissions(m.Handle, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	for _, req := range []struct{ method, path string }{
 		{"GET", "/v1/missions"},
@@ -62,7 +62,7 @@ func TestMissionsListFilterValidation(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	call := func(path string) int {
 		req := httptest.NewRequest("GET", path, nil)
@@ -110,7 +110,7 @@ func TestMissionsDeleteReachesStore(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	req := httptest.NewRequest("DELETE", "/v1/missions/abc", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -140,7 +140,7 @@ func TestMissionsCreateValidatesHarness(t *testing.T) {
 
 	post := func(codingExecutorDefault func(context.Context) string, body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, codingExecutorDefault, nil, nil, nil, nil, nil, "")
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, codingExecutorDefault, nil, nil, nil, nil, nil, "", nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -208,7 +208,7 @@ func TestMissionsCreateValidatesRepoURL(t *testing.T) {
 
 	post := func(body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "")
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "", nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -234,7 +234,7 @@ func TestMissionsCreateValidatesRepoURL(t *testing.T) {
 	// No conns wired at all: repo_url is rejected outright rather than
 	// panicking on a nil manager.
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(`{"goal":"g","kind":"coding","repo_url":"https://github.com/o/r","connector_id":"1"}`))
 	req.Header.Set("Authorization", "Bearer tok")
 	w := httptest.NewRecorder()
@@ -259,7 +259,7 @@ func TestMissionsCreateValidatesOnComplete(t *testing.T) {
 
 	post := func(body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "")
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "", nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -297,7 +297,7 @@ func TestMissionsCreateValidatesGitStrategy(t *testing.T) {
 
 	post := func(body string) (int, string) {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -337,7 +337,7 @@ func TestMissionsCreateValidatesParentMission(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(`{"goal":"g","kind":"general","parent_mission_id":"00000000-0000-0000-0000-000000000000"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -412,7 +412,7 @@ func TestMissionsCreateAttachmentsValidation(t *testing.T) {
 		t.Helper()
 		a, _, _ := testAPI(t, "tok", nil)
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, atts, markitdownURL)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, atts, markitdownURL, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -524,7 +524,7 @@ func TestMissionsClassifyEndpoint(t *testing.T) {
 	a, _, _ := testAPI(t, "tok", nil)
 	classify := func(context.Context, string) (string, error) { return "general", nil }
 	m := mux(a)
-	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "", nil)
 
 	call := func(body string) (int, string) {
 		req := httptest.NewRequest("POST", "/v1/missions/classify", strings.NewReader(body))
@@ -557,7 +557,7 @@ func TestMissionsResumeMalformedBodyRejected(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/abc/resume", strings.NewReader(`{not json`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -580,7 +580,7 @@ func TestMissionsResumeEmptyBodyUnchanged(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	call := func(body io.Reader) int {
 		req := httptest.NewRequest("POST", "/v1/missions/abc/resume", body)
@@ -611,7 +611,7 @@ func TestMissionsNoteMalformedOrEmptyBodyRejected(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	call := func(body io.Reader) int {
 		req := httptest.NewRequest("POST", "/v1/missions/abc/note", body)
@@ -758,7 +758,7 @@ func TestMissionsCreateKindOptional(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	call := func(body string) (int, string) {
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -795,7 +795,7 @@ func TestPRRejectsNonGitHubConnectionMission(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 
 	// Against a degraded pool, store.Get itself fails before the
 	// connector_id/repo_url gate is ever reached — this test only

--- a/internal/brain/connectors/google.go
+++ b/internal/brain/connectors/google.go
@@ -300,6 +300,56 @@ func (g *Google) token(ctx context.Context, cfg GoogleConfig, ref string) (strin
 	return fresh.AccessToken, nil
 }
 
+// SendMail sends a plain-text email through connectorID's Gmail
+// account — the same authed-token-plus-raw-MIME send gmailSend's tool
+// uses (google_tools.go), reused directly here so destinations' email
+// adapter and the chat tool can never diverge on how a message
+// actually goes out. connectorID must name a google-kind connector
+// with the gmail scope; callers (destinations' validation) check that
+// before ever reaching here.
+func (g *Google) SendMail(ctx context.Context, connectorID, to, subject, body string) error {
+	c, err := g.Rows.Get(ctx, connectorID)
+	if err != nil {
+		return fmt.Errorf("send mail: %w", err)
+	}
+	cfg, err := googleConfig(c)
+	if err != nil {
+		return fmt.Errorf("send mail: %w", err)
+	}
+	if c.CredentialRef == "" {
+		return fmt.Errorf("send mail: connector %s has no credential_ref", c.Name)
+	}
+	token, err := g.token(ctx, cfg, c.CredentialRef)
+	if err != nil {
+		return fmt.Errorf("send mail: %w", err)
+	}
+
+	var raw strings.Builder
+	fmt.Fprintf(&raw, "To: %s\r\n", to)
+	fmt.Fprintf(&raw, "Subject: %s\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n%s", subject, body)
+	payload := map[string]string{"raw": base64.URLEncoding.EncodeToString([]byte(raw.String()))}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("send mail: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, g.GmailBase+"/gmail/v1/users/me/messages/send", strings.NewReader(string(data)))
+	if err != nil {
+		return fmt.Errorf("send mail: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := g.Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send mail: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("send mail: gmail api status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
 func googleConfig(c Connector) (GoogleConfig, error) {
 	var cfg GoogleConfig
 	if err := json.Unmarshal(c.Config, &cfg); err != nil {

--- a/internal/brain/destinations/adapters.go
+++ b/internal/brain/destinations/adapters.go
@@ -1,0 +1,108 @@
+package destinations
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// webhookTimeout bounds one webhook POST — matches missions/notify.go's
+// own webhookTimeout for the same reasoning (a slow/unreachable
+// receiver must never stall the caller).
+const webhookTimeout = 10 * time.Second
+
+// Adapter delivers one rendered Payload to a destination's config.
+type Adapter interface {
+	Deliver(ctx context.Context, config json.RawMessage, payload Payload) error
+}
+
+// mailSender is the narrow slice of *connectors.Google the email
+// adapter needs — an interface so this package never imports
+// connectors, mirroring the rest of destinations' dependency
+// direction (connectorLookup above).
+type mailSender interface {
+	SendMail(ctx context.Context, connectorID, to, subject, body string) error
+}
+
+// EmailAdapter sends a destination's payload via the SAME Gmail send
+// path gmail_send's tool uses (connectors.Google.SendMail) — never the
+// tool-execution layer, so a destination's delivery never depends on
+// the agent loop or permission chain.
+type EmailAdapter struct {
+	Mail mailSender
+}
+
+func (a *EmailAdapter) Deliver(ctx context.Context, config json.RawMessage, payload Payload) error {
+	var cfg EmailConfig
+	if err := json.Unmarshal(config, &cfg); err != nil {
+		return fmt.Errorf("email adapter: config: %w", err)
+	}
+	subject := "Timothy mission: " + payload.Name
+	return a.Mail.SendMail(ctx, cfg.ConnectorID, cfg.To, subject, renderText(payload))
+}
+
+// WebhookAdapter POSTs a destination's payload as JSON or plain text
+// per config.format. credential_ref-based Authorization is
+// deliberately OMITTED in this slice: brain has no secret-value
+// resolution path of its own for arbitrary credential refs (secrets
+// resolve gateway/connector-side); wiring one here would mean
+// inventing a new resolution path rather than reusing an existing one.
+// Revisit if a real need for authenticated webhooks shows up.
+type WebhookAdapter struct {
+	HTTP *http.Client
+}
+
+func (a *WebhookAdapter) Deliver(ctx context.Context, config json.RawMessage, payload Payload) error {
+	var cfg WebhookConfig
+	if err := json.Unmarshal(config, &cfg); err != nil {
+		return fmt.Errorf("webhook adapter: config: %w", err)
+	}
+	var body []byte
+	contentType := "text/plain; charset=UTF-8"
+	if cfg.Format == "json" {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("webhook adapter: marshal: %w", err)
+		}
+		body = data
+		contentType = "application/json"
+	} else {
+		body = []byte(renderText(payload))
+	}
+	cctx, cancel := context.WithTimeout(ctx, webhookTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(cctx, http.MethodPost, cfg.URL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("webhook adapter: request: %w", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	client := a.HTTP
+	if client == nil {
+		client = &http.Client{Timeout: webhookTimeout}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("webhook adapter: post: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook adapter: status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// renderText is the plain-text rendering shared by the email body and
+// a text-format webhook.
+func renderText(p Payload) string {
+	out := p.Body
+	if len(p.Links) > 0 {
+		out += "\n\nLinks:\n"
+		for _, l := range p.Links {
+			out += "- " + l + "\n"
+		}
+	}
+	return out
+}

--- a/internal/brain/destinations/deliver.go
+++ b/internal/brain/destinations/deliver.go
@@ -1,0 +1,210 @@
+package destinations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+// deliverBackoff is the fixed retry schedule for one destination's
+// delivery attempt: 2 retries (3 attempts total) with a short backoff
+// — best-effort, never blocking the terminal transition it's called
+// from for long.
+var deliverBackoff = []time.Duration{1 * time.Second, 3 * time.Second}
+
+// destinationStore is the narrow slice of *Store the Deliverer reads.
+type destinationStore interface {
+	Get(ctx context.Context, id string) (Destination, error)
+}
+
+// eventRecorder is the narrow slice of *missions.Store the Deliverer
+// writes its outcome events through.
+type eventRecorder interface {
+	AppendEvent(ctx context.Context, missionID, kind string, payload map[string]any) error
+	Events(ctx context.Context, missionID string) ([]missions.Event, error)
+}
+
+// Deliverer resolves a mission's destination_ids, renders the digest,
+// and calls each destination's adapter — fire-and-forget from the
+// driver's terminal-transition hook (see missions/driver.go). Never
+// returns an error: every failure is logged and recorded as a
+// mission_events row, exactly matching notify.go's own best-effort
+// contract.
+type Deliverer struct {
+	store    destinationStore
+	events   eventRecorder
+	adapters map[string]Adapter
+	webURL   func(ctx context.Context) string
+	log      *slog.Logger
+}
+
+// NewDeliverer builds a Deliverer. webURL resolves the web_base_url
+// setting fresh at delivery time (never cached on the struct) so an
+// operator's later change applies without a restart. email nil (no
+// google connectors wired) leaves "email" unregistered in adapters —
+// deliverOne's map lookup then reports "no adapter for kind" rather
+// than boxing a nil *EmailAdapter as a non-nil Adapter (which would
+// panic on first field access inside Deliver).
+func NewDeliverer(store destinationStore, events eventRecorder, email *EmailAdapter, webhook *WebhookAdapter, webURL func(ctx context.Context) string, log *slog.Logger) *Deliverer {
+	adapters := map[string]Adapter{"webhook": webhook}
+	if email != nil {
+		adapters["email"] = email
+	}
+	return &Deliverer{
+		store:    store,
+		events:   events,
+		adapters: adapters,
+		webURL:   webURL,
+		log:      log,
+	}
+}
+
+// eventDelivered/eventDeliveryFailed name the mission_events rows
+// Deliver appends — one per destination per mission, guarded below so
+// a re-drive (Signal racing Advance) never double-delivers.
+const (
+	eventDelivered      = "mission.delivered"
+	eventDeliveryFailed = "mission.delivery_failed"
+)
+
+// Deliver runs delivery for every id in destinationIDs, best-effort.
+// digest is the mission's already-computed OutcomeDigest (the driver's
+// terminal-transition hook computes it once and passes it through —
+// this never recomputes it). Guards against a mission that already
+// recorded an outcome event for a given destination (idempotent under
+// a re-drive), and no-ops immediately for an empty destinationIDs —
+// zero adapter/store calls for a mission with no destinations.
+func (d *Deliverer) Deliver(ctx context.Context, m missions.Mission, destinationIDs []string, digest string) {
+	if len(destinationIDs) == 0 {
+		return
+	}
+	already, err := d.alreadyDelivered(ctx, m.ID)
+	if err != nil {
+		d.log.Warn("destinations: load prior delivery events failed", "mission_id", m.ID, "error", err)
+		return
+	}
+	events, err := d.events.Events(ctx, m.ID)
+	if err != nil {
+		d.log.Warn("destinations: load events for render failed", "mission_id", m.ID, "error", err)
+		events = nil
+	}
+	var webBaseURL string
+	if d.webURL != nil {
+		webBaseURL = d.webURL(ctx)
+	}
+	payload := Render(m, digest, webBaseURL, events)
+
+	for _, id := range destinationIDs {
+		if already[id] {
+			continue
+		}
+		d.deliverOne(ctx, m.ID, id, payload)
+	}
+}
+
+func (d *Deliverer) deliverOne(ctx context.Context, missionID, destinationID string, payload Payload) {
+	dest, err := d.store.Get(ctx, destinationID)
+	if err != nil {
+		d.recordOutcome(ctx, missionID, destinationID, "", false, "destination not found: "+err.Error())
+		return
+	}
+	if !dest.Enabled {
+		d.recordOutcome(ctx, missionID, destinationID, dest.Name, false, "destination is disabled")
+		return
+	}
+	adapter := d.adapters[dest.Kind]
+	if adapter == nil {
+		d.recordOutcome(ctx, missionID, destinationID, dest.Name, false, "no adapter for kind "+dest.Kind)
+		return
+	}
+
+	var lastErr error
+	attempts := append([]time.Duration{0}, deliverBackoff...)
+	for i, wait := range attempts {
+		if wait > 0 {
+			timer := time.NewTimer(wait)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				d.recordOutcome(ctx, missionID, destinationID, dest.Name, false, ctx.Err().Error())
+				return
+			case <-timer.C:
+			}
+		}
+		lastErr = adapter.Deliver(ctx, dest.Config, payload)
+		if lastErr == nil {
+			d.recordOutcome(ctx, missionID, destinationID, dest.Name, true, "")
+			return
+		}
+		d.log.Warn("destinations: delivery attempt failed", "mission_id", missionID, "destination_id", destinationID, "attempt", i+1, "error", lastErr)
+	}
+	d.recordOutcome(ctx, missionID, destinationID, dest.Name, false, lastErr.Error())
+}
+
+func (d *Deliverer) recordOutcome(ctx context.Context, missionID, destinationID, name string, ok bool, reason string) {
+	kind := eventDelivered
+	payload := map[string]any{"destination_id": destinationID, "destination_name": name}
+	if !ok {
+		kind = eventDeliveryFailed
+		payload["reason"] = reason
+	}
+	if err := d.events.AppendEvent(ctx, missionID, kind, payload); err != nil {
+		d.log.Warn("destinations: record outcome event failed", "mission_id", missionID, "destination_id", destinationID, "error", err)
+	}
+}
+
+// testPayload is the canned content a destination's test-send button
+// delivers — no mission behind it, so every field is a fixed stand-in.
+var testPayload = Payload{
+	MissionID: "test",
+	Name:      "Timothy test delivery",
+	Goal:      "verify this destination is reachable",
+	Body:      "This is a test delivery from Timothy to confirm this destination is configured correctly.",
+}
+
+// Test sends testPayload through id's real adapter, synchronously, no
+// retry — the Settings "Test send" button's backing call. Unlike
+// Deliver, this never touches mission_events (there is no mission) and
+// reports its outcome directly to the caller instead of best-effort
+// logging.
+func (d *Deliverer) Test(ctx context.Context, id string) error {
+	dest, err := d.store.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	adapter := d.adapters[dest.Kind]
+	if adapter == nil {
+		return fmt.Errorf("no adapter for kind %q", dest.Kind)
+	}
+	return adapter.Deliver(ctx, dest.Config, testPayload)
+}
+
+// alreadyDelivered scans a mission's events for prior
+// mission.delivered/mission.delivery_failed rows, keyed by
+// destination_id — the one-per-destination-per-mission idempotency
+// guard, mirroring notify.go's sendOncePerMission reasoning but via
+// AppendEvent + a prior-existence check (mission_events is append-only
+// so there is no upsert form here).
+func (d *Deliverer) alreadyDelivered(ctx context.Context, missionID string) (map[string]bool, error) {
+	events, err := d.events.Events(ctx, missionID)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]bool{}
+	for _, ev := range events {
+		if ev.Kind != eventDelivered && ev.Kind != eventDeliveryFailed {
+			continue
+		}
+		var payload struct {
+			DestinationID string `json:"destination_id"`
+		}
+		if jsonErr := json.Unmarshal(ev.Payload, &payload); jsonErr == nil && payload.DestinationID != "" {
+			out[payload.DestinationID] = true
+		}
+	}
+	return out, nil
+}

--- a/internal/brain/destinations/deliver_test.go
+++ b/internal/brain/destinations/deliver_test.go
@@ -1,0 +1,197 @@
+package destinations
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+func discardLog() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+type fakeDestStore struct {
+	rows map[string]Destination
+}
+
+func (f *fakeDestStore) Get(_ context.Context, id string) (Destination, error) {
+	d, ok := f.rows[id]
+	if !ok {
+		return Destination{}, ErrNotFound
+	}
+	return d, nil
+}
+
+type fakeEventStore struct {
+	mu     sync.Mutex
+	events []missions.Event
+}
+
+func (f *fakeEventStore) AppendEvent(_ context.Context, _, kind string, payload map[string]any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	data, _ := json.Marshal(payload)
+	f.events = append(f.events, missions.Event{Kind: kind, Payload: data})
+	return nil
+}
+
+func (f *fakeEventStore) Events(_ context.Context, _ string) ([]missions.Event, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]missions.Event, len(f.events))
+	copy(out, f.events)
+	return out, nil
+}
+
+// fakeAdapter fails the first failCount calls then succeeds (or always
+// fails when failCount is negative).
+type fakeAdapter struct {
+	mu        sync.Mutex
+	calls     int
+	failCount int
+}
+
+func (f *fakeAdapter) Deliver(_ context.Context, _ json.RawMessage, _ Payload) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.failCount < 0 || f.calls <= f.failCount {
+		return errors.New("simulated delivery failure")
+	}
+	return nil
+}
+
+func (f *fakeAdapter) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func withFastBackoff(t *testing.T) {
+	t.Helper()
+	orig := deliverBackoff
+	deliverBackoff = []time.Duration{time.Millisecond, time.Millisecond}
+	t.Cleanup(func() { deliverBackoff = orig })
+}
+
+func TestDeliverZeroDestinationsNoop(t *testing.T) {
+	destStore := &fakeDestStore{rows: map[string]Destination{}}
+	eventStore := &fakeEventStore{}
+	d := NewDeliverer(destStore, eventStore, nil, &WebhookAdapter{}, nil, discardLog())
+
+	d.Deliver(t.Context(), missions.Mission{ID: "m1"}, nil, "digest")
+
+	if len(eventStore.events) != 0 {
+		t.Fatalf("expected no events for zero destinations, got %d", len(eventStore.events))
+	}
+}
+
+func TestDeliverRetryThenSucceed(t *testing.T) {
+	withFastBackoff(t)
+	adapter := &fakeAdapter{failCount: 2} // fails twice, succeeds on 3rd (last) attempt
+	destStore := &fakeDestStore{rows: map[string]Destination{
+		"d1": {ID: "d1", Name: "webhook-1", Kind: "webhook", Enabled: true, Config: json.RawMessage(`{"url":"https://example.com","format":"json"}`)},
+	}}
+	eventStore := &fakeEventStore{}
+	d := &Deliverer{store: destStore, events: eventStore, adapters: map[string]Adapter{"webhook": adapter}, log: discardLog()}
+
+	d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"d1"}, "digest")
+
+	if adapter.callCount() != 3 {
+		t.Fatalf("expected 3 attempts, got %d", adapter.callCount())
+	}
+	if len(eventStore.events) != 1 || eventStore.events[0].Kind != eventDelivered {
+		t.Fatalf("expected one mission.delivered event, got %+v", eventStore.events)
+	}
+}
+
+func TestDeliverRetryExhaustedThenFail(t *testing.T) {
+	withFastBackoff(t)
+	adapter := &fakeAdapter{failCount: -1} // always fails
+	destStore := &fakeDestStore{rows: map[string]Destination{
+		"d1": {ID: "d1", Name: "webhook-1", Kind: "webhook", Enabled: true, Config: json.RawMessage(`{"url":"https://example.com","format":"json"}`)},
+	}}
+	eventStore := &fakeEventStore{}
+	d := &Deliverer{store: destStore, events: eventStore, adapters: map[string]Adapter{"webhook": adapter}, log: discardLog()}
+
+	d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"d1"}, "digest")
+
+	if adapter.callCount() != 3 {
+		t.Fatalf("expected 3 attempts (1 + 2 retries), got %d", adapter.callCount())
+	}
+	if len(eventStore.events) != 1 || eventStore.events[0].Kind != eventDeliveryFailed {
+		t.Fatalf("expected one mission.delivery_failed event, got %+v", eventStore.events)
+	}
+}
+
+func TestDeliverOncePerMissionGuard(t *testing.T) {
+	withFastBackoff(t)
+	adapter := &fakeAdapter{failCount: 0}
+	destStore := &fakeDestStore{rows: map[string]Destination{
+		"d1": {ID: "d1", Name: "webhook-1", Kind: "webhook", Enabled: true, Config: json.RawMessage(`{"url":"https://example.com","format":"json"}`)},
+	}}
+	eventStore := &fakeEventStore{}
+	d := &Deliverer{store: destStore, events: eventStore, adapters: map[string]Adapter{"webhook": adapter}, log: discardLog()}
+
+	d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"d1"}, "digest")
+	d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"d1"}, "digest") // re-drive
+
+	if adapter.callCount() != 1 {
+		t.Fatalf("expected exactly 1 delivery attempt across both calls, got %d", adapter.callCount())
+	}
+	if len(eventStore.events) != 1 {
+		t.Fatalf("expected exactly 1 outcome event, got %d", len(eventStore.events))
+	}
+}
+
+func TestDeliverUnknownDestinationRecordsFailure(t *testing.T) {
+	destStore := &fakeDestStore{rows: map[string]Destination{}}
+	eventStore := &fakeEventStore{}
+	d := &Deliverer{store: destStore, events: eventStore, adapters: map[string]Adapter{"webhook": &WebhookAdapter{}}, log: discardLog()}
+
+	d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"missing"}, "digest")
+
+	if len(eventStore.events) != 1 || eventStore.events[0].Kind != eventDeliveryFailed {
+		t.Fatalf("expected one mission.delivery_failed event, got %+v", eventStore.events)
+	}
+}
+
+func TestDeliverDisabledDestinationRecordsFailure(t *testing.T) {
+	destStore := &fakeDestStore{rows: map[string]Destination{
+		"d1": {ID: "d1", Name: "off", Kind: "webhook", Enabled: false},
+	}}
+	eventStore := &fakeEventStore{}
+	d := &Deliverer{store: destStore, events: eventStore, adapters: map[string]Adapter{"webhook": &WebhookAdapter{}}, log: discardLog()}
+
+	d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"d1"}, "digest")
+
+	if len(eventStore.events) != 1 || eventStore.events[0].Kind != eventDeliveryFailed {
+		t.Fatalf("expected one mission.delivery_failed event, got %+v", eventStore.events)
+	}
+}
+
+func TestDeliverTest(t *testing.T) {
+	destStore := &fakeDestStore{rows: map[string]Destination{
+		"d1": {ID: "d1", Name: "webhook-1", Kind: "webhook", Enabled: true, Config: json.RawMessage(`{"url":"https://example.com","format":"json"}`)},
+	}}
+	okAdapter := &fakeAdapter{failCount: 0}
+	d := &Deliverer{store: destStore, adapters: map[string]Adapter{"webhook": okAdapter}, log: discardLog()}
+
+	if err := d.Test(t.Context(), "d1"); err != nil {
+		t.Fatalf("Test() error = %v, want nil", err)
+	}
+	if okAdapter.callCount() != 1 {
+		t.Fatalf("expected exactly 1 call, got %d", okAdapter.callCount())
+	}
+
+	if err := d.Test(t.Context(), "unknown"); err == nil {
+		t.Fatal("expected error for unknown destination")
+	}
+}

--- a/internal/brain/destinations/destinations.go
+++ b/internal/brain/destinations/destinations.go
@@ -1,0 +1,313 @@
+// Package destinations implements operator-created outbound sinks
+// mission results deliver to: email (rides a google connector's Gmail
+// send path) and webhook in slice 1. Delivery is harness-owned and
+// deterministic (D-061) — the model never supplies or addresses a
+// destination, only ids resolved against this operator-owned table are
+// ever reachable.
+package destinations
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+// Destination is the API/DB shape of one destinations row.
+type Destination struct {
+	ID            string          `json:"id"`
+	Name          string          `json:"name"`
+	Kind          string          `json:"kind"` // email | webhook | telegram
+	Config        json.RawMessage `json:"config"`
+	CredentialRef string          `json:"credential_ref"`
+	Enabled       bool            `json:"enabled"`
+	CreatedAt     time.Time       `json:"created_at"`
+	UpdatedAt     time.Time       `json:"updated_at"`
+}
+
+// EmailConfig is the config shape for kind='email': rides an existing
+// google connector's Gmail send path rather than owning its own auth.
+type EmailConfig struct {
+	ConnectorID string `json:"connector_id"`
+	To          string `json:"to"`
+}
+
+// WebhookConfig is the config shape for kind='webhook'.
+type WebhookConfig struct {
+	URL    string `json:"url"`
+	Format string `json:"format"` // json | text
+}
+
+var namePattern = regexp.MustCompile(`^[a-z0-9]+(?:[-_][a-z0-9]+)*$`)
+
+// connectorLookup is the narrow slice of *connectors.Store a
+// destination's email config validates against — an interface so this
+// package never imports connectors (avoiding a cycle risk and keeping
+// the dependency direction the same as api/missions.go's own
+// connector validation).
+type connectorLookup interface {
+	Get(ctx context.Context, id string) (Connector, error)
+}
+
+// Connector is the narrow shape destinations needs from a connectors
+// row to validate an email destination's connector_id.
+type Connector struct {
+	Kind    string
+	Enabled bool
+}
+
+// Sentinel errors the HTTP layer maps onto status codes.
+var (
+	ErrNotFound = fmt.Errorf("not found")
+	// ErrReferenced guards Delete: a destination referenced by any
+	// non-terminal mission cannot be removed out from under it.
+	ErrReferenced = fmt.Errorf("destination is referenced by an active mission")
+)
+
+func validate(ctx context.Context, conns connectorLookup, d Destination) error {
+	if !namePattern.MatchString(d.Name) {
+		return fmt.Errorf("name must be a lowercase slug (a-z, 0-9, - or _)")
+	}
+	switch d.Kind {
+	case "email":
+		var cfg EmailConfig
+		if err := json.Unmarshal(d.Config, &cfg); err != nil {
+			return fmt.Errorf("email config: %w", err)
+		}
+		if cfg.ConnectorID == "" {
+			return fmt.Errorf("email destination requires config.connector_id")
+		}
+		if cfg.To == "" {
+			return fmt.Errorf("email destination requires config.to")
+		}
+		if conns == nil {
+			return fmt.Errorf("email destination requires connectors to be enabled")
+		}
+		c, err := conns.Get(ctx, cfg.ConnectorID)
+		if err != nil {
+			return fmt.Errorf("config.connector_id: %w", err)
+		}
+		if c.Kind != "google" {
+			return fmt.Errorf("config.connector_id must name a google-kind connector")
+		}
+		if !c.Enabled {
+			return fmt.Errorf("config.connector_id names a disabled connector")
+		}
+	case "webhook":
+		var cfg WebhookConfig
+		if err := json.Unmarshal(d.Config, &cfg); err != nil {
+			return fmt.Errorf("webhook config: %w", err)
+		}
+		if !hasHTTPScheme(cfg.URL) {
+			return fmt.Errorf("webhook destination requires config.url starting with http:// or https://")
+		}
+		switch cfg.Format {
+		case "json", "text":
+		default:
+			return fmt.Errorf(`webhook destination requires config.format to be "json" or "text"`)
+		}
+	default:
+		// Slice 1 accepts only email/webhook at the Go layer, even
+		// though the DB CHECK also allows 'telegram' for forward
+		// compatibility (see 0014_destinations.sql).
+		return fmt.Errorf("unsupported kind %q (only email, webhook in this release)", d.Kind)
+	}
+	return nil
+}
+
+func hasHTTPScheme(url string) bool {
+	const httpPrefix, httpsPrefix = "http://", "https://"
+	return len(url) > len(httpPrefix) && url[:len(httpPrefix)] == httpPrefix ||
+		len(url) > len(httpsPrefix) && url[:len(httpsPrefix)] == httpsPrefix
+}
+
+// Store is the destinations table's CRUD.
+type Store struct {
+	db    *pgpool.Pool
+	log   *slog.Logger
+	conns connectorLookup
+}
+
+// NewStore builds a Store; conns resolves a connector_id at
+// create/update time for email destinations. Pass nil when connectors
+// are disabled — any email destination create/update then fails
+// validation with a clear error, same as api/missions.go's own
+// nil-connectors gate.
+func NewStore(db *pgpool.Pool, conns connectorLookup, log *slog.Logger) *Store {
+	return &Store{db: db, log: log, conns: conns}
+}
+
+const columns = `id, name, kind, config, credential_ref, enabled, created_at, updated_at`
+
+func scan(row pgx.Row) (Destination, error) {
+	var d Destination
+	if err := row.Scan(&d.ID, &d.Name, &d.Kind, &d.Config, &d.CredentialRef, &d.Enabled, &d.CreatedAt, &d.UpdatedAt); err != nil {
+		return Destination{}, err
+	}
+	return d, nil
+}
+
+// List returns every destination, ordered by name.
+func (s *Store) List(ctx context.Context) ([]Destination, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("destinations list: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT `+columns+` FROM destinations ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("destinations list: %w", err)
+	}
+	defer rows.Close()
+	out := []Destination{}
+	for rows.Next() {
+		d, err := scan(rows)
+		if err != nil {
+			return nil, fmt.Errorf("destinations list: %w", err)
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// Get returns one destination by id.
+func (s *Store) Get(ctx context.Context, id string) (Destination, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return Destination{}, fmt.Errorf("destinations get: %w", err)
+	}
+	d, err := scan(db.QueryRow(ctx, `SELECT `+columns+` FROM destinations WHERE id = $1`, id))
+	if err != nil {
+		return Destination{}, fmt.Errorf("destination %s: %w", id, ErrNotFound)
+	}
+	return d, nil
+}
+
+// EnabledByID reports whether id names a real, enabled destination —
+// the mission create handler's validation call (api/missions.go): an
+// id must exist AND be enabled to be accepted onto a mission's
+// destination_ids, never a bare existence check.
+func (s *Store) EnabledByID(ctx context.Context, id string) (bool, error) {
+	d, err := s.Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return d.Enabled, nil
+}
+
+// Create validates and inserts a destination row.
+func (s *Store) Create(ctx context.Context, d Destination) (string, error) {
+	if err := validate(ctx, s.conns, d); err != nil {
+		return "", err
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		return "", fmt.Errorf("destinations create: %w", err)
+	}
+	cfg := d.Config
+	if len(cfg) == 0 {
+		cfg = json.RawMessage("{}")
+	}
+	var id string
+	err = db.QueryRow(ctx, `INSERT INTO destinations (name, kind, config, credential_ref, enabled)
+		VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+		d.Name, d.Kind, cfg, d.CredentialRef, d.Enabled).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("destinations create: %w", err)
+	}
+	return id, nil
+}
+
+// Patch applies a partial update. Name and kind are immutable — a
+// destination's kind decides which adapter delivers it, and changing
+// it mid-flight would silently re-target existing mission references.
+type Patch struct {
+	Config        *json.RawMessage `json:"config"`
+	CredentialRef *string          `json:"credential_ref"`
+	Enabled       *bool            `json:"enabled"`
+}
+
+func (s *Store) Patch(ctx context.Context, id string, patch Patch) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("destinations patch: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("destinations patch: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	before, err := scan(tx.QueryRow(ctx, `SELECT `+columns+` FROM destinations WHERE id = $1 FOR UPDATE`, id))
+	if err != nil {
+		return fmt.Errorf("destination %s: %w", id, ErrNotFound)
+	}
+	after := before
+	if patch.Config != nil {
+		after.Config = *patch.Config
+	}
+	if patch.CredentialRef != nil {
+		after.CredentialRef = *patch.CredentialRef
+	}
+	if patch.Enabled != nil {
+		after.Enabled = *patch.Enabled
+	}
+	if err := validate(ctx, s.conns, after); err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec(ctx, `UPDATE destinations SET config = $2, credential_ref = $3,
+			enabled = $4, updated_at = now() WHERE id = $1`,
+		id, after.Config, after.CredentialRef, after.Enabled); err != nil {
+		return fmt.Errorf("destinations patch: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("destinations patch: %w", err)
+	}
+	return nil
+}
+
+// missionReferenceChecker is the narrow slice of *missions.Store
+// Delete needs to refuse removing a destination still referenced by an
+// active mission — an interface so this package never imports
+// missions (missions already imports nothing from here; the harness
+// hook flows the other way, through a func type in missions itself).
+type missionReferenceChecker interface {
+	ActiveMissionReferencesDestination(ctx context.Context, destinationID string) (bool, error)
+}
+
+// Delete removes a destination, refusing with ErrReferenced while any
+// non-terminal mission's destination_ids still names it — a historical
+// (terminal) mission's reference never blocks deletion.
+func (s *Store) Delete(ctx context.Context, id string, refs missionReferenceChecker) error {
+	if refs != nil {
+		referenced, err := refs.ActiveMissionReferencesDestination(ctx, id)
+		if err != nil {
+			return fmt.Errorf("destinations delete: check references: %w", err)
+		}
+		if referenced {
+			return ErrReferenced
+		}
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("destinations delete: %w", err)
+	}
+	tag, err := db.Exec(ctx, `DELETE FROM destinations WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("destinations delete: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("destination %s: %w", id, ErrNotFound)
+	}
+	return nil
+}

--- a/internal/brain/destinations/destinations_integration_test.go
+++ b/internal/brain/destinations/destinations_integration_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+
+package destinations
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/SumonMSelim/timothy/internal/platform/migrate"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+	"github.com/SumonMSelim/timothy/migrations"
+)
+
+const marker = "itest-dest-"
+
+func testStore(t *testing.T) *Store {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if _, err := db.Exec(ctx, "DELETE FROM destinations WHERE name LIKE $1 || '%'", marker); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer ccancel()
+		conn, err := pgx.Connect(cctx, dsn)
+		if err != nil {
+			t.Errorf("cleanup connect: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close(cctx) }()
+		_, _ = conn.Exec(cctx, "DELETE FROM destinations WHERE name LIKE $1 || '%'", marker)
+	})
+	return NewStore(pool, nil, log)
+}
+
+func TestStoreCRUDIntegration(t *testing.T) {
+	store := testStore(t)
+	ctx := t.Context()
+	name := marker + "webhook"
+
+	id, err := store.Create(ctx, Destination{
+		Name: name, Kind: "webhook", Enabled: true,
+		Config: json.RawMessage(`{"url":"https://example.com/hook","format":"json"}`),
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := store.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Name != name || got.Kind != "webhook" || !got.Enabled {
+		t.Fatalf("Get returned unexpected row: %+v", got)
+	}
+
+	rows, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	found := false
+	for _, r := range rows {
+		if r.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("List did not include the created destination")
+	}
+
+	enabled, err := store.EnabledByID(ctx, id)
+	if err != nil || !enabled {
+		t.Fatalf("EnabledByID = %v, %v; want true, nil", enabled, err)
+	}
+
+	disabled := false
+	if err := store.Patch(ctx, id, Patch{Enabled: &disabled}); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	enabled, err = store.EnabledByID(ctx, id)
+	if err != nil || enabled {
+		t.Fatalf("EnabledByID after disable = %v, %v; want false, nil", enabled, err)
+	}
+
+	if err := store.Delete(ctx, id, nil); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := store.Get(ctx, id); err == nil {
+		t.Fatal("Get after Delete: expected error, got nil")
+	}
+}
+
+func TestStoreCreateRejectsUnknownConnector(t *testing.T) {
+	store := testStore(t)
+	ctx := t.Context()
+
+	_, err := store.Create(ctx, Destination{
+		Name: marker + "email", Kind: "email", Enabled: true,
+		Config: json.RawMessage(`{"connector_id":"00000000-0000-0000-0000-000000000000","to":"ops@example.com"}`),
+	})
+	if err == nil {
+		t.Fatal("expected error creating an email destination with no connectors configured")
+	}
+}

--- a/internal/brain/destinations/destinations_test.go
+++ b/internal/brain/destinations/destinations_test.go
@@ -1,0 +1,127 @@
+package destinations
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+type fakeConns struct {
+	rows map[string]Connector
+}
+
+func (f fakeConns) Get(_ context.Context, id string) (Connector, error) {
+	c, ok := f.rows[id]
+	if !ok {
+		return Connector{}, errors.New("connector not found")
+	}
+	return c, nil
+}
+
+func TestValidate(t *testing.T) {
+	conns := fakeConns{rows: map[string]Connector{
+		"gmail-ok":       {Kind: "google", Enabled: true},
+		"gmail-disabled": {Kind: "google", Enabled: false},
+		"mcp-conn":       {Kind: "mcp", Enabled: true},
+	}}
+
+	tests := []struct {
+		name    string
+		d       Destination
+		wantErr bool
+	}{
+		{
+			name: "valid email",
+			d: Destination{Name: "ops-inbox", Kind: "email",
+				Config: json.RawMessage(`{"connector_id":"gmail-ok","to":"ops@example.com"}`)},
+			wantErr: false,
+		},
+		{
+			name: "email missing connector_id",
+			d: Destination{Name: "ops-inbox", Kind: "email",
+				Config: json.RawMessage(`{"to":"ops@example.com"}`)},
+			wantErr: true,
+		},
+		{
+			name: "email missing to",
+			d: Destination{Name: "ops-inbox", Kind: "email",
+				Config: json.RawMessage(`{"connector_id":"gmail-ok"}`)},
+			wantErr: true,
+		},
+		{
+			name: "email connector not google-kind",
+			d: Destination{Name: "ops-inbox", Kind: "email",
+				Config: json.RawMessage(`{"connector_id":"mcp-conn","to":"ops@example.com"}`)},
+			wantErr: true,
+		},
+		{
+			name: "email connector disabled",
+			d: Destination{Name: "ops-inbox", Kind: "email",
+				Config: json.RawMessage(`{"connector_id":"gmail-disabled","to":"ops@example.com"}`)},
+			wantErr: true,
+		},
+		{
+			name: "email connector unknown",
+			d: Destination{Name: "ops-inbox", Kind: "email",
+				Config: json.RawMessage(`{"connector_id":"nope","to":"ops@example.com"}`)},
+			wantErr: true,
+		},
+		{
+			name: "valid webhook json",
+			d: Destination{Name: "ops-hook", Kind: "webhook",
+				Config: json.RawMessage(`{"url":"https://example.com/hook","format":"json"}`)},
+			wantErr: false,
+		},
+		{
+			name: "valid webhook text",
+			d: Destination{Name: "ops-hook", Kind: "webhook",
+				Config: json.RawMessage(`{"url":"http://example.com/hook","format":"text"}`)},
+			wantErr: false,
+		},
+		{
+			name: "webhook bad url scheme",
+			d: Destination{Name: "ops-hook", Kind: "webhook",
+				Config: json.RawMessage(`{"url":"ftp://example.com/hook","format":"json"}`)},
+			wantErr: true,
+		},
+		{
+			name: "webhook bad format",
+			d: Destination{Name: "ops-hook", Kind: "webhook",
+				Config: json.RawMessage(`{"url":"https://example.com/hook","format":"xml"}`)},
+			wantErr: true,
+		},
+		{
+			name:    "telegram rejected at go layer",
+			d:       Destination{Name: "tg", Kind: "telegram", Config: json.RawMessage(`{"chat_id":"123"}`)},
+			wantErr: true,
+		},
+		{
+			name:    "unknown kind rejected",
+			d:       Destination{Name: "whatsapp", Kind: "whatsapp", Config: json.RawMessage(`{}`)},
+			wantErr: true,
+		},
+		{
+			name:    "bad name slug",
+			d:       Destination{Name: "Ops Inbox", Kind: "webhook", Config: json.RawMessage(`{"url":"https://example.com","format":"json"}`)},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validate(t.Context(), conns, tt.d)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateEmailNoConnectors(t *testing.T) {
+	d := Destination{Name: "ops-inbox", Kind: "email",
+		Config: json.RawMessage(`{"connector_id":"gmail-ok","to":"ops@example.com"}`)}
+	if err := validate(t.Context(), nil, d); err == nil {
+		t.Fatal("expected error when connectors are disabled")
+	}
+}

--- a/internal/brain/destinations/render.go
+++ b/internal/brain/destinations/render.go
@@ -1,0 +1,66 @@
+package destinations
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+// Payload is the rendered delivery content, kind-agnostic: adapters
+// format it per their own contract (email HTML, webhook JSON/text).
+type Payload struct {
+	MissionID string   `json:"mission_id"`
+	Name      string   `json:"name"`
+	Goal      string   `json:"goal"`
+	Body      string   `json:"body"`
+	Links     []string `json:"links"`
+}
+
+// Render builds a mission's delivery Payload: body is the outcome
+// digest verbatim (missions.OutcomeDigest, already computed by the
+// driver's terminal-transition hook — never recomputed here). links is
+// the mission detail URL (built from webBaseURL when non-empty) plus
+// branch/PR URL when the mission has them.
+func Render(m missions.Mission, digest string, webBaseURL string, events []missions.Event) Payload {
+	name := m.Name
+	if name == "" {
+		name = m.Goal
+	}
+	var links []string
+	if webBaseURL != "" {
+		links = append(links, strings.TrimRight(webBaseURL, "/")+"/missions/"+m.ID)
+	}
+	if m.Branch != "" {
+		links = append(links, "branch: "+m.Branch)
+	}
+	if url, ok := lastPROpenedURL(events); ok {
+		links = append(links, url)
+	}
+	return Payload{
+		MissionID: m.ID,
+		Name:      name,
+		Goal:      m.Goal,
+		Body:      digest,
+		Links:     links,
+	}
+}
+
+// lastPROpenedURL scans events for the most recent mission.pr_opened
+// event's url — missions has no dedicated PR-URL column, only the
+// event Completer.OpenPR appends.
+func lastPROpenedURL(events []missions.Event) (string, bool) {
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].Kind != "mission.pr_opened" {
+			continue
+		}
+		var payload struct {
+			URL string `json:"url"`
+		}
+		if err := json.Unmarshal(events[i].Payload, &payload); err != nil || payload.URL == "" {
+			return "", false
+		}
+		return payload.URL, true
+	}
+	return "", false
+}

--- a/internal/brain/destinations/render_test.go
+++ b/internal/brain/destinations/render_test.go
@@ -1,0 +1,78 @@
+package destinations
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+func TestRender(t *testing.T) {
+	m := missions.Mission{ID: "m1", Goal: "ship the thing", Name: "Ship it"}
+	digest := "mission goal: ship the thing\nterminal state: done\n"
+
+	t.Run("no web base url, no branch, no pr", func(t *testing.T) {
+		p := Render(m, digest, "", nil)
+		if p.MissionID != "m1" || p.Name != "Ship it" || p.Goal != "ship the thing" || p.Body != digest {
+			t.Fatalf("unexpected payload: %+v", p)
+		}
+		if len(p.Links) != 0 {
+			t.Fatalf("expected no links, got %v", p.Links)
+		}
+	})
+
+	t.Run("with web base url", func(t *testing.T) {
+		p := Render(m, digest, "https://timothy.example.lan/", nil)
+		if len(p.Links) != 1 || p.Links[0] != "https://timothy.example.lan/missions/m1" {
+			t.Fatalf("unexpected links: %v", p.Links)
+		}
+	})
+
+	t.Run("with branch", func(t *testing.T) {
+		coding := m
+		coding.Branch = "feat/ship-it"
+		p := Render(coding, digest, "", nil)
+		if len(p.Links) != 1 || p.Links[0] != "branch: feat/ship-it" {
+			t.Fatalf("unexpected links: %v", p.Links)
+		}
+	})
+
+	t.Run("with pr opened event", func(t *testing.T) {
+		payload, _ := json.Marshal(map[string]any{"url": "https://github.com/org/repo/pull/1", "number": 1})
+		events := []missions.Event{{Kind: "mission.pr_opened", Payload: payload}}
+		p := Render(m, digest, "", events)
+		if len(p.Links) != 1 || p.Links[0] != "https://github.com/org/repo/pull/1" {
+			t.Fatalf("unexpected links: %v", p.Links)
+		}
+	})
+
+	t.Run("branch and pr and web base url together", func(t *testing.T) {
+		coding := m
+		coding.Branch = "feat/ship-it"
+		payload, _ := json.Marshal(map[string]any{"url": "https://github.com/org/repo/pull/1"})
+		events := []missions.Event{{Kind: "mission.pr_opened", Payload: payload}}
+		p := Render(coding, digest, "https://timothy.example.lan", events)
+		want := []string{
+			"https://timothy.example.lan/missions/m1",
+			"branch: feat/ship-it",
+			"https://github.com/org/repo/pull/1",
+		}
+		if len(p.Links) != len(want) {
+			t.Fatalf("links = %v, want %v", p.Links, want)
+		}
+		for i := range want {
+			if p.Links[i] != want[i] {
+				t.Fatalf("links[%d] = %q, want %q", i, p.Links[i], want[i])
+			}
+		}
+	})
+
+	t.Run("falls back to goal when name empty", func(t *testing.T) {
+		noName := m
+		noName.Name = ""
+		p := Render(noName, digest, "", nil)
+		if p.Name != "ship the thing" {
+			t.Fatalf("Name = %q, want fallback to goal", p.Name)
+		}
+	})
+}

--- a/internal/brain/missions/destination_deliver_test.go
+++ b/internal/brain/missions/destination_deliver_test.go
@@ -1,0 +1,134 @@
+package missions
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recordingDeliver is a DestinationDeliver fake that records every call
+// it receives, synchronized so tests can assert on it after the
+// driver's dispatching goroutine has had a chance to run (Deliver is
+// fired via `go` from deliverToDestinations, same as MemoryExtract).
+type recordingDeliver struct {
+	mu    sync.Mutex
+	calls []struct {
+		missionID string
+		destIDs   []string
+		digest    string
+	}
+}
+
+func (r *recordingDeliver) fn() DestinationDeliver {
+	return func(ctx context.Context, m Mission, destinationIDs []string, digest string) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.calls = append(r.calls, struct {
+			missionID string
+			destIDs   []string
+			digest    string
+		}{m.ID, destinationIDs, digest})
+	}
+}
+
+func (r *recordingDeliver) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
+}
+
+func waitForDeliverCalls(t *testing.T, r *recordingDeliver, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if r.count() == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("deliver calls = %d, want %d", r.count(), want)
+}
+
+func TestDriverDeliversToDestinationsOnDone(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8, DestinationIDs: []string{"d1", "d2"}})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner)
+	rec := &recordingDeliver{}
+	d.SetDestinationDeliver(rec.fn())
+
+	driveN(t, d, "m1", 4) // explore -> plan -> execute -> review -> done
+
+	waitForDeliverCalls(t, rec, 1)
+	if got := rec.calls[0].destIDs; len(got) != 2 || got[0] != "d1" || got[1] != "d2" {
+		t.Fatalf("destination ids = %v, want [d1 d2]", got)
+	}
+}
+
+func TestDriverSkipsDeliveryOnFailed(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 1, DestinationIDs: []string{"d1"}})
+	runner := &scriptedRunner{
+		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "nope"}},
+	}
+	d := testDriver(store, runner)
+	rec := &recordingDeliver{}
+	d.SetDestinationDeliver(rec.fn())
+
+	// MaxIterations=1: the first retry immediately exhausts iterations
+	// and the state machine fails the mission (stepWorkerRetry).
+	driveN(t, d, "m1", 1)
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseFailed {
+		t.Fatalf("mission phase = %s, want failed", m.Phase)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if got := rec.count(); got != 0 {
+		t.Fatalf("deliver calls on a failed mission = %d, want 0 (v1 never delivers on failure)", got)
+	}
+}
+
+func TestDriverSkipsDeliveryWhenNoDestinations(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner)
+	rec := &recordingDeliver{}
+	d.SetDestinationDeliver(rec.fn())
+
+	driveN(t, d, "m1", 4)
+
+	time.Sleep(20 * time.Millisecond)
+	if got := rec.count(); got != 0 {
+		t.Fatalf("deliver calls for a mission with no destination_ids = %d, want 0", got)
+	}
+}
+
+func TestDriverSkipsDeliveryWhenNilHook(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8, DestinationIDs: []string{"d1"}})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner) // no SetDestinationDeliver call: d.deliverDestinations stays nil
+
+	// This must not panic — the whole point of the nil-safe field.
+	driveN(t, d, "m1", 4)
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseDone {
+		t.Fatalf("mission phase = %s, want done", m.Phase)
+	}
+}

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -191,6 +191,16 @@ type Driver struct {
 	// unnamed missions unnamed, same as before this existed.
 	nameMission func(context.Context, string) string
 
+	// deliverDestinations wires the destinations delivery hook fired on
+	// a mission's terminal done transition (see SetDestinationDeliver /
+	// deliverToDestinations) — nil-safe: unset skips delivery entirely.
+	// A func type, not an interface importing the destinations package,
+	// since destinations.Deliverer needs missions.Mission/Event —
+	// importing missions from there and missions from destinations back
+	// would cycle; cmd/brain/main.go's wiring closure bridges the two,
+	// same as SetMemoryExtract does for memoryd.
+	deliverDestinations DestinationDeliver
+
 	// gatekeepers holds each mission's in-progress reviewer session
 	// state, keyed by mission id, for the "delta recheck" resume on
 	// rework. Process-local by design: lost on restart is acceptable —
@@ -336,6 +346,54 @@ func (d *Driver) SetMemoryExtract(fn MemoryExtract) {
 // SetMemoryExtract is. Optional — nil leaves unnamed missions unnamed.
 func (d *Driver) SetNameMission(fn func(context.Context, string) string) {
 	d.nameMission = fn
+}
+
+// DestinationDeliver delivers a terminal mission's outcome digest to
+// its attached destination_ids — destinations.Deliverer.Deliver
+// satisfies this signature. Fire-and-forget by contract, same as
+// MemoryExtract: it must never return an error, block, or affect
+// mission state.
+type DestinationDeliver func(ctx context.Context, m Mission, destinationIDs []string, digest string)
+
+// SetDestinationDeliver wires the destinations delivery hook fired on
+// a mission's terminal done transition (see deliverToDestinations) — a
+// setter for the same reason SetMemoryExtract is. Optional — nil skips
+// delivery entirely, same as a mission with no destination_ids.
+func (d *Driver) SetDestinationDeliver(fn DestinationDeliver) {
+	d.deliverDestinations = fn
+}
+
+// deliverToDestinations fires the destinations delivery hook exactly
+// on a transition into phase=done (never phase=failed — v1 doesn't
+// deliver on failure, the notifier already covers failure alerts) and
+// only when the mission actually has destination_ids attached. Reuses
+// OutcomeDigest the same way extractMissionMemory does — computed once
+// here from a fresh Events() read, not duplicated logic. Detached from
+// ctx like fireOnComplete: the mission is already terminal, so delivery
+// must outlive a request that may be winding down.
+func (d *Driver) deliverToDestinations(ctx context.Context, id string, terminal Phase) {
+	if d.deliverDestinations == nil || terminal != PhaseDone {
+		return
+	}
+	m, err := d.store.Get(ctx, id)
+	if err != nil {
+		d.log.Warn("driver: destination delivery: reload mission failed", "mission_id", id, "error", err)
+		return
+	}
+	if len(m.DestinationIDs) == 0 {
+		return
+	}
+	events, err := d.store.Events(ctx, id)
+	if err != nil {
+		d.log.Warn("driver: destination delivery: load events failed", "mission_id", id, "error", err)
+		return
+	}
+	// terminal is always PhaseDone here (checked above), so there is no
+	// failure reason to pass — OutcomeDigest only renders one when
+	// terminal == PhaseFailed.
+	digest := OutcomeDigest(m, events, terminal, "")
+	rctx := context.Background()
+	go d.deliverDestinations(rctx, m, m.DestinationIDs, digest) //nolint:gosec // G118: deliberate — the mission is already terminal, delivery must outlive whatever request/ctx observed that transition
 }
 
 // fireOnComplete runs a mission's recorded on_complete choice
@@ -688,6 +746,7 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 		d.removeSandbox(id)
 		d.extractMissionMemory(ctx, id, t.Next.Phase, failedReason(t.Events))
 		d.backfillMissionName(ctx, id)
+		d.deliverToDestinations(ctx, id, t.Next.Phase)
 	}
 	if t.Next.Phase == PhaseDone {
 		// m is the pre-transition snapshot (re-fetched above, before this
@@ -772,6 +831,7 @@ func (d *Driver) Signal(ctx context.Context, id string, input Input) error {
 		d.removeSandbox(id)
 		d.extractMissionMemory(ctx, id, t.Next.Phase, failedReason(t.Events))
 		d.backfillMissionName(ctx, id)
+		d.deliverToDestinations(ctx, id, t.Next.Phase)
 	}
 	if d.notify != nil {
 		if err := d.notify.OnTransition(ctx, m, before, t.Next.Status, failedReason(t.Events)); err != nil {

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -157,9 +157,15 @@ type Mission struct {
 	// worker/reviewer/planner turns run under — loop.Agent's tool-call
 	// bookkeeping (session_events, audit) hard-requires a real session
 	// id, which a mission otherwise has no reason to have.
-	SessionID string    `json:"-"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	SessionID string `json:"-"`
+	// DestinationIDs names the operator-created destinations (email,
+	// webhook) this mission's outcome digest delivers to on the
+	// terminal done transition (driver.go's deliverToDestinations) —
+	// validated against the destinations table at create time
+	// (api/missions.go), never model-decided.
+	DestinationIDs []string  `json:"destination_ids,omitempty"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
 }
 
 // MissionAttachment is one PDF document attached at mission create

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -50,7 +50,7 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 	pending_permission, pending_permission_tool, pending_permission_args,
 	pending_permission_danger, pending_permission_rationale, auto_approve_safe, last_evidence,
 	explore_notes, replan_used, schedule_id, session_id, harness, environment, repo_url, connector_id, on_complete,
-	branch_pattern, commit_style, parent_mission_id, parent_context, attachments, created_at, updated_at`
+	branch_pattern, commit_style, parent_mission_id, parent_context, attachments, destination_ids, created_at, updated_at`
 
 // scanMissionWithFailureReason is scanMission plus one extra trailing
 // column: the mission's latest mission.failed event's payload.reason
@@ -74,6 +74,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&m.PendingPermissionDanger, &m.PendingPermissionRationale, &m.AutoApproveSafe, &m.LastEvidence,
 		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &attachmentsRaw,
+		&m.DestinationIDs,
 		&m.CreatedAt, &m.UpdatedAt,
 		&failureReason); err != nil {
 		return Mission{}, err
@@ -149,6 +150,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&m.PendingPermissionDanger, &m.PendingPermissionRationale, &m.AutoApproveSafe, &m.LastEvidence,
 		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &attachmentsRaw,
+		&m.DestinationIDs,
 		&m.CreatedAt, &m.UpdatedAt); err != nil {
 		return Mission{}, err
 	}
@@ -230,10 +232,17 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	if budgetCurrency == "" {
 		budgetCurrency = "USD"
 	}
+	// destination_ids is NOT NULL; a nil slice binds as a NULL array
+	// parameter, so a mission with no destinations gets an empty slice
+	// instead.
+	destinationIDs := m.DestinationIDs
+	if destinationIDs == nil {
+		destinationIDs = []string{}
+	}
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, attachments)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NULLIF($15, '')::uuid, $16, $17, $18, $19, $20, $21, $22, $23, NULLIF($24, '')::uuid, $25, $26) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 8), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, attachmentsJSON,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, attachments, destination_ids)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NULLIF($15, '')::uuid, $16, $17, $18, $19, $20, $21, $22, $23, NULLIF($24, '')::uuid, $25, $26, $27) RETURNING id`,
+		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 8), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, attachmentsJSON, destinationIDs,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)
@@ -969,6 +978,28 @@ func (s *Store) RecoverStaleWorking(ctx context.Context, staleAfter time.Duratio
 		out = append(out, m)
 	}
 	return out, rows.Err()
+}
+
+// ActiveMissionReferencesDestination reports whether any NON-terminal
+// mission (phase NOT IN ('done', 'failed')) still names destinationID
+// in its destination_ids — the guard destinations.Store.Delete calls
+// before removing a row, so a live mission's delivery target can't
+// vanish out from under it. A historical (terminal) mission's
+// reference never blocks deletion.
+func (s *Store) ActiveMissionReferencesDestination(ctx context.Context, destinationID string) (bool, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return false, fmt.Errorf("missions active destination reference: %w", err)
+	}
+	var exists bool
+	err = db.QueryRow(ctx, `SELECT EXISTS (
+		SELECT 1 FROM missions
+		WHERE phase NOT IN ('done', 'failed') AND $1 = ANY(destination_ids)
+	)`, destinationID).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("missions active destination reference: %w", err)
+	}
+	return exists, nil
 }
 
 // MissionSpend is a mission's cost_ledger footprint broken out by

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -71,6 +71,11 @@ const (
 	// mission's own commit_style column overrides this per create
 	// request.
 	ValueGitCommitStyle = "git_commit_style"
+	// ValueWebBaseURL is Timothy's own web UI base address (e.g.
+	// https://timothy.example.lan), used to build a mission detail link
+	// in destination deliveries (destinations/render.go); "" omits the
+	// link entirely rather than guessing a LAN address.
+	ValueWebBaseURL = "web_base_url"
 )
 
 var knownValueKeys = map[string]bool{
@@ -79,6 +84,7 @@ var knownValueKeys = map[string]bool{
 	ValueSensitiveToolRoute: true, ValueDefaultCurrency: true,
 	ValueCodingExecutor:   true,
 	ValueGitBranchPattern: true, ValueGitCommitStyle: true,
+	ValueWebBaseURL: true,
 }
 
 // allowedCurrencies is the flat, fixed list of ISO 4217 codes the
@@ -184,6 +190,12 @@ func (s *Store) GitBranchPattern(ctx context.Context) string {
 // "" (missions.CommitStyleConventional) when unset.
 func (s *Store) GitCommitStyle(ctx context.Context) string {
 	return s.Value(ctx, ValueGitCommitStyle)
+}
+
+// WebBaseURL returns the configured web UI base address, "" (omit the
+// mission link) when unset.
+func (s *Store) WebBaseURL(ctx context.Context) string {
+	return s.Value(ctx, ValueWebBaseURL)
 }
 
 // SkillAllowed reports whether the allowlist admits a pack name;

--- a/migrations/0010_missions.sql
+++ b/migrations/0010_missions.sql
@@ -166,7 +166,13 @@ CREATE TABLE IF NOT EXISTS missions (
     -- branch_pattern is a validated template (internal/brain/missions/
     -- branchtemplate.go); commit_style is 'conventional' or 'plain'.
     branch_pattern        text NOT NULL DEFAULT '',
-    commit_style          text NOT NULL DEFAULT ''
+    commit_style          text NOT NULL DEFAULT '',
+    -- Destination ids to deliver this mission's outcome digest to on
+    -- the terminal done transition (destinations.go's Deliverer,
+    -- driver.go's terminal-transition hook). Never model-decided —
+    -- api/missions.go's create validates every id against the
+    -- operator-owned destinations table before it lands here.
+    destination_ids       uuid[] NOT NULL DEFAULT '{}'
 );
 
 CREATE INDEX IF NOT EXISTS missions_status_idx ON missions (status);

--- a/migrations/0014_destinations.sql
+++ b/migrations/0014_destinations.sql
@@ -1,0 +1,15 @@
+-- Destinations: operator-created outbound sinks missions deliver
+-- results to (internal/brain/destinations). config is per-kind and
+-- never a secret value; credential_ref names a secret store ref
+-- (unused for email/webhook in slice 1, present for forward
+-- compatibility with telegram).
+CREATE TABLE destinations (
+    id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        text NOT NULL UNIQUE,
+    kind        text NOT NULL CHECK (kind IN ('email', 'webhook', 'telegram')),
+    config      jsonb NOT NULL DEFAULT '{}',
+    credential_ref text NOT NULL DEFAULT '',
+    enabled     boolean NOT NULL DEFAULT true,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    updated_at  timestamptz NOT NULL DEFAULT now()
+);

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -17,6 +17,7 @@ import type {
   ChainEntry,
   ChatEvent,
   ChatRequest,
+  Destination,
   EntityGraphData,
   GitHubIdentity,
   GitHubRepo,
@@ -1074,6 +1075,43 @@ export async function connectorOAuthStart(id: string): Promise<string> {
   return url
 }
 
+// --- destinations (mission result delivery) ---
+
+export async function listDestinations(): Promise<Destination[]> {
+  const { destinations } = await request<{ destinations: Destination[] }>('/v1/admin/destinations')
+  return destinations ?? []
+}
+
+export async function createDestination(d: Partial<Destination>): Promise<string> {
+  const { id } = await request<{ id: string }>('/v1/admin/destinations', {
+    method: 'POST',
+    body: JSON.stringify(d),
+  })
+  return id
+}
+
+export async function patchDestination(
+  id: string,
+  patch: Partial<Pick<Destination, 'config' | 'credential_ref' | 'enabled'>>,
+): Promise<void> {
+  await request<void>(`/v1/admin/destinations/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(patch),
+  })
+}
+
+export async function deleteDestination(id: string): Promise<void> {
+  await request<void>(`/v1/admin/destinations/${id}`, { method: 'DELETE' })
+}
+
+// testDestination sends a canned "Timothy test delivery" payload
+// through the destination's real adapter and reports success/failure.
+export async function testDestination(id: string): Promise<{ ok: boolean; error?: string }> {
+  return request<{ ok: boolean; error?: string }>(`/v1/admin/destinations/${id}/test`, {
+    method: 'POST',
+  })
+}
+
 export async function listRoutes(): Promise<AdminRoute[]> {
   const { routes } = await request<{ routes: AdminRoute[] }>('/v1/admin/routes')
   return routes ?? []
@@ -1190,6 +1228,10 @@ export interface CreateMissionInput {
   // attachments name already-uploaded PDFs (POST /v1/attachments) to
   // convert to markdown once at create time — PDF only, up to 8.
   attachments?: { id: string; name: string }[]
+  // destination_ids names operator-created destinations to deliver this
+  // mission's outcome digest to on the terminal done transition; omit
+  // (or empty) delivers nowhere.
+  destination_ids?: string[]
 }
 
 // ExecutorOption is one registered harness's usability on a given

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -762,6 +762,25 @@ export interface Mission {
   // attachments are PDF documents attached at create time — markdown is
   // never sent over the wire (see api/missions.go's sanitizeMission).
   attachments?: { id: string; mime: string; name?: string }[]
+  // destination_ids names operator-created destinations (email,
+  // webhook) this mission delivers its outcome digest to on the
+  // terminal done transition. Validated against the destinations table
+  // at create time — never model-decided.
+  destination_ids?: string[]
+  created_at: string
+  updated_at: string
+}
+
+// Destination is one operator-created outbound sink for mission
+// results (internal/brain/destinations.Destination) — Settings →
+// Destinations CRUD, and the mission form's destinations multi-select.
+export interface Destination {
+  id: string
+  name: string
+  kind: 'email' | 'webhook' | 'telegram'
+  config: Record<string, unknown>
+  credential_ref: string
+  enabled: boolean
   created_at: string
   updated_at: string
 }

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -18,6 +18,7 @@ vi.mock('../../api/client', () => ({
   getMissionExecutorOptions: vi.fn(),
   testConnector: vi.fn().mockResolvedValue({ ok: true }),
   uploadAttachment: vi.fn(),
+  listDestinations: vi.fn().mockResolvedValue([]),
 }))
 
 import {
@@ -30,10 +31,12 @@ import {
   listAgents,
   listConnectorRepos,
   listConnectors,
+  listDestinations,
   listRoutes,
   patchSchedule,
   uploadAttachment,
 } from '../../api/client'
+import type { Destination } from '../../api/types'
 
 // renderForm wraps MissionForm in a MemoryRouter — the repository
 // section's "no connectors" hint links to Settings → Connectors, which
@@ -239,6 +242,76 @@ describe('MissionForm — create mode, one-off mission', () => {
 
     resolveUpload({ id: 'att1', mime: 'application/pdf', size_bytes: 100 })
     await waitFor(() => expect(createButton.disabled).toBe(false))
+  })
+})
+
+const destinations: Destination[] = [
+  {
+    id: 'd1',
+    name: 'ops-inbox',
+    kind: 'email',
+    config: { connector_id: 'c1', to: 'ops@example.com' },
+    credential_ref: '',
+    enabled: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'd2',
+    name: 'ops-hook',
+    kind: 'webhook',
+    config: { url: 'https://example.com/hook', format: 'json' },
+    credential_ref: '',
+    enabled: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+]
+
+describe('MissionForm — destinations multi-select', () => {
+  it('hides the section when there are no destinations', async () => {
+    vi.mocked(listDestinations).mockResolvedValue([])
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await waitFor(() => expect(listDestinations).toHaveBeenCalled())
+    expect(screen.queryByText('Deliver results to')).toBeNull()
+  })
+
+  it('renders a checkbox per destination, unchecked by default, and submits the picked ids', async () => {
+    vi.mocked(listDestinations).mockResolvedValue(destinations)
+    vi.mocked(createMission).mockResolvedValue({ id: 'm2' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await screen.findByText('Deliver results to')
+    const opsInbox = screen.getByLabelText(/^ops-inbox/) as HTMLInputElement
+    const opsHook = screen.getByLabelText(/^ops-hook/) as HTMLInputElement
+    expect(opsInbox.checked).toBe(false)
+    expect(opsHook.checked).toBe(false)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Send me the digest' } })
+    fireEvent.click(opsInbox)
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(
+        expect.objectContaining({ destination_ids: ['d1'] }),
+      ),
+    )
+  })
+
+  it('omits destination_ids from the create payload when none are picked', async () => {
+    vi.mocked(listDestinations).mockResolvedValue(destinations)
+    vi.mocked(createMission).mockResolvedValue({ id: 'm2' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await screen.findByText('Deliver results to')
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'No delivery please' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() => expect(createMission).toHaveBeenCalled())
+    expect(createMission).toHaveBeenCalledWith(
+      expect.not.objectContaining({ destination_ids: expect.anything() }),
+    )
   })
 })
 

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -12,6 +12,7 @@ import {
   getSettings,
   listConnectorRepos,
   listConnectors,
+  listDestinations,
   patchSchedule,
   testConnector,
 } from '../../api/client'
@@ -19,6 +20,7 @@ import type {
   AdminAgent,
   AdminConnector,
   AdminRoute,
+  Destination,
   GitHubIdentity,
   GitHubRepo,
   Schedule,
@@ -251,6 +253,22 @@ export function MissionForm({
   const [kindLocked, setKindLocked] = useState(!!initial?.kind)
   const [classifying, setClassifying] = useState(false)
   const [agentID, setAgentID] = useState(initial?.agent_id ?? '')
+  // Destinations multi-select — visible, not advanced; default is
+  // empty (deliver nowhere). Only ever offered for a one-off create
+  // (mode === 'create'), same scope as schedule integration being a
+  // later slice.
+  const [destinations, setDestinations] = useState<Destination[] | null>(null)
+  const [destinationIDs, setDestinationIDs] = useState<string[]>([])
+  useEffect(() => {
+    if (mode !== 'create') return
+    listDestinations()
+      .then(setDestinations)
+      .catch(() => {
+        // Non-fatal: the section just stays hidden if this fails, same
+        // degrade as any other optional list fetch in this form.
+      })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [route, setRoute] = useState(initial?.route ?? '')
   const [reviewRoute, setReviewRoute] = useState(initial?.review_route ?? '')
@@ -529,6 +547,7 @@ export function MissionForm({
       parent_mission_id: parentMissionId,
       attachments:
         attachments.length > 0 ? attachments.map((a) => ({ id: a.id, name: a.name ?? '' })) : undefined,
+      destination_ids: destinationIDs.length > 0 ? destinationIDs : undefined,
     })
     toast.success('Mission created')
     onDone({ kind: 'mission', id })
@@ -1114,6 +1133,30 @@ export function MissionForm({
             </span>
           </span>
         </label>
+
+        {mode === 'create' && destinations && destinations.length > 0 && (
+          <div className="space-y-1.5">
+            <Label>Deliver results to</Label>
+            <div className="space-y-1.5 rounded-xl border border-border p-3">
+              {destinations.map((d) => (
+                <label key={d.id} htmlFor={`mission-destination-${d.id}`} className="flex items-center gap-2 text-sm">
+                  <input
+                    id={`mission-destination-${d.id}`}
+                    type="checkbox"
+                    checked={destinationIDs.includes(d.id)}
+                    onChange={(e) =>
+                      setDestinationIDs((prev) =>
+                        e.target.checked ? [...prev, d.id] : prev.filter((id) => id !== d.id),
+                      )
+                    }
+                  />
+                  <span>{d.name}</span>
+                  <span className="text-xs text-muted-foreground uppercase">{d.kind}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
 
         <Collapsible open={showAdvanced} onOpenChange={setShowAdvanced}>
           <CollapsibleTrigger className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground">

--- a/web/src/components/settings/DestinationAdd.tsx
+++ b/web/src/components/settings/DestinationAdd.tsx
@@ -1,0 +1,233 @@
+import { ArrowLeft01Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useEffect, useState } from 'react'
+import { Link, Navigate, useNavigate, useParams } from 'react-router'
+import { toast } from 'sonner'
+import { createDestination, listConnectors, patchDestination, testDestination } from '../../api/client'
+import type { AdminConnector } from '../../api/types'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { Field } from './shared'
+import { errText } from './util'
+
+function slugify(v: string): string {
+  return v
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+// DestinationAdd is kind-aware (email vs webhook) and its own page,
+// mirroring ConnectorAdd's shape: the destination row is created
+// (disabled) as part of testing, and a passing test enables it.
+export function DestinationAdd() {
+  const { kind } = useParams<{ kind: 'email' | 'webhook' }>()
+  const navigate = useNavigate()
+
+  const [name, setName] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [test, setTest] = useState<{ ok: boolean; error?: string } | null>(null)
+  const [createdID, setCreatedID] = useState<string | null>(null)
+
+  // email fields
+  const [connectors, setConnectors] = useState<AdminConnector[] | null>(null)
+  const [connectorID, setConnectorID] = useState('')
+  const [to, setTo] = useState('')
+
+  // webhook fields
+  const [url, setURL] = useState('')
+  const [format, setFormat] = useState<'json' | 'text'>('json')
+
+  useEffect(() => {
+    if (kind !== 'email') return
+    listConnectors()
+      .then((rows) => setConnectors(rows.filter((c) => c.kind === 'google' && c.enabled)))
+      .catch((err: unknown) => toast.error('Could not load connectors', { description: errText(err) }))
+  }, [kind])
+
+  if (kind !== 'email' && kind !== 'webhook') return <Navigate to="/settings/destinations" replace />
+
+  const invalidate = () => {
+    setTest(null)
+    setCreatedID(null)
+  }
+
+  const config = kind === 'email' ? { connector_id: connectorID, to: to.trim() } : { url: url.trim(), format }
+
+  const canTest =
+    slugify(name) !== '' &&
+    (kind === 'email' ? connectorID !== '' && to.trim() !== '' : url.trim() !== '')
+
+  const runTest = async () => {
+    setBusy(true)
+    setTest(null)
+    try {
+      const id = await createDestination({
+        name: slugify(name),
+        kind,
+        config,
+        enabled: false,
+      })
+      setCreatedID(id)
+      setTest(await testDestination(id))
+    } catch (err) {
+      setTest({ ok: false, error: errText(err) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const submit = async () => {
+    if (!test?.ok || !createdID) return
+    // The destination was created disabled to test it; enabling it is
+    // a separate concern from the create form itself, so route through
+    // the same list-page toggle the manage page uses.
+    setBusy(true)
+    try {
+      await patchDestination(createdID, { enabled: true })
+      toast.success('Destination added')
+      navigate('/settings/destinations')
+    } catch (err) {
+      toast.error('Could not enable destination', { description: errText(err) })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const tested = test?.ok === true
+
+  return (
+    <div className="mt-6 w-full space-y-6">
+      <Link
+        to="/settings/destinations"
+        className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+      >
+        <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+        Destinations
+      </Link>
+
+      <div className="border-b border-border pb-6">
+        <h1 className="text-xl font-semibold tracking-tight">
+          Add {kind === 'email' ? 'Email' : 'Webhook'} destination
+        </h1>
+        <p className="text-sm text-muted-foreground">kind: {kind}</p>
+      </div>
+
+      <div className="grid max-w-3xl gap-5">
+        <Field label="Name" hint="lowercase slug">
+          <Input
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value)
+              invalidate()
+            }}
+            placeholder="ops-inbox"
+            className="mt-1.5 h-10"
+          />
+        </Field>
+
+        {kind === 'email' ? (
+          <>
+            <div className="space-y-1.5">
+              <span className="text-sm font-medium text-foreground">Google connector</span>
+              <Select
+                value={connectorID}
+                onValueChange={(v) => {
+                  setConnectorID(v)
+                  invalidate()
+                }}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Choose a connected Gmail account" />
+                </SelectTrigger>
+                <SelectContent>
+                  {(connectors ?? []).map((c) => (
+                    <SelectItem key={c.id} value={c.id}>
+                      {c.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {connectors && connectors.length === 0 && (
+                <p className="text-sm text-muted-foreground">
+                  No enabled Google connectors yet — add one under Connectors first.
+                </p>
+              )}
+            </div>
+            <Field label="To" hint="recipient address">
+              <Input
+                value={to}
+                onChange={(e) => {
+                  setTo(e.target.value)
+                  invalidate()
+                }}
+                placeholder="ops@example.com"
+                className="mt-1.5 h-10"
+              />
+            </Field>
+          </>
+        ) : (
+          <>
+            <Field label="URL">
+              <Input
+                value={url}
+                onChange={(e) => {
+                  setURL(e.target.value)
+                  invalidate()
+                }}
+                placeholder="https://…/hook"
+                className="mt-1.5 h-10"
+              />
+            </Field>
+            <div className="space-y-1.5">
+              <span className="text-sm font-medium text-foreground">Format</span>
+              <Select value={format} onValueChange={(v) => setFormat(v as 'json' | 'text')}>
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="json">JSON</SelectItem>
+                  <SelectItem value="text">Plain text</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </>
+        )}
+
+        <div
+          className={
+            'flex flex-wrap items-center gap-3 rounded-xl border p-4 text-sm ' +
+            (tested
+              ? 'border-good/30 bg-good-soft text-good'
+              : test && !test.ok
+                ? 'border-destructive/30 bg-destructive/5 text-destructive'
+                : 'border-border bg-muted/40 text-muted-foreground')
+          }
+        >
+          <span className="min-w-0 flex-1 font-medium">
+            {busy
+              ? 'Testing…'
+              : tested
+                ? 'Test delivery sent, ready to add.'
+                : test && !test.ok
+                  ? `Test failed: ${test.error}. The destination was saved disabled, fix and retry.`
+                  : 'Not tested yet, run a test before adding.'}
+          </span>
+          <Button size="sm" variant="test" disabled={busy || !canTest} onClick={() => void runTest()}>
+            {busy ? 'Testing…' : 'Test send'}
+          </Button>
+        </div>
+
+        <div className="flex gap-3 pt-2">
+          <Button variant="outline" disabled={busy} onClick={() => navigate('/settings/destinations')}>
+            Cancel
+          </Button>
+          <Button disabled={!tested || busy} onClick={() => void submit()}>
+            Add destination
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/settings/DestinationEdit.tsx
+++ b/web/src/components/settings/DestinationEdit.tsx
@@ -1,0 +1,245 @@
+import { ArrowLeft01Icon, Delete02Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useCallback, useEffect, useState } from 'react'
+import { Link, Navigate, useNavigate, useParams } from 'react-router'
+import { toast } from 'sonner'
+import {
+  deleteDestination,
+  listConnectors,
+  listDestinations,
+  patchDestination,
+  testDestination,
+} from '../../api/client'
+import type { AdminConnector, Destination } from '../../api/types'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+import { Input } from '../ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { Field, Toggle } from './shared'
+import { errText } from './util'
+
+export function DestinationEdit() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+
+  const [destination, setDestination] = useState<Destination | null | undefined>(undefined)
+  const [connectors, setConnectors] = useState<AdminConnector[]>([])
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [test, setTest] = useState<{ ok: boolean; error?: string } | null>(null)
+  const [testing, setTesting] = useState(false)
+
+  // Editable config fields, seeded from the loaded destination.
+  const [to, setTo] = useState('')
+  const [connectorID, setConnectorID] = useState('')
+  const [url, setURL] = useState('')
+  const [format, setFormat] = useState<'json' | 'text'>('json')
+  const [savingConfig, setSavingConfig] = useState(false)
+
+  const refresh = useCallback(() => {
+    listDestinations()
+      .then((list) => {
+        const found = list.find((d) => d.id === id) ?? null
+        setDestination(found)
+        if (found?.kind === 'email') {
+          setConnectorID(String(found.config.connector_id ?? ''))
+          setTo(String(found.config.to ?? ''))
+        } else if (found?.kind === 'webhook') {
+          setURL(String(found.config.url ?? ''))
+          setFormat((found.config.format as 'json' | 'text') ?? 'json')
+        }
+      })
+      .catch((err: unknown) => toast.error('Could not load destination', { description: errText(err) }))
+  }, [id])
+  useEffect(refresh, [refresh])
+
+  useEffect(() => {
+    listConnectors()
+      .then((rows) => setConnectors(rows.filter((c) => c.kind === 'google' && c.enabled)))
+      .catch(() => {
+        // Non-fatal: the connector select just shows the currently
+        // stored id with no friendly name if this fails.
+      })
+  }, [])
+
+  const remove = async () => {
+    if (!destination) return
+    try {
+      await deleteDestination(destination.id)
+      toast.success('Destination removed')
+      navigate('/settings/destinations')
+    } catch (err) {
+      toast.error('Could not remove destination', { description: errText(err) })
+      setConfirmDelete(false)
+    }
+  }
+
+  const runTest = async () => {
+    if (!destination) return
+    setTesting(true)
+    setTest(null)
+    try {
+      setTest(await testDestination(destination.id))
+    } catch (err) {
+      setTest({ ok: false, error: errText(err) })
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  const toggleEnabled = (enabled: boolean) => {
+    if (!destination) return
+    patchDestination(destination.id, { enabled })
+      .then(refresh)
+      .catch((err: unknown) => toast.error('Could not update destination', { description: errText(err) }))
+  }
+
+  const saveConfig = async () => {
+    if (!destination) return
+    setSavingConfig(true)
+    try {
+      const config =
+        destination.kind === 'email' ? { connector_id: connectorID, to: to.trim() } : { url: url.trim(), format }
+      await patchDestination(destination.id, { config })
+      toast.success('Destination updated')
+      refresh()
+    } catch (err) {
+      toast.error('Could not update destination', { description: errText(err) })
+    } finally {
+      setSavingConfig(false)
+    }
+  }
+
+  if (destination === null) return <Navigate to="/settings/destinations" replace />
+  if (destination === undefined) return null
+
+  return (
+    <div className="mt-6 w-full space-y-6">
+      <Link
+        to="/settings/destinations"
+        className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+      >
+        <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+        Destinations
+      </Link>
+
+      <div className="flex items-center gap-4 border-b border-border pb-6">
+        <div className="min-w-0 flex-1">
+          <h1 className="truncate text-xl font-semibold tracking-tight">{destination.name}</h1>
+          <p className="text-sm text-muted-foreground uppercase">{destination.kind}</p>
+        </div>
+        <Button variant="destructive" onClick={() => setConfirmDelete(true)}>
+          <HugeiconsIcon icon={Delete02Icon} />
+          Delete
+        </Button>
+      </div>
+
+      <div className="grid max-w-3xl gap-5">
+        <div className="flex items-center justify-between gap-4 rounded-xl border border-border p-4">
+          <div className="min-w-0">
+            <div className="text-sm font-medium">Enabled</div>
+            <p className="text-sm text-muted-foreground">
+              Disabled destinations are skipped by mission delivery without an error.
+            </p>
+          </div>
+          <Toggle on={destination.enabled} onChange={toggleEnabled} label={`${destination.name} enabled`} />
+        </div>
+
+        <div
+          className={
+            'flex flex-wrap items-center gap-3 rounded-xl border p-4 text-sm ' +
+            (test?.ok
+              ? 'border-good/30 bg-good-soft text-good'
+              : test && !test.ok
+                ? 'border-destructive/30 bg-destructive/5 text-destructive'
+                : 'border-border bg-muted/40 text-muted-foreground')
+          }
+        >
+          <span className="min-w-0 flex-1 font-medium">
+            {testing
+              ? 'Sending test delivery…'
+              : test?.ok
+                ? 'Test delivery sent.'
+                : test && !test.ok
+                  ? `Failed: ${test.error}`
+                  : 'Not tested yet.'}
+          </span>
+          <Button size="sm" variant="test" disabled={testing} onClick={() => void runTest()}>
+            {testing ? 'Sending…' : 'Test send'}
+          </Button>
+        </div>
+
+        {destination.kind === 'email' ? (
+          <>
+            <div className="space-y-1.5">
+              <span className="text-sm font-medium text-foreground">Google connector</span>
+              <Select value={connectorID} onValueChange={setConnectorID}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Choose a connected Gmail account" />
+                </SelectTrigger>
+                <SelectContent>
+                  {connectors.map((c) => (
+                    <SelectItem key={c.id} value={c.id}>
+                      {c.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Field label="To">
+              <Input value={to} onChange={(e) => setTo(e.target.value)} className="mt-1.5 h-10" />
+            </Field>
+          </>
+        ) : (
+          <>
+            <Field label="URL">
+              <Input value={url} onChange={(e) => setURL(e.target.value)} className="mt-1.5 h-10" />
+            </Field>
+            <div className="space-y-1.5">
+              <span className="text-sm font-medium text-foreground">Format</span>
+              <Select value={format} onValueChange={(v) => setFormat(v as 'json' | 'text')}>
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="json">JSON</SelectItem>
+                  <SelectItem value="text">Plain text</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </>
+        )}
+
+        <div className="flex gap-3 pt-2">
+          <Button disabled={savingConfig} onClick={() => void saveConfig()}>
+            {savingConfig ? 'Saving…' : 'Save changes'}
+          </Button>
+        </div>
+      </div>
+
+      <Dialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete {destination.name}?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Removes the destination. Refused while any in-progress mission still delivers to it.
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmDelete(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={() => void remove()}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/web/src/components/settings/DestinationsList.tsx
+++ b/web/src/components/settings/DestinationsList.tsx
@@ -1,0 +1,197 @@
+import { Mail01Icon, GlobalIcon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router'
+import { toast } from 'sonner'
+import { deleteDestination, listDestinations, patchDestination, testDestination } from '../../api/client'
+import type { Destination } from '../../api/types'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog'
+import { Toggle } from './shared'
+import { errText } from './util'
+
+const kindIcon = { email: Mail01Icon, webhook: GlobalIcon, telegram: GlobalIcon } as const
+
+export function DestinationsList() {
+  const [destinations, setDestinations] = useState<Destination[]>([])
+  const navigate = useNavigate()
+
+  const refresh = useCallback(() => {
+    listDestinations()
+      .then(setDestinations)
+      .catch((err: unknown) => toast.error('Could not load destinations', { description: errText(err) }))
+  }, [])
+  useEffect(refresh, [refresh])
+
+  return (
+    <div className="mt-6 space-y-8">
+      <section className="space-y-3">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {destinations.length > 0 ? `Your destinations · ${destinations.length}` : 'Your destinations'}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Where mission results go. Attach one or more to a mission and its outcome digest
+          delivers there once it finishes.
+        </p>
+        {destinations.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-border p-10 text-center text-sm text-muted-foreground">
+            No destinations yet, add one below.
+          </div>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {destinations.map((d) => (
+              <DestinationCard
+                key={d.id}
+                destination={d}
+                onChanged={refresh}
+                onManage={() => navigate(`/settings/destinations/${d.id}`)}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Add a destination
+        </h2>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <button
+            type="button"
+            onClick={() => navigate('/settings/destinations/new/email')}
+            className="flex items-center gap-3 rounded-xl border border-dashed border-border p-4 text-left transition hover:border-brand hover:bg-muted/50"
+          >
+            <HugeiconsIcon icon={Mail01Icon} className="size-9" />
+            <span className="min-w-0">
+              <span className="block text-sm font-semibold">Email</span>
+              <span className="block truncate text-sm text-muted-foreground">
+                Sends via a connected Gmail account
+              </span>
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate('/settings/destinations/new/webhook')}
+            className="flex items-center gap-3 rounded-xl border border-dashed border-border p-4 text-left transition hover:border-brand hover:bg-muted/50"
+          >
+            <HugeiconsIcon icon={GlobalIcon} className="size-9" />
+            <span className="min-w-0">
+              <span className="block text-sm font-semibold">Webhook</span>
+              <span className="block truncate text-sm text-muted-foreground">
+                POSTs the digest as JSON or plain text
+              </span>
+            </span>
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function DestinationCard({
+  destination,
+  onChanged,
+  onManage,
+}: {
+  destination: Destination
+  onChanged: () => void
+  onManage: () => void
+}) {
+  const [testing, setTesting] = useState(false)
+  const [test, setTest] = useState<{ ok: boolean; error?: string } | null>(null)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  const toggle = (enabled: boolean) => {
+    patchDestination(destination.id, { enabled }).then(onChanged, (err: unknown) =>
+      toast.error('Could not update destination', { description: errText(err) }),
+    )
+  }
+
+  const runTest = async () => {
+    setTesting(true)
+    setTest(null)
+    try {
+      setTest(await testDestination(destination.id))
+    } catch (err) {
+      setTest({ ok: false, error: errText(err) })
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  const remove = async () => {
+    try {
+      await deleteDestination(destination.id)
+      toast.success('Destination removed')
+      onChanged()
+    } catch (err) {
+      toast.error('Could not remove destination', { description: errText(err) })
+    } finally {
+      setConfirmDelete(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 shadow-sm transition hover:shadow-md">
+      <div className="flex items-center gap-3">
+        <HugeiconsIcon icon={kindIcon[destination.kind]} className="size-9" />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-semibold">{destination.name}</div>
+          <div className="text-xs text-muted-foreground uppercase">{destination.kind}</div>
+        </div>
+        <Toggle on={destination.enabled} onChange={toggle} label={`${destination.name} enabled`} />
+      </div>
+
+      <div className="truncate text-xs text-muted-foreground">
+        {destination.kind === 'email'
+          ? String(destination.config.to ?? '')
+          : String(destination.config.url ?? '')}
+      </div>
+
+      {test && (
+        <div
+          className={`rounded-lg border p-2 text-xs ${test.ok ? 'border-good/30 bg-good-soft text-good' : 'border-destructive/30 bg-destructive/5 text-destructive'}`}
+        >
+          {test.ok ? 'Test delivery sent' : `Failed: ${test.error}`}
+        </div>
+      )}
+
+      <div className="mt-auto flex items-center gap-2 pt-1">
+        <Button size="sm" variant="test" disabled={testing} onClick={() => void runTest()} className="flex-1">
+          {testing ? 'Sending…' : 'Test send'}
+        </Button>
+        <Button size="sm" variant="outline" onClick={onManage} className="flex-1">
+          Manage
+        </Button>
+        <Button size="sm" variant="destructive" onClick={() => setConfirmDelete(true)}>
+          Delete
+        </Button>
+      </div>
+
+      <Dialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete {destination.name}?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Removes the destination. Refused while any in-progress mission still delivers to it.
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmDelete(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={() => void remove()}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/web/src/components/settings/DestinationsTab.test.tsx
+++ b/web/src/components/settings/DestinationsTab.test.tsx
@@ -1,0 +1,208 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AdminConnector, Destination } from '../../api/types'
+import { DestinationsTab } from './DestinationsTab'
+
+vi.mock('../../api/client', () => ({
+  createDestination: vi.fn(),
+  deleteDestination: vi.fn(),
+  listConnectors: vi.fn(),
+  listDestinations: vi.fn(),
+  patchDestination: vi.fn(),
+  testDestination: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+import {
+  createDestination,
+  deleteDestination,
+  listConnectors,
+  listDestinations,
+  patchDestination,
+  testDestination,
+} from '../../api/client'
+import { toast } from 'sonner'
+
+const webhookDestination: Destination = {
+  id: 'd1',
+  name: 'ops-hook',
+  kind: 'webhook',
+  config: { url: 'https://example.com/hook', format: 'json' },
+  credential_ref: '',
+  enabled: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const googleConnector: AdminConnector = {
+  id: 'c1',
+  name: 'gmail',
+  kind: 'google',
+  config: { scopes: ['https://www.googleapis.com/auth/gmail.send'] },
+  credential_ref: 'GMAIL_GOOGLE_OAUTH',
+  enabled: true,
+  sensitive: false,
+}
+
+function renderTab(entry = '/settings/destinations') {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/settings/destinations/*" element={<DestinationsTab />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  vi.clearAllMocks()
+  vi.mocked(listDestinations).mockResolvedValue([])
+  vi.mocked(listConnectors).mockResolvedValue([googleConnector])
+})
+
+describe('Destinations tab', () => {
+  it('shows the empty state and the add tiles when there are none', async () => {
+    renderTab()
+    expect(await screen.findByText('Your destinations')).toBeTruthy()
+    expect(screen.getByText('No destinations yet, add one below.')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /^Email/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /^Webhook/ })).toBeTruthy()
+  })
+
+  it('renders a configured destination card', async () => {
+    vi.mocked(listDestinations).mockResolvedValue([webhookDestination])
+    renderTab()
+    expect(await screen.findByText('Your destinations · 1')).toBeTruthy()
+    expect(screen.getByText('ops-hook')).toBeTruthy()
+    expect(screen.getByText('https://example.com/hook')).toBeTruthy()
+  })
+
+  it('toggles a destination enabled from the list card', async () => {
+    vi.mocked(listDestinations).mockResolvedValue([webhookDestination])
+    vi.mocked(patchDestination).mockResolvedValue()
+    renderTab()
+
+    const toggle = await screen.findByRole('switch', { name: 'ops-hook enabled' })
+    fireEvent.click(toggle)
+
+    await waitFor(() => expect(patchDestination).toHaveBeenCalledWith('d1', { enabled: false }))
+  })
+
+  it('test-sends from the list card and shows success', async () => {
+    vi.mocked(listDestinations).mockResolvedValue([webhookDestination])
+    vi.mocked(testDestination).mockResolvedValue({ ok: true })
+    renderTab()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Test send' }))
+    expect(await screen.findByText('Test delivery sent')).toBeTruthy()
+    expect(testDestination).toHaveBeenCalledWith('d1')
+  })
+
+  it('test-sends from the list card and shows the failure reason', async () => {
+    vi.mocked(listDestinations).mockResolvedValue([webhookDestination])
+    vi.mocked(testDestination).mockResolvedValue({ ok: false, error: 'connection refused' })
+    renderTab()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Test send' }))
+    expect(await screen.findByText(/Failed: connection refused/)).toBeTruthy()
+  })
+
+  it('surfaces the 409 referenced error when delete is refused', async () => {
+    vi.mocked(listDestinations).mockResolvedValue([webhookDestination])
+    vi.mocked(deleteDestination).mockRejectedValue(
+      new Error('destination is referenced by an active mission'),
+    )
+    renderTab()
+
+    // Opens the confirm dialog.
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+    // The dialog's own confirm button is the second "Delete" in the
+    // document once it's open (card's own button + dialog's).
+    const confirmButtons = await screen.findAllByRole('button', { name: 'Delete' })
+    fireEvent.click(confirmButtons[confirmButtons.length - 1])
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        'Could not remove destination',
+        expect.objectContaining({ description: expect.stringContaining('referenced by an active mission') }),
+      ),
+    )
+  })
+
+  it('adds a webhook destination: create disabled, test, enable', async () => {
+    vi.mocked(createDestination).mockResolvedValue('d2')
+    vi.mocked(testDestination).mockResolvedValue({ ok: true })
+    vi.mocked(patchDestination).mockResolvedValue()
+
+    renderTab()
+    fireEvent.click(await screen.findByRole('button', { name: /^Webhook/ }))
+    fireEvent.change(await screen.findByPlaceholderText('ops-inbox'), { target: { value: 'ops-hook' } })
+    fireEvent.change(screen.getByPlaceholderText('https://…/hook'), {
+      target: { value: 'https://example.com/hook' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Test send' }))
+
+    const addButton = await screen.findByRole('button', { name: 'Add destination' })
+    await waitFor(() => expect((addButton as HTMLButtonElement).disabled).toBe(false))
+    fireEvent.click(addButton)
+
+    await waitFor(() => expect(patchDestination).toHaveBeenCalledWith('d2', { enabled: true }))
+    expect(createDestination).toHaveBeenCalledWith({
+      name: 'ops-hook',
+      kind: 'webhook',
+      config: { url: 'https://example.com/hook', format: 'json' },
+      enabled: false,
+    })
+  })
+
+  it('keeps a failing webhook destination disabled and says why', async () => {
+    vi.mocked(createDestination).mockResolvedValue('d2')
+    vi.mocked(testDestination).mockResolvedValue({ ok: false, error: 'status 500' })
+
+    renderTab()
+    fireEvent.click(await screen.findByRole('button', { name: /^Webhook/ }))
+    fireEvent.change(await screen.findByPlaceholderText('ops-inbox'), { target: { value: 'ops-hook' } })
+    fireEvent.change(screen.getByPlaceholderText('https://…/hook'), {
+      target: { value: 'https://example.com/hook' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Test send' }))
+
+    expect(await screen.findByText(/Test failed: status 500/)).toBeTruthy()
+    expect(patchDestination).not.toHaveBeenCalled()
+    expect((screen.getByRole('button', { name: 'Add destination' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+  })
+
+  it('adds an email destination with a picked google connector', async () => {
+    vi.mocked(createDestination).mockResolvedValue('d3')
+    vi.mocked(testDestination).mockResolvedValue({ ok: true })
+    vi.mocked(patchDestination).mockResolvedValue()
+
+    renderTab()
+    fireEvent.click(await screen.findByRole('button', { name: /^Email/ }))
+    fireEvent.change(await screen.findByPlaceholderText('ops-inbox'), { target: { value: 'ops-inbox' } })
+    fireEvent.click(await screen.findByText('Choose a connected Gmail account'))
+    fireEvent.click(await screen.findByRole('option', { name: 'gmail' }))
+    fireEvent.change(screen.getByPlaceholderText('ops@example.com'), {
+      target: { value: 'ops@example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Test send' }))
+
+    const addButton = await screen.findByRole('button', { name: 'Add destination' })
+    await waitFor(() => expect((addButton as HTMLButtonElement).disabled).toBe(false))
+    fireEvent.click(addButton)
+
+    await waitFor(() => expect(patchDestination).toHaveBeenCalledWith('d3', { enabled: true }))
+    expect(createDestination).toHaveBeenCalledWith({
+      name: 'ops-inbox',
+      kind: 'email',
+      config: { connector_id: 'c1', to: 'ops@example.com' },
+      enabled: false,
+    })
+  })
+})

--- a/web/src/components/settings/DestinationsTab.tsx
+++ b/web/src/components/settings/DestinationsTab.tsx
@@ -1,0 +1,17 @@
+import { Route, Routes } from 'react-router'
+import { DestinationAdd } from './DestinationAdd'
+import { DestinationEdit } from './DestinationEdit'
+import { DestinationsList } from './DestinationsList'
+
+// DestinationsTab is the route container for the destinations area: a
+// list screen, a dedicated add screen, and a dedicated manage screen —
+// mirrors ConnectorsTab's file split.
+export function DestinationsTab() {
+  return (
+    <Routes>
+      <Route path="/" element={<DestinationsList />} />
+      <Route path="new/:kind" element={<DestinationAdd />} />
+      <Route path=":id" element={<DestinationEdit />} />
+    </Routes>
+  )
+}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes, useParams } from 'react-router'
 import { AgentsTab } from '../components/settings/AgentsTab'
 import { ConnectorsTab } from '../components/settings/ConnectorsTab'
 import { CredentialsTab } from '../components/settings/CredentialsTab'
+import { DestinationsTab } from '../components/settings/DestinationsTab'
 import { FeaturesTab } from '../components/settings/FeaturesTab'
 import { ProvidersTab } from '../components/settings/ProvidersTab'
 import { RoutesTab } from '../components/settings/RoutesTab'
@@ -48,6 +49,12 @@ export const settingsAreas = [
     label: 'Credentials',
     description: 'API keys and tokens stored for providers and connectors.',
     render: CredentialsTab,
+  },
+  {
+    key: 'destinations',
+    label: 'Destinations',
+    description: 'Where mission results get delivered: email, webhook.',
+    render: DestinationsTab,
   },
   {
     key: 'features',


### PR DESCRIPTION
Destinations are operator-created, named outbound sinks — the content-delivery counterpart to the status-only notify webhook. A mission created with destination_ids gets its outcome digest (plus mission/branch/PR links) rendered and delivered harness-side on the terminal done transition, next to the notifier: deterministic, bounded retries, an append-only mission.delivered/mission.delivery_failed event per destination, and never any effect on mission state.

The exfiltration guard is structural: the model never supplies an address. Destinations exist only via the admin API/Settings UI; missions reference them by id, validated at create.

Slice 1 ships email (rides a google connector's authed send path) and webhook (JSON or text POST) kinds, the destinations Settings page with test-send, and the mission-form multi-select. Telegram, artifact attachment, and the deliver tool follow in later slices (plan doc, 2026-08-19).

web_base_url settings value controls whether mission links render; webhook auth is deliberately omitted until brain grows a credential-value resolution path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789754527&installation_model_id=431401&pr_number=256&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F256&signature=dcddac58c955742243e9b60cf706ad71ba83f21e5b4bd9633ff62fd6296b8703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->