### PR TITLE
fix: suppress gosec g204 on verify_cmd syntax check

### DIFF
--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -1096,7 +1096,7 @@ func parseSpec(raw string) (Spec, error) {
 	if shPath, err := exec.LookPath("/bin/sh"); err == nil {
 		for _, u := range spec.Units {
 			shCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			out, err := exec.CommandContext(shCtx, shPath, "-n", "-c", u.VerifyCmd).CombinedOutput()
+			out, err := exec.CommandContext(shCtx, shPath, "-n", "-c", u.VerifyCmd).CombinedOutput() //nolint:gosec // G204: shPath is LookPath("/bin/sh"); -n parses only, never executes
 			cancel()
 			if err != nil {
 				stderr := strings.TrimSpace(string(out))


### PR DESCRIPTION
gosec flags the D-068 `/bin/sh -n -c` syntax gate as G204 (subprocess with variable). The binary is `exec.LookPath("/bin/sh")` and the flags are fixed; `-n` parses only and never executes the checked command. nolint with justification.

This landed on main via #286's admin merge — its lint failure was mistaken for the base-branch policy block. This PR restores a green main and unblocks #288's ci-ok.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790097102&installation_model_id=431401&pr_number=289&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F289&signature=44ade5594023c24cebb3d3371568ef76904e328911ae572266cd088b057d2aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->