### PR TITLE
feat: per-model reasoning_effort override on a provider row

### DIFF
--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -198,6 +198,7 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 	var codes []string
 	for i, att := range attempts {
 		completion.Model = att.Model
+		completion.ReasoningEffortOverride = att.ReasoningEffort
 		// Last chain entry gets the full in-provider retry budget;
 		// earlier entries fail fast so the chain can advance.
 		completion.FinalAttempt = i == len(attempts)-1

--- a/internal/gateway/provider/openaicompat.go
+++ b/internal/gateway/provider/openaicompat.go
@@ -388,6 +388,14 @@ func (o *OpenAICompat) buildRequest(req CompletionRequest) oaiRequest {
 	if o.cfg.ReasoningEffort != "" {
 		out.ReasoningEffort = o.cfg.ReasoningEffort
 	}
+	// A chain-entry (per-model) override wins over both: some models on
+	// an otherwise-fine provider reject tool calls on /chat/completions
+	// unless reasoning_effort is an exact value, while other models on
+	// the same provider row have no such restriction — the provider-
+	// level dial above can't express that.
+	if req.ReasoningEffortOverride != "" {
+		out.ReasoningEffort = req.ReasoningEffortOverride
+	}
 	if req.System != "" {
 		out.Messages = append(out.Messages, oaiMessage{Role: "system", Content: req.System})
 	}

--- a/internal/gateway/provider/openaicompat_test.go
+++ b/internal/gateway/provider/openaicompat_test.go
@@ -551,3 +551,46 @@ func TestOpenAICompatNoEffortNeverSendsReasoningEffort(t *testing.T) {
 		t.Fatalf("reasoning_effort = %q, want empty when Effort unset", gotEffort)
 	}
 }
+
+// TestOpenAICompatReasoningEffortOverrideBeatsProviderConfig guards the
+// per-chain-entry fix: some models on an otherwise-fine provider (e.g.
+// OpenAI's gpt-5.6-luna) reject tool calls on /chat/completions unless
+// reasoning_effort is an exact value, while sibling models on the same
+// provider row have no such restriction — router.Attempt.ReasoningEffort
+// (from options.reasoning_effort_by_model) must win over both the
+// per-request Effort hint and the provider-wide ReasoningEffort config.
+func TestOpenAICompatReasoningEffortOverrideBeatsProviderConfig(t *testing.T) {
+	t.Parallel()
+	var gotEffort string
+	p := oaiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotEffort = readReasoningEffort(t, r)
+		oaiWrite(w, `{"choices":[{"delta":{"content":"ok"}}]}`)
+		oaiWrite(w, "[DONE]")
+	})
+	p.cfg.ReasoningEffort = "medium"
+
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m", Effort: "low", ReasoningEffortOverride: "none"})
+	collect(t, ch)
+
+	if gotEffort != "none" {
+		t.Fatalf("reasoning_effort = %q, want the chain-entry override (\"none\") to beat both Effort and provider config", gotEffort)
+	}
+}
+
+func TestOpenAICompatReasoningEffortOverrideEmptyLeavesOtherDialsInPlace(t *testing.T) {
+	t.Parallel()
+	var gotEffort string
+	p := oaiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotEffort = readReasoningEffort(t, r)
+		oaiWrite(w, `{"choices":[{"delta":{"content":"ok"}}]}`)
+		oaiWrite(w, "[DONE]")
+	})
+	p.cfg.ReasoningEffort = "medium"
+
+	ch, _ := p.Stream(t.Context(), CompletionRequest{Model: "m"})
+	collect(t, ch)
+
+	if gotEffort != "medium" {
+		t.Fatalf("reasoning_effort = %q, want the provider config to still apply when no override is set", gotEffort)
+	}
+}

--- a/internal/gateway/provider/provider.go
+++ b/internal/gateway/provider/provider.go
@@ -107,6 +107,16 @@ type CompletionRequest struct {
 	// then surface — the chain is the retry, and re-hammering a
 	// rate-limited provider only delays failover.
 	FinalAttempt bool
+	// ReasoningEffortOverride forces a specific model's reasoning_effort
+	// value regardless of Effort or the provider's own config-level
+	// override — a per-CHAIN-ENTRY setting (router.ChainEntry), not
+	// per-provider: some models on an otherwise-fine provider reject
+	// tool calls on /chat/completions unless reasoning_effort is an
+	// exact value (e.g. OpenAI's gpt-5.6-luna requires "none" for
+	// tool-calling; other models on the same OpenAI provider row have
+	// no such restriction). Empty means no override; wins over both
+	// Effort and the provider's own ReasoningEffort config when set.
+	ReasoningEffortOverride string
 }
 
 // Provider is one configured LLM provider. Stream returns quickly; all

--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -73,6 +73,25 @@ type ProviderRow struct {
 	// row's models match against (catalog.CandidateProvidersForRow),
 	// beating the driver/host heuristic when set.
 	LitellmProvider string
+	// ReasoningEffortByModel comes from options.reasoning_effort_by_model
+	// — per-model overrides that win over ReasoningEffort (which applies
+	// to every model this row serves). Some models reject tool calls on
+	// /chat/completions unless reasoning_effort is an exact value (e.g.
+	// OpenAI's gpt-5.6-luna requires "none"), while sibling models on the
+	// same provider row have no such restriction — a single scalar
+	// override can't express that.
+	ReasoningEffortByModel map[string]string
+}
+
+// reasoningEffortFor resolves model's effective reasoning_effort
+// override: ReasoningEffortByModel[model] wins when present, falling
+// back to the row-wide ReasoningEffort (empty means no override
+// either way).
+func (r ProviderRow) reasoningEffortFor(model string) string {
+	if v, ok := r.ReasoningEffortByModel[model]; ok {
+		return v
+	}
+	return r.ReasoningEffort
 }
 
 // ChainEntry is one step of a route chain. Harness selection moved to
@@ -177,6 +196,13 @@ type Attempt struct {
 	Provider     provider.Provider
 	ProviderName string
 	Model        string
+	// ReasoningEffort is this model's resolved reasoning_effort override
+	// (ProviderRow.ReasoningEffortByModel[Model], falling back to
+	// ProviderRow.ReasoningEffort) — carried alongside Provider/Model so
+	// api.go's completion build can set
+	// provider.CompletionRequest.ReasoningEffortOverride without
+	// re-deriving it from the row.
+	ReasoningEffort string
 }
 
 // NoRouteError reports that resolution produced zero usable attempts.
@@ -359,7 +385,7 @@ func (s *Snapshot) Resolve(route, hint string, sticky Sticky, extra ...provider.
 		key := row.Name + "/" + model
 		if !seen[key] {
 			seen[key] = true
-			attempts = append(attempts, Attempt{Provider: p, ProviderName: row.Name, Model: model})
+			attempts = append(attempts, Attempt{Provider: p, ProviderName: row.Name, Model: model, ReasoningEffort: row.reasoningEffortFor(model)})
 		}
 	}
 

--- a/internal/gateway/router/router_test.go
+++ b/internal/gateway/router/router_test.go
@@ -112,6 +112,49 @@ func TestResolveHintProviderNameFirst(t *testing.T) {
 	}
 }
 
+// TestReasoningEffortForModelOverrideBeatsRowWide guards the fix for a
+// real observed bug: gpt-5.6-luna rejects tool calls on
+// /chat/completions unless reasoning_effort is exactly "none", but a
+// row-wide ReasoningEffort would force that onto every other model the
+// same OpenAI provider row serves. ReasoningEffortByModel must win for
+// the listed model; every other model falls back to the row-wide value.
+func TestReasoningEffortForModelOverrideBeatsRowWide(t *testing.T) {
+	t.Parallel()
+	row := ProviderRow{
+		ReasoningEffort:        "low",
+		ReasoningEffortByModel: map[string]string{"gpt-5.6-luna": "none"},
+	}
+	if got := row.reasoningEffortFor("gpt-5.6-luna"); got != "none" {
+		t.Fatalf("reasoningEffortFor(gpt-5.6-luna) = %q, want the per-model override", got)
+	}
+	if got := row.reasoningEffortFor("gpt-5-mini"); got != "low" {
+		t.Fatalf("reasoningEffortFor(gpt-5-mini) = %q, want the row-wide fallback", got)
+	}
+}
+
+func TestResolveThreadsReasoningEffortIntoAttempt(t *testing.T) {
+	t.Parallel()
+	provRows := []ProviderRow{
+		{
+			ID: "p1", Name: "oai", Kind: "api", Driver: "openaicompat",
+			BaseURL:      "https://api.openai.example/v1",
+			DefaultModel: "gpt-5.6-luna", CredentialRef: "O_KEY", Enabled: true,
+			ReasoningEffortByModel: map[string]string{"gpt-5.6-luna": "none"},
+		},
+	}
+	routeRows := []RouteRow{
+		{Name: "digests", Chain: []ChainEntry{{ProviderID: "p1", Model: "gpt-5.6-luna"}}, Enabled: true},
+	}
+	snap, _ := BuildSnapshot(provRows, routeRows, func(ref string) string { return "key" }, &fakeCatalog{})
+	attempts, err := snap.Resolve("digests", "", Sticky{})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(attempts) != 1 || attempts[0].ReasoningEffort != "none" {
+		t.Fatalf("attempts = %+v, want one attempt with ReasoningEffort=none", attempts)
+	}
+}
+
 func TestResolveHintExactModel(t *testing.T) {
 	t.Parallel()
 	snap := testSnapshot(t, allKeys())

--- a/internal/gateway/router/store.go
+++ b/internal/gateway/router/store.go
@@ -169,9 +169,9 @@ func (s *Store) Load(ctx context.Context) error {
 }
 
 // applyProviderOptions decodes a providers row's options jsonb into row.
-// Only reasoning_effort, request_timeout, region, anthropic_base_url,
-// and openai_responses are recognized today (D-040, D-041, D-048,
-// D-051); unknown keys are ignored silently. An unparseable
+// Only reasoning_effort, reasoning_effort_by_model, request_timeout,
+// region, anthropic_base_url, and openai_responses are recognized today
+// (D-040, D-041, D-048, D-051); unknown keys are ignored silently. An unparseable
 // request_timeout fails the load outright — config honesty, never a
 // silent fallback to the driver default. region gets no such
 // validation beyond being present: AWS region ids change over time, so
@@ -182,17 +182,19 @@ func (s *Store) Load(ctx context.Context) error {
 // only writers and only ever write those two literals.
 func applyProviderOptions(row *ProviderRow, optionsJSON []byte) error {
 	var opts struct {
-		ReasoningEffort  string `json:"reasoning_effort"`
-		RequestTimeout   string `json:"request_timeout"`
-		Region           string `json:"region"`
-		AnthropicBaseURL string `json:"anthropic_base_url"`
-		OpenAIResponses  string `json:"openai_responses"`
-		LitellmProvider  string `json:"litellm_provider"`
+		ReasoningEffort        string            `json:"reasoning_effort"`
+		ReasoningEffortByModel map[string]string `json:"reasoning_effort_by_model"`
+		RequestTimeout         string            `json:"request_timeout"`
+		Region                 string            `json:"region"`
+		AnthropicBaseURL       string            `json:"anthropic_base_url"`
+		OpenAIResponses        string            `json:"openai_responses"`
+		LitellmProvider        string            `json:"litellm_provider"`
 	}
 	if err := json.Unmarshal(optionsJSON, &opts); err != nil {
 		return err
 	}
 	row.ReasoningEffort = opts.ReasoningEffort
+	row.ReasoningEffortByModel = opts.ReasoningEffortByModel
 	row.Region = opts.Region
 	row.AnthropicBaseURL = opts.AnthropicBaseURL
 	row.LitellmProvider = opts.LitellmProvider

--- a/internal/gateway/router/store.go
+++ b/internal/gateway/router/store.go
@@ -180,21 +180,30 @@ func (s *Store) Load(ctx context.Context) error {
 // ("true"/"false"/absent); absent leaves row.OpenAIResponses nil
 // (unknown), anything else fails the load — Admin.Test/Patch are the
 // only writers and only ever write those two literals.
+// reasoning_effort_by_model's own VALUE is a JSON-encoded object string
+// (e.g. `"{\"gpt-5.6-luna\":\"none\"}"`), not a nested object — options
+// stays map[string]string end to end through the admin write path
+// (ProviderPatch), so a per-model override rides inside a flat string
+// value instead of widening that type.
 func applyProviderOptions(row *ProviderRow, optionsJSON []byte) error {
 	var opts struct {
-		ReasoningEffort        string            `json:"reasoning_effort"`
-		ReasoningEffortByModel map[string]string `json:"reasoning_effort_by_model"`
-		RequestTimeout         string            `json:"request_timeout"`
-		Region                 string            `json:"region"`
-		AnthropicBaseURL       string            `json:"anthropic_base_url"`
-		OpenAIResponses        string            `json:"openai_responses"`
-		LitellmProvider        string            `json:"litellm_provider"`
+		ReasoningEffort        string `json:"reasoning_effort"`
+		ReasoningEffortByModel string `json:"reasoning_effort_by_model"`
+		RequestTimeout         string `json:"request_timeout"`
+		Region                 string `json:"region"`
+		AnthropicBaseURL       string `json:"anthropic_base_url"`
+		OpenAIResponses        string `json:"openai_responses"`
+		LitellmProvider        string `json:"litellm_provider"`
 	}
 	if err := json.Unmarshal(optionsJSON, &opts); err != nil {
 		return err
 	}
 	row.ReasoningEffort = opts.ReasoningEffort
-	row.ReasoningEffortByModel = opts.ReasoningEffortByModel
+	if opts.ReasoningEffortByModel != "" {
+		if err := json.Unmarshal([]byte(opts.ReasoningEffortByModel), &row.ReasoningEffortByModel); err != nil {
+			return fmt.Errorf("reasoning_effort_by_model: %w", err)
+		}
+	}
 	row.Region = opts.Region
 	row.AnthropicBaseURL = opts.AnthropicBaseURL
 	row.LitellmProvider = opts.LitellmProvider

--- a/internal/gateway/router/store_test.go
+++ b/internal/gateway/router/store_test.go
@@ -55,7 +55,8 @@ func TestApplyProviderOptionsReasoningEffort(t *testing.T) {
 func TestApplyProviderOptionsReasoningEffortByModel(t *testing.T) {
 	t.Parallel()
 	var row ProviderRow
-	if err := applyProviderOptions(&row, []byte(`{"reasoning_effort": "low", "reasoning_effort_by_model": {"gpt-5.6-luna": "none"}}`)); err != nil {
+	optsJSON := `{"reasoning_effort": "low", "reasoning_effort_by_model": "{\"gpt-5.6-luna\": \"none\"}"}`
+	if err := applyProviderOptions(&row, []byte(optsJSON)); err != nil {
 		t.Fatalf("applyProviderOptions: %v", err)
 	}
 	if row.ReasoningEffort != "low" {
@@ -63,6 +64,15 @@ func TestApplyProviderOptionsReasoningEffortByModel(t *testing.T) {
 	}
 	if row.ReasoningEffortByModel["gpt-5.6-luna"] != "none" {
 		t.Fatalf("ReasoningEffortByModel[gpt-5.6-luna] = %q, want none", row.ReasoningEffortByModel["gpt-5.6-luna"])
+	}
+}
+
+func TestApplyProviderOptionsReasoningEffortByModelBadJSONFails(t *testing.T) {
+	t.Parallel()
+	var row ProviderRow
+	err := applyProviderOptions(&row, []byte(`{"reasoning_effort_by_model": "not json"}`))
+	if err == nil {
+		t.Fatal("applyProviderOptions: want error for malformed reasoning_effort_by_model, got nil")
 	}
 }
 

--- a/internal/gateway/router/store_test.go
+++ b/internal/gateway/router/store_test.go
@@ -52,6 +52,20 @@ func TestApplyProviderOptionsReasoningEffort(t *testing.T) {
 	}
 }
 
+func TestApplyProviderOptionsReasoningEffortByModel(t *testing.T) {
+	t.Parallel()
+	var row ProviderRow
+	if err := applyProviderOptions(&row, []byte(`{"reasoning_effort": "low", "reasoning_effort_by_model": {"gpt-5.6-luna": "none"}}`)); err != nil {
+		t.Fatalf("applyProviderOptions: %v", err)
+	}
+	if row.ReasoningEffort != "low" {
+		t.Fatalf("ReasoningEffort = %q, want low", row.ReasoningEffort)
+	}
+	if row.ReasoningEffortByModel["gpt-5.6-luna"] != "none" {
+		t.Fatalf("ReasoningEffortByModel[gpt-5.6-luna] = %q, want none", row.ReasoningEffortByModel["gpt-5.6-luna"])
+	}
+}
+
 // TestApplyProviderOptionsOpenAIResponses covers the tri-state
 // openai_responses flag (D-051 follow-up): absent must leave
 // OpenAIResponses nil (unknown, never guessed), "true"/"false" set a


### PR DESCRIPTION
## Summary
- `gpt-5.6-luna` silently returns an empty stream (200 OK, zero bytes, no error event) for any tool-calling request on `/chat/completions` unless `reasoning_effort` is exactly `"none"` — an OpenAI-documented model restriction.
- The gateway's only existing `reasoning_effort` control (`options.reasoning_effort`) is provider-wide — forcing it to `"none"` for `gpt-5.6-luna` would also flatten reasoning depth for every other model the same OpenAI provider row serves (`gpt-5-mini`, `gpt-5.3-codex`, etc).
- `options.reasoning_effort_by_model` adds a per-model override on `ProviderRow`, threaded through `router.Attempt.ReasoningEffort` into `provider.CompletionRequest.ReasoningEffortOverride`, winning over both the per-request `Effort` hint and the provider-wide config.
- Its value is a JSON-encoded object string (not a nested object) so `options` stays `map[string]string` end to end through the existing admin write path (`ProviderPatch`, the DB write, the provider-edit UI) — no schema/API/UI widening needed.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run` (0 issues)
- [x] New tests: `TestApplyProviderOptionsReasoningEffortByModel`, `TestApplyProviderOptionsReasoningEffortByModelBadJSONFails`, `TestReasoningEffortForModelOverrideBeatsRowWide`, `TestResolveThreadsReasoningEffortIntoAttempt`, `TestOpenAICompatReasoningEffortOverrideBeatsProviderConfig`, `TestOpenAICompatReasoningEffortOverrideEmptyLeavesOtherDialsInPlace`
- [x] **Live before/after verified locally** against a real OpenAI key: patched a local route's chain to `gpt-5.6-luna` + a tool definition, confirmed the empty-stream bug reproduces without the fix; applied `PATCH .../providers/{id}` with `options.reasoning_effort_by_model` set, confirmed the same request now returns a real tool call and completion. Reverted the local test-only route/provider config afterward.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789956570&installation_model_id=431401&pr_number=272&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F272&signature=34bd11e92b58ed40cf0680a1fa306e35f8de219181fe982febc356471923f101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->