### PR TITLE
fix: pass model as the catalog search query when pricing a chain entry

### DIFF
--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -829,7 +829,9 @@ func (s *Snapshot) catalogModel(row ProviderRow, model string) (catalog.Model, b
 		opts = map[string]string{"litellm_provider": row.LitellmProvider}
 	}
 	candidates := catalog.CandidateProvidersForRow(row.Kind, row.Driver, row.BaseURL, opts)
-	pool, err := s.cat.SearchProviders(context.Background(), "", candidates, 0)
+	// model as the query, not "", to avoid the default result cap
+	// dropping real matches for large litellm_provider buckets.
+	pool, err := s.cat.SearchProviders(context.Background(), model, candidates, 0)
 	if err != nil {
 		return catalog.Model{}, false
 	}

--- a/internal/gateway/router/router_test.go
+++ b/internal/gateway/router/router_test.go
@@ -3,6 +3,7 @@ package router
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -398,6 +399,54 @@ func TestProvidersSortedByName(t *testing.T) {
 		if rows[i-1].Name > rows[i].Name {
 			t.Fatalf("providers not sorted: %s > %s", rows[i-1].Name, rows[i].Name)
 		}
+	}
+}
+
+// truncatingCatalog mimics catalog.Store's real search-limit behavior
+// (fakeCatalog ignores q/limit entirely) — q filters by substring on
+// ModelKey, and the result is capped at limit (defaulting like the
+// real store when limit<=0), so a large pool can silently drop a
+// target model past the cap when queried with q="".
+type truncatingCatalog struct {
+	pool  []catalog.Model
+	limit int
+}
+
+func (t *truncatingCatalog) SearchProviders(_ context.Context, q string, _ []string, limit int) ([]catalog.Model, error) {
+	if limit <= 0 {
+		limit = t.limit
+	}
+	var out []catalog.Model
+	for _, m := range t.pool {
+		if q == "" || strings.Contains(m.ModelKey, q) {
+			out = append(out, m)
+		}
+	}
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// TestPricesFindsModelPastDefaultSearchCap guards a real bug: Prices
+// called SearchProviders with q="" and limit=0, so a provider with more
+// catalog entries than the default cap silently lost models sorted
+// past it — cost_ledger.cost stayed nil for every affected call.
+func TestPricesFindsModelPastDefaultSearchCap(t *testing.T) {
+	t.Parallel()
+	pool := make([]catalog.Model, 0, 60)
+	for i := 0; i < 60; i++ {
+		pool = append(pool, catModel(fmt.Sprintf("aaa-filler-%02d", i), "chat", fp(1)))
+	}
+	pool = append(pool, catModel("zzz-target-model", "chat", fp(9)))
+
+	provRows := []ProviderRow{
+		{ID: "p1", Name: "oai", Kind: "api", Driver: "openaicompat", BaseURL: "https://api.example/v1", DefaultModel: "zzz-target-model", CredentialRef: "K", Enabled: true},
+	}
+	snap, _ := BuildSnapshot(provRows, nil, func(string) string { return "key" }, &truncatingCatalog{pool: pool, limit: 50})
+
+	if p := snap.Prices("oai", "zzz-target-model"); p == nil || p.InputPerMTok != 9 {
+		t.Fatalf("Prices(oai, zzz-target-model) = %+v, want InputPerMTok=9 (model past the 50-item cap must still resolve)", p)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `Snapshot.catalogModel` called `SearchProviders(ctx, "", candidates, 0)` — empty query, default limit (50) — to find a chain entry's catalog price row.
- For a large `litellm_provider` bucket (OpenAI has hundreds of catalog entries), the target model can sort past the 50-item cap and never appear in the returned pool, even though it genuinely exists in the catalog.
- Confirmed live on the homelab install: **every** OpenAI call (`gpt-5-mini`, `gpt-5.6-luna`, every codex model) had `cost_ledger.cost = NULL` — this is what originally looked like a codex-specific billing gap (D-013's "never guess" cost policy) but turned out to be this unrelated truncation bug affecting the whole provider.
- Fix: pass `model` as the search query instead of `""`, narrowing to a substring match on the model key so the pool stays well under the cap regardless of provider size. `CatalogModelsForRow` (the UI's browse-all-models listing) is intentionally left alone — its empty query is the correct behavior there.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run` (0 issues)
- [x] New `TestPricesFindsModelPastDefaultSearchCap`: a fake catalog that actually respects `q`/`limit` (the shared test fixture's fake doesn't), with a 60-model pool and the target sorted last — fails without the fix, passes with it (verified both ways).
- [x] **Live before/after verified locally** against a real OpenAI key: a plain `gpt-5-mini` completion's `done` event carried no `cost`/`currency` fields before the fix; after rebuilding gateway with the fix, the same request reports a real per-call cost (`cost: 0.00015475, currency: USD`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789989839&installation_model_id=431401&pr_number=273&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F273&signature=e6e04f4a463fad5d48e0935d589610c0e7c0096aa66e84d362b0a392513b0a29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->