### PR TITLE
fix: stop sending native mission_status preamble to delegated CLIs

### DIFF
--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -377,7 +377,7 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 		return WorkerVerdict{}, "", err
 	}
 	rdir := runDir(m.Workspace, runID)
-	system, user := packet.Render()
+	system, user := packet.RenderForDelegated()
 	system += delegatedSystemAppend
 
 	spec := executor.InvocationSpec{

--- a/internal/brain/missions/packet.go
+++ b/internal/brain/missions/packet.go
@@ -48,13 +48,35 @@ type WorkPacket struct {
 	Attachments []MissionAttachment
 }
 
-// Render turns the packet into the system/user message a worker
-// session's first turn receives. Progress notes and git log content
-// can contain prior model-produced text (a worker's own commit
-// messages, an earlier note); both pass through NeutralizeSlot before
-// insertion — self-injection hardening.
+// nativeSystemPreamble is the mission_status/write_file contract a
+// native (in-process loop.Agent) worker turn must follow — meaningless
+// to a delegated CLI, which has neither tool (RenderForDelegated uses
+// delegatedSystemPreamble instead).
+const nativeSystemPreamble = "You are executing one unit of a plan. Work toward the goal, then end your turn with exactly one mission_status tool call: done (with evidence), retry (with analysis), or blocked (with a question). Create or update files ONLY with the write_file tool using workspace-relative paths — never shell redirects (>, >>) or heredocs, which classify as writes requiring interactive approval and will stall you; artifact tracking depends on write_file being the only way files get created. Use shell for reading and checking, not writing. The harness verifies your declared artifacts exist on disk; describing a file is not producing it. When you end with retry or blocked, include a handoff note summarizing state, remaining work, and gotchas — the next session starts fresh and sees only your handoff, the plan, and the git log."
+
+// Render turns the packet into the system/user message a native
+// worker session's first turn receives. Progress notes and git log
+// content can contain prior model-produced text (a worker's own
+// commit messages, an earlier note); both pass through NeutralizeSlot
+// before insertion — self-injection hardening.
 func (p WorkPacket) Render() (system, user string) {
-	system = "You are executing one unit of a plan. Work toward the goal, then end your turn with exactly one mission_status tool call: done (with evidence), retry (with analysis), or blocked (with a question). Create or update files ONLY with the write_file tool using workspace-relative paths — never shell redirects (>, >>) or heredocs, which classify as writes requiring interactive approval and will stall you; artifact tracking depends on write_file being the only way files get created. Use shell for reading and checking, not writing. The harness verifies your declared artifacts exist on disk; describing a file is not producing it. When you end with retry or blocked, include a handoff note summarizing state, remaining work, and gotchas — the next session starts fresh and sees only your handoff, the plan, and the git log." + p.ExecEnvironmentNote
+	return p.render(nativeSystemPreamble)
+}
+
+// RenderForDelegated is Render's delegated-executor counterpart: same
+// goal/plan/progress/git-log/attachments body, but without the
+// mission_status/write_file preamble a delegated CLI (codex, claude
+// code) has no way to honor — sending both that preamble AND
+// delegatedSystemAppend's correction in the same prompt was observed
+// to confuse a model into reporting BLOCKED over tools it was never
+// offered, rather than using its own native file-edit/patch tool and
+// the harness's structured-output contract.
+func (p WorkPacket) RenderForDelegated() (system, user string) {
+	return p.render("")
+}
+
+func (p WorkPacket) render(preamble string) (system, user string) {
+	system = preamble + p.ExecEnvironmentNote
 	if p.PromptOverlay != "" {
 		// Operator-authored config, not model output — unlike Progress/
 		// GitLog below, this never passes through NeutralizeSlot.

--- a/internal/brain/missions/packet_test.go
+++ b/internal/brain/missions/packet_test.go
@@ -37,6 +37,30 @@ func TestWorkPacketRender(t *testing.T) {
 	}
 }
 
+// TestWorkPacketRenderForDelegatedOmitsNativePreamble guards the fix
+// for a real observed failure: a delegated executor (codex-cli) was
+// sent both Render's mission_status/write_file preamble AND
+// delegated.go's own correction appended after it, and reported itself
+// BLOCKED over tools it was never offered. RenderForDelegated must
+// never mention either tool name, while still including the same
+// goal/plan body Render produces.
+func TestWorkPacketRenderForDelegatedOmitsNativePreamble(t *testing.T) {
+	p := WorkPacket{
+		Goal: "Merge dependabot PRs",
+		Spec: Spec{Units: []PlanUnit{{Title: "Assess PRs"}}},
+	}
+	system, user := p.RenderForDelegated()
+	if strings.Contains(system, "mission_status") || strings.Contains(system, "write_file") {
+		t.Fatalf("RenderForDelegated system prompt mentions native-only tools: %q", system)
+	}
+	if !strings.Contains(user, "Merge dependabot PRs") {
+		t.Fatal("RenderForDelegated did not include the goal")
+	}
+	if !strings.Contains(user, "Assess PRs") {
+		t.Fatal("RenderForDelegated did not include the plan")
+	}
+}
+
 func TestWorkPacketRenderNeutralizesInjectedContent(t *testing.T) {
 	p := WorkPacket{
 		Goal:     "Do the thing",


### PR DESCRIPTION
## Summary
- Every delegated executor turn (codex-cli, claude-code, etc.) received `WorkPacket.Render()`'s native `mission_status`/`write_file` preamble, followed by `delegatedSystemAppend`'s correction saying those tools don't apply to this harness.
- Observed live: a codex-cli mission (merge dependabot PRs) reported itself BLOCKED, citing missing `write_file` and `mission_status` tools — tools it was never supposed to be offered. The model read the contradictory instructions and fixated on the first (wrong) one.
- `WorkPacket.RenderForDelegated()` produces the same goal/plan/progress/git-log body as `Render()` but omits the native-only preamble entirely, so a delegated CLI only ever sees harness-appropriate instructions (its own file-edit tool + structured DONE/RETRY/BLOCKED output).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run` (0 issues)
- [x] New `TestWorkPacketRenderForDelegatedOmitsNativePreamble`: confirms the delegated render never mentions `mission_status`/`write_file` while still including the goal/plan body.
- [x] Live verification pending: will resume the previously-blocked mission on the homelab deployment once this ships, to confirm codex-cli no longer reports a false BLOCKED.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789949566&installation_model_id=431401&pr_number=271&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F271&signature=7dbfc1d8b809c9bae0f8a995f1c48a086c81cd5db253c3efb749ae95b0841f34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->