### PR TITLE
fix: deterministic hint model lookup, skip disabled providers

### DIFF
--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -863,9 +863,22 @@ func hasCapability(p provider.Provider, want provider.Capability) bool {
 }
 
 // findModel locates the first provider whose catalog entry has the
-// exact model id.
+// exact model id — in provider-name order, since map iteration would
+// make hint resolution nondeterministic when several providers serve
+// the same model id. Disabled rows are skipped here rather than left
+// for Resolve's entryGate: a disabled provider matching first would
+// consume the hint and silently drop it at the gate.
 func (s *Snapshot) findModel(model string) (ProviderRow, string, bool) {
-	for _, row := range s.byName {
+	names := make([]string, 0, len(s.byName))
+	for name := range s.byName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		row := s.byName[name]
+		if !row.Enabled {
+			continue
+		}
 		if _, ok := s.catalogModel(row, model); ok {
 			return row, model, true
 		}


### PR DESCRIPTION
`findModel` iterated the `byName` map: a model hint matching several providers resolved to a random one per request, and a disabled provider matching first consumed the hint and silently dropped it at the usability gate — the root of flaky `TestResolveHintExactModel` CI failures (its fixture has a disabled provider sharing the catalog namespace). Providers now try in sorted-name order, disabled rows skipped. Verified with -count=30 on the previously-flaky tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790082349&installation_model_id=431401&pr_number=284&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F284&signature=f79ae69f2b684e8145f307b4ae082e9ef4d3ecfcbcd77df87f4cacb92ac593af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->