### PR TITLE
feat: telegram destination kind with artifact file attachments

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -285,7 +285,7 @@ func main() {
 	if missionDriver != nil {
 		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, app.Log)
 	}
-	destinationStore, destinationDeliverer := buildDestinations(app.DB, conns, goog, flags, missionStore, app.Log)
+	destinationStore, destinationDeliverer := buildDestinations(app.DB, conns, goog, secrets, flags, missionStore, app.Log)
 	if missionDriver != nil && destinationDeliverer != nil {
 		missionDriver.SetDestinationDeliver(destinationDeliverer.Deliver)
 	}
@@ -628,8 +628,9 @@ func buildConnectors(db *pgpool.Pool, secrets *secretstore.Store, log *slog.Logg
 // nil still builds the store (webhook destinations work without
 // connectors); an email destination's create/update then fails
 // validation with a clear error, same nil-gated shape as
-// api/missions.go's own repo_url-needs-connectors check.
-func buildDestinations(db *pgpool.Pool, conns *connectors.Manager, goog *connectors.Google, flags *settings.Store, missionStore *missions.Store, log *slog.Logger) (*destinations.Store, *destinations.Deliverer) {
+// api/missions.go's own repo_url-needs-connectors check. secrets nil
+// (no valid master key) leaves telegram unregistered the same way.
+func buildDestinations(db *pgpool.Pool, conns *connectors.Manager, goog *connectors.Google, secrets *secretstore.Store, flags *settings.Store, missionStore *missions.Store, log *slog.Logger) (*destinations.Store, *destinations.Deliverer) {
 	if missionStore == nil {
 		return nil, nil
 	}
@@ -644,11 +645,34 @@ func buildDestinations(db *pgpool.Pool, conns *connectors.Manager, goog *connect
 	// already requires an enabled google connector to exist.
 	var email *destinations.EmailAdapter
 	if goog != nil {
-		email = &destinations.EmailAdapter{Mail: goog}
+		email = &destinations.EmailAdapter{Mail: destinationMailSender{goog}}
 	}
 	webhook := &destinations.WebhookAdapter{}
-	deliverer := destinations.NewDeliverer(store, missionStore, email, webhook, flags.WebBaseURL, log)
+	var telegram *destinations.TelegramAdapter
+	if secrets != nil {
+		telegram = &destinations.TelegramAdapter{ResolveToken: secrets.Resolve}
+	}
+	deliverer := destinations.NewDeliverer(store, missionStore, email, webhook, telegram, flags.WebBaseURL, log)
 	return store, deliverer
+}
+
+// destinationMailSender adapts *connectors.Google's attachment type to
+// destinations' own narrow mailAttachment shape — same
+// never-import-connectors reasoning as destinationConnectorLookup.
+type destinationMailSender struct {
+	goog *connectors.Google
+}
+
+func (d destinationMailSender) SendMail(ctx context.Context, connectorID, to, subject, body string) error {
+	return d.goog.SendMail(ctx, connectorID, to, subject, body)
+}
+
+func (d destinationMailSender) SendMailWithAttachments(ctx context.Context, connectorID, to, subject, body string, attachments []destinations.MailAttachment) error {
+	converted := make([]connectors.Attachment, len(attachments))
+	for i, a := range attachments {
+		converted[i] = connectors.Attachment{Name: a.Name, Data: a.Data}
+	}
+	return d.goog.SendMailWithAttachments(ctx, connectorID, to, subject, body, converted)
 }
 
 // destinationConnectorLookup adapts *connectors.Manager to

--- a/internal/brain/connectors/google.go
+++ b/internal/brain/connectors/google.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"strings"
 	"sync"
@@ -346,6 +348,89 @@ func (g *Google) SendMail(ctx context.Context, connectorID, to, subject, body st
 	if resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return fmt.Errorf("send mail: gmail api status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// Attachment is one file to include on a SendMailWithAttachments call.
+type Attachment struct {
+	Name string
+	Data []byte
+}
+
+// SendMailWithAttachments is SendMail plus a multipart/mixed body for
+// destinations' artifact-file delivery — a separate method rather than
+// an optional param on SendMail so the plain-text tool-call path
+// (gmailSend) never builds MIME multipart machinery it doesn't need.
+func (g *Google) SendMailWithAttachments(ctx context.Context, connectorID, to, subject, body string, attachments []Attachment) error {
+	if len(attachments) == 0 {
+		return g.SendMail(ctx, connectorID, to, subject, body)
+	}
+	c, err := g.Rows.Get(ctx, connectorID)
+	if err != nil {
+		return fmt.Errorf("send mail: %w", err)
+	}
+	cfg, err := googleConfig(c)
+	if err != nil {
+		return fmt.Errorf("send mail: %w", err)
+	}
+	if c.CredentialRef == "" {
+		return fmt.Errorf("send mail: connector %s has no credential_ref", c.Name)
+	}
+	token, err := g.token(ctx, cfg, c.CredentialRef)
+	if err != nil {
+		return fmt.Errorf("send mail: %w", err)
+	}
+
+	var mime strings.Builder
+	w := multipart.NewWriter(&mime)
+	fmt.Fprintf(&mime, "To: %s\r\nSubject: %s\r\nMIME-Version: 1.0\r\n", to, subject)
+	fmt.Fprintf(&mime, "Content-Type: multipart/mixed; boundary=%s\r\n\r\n", w.Boundary())
+
+	textPart, err := w.CreatePart(textproto.MIMEHeader{"Content-Type": {"text/plain; charset=UTF-8"}})
+	if err != nil {
+		return fmt.Errorf("send mail: build text part: %w", err)
+	}
+	if _, err := textPart.Write([]byte(body)); err != nil {
+		return fmt.Errorf("send mail: write text part: %w", err)
+	}
+	for _, a := range attachments {
+		header := textproto.MIMEHeader{
+			"Content-Type":              {"application/octet-stream"},
+			"Content-Transfer-Encoding": {"base64"},
+			"Content-Disposition":       {fmt.Sprintf(`attachment; filename=%q`, a.Name)},
+		}
+		part, err := w.CreatePart(header)
+		if err != nil {
+			return fmt.Errorf("send mail: build attachment part: %w", err)
+		}
+		if _, err := part.Write([]byte(base64.StdEncoding.EncodeToString(a.Data))); err != nil {
+			return fmt.Errorf("send mail: write attachment part: %w", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("send mail: close multipart: %w", err)
+	}
+
+	payload := map[string]string{"raw": base64.URLEncoding.EncodeToString([]byte(mime.String()))}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("send mail: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, g.GmailBase+"/gmail/v1/users/me/messages/send", strings.NewReader(string(data)))
+	if err != nil {
+		return fmt.Errorf("send mail: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := g.Client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send mail: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("send mail: gmail api status %d: %s", resp.StatusCode, string(respBody))
 	}
 	return nil
 }

--- a/internal/brain/connectors/google_test.go
+++ b/internal/brain/connectors/google_test.go
@@ -565,6 +565,55 @@ func TestGmailToolsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSendMailWithAttachments(t *testing.T) {
+	t.Parallel()
+	f := &fakeGoogle{}
+	row := googleRow(bothScopes)
+	g, secrets := testGoogle(t, f, row)
+	//nolint:gosec // G117: fake token fixture.
+	live, _ := json.Marshal(tokenBundle{AccessToken: "at-live", Expiry: time.Now().Add(time.Hour)})
+	_ = secrets.Set(t.Context(), "PERSONAL_GOOGLE_OAUTH", string(live))
+
+	err := g.SendMailWithAttachments(t.Context(), row.ID, "ops@example.com", "digest", "body text",
+		[]Attachment{{Name: "report.txt", Data: []byte("report contents")}})
+	if err != nil {
+		t.Fatalf("SendMailWithAttachments: %v", err)
+	}
+	if len(f.gmailSent) != 1 {
+		t.Fatalf("expected 1 sent message, got %d", len(f.gmailSent))
+	}
+	raw := f.gmailSent[0]
+	if !strings.Contains(raw, "multipart/mixed") {
+		t.Fatalf("expected a multipart/mixed message, got %q", raw)
+	}
+	if !strings.Contains(raw, "body text") {
+		t.Fatalf("expected the body text part, got %q", raw)
+	}
+	if !strings.Contains(raw, `filename="report.txt"`) {
+		t.Fatalf("expected the attachment filename, got %q", raw)
+	}
+	if !strings.Contains(raw, base64.StdEncoding.EncodeToString([]byte("report contents"))) {
+		t.Fatalf("expected the base64 attachment content, got %q", raw)
+	}
+}
+
+func TestSendMailWithAttachmentsFallsBackToPlainSend(t *testing.T) {
+	t.Parallel()
+	f := &fakeGoogle{}
+	row := googleRow(bothScopes)
+	g, secrets := testGoogle(t, f, row)
+	//nolint:gosec // G117: fake token fixture.
+	live, _ := json.Marshal(tokenBundle{AccessToken: "at-live", Expiry: time.Now().Add(time.Hour)})
+	_ = secrets.Set(t.Context(), "PERSONAL_GOOGLE_OAUTH", string(live))
+
+	if err := g.SendMailWithAttachments(t.Context(), row.ID, "ops@example.com", "digest", "body text", nil); err != nil {
+		t.Fatalf("SendMailWithAttachments: %v", err)
+	}
+	if len(f.gmailSent) != 1 || strings.Contains(f.gmailSent[0], "multipart/mixed") {
+		t.Fatalf("expected a plain (non-multipart) send with no attachments, got %q", f.gmailSent)
+	}
+}
+
 // TestGmailSearchZeroResultsSuggestsBroadening pins a real search-
 // coverage miss found in production: a from:-scoped query missed a
 // real email (the sender's exact address differed from what was

--- a/internal/brain/destinations/adapters.go
+++ b/internal/brain/destinations/adapters.go
@@ -15,8 +15,20 @@ import (
 const webhookTimeout = 10 * time.Second
 
 // Adapter delivers one rendered Payload to a destination's config.
+// credentialRef is the destination's stored credential_ref name (never
+// a resolved value) — only TelegramAdapter uses it; email/webhook
+// ignore it (email rides its connector's own auth, webhook has none in
+// this slice).
 type Adapter interface {
-	Deliver(ctx context.Context, config json.RawMessage, payload Payload) error
+	Deliver(ctx context.Context, config json.RawMessage, credentialRef string, payload Payload) error
+}
+
+// MailAttachment mirrors connectors.Attachment — a local copy so this
+// package never imports connectors, mirroring the rest of
+// destinations' dependency direction (connectorLookup above).
+type MailAttachment struct {
+	Name string
+	Data []byte
 }
 
 // mailSender is the narrow slice of *connectors.Google the email
@@ -25,37 +37,47 @@ type Adapter interface {
 // direction (connectorLookup above).
 type mailSender interface {
 	SendMail(ctx context.Context, connectorID, to, subject, body string) error
+	SendMailWithAttachments(ctx context.Context, connectorID, to, subject, body string, attachments []MailAttachment) error
 }
 
 // EmailAdapter sends a destination's payload via the SAME Gmail send
-// path gmail_send's tool uses (connectors.Google.SendMail) — never the
-// tool-execution layer, so a destination's delivery never depends on
-// the agent loop or permission chain.
+// path gmail_send's tool uses (connectors.Google.SendMail /
+// SendMailWithAttachments) — never the tool-execution layer, so a
+// destination's delivery never depends on the agent loop or
+// permission chain.
 type EmailAdapter struct {
 	Mail mailSender
 }
 
-func (a *EmailAdapter) Deliver(ctx context.Context, config json.RawMessage, payload Payload) error {
+func (a *EmailAdapter) Deliver(ctx context.Context, config json.RawMessage, _ string, payload Payload) error {
 	var cfg EmailConfig
 	if err := json.Unmarshal(config, &cfg); err != nil {
 		return fmt.Errorf("email adapter: config: %w", err)
 	}
 	subject := "Timothy mission: " + payload.Name
-	return a.Mail.SendMail(ctx, cfg.ConnectorID, cfg.To, subject, renderText(payload))
+	if len(payload.Files) == 0 {
+		return a.Mail.SendMail(ctx, cfg.ConnectorID, cfg.To, subject, renderText(payload))
+	}
+	attachments := make([]MailAttachment, len(payload.Files))
+	for i, f := range payload.Files {
+		attachments[i] = MailAttachment(f)
+	}
+	return a.Mail.SendMailWithAttachments(ctx, cfg.ConnectorID, cfg.To, subject, renderText(payload), attachments)
 }
 
 // WebhookAdapter POSTs a destination's payload as JSON or plain text
 // per config.format. credential_ref-based Authorization is
-// deliberately OMITTED in this slice: brain has no secret-value
-// resolution path of its own for arbitrary credential refs (secrets
-// resolve gateway/connector-side); wiring one here would mean
-// inventing a new resolution path rather than reusing an existing one.
-// Revisit if a real need for authenticated webhooks shows up.
+// deliberately OMITTED in this slice: the plan named no header config
+// for it yet (see 2026-08-19-destinations-plan.md's open questions),
+// not a resolution-path limitation — brain's own secret store
+// (secretstore.Store.Resolve) is already used directly elsewhere
+// (connectors, telegram below). Revisit if a real need for
+// authenticated webhooks shows up.
 type WebhookAdapter struct {
 	HTTP *http.Client
 }
 
-func (a *WebhookAdapter) Deliver(ctx context.Context, config json.RawMessage, payload Payload) error {
+func (a *WebhookAdapter) Deliver(ctx context.Context, config json.RawMessage, _ string, payload Payload) error {
 	var cfg WebhookConfig
 	if err := json.Unmarshal(config, &cfg); err != nil {
 		return fmt.Errorf("webhook adapter: config: %w", err)
@@ -95,7 +117,9 @@ func (a *WebhookAdapter) Deliver(ctx context.Context, config json.RawMessage, pa
 }
 
 // renderText is the plain-text rendering shared by the email body and
-// a text-format webhook.
+// a text-format webhook. Oversize artifact names are listed here for
+// every kind — a webhook never receives the files themselves, but
+// still gets to know they exist.
 func renderText(p Payload) string {
 	out := p.Body
 	if len(p.Links) > 0 {
@@ -104,5 +128,6 @@ func renderText(p Payload) string {
 			out += "- " + l + "\n"
 		}
 	}
+	out += oversizeNotice(p.OversizeFiles)
 	return out
 }

--- a/internal/brain/destinations/adapters_test.go
+++ b/internal/brain/destinations/adapters_test.go
@@ -1,0 +1,101 @@
+package destinations
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type fakeMailSender struct {
+	plainCalls int
+	lastBody   string
+	attached   []MailAttachment
+}
+
+func (f *fakeMailSender) SendMail(_ context.Context, _, _, _, body string) error {
+	f.plainCalls++
+	f.lastBody = body
+	return nil
+}
+
+func (f *fakeMailSender) SendMailWithAttachments(_ context.Context, _, _, _, body string, attachments []MailAttachment) error {
+	f.lastBody = body
+	f.attached = attachments
+	return nil
+}
+
+func TestEmailAdapterDeliverNoFilesUsesPlainSend(t *testing.T) {
+	mail := &fakeMailSender{}
+	a := &EmailAdapter{Mail: mail}
+	err := a.Deliver(t.Context(), json.RawMessage(`{"connector_id":"c1","to":"a@b.com"}`), "", Payload{Body: "digest"})
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if mail.plainCalls != 1 || mail.attached != nil {
+		t.Fatalf("expected a plain send with no attachments, got calls=%d attached=%v", mail.plainCalls, mail.attached)
+	}
+}
+
+func TestEmailAdapterDeliverWithFilesUsesAttachments(t *testing.T) {
+	mail := &fakeMailSender{}
+	a := &EmailAdapter{Mail: mail}
+	files := []File{{Name: "out.md", Data: []byte("content")}}
+	err := a.Deliver(t.Context(), json.RawMessage(`{"connector_id":"c1","to":"a@b.com"}`), "", Payload{Body: "digest", Files: files})
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if mail.plainCalls != 0 {
+		t.Fatalf("expected the attachment send path, not the plain one")
+	}
+	if len(mail.attached) != 1 || mail.attached[0].Name != "out.md" || string(mail.attached[0].Data) != "content" {
+		t.Fatalf("unexpected attachments: %+v", mail.attached)
+	}
+}
+
+func TestWebhookAdapterJSONNeverIncludesFiles(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		gotBody = string(buf)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := &WebhookAdapter{}
+	payload := Payload{
+		Body:  "digest",
+		Files: []File{{Name: "secret.txt", Data: []byte("should never appear in the webhook body")}},
+	}
+	cfg, _ := json.Marshal(WebhookConfig{URL: srv.URL, Format: "json"})
+	if err := a.Deliver(t.Context(), cfg, "", payload); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if strings.Contains(gotBody, "secret.txt") || strings.Contains(gotBody, "should never appear") {
+		t.Fatalf("webhook JSON body leaked file content: %q", gotBody)
+	}
+}
+
+func TestWebhookAdapterTextMentionsOversizeByNameOnly(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		gotBody = string(buf)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := &WebhookAdapter{}
+	payload := Payload{Body: "digest", OversizeFiles: []string{"huge.zip"}}
+	cfg, _ := json.Marshal(WebhookConfig{URL: srv.URL, Format: "text"})
+	if err := a.Deliver(t.Context(), cfg, "", payload); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if !strings.Contains(gotBody, "huge.zip") {
+		t.Fatalf("expected the oversize file name mentioned in text body, got %q", gotBody)
+	}
+}

--- a/internal/brain/destinations/deliver.go
+++ b/internal/brain/destinations/deliver.go
@@ -44,15 +44,19 @@ type Deliverer struct {
 
 // NewDeliverer builds a Deliverer. webURL resolves the web_base_url
 // setting fresh at delivery time (never cached on the struct) so an
-// operator's later change applies without a restart. email nil (no
-// google connectors wired) leaves "email" unregistered in adapters —
-// deliverOne's map lookup then reports "no adapter for kind" rather
-// than boxing a nil *EmailAdapter as a non-nil Adapter (which would
-// panic on first field access inside Deliver).
-func NewDeliverer(store destinationStore, events eventRecorder, email *EmailAdapter, webhook *WebhookAdapter, webURL func(ctx context.Context) string, log *slog.Logger) *Deliverer {
+// operator's later change applies without a restart. email/telegram
+// nil (no google connectors / no secret store wired, respectively)
+// leaves that kind unregistered in adapters — deliverOne's map lookup
+// then reports "no adapter for kind" rather than boxing a nil adapter
+// as a non-nil Adapter (which would panic on first field access
+// inside Deliver).
+func NewDeliverer(store destinationStore, events eventRecorder, email *EmailAdapter, webhook *WebhookAdapter, telegram *TelegramAdapter, webURL func(ctx context.Context) string, log *slog.Logger) *Deliverer {
 	adapters := map[string]Adapter{"webhook": webhook}
 	if email != nil {
 		adapters["email"] = email
+	}
+	if telegram != nil {
+		adapters["telegram"] = telegram
 	}
 	return &Deliverer{
 		store:    store,
@@ -135,7 +139,7 @@ func (d *Deliverer) deliverOne(ctx context.Context, missionID, destinationID str
 			case <-timer.C:
 			}
 		}
-		lastErr = adapter.Deliver(ctx, dest.Config, payload)
+		lastErr = adapter.Deliver(ctx, dest.Config, dest.CredentialRef, payload)
 		if lastErr == nil {
 			d.recordOutcome(ctx, missionID, destinationID, dest.Name, true, "")
 			return
@@ -180,7 +184,7 @@ func (d *Deliverer) Test(ctx context.Context, id string) error {
 	if adapter == nil {
 		return fmt.Errorf("no adapter for kind %q", dest.Kind)
 	}
-	return adapter.Deliver(ctx, dest.Config, testPayload)
+	return adapter.Deliver(ctx, dest.Config, dest.CredentialRef, testPayload)
 }
 
 // alreadyDelivered scans a mission's events for prior

--- a/internal/brain/destinations/deliver_test.go
+++ b/internal/brain/destinations/deliver_test.go
@@ -58,7 +58,7 @@ type fakeAdapter struct {
 	failCount int
 }
 
-func (f *fakeAdapter) Deliver(_ context.Context, _ json.RawMessage, _ Payload) error {
+func (f *fakeAdapter) Deliver(_ context.Context, _ json.RawMessage, _ string, _ Payload) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.calls++
@@ -84,7 +84,7 @@ func withFastBackoff(t *testing.T) {
 func TestDeliverZeroDestinationsNoop(t *testing.T) {
 	destStore := &fakeDestStore{rows: map[string]Destination{}}
 	eventStore := &fakeEventStore{}
-	d := NewDeliverer(destStore, eventStore, nil, &WebhookAdapter{}, nil, discardLog())
+	d := NewDeliverer(destStore, eventStore, nil, &WebhookAdapter{}, nil, nil, discardLog())
 
 	d.Deliver(t.Context(), missions.Mission{ID: "m1"}, nil, "digest")
 

--- a/internal/brain/destinations/destinations.go
+++ b/internal/brain/destinations/destinations.go
@@ -1,9 +1,9 @@
 // Package destinations implements operator-created outbound sinks
 // mission results deliver to: email (rides a google connector's Gmail
-// send path) and webhook in slice 1. Delivery is harness-owned and
-// deterministic (D-061) — the model never supplies or addresses a
-// destination, only ids resolved against this operator-owned table are
-// ever reachable.
+// send path), webhook, and telegram (Bot API). Delivery is
+// harness-owned and deterministic (D-061) — the model never supplies
+// or addresses a destination, only ids resolved against this
+// operator-owned table are ever reachable.
 package destinations
 
 import (
@@ -43,6 +43,12 @@ type EmailConfig struct {
 type WebhookConfig struct {
 	URL    string `json:"url"`
 	Format string `json:"format"` // json | text
+}
+
+// TelegramConfig is the config shape for kind='telegram'. The bot
+// token lives in Destination.CredentialRef, never here.
+type TelegramConfig struct {
+	ChatID string `json:"chat_id"`
 }
 
 var namePattern = regexp.MustCompile(`^[a-z0-9]+(?:[-_][a-z0-9]+)*$`)
@@ -113,11 +119,19 @@ func validate(ctx context.Context, conns connectorLookup, d Destination) error {
 		default:
 			return fmt.Errorf(`webhook destination requires config.format to be "json" or "text"`)
 		}
+	case "telegram":
+		var cfg TelegramConfig
+		if err := json.Unmarshal(d.Config, &cfg); err != nil {
+			return fmt.Errorf("telegram config: %w", err)
+		}
+		if cfg.ChatID == "" {
+			return fmt.Errorf("telegram destination requires config.chat_id")
+		}
+		if d.CredentialRef == "" {
+			return fmt.Errorf("telegram destination requires credential_ref (bot token)")
+		}
 	default:
-		// Slice 1 accepts only email/webhook at the Go layer, even
-		// though the DB CHECK also allows 'telegram' for forward
-		// compatibility (see 0014_destinations.sql).
-		return fmt.Errorf("unsupported kind %q (only email, webhook in this release)", d.Kind)
+		return fmt.Errorf("unsupported kind %q (only email, webhook, telegram in this release)", d.Kind)
 	}
 	return nil
 }

--- a/internal/brain/destinations/destinations_test.go
+++ b/internal/brain/destinations/destinations_test.go
@@ -93,7 +93,20 @@ func TestValidate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "telegram rejected at go layer",
+			name: "valid telegram",
+			//nolint:gosec // G101: a ref NAME, not a credential value.
+			d: Destination{Name: "tg", Kind: "telegram", CredentialRef: "TG_BOT_TOKEN",
+				Config: json.RawMessage(`{"chat_id":"123"}`)},
+			wantErr: false,
+		},
+		{
+			name: "telegram missing chat_id",
+			//nolint:gosec // G101: a ref NAME, not a credential value.
+			d:       Destination{Name: "tg", Kind: "telegram", CredentialRef: "TG_BOT_TOKEN", Config: json.RawMessage(`{}`)},
+			wantErr: true,
+		},
+		{
+			name:    "telegram missing credential_ref",
 			d:       Destination{Name: "tg", Kind: "telegram", Config: json.RawMessage(`{"chat_id":"123"}`)},
 			wantErr: true,
 		},

--- a/internal/brain/destinations/files.go
+++ b/internal/brain/destinations/files.go
@@ -1,0 +1,94 @@
+package destinations
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// File is one artifact file resolved and read from a mission's
+// workspace, ready to attach to a delivery.
+type File struct {
+	Name string // base name, for display and as the sent filename
+	Data []byte
+}
+
+// MaxAttachBytes bounds a single artifact file this package will read
+// into memory and attach — an operator-declared plan artifact, not
+// user upload, but still worth a ceiling. Telegram's own sendDocument
+// cap (50MB) is higher than email's practical attachment limit, so
+// this stays the smaller of the two: an oversize file is listed by
+// name in the body instead of attached, for every kind.
+const MaxAttachBytes = 25 << 20 // 25MB
+
+// artifactPaths collects every workspace-relative artifact path
+// declared across a mission's plan units, deduplicated, in plan order
+// — exactly the paths CheckArtifacts already verified exist and are
+// non-empty before the mission could reach done.
+func artifactPaths(m missions.Mission) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, u := range m.Spec.Units {
+		for _, a := range u.Artifacts {
+			rel := strings.TrimSpace(a)
+			if rel == "" || seen[rel] {
+				continue
+			}
+			seen[rel] = true
+			out = append(out, rel)
+		}
+	}
+	return out
+}
+
+// resolveArtifactFiles reads a mission's declared artifact files from
+// its workspace for attachment. files holds every path that read
+// clean and within ceiling; oversize holds the names of paths that
+// exist but exceed MaxAttachBytes (listed by name in the body
+// instead). A path that fails the same within-workspace guard
+// CheckArtifacts uses, or that no longer reads back (moved/removed
+// since verification), is silently skipped — delivery is best-effort
+// and must never fail a mission over a since-vanished file.
+func resolveArtifactFiles(m missions.Mission) (files []File, oversize []string) {
+	root := m.WorkRoot()
+	if root == "" {
+		return nil, nil
+	}
+	for _, rel := range artifactPaths(m) {
+		cleaned := filepath.Clean(rel)
+		if filepath.IsAbs(rel) || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+			continue
+		}
+		abs := filepath.Join(root, cleaned)
+		if err := tools.WithinRoot(root, abs); err != nil {
+			continue
+		}
+		info, err := os.Stat(abs)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		if info.Size() > MaxAttachBytes {
+			oversize = append(oversize, filepath.Base(cleaned))
+			continue
+		}
+		data, err := os.ReadFile(abs) //nolint:gosec // G304: abs is guarded by WithinRoot above
+		if err != nil {
+			continue
+		}
+		files = append(files, File{Name: filepath.Base(cleaned), Data: data})
+	}
+	return files, oversize
+}
+
+// oversizeNotice renders the oversize-files line appended to a
+// delivery body when any artifact exceeded MaxAttachBytes.
+func oversizeNotice(oversize []string) string {
+	if len(oversize) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("\n\nToo large to attach (over %dMB): %s\n", MaxAttachBytes>>20, strings.Join(oversize, ", "))
+}

--- a/internal/brain/destinations/files_test.go
+++ b/internal/brain/destinations/files_test.go
@@ -1,0 +1,140 @@
+package destinations
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+func TestArtifactPathsDedupesAcrossUnits(t *testing.T) {
+	m := missions.Mission{Spec: missions.Spec{Units: []missions.PlanUnit{
+		{Artifacts: []string{"a.md", "b.md"}},
+		{Artifacts: []string{"b.md", "c.md", ""}},
+	}}}
+	got := artifactPaths(m)
+	want := []string{"a.md", "b.md", "c.md"}
+	if len(got) != len(want) {
+		t.Fatalf("artifactPaths = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("artifactPaths[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestResolveArtifactFilesReadsUnderWorkspace(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "out.md"), []byte("report body"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	m := missions.Mission{Workspace: root, Spec: missions.Spec{Units: []missions.PlanUnit{
+		{Artifacts: []string{"out.md"}},
+	}}}
+
+	files, oversize := resolveArtifactFiles(m)
+	if len(oversize) != 0 {
+		t.Fatalf("expected no oversize files, got %v", oversize)
+	}
+	if len(files) != 1 || files[0].Name != "out.md" || string(files[0].Data) != "report body" {
+		t.Fatalf("unexpected files: %+v", files)
+	}
+}
+
+func TestResolveArtifactFilesUsesWorktreeOverWorkspace(t *testing.T) {
+	workspace := t.TempDir()
+	worktree := t.TempDir()
+	if err := os.WriteFile(filepath.Join(worktree, "out.md"), []byte("from worktree"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	m := missions.Mission{Workspace: workspace, Worktree: worktree, Spec: missions.Spec{Units: []missions.PlanUnit{
+		{Artifacts: []string{"out.md"}},
+	}}}
+
+	files, _ := resolveArtifactFiles(m)
+	if len(files) != 1 || string(files[0].Data) != "from worktree" {
+		t.Fatalf("expected the worktree copy to win, got %+v", files)
+	}
+}
+
+func TestResolveArtifactFilesRejectsPathTraversal(t *testing.T) {
+	root := t.TempDir()
+	// A file that genuinely exists just outside root, so a naive
+	// filepath.Join without the guard would happily read it.
+	outside := filepath.Dir(root)
+	secretPath := filepath.Join(outside, "secret-"+filepath.Base(root)+".txt")
+	if err := os.WriteFile(secretPath, []byte("should never be read"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(secretPath) })
+
+	tests := []string{
+		"../" + filepath.Base(secretPath),
+		"/etc/passwd",
+		"..",
+	}
+	for _, artifact := range tests {
+		m := missions.Mission{Workspace: root, Spec: missions.Spec{Units: []missions.PlanUnit{
+			{Artifacts: []string{artifact}},
+		}}}
+		files, _ := resolveArtifactFiles(m)
+		if len(files) != 0 {
+			t.Fatalf("artifact %q: expected no files resolved (path escapes workspace), got %+v", artifact, files)
+		}
+	}
+}
+
+func TestResolveArtifactFilesSkipsMissingFile(t *testing.T) {
+	root := t.TempDir()
+	m := missions.Mission{Workspace: root, Spec: missions.Spec{Units: []missions.PlanUnit{
+		{Artifacts: []string{"never-written.md"}},
+	}}}
+	files, oversize := resolveArtifactFiles(m)
+	if len(files) != 0 || len(oversize) != 0 {
+		t.Fatalf("expected nothing resolved for a missing file, got files=%v oversize=%v", files, oversize)
+	}
+}
+
+func TestResolveArtifactFilesOversizeListedByName(t *testing.T) {
+	root := t.TempDir()
+	big := make([]byte, MaxAttachBytes+1)
+	if err := os.WriteFile(filepath.Join(root, "huge.bin"), big, 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	m := missions.Mission{Workspace: root, Spec: missions.Spec{Units: []missions.PlanUnit{
+		{Artifacts: []string{"huge.bin"}},
+	}}}
+	files, oversize := resolveArtifactFiles(m)
+	if len(files) != 0 {
+		t.Fatalf("expected the oversize file not attached, got %+v", files)
+	}
+	if len(oversize) != 1 || oversize[0] != "huge.bin" {
+		t.Fatalf("expected huge.bin listed as oversize, got %v", oversize)
+	}
+}
+
+func TestResolveArtifactFilesNoWorkspace(t *testing.T) {
+	m := missions.Mission{Spec: missions.Spec{Units: []missions.PlanUnit{{Artifacts: []string{"a.md"}}}}}
+	files, oversize := resolveArtifactFiles(m)
+	if len(files) != 0 || len(oversize) != 0 {
+		t.Fatalf("expected nothing resolved with no workspace, got files=%v oversize=%v", files, oversize)
+	}
+}
+
+func TestOversizeNotice(t *testing.T) {
+	if got := oversizeNotice(nil); got != "" {
+		t.Fatalf("oversizeNotice(nil) = %q, want empty", got)
+	}
+	got := oversizeNotice([]string{"a.zip", "b.zip"})
+	if got == "" {
+		t.Fatal("expected a non-empty notice")
+	}
+	for _, name := range []string{"a.zip", "b.zip"} {
+		if !strings.Contains(got, name) {
+			t.Fatalf("notice %q missing %q", got, name)
+		}
+	}
+}

--- a/internal/brain/destinations/render.go
+++ b/internal/brain/destinations/render.go
@@ -8,20 +8,29 @@ import (
 )
 
 // Payload is the rendered delivery content, kind-agnostic: adapters
-// format it per their own contract (email HTML, webhook JSON/text).
+// format it per their own contract (email HTML, webhook JSON/text,
+// telegram MarkdownV2). Files/OversizeFiles are never serialized —
+// webhook's JSON body is body+links only, per the plan's kind gate;
+// they carry through only for the email/telegram adapters, which read
+// the fields directly rather than through JSON.
 type Payload struct {
-	MissionID string   `json:"mission_id"`
-	Name      string   `json:"name"`
-	Goal      string   `json:"goal"`
-	Body      string   `json:"body"`
-	Links     []string `json:"links"`
+	MissionID     string   `json:"mission_id"`
+	Name          string   `json:"name"`
+	Goal          string   `json:"goal"`
+	Body          string   `json:"body"`
+	Links         []string `json:"links"`
+	Files         []File   `json:"-"`
+	OversizeFiles []string `json:"-"`
 }
 
 // Render builds a mission's delivery Payload: body is the outcome
 // digest verbatim (missions.OutcomeDigest, already computed by the
 // driver's terminal-transition hook — never recomputed here). links is
 // the mission detail URL (built from webBaseURL when non-empty) plus
-// branch/PR URL when the mission has them.
+// branch/PR URL when the mission has them. Files/OversizeFiles come
+// from the mission's declared plan-unit artifacts, read from its
+// workspace (resolveArtifactFiles) — exactly what CheckArtifacts
+// already verified exists.
 func Render(m missions.Mission, digest string, webBaseURL string, events []missions.Event) Payload {
 	name := m.Name
 	if name == "" {
@@ -37,12 +46,15 @@ func Render(m missions.Mission, digest string, webBaseURL string, events []missi
 	if url, ok := lastPROpenedURL(events); ok {
 		links = append(links, url)
 	}
+	files, oversize := resolveArtifactFiles(m)
 	return Payload{
-		MissionID: m.ID,
-		Name:      name,
-		Goal:      m.Goal,
-		Body:      digest,
-		Links:     links,
+		MissionID:     m.ID,
+		Name:          name,
+		Goal:          m.Goal,
+		Body:          digest,
+		Links:         links,
+		Files:         files,
+		OversizeFiles: oversize,
 	}
 }
 

--- a/internal/brain/destinations/render_test.go
+++ b/internal/brain/destinations/render_test.go
@@ -2,6 +2,8 @@ package destinations
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
@@ -73,6 +75,20 @@ func TestRender(t *testing.T) {
 		p := Render(noName, digest, "", nil)
 		if p.Name != "ship the thing" {
 			t.Fatalf("Name = %q, want fallback to goal", p.Name)
+		}
+	})
+
+	t.Run("includes declared artifact files", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "report.md"), []byte("report"), 0o600); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+		withArtifact := m
+		withArtifact.Workspace = root
+		withArtifact.Spec = missions.Spec{Units: []missions.PlanUnit{{Artifacts: []string{"report.md"}}}}
+		p := Render(withArtifact, digest, "", nil)
+		if len(p.Files) != 1 || p.Files[0].Name != "report.md" {
+			t.Fatalf("expected report.md attached, got %+v", p.Files)
 		}
 	})
 }

--- a/internal/brain/destinations/telegram.go
+++ b/internal/brain/destinations/telegram.go
@@ -1,0 +1,217 @@
+package destinations
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// telegramTimeout bounds one Telegram Bot API call — same reasoning as
+// webhookTimeout.
+const telegramTimeout = 10 * time.Second
+
+// telegramMessageLimit is the Bot API's sendMessage text cap. A
+// message over this is truncated with a notice + mission link
+// appended, never rejected.
+const telegramMessageLimit = 4096
+
+// tokenResolver resolves a credential_ref to its secret value. Brain's
+// own secretstore.Store.Resolve satisfies this directly, the same way
+// connectors and missions already resolve their own credential_refs —
+// there is no gateway hop for this (see D-062 in adapters.go/deliver.go
+// comments for the fuller reasoning).
+type tokenResolver func(ctx context.Context, refName string) (string, error)
+
+// TelegramAdapter sends a destination's payload via the Telegram Bot
+// API: sendMessage for the body (MarkdownV2, truncated to the API's
+// 4096-char cap), sendDocument for each attached file.
+type TelegramAdapter struct {
+	ResolveToken tokenResolver
+	HTTP         *http.Client
+	// APIBase overrides the Bot API's base URL for tests; empty uses
+	// the real API.
+	APIBase string
+}
+
+func (a *TelegramAdapter) apiBase() string {
+	if a.APIBase != "" {
+		return a.APIBase
+	}
+	return "https://api.telegram.org"
+}
+
+func (a *TelegramAdapter) client() *http.Client {
+	if a.HTTP != nil {
+		return a.HTTP
+	}
+	return &http.Client{Timeout: telegramTimeout}
+}
+
+func (a *TelegramAdapter) Deliver(ctx context.Context, config json.RawMessage, credentialRef string, payload Payload) error {
+	var cfg TelegramConfig
+	if err := json.Unmarshal(config, &cfg); err != nil {
+		return fmt.Errorf("telegram adapter: config: %w", err)
+	}
+	if a.ResolveToken == nil {
+		return fmt.Errorf("telegram adapter: no token resolver configured")
+	}
+	if credentialRef == "" {
+		return fmt.Errorf("telegram adapter: destination has no credential_ref")
+	}
+	token, err := a.ResolveToken(ctx, credentialRef)
+	if err != nil {
+		return fmt.Errorf("telegram adapter: resolve bot token: %w", err)
+	}
+
+	text := renderTelegramText(payload)
+	if err := a.sendMessage(ctx, token, cfg.ChatID, text); err != nil {
+		return fmt.Errorf("telegram adapter: send message: %w", err)
+	}
+	for _, f := range payload.Files {
+		if err := a.sendDocument(ctx, token, cfg.ChatID, f); err != nil {
+			return fmt.Errorf("telegram adapter: send document %s: %w", f.Name, err)
+		}
+	}
+	return nil
+}
+
+// renderTelegramText builds the MarkdownV2 body: digest + links +
+// oversize notice, escaped, then truncated to telegramMessageLimit
+// with a notice appended (the mission link, when present, is preserved
+// after truncation rather than being the first thing cut).
+func renderTelegramText(p Payload) string {
+	var b strings.Builder
+	b.WriteString(escapeMarkdownV2(p.Body))
+	if len(p.Links) > 0 {
+		b.WriteString("\n\n")
+		b.WriteString(escapeMarkdownV2("Links:"))
+		for _, l := range p.Links {
+			b.WriteString("\n")
+			b.WriteString(escapeMarkdownV2("- " + l))
+		}
+	}
+	if notice := oversizeNotice(p.OversizeFiles); notice != "" {
+		b.WriteString(escapeMarkdownV2(notice))
+	}
+	full := b.String()
+	if len(full) <= telegramMessageLimit {
+		return full
+	}
+	return truncateMarkdownV2(full, p.Links)
+}
+
+// truncationSuffix is appended, escaped, when a message is cut for
+// length — the mission link (if any) is repeated here since it may
+// have been cut from the body itself.
+func truncationSuffix(links []string) string {
+	suffix := "\n\n" + escapeMarkdownV2("[truncated]")
+	if len(links) > 0 {
+		suffix += "\n" + escapeMarkdownV2(links[0])
+	}
+	return suffix
+}
+
+// truncateMarkdownV2 cuts full to fit telegramMessageLimit once the
+// truncation suffix is accounted for, at a rune boundary so no
+// multi-byte rune (or its escaping backslash) is split.
+func truncateMarkdownV2(full string, links []string) string {
+	suffix := truncationSuffix(links)
+	budget := telegramMessageLimit - len(suffix)
+	if budget < 0 {
+		budget = 0
+	}
+	cut := 0
+	for i, r := range full {
+		if i+len(string(r)) > budget {
+			break
+		}
+		cut = i + len(string(r))
+	}
+	return full[:cut] + suffix
+}
+
+// markdownV2Escapes are the characters Telegram's MarkdownV2 requires
+// escaped anywhere in plain text (Bot API docs, "MarkdownV2 style").
+const markdownV2Escapes = "_*[]()~`>#+-=|{}.!\\"
+
+// escapeMarkdownV2 backslash-escapes every MarkdownV2 special
+// character in s so arbitrary mission text (goal, digest, links) can
+// never break message formatting or be misread as formatting markup.
+func escapeMarkdownV2(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if strings.ContainsRune(markdownV2Escapes, r) {
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func (a *TelegramAdapter) sendMessage(ctx context.Context, token, chatID, text string) error {
+	body, err := json.Marshal(map[string]any{
+		"chat_id":    chatID,
+		"text":       text,
+		"parse_mode": "MarkdownV2",
+	})
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	return a.call(ctx, token, "sendMessage", "application/json", bytes.NewReader(body))
+}
+
+func (a *TelegramAdapter) sendDocument(ctx context.Context, token, chatID string, f File) error {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	if err := w.WriteField("chat_id", chatID); err != nil {
+		return fmt.Errorf("build form: %w", err)
+	}
+	part, err := w.CreateFormFile("document", f.Name)
+	if err != nil {
+		return fmt.Errorf("build form: %w", err)
+	}
+	if _, err := part.Write(f.Data); err != nil {
+		return fmt.Errorf("build form: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("build form: %w", err)
+	}
+	return a.call(ctx, token, "sendDocument", w.FormDataContentType(), &buf)
+}
+
+// call POSTs one Bot API method and treats any non-2xx status or
+// {"ok": false} response body as failure.
+func (a *TelegramAdapter) call(ctx context.Context, token, method, contentType string, body io.Reader) error {
+	cctx, cancel := context.WithTimeout(ctx, telegramTimeout)
+	defer cancel()
+	url := a.apiBase() + "/bot" + token + "/" + method
+	req, err := http.NewRequestWithContext(cctx, http.MethodPost, url, body)
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	resp, err := a.client().Do(req)
+	if err != nil {
+		return fmt.Errorf("post: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("api status %d: %s", resp.StatusCode, string(data))
+	}
+	var result struct {
+		OK          bool   `json:"ok"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal(data, &result); err == nil && !result.OK {
+		return fmt.Errorf("api error: %s", result.Description)
+	}
+	return nil
+}

--- a/internal/brain/destinations/telegram_test.go
+++ b/internal/brain/destinations/telegram_test.go
@@ -1,0 +1,172 @@
+package destinations
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestEscapeMarkdownV2(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"plain text unchanged", "hello world", "hello world"},
+		{"each special char escaped", "_*[]()~`>#+-=|{}.!", `\_\*\[\]\(\)\~\` + "`" + `\>\#\+\-\=\|\{\}\.\!`},
+		{"backslash escaped", `a\b`, `a\\b`},
+		{"mixed prose", "done! see: https://x.example/a_b (link)", `done\! see: https://x\.example/a\_b \(link\)`},
+		{"empty string", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := escapeMarkdownV2(tt.in); got != tt.want {
+				t.Fatalf("escapeMarkdownV2(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderTelegramTextUnderLimit(t *testing.T) {
+	p := Payload{Body: "short digest.", Links: []string{"https://timothy.example/missions/m1"}}
+	got := renderTelegramText(p)
+	if len(got) > telegramMessageLimit {
+		t.Fatalf("got %d bytes, want <= %d", len(got), telegramMessageLimit)
+	}
+	if !strings.Contains(got, "short digest") {
+		t.Fatalf("expected digest content, got %q", got)
+	}
+	if !strings.Contains(got, `missions/m1`) {
+		t.Fatalf("expected link content, got %q", got)
+	}
+}
+
+func TestRenderTelegramTextTruncatesOverLimit(t *testing.T) {
+	p := Payload{Body: strings.Repeat("x", telegramMessageLimit*2), Links: []string{"https://timothy.example/missions/m1"}}
+	got := renderTelegramText(p)
+	if len(got) > telegramMessageLimit {
+		t.Fatalf("truncated text is %d bytes, want <= %d", len(got), telegramMessageLimit)
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Fatalf("expected a truncation notice, got tail %q", got[len(got)-80:])
+	}
+	if !strings.Contains(got, "missions/m1") {
+		t.Fatalf("expected the mission link preserved after truncation, got tail %q", got[len(got)-200:])
+	}
+}
+
+func TestRenderTelegramTextTruncationRespectsMultibyteRunes(t *testing.T) {
+	// A body made entirely of multi-byte runes must not panic or corrupt
+	// output when cut for length.
+	p := Payload{Body: strings.Repeat("测试", telegramMessageLimit)}
+	got := renderTelegramText(p)
+	if len(got) > telegramMessageLimit {
+		t.Fatalf("got %d bytes, want <= %d", len(got), telegramMessageLimit)
+	}
+	if !strings.HasPrefix(got, "测试") {
+		t.Fatalf("expected valid utf8 prefix preserved, got %q", got[:min(20, len(got))])
+	}
+}
+
+func TestRenderTelegramTextIncludesOversizeNotice(t *testing.T) {
+	p := Payload{Body: "digest", OversizeFiles: []string{"huge.zip"}}
+	got := renderTelegramText(p)
+	// The oversize notice text is itself MarkdownV2-escaped, so the
+	// file name's literal dot comes through escaped too.
+	if !strings.Contains(got, escapeMarkdownV2("huge.zip")) {
+		t.Fatalf("expected oversize file name in text, got %q", got)
+	}
+}
+
+// fakeTokenResolver resolves exactly one ref to one value, erroring on
+// anything else.
+func fakeTokenResolver(ref, value string) tokenResolver {
+	return func(_ context.Context, r string) (string, error) {
+		if r != ref {
+			return "", errors.New("unknown ref")
+		}
+		return value, nil
+	}
+}
+
+func TestTelegramAdapterDeliverSendsMessageAndDocument(t *testing.T) {
+	var gotMessages []map[string]any
+	var gotDocuments []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/sendMessage"):
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			gotMessages = append(gotMessages, body)
+		case strings.HasSuffix(r.URL.Path, "/sendDocument"):
+			if err := r.ParseMultipartForm(1 << 20); err != nil { //nolint:gosec // G120: test server, fixed small fixture body
+				t.Fatalf("parse multipart: %v", err)
+			}
+			gotDocuments = append(gotDocuments, r.FormValue("chat_id"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	a := &TelegramAdapter{
+		ResolveToken: fakeTokenResolver("TG_BOT_TOKEN", "secret-token"),
+		APIBase:      srv.URL,
+	}
+	payload := Payload{Body: "mission done", Files: []File{{Name: "out.txt", Data: []byte("data")}}}
+	err := a.Deliver(t.Context(), json.RawMessage(`{"chat_id":"123"}`), "TG_BOT_TOKEN", payload)
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if len(gotMessages) != 1 || gotMessages[0]["chat_id"] != "123" {
+		t.Fatalf("expected one sendMessage to chat 123, got %+v", gotMessages)
+	}
+	if gotMessages[0]["parse_mode"] != "MarkdownV2" {
+		t.Fatalf("expected MarkdownV2 parse_mode, got %+v", gotMessages[0])
+	}
+	if len(gotDocuments) != 1 || gotDocuments[0] != "123" {
+		t.Fatalf("expected one sendDocument to chat 123, got %v", gotDocuments)
+	}
+}
+
+func TestTelegramAdapterDeliverMissingCredentialRef(t *testing.T) {
+	a := &TelegramAdapter{ResolveToken: fakeTokenResolver("TG_BOT_TOKEN", "secret-token")}
+	err := a.Deliver(t.Context(), json.RawMessage(`{"chat_id":"123"}`), "", Payload{})
+	if err == nil {
+		t.Fatal("expected error for missing credential_ref")
+	}
+}
+
+func TestTelegramAdapterDeliverResolveTokenFails(t *testing.T) {
+	a := &TelegramAdapter{ResolveToken: fakeTokenResolver("OTHER_REF", "secret-token")}
+	err := a.Deliver(t.Context(), json.RawMessage(`{"chat_id":"123"}`), "TG_BOT_TOKEN", Payload{})
+	if err == nil {
+		t.Fatal("expected error when the token resolver fails")
+	}
+}
+
+func TestTelegramAdapterDeliverAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":false,"description":"chat not found"}`))
+	}))
+	defer srv.Close()
+
+	a := &TelegramAdapter{ResolveToken: fakeTokenResolver("TG_BOT_TOKEN", "secret-token"), APIBase: srv.URL}
+	err := a.Deliver(t.Context(), json.RawMessage(`{"chat_id":"123"}`), "TG_BOT_TOKEN", Payload{Body: "hi"})
+	if err == nil || !strings.Contains(err.Error(), "chat not found") {
+		t.Fatalf("expected api error surfaced, got %v", err)
+	}
+}
+
+func TestTelegramAdapterDeliverBadConfig(t *testing.T) {
+	a := &TelegramAdapter{ResolveToken: fakeTokenResolver("TG_BOT_TOKEN", "secret-token")}
+	err := a.Deliver(t.Context(), json.RawMessage(`not json`), "TG_BOT_TOKEN", Payload{})
+	if err == nil {
+		t.Fatal("expected error for malformed config")
+	}
+}

--- a/web/src/components/settings/DestinationAdd.tsx
+++ b/web/src/components/settings/DestinationAdd.tsx
@@ -3,11 +3,12 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useState } from 'react'
 import { Link, Navigate, useNavigate, useParams } from 'react-router'
 import { toast } from 'sonner'
-import { createDestination, listConnectors, patchDestination, testDestination } from '../../api/client'
+import { createDestination, listConnectors, patchDestination, setSecret, testDestination } from '../../api/client'
 import type { AdminConnector } from '../../api/types'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { CredentialModeToggle, ExistingCredentialSelect, type CredentialMode } from './CredentialRefPicker'
 import { Field } from './shared'
 import { errText } from './util'
 
@@ -18,11 +19,12 @@ function slugify(v: string): string {
     .replace(/^-+|-+$/g, '')
 }
 
-// DestinationAdd is kind-aware (email vs webhook) and its own page,
-// mirroring ConnectorAdd's shape: the destination row is created
-// (disabled) as part of testing, and a passing test enables it.
+// DestinationAdd is kind-aware (email vs webhook vs telegram) and its
+// own page, mirroring ConnectorAdd's shape: the destination row is
+// created (disabled) as part of testing, and a passing test enables
+// it.
 export function DestinationAdd() {
-  const { kind } = useParams<{ kind: 'email' | 'webhook' }>()
+  const { kind } = useParams<{ kind: 'email' | 'webhook' | 'telegram' }>()
   const navigate = useNavigate()
 
   const [name, setName] = useState('')
@@ -39,6 +41,12 @@ export function DestinationAdd() {
   const [url, setURL] = useState('')
   const [format, setFormat] = useState<'json' | 'text'>('json')
 
+  // telegram fields
+  const [chatID, setChatID] = useState('')
+  const [botToken, setBotToken] = useState('')
+  const [botTokenMode, setBotTokenMode] = useState<CredentialMode>('new')
+  const [existingBotTokenRef, setExistingBotTokenRef] = useState('')
+
   useEffect(() => {
     if (kind !== 'email') return
     listConnectors()
@@ -46,27 +54,44 @@ export function DestinationAdd() {
       .catch((err: unknown) => toast.error('Could not load connectors', { description: errText(err) }))
   }, [kind])
 
-  if (kind !== 'email' && kind !== 'webhook') return <Navigate to="/settings/destinations" replace />
+  if (kind !== 'email' && kind !== 'webhook' && kind !== 'telegram') {
+    return <Navigate to="/settings/destinations" replace />
+  }
 
   const invalidate = () => {
     setTest(null)
     setCreatedID(null)
   }
 
-  const config = kind === 'email' ? { connector_id: connectorID, to: to.trim() } : { url: url.trim(), format }
+  const slug = slugify(name)
+  const usingExistingBotToken = botTokenMode === 'existing'
+  const botTokenRef = usingExistingBotToken ? existingBotTokenRef : `${slug.toUpperCase().replace(/-/g, '_')}_TELEGRAM_BOT_TOKEN`
+
+  const config =
+    kind === 'email'
+      ? { connector_id: connectorID, to: to.trim() }
+      : kind === 'telegram'
+        ? { chat_id: chatID.trim() }
+        : { url: url.trim(), format }
 
   const canTest =
-    slugify(name) !== '' &&
-    (kind === 'email' ? connectorID !== '' && to.trim() !== '' : url.trim() !== '')
+    slug !== '' &&
+    (kind === 'email'
+      ? connectorID !== '' && to.trim() !== ''
+      : kind === 'telegram'
+        ? chatID.trim() !== '' && (usingExistingBotToken ? existingBotTokenRef !== '' : botToken.trim() !== '')
+        : url.trim() !== '')
 
   const runTest = async () => {
     setBusy(true)
     setTest(null)
     try {
+      if (kind === 'telegram' && !usingExistingBotToken) await setSecret(botTokenRef, botToken.trim())
       const id = await createDestination({
-        name: slugify(name),
+        name: slug,
         kind,
         config,
+        credential_ref: kind === 'telegram' ? botTokenRef : undefined,
         enabled: false,
       })
       setCreatedID(id)
@@ -109,7 +134,7 @@ export function DestinationAdd() {
 
       <div className="border-b border-border pb-6">
         <h1 className="text-xl font-semibold tracking-tight">
-          Add {kind === 'email' ? 'Email' : 'Webhook'} destination
+          Add {kind === 'email' ? 'Email' : kind === 'telegram' ? 'Telegram' : 'Webhook'} destination
         </h1>
         <p className="text-sm text-muted-foreground">kind: {kind}</p>
       </div>
@@ -166,6 +191,53 @@ export function DestinationAdd() {
                 className="mt-1.5 h-10"
               />
             </Field>
+          </>
+        ) : kind === 'telegram' ? (
+          <>
+            <Field label="Chat ID" hint="the numeric chat or channel id the bot posts to">
+              <Input
+                value={chatID}
+                onChange={(e) => {
+                  setChatID(e.target.value)
+                  invalidate()
+                }}
+                placeholder="123456789"
+                className="mt-1.5 h-10"
+              />
+            </Field>
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-foreground">Bot token</span>
+                <CredentialModeToggle
+                  mode={botTokenMode}
+                  onChange={(m) => {
+                    setBotTokenMode(m)
+                    invalidate()
+                  }}
+                />
+              </div>
+              {botTokenMode === 'existing' ? (
+                <Field label="Existing credential">
+                  <ExistingCredentialSelect
+                    value={existingBotTokenRef}
+                    onChange={(v) => {
+                      setExistingBotTokenRef(v)
+                      invalidate()
+                    }}
+                  />
+                </Field>
+              ) : (
+                <Input
+                  value={botToken}
+                  onChange={(e) => {
+                    setBotToken(e.target.value)
+                    invalidate()
+                  }}
+                  placeholder="123456:ABC-DEF..."
+                  className="h-10"
+                />
+              )}
+            </div>
           </>
         ) : (
           <>

--- a/web/src/components/settings/DestinationEdit.tsx
+++ b/web/src/components/settings/DestinationEdit.tsx
@@ -8,6 +8,7 @@ import {
   listConnectors,
   listDestinations,
   patchDestination,
+  setSecret,
   testDestination,
 } from '../../api/client'
 import type { AdminConnector, Destination } from '../../api/types'
@@ -21,6 +22,7 @@ import {
 } from '../ui/dialog'
 import { Input } from '../ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { CredentialModeToggle, ExistingCredentialSelect, type CredentialMode } from './CredentialRefPicker'
 import { Field, Toggle } from './shared'
 import { errText } from './util'
 
@@ -39,7 +41,15 @@ export function DestinationEdit() {
   const [connectorID, setConnectorID] = useState('')
   const [url, setURL] = useState('')
   const [format, setFormat] = useState<'json' | 'text'>('json')
+  const [chatID, setChatID] = useState('')
   const [savingConfig, setSavingConfig] = useState(false)
+
+  // Rotating the bot token is a separate save from the rest of the
+  // config: it writes credential_ref's value, not config.
+  const [botToken, setBotToken] = useState('')
+  const [botTokenMode, setBotTokenMode] = useState<CredentialMode>('new')
+  const [existingBotTokenRef, setExistingBotTokenRef] = useState('')
+  const [savingToken, setSavingToken] = useState(false)
 
   const refresh = useCallback(() => {
     listDestinations()
@@ -52,6 +62,8 @@ export function DestinationEdit() {
         } else if (found?.kind === 'webhook') {
           setURL(String(found.config.url ?? ''))
           setFormat((found.config.format as 'json' | 'text') ?? 'json')
+        } else if (found?.kind === 'telegram') {
+          setChatID(String(found.config.chat_id ?? ''))
         }
       })
       .catch((err: unknown) => toast.error('Could not load destination', { description: errText(err) }))
@@ -104,7 +116,11 @@ export function DestinationEdit() {
     setSavingConfig(true)
     try {
       const config =
-        destination.kind === 'email' ? { connector_id: connectorID, to: to.trim() } : { url: url.trim(), format }
+        destination.kind === 'email'
+          ? { connector_id: connectorID, to: to.trim() }
+          : destination.kind === 'telegram'
+            ? { chat_id: chatID.trim() }
+            : { url: url.trim(), format }
       await patchDestination(destination.id, { config })
       toast.success('Destination updated')
       refresh()
@@ -112,6 +128,25 @@ export function DestinationEdit() {
       toast.error('Could not update destination', { description: errText(err) })
     } finally {
       setSavingConfig(false)
+    }
+  }
+
+  const usingExistingBotToken = botTokenMode === 'existing'
+
+  const saveBotToken = async () => {
+    if (!destination) return
+    setSavingToken(true)
+    try {
+      const ref = usingExistingBotToken ? existingBotTokenRef : destination.credential_ref
+      if (!usingExistingBotToken) await setSecret(ref, botToken.trim())
+      await patchDestination(destination.id, { credential_ref: ref })
+      toast.success('Bot token updated')
+      setBotToken('')
+      refresh()
+    } catch (err) {
+      toast.error('Could not update bot token', { description: errText(err) })
+    } finally {
+      setSavingToken(false)
     }
   }
 
@@ -195,6 +230,12 @@ export function DestinationEdit() {
               <Input value={to} onChange={(e) => setTo(e.target.value)} className="mt-1.5 h-10" />
             </Field>
           </>
+        ) : destination.kind === 'telegram' ? (
+          <>
+            <Field label="Chat ID">
+              <Input value={chatID} onChange={(e) => setChatID(e.target.value)} className="mt-1.5 h-10" />
+            </Field>
+          </>
         ) : (
           <>
             <Field label="URL">
@@ -220,6 +261,34 @@ export function DestinationEdit() {
             {savingConfig ? 'Saving…' : 'Save changes'}
           </Button>
         </div>
+
+        {destination.kind === 'telegram' && (
+          <div className="space-y-3 rounded-xl border border-border p-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-foreground">Rotate bot token</span>
+              <CredentialModeToggle mode={botTokenMode} onChange={setBotTokenMode} />
+            </div>
+            {botTokenMode === 'existing' ? (
+              <Field label="Existing credential">
+                <ExistingCredentialSelect value={existingBotTokenRef} onChange={setExistingBotTokenRef} />
+              </Field>
+            ) : (
+              <Input
+                value={botToken}
+                onChange={(e) => setBotToken(e.target.value)}
+                placeholder="123456:ABC-DEF..."
+                className="h-10"
+              />
+            )}
+            <Button
+              size="sm"
+              disabled={savingToken || (usingExistingBotToken ? !existingBotTokenRef : !botToken.trim())}
+              onClick={() => void saveBotToken()}
+            >
+              {savingToken ? 'Saving…' : 'Save token'}
+            </Button>
+          </div>
+        )}
       </div>
 
       <Dialog open={confirmDelete} onOpenChange={setConfirmDelete}>

--- a/web/src/components/settings/DestinationsList.tsx
+++ b/web/src/components/settings/DestinationsList.tsx
@@ -1,4 +1,4 @@
-import { Mail01Icon, GlobalIcon } from '@hugeicons-pro/core-stroke-rounded'
+import { Mail01Icon, GlobalIcon, TelegramIcon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
@@ -16,7 +16,7 @@ import {
 import { Toggle } from './shared'
 import { errText } from './util'
 
-const kindIcon = { email: Mail01Icon, webhook: GlobalIcon, telegram: GlobalIcon } as const
+const kindIcon = { email: Mail01Icon, webhook: GlobalIcon, telegram: TelegramIcon } as const
 
 export function DestinationsList() {
   const [destinations, setDestinations] = useState<Destination[]>([])
@@ -88,6 +88,19 @@ export function DestinationsList() {
               </span>
             </span>
           </button>
+          <button
+            type="button"
+            onClick={() => navigate('/settings/destinations/new/telegram')}
+            className="flex items-center gap-3 rounded-xl border border-dashed border-border p-4 text-left transition hover:border-brand hover:bg-muted/50"
+          >
+            <HugeiconsIcon icon={TelegramIcon} className="size-9" />
+            <span className="min-w-0">
+              <span className="block text-sm font-semibold">Telegram</span>
+              <span className="block truncate text-sm text-muted-foreground">
+                Sends via a bot to a chat
+              </span>
+            </span>
+          </button>
         </div>
       </section>
     </div>
@@ -151,7 +164,9 @@ function DestinationCard({
       <div className="truncate text-xs text-muted-foreground">
         {destination.kind === 'email'
           ? String(destination.config.to ?? '')
-          : String(destination.config.url ?? '')}
+          : destination.kind === 'telegram'
+            ? `chat ${String(destination.config.chat_id ?? '')}`
+            : String(destination.config.url ?? '')}
       </div>
 
       {test && (

--- a/web/src/components/settings/DestinationsTab.test.tsx
+++ b/web/src/components/settings/DestinationsTab.test.tsx
@@ -9,7 +9,9 @@ vi.mock('../../api/client', () => ({
   deleteDestination: vi.fn(),
   listConnectors: vi.fn(),
   listDestinations: vi.fn(),
+  listSecretRefs: vi.fn(),
   patchDestination: vi.fn(),
+  setSecret: vi.fn(),
   testDestination: vi.fn(),
 }))
 
@@ -20,7 +22,9 @@ import {
   deleteDestination,
   listConnectors,
   listDestinations,
+  listSecretRefs,
   patchDestination,
+  setSecret,
   testDestination,
 } from '../../api/client'
 import { toast } from 'sonner'
@@ -31,6 +35,17 @@ const webhookDestination: Destination = {
   kind: 'webhook',
   config: { url: 'https://example.com/hook', format: 'json' },
   credential_ref: '',
+  enabled: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const telegramDestination: Destination = {
+  id: 'd4',
+  name: 'ops-telegram',
+  kind: 'telegram',
+  config: { chat_id: '123456' },
+  credential_ref: 'OPS_TELEGRAM_TELEGRAM_BOT_TOKEN',
   enabled: true,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
@@ -62,6 +77,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(listDestinations).mockResolvedValue([])
   vi.mocked(listConnectors).mockResolvedValue([googleConnector])
+  vi.mocked(listSecretRefs).mockResolvedValue([])
 })
 
 describe('Destinations tab', () => {
@@ -204,5 +220,84 @@ describe('Destinations tab', () => {
       config: { connector_id: 'c1', to: 'ops@example.com' },
       enabled: false,
     })
+  })
+
+  it('adds a telegram destination: writes the bot token secret then creates', async () => {
+    vi.mocked(setSecret).mockResolvedValue()
+    vi.mocked(createDestination).mockResolvedValue('d4')
+    vi.mocked(testDestination).mockResolvedValue({ ok: true })
+    vi.mocked(patchDestination).mockResolvedValue()
+
+    renderTab()
+    fireEvent.click(await screen.findByRole('button', { name: /^Telegram/ }))
+    fireEvent.change(await screen.findByPlaceholderText('ops-inbox'), { target: { value: 'ops-telegram' } })
+    fireEvent.change(screen.getByPlaceholderText('123456789'), { target: { value: '123456' } })
+    fireEvent.change(screen.getByPlaceholderText('123456:ABC-DEF...'), { target: { value: 'bot-token-value' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Test send' }))
+
+    const addButton = await screen.findByRole('button', { name: 'Add destination' })
+    await waitFor(() => expect((addButton as HTMLButtonElement).disabled).toBe(false))
+    fireEvent.click(addButton)
+
+    await waitFor(() => expect(patchDestination).toHaveBeenCalledWith('d4', { enabled: true }))
+    expect(setSecret).toHaveBeenCalledWith('OPS_TELEGRAM_TELEGRAM_BOT_TOKEN', 'bot-token-value')
+    expect(createDestination).toHaveBeenCalledWith({
+      name: 'ops-telegram',
+      kind: 'telegram',
+      config: { chat_id: '123456' },
+      credential_ref: 'OPS_TELEGRAM_TELEGRAM_BOT_TOKEN',
+      enabled: false,
+    })
+  })
+
+  it('reuses an existing credential for a telegram bot token, skipping the secret write', async () => {
+    vi.mocked(listSecretRefs).mockResolvedValue([{ name: 'SHARED_BOT_TOKEN', backend: 'db', referenced_by: [] }])
+    vi.mocked(createDestination).mockResolvedValue('d4')
+    vi.mocked(testDestination).mockResolvedValue({ ok: true })
+
+    renderTab()
+    fireEvent.click(await screen.findByRole('button', { name: /^Telegram/ }))
+    fireEvent.change(await screen.findByPlaceholderText('ops-inbox'), { target: { value: 'ops-telegram' } })
+    fireEvent.change(screen.getByPlaceholderText('123456789'), { target: { value: '123456' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Use existing' }))
+    fireEvent.click(await screen.findByLabelText('existing credential'))
+    fireEvent.click(await screen.findByRole('option', { name: 'SHARED_BOT_TOKEN' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Test send' }))
+
+    await waitFor(() => expect(testDestination).toHaveBeenCalled())
+    expect(setSecret).not.toHaveBeenCalled()
+    expect(createDestination).toHaveBeenCalledWith({
+      name: 'ops-telegram',
+      kind: 'telegram',
+      config: { chat_id: '123456' },
+      credential_ref: 'SHARED_BOT_TOKEN',
+      enabled: false,
+    })
+  })
+
+  it('edits a telegram destination config and rotates its bot token', async () => {
+    vi.mocked(listDestinations).mockResolvedValue([telegramDestination])
+    vi.mocked(patchDestination).mockResolvedValue()
+    vi.mocked(setSecret).mockResolvedValue()
+
+    render(
+      <MemoryRouter initialEntries={['/settings/destinations/d4']}>
+        <Routes>
+          <Route path="/settings/destinations/*" element={<DestinationsTab />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    const chatIDInput = await screen.findByDisplayValue('123456')
+    fireEvent.change(chatIDInput, { target: { value: '987654' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+    await waitFor(() =>
+      expect(patchDestination).toHaveBeenCalledWith('d4', { config: { chat_id: '987654' } }),
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('123456:ABC-DEF...'), { target: { value: 'new-token' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save token' }))
+    await waitFor(() => expect(setSecret).toHaveBeenCalledWith('OPS_TELEGRAM_TELEGRAM_BOT_TOKEN', 'new-token'))
+    expect(patchDestination).toHaveBeenCalledWith('d4', { credential_ref: 'OPS_TELEGRAM_TELEGRAM_BOT_TOKEN' })
   })
 })


### PR DESCRIPTION
Slice 2 of the destinations plan: telegram + files.

- Telegram adapter: Bot API sendMessage (MarkdownV2 escaping, 4096-char cap with truncation notice, mission link preserved) + sendDocument per artifact file; config `{chat_id}`, bot token via required `credential_ref` resolved brain-side through the existing secretstore path (same as connectors)
- Artifact attachment: plan-unit declared paths (exactly what CheckArtifacts verified), read with the same within-workspace guard, 25MB ceiling — oversize files listed by name in the body instead
- Email gains multipart attachments via `SendMailWithAttachments`; webhook payloads structurally cannot carry files (`json:"-"`)
- Web: telegram form (chat_id + role-aware bot-token credential picker), list tile and kind icon
- Corrected slice-1 comment claiming brain lacks a secret-resolution path — `secretstore.Store.Resolve` has always been brain-side

No migration: 0014's kind CHECK already allowed 'telegram'; only Go validation changed. No manual ALTER on deploy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789780671&installation_model_id=431401&pr_number=258&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F258&signature=f90d3085b93c276d36834f4aae8014dfcb725d957015efc28f8bbab82eddf40a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->