### PR TITLE
feat: openai-responses gateway driver with reasoning continuity

### DIFF
--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -48,6 +48,9 @@ type StreamRequest struct {
 	// ForceTool names the single offered tool the model must call this
 	// step (D-063). Empty means auto, today's behavior.
 	ForceTool string `json:"force_tool,omitempty"`
+	// ProviderState is opaque driver continuation state (D-067), echoed
+	// back from the previous step's done Meta.ProviderState.
+	ProviderState json.RawMessage `json:"provider_state,omitempty"`
 }
 
 // windowsTTL matches the gateway's own config poll cadence: a fresher

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -243,7 +243,7 @@ func (a *Agent) SetWaitToolsReady(fn func(context.Context)) {
 type Request struct {
 	SessionID string
 	Route     string
-	Agent     string   // serving agent, for ledger attribution
+	Agent     string // serving agent, for ledger attribution
 	// ToolAllow filters the offered tool surface; empty means every
 	// base tool. Missions leave this nil for anything but the planner
 	// call (see runner.go). Chat's agent-authored allowlist (empty =
@@ -377,6 +377,14 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 	msgs := append([]provider.Message(nil), req.Messages...)
 	total := stream.Usage{}
 	var lastMeta *stream.Meta
+	// providerState is turn-local driver continuation state (D-067,
+	// e.g. openai-responses' previous_response_id): captured off each
+	// step's done Meta and echoed on the next step's request. It dies
+	// with the turn — nothing resets it mid-turn on purpose. On chain
+	// failover the serving driver can change mid-turn; the state names
+	// its origin driver, so a different driver ignores foreign state
+	// with no handling needed here.
+	var providerState json.RawMessage
 	effort := ""
 	toolCallCount := 0
 	coerced := false
@@ -400,17 +408,18 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			directive = tools.StepForceSynthesis
 		}
 		sreq := gwclient.StreamRequest{
-			Route:     route,
-			Agent:     req.Agent,
-			Purpose:   "chat",
-			ModelHint: hint,
-			System:    req.System,
-			Messages:  msgs,
-			Tools:     defs,
-			Effort:    effort,
-			SessionID: req.SessionID,
-			MissionID: req.MissionID,
-			ForceTool: forceTool,
+			Route:         route,
+			Agent:         req.Agent,
+			Purpose:       "chat",
+			ModelHint:     hint,
+			System:        req.System,
+			Messages:      msgs,
+			Tools:         defs,
+			Effort:        effort,
+			SessionID:     req.SessionID,
+			MissionID:     req.MissionID,
+			ForceTool:     forceTool,
+			ProviderState: providerState,
 		}
 		switch directive {
 		case tools.StepWarnFinalize:
@@ -492,6 +501,7 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 					terminal = ev
 					if ev.Meta != nil {
 						lastMeta = ev.Meta
+						providerState = ev.Meta.ProviderState
 					}
 				case stream.EventIncomplete:
 					terminal = ev

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -262,6 +262,40 @@ func TestAgentToolCallThenAnswer(t *testing.T) {
 	}
 }
 
+// TestAgentProviderStateEchoedAcrossSteps pins D-067: a driver's
+// continuation state (e.g. the openai-responses driver's
+// previous_response_id) riding a step's done Meta.ProviderState must be
+// echoed back on the turn's NEXT step request, and a fresh turn must
+// start with no state at all.
+func TestAgentProviderStateEchoedAcrossSteps(t *testing.T) {
+	t.Parallel()
+	state := json.RawMessage(`{"driver":"openai-responses","previous_response_id":"resp_1"}`)
+	toolStep := toolCallStep([2]string{"echo", `{"text":"hi"}`})
+	toolStep[len(toolStep)-1].Meta = &stream.Meta{Provider: "fake", Model: "fake-1", ProviderState: state}
+
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolStep,
+		finalStep("the echo said hi"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding", Messages: []provider.Message{{Role: "user", Content: "go"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	if len(gw.requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(gw.requests))
+	}
+	if len(gw.requests[0].ProviderState) != 0 {
+		t.Fatalf("first step ProviderState = %s, want empty on a fresh turn", gw.requests[0].ProviderState)
+	}
+	if string(gw.requests[1].ProviderState) != string(state) {
+		t.Fatalf("second step ProviderState = %s, want %s echoed from step 1's done Meta", gw.requests[1].ProviderState, state)
+	}
+}
+
 // cancelThenCutGateway streams one chunk, waits until the caller's
 // context is canceled, then closes the channel bare — no terminal.
 // This is the exact shape of the turn deadline racing a provider cut.

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -39,7 +39,7 @@ type pgxQuerier interface {
 // driver for — kind='api' rows only. kind='cli' rows (D-051) validate
 // against cliDrivers instead: they're mission-only executor providers
 // the gateway never builds a chat driver for at all.
-var drivers = map[string]bool{"anthropic": true, "openaicompat": true, "bedrock": true}
+var drivers = map[string]bool{"anthropic": true, "openaicompat": true, "openai-responses": true, "bedrock": true}
 
 // cliDrivers whitelists driver names valid on a kind='cli' provider
 // row. These never go through provider.Build; only their name and
@@ -1207,7 +1207,7 @@ func (a *Admin) Test(ctx context.Context, id, model string) (TestResult, error) 
 
 	timeout := probeTimeout(p.Options)
 	res := a.probe(ctx, drv, p.Name, model, snap.Prices(p.Name, model), timeout)
-	if res.OK && p.Driver == "openaicompat" && p.BaseURL != "" {
+	if res.OK && (p.Driver == "openaicompat" || p.Driver == "openai-responses") && p.BaseURL != "" {
 		res.ResponsesOK = a.probeResponses(ctx, p.BaseURL, p.CredentialRef, model, timeout)
 		if res.ResponsesOK != nil {
 			if err := a.setOpenAIResponses(ctx, id, *res.ResponsesOK); err != nil {
@@ -1293,7 +1293,7 @@ func (a *Admin) Validate(ctx context.Context, p Provider, model string) (TestRes
 
 	probeTO := probeTimeout(p.Options)
 	res := a.probe(ctx, drv, p.Name, model, nil, probeTO)
-	if res.OK && p.Driver == "openaicompat" && p.BaseURL != "" {
+	if res.OK && (p.Driver == "openaicompat" || p.Driver == "openai-responses") && p.BaseURL != "" {
 		// Report-only: Validate probes an unsaved config, so there is
 		// nothing to persist the result onto.
 		res.ResponsesOK = a.probeResponses(ctx, p.BaseURL, p.CredentialRef, model, probeTO)

--- a/internal/gateway/api/api.go
+++ b/internal/gateway/api/api.go
@@ -124,6 +124,9 @@ type streamRequest struct {
 	// ForceTool names the single offered tool the model must call this
 	// step (D-063). Empty means auto, today's behavior.
 	ForceTool string `json:"force_tool,omitempty"`
+	// ProviderState is opaque driver continuation state (D-067), echoed
+	// back from the previous step's done Meta.ProviderState.
+	ProviderState json.RawMessage `json:"provider_state,omitempty"`
 }
 
 // requiredVisionCapability derives whether this request needs a
@@ -238,12 +241,13 @@ func (a *API) handleStream(w http.ResponseWriter, r *http.Request) {
 	}
 
 	completion := provider.CompletionRequest{
-		System:    req.System,
-		Messages:  req.Messages,
-		Tools:     req.Tools,
-		MaxTokens: req.MaxTokens,
-		Effort:    req.Effort,
-		ForceTool: req.ForceTool,
+		System:        req.System,
+		Messages:      req.Messages,
+		Tools:         req.Tools,
+		MaxTokens:     req.MaxTokens,
+		Effort:        req.Effort,
+		ForceTool:     req.ForceTool,
+		ProviderState: req.ProviderState,
 	}
 
 	var codes []string
@@ -423,12 +427,20 @@ func streamAttempt(ctx context.Context, att router.Attempt, completion provider.
 			if currency == "" && res.entry.Cost != nil {
 				currency = "USD"
 			}
+			// Preserve the driver's own ProviderState (D-067) — e.g. the
+			// openai-responses driver's previous_response_id — the caller
+			// must echo it back on the turn's next step.
+			var providerState json.RawMessage
+			if ev.Meta != nil {
+				providerState = ev.Meta.ProviderState
+			}
 			ev.Meta = &stream.Meta{
-				Provider: att.ProviderName,
-				Model:    att.Model,
-				LedgerID: entry.ID,
-				Cost:     res.entry.Cost,
-				Currency: currency,
+				Provider:      att.ProviderName,
+				Model:         att.Model,
+				LedgerID:      entry.ID,
+				Cost:          res.entry.Cost,
+				Currency:      currency,
+				ProviderState: providerState,
 			}
 			send(ev)
 		default:

--- a/internal/gateway/api/api_test.go
+++ b/internal/gateway/api/api_test.go
@@ -118,8 +118,8 @@ func oaiEmptyDone(t *testing.T) *httptest.Server {
 // its ctx is done), so the provider layer never surfaces why.
 type silentCutProvider struct{ name string }
 
-func (p silentCutProvider) Name() string                    { return p.name }
-func (p silentCutProvider) Kind() provider.Kind              { return provider.KindAPI }
+func (p silentCutProvider) Name() string                        { return p.name }
+func (p silentCutProvider) Kind() provider.Kind                 { return provider.KindAPI }
 func (p silentCutProvider) Capabilities() []provider.Capability { return nil }
 func (p silentCutProvider) Stream(context.Context, provider.CompletionRequest) (<-chan stream.StreamEvent, error) {
 	ch := make(chan stream.StreamEvent)
@@ -134,12 +134,32 @@ func (p silentCutProvider) Stream(context.Context, provider.CompletionRequest) (
 // client must instead get an explicit terminal error frame.
 type midStreamCutProvider struct{ name string }
 
-func (p midStreamCutProvider) Name() string                       { return p.name }
+func (p midStreamCutProvider) Name() string                        { return p.name }
 func (p midStreamCutProvider) Kind() provider.Kind                 { return provider.KindAPI }
 func (p midStreamCutProvider) Capabilities() []provider.Capability { return nil }
 func (p midStreamCutProvider) Stream(context.Context, provider.CompletionRequest) (<-chan stream.StreamEvent, error) {
 	ch := make(chan stream.StreamEvent, 1)
 	ch <- stream.StreamEvent{Type: stream.EventChunk, Text: "hel"}
+	close(ch)
+	return ch, nil
+}
+
+// providerStateDoneProvider streams one chunk then a done event
+// carrying Meta.ProviderState — standing in for the openai-responses
+// driver's continuation state (D-067), to pin that streamAttempt/
+// handleStream preserve it rather than overwriting Meta wholesale.
+type providerStateDoneProvider struct {
+	name  string
+	state json.RawMessage
+}
+
+func (p providerStateDoneProvider) Name() string                        { return p.name }
+func (p providerStateDoneProvider) Kind() provider.Kind                 { return provider.KindAPI }
+func (p providerStateDoneProvider) Capabilities() []provider.Capability { return nil }
+func (p providerStateDoneProvider) Stream(context.Context, provider.CompletionRequest) (<-chan stream.StreamEvent, error) {
+	ch := make(chan stream.StreamEvent, 2)
+	ch <- stream.StreamEvent{Type: stream.EventChunk, Text: "hi"}
+	ch <- stream.StreamEvent{Type: stream.EventDone, Meta: &stream.Meta{ProviderState: p.state}}
 	close(ch)
 	return ch, nil
 }
@@ -633,6 +653,79 @@ func TestStreamAttemptMidStreamCutSendsErrorEvent(t *testing.T) {
 	}
 	if sent[1].Type != stream.EventError || sent[1].Err == nil || sent[1].Err.Code != "stream_cut" {
 		t.Fatalf("sent[1] = %+v, want an EventError with code stream_cut", sent[1])
+	}
+}
+
+// TestStreamAttemptPreservesProviderState pins D-067: a driver's own
+// Meta.ProviderState on the done event must survive streamAttempt's
+// Meta rebuild (which otherwise attributes provider/model/cost from
+// scratch, clobbering whatever the driver set).
+func TestStreamAttemptPreservesProviderState(t *testing.T) {
+	t.Parallel()
+	state := json.RawMessage(`{"driver":"openai-responses","previous_response_id":"resp_1"}`)
+	att := router.Attempt{Provider: providerStateDoneProvider{name: "one", state: state}, ProviderName: "one", Model: "m1"}
+	var sent []stream.StreamEvent
+	res := streamAttempt(t.Context(), att, provider.CompletionRequest{}, ledger.Entry{ID: "e1"}, nil, func(ev stream.StreamEvent) {
+		sent = append(sent, ev)
+	})
+	if res.failed {
+		t.Fatalf("res.failed = true, want a clean success: %+v", res)
+	}
+	if len(sent) != 2 || sent[1].Type != stream.EventDone {
+		t.Fatalf("sent = %+v, want [chunk, done]", sent)
+	}
+	if sent[1].Meta == nil || string(sent[1].Meta.ProviderState) != string(state) {
+		t.Fatalf("done Meta.ProviderState = %+v, want %s", sent[1].Meta, state)
+	}
+}
+
+// TestStreamProviderStatePassthrough pins D-067 end to end through
+// handleStream: streamRequest.provider_state reaches the openai-
+// responses driver's CompletionRequest.ProviderState (previous_response_id
+// on the wire), and the driver's own done Meta.ProviderState (the new
+// response id) rides back out on the SSE done event.
+func TestStreamProviderStatePassthrough(t *testing.T) {
+	t.Parallel()
+	incoming := `{"driver":"openai-responses","previous_response_id":"resp_old"}`
+
+	var gotPreviousID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var wire struct {
+			PreviousResponseID string `json:"previous_response_id"`
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &wire)
+		gotPreviousID = wire.PreviousResponseID
+		_, _ = fmt.Fprint(w, "event: response.output_text.delta\ndata: {\"delta\":\"ok\"}\n\n")
+		_, _ = fmt.Fprint(w, "event: response.completed\ndata: {\"response\":{\"id\":\"resp_new\",\"status\":\"completed\"}}\n\n")
+	}))
+	t.Cleanup(srv.Close)
+
+	rows := []router.ProviderRow{
+		{ID: "p1", Name: "one", Kind: "api", Driver: "openai-responses", BaseURL: srv.URL,
+			DefaultModel: "m1", Enabled: true},
+	}
+	routes := []router.RouteRow{
+		{Name: "coding", Chain: []router.ChainEntry{{ProviderID: "p1", Model: "m1"}}, Enabled: true},
+	}
+	snap, _ := router.BuildSnapshot(rows, routes, func(string) string { return "" }, nil)
+
+	a, _ := newAPI(snap)
+	body := fmt.Sprintf(`{"route":"coding","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"prior"}],"provider_state":%s}`, incoming)
+	w := postJSON(t, a.handleStream, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, body = %s", w.Code, w.Body.String())
+	}
+	if gotPreviousID != "resp_old" {
+		t.Fatalf("wire previous_response_id = %q, want resp_old", gotPreviousID)
+	}
+	events := sseEvents(t, w.Body.String())
+	done := events[len(events)-1]
+	if done.Type != stream.EventDone || done.Meta == nil || len(done.Meta.ProviderState) == 0 {
+		t.Fatalf("done event = %+v, want Meta.ProviderState set", done)
+	}
+	if !strings.Contains(string(done.Meta.ProviderState), "resp_new") {
+		t.Fatalf("done Meta.ProviderState = %s, want it to carry resp_new", done.Meta.ProviderState)
 	}
 }
 

--- a/internal/gateway/catalog/match.go
+++ b/internal/gateway/catalog/match.go
@@ -16,7 +16,7 @@ func CandidateProviders(driver, baseURL string) []string {
 		return []string{"anthropic"}
 	case "bedrock":
 		return []string{"bedrock", "bedrock_converse"}
-	case "openaicompat":
+	case "openaicompat", "openai-responses":
 		return candidatesForHost(baseURL)
 	default:
 		return nil

--- a/internal/gateway/provider/openairesponses.go
+++ b/internal/gateway/provider/openairesponses.go
@@ -1,0 +1,532 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+	"github.com/SumonMSelim/timothy/internal/platform/sse"
+)
+
+// OpenAIResponsesConfig configures one OpenAI Responses API provider
+// instance (D-067): every reasoning-class OpenAI model (gpt-5.4,
+// gpt-5.4-mini, gpt-5.6-*) returns empty streams over chat/completions
+// on tool-mandatory turns — the Responses API is required for
+// reasoning-item continuity.
+type OpenAIResponsesConfig struct {
+	Name    string
+	BaseURL string            // e.g. https://api.openai.com/v1 — no trailing slash
+	APIKey  string            // resolved secret value, never logged
+	Headers map[string]string // extra request headers
+	Timeout time.Duration     // hard per-request timeout, default 5m
+	// ReasoningEffort, when set, overrides the request's own Effort on
+	// every call to this provider instance (D-040), same precedence
+	// rules as OpenAICompatConfig.
+	ReasoningEffort string
+}
+
+// OpenAIResponses streams from OpenAI's Responses API.
+type OpenAIResponses struct {
+	cfg    OpenAIResponsesConfig
+	client *http.Client
+}
+
+// NewOpenAIResponses builds the driver; it performs no I/O.
+func NewOpenAIResponses(cfg OpenAIResponsesConfig) *OpenAIResponses {
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultTimeout
+	}
+	return &OpenAIResponses{cfg: cfg, client: &http.Client{}}
+}
+
+func (o *OpenAIResponses) Name() string { return o.cfg.Name }
+func (o *OpenAIResponses) Kind() Kind   { return KindAPI }
+
+func (o *OpenAIResponses) Capabilities() []Capability {
+	return []Capability{CapChat, CapStreaming, CapTools, CapVision}
+}
+
+// wire types (request)
+
+type orsContentPart struct {
+	Type     string `json:"type"` // "input_text" | "output_text" | "input_image"
+	Text     string `json:"text,omitempty"`
+	ImageURL string `json:"image_url,omitempty"`
+}
+
+// orsInputItem is one entry of the Responses API "input" array: a
+// message, a function call, or a function call's output. Only the
+// fields matching Type are populated.
+type orsInputItem struct {
+	Type    string           `json:"type"`
+	Role    string           `json:"role,omitempty"`
+	Content []orsContentPart `json:"content,omitempty"`
+	// function_call fields
+	CallID    string `json:"call_id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+	// function_call_output field
+	Output string `json:"output,omitempty"`
+}
+
+type orsTool struct {
+	Type        string          `json:"type"`
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
+	Strict      bool            `json:"strict"`
+}
+
+type orsRequest struct {
+	Model              string         `json:"model"`
+	Stream             bool           `json:"stream"`
+	Instructions       string         `json:"instructions,omitempty"`
+	Input              []orsInputItem `json:"input"`
+	MaxOutputTokens    int            `json:"max_output_tokens,omitempty"`
+	Reasoning          *orsReasoning  `json:"reasoning,omitempty"`
+	Tools              []orsTool      `json:"tools,omitempty"`
+	ToolChoice         any            `json:"tool_choice,omitempty"`
+	Store              bool           `json:"store"`
+	PreviousResponseID string         `json:"previous_response_id,omitempty"`
+}
+
+type orsReasoning struct {
+	Effort string `json:"effort"`
+}
+
+// orsState is the opaque continuation state this driver reads from
+// CompletionRequest.ProviderState and writes back on
+// stream.Meta.ProviderState — the reasoning-item passback the
+// Responses API requires without ever storing reasoning content
+// itself (D-067).
+type orsState struct {
+	Driver             string `json:"driver"`
+	PreviousResponseID string `json:"previous_response_id"`
+}
+
+const orsDriverTag = "openai-responses"
+
+// strictSchema normalizes t's input schema for OpenAI's strict
+// function-calling mode: unmarshal, and on the TOP-LEVEL object only
+// set additionalProperties:false and required to every declared
+// property name (strict mode demands every property required). If
+// unmarshal fails or there are no properties, the schema is returned
+// unchanged and strict is false for that tool — mirrors
+// sanitizeNovaSchema's top-level-only scoping (bedrock.go).
+func strictSchema(raw json.RawMessage) (json.RawMessage, bool) {
+	if len(raw) == 0 {
+		return raw, false
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return raw, false
+	}
+	props, ok := m["properties"].(map[string]any)
+	if !ok || len(props) == 0 {
+		return raw, false
+	}
+	required := make([]string, 0, len(props))
+	for k := range props {
+		required = append(required, k)
+	}
+	m["additionalProperties"] = false
+	m["required"] = required
+	out, err := json.Marshal(m)
+	if err != nil {
+		return raw, false
+	}
+	return out, true
+}
+
+// imageInputParts builds the input_image content parts for a user
+// message carrying images.
+func imageInputParts(images []ImageData) []orsContentPart {
+	parts := make([]orsContentPart, 0, len(images))
+	for _, img := range images {
+		parts = append(parts, orsContentPart{
+			Type:     "input_image",
+			ImageURL: "data:" + img.MediaType + ";base64," + img.Data,
+		})
+	}
+	return parts
+}
+
+// messageItem builds one message input item for a user/assistant
+// message.
+func messageItem(m Message) orsInputItem {
+	textType := "input_text"
+	if m.Role == "assistant" {
+		textType = "output_text"
+	}
+	item := orsInputItem{Type: "message", Role: m.Role}
+	if m.Content != "" {
+		item.Content = append(item.Content, orsContentPart{Type: textType, Text: m.Content})
+	}
+	if m.Role == "user" && len(m.Images) > 0 {
+		item.Content = append(item.Content, imageInputParts(m.Images)...)
+	}
+	return item
+}
+
+// appendMessage translates one req.Messages entry into its input
+// item(s), mirroring openaicompat.buildRequest's per-message switch:
+// a plain message becomes a message item, an assistant's tool calls
+// each become a function_call item (after the text item when
+// non-empty), and a tool result becomes a function_call_output item.
+func appendMessage(items []orsInputItem, m Message) []orsInputItem {
+	switch {
+	case m.Role == "tool" && m.ToolResult != nil:
+		output := m.ToolResult.Content
+		if m.ToolResult.IsError {
+			// Mirrors openaicompat's chat/completions convention: no
+			// native is_error flag on this shape either.
+			output = "ERROR: " + output
+		}
+		return append(items, orsInputItem{
+			Type: "function_call_output", CallID: m.ToolResult.ID, Output: output,
+		})
+	case len(m.ToolCalls) > 0:
+		if m.Content != "" {
+			items = append(items, messageItem(m))
+		}
+		for _, tc := range m.ToolCalls {
+			args := string(tc.Input)
+			if args == "" {
+				args = "{}"
+			}
+			items = append(items, orsInputItem{
+				Type: "function_call", CallID: tc.ID, Name: tc.Name, Arguments: args,
+			})
+		}
+		return items
+	default:
+		return append(items, messageItem(m))
+	}
+}
+
+// buildRequest builds the wire request. Fresh (state == nil) maps the
+// full req.Messages history; a matching continuation state instead
+// sets previous_response_id and maps only the messages after the last
+// assistant message — within a turn the loop appends
+// [assistant(tool_calls), tool results…] each step, and OpenAI holds
+// the reasoning items server-side under the previous response id
+// (D-067).
+func (o *OpenAIResponses) buildRequest(req CompletionRequest, state *orsState) orsRequest {
+	out := orsRequest{
+		Model:           req.Model,
+		Stream:          true,
+		Instructions:    req.System,
+		MaxOutputTokens: req.MaxTokens,
+		Store:           true,
+	}
+
+	effort := ""
+	if req.Effort == "low" {
+		effort = "low"
+	}
+	// A provider-level override wins over the per-request hint (D-040);
+	// a chain-entry override wins over both (D-063 precedent) — same
+	// precedence as openaicompat.buildRequest.
+	if o.cfg.ReasoningEffort != "" {
+		effort = o.cfg.ReasoningEffort
+	}
+	if req.ReasoningEffortOverride != "" {
+		effort = req.ReasoningEffortOverride
+	}
+	if effort == "none" {
+		// The Responses API rejects "none" outright; "minimal" is its
+		// closest equivalent for disabling visible reasoning effort.
+		effort = "minimal"
+	}
+	if effort != "" {
+		out.Reasoning = &orsReasoning{Effort: effort}
+	}
+
+	msgs := req.Messages
+	if state != nil {
+		msgs = messagesAfterLastAssistant(req.Messages)
+		out.PreviousResponseID = state.PreviousResponseID
+	}
+	for _, m := range msgs {
+		out.Input = appendMessage(out.Input, m)
+	}
+
+	for _, t := range req.Tools {
+		schema, strict := strictSchema(t.InputSchema)
+		out.Tools = append(out.Tools, orsTool{
+			Type: "function", Name: t.Name, Description: t.Description,
+			Parameters: schema, Strict: strict,
+		})
+	}
+	if req.ForceTool != "" && len(out.Tools) > 0 {
+		out.ToolChoice = map[string]any{"type": "function", "name": req.ForceTool}
+	}
+	return out
+}
+
+// messagesAfterLastAssistant returns the suffix of msgs strictly after
+// the last assistant message — the tool outputs (and any trailing user
+// correction) OpenAI hasn't seen yet under the chained response id. No
+// assistant message at all means the whole history is "after" (empty
+// slice would drop it); that shouldn't arise on a continuation in
+// practice but is handled safely by returning everything.
+func messagesAfterLastAssistant(msgs []Message) []Message {
+	last := -1
+	for i, m := range msgs {
+		if m.Role == "assistant" {
+			last = i
+		}
+	}
+	if last < 0 {
+		return msgs
+	}
+	return msgs[last+1:]
+}
+
+// parseState reads req.ProviderState, returning nil unless it names
+// this driver — a chain failover mid-turn can change the serving
+// driver, and the state carries its origin so a different driver
+// ignores foreign state rather than misinterpreting it.
+func parseState(raw json.RawMessage) *orsState {
+	if len(raw) == 0 {
+		return nil
+	}
+	var s orsState
+	if err := json.Unmarshal(raw, &s); err != nil || s.Driver != orsDriverTag {
+		return nil
+	}
+	return &s
+}
+
+// Stream implements Provider.
+func (o *OpenAIResponses) Stream(ctx context.Context, req CompletionRequest) (<-chan stream.StreamEvent, error) {
+	if req.Model == "" {
+		return nil, fmt.Errorf("openairesponses: model is required")
+	}
+	state := parseState(req.ProviderState)
+	wire := o.buildRequest(req, state)
+	body, err := json.Marshal(wire)
+	if err != nil {
+		return nil, fmt.Errorf("openairesponses: marshal request: %w", err)
+	}
+
+	ch := runStream(ctx, o.client, o.cfg.Timeout, retriesFor(req.FinalAttempt), o.buildFor(body), o.relay)
+	if state == nil {
+		return ch, nil
+	}
+	// A stale or foreign previous_response_id degrades to a fresh
+	// request (full history) rather than killing the turn — see
+	// retryStaleState.
+	return retryStaleState(ctx, o, req, ch), nil
+}
+
+// buildFor returns the request builder for a fixed, already-marshaled
+// body.
+func (o *OpenAIResponses) buildFor(body []byte) func(ctx context.Context) (*http.Request, error) {
+	return func(ctx context.Context) (*http.Request, error) {
+		r, err := http.NewRequestWithContext(ctx, http.MethodPost, o.cfg.BaseURL+"/responses", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		r.Header.Set("Content-Type", "application/json")
+		r.Header.Set("Authorization", "Bearer "+o.cfg.APIKey)
+		for k, v := range o.cfg.Headers {
+			r.Header.Set(k, v)
+		}
+		return r, nil
+	}
+}
+
+// retryStaleState peeks the first event off first (same pattern as
+// openaicompat.retryOn400): a bare http_400 as the very first event
+// means the request was rejected before any stream activity, which for
+// a previous_response_id request most likely means that id is stale or
+// belongs to a different conversation. Rebuild without continuation
+// state (full history) and retry once rather than failing the whole
+// turn over a passback quirk.
+func retryStaleState(ctx context.Context, o *OpenAIResponses, req CompletionRequest, first <-chan stream.StreamEvent) <-chan stream.StreamEvent {
+	out := make(chan stream.StreamEvent)
+	go func() {
+		defer close(out)
+		ev, ok := <-first
+		if !ok {
+			return
+		}
+		if isHTTP400(ev) {
+			wire := o.buildRequest(req, nil)
+			body, err := json.Marshal(wire)
+			if err != nil {
+				emit(ctx, out, errEvent(fmt.Errorf("openairesponses: marshal retry request: %w", err)))
+				return
+			}
+			retry := runStream(ctx, o.client, o.cfg.Timeout, retriesFor(req.FinalAttempt), o.buildFor(body), o.relay)
+			for ev := range retry {
+				if !emit(ctx, out, ev) {
+					return
+				}
+			}
+			return
+		}
+		if !emit(ctx, out, ev) {
+			return
+		}
+		for ev := range first {
+			if !emit(ctx, out, ev) {
+				return
+			}
+		}
+	}()
+	return out
+}
+
+// wire types (SSE payloads; only the fields we read)
+
+type orsOutputItem struct {
+	Type   string `json:"type"`
+	CallID string `json:"call_id"`
+	Name   string `json:"name"`
+}
+
+type orsUsage struct {
+	InputTokens        int `json:"input_tokens"`
+	InputTokensDetails struct {
+		CachedTokens int `json:"cached_tokens"`
+	} `json:"input_tokens_details"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+type orsResponse struct {
+	ID                string    `json:"id"`
+	Status            string    `json:"status"`
+	Usage             *orsUsage `json:"usage"`
+	IncompleteDetails *struct {
+		Reason string `json:"reason"`
+	} `json:"incomplete_details"`
+}
+
+type orsEventPayload struct {
+	Delta       string         `json:"delta"`
+	OutputIndex int            `json:"output_index"`
+	Item        *orsOutputItem `json:"item"`
+	Response    *orsResponse   `json:"response"`
+	Error       *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// relay translates the Responses API SSE stream into normalized
+// events.
+func (o *OpenAIResponses) relay(ctx context.Context, body io.Reader, ch chan<- stream.StreamEvent) (bool, error) {
+	tools := newToolAccumulator()
+	finished := false
+
+	err := sse.Read(body, func(ev sse.Event) bool {
+		var p orsEventPayload
+		if ev.Data != "" {
+			if err := json.Unmarshal([]byte(ev.Data), &p); err != nil {
+				emit(ctx, ch, stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
+					Code: "malformed_stream", Message: fmt.Sprintf("bad SSE payload: %v", err), Retryable: true,
+				}})
+				finished = true
+				return false
+			}
+		}
+
+		switch ev.Name {
+		case "response.output_text.delta":
+			return emit(ctx, ch, stream.StreamEvent{Type: stream.EventChunk, Text: p.Delta})
+		case "response.reasoning_summary_text.delta":
+			return emit(ctx, ch, stream.StreamEvent{Type: stream.EventReasoningChunk, Text: p.Delta})
+		case "response.output_item.added":
+			if p.Item != nil && p.Item.Type == "function_call" {
+				return emit(ctx, ch, tools.start(p.OutputIndex, p.Item.CallID, p.Item.Name))
+			}
+			return true
+		case "response.function_call_arguments.delta":
+			tools.append(p.OutputIndex, p.Delta)
+			return true
+		case "response.output_item.done":
+			if p.Item != nil && p.Item.Type == "function_call" {
+				if tev, ok := tools.finish(p.OutputIndex); ok {
+					return emit(ctx, ch, tev)
+				}
+			}
+			return true
+		case "response.completed":
+			if p.Response != nil && p.Response.Status == "failed" {
+				finished = true
+				msg := "response status failed"
+				if p.Error != nil && p.Error.Message != "" {
+					msg = p.Error.Message
+				}
+				emit(ctx, ch, stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
+					Code: "provider_error", Message: msg, Retryable: true,
+				}})
+				return false
+			}
+			finished = true
+			for _, tev := range tools.finishAll() {
+				if !emit(ctx, ch, tev) {
+					return false
+				}
+			}
+			var state *orsState
+			if p.Response != nil {
+				if p.Response.Usage != nil {
+					cached := p.Response.Usage.InputTokensDetails.CachedTokens
+					u := &stream.Usage{
+						InputTokens:     max(p.Response.Usage.InputTokens-cached, 0),
+						OutputTokens:    p.Response.Usage.OutputTokens,
+						CacheReadTokens: cached,
+					}
+					if !emit(ctx, ch, stream.StreamEvent{Type: stream.EventUsage, Usage: u}) {
+						return false
+					}
+				}
+				state = &orsState{Driver: orsDriverTag, PreviousResponseID: p.Response.ID}
+			}
+			var meta *stream.Meta
+			if state != nil {
+				if raw, err := json.Marshal(state); err == nil {
+					meta = &stream.Meta{ProviderState: raw}
+				}
+			}
+			emit(ctx, ch, stream.StreamEvent{Type: stream.EventDone, Meta: meta})
+			return false
+		case "response.failed", "error":
+			finished = true
+			msg := "response failed"
+			if p.Error != nil && p.Error.Message != "" {
+				msg = p.Error.Message
+			} else if p.Response != nil {
+				msg = fmt.Sprintf("response status %s", p.Response.Status)
+			}
+			emit(ctx, ch, stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
+				Code: "provider_error", Message: msg, Retryable: true,
+			}})
+			return false
+		case "response.incomplete":
+			finished = true
+			reason := "response incomplete"
+			if p.Response != nil && p.Response.IncompleteDetails != nil && p.Response.IncompleteDetails.Reason != "" {
+				reason = p.Response.IncompleteDetails.Reason
+			}
+			if !emit(ctx, ch, stream.StreamEvent{Type: stream.EventIncomplete, Text: reason}) {
+				return false
+			}
+			emit(ctx, ch, stream.StreamEvent{Type: stream.EventDone})
+			return false
+		default:
+			// Unknown event names (response.created, response.in_progress,
+			// output_item indices for message items, etc.) carry nothing
+			// this driver needs to forward.
+			return ctx.Err() == nil
+		}
+	})
+	return finished, err
+}

--- a/internal/gateway/provider/openairesponses_test.go
+++ b/internal/gateway/provider/openairesponses_test.go
@@ -1,0 +1,489 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/gateway/stream"
+)
+
+func orsWrite(w http.ResponseWriter, event, data string) {
+	_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data)
+	w.(http.Flusher).Flush()
+}
+
+func orsServer(t *testing.T, handler http.HandlerFunc) *OpenAIResponses {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return NewOpenAIResponses(OpenAIResponsesConfig{
+		Name: "ors-test", BaseURL: srv.URL, APIKey: "test-key",
+		Timeout: 10 * time.Second,
+	})
+}
+
+func decodeORSRequest(t *testing.T, r *http.Request) orsRequest {
+	t.Helper()
+	var req orsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	return req
+}
+
+// --- request build: fresh ---
+
+func TestOpenAIResponsesBuildFreshFullHistory(t *testing.T) {
+	t.Parallel()
+	var got orsRequest
+	p := orsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = decodeORSRequest(t, r)
+		orsWrite(w, "response.completed", `{"response":{"id":"resp_1","status":"completed"}}`)
+	})
+
+	req := CompletionRequest{
+		Model:  "gpt-5.4",
+		System: "be helpful",
+		Messages: []Message{
+			{Role: "user", Content: "hi"},
+			{Role: "assistant", Content: "hello"},
+		},
+	}
+	ch, err := p.Stream(t.Context(), req)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	collect(t, ch)
+
+	if got.Instructions != "be helpful" {
+		t.Fatalf("instructions = %q", got.Instructions)
+	}
+	if !got.Stream || !got.Store {
+		t.Fatalf("stream/store = %v/%v, want true/true", got.Stream, got.Store)
+	}
+	if got.PreviousResponseID != "" {
+		t.Fatalf("previous_response_id = %q, want empty on fresh request", got.PreviousResponseID)
+	}
+	if len(got.Input) != 2 {
+		t.Fatalf("input items = %d, want 2", len(got.Input))
+	}
+	if got.Input[0].Role != "user" || got.Input[0].Content[0].Type != "input_text" {
+		t.Fatalf("input[0] = %+v", got.Input[0])
+	}
+	if got.Input[1].Role != "assistant" || got.Input[1].Content[0].Type != "output_text" {
+		t.Fatalf("input[1] = %+v", got.Input[1])
+	}
+}
+
+func TestOpenAIResponsesStrictTools(t *testing.T) {
+	t.Parallel()
+	var got orsRequest
+	p := orsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = decodeORSRequest(t, r)
+		orsWrite(w, "response.completed", `{"response":{"id":"resp_1","status":"completed"}}`)
+	})
+
+	req := CompletionRequest{
+		Model:    "gpt-5.4",
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		Tools: []ToolDef{{
+			Name: "get_weather", Description: "gets weather",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`),
+		}},
+		ForceTool: "get_weather",
+	}
+	ch, err := p.Stream(t.Context(), req)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	collect(t, ch)
+
+	if len(got.Tools) != 1 {
+		t.Fatalf("tools = %d, want 1", len(got.Tools))
+	}
+	tool := got.Tools[0]
+	if !tool.Strict {
+		t.Fatalf("strict = false, want true for a valid object schema")
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(tool.Parameters, &schema); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	if schema["additionalProperties"] != false {
+		t.Fatalf("additionalProperties = %v, want false", schema["additionalProperties"])
+	}
+	required, _ := schema["required"].([]any)
+	if len(required) != 1 || required[0] != "city" {
+		t.Fatalf("required = %v, want [city]", required)
+	}
+	tc, ok := got.ToolChoice.(map[string]any)
+	if !ok || tc["type"] != "function" || tc["name"] != "get_weather" {
+		t.Fatalf("tool_choice = %+v", got.ToolChoice)
+	}
+}
+
+func TestOpenAIResponsesStrictToolFallback(t *testing.T) {
+	t.Parallel()
+	var got orsRequest
+	p := orsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = decodeORSRequest(t, r)
+		orsWrite(w, "response.completed", `{"response":{"id":"resp_1","status":"completed"}}`)
+	})
+
+	req := CompletionRequest{
+		Model:    "gpt-5.4",
+		Messages: []Message{{Role: "user", Content: "hi"}},
+		Tools: []ToolDef{{
+			Name: "no_props", Description: "has no properties key",
+			InputSchema: json.RawMessage(`{"type":"object"}`),
+		}},
+	}
+	ch, err := p.Stream(t.Context(), req)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	collect(t, ch)
+
+	if got.Tools[0].Strict {
+		t.Fatalf("strict = true, want false when the schema has no properties")
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(got.Tools[0].Parameters, &schema); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	if _, ok := schema["additionalProperties"]; ok {
+		t.Fatalf("schema mutated despite no properties: %+v", schema)
+	}
+}
+
+func TestOpenAIResponsesReasoningEffortPrecedence(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		reqEffort  string
+		cfgEffort  string
+		override   string
+		wantEffort string
+		wantOmit   bool
+	}{
+		{name: "empty omits reasoning", wantOmit: true},
+		{name: "req low", reqEffort: "low", wantEffort: "low"},
+		{name: "config overrides req", reqEffort: "low", cfgEffort: "medium", wantEffort: "medium"},
+		{name: "override wins over both", reqEffort: "low", cfgEffort: "medium", override: "high", wantEffort: "high"},
+		{name: "none maps to minimal", override: "none", wantEffort: "minimal"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var got orsRequest
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = decodeORSRequest(t, r)
+				orsWrite(w, "response.completed", `{"response":{"id":"resp_1","status":"completed"}}`)
+			}))
+			t.Cleanup(srv.Close)
+			p := NewOpenAIResponses(OpenAIResponsesConfig{
+				Name: "ors-test", BaseURL: srv.URL, APIKey: "k",
+				Timeout: 10 * time.Second, ReasoningEffort: tt.cfgEffort,
+			})
+			req := CompletionRequest{
+				Model: "gpt-5.4", Messages: []Message{{Role: "user", Content: "hi"}},
+				Effort: tt.reqEffort, ReasoningEffortOverride: tt.override,
+			}
+			ch, err := p.Stream(t.Context(), req)
+			if err != nil {
+				t.Fatalf("Stream: %v", err)
+			}
+			collect(t, ch)
+
+			if tt.wantOmit {
+				if got.Reasoning != nil {
+					t.Fatalf("reasoning = %+v, want omitted", got.Reasoning)
+				}
+				return
+			}
+			if got.Reasoning == nil || got.Reasoning.Effort != tt.wantEffort {
+				t.Fatalf("reasoning = %+v, want effort %q", got.Reasoning, tt.wantEffort)
+			}
+		})
+	}
+}
+
+func TestOpenAIResponsesImages(t *testing.T) {
+	t.Parallel()
+	var got orsRequest
+	p := orsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = decodeORSRequest(t, r)
+		orsWrite(w, "response.completed", `{"response":{"id":"resp_1","status":"completed"}}`)
+	})
+
+	req := CompletionRequest{
+		Model: "gpt-5.4",
+		Messages: []Message{{
+			Role: "user", Content: "what is this",
+			Images: []ImageData{{MediaType: "image/png", Data: "AAAA"}},
+		}},
+	}
+	ch, err := p.Stream(t.Context(), req)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	collect(t, ch)
+
+	if len(got.Input) != 1 || len(got.Input[0].Content) != 2 {
+		t.Fatalf("input = %+v", got.Input)
+	}
+	if got.Input[0].Content[1].Type != "input_image" || got.Input[0].Content[1].ImageURL != "data:image/png;base64,AAAA" {
+		t.Fatalf("image part = %+v", got.Input[0].Content[1])
+	}
+}
+
+// --- request build: continuation ---
+
+func TestOpenAIResponsesContinuationMatchingDriver(t *testing.T) {
+	t.Parallel()
+	var got orsRequest
+	p := orsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = decodeORSRequest(t, r)
+		orsWrite(w, "response.completed", `{"response":{"id":"resp_2","status":"completed"}}`)
+	})
+
+	state, _ := json.Marshal(orsState{Driver: "openai-responses", PreviousResponseID: "resp_1"})
+	req := CompletionRequest{
+		Model: "gpt-5.4",
+		Messages: []Message{
+			{Role: "user", Content: "hi"},
+			{Role: "assistant", ToolCalls: []ToolCall{{ID: "call_1", Name: "get_weather", Input: json.RawMessage(`{"city":"SF"}`)}}},
+			{Role: "tool", ToolResult: &ToolResult{ID: "call_1", Content: "sunny"}},
+		},
+		ProviderState: state,
+	}
+	ch, err := p.Stream(t.Context(), req)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	collect(t, ch)
+
+	if got.PreviousResponseID != "resp_1" {
+		t.Fatalf("previous_response_id = %q, want resp_1", got.PreviousResponseID)
+	}
+	// Only the post-last-assistant messages: the tool result.
+	if len(got.Input) != 1 {
+		t.Fatalf("input items = %d, want 1 (only the tool result): %+v", len(got.Input), got.Input)
+	}
+	if got.Input[0].Type != "function_call_output" || got.Input[0].CallID != "call_1" || got.Input[0].Output != "sunny" {
+		t.Fatalf("input[0] = %+v", got.Input[0])
+	}
+}
+
+func TestOpenAIResponsesContinuationForeignDriverIgnored(t *testing.T) {
+	t.Parallel()
+	var got orsRequest
+	p := orsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		got = decodeORSRequest(t, r)
+		orsWrite(w, "response.completed", `{"response":{"id":"resp_2","status":"completed"}}`)
+	})
+
+	state, _ := json.Marshal(orsState{Driver: "openaicompat", PreviousResponseID: "resp_1"})
+	req := CompletionRequest{
+		Model: "gpt-5.4",
+		Messages: []Message{
+			{Role: "user", Content: "hi"},
+			{Role: "assistant", Content: "hello"},
+		},
+		ProviderState: state,
+	}
+	ch, err := p.Stream(t.Context(), req)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	collect(t, ch)
+
+	if got.PreviousResponseID != "" {
+		t.Fatalf("previous_response_id = %q, want empty for foreign driver state", got.PreviousResponseID)
+	}
+	if len(got.Input) != 2 {
+		t.Fatalf("input items = %d, want full history (2)", len(got.Input))
+	}
+}
+
+// --- relay ---
+
+func TestOpenAIResponsesRelayFullTurn(t *testing.T) {
+	t.Parallel()
+	p := orsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		orsWrite(w, "response.output_text.delta", `{"delta":"Hel"}`)
+		orsWrite(w, "response.output_text.delta", `{"delta":"lo"}`)
+		orsWrite(w, "response.output_item.added", `{"output_index":0,"item":{"type":"function_call","call_id":"call_1","name":"get_weather"}}`)
+		orsWrite(w, "response.function_call_arguments.delta", `{"output_index":0,"delta":"{\"city"}`)
+		orsWrite(w, "response.function_call_arguments.delta", `{"output_index":0,"delta":"\":\"SF\"}"}`)
+		orsWrite(w, "response.output_item.done", `{"output_index":0,"item":{"type":"function_call","call_id":"call_1","name":"get_weather"}}`)
+		orsWrite(w, "response.completed", `{"response":{"id":"resp_9","status":"completed","usage":{"input_tokens":100,"output_tokens":10,"input_tokens_details":{"cached_tokens":40}}}}`)
+	})
+
+	ch, err := p.Stream(t.Context(), CompletionRequest{Model: "gpt-5.4", Messages: []Message{{Role: "user", Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	if got := textOf(events, stream.EventChunk); got != "Hello" {
+		t.Fatalf("chunks = %q, want Hello", got)
+	}
+	toolEnds := eventsOfType(events, stream.EventToolEnd)
+	if len(toolEnds) != 1 {
+		t.Fatalf("tool_end events = %d, want 1", len(toolEnds))
+	}
+	if toolEnds[0].ToolCall.ID != "call_1" || toolEnds[0].ToolCall.Name != "get_weather" {
+		t.Fatalf("tool call = %+v", toolEnds[0].ToolCall)
+	}
+	if string(toolEnds[0].ToolCall.Input) != `{"city":"SF"}` {
+		t.Fatalf("tool input = %s", toolEnds[0].ToolCall.Input)
+	}
+
+	usages := eventsOfType(events, stream.EventUsage)
+	if len(usages) != 1 {
+		t.Fatalf("usage events = %d, want 1", len(usages))
+	}
+	u := usages[0].Usage
+	if u.InputTokens != 60 || u.OutputTokens != 10 || u.CacheReadTokens != 40 {
+		t.Fatalf("usage = %+v", u)
+	}
+
+	done := events[len(events)-1]
+	if done.Type != stream.EventDone {
+		t.Fatalf("last = %v, want done", done.Type)
+	}
+	if done.Meta == nil || len(done.Meta.ProviderState) == 0 {
+		t.Fatalf("done Meta.ProviderState missing: %+v", done.Meta)
+	}
+	var state orsState
+	if err := json.Unmarshal(done.Meta.ProviderState, &state); err != nil {
+		t.Fatalf("unmarshal provider state: %v", err)
+	}
+	if state.Driver != "openai-responses" || state.PreviousResponseID != "resp_9" {
+		t.Fatalf("state = %+v", state)
+	}
+
+	// Ordering: chunks and tool_start before tool_end, usage before done.
+	toolStarts := eventsOfType(events, stream.EventToolStart)
+	if len(toolStarts) != 1 {
+		t.Fatalf("tool_start events = %d, want 1", len(toolStarts))
+	}
+}
+
+func TestOpenAIResponsesEmptyStream(t *testing.T) {
+	t.Parallel()
+	p := orsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		orsWrite(w, "response.completed", `{"response":{"id":"resp_1","status":"completed","usage":{"input_tokens":5,"output_tokens":0,"input_tokens_details":{"cached_tokens":0}}}}`)
+	})
+
+	ch, err := p.Stream(t.Context(), CompletionRequest{Model: "gpt-5.4", Messages: []Message{{Role: "user", Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	if len(eventsOfType(events, stream.EventChunk)) != 0 {
+		t.Fatalf("want no chunks: %+v", events)
+	}
+	if len(eventsOfType(events, stream.EventUsage)) != 1 {
+		t.Fatalf("want one usage event: %+v", events)
+	}
+	if lastType(t, events) != stream.EventDone {
+		t.Fatalf("last = %v, want done", lastType(t, events))
+	}
+}
+
+func TestOpenAIResponsesFailedEvent(t *testing.T) {
+	t.Parallel()
+	p := orsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		orsWrite(w, "response.failed", `{"error":{"message":"boom"}}`)
+	})
+
+	ch, err := p.Stream(t.Context(), CompletionRequest{Model: "gpt-5.4", Messages: []Message{{Role: "user", Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	errs := eventsOfType(events, stream.EventError)
+	if len(errs) != 1 || errs[0].Err.Message != "boom" || !errs[0].Err.Retryable {
+		t.Fatalf("error event = %+v", errs)
+	}
+}
+
+func TestOpenAIResponsesIncomplete(t *testing.T) {
+	t.Parallel()
+	p := orsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		orsWrite(w, "response.output_text.delta", `{"delta":"partial"}`)
+		orsWrite(w, "response.incomplete", `{"response":{"incomplete_details":{"reason":"max_output_tokens"}}}`)
+	})
+
+	ch, err := p.Stream(t.Context(), CompletionRequest{Model: "gpt-5.4", Messages: []Message{{Role: "user", Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	incs := eventsOfType(events, stream.EventIncomplete)
+	if len(incs) != 1 || incs[0].Text != "max_output_tokens" {
+		t.Fatalf("incomplete event = %+v", incs)
+	}
+	if lastType(t, events) != stream.EventDone {
+		t.Fatalf("last = %v, want done", lastType(t, events))
+	}
+}
+
+// --- stale-state 400 retry ---
+
+func TestOpenAIResponsesStaleStateRetry(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	var sawPreviousID []string
+	p := orsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		req := decodeORSRequest(t, r)
+		sawPreviousID = append(sawPreviousID, req.PreviousResponseID)
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		orsWrite(w, "response.output_text.delta", `{"delta":"ok"}`)
+		orsWrite(w, "response.completed", `{"response":{"id":"resp_new","status":"completed"}}`)
+	})
+
+	state, _ := json.Marshal(orsState{Driver: "openai-responses", PreviousResponseID: "resp_stale"})
+	req := CompletionRequest{
+		Model: "gpt-5.4",
+		Messages: []Message{
+			{Role: "user", Content: "hi"},
+			{Role: "assistant", Content: "hello"},
+		},
+		ProviderState: state,
+	}
+	ch, err := p.Stream(t.Context(), req)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	events := collect(t, ch)
+
+	if calls.Load() != 2 {
+		t.Fatalf("calls = %d, want 2 (retry after 400)", calls.Load())
+	}
+	if len(sawPreviousID) != 2 || sawPreviousID[0] != "resp_stale" || sawPreviousID[1] != "" {
+		t.Fatalf("previous_response_id across attempts = %v, want [resp_stale, \"\"]", sawPreviousID)
+	}
+	if got := textOf(events, stream.EventChunk); got != "ok" {
+		t.Fatalf("chunks = %q, want ok", got)
+	}
+	if len(eventsOfType(events, stream.EventError)) != 0 {
+		t.Fatalf("want no error event surfaced after successful retry: %+v", events)
+	}
+	if lastType(t, events) != stream.EventDone {
+		t.Fatalf("last = %v, want done", lastType(t, events))
+	}
+}

--- a/internal/gateway/provider/provider.go
+++ b/internal/gateway/provider/provider.go
@@ -122,6 +122,10 @@ type CompletionRequest struct {
 	// (D-063). Empty means auto, today's behavior. Drivers that cannot
 	// express a forced choice on the wire ignore it.
 	ForceTool string
+	// ProviderState is opaque driver continuation state (D-067), echoed
+	// by the caller from the previous response's Meta.ProviderState.
+	// Drivers ignore state naming a different driver or absent entirely.
+	ProviderState json.RawMessage
 }
 
 // Provider is one configured LLM provider. Stream returns quickly; all

--- a/internal/gateway/provider/registry.go
+++ b/internal/gateway/provider/registry.go
@@ -12,7 +12,7 @@ import (
 type Config struct {
 	Name          string
 	Kind          Kind
-	Driver        string // "anthropic" | "openaicompat" | "bedrock"
+	Driver        string // "anthropic" | "openaicompat" | "openai-responses" | "bedrock"
 	BaseURL       string
 	CredentialRef string
 	Headers       map[string]string
@@ -71,6 +71,18 @@ func Build(cfgs []Config, lookup func(string) string) (*Registry, error) {
 				return nil, fmt.Errorf("registry: provider %q: openaicompat requires base_url", c.Name)
 			}
 			p = NewOpenAICompat(OpenAICompatConfig{
+				Name: c.Name, BaseURL: c.BaseURL, APIKey: key,
+				Headers: c.Headers, Timeout: c.Timeout,
+				ReasoningEffort: c.ReasoningEffort,
+			})
+		case "openai-responses":
+			// D-067: the Responses API driver for reasoning-class OpenAI
+			// models that return empty streams over chat/completions on
+			// tool-mandatory turns.
+			if c.BaseURL == "" {
+				return nil, fmt.Errorf("registry: provider %q: openai-responses requires base_url", c.Name)
+			}
+			p = NewOpenAIResponses(OpenAIResponsesConfig{
 				Name: c.Name, BaseURL: c.BaseURL, APIKey: key,
 				Headers: c.Headers, Timeout: c.Timeout,
 				ReasoningEffort: c.ReasoningEffort,

--- a/internal/gateway/provider/registry_test.go
+++ b/internal/gateway/provider/registry_test.go
@@ -68,6 +68,31 @@ func TestBuildPassesReasoningEffortToOpenAICompat(t *testing.T) {
 	}
 }
 
+func TestBuildOpenAIResponses(t *testing.T) {
+	t.Parallel()
+	r, err := Build([]Config{
+		{Name: "oai-responses", Kind: KindAPI, Driver: "openai-responses",
+			BaseURL: "https://api.openai.com/v1", ReasoningEffort: "low"},
+	}, func(string) string { return "" })
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	p, ok := r.Get("oai-responses")
+	if !ok {
+		t.Fatal("oai-responses missing")
+	}
+	ors, ok := p.(*OpenAIResponses)
+	if !ok {
+		t.Fatalf("provider type = %T, want *OpenAIResponses", p)
+	}
+	if ors.cfg.ReasoningEffort != "low" {
+		t.Fatalf("ReasoningEffort = %q, want low", ors.cfg.ReasoningEffort)
+	}
+	if p.Kind() != KindAPI {
+		t.Fatalf("Kind = %v", p.Kind())
+	}
+}
+
 func TestBuildErrors(t *testing.T) {
 	t.Parallel()
 	noLookup := func(string) string { return "" }
@@ -92,6 +117,11 @@ func TestBuildErrors(t *testing.T) {
 		{
 			name:    "openaicompat without base url",
 			cfgs:    []Config{{Name: "p", Driver: "openaicompat"}},
+			wantErr: "requires base_url",
+		},
+		{
+			name:    "openai-responses without base url",
+			cfgs:    []Config{{Name: "p", Driver: "openai-responses"}},
 			wantErr: "requires base_url",
 		},
 		{

--- a/internal/gateway/stream/events.go
+++ b/internal/gateway/stream/events.go
@@ -95,6 +95,11 @@ type Meta struct {
 	DurationMs int64    `json:"duration_ms,omitempty"`
 	Cost       *float64 `json:"cost,omitempty"`
 	Currency   string   `json:"currency,omitempty"`
+	// ProviderState is opaque driver continuation state (D-067) — e.g.
+	// the openai-responses driver's previous_response_id — echoed back
+	// by the caller on the next CompletionRequest.ProviderState so the
+	// driver can chain reasoning items across turn steps.
+	ProviderState json.RawMessage `json:"provider_state,omitempty"`
 }
 
 // ToolCallEvent identifies a tool call. Input carries the complete

--- a/web/src/components/settings/presets.test.ts
+++ b/web/src/components/settings/presets.test.ts
@@ -51,4 +51,9 @@ describe('matchPreset', () => {
     const p = provider({ kind: 'cli', driver: 'claude-cli', base_url: '' })
     expect(matchPreset(p).id).toBe('anthropic')
   })
+
+  it('matches the openai-responses preset by driver, not the openai preset sharing its host', () => {
+    const p = provider({ driver: 'openai-responses', base_url: 'https://api.openai.com/v1' })
+    expect(matchPreset(p).id).toBe('openai-responses')
+  })
 })

--- a/web/src/components/settings/presets.ts
+++ b/web/src/components/settings/presets.ts
@@ -6,7 +6,7 @@ import type { AdminProvider } from '../../api/types'
 export interface ProviderPreset {
   id: string
   name: string
-  driver: 'openaicompat' | 'anthropic' | 'bedrock' | 'claude-cli'
+  driver: 'openaicompat' | 'openai-responses' | 'anthropic' | 'bedrock' | 'claude-cli'
   description: string
   // Sprite symbol in ProviderLogo; custom endpoints render a glyph.
   logo?: string
@@ -89,6 +89,21 @@ export const providerPresets: ProviderPreset[] = [
     name: 'OpenAI',
     driver: 'openaicompat',
     description: 'GPT and o-series models',
+    logo: 'openai',
+    brandColor: '#10A37F',
+    baseURL: 'https://api.openai.com/v1',
+    requiresKey: true,
+    defaultRef: 'OPENAI_API_KEY',
+    keyPlaceholder: 'sk-…',
+    keyHint: 'Create one at platform.openai.com/api-keys.',
+    keyURL: 'https://platform.openai.com/api-keys',
+    validateModel: 'gpt-4o-mini',
+  },
+  {
+    id: 'openai-responses',
+    name: 'OpenAI (Responses)',
+    driver: 'openai-responses',
+    description: 'GPT reasoning models via the Responses API',
     logo: 'openai',
     brandColor: '#10A37F',
     baseURL: 'https://api.openai.com/v1',
@@ -195,7 +210,7 @@ export function matchPreset(p: AdminProvider): ProviderPreset {
   if (p.kind === 'cli') {
     return providerPresets.find((x) => x.id === 'anthropic') ?? custom
   }
-  if (p.driver === 'anthropic' || p.driver === 'bedrock') {
+  if (p.driver === 'anthropic' || p.driver === 'bedrock' || p.driver === 'openai-responses') {
     return providerPresets.find((x) => x.driver === p.driver) ?? custom
   }
   // Ollama's fixed default port (11434) is a stronger signal than


### PR DESCRIPTION
Every reasoning-class OpenAI model (gpt-5.4, gpt-5.4-mini, gpt-5.6-luna/terra) returns empty streams over chat/completions on tool-mandatory mission turns — verified across 8 live mission runs. OpenAI's function-calling guide requires reasoning items returned with tool calls to be passed back with tool outputs; only the Responses API carries them.

New `openai-responses` driver (D-067):
- POST /responses streaming; SSE named-event relay onto the normalized stream contract (chunk/reasoning_chunk/tool_start/tool_end/usage/done), cached-token usage normalization matching openaicompat.
- **Reasoning continuity without storing reasoning**: within a turn, steps chain via `previous_response_id` carried as an opaque `ProviderState` blob on the done event's Meta and echoed by the brain loop on the next step; continuation requests send only post-last-assistant messages. Foreign/stale state is ignored or degrades to one fresh full-history retry on 400.
- `strict: true` tool schemas (top-level normalization) → guaranteed schema-valid tool arguments; per-tool fallback to non-strict when a schema can't normalize.
- ForceTool → forced function tool_choice; reasoning-effort precedence mirrors openaicompat with "none"→"minimal" mapping.
- Wiring: registry case, admin driver allowlist + /responses probe coverage, catalog namespace matching, web preset ("OpenAI (Responses)").

Providers stay wire adapters; using it is pure data (a second OpenAI provider row + chain entries). Tests: request-build (fresh/continuation/foreign state/strict/images/effort), full relay fixture, empty stream, failed/incomplete, stale-state retry, Meta preservation through the gateway, loop echo of ProviderState, registry, presets. Live homelab validation with gpt-5.4 planned post-merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790092644&installation_model_id=431401&pr_number=285&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F285&signature=946a7613bf180284b50a497d131c5b1fa675aa8eb079a97572d812a2dd2c9059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->