### PR TITLE
fix: gate sensitive-route pin on connector flag, not hardcoded gmail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,17 +50,25 @@ First run: `cp deploy/env.example deploy/.env` and set
 
 ## Layout
 
-- `cmd/{brain,gateway,memoryd,skills-validate}`: binaries; all wiring
-  in each `main.go` (nil-able deps, env-gated features).
+- `cmd/{brain,gateway,memoryd,sandboxd,skills-validate}`: binaries; all
+  wiring in each `main.go` (nil-able deps, env-gated features).
 - `internal/brain/`: `api` (HTTP handlers, nil-gated `register*`
   pattern), `loop` (THE tool loop, lives here only), `tools` +
   `tools/builtin` (registry, permission chain, builtin tools), `chat`,
   `session`, `agents`, `missions` (agent harness), `connectors`
-  (Google/MCP), `gwclient`, `memclient`, `settings`, `skills`.
+  (Google/MCP), `destinations` (mission result delivery: email/webhook/
+  telegram), `kb` (knowledge-base collections/documents), `attachments`,
+  `gwclient`, `memclient`, `sandboxclient`, `settings`, `skills`.
 - `internal/gateway/`: `provider` (wire adapters only), `router`,
-  `ledger`, `stream`, `admin`, `api`.
+  `catalog` (LiteLLM-synced model/pricing catalog), `ledger`, `stream`,
+  `admin`, `api`.
+- `internal/memory/` (memoryd's implementation): `api`, `store`
+  (pgvector), `chunk`, `extract`, `retrieval` (hybrid vector+text+entity,
+  RRF-fused).
 - `internal/platform/`: shared: `migrate`, `pgpool`, `sse`,
-  `httpserver`, `metrics`, `logging`, `config`, `service`.
+  `httpserver`, `metrics`, `logging`, `config`, `service`, `netguard`
+  (SSRF-guarded outbound dialer), `markitdown`, `whisper` (sidecar
+  clients).
 - `migrations/`: numbered idempotent SQL, embedded via `embed.go`;
   never edit an applied migration.
 - `skills/`: skill packs baked into the brain image.
@@ -109,7 +117,7 @@ First run: `cp deploy/env.example deploy/.env` and set
 - Secrets by `credential_ref` name only; raw values never in DB, API,
   logs, or frontend. Never read `.env*`, `~/.ssh`, credentials.
 - Providers are wire adapters; routing/model choice is data
-  (`providers`/`task_routes` rows), not code.
+  (`providers`/`routes` rows), not code.
 - Cost honesty: unknown price recorded as NULL, never guessed.
 - No speculative abstractions: no interface with one implementation, no
   config nothing reads.

--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -53,13 +53,6 @@ import (
 // driven budgets arrive when model rows carry context windows.
 const defaultTokenBudget = 60_000
 
-// sensitiveToolSuffixes is the single source of truth for which tools'
-// output must never leave the sensitive route floor once called: the
-// in-turn pin (loop.Agent.SetForceRoute) and the side-call route
-// (session.SensitiveTools, chat/memoryd/compactor) both key off this
-// same list, so a tool added here is covered everywhere at once.
-var sensitiveToolSuffixes = []string{"gmail_read", "gmail_read_attachment"}
-
 // builtinToolSet guards the compiled-in tool slice buildAgent
 // returns: the connector reload goroutine reads it (via
 // conns.SetOnReload's closure) on its own timer, concurrently with
@@ -375,15 +368,15 @@ func main() {
 	}
 
 	// Single source of truth for "this turn/session executed a sensitive
-	// tool": the loop's in-turn SetForceRoute pin above and this
-	// SensitiveTools value share sensitiveToolSuffixes and the same
-	// sensitiveRoute resolver, so side-calls (extraction, compaction
+	// tool": a connector's own "sensitive" flag (set from the connectors
+	// settings UI) and the same sensitiveRoute resolver drive both the
+	// loop's in-turn SetForceRouteByConnector pin below and this
+	// SensitiveTools value, so side-calls (extraction, compaction
 	// summarize) honor the same route floor the tool loop already
 	// pinned the turn to. Wired unconditionally — sensitiveRoute
 	// resolving to "" at call time means the feature is currently off,
 	// same as before, but now editable at runtime from the settings UI.
 	sensitiveTools := &session.SensitiveTools{
-		Suffixes:       func(context.Context) []string { return sensitiveToolSuffixes },
 		ConnectorNames: sensitiveConnectorNames,
 		Route:          sensitiveRoute,
 	}
@@ -1271,17 +1264,10 @@ func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, wor
 	// Shell dumps grow fast; offload them sooner than the default so a
 	// long command output never bloats the context (D-019).
 	agent.SetOffloadThreshold("shell", 4<<10)
-	// Reading real email content is sensitive: once a Gmail read tool
-	// fires, pin the rest of the turn to a trusted route (e.g. one
-	// chained only to a local Ollama provider) instead of whatever
-	// route the turn started on — optional, since not everyone runs a
-	// local model. sensitiveRoute resolving to "" at flip time means
-	// the feature is currently off; wired unconditionally since the
-	// route is now runtime-configurable from the settings UI, not just
-	// boot-time env.
-	for _, suffix := range sensitiveToolSuffixes {
-		agent.SetForceRoute(suffix, sensitiveRoute)
-	}
+	// Connector-level sensitivity's in-turn pin (a connector marked
+	// sensitive in the connectors settings UI, e.g. gmail) is wired
+	// later via agent.SetForceRouteByConnector, once conns exists —
+	// buildAgent runs before that, so there is nothing to wire here.
 	return agent, broker, outputs, set, perms, nil
 }
 

--- a/internal/brain/chat/attachments_test.go
+++ b/internal/brain/chat/attachments_test.go
@@ -264,7 +264,7 @@ func TestChatImageMessageOnSensitivePinnedSessionKeepsPinnedRoute(t *testing.T) 
 	seedSensitiveSession(t, log, "s1")
 	gw := &fakeGW{events: okEvents("described")}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 	fa := newFakeAttachments()
 	fa.seed("img1", "image/png", []byte("bytes"))
 	svc.SetAttachments(fa)

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -2157,7 +2157,7 @@ func TestMemoryExtractUsesSensitiveRouteWhenTurnRanSensitiveTool(t *testing.T) {
 		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
 	}}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 
 	got := make(chan string, 1)
 	svc.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) {
@@ -2193,7 +2193,7 @@ func TestMemoryExtractUsesEmptyRouteWhenTurnDidNotRunSensitiveTool(t *testing.T)
 		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod"}},
 	}}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 
 	got := make(chan string, 1)
 	svc.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) {
@@ -2404,7 +2404,7 @@ func TestDistillUsesSensitiveRouteWhenTurnRanSensitiveTool(t *testing.T) {
 		return nil
 	}
 	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize my inbox"})
 	if err != nil {
@@ -2440,7 +2440,7 @@ func TestDistillUsesEmptyRouteWhenTurnDidNotRunSensitiveTool(t *testing.T) {
 		return nil
 	}
 	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "run a shell command"})
 	if err != nil {
@@ -2486,7 +2486,7 @@ func TestChatPinsSessionSensitiveRouteOnNextTurn(t *testing.T) {
 	seedSensitiveSession(t, log, "s1")
 	gw := &fakeGW{events: okEvents("the answer")}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "another question", Route: "mini", ModelHint: "big-model"})
 	if err != nil {
@@ -2513,7 +2513,7 @@ func TestChatSessionPinNoopWhenSensitiveRouteUnset(t *testing.T) {
 	seedSensitiveSession(t, log, "s1")
 	gw := &fakeGW{events: okEvents("the answer")}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "" }})
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "another question", Route: "mini", ModelHint: "big-model"})
 	if err != nil {
@@ -2538,7 +2538,7 @@ func TestChatFreshSessionRoutesNormally(t *testing.T) {
 	log := newFakeLog()
 	gw := &fakeGW{events: okEvents("the answer")}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "a question", Route: "mini", ModelHint: "big-model"})
 	if err != nil {
@@ -2570,7 +2570,7 @@ func TestRetryPinsSessionSensitiveRoute(t *testing.T) {
 	}
 	gw := &fakeGW{events: okEvents("the answer")}
 	svc := newService(gw, log)
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 
 	_, ch, err := svc.Retry(t.Context(), "s1")
 	if err != nil {
@@ -2608,7 +2608,7 @@ func TestPersistTurnPinsSideCallsWhenSessionPreviouslySensitive(t *testing.T) {
 		return nil
 	}
 	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
-	svc.SetSensitiveTools(&session.SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
+	svc.SetSensitiveTools(&session.SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 
 	extractRoute := make(chan string, 1)
 	svc.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) {

--- a/internal/brain/connectors/manager.go
+++ b/internal/brain/connectors/manager.go
@@ -232,9 +232,9 @@ func (m *Manager) Names() []string {
 }
 
 // SensitiveNames returns the names of every enabled connector marked
-// sensitive — the connector-level input to session.SensitiveTools'
-// suffix set (D-036): a connector named "gmail" being sensitive means
-// "gmail" joins the set, and Matches' namespace-prefix check catches
+// sensitive — the sole input to session.SensitiveTools.ConnectorNames
+// (D-036): a connector named "gmail" being sensitive means "gmail"
+// joins the set, and Matches' namespace-prefix check catches
 // gmail_search/gmail_read/etc. at once. Reads rows fresh each call (no
 // restart needed for a settings toggle to take effect), same reasoning
 // as sensitiveRoute.

--- a/internal/brain/session/compactor_test.go
+++ b/internal/brain/session/compactor_test.go
@@ -539,7 +539,7 @@ func TestCompactionUsesSensitiveRouteWhenSessionRanSensitiveTool(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
-	c.SetSensitiveTools(&SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
+	c.SetSensitiveTools(&SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 
 	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
 		t.Fatalf("MaybeCompact: %v", err)
@@ -562,7 +562,7 @@ func TestCompactionUsesDefaultRouteWithoutSensitiveTool(t *testing.T) {
 	gw := &summarizerGW{summary: "short summary"}
 	seedConversation(t, log, "s1", 10)
 	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
-	c.SetSensitiveTools(&SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
+	c.SetSensitiveTools(&SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 
 	if err := c.MaybeCompact(t.Context(), "s1"); err != nil {
 		t.Fatalf("MaybeCompact: %v", err)
@@ -591,7 +591,7 @@ func TestCompactionExtractUsesSensitiveRouteWhenSessionRanSensitiveTool(t *testi
 		t.Fatal(err)
 	}
 	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
-	c.SetSensitiveTools(&SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
+	c.SetSensitiveTools(&SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 
 	var sawRoute string
 	c.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) []string {
@@ -617,7 +617,7 @@ func TestCompactionExtractUsesEmptyRouteWithoutSensitiveTool(t *testing.T) {
 	gw := &summarizerGW{summary: "short summary"}
 	seedConversation(t, log, "s1", 10)
 	c := NewCompactor(log, gw, nil, staticBudget(500), discardLogger(), nil)
-	c.SetSensitiveTools(&SensitiveTools{Suffixes: func(context.Context) []string { return []string{"gmail_read"} }, Route: func(context.Context) string { return "local" }})
+	c.SetSensitiveTools(&SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 
 	sawRoute := "unset"
 	c.SetMemoryExtract(func(_ context.Context, _ string, _ int64, _ string, route string) []string {

--- a/internal/brain/session/sensitive.go
+++ b/internal/brain/session/sensitive.go
@@ -5,55 +5,36 @@ import (
 	"strings"
 )
 
-// SensitiveTools names the tools whose execution marks a turn/session
+// SensitiveTools names the connectors whose tools mark a turn/session
 // sensitive, and the route side-calls must fall back to when they are.
 // The loop pins the TURN's own route once a matching tool runs
-// (Agent.SetForceRoute), but side-calls — memory extraction, session
-// compaction — re-send turn/conversation content to their own routes
-// LATER, on their own schedule; without this they'd bypass the same
-// floor the in-turn steps already honor and ship raw sensitive content
-// (e.g. email text) to a cloud model. Suffix, not exact name: connector
-// tools are namespaced "<connector-name>_<tool-name>" with a user-chosen
-// connector name (same rule as Agent.SetForceRoute/matchGrant, D-036).
-// Route is a func, not a static string, so a settings change applies to
-// the next side-call without a restart; an empty result means the
+// (Agent.SetForceRouteByConnector), but side-calls — memory extraction,
+// session compaction — re-send turn/conversation content to their own
+// routes LATER, on their own schedule; without this they'd bypass the
+// same floor the in-turn steps already honor and ship raw sensitive
+// content (e.g. email text) to a cloud model. ConnectorNames is the
+// user-controlled input (a connector's own "sensitive" flag, set from
+// the connectors settings UI): connectors are namespaced
+// "<connector-name>_<tool-name>" (connectors.Manager.Tools), so a
+// connector's own name is the PREFIX of every tool it serves. Both
+// ConnectorNames and Route are funcs, not static values, so toggling a
+// connector's sensitive flag (or the configured route) applies to the
+// next side-call without a restart; an empty Route result means the
 // feature is currently off (callers keep their own default route).
-// Suffixes is likewise a func, not a static slice: a specific tool's
-// own name (e.g. "gmail_read") that must stay pinned regardless of
-// which connector namespace wraps it — matched as a suffix, same rule
-// as Agent.SetForceRoute/matchGrant (D-036). ConnectorNames is the
-// separate, additive input for marking a WHOLE connector sensitive:
-// connectors are namespaced "<connector-name>_<tool-name>"
-// (connectors.Manager.Tools), so a connector's own name is the PREFIX
-// of every tool it serves, never a suffix — it needs its own match
-// rule, not Suffixes' suffix check, to avoid a floor entry like
-// "gmail_read" also prefix-matching an unrelated "gmail_read_all"
-// tool. Both are funcs, not static slices, so a settings change
-// applies to the next side-call without a restart, same reasoning as
-// Route.
 type SensitiveTools struct {
-	Suffixes       func(context.Context) []string
 	ConnectorNames func(context.Context) []string
 	Route          func(context.Context) string
 }
 
-// Matches reports whether toolName is covered: exact match or
-// "_"+suffix suffix against Suffixes, or suffix+"_" prefix (a whole
-// connector's namespace) against ConnectorNames.
+// Matches reports whether toolName is covered: suffix+"_" prefix (a
+// whole connector's namespace) against ConnectorNames.
 func (s *SensitiveTools) Matches(ctx context.Context, toolName string) bool {
-	if s == nil {
+	if s == nil || s.ConnectorNames == nil {
 		return false
 	}
-	for _, suffix := range s.Suffixes(ctx) {
-		if toolName == suffix || strings.HasSuffix(toolName, "_"+suffix) {
+	for _, name := range s.ConnectorNames(ctx) {
+		if strings.HasPrefix(toolName, name+"_") {
 			return true
-		}
-	}
-	if s.ConnectorNames != nil {
-		for _, name := range s.ConnectorNames(ctx) {
-			if strings.HasPrefix(toolName, name+"_") {
-				return true
-			}
 		}
 	}
 	return false

--- a/internal/brain/session/sensitive_test.go
+++ b/internal/brain/session/sensitive_test.go
@@ -5,37 +5,6 @@ import (
 	"testing"
 )
 
-// TestSensitiveToolsMatches pins the suffix semantics: exact name, or
-// name ending "_"+suffix (connector namespacing), same rule as
-// loop.Agent.SetForceRoute/matchGrant (D-036).
-func TestSensitiveToolsMatches(t *testing.T) {
-	t.Parallel()
-	s := &SensitiveTools{
-		Suffixes: func(context.Context) []string { return []string{"gmail_read", "gmail_read_attachment"} },
-		Route:    func(context.Context) string { return "local" },
-	}
-	tests := []struct {
-		name string
-		tool string
-		want bool
-	}{
-		{name: "exact match", tool: "gmail_read", want: true},
-		{name: "connector-namespaced match", tool: "personal_gmail_read", want: true},
-		{name: "other suffix connector-namespaced", tool: "work_gmail_read_attachment", want: true},
-		{name: "unrelated tool", tool: "shell", want: false},
-		{name: "prefix only, not suffix", tool: "gmail_read_something_else", want: false},
-		{name: "partial suffix without underscore boundary", tool: "xgmail_read", want: false},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			if got := s.Matches(context.Background(), tc.tool); got != tc.want {
-				t.Fatalf("Matches(%q) = %v, want %v", tc.tool, got, tc.want)
-			}
-		})
-	}
-}
-
 func TestSensitiveToolsMatchesNilReceiver(t *testing.T) {
 	t.Parallel()
 	var s *SensitiveTools
@@ -45,17 +14,13 @@ func TestSensitiveToolsMatchesNilReceiver(t *testing.T) {
 }
 
 // TestSensitiveToolsMatchesConnectorPrefix pins the connector-level
-// case: a connector's own name is the NAMESPACE PREFIX of every tool it
-// serves ("<connector-name>_<tool-name>", connectors.Manager.Tools),
-// never a suffix — so marking a whole connector sensitive adds its bare
-// name to ConnectorNames, matched via a prefix check that is separate
-// from Suffixes' tool-name suffix rule (mixing the two in one list
-// would make a floor entry like "gmail_read" falsely prefix-match an
-// unrelated "gmail_read_all_labels" tool).
+// match rule: a connector's own name is the NAMESPACE PREFIX of every
+// tool it serves ("<connector-name>_<tool-name>",
+// connectors.Manager.Tools) — marking a whole connector sensitive adds
+// its bare name to ConnectorNames, matched via a prefix check.
 func TestSensitiveToolsMatchesConnectorPrefix(t *testing.T) {
 	t.Parallel()
 	s := &SensitiveTools{
-		Suffixes:       func(context.Context) []string { return []string{"gmail_read"} },
 		ConnectorNames: func(context.Context) []string { return []string{"slack"} },
 		Route:          func(context.Context) string { return "local" },
 	}
@@ -68,7 +33,6 @@ func TestSensitiveToolsMatchesConnectorPrefix(t *testing.T) {
 		{name: "another tool under the same sensitive connector", tool: "slack_send_message", want: true},
 		{name: "unrelated connector", tool: "calendar_list_events", want: false},
 		{name: "connector name embedded but not as a namespace boundary", tool: "backslack_read", want: false},
-		{name: "floor suffix does not falsely prefix-match", tool: "gmail_read_all_labels", want: false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -81,13 +45,11 @@ func TestSensitiveToolsMatchesConnectorPrefix(t *testing.T) {
 }
 
 // TestSensitiveToolsMatchesConnectorNamesNil pins that a nil
-// ConnectorNames func (not every caller wires it) never panics —
-// Matches falls back to Suffixes alone.
+// ConnectorNames func (not every caller wires it) never panics.
 func TestSensitiveToolsMatchesConnectorNamesNil(t *testing.T) {
 	t.Parallel()
 	s := &SensitiveTools{
-		Suffixes: func(context.Context) []string { return []string{"gmail_read"} },
-		Route:    func(context.Context) string { return "local" },
+		Route: func(context.Context) string { return "local" },
 	}
 	if s.Matches(context.Background(), "slack_read_channel") {
 		t.Fatal("Matches true with nil ConnectorNames, want false")
@@ -104,7 +66,6 @@ func TestSensitiveToolsMatchesDynamicConnectorNames(t *testing.T) {
 	t.Parallel()
 	sensitiveConnector := false
 	s := &SensitiveTools{
-		Suffixes: func(context.Context) []string { return []string{"gmail_read"} },
 		ConnectorNames: func(context.Context) []string {
 			if sensitiveConnector {
 				return []string{"slack"}

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -46,10 +46,10 @@ const (
 	// timothy/timothy@localhost identity.
 	ValueGitAuthorName  = "git_author_name"
 	ValueGitAuthorEmail = "git_author_email"
-	// ValueSensitiveToolRoute names the route that sensitive-tool turns
-	// (e.g. gmail_read) and their side-calls (memory extraction,
-	// compaction) pin to; empty means the feature is off. Set from the
-	// web settings panel.
+	// ValueSensitiveToolRoute names the route that turns using a
+	// connector marked sensitive (e.g. gmail) and their side-calls
+	// (memory extraction, compaction) pin to; empty means the feature is
+	// off. Set from the web settings panel.
 	ValueSensitiveToolRoute = "sensitive_tool_route"
 	// ValueDefaultCurrency is the ISO 4217 code new budgets/missions
 	// default to when the caller doesn't specify one; empty defers to

--- a/web/src/components/settings/FeaturesTab.tsx
+++ b/web/src/components/settings/FeaturesTab.tsx
@@ -332,11 +332,12 @@ function GitCommitStyleCard({
 
 const SENSITIVE_ROUTE_OFF = '__off__'
 
-// SensitiveRouteCard picks the route sensitive-tool turns (e.g. reading
-// email content) and their memory extraction/compaction side-calls pin
-// to. Fetches the route list on mount like AgentAdd/AgentEdit; if that
-// fetch fails (or the admin proxy is nil-gated), falls back to a plain
-// text input so the setting stays editable without the picker.
+// SensitiveRouteCard picks the route a turn using a connector marked
+// "sensitive" (e.g. gmail) and its memory extraction/compaction
+// side-calls pin to. Fetches the route list on mount like
+// AgentAdd/AgentEdit; if that fetch fails (or the admin proxy is
+// nil-gated), falls back to a plain text input so the setting stays
+// editable without the picker.
 function SensitiveRouteCard({
   values,
   onError,
@@ -404,8 +405,9 @@ function SensitiveRouteCard({
         {saved && <span className="text-xs text-muted-foreground">Saved.</span>}
       </div>
       <p className="mt-2 text-xs text-muted-foreground">
-        Turns that read email content switch to this route, and their memory extraction and
-        compaction follow. Chain it to a local provider for a privacy floor.
+        Turns that use a connector marked "sensitive" (toggle it on that connector's own settings)
+        switch to this route, and their memory extraction and compaction follow. Chain it to a
+        local provider for a privacy floor.
       </p>
     </div>
   )


### PR DESCRIPTION
## Summary
- `sensitive_tool_route` previously pinned every `gmail_read`/`gmail_read_attachment` call to a fixed route via a hardcoded suffix list in `main.go`, regardless of a connector's own "sensitive" toggle.
- Root-caused via a stuck production mission on homelab: the route pointed at a wedged remote Ollama box, stalling the mission for 20+ minutes with no visible cause in settings.
- `SensitiveTools.ConnectorNames` (driven by each connector's `sensitive` DB flag, already editable from Settings → Connectors) is now the sole mechanism. Removed the dead `Suffixes` field/list.
- Reconciled stale comments/copy referencing the old hardcoded behavior, including misleading settings-page copy that implied the pin was automatic for email.
- Also includes an unrelated `CLAUDE.md` reconciliation (missing packages, stale table name) as a separate commit.

## Test plan
- [x] `go build/vet/test -race ./...` all green (including the known-flaky `TestResolveHintExactModel`, unrelated, passed this run)
- [x] `golangci-lint run` — 0 issues
- [x] Verified locally: toggled the `gmail` connector's `sensitive` flag on/off via the connectors API, confirmed it now drives the pin end-to-end with no code-level special case remaining
- [x] Frontend build/lint/test all green (733/733)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790025901&installation_model_id=431401&pr_number=276&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F276&signature=45c7c24476eabbacd5c819ac56d0b312bba76998f92e343bd16aeb22335d8c95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->