### PR TITLE
feat: auto-classify knowledgebase uploads into collections

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -557,7 +557,7 @@ func main() {
 	api.Register(app.Server, svc, store, broker,
 		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, usageDecorator.Decorate, app.Log), flags, fxStore,
 		agentReg, conns, goog, secrets, agent, packs, missionStore, missionDriver, missionNotifier,
-		missionWorkspace, resolveSecret, routeForRole, chat.ClassifyOverGateway(gwc), gwc.ResolveRoute, chat.TitleOverGateway(gwc, app.Log), ledgerAgg.TopModelByMission, missionHub, attachmentStore, &http.Client{}, whisperURL, markitdownURL, token, app.Log, gwc, kbStore, mc, destinationStore, destinationTest)
+		missionWorkspace, resolveSecret, routeForRole, chat.ClassifyOverGateway(gwc), gwc.ResolveRoute, chat.TitleOverGateway(gwc, app.Log), ledgerAgg.TopModelByMission, missionHub, attachmentStore, &http.Client{}, whisperURL, markitdownURL, token, app.Log, gwc, kbStore, mc, chat.ClassifyCollectionOverGateway(gwc, app.Log), destinationStore, destinationTest)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -100,7 +100,7 @@ var memoryRoutePatterns = []string{
 // proxy to the gateway's internal control plane, conns the local
 // connector control plane (nil leaves any of them unmounted).
 // whisperURL empty leaves /v1/transcribe unmounted (WHISPER_URL unset).
-func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, secrets *secretstore.Store, toolset Toolset, packs []skills.Skill, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, markitdownURL string, token string, log *slog.Logger, gwSecrets GatewaySecrets, kbStore *kb.Store, kbIngest kbIngester, destinationStore *destinations.Store, destinationTest destinationTester) {
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, secrets *secretstore.Store, toolset Toolset, packs []skills.Skill, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, markitdownURL string, token string, log *slog.Logger, gwSecrets GatewaySecrets, kbStore *kb.Store, kbIngest kbIngester, kbClassify kbClassifier, destinationStore *destinations.Store, destinationTest destinationTester) {
 	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log, flags: flags, rates: rates}
 	if kbStore != nil {
 		a.kbCollections = kbStore.ListCollections
@@ -125,7 +125,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	a.registerConnectors(srv.Handle, conns, goog, secrets)
 	a.registerTools(srv.Handle, toolset)
 	a.registerSkills(srv.Handle, packs)
-	a.registerKB(srv.Handle, kbStore, kbIngest, markitdownURL)
+	a.registerKB(srv.Handle, kbStore, kbIngest, markitdownURL, kbClassify)
 	var codingExecutorDefault func(context.Context) string
 	if flags != nil {
 		codingExecutorDefault = flags.CodingExecutor

--- a/internal/brain/api/kb.go
+++ b/internal/brain/api/kb.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/SumonMSelim/timothy/internal/brain/chat"
 	"github.com/SumonMSelim/timothy/internal/brain/kb"
 	"github.com/SumonMSelim/timothy/internal/platform/markitdown"
 	"github.com/SumonMSelim/timothy/internal/platform/netguard"
@@ -37,14 +38,20 @@ type kbIngester interface {
 	IngestDocument(ctx context.Context, documentID, title, markdown string) (int, error)
 }
 
+// kbClassifier picks (or proposes) a collection for a document at
+// auto-ingest time — chat.ClassifyCollectionOverGateway in production,
+// faked in tests. Never errors (same best-effort contract as the
+// classifier itself): a document must always resolve to some choice.
+type kbClassifier func(ctx context.Context, docTitle, docText string, collections []kb.Collection) chat.CollectionChoice
+
 // registerKB mounts the knowledge-base admin surface (D-060). Nil
 // store leaves it unmounted, same nil-gate pattern as agents/skills.
-func (a *API) registerKB(handle func(pattern string, h http.Handler), store *kb.Store, ingest kbIngester, markitdownURL string) {
+func (a *API) registerKB(handle func(pattern string, h http.Handler), store *kb.Store, ingest kbIngester, markitdownURL string, classify kbClassifier) {
 	if store == nil {
 		return
 	}
 	h := &kbAPI{
-		store: store, ingest: ingest, markitdownURL: markitdownURL,
+		store: store, ingest: ingest, markitdownURL: markitdownURL, classify: classify,
 		markitdownHTTP: &http.Client{},
 		fetchHTTP:      &http.Client{Timeout: kbURLFetchTimeout, Transport: kbFetchTransport},
 		log:            a.log,
@@ -56,6 +63,8 @@ func (a *API) registerKB(handle func(pattern string, h http.Handler), store *kb.
 	handle("GET /v1/admin/kb/collections/{id}/documents", a.auth(http.HandlerFunc(h.listDocuments)))
 	handle("POST /v1/admin/kb/collections/{id}/documents", a.auth(http.HandlerFunc(h.uploadDocument)))
 	handle("POST /v1/admin/kb/collections/{id}/documents/url", a.auth(http.HandlerFunc(h.addDocumentFromURL)))
+	handle("POST /v1/admin/kb/documents", a.auth(http.HandlerFunc(h.uploadDocumentAuto)))
+	handle("POST /v1/admin/kb/documents/url", a.auth(http.HandlerFunc(h.addDocumentFromURLAuto)))
 	handle("DELETE /v1/admin/kb/documents/{id}", a.auth(http.HandlerFunc(h.deleteDocument)))
 	handle("POST /v1/admin/kb/documents/{id}/reingest", a.auth(http.HandlerFunc(h.reingestDocument)))
 }
@@ -63,6 +72,7 @@ func (a *API) registerKB(handle func(pattern string, h http.Handler), store *kb.
 type kbAPI struct {
 	store          *kb.Store
 	ingest         kbIngester
+	classify       kbClassifier
 	markitdownURL  string
 	markitdownHTTP *http.Client
 	// fetchHTTP fetches user-supplied URLs; production wires it through
@@ -70,6 +80,32 @@ type kbAPI struct {
 	// substitute an unguarded client.
 	fetchHTTP *http.Client
 	log       *slog.Logger
+}
+
+// resolveCollection runs the auto-classify path shared by
+// uploadDocumentAuto/addDocumentFromURLAuto: lists existing collections,
+// classifies the document against them, and creates a new collection
+// when the classifier proposes one. Never fails outright — a
+// CreateCollection error just logs and falls through to "Unsorted" via
+// a second attempt, since ingest must not block on this step.
+func (h *kbAPI) resolveCollection(ctx context.Context, title, markdownText string) (string, error) {
+	collections, err := h.store.ListCollections(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list collections: %w", err)
+	}
+	choice := h.classify(ctx, title, markdownText, collections)
+	if choice.ExistingID != "" {
+		return choice.ExistingID, nil
+	}
+	name := choice.NewName
+	if name == "" {
+		name = "Unsorted"
+	}
+	id, err := h.store.CreateCollection(ctx, name, choice.NewDesc)
+	if err != nil {
+		return "", fmt.Errorf("create collection %q: %w", name, err)
+	}
+	return id, nil
 }
 
 func failKB(w http.ResponseWriter, err error) {
@@ -152,39 +188,40 @@ func (h *kbAPI) listDocuments(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"documents": out})
 }
 
-// uploadDocument accepts a single multipart file field "file", caps
-// its size at maxKBUploadBytes, converts it to markdown via markitdown
-// (skipped for .md/.txt, already markdown/plain text), creates a
-// pending document row, then fires the background ingest goroutine.
-func (h *kbAPI) uploadDocument(w http.ResponseWriter, r *http.Request) {
-	collectionID := r.PathValue("id")
-	if _, err := h.store.GetCollection(r.Context(), collectionID); err != nil {
-		failKB(w, err)
-		return
-	}
+// decodedUpload is one multipart file field, parsed and converted to
+// markdown — shared by uploadDocument (collection given) and
+// uploadDocumentAuto (collection classified after this step).
+type decodedUpload struct {
+	title, filename, markdown string
+	rawBytes                  int64
+}
 
+// decodeUpload parses the multipart "file" field, caps it at
+// maxKBUploadBytes, and converts it to markdown via markitdown (skipped
+// for .md/.txt, already markdown/plain text).
+func (h *kbAPI) decodeUpload(w http.ResponseWriter, r *http.Request) (decodedUpload, bool) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxKBUploadBytes)
 	if err := r.ParseMultipartForm(maxKBUploadBytes); err != nil { //nolint:gosec // G120: r.Body is already MaxBytesReader-capped above at the same limit
 		jsonError(w, http.StatusBadRequest, "too_large", "file exceeds the 32MiB limit")
-		return
+		return decodedUpload{}, false
 	}
 	file, header, err := r.FormFile("file")
 	if err != nil {
 		jsonError(w, http.StatusBadRequest, "bad_request", "multipart field \"file\" is required")
-		return
+		return decodedUpload{}, false
 	}
 	defer func() { _ = file.Close() }()
 
 	ext := strings.ToLower(filepath.Ext(header.Filename))
 	if !kbAllowedExt[ext] {
 		jsonError(w, http.StatusBadRequest, "unsupported_type", "file must be .pdf, .md, .txt, .docx, or .html")
-		return
+		return decodedUpload{}, false
 	}
 
 	raw, err := io.ReadAll(file)
 	if err != nil {
 		jsonError(w, http.StatusBadRequest, "bad_request", "failed to read upload: "+err.Error())
-		return
+		return decodedUpload{}, false
 	}
 
 	var markdownText string
@@ -193,12 +230,12 @@ func (h *kbAPI) uploadDocument(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if h.markitdownURL == "" {
 			jsonError(w, http.StatusBadRequest, "bad_request", "document conversion requires the markitdown sidecar (MARKITDOWN_URL)")
-			return
+			return decodedUpload{}, false
 		}
 		md, err := markitdown.Convert(r.Context(), h.markitdownHTTP, h.markitdownURL, header.Filename, "", raw)
 		if err != nil {
 			jsonError(w, http.StatusBadGateway, "conversion_failed", err.Error())
-			return
+			return decodedUpload{}, false
 		}
 		markdownText = markitdown.TruncateMarkdown(md)
 	}
@@ -207,8 +244,19 @@ func (h *kbAPI) uploadDocument(w http.ResponseWriter, r *http.Request) {
 	// real PDFs); Postgres text columns reject both (SQLSTATE 22021).
 	markdownText = strings.ToValidUTF8(strings.ReplaceAll(markdownText, "\x00", ""), "�")
 
-	title := strings.TrimSuffix(header.Filename, filepath.Ext(header.Filename))
-	docID, err := h.store.CreateDocument(r.Context(), collectionID, title, "file", header.Filename, markdownText, int64(len(raw)))
+	return decodedUpload{
+		title:    strings.TrimSuffix(header.Filename, filepath.Ext(header.Filename)),
+		filename: header.Filename,
+		markdown: markdownText,
+		rawBytes: int64(len(raw)),
+	}, true
+}
+
+// finishIngest creates the pending document row, fires the background
+// ingest goroutine, and writes the created document back — the shared
+// tail of every ingest entry point (scoped and auto alike).
+func (h *kbAPI) finishIngest(w http.ResponseWriter, r *http.Request, collectionID, title, sourceType, sourceRef, markdownText string, size int64) {
+	docID, err := h.store.CreateDocument(r.Context(), collectionID, title, sourceType, sourceRef, markdownText, size)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
 		return
@@ -221,6 +269,38 @@ func (h *kbAPI) uploadDocument(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, sanitizeDocument(doc))
+}
+
+// uploadDocument accepts a single multipart file field "file" into a
+// caller-chosen collection.
+func (h *kbAPI) uploadDocument(w http.ResponseWriter, r *http.Request) {
+	collectionID := r.PathValue("id")
+	if _, err := h.store.GetCollection(r.Context(), collectionID); err != nil {
+		failKB(w, err)
+		return
+	}
+	up, ok := h.decodeUpload(w, r)
+	if !ok {
+		return
+	}
+	h.finishIngest(w, r, collectionID, up.title, "file", up.filename, up.markdown, up.rawBytes)
+}
+
+// uploadDocumentAuto accepts the same multipart upload as
+// uploadDocument but with no collection chosen: the document is
+// classified against existing collections (or files into a newly
+// proposed one) before ingest.
+func (h *kbAPI) uploadDocumentAuto(w http.ResponseWriter, r *http.Request) {
+	up, ok := h.decodeUpload(w, r)
+	if !ok {
+		return
+	}
+	collectionID, err := h.resolveCollection(r.Context(), up.title, up.markdown)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
+		return
+	}
+	h.finishIngest(w, r, collectionID, up.title, "file", up.filename, up.markdown, up.rawBytes)
 }
 
 // kbURLFetchTimeout bounds one whole URL fetch (dial through read).
@@ -236,27 +316,23 @@ type kbURLRequest struct {
 	Title string `json:"title"`
 }
 
-// addDocumentFromURL fetches a user-supplied URL (public addresses
-// only — the client dials through netguard), converts the response to
-// markdown the same way upload does (HTML/PDF via markitdown, plain
-// text and markdown taken as-is), creates a pending document row with
-// the URL as source_ref, then fires the same background ingest.
-func (h *kbAPI) addDocumentFromURL(w http.ResponseWriter, r *http.Request) {
-	collectionID := r.PathValue("id")
-	if _, err := h.store.GetCollection(r.Context(), collectionID); err != nil {
-		failKB(w, err)
-		return
-	}
+// decodedURL is one fetched-and-converted URL — shared by
+// addDocumentFromURL (collection given) and addDocumentFromURLAuto
+// (collection classified after this step).
+type decodedURL struct {
+	title, url, markdown string
+	rawBytes             int64
+}
 
-	var req kbURLRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
-		return
-	}
+// decodeURL parses req.URL, fetches it (public addresses only — the
+// client dials through netguard), and converts the response to
+// markdown the same way upload does (HTML/PDF via markitdown, plain
+// text and markdown taken as-is).
+func (h *kbAPI) decodeURL(w http.ResponseWriter, r *http.Request, req kbURLRequest) (decodedURL, bool) {
 	u, err := url.Parse(strings.TrimSpace(req.URL))
 	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
 		jsonError(w, http.StatusBadRequest, "bad_request", "url must be a full http:// or https:// URL")
-		return
+		return decodedURL{}, false
 	}
 	// Never forward embedded credentials (and never leak them on a
 	// redirect to another host).
@@ -265,39 +341,68 @@ func (h *kbAPI) addDocumentFromURL(w http.ResponseWriter, r *http.Request) {
 	body, contentType, err := h.fetchURL(r.Context(), u)
 	if err != nil {
 		jsonError(w, http.StatusBadGateway, "fetch_failed", err.Error())
-		return
+		return decodedURL{}, false
 	}
 
 	markdownText, err := h.convertFetched(r.Context(), u, body, contentType)
 	if err != nil {
 		jsonError(w, http.StatusBadRequest, "conversion_failed", err.Error())
-		return
+		return decodedURL{}, false
 	}
 	// Same sanitation as upload: converted output can carry NUL bytes
 	// or invalid UTF-8, which Postgres text columns reject (22021).
 	markdownText = strings.ToValidUTF8(strings.ReplaceAll(markdownText, "\x00", ""), "�")
 	if strings.TrimSpace(markdownText) == "" {
 		jsonError(w, http.StatusBadRequest, "conversion_failed", "page had no extractable text")
-		return
+		return decodedURL{}, false
 	}
 
 	title := strings.TrimSpace(req.Title)
 	if title == "" {
 		title = titleFromURL(u)
 	}
-	docID, err := h.store.CreateDocument(r.Context(), collectionID, title, "url", u.String(), markdownText, int64(len(body)))
-	if err != nil {
-		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
-		return
-	}
-	h.startIngest(docID, title)
+	return decodedURL{title: title, url: u.String(), markdown: markdownText, rawBytes: int64(len(body))}, true
+}
 
-	doc, err := h.store.GetDocument(r.Context(), docID)
+// addDocumentFromURL fetches a user-supplied URL into a caller-chosen
+// collection.
+func (h *kbAPI) addDocumentFromURL(w http.ResponseWriter, r *http.Request) {
+	collectionID := r.PathValue("id")
+	if _, err := h.store.GetCollection(r.Context(), collectionID); err != nil {
+		failKB(w, err)
+		return
+	}
+	var req kbURLRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	d, ok := h.decodeURL(w, r, req)
+	if !ok {
+		return
+	}
+	h.finishIngest(w, r, collectionID, d.title, "url", d.url, d.markdown, d.rawBytes)
+}
+
+// addDocumentFromURLAuto fetches a user-supplied URL with no collection
+// chosen: the document is classified against existing collections (or
+// files into a newly proposed one) before ingest.
+func (h *kbAPI) addDocumentFromURLAuto(w http.ResponseWriter, r *http.Request) {
+	var req kbURLRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	d, ok := h.decodeURL(w, r, req)
+	if !ok {
+		return
+	}
+	collectionID, err := h.resolveCollection(r.Context(), d.title, d.markdown)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
 		return
 	}
-	writeJSON(w, http.StatusCreated, sanitizeDocument(doc))
+	h.finishIngest(w, r, collectionID, d.title, "url", d.url, d.markdown, d.rawBytes)
 }
 
 // fetchURL GETs u, capping the body at maxKBUploadBytes, and returns

--- a/internal/brain/api/kb_integration_test.go
+++ b/internal/brain/api/kb_integration_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/SumonMSelim/timothy/internal/brain/chat"
 	"github.com/SumonMSelim/timothy/internal/brain/kb"
 	"github.com/SumonMSelim/timothy/internal/platform/migrate"
 	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
@@ -106,11 +107,18 @@ func (f *fakeIngester) callCount() int {
 	return f.calls
 }
 
+// fixedClassifier always proposes the same new collection — these
+// integration tests exercise brain's own CRUD/upload surface, not the
+// classify prompt itself (covered in internal/brain/chat).
+func fixedClassifier(ctx context.Context, docTitle, docText string, collections []kb.Collection) chat.CollectionChoice {
+	return chat.CollectionChoice{NewName: "itest-auto", NewDesc: "auto-classified in a test"}
+}
+
 func TestKBCollectionsCRUD(t *testing.T) {
 	store := testKBStore(t)
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "")
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier)
 
 	create := httptest.NewRequest("POST", "/v1/admin/kb/collections", strings.NewReader(`{"name":"itest-docs","description":"test collection"}`))
 	create.Header.Set("Authorization", "Bearer tok")
@@ -169,7 +177,7 @@ func TestKBDocumentUploadSkipsMarkitdownForMarkdown(t *testing.T) {
 	ingester := &fakeIngester{}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "")
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-upload", "")
 	if err != nil {
@@ -233,7 +241,7 @@ func TestKBDocumentUploadStripsNULAndInvalidUTF8(t *testing.T) {
 	ingester := &fakeIngester{}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "")
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-nul", "")
 	if err != nil {
@@ -271,7 +279,7 @@ func TestKBDocumentUploadRejectsUnsupportedType(t *testing.T) {
 	store := testKBStore(t)
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "")
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-upload-bad", "")
 	if err != nil {
@@ -307,7 +315,7 @@ func TestKBDocumentFromURLIngestsFetchedMarkdown(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "")
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-url", "")
 	if err != nil {
@@ -357,6 +365,92 @@ func TestKBDocumentFromURLIngestsFetchedMarkdown(t *testing.T) {
 	}
 	if got := ingester.callCount(); got != 1 {
 		t.Fatalf("ingester calls = %d, want 1", got)
+	}
+}
+
+// TestKBDocumentUploadAutoCreatesNewCollection exercises the unscoped
+// upload route: no collection is chosen up front, so the classifier's
+// proposed new collection (fixedClassifier) must be created and the
+// document filed into it.
+func TestKBDocumentUploadAutoCreatesNewCollection(t *testing.T) {
+	store := testKBStore(t)
+	ingester := &fakeIngester{}
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier)
+
+	body, contentType := multipartFile(t, "file", "notes.md", []byte("# Title\nsome content"))
+	req := httptest.NewRequest("POST", "/v1/admin/kb/documents", body)
+	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("Content-Type", contentType)
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("upload status = %d body %s", w.Code, w.Body)
+	}
+
+	var doc struct {
+		ID           string `json:"id"`
+		CollectionID string `json:"collection_id"`
+	}
+	if err := decodeBody(t, w.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	coll, err := store.GetCollection(context.Background(), doc.CollectionID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	if coll.Name != "itest-auto" {
+		t.Fatalf("collection name = %q, want the classifier's proposed itest-auto", coll.Name)
+	}
+}
+
+// TestKBDocumentFromURLAutoUsesExistingCollection exercises the
+// unscoped URL route with a classifier that matches an existing
+// collection instead of proposing a new one.
+func TestKBDocumentFromURLAutoUsesExistingCollection(t *testing.T) {
+	store := testKBStore(t)
+	ingester := &fakeIngester{}
+
+	page := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+		_, _ = w.Write([]byte("# Fetched\nbody from the web"))
+	}))
+	defer page.Close()
+
+	saved := kbFetchTransport
+	kbFetchTransport = http.DefaultTransport
+	defer func() { kbFetchTransport = saved }()
+
+	existingID, err := store.CreateCollection(context.Background(), "itest-existing", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	matchExisting := func(ctx context.Context, docTitle, docText string, collections []kb.Collection) chat.CollectionChoice {
+		return chat.CollectionChoice{ExistingID: existingID}
+	}
+
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, ingester, "", matchExisting)
+
+	req := httptest.NewRequest("POST", "/v1/admin/kb/documents/url",
+		strings.NewReader(`{"url":"`+page.URL+`/notes.md","title":""}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d body %s", w.Code, w.Body)
+	}
+
+	var doc struct {
+		CollectionID string `json:"collection_id"`
+	}
+	if err := decodeBody(t, w.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.CollectionID != existingID {
+		t.Fatalf("collection_id = %q, want the classifier's matched %q", doc.CollectionID, existingID)
 	}
 }
 
@@ -425,7 +519,7 @@ func TestKBDocumentFromURLRejectsBadURL(t *testing.T) {
 	store := testKBStore(t)
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "")
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-url-bad", "")
 	if err != nil {
@@ -449,7 +543,7 @@ func TestKBDocumentFromURLBlocksLocalAddresses(t *testing.T) {
 	m := mux(a)
 	// Real guarded transport: the loopback httptest server must be
 	// refused at dial time.
-	a.registerKB(m.Handle, store, &fakeIngester{}, "")
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier)
 
 	page := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("secret internal page"))
@@ -476,7 +570,7 @@ func TestKBDocumentReingestFailureSetsFailedStatus(t *testing.T) {
 	ingester := &fakeIngester{err: errors.New("memoryd unreachable")}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "")
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-reingest", "")
 	if err != nil {

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -23,6 +23,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/agents"
 	"github.com/SumonMSelim/timothy/internal/brain/attachments"
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/brain/kb"
 	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/brain/skills"
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
@@ -569,6 +570,120 @@ func TitleOverGateway(gw Gateway, log *slog.Logger) func(ctx context.Context, in
 			}
 		}
 		return ""
+	}
+}
+
+// collectionClassifyDocRunes caps how much document text rides into the
+// classify prompt — the model only needs the gist to pick a topic, not
+// the full document (which can run to markitdown.TruncateMarkdown's own
+// 128KB cap).
+const collectionClassifyDocRunes = 4000
+
+// CollectionChoice is ClassifyCollectionOverGateway's result: either an
+// existing collection to file into (ExistingID) or a new one to create
+// first (NewName/NewDesc). Exactly one of the two is ever set.
+type CollectionChoice struct {
+	ExistingID string
+	NewName    string
+	NewDesc    string
+}
+
+// unsortedCollectionName is the fallback CollectionChoice when
+// classification can't be trusted (gateway error, empty/malformed
+// reply) — a document must land somewhere, so it lands in a generic
+// catch-all rather than blocking ingest on a model failure.
+const unsortedCollectionName = "Unsorted"
+
+// ClassifyCollectionOverGateway mirrors TitleOverGateway's mechanism
+// (same route resolution, same Stream-and-drain, same never-errors
+// contract) for a different one-shot job: given a document's title/text
+// and the existing knowledge-base collections, pick the best matching
+// collection or propose a new one. Free-text protocol, not JSON — this
+// codebase has no precedent for parsing prose-as-JSON from a model
+// reply (every json.Unmarshal on model output elsewhere unmarshals
+// provider-structured tool-call arguments, never free text), so the
+// model is asked for exactly one line: either a bare collection ID from
+// the list, or "NEW: <name> | <description>". Any reply that doesn't
+// parse cleanly (gateway error, empty stream, malformed line) falls
+// back to unsortedCollectionName — the one guaranteed outcome, since
+// auto-classify ingest has no path to ask the user instead.
+func ClassifyCollectionOverGateway(gw Gateway, log *slog.Logger) func(ctx context.Context, docTitle, docText string, collections []kb.Collection) CollectionChoice {
+	return func(ctx context.Context, docTitle, docText string, collections []kb.Collection) CollectionChoice {
+		ctx, cancel := context.WithTimeout(ctx, titleTimeout)
+		defer cancel()
+
+		fallback := CollectionChoice{NewName: unsortedCollectionName}
+
+		var list strings.Builder
+		if len(collections) == 0 {
+			list.WriteString("No collections exist yet.")
+		} else {
+			for _, c := range collections {
+				fmt.Fprintf(&list, "%s: %s — %s\n", c.ID, c.Name, c.Description)
+			}
+		}
+
+		const classifySystem = `You file documents into a knowledge base. Given a document and a list of existing collections, reply with exactly one line: either the bare id of the best-matching existing collection, or "NEW: <name> | <description>" to propose a new collection when nothing fits. No other text.`
+		route, ok, err := gw.RouteForRole(ctx, "summarize")
+		if err != nil || !ok {
+			route, ok, err = gw.RouteForRole(ctx, "default")
+			if err != nil {
+				log.Warn("classify collection: route lookup failed", "error", err)
+				return fallback
+			}
+			if !ok {
+				log.Warn("classify collection: no route bound for summarize or default")
+				return fallback
+			}
+		}
+
+		docText = truncateRunes(docText, collectionClassifyDocRunes)
+		user := fmt.Sprintf("Existing collections:\n%s\nDocument title: %s\n\n%s", list.String(), docTitle, docText)
+
+		events, err := gw.Stream(ctx, gwclient.StreamRequest{
+			Route:     route,
+			Purpose:   "kb_classify",
+			System:    classifySystem,
+			Messages:  []provider.Message{{Role: "user", Content: user}},
+			MaxTokens: 1000,
+		})
+		if err != nil {
+			log.Warn("classify collection: stream failed", "error", err)
+			return fallback
+		}
+		var b strings.Builder
+		var streamErr *stream.StreamError
+		for ev := range events {
+			switch ev.Type {
+			case stream.EventChunk:
+				b.WriteString(ev.Text)
+			case stream.EventError:
+				streamErr = ev.Err
+			}
+		}
+		reply, _, _ := strings.Cut(strings.TrimSpace(b.String()), "\n")
+		reply = strings.TrimSpace(reply)
+		if reply == "" {
+			if streamErr != nil {
+				log.Warn("classify collection: stream error event", "code", streamErr.Code, "message", streamErr.Message)
+			}
+			return fallback
+		}
+		for _, c := range collections {
+			if reply == c.ID {
+				return CollectionChoice{ExistingID: c.ID}
+			}
+		}
+		if rest, ok := strings.CutPrefix(reply, "NEW:"); ok {
+			name, desc, _ := strings.Cut(rest, "|")
+			name = strings.TrimSpace(name)
+			desc = strings.TrimSpace(desc)
+			if name != "" {
+				return CollectionChoice{NewName: truncateRunes(name, 80), NewDesc: truncateRunes(desc, 300)}
+			}
+		}
+		log.Warn("classify collection: reply matched neither an existing id nor NEW:", "reply", truncateRunes(reply, 80))
+		return fallback
 	}
 }
 

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/SumonMSelim/timothy/internal/brain/agents"
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/brain/kb"
 	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/brain/skills"
 	"github.com/SumonMSelim/timothy/internal/brain/tools/builtin"
@@ -1982,6 +1983,64 @@ func TestTitleOverGatewayEmptyOnGatewayError(t *testing.T) {
 	name := TitleOverGateway(gw, discard())(context.Background(), "a goal")
 	if name != "" {
 		t.Fatalf("name = %q, want empty on gateway error", name)
+	}
+}
+
+// TestClassifyCollectionOverGatewayMatchesExistingID confirms a reply
+// that is exactly one listed collection's id resolves to ExistingID.
+func TestClassifyCollectionOverGatewayMatchesExistingID(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGW{events: okEvents("col-2")}
+	choice := ClassifyCollectionOverGateway(gw, discard())(context.Background(), "Q3 Invoice", "some invoice text",
+		[]kb.Collection{{ID: "col-1", Name: "Recipes"}, {ID: "col-2", Name: "Finance"}})
+	if choice.ExistingID != "col-2" || choice.NewName != "" {
+		t.Fatalf("choice = %+v, want ExistingID=col-2", choice)
+	}
+
+	gw.mu.Lock()
+	defer gw.mu.Unlock()
+	if gw.requests[0].Route != "summarize" {
+		t.Fatalf("route = %q, want summarize", gw.requests[0].Route)
+	}
+	if gw.requests[0].Purpose != "kb_classify" {
+		t.Fatalf("purpose = %q, want kb_classify", gw.requests[0].Purpose)
+	}
+}
+
+// TestClassifyCollectionOverGatewayProposesNewCollection confirms a
+// "NEW: name | description" reply parses into NewName/NewDesc.
+func TestClassifyCollectionOverGatewayProposesNewCollection(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGW{events: okEvents("NEW: Home Repairs | Notes about fixing things around the house")}
+	choice := ClassifyCollectionOverGateway(gw, discard())(context.Background(), "Fixing the sink", "plumbing notes",
+		[]kb.Collection{{ID: "col-1", Name: "Recipes"}})
+	if choice.ExistingID != "" || choice.NewName != "Home Repairs" || choice.NewDesc != "Notes about fixing things around the house" {
+		t.Fatalf("choice = %+v, want new collection Home Repairs", choice)
+	}
+}
+
+// TestClassifyCollectionOverGatewayFallsBackToUnsortedOnGatewayError
+// confirms the best-effort contract: any Stream error resolves to the
+// Unsorted fallback rather than propagating.
+func TestClassifyCollectionOverGatewayFallsBackToUnsortedOnGatewayError(t *testing.T) {
+	t.Parallel()
+	gw := &erroringGW{}
+	choice := ClassifyCollectionOverGateway(gw, discard())(context.Background(), "title", "text", nil)
+	if choice.NewName != unsortedCollectionName || choice.ExistingID != "" {
+		t.Fatalf("choice = %+v, want Unsorted fallback", choice)
+	}
+}
+
+// TestClassifyCollectionOverGatewayFallsBackOnMalformedReply confirms a
+// reply that neither matches a known id nor starts with "NEW:" falls
+// back to Unsorted instead of being trusted as a collection id.
+func TestClassifyCollectionOverGatewayFallsBackOnMalformedReply(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGW{events: okEvents("not-a-real-id")}
+	choice := ClassifyCollectionOverGateway(gw, discard())(context.Background(), "title", "text",
+		[]kb.Collection{{ID: "col-1", Name: "Recipes"}})
+	if choice.NewName != unsortedCollectionName || choice.ExistingID != "" {
+		t.Fatalf("choice = %+v, want Unsorted fallback", choice)
 	}
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1003,6 +1003,41 @@ export async function reingestKbDocument(id: string): Promise<void> {
   await request<void>(`/v1/admin/kb/documents/${id}/reingest`, { method: 'POST' })
 }
 
+// uploadKbDocumentAuto posts one file with no collection chosen: brain
+// classifies it against existing collections (or creates a new one) and
+// files it there. Same multipart shape as uploadKbDocument.
+export async function uploadKbDocumentAuto(file: File): Promise<KbDocument> {
+  const form = new FormData()
+  form.append('file', file)
+  const res = await fetch('/v1/admin/kb/documents', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${getToken()}` },
+    body: form,
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    let message = body
+    try {
+      const parsed = JSON.parse(body) as { message?: string }
+      message = parsed.message ?? body
+    } catch {
+      // Non-JSON error body: keep the raw text.
+    }
+    failChat(res.status, message || `upload failed (${res.status})`)
+  }
+  return (await res.json()) as KbDocument
+}
+
+// addKbDocumentFromUrlAuto is addKbDocumentFromUrl with no collection
+// chosen: brain classifies the fetched document the same way
+// uploadKbDocumentAuto does.
+export async function addKbDocumentFromUrlAuto(url: string): Promise<KbDocument> {
+  return request<KbDocument>('/v1/admin/kb/documents/url', {
+    method: 'POST',
+    body: JSON.stringify({ url }),
+  })
+}
+
 // --- connectors (integrations) ---
 
 export async function listConnectors(): Promise<AdminConnector[]> {

--- a/web/src/components/knowledge/KbUploadForm.test.tsx
+++ b/web/src/components/knowledge/KbUploadForm.test.tsx
@@ -1,0 +1,72 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { KbDocument } from '../../api/types'
+import { KbUploadForm, parseUrls } from './KbUploadForm'
+
+afterEach(cleanup)
+
+const doc: KbDocument = {
+  id: 'd1',
+  collection_id: 'c1',
+  title: 'notes',
+  source_type: 'file',
+  source_ref: 'notes.md',
+  status: 'pending',
+  error: '',
+  chunk_count: 0,
+  bytes: 12,
+  ingested_at: null,
+  created_at: '2026-07-01T00:00:00Z',
+}
+
+describe('parseUrls', () => {
+  it('keeps only unique valid http(s) URLs in first-seen order', () => {
+    expect(parseUrls('https://a.com http://b.com not-a-url https://a.com')).toEqual([
+      'https://a.com',
+      'http://b.com',
+    ])
+  })
+})
+
+describe('KbUploadForm', () => {
+  it('calls uploadFile for a chosen file and reports the created document', async () => {
+    const uploadFile = vi.fn().mockResolvedValue(doc)
+    const addUrl = vi.fn()
+    const onUploaded = vi.fn()
+    render(<KbUploadForm uploadFile={uploadFile} addUrl={addUrl} onUploaded={onUploaded} />)
+
+    const file = new File(['content'], 'notes.md', { type: 'text/markdown' })
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(input, { target: { files: [file] } })
+
+    await waitFor(() => expect(uploadFile).toHaveBeenCalledWith(file))
+    await waitFor(() => expect(onUploaded).toHaveBeenCalledWith(doc))
+    expect(addUrl).not.toHaveBeenCalled()
+  })
+
+  it('submits each parsed URL and reports each created document', async () => {
+    const uploadFile = vi.fn()
+    const addUrl = vi.fn().mockResolvedValue(doc)
+    const onUploaded = vi.fn()
+    render(<KbUploadForm uploadFile={uploadFile} addUrl={addUrl} onUploaded={onUploaded} />)
+
+    fireEvent.change(screen.getByPlaceholderText(/add a page or PDF by URL/), {
+      target: { value: 'https://example.com/a' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add URL' }))
+
+    await waitFor(() => expect(addUrl).toHaveBeenCalledWith('https://example.com/a'))
+    await waitFor(() => expect(onUploaded).toHaveBeenCalledWith(doc))
+    expect(uploadFile).not.toHaveBeenCalled()
+  })
+
+  it('disables Add URL until the textarea has a valid URL', () => {
+    render(<KbUploadForm uploadFile={vi.fn()} addUrl={vi.fn()} onUploaded={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Add URL' })).toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText(/add a page or PDF by URL/), {
+      target: { value: 'https://example.com/a' },
+    })
+    expect(screen.getByRole('button', { name: 'Add URL' })).not.toBeDisabled()
+  })
+})

--- a/web/src/components/knowledge/KbUploadForm.tsx
+++ b/web/src/components/knowledge/KbUploadForm.tsx
@@ -1,0 +1,166 @@
+import { CloudUploadIcon, Loading03Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useRef, useState } from 'react'
+import { toast } from 'sonner'
+import type { KbDocument } from '../../api/types'
+import { Button } from '../ui/button'
+import { errText } from '../settings/util'
+
+const acceptExt = '.pdf,.md,.txt,.docx,.html'
+
+// parseUrls splits pasted/typed text on whitespace into unique, valid
+// http(s) URLs, preserving first-seen order.
+export function parseUrls(text: string): string[] {
+  const seen = new Set<string>()
+  const urls: string[] = []
+  for (const token of text.split(/\s+/)) {
+    if (!token || seen.has(token)) continue
+    try {
+      const parsed = new URL(token)
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') continue
+    } catch {
+      continue
+    }
+    seen.add(token)
+    urls.push(token)
+  }
+  return urls
+}
+
+// KbUploadForm is the drag/drop-file + paste-URL(s) upload UI shared by
+// a collection's own detail page (uploadFile/addUrl scoped to that
+// collection) and the top-level auto-classify entry point (scoped to
+// nothing — brain picks or creates the collection).
+export function KbUploadForm({
+  uploadFile,
+  addUrl,
+  onUploaded,
+}: {
+  uploadFile: (file: File) => Promise<KbDocument>
+  addUrl: (url: string) => Promise<KbDocument>
+  onUploaded: (doc: KbDocument) => void
+}) {
+  const [uploading, setUploading] = useState<Record<string, boolean>>({})
+  const [url, setUrl] = useState('')
+  const [urlProgress, setUrlProgress] = useState<{ done: number; total: number } | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const uploadFiles = async (files: File[]) => {
+    for (const file of files) {
+      const key = crypto.randomUUID()
+      setUploading((prev) => ({ ...prev, [key]: true }))
+      try {
+        const doc = await uploadFile(file)
+        onUploaded(doc)
+      } catch (err) {
+        toast.error(`${file.name}: upload failed`, { description: errText(err) })
+      } finally {
+        setUploading((prev) => {
+          const next = { ...prev }
+          delete next[key]
+          return next
+        })
+      }
+    }
+  }
+
+  const submitUrls = async () => {
+    if (urlProgress) return
+    const urls = parseUrls(url)
+    if (urls.length === 0) return
+    setUrlProgress({ done: 0, total: urls.length })
+    const failed: string[] = []
+    for (const [i, u] of urls.entries()) {
+      try {
+        const doc = await addUrl(u)
+        onUploaded(doc)
+      } catch {
+        failed.push(u)
+      }
+      setUrlProgress({ done: i + 1, total: urls.length })
+    }
+    setUrlProgress(null)
+    setUrl('')
+    if (failed.length > 0) {
+      toast.error(`${failed.length} of ${urls.length} failed: ${failed[0]}${failed.length > 1 ? '…' : ''}`)
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={(e) => {
+          e.preventDefault()
+          const files = [...e.dataTransfer.files]
+          if (files.length > 0) void uploadFiles(files)
+        }}
+        className="flex flex-col items-center gap-2 rounded-xl border border-dashed border-border p-6 text-center"
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          accept={acceptExt}
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            const files = [...(e.target.files ?? [])]
+            e.target.value = ''
+            if (files.length > 0) void uploadFiles(files)
+          }}
+        />
+        <HugeiconsIcon icon={CloudUploadIcon} className="size-6 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">
+          Drag files here or{' '}
+          <button type="button" onClick={() => inputRef.current?.click()} className="text-brand underline">
+            browse
+          </button>
+          {' '}· {acceptExt}
+        </p>
+        {Object.keys(uploading).length > 0 && (
+          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <HugeiconsIcon icon={Loading03Icon} className="size-3 animate-spin" />
+            Uploading {Object.keys(uploading).length} file
+            {Object.keys(uploading).length === 1 ? '' : 's'}…
+          </p>
+        )}
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          void submitUrls()
+        }}
+        className="flex items-end gap-2"
+      >
+        <textarea
+          rows={1}
+          value={url}
+          onChange={(e) => {
+            setUrl(e.target.value)
+            e.target.style.height = 'auto'
+            e.target.style.height = `${e.target.scrollHeight}px`
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              void submitUrls()
+            }
+          }}
+          placeholder="https://example.com/article — add a page or PDF by URL (paste several to bulk-add)"
+          className="max-h-40 min-h-9 w-full resize-none rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-ring"
+        />
+        <Button type="submit" variant="outline" disabled={parseUrls(url).length === 0 || !!urlProgress}>
+          {urlProgress ? (
+            <>
+              <HugeiconsIcon icon={Loading03Icon} className="animate-spin" />
+              adding {urlProgress.done}/{urlProgress.total}…
+            </>
+          ) : (
+            'Add URL'
+          )}
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/web/src/components/knowledge/KnowledgeAutoAdd.test.tsx
+++ b/web/src/components/knowledge/KnowledgeAutoAdd.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { KbDocument } from '../../api/types'
+import { KnowledgeAutoAdd } from './KnowledgeAutoAdd'
+
+vi.mock('../../api/client', () => ({
+  uploadKbDocumentAuto: vi.fn(),
+  addKbDocumentFromUrlAuto: vi.fn(),
+}))
+
+import { addKbDocumentFromUrlAuto, uploadKbDocumentAuto } from '../../api/client'
+
+const doc: KbDocument = {
+  id: 'd1',
+  collection_id: 'c-classified',
+  title: 'notes',
+  source_type: 'file',
+  source_ref: 'notes.md',
+  status: 'pending',
+  error: '',
+  chunk_count: 0,
+  bytes: 12,
+  ingested_at: null,
+  created_at: '2026-07-01T00:00:00Z',
+}
+
+function renderPage() {
+  const router = createMemoryRouter(
+    [
+      { path: '/knowledge/add', element: <KnowledgeAutoAdd /> },
+      { path: '/knowledge/:id', element: <div>collection detail page</div> },
+    ],
+    { initialEntries: ['/knowledge/add'] },
+  )
+  return render(<RouterProvider router={router} />)
+}
+
+afterEach(cleanup)
+beforeEach(() => vi.clearAllMocks())
+
+describe('KnowledgeAutoAdd', () => {
+  it('uploads a file with no collection chosen and navigates to the classified collection', async () => {
+    vi.mocked(uploadKbDocumentAuto).mockResolvedValue(doc)
+    renderPage()
+
+    const file = new File(['content'], 'notes.md', { type: 'text/markdown' })
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(input, { target: { files: [file] } })
+
+    await waitFor(() => expect(uploadKbDocumentAuto).toHaveBeenCalledWith(file))
+    expect(await screen.findByText('collection detail page')).toBeTruthy()
+    expect(addKbDocumentFromUrlAuto).not.toHaveBeenCalled()
+  })
+
+  it('adds a URL with no collection chosen and navigates to the classified collection', async () => {
+    vi.mocked(addKbDocumentFromUrlAuto).mockResolvedValue(doc)
+    renderPage()
+
+    fireEvent.change(screen.getByPlaceholderText(/add a page or PDF by URL/), {
+      target: { value: 'https://example.com/article' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Add URL' }))
+
+    await waitFor(() => expect(addKbDocumentFromUrlAuto).toHaveBeenCalledWith('https://example.com/article'))
+    expect(await screen.findByText('collection detail page')).toBeTruthy()
+  })
+})

--- a/web/src/components/knowledge/KnowledgeAutoAdd.tsx
+++ b/web/src/components/knowledge/KnowledgeAutoAdd.tsx
@@ -1,0 +1,44 @@
+import { ArrowLeft01Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { Link, useNavigate } from 'react-router'
+import { toast } from 'sonner'
+import { addKbDocumentFromUrlAuto, uploadKbDocumentAuto } from '../../api/client'
+import { KbUploadForm } from './KbUploadForm'
+
+// KnowledgeAutoAdd is the top-level "Add to Knowledgebase" entry point:
+// no collection is chosen here — brain classifies each upload against
+// existing collections (or creates a new one) and files it there. On
+// success, jump to the collection the document landed in so the user
+// sees where it went.
+export function KnowledgeAutoAdd() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="mt-6 space-y-6">
+      <Link
+        to="/knowledge"
+        className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+      >
+        <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+        Knowledge
+      </Link>
+
+      <div>
+        <h2 className="text-sm font-semibold">Add to Knowledgebase</h2>
+        <p className="text-sm text-muted-foreground">
+          Drop a file or paste a URL — it's classified into the best matching collection
+          automatically, or a new one is created if nothing fits.
+        </p>
+      </div>
+
+      <KbUploadForm
+        uploadFile={uploadKbDocumentAuto}
+        addUrl={addKbDocumentFromUrlAuto}
+        onUploaded={(doc) => {
+          toast.success(`${doc.title} added`)
+          navigate(`/knowledge/${doc.collection_id}`)
+        }}
+      />
+    </div>
+  )
+}

--- a/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
@@ -1,7 +1,6 @@
 import {
   ArrowLeft01Icon,
   CancelCircleIcon,
-  CloudUploadIcon,
   Delete02Icon,
   File02Icon,
   Loading03Icon,
@@ -9,7 +8,7 @@ import {
   Tick02Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Link, Navigate, useNavigate, useParams } from 'react-router'
 import { toast } from 'sonner'
 import {
@@ -32,8 +31,7 @@ import {
   DialogTitle,
 } from '../ui/dialog'
 import { errText } from '../settings/util'
-
-const acceptExt = '.pdf,.md,.txt,.docx,.html'
+import { KbUploadForm } from './KbUploadForm'
 
 const statusStyle: Record<KbDocument['status'], string> = {
   pending: 'bg-muted text-muted-foreground',
@@ -67,25 +65,6 @@ function StatusBadge({ doc }: { doc: KbDocument }) {
 // document in the collection reaches a terminal state.
 const pollMs = 3000
 
-// parseUrls splits pasted/typed text on whitespace into unique, valid
-// http(s) URLs, preserving first-seen order.
-function parseUrls(text: string): string[] {
-  const seen = new Set<string>()
-  const urls: string[] = []
-  for (const token of text.split(/\s+/)) {
-    if (!token || seen.has(token)) continue
-    try {
-      const parsed = new URL(token)
-      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') continue
-    } catch {
-      continue
-    }
-    seen.add(token)
-    urls.push(token)
-  }
-  return urls
-}
-
 export function KnowledgeCollectionDetail() {
   const { id } = useParams()
   const navigate = useNavigate()
@@ -93,10 +72,6 @@ export function KnowledgeCollectionDetail() {
   const [documents, setDocuments] = useState<KbDocument[]>([])
   const [confirmDeleteCollection, setConfirmDeleteCollection] = useState(false)
   const [confirmDeleteDoc, setConfirmDeleteDoc] = useState<KbDocument | null>(null)
-  const [uploading, setUploading] = useState<Record<string, boolean>>({})
-  const [url, setUrl] = useState('')
-  const [urlProgress, setUrlProgress] = useState<{ done: number; total: number } | null>(null)
-  const inputRef = useRef<HTMLInputElement>(null)
 
   const refresh = useCallback(() => {
     if (!id) return
@@ -122,52 +97,9 @@ export function KnowledgeCollectionDetail() {
   }, [hasPending, id])
 
   if (collection === null) return <Navigate to="/knowledge" replace />
-  if (collection === undefined) return null
-
-  async function uploadFiles(files: File[]) {
-    if (!id) return
-    for (const file of files) {
-      const key = crypto.randomUUID()
-      setUploading((prev) => ({ ...prev, [key]: true }))
-      try {
-        const doc = await uploadKbDocument(id, file)
-        setDocuments((prev) => [doc, ...prev])
-      } catch (err) {
-        toast.error(`${file.name}: upload failed`, { description: errText(err) })
-      } finally {
-        setUploading((prev) => {
-          const next = { ...prev }
-          delete next[key]
-          return next
-        })
-      }
-    }
-  }
-
-  const addUrl = async () => {
-    if (!id || urlProgress) return
-    const urls = parseUrls(url)
-    if (urls.length === 0) return
-    setUrlProgress({ done: 0, total: urls.length })
-    const failed: string[] = []
-    for (const [i, u] of urls.entries()) {
-      try {
-        await addKbDocumentFromUrl(id, u)
-      } catch {
-        failed.push(u)
-      }
-      setUrlProgress({ done: i + 1, total: urls.length })
-    }
-    setUrlProgress(null)
-    setUrl('')
-    refresh()
-    if (failed.length > 0) {
-      toast.error(`${failed.length} of ${urls.length} failed: ${failed[0]}${failed.length > 1 ? '…' : ''}`)
-    }
-  }
+  if (collection === undefined || !id) return null
 
   const removeCollection = async () => {
-    if (!id) return
     try {
       await deleteKbCollection(id)
       toast.success('Collection removed')
@@ -225,79 +157,11 @@ export function KnowledgeCollectionDetail() {
         </Button>
       </div>
 
-      <div
-        onDragOver={(e) => e.preventDefault()}
-        onDrop={(e) => {
-          e.preventDefault()
-          const files = [...e.dataTransfer.files]
-          if (files.length > 0) void uploadFiles(files)
-        }}
-        className="flex flex-col items-center gap-2 rounded-xl border border-dashed border-border p-6 text-center"
-      >
-        <input
-          ref={inputRef}
-          type="file"
-          accept={acceptExt}
-          multiple
-          className="hidden"
-          onChange={(e) => {
-            const files = [...(e.target.files ?? [])]
-            e.target.value = ''
-            if (files.length > 0) void uploadFiles(files)
-          }}
-        />
-        <HugeiconsIcon icon={CloudUploadIcon} className="size-6 text-muted-foreground" />
-        <p className="text-sm text-muted-foreground">
-          Drag files here or{' '}
-          <button type="button" onClick={() => inputRef.current?.click()} className="text-brand underline">
-            browse
-          </button>
-          {' '}· {acceptExt}
-        </p>
-        {Object.keys(uploading).length > 0 && (
-          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <HugeiconsIcon icon={Loading03Icon} className="size-3 animate-spin" />
-            Uploading {Object.keys(uploading).length} file
-            {Object.keys(uploading).length === 1 ? '' : 's'}…
-          </p>
-        )}
-      </div>
-
-      <form
-        onSubmit={(e) => {
-          e.preventDefault()
-          void addUrl()
-        }}
-        className="flex items-end gap-2"
-      >
-        <textarea
-          rows={1}
-          value={url}
-          onChange={(e) => {
-            setUrl(e.target.value)
-            e.target.style.height = 'auto'
-            e.target.style.height = `${e.target.scrollHeight}px`
-          }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault()
-              void addUrl()
-            }
-          }}
-          placeholder="https://example.com/article — add a page or PDF by URL (paste several to bulk-add)"
-          className="max-h-40 min-h-9 w-full resize-none rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus:border-ring"
-        />
-        <Button type="submit" variant="outline" disabled={parseUrls(url).length === 0 || !!urlProgress}>
-          {urlProgress ? (
-            <>
-              <HugeiconsIcon icon={Loading03Icon} className="animate-spin" />
-              adding {urlProgress.done}/{urlProgress.total}…
-            </>
-          ) : (
-            'Add URL'
-          )}
-        </Button>
-      </form>
+      <KbUploadForm
+        uploadFile={(file) => uploadKbDocument(id, file)}
+        addUrl={(u) => addKbDocumentFromUrl(id, u)}
+        onUploaded={(doc) => setDocuments((prev) => [doc, ...prev])}
+      />
 
       {documents.length === 0 ? (
         <p className="text-sm text-muted-foreground">No documents yet.</p>

--- a/web/src/components/knowledge/KnowledgeCollectionsList.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionsList.tsx
@@ -1,4 +1,4 @@
-import { Add01Icon, LibraryIcon } from '@hugeicons-pro/core-stroke-rounded'
+import { Add01Icon, CloudUploadIcon, LibraryIcon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
@@ -32,10 +32,16 @@ export function KnowledgeCollectionsList() {
         <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           Collections · {collections.length}
         </h2>
-        <Button onClick={() => navigate('/knowledge/new')}>
-          <HugeiconsIcon icon={Add01Icon} />
-          New collection
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" onClick={() => navigate('/knowledge/add')}>
+            <HugeiconsIcon icon={CloudUploadIcon} />
+            Add to Knowledgebase
+          </Button>
+          <Button onClick={() => navigate('/knowledge/new')}>
+            <HugeiconsIcon icon={Add01Icon} />
+            New collection
+          </Button>
+        </div>
       </div>
 
       {collections.length === 0 ? (

--- a/web/src/pages/Knowledge.tsx
+++ b/web/src/pages/Knowledge.tsx
@@ -1,4 +1,5 @@
 import { Route, Routes } from 'react-router'
+import { KnowledgeAutoAdd } from '../components/knowledge/KnowledgeAutoAdd'
 import { KnowledgeCollectionAdd } from '../components/knowledge/KnowledgeCollectionAdd'
 import { KnowledgeCollectionDetail } from '../components/knowledge/KnowledgeCollectionDetail'
 import { KnowledgeCollectionsList } from '../components/knowledge/KnowledgeCollectionsList'
@@ -11,6 +12,7 @@ export function Knowledge() {
         <Routes>
           <Route path="/" element={<KnowledgeCollectionsList />} />
           <Route path="new" element={<KnowledgeCollectionAdd />} />
+          <Route path="add" element={<KnowledgeAutoAdd />} />
           <Route path=":id" element={<KnowledgeCollectionDetail />} />
         </Routes>
       </div>


### PR DESCRIPTION
## Summary
- New unscoped upload entry point (`POST /v1/admin/kb/documents`, `.../documents/url`) — drop a file/URL with no collection chosen, and it's classified against existing collections (or files into a newly created one) via a one-shot LLM call, `chat.ClassifyCollectionOverGateway`, mirroring `TitleOverGateway`'s mechanism.
- New "Add to Knowledgebase" page (`/knowledge/add`), backed by a shared `KbUploadForm` component reused by the existing per-collection upload UI.
- Existing per-collection upload/URL flows are unchanged — this is purely additive.

## Test plan
- [x] `go build/vet/test -race ./...` all green, `golangci-lint run` — 0 issues
- [x] New unit tests: `chat_test.go` (classifier matches existing ID, proposes new collection, falls back to "Unsorted" on gateway error/malformed reply)
- [x] New integration tests (real Postgres): auto-upload creates a new collection from the classifier's proposal; auto-URL routes into an existing collection when the classifier matches one
- [x] Frontend build/lint/test all green (739/739 including 6 new tests)
- [x] Live-verified against the local stack: an unrelated doc auto-created a sensibly-named "car-maintenance" collection; a related second doc correctly filed into the same existing collection instead of duplicating; URL variant confirmed too

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790026152&installation_model_id=431401&pr_number=277&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F277&signature=0109bf59ad0c12f84ab78aa1b16ff418c44d8c393adb036d885737d724fc16a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->