### PR TITLE
feat: mission resilience — retry pacing, bounded auto-resume, failure capture

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -276,7 +276,7 @@ func main() {
 	}
 	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub, missionScheduler := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, fxStore, gwc, secrets, conns, mc, app.Log)
 	if missionDriver != nil {
-		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, app.Log)
+		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, missionNotifier, app.Log)
 	}
 	destinationStore, destinationDeliverer := buildDestinations(app.DB, conns, goog, secrets, flags, missionStore, app.Log)
 	if missionDriver != nil && destinationDeliverer != nil {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -69,7 +69,9 @@ func main() {
 	led := ledger.New(app.DB, app.Log)
 	agg := ledger.NewAggregator(app.DB)
 	budgets := ledger.NewBudgetStore(app.DB)
-	api.Register(app.Server, store, led, app.Log, app.Metrics)
+	// GATEWAY_FAILURE_CAPTURE_DIR: opt-in local diagnostics, off by
+	// default (D-066) — see api.Register.
+	api.Register(app.Server, store, led, app.Log, app.Metrics, os.Getenv("GATEWAY_FAILURE_CAPTURE_DIR"))
 	api.RegisterUsage(app.Server, agg, budgets)
 	api.RegisterAdmin(app.Server, admin.New(app.DB, store, led, budgets, secrets, cat, app.Log))
 

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -51,3 +51,9 @@ DOCKER_SOCK_GID=0
 # Local speech-to-text for the web mic button (~3 GiB RAM). Enable both:
 # COMPOSE_PROFILES=whisper
 # WHISPER_URL=http://whisper:8001
+
+# --- Gateway (optional) ---
+# Local-disk directory for failed-provider-attempt request capture
+# (debugging only). WARNING: captured files may contain sensitive
+# prompt content. Off by default; never enable on a shared host.
+# GATEWAY_FAILURE_CAPTURE_DIR=

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -144,6 +144,12 @@ type Driver struct {
 	// the clone.
 	resolveCloneToken CloneTokenResolver
 
+	// retryDelayFn paces a worker_failed retry (see retryDelay) —
+	// defaults to retryDelay in NewDriver, overridden to a zero-delay
+	// stub by tests that drive multiple worker_failed rounds and can't
+	// afford to actually sleep.
+	retryDelayFn func(consecutiveFailures int) time.Duration
+
 	// resolveCloneIdentity resolves a github-kind connector_id to the
 	// commit identity (name, email) ensureProvisioned sets as the
 	// clone's local git config (see SetCloneIdentityResolver) — nil-safe:
@@ -227,10 +233,33 @@ func NewDriver(store driverStore, runner Runner, workspace *Workspace, notify no
 	return &Driver{
 		store: store, runner: runner, workspace: workspace, notify: notify, sessions: sessions, perms: perms, log: log,
 		sandboxExec: sandboxExec, sandboxRemove: sandboxRemove,
-		cfg:         DefaultConfig,
-		gatekeepers: map[string]*GatekeeperState{},
-		driving:     map[string]bool{},
+		cfg:          DefaultConfig,
+		gatekeepers:  map[string]*GatekeeperState{},
+		driving:      map[string]bool{},
+		retryDelayFn: retryDelay,
 	}
+}
+
+// workerFailedRetryDelays paces retries after a worker_failed
+// transition (D-064): back-to-back Advance calls with no delay hammer
+// a failing model at ~1/sec until the backoff pause finally kicks in —
+// this ladder slows that down without changing when the pause itself
+// fires (stepWorkerFailed's cfg.BackoffFailures ceiling is unchanged).
+var workerFailedRetryDelays = [...]time.Duration{5 * time.Second, 15 * time.Second, 45 * time.Second}
+
+// retryDelay maps a post-transition ConsecutiveFailures count to a
+// delay from workerFailedRetryDelays, saturating at the last rung.
+// consecutiveFailures <= 0 returns 0 (shouldn't happen post-failure,
+// but never a negative sleep).
+func retryDelay(consecutiveFailures int) time.Duration {
+	if consecutiveFailures <= 0 {
+		return 0
+	}
+	idx := consecutiveFailures - 1
+	if idx >= len(workerFailedRetryDelays) {
+		idx = len(workerFailedRetryDelays) - 1
+	}
+	return workerFailedRetryDelays[idx]
 }
 
 // SetAgentResolver wires the resolver ensureProvisioned uses to grant
@@ -748,6 +777,19 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 	if d.notify != nil {
 		if err := d.notify.OnTransition(ctx, m, before, t.Next.Status, failedReason(t.Events)); err != nil {
 			d.log.Warn("driver: notify failed", "mission_id", id, "error", err)
+		}
+	}
+	// D-064: a worker_failed retry that stays working (mission.retry, not
+	// a pause/fail) paces the next Advance instead of spinning back-to-back
+	// against a failing model at ~1/sec until the backoff pause. Only this
+	// input paces — InputWorkerRetry is the worker actively progressing,
+	// not failing, so it must not slow down.
+	if in.Input == InputWorkerFailed && t.Next.Status == StatusWorking {
+		if delay := d.retryDelayFn(t.Next.ConsecutiveFailures); delay > 0 {
+			select {
+			case <-ctx.Done():
+			case <-time.After(delay):
+			}
 		}
 	}
 	return t.Next.Status == StatusIdle || t.Next.Status == StatusWorking, nil

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -283,7 +283,9 @@ func fakeSandboxExec(ctx context.Context, missionID, environment, workdir, comma
 }
 
 func testDriver(store driverStore, runner Runner) *Driver {
-	return NewDriver(store, runner, nil, nil, nil, nil, fakeSandboxExec, nil, slog.Default())
+	d := NewDriver(store, runner, nil, nil, nil, nil, fakeSandboxExec, nil, slog.Default())
+	d.retryDelayFn = func(int) time.Duration { return 0 } // tests drive worker_failed rounds back-to-back; no real sleeps
+	return d
 }
 
 // fakeFXRates scripts LatestUSDRates for the budget-brake conversion
@@ -2125,5 +2127,24 @@ func TestFailedReason(t *testing.T) {
 				t.Fatalf("failedReason(%+v) = %q, want %q", tc.events, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestRetryDelay(t *testing.T) {
+	cases := []struct {
+		consecutiveFailures int
+		want                time.Duration
+	}{
+		{-1, 0},
+		{0, 0},
+		{1, 5 * time.Second},
+		{2, 15 * time.Second},
+		{3, 45 * time.Second},
+		{4, 45 * time.Second},
+	}
+	for _, tc := range cases {
+		if got := retryDelay(tc.consecutiveFailures); got != tc.want {
+			t.Fatalf("retryDelay(%d) = %v, want %v", tc.consecutiveFailures, got, tc.want)
+		}
 	}
 }

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -1041,3 +1041,51 @@ func (s *Store) Spend(ctx context.Context, missionID string) (MissionSpend, erro
 	}
 	return out, rows.Err()
 }
+
+// BackoffPausedMission is BackoffPaused's row: just enough to drive the
+// auto-resume ladder (sweep.go's autoResumeBackoff) without the cost of
+// a full Mission scan.
+type BackoffPausedMission struct {
+	ID        string
+	UpdatedAt time.Time
+}
+
+// BackoffPaused returns every mission currently paused with
+// pause_reason='backoff' — autoResumeBackoff's input.
+func (s *Store) BackoffPaused(ctx context.Context) ([]BackoffPausedMission, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("missions backoff paused: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT id, updated_at FROM missions WHERE status = 'paused' AND pause_reason = 'backoff'`)
+	if err != nil {
+		return nil, fmt.Errorf("missions backoff paused: %w", err)
+	}
+	defer rows.Close()
+	out := []BackoffPausedMission{}
+	for rows.Next() {
+		var m BackoffPausedMission
+		if err := rows.Scan(&m.ID, &m.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("missions backoff paused: %w", err)
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// CountBackoffPauses counts how many times missionID has previously
+// paused for backoff (mission.paused events with reason=backoff) —
+// autoResumeBackoff's input to the resume ladder.
+func (s *Store) CountBackoffPauses(ctx context.Context, missionID string) (int, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return 0, fmt.Errorf("missions count backoff pauses: %w", err)
+	}
+	var n int
+	err = db.QueryRow(ctx, `SELECT count(*) FROM mission_events
+		WHERE mission_id = $1 AND kind = 'mission.paused' AND payload->>'reason' = 'backoff'`, missionID).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("missions count backoff pauses: %w", err)
+	}
+	return n, nil
+}

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -1079,6 +1079,81 @@ func TestRecoverStaleWorking(t *testing.T) {
 	}
 }
 
+func TestBackoffPausedAndCountBackoffPauses(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	backoffID, err := s.Create(ctx, Mission{Goal: marker + "backoff-paused", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create backoff: %v", err)
+	}
+	pauseBackoff := func() {
+		if err := s.ApplyTransition(ctx, backoffID, Transition{
+			Next:   StepState{Phase: PhaseExecute, Status: StatusPaused, PauseReason: PauseBackoff},
+			Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseBackoff)}}},
+		}); err != nil {
+			t.Fatalf("ApplyTransition pause backoff: %v", err)
+		}
+	}
+	pauseBackoff()
+
+	infraID, err := s.Create(ctx, Mission{Goal: marker + "infra-paused", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create infra: %v", err)
+	}
+	if err := s.ApplyTransition(ctx, infraID, Transition{
+		Next:   StepState{Phase: PhaseExecute, Status: StatusPaused, PauseReason: PauseInfra},
+		Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseInfra)}}},
+	}); err != nil {
+		t.Fatalf("ApplyTransition pause infra: %v", err)
+	}
+
+	paused, err := s.BackoffPaused(ctx)
+	if err != nil {
+		t.Fatalf("BackoffPaused: %v", err)
+	}
+	byID := map[string]bool{}
+	for _, m := range paused {
+		byID[m.ID] = true
+	}
+	if !byID[backoffID] {
+		t.Fatal("BackoffPaused did not return the backoff-paused mission")
+	}
+	if byID[infraID] {
+		t.Fatal("BackoffPaused incorrectly returned an infra-paused mission")
+	}
+
+	n, err := s.CountBackoffPauses(ctx, backoffID)
+	if err != nil {
+		t.Fatalf("CountBackoffPauses: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("CountBackoffPauses after 1 pause = %d, want 1", n)
+	}
+
+	// Resume, then pause for backoff again — count must accumulate.
+	if err := s.ApplyTransition(ctx, backoffID, Transition{Next: StepState{Phase: PhaseExecute, Status: StatusIdle}}); err != nil {
+		t.Fatalf("ApplyTransition resume: %v", err)
+	}
+	pauseBackoff()
+
+	n, err = s.CountBackoffPauses(ctx, backoffID)
+	if err != nil {
+		t.Fatalf("CountBackoffPauses after 2nd pause: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("CountBackoffPauses after 2 pauses = %d, want 2", n)
+	}
+
+	n, err = s.CountBackoffPauses(ctx, infraID)
+	if err != nil {
+		t.Fatalf("CountBackoffPauses infra: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("CountBackoffPauses for an infra-only mission = %d, want 0", n)
+	}
+}
+
 func TestSpendExcludesUnbilledRows(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()

--- a/internal/brain/missions/sweep.go
+++ b/internal/brain/missions/sweep.go
@@ -2,6 +2,7 @@ package missions
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 )
@@ -47,6 +48,42 @@ type capacityChecker interface {
 	Capacity(ctx context.Context) (admit bool, reason string, err error)
 }
 
+// messageNotifier is the narrow slice of Notifier autoResumeBackoff
+// needs to warn about a mission it's given up auto-resuming — kept as
+// an interface for the same reason sandboxSweeper/capacityChecker are:
+// no unnecessary coupling to notify.go's concrete type from here.
+type messageNotifier interface {
+	NotifyMessage(ctx context.Context, missionID, kind, message string) error
+}
+
+// backoffStore is the narrow slice of *Store autoResumeBackoff needs —
+// an interface so its ladder logic is unit-testable against a faked
+// store, the same reasoning as driverStore in driver.go.
+type backoffStore interface {
+	BackoffPaused(ctx context.Context) ([]BackoffPausedMission, error)
+	CountBackoffPauses(ctx context.Context, missionID string) (int, error)
+}
+
+// signaler is the narrow slice of *Driver autoResumeBackoff needs to
+// resume a mission — an interface so the ladder logic is testable
+// against a fake capturing Signal calls without a real Store/Runner.
+type signaler interface {
+	Signal(ctx context.Context, id string, input Input) error
+}
+
+// autoResumeBackoffDelays ladders how long a backoff-paused mission
+// waits (since its last pause) before autoResumeBackoff resumes it
+// again, indexed by prior-backoff-pause count (1st, 2nd, 3rd). A
+// mission that has paused for backoff 4 or more times has a persistent
+// problem, not a transient outage, and needs a human — see
+// autoResumeBackoff.
+var autoResumeBackoffDelays = [...]time.Duration{5 * time.Minute, 15 * time.Minute, 60 * time.Minute}
+
+// autoResumeExhaustedAfter is the prior-backoff-pause count at and
+// above which autoResumeBackoff stops resuming a mission and instead
+// notifies once and leaves it paused for a human.
+const autoResumeExhaustedAfter = 4
+
 // admitWork reports whether the host can afford claiming another work
 // slot right now (D-056). A nil gate always admits (tests, and any
 // sandbox-less setup that never wired sandboxclient in). A gate that
@@ -72,9 +109,9 @@ func admitWork(ctx context.Context, gate capacityChecker, log *slog.Logger) (adm
 // sweeps orphaned sandbox containers on the same tick (see
 // runWorkSlotSweep). This is the one entry point cmd/brain/main.go
 // needs — it owns the Driver, which carries its own Store reference.
-func RecoverAndSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, log *slog.Logger) {
+func RecoverAndSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, notify messageNotifier, log *slog.Logger) {
 	recoverWorking(ctx, d, store, log)
-	runWorkSlotSweep(ctx, d, store, maxConcurrent, sandbox, capacity, log)
+	runWorkSlotSweep(ctx, d, store, maxConcurrent, sandbox, capacity, notify, log)
 }
 
 // sweepOrphanSandboxes runs on every runWorkSlotSweep tick (previously
@@ -144,7 +181,7 @@ func recoverWorking(ctx context.Context, d *Driver, store *Store, log *slog.Logg
 // re-Drives any 'working' mission stale past staleWorkingAfter — all on
 // the same tick. Runs until ctx is done — this call blocks, so
 // RecoverAndSweep's caller runs it in its own goroutine.
-func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, log *slog.Logger) {
+func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, notify messageNotifier, log *slog.Logger) {
 	ticker := time.NewTicker(workSlotSweepInterval)
 	defer ticker.Stop()
 	for {
@@ -154,6 +191,7 @@ func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurren
 		case <-ticker.C:
 			sweepOrphanSandboxes(ctx, store, sandbox, log)
 			reDriveStaleWorking(ctx, d, store, log)
+			autoResumeBackoff(ctx, d, store, notify, log)
 			// D-056: skip the claim entirely this tick if the host can't
 			// afford another working mission — the mission stays idle,
 			// and this same sweep retries it in workSlotSweepInterval; that
@@ -197,5 +235,60 @@ func reDriveStaleWorking(ctx context.Context, d *Driver, store *Store, log *slog
 				log.Error("stale working sweep: drive failed", "mission_id", id, "error", err)
 			}
 		}(m.ID)
+	}
+}
+
+// autoResumeBackoff self-heals missions paused for backoff (transient
+// worker/provider failures, PauseBackoff) without a human hitting
+// resume every time (D-065): n = prior backoff-pause count for the
+// mission; the ladder in autoResumeBackoffDelays gates how long since
+// the pause before resuming, growing with each successive pause so a
+// mission that keeps hitting backoff backs off harder each time. At
+// autoResumeExhaustedAfter or more prior pauses, the problem is
+// probably not transient — stop resuming and notify a human once
+// instead; NotifyMessage's per-(mission,kind,unread) dedupe (notify.go)
+// makes this safe to call again on every later tick without extra
+// state here.
+//
+// A resumed mission that is still over budget re-pauses immediately
+// with pause_reason='budget' (statemachine.go's budget brake runs
+// before the input switch), not 'backoff' — it naturally leaves
+// BackoffPaused's result set on the very next tick, no special case
+// needed here.
+func autoResumeBackoff(ctx context.Context, d signaler, store backoffStore, notify messageNotifier, log *slog.Logger) {
+	missions, err := store.BackoffPaused(ctx)
+	if err != nil {
+		log.Error("auto-resume backoff sweep: list failed", "error", err)
+		return
+	}
+	for _, m := range missions {
+		n, err := store.CountBackoffPauses(ctx, m.ID)
+		if err != nil {
+			log.Error("auto-resume backoff sweep: count pauses failed", "mission_id", m.ID, "error", err)
+			continue
+		}
+		if n <= 0 {
+			continue // no recorded backoff pause yet — nothing to ladder from
+		}
+		if n >= autoResumeExhaustedAfter {
+			if notify != nil {
+				msg := fmt.Sprintf("this mission has paused for backoff %d times and will not auto-resume again — it needs a human look", n)
+				if err := notify.NotifyMessage(ctx, m.ID, "auto_resume_exhausted", msg); err != nil {
+					log.Warn("auto-resume backoff sweep: notify failed", "mission_id", m.ID, "error", err)
+				}
+			}
+			continue
+		}
+		idx := n - 1
+		if idx >= len(autoResumeBackoffDelays) {
+			idx = len(autoResumeBackoffDelays) - 1
+		}
+		if time.Since(m.UpdatedAt) < autoResumeBackoffDelays[idx] {
+			continue // not due yet
+		}
+		log.Info("auto-resume backoff sweep: resuming a backoff-paused mission", "mission_id", m.ID, "prior_pauses", n)
+		if err := d.Signal(ctx, m.ID, InputResume); err != nil {
+			log.Error("auto-resume backoff sweep: signal failed", "mission_id", m.ID, "error", err)
+		}
 	}
 }

--- a/internal/brain/missions/sweep_test.go
+++ b/internal/brain/missions/sweep_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 )
 
 // fakeCapacityChecker scripts one Capacity call per test case.
@@ -62,5 +63,101 @@ func TestAdmitWork(t *testing.T) {
 				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
 			}
 		})
+	}
+}
+
+// fakeBackoffStore scripts BackoffPaused/CountBackoffPauses for
+// autoResumeBackoff tests without a real Postgres pool.
+type fakeBackoffStore struct {
+	paused []BackoffPausedMission
+	counts map[string]int
+}
+
+func (f fakeBackoffStore) BackoffPaused(ctx context.Context) ([]BackoffPausedMission, error) {
+	return f.paused, nil
+}
+
+func (f fakeBackoffStore) CountBackoffPauses(ctx context.Context, missionID string) (int, error) {
+	return f.counts[missionID], nil
+}
+
+// fakeSignaler captures Signal calls for autoResumeBackoff tests.
+type fakeSignaler struct {
+	signaled []string
+}
+
+func (f *fakeSignaler) Signal(ctx context.Context, id string, input Input) error {
+	f.signaled = append(f.signaled, id)
+	return nil
+}
+
+// fakeMessageNotifier captures NotifyMessage calls for
+// autoResumeBackoff tests.
+type fakeMessageNotifier struct {
+	notified []string
+}
+
+func (f *fakeMessageNotifier) NotifyMessage(ctx context.Context, missionID, kind, message string) error {
+	f.notified = append(f.notified, missionID)
+	return nil
+}
+
+// TestAutoResumeBackoffLadder covers D-065's ladder boundaries: just
+// before each threshold, the mission is left alone; just after, it's
+// resumed. n>=4 never resumes, and notifies exactly once per tick.
+func TestAutoResumeBackoffLadder(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	now := time.Now()
+
+	cases := []struct {
+		name       string
+		n          int
+		since      time.Duration
+		wantResume bool
+		wantNotify bool
+	}{
+		{"n=1 just before 5m due", 1, 5*time.Minute - time.Second, false, false},
+		{"n=1 just after 5m due", 1, 5*time.Minute + time.Second, true, false},
+		{"n=2 just before 15m due", 2, 15*time.Minute - time.Second, false, false},
+		{"n=2 just after 15m due", 2, 15*time.Minute + time.Second, true, false},
+		{"n=3 just before 60m due", 3, 60*time.Minute - time.Second, false, false},
+		{"n=3 just after 60m due", 3, 60*time.Minute + time.Second, true, false},
+		{"n=4 exhausted, never resumes", 4, 999 * time.Hour, false, true},
+		{"n=5 exhausted, never resumes", 5, 999 * time.Hour, false, true},
+		{"n=0 no recorded pause yet, skipped", 0, 999 * time.Hour, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := fakeBackoffStore{
+				paused: []BackoffPausedMission{{ID: "m1", UpdatedAt: now.Add(-tc.since)}},
+				counts: map[string]int{"m1": tc.n},
+			}
+			signaler := &fakeSignaler{}
+			notifier := &fakeMessageNotifier{}
+			autoResumeBackoff(context.Background(), signaler, store, notifier, log)
+
+			if resumed := len(signaler.signaled) == 1; resumed != tc.wantResume {
+				t.Fatalf("signaled = %v, want resume=%v", signaler.signaled, tc.wantResume)
+			}
+			if notified := len(notifier.notified) == 1; notified != tc.wantNotify {
+				t.Fatalf("notified = %v, want notify=%v", notifier.notified, tc.wantNotify)
+			}
+		})
+	}
+}
+
+// TestAutoResumeBackoffNilNotifierSafe confirms a nil notifier (no
+// wiring, matching every other nil-safe hook in this package) never
+// panics on the exhausted path.
+func TestAutoResumeBackoffNilNotifierSafe(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := fakeBackoffStore{
+		paused: []BackoffPausedMission{{ID: "m1", UpdatedAt: time.Now().Add(-999 * time.Hour)}},
+		counts: map[string]int{"m1": 4},
+	}
+	signaler := &fakeSignaler{}
+	autoResumeBackoff(context.Background(), signaler, store, nil, log)
+	if len(signaler.signaled) != 0 {
+		t.Fatal("exhausted mission must never be resumed")
 	}
 }

--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -36,16 +38,22 @@ type API struct {
 	ledger        ledger.Recorder
 	log           *slog.Logger
 	providerCalls *prometheus.CounterVec
+	// failureCaptureDir is GATEWAY_FAILURE_CAPTURE_DIR (D-066): empty
+	// (default) disables capture entirely.
+	failureCaptureDir string
 }
 
-// Register mounts the gateway API on the shared server.
-func Register(srv *httpserver.Server, store ConfigSource, rec ledger.Recorder, log *slog.Logger, m *metrics.Metrics) {
+// Register mounts the gateway API on the shared server. failureCaptureDir
+// is GATEWAY_FAILURE_CAPTURE_DIR — empty disables failed-attempt capture
+// (see captureFailure).
+func Register(srv *httpserver.Server, store ConfigSource, rec ledger.Recorder, log *slog.Logger, m *metrics.Metrics, failureCaptureDir string) {
 	a := &API{
 		store:  store,
 		ledger: rec,
 		log:    log,
 		providerCalls: m.NewCounterVec("provider_calls_total",
 			"Provider attempts by provider, route, and outcome.", "provider", "route", "status"),
+		failureCaptureDir: failureCaptureDir,
 	}
 	srv.Handle("POST /v1/stream", http.HandlerFunc(a.handleStream))
 	srv.Handle("POST /v1/embed", http.HandlerFunc(a.handleEmbed))
@@ -60,6 +68,45 @@ func Register(srv *httpserver.Server, store ConfigSource, rec ledger.Recorder, l
 func (a *API) recordAttempt(ctx context.Context, entry ledger.Entry) {
 	a.ledger.Record(ctx, entry)
 	a.providerCalls.WithLabelValues(entry.Provider, entry.Route, entry.Status).Inc()
+}
+
+// captureFailure writes one JSON file per failed-over provider attempt
+// to failureCaptureDir (D-066), when set — off by default. Debugging a
+// provider 400 otherwise means reaching for a stub provider just to see
+// the request the gateway actually sent, since a failed attempt is
+// dropped once its ledger row is written. A write failure here (bad
+// permissions, disk full) is logged and never affects the stream.
+func (a *API) captureFailure(entry ledger.Entry, route, purpose, providerName, model, reason string, completion provider.CompletionRequest) {
+	if a.failureCaptureDir == "" {
+		return
+	}
+	if err := os.MkdirAll(a.failureCaptureDir, 0o750); err != nil {
+		a.log.Warn("failure capture: mkdir failed", "dir", a.failureCaptureDir, "error", err)
+		return
+	}
+	capture := struct {
+		TS        time.Time                  `json:"ts"`
+		Route     string                     `json:"route"`
+		Purpose   string                     `json:"purpose"`
+		Provider  string                     `json:"provider"`
+		Model     string                     `json:"model"`
+		ErrorCode string                     `json:"error_code"`
+		Reason    string                     `json:"reason"`
+		Request   provider.CompletionRequest `json:"request"`
+	}{
+		TS: time.Now(), Route: route, Purpose: purpose,
+		Provider: providerName, Model: model,
+		ErrorCode: entry.ErrorCode, Reason: reason, Request: completion,
+	}
+	data, err := json.MarshalIndent(capture, "", "  ")
+	if err != nil {
+		a.log.Warn("failure capture: marshal failed", "error", err)
+		return
+	}
+	path := filepath.Join(a.failureCaptureDir, entry.ID+".json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		a.log.Warn("failure capture: write failed", "path", path, "error", err)
+	}
 }
 
 type streamRequest struct {
@@ -222,6 +269,7 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 				"provider", att.ProviderName, "model", att.Model,
 				"route", req.Route, "code", res.entry.ErrorCode,
 				"reason", res.reason)
+			a.captureFailure(res.entry, req.Route, req.Purpose, att.ProviderName, att.Model, res.reason, completion)
 			codes = append(codes, res.entry.ErrorCode)
 			a.recordAttempt(r.Context(), res.entry)
 			if next := i + 1; next < len(attempts) {

--- a/internal/gateway/api/api_test.go
+++ b/internal/gateway/api/api_test.go
@@ -512,7 +512,7 @@ func TestStreamFailoverCapturesFailedAttempt(t *testing.T) {
 	if len(entries) != 1 {
 		t.Fatalf("capture files = %d, want 1 (only the failed attempt)", len(entries))
 	}
-	data, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	data, err := os.ReadFile(filepath.Join(dir, entries[0].Name())) //nolint:gosec // reads back this test's own t.TempDir capture file
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}

--- a/internal/gateway/api/api_test.go
+++ b/internal/gateway/api/api_test.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -488,6 +490,62 @@ func TestStreamFailoverToSecondProvider(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(a.providerCalls.WithLabelValues("two", "coding", "ok")); got != 1 {
 		t.Fatalf("provider_calls_total{two,coding,ok} = %v, want 1", got)
+	}
+}
+
+// TestStreamFailoverCapturesFailedAttempt covers D-066's opt-in
+// diagnostics: with failureCaptureDir set, a failed-over attempt writes
+// one parseable JSON file containing the request messages and error
+// code.
+func TestStreamFailoverCapturesFailedAttempt(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a, _ := newAPI(snapshotFor(t, oaiFail(t).URL, oaiOK(t, "backup").URL))
+	a.failureCaptureDir = dir
+
+	postJSON(t, a.handleStream, `{"route":"coding","messages":[{"role":"user","content":"hi"}]}`)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("capture files = %d, want 1 (only the failed attempt)", len(entries))
+	}
+	data, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var capture struct {
+		Route     string `json:"route"`
+		Provider  string `json:"provider"`
+		ErrorCode string `json:"error_code"`
+		Request   struct {
+			Messages []provider.Message `json:"messages"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal(data, &capture); err != nil {
+		t.Fatalf("Unmarshal capture file: %v", err)
+	}
+	if capture.Route != "coding" || capture.Provider != "one" || capture.ErrorCode != "http_401" {
+		t.Fatalf("capture = %+v, want route=coding provider=one error_code=http_401", capture)
+	}
+	if len(capture.Request.Messages) != 1 || capture.Request.Messages[0].Content != "hi" {
+		t.Fatalf("capture.Request.Messages = %+v, want the original request messages", capture.Request.Messages)
+	}
+}
+
+// TestStreamFailoverNoCaptureWhenDirUnset confirms capture is off by
+// default: no failureCaptureDir means no files written anywhere, even
+// when an attempt fails over.
+func TestStreamFailoverNoCaptureWhenDirUnset(t *testing.T) {
+	t.Parallel()
+	a, _ := newAPI(snapshotFor(t, oaiFail(t).URL, oaiOK(t, "backup").URL))
+
+	postJSON(t, a.handleStream, `{"route":"coding","messages":[{"role":"user","content":"hi"}]}`)
+
+	if a.failureCaptureDir != "" {
+		t.Fatalf("failureCaptureDir = %q, want empty (default)", a.failureCaptureDir)
 	}
 }
 


### PR DESCRIPTION
Follow-ups from tonight's luna incident, hardening the failure-policy layer:

- **Retry pacing (D-064)**: worker_failed retries now wait 5s/15s/45s by consecutive-failure count instead of hammering a failing model ~1/sec until backoff.
- **Bounded auto-resume (D-065)**: the work sweep resumes backoff-paused missions 5m/15m/60m after each pause; a fourth backoff pause notifies once (`auto_resume_exhausted`) and stays paused for a human. Transient provider outages now self-heal; persistent problems still surface.
- **Failure capture (D-066)**: `GATEWAY_FAILURE_CAPTURE_DIR` (off by default) writes one JSON file per failed stream attempt with the full request + failure metadata — tonight's bedrock 400 took a stub provider to diagnose because the request was dropped. Local-only diagnostics, never served by any route; documented in env.example with a sensitivity warning.

Unit tests for the ladder boundaries, delay table, and capture on/off; integration tests for the two new Store queries. Canary run before merge (harness change).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790043147&installation_model_id=431401&pr_number=283&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F283&signature=faa03a0b67b1cf6f94b1bc0d6178fd0bec8aabb2b6fc47e4c0686fe5d08ea415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->