### PR TITLE
fix: fail over on empty provider output and force sentinel tool choice

### DIFF
--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -45,6 +45,9 @@ type StreamRequest struct {
 	Effort     string             `json:"effort,omitempty"` // D-020: "low" | "" (normal)
 	SessionID  string             `json:"session_id,omitempty"`
 	MissionID  string             `json:"mission_id,omitempty"` // ledger tag: the mission this turn serves
+	// ForceTool names the single offered tool the model must call this
+	// step (D-063). Empty means auto, today's behavior.
+	ForceTool string `json:"force_tool,omitempty"`
 }
 
 // windowsTTL matches the gateway's own config poll cadence: a fresher

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -283,6 +283,11 @@ type Request struct {
 	// missions): a permission ask resolves as immediate denial instead
 	// of parking on a human prompt for the full timeout (D-039).
 	Unattended bool
+
+	// ForceTool names the single offered tool the model must call this
+	// step (D-063). Only set by callers whose turn ends on that tool
+	// (mission sentinel turns). Empty means auto, today's behavior.
+	ForceTool string
 }
 
 // Start launches the loop and returns its event stream. The channel
@@ -362,6 +367,13 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 	for _, d := range defs {
 		toolNames[d.Name] = true
 	}
+	// ForceTool is wire-invalid against a tool the turn doesn't actually
+	// offer (D-063) — defensive only, callers are expected to name a
+	// tool already in their own ToolAllow.
+	forceTool := req.ForceTool
+	if forceTool != "" && !toolNames[forceTool] {
+		forceTool = ""
+	}
 	msgs := append([]provider.Message(nil), req.Messages...)
 	total := stream.Usage{}
 	var lastMeta *stream.Meta
@@ -398,6 +410,7 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			Effort:    effort,
 			SessionID: req.SessionID,
 			MissionID: req.MissionID,
+			ForceTool: forceTool,
 		}
 		switch directive {
 		case tools.StepWarnFinalize:
@@ -405,7 +418,10 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			msgs = sreq.Messages
 		case tools.StepForceSynthesis:
 			// Drop the schemas: the model must answer with what it has.
+			// ForceTool goes with them — forcing a call with no tools
+			// offered is a wire error.
 			sreq.Tools = nil
+			sreq.ForceTool = ""
 		}
 
 		// Inner attempt loop: a stream that dies before anything

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -1667,6 +1667,81 @@ func TestAgentToolAllowExcludedToolRejected(t *testing.T) {
 	}
 }
 
+// TestAgentForceToolCopiedToStreamRequest pins D-063: Request.ForceTool
+// rides onto every outgoing gwclient.StreamRequest unchanged when the
+// named tool is offered.
+func TestAgentForceToolCopiedToStreamRequest(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{finalStep("done")}}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding", ForceTool: "echo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	if len(gw.requests) != 1 || gw.requests[0].ForceTool != "echo" {
+		t.Fatalf("requests = %+v, want ForceTool=echo on the single request", gw.requests)
+	}
+}
+
+// TestAgentForceToolClearedUnderForceSynthesis pins D-063: once the
+// loop forces synthesis (tools.StepForceSynthesis drops Tools, no
+// schemas offered), ForceTool must clear alongside — forcing a call
+// with no tools offered is a wire error. Three identical echo calls in
+// a row trip RepeatGuard's "stuck" path, which forces synthesis on the
+// very next step without needing to hit the real step ceiling.
+func TestAgentForceToolClearedUnderForceSynthesis(t *testing.T) {
+	t.Parallel()
+	repeat := toolCallStep([2]string{"echo", `{"text":"x"}`})
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		repeat, repeat, repeat, finalStep("done"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding", ForceTool: "echo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	if len(gw.requests) != 4 {
+		t.Fatalf("requests = %d, want 4 (3 repeats + forced synthesis)", len(gw.requests))
+	}
+	last := gw.requests[3]
+	if last.ForceTool != "" {
+		t.Fatalf("last request ForceTool = %q, want cleared under forced synthesis", last.ForceTool)
+	}
+	if len(last.Tools) != 0 {
+		t.Fatalf("last request Tools = %+v, want none under forced synthesis", last.Tools)
+	}
+}
+
+// TestAgentForceToolClearedWhenNotOffered pins D-063's defensive
+// clause: forcing a tool absent from the turn's own filtered surface
+// (ToolAllow excludes it here) is a wire error, so the loop drops it
+// rather than send an invalid tool_choice.
+func TestAgentForceToolClearedWhenNotOffered(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{finalStep("done")}}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{
+		SessionID: "s1", Route: "coding",
+		ToolAllow: []string{"echo"},
+		ForceTool: "not_offered",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	if len(gw.requests) != 1 || gw.requests[0].ForceTool != "" {
+		t.Fatalf("requests = %+v, want ForceTool cleared for an unoffered tool", gw.requests)
+	}
+}
+
 // TestAgentUnattendedAskDeniesImmediately is D-039's second failure
 // mode: an unattended (schedule-fired) turn hitting DecisionAsk must
 // deny immediately with feedback naming the rationale, never call

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -964,6 +964,12 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 		BuiltinsOnly: true,
 		Unattended:   m.ScheduleID != "",
 	}
+	// Force submit_plan only when it is the turn's sole tool (D-063):
+	// a KB-attached mission also offers kb_search/kb_read here, and a
+	// forced choice would make consulting them impossible.
+	if len(extra) == 1 {
+		req.ForceTool = planToolName
+	}
 	text, args, _, err := r.runTurn(ctx, req, planToolName)
 	if err != nil {
 		return Spec{}, err

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -433,6 +433,41 @@ func TestPlanSessionParsesSpec(t *testing.T) {
 	}
 }
 
+// TestPlanSessionForcesPlanTool pins D-063: when submit_plan is the
+// planning turn's sole tool, the request forces it.
+func TestPlanSessionForcesPlanTool(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","verify_cmd":"go test ./...","passes":true}]}`)},
+	}}
+	r := newTestRunner(agent)
+	if _, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, ""); err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if got := agent.requests[0].ForceTool; got != planToolName {
+		t.Fatalf("planner ForceTool = %q, want %s", got, planToolName)
+	}
+}
+
+// TestPlanSessionNoForceToolWithKB pins the D-063 carve-out: a
+// KB-attached mission also offers kb_search/kb_read on the planning
+// turn, so forcing submit_plan would make consulting them impossible.
+func TestPlanSessionNoForceToolWithKB(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","verify_cmd":"go test ./...","passes":true}]}`)},
+	}}
+	r := newTestRunner(agent)
+	r.kbSearch = func(ctx context.Context, query string, collections []string, mode string, k int) ([]builtin.KBSearchHit, error) {
+		return nil, nil
+	}
+	m := Mission{ID: "m1", Route: "default", Goal: "fix bug", Knowledge: []string{"docs"}}
+	if _, err := r.PlanSession(context.Background(), m, ""); err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if got := agent.requests[0].ForceTool; got != "" {
+		t.Fatalf("planner ForceTool = %q, want empty with KB tools offered", got)
+	}
+}
+
 // TestPlanSessionUsesPlanRoute confirms a mission's plan phase runs on
 // PlanRoute when set, instead of Route.
 func TestPlanSessionUsesPlanRoute(t *testing.T) {

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -859,6 +859,7 @@ type RouteEntryStatus struct {
 	Uptime        *float64 `json:"uptime,omitempty"`
 	LatencyMS     *float64 `json:"latency_ms,omitempty"`
 	TokensPerS    *float64 `json:"tokens_per_s,omitempty"`
+	InputPerMTok  *float64 `json:"input_per_mtok,omitempty"`
 	OutputPerMTok *float64 `json:"output_per_mtok,omitempty"`
 }
 
@@ -888,6 +889,7 @@ func resolvedForRoute(snap *router.Snapshot, name string) ([]RouteEntryStatus, *
 			Uptime:        opt(d.Uptime, -1),
 			LatencyMS:     opt(d.LatencyMS, 0),
 			TokensPerS:    opt(d.TokensPerS, 0),
+			InputPerMTok:  opt(d.InputPerMTok, 0),
 			OutputPerMTok: opt(d.OutputPerMTok, 0),
 		}
 		if d.Scored {

--- a/internal/gateway/admin/admin_routes_test.go
+++ b/internal/gateway/admin/admin_routes_test.go
@@ -35,8 +35,8 @@ func routesSnapshot(t *testing.T, strategy string) *router.Snapshot {
 		{ProviderID: "p2", Model: "small"},
 	}}}
 	cat := fakeCatalog{models: []catalog.Model{
-		{ID: "big", ModelKey: "big", Mode: "chat", OutputPerMTok: f64(25)},
-		{ID: "small", ModelKey: "small", Mode: "chat", OutputPerMTok: f64(1)},
+		{ID: "big", ModelKey: "big", Mode: "chat", InputPerMTok: f64(10), OutputPerMTok: f64(25)},
+		{ID: "small", ModelKey: "small", Mode: "chat", InputPerMTok: f64(0.5), OutputPerMTok: f64(1)},
 	}}
 	snap, _ := router.BuildSnapshot(provRows, routeRows, func(string) string { return "sk" }, cat)
 	return snap
@@ -65,6 +65,9 @@ func TestResolvedForRouteOrdered(t *testing.T) {
 	}
 	if *first.OutputPerMTok != 25 {
 		t.Fatalf("price not mapped: %+v", first)
+	}
+	if first.InputPerMTok == nil || *first.InputPerMTok != 10 {
+		t.Fatalf("input price not mapped: %+v", first)
 	}
 	if resolved[1].Usable || resolved[1].SkipReason != "disabled" {
 		t.Fatalf("disabled entry = %+v", resolved[1])

--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -74,6 +74,9 @@ type streamRequest struct {
 	Effort    string             `json:"effort,omitempty"` // D-020: "low" | "" (normal)
 	SessionID string             `json:"session_id,omitempty"`
 	MissionID string             `json:"mission_id,omitempty"`
+	// ForceTool names the single offered tool the model must call this
+	// step (D-063). Empty means auto, today's behavior.
+	ForceTool string `json:"force_tool,omitempty"`
 }
 
 // requiredVisionCapability derives whether this request needs a
@@ -193,6 +196,7 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 		Tools:     req.Tools,
 		MaxTokens: req.MaxTokens,
 		Effort:    req.Effort,
+		ForceTool: req.ForceTool,
 	}
 
 	var codes []string
@@ -256,6 +260,9 @@ type attemptResult struct {
 // bad, so the next provider would reject it identically. Everything
 // else — 5xx, timeouts, connection errors, 401/403 (bad key for THIS
 // provider), 429 — advances the chain.
+// empty_output (D-063) is deliberately absent: a zero-output terminal
+// is exactly the case a different provider might fix, so it must
+// advance the chain rather than be reported as final.
 var noFailoverCodes = map[string]bool{
 	"invalid_request": true,
 	"http_400":        true,
@@ -315,6 +322,18 @@ func streamAttempt(ctx context.Context, att router.Attempt, completion provider.
 			send(ev)
 		case stream.EventIncomplete:
 			sawTerminal = true
+			// A provider-relayed incomplete with nothing ever streamed is
+			// a failed attempt eligible for chain failover (D-063): hold
+			// it back instead of forwarding, the same as EventError above.
+			if !res.streamed {
+				res.failed = true
+				res.reason = "provider produced no output"
+				if ev.Text != "" {
+					res.reason = ev.Text
+				}
+				res.entry.ErrorCode = "empty_output"
+				continue // drain quietly; the client saw nothing
+			}
 			if res.entry.Status == "" {
 				res.entry.Status = "incomplete"
 			}
@@ -325,11 +344,17 @@ func streamAttempt(ctx context.Context, att router.Attempt, completion provider.
 		case stream.EventDone:
 			sawTerminal = true
 			// A stream that closes clean but produced no content (e.g.
-			// [DONE] with zero deltas) is not a success (D-044): tell the
-			// client before the terminal done, the same incomplete-then-
-			// done shape a cut-off stream already uses (see httpx.go).
+			// [DONE] with zero deltas, or a suppressed EventIncomplete
+			// above) is a failed attempt eligible for chain failover
+			// (D-063) rather than a success (D-044) — hold the done back
+			// too, so no terminal reaches the client for this attempt.
 			if !res.streamed {
-				send(stream.StreamEvent{Type: stream.EventIncomplete, Text: "provider produced no output"})
+				if !res.failed {
+					res.failed = true
+					res.reason = "provider produced no output"
+					res.entry.ErrorCode = "empty_output"
+				}
+				continue
 			}
 			// Attribute the serving provider on the terminal event so
 			// callers need no second lookup. Cost/Currency ride along when
@@ -387,6 +412,12 @@ func finalStatus(res attemptResult) string {
 	switch {
 	case res.entry.Status != "": // incomplete already decided
 		return res.entry.Status
+	// empty_output books "incomplete", not "error" (D-063): it's a
+	// failed attempt for chain-failover purposes, but the ledger keeps
+	// treating a zero-output terminal the same as any other incomplete
+	// so it doesn't poison LastSuccess stickiness differently than before.
+	case res.entry.ErrorCode == "empty_output":
+		return "incomplete"
 	case res.failed, res.entry.ErrorCode != "":
 		return "error"
 	// A drained stream that produced no content is not a success (D-044):

--- a/internal/gateway/api/api_test.go
+++ b/internal/gateway/api/api_test.go
@@ -97,8 +97,8 @@ func oaiFail(t *testing.T) *httptest.Server {
 }
 
 // oaiEmptyDone streams usage then [DONE] with zero content deltas — a
-// provider stream that terminates cleanly but produced no output
-// (D-044).
+// provider stream that terminates cleanly but produced no output, a
+// failed attempt eligible for chain failover (D-063).
 func oaiEmptyDone(t *testing.T) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -232,6 +232,29 @@ func pricedSnapshotFor(t *testing.T, firstURL, secondURL string) *router.Snapsho
 	return snap
 }
 
+// TestStreamForceToolReachesProvider pins D-063: streamRequest's
+// force_tool field threads into provider.CompletionRequest.ForceTool
+// and onto the wire as a forced tool_choice.
+func TestStreamForceToolReachesProvider(t *testing.T) {
+	t.Parallel()
+	var body []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ = io.ReadAll(r.Body)
+		_, _ = fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	t.Cleanup(srv.Close)
+	a, _ := newAPI(snapshotFor(t, srv.URL, oaiFail(t).URL))
+
+	w := postJSON(t, a.handleStream, `{"route":"coding","force_tool":"submit_plan","tools":[{"name":"submit_plan","description":"d","input_schema":{}}],"messages":[{"role":"user","content":"hi"}]}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(string(body), `"tool_choice":{"function":{"name":"submit_plan"},"type":"function"}`) {
+		t.Fatalf("wire body = %s, want a forced tool_choice", body)
+	}
+}
+
 func TestStreamHappyPathWithLedger(t *testing.T) {
 	t.Parallel()
 	a, rec := newAPI(pricedSnapshotFor(t, oaiOK(t, "hello").URL, oaiFail(t).URL))
@@ -287,43 +310,101 @@ func TestStreamHappyPathWithLedger(t *testing.T) {
 	}
 }
 
-// TestStreamEmptyOutputBookedIncomplete pins D-044: a provider stream
-// that terminates cleanly with zero content deltas ([DONE] only) must
-// not be booked as a success. res.streamed is set only by content
-// events (chunk/reasoning/tool) — never by EventUsage — so the ledger
-// status flips to "incomplete" even though usage/cost are still known
-// (a real, reported zero, not the unknown-so-NULL case D-013 covers).
-// The client sees an EventIncomplete before the terminal done, the same
-// shape a cut-off stream already uses.
-func TestStreamEmptyOutputBookedIncomplete(t *testing.T) {
+// TestStreamEmptyOutputFailsOver pins D-063: a provider stream that
+// terminates cleanly with zero content deltas ([DONE] only) is a failed
+// attempt, not a success — the client never sees its incomplete/done,
+// and the chain fails over to the next entry instead. The client sees a
+// failover event, then the second provider's real content and terminal
+// done. Two ledger entries: the empty one booked "incomplete" with
+// ErrorCode "empty_output" (still not "error" — D-044's stickiness
+// concern), the second "ok".
+func TestStreamEmptyOutputFailsOver(t *testing.T) {
 	t.Parallel()
-	a, rec := newAPI(snapshotFor(t, oaiEmptyDone(t).URL, oaiFail(t).URL))
+	a, rec := newAPI(snapshotFor(t, oaiEmptyDone(t).URL, oaiOK(t, "backup").URL))
 
 	w := postJSON(t, a.handleStream, `{"route":"coding","session_id":"s1","messages":[{"role":"user","content":"hi"}]}`)
 
 	events := sseEvents(t, w.Body.String())
-	if len(events) < 2 {
-		t.Fatalf("events = %+v, want at least incomplete+done", events)
+	var failover *stream.StreamEvent
+	var text string
+	for i, ev := range events {
+		switch ev.Type {
+		case stream.EventFailover:
+			failover = &events[i]
+		case stream.EventIncomplete, stream.EventError:
+			t.Fatalf("empty attempt's terminal leaked to client: %+v", ev)
+		case stream.EventChunk:
+			text += ev.Text
+		}
+	}
+	if failover == nil {
+		t.Fatalf("events = %+v, want a failover event", events)
+	}
+	if failover.Failover.Code != "empty_output" {
+		t.Fatalf("failover code = %q, want empty_output", failover.Failover.Code)
+	}
+	if text != "backup" {
+		t.Fatalf("chunks = %q, want backup", text)
 	}
 	last := events[len(events)-1]
 	if last.Type != stream.EventDone {
 		t.Fatalf("last event = %v, want done", last.Type)
 	}
-	prev := events[len(events)-2]
-	if prev.Type != stream.EventIncomplete {
-		t.Fatalf("event before done = %v, want incomplete", prev.Type)
+
+	entries := rec.all()
+	if len(entries) != 2 {
+		t.Fatalf("ledger entries = %d, want 2", len(entries))
+	}
+	if entries[0].Status != "incomplete" || entries[0].ErrorCode != "empty_output" {
+		t.Fatalf("first entry = %+v, want incomplete/empty_output", entries[0])
+	}
+	if entries[0].Usage == nil || entries[0].Usage.OutputTokens != 0 {
+		t.Fatalf("first entry usage = %+v, want reported zero output tokens", entries[0].Usage)
+	}
+	if entries[1].Status != "ok" {
+		t.Fatalf("second entry = %+v, want ok", entries[1])
+	}
+}
+
+// TestStreamEmptyOutputChainExhausted covers every chain entry
+// producing zero output: the chain fails over on each, and once
+// exhausted the client gets the existing chain_exhausted terminal
+// error — every entry booked incomplete/empty_output, none "ok".
+func TestStreamEmptyOutputChainExhausted(t *testing.T) {
+	t.Parallel()
+	a, rec := newAPI(snapshotFor(t, oaiEmptyDone(t).URL, oaiEmptyDone(t).URL))
+
+	w := postJSON(t, a.handleStream, `{"route":"coding","messages":[{"role":"user","content":"hi"}]}`)
+
+	events := sseEvents(t, w.Body.String())
+	var sawFailover bool
+	last := events[len(events)-1]
+	for _, ev := range events[:len(events)-1] {
+		switch ev.Type {
+		case stream.EventFailover:
+			sawFailover = true
+		case stream.EventIncomplete, stream.EventChunk:
+			t.Fatalf("empty attempt's terminal or content leaked to client: %+v", ev)
+		}
+	}
+	if !sawFailover {
+		t.Fatalf("events = %+v, want a failover event", events)
+	}
+	if last.Type != stream.EventError || last.Err.Code != "chain_exhausted" {
+		t.Fatalf("last event = %+v, want chain_exhausted error", last)
+	}
+	if !strings.Contains(last.Err.Message, "empty_output") {
+		t.Fatalf("exhaustion message missing empty_output: %s", last.Err.Message)
 	}
 
 	entries := rec.all()
-	if len(entries) != 1 {
-		t.Fatalf("ledger entries = %d, want 1", len(entries))
+	if len(entries) != 2 {
+		t.Fatalf("ledger entries = %d, want 2", len(entries))
 	}
-	e := entries[0]
-	if e.Status != "incomplete" {
-		t.Fatalf("status = %q, want incomplete", e.Status)
-	}
-	if e.Usage == nil || e.Usage.OutputTokens != 0 {
-		t.Fatalf("usage = %+v, want reported zero output tokens", e.Usage)
+	for _, e := range entries {
+		if e.Status != "incomplete" || e.ErrorCode != "empty_output" {
+			t.Fatalf("entry = %+v, want incomplete/empty_output", e)
+		}
 	}
 }
 

--- a/internal/gateway/provider/anthropic.go
+++ b/internal/gateway/provider/anthropic.go
@@ -75,6 +75,8 @@ type anthropicRequest struct {
 	System    []anthropicTextBlock `json:"system,omitempty"`
 	Messages  []anthropicMessage   `json:"messages"`
 	Tools     []anthropicTool      `json:"tools,omitempty"`
+	// ToolChoice forces a specific tool call (D-063: CompletionRequest.ForceTool).
+	ToolChoice any `json:"tool_choice,omitempty"`
 }
 
 // anthropicMessage carries either a plain string or content blocks
@@ -249,6 +251,9 @@ func (a *Anthropic) buildRequest(req CompletionRequest) anthropicRequest {
 	}
 	for _, t := range req.Tools {
 		out.Tools = append(out.Tools, anthropicTool(t))
+	}
+	if req.ForceTool != "" && len(out.Tools) > 0 {
+		out.ToolChoice = map[string]any{"type": "tool", "name": req.ForceTool}
 	}
 	return out
 }

--- a/internal/gateway/provider/bedrock.go
+++ b/internal/gateway/provider/bedrock.go
@@ -318,7 +318,20 @@ func buildConverseStreamInput(req CompletionRequest) *bedrockruntime.ConverseStr
 			"inferenceConfig": map[string]any{"topK": 1},
 		})
 	}
+	if req.ForceTool != "" && input.ToolConfig != nil && converseSupportsToolChoice(req.Model) {
+		input.ToolConfig.ToolChoice = &types.ToolChoiceMemberTool{
+			Value: types.SpecificToolChoice{Name: aws.String(req.ForceTool)},
+		}
+	}
 	return input
+}
+
+// converseSupportsToolChoice reports whether Converse's ToolChoice
+// field is honored for this model (D-063): Anthropic and Mistral
+// Large support forced tool choice; Amazon Nova does not, so
+// CompletionRequest.ForceTool is ignored there (graceful degrade).
+func converseSupportsToolChoice(model string) bool {
+	return strings.Contains(model, "anthropic.") || strings.Contains(model, "mistral-large")
 }
 
 // converseMessages maps normalized messages onto Bedrock Converse

--- a/internal/gateway/provider/bedrock_test.go
+++ b/internal/gateway/provider/bedrock_test.go
@@ -274,6 +274,46 @@ func TestBuildConverseStreamInput(t *testing.T) {
 	}
 }
 
+// TestBuildConverseStreamInputForceTool pins D-063: Converse's
+// ToolChoice is set only for model families that support forced tool
+// choice (Anthropic, Mistral Large); Nova ignores ForceTool entirely
+// (graceful degrade) since it rejects the field.
+func TestBuildConverseStreamInputForceTool(t *testing.T) {
+	t.Parallel()
+	tools := []ToolDef{{Name: "submit_plan", InputSchema: json.RawMessage(`{"type":"object"}`)}}
+
+	cases := []struct {
+		name    string
+		model   string
+		wantSet bool
+	}{
+		{"nova ignores ForceTool", "us.amazon.nova-pro-v1:0", false},
+		{"anthropic honors ForceTool", "us.anthropic.claude-sonnet-4-5-20250929-v1:0", true},
+		{"mistral large honors ForceTool", "mistral.mistral-large-2407-v1:0", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			input := buildConverseStreamInput(CompletionRequest{
+				Model: tc.model, Tools: tools, ForceTool: "submit_plan",
+			})
+			if !tc.wantSet {
+				if input.ToolConfig.ToolChoice != nil {
+					t.Fatalf("ToolChoice = %#v, want nil", input.ToolConfig.ToolChoice)
+				}
+				return
+			}
+			choice, ok := input.ToolConfig.ToolChoice.(*types.ToolChoiceMemberTool)
+			if !ok {
+				t.Fatalf("ToolChoice = %#v, want *types.ToolChoiceMemberTool", input.ToolConfig.ToolChoice)
+			}
+			if choice.Value.Name == nil || *choice.Value.Name != "submit_plan" {
+				t.Fatalf("ToolChoice name = %#v, want submit_plan", choice.Value.Name)
+			}
+		})
+	}
+}
+
 func TestDocumentFromJSON(t *testing.T) {
 	t.Parallel()
 	if documentFromJSON(nil) != nil {

--- a/internal/gateway/provider/openaicompat.go
+++ b/internal/gateway/provider/openaicompat.go
@@ -185,6 +185,8 @@ type oaiRequest struct {
 	// that don't recognize it. Stream retries once without it on that
 	// exact failure (see retryOn400).
 	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	// ToolChoice forces a specific tool call (D-063: CompletionRequest.ForceTool).
+	ToolChoice any `json:"tool_choice,omitempty"`
 }
 
 // wire types (stream chunks; only the fields we read)
@@ -436,6 +438,9 @@ func (o *OpenAICompat) buildRequest(req CompletionRequest) oaiRequest {
 		ot.Function.Description = t.Description
 		ot.Function.Parameters = t.InputSchema
 		out.Tools = append(out.Tools, ot)
+	}
+	if req.ForceTool != "" && len(out.Tools) > 0 {
+		out.ToolChoice = map[string]any{"type": "function", "function": map[string]any{"name": req.ForceTool}}
 	}
 	return out
 }

--- a/internal/gateway/provider/provider.go
+++ b/internal/gateway/provider/provider.go
@@ -117,6 +117,11 @@ type CompletionRequest struct {
 	// no such restriction). Empty means no override; wins over both
 	// Effort and the provider's own ReasoningEffort config when set.
 	ReasoningEffortOverride string
+	// ForceTool names the single offered tool the model must call this
+	// step (forced tool_choice), instead of choosing freely among Tools
+	// (D-063). Empty means auto, today's behavior. Drivers that cannot
+	// express a forced choice on the wire ignore it.
+	ForceTool string
 }
 
 // Provider is one configured LLM provider. Stream returns quickly; all

--- a/internal/gateway/provider/toolwire_test.go
+++ b/internal/gateway/provider/toolwire_test.go
@@ -71,6 +71,30 @@ func TestAnthropicMessagesEmptyToolInput(t *testing.T) {
 	}
 }
 
+// TestAnthropicForceTool pins D-063: ForceTool wires onto the wire's
+// tool_choice as a forced tool selection, and is absent when ForceTool
+// is empty.
+func TestAnthropicForceTool(t *testing.T) {
+	t.Parallel()
+	a := NewAnthropic(AnthropicConfig{APIKey: "k"})
+	tools := []ToolDef{{Name: "submit_plan", Description: "d", InputSchema: json.RawMessage(`{}`)}}
+
+	forced := a.buildRequest(CompletionRequest{Model: "m", Tools: tools, ForceTool: "submit_plan"})
+	data, err := json.Marshal(forced)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"tool_choice":{"name":"submit_plan","type":"tool"}`) {
+		t.Fatalf("wire = %s, want a forced tool_choice", data)
+	}
+
+	unforced := a.buildRequest(CompletionRequest{Model: "m", Tools: tools})
+	data, _ = json.Marshal(unforced)
+	if strings.Contains(string(data), "tool_choice") {
+		t.Fatalf("wire = %s, want no tool_choice when ForceTool is empty", data)
+	}
+}
+
 func TestOpenAICompatToolRoundTrip(t *testing.T) {
 	t.Parallel()
 	o := NewOpenAICompat(OpenAICompatConfig{BaseURL: "http://x", APIKey: "k"})
@@ -117,6 +141,30 @@ func TestOpenAICompatEffortDial(t *testing.T) {
 	data, _ := json.Marshal(normal)
 	if strings.Contains(string(data), "reasoning_effort") {
 		t.Fatal("normal effort must omit the field entirely")
+	}
+}
+
+// TestOpenAICompatForceTool pins D-063: ForceTool wires onto the
+// wire's tool_choice as a forced function call, and is absent when
+// ForceTool is empty.
+func TestOpenAICompatForceTool(t *testing.T) {
+	t.Parallel()
+	o := NewOpenAICompat(OpenAICompatConfig{BaseURL: "http://x", APIKey: "k"})
+	tools := []ToolDef{{Name: "submit_plan", Description: "d", InputSchema: json.RawMessage(`{}`)}}
+
+	forced := o.buildRequest(CompletionRequest{Model: "m", Tools: tools, ForceTool: "submit_plan"})
+	data, err := json.Marshal(forced)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"tool_choice":{"function":{"name":"submit_plan"},"type":"function"}`) {
+		t.Fatalf("wire = %s, want a forced tool_choice", data)
+	}
+
+	unforced := o.buildRequest(CompletionRequest{Model: "m", Tools: tools})
+	data, _ = json.Marshal(unforced)
+	if strings.Contains(string(data), "tool_choice") {
+		t.Fatalf("wire = %s, want no tool_choice when ForceTool is empty", data)
 	}
 }
 

--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -470,8 +470,8 @@ var strategyWeights = map[string]struct{ price, latency, tps float64 }{
 // with the usability gate Resolve applies and the factors the scored
 // strategies use. Sentinels: Uptime and the Norm* fields are -1 when
 // the ledger has no data (scoring treats the factor as neutral); raw
-// LatencyMS, TokensPerS, and OutputPerMTok are 0 when unknown — an
-// absent price stays absent, never guessed.
+// LatencyMS, TokensPerS, InputPerMTok, and OutputPerMTok are 0 when
+// unknown — an absent price stays absent, never guessed.
 type ResolvedEntry struct {
 	Entry         ChainEntry
 	ProviderName  string // empty when the provider id is unknown
@@ -487,6 +487,7 @@ type ResolvedEntry struct {
 	Uptime        float64 // raw weighted success rate, 0..1
 	LatencyMS     float64 // raw weighted mean latency
 	TokensPerS    float64 // raw weighted output tokens per second
+	InputPerMTok  float64 // declared input price; display only, not used for scoring
 	OutputPerMTok float64 // declared output price used for scoring
 }
 
@@ -524,10 +525,15 @@ func (s *Snapshot) ResolveDetail(route string) []ResolvedEntry {
 		// defaulted above) — an entry with no model of its own serves
 		// row.DefaultModel, and that's what the ledger and price rows
 		// are keyed by.
-		if p := s.Prices(row.Name, d.Model); p != nil && p.OutputPerMTok > 0 {
-			d.OutputPerMTok = p.OutputPerMTok
-			if minPrice == 0 || d.OutputPerMTok < minPrice {
-				minPrice = d.OutputPerMTok
+		if p := s.Prices(row.Name, d.Model); p != nil {
+			if p.InputPerMTok > 0 {
+				d.InputPerMTok = p.InputPerMTok
+			}
+			if p.OutputPerMTok > 0 {
+				d.OutputPerMTok = p.OutputPerMTok
+				if minPrice == 0 || d.OutputPerMTok < minPrice {
+					minPrice = d.OutputPerMTok
+				}
 			}
 		}
 		if st, ok := s.stats[row.Name+"/"+d.Model]; ok {

--- a/internal/gateway/router/router_test.go
+++ b/internal/gateway/router/router_test.go
@@ -797,9 +797,9 @@ func TestResolveDetailScoredMatchesResolve(t *testing.T) {
 		{ProviderID: "p1", Model: "big"},
 		{ProviderID: "p2", Model: "small"},
 	}}}
-	big := catModel("big", "chat", nil)
+	big := catModel("big", "chat", fp(10))
 	big.OutputPerMTok = fp(25)
-	small := catModel("small", "chat", nil)
+	small := catModel("small", "chat", fp(0.5))
 	small.OutputPerMTok = fp(1)
 	cat := &fakeCatalog{pool: []catalog.Model{big, small}}
 	snap, _ := BuildSnapshot(provRows, routeRows, func(string) string { return "sk" }, cat)
@@ -830,6 +830,9 @@ func TestResolveDetailScoredMatchesResolve(t *testing.T) {
 	}
 	if !almostEqual(pricey.Score, 0.9/25+0.02) {
 		t.Fatalf("pricey score = %v", pricey.Score)
+	}
+	if cheap.InputPerMTok != 0.5 || pricey.InputPerMTok != 10 {
+		t.Fatalf("input prices wrong: cheap=%v pricey=%v", cheap.InputPerMTok, pricey.InputPerMTok)
 	}
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -506,6 +506,7 @@ export interface RouteEntryStatus {
   uptime?: number
   latency_ms?: number
   tokens_per_s?: number
+  input_per_mtok?: number
   output_per_mtok?: number
 }
 

--- a/web/src/components/settings/RouteEdit.test.tsx
+++ b/web/src/components/settings/RouteEdit.test.tsx
@@ -106,7 +106,7 @@ describe('RouteEdit ordered pipeline', () => {
     renderRoute('default')
     const cards = await screen.findAllByTestId('pipeline-card')
     expect(cards[0]).toHaveTextContent('812 ms')
-    expect(cards[0]).toHaveTextContent('$15/MTok')
+    expect(cards[0]).toHaveTextContent('out $15')
     expect(cards[0]).toHaveTextContent('98%')
     expect(cards[1]).toHaveTextContent('unpriced')
   })

--- a/web/src/components/settings/pipeline/Pipeline.tsx
+++ b/web/src/components/settings/pipeline/Pipeline.tsx
@@ -1,6 +1,3 @@
-import { ArrowRight02Icon } from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
-import { Fragment } from 'react'
 import type { AdminProvider, ChainEntry, RouteEntryStatus } from '../../../api/types'
 import { PipelineCard } from './PipelineCard'
 import { reorder, useReorderDrag } from './useReorderDrag'
@@ -49,7 +46,7 @@ export function Pipeline({
   }
 
   return (
-    <div className="flex items-center gap-2 overflow-x-auto pb-2" data-testid="pipeline">
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-4" data-testid="pipeline">
       {display.map((e, i) => {
         const original = entries.indexOf(e)
         const provider = providerOf(e.entry.provider_id)
@@ -59,31 +56,26 @@ export function Pipeline({
           serving.provider_id === e.entry.provider_id &&
           serving.model === e.entry.model
         return (
-          <Fragment key={`${e.entry.provider_id}-${e.entry.model}-${original}`}>
-            {i > 0 && (
-              <HugeiconsIcon
-                icon={ArrowRight02Icon}
-                className="size-4 shrink-0 text-muted-foreground/60"
-                aria-hidden="true"
-              />
-            )}
-            <div ref={setItemRef(i)} {...handleProps(original)}>
-              <PipelineCard
-                provider={provider}
-                name={e.status?.provider_name ?? provider?.name ?? e.entry.provider_id.slice(0, 8)}
-                model={e.status?.model ?? e.entry.model}
-                status={e.status}
-                serving={isServing}
-                scored={scored}
-                maxScore={maxScore}
-                index={original}
-                count={entries.length}
-                onMove={onReorder}
-                onRemove={() => onRemove(original)}
-                dragging={dragIndex === original}
-              />
-            </div>
-          </Fragment>
+          <div
+            key={`${e.entry.provider_id}-${e.entry.model}-${original}`}
+            ref={setItemRef(i)}
+            {...handleProps(original)}
+          >
+            <PipelineCard
+              provider={provider}
+              name={e.status?.provider_name ?? provider?.name ?? e.entry.provider_id.slice(0, 8)}
+              model={e.status?.model ?? e.entry.model}
+              status={e.status}
+              serving={isServing}
+              scored={scored}
+              maxScore={maxScore}
+              index={original}
+              count={entries.length}
+              onMove={onReorder}
+              onRemove={() => onRemove(original)}
+              dragging={dragIndex === original}
+            />
+          </div>
         )
       })}
     </div>

--- a/web/src/components/settings/pipeline/PipelineCard.tsx
+++ b/web/src/components/settings/pipeline/PipelineCard.tsx
@@ -10,7 +10,14 @@ import { ProviderLogo } from '../ProviderLogo'
 import { ScoreBar } from './ScoreBar'
 
 const fmtLatency = (v?: number) => (v === undefined ? 'N/A' : `${Math.round(v)} ms`)
-const fmtPrice = (v?: number) => (v === undefined ? 'unpriced' : `$${v}/MTok`)
+// Trims binary-float noise (e.g. 0.39999999999999997) before display.
+const fmtMTok = (v: number) => `$${+v.toFixed(2)}`
+const fmtPrice = (input?: number, output?: number) => {
+  if (input === undefined && output === undefined) return 'unpriced'
+  if (input === undefined) return `out ${fmtMTok(output as number)}`
+  if (output === undefined) return `in ${fmtMTok(input)}`
+  return `${fmtMTok(input)} / ${fmtMTok(output)}`
+}
 const fmtUptime = (v?: number) => (v === undefined ? 'N/A' : `${Math.round(v * 100)}%`)
 
 export function PipelineCard({
@@ -41,14 +48,19 @@ export function PipelineCard({
   dragging?: boolean
 }) {
   const usable = status ? status.usable : true
+  const priceTitle =
+    status?.input_per_mtok !== undefined || status?.output_per_mtok !== undefined
+      ? `in $${status?.input_per_mtok ?? '?'} / out $${status?.output_per_mtok ?? '?'} per MTok`
+      : undefined
   return (
     <div
       data-testid="pipeline-card"
-      className={`w-56 shrink-0 select-none space-y-2.5 rounded-xl border border-border bg-card p-4 shadow-sm transition ${
+      className={`w-full select-none space-y-2.5 rounded-xl border border-border bg-card p-4 shadow-sm transition ${
         dragging ? 'opacity-60 ring-2 ring-brand' : ''
       } ${scored ? '' : 'cursor-grab'}`}
     >
       <div className="flex items-center gap-2.5">
+        <span className="shrink-0 font-mono text-[10px] text-muted-foreground">#{index + 1}</span>
         {provider && <ProviderLogo preset={matchPreset(provider)} className="size-7" />}
         <span className="min-w-0 flex-1 truncate text-sm font-semibold">{name}</span>
         <span
@@ -65,9 +77,11 @@ export function PipelineCard({
           <dt>latency</dt>
           <dd className="font-mono text-foreground">{fmtLatency(status?.latency_ms)}</dd>
         </div>
-        <div>
-          <dt>price</dt>
-          <dd className="font-mono text-foreground">{fmtPrice(status?.output_per_mtok)}</dd>
+        <div className="min-w-0">
+          <dt>price /MTok</dt>
+          <dd className="truncate font-mono text-foreground" title={priceTitle}>
+            {fmtPrice(status?.input_per_mtok, status?.output_per_mtok)}
+          </dd>
         </div>
         <div>
           <dt>uptime</dt>


### PR DESCRIPTION
## Why

gpt-5.6-luna stalled two scheduled missions into backoff last night: on plan turns it answered with prose instead of the mandatory submit_plan call, and its recovery retry deterministically returned a zero-content stream. Two gaps let one flaky model take the mission down despite a healthy fallback in the chain:

1. A stream that closes clean with zero content deltas (D-044) was booked incomplete and returned to the caller — the router never tried the next chain entry.
2. Nothing in the stack ever set tool_choice on the wire, so a turn offering exactly one mandatory tool still left the model free to answer with text.

## What

- **Empty-output failover (D-063)**: a terminal with nothing ever streamed now fails the attempt with error_code empty_output and advances the chain; all-empty chains exhaust cleanly. Ledger keeps booking incomplete so LastSuccess stickiness is unchanged.
- **ForceTool**: new field rides loop.Request → gwclient → gateway API → provider.CompletionRequest. openaicompat sends forced function tool_choice, anthropic forced tool, bedrock only for families supporting it (Nova degrades to auto). Loop clears it under force-synthesis and when the tool is not offered. PlanSession forces submit_plan when it is the sole offered tool; KB-attached missions keep auto so kb_search/kb_read stay reachable.
- **Route chain UI**: cards wrap 4-per-row grid with order badges, price cell shows in/out per MTok rounded (raw float noise gone), input_per_mtok plumbed router → admin API → web.

## Testing

- go build/vet/test whole repo; web build + lint + 739 tests.
- Live local verification with a stub provider: empty-output failover event + fallback content + correct ledger rows; all-empty chain → chain_exhausted; force_tool produces tool_choice on the captured wire request.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790033617&installation_model_id=431401&pr_number=278&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F278&signature=5020971ad60643aa7166cd6bc21f1d1d6fdf0dfc4217923804787531125ea350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->