### PR TITLE
feat: destinations on schedules

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -281,13 +281,16 @@ func main() {
 		}
 		return name
 	}
-	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, fxStore, gwc, secrets, conns, mc, app.Log)
+	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub, missionScheduler := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, fxStore, gwc, secrets, conns, mc, app.Log)
 	if missionDriver != nil {
 		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, app.Log)
 	}
 	destinationStore, destinationDeliverer := buildDestinations(app.DB, conns, goog, flags, missionStore, app.Log)
 	if missionDriver != nil && destinationDeliverer != nil {
 		missionDriver.SetDestinationDeliver(destinationDeliverer.Deliver)
+	}
+	if missionScheduler != nil && destinationStore != nil {
+		missionScheduler.SetDestinationEnabled(destinationStore.EnabledByID)
 	}
 	// Chat-facing mission tools (D-0xx: "is mission X done?" / "push
 	// mission X"): registered here, not inside buildAgent, since both
@@ -743,11 +746,11 @@ func intersectReadOnlyConnectorTools(allow []string, available []*tools.Tool) []
 // time) so an agent edited after the fact still applies. The hub
 // lives inside the same gate as everything else here — no missions,
 // no push events either.
-func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, agentReg *agents.Store, routeForRole func(context.Context, string) string, fxStore *fxrates.Store, gwc *gwclient.Client, secrets *secretstore.Store, conns *connectors.Manager, mc *memclient.Client, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace, *missions.Hub) {
+func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, agentReg *agents.Store, routeForRole func(context.Context, string) string, fxStore *fxrates.Store, gwc *gwclient.Client, secrets *secretstore.Store, conns *connectors.Manager, mc *memclient.Client, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace, *missions.Hub, *missions.Scheduler) {
 	root := os.Getenv("WORKSPACES")
 	if root == "" {
 		log.Info("WORKSPACES not set; missions disabled")
-		return nil, nil, nil, nil, nil
+		return nil, nil, nil, nil, nil, nil
 	}
 	hub := missions.NewHub()
 	store := missions.NewStore(db, log)
@@ -894,9 +897,9 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 		_, err := gwc.ResolveRoute(ctx, name, "")
 		return err == nil
 	}
-	scheduler := missions.NewScheduler(db, store, resolveAgent, schedulerEnabled, routeForRole, routeExists, flags.CodingExecutor, log)
+	scheduler := missions.NewScheduler(db, store, resolveAgent, schedulerEnabled, routeForRole, routeExists, flags.CodingExecutor, nil, log)
 	go scheduler.Run(ctx)
-	return store, driver, notifier, workspace, hub
+	return store, driver, notifier, workspace, hub, scheduler
 }
 
 // connsPRSource adapts *connectors.Manager to missions.PRSource for the

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -146,15 +146,18 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 		destLookup = destinationStore
 	}
 	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret, routeForRole, missionClassify, codingExecutorDefault, resolveExecutorOptions, nameMission, topModels, conns, missionAttachments, markitdownURL, destLookup)
-	a.registerSchedules(srv.Handle, missionStore)
-	// destinationRefs is *missions.Store itself (ActiveMissionReferencesDestination) —
+	a.registerSchedules(srv.Handle, missionStore, destLookup)
+	// destinationRefs/destinationScheduleRefs are *missions.Store itself
+	// (ActiveMissionReferencesDestination / ScheduleReferencingDestinationID) —
 	// nil-boxed the same way connLister is above so a nil missionStore
-	// keeps registerDestinations' refs check honest.
+	// keeps registerDestinations' refs checks honest.
 	var destRefs destinationRefs
+	var destScheduleRefs destinationScheduleRefs
 	if missionStore != nil {
 		destRefs = missionStore
+		destScheduleRefs = missionStore
 	}
-	a.registerDestinations(srv.Handle, destinationStore, destRefs, destinationTest)
+	a.registerDestinations(srv.Handle, destinationStore, destRefs, destScheduleRefs, destinationTest)
 	a.registerEvents(srv.Handle, hub)
 	a.registerTranscribe(srv.Handle, whisperClient, whisperURL)
 	a.registerAttachments(srv.Handle, attachmentStore)

--- a/internal/brain/api/destinations.go
+++ b/internal/brain/api/destinations.go
@@ -17,6 +17,13 @@ type destinationRefs interface {
 	ActiveMissionReferencesDestination(ctx context.Context, destinationID string) (bool, error)
 }
 
+// destinationScheduleRefs is the narrow slice of *missions.Store the
+// delete guard needs to also refuse deletion while an enabled
+// schedule's mission_template still references the destination.
+type destinationScheduleRefs interface {
+	ScheduleReferencingDestinationID(ctx context.Context, destinationID string) (name string, ok bool, err error)
+}
+
 // destinationTester sends a canned test payload through a
 // destination's real adapter — destinations.Deliverer's own
 // deliverOne machinery isn't reused here since a test send must report
@@ -30,11 +37,11 @@ type destinationTester interface {
 // surface — served locally like connectors, nil-gated on store (no
 // WORKSPACES/missions disables destinations too, since delivery has no
 // meaning without missions).
-func (a *API) registerDestinations(handle func(pattern string, h http.Handler), store *destinations.Store, refs destinationRefs, tester destinationTester) {
+func (a *API) registerDestinations(handle func(pattern string, h http.Handler), store *destinations.Store, refs destinationRefs, scheduleRefs destinationScheduleRefs, tester destinationTester) {
 	if store == nil {
 		return
 	}
-	h := &destinationAPI{store: store, refs: refs, tester: tester}
+	h := &destinationAPI{store: store, refs: refs, scheduleRefs: scheduleRefs, tester: tester}
 	handle("GET /v1/admin/destinations", a.auth(http.HandlerFunc(h.list)))
 	handle("POST /v1/admin/destinations", a.auth(http.HandlerFunc(h.create)))
 	handle("PATCH /v1/admin/destinations/{id}", a.auth(http.HandlerFunc(h.patch)))
@@ -43,9 +50,10 @@ func (a *API) registerDestinations(handle func(pattern string, h http.Handler), 
 }
 
 type destinationAPI struct {
-	store  *destinations.Store
-	refs   destinationRefs
-	tester destinationTester
+	store        *destinations.Store
+	refs         destinationRefs
+	scheduleRefs destinationScheduleRefs
+	tester       destinationTester
 }
 
 func failDestination(w http.ResponseWriter, err error) {
@@ -95,11 +103,12 @@ func (h *destinationAPI) patch(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// delete refuses with 409 while any non-terminal mission references
-// this destination — historical (terminal) mission references never
-// block deletion.
+// delete refuses with 409 while any non-terminal mission, or any
+// enabled schedule's mission_template, still references this
+// destination (naming the schedule) — historical (terminal) mission
+// references and disabled schedules never block deletion.
 func (h *destinationAPI) delete(w http.ResponseWriter, r *http.Request) {
-	if err := h.store.Delete(r.Context(), r.PathValue("id"), h.refs); err != nil {
+	if err := h.store.Delete(r.Context(), r.PathValue("id"), h.refs, h.scheduleRefs); err != nil {
 		failDestination(w, err)
 		return
 	}

--- a/internal/brain/api/destinations_test.go
+++ b/internal/brain/api/destinations_test.go
@@ -13,7 +13,7 @@ func TestDestinationsEndpointsUnmountedWhenStoreNil(t *testing.T) {
 	t.Parallel()
 	a, _, _ := testAPI(t, "tok", nil)
 	m := mux(a)
-	a.registerDestinations(m.Handle, nil, nil, nil)
+	a.registerDestinations(m.Handle, nil, nil, nil, nil)
 
 	for _, req := range []struct{ method, path string }{
 		{"GET", "/v1/admin/destinations"},
@@ -68,7 +68,7 @@ func TestDestinationTestHandler(t *testing.T) {
 	m := mux(a)
 
 	t.Run("nil tester 404s", func(t *testing.T) {
-		a.registerDestinations(m.Handle, nil, nil, nil)
+		a.registerDestinations(m.Handle, nil, nil, nil, nil)
 		// store is nil so the whole surface is unmounted; nothing to
 		// assert beyond the unmounted test above — covered there.
 	})

--- a/internal/brain/api/schedules.go
+++ b/internal/brain/api/schedules.go
@@ -1,9 +1,12 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
@@ -13,12 +16,15 @@ import (
 // schedules is missions' domain (the table lives in
 // internal/brain/missions), same nil-gating pattern as agents/
 // connectors. store is *missions.Store — schedules and missions share
-// one store since schedules is this package's own table.
-func (a *API) registerSchedules(handle func(pattern string, h http.Handler), store *missions.Store) {
+// one store since schedules is this package's own table. destinations
+// validates a create/patch request's mission_template.destination_ids
+// (D-061) the same way missionAPI.validateDestinationIDs does — nil
+// (destinations disabled) rejects any non-empty destination_ids.
+func (a *API) registerSchedules(handle func(pattern string, h http.Handler), store *missions.Store, destinations destinationLookup) {
 	if store == nil {
 		return
 	}
-	h := &scheduleAPI{store: store}
+	h := &scheduleAPI{store: store, destinations: destinations}
 	handle("GET /v1/schedules", a.auth(http.HandlerFunc(h.list)))
 	handle("POST /v1/schedules", a.auth(http.HandlerFunc(h.create)))
 	handle("PATCH /v1/schedules/{id}", a.auth(http.HandlerFunc(h.patch)))
@@ -26,7 +32,35 @@ func (a *API) registerSchedules(handle func(pattern string, h http.Handler), sto
 }
 
 type scheduleAPI struct {
-	store *missions.Store
+	store        *missions.Store
+	destinations destinationLookup
+}
+
+// validateDestinationIDs rejects any id that doesn't name a real,
+// enabled destinations row — same rule and error shape as
+// missionAPI.validateDestinationIDs (api/missions.go), applied to a
+// schedule's mission_template instead of a one-off mission create.
+func (h *scheduleAPI) validateDestinationIDs(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	if h.destinations == nil {
+		return fmt.Errorf("destinations are not enabled")
+	}
+	var invalid []string
+	for _, id := range ids {
+		ok, err := h.destinations.EnabledByID(ctx, id)
+		if err != nil {
+			return fmt.Errorf("mission_template.destination_ids: %w", err)
+		}
+		if !ok {
+			invalid = append(invalid, id)
+		}
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("unknown or disabled destination id(s): %s", strings.Join(invalid, ", "))
+	}
+	return nil
 }
 
 func failSchedule(w http.ResponseWriter, err error) {
@@ -95,6 +129,10 @@ func (h *scheduleAPI) create(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
+	if err := h.validateDestinationIDs(r.Context(), req.MissionTemplate.DestinationIDs); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
 	enabled := true
 	if req.Enabled != nil {
 		enabled = *req.Enabled
@@ -128,6 +166,12 @@ func (h *scheduleAPI) patch(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
+	}
+	if req.MissionTemplate != nil {
+		if err := h.validateDestinationIDs(r.Context(), req.MissionTemplate.DestinationIDs); err != nil {
+			jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
 	}
 	p := missions.SchedulePatch{
 		Name: req.Name, Cron: req.Cron,

--- a/internal/brain/api/schedules_test.go
+++ b/internal/brain/api/schedules_test.go
@@ -1,6 +1,10 @@
 package api
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -8,11 +12,27 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
 )
 
+// fakeDestinationLookup is a destinationLookup fake keyed by id ->
+// enabled, so validateDestinationIDs' create/patch tests don't need a
+// real *destinations.Store/Postgres.
+type fakeDestinationLookup map[string]bool
+
+func (f fakeDestinationLookup) EnabledByID(_ context.Context, id string) (bool, error) {
+	ok, exists := f[id]
+	return exists && ok, nil
+}
+
+type erroringDestinationLookup struct{}
+
+func (erroringDestinationLookup) EnabledByID(context.Context, string) (bool, error) {
+	return false, errors.New("lookup failed")
+}
+
 func TestSchedulesEndpointsUnmountedWhenStoreNil(t *testing.T) {
 	t.Parallel()
 	a, _, _ := testAPI(t, "tok", nil)
 	m := mux(a)
-	a.registerSchedules(m.Handle, nil)
+	a.registerSchedules(m.Handle, nil, nil)
 
 	for _, req := range []struct{ method, path string }{
 		{"GET", "/v1/schedules"},
@@ -62,5 +82,94 @@ func TestDecorateNextRun(t *testing.T) {
 	view = decorate(sc)
 	if view.NextRun != nil {
 		t.Fatalf("NextRun for invalid cron = %v, want nil", view.NextRun)
+	}
+}
+
+func TestScheduleValidateDestinationIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty ids always pass, even with destinations disabled", func(t *testing.T) {
+		t.Parallel()
+		h := &scheduleAPI{}
+		if err := h.validateDestinationIDs(t.Context(), nil); err != nil {
+			t.Fatalf("validateDestinationIDs(nil) = %v, want nil", err)
+		}
+	})
+
+	t.Run("nil destinations rejects any non-empty ids", func(t *testing.T) {
+		t.Parallel()
+		h := &scheduleAPI{}
+		err := h.validateDestinationIDs(t.Context(), []string{"d1"})
+		if err == nil {
+			t.Fatal("validateDestinationIDs with destinations disabled = nil, want error")
+		}
+	})
+
+	t.Run("unknown or disabled id rejected, naming it", func(t *testing.T) {
+		t.Parallel()
+		h := &scheduleAPI{destinations: fakeDestinationLookup{"d1": true, "d2": false}}
+		err := h.validateDestinationIDs(t.Context(), []string{"d1", "d2", "d3"})
+		if err == nil {
+			t.Fatal("validateDestinationIDs = nil, want error naming d2 and d3")
+		}
+		msg := err.Error()
+		if !bytes.Contains([]byte(msg), []byte("d2")) || !bytes.Contains([]byte(msg), []byte("d3")) {
+			t.Fatalf("error %q does not name both invalid ids", msg)
+		}
+	})
+
+	t.Run("all enabled ids pass", func(t *testing.T) {
+		t.Parallel()
+		h := &scheduleAPI{destinations: fakeDestinationLookup{"d1": true, "d2": true}}
+		if err := h.validateDestinationIDs(t.Context(), []string{"d1", "d2"}); err != nil {
+			t.Fatalf("validateDestinationIDs = %v, want nil", err)
+		}
+	})
+
+	t.Run("lookup error propagates", func(t *testing.T) {
+		t.Parallel()
+		h := &scheduleAPI{destinations: erroringDestinationLookup{}}
+		if err := h.validateDestinationIDs(t.Context(), []string{"d1"}); err == nil {
+			t.Fatal("validateDestinationIDs = nil, want propagated lookup error")
+		}
+	})
+}
+
+// TestScheduleCreateRejectsInvalidDestinationIDs exercises the HTTP
+// handler end to end for the rejection path only — validation runs
+// before h.store is ever touched, so a nil store is fine here (the
+// success path needs a real Postgres-backed store and is covered by
+// the integration suite instead).
+func TestScheduleCreateRejectsInvalidDestinationIDs(t *testing.T) {
+	t.Parallel()
+	h := &scheduleAPI{destinations: fakeDestinationLookup{"d1": true}}
+	body, _ := json.Marshal(createScheduleRequest{
+		Name: "daily", Cron: "0 7 * * *",
+		MissionTemplate: missions.MissionTemplate{Goal: "g", Kind: "general", DestinationIDs: []string{"d1", "unknown"}},
+	})
+	req := httptest.NewRequest("POST", "/v1/schedules", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.create(w, req)
+	if w.Code != 400 {
+		t.Fatalf("create with an unknown destination id = %d, want 400", w.Code)
+	}
+}
+
+// TestSchedulePatchRejectsInvalidDestinationIDs mirrors the create
+// test for PATCH — an omitted mission_template must skip validation
+// entirely (nil pointer means "leave unchanged"), only a present one
+// is checked.
+func TestSchedulePatchRejectsInvalidDestinationIDs(t *testing.T) {
+	t.Parallel()
+	h := &scheduleAPI{destinations: fakeDestinationLookup{"d1": false}}
+	body, _ := json.Marshal(patchScheduleRequest{
+		MissionTemplate: &missions.MissionTemplate{Goal: "g", Kind: "general", DestinationIDs: []string{"d1"}},
+	})
+	req := httptest.NewRequest("PATCH", "/v1/schedules/abc", bytes.NewReader(body))
+	req.SetPathValue("id", "abc")
+	w := httptest.NewRecorder()
+	h.patch(w, req)
+	if w.Code != 400 {
+		t.Fatalf("patch with a disabled destination id = %d, want 400", w.Code)
 	}
 }

--- a/internal/brain/destinations/destinations.go
+++ b/internal/brain/destinations/destinations.go
@@ -285,10 +285,23 @@ type missionReferenceChecker interface {
 	ActiveMissionReferencesDestination(ctx context.Context, destinationID string) (bool, error)
 }
 
+// scheduleReferenceChecker is the narrow slice of *missions.Store
+// Delete needs to refuse removing a destination still referenced by an
+// enabled schedule's mission_template — same interface-boundary
+// reasoning as missionReferenceChecker. Returns the schedule's name
+// (not just a bool) so Delete's error can name it, same reason the
+// mission-side check settles for a bare bool: a mission has no
+// operator-facing name worth surfacing, a schedule does.
+type scheduleReferenceChecker interface {
+	ScheduleReferencingDestinationID(ctx context.Context, destinationID string) (name string, ok bool, err error)
+}
+
 // Delete removes a destination, refusing with ErrReferenced while any
-// non-terminal mission's destination_ids still names it — a historical
-// (terminal) mission's reference never blocks deletion.
-func (s *Store) Delete(ctx context.Context, id string, refs missionReferenceChecker) error {
+// non-terminal mission's destination_ids still names it, or any
+// enabled schedule's mission_template still names it (naming the
+// schedule in the error) — a historical (terminal) mission's
+// reference, or a disabled schedule's, never blocks deletion.
+func (s *Store) Delete(ctx context.Context, id string, refs missionReferenceChecker, scheduleRefs scheduleReferenceChecker) error {
 	if refs != nil {
 		referenced, err := refs.ActiveMissionReferencesDestination(ctx, id)
 		if err != nil {
@@ -296,6 +309,15 @@ func (s *Store) Delete(ctx context.Context, id string, refs missionReferenceChec
 		}
 		if referenced {
 			return ErrReferenced
+		}
+	}
+	if scheduleRefs != nil {
+		name, referenced, err := scheduleRefs.ScheduleReferencingDestinationID(ctx, id)
+		if err != nil {
+			return fmt.Errorf("destinations delete: check schedule references: %w", err)
+		}
+		if referenced {
+			return fmt.Errorf("%w: schedule %q", ErrReferenced, name)
 		}
 	}
 	db, err := s.db.Get()

--- a/internal/brain/destinations/destinations_integration_test.go
+++ b/internal/brain/destinations/destinations_integration_test.go
@@ -106,7 +106,7 @@ func TestStoreCRUDIntegration(t *testing.T) {
 		t.Fatalf("EnabledByID after disable = %v, %v; want false, nil", enabled, err)
 	}
 
-	if err := store.Delete(ctx, id, nil); err != nil {
+	if err := store.Delete(ctx, id, nil, nil); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
 	if _, err := store.Get(ctx, id); err == nil {

--- a/internal/brain/destinations/destinations_test.go
+++ b/internal/brain/destinations/destinations_test.go
@@ -1,6 +1,7 @@
 package destinations
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -124,4 +125,72 @@ func TestValidateEmailNoConnectors(t *testing.T) {
 	if err := validate(t.Context(), nil, d); err == nil {
 		t.Fatal("expected error when connectors are disabled")
 	}
+}
+
+// fakeMissionRefs/fakeScheduleRefs let TestDeleteReferenceGuards
+// exercise Delete's two reference checks without a real Postgres pool
+// — both fakes return before Delete ever reaches s.db.Get() when they
+// report a reference, which is the only path this test needs (a
+// non-referenced Delete would go on to hit the db and belongs in the
+// integration suite instead).
+type fakeMissionRefs struct {
+	referenced bool
+	err        error
+}
+
+func (f fakeMissionRefs) ActiveMissionReferencesDestination(context.Context, string) (bool, error) {
+	return f.referenced, f.err
+}
+
+type fakeScheduleRefs struct {
+	name       string
+	referenced bool
+	err        error
+}
+
+func (f fakeScheduleRefs) ScheduleReferencingDestinationID(context.Context, string) (string, bool, error) {
+	return f.name, f.referenced, f.err
+}
+
+func TestDeleteReferenceGuards(t *testing.T) {
+	t.Parallel()
+
+	t.Run("active mission reference refuses with ErrReferenced", func(t *testing.T) {
+		t.Parallel()
+		s := &Store{}
+		err := s.Delete(t.Context(), "d1", fakeMissionRefs{referenced: true}, nil)
+		if !errors.Is(err, ErrReferenced) {
+			t.Fatalf("Delete = %v, want ErrReferenced", err)
+		}
+	})
+
+	t.Run("mission reference lookup error propagates", func(t *testing.T) {
+		t.Parallel()
+		s := &Store{}
+		err := s.Delete(t.Context(), "d1", fakeMissionRefs{err: errors.New("db down")}, nil)
+		if err == nil || errors.Is(err, ErrReferenced) {
+			t.Fatalf("Delete = %v, want a propagated (non-ErrReferenced) error", err)
+		}
+	})
+
+	t.Run("enabled schedule reference refuses with ErrReferenced naming the schedule", func(t *testing.T) {
+		t.Parallel()
+		s := &Store{}
+		err := s.Delete(t.Context(), "d1", nil, fakeScheduleRefs{name: "daily-brief", referenced: true})
+		if !errors.Is(err, ErrReferenced) {
+			t.Fatalf("Delete = %v, want ErrReferenced", err)
+		}
+		if !bytes.Contains([]byte(err.Error()), []byte("daily-brief")) {
+			t.Fatalf("Delete error %q does not name the referencing schedule", err.Error())
+		}
+	})
+
+	t.Run("schedule reference lookup error propagates", func(t *testing.T) {
+		t.Parallel()
+		s := &Store{}
+		err := s.Delete(t.Context(), "d1", nil, fakeScheduleRefs{err: errors.New("db down")})
+		if err == nil || errors.Is(err, ErrReferenced) {
+			t.Fatalf("Delete = %v, want a propagated (non-ErrReferenced) error", err)
+		}
+	})
 }

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -80,6 +80,14 @@ type MissionTemplate struct {
 	// needs the same standing shell approval a UI-created one gets by
 	// default, or its very first shell call parks with nobody watching.
 	AutoApproveSafe bool `json:"auto_approve_safe"`
+	// DestinationIDs names operator-created destinations (D-061) this
+	// template's fired missions deliver their outcome digest to.
+	// Validated at schedule create/patch time (same rule as mission
+	// create, api/missions.go's validateDestinationIDs); re-filtered at
+	// FIRE time by resolveTemplateDefaults since a destination can be
+	// deleted or disabled between when the schedule was made and when
+	// it next fires.
+	DestinationIDs []string `json:"destination_ids,omitempty"`
 }
 
 // AgentDefaults is the slice of an agents row a fired mission borrows
@@ -109,6 +117,15 @@ type AgentDefaults struct {
 // created. ok reports whether the id resolved to a real agent.
 type AgentResolver func(ctx context.Context, agentID string) (AgentDefaults, bool)
 
+// DestinationEnabled reports whether id names a real, enabled
+// destinations row — the fire-time re-check resolveTemplateDefaults
+// runs on a template's DestinationIDs, mirroring
+// api/missions.go's validateDestinationIDs but tolerant instead of
+// rejecting: a destination deleted or disabled since the schedule was
+// created is dropped silently (with a log warning), never blocks the
+// fire.
+type DestinationEnabled func(ctx context.Context, id string) (bool, error)
+
 // Scheduler ticks every schedulerTick, evaluating schedules rows
 // against their cron expression (5-field, parsed via robfig/cron/v3's
 // standard parser — parsing only, not its own goroutine scheduler: the
@@ -123,6 +140,7 @@ type Scheduler struct {
 	routeForRole          func(context.Context, string) string
 	routeExists           func(context.Context, string) bool
 	codingExecutorDefault func(context.Context) string
+	destinationEnabled    DestinationEnabled
 	log                   *slog.Logger
 }
 
@@ -133,17 +151,29 @@ type Scheduler struct {
 // the "default" system role's route when an agent's own route is also
 // empty, routeExists for a coding template's route preferring the
 // operator's "coding" route over "default" when it exists (see
-// DefaultCodingRoute), and codingExecutorDefault (D-051) for a coding
-// template that omits harness — nil-safe on all five: a nil resolve
-// leaves an unresolved AgentID's fields at whatever the template
-// already specified, a nil enabled defaults every tick to enabled
-// (degrade open, since a config-read hiccup pausing every schedule
-// silently would be worse than one that keeps firing), a nil/unbound
-// routeForRole leaves the route "", a nil routeExists skips straight
-// to the default route, and a nil codingExecutorDefault leaves harness
-// at whatever the template specified (native if empty).
-func NewScheduler(db *pgpool.Pool, missions *Store, resolve AgentResolver, enabled func(ctx context.Context) bool, routeForRole func(context.Context, string) string, routeExists func(context.Context, string) bool, codingExecutorDefault func(context.Context) string, log *slog.Logger) *Scheduler {
-	return &Scheduler{db: db, missions: missions, resolve: resolve, enabled: enabled, routeForRole: routeForRole, routeExists: routeExists, codingExecutorDefault: codingExecutorDefault, log: log}
+// DefaultCodingRoute), codingExecutorDefault (D-051) for a coding
+// template that omits harness, and destinationEnabled for the
+// fire-time re-check of a template's DestinationIDs — nil-safe on all
+// six: a nil resolve leaves an unresolved AgentID's fields at whatever
+// the template already specified, a nil enabled defaults every tick to
+// enabled (degrade open, since a config-read hiccup pausing every
+// schedule silently would be worse than one that keeps firing), a
+// nil/unbound routeForRole leaves the route "", a nil routeExists
+// skips straight to the default route, a nil codingExecutorDefault
+// leaves harness at whatever the template specified (native if
+// empty), and a nil destinationEnabled leaves DestinationIDs
+// unfiltered (destinations disabled entirely — nothing to check
+// against).
+func NewScheduler(db *pgpool.Pool, missions *Store, resolve AgentResolver, enabled func(ctx context.Context) bool, routeForRole func(context.Context, string) string, routeExists func(context.Context, string) bool, codingExecutorDefault func(context.Context) string, destinationEnabled DestinationEnabled, log *slog.Logger) *Scheduler {
+	return &Scheduler{db: db, missions: missions, resolve: resolve, enabled: enabled, routeForRole: routeForRole, routeExists: routeExists, codingExecutorDefault: codingExecutorDefault, destinationEnabled: destinationEnabled, log: log}
+}
+
+// SetDestinationEnabled wires the fire-time destination re-check after
+// construction — main.go builds the destinations store AFTER the
+// scheduler (buildDestinations needs missionStore, built inside
+// buildMissions), same late-wiring shape as Driver.SetDestinationDeliver.
+func (s *Scheduler) SetDestinationEnabled(fn DestinationEnabled) {
+	s.destinationEnabled = fn
 }
 
 // Run ticks forever until ctx is done. Double-fire protection across
@@ -381,6 +411,12 @@ func (s *Scheduler) markSkipped(ctx context.Context, tx pgx.Tx, sc Schedule, now
 // ensureProvisioned).
 func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedule) error {
 	t, promptOverlay, knowledge := resolveTemplateDefaults(ctx, sc.MissionTemplate, s.resolve, s.routeForRole, s.routeExists, s.codingExecutorDefault)
+	// destination_ids is NOT NULL; a nil slice binds as a NULL array
+	// parameter, same fix as store.go's Create.
+	destinationIDs := s.filterDestinationIDs(ctx, t.DestinationIDs)
+	if destinationIDs == nil {
+		destinationIDs = []string{}
+	}
 	spec, _ := json.Marshal(Spec{})
 	budgetCurrency := t.BudgetCurrency
 	if budgetCurrency == "" {
@@ -394,11 +430,41 @@ func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedu
 		return fmt.Errorf("marshal knowledge: %w", err)
 	}
 	_, err = tx.Exec(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, knowledge, auto_approve_safe, spec, schedule_id, harness, environment)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, knowledge, auto_approve_safe, spec, schedule_id, harness, environment, destination_ids)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`,
 		t.Goal, sc.Name, t.Kind, t.AgentID, orDefault(t.MaxIterations, 8), t.BudgetAmount, budgetCurrency, t.Route, t.ReviewRoute, t.PlanRoute,
-		promptOverlay, knowledgeJSON, t.AutoApproveSafe, spec, sc.ID, t.Harness, t.Environment)
+		promptOverlay, knowledgeJSON, t.AutoApproveSafe, spec, sc.ID, t.Harness, t.Environment, destinationIDs)
 	return err
+}
+
+// filterDestinationIDs is the fire-time re-check on a template's
+// DestinationIDs: a destination deleted or disabled since the
+// schedule was created must not silently attach to the new mission
+// row, but must also never fail the fire — it's dropped and logged
+// instead. A nil destinationEnabled (destinations disabled) drops
+// every id, since none of them can be verified to still be valid.
+func (s *Scheduler) filterDestinationIDs(ctx context.Context, ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	if s.destinationEnabled == nil {
+		s.log.Warn("scheduler: dropping schedule destination_ids, destinations are not enabled", "destination_ids", ids)
+		return nil
+	}
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		ok, err := s.destinationEnabled(ctx, id)
+		if err != nil {
+			s.log.Warn("scheduler: dropping schedule destination id, lookup failed", "destination_id", id, "error", err)
+			continue
+		}
+		if !ok {
+			s.log.Warn("scheduler: dropping schedule destination id, unknown or disabled", "destination_id", id)
+			continue
+		}
+		out = append(out, id)
+	}
+	return out
 }
 
 // resolveTemplateDefaults is the pure fire-time resolution step

--- a/internal/brain/missions/scheduler_integration_test.go
+++ b/internal/brain/missions/scheduler_integration_test.go
@@ -47,8 +47,8 @@ func TestSchedulerNoDoubleFireAcrossInstances(t *testing.T) {
 		t.Fatalf("backdate schedule: %v", err)
 	}
 
-	sched1 := NewScheduler(store.db, store, nil, nil, nil, nil, nil, store.log)
-	sched2 := NewScheduler(store.db, store, nil, nil, nil, nil, nil, store.log)
+	sched1 := NewScheduler(store.db, store, nil, nil, nil, nil, nil, nil, store.log)
+	sched2 := NewScheduler(store.db, store, nil, nil, nil, nil, nil, nil, store.log)
 
 	now := time.Now()
 	var wg sync.WaitGroup
@@ -87,7 +87,7 @@ func TestSchedulerFireUsesScheduleNameDirectly(t *testing.T) {
 		t.Fatalf("backdate schedule: %v", err)
 	}
 
-	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, store.log)
+	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, nil, store.log)
 	if err := sched.tick(ctx, time.Now()); err != nil {
 		t.Fatalf("tick: %v", err)
 	}
@@ -98,6 +98,63 @@ func TestSchedulerFireUsesScheduleNameDirectly(t *testing.T) {
 	}
 	if name != marker+"named-schedule" {
 		t.Fatalf("fired mission name = %q, want the schedule's own name %q", name, marker+"named-schedule")
+	}
+}
+
+// TestSchedulerFireFiltersDestinationIDs confirms the fire-time
+// re-check (filterDestinationIDs) drops ids that no longer resolve
+// through destinationEnabled — missing/disabled destinations never
+// fail the fire, they're just excluded from what lands on the new
+// mission row.
+func TestSchedulerFireFiltersDestinationIDs(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	// destination_ids is a uuid[] column — the ids exercised here must
+	// parse as UUIDs even though no destinations row backs them (the
+	// fake destinationEnabled below stands in for the real lookup).
+	const (
+		kept            = "11111111-1111-1111-1111-111111111111"
+		droppedDisabled = "22222222-2222-2222-2222-222222222222"
+		droppedMissing  = "33333333-3333-3333-3333-333333333333"
+	)
+	scID, err := store.CreateSchedule(ctx, Schedule{
+		Name: slugMarker + "-dest-filter", Cron: "* * * * *", Enabled: true,
+		MissionTemplate: MissionTemplate{
+			Goal: marker + "digest", Kind: "general",
+			DestinationIDs: []string{kept, droppedDisabled, droppedMissing},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSchedule: %v", err)
+	}
+	db, _ := store.db.Get()
+	past := time.Now().Add(-2 * time.Minute)
+	if _, err := db.Exec(ctx, "UPDATE schedules SET created_at = $2 WHERE id = $1", scID, past); err != nil {
+		t.Fatalf("backdate schedule: %v", err)
+	}
+
+	destinationEnabled := func(_ context.Context, id string) (bool, error) {
+		switch id {
+		case kept:
+			return true, nil
+		case droppedDisabled:
+			return false, nil // exists, disabled
+		default:
+			return false, nil // droppedMissing: unknown id
+		}
+	}
+	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, destinationEnabled, store.log)
+	if err := sched.tick(ctx, time.Now()); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	var got []string
+	if err := db.QueryRow(ctx, `SELECT destination_ids FROM missions WHERE schedule_id = $1`, scID).Scan(&got); err != nil {
+		t.Fatalf("query fired mission's destination_ids: %v", err)
+	}
+	if len(got) != 1 || got[0] != kept {
+		t.Fatalf("fired mission destination_ids = %v, want [%s]", got, kept)
 	}
 }
 
@@ -124,7 +181,7 @@ func TestSchedulerLiveQueueDedup(t *testing.T) {
 		t.Fatalf("attach schedule: %v", err)
 	}
 
-	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, store.log)
+	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, nil, store.log)
 	now := time.Now()
 	if err := sched.tick(ctx, now); err != nil {
 		t.Fatalf("tick: %v", err)
@@ -180,7 +237,7 @@ func TestSchedulerDedupSkipSetsPendingFireAndRecordsReason(t *testing.T) {
 		t.Fatalf("attach schedule: %v", err)
 	}
 
-	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, store.log)
+	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, nil, store.log)
 	if err := sched.tick(ctx, time.Now()); err != nil {
 		t.Fatalf("tick: %v", err)
 	}
@@ -217,7 +274,7 @@ func TestSchedulerPendingFireResolvesOnceMissionClears(t *testing.T) {
 		t.Fatalf("attach schedule: %v", err)
 	}
 
-	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, store.log)
+	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, nil, store.log)
 	// First tick: due, but the mission above is active -> dedup skip,
 	// pending_fire set.
 	if err := sched.tick(ctx, time.Now()); err != nil {
@@ -270,7 +327,7 @@ func TestSchedulerDueAndPendingFiresOnce(t *testing.T) {
 		t.Fatalf("seed pending schedule: %v", err)
 	}
 
-	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, store.log)
+	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, nil, store.log)
 	if err := sched.tick(ctx, time.Now()); err != nil {
 		t.Fatalf("tick: %v", err)
 	}
@@ -305,7 +362,7 @@ func TestSchedulerBackfillSkipRecordsReason(t *testing.T) {
 		t.Fatalf("backdate schedule: %v", err)
 	}
 
-	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, store.log)
+	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, nil, store.log)
 	if err := sched.tick(ctx, time.Now()); err != nil {
 		t.Fatalf("tick: %v", err)
 	}

--- a/internal/brain/missions/scheduler_test.go
+++ b/internal/brain/missions/scheduler_test.go
@@ -2,6 +2,9 @@ package missions
 
 import (
 	"context"
+	"errors"
+	"io"
+	"log/slog"
 	"slices"
 	"testing"
 	"time"
@@ -308,4 +311,65 @@ func TestTickNilEnabledDegradesOpen(t *testing.T) {
 	}()
 	s := &Scheduler{enabled: nil}
 	_ = s.tick(context.Background(), time.Now())
+}
+
+// TestFilterDestinationIDs covers the fire-time re-check on a
+// template's DestinationIDs: dropped ids never fail the fire, they're
+// just excluded from what actually lands on the fired mission's row.
+func TestFilterDestinationIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty input returns nil without consulting the lookup", func(t *testing.T) {
+		t.Parallel()
+		s := &Scheduler{log: discardLog()}
+		if got := s.filterDestinationIDs(context.Background(), nil); got != nil {
+			t.Fatalf("filterDestinationIDs(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("nil destinationEnabled drops every id (destinations disabled)", func(t *testing.T) {
+		t.Parallel()
+		s := &Scheduler{log: discardLog()}
+		got := s.filterDestinationIDs(context.Background(), []string{"d1", "d2"})
+		if len(got) != 0 {
+			t.Fatalf("filterDestinationIDs with nil destinationEnabled = %v, want empty", got)
+		}
+	})
+
+	t.Run("drops disabled and missing ids, passes valid ones", func(t *testing.T) {
+		t.Parallel()
+		lookup := map[string]bool{"d1": true, "d2": false} // d3 absent entirely
+		s := &Scheduler{
+			log: discardLog(),
+			destinationEnabled: func(_ context.Context, id string) (bool, error) {
+				ok, exists := lookup[id]
+				return exists && ok, nil
+			},
+		}
+		got := s.filterDestinationIDs(context.Background(), []string{"d1", "d2", "d3"})
+		if !slices.Equal(got, []string{"d1"}) {
+			t.Fatalf("filterDestinationIDs = %v, want [d1]", got)
+		}
+	})
+
+	t.Run("a lookup error drops that id without failing the fire", func(t *testing.T) {
+		t.Parallel()
+		s := &Scheduler{
+			log: discardLog(),
+			destinationEnabled: func(_ context.Context, id string) (bool, error) {
+				if id == "d1" {
+					return false, errors.New("db unreachable")
+				}
+				return true, nil
+			},
+		}
+		got := s.filterDestinationIDs(context.Background(), []string{"d1", "d2"})
+		if !slices.Equal(got, []string{"d2"}) {
+			t.Fatalf("filterDestinationIDs = %v, want [d2]", got)
+		}
+	})
+}
+
+func discardLog() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }

--- a/internal/brain/missions/schedules.go
+++ b/internal/brain/missions/schedules.go
@@ -225,6 +225,43 @@ func (s *Store) DeleteSchedule(ctx context.Context, id string) error {
 	return nil
 }
 
+// ScheduleReferencingDestinationID reports the name of the first
+// enabled schedule whose mission_template.destination_ids still names
+// destinationID — the guard destinations.Store.Delete calls before
+// removing a row, so a schedule's next fire can't lose its delivery
+// target out from under it. Disabled schedules never block deletion
+// (same "active only" rule ActiveMissionReferencesDestination applies
+// to non-terminal missions): a disabled schedule cannot fire again
+// until re-enabled, at which point re-attaching or removing the
+// destination is the operator's own call. ok reports whether any
+// schedule references it.
+func (s *Store) ScheduleReferencingDestinationID(ctx context.Context, destinationID string) (name string, ok bool, err error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return "", false, fmt.Errorf("schedules destination reference: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT name, mission_template FROM schedules WHERE enabled`)
+	if err != nil {
+		return "", false, fmt.Errorf("schedules destination reference: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var scName string
+		var templateJSON []byte
+		if err := rows.Scan(&scName, &templateJSON); err != nil {
+			return "", false, fmt.Errorf("schedules destination reference: %w", err)
+		}
+		var t MissionTemplate
+		_ = json.Unmarshal(templateJSON, &t)
+		for _, d := range t.DestinationIDs {
+			if d == destinationID {
+				return scName, true, rows.Err()
+			}
+		}
+	}
+	return "", false, rows.Err()
+}
+
 // isForeignKeyViolation reports whether err is Postgres's
 // foreign_key_violation (23503) — a schedule delete blocked by
 // missions still referencing it.

--- a/internal/brain/missions/schedules_integration_test.go
+++ b/internal/brain/missions/schedules_integration_test.go
@@ -121,3 +121,54 @@ func TestScheduleDeleteBlockedByReferencingMission(t *testing.T) {
 		t.Fatalf("DeleteSchedule with a referencing mission = %v, want ErrScheduleInUse", err)
 	}
 }
+
+// TestScheduleReferencingDestinationID is the destinations delete
+// guard's other half (ActiveMissionReferencesDestination covers
+// missions; this covers schedules): an enabled schedule whose
+// mission_template still names a destination id must be found and
+// named, a disabled schedule's reference must never block, and no
+// match must report ok=false cleanly.
+func TestScheduleReferencingDestinationID(t *testing.T) {
+	store := testStore(t)
+	ctx := t.Context()
+
+	destID := "11111111-1111-1111-1111-111111111111"
+
+	name, ok, err := store.ScheduleReferencingDestinationID(ctx, destID)
+	if err != nil {
+		t.Fatalf("ScheduleReferencingDestinationID with no schedules: %v", err)
+	}
+	if ok {
+		t.Fatalf("ScheduleReferencingDestinationID = %q, true; want false with no schedules referencing it", name)
+	}
+
+	scID, err := store.CreateSchedule(ctx, Schedule{
+		Name: slugMarker + "-dest-ref", Cron: "0 7 * * *", Enabled: true,
+		MissionTemplate: MissionTemplate{Goal: marker + "digest", Kind: "general", DestinationIDs: []string{destID}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSchedule: %v", err)
+	}
+
+	name, ok, err = store.ScheduleReferencingDestinationID(ctx, destID)
+	if err != nil {
+		t.Fatalf("ScheduleReferencingDestinationID: %v", err)
+	}
+	if !ok || name != slugMarker+"-dest-ref" {
+		t.Fatalf("ScheduleReferencingDestinationID = %q, %v; want %q, true", name, ok, slugMarker+"-dest-ref")
+	}
+
+	// Disabling the schedule stops it from blocking deletion — same
+	// "active only" rule the mission-side check applies.
+	disabled := false
+	if err := store.PatchSchedule(ctx, scID, SchedulePatch{Enabled: &disabled}); err != nil {
+		t.Fatalf("PatchSchedule disable: %v", err)
+	}
+	_, ok, err = store.ScheduleReferencingDestinationID(ctx, destID)
+	if err != nil {
+		t.Fatalf("ScheduleReferencingDestinationID after disable: %v", err)
+	}
+	if ok {
+		t.Fatal("ScheduleReferencingDestinationID after disabling the schedule = true, want false")
+	}
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -959,6 +959,11 @@ export interface MissionTemplate {
   environment?: string
   branch_pattern?: string
   commit_style?: string
+  // destination_ids names operator-created destinations this template's
+  // fired missions deliver their outcome digest to. Re-validated at
+  // fire time — a destination deleted or disabled since the schedule
+  // was created is dropped silently rather than failing the fire.
+  destination_ids?: string[]
 }
 
 // Schedule is a recurring cron trigger that fires mission_template

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -313,6 +313,55 @@ describe('MissionForm — destinations multi-select', () => {
       expect.not.objectContaining({ destination_ids: expect.anything() }),
     )
   })
+
+  it('offers the multi-select for a new schedule (repeat on) and submits picked ids', async () => {
+    vi.mocked(listDestinations).mockResolvedValue(destinations)
+    vi.mocked(createSchedule).mockResolvedValue({ id: 'sched1' })
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Weekly digest' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
+
+    await screen.findByText('Deliver results to')
+    fireEvent.click(screen.getByLabelText(/^ops-hook/))
+    fireEvent.click(screen.getByRole('button', { name: 'Create schedule' }))
+
+    await waitFor(() =>
+      expect(createSchedule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mission_template: expect.objectContaining({ destination_ids: ['d2'] }),
+        }),
+      ),
+    )
+  })
+
+  it('seeds the multi-select from an edited schedule and submits the updated picks', async () => {
+    vi.mocked(listDestinations).mockResolvedValue(destinations)
+    vi.mocked(patchSchedule).mockResolvedValue(schedule)
+    const seeded: Schedule = {
+      ...schedule,
+      mission_template: { ...schedule.mission_template, destination_ids: ['d1'] },
+    }
+    renderForm(<MissionForm mode="edit" schedule={seeded} onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await screen.findByText('Deliver results to')
+    const opsInbox = screen.getByLabelText(/^ops-inbox/) as HTMLInputElement
+    const opsHook = screen.getByLabelText(/^ops-hook/) as HTMLInputElement
+    expect(opsInbox.checked).toBe(true)
+    expect(opsHook.checked).toBe(false)
+
+    fireEvent.click(opsHook) // now both picked
+    fireEvent.click(screen.getByRole('button', { name: 'Save schedule' }))
+
+    await waitFor(() =>
+      expect(patchSchedule).toHaveBeenCalledWith(
+        's1',
+        expect.objectContaining({
+          mission_template: expect.objectContaining({ destination_ids: ['d1', 'd2'] }),
+        }),
+      ),
+    )
+  })
 })
 
 describe('MissionForm — follow-up', () => {

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -254,20 +254,18 @@ export function MissionForm({
   const [classifying, setClassifying] = useState(false)
   const [agentID, setAgentID] = useState(initial?.agent_id ?? '')
   // Destinations multi-select — visible, not advanced; default is
-  // empty (deliver nowhere). Only ever offered for a one-off create
-  // (mode === 'create'), same scope as schedule integration being a
-  // later slice.
+  // empty (deliver nowhere). Offered for a one-off create, a new
+  // schedule (repeat on), and editing an existing schedule — fetched
+  // once per form regardless of mode.
   const [destinations, setDestinations] = useState<Destination[] | null>(null)
   const [destinationIDs, setDestinationIDs] = useState<string[]>([])
   useEffect(() => {
-    if (mode !== 'create') return
     listDestinations()
       .then(setDestinations)
       .catch(() => {
         // Non-fatal: the section just stays hidden if this fails, same
         // degrade as any other optional list fetch in this form.
       })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [route, setRoute] = useState(initial?.route ?? '')
@@ -426,6 +424,7 @@ export function MissionForm({
     setEnvironment(schedule.mission_template.environment ?? '')
     setBranchPattern(schedule.mission_template.branch_pattern ?? '')
     setCommitStyle(schedule.mission_template.commit_style ?? '')
+    setDestinationIDs(schedule.mission_template.destination_ids ?? [])
     setExpiresAt(schedule.expires_at ? schedule.expires_at.slice(0, 16) : '')
     setCronError(null)
   }, [mode, schedule])
@@ -572,6 +571,7 @@ export function MissionForm({
         environment: kind === 'coding' ? environment || undefined : undefined,
         branch_pattern: kind === 'coding' ? branchPattern.trim() || undefined : undefined,
         commit_style: kind === 'coding' ? commitStyle || undefined : undefined,
+        destination_ids: destinationIDs.length > 0 ? destinationIDs : undefined,
       },
       expires_at: expiresAt ? new Date(expiresAt).toISOString() : undefined,
     })
@@ -604,6 +604,7 @@ export function MissionForm({
             : undefined,
         commit_style:
           schedule.mission_template.kind === 'coding' ? commitStyle || undefined : undefined,
+        destination_ids: destinationIDs.length > 0 ? destinationIDs : undefined,
       },
       expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
     })
@@ -1134,7 +1135,7 @@ export function MissionForm({
           </span>
         </label>
 
-        {mode === 'create' && destinations && destinations.length > 0 && (
+        {destinations && destinations.length > 0 && (
           <div className="space-y-1.5">
             <Label>Deliver results to</Label>
             <div className="space-y-1.5 rounded-xl border border-border p-3">

--- a/web/src/pages/AutomationDetail.test.tsx
+++ b/web/src/pages/AutomationDetail.test.tsx
@@ -1,15 +1,16 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Mission, Schedule } from '../api/types'
+import type { Destination, Mission, Schedule } from '../api/types'
 import { AutomationDetail } from './AutomationDetail'
 
 vi.mock('../api/client', () => ({
   listSchedules: vi.fn(),
   listMissions: vi.fn(),
+  listDestinations: vi.fn(),
 }))
 
-import { listMissions, listSchedules } from '../api/client'
+import { listDestinations, listMissions, listSchedules } from '../api/client'
 
 const schedule: Schedule = {
   id: 's1',
@@ -21,6 +22,17 @@ const schedule: Schedule = {
   created_at: '2026-07-01T00:00:00Z',
   updated_at: '2026-07-01T00:00:00Z',
   pending_fire: false,
+}
+
+const destination: Destination = {
+  id: 'd1',
+  name: 'ops-inbox',
+  kind: 'email',
+  config: {},
+  credential_ref: '',
+  enabled: true,
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
 }
 
 const firedMission: Mission = {
@@ -56,6 +68,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(listSchedules).mockResolvedValue([])
   vi.mocked(listMissions).mockResolvedValue([])
+  vi.mocked(listDestinations).mockResolvedValue([])
 })
 
 describe('AutomationDetail', () => {
@@ -79,5 +92,22 @@ describe('AutomationDetail', () => {
     vi.mocked(listSchedules).mockResolvedValue([schedule])
     renderAt('s1')
     expect(await screen.findByText('No missions fired yet.')).toBeTruthy()
+  })
+
+  it('shows destination badges when the schedule has destination_ids', async () => {
+    vi.mocked(listDestinations).mockResolvedValue([destination])
+    vi.mocked(listSchedules).mockResolvedValue([
+      { ...schedule, mission_template: { ...schedule.mission_template, destination_ids: ['d1'] } },
+    ])
+    renderAt('s1')
+    expect(await screen.findByText('ops-inbox')).toBeTruthy()
+  })
+
+  it('shows no destination badges when the schedule has none attached', async () => {
+    vi.mocked(listDestinations).mockResolvedValue([destination])
+    vi.mocked(listSchedules).mockResolvedValue([schedule])
+    renderAt('s1')
+    await screen.findByText('weekly-digest')
+    expect(screen.queryByText('ops-inbox')).toBeNull()
   })
 })

--- a/web/src/pages/AutomationDetail.tsx
+++ b/web/src/pages/AutomationDetail.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router'
-import { listMissions, listSchedules } from '../api/client'
-import type { Mission, Schedule } from '../api/types'
+import { listDestinations, listMissions, listSchedules } from '../api/client'
+import type { Destination, Mission, Schedule } from '../api/types'
 import { MissionCard } from '../components/missions/MissionCard'
+import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
 import { describeCron } from '../lib/schedules'
 import { relativeTime } from '../lib/format'
@@ -16,6 +17,16 @@ export function AutomationDetail() {
   const [schedule, setSchedule] = useState<Schedule | null>(null)
   const [loading, setLoading] = useState(true)
   const [missions, setMissions] = useState<Mission[]>([])
+  // Destinations fetched once per page, just to resolve
+  // destination_ids into display names for the badges below.
+  const [destinations, setDestinations] = useState<Destination[]>([])
+  useEffect(() => {
+    listDestinations()
+      .then(setDestinations)
+      .catch(() => {
+        // Non-fatal: badges just don't render if this fails.
+      })
+  }, [])
 
   const refresh = useCallback(() => {
     if (!id) return
@@ -66,6 +77,19 @@ export function AutomationDetail() {
             {schedule.last_run && <span>last {relativeTime(schedule.last_run)}</span>}
             <span>{schedule.enabled ? 'enabled' : 'disabled'}</span>
           </div>
+          {schedule.mission_template.destination_ids &&
+            schedule.mission_template.destination_ids.length > 0 && (
+              <div className="mt-1.5 flex flex-wrap gap-1">
+                {schedule.mission_template.destination_ids.map((did) => {
+                  const d = destinations.find((d) => d.id === did)
+                  return (
+                    <Badge key={did} variant="outline" className="text-xs">
+                      {d?.name ?? did}
+                    </Badge>
+                  )
+                })}
+              </div>
+            )}
         </div>
         <Button variant="outline" onClick={() => navigate(`/automations/${id}/edit`)}>
           Edit

--- a/web/src/pages/Automations.test.tsx
+++ b/web/src/pages/Automations.test.tsx
@@ -1,16 +1,17 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Schedule } from '../api/types'
+import type { Destination, Schedule } from '../api/types'
 import { Automations } from './Automations'
 
 vi.mock('../api/client', () => ({
   listSchedules: vi.fn(),
   patchSchedule: vi.fn(),
   deleteSchedule: vi.fn(),
+  listDestinations: vi.fn(),
 }))
 
-import { deleteSchedule, listSchedules, patchSchedule } from '../api/client'
+import { deleteSchedule, listDestinations, listSchedules, patchSchedule } from '../api/client'
 
 const schedule: Schedule = {
   id: 's1',
@@ -22,6 +23,17 @@ const schedule: Schedule = {
   created_at: '2026-07-01T00:00:00Z',
   updated_at: '2026-07-01T00:00:00Z',
   pending_fire: false,
+}
+
+const destination: Destination = {
+  id: 'd1',
+  name: 'ops-inbox',
+  kind: 'email',
+  config: {},
+  credential_ref: '',
+  enabled: true,
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
 }
 
 function renderPage() {
@@ -42,6 +54,7 @@ beforeEach(() => {
   Element.prototype.scrollIntoView = vi.fn()
   vi.clearAllMocks()
   vi.mocked(listSchedules).mockResolvedValue([])
+  vi.mocked(listDestinations).mockResolvedValue([])
 })
 
 describe('Automations page', () => {
@@ -86,6 +99,24 @@ describe('Automations page', () => {
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/automations/s1'))
     expect(await screen.findByText('automation detail page')).toBeTruthy()
+  })
+
+  it('shows destination badges when the schedule has destination_ids', async () => {
+    vi.mocked(listDestinations).mockResolvedValue([destination])
+    vi.mocked(listSchedules).mockResolvedValue([
+      { ...schedule, mission_template: { ...schedule.mission_template, destination_ids: ['d1'] } },
+    ])
+    renderPage()
+    await screen.findByText('weekly-digest')
+    expect(await screen.findByText('ops-inbox')).toBeTruthy()
+  })
+
+  it('shows no destination badges when the schedule has none attached', async () => {
+    vi.mocked(listDestinations).mockResolvedValue([destination])
+    vi.mocked(listSchedules).mockResolvedValue([schedule])
+    renderPage()
+    await screen.findByText('weekly-digest')
+    expect(screen.queryByText('ops-inbox')).toBeNull()
   })
 
   it('navigates to the edit automation page', async () => {

--- a/web/src/pages/Automations.tsx
+++ b/web/src/pages/Automations.tsx
@@ -3,10 +3,11 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import { useCallback, useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router'
 import { toast } from 'sonner'
-import { deleteSchedule, patchSchedule, listSchedules } from '../api/client'
-import type { Schedule } from '../api/types'
+import { deleteSchedule, listDestinations, patchSchedule, listSchedules } from '../api/client'
+import type { Destination, Schedule } from '../api/types'
 import { describeCron } from '../lib/schedules'
 import { relativeTime } from '../lib/format'
+import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
 import {
   Dialog,
@@ -27,6 +28,17 @@ export function Automations() {
   const navigate = useNavigate()
   const [schedules, setSchedules] = useState<Schedule[]>([])
   const [confirmDelete, setConfirmDelete] = useState<Schedule | null>(null)
+  // Destinations fetched once per page, just to resolve a schedule's
+  // destination_ids into display names for the badges below — best
+  // effort, an empty/failed fetch just renders no badges.
+  const [destinations, setDestinations] = useState<Destination[]>([])
+  useEffect(() => {
+    listDestinations()
+      .then(setDestinations)
+      .catch(() => {
+        // Non-fatal: badges just don't render if this fails.
+      })
+  }, [])
 
   const refresh = useCallback(() => {
     listSchedules()
@@ -79,6 +91,18 @@ export function Automations() {
                 {sc.next_run && <span>next {relativeTime(sc.next_run)}</span>}
                 {sc.last_run && <span>last {relativeTime(sc.last_run)}</span>}
               </div>
+              {sc.mission_template.destination_ids && sc.mission_template.destination_ids.length > 0 && (
+                <div className="mt-1.5 flex flex-wrap gap-1">
+                  {sc.mission_template.destination_ids.map((id) => {
+                    const d = destinations.find((d) => d.id === id)
+                    return (
+                      <Badge key={id} variant="outline" className="text-xs">
+                        {d?.name ?? id}
+                      </Badge>
+                    )
+                  })}
+                </div>
+              )}
             </Link>
             <div className="flex items-center gap-2">
               <Toggle on={sc.enabled} onChange={(v) => toggle(sc, v)} label={`${sc.name} enabled`} />


### PR DESCRIPTION
Slice 4 of the destinations plan: automations integration.

- `MissionTemplate.DestinationIDs`, validated at schedule create/patch (unknown/disabled → 400 naming the ids)
- Fire-time re-filter in the scheduler: destinations deleted or disabled since the schedule was created are dropped with a log warning, never fail the fire
- `destinations.Store.Delete` now also refuses while an enabled schedule's template references the destination (error names the schedule); disabled schedules never block
- Web: schedule create/edit multi-select, attached-destination badges on Automations cards and detail

No migration — `mission_template` stays jsonb.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789777802&installation_model_id=431401&pr_number=257&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F257&signature=6e53fcda3e1241216c122556a5e7864e209796b3b88385d15e1be5ce7d4abed6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->