### PR TITLE
feat: light missions skip explore, plan, and review (D-069)

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -398,6 +398,11 @@ type createMissionRequest struct {
 	// enabled at create time (see create() below); the model never
 	// supplies or addresses a destination (D-061).
 	DestinationIDs []string `json:"destination_ids"`
+	// Light requests a mission that skips explore/plan/review (D-069):
+	// kind=general only, rejected outright on kind=coding (explicit or
+	// classified). Always the operator's explicit choice — the classify
+	// preview only suggests a value, never sets it.
+	Light bool `json:"light"`
 }
 
 // missionAttachmentInput names one already-uploaded attachment to
@@ -428,6 +433,10 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 	case "coding", "general":
 	default:
 		jsonError(w, http.StatusBadRequest, "bad_request", `kind must be "coding" or "general"`)
+		return
+	}
+	if req.Light && req.Kind != "general" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "light is only valid for kind=general missions")
 		return
 	}
 	if req.Harness == "native" {
@@ -609,7 +618,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		RepoURL: req.RepoURL, ConnectorID: req.ConnectorID, OnComplete: req.OnComplete,
 		BranchPattern: req.BranchPattern, CommitStyle: req.CommitStyle,
 		ParentMissionID: parentMissionID, ParentContext: parentContext,
-		Attachments: missionAtts, DestinationIDs: req.DestinationIDs,
+		Attachments: missionAtts, DestinationIDs: req.DestinationIDs, Light: req.Light,
 	}
 	id, err := h.driver.Create(r.Context(), m)
 	if err != nil {
@@ -744,10 +753,32 @@ func classifyKind(ctx context.Context, classify agents.Classify, goal string) st
 	return "coding"
 }
 
+// classifyLight decides whether a general-kind goal is single-pass
+// (deliverable in one worker turn, no plan or artifacts needed) — only
+// ever a suggestion for the web UI's toggle default; create() still
+// requires the operator's explicit light flag. Biased false on any
+// ambiguity or classify failure: a light suggestion is only useful when
+// confident, and defaulting the toggle on for a multi-step goal would
+// silently drop review/artifact checks the operator likely wants.
+func classifyLight(ctx context.Context, classify agents.Classify, goal string) bool {
+	if classify == nil {
+		return false
+	}
+	prompt := "Is this goal a single-pass task deliverable in one response — a read, summary, lookup, or short write-up with no multi-step plan or file artifacts? Answer with exactly one word, yes or no.\n\n" +
+		"Goal: " + goal
+	reply, err := classify(ctx, prompt)
+	if err != nil {
+		return false
+	}
+	reply = strings.ToLower(reply)
+	return strings.Contains(reply, "yes") && !strings.Contains(reply, "no")
+}
+
 // classifyGoal serves POST /v1/missions/classify: the same
 // classification create() falls back to when kind is omitted, exposed
 // standalone so the web UI's chip preview can show a mission's inferred
-// kind before submit without actually creating anything.
+// kind (and, for a general goal, a light suggestion) before submit
+// without actually creating anything.
 func (h *missionAPI) classifyGoal(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Goal string `json:"goal"`
@@ -760,7 +791,9 @@ func (h *missionAPI) classifyGoal(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "bad_request", "goal is required")
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]string{"kind": classifyKind(r.Context(), h.classify, req.Goal)})
+	kind := classifyKind(r.Context(), h.classify, req.Goal)
+	light := kind == "general" && classifyLight(r.Context(), h.classify, req.Goal)
+	writeJSON(w, http.StatusOK, map[string]any{"kind": kind, "light": light})
 }
 
 // executorOption is one registered harness's live pairing preview for

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -186,6 +186,42 @@ func TestMissionsCreateValidatesHarness(t *testing.T) {
 	}
 }
 
+// TestMissionsCreateValidatesLight covers light's create() gate
+// (D-069): rejected outright on an explicit kind=coding, and rejected
+// when kind is omitted and classifies as coding — light never overrides
+// a coding classification. light+general passes validation (reaching
+// the degraded store, same 400-for-a-different-reason shape
+// TestMissionsCreateValidatesHarness documents).
+func TestMissionsCreateValidatesLight(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+
+	post := func(classify func(context.Context, string) (string, error), body string) int {
+		m := mux(a)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "", nil)
+		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := post(nil, `{"goal":"g","kind":"coding","light":true}`); code != 400 {
+		t.Fatalf("light on explicit kind=coding = %d, want 400", code)
+	}
+	codingClassify := func(context.Context, string) (string, error) { return "coding", nil }
+	if code := post(codingClassify, `{"goal":"g","light":true}`); code != 400 {
+		t.Fatalf("light with omitted kind classified as coding = %d, want 400", code)
+	}
+	// light+general passes validation, reaching the degraded store.
+	if code := post(nil, `{"goal":"g","kind":"general","light":true}`); code != 400 {
+		t.Fatalf("light+general = %d, want 400 (passed validation, reached degraded store)", code)
+	}
+}
+
 // TestMissionsCreateValidatesRepoURL covers repo_url/connector_id's
 // create() gate: repo_url is coding-only, requires connector_id,
 // connector_id is only valid alongside repo_url, and an unknown
@@ -515,14 +551,69 @@ func TestClassifyKind(t *testing.T) {
 	}
 }
 
+// TestClassifyLight covers classifyLight's bias-false-on-ambiguity
+// shape, same reasoning as TestClassifyKind's bias-toward-coding: a
+// wrong "light" suggestion (the web UI's toggle default, never
+// create()'s own gate) is worse when it defaults a multi-step goal's
+// toggle to on than when it under-suggests.
+func TestClassifyLight(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		classify func(ctx context.Context, prompt string) (string, error)
+		want     bool
+	}{
+		{"nil classify defaults to false", nil, false},
+		{
+			"unambiguous yes reply", func(context.Context, string) (string, error) {
+				return "Yes", nil
+			}, true,
+		},
+		{
+			"unambiguous no reply", func(context.Context, string) (string, error) {
+				return "no", nil
+			}, false,
+		},
+		{
+			"reply mentioning both words defaults to false", func(context.Context, string) (string, error) {
+				return "yes, but also no", nil
+			}, false,
+		},
+		{
+			"garbage reply defaults to false", func(context.Context, string) (string, error) {
+				return "banana", nil
+			}, false,
+		},
+		{
+			"classify error defaults to false", func(context.Context, string) (string, error) {
+				return "", errors.New("gateway down")
+			}, false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyLight(context.Background(), tc.classify, "some goal")
+			if got != tc.want {
+				t.Fatalf("classifyLight() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestMissionsClassifyEndpoint covers POST /v1/missions/classify: the
-// happy path returning the classifier's verdict, and the empty-goal
-// 400 — this endpoint has no store/driver dependency, so it can be
-// tested end to end without Postgres.
+// happy path returning the classifier's verdict (kind and light), and
+// the empty-goal 400 — this endpoint has no store/driver dependency, so
+// it can be tested end to end without Postgres.
 func TestMissionsClassifyEndpoint(t *testing.T) {
 	t.Parallel()
 	a, _, _ := testAPI(t, "tok", nil)
-	classify := func(context.Context, string) (string, error) { return "general", nil }
+	classify := func(ctx context.Context, prompt string) (string, error) {
+		if strings.Contains(prompt, "single-pass") {
+			return "yes", nil
+		}
+		return "general", nil
+	}
 	m := mux(a)
 	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "", nil)
 
@@ -536,8 +627,8 @@ func TestMissionsClassifyEndpoint(t *testing.T) {
 
 	if code, body := call(`{"goal":"write a report on Q3 sales"}`); code != http.StatusOK {
 		t.Fatalf("classify with a goal = %d %s, want 200", code, body)
-	} else if !strings.Contains(body, `"kind":"general"`) {
-		t.Fatalf("classify body = %s, want kind general", body)
+	} else if !strings.Contains(body, `"kind":"general"`) || !strings.Contains(body, `"light":true`) {
+		t.Fatalf("classify body = %s, want kind general and light true", body)
 	}
 
 	if code, _ := call(`{"goal":""}`); code != http.StatusBadRequest {

--- a/internal/brain/api/schedules.go
+++ b/internal/brain/api/schedules.go
@@ -63,6 +63,16 @@ func (h *scheduleAPI) validateDestinationIDs(ctx context.Context, ids []string) 
 	return nil
 }
 
+// validateLightTemplate rejects a template that pairs light with
+// kind=coding — light (D-069) only makes sense for a kind=general
+// mission, same rule create() enforces for a one-off mission.
+func validateLightTemplate(t missions.MissionTemplate) error {
+	if t.Light && t.Kind != "general" {
+		return fmt.Errorf("mission_template.light is only valid for kind=general")
+	}
+	return nil
+}
+
 func failSchedule(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, missions.ErrNotFound):
@@ -133,6 +143,10 @@ func (h *scheduleAPI) create(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
+	if err := validateLightTemplate(req.MissionTemplate); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
 	enabled := true
 	if req.Enabled != nil {
 		enabled = *req.Enabled
@@ -169,6 +183,10 @@ func (h *scheduleAPI) patch(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.MissionTemplate != nil {
 		if err := h.validateDestinationIDs(r.Context(), req.MissionTemplate.DestinationIDs); err != nil {
+			jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+		if err := validateLightTemplate(*req.MissionTemplate); err != nil {
 			jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 			return
 		}

--- a/internal/brain/destinations/render.go
+++ b/internal/brain/destinations/render.go
@@ -64,11 +64,18 @@ func Render(m missions.Mission, webBaseURL string, events []missions.Event) Payl
 		links = append(links, url)
 	}
 	files, texts, oversize := resolveArtifactFiles(m)
+	body := "Mission complete: " + name
+	if m.Light && m.FinalOutput != "" {
+		// D-069: a light mission has no plan/artifacts, only its final
+		// worker message — that IS the result recipients want, not a
+		// completion line pointing them elsewhere.
+		body = m.FinalOutput
+	}
 	return Payload{
 		MissionID:     m.ID,
 		Name:          name,
 		Goal:          m.Goal,
-		Body:          "Mission complete: " + name,
+		Body:          body,
 		CompletedAt:   m.UpdatedAt.UTC(),
 		Links:         links,
 		Files:         files,

--- a/internal/brain/destinations/render_test.go
+++ b/internal/brain/destinations/render_test.go
@@ -115,6 +115,25 @@ func TestRender(t *testing.T) {
 		}
 	})
 
+	t.Run("light mission body is the final output, not a completion line", func(t *testing.T) {
+		light := m
+		light.Light = true
+		light.FinalOutput = "here is the complete deliverable"
+		p := Render(light, "", nil)
+		if p.Body != "here is the complete deliverable" {
+			t.Fatalf("Body = %q, want the light mission's final output", p.Body)
+		}
+	})
+
+	t.Run("light mission with no final output falls back to the completion line", func(t *testing.T) {
+		light := m
+		light.Light = true
+		p := Render(light, "", nil)
+		if p.Body != "Mission complete: Ship it" {
+			t.Fatalf("Body = %q, want the completion-line fallback", p.Body)
+		}
+	})
+
 	t.Run("CompletedAt carries the mission's UpdatedAt in UTC", func(t *testing.T) {
 		withTime := m
 		parsed, err := time.Parse(time.RFC3339, "2026-08-21T20:30:00+02:00")

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -74,6 +74,7 @@ type driverStore interface {
 	SetSession(ctx context.Context, id, sessionID string) error
 	SetProvisioned(ctx context.Context, id, workspace, worktree, branch, baseCommit string) error
 	SetLastEvidence(ctx context.Context, id, evidence string) error
+	SetFinalOutput(ctx context.Context, id, text string) error
 	SetExploreNotes(ctx context.Context, id, notes string) error
 	SetNameIfEmpty(ctx context.Context, id, name string) error
 	AppendProgress(ctx context.Context, id, note string) error
@@ -913,7 +914,7 @@ func (d *Driver) toStepState(ctx context.Context, m Mission) StepState {
 		ConsecutiveFailures: m.ConsecutiveFailures, LastGapFingerprint: m.LastGapFingerprint,
 		StallCount: m.StallCount, Spent: spent, Budget: m.BudgetAmount,
 		MixedCurrencySpend: mixed, RateAsOf: rateAsOf,
-		LastUnit: isLastUnit(m.Spec), ReplanUsed: m.ReplanUsed,
+		LastUnit: isLastUnit(m.Spec), ReplanUsed: m.ReplanUsed, Light: m.Light,
 	}
 }
 
@@ -978,7 +979,10 @@ func isLastUnit(spec Spec) bool {
 // runPhase runs the phase-appropriate session and returns the StepInput
 // its outcome maps to. It does not itself decide pass/fail semantics
 // beyond what each phase's contract already defines (worker sentinel,
-// review verdict, planner output).
+// review verdict, planner output). Light missions (D-069) are born in
+// PhaseExecute and short-circuit out of runExecute's done branch
+// straight to InputReviewApprove, so they never reach the explore/plan/
+// review cases below by construction.
 func (d *Driver) runPhase(ctx context.Context, m Mission) (StepInput, error) {
 	switch m.Phase {
 	case PhaseExplore:
@@ -1144,6 +1148,27 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 		}
 		if err := d.store.SetLastEvidence(ctx, m.ID, verdict.Evidence); err != nil {
 			d.log.Warn("driver: record evidence failed", "mission_id", m.ID, "error", err)
+		}
+		if m.Light {
+			// D-069: a light mission has no plan/artifacts for
+			// trySkipReview to check (it would bail into review for want
+			// of them) — the worker's final message IS the deliverable,
+			// so approve directly instead. FinalMessage is the text
+			// written since the worker's last non-sentinel tool call, not
+			// the whole multi-turn transcript (text) — fall back to text
+			// only when a worker never wrote anything after its last tool
+			// call (e.g. it called a tool, then immediately mission_status).
+			finalOutput := verdict.FinalMessage
+			if finalOutput == "" {
+				finalOutput = text
+			}
+			if err := d.store.SetFinalOutput(ctx, m.ID, finalOutput); err != nil {
+				d.log.Warn("driver: record final output failed", "mission_id", m.ID, "error", err)
+			}
+			if err := d.store.AppendEvent(ctx, m.ID, "mission.review_skipped", map[string]any{"reason": "light"}); err != nil {
+				d.log.Warn("driver: record review skip failed", "mission_id", m.ID, "error", err)
+			}
+			return StepInput{Input: InputReviewApprove}, nil
 		}
 		if in, ok := d.trySkipReview(ctx, m, verdict.SeenURLs); ok {
 			return in, nil
@@ -1483,6 +1508,7 @@ func (d *Driver) packet(ctx context.Context, m Mission) (WorkPacket, error) {
 		Goal: m.Goal, Kind: m.Kind, Spec: m.Spec, Progress: m.Progress,
 		GitLog: gitLog, Iteration: m.Iteration, PromptOverlay: m.PromptOverlay,
 		ExecEnvironmentNote: execEnvironmentNote(), ParentContext: m.ParentContext, Attachments: m.Attachments,
+		Light: m.Light,
 	}, nil
 }
 

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -154,6 +154,15 @@ func (f *fakeStore) SetLastEvidence(ctx context.Context, id, evidence string) er
 	return nil
 }
 
+func (f *fakeStore) SetFinalOutput(ctx context.Context, id, text string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	m := f.missions[id]
+	m.FinalOutput = text
+	f.missions[id] = m
+	return nil
+}
+
 func (f *fakeStore) SetExploreNotes(ctx context.Context, id, notes string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -613,6 +622,101 @@ func TestDriverExecuteRecordsRawTextWithoutHandoff(t *testing.T) {
 	}
 	if m.Progress[0].Note != "raw turn text" {
 		t.Fatalf("progress note = %q, want the raw turn text", m.Progress[0].Note)
+	}
+}
+
+// TestDriverLightDoneSetsFinalOutputAndSkipsToDone confirms a light
+// mission's done branch (D-069) short-circuits trySkipReview: it sets
+// FinalOutput to the worker's FinalMessage (the text since its last
+// non-sentinel tool call, NOT the whole multi-turn transcript — see
+// TestRunWorkerFinalMessageExcludesPriorToolRoundNarration for the
+// runner-level guarantee this relies on), records a mission.review_skipped
+// event with reason "light", and reaches PhaseDone in the same Advance
+// call without ever routing through review — Spec is empty, so LastUnit
+// is trivially true.
+func TestDriverLightDoneSetsFinalOutputAndSkipsToDone(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Light: true, Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
+	runner := &scriptedRunner{
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did the thing", FinalMessage: "here is the complete deliverable"}},
+		workerText:     "draft1 tool-retry-narration here is the complete deliverable",
+	}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseDone || m.Status != StatusDone {
+		t.Fatalf("light mission after done = %+v, want phase=done status=done", m)
+	}
+	if m.FinalOutput != "here is the complete deliverable" {
+		t.Fatalf("FinalOutput = %q, want the worker's FinalMessage, not the full multi-turn text", m.FinalOutput)
+	}
+	events, _ := store.Events(context.Background(), "m1")
+	found := false
+	for _, e := range events {
+		if e.Kind != "mission.review_skipped" {
+			continue
+		}
+		found = true
+		var payload struct {
+			Reason string `json:"reason"`
+		}
+		if err := json.Unmarshal(e.Payload, &payload); err != nil || payload.Reason != "light" {
+			t.Fatalf("mission.review_skipped payload = %s, want reason=light", e.Payload)
+		}
+	}
+	if !found {
+		t.Fatal("no mission.review_skipped event recorded for a light mission's done transition")
+	}
+}
+
+// TestDriverLightDoneFallsBackToFullTextWhenFinalMessageEmpty confirms
+// the defensive fallback: a worker verdict with no FinalMessage (e.g.
+// the delegated path, or a native worker whose last action was a tool
+// call immediately followed by mission_status with nothing written
+// after) still records something rather than an empty FinalOutput.
+func TestDriverLightDoneFallsBackToFullTextWhenFinalMessageEmpty(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Light: true, Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8})
+	runner := &scriptedRunner{
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did the thing"}}, // FinalMessage left empty
+		workerText:     "the only text the runner produced",
+	}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.FinalOutput != "the only text the runner produced" {
+		t.Fatalf("FinalOutput = %q, want fallback to the full turn text when FinalMessage is empty", m.FinalOutput)
+	}
+}
+
+// TestDriverNonLightDoneStillGoesThroughReview confirms the light
+// short-circuit is gated on m.Light: an ordinary general mission with a
+// unit that has no declared artifacts still falls through to
+// InputPhaseComplete (review), unchanged from before this feature.
+func TestDriverNonLightDoneStillGoesThroughReview(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8,
+		Spec: Spec{Units: []PlanUnit{{Title: "write summary.md"}}},
+	})
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did the thing"}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseReview {
+		t.Fatalf("non-light mission after done with no declared artifacts = %+v, want phase=review", m)
+	}
+	if m.FinalOutput != "" {
+		t.Fatalf("FinalOutput = %q, want empty for a non-light mission", m.FinalOutput)
 	}
 }
 

--- a/internal/brain/missions/memory.go
+++ b/internal/brain/missions/memory.go
@@ -15,6 +15,23 @@ import (
 // non-transition bookkeeping).
 const memoryExtractedKind = "mission.memory_extracted"
 
+// finalOutputDigestCap bounds how much of a light mission's
+// FinalOutput OutcomeDigest carries — the digest feeds memory
+// extraction and a follow-up mission's parent_context, not the whole
+// deliverable verbatim.
+const finalOutputDigestCap = 2000
+
+// truncateRunes is truncate's rune-safe counterpart: FinalOutput is
+// user-authored model output that can contain multi-byte UTF-8, where
+// byte-slicing risks cutting mid-character.
+func truncateRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
+}
+
 // MemoryExtract posts one mission's curated digest to memoryd for
 // long-term memory extraction — the same signature and fire-and-forget
 // contract as chat.MemoryExtract (see chat.go), so cmd/brain/main.go
@@ -137,6 +154,11 @@ func OutcomeDigest(m Mission, events []Event, terminal Phase, failureReason stri
 			}
 			fmt.Fprintf(&b, "- %s: %s\n", u.Title, status)
 		}
+	}
+	if m.Light && m.FinalOutput != "" {
+		b.WriteString("\nfinal output:\n")
+		b.WriteString(truncateRunes(m.FinalOutput, finalOutputDigestCap))
+		b.WriteString("\n")
 	}
 	if decision, findings, ok := lastReviewVerdict(events); ok {
 		fmt.Fprintf(&b, "\nreview verdict: %s\n", decision)

--- a/internal/brain/missions/memory_test.go
+++ b/internal/brain/missions/memory_test.go
@@ -70,6 +70,22 @@ func TestOutcomeDigest(t *testing.T) {
 			terminal:     PhaseDone,
 			wantExcludes: []string{"mission.turn", "\"ok\":true", "phase_complete"},
 		},
+		{
+			name: "light mission includes final output",
+			mission: Mission{
+				Goal: "summarize the doc", Kind: "general", Light: true,
+				FinalOutput: "the doc says X, Y, and Z",
+			},
+			events:       []Event{{Kind: "mission.review_skipped", Payload: json.RawMessage(`{"reason":"light"}`)}},
+			terminal:     PhaseDone,
+			wantContains: []string{"final output:", "the doc says X, Y, and Z"},
+		},
+		{
+			name:         "non-light mission never includes final output even if set",
+			mission:      Mission{Goal: "coded task", Kind: "coding", FinalOutput: "should never appear"},
+			terminal:     PhaseDone,
+			wantExcludes: []string{"final output:", "should never appear"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -85,6 +101,30 @@ func TestOutcomeDigest(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestOutcomeDigestTruncatesLightFinalOutput confirms a light mission's
+// FinalOutput is capped at finalOutputDigestCap runes (D-069) — the
+// digest feeds memory extraction and parent_context, not the whole
+// deliverable verbatim.
+func TestOutcomeDigestTruncatesLightFinalOutput(t *testing.T) {
+	long := strings.Repeat("é", finalOutputDigestCap+500) // multi-byte rune, proves rune- not byte-counting
+	m := Mission{Goal: "g", Kind: "general", Light: true, FinalOutput: long}
+	digest := OutcomeDigest(m, nil, PhaseDone, "")
+	i := strings.Index(digest, "final output:\n")
+	if i < 0 {
+		t.Fatal("digest missing final output section")
+	}
+	rendered := digest[i+len("final output:\n"):]
+	rendered, _, ok := strings.Cut(rendered, "\n\nterminal state:")
+	if !ok {
+		t.Fatalf("could not isolate the final output section from the rest of the digest:\n%s", digest)
+	}
+	got := []rune(rendered)
+	// truncateRunes appends one "…" rune after the cap.
+	if len(got) != finalOutputDigestCap+1 {
+		t.Fatalf("rendered final output = %d runes, want %d (cap + ellipsis)", len(got), finalOutputDigestCap+1)
 	}
 }
 

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -112,6 +112,14 @@ type Mission struct {
 	// (internal/brain/missions/executor). Coding-only; a general mission
 	// always runs native.
 	Harness string `json:"harness,omitempty"`
+	// Light missions (D-069, general kind only) skip explore/plan/
+	// review entirely: born in phase=execute, one bare worker turn, the
+	// final worker message is the deliverable.
+	Light bool `json:"light"`
+	// FinalOutput is a light mission's verbatim final worker message,
+	// set on the done transition (driver.go's runExecute) — the
+	// deliverable for destinations delivery and memory extraction.
+	FinalOutput string `json:"final_output,omitempty"`
 	// Environment selects the per-language sandbox image (D-05x) a
 	// coding mission's container runs: "" is the base image. Unlike
 	// Harness, there is no settings default — precedence is explicit

--- a/internal/brain/missions/packet.go
+++ b/internal/brain/missions/packet.go
@@ -46,6 +46,10 @@ type WorkPacket struct {
 	// every worker turn via Render, including a delegated executor's
 	// turn (executor packets also go through Render).
 	Attachments []MissionAttachment
+	// Light marks a mission that skips explore/plan/review (D-069) —
+	// Render uses lightSystemPreamble instead of nativeSystemPreamble,
+	// and Spec is always empty so the Plan block never renders.
+	Light bool
 }
 
 // nativeSystemPreamble is the mission_status/write_file contract a
@@ -54,12 +58,20 @@ type WorkPacket struct {
 // delegatedSystemPreamble instead).
 const nativeSystemPreamble = "You are executing one unit of a plan. Work toward the goal, then end your turn with exactly one mission_status tool call: done (with evidence), retry (with analysis), or blocked (with a question). Create or update files ONLY with the write_file tool using workspace-relative paths — never shell redirects (>, >>) or heredocs, which classify as writes requiring interactive approval and will stall you; artifact tracking depends on write_file being the only way files get created. Use shell for reading and checking, not writing. The harness verifies your declared artifacts exist on disk; describing a file is not producing it. When you end with retry or blocked, include a handoff note summarizing state, remaining work, and gotchas — the next session starts fresh and sees only your handoff, the plan, and the git log."
 
+// lightSystemPreamble is nativeSystemPreamble's counterpart for a light
+// mission (D-069): single pass, no plan, no artifact check — the
+// worker's final message is delivered to the user verbatim.
+const lightSystemPreamble = "You are completing this goal in a single pass. Work toward the goal, then end your turn with exactly one mission_status tool call: done (with evidence), retry (with analysis), or blocked (with a question). Your final message on done is delivered to the user as the result — make it the complete deliverable, not a summary of work done. Create or update files ONLY with the write_file tool using workspace-relative paths — never shell redirects (>, >>) or heredocs, which classify as writes requiring interactive approval and will stall you. Use shell for reading and checking, not writing. When you end with retry or blocked, include a handoff note summarizing state, remaining work, and gotchas — the next session starts fresh and sees only your handoff and the git log."
+
 // Render turns the packet into the system/user message a native
 // worker session's first turn receives. Progress notes and git log
 // content can contain prior model-produced text (a worker's own
 // commit messages, an earlier note); both pass through NeutralizeSlot
 // before insertion — self-injection hardening.
 func (p WorkPacket) Render() (system, user string) {
+	if p.Light {
+		return p.render(lightSystemPreamble)
+	}
 	return p.render(nativeSystemPreamble)
 }
 

--- a/internal/brain/missions/packet_test.go
+++ b/internal/brain/missions/packet_test.go
@@ -80,6 +80,21 @@ func TestWorkPacketRenderEmptyPacket(t *testing.T) {
 	}
 }
 
+// TestWorkPacketRenderLightUsesLightPreamble confirms a light packet
+// (D-069) gets lightSystemPreamble instead of the artifact-check
+// contract nativeSystemPreamble promises — a light mission has no plan
+// or artifacts for the harness to verify.
+func TestWorkPacketRenderLightUsesLightPreamble(t *testing.T) {
+	p := WorkPacket{Goal: "Summarize the doc", Light: true}
+	system, _ := p.Render()
+	if strings.Contains(system, "declared artifacts exist on disk") {
+		t.Fatalf("light system prompt still promises the artifact-check contract: %q", system)
+	}
+	if !strings.Contains(system, "delivered to the user as the result") {
+		t.Fatalf("light system prompt missing the deliverable framing: %q", system)
+	}
+}
+
 func TestWorkPacketRenderIncludesPromptOverlay(t *testing.T) {
 	p := WorkPacket{Goal: "Fix the login bug", PromptOverlay: "You are a careful senior engineer."}
 	system, _ := p.Render()

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -432,14 +432,22 @@ func (r *nativeRunner) belowFloor(model string) bool {
 // full assistant text. It does not itself decide what a missing
 // sentinel means — that's the caller's job (worker vs review have
 // different enforcement/parsing needs).
-func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTool string) (text string, sentinelArgs json.RawMessage, seenURLs []string, err error) {
+//
+// finalSeg is the assistant text written since the last non-sentinel
+// tool activity (EventToolEnd/EventToolResult) — a session can run
+// several internal tool-calling rounds before its sentinel call, and
+// full is every chunk across all of them (draft narration, tool-retry
+// commentary included), while finalSeg is just what the model wrote
+// right before ending its turn. The sentinel call itself never resets
+// finalSeg (it carries no assistant text of its own to lose).
+func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTool string) (full string, sentinelArgs json.RawMessage, seenURLs []string, finalSeg string, err error) {
 	ctx, cancel := context.WithTimeout(ctx, turnTimeout)
 	defer cancel()
 	events, err := r.agent.Start(ctx, req)
 	if err != nil {
-		return "", nil, nil, err
+		return "", nil, nil, "", err
 	}
-	var b strings.Builder
+	var b, finalB strings.Builder
 	// parked tracks in-flight parks by CallID, not a single flag — a
 	// turn can issue concurrent tool calls (executeAll runs up to
 	// maxParallelTools at once), so a sibling call finishing first must
@@ -457,12 +465,20 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 		switch ev.Type {
 		case stream.EventChunk:
 			b.WriteString(ev.Text)
+			finalB.WriteString(ev.Text)
 		case stream.EventToolEnd:
 			if ev.ToolCall != nil && ev.ToolCall.Name == sentinelTool {
 				sentinelArgs = ev.ToolCall.Input
 			}
 			if ev.ToolCall != nil && ev.ToolCall.Name == "web_fetch" {
 				seenURLs = append(seenURLs, webFetchArgURL(ev.ToolCall.Input)...)
+			}
+			// Any tool call OTHER than the sentinel is mid-turn activity —
+			// the text written before it is stale narration, not the
+			// deliverable. The sentinel call itself carries no assistant
+			// text of its own, so it must not reset finalSeg.
+			if ev.ToolCall != nil && ev.ToolCall.Name != sentinelTool {
+				finalB.Reset()
 			}
 		case stream.EventPermissionRequest:
 			if r.parker != nil && ev.Permission != nil {
@@ -490,6 +506,9 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if ev.ToolResult != nil && ev.ToolResult.Status == "ok" && ev.ToolResult.Name == "web_search" {
 				seenURLs = append(seenURLs, webSearchResultURLs(ev.ToolResult.Digest)...)
 			}
+			if ev.ToolResult != nil && ev.ToolResult.Name != sentinelTool {
+				finalB.Reset()
+			}
 		case stream.EventDone:
 			sawTerminal = true
 			if ev.Meta != nil {
@@ -504,7 +523,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if len(parked) > 0 && r.parker != nil {
 				r.parker.OnPermissionCleared(ctx, req.MissionID)
 			}
-			return b.String(), sentinelArgs, seenURLs, fmt.Errorf("mission runner: incomplete stream: %s", ev.Text)
+			return b.String(), sentinelArgs, seenURLs, finalB.String(), fmt.Errorf("mission runner: incomplete stream: %s", ev.Text)
 		case stream.EventError:
 			if len(parked) > 0 && r.parker != nil {
 				r.parker.OnPermissionCleared(ctx, req.MissionID)
@@ -513,19 +532,19 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if ev.Err != nil {
 				msg = ev.Err.Message
 			}
-			return b.String(), sentinelArgs, seenURLs, fmt.Errorf("mission runner: %s", msg)
+			return b.String(), sentinelArgs, seenURLs, finalB.String(), fmt.Errorf("mission runner: %s", msg)
 		}
 	}
 	if !sawTerminal {
 		if len(parked) > 0 && r.parker != nil {
 			r.parker.OnPermissionCleared(ctx, req.MissionID)
 		}
-		return b.String(), sentinelArgs, seenURLs, fmt.Errorf("mission runner: stream ended without a terminal event")
+		return b.String(), sentinelArgs, seenURLs, finalB.String(), fmt.Errorf("mission runner: stream ended without a terminal event")
 	}
 	if servedModel != "" && r.belowFloor(servedModel) {
-		return b.String(), sentinelArgs, seenURLs, fmt.Errorf("%w: %s", ErrModelFloor, servedModel)
+		return b.String(), sentinelArgs, seenURLs, finalB.String(), fmt.Errorf("%w: %s", ErrModelFloor, servedModel)
 	}
-	return b.String(), sentinelArgs, seenURLs, nil
+	return b.String(), sentinelArgs, seenURLs, finalB.String(), nil
 }
 
 // webFetchArgURL extracts the url arg from a web_fetch call's raw
@@ -637,12 +656,13 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		Unattended: m.ScheduleID != "",
 	}
 
-	text, args, seenURLs, err := r.runTurn(ctx, req, missionStatusToolName)
+	text, args, seenURLs, finalSeg, err := r.runTurn(ctx, req, missionStatusToolName)
 	if err != nil {
 		return WorkerVerdict{}, text, err
 	}
 	if v, ok := r.tryParseVerdict(args); ok {
 		v.SeenURLs = append(seenURLs, kbSeen.all()...)
+		v.FinalMessage = finalSeg
 		return v, text, nil
 	}
 
@@ -652,13 +672,14 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		provider.Message{Role: "assistant", Content: text},
 		provider.Message{Role: "user", Content: "[system] You must end your turn with exactly one mission_status tool call: done, retry, or blocked."},
 	)
-	recoverText, recoverArgs, recoverSeenURLs, err := r.runTurn(ctx, recoverReq, missionStatusToolName)
+	recoverText, recoverArgs, recoverSeenURLs, recoverFinalSeg, err := r.runTurn(ctx, recoverReq, missionStatusToolName)
 	seenURLs = append(seenURLs, recoverSeenURLs...)
 	if err != nil {
 		return WorkerVerdict{}, text + "\n" + recoverText, err
 	}
 	if v, ok := r.tryParseVerdict(recoverArgs); ok {
 		v.SeenURLs = append(seenURLs, kbSeen.all()...)
+		v.FinalMessage = recoverFinalSeg
 		return v, text + "\n" + recoverText, nil
 	}
 
@@ -676,6 +697,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		if v, ok := r.tryParseVerdict(raw); ok {
 			r.log.Warn("mission worker expressed mission_status as text, not a tool call", "mission_id", m.ID)
 			v.SeenURLs = append(seenURLs, kbSeen.all()...)
+			v.FinalMessage = recoverFinalSeg
 			return v, combined, nil
 		}
 	}
@@ -746,7 +768,7 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 		Unattended:   m.ScheduleID != "",
 	}
 
-	text, args, _, err := r.runTurn(ctx, req, exploreNotesToolName)
+	text, args, _, _, err := r.runTurn(ctx, req, exploreNotesToolName)
 	if err != nil {
 		return "", err
 	}
@@ -760,7 +782,7 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 		provider.Message{Role: "assistant", Content: text},
 		provider.Message{Role: "user", Content: "[system] You must end your turn with exactly one explore_notes tool call containing your findings."},
 	)
-	recoverText, recoverArgs, _, err := r.runTurn(ctx, recoverReq, exploreNotesToolName)
+	recoverText, recoverArgs, _, _, err := r.runTurn(ctx, recoverReq, exploreNotesToolName)
 	if err != nil {
 		return "", err
 	}
@@ -824,7 +846,7 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 		BuiltinsOnly: true,
 		Unattended:   m.ScheduleID != "",
 	}
-	text, args, _, err := r.runTurn(ctx, req, reviewVerdictToolName)
+	text, args, _, _, err := r.runTurn(ctx, req, reviewVerdictToolName)
 	if err != nil {
 		return ReviewVerdict{}, nil, err
 	}
@@ -838,7 +860,7 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 			provider.Message{Role: "assistant", Content: text},
 			provider.Message{Role: "user", Content: "[system] You must end your turn with exactly one review_verdict tool call: approve or rework."},
 		)
-		recoverText, recoverArgs, _, err := r.runTurn(ctx, recoverReq, reviewVerdictToolName)
+		recoverText, recoverArgs, _, _, err := r.runTurn(ctx, recoverReq, reviewVerdictToolName)
 		if err != nil {
 			return ReviewVerdict{}, nil, err
 		}
@@ -970,7 +992,7 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 	if len(extra) == 1 {
 		req.ForceTool = planToolName
 	}
-	text, args, _, err := r.runTurn(ctx, req, planToolName)
+	text, args, _, _, err := r.runTurn(ctx, req, planToolName)
 	if err != nil {
 		return Spec{}, err
 	}
@@ -996,7 +1018,7 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 		provider.Message{Role: "assistant", Content: text},
 		provider.Message{Role: "user", Content: "[system] Your last turn did not produce a usable plan: " + recoverReason + ". You must end this turn with exactly one submit_plan tool call."},
 	)
-	recoverText, recoverArgs, _, err := r.runTurn(ctx, recoverReq, planToolName)
+	recoverText, recoverArgs, _, _, err := r.runTurn(ctx, recoverReq, planToolName)
 	if err != nil {
 		return Spec{}, err
 	}

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -136,6 +136,34 @@ func TestRunWorkerSentinelPresent(t *testing.T) {
 	}
 }
 
+// TestRunWorkerFinalMessageExcludesPriorToolRoundNarration guards D-069's
+// light-mission delivery: a worker session with several internal
+// tool-calling rounds within ONE loop.Agent turn (draft narration, a
+// shell call, more narration, then the sentinel) must expose only the
+// text written since the last non-sentinel tool call as FinalMessage —
+// the deliverable, not the whole session's chatter. The full text
+// return (RunWorker's second value) stays unchanged: everything, in
+// order, for progress-note/log purposes.
+func TestRunWorkerFinalMessageExcludesPriorToolRoundNarration(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{{
+		textEvent("draft1"),
+		toolEndEvent("shell", `{"command":"ls"}`),
+		textEvent("final answer"),
+		toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"tests pass"}`),
+	}}}
+	r := newTestRunner(agent)
+	v, text, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if v.FinalMessage != "final answer" {
+		t.Fatalf("FinalMessage = %q, want only the text written after the last non-sentinel tool call", v.FinalMessage)
+	}
+	if text != "draft1final answer" {
+		t.Fatalf("text = %q, want the full unchanged multi-round transcript", text)
+	}
+}
+
 func TestRunWorkerRecoversWhenSentinelMissingThenPresent(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{textEvent("I made some progress")}, // no sentinel
@@ -1350,7 +1378,7 @@ func TestRunTurnBareCloseIsError(t *testing.T) {
 		textEvent("partial work"),
 	}}}
 	r := newTestRunner(agent)
-	text, _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName)
+	text, _, _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName)
 	if err == nil || !strings.Contains(err.Error(), "without a terminal event") {
 		t.Fatalf("err = %v, want no-terminal error", err)
 	}
@@ -1368,7 +1396,7 @@ func TestRunTurnIncompleteIsError(t *testing.T) {
 		{Type: stream.EventIncomplete, Text: "stream ended without a terminal event"},
 	}}}
 	r := newTestRunner(agent)
-	if _, _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "incomplete stream") {
+	if _, _, _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "incomplete stream") {
 		t.Fatalf("err = %v, want incomplete-stream error", err)
 	}
 }
@@ -1381,7 +1409,7 @@ func TestRunTurnNilErrErrorEvent(t *testing.T) {
 		{Type: stream.EventError},
 	}}}
 	r := newTestRunner(agent)
-	if _, _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "provider stream error") {
+	if _, _, _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "provider stream error") {
 		t.Fatalf("err = %v, want generic provider stream error", err)
 	}
 }
@@ -1416,7 +1444,7 @@ func TestRunTurnTimesOutOnHungStream(t *testing.T) {
 	done := make(chan struct{})
 	var err error
 	go func() {
-		_, _, _, err = r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName)
+		_, _, _, _, err = r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName)
 		close(done)
 	}()
 	select {

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -77,6 +77,10 @@ type MissionTemplate struct {
 	// time via resolveTemplateDefaults, same precedence as create()'s
 	// own handling of an omitted request field.
 	Harness string `json:"harness,omitempty"`
+	// Light missions (D-069) skip explore/plan/review; only meaningful
+	// on a kind=general template (rejected at schedule create/update for
+	// kind=coding, api/schedules.go).
+	Light bool `json:"light,omitempty"`
 	// Environment selects the sandbox image key (D-05x) a coding
 	// mission's container runs; empty auto-detects at fire time via
 	// resolveTemplateDefaults (goal keyword only — no worktree exists
@@ -440,11 +444,15 @@ func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedu
 	if name == "" {
 		name = sc.Name
 	}
+	phase := PhaseExplore
+	if t.Light {
+		phase = PhaseExecute
+	}
 	_, err = tx.Exec(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, knowledge, auto_approve_safe, spec, schedule_id, harness, environment, destination_ids)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, knowledge, auto_approve_safe, spec, schedule_id, harness, environment, destination_ids, light, phase)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)`,
 		t.Goal, name, t.Kind, t.AgentID, orDefault(t.MaxIterations, 3), t.BudgetAmount, budgetCurrency, t.Route, t.ReviewRoute, t.PlanRoute,
-		promptOverlay, knowledgeJSON, t.AutoApproveSafe, spec, sc.ID, t.Harness, t.Environment, destinationIDs)
+		promptOverlay, knowledgeJSON, t.AutoApproveSafe, spec, sc.ID, t.Harness, t.Environment, destinationIDs, t.Light, phase)
 	return err
 }
 

--- a/internal/brain/missions/scheduler_test.go
+++ b/internal/brain/missions/scheduler_test.go
@@ -280,6 +280,18 @@ func TestResolveTemplateDefaults(t *testing.T) {
 	}
 }
 
+// TestResolveTemplateDefaultsPassesLightThrough confirms light (D-069)
+// is untouched by fire-time resolution — it has no agent-level default
+// and no coding-only precedence the way harness/environment do.
+func TestResolveTemplateDefaultsPassesLightThrough(t *testing.T) {
+	t.Parallel()
+	routeForRole := func(context.Context, string) string { return "default" }
+	got, _, _ := resolveTemplateDefaults(context.Background(), MissionTemplate{Goal: "g", Kind: "general", Light: true}, nil, routeForRole, nil, nil)
+	if !got.Light {
+		t.Fatal("Light = false, want true (passed through unchanged)")
+	}
+}
+
 func TestTickSkipsAllWorkWhenDisabled(t *testing.T) {
 	t.Parallel()
 	called := false

--- a/internal/brain/missions/sentinel.go
+++ b/internal/brain/missions/sentinel.go
@@ -167,6 +167,14 @@ type WorkerVerdict struct {
 	// which has no stream to observe; citations verification is native-
 	// runner-only for now.
 	SeenURLs []string
+	// FinalMessage is the assistant text written since the last
+	// non-sentinel tool call (nativeRunner's runTurn) — the deliverable
+	// for a light mission (D-069), as opposed to the full turn text
+	// (RunWorker's second return), which includes every intermediate
+	// tool-retry narration across the whole session. Never populated by
+	// the mission_status tool call's own JSON args; set by RunWorker
+	// after parsing. Empty for the delegated (CLI harness) path.
+	FinalMessage string `json:"-"`
 }
 
 // parseWorkerVerdict decodes a mission_status tool call's arguments.

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -138,6 +138,10 @@ type StepState struct {
 	// stepReviewRework) — a second stall pauses for a human same as
 	// before this feature existed.
 	ReplanUsed bool
+	// Light marks a mission that skips explore/plan/review (D-069) —
+	// a stall can never replan into PhasePlan for one, since it never
+	// visits that phase.
+	Light bool
 }
 
 // StepInput bundles the triggering Input with whatever data it
@@ -345,7 +349,11 @@ func stepWorkerRetry(s StepState, in StepInput, cfg Config) Transition {
 			s.StallCount = 1
 		}
 		s.LastGapFingerprint = in.GapFingerprint
-		if s.StallCount >= cfg.StallRounds {
+		// D-069: light missions never visit PhasePlan, so a stall skips
+		// the replan/no-progress-pause brake entirely and falls straight
+		// through to the plain retry/max_iterations path below, same as
+		// stepWorkerFailed's backoff ceiling.
+		if s.StallCount >= cfg.StallRounds && !s.Light {
 			if !s.ReplanUsed {
 				return replanTransition(s, in)
 			}

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -359,6 +359,56 @@ func TestStepReplanEmitsReasonAndUsesReplanOnlyOnce(t *testing.T) {
 	}
 }
 
+// TestStepLightApproveGoesDone confirms a light mission (born in
+// PhaseExecute, empty spec so LastUnit is always true) reaches done on
+// review_approve exactly like a coding/general mission's last unit.
+func TestStepLightApproveGoesDone(t *testing.T) {
+	got := Step(
+		StepState{Phase: PhaseExecute, Status: StatusWorking, Light: true, LastUnit: true},
+		StepInput{Input: InputReviewApprove},
+		DefaultConfig,
+	)
+	if got.Next.Phase != PhaseDone || got.Next.Status != StatusDone {
+		t.Fatalf("Step(light approve) = %+v, want phase=done status=done", got.Next)
+	}
+}
+
+// TestStepLightStallNeverReplans confirms a light mission's stall
+// brake (D-069) skips replanTransition — which would otherwise send it
+// to PhasePlan, a phase a light mission never visits — and instead
+// keeps retrying until max_iterations fails it, the same ceiling
+// stepWorkerFailed's backoff path respects.
+func TestStepLightStallNeverReplans(t *testing.T) {
+	// A stall that would trigger replanTransition for an ordinary
+	// mission (StallCount already at the threshold, ReplanUsed false)
+	// must instead fall through to the plain retry path for a light one.
+	got := Step(
+		StepState{Phase: PhaseExecute, Status: StatusWorking, Light: true, MaxIterations: 8, Iteration: 0, StallCount: 1, LastGapFingerprint: "fp"},
+		StepInput{Input: InputWorkerRetry, GapFingerprint: "fp", Reason: "stuck"},
+		DefaultConfig,
+	)
+	if got.Next.Phase == PhasePlan {
+		t.Fatalf("Step(light stall) = %+v, must never route to PhasePlan", got.Next)
+	}
+	if got.Next.Status == StatusPaused {
+		t.Fatalf("Step(light stall) = %+v, must not pause no_progress either — retry to max_iterations instead", got.Next)
+	}
+	if len(got.Events) != 1 || got.Events[0].Kind != "mission.retry" {
+		t.Fatalf("Events = %+v, want exactly one mission.retry event", got.Events)
+	}
+
+	// Repeated identical-fingerprint stalls still respect the hard
+	// max_iterations ceiling, exactly like worker_failed.
+	final := Step(
+		StepState{Phase: PhaseExecute, Status: StatusWorking, Light: true, MaxIterations: 1, Iteration: 0, StallCount: 1, LastGapFingerprint: "fp"},
+		StepInput{Input: InputWorkerRetry, GapFingerprint: "fp", Reason: "stuck"},
+		DefaultConfig,
+	)
+	if final.Next.Phase != PhaseFailed {
+		t.Fatalf("Step(light stall at max_iterations) = %+v, want phase=failed", final.Next)
+	}
+}
+
 func TestParsePhase(t *testing.T) {
 	valid := []Phase{PhaseExplore, PhasePlan, PhaseExecute, PhaseReview, PhaseDone, PhaseFailed}
 	for _, p := range valid {

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -50,7 +50,7 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 	pending_permission, pending_permission_tool, pending_permission_args,
 	pending_permission_danger, pending_permission_rationale, auto_approve_safe, last_evidence,
 	explore_notes, replan_used, schedule_id, session_id, harness, environment, repo_url, connector_id, on_complete,
-	branch_pattern, commit_style, parent_mission_id, parent_context, attachments, destination_ids, created_at, updated_at`
+	branch_pattern, commit_style, parent_mission_id, parent_context, attachments, destination_ids, light, final_output, created_at, updated_at`
 
 // scanMissionWithFailureReason is scanMission plus one extra trailing
 // column: the mission's latest mission.failed event's payload.reason
@@ -74,7 +74,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&m.PendingPermissionDanger, &m.PendingPermissionRationale, &m.AutoApproveSafe, &m.LastEvidence,
 		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &attachmentsRaw,
-		&m.DestinationIDs,
+		&m.DestinationIDs, &m.Light, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
 		&failureReason); err != nil {
 		return Mission{}, err
@@ -150,7 +150,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&m.PendingPermissionDanger, &m.PendingPermissionRationale, &m.AutoApproveSafe, &m.LastEvidence,
 		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &attachmentsRaw,
-		&m.DestinationIDs,
+		&m.DestinationIDs, &m.Light, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt); err != nil {
 		return Mission{}, err
 	}
@@ -239,10 +239,14 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	if destinationIDs == nil {
 		destinationIDs = []string{}
 	}
+	phase := PhaseExplore
+	if m.Light {
+		phase = PhaseExecute
+	}
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, attachments, destination_ids)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NULLIF($15, '')::uuid, $16, $17, $18, $19, $20, $21, $22, $23, NULLIF($24, '')::uuid, $25, $26, $27) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, attachmentsJSON, destinationIDs,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, attachments, destination_ids, light, phase)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NULLIF($15, '')::uuid, $16, $17, $18, $19, $20, $21, $22, $23, NULLIF($24, '')::uuid, $25, $26, $27, $28, $29) RETURNING id`,
+		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, attachmentsJSON, destinationIDs, m.Light, phase,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)
@@ -470,6 +474,20 @@ func (s *Store) SetLastEvidence(ctx context.Context, id, evidence string) error 
 	if _, err := db.Exec(ctx, `UPDATE missions SET last_evidence = $2, updated_at = now() WHERE id = $1`,
 		id, evidence); err != nil {
 		return fmt.Errorf("missions set last evidence: %w", err)
+	}
+	return nil
+}
+
+// SetFinalOutput stores a light mission's verbatim final worker
+// message (D-069) — mission state, not an event.
+func (s *Store) SetFinalOutput(ctx context.Context, id, text string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("missions set final output: %w", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE missions SET final_output = $2, updated_at = now() WHERE id = $1`,
+		id, text); err != nil {
+		return fmt.Errorf("missions set final output: %w", err)
 	}
 	return nil
 }

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -384,6 +384,59 @@ func TestMissionHarnessRoundTrips(t *testing.T) {
 	}
 }
 
+// TestMissionLightAndFinalOutputRoundTrip covers light (D-069, born
+// phase=execute) and SetFinalOutput — same shape as
+// TestMissionHarnessRoundTrips above, plus the setter mission state
+// (not an event) is written and read back correctly.
+func TestMissionLightAndFinalOutputRoundTrip(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{Goal: marker + "light", Kind: "general", Route: "default", Light: true})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !m.Light {
+		t.Fatal("Light = false, want true")
+	}
+	if m.Phase != PhaseExecute {
+		t.Fatalf("Phase = %q, want execute for a light mission at create", m.Phase)
+	}
+	if m.FinalOutput != "" {
+		t.Fatalf("FinalOutput = %q, want empty before SetFinalOutput", m.FinalOutput)
+	}
+
+	if err := s.SetFinalOutput(ctx, id, "the complete deliverable"); err != nil {
+		t.Fatalf("SetFinalOutput: %v", err)
+	}
+	m, err = s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get after SetFinalOutput: %v", err)
+	}
+	if m.FinalOutput != "the complete deliverable" {
+		t.Fatalf("FinalOutput = %q, want %q", m.FinalOutput, "the complete deliverable")
+	}
+
+	id2, err := s.Create(ctx, Mission{Goal: marker + "not-light", Kind: "general", Route: "default"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	m2, err := s.Get(ctx, id2)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m2.Light {
+		t.Fatal("Light = true, want false when not set")
+	}
+	if m2.Phase != PhaseExplore {
+		t.Fatalf("Phase = %q, want explore for a non-light mission at create", m2.Phase)
+	}
+}
+
 // TestMissionOnCompleteRoundTrips covers on_complete: a first-class
 // column snapshotted at create time, same shape as Harness above — ""
 // (do nothing) is the default when a mission omits it.

--- a/migrations/0010_missions.sql
+++ b/migrations/0010_missions.sql
@@ -82,6 +82,10 @@ CREATE TABLE IF NOT EXISTS missions (
     -- settings at dispatch. "" is native; "claude-cli" (etc) names a
     -- registered delegated executor (internal/brain/missions/executor).
     harness               text NOT NULL DEFAULT '',
+    -- Light missions (D-069, general kind only) skip explore/plan/
+    -- review: born in phase=execute, one bare worker turn, the final
+    -- worker message is the deliverable.
+    light                 boolean NOT NULL DEFAULT false,
     -- Mission worker turns run through loop.Agent same as chat, but
     -- tool-call bookkeeping (session_events, tools audit) hard-requires
     -- a real session_id uuid FK -- a mission has no chat session of its
@@ -130,6 +134,10 @@ CREATE TABLE IF NOT EXISTS missions (
     -- Sticky once detected (store.SetEnvironment) so a mission never
     -- re-detects mid-run. General missions never set this.
     environment           text NOT NULL DEFAULT '',
+    -- FinalOutput is a light mission's verbatim final worker message
+    -- (D-069) — the deliverable itself, since destinations delivery has
+    -- no other body content for a mission with no review/artifacts.
+    final_output          text NOT NULL DEFAULT '',
     -- Short display name, generated once (store.SetNameIfEmpty) the
     -- same way a chat session's title is (chat.go's autoTitle) — a
     -- one-shot best-effort gateway call after creation, never blocking

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1263,6 +1263,10 @@ export interface CreateMissionInput {
   // mission's outcome digest to on the terminal done transition; omit
   // (or empty) delivers nowhere.
   destination_ids?: string[]
+  // light requests a mission that skips explore/plan/review (D-069):
+  // single worker turn, final message delivered as the result. Only
+  // valid when kind === 'general'.
+  light?: boolean
 }
 
 // ExecutorOption is one registered harness's usability on a given
@@ -1309,11 +1313,16 @@ export async function createMission(input: CreateMissionInput): Promise<Mission>
   })
 }
 
-// classifyMission previews the kind create() would infer for goal —
-// the same classifyKind logic the server falls back to when kind is
-// omitted, exposed standalone for the create form's live chip.
-export async function classifyMission(goal: string): Promise<{ kind: 'coding' | 'general' }> {
-  return request<{ kind: 'coding' | 'general' }>('/v1/missions/classify', {
+// classifyMission previews the kind create() would infer for goal, and
+// (for a general goal) whether it looks like a single-pass light
+// mission — the same classifyKind/classifyLight logic the server falls
+// back to/suggests, exposed standalone for the create form's live chip
+// and light toggle default. light is only ever a suggestion; create()
+// still requires the operator's explicit flag.
+export async function classifyMission(
+  goal: string,
+): Promise<{ kind: 'coding' | 'general'; light: boolean }> {
+  return request<{ kind: 'coding' | 'general'; light: boolean }>('/v1/missions/classify', {
     method: 'POST',
     body: JSON.stringify({ goal }),
   })

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -742,6 +742,12 @@ export interface Mission {
   // terminal done transition. Validated against the destinations table
   // at create time — never model-decided.
   destination_ids?: string[]
+  // light marks a mission that skips explore/plan/review (D-069):
+  // kind=general only, born in phase=execute, one bare worker turn.
+  // final_output is that worker's verbatim final message — the
+  // deliverable itself, absent/empty until the mission reaches done.
+  light?: boolean
+  final_output?: string
   created_at: string
   updated_at: string
 }
@@ -939,6 +945,10 @@ export interface MissionTemplate {
   // fire time — a destination deleted or disabled since the schedule
   // was created is dropped silently rather than failing the fire.
   destination_ids?: string[]
+  // light marks a mission that skips explore/plan/review (D-069);
+  // only valid for kind=general, rejected for kind=coding at schedule
+  // create/update.
+  light?: boolean
 }
 
 // Schedule is a recurring cron trigger that fires mission_template

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -131,7 +131,7 @@ beforeEach(() => {
   vi.mocked(listAgents).mockResolvedValue([])
   vi.mocked(listRoutes).mockResolvedValue(routes)
   vi.mocked(getSettings).mockResolvedValue({ settings: {}, values: {} })
-  vi.mocked(classifyMission).mockResolvedValue({ kind: 'general' })
+  vi.mocked(classifyMission).mockResolvedValue({ kind: 'general', light: false })
   vi.mocked(getMissionExecutorOptions).mockResolvedValue([])
   vi.mocked(listConnectors).mockResolvedValue([])
 })
@@ -416,7 +416,7 @@ describe('MissionForm — kind chip', () => {
   })
 
   it('shows a detecting state then the classified kind after the debounce', async () => {
-    vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding' })
+    vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding', light: false })
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Fix a bug in the repo' } })
@@ -444,7 +444,7 @@ describe('MissionForm — kind chip', () => {
   })
 
   it('submits the mission with the classified kind', async () => {
-    vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding' })
+    vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding', light: false })
     vi.mocked(createMission).mockResolvedValue({ id: 'm3' } as Mission)
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
@@ -559,6 +559,82 @@ describe('MissionForm — environment select', () => {
 
     await waitFor(() =>
       expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ environment: undefined })),
+    )
+  })
+})
+
+describe('MissionForm — light mission toggle', () => {
+  it('shows the light toggle for a general mission', async () => {
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    expect(await screen.findByText('General · scratch workspace')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Light mission/)).toBeInTheDocument()
+  })
+
+  it('hides the light toggle for a coding mission', async () => {
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(await screen.findByText('General · scratch workspace'))
+    expect(await screen.findByText('Coding · branches from repo')).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Light mission/)).toBeNull()
+  })
+
+  it('defaults the toggle from the classify preview when untouched', async () => {
+    vi.useFakeTimers()
+    vi.mocked(classifyMission).mockResolvedValue({ kind: 'general', light: true })
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'summarize this' } })
+    await vi.advanceTimersByTimeAsync(600)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(screen.getByLabelText(/Light mission/)).toBeChecked()
+  })
+
+  it('an operator-touched toggle is never overridden by a later classify preview', async () => {
+    vi.useFakeTimers()
+    vi.mocked(classifyMission).mockResolvedValue({ kind: 'general', light: true })
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'summarize this' } })
+    // Explicitly check it, then immediately uncheck it — the operator's
+    // deliberate final choice is false, which must survive the classify
+    // preview resolving to light: true.
+    fireEvent.click(screen.getByLabelText(/Light mission/))
+    fireEvent.click(screen.getByLabelText(/Light mission/))
+    expect(screen.getByLabelText(/Light mission/)).not.toBeChecked()
+
+    await vi.advanceTimersByTimeAsync(600)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(screen.getByLabelText(/Light mission/)).not.toBeChecked()
+  })
+
+  it('submits light=true for a general mission when checked', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm8' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(await screen.findByLabelText(/Light mission/))
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ light: true })),
+    )
+  })
+
+  it('omits light from the create payload for a coding mission', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm9' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(await screen.findByText('General · scratch workspace'))
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ light: undefined })),
     )
   })
 })
@@ -907,7 +983,7 @@ describe('MissionForm — create mode, repeat on schedule', () => {
 
   it('forces kind to general and locks it when repeat turns on with coding selected', async () => {
     vi.useFakeTimers()
-    vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding' })
+    vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding', light: false })
     vi.mocked(createSchedule).mockResolvedValue({ id: 'sc1' })
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -252,6 +252,10 @@ export function MissionForm({
   // seeded kind counts as an explicit choice too.
   const [kindLocked, setKindLocked] = useState(!!initial?.kind)
   const [classifying, setClassifying] = useState(false)
+  // light (D-069): defaults from the debounced classify preview below
+  // unless the operator has touched the toggle directly (lightTouched).
+  const [light, setLight] = useState(initial?.light ?? false)
+  const [lightTouched, setLightTouched] = useState(!!initial?.light)
   const [agentID, setAgentID] = useState(initial?.agent_id ?? '')
   // Destinations multi-select — visible, not advanced; default is
   // empty (deliver nowhere). Offered for a one-off create, a new
@@ -404,6 +408,8 @@ export function MissionForm({
     setKind(schedule.mission_template.kind)
     setKindLocked(true)
     setAgentID(schedule.mission_template.agent_id ?? '')
+    setLight(schedule.mission_template.light ?? false)
+    setLightTouched(true)
     setAutoApproveSafe(schedule.mission_template.auto_approve_safe ?? true)
     setShowAdvanced(hasNonDefaults(schedule.mission_template))
     setRoute(schedule.mission_template.route ?? '')
@@ -441,7 +447,13 @@ export function MissionForm({
     setClassifying(true)
     const t = setTimeout(() => {
       classifyMission(goal.trim())
-        .then((r) => setKind(r.kind))
+        .then((r) => {
+          setKind(r.kind)
+          // light only ever defaults the toggle, never overrides an
+          // operator's own choice (lightTouched) — and only makes sense
+          // once the goal actually classified as general.
+          if (!lightTouched) setLight(r.kind === 'general' && r.light)
+        })
         .catch(() => {
           // Best-effort preview: a failed classify leaves whatever kind
           // was already showing rather than blocking the form.
@@ -452,7 +464,7 @@ export function MissionForm({
       clearTimeout(t)
       setClassifying(false)
     }
-  }, [goal, kindLocked])
+  }, [goal, kindLocked, lightTouched])
 
   const onGoalChange = (v: string) => {
     setGoal(v)
@@ -547,6 +559,7 @@ export function MissionForm({
       attachments:
         attachments.length > 0 ? attachments.map((a) => ({ id: a.id, name: a.name ?? '' })) : undefined,
       destination_ids: destinationIDs.length > 0 ? destinationIDs : undefined,
+      light: kind === 'general' ? light : undefined,
     })
     toast.success('Mission created')
     onDone({ kind: 'mission', id })
@@ -572,6 +585,7 @@ export function MissionForm({
         branch_pattern: kind === 'coding' ? branchPattern.trim() || undefined : undefined,
         commit_style: kind === 'coding' ? commitStyle || undefined : undefined,
         destination_ids: destinationIDs.length > 0 ? destinationIDs : undefined,
+        light: kind === 'general' ? light : undefined,
       },
       expires_at: expiresAt ? new Date(expiresAt).toISOString() : undefined,
     })
@@ -605,6 +619,7 @@ export function MissionForm({
         commit_style:
           schedule.mission_template.kind === 'coding' ? commitStyle || undefined : undefined,
         destination_ids: destinationIDs.length > 0 ? destinationIDs : undefined,
+        light: schedule.mission_template.kind === 'general' ? light : undefined,
       },
       expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
     })
@@ -672,6 +687,27 @@ export function MissionForm({
             Coding missions aren't supported on a recurring schedule yet: each fire has no
             repository to work in.
           </p>
+        )}
+        {kind === 'general' && (
+          <label htmlFor="mission-light" className="flex items-start gap-2 text-sm">
+            <input
+              id="mission-light"
+              type="checkbox"
+              checked={light}
+              onChange={(e) => {
+                setLight(e.target.checked)
+                setLightTouched(true)
+              }}
+              className="mt-0.5"
+            />
+            <span>
+              Light mission
+              <span className="block text-xs text-muted-foreground">
+                Skips explore/plan/review for a single-pass task — the worker's final message
+                is delivered as the result.
+              </span>
+            </span>
+          </label>
         )}
         {mode === 'create' && !repeat && (
           <MissionAttachments attachments={attachments} onChange={setAttachments} />

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -886,6 +886,34 @@ describe('MissionDetail', () => {
     expect(screen.queryByText('Result')).toBeNull()
   })
 
+  it('renders a light mission Result section from final_output, not last_evidence', async () => {
+    vi.mocked(getMission).mockResolvedValue({
+      ...baseMission,
+      phase: 'done',
+      status: 'done',
+      light: true,
+      last_evidence: 'worker evidence text',
+      final_output: 'the complete deliverable',
+    })
+    renderPage()
+    expect(await screen.findByText('Result')).toBeTruthy()
+    expect(screen.getByText('the complete deliverable')).toBeTruthy()
+    expect(screen.queryByText('worker evidence text')).toBeNull()
+  })
+
+  it('omits the Result section for a light mission with no final_output', async () => {
+    vi.mocked(getMission).mockResolvedValue({
+      ...baseMission,
+      phase: 'done',
+      status: 'done',
+      light: true,
+      last_evidence: 'worker evidence text',
+    })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(screen.queryByText('Result')).toBeNull()
+  })
+
   it('shows a recurring schedule strip when the mission fired from a schedule', async () => {
     vi.mocked(getMission).mockResolvedValue({ ...baseMission, schedule_id: 'sc1' })
     vi.mocked(listSchedules).mockResolvedValue([

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -827,7 +827,14 @@ export function MissionDetail() {
         <TimelineSection events={events} />
       </section>
 
-      {terminalPhases.has(mission.phase) && mission.last_evidence && (
+      {terminalPhases.has(mission.phase) && mission.light && mission.final_output && (
+        <section>
+          <h2 className="mb-2 text-sm font-semibold tracking-tight">Result</h2>
+          <ResultSection evidence={mission.final_output} />
+        </section>
+      )}
+
+      {terminalPhases.has(mission.phase) && !mission.light && mission.last_evidence && (
         <section>
           <h2 className="mb-2 text-sm font-semibold tracking-tight">Result</h2>
           <ResultSection evidence={mission.last_evidence} />


### PR DESCRIPTION
Digest-class goals kept failing on harness machinery they never needed (forced submit_plan, artifact contracts, model-authored verify_cmds). A light mission keeps the envelope — record, append-only events, retry/backoff (D-064/065), steering, destinations, memory extraction, max_iterations — and drops the contract layer entirely.

- `light` flag on missions + schedule templates (kind=general only; 400 on coding, explicit or classified); columns added in place in 0010 (pre-release rule)
- born in `phase='execute'`; worker gets a light preamble (single pass, final message is the deliverable); done branch short-circuits to approve with a `mission.review_skipped {reason: light}` event
- stall brake never replans into PhasePlan for light (falls through to retry/max_iterations)
- `final_output` stores the worker's final message segment — captured runner-side as text since the last non-sentinel tool activity (`WorkerVerdict.FinalMessage`, `json:"-"` so model JSON can't inject it), full-transcript fallback
- delivered as the destination payload body; included (2000-rune cap) in OutcomeDigest for memory + follow-ups
- `/v1/missions/classify` now returns `{kind, light}` — suggestion only, biased false; create requires the explicit flag
- web: light toggle on general missions/schedules (classify-suggested default), MissionDetail renders final_output

Tests across statemachine/driver/runner/store/scheduler/api/destinations/web; full containerized suite + web build/lint/test green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790096703&installation_model_id=431401&pr_number=288&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F288&signature=bb274eb3a57c3cf2168955266658c831a8b9f7e413a088cfcda872dd9517094b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->