### PR TITLE
feat: deliver builtin tool for ad-hoc destination sends

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -292,6 +292,28 @@ func main() {
 	if missionScheduler != nil && destinationStore != nil {
 		missionScheduler.SetDestinationEnabled(destinationStore.EnabledByID)
 	}
+	// deliver: chat-facing ad-hoc send to one operator-configured
+	// destination. Registered here, not inside buildAgent, for the same
+	// reason as the mission tools below — destinationStore/Deliverer
+	// don't exist yet at that point. Like missions/mission_push, this
+	// reaches the live tool surface (chat + connector-reload swaps)
+	// only, never the BuiltinsOnly base surface a mission worker turn
+	// resolves to: a mission worker must never gain an outward-write
+	// tool the harness itself doesn't grant it (same reasoning as
+	// BuiltinsOnly excluding connector writes in loop.Request's doc
+	// comment). A mission that wants a destination attaches it at
+	// create instead; the harness delivers on terminal done.
+	if destinationStore != nil && destinationDeliverer != nil {
+		deliverTool := builtin.Deliver(destinationLister{destinationStore}.List, destinationDeliverer.DeliverNow)
+		current := builtinSet.add(deliverTool)
+		if conns != nil {
+			swapAgentTools(agent, current, conns, app.Log, toolCalls)
+		} else if constrained, defs, err := compileToolset(current, nil, app.Log, toolCalls); err != nil {
+			app.Log.Warn("deliver tool registration failed; agent keeps its previous tool surface", "error", err)
+		} else {
+			agent.SwapTools(constrained, defs)
+		}
+	}
 	// Chat-facing mission tools (D-0xx: "is mission X done?" / "push
 	// mission X"): registered here, not inside buildAgent, since both
 	// need missionStore (built above, after buildAgent) and mission_push
@@ -691,6 +713,26 @@ func (d destinationConnectorLookup) Get(ctx context.Context, id string) (destina
 		return destinations.Connector{}, err
 	}
 	return destinations.Connector{Kind: c.Kind, Enabled: c.Enabled}, nil
+}
+
+// destinationLister adapts *destinations.Store.List to the deliver
+// tool's own DestinationInfo shape — builtin never imports
+// destinations directly (import cycle: destinations -> missions ->
+// builtin), same reasoning as builtin.MissionRecord.
+type destinationLister struct {
+	store *destinations.Store
+}
+
+func (d destinationLister) List(ctx context.Context) ([]builtin.DestinationInfo, error) {
+	rows, err := d.store.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]builtin.DestinationInfo, len(rows))
+	for i, r := range rows {
+		out[i] = builtin.DestinationInfo{ID: r.ID, Name: r.Name, Enabled: r.Enabled}
+	}
+	return out, nil
 }
 
 // missionWorkSlotMax bounds how many missions may be status='working'

--- a/internal/brain/destinations/adapters.go
+++ b/internal/brain/destinations/adapters.go
@@ -54,7 +54,10 @@ func (a *EmailAdapter) Deliver(ctx context.Context, config json.RawMessage, _ st
 	if err := json.Unmarshal(config, &cfg); err != nil {
 		return fmt.Errorf("email adapter: config: %w", err)
 	}
-	subject := "Timothy mission: " + payload.Name
+	subject := payload.Subject
+	if subject == "" {
+		subject = "Timothy mission: " + payload.Name
+	}
 	if len(payload.Files) == 0 {
 		return a.Mail.SendMail(ctx, cfg.ConnectorID, cfg.To, subject, renderText(payload))
 	}
@@ -122,6 +125,9 @@ func (a *WebhookAdapter) Deliver(ctx context.Context, config json.RawMessage, _ 
 // still gets to know they exist.
 func renderText(p Payload) string {
 	out := p.Body
+	if p.Subject != "" {
+		out = p.Subject + "\n\n" + out
+	}
 	if len(p.Links) > 0 {
 		out += "\n\nLinks:\n"
 		for _, l := range p.Links {

--- a/internal/brain/destinations/adapters_test.go
+++ b/internal/brain/destinations/adapters_test.go
@@ -10,13 +10,15 @@ import (
 )
 
 type fakeMailSender struct {
-	plainCalls int
-	lastBody   string
-	attached   []MailAttachment
+	plainCalls  int
+	lastSubject string
+	lastBody    string
+	attached    []MailAttachment
 }
 
-func (f *fakeMailSender) SendMail(_ context.Context, _, _, _, body string) error {
+func (f *fakeMailSender) SendMail(_ context.Context, _, _, subject, body string) error {
 	f.plainCalls++
+	f.lastSubject = subject
 	f.lastBody = body
 	return nil
 }
@@ -52,6 +54,30 @@ func TestEmailAdapterDeliverWithFilesUsesAttachments(t *testing.T) {
 	}
 	if len(mail.attached) != 1 || mail.attached[0].Name != "out.md" || string(mail.attached[0].Data) != "content" {
 		t.Fatalf("unexpected attachments: %+v", mail.attached)
+	}
+}
+
+func TestEmailAdapterUsesMissionSubjectByDefault(t *testing.T) {
+	mail := &fakeMailSender{}
+	a := &EmailAdapter{Mail: mail}
+	err := a.Deliver(t.Context(), json.RawMessage(`{"connector_id":"c1","to":"a@b.com"}`), "", Payload{Name: "Ship it", Body: "digest"})
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if mail.lastSubject != "Timothy mission: Ship it" {
+		t.Fatalf("subject = %q, want mission-derived default", mail.lastSubject)
+	}
+}
+
+func TestEmailAdapterUsesPayloadSubjectWhenSet(t *testing.T) {
+	mail := &fakeMailSender{}
+	a := &EmailAdapter{Mail: mail}
+	err := a.Deliver(t.Context(), json.RawMessage(`{"connector_id":"c1","to":"a@b.com"}`), "", Payload{Name: "Ship it", Subject: "Daily digest", Body: "digest"})
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if mail.lastSubject != "Daily digest" {
+		t.Fatalf("subject = %q, want the payload's own subject", mail.lastSubject)
 	}
 }
 
@@ -97,5 +123,47 @@ func TestWebhookAdapterTextMentionsOversizeByNameOnly(t *testing.T) {
 	}
 	if !strings.Contains(gotBody, "huge.zip") {
 		t.Fatalf("expected the oversize file name mentioned in text body, got %q", gotBody)
+	}
+}
+
+func TestWebhookAdapterTextPrependsSubjectWhenSet(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		gotBody = string(buf)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := &WebhookAdapter{}
+	payload := Payload{Subject: "Daily digest", Body: "the content"}
+	cfg, _ := json.Marshal(WebhookConfig{URL: srv.URL, Format: "text"})
+	if err := a.Deliver(t.Context(), cfg, "", payload); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if !strings.HasPrefix(gotBody, "Daily digest\n\nthe content") {
+		t.Fatalf("gotBody = %q, want subject prepended", gotBody)
+	}
+}
+
+func TestWebhookAdapterJSONIncludesSubjectField(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		gotBody = string(buf)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := &WebhookAdapter{}
+	payload := Payload{Subject: "Daily digest", Body: "the content"}
+	cfg, _ := json.Marshal(WebhookConfig{URL: srv.URL, Format: "json"})
+	if err := a.Deliver(t.Context(), cfg, "", payload); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if !strings.Contains(gotBody, `"subject":"Daily digest"`) {
+		t.Fatalf("gotBody = %q, want subject field present", gotBody)
 	}
 }

--- a/internal/brain/destinations/deliver.go
+++ b/internal/brain/destinations/deliver.go
@@ -187,6 +187,32 @@ func (d *Deliverer) Test(ctx context.Context, id string) error {
 	return adapter.Deliver(ctx, dest.Config, dest.CredentialRef, testPayload)
 }
 
+// DeliverNow sends subject+body to one destination synchronously, no
+// retry — the deliver tool's backing call (chat and mission turns
+// alike). Unlike Deliver/Test this never touches mission_events (the
+// tool's own result string is the caller's record) and carries no
+// files: attachments are the harness terminal-delivery path's concern
+// only. Returns the destination's name and kind on success so the
+// tool can report what it delivered to.
+func (d *Deliverer) DeliverNow(ctx context.Context, id, subject, body string) (name, kind string, err error) {
+	dest, err := d.store.Get(ctx, id)
+	if err != nil {
+		return "", "", err
+	}
+	if !dest.Enabled {
+		return "", "", fmt.Errorf("destination %q is disabled", dest.Name)
+	}
+	adapter := d.adapters[dest.Kind]
+	if adapter == nil {
+		return "", "", fmt.Errorf("no adapter for kind %q", dest.Kind)
+	}
+	payload := Payload{Subject: subject, Body: body}
+	if err := adapter.Deliver(ctx, dest.Config, dest.CredentialRef, payload); err != nil {
+		return "", "", err
+	}
+	return dest.Name, dest.Kind, nil
+}
+
 // alreadyDelivered scans a mission's events for prior
 // mission.delivered/mission.delivery_failed rows, keyed by
 // destination_id — the one-per-destination-per-mission idempotency

--- a/internal/brain/destinations/deliver_test.go
+++ b/internal/brain/destinations/deliver_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -174,6 +175,60 @@ func TestDeliverDisabledDestinationRecordsFailure(t *testing.T) {
 
 	if len(eventStore.events) != 1 || eventStore.events[0].Kind != eventDeliveryFailed {
 		t.Fatalf("expected one mission.delivery_failed event, got %+v", eventStore.events)
+	}
+}
+
+func TestDeliverNowSuccess(t *testing.T) {
+	destStore := &fakeDestStore{rows: map[string]Destination{
+		"d1": {ID: "d1", Name: "webhook-1", Kind: "webhook", Enabled: true, Config: json.RawMessage(`{"url":"https://example.com","format":"json"}`)},
+	}}
+	adapter := &fakeAdapter{failCount: 0}
+	d := &Deliverer{store: destStore, adapters: map[string]Adapter{"webhook": adapter}, log: discardLog()}
+
+	name, kind, err := d.DeliverNow(t.Context(), "d1", "subject", "body")
+	if err != nil {
+		t.Fatalf("DeliverNow: %v", err)
+	}
+	if name != "webhook-1" || kind != "webhook" {
+		t.Fatalf("name/kind = %q/%q, want webhook-1/webhook", name, kind)
+	}
+	if adapter.callCount() != 1 {
+		t.Fatalf("expected exactly 1 call, no retry, got %d", adapter.callCount())
+	}
+}
+
+func TestDeliverNowUnknownDestination(t *testing.T) {
+	destStore := &fakeDestStore{rows: map[string]Destination{}}
+	d := &Deliverer{store: destStore, adapters: map[string]Adapter{}, log: discardLog()}
+	if _, _, err := d.DeliverNow(t.Context(), "missing", "s", "b"); err == nil {
+		t.Fatal("expected error for unknown destination")
+	}
+}
+
+func TestDeliverNowDisabledDestination(t *testing.T) {
+	destStore := &fakeDestStore{rows: map[string]Destination{
+		"d1": {ID: "d1", Name: "off", Kind: "webhook", Enabled: false},
+	}}
+	d := &Deliverer{store: destStore, adapters: map[string]Adapter{"webhook": &WebhookAdapter{}}, log: discardLog()}
+	_, _, err := d.DeliverNow(t.Context(), "d1", "s", "b")
+	if err == nil || !strings.Contains(err.Error(), "disabled") || !strings.Contains(err.Error(), "off") {
+		t.Fatalf("err = %v, want disabled error naming the destination", err)
+	}
+}
+
+func TestDeliverNowNeverRetries(t *testing.T) {
+	destStore := &fakeDestStore{rows: map[string]Destination{
+		"d1": {ID: "d1", Name: "webhook-1", Kind: "webhook", Enabled: true, Config: json.RawMessage(`{"url":"https://example.com","format":"json"}`)},
+	}}
+	adapter := &fakeAdapter{failCount: -1} // always fails
+	d := &Deliverer{store: destStore, adapters: map[string]Adapter{"webhook": adapter}, log: discardLog()}
+
+	_, _, err := d.DeliverNow(t.Context(), "d1", "s", "b")
+	if err == nil {
+		t.Fatal("expected the adapter error surfaced")
+	}
+	if adapter.callCount() != 1 {
+		t.Fatalf("expected exactly 1 attempt (no retry), got %d", adapter.callCount())
 	}
 }
 

--- a/internal/brain/destinations/render.go
+++ b/internal/brain/destinations/render.go
@@ -14,9 +14,13 @@ import (
 // they carry through only for the email/telegram adapters, which read
 // the fields directly rather than through JSON.
 type Payload struct {
-	MissionID     string   `json:"mission_id"`
-	Name          string   `json:"name"`
-	Goal          string   `json:"goal"`
+	MissionID string `json:"mission_id"`
+	Name      string `json:"name"`
+	Goal      string `json:"goal"`
+	// Subject is set only by the ad-hoc deliver tool (missions never
+	// set it); the email adapter uses it as the subject line in place
+	// of its mission-derived default when non-empty.
+	Subject       string   `json:"subject,omitempty"`
 	Body          string   `json:"body"`
 	Links         []string `json:"links"`
 	Files         []File   `json:"-"`

--- a/internal/brain/destinations/telegram.go
+++ b/internal/brain/destinations/telegram.go
@@ -87,6 +87,10 @@ func (a *TelegramAdapter) Deliver(ctx context.Context, config json.RawMessage, c
 // after truncation rather than being the first thing cut).
 func renderTelegramText(p Payload) string {
 	var b strings.Builder
+	if p.Subject != "" {
+		b.WriteString(escapeMarkdownV2(p.Subject))
+		b.WriteString("\n\n")
+	}
 	b.WriteString(escapeMarkdownV2(p.Body))
 	if len(p.Links) > 0 {
 		b.WriteString("\n\n")

--- a/internal/brain/destinations/telegram_test.go
+++ b/internal/brain/destinations/telegram_test.go
@@ -43,6 +43,14 @@ func TestRenderTelegramTextUnderLimit(t *testing.T) {
 	}
 }
 
+func TestRenderTelegramTextPrependsSubjectWhenSet(t *testing.T) {
+	p := Payload{Subject: "Daily digest", Body: "the content"}
+	got := renderTelegramText(p)
+	if !strings.HasPrefix(got, "Daily digest\n\nthe content") {
+		t.Fatalf("got = %q, want subject prepended", got)
+	}
+}
+
 func TestRenderTelegramTextTruncatesOverLimit(t *testing.T) {
 	p := Payload{Body: strings.Repeat("x", telegramMessageLimit*2), Links: []string{"https://timothy.example/missions/m1"}}
 	got := renderTelegramText(p)

--- a/internal/brain/tools/builtin/deliver.go
+++ b/internal/brain/tools/builtin/deliver.go
@@ -1,0 +1,196 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// DestinationInfo is the deliver tool's own view of one destinations
+// row — a local struct (not an import of internal/brain/destinations)
+// because destinations imports internal/brain/missions, which imports
+// this package (runner.go's builtin.Shell/WriteFile); a destinations
+// import here would create an import cycle. cmd/brain/main.go, which
+// imports both packages, adapts real destinations.Destination values
+// into this shape.
+type DestinationInfo struct {
+	ID      string
+	Name    string
+	Enabled bool
+}
+
+// DeliverLister lists every destination for name/id resolution; main
+// curries destinations.Store.List in.
+type DeliverLister func(ctx context.Context) ([]DestinationInfo, error)
+
+// DeliverFunc sends subject+body to one already-resolved destination
+// id, synchronously, no retry, and reports what it delivered to; main
+// curries destinations.Deliverer.DeliverNow in.
+type DeliverFunc func(ctx context.Context, destinationID, subject, body string) (name, kind string, err error)
+
+// deliverKnownArgs are the only keys deliver's schema declares. Any
+// other key in the raw call — to, url, chat_id, email, or anything
+// else — is rejected before the model's args are even parsed: the
+// exfil guard is enforced here in Go, never left to the JSON schema
+// alone, since a schema is only a hint to the model, not a boundary.
+var deliverKnownArgs = map[string]bool{"destination": true, "subject": true, "body": true}
+
+type deliverArgs struct {
+	Destination string `json:"destination"`
+	Subject     string `json:"subject"`
+	Body        string `json:"body"`
+}
+
+// Deliver lets the model send a message to one operator-configured
+// destination (email, webhook, or Telegram). list resolves the
+// destination argument to an id; deliver performs the actual send.
+//
+// Exfiltration guard (Go code, not prompt text): the model can only
+// pick a destination from the operator's own list, by name or id —
+// there is no argument for an address, URL, or chat id, and any
+// unrecognized argument is rejected outright rather than silently
+// dropped. A prompt-injected "send this to attacker@x" has nothing to
+// call.
+func Deliver(list DeliverLister, deliver DeliverFunc) *tools.Tool {
+	return &tools.Tool{
+		Name: "deliver",
+		Description: `Sends a message to one operator-configured destination
+(email, webhook, or Telegram) set up in Settings → Destinations.
+
+Use when asked to send/deliver/forward something to a named
+destination ("send this to my telegram", "email the summary to
+ops-webhook"). There is no way to specify an address, URL, or chat id
+here — only a destination already configured by the operator can be
+targeted; if none fits, say so instead of guessing a destination name.
+
+This is a plain text delivery: subject + body only, no file
+attachments (mission artifact files are delivered automatically at
+mission completion for destinations attached to that mission, not
+through this tool).
+
+Arguments:
+- destination (string, required): the destination's name or id, as
+  configured in Settings → Destinations.
+- subject (string, optional): subject line (used by email; prepended
+  to the message body for webhook/Telegram).
+- body (string, required): the message content.
+
+Returns the destination's name and kind on success. On failure,
+returns the delivery error (e.g. connection refused) — this call is
+best-effort and does not retry.`,
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"destination": {
+					"type": "string",
+					"description": "Destination name or id, as configured in Settings → Destinations."
+				},
+				"subject": {
+					"type": "string",
+					"description": "Optional subject line."
+				},
+				"body": {
+					"type": "string",
+					"description": "Message content to deliver."
+				}
+			},
+			"required": ["destination", "body"],
+			"additionalProperties": false
+		}`),
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
+			var loose map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &loose); err != nil {
+				return "", fmt.Errorf("deliver: invalid arguments: %w", err)
+			}
+			for key := range loose {
+				if !deliverKnownArgs[key] {
+					return "", fmt.Errorf("deliver: unknown argument %q — destinations are operator-configured, addresses cannot be supplied here", key)
+				}
+			}
+			var args deliverArgs
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return "", fmt.Errorf("deliver: invalid arguments: %w", err)
+			}
+			destination := strings.TrimSpace(args.Destination)
+			if destination == "" {
+				return "", fmt.Errorf("deliver: destination is required")
+			}
+			body := strings.TrimSpace(args.Body)
+			if body == "" {
+				return "", fmt.Errorf("deliver: body is required")
+			}
+			if list == nil || deliver == nil {
+				return "", fmt.Errorf("deliver: destinations are not configured")
+			}
+			destinations, err := list(ctx)
+			if err != nil {
+				return "", fmt.Errorf("deliver: %w", err)
+			}
+			id, err := resolveDestination(destinations, destination)
+			if err != nil {
+				return "", err
+			}
+			name, kind, err := deliver(ctx, id, args.Subject, body)
+			if err != nil {
+				return "", fmt.Errorf("deliver: %w", err)
+			}
+			return fmt.Sprintf("delivered to %q (%s)", name, kind), nil
+		},
+	}
+}
+
+// resolveDestination matches ref against the operator's destination
+// list: an exact id match first, else a unique case-insensitive name
+// match, else an error naming every enabled destination the model
+// could have meant. A disabled destination is only matched by
+// explicit id/name (never silently skipped in that resolution step)
+// but reported as disabled rather than delivered to.
+func resolveDestination(all []DestinationInfo, ref string) (string, error) {
+	for _, d := range all {
+		if d.ID == ref {
+			if !d.Enabled {
+				return "", fmt.Errorf("deliver: destination %q is disabled", d.Name)
+			}
+			return d.ID, nil
+		}
+	}
+	var matches []DestinationInfo
+	lower := strings.ToLower(ref)
+	for _, d := range all {
+		if strings.ToLower(d.Name) == lower {
+			matches = append(matches, d)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		if !matches[0].Enabled {
+			return "", fmt.Errorf("deliver: destination %q is disabled", matches[0].Name)
+		}
+		return matches[0].ID, nil
+	case 0:
+		return "", fmt.Errorf("deliver: no destination named %q — valid destinations: %s", ref, enabledNames(all))
+	default:
+		return "", fmt.Errorf("deliver: %q matches more than one destination — use its id instead", ref)
+	}
+}
+
+// enabledNames lists every enabled destination's name, sorted, for the
+// "unknown destination" error — a disabled destination is never
+// offered as something the model could have meant.
+func enabledNames(all []DestinationInfo) string {
+	var names []string
+	for _, d := range all {
+		if d.Enabled {
+			names = append(names, d.Name)
+		}
+	}
+	if len(names) == 0 {
+		return "(none configured)"
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}

--- a/internal/brain/tools/builtin/deliver_test.go
+++ b/internal/brain/tools/builtin/deliver_test.go
@@ -1,0 +1,194 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+func testDestinations() []DestinationInfo {
+	return []DestinationInfo{
+		{ID: "id-1", Name: "ops-webhook", Enabled: true},
+		{ID: "id-2", Name: "my-telegram", Enabled: true},
+		{ID: "id-3", Name: "old-webhook", Enabled: false},
+		{ID: "id-4", Name: "dup", Enabled: true},
+		{ID: "id-5", Name: "dup", Enabled: true},
+	}
+}
+
+type deliverCall struct {
+	tool              *tools.Tool
+	id, subject, body string
+}
+
+func newDeliverTool(t *testing.T, deliver DeliverFunc) *deliverCall {
+	t.Helper()
+	call := &deliverCall{}
+	call.tool = Deliver(func(context.Context) ([]DestinationInfo, error) {
+		return testDestinations(), nil
+	}, func(ctx context.Context, id, subject, body string) (string, string, error) {
+		call.id, call.subject, call.body = id, subject, body
+		if deliver != nil {
+			return deliver(ctx, id, subject, body)
+		}
+		return "", "", nil
+	})
+	return call
+}
+
+func TestDeliverResolvesByExactID(t *testing.T) {
+	t.Parallel()
+	call := newDeliverTool(t, func(context.Context, string, string, string) (string, string, error) {
+		return "ops-webhook", "webhook", nil
+	})
+	out, err := call.tool.Execute(t.Context(), json.RawMessage(`{"destination":"id-1","body":"hi"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if call.id != "id-1" {
+		t.Fatalf("resolved id = %q, want id-1", call.id)
+	}
+	if !strings.Contains(out, "ops-webhook") || !strings.Contains(out, "webhook") {
+		t.Fatalf("out = %q, want name+kind", out)
+	}
+}
+
+func TestDeliverResolvesByCaseInsensitiveName(t *testing.T) {
+	t.Parallel()
+	call := newDeliverTool(t, nil)
+	_, err := call.tool.Execute(t.Context(), json.RawMessage(`{"destination":"OPS-Webhook","body":"hi"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if call.id != "id-1" {
+		t.Fatalf("resolved id = %q, want id-1", call.id)
+	}
+}
+
+func TestDeliverAmbiguousNameErrors(t *testing.T) {
+	t.Parallel()
+	call := newDeliverTool(t, nil)
+	_, err := call.tool.Execute(t.Context(), json.RawMessage(`{"destination":"dup","body":"hi"}`))
+	if err == nil || !strings.Contains(err.Error(), "more than one") {
+		t.Fatalf("err = %v, want ambiguous-match error", err)
+	}
+	if call.id != "" {
+		t.Fatal("deliver must not run on an ambiguous match")
+	}
+}
+
+func TestDeliverUnknownNameListsValidNames(t *testing.T) {
+	t.Parallel()
+	call := newDeliverTool(t, nil)
+	_, err := call.tool.Execute(t.Context(), json.RawMessage(`{"destination":"nope","body":"hi"}`))
+	if err == nil {
+		t.Fatal("expected error for unknown destination")
+	}
+	// disabled destination must never appear in the valid-names list
+	if strings.Contains(err.Error(), "old-webhook") {
+		t.Fatalf("err = %v, disabled destination must not be listed", err)
+	}
+	for _, name := range []string{"ops-webhook", "my-telegram"} {
+		if !strings.Contains(err.Error(), name) {
+			t.Fatalf("err = %v, want it to list %q", err, name)
+		}
+	}
+}
+
+func TestDeliverDisabledDestinationByID(t *testing.T) {
+	t.Parallel()
+	call := newDeliverTool(t, nil)
+	_, err := call.tool.Execute(t.Context(), json.RawMessage(`{"destination":"id-3","body":"hi"}`))
+	if err == nil || !strings.Contains(err.Error(), "disabled") || !strings.Contains(err.Error(), "old-webhook") {
+		t.Fatalf("err = %v, want disabled error naming old-webhook", err)
+	}
+}
+
+func TestDeliverDisabledDestinationByName(t *testing.T) {
+	t.Parallel()
+	call := newDeliverTool(t, nil)
+	_, err := call.tool.Execute(t.Context(), json.RawMessage(`{"destination":"old-webhook","body":"hi"}`))
+	if err == nil || !strings.Contains(err.Error(), "disabled") {
+		t.Fatalf("err = %v, want disabled error", err)
+	}
+}
+
+func TestDeliverRejectsAddressArguments(t *testing.T) {
+	t.Parallel()
+	for _, key := range []string{"to", "url", "chat_id", "email", "recipient"} {
+		key := key
+		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+			call := newDeliverTool(t, nil)
+			raw := json.RawMessage(`{"destination":"id-1","body":"hi","` + key + `":"attacker@example.com"}`)
+			_, err := call.tool.Execute(t.Context(), raw)
+			if err == nil {
+				t.Fatalf("expected rejection for unknown argument %q", key)
+			}
+			if call.id != "" {
+				t.Fatal("deliver must not run when an unknown argument is present")
+			}
+		})
+	}
+}
+
+func TestDeliverRequiresDestinationAndBody(t *testing.T) {
+	t.Parallel()
+	call := newDeliverTool(t, nil)
+	if _, err := call.tool.Execute(t.Context(), json.RawMessage(`{"destination":"","body":"hi"}`)); err == nil {
+		t.Fatal("expected error for empty destination")
+	}
+	if _, err := call.tool.Execute(t.Context(), json.RawMessage(`{"destination":"id-1","body":"  "}`)); err == nil {
+		t.Fatal("expected error for empty body")
+	}
+}
+
+func TestDeliverPassesSubjectAndBodyThrough(t *testing.T) {
+	t.Parallel()
+	call := newDeliverTool(t, func(context.Context, string, string, string) (string, string, error) {
+		return "ops-webhook", "webhook", nil
+	})
+	if _, err := call.tool.Execute(t.Context(), json.RawMessage(`{"destination":"id-1","subject":"Daily digest","body":"the content"}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if call.subject != "Daily digest" || call.body != "the content" {
+		t.Fatalf("subject/body = %q/%q, want passed through verbatim", call.subject, call.body)
+	}
+}
+
+func TestDeliverSurfacesAdapterError(t *testing.T) {
+	t.Parallel()
+	call := newDeliverTool(t, func(context.Context, string, string, string) (string, string, error) {
+		return "", "", errors.New("connection refused")
+	})
+	_, err := call.tool.Execute(t.Context(), json.RawMessage(`{"destination":"id-1","body":"hi"}`))
+	if err == nil || !strings.Contains(err.Error(), "connection refused") {
+		t.Fatalf("err = %v, want adapter error surfaced", err)
+	}
+}
+
+func TestDeliverListerError(t *testing.T) {
+	t.Parallel()
+	tool := Deliver(func(context.Context) ([]DestinationInfo, error) {
+		return nil, errors.New("db down")
+	}, func(context.Context, string, string, string) (string, string, error) {
+		t.Fatal("deliver must not run when the lister fails")
+		return "", "", nil
+	})
+	_, err := tool.Execute(t.Context(), json.RawMessage(`{"destination":"id-1","body":"hi"}`))
+	if err == nil || !strings.Contains(err.Error(), "db down") {
+		t.Fatalf("err = %v, want lister error surfaced", err)
+	}
+}
+
+func TestDeliverNilDependencies(t *testing.T) {
+	t.Parallel()
+	tool := Deliver(nil, nil)
+	if _, err := tool.Execute(t.Context(), json.RawMessage(`{"destination":"id-1","body":"hi"}`)); err == nil {
+		t.Fatal("expected error when destinations are not configured")
+	}
+}


### PR DESCRIPTION
Slice 3 of the destinations plan: the `deliver` tool.

- New builtin: send subject+body to one operator-configured destination by name or id; resolution is exact id, then unique case-insensitive name, else an error listing valid names
- Exfil guard in Go: no address/URL/chat_id argument exists, and any unrecognized argument is rejected outright — a prompt-injected address has nothing to call
- `Deliverer.DeliverNow`: synchronous single-attempt send (no retries, no mission_events) as the ad-hoc counterpart to harness terminal delivery; adapters gain optional subject support
- Not permission-exempt (outward write), not seeded into any agent allowlist (#229 opt-in)
- Chat surface only: mission BuiltinsOnly turns resolve to the startup-time base toolset, and this tool registers post-startup like missions/mission_push — matching the harness rule that workers never get outward writes; missions attach destinations at create for harness-side delivery

No web changes, no migration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789782122&installation_model_id=431401&pr_number=259&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F259&signature=443d24a70cd535b82d9ba1919df4754a5b7f4880b01903e87d9c732792cbb059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->