### PR TITLE
fix: refuse deleting secret-backend bootstrap credentials

### DIFF
--- a/internal/brain/api/admin.go
+++ b/internal/brain/api/admin.go
@@ -129,13 +129,16 @@ type connectorLister interface {
 // secretRefEntry is the credentials panel's per-ref shape: the
 // gateway's directory metadata plus every referent (provider or
 // connector) across both services, merged here because neither service
-// alone can see both tables. Never a value.
+// alone can see both tables. Never a value. System marks a configured
+// secret backend's own bootstrap credential (passed straight through
+// from the gateway) — the panel hides the delete action for these.
 type secretRefEntry struct {
 	RefName      string          `json:"name"`
 	Backend      string          `json:"backend"`
 	CreatedAt    any             `json:"created_at,omitempty"`
 	UpdatedAt    any             `json:"updated_at,omitempty"`
 	ReferencedBy []referenceInfo `json:"referenced_by"`
+	System       bool            `json:"system"`
 }
 
 type referenceInfo struct {
@@ -244,7 +247,7 @@ func (h *secretsAPI) list(w http.ResponseWriter, r *http.Request) {
 		referents = append(referents, byConnector[ref.RefName]...)
 		out[i] = secretRefEntry{
 			RefName: ref.RefName, Backend: ref.Backend, CreatedAt: ref.CreatedAt, UpdatedAt: ref.UpdatedAt,
-			ReferencedBy: referents,
+			ReferencedBy: referents, System: ref.System,
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"secrets": out})

--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -261,13 +261,16 @@ func (c *Client) ResolveRoute(ctx context.Context, name, harness string) (*Resol
 
 // SecretRef mirrors the gateway admin's SecretRef: a stored secret's
 // directory metadata plus the provider names that reference it. Never
-// a value.
+// a value. System marks a configured secret backend's own bootstrap
+// credential — the gateway refuses to delete these regardless, but the
+// UI uses the flag to hide the delete action up front.
 type SecretRef struct {
 	RefName      string    `json:"ref_name"`
 	Backend      string    `json:"backend"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 	ReferencedBy []string  `json:"referenced_by_providers"`
+	System       bool      `json:"system"`
 }
 
 // ListSecrets fetches the gateway's secrets directory (names,

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -218,13 +218,17 @@ func (a *Admin) MigrateAllSecrets(ctx context.Context, targetBackend string) ([]
 // SecretRef is one stored secret's directory entry: name and
 // timestamps, plus the providers that name it as credential_ref. Values
 // are never included — ListSecrets exists so the UI can show what
-// exists and what would break on delete, nothing more.
+// exists and what would break on delete, nothing more. System marks a
+// configured secret backend's own bootstrap credential (see
+// secretstore.bootstrapRefs) — Delete refuses these regardless, but the
+// UI uses the flag to hide the delete action up front.
 type SecretRef struct {
 	RefName      string    `json:"ref_name"`
 	Backend      string    `json:"backend"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 	ReferencedBy []string  `json:"referenced_by_providers"`
+	System       bool      `json:"system"`
 }
 
 // ListSecrets returns every stored secret's directory metadata with the
@@ -234,6 +238,10 @@ type SecretRef struct {
 // tables know about.
 func (a *Admin) ListSecrets(ctx context.Context) ([]SecretRef, error) {
 	refs, err := a.secrets.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	bootstrap, err := a.secrets.BootstrapRefs(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +269,7 @@ func (a *Admin) ListSecrets(ctx context.Context) ([]SecretRef, error) {
 	out := make([]SecretRef, len(refs))
 	for i, r := range refs {
 		out[i] = SecretRef{RefName: r.RefName, Backend: r.Backend, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
-			ReferencedBy: byRef[r.RefName]}
+			ReferencedBy: byRef[r.RefName], System: bootstrap[r.RefName] != ""}
 	}
 	return out, nil
 }

--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -908,6 +908,63 @@ func TestDeleteSecretRefusesWhileProviderReferencesIt(t *testing.T) {
 	}
 }
 
+// TestDeleteSecretRefusesBootstrapRef pins the delete-side lockout
+// guard at the admin layer: with vault configured (default token_ref),
+// DeleteSecret must refuse to remove VAULT_TOKEN, and ListSecrets must
+// flag it System: true so the UI can hide its delete action up front.
+func TestDeleteSecretRefusesBootstrapRef(t *testing.T) {
+	adm, _, _ := testAdmin(t)
+	ctx := t.Context()
+
+	origCfg, err := adm.SecretBackendConfig(ctx, "vault")
+	if err != nil {
+		t.Fatalf("SecretBackendConfig (orig): %v", err)
+	}
+	defer func() {
+		if string(origCfg) != "{}" {
+			if err := adm.SetSecretBackendConfig(ctx, "vault", origCfg); err != nil {
+				t.Errorf("restore vault config: %v", err)
+			}
+		} else if err := adm.DeleteSecretBackendConfig(ctx, "vault"); err != nil {
+			t.Errorf("remove test vault config: %v", err)
+		}
+		_ = adm.secrets.Delete(ctx, "VAULT_TOKEN")
+	}()
+
+	if err := adm.SetSecretBackendConfig(ctx, "vault",
+		[]byte(`{"address":"http://`+adminMarker+`vault.invalid:8200","mount":"kv"}`)); err != nil {
+		t.Fatalf("SetSecretBackendConfig: %v", err)
+	}
+	if err := adm.SetSecret(ctx, "VAULT_TOKEN", "vault-tok-x"); err != nil {
+		t.Fatalf("SetSecret VAULT_TOKEN: %v", err)
+	}
+
+	if err := adm.DeleteSecret(ctx, "VAULT_TOKEN"); err == nil || !strings.Contains(err.Error(), "bootstrap credential") {
+		t.Fatalf("DeleteSecret(VAULT_TOKEN) = %v, want a bootstrap-credential refusal", err)
+	}
+	if configured, _, err := adm.SecretStatus(ctx, "VAULT_TOKEN"); err != nil || !configured {
+		t.Fatalf("SecretStatus after refused delete: configured=%v err=%v, want still configured", configured, err)
+	}
+
+	refs, err := adm.ListSecrets(ctx)
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+	var found bool
+	for _, r := range refs {
+		if r.RefName != "VAULT_TOKEN" {
+			continue
+		}
+		found = true
+		if !r.System {
+			t.Errorf("ListSecrets VAULT_TOKEN.System = false, want true while vault is configured")
+		}
+	}
+	if !found {
+		t.Fatal("ListSecrets did not report VAULT_TOKEN")
+	}
+}
+
 func TestSecretExternalBackendConfig(t *testing.T) {
 	adm, _, _ := testAdmin(t)
 	ctx := t.Context()

--- a/internal/secretstore/secretstore.go
+++ b/internal/secretstore/secretstore.go
@@ -244,15 +244,24 @@ func (s *Store) upsertRef(ctx context.Context, refName, backend, backendRef stri
 	return nil
 }
 
+// BootstrapRefs is the exported form of bootstrapRefs, for callers
+// outside this package (the gateway admin's secrets list, which flags
+// each ref as "system" so the UI can hide its delete action).
+func (s *Store) BootstrapRefs(ctx context.Context) (map[string]string, error) {
+	return s.bootstrapRefs(ctx)
+}
+
 // bootstrapRefs collects the ref names every configured external
 // backend needs to log in with — vault's token/secret_id ref, asm's
 // static secret key ref — applying each config loader's own
-// defaulting for an empty ref field. Unconfigured backends contribute
-// nothing. These refs unlock the backend they name, so migrating one
-// of them into that same backend is a chicken-and-egg lockout: nothing
-// left in db can decrypt the login credential needed to resolve it.
-func (s *Store) bootstrapRefs(ctx context.Context) (map[string]bool, error) {
-	out := map[string]bool{}
+// defaulting for an empty ref field, mapped to the backend name that
+// needs it. Unconfigured backends contribute nothing. These refs
+// unlock the backend they name, so migrating or deleting one of them
+// is a chicken-and-egg lockout: nothing left in db can decrypt (or
+// nothing remains at all for) the login credential needed to resolve
+// every other secret in that backend.
+func (s *Store) bootstrapRefs(ctx context.Context) (map[string]string, error) {
+	out := map[string]string{}
 	vaultCfg, err := s.GetBackendConfig(ctx, "vault")
 	if err != nil {
 		return nil, err
@@ -266,13 +275,13 @@ func (s *Store) bootstrapRefs(ctx context.Context) (map[string]bool, error) {
 		if tokenRef == "" {
 			tokenRef = defaultVaultTokenRef
 		}
-		out[tokenRef] = true
+		out[tokenRef] = "vault"
 		if v.Auth == "approle" {
 			secretIDRef := v.SecretIDRef
 			if secretIDRef == "" {
 				secretIDRef = defaultVaultSecretIDRef
 			}
-			out[secretIDRef] = true
+			out[secretIDRef] = "vault"
 		}
 	}
 	asmCfg, err := s.GetBackendConfig(ctx, "asm")
@@ -289,7 +298,7 @@ func (s *Store) bootstrapRefs(ctx context.Context) (map[string]bool, error) {
 			if secretKeyRef == "" {
 				secretKeyRef = defaultASMSecretKeyRef
 			}
-			out[secretKeyRef] = true
+			out[secretKeyRef] = "asm"
 		}
 	}
 	return out, nil
@@ -319,7 +328,7 @@ func (s *Store) Migrate(ctx context.Context, refName, targetBackend string) erro
 		if err != nil {
 			return err
 		}
-		if bootstrap[refName] {
+		if bootstrap[refName] != "" {
 			return fmt.Errorf("secretstore: %q is a backend bootstrap credential (vault/asm login secret) and must stay in built-in db storage", refName)
 		}
 	}
@@ -393,8 +402,21 @@ func (s *Store) Migrate(ctx context.Context, refName, targetBackend string) erro
 // external copy first when this store owns it (backend_ref follows the
 // timothy/<ref_name> convention it writes in Set) — a reference typed
 // against the old external-reference model points at a secret Timothy
-// never owned and must never delete.
+// never owned and must never delete. Refused for a backend bootstrap
+// credential (see bootstrapRefs): deleting the login secret a
+// configured backend needs would strand every other secret already
+// stored there, unresolvable, with no recovery path (Migrate at least
+// leaves the old copy in place on a rejected move; a delete has
+// nothing to fall back to).
 func (s *Store) Delete(ctx context.Context, refName string) error {
+	bootstrap, err := s.bootstrapRefs(ctx)
+	if err != nil {
+		return err
+	}
+	if backend := bootstrap[refName]; backend != "" {
+		return fmt.Errorf("secretstore: refusing to delete %q: it is the bootstrap credential for the %s secret backend; deleting it would make every %s-stored secret unresolvable",
+			refName, backend, backend)
+	}
 	r, err := s.row(ctx, refName)
 	if err != nil && !errors.Is(err, ErrNotFound) {
 		return err

--- a/internal/secretstore/secretstore_integration_test.go
+++ b/internal/secretstore/secretstore_integration_test.go
@@ -689,3 +689,179 @@ func TestMigrateRefusesASMSecretKeyBootstrapRef(t *testing.T) {
 		t.Fatalf("error = %v, want it to mention bootstrap credential", err)
 	}
 }
+
+// TestDeleteRefusesVaultTokenBootstrapRef pins the delete-side lockout
+// fix: vault's token_ref must never be deleted while vault is
+// configured, since resolving anything else stored in vault would need
+// a token that no longer exists anywhere.
+func TestDeleteRefusesVaultTokenBootstrapRef(t *testing.T) {
+	s := integrationStore(t)
+	ctx := t.Context()
+	tokenRef := "TEST_DELETE_BOOTSTRAP_TOKEN_" + t.Name()
+
+	srv, _ := fakeVaultKV(t)
+	defer srv.Close()
+	restore := setUpVaultDefault(t, s, srv, tokenRef)
+	defer restore()
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer func() {
+		_, _ = db.Exec(ctx, `DELETE FROM secrets WHERE ref_name = $1`, tokenRef)
+	}()
+
+	err = s.Delete(ctx, tokenRef)
+	if err == nil {
+		t.Fatal("Delete accepted removing the vault token_ref while vault is configured")
+	}
+	if !strings.Contains(err.Error(), "bootstrap credential") {
+		t.Fatalf("error = %v, want it to mention bootstrap credential", err)
+	}
+	if configured, backend, err := s.Status(ctx, tokenRef); err != nil || !configured || backend != "db" {
+		t.Fatalf("row changed after a rejected delete: configured=%v backend=%q err=%v", configured, backend, err)
+	}
+}
+
+// TestDeleteRefusesVaultSecretIDBootstrapRef covers approle auth's
+// secret_id_ref (defaulting to VAULT_SECRET_ID) — the same production
+// incident Migrate's guard covers, on the delete path.
+func TestDeleteRefusesVaultSecretIDBootstrapRef(t *testing.T) {
+	s := integrationStore(t)
+	ctx := t.Context()
+	secretIDRef := "TEST_DELETE_BOOTSTRAP_SECRETID_" + t.Name()
+
+	srv, _ := fakeVaultKV(t)
+	defer srv.Close()
+
+	origCfg, err := s.GetBackendConfig(ctx, "vault")
+	if err != nil {
+		t.Fatalf("GetBackendConfig: %v", err)
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer func() {
+		_, _ = db.Exec(ctx, `DELETE FROM secrets WHERE ref_name = $1`, secretIDRef)
+		if string(origCfg) != "{}" {
+			if _, err := s.SetBackendConfig(ctx, "vault", origCfg); err != nil {
+				t.Errorf("restore vault config: %v", err)
+			}
+		} else if err := s.DeleteBackendConfig(ctx, "vault"); err != nil {
+			t.Errorf("delete vault config: %v", err)
+		}
+	}()
+
+	cfg := `{"address":"` + srv.URL + `","mount":"kv","auth":"approle","role_id":"role-x","secret_id_ref":"` + secretIDRef + `"}`
+	if _, err := s.SetBackendConfig(ctx, "vault", []byte(cfg)); err != nil {
+		t.Fatalf("SetBackendConfig: %v", err)
+	}
+	if err := s.SetDB(ctx, secretIDRef, "secret-id-x"); err != nil {
+		t.Fatalf("SetDB: %v", err)
+	}
+
+	err = s.Delete(ctx, secretIDRef)
+	if err == nil {
+		t.Fatal("Delete accepted removing the vault secret_id_ref while vault approle is configured")
+	}
+	if !strings.Contains(err.Error(), "bootstrap credential") {
+		t.Fatalf("error = %v, want it to mention bootstrap credential", err)
+	}
+}
+
+// TestDeleteRefusesASMSecretKeyBootstrapRef covers asm's static-keys
+// auth: the secret_key_ref (defaulting to AWS_SECRET_ACCESS_KEY) must
+// be refused on delete while asm is configured for keys auth.
+func TestDeleteRefusesASMSecretKeyBootstrapRef(t *testing.T) {
+	s := integrationStore(t)
+	ctx := t.Context()
+	secretKeyRef := "TEST_DELETE_BOOTSTRAP_ASMKEY_" + t.Name()
+
+	origCfg, err := s.GetBackendConfig(ctx, "asm")
+	if err != nil {
+		t.Fatalf("GetBackendConfig: %v", err)
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer func() {
+		_, _ = db.Exec(ctx, `DELETE FROM secrets WHERE ref_name = $1`, secretKeyRef)
+		if string(origCfg) != "{}" {
+			if _, err := s.SetBackendConfig(ctx, "asm", origCfg); err != nil {
+				t.Errorf("restore asm config: %v", err)
+			}
+		} else if err := s.DeleteBackendConfig(ctx, "asm"); err != nil {
+			t.Errorf("delete asm config: %v", err)
+		}
+	}()
+
+	cfg := `{"auth":"keys","access_key_id":"AKIAEXAMPLE","secret_key_ref":"` + secretKeyRef + `"}`
+	if _, err := s.SetBackendConfig(ctx, "asm", []byte(cfg)); err != nil {
+		t.Fatalf("SetBackendConfig: %v", err)
+	}
+	if err := s.SetDB(ctx, secretKeyRef, "secret-key-x"); err != nil {
+		t.Fatalf("SetDB: %v", err)
+	}
+
+	err = s.Delete(ctx, secretKeyRef)
+	if err == nil {
+		t.Fatal("Delete accepted removing the asm secret_key_ref while asm keys auth is configured")
+	}
+	if !strings.Contains(err.Error(), "bootstrap credential") {
+		t.Fatalf("error = %v, want it to mention bootstrap credential", err)
+	}
+}
+
+// TestDeleteAllowsOrdinaryRefWhenNoBackendConfigured pins that the new
+// guard only ever blocks an actual bootstrap ref: with no external
+// backend configured, bootstrapRefs is empty and any ordinary secret
+// deletes exactly as before.
+func TestDeleteAllowsOrdinaryRefWhenNoBackendConfigured(t *testing.T) {
+	s := integrationStore(t)
+	ctx := t.Context()
+	ref := "TEST_DELETE_ORDINARY_" + t.Name()
+
+	if err := s.SetDB(ctx, ref, "sk-ordinary"); err != nil {
+		t.Fatalf("SetDB: %v", err)
+	}
+	if err := s.Delete(ctx, ref); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if configured, _, err := s.Status(ctx, ref); err != nil || configured {
+		t.Fatalf("Status after Delete: configured=%v err=%v", configured, err)
+	}
+}
+
+// TestBootstrapRefsExported pins BootstrapRefs (the exported wrapper
+// admin.ListSecrets uses to flag "system" refs) against a configured
+// vault backend with a non-default token_ref name.
+func TestBootstrapRefsExported(t *testing.T) {
+	s := integrationStore(t)
+	ctx := t.Context()
+	tokenRef := "TEST_BOOTSTRAPREFS_CUSTOM_TOKEN_" + t.Name()
+
+	srv, _ := fakeVaultKV(t)
+	defer srv.Close()
+	restore := setUpVaultDefault(t, s, srv, tokenRef)
+	defer restore()
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer func() {
+		_, _ = db.Exec(ctx, `DELETE FROM secrets WHERE ref_name = $1`, tokenRef)
+	}()
+
+	refs, err := s.BootstrapRefs(ctx)
+	if err != nil {
+		t.Fatalf("BootstrapRefs: %v", err)
+	}
+	if refs[tokenRef] != "vault" {
+		t.Fatalf("BootstrapRefs[%q] = %q, want vault", tokenRef, refs[tokenRef])
+	}
+	if refs["SOME_OTHER_REF"] != "" {
+		t.Fatalf("BootstrapRefs flagged an unrelated ref: %q", refs["SOME_OTHER_REF"])
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -811,13 +811,17 @@ export interface SecretReference {
 // SecretRefEntry is one stored secret's directory entry: name,
 // timestamps (when the row has them), and every referent across both
 // providers and connectors. Never a value — the credentials panel is a
-// directory, not a vault viewer.
+// directory, not a vault viewer. system marks a configured secret
+// backend's own bootstrap credential (e.g. the vault token) — the
+// gateway refuses to delete these regardless, but the panel hides the
+// delete action for them up front.
 export interface SecretRefEntry {
   name: string
   backend: string
   created_at?: string
   updated_at?: string
   referenced_by: SecretReference[]
+  system?: boolean
 }
 
 // listSecretRefs lists every stored credential ref for the Credentials

--- a/web/src/components/settings/CredentialsTab.test.tsx
+++ b/web/src/components/settings/CredentialsTab.test.tsx
@@ -24,12 +24,21 @@ const referenced: SecretRefEntry = {
     { kind: 'connector', name: 'github-mcp', role: 'credential' },
     { kind: 'provider', name: 'github-provider', role: 'credential' },
   ],
+  system: false,
 }
 
 const orphaned: SecretRefEntry = {
   name: 'OLD_KEY',
   backend: 'db',
   referenced_by: [],
+  system: false,
+}
+
+const systemRef: SecretRefEntry = {
+  name: 'VAULT_TOKEN',
+  backend: 'db',
+  referenced_by: [],
+  system: true,
 }
 
 afterEach(cleanup)
@@ -88,6 +97,16 @@ describe('CredentialsTab', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
 
     expect(deleteSecret).not.toHaveBeenCalled()
+  })
+
+  it('shows a System badge and disables delete for a bootstrap-credential ref', async () => {
+    vi.mocked(listSecretRefs).mockResolvedValue([systemRef])
+    render(<CredentialsTab />)
+
+    expect(await screen.findByText('VAULT_TOKEN')).toBeInTheDocument()
+    expect(screen.getByText('System')).toBeInTheDocument()
+    expect(screen.queryByText('orphaned')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Delete VAULT_TOKEN' })).not.toBeInTheDocument()
   })
 
   it('hides the migrate-all button when the default backend is db', async () => {

--- a/web/src/components/settings/CredentialsTab.tsx
+++ b/web/src/components/settings/CredentialsTab.tsx
@@ -19,7 +19,11 @@ const BACKEND_LABEL: Record<string, string> = {
 // no reveal/show-value affordance anywhere — this lists what exists
 // and what references it, never a value. Delete is only offered for
 // orphaned refs; a referenced ref's delete button is replaced by its
-// used-by chips explaining why.
+// used-by chips explaining why. A "system" ref (a configured secret
+// backend's own bootstrap credential, e.g. the vault token) gets a
+// System badge instead and its delete action is disabled with an
+// explanatory tooltip — the gateway refuses the delete regardless
+// (secretstore.Delete's own guard), this is purely cosmetic.
 export function CredentialsTab() {
   const [refs, setRefs] = useState<SecretRefEntry[]>([])
   const [loaded, setLoaded] = useState(false)
@@ -120,7 +124,11 @@ export function CredentialsTab() {
                 <tr key={r.name}>
                   <td className="px-4 py-2 font-mono text-xs">{r.name}</td>
                   <td className="px-4 py-2">
-                    {r.referenced_by.length === 0 ? (
+                    {r.system ? (
+                      <span className="shrink-0 rounded-full border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-600 dark:text-amber-400">
+                        System
+                      </span>
+                    ) : r.referenced_by.length === 0 ? (
                       <span className="text-xs text-muted-foreground">orphaned</span>
                     ) : (
                       <div className="flex flex-wrap gap-1">
@@ -142,15 +150,24 @@ export function CredentialsTab() {
                     {r.updated_at ? new Date(r.updated_at).toLocaleDateString() : '—'}
                   </td>
                   <td className="px-4 py-2 text-right">
-                    {r.referenced_by.length === 0 && (
-                      <button
-                        type="button"
-                        aria-label={`Delete ${r.name}`}
-                        onClick={() => setPendingDelete(r.name)}
-                        className="text-muted-foreground hover:text-red-500"
+                    {r.system ? (
+                      <span
+                        className="inline-block text-muted-foreground/40"
+                        title={`${r.name} is the bootstrap credential for the ${BACKEND_LABEL[r.backend] ?? r.backend} secret backend and can't be deleted while it's configured.`}
                       >
                         <HugeiconsIcon icon={Delete02Icon} className="size-4" />
-                      </button>
+                      </span>
+                    ) : (
+                      r.referenced_by.length === 0 && (
+                        <button
+                          type="button"
+                          aria-label={`Delete ${r.name}`}
+                          onClick={() => setPendingDelete(r.name)}
+                          className="text-muted-foreground hover:text-red-500"
+                        >
+                          <HugeiconsIcon icon={Delete02Icon} className="size-4" />
+                        </button>
+                      )
                     )}
                   </td>
                 </tr>


### PR DESCRIPTION
Companion to #253's migrate guard, closing the other lockout path.

- `secretstore.Store.Delete` refuses when the ref is a configured backend's bootstrap credential (vault token/secret_id, ASM secret key, loader defaulting applied) — deleting it would strand every secret in that backend with no recovery, worse than a rejected migrate which at least keeps the old copy
- `bootstrapRefs` now maps ref → backend name so both guards name the backend in their error
- Secrets list responses gain `system: true` for bootstrap refs; the credentials UI shows a System badge instead of the misleading "orphaned" label and disables delete with an explanation — cosmetic layer, the Go guard is the boundary

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789783279&installation_model_id=431401&pr_number=260&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F260&signature=1b6b4638456d1d977d13e25332e22c04c49a656891e6306514747a44a44c8866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->