### PR TITLE
fix: bound mission worker turns with a per-turn timeout

### DIFF
--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -325,6 +325,18 @@ func (s *kbRefSink) all() []string {
 // a longer ceiling here is a capability tradeoff, not a safety one.
 const sandboxShellMaxTimeout = 15 * time.Minute
 
+// turnTimeout bounds one runTurn call (worker, explore, plan, or
+// review). Without this, a stream that never emits an error or
+// terminal event — no chunk, no EventDone, no EventError, just
+// silence — hangs runTurn's `for ev := range events` forever: nothing
+// upstream aborts it, and driveTimeBound (4h) is the mission's own
+// lifetime cap, not a per-turn one. Set above sandboxShellMaxTimeout
+// (15m) plus headroom for a turn issuing several tool calls in
+// sequence (e.g. multiple gmail searches/reads), well under
+// driveTimeBound.
+// var, not const, so tests can shrink it instead of waiting 20 real minutes.
+var turnTimeout = 20 * time.Minute
+
 func (r *nativeRunner) missionTools(m Mission) []*tools.Tool {
 	shell := r.missionShell(m)
 	if shell == nil {
@@ -421,6 +433,8 @@ func (r *nativeRunner) belowFloor(model string) bool {
 // sentinel means — that's the caller's job (worker vs review have
 // different enforcement/parsing needs).
 func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTool string) (text string, sentinelArgs json.RawMessage, seenURLs []string, err error) {
+	ctx, cancel := context.WithTimeout(ctx, turnTimeout)
+	defer cancel()
 	events, err := r.agent.Start(ctx, req)
 	if err != nil {
 		return "", nil, nil, err

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -1351,6 +1351,49 @@ func TestRunTurnNilErrErrorEvent(t *testing.T) {
 	}
 }
 
+// hangingAgent is a fake agentStream whose Start never sends and never
+// closes its channel on its own — it only closes once ctx is
+// cancelled, modeling a stream that emits no chunk, no terminal, and
+// no error (the observed production hang: a worker turn silently wedged
+// for 35+ minutes with driveTimeBound, at 4h, nowhere near catching it).
+type hangingAgent struct{}
+
+func (hangingAgent) Start(ctx context.Context, req loop.Request) (<-chan stream.StreamEvent, error) {
+	ch := make(chan stream.StreamEvent)
+	go func() {
+		<-ctx.Done()
+		close(ch)
+	}()
+	return ch, nil
+}
+
+// TestRunTurnTimesOutOnHungStream: runTurn must not block forever on a
+// stream that never emits anything — turnTimeout bounds it, and the
+// resulting bare channel close falls into the same "stream ended
+// without a terminal event" retryable-failure path as a real stream
+// cut, rather than hanging the driver's Drive goroutine.
+func TestRunTurnTimesOutOnHungStream(t *testing.T) {
+	old := turnTimeout
+	turnTimeout = 50 * time.Millisecond
+	defer func() { turnTimeout = old }()
+
+	r := newTestRunner(hangingAgent{})
+	done := make(chan struct{})
+	var err error
+	go func() {
+		_, _, _, err = r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runTurn did not return after turnTimeout elapsed")
+	}
+	if err == nil || !strings.Contains(err.Error(), "without a terminal event") {
+		t.Fatalf("err = %v, want no-terminal error", err)
+	}
+}
+
 // TestMissionRunnerRequestsAreBuiltinsOnly guards the security fix:
 // every loop.Request the native runner builds — worker, explorer,
 // reviewer, planner — must set BuiltinsOnly, so a mission turn's base


### PR DESCRIPTION
## Summary
- A stream that emits no chunk, error, or terminal event hung `runTurn`'s event loop indefinitely — nothing upstream aborted it, and `driveTimeBound` (4h) is the mission's own lifetime cap, not a per-turn one.
- Observed live: two `gpt-5-mini`-routed missions (`inbox-digest-8h`, `daily-expense-report` follow-up) stuck in `execute` for 30+ minutes with zero progress notes, requiring manual cancel.
- `turnTimeout` (20 minutes) now wraps every `runTurn` call — worker, explore, plan, review — so a hung stream is cancelled and falls into the existing "stream ended without a terminal event" retryable-failure path, same bucket as a genuine stream cut.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run` (0 issues)
- [x] New `TestRunTurnTimesOutOnHungStream`: a fake agent that never sends/closes until ctx cancels; confirms `runTurn` returns within the (test-shrunk) timeout with the no-terminal error, instead of hanging.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789943003&installation_model_id=431401&pr_number=270&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F270&signature=5356df70cbbc36807c6b127c04974298fa22a8ce093500c3f6d88e9425da5491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->