### PR TITLE
fix: bedrock flattens tool history when no toolConfig is sent

### DIFF
--- a/internal/gateway/provider/bedrock.go
+++ b/internal/gateway/provider/bedrock.go
@@ -298,10 +298,19 @@ func (b *Bedrock) Stream(ctx context.Context, req CompletionRequest) (<-chan str
 // from AdditionalModelRequestFields instead. Titan has no such
 // failure mode and no topK field, so the workaround is gated to Nova.
 func buildConverseStreamInput(req CompletionRequest) *bedrockruntime.ConverseStreamInput {
+	toolConfig := converseTools(req.Tools)
 	input := &bedrockruntime.ConverseStreamInput{
-		ModelId:    aws.String(req.Model),
-		Messages:   converseMessages(req.Messages),
-		ToolConfig: converseTools(req.Tools),
+		ModelId: aws.String(req.Model),
+		// hasTools gates whether tool call/result content blocks are
+		// legal to emit at all: Bedrock's ValidationException
+		// "The toolConfig field must be defined when using toolUse and
+		// toolResult content blocks" fires whenever such blocks appear
+		// on a request with no ToolConfig — e.g. the brain loop's
+		// force-synthesis turn nils Tools but keeps prior tool-call/
+		// tool-result history in messages. When no tools are offered,
+		// converseMessages flattens that history to plain text instead.
+		Messages:   converseMessages(req.Messages, toolConfig != nil),
+		ToolConfig: toolConfig,
 		System:     converseSystem(req.System, req.Model),
 	}
 	if req.MaxTokens > 0 {
@@ -338,7 +347,15 @@ func converseSupportsToolChoice(model string) bool {
 // messages. Tool results ride as user-role toolResult blocks;
 // assistant messages that carry neither text nor tool calls are
 // dropped — Converse rejects empty content blocks.
-func converseMessages(msgs []Message) []types.Message {
+//
+// hasTools reports whether the request's ToolConfig will be non-nil.
+// Bedrock rejects toolUse/toolResult content blocks outright when no
+// ToolConfig is sent ("The toolConfig field must be defined when using
+// toolUse and toolResult content blocks"), so when hasTools is false
+// any tool call / tool result in the history is flattened to plain
+// text instead of emitted as a toolUse/toolResult block. When hasTools
+// is true, behavior is unchanged.
+func converseMessages(msgs []Message, hasTools bool) []types.Message {
 	out := make([]types.Message, 0, len(msgs))
 	for _, m := range msgs {
 		switch m.Role {
@@ -368,6 +385,14 @@ func converseMessages(msgs []Message) []types.Message {
 				blocks = append(blocks, &types.ContentBlockMemberText{Value: m.Content})
 			}
 			for _, tc := range m.ToolCalls {
+				if !hasTools {
+					// No ToolConfig on this request: fold the call into
+					// text instead of a toolUse block Bedrock would reject.
+					blocks = append(blocks, &types.ContentBlockMemberText{
+						Value: flattenToolCallText(tc),
+					})
+					continue
+				}
 				blocks = append(blocks, &types.ContentBlockMemberToolUse{
 					Value: types.ToolUseBlock{
 						ToolUseId: aws.String(tc.ID),
@@ -385,6 +410,17 @@ func converseMessages(msgs []Message) []types.Message {
 			})
 		case "tool":
 			if m.ToolResult == nil {
+				continue
+			}
+			if !hasTools {
+				// No ToolConfig on this request: a toolResult block is
+				// rejected outright, so flatten to plain user text.
+				out = append(out, types.Message{
+					Role: types.ConversationRoleUser,
+					Content: []types.ContentBlock{&types.ContentBlockMemberText{
+						Value: flattenToolResultText(*m.ToolResult),
+					}},
+				})
 				continue
 			}
 			resultBlock := types.ContentBlock(&types.ContentBlockMemberToolResult{Value: types.ToolResultBlock{
@@ -429,6 +465,23 @@ func bedrockImageFormat(mime string) types.ImageFormat {
 	default:
 		return types.ImageFormatPng
 	}
+}
+
+// flattenToolCallText renders an assistant tool call as plain text for
+// requests with no ToolConfig, where a toolUse block would be rejected.
+func flattenToolCallText(tc ToolCall) string {
+	input := tc.Input
+	if len(input) == 0 {
+		input = json.RawMessage("{}")
+	}
+	return fmt.Sprintf("[tool call: %s(%s)]", tc.Name, string(input))
+}
+
+// flattenToolResultText renders a tool result as plain user text for
+// requests with no ToolConfig, where a toolResult block would be
+// rejected.
+func flattenToolResultText(tr ToolResult) string {
+	return fmt.Sprintf("[tool result for %s: %s]", tr.ID, tr.Content)
 }
 
 func toolResultStatus(isError bool) types.ToolResultStatus {

--- a/internal/gateway/provider/bedrock_test.go
+++ b/internal/gateway/provider/bedrock_test.go
@@ -21,7 +21,7 @@ func TestConverseMessages(t *testing.T) {
 		{Role: "tool"},      // no result payload: must be dropped
 	}
 
-	out := converseMessages(msgs)
+	out := converseMessages(msgs, true)
 	if len(out) != 3 {
 		t.Fatalf("len = %d, want 3", len(out))
 	}
@@ -62,7 +62,7 @@ func TestConverseMessagesMergesParallelToolResults(t *testing.T) {
 		{Role: "tool", ToolResult: &ToolResult{ID: "t2", Content: "9"}},
 	}
 
-	out := converseMessages(msgs)
+	out := converseMessages(msgs, true)
 	if len(out) != 2 {
 		t.Fatalf("len = %d, want 2 (one assistant turn, one merged user turn)", len(out))
 	}
@@ -93,7 +93,7 @@ func TestConverseMessagesDoesNotMergeIntoRealUserText(t *testing.T) {
 		{Role: "user", Content: "thanks, one more question"},
 	}
 
-	out := converseMessages(msgs)
+	out := converseMessages(msgs, true)
 	if len(out) != 3 {
 		t.Fatalf("len = %d, want 3 (assistant, tool result, plain user text kept separate)", len(out))
 	}
@@ -103,6 +103,100 @@ func TestConverseMessagesDoesNotMergeIntoRealUserText(t *testing.T) {
 	txt, ok := out[2].Content[0].(*types.ContentBlockMemberText)
 	if !ok || txt.Value != "thanks, one more question" {
 		t.Fatalf("msg 2 = %#v", out[2].Content[0])
+	}
+}
+
+// TestConverseMessagesFlattensToolHistoryWithoutTools reproduces the
+// live Bedrock ConverseStream 400: "ValidationException: The
+// toolConfig field must be defined when using toolUse and toolResult
+// content blocks." The brain loop's force-synthesis step nils Tools
+// but keeps the turn's tool call/result history in messages; with no
+// ToolConfig, toolUse/toolResult blocks must not appear at all.
+func TestConverseMessagesFlattensToolHistoryWithoutTools(t *testing.T) {
+	t.Parallel()
+	msgs := []Message{
+		{Role: "user", Content: "hi"},
+		{Role: "assistant", Content: "calling", ToolCalls: []ToolCall{
+			{ID: "t1", Name: "calc", Input: json.RawMessage(`{"a":1}`)},
+		}},
+		{Role: "tool", ToolResult: &ToolResult{ID: "t1", Content: "2"}},
+	}
+
+	out := converseMessages(msgs, false)
+	if len(out) != 3 {
+		t.Fatalf("len = %d, want 3", len(out))
+	}
+
+	// No toolUse or toolResult blocks anywhere.
+	for i, msg := range out {
+		for _, c := range msg.Content {
+			if _, ok := c.(*types.ContentBlockMemberToolUse); ok {
+				t.Fatalf("msg %d: found toolUse block, want none", i)
+			}
+			if _, ok := c.(*types.ContentBlockMemberToolResult); ok {
+				t.Fatalf("msg %d: found toolResult block, want none", i)
+			}
+		}
+	}
+
+	// Assistant message keeps its text plus a flattened tool-call block;
+	// it must never end up with zero content blocks.
+	if out[1].Role != types.ConversationRoleAssistant || len(out[1].Content) != 2 {
+		t.Fatalf("msg 1: role %v, %d blocks", out[1].Role, len(out[1].Content))
+	}
+	txt0, ok := out[1].Content[0].(*types.ContentBlockMemberText)
+	if !ok || txt0.Value != "calling" {
+		t.Fatalf("msg 1 block 0 = %#v", out[1].Content[0])
+	}
+	txt1, ok := out[1].Content[1].(*types.ContentBlockMemberText)
+	if !ok || !strings.Contains(txt1.Value, "calc") || !strings.Contains(txt1.Value, `"a":1`) {
+		t.Fatalf("msg 1 block 1 = %#v, want flattened tool call text", out[1].Content[1])
+	}
+
+	// Tool result flattens to plain user-role text.
+	if out[2].Role != types.ConversationRoleUser {
+		t.Fatalf("msg 2 role = %v, want user", out[2].Role)
+	}
+	if len(out[2].Content) != 1 {
+		t.Fatalf("msg 2 blocks = %d, want 1", len(out[2].Content))
+	}
+	rtxt, ok := out[2].Content[0].(*types.ContentBlockMemberText)
+	if !ok || !strings.Contains(rtxt.Value, "t1") || !strings.Contains(rtxt.Value, "2") {
+		t.Fatalf("msg 2 block 0 = %#v, want flattened tool result text", out[2].Content[0])
+	}
+}
+
+// TestConverseMessagesKeepsToolBlocksWhenToolsOffered proves the
+// hasTools=true path is byte-identical to pre-fix behavior: the same
+// history that gets flattened above must still produce real
+// toolUse/toolResult blocks when the request offers tools.
+func TestConverseMessagesKeepsToolBlocksWhenToolsOffered(t *testing.T) {
+	t.Parallel()
+	msgs := []Message{
+		{Role: "user", Content: "hi"},
+		{Role: "assistant", Content: "calling", ToolCalls: []ToolCall{
+			{ID: "t1", Name: "calc", Input: json.RawMessage(`{"a":1}`)},
+		}},
+		{Role: "tool", ToolResult: &ToolResult{ID: "t1", Content: "2"}},
+	}
+
+	out := converseMessages(msgs, true)
+	if len(out) != 3 {
+		t.Fatalf("len = %d, want 3", len(out))
+	}
+	if len(out[1].Content) != 2 {
+		t.Fatalf("msg 1 blocks = %d, want 2", len(out[1].Content))
+	}
+	tu, ok := out[1].Content[1].(*types.ContentBlockMemberToolUse)
+	if !ok || *tu.Value.ToolUseId != "t1" || *tu.Value.Name != "calc" {
+		t.Fatalf("msg 1 block 1 = %#v, want toolUse block", out[1].Content[1])
+	}
+	if out[2].Role != types.ConversationRoleUser {
+		t.Fatalf("msg 2 role = %v", out[2].Role)
+	}
+	tr, ok := out[2].Content[0].(*types.ContentBlockMemberToolResult)
+	if !ok || *tr.Value.ToolUseId != "t1" {
+		t.Fatalf("msg 2 block 0 = %#v, want toolResult block", out[2].Content[0])
 	}
 }
 

--- a/internal/gateway/provider/images_test.go
+++ b/internal/gateway/provider/images_test.go
@@ -148,7 +148,7 @@ func TestAnthropicMessagesTextOnlyUnchangedWireShape(t *testing.T) {
 
 func TestConverseMessagesImageBlock(t *testing.T) {
 	t.Parallel()
-	out := converseMessages([]Message{imageMsg("what is this?", "image/webp", "Q0M=")}) // base64("CC")
+	out := converseMessages([]Message{imageMsg("what is this?", "image/webp", "Q0M=")}, true) // base64("CC")
 
 	if len(out) != 1 || out[0].Role != types.ConversationRoleUser {
 		t.Fatalf("messages = %+v, want 1 user message", out)
@@ -180,7 +180,7 @@ func TestConverseMessagesImageBlock(t *testing.T) {
 // block appended, when Images is empty.
 func TestConverseMessagesTextOnlyUnchangedWireShape(t *testing.T) {
 	t.Parallel()
-	out := converseMessages([]Message{{Role: "user", Content: "hello"}})
+	out := converseMessages([]Message{{Role: "user", Content: "hello"}}, true)
 
 	if len(out) != 1 || len(out[0].Content) != 1 {
 		t.Fatalf("messages = %+v, want 1 message with exactly 1 content block", out)


### PR DESCRIPTION
AWS Bedrock ConverseStream rejects requests whose messages contain toolUse/toolResult content blocks but carry no ToolConfig (`ValidationException: The toolConfig field must be defined when using toolUse and toolResult content blocks`) — observed live on homelab as `bedrock_error` every time nova-lite served as a failover target for a conversation carrying tool history with no offered tools (the loop's force-synthesis turn nils Tools but keeps history).

When no tools are offered, the bedrock driver now flattens assistant tool calls to `[tool call: name(args)]` text blocks and tool results to user-role `[tool result for id: ...]` text blocks. Tool-bearing requests are byte-identical to before, pinned by test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790038234&installation_model_id=431401&pr_number=282&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F282&signature=4a40a062bc71618d3b2374bbf58ae6903c6cccf76cf7ecc69fd956769967b63e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->