### PR TITLE
fix: log failed stream attempts with provider error reason

### DIFF
--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -215,6 +215,13 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 		}, prices, send)
 
 		if res.failedOver() {
+			// The client only ever sees error codes (see chain-exhausted
+			// note below); the raw reason is server-side log only, or
+			// the actual provider error is lost to debugging entirely.
+			a.log.Warn("stream attempt failed",
+				"provider", att.ProviderName, "model", att.Model,
+				"route", req.Route, "code", res.entry.ErrorCode,
+				"reason", res.reason)
 			codes = append(codes, res.entry.ErrorCode)
 			a.recordAttempt(r.Context(), res.entry)
 			if next := i + 1; next < len(attempts) {


### PR DESCRIPTION
Chain failover keeps only error codes (ledger + chain_exhausted terminal); the raw provider error text is deliberately withheld from clients and was therefore lost entirely — debugging a failing fallback (live bedrock_error on homelab right now) is impossible without it. One WARN log per failed attempt with provider, model, route, code, reason. Server-side logs only; client contract unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790035475&installation_model_id=431401&pr_number=279&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F279&signature=c2ee65bfe7addbb90193ff02e525b9f395437a1134dfa2ce5c612653a31e164a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->