### PR TITLE
feat: show mission created time in list and detail

### DIFF
--- a/web/src/components/missions/MissionCard.test.tsx
+++ b/web/src/components/missions/MissionCard.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Mission } from '../../api/types'
 import { MissionCard } from './MissionCard'
 
@@ -101,6 +101,18 @@ describe('MissionCard harness and model', () => {
   it('omits model text when top_model is absent', () => {
     renderCard({ ...baseMission })
     expect(screen.queryByText('claude-sonnet-5')).not.toBeInTheDocument()
+  })
+})
+
+describe('MissionCard created timestamp', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('shows the relative created time with an absolute tooltip', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T03:00:00Z'))
+    renderCard({ ...baseMission, created_at: '2026-01-01T00:00:00Z' })
+    const el = screen.getByText('3h ago')
+    expect(el).toHaveAttribute('title', new Date('2026-01-01T00:00:00Z').toLocaleString())
   })
 })
 

--- a/web/src/components/missions/MissionCard.tsx
+++ b/web/src/components/missions/MissionCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router'
 import type { Mission } from '../../api/types'
-import { missionDisplayName } from '../../lib/format'
+import { missionDisplayName, relativeTime } from '../../lib/format'
 import { BrandMark } from '../BrandMark'
 import { ClaudeCodeIcon } from '../icons/ClaudeCodeIcon'
 import { OpenAIIcon } from '../icons/OpenAIIcon'
@@ -83,6 +83,9 @@ export function MissionCard({ mission }: { mission: Mission }) {
           {harnessLabel(mission.harness)}
         </span>
         {mission.top_model && <span className="max-w-32 truncate">{mission.top_model}</span>}
+        <span title={new Date(mission.created_at).toLocaleString()}>
+          {relativeTime(mission.created_at)}
+        </span>
       </div>
       {mission.pause_message && (
         <p className="line-clamp-2 text-xs text-amber-700 dark:text-amber-400">{mission.pause_message}</p>

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -442,6 +442,16 @@ describe('MissionDetail on_complete badge', () => {
   })
 })
 
+describe('MissionDetail created timestamp', () => {
+  it('shows the relative created time with an absolute tooltip', async () => {
+    const createdAt = new Date(Date.now() - 3 * 3_600_000).toISOString()
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, created_at: createdAt })
+    renderPage()
+    const el = await screen.findByText('created 3h ago')
+    expect(el).toHaveAttribute('title', new Date(createdAt).toLocaleString())
+  })
+})
+
 describe('MissionDetail', () => {
   it('renders mission header, plan, and progress', async () => {
     renderPage()

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -53,7 +53,7 @@ import { errText } from '../components/settings/util'
 import { describeCron } from '../lib/schedules'
 import { playAlertSound } from '../lib/alertSound'
 import { subscribeEvents } from '../lib/events'
-import { compact, formatDuration, missionDisplayName, money } from '../lib/format'
+import { compact, formatDuration, missionDisplayName, money, relativeTime } from '../lib/format'
 
 // unbilledTooltipLine formats the billed cost pill's tooltip line, in
 // that pill's OWN currency only — prefers the currency-converted
@@ -480,6 +480,9 @@ export function MissionDetail() {
               <span className="capitalize">{mission.kind}</span>
               <span>{mission.phase}</span>
               <span>{mission.status.replace(/_/g, ' ')}</span>
+              <span title={new Date(mission.created_at).toLocaleString()}>
+                created {relativeTime(mission.created_at)}
+              </span>
               {executorActivity && (
                 <span>
                   harness: {executorActivity.turns} turn{executorActivity.turns === 1 ? '' : 's'},{' '}


### PR DESCRIPTION
Mission cards and the detail header now show when a mission was created — relative form ("3h ago") with absolute local datetime tooltip, reusing the existing relativeTime helper. Distinguishing a fresh schedule fire from an old stuck mission previously required querying the API.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790035885&installation_model_id=431401&pr_number=280&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F280&signature=a767a1df2ecfbe629a8f62f174f9dcb5b8a7bfcf4aaaf965b73f10a447c69c33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->