### PR TITLE
fix: enforce iteration ceiling before backoff, default 3 not 8

### DIFF
--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -443,7 +443,7 @@ func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedu
 	_, err = tx.Exec(ctx, `INSERT INTO missions
 			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, knowledge, auto_approve_safe, spec, schedule_id, harness, environment, destination_ids)
 		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`,
-		t.Goal, name, t.Kind, t.AgentID, orDefault(t.MaxIterations, 8), t.BudgetAmount, budgetCurrency, t.Route, t.ReviewRoute, t.PlanRoute,
+		t.Goal, name, t.Kind, t.AgentID, orDefault(t.MaxIterations, 3), t.BudgetAmount, budgetCurrency, t.Route, t.ReviewRoute, t.PlanRoute,
 		promptOverlay, knowledgeJSON, t.AutoApproveSafe, spec, sc.ID, t.Harness, t.Environment, destinationIDs)
 	return err
 }

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -303,19 +303,24 @@ func stepPhaseComplete(s StepState) Transition {
 // stepWorkerFailed counts consecutive failures toward the backoff
 // brake; a fresh success (any non-failed input) resets the counter
 // elsewhere (the driver clears ConsecutiveFailures on progress).
+//
+// The MaxIterations ceiling is checked before the backoff pause: it is
+// a hard stop, and a backoff pause must only ever happen below the
+// ceiling. Checking backoff first would let a mission repeatedly
+// resumed after backoff pauses exceed its iteration ceiling forever.
 func stepWorkerFailed(s StepState, in StepInput, cfg Config) Transition {
 	s.ConsecutiveFailures++
 	s.Iteration++
-	if s.ConsecutiveFailures >= cfg.BackoffFailures {
-		return Transition{
-			Next:   withPause(s, PauseBackoff),
-			Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseBackoff), "detail": in.Reason}}},
-		}
-	}
 	if s.Iteration >= s.MaxIterations {
 		return Transition{
 			Next:   withPhaseFailed(s),
 			Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "max_iterations", "detail": in.Reason}}},
+		}
+	}
+	if s.ConsecutiveFailures >= cfg.BackoffFailures {
+		return Transition{
+			Next:   withPause(s, PauseBackoff),
+			Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseBackoff), "detail": in.Reason}}},
 		}
 	}
 	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.retry", Payload: map[string]any{"cause": "worker_failed", "reason": in.Reason}}}}

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -142,6 +142,16 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhaseFailed, Status: StatusError, MaxIterations: 1, ConsecutiveFailures: 1, Iteration: 1},
 		},
 		{
+			// Ceiling is a hard stop checked before backoff: reaching
+			// MaxIterations and BackoffFailures on the same failure must
+			// fail terminally, never pause for backoff.
+			name:  "worker_failed hitting both ceiling and backoff threshold hard-fails, not pauses",
+			state: StepState{Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 3, Iteration: 2, ConsecutiveFailures: 2},
+			input: StepInput{Input: InputWorkerFailed},
+			cfg:   Config{BackoffFailures: 3, StallRounds: 10},
+			want:  StepState{Phase: PhaseFailed, Status: StatusError, MaxIterations: 3, Iteration: 3, ConsecutiveFailures: 3},
+		},
+		{
 			name:  "worker_retry costs an iteration and resets consecutive failures",
 			state: StepState{Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, ConsecutiveFailures: 2, Iteration: 1},
 			input: StepInput{Input: InputWorkerRetry},

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -242,7 +242,7 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	err = db.QueryRow(ctx, `INSERT INTO missions
 			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, attachments, destination_ids)
 		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NULLIF($15, '')::uuid, $16, $17, $18, $19, $20, $21, $22, $23, NULLIF($24, '')::uuid, $25, $26, $27) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 8), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, attachmentsJSON, destinationIDs,
+		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, attachmentsJSON, destinationIDs,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -112,8 +112,8 @@ func TestMissionCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if m.Phase != PhaseExplore || m.Status != StatusIdle || m.MaxIterations != 8 {
-		t.Fatalf("Get = %+v, want default explore/idle/8", m)
+	if m.Phase != PhaseExplore || m.Status != StatusIdle || m.MaxIterations != 3 {
+		t.Fatalf("Get = %+v, want default explore/idle/3", m)
 	}
 
 	list, err := s.List(ctx, ListFilter{})


### PR DESCRIPTION
Two changes to mission failure limits:

- **Ceiling before backoff** in stepWorkerFailed: the backoff pause was evaluated first, so a mission resumed after each backoff pause could exceed max_iterations forever — observed live at iteration 13 of max 8. The ceiling is now a hard stop.
- **Default max_iterations 8 → 3** (store + scheduler orDefault sites). Iteration counts only failed/reworked attempts within one phase — phase changes and approved units reset it to 0 — so multi-unit missions are unaffected and 3 straight failures now end a default mission instead of cycling backoff pauses that need manual resumes.

Consequence: with both defaults at 3, a default mission fails terminally on its third consecutive failure rather than pausing — cleaner for scheduled missions (notification + fresh start next fire). Explicitly raised ceilings still reach backoff pauses.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790036213&installation_model_id=431401&pr_number=281&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F281&signature=81192917680b2a530b9ef92aa716aef2fe7e0e40345c89252ae4b9038301a0f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->