### PR TITLE
feat: validate plan contract at acceptance (D-068)

### DIFF
--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os/exec"
 	"regexp"
 	"slices"
 	"sort"
@@ -930,7 +931,7 @@ func renderReviewContent(p ReviewPacket) string {
 // stuck mission (5 straight "invalid plan JSON" failures, identical
 // each retry since nothing told the model what went wrong).
 func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes string) (Spec, error) {
-	system := "You are planning one mission. Break the goal into the SMALLEST ordered list of verifiable units that achieves it — one unit is correct for a simple goal; never pad the plan. artifacts lists the workspace-relative file(s) the unit must produce — the harness itself checks each exists and is non-empty, so name the real deliverables. verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory — it must be a real POSIX shell command (using binaries like grep, test, wc — NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Never use command substitution ($(...) or backticks) in verify_cmd — write the direct command instead. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. End your turn with exactly one submit_plan tool call." + r.execEnvironmentNote()
+	system := "You are planning one mission. Break the goal into the SMALLEST ordered list of verifiable units that achieves it — one unit is correct for a simple goal; never pad the plan. Every unit must list at least one artifact — the workspace-relative file(s) the unit must produce (for a report-style goal, the report file itself is the artifact); the harness itself checks each exists and is non-empty, so name the real deliverables. verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory — it must be a real POSIX shell command (using binaries like grep, test, wc — NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Never use command substitution ($(...) or backticks) in verify_cmd — write the direct command instead. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. End your turn with exactly one submit_plan tool call." + r.execEnvironmentNote()
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if exploreNotes != "" {
 		user += "\n\nExploration findings:\n" + NeutralizeSlot(exploreNotes)
@@ -1064,6 +1065,46 @@ func parseSpec(raw string) (Spec, error) {
 	for _, u := range spec.Units {
 		if strings.Contains(u.VerifyCmd, "$(") || strings.Contains(u.VerifyCmd, "`") {
 			return Spec{}, fmt.Errorf("mission runner: verify_cmd must not use command substitution ($(...) or backticks) — write the direct command instead")
+		}
+	}
+	// D-068: every unit must declare at least one artifact so the
+	// harness's CheckArtifacts has something to verify.
+	for _, u := range spec.Units {
+		if len(u.Artifacts) == 0 {
+			return Spec{}, fmt.Errorf("mission runner: unit %q must list at least one workspace-relative artifact file the harness can check (for a report-style goal, the report file itself is the artifact)", u.Title)
+		}
+	}
+	// D-068: reject verify_cmds that succeed regardless of outcome.
+	// Deny-set on the first shell word only, deliberately not a shell
+	// parser; a no-op buried after && is out of scope.
+	for _, u := range spec.Units {
+		cmd := strings.TrimSpace(u.VerifyCmd)
+		if cmd == "" {
+			return Spec{}, fmt.Errorf("mission runner: unit %q must have a verify_cmd that checks the CONTENT of its artifacts (e.g. grep) — a bare echo, true, :, or printf proves nothing", u.Title)
+		}
+		firstWord := cmd
+		if i := strings.IndexAny(cmd, " \t"); i >= 0 {
+			firstWord = cmd[:i]
+		}
+		switch firstWord {
+		case "echo", "true", ":", "printf":
+			return Spec{}, fmt.Errorf("mission runner: unit %q verify_cmd must check the CONTENT of its artifacts (e.g. grep) — a bare echo, true, :, or printf proves nothing", u.Title)
+		}
+	}
+	// D-068: verify_cmd must parse as POSIX shell (-n never executes).
+	// Skip silently if /bin/sh is missing so tests stay hermetic.
+	if shPath, err := exec.LookPath("/bin/sh"); err == nil {
+		for _, u := range spec.Units {
+			shCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			out, err := exec.CommandContext(shCtx, shPath, "-n", "-c", u.VerifyCmd).CombinedOutput()
+			cancel()
+			if err != nil {
+				stderr := strings.TrimSpace(string(out))
+				if len(stderr) > 200 {
+					stderr = stderr[:200]
+				}
+				return Spec{}, fmt.Errorf("mission runner: unit %q verify_cmd does not parse as POSIX shell: %s", u.Title, stderr)
+			}
 		}
 	}
 	// Passes is harness-only evidence (RunVerify); a plan is never born

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
+	"os/exec"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -410,7 +412,7 @@ func TestRunReviewFallsBackToTokenJSONTextSentinel(t *testing.T) {
 
 func TestPlanSessionParsesSpec(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
@@ -437,7 +439,7 @@ func TestPlanSessionParsesSpec(t *testing.T) {
 // planning turn's sole tool, the request forces it.
 func TestPlanSessionForcesPlanTool(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	if _, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, ""); err != nil {
@@ -453,7 +455,7 @@ func TestPlanSessionForcesPlanTool(t *testing.T) {
 // turn, so forcing submit_plan would make consulting them impossible.
 func TestPlanSessionNoForceToolWithKB(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	r.kbSearch = func(ctx context.Context, query string, collections []string, mode string, k int) ([]builtin.KBSearchHit, error) {
@@ -472,7 +474,7 @@ func TestPlanSessionNoForceToolWithKB(t *testing.T) {
 // PlanRoute when set, instead of Route.
 func TestPlanSessionUsesPlanRoute(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	m := Mission{ID: "m1", Route: "mini", PlanRoute: "strong", Goal: "fix bug"}
@@ -488,7 +490,7 @@ func TestPlanSessionUsesPlanRoute(t *testing.T) {
 // prior outcome digest reaches the planner's user prompt.
 func TestPlanSessionIncludesParentContext(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	m := Mission{ID: "m1", Route: "default", Goal: "fix bug", ParentContext: "prior mission fixed the signup bug"}
@@ -506,7 +508,7 @@ func TestPlanSessionIncludesParentContext(t *testing.T) {
 // attachment's markdown reaches the planner's user prompt.
 func TestPlanSessionIncludesAttachments(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	m := Mission{ID: "m1", Route: "default", Goal: "fix bug", Attachments: []MissionAttachment{
@@ -543,8 +545,8 @@ func TestPlanSessionRejectsEmptyPlan(t *testing.T) {
 // submission, with feedback the planner can act on immediately.
 func TestPlanSessionRejectsCommandSubstitution(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
-		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	_, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
@@ -560,8 +562,8 @@ func TestPlanSessionRejectsCommandSubstitution(t *testing.T) {
 // other opaque-form spelling of command substitution.
 func TestPlanSessionRejectsBackticks(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, "{\"units\":[{\"title\":\"Check output\",\"verify_cmd\":\"test `cat out.md` = ok\"}]}")},
-		{toolEndEvent(planToolName, "{\"units\":[{\"title\":\"Check output\",\"verify_cmd\":\"test `cat out.md` = ok\"}]}")},
+		{toolEndEvent(planToolName, "{\"units\":[{\"title\":\"Check output\",\"artifacts\":[\"out.md\"],\"verify_cmd\":\"test `cat out.md` = ok\"}]}")},
+		{toolEndEvent(planToolName, "{\"units\":[{\"title\":\"Check output\",\"artifacts\":[\"out.md\"],\"verify_cmd\":\"test `cat out.md` = ok\"}]}")},
 	}}
 	r := newTestRunner(agent)
 	_, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
@@ -579,8 +581,8 @@ func TestPlanSessionRejectsBackticks(t *testing.T) {
 // what was wrong and a corrected plan on the next turn is accepted.
 func TestPlanSessionRecoversFromCommandSubstitutionFeedback(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
-		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","verify_cmd":"grep -qi ok out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"verify_cmd":"grep -qi ok out.md"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
@@ -604,8 +606,8 @@ func TestPlanSessionRecoversFromCommandSubstitutionFeedback(t *testing.T) {
 func TestPlanSessionAcceptsLegitimateVerifyCmd(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{toolEndEvent(planToolName, `{"units":[`+
-			`{"title":"Check content","verify_cmd":"grep -qi 'foo' out.md"},`+
-			`{"title":"Check line count","verify_cmd":"test -f x && wc -l < x"}`+
+			`{"title":"Check content","artifacts":["out.md"],"verify_cmd":"grep -qi 'foo' out.md"},`+
+			`{"title":"Check line count","artifacts":["x"],"verify_cmd":"test -f x && wc -l < x"}`+
 			`]}`)},
 	}}
 	r := newTestRunner(agent)
@@ -618,6 +620,143 @@ func TestPlanSessionAcceptsLegitimateVerifyCmd(t *testing.T) {
 	}
 	if spec.Units[0].VerifyCmd != "grep -qi 'foo' out.md" || spec.Units[1].VerifyCmd != "test -f x && wc -l < x" {
 		t.Fatalf("PlanSession spec units = %+v", spec.Units)
+	}
+	if agent.call != 1 {
+		t.Fatalf("expected exactly one turn (no recovery needed), got %d", agent.call)
+	}
+}
+
+// TestPlanSessionRejectsUnitWithNoArtifacts guards D-068: a unit that
+// declares zero artifacts leaves the harness nothing to check, which
+// is exactly what let amazon.nova-2-lite's empty-contract unit
+// "succeed" on a verify_cmd that always exits 0. Recovery with an
+// artifact added must succeed.
+func TestPlanSessionRejectsUnitWithNoArtifacts(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, `{"units":[{"title":"Integrate Gmail API","verify_cmd":"grep -qi ok out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Integrate Gmail API","artifacts":["out.md"],"verify_cmd":"grep -qi ok out.md"}]}`)},
+	}}
+	r := newTestRunner(agent)
+	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if len(spec.Units) != 1 || len(spec.Units[0].Artifacts) != 1 {
+		t.Fatalf("PlanSession spec = %+v", spec)
+	}
+	if agent.call != 2 {
+		t.Fatalf("expected exactly two turns (original + one recovery), got %d", agent.call)
+	}
+	recoverReq := agent.requests[1]
+	last := recoverReq.Messages[len(recoverReq.Messages)-1]
+	if !strings.Contains(last.Content, "Integrate Gmail API") || !strings.Contains(last.Content, "artifact") {
+		t.Fatalf("recovery message = %q, want it to name the unit and mention artifacts", last.Content)
+	}
+}
+
+// TestPlanSessionRejectsNoOpVerifyCmd guards D-068's deny-set on the
+// verify_cmd's first shell word: echo/true/:/printf always exit 0
+// regardless of content, which is exactly the shape of the real
+// amazon.nova-2-lite incident (verify_cmd `echo 'Gmail API integration
+// required for actual execution'`, always passing, proving nothing).
+// A command that merely CONTAINS one of those words — as an argument,
+// or after && — must still be accepted; the deny-set only looks at
+// the first token, by design (see the scoping comment in parseSpec).
+func TestPlanSessionRejectsNoOpVerifyCmd(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+	}{
+		{"echo", `echo 'Gmail API integration required for actual execution'`},
+		{"true", `true`},
+		{"colon", `:`},
+		{"printf", `printf 'done\n'`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := fmt.Sprintf(`{"units":[{"title":"Ship it","artifacts":["out.md"],"verify_cmd":%q}]}`, tc.cmd)
+			agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+				{toolEndEvent(planToolName, plan)},
+				{toolEndEvent(planToolName, plan)},
+			}}
+			r := newTestRunner(agent)
+			_, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
+			if err == nil {
+				t.Fatalf("PlanSession accepted a no-op verify_cmd %q", tc.cmd)
+			}
+			if !strings.Contains(err.Error(), "CONTENT") {
+				t.Fatalf("PlanSession error = %q, want it to demand a content check", err.Error())
+			}
+		})
+	}
+}
+
+// TestPlanSessionAcceptsVerifyCmdContainingEchoWord confirms the
+// no-op deny-set only inspects the verify_cmd's FIRST shell word — a
+// real content check that happens to contain the word "echo" as an
+// argument, or a command containing "echo" later after &&, must pass.
+func TestPlanSessionAcceptsVerifyCmdContainingEchoWord(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, `{"units":[`+
+			`{"title":"Check literal word","artifacts":["file.md"],"verify_cmd":"grep -q echo file.md"},`+
+			`{"title":"Check then echo","artifacts":["report.md"],"verify_cmd":"test -s report.md && grep -q x report.md"}`+
+			`]}`)},
+	}}
+	r := newTestRunner(agent)
+	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if len(spec.Units) != 2 {
+		t.Fatalf("PlanSession spec = %+v", spec)
+	}
+	if agent.call != 1 {
+		t.Fatalf("expected exactly one turn (no recovery needed), got %d", agent.call)
+	}
+}
+
+// TestPlanSessionRejectsUnterminatedQuote guards D-068's POSIX shell
+// syntax gate: verify_cmd is run through the REAL /bin/sh -n (per this
+// repo's real-shell-tests convention — a fake shell would forgive
+// exactly the quoting bugs this check exists to catch). This mirrors
+// the real amazon.nova-lite incident, whose unterminated quote burned
+// execute iterations before failing at verify time, well after the
+// plan was accepted.
+func TestPlanSessionRejectsUnterminatedQuote(t *testing.T) {
+	if _, err := exec.LookPath("/bin/sh"); err != nil {
+		t.Skip("no /bin/sh on this machine")
+	}
+	bad := `grep -q "unterminated report.md`
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, fmt.Sprintf(`{"units":[{"title":"Ship it","artifacts":["report.md"],"verify_cmd":%q}]}`, bad))},
+		{toolEndEvent(planToolName, fmt.Sprintf(`{"units":[{"title":"Ship it","artifacts":["report.md"],"verify_cmd":%q}]}`, bad))},
+	}}
+	r := newTestRunner(agent)
+	_, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
+	if err == nil {
+		t.Fatal("PlanSession accepted a verify_cmd with an unterminated quote")
+	}
+	if !strings.Contains(err.Error(), "does not parse as POSIX shell") {
+		t.Fatalf("PlanSession error = %q, want it to name the shell parse failure", err.Error())
+	}
+}
+
+// TestPlanSessionAcceptsValidQuoting confirms the /bin/sh -n gate
+// doesn't false-positive on real, properly quoted verify_cmds.
+func TestPlanSessionAcceptsValidQuoting(t *testing.T) {
+	if _, err := exec.LookPath("/bin/sh"); err != nil {
+		t.Skip("no /bin/sh on this machine")
+	}
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, `{"units":[{"title":"Ship it","artifacts":["report.md"],"verify_cmd":"grep -qi 'retry-after' report.md"}]}`)},
+	}}
+	r := newTestRunner(agent)
+	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if len(spec.Units) != 1 {
+		t.Fatalf("PlanSession spec = %+v", spec)
 	}
 	if agent.call != 1 {
 		t.Fatalf("expected exactly one turn (no recovery needed), got %d", agent.call)
@@ -646,7 +785,7 @@ func TestPlanSessionRejectsMalformedJSON(t *testing.T) {
 func TestPlanSessionRecoversWithFeedback(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{textEvent("here's my plan in prose, no tool call")},
-		{toolEndEvent(planToolName, `{"units":[{"title":"Fix it","verify_cmd":"true"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Fix it","artifacts":["out.md"],"verify_cmd":"grep -qi ok out.md"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
@@ -1471,7 +1610,7 @@ func TestMissionRunnerRequestsAreBuiltinsOnly(t *testing.T) {
 	}
 
 	agent = &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"do it","verify_cmd":"true"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"do it","artifacts":["out.md"],"verify_cmd":"grep -qi ok out.md"}]}`)},
 	}}
 	r = newTestRunner(agent)
 	if _, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, ""); err != nil {

--- a/internal/brain/missions/sentinel.go
+++ b/internal/brain/missions/sentinel.go
@@ -86,14 +86,14 @@ func PlanTool() *tools.Tool {
 							"artifacts": {
 								"type": "array",
 								"items": {"type": "string"},
-								"description": "Workspace-relative file path(s) this unit must produce. Files only — the harness rejects directories."
+								"description": "Workspace-relative file path(s) this unit must produce. Required: at least one. Files only — the harness rejects directories."
 							},
 							"verify_cmd": {
 								"type": "string",
 								"description": "A real POSIX shell command, run as /bin/sh -c \"<verify_cmd>\" in the mission's workspace, that checks the CONTENT of the artifacts."
 							}
 						},
-						"required": ["title", "verify_cmd"]
+						"required": ["title", "artifacts", "verify_cmd"]
 					}
 				}
 			},


### PR DESCRIPTION
Rejects plans at acceptance that the harness has no way to check, feeding the planner's existing recovery loop instead of failing later at verify time:

- every unit must declare at least one workspace-relative artifact (report file counts for report-style goals)
- verify_cmd deny-set on the first shell word: bare `echo`, `true`, `:`, `printf` (and empty) rejected — always exit 0, prove nothing; first-token only by design, a no-op buried after `&&` is out of scope
- verify_cmd must parse as POSIX shell (`/bin/sh -n`, never executes; skipped if /bin/sh absent)

All three shapes came from real incidents (nova-lite/nova-2-lite plans). Plan-phase system prompt and submit_plan schema updated to state the artifact requirement; `artifacts` now in the tool schema's `required`.

Tests: six new PlanSession cases including real-/bin/sh round-trips for the syntax gate and first-word-only scoping; all existing parseSpec-reachable fixtures updated with artifacts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790094191&installation_model_id=431401&pr_number=286&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F286&signature=313b6c5e59bdcbdbb79c5b7ced80621b1991843082877b5331c19f57e4b7cfcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->