### PR TITLE
feat: let a schedule's mission_template set a display name

### DIFF
--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -53,7 +53,14 @@ type Schedule struct {
 // MissionTemplate is applied verbatim as a new mission's initial
 // columns each time its schedule fires.
 type MissionTemplate struct {
-	Goal        string `json:"goal"`
+	Goal string `json:"goal"`
+	// Name, when set, becomes the created mission's display name
+	// (Mission.Name — the UI/destination-delivery title) instead of the
+	// schedule's own slug identifier. The schedule name stays a strict
+	// lowercase slug for consistency with connectors/destinations/agents;
+	// this lets a schedule read "Today's Meetings" in Telegram without
+	// relaxing that.
+	Name        string `json:"name,omitempty"`
 	Kind        string `json:"kind"`
 	AgentID     string `json:"agent_id"`
 	Route       string `json:"route"`
@@ -429,10 +436,14 @@ func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedu
 	if err != nil {
 		return fmt.Errorf("marshal knowledge: %w", err)
 	}
+	name := t.Name
+	if name == "" {
+		name = sc.Name
+	}
 	_, err = tx.Exec(ctx, `INSERT INTO missions
 			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, knowledge, auto_approve_safe, spec, schedule_id, harness, environment, destination_ids)
 		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`,
-		t.Goal, sc.Name, t.Kind, t.AgentID, orDefault(t.MaxIterations, 8), t.BudgetAmount, budgetCurrency, t.Route, t.ReviewRoute, t.PlanRoute,
+		t.Goal, name, t.Kind, t.AgentID, orDefault(t.MaxIterations, 8), t.BudgetAmount, budgetCurrency, t.Route, t.ReviewRoute, t.PlanRoute,
 		promptOverlay, knowledgeJSON, t.AutoApproveSafe, spec, sc.ID, t.Harness, t.Environment, destinationIDs)
 	return err
 }

--- a/internal/brain/missions/scheduler_integration_test.go
+++ b/internal/brain/missions/scheduler_integration_test.go
@@ -4,6 +4,7 @@ package missions
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 	"testing"
 	"time"
@@ -98,6 +99,58 @@ func TestSchedulerFireUsesScheduleNameDirectly(t *testing.T) {
 	}
 	if name != marker+"named-schedule" {
 		t.Fatalf("fired mission name = %q, want the schedule's own name %q", name, marker+"named-schedule")
+	}
+}
+
+// TestSchedulerFireUsesTemplateNameOverSlug guards the fix for a real
+// UI gap: schedule names are strict lowercase slugs (shared validation
+// with connectors/destinations/agents), so a scheduled mission's
+// display title showed the raw slug (e.g. "inbox-digest-8h") instead
+// of something presentable. mission_template.name, when set, must win
+// over the schedule's own slug.
+func TestSchedulerFireUsesTemplateNameOverSlug(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	db, err := store.db.Get()
+	if err != nil {
+		t.Fatalf("Get pool: %v", err)
+	}
+	tmplJSON, err := json.Marshal(map[string]string{
+		"goal": marker + "scheduled run",
+		"kind": "general",
+		"name": "Today's Meetings",
+	})
+	if err != nil {
+		t.Fatalf("marshal template: %v", err)
+	}
+	var id string
+	err = db.QueryRow(ctx, `INSERT INTO schedules (name, cron, mission_template)
+		VALUES ($1, $2, $3) RETURNING id`, marker+"titled-schedule", "* * * * *", tmplJSON).Scan(&id)
+	if err != nil {
+		t.Fatalf("create schedule: %v", err)
+	}
+	t.Cleanup(func() {
+		cctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_, _ = db.Exec(cctx, "DELETE FROM schedules WHERE id = $1", id)
+	})
+	past := time.Now().Add(-2 * time.Minute)
+	if _, err := db.Exec(ctx, "UPDATE schedules SET created_at = $2 WHERE id = $1", id, past); err != nil {
+		t.Fatalf("backdate schedule: %v", err)
+	}
+
+	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, nil, store.log)
+	if err := sched.tick(ctx, time.Now()); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	var name string
+	if err := db.QueryRow(ctx, `SELECT name FROM missions WHERE schedule_id = $1`, id).Scan(&name); err != nil {
+		t.Fatalf("query fired mission's name: %v", err)
+	}
+	if name != "Today's Meetings" {
+		t.Fatalf("fired mission name = %q, want the template's display name %q", name, "Today's Meetings")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Scheduled missions get `name = <schedule's own slug>` directly at fire time (deliberate — no LLM naming call for scheduled missions).
- Schedule names are strict lowercase slugs (`a-z, 0-9, -, _`), the same validation shared with connectors/destinations/agents — so the UI/Telegram title for every scheduled digest showed the raw identifier (`inbox-digest-8h`, `daily-meetings-summary`) instead of something presentable.
- `mission_template.name`, when set, now wins over the schedule's slug for the created mission's display name. The schedule's own identifier stays a clean slug; the title shown to the user can read "Today's Meetings".

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run` (0 issues)
- [x] New `TestSchedulerFireUsesTemplateNameOverSlug` (integration): confirms a fired mission's `name` uses `mission_template.name` over the schedule's slug when set — run against a live local Postgres, passing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790005701&installation_model_id=431401&pr_number=274&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F274&signature=6296ed6f25aa1f9d1a876feb8f4e21f29c67669a73dbabda9a290d59f36df78e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->