### PR TITLE
feat: workflows engine core + domain create validation (D-070, D-071)

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -286,6 +286,24 @@ func main() {
 	if missionScheduler != nil && destinationStore != nil {
 		missionScheduler.SetDestinationEnabled(destinationStore.EnabledByID)
 	}
+	if missionDriver != nil {
+		// D-071: close the unvalidated Driver.Create path (the workflows
+		// engine's spawnStep is now a second caller besides the HTTP create
+		// handler). routeExists reuses the exact same gwc.ResolveRoute
+		// check buildMissions wires for the scheduler; destinationStore may
+		// still be nil (destinations disabled), which just skips that one
+		// check (see ValidateDeps' nil-gating).
+		deps := missions.ValidateDeps{
+			RouteExists: func(ctx context.Context, name string) bool {
+				_, err := gwc.ResolveRoute(ctx, name, "")
+				return err == nil
+			},
+		}
+		if destinationStore != nil {
+			deps.DestinationEnabled = destinationStore.EnabledByID
+		}
+		missionDriver.SetValidateDeps(deps)
+	}
 	// WORKFLOWS_ENABLED gates the orchestration-above-missions layer
 	// (D-070, slice 1): requires missions to already be enabled
 	// (WORKSPACES set), since a workflow step is just a follow-up
@@ -295,6 +313,7 @@ func main() {
 	if missionDriver != nil && os.Getenv("WORKFLOWS_ENABLED") != "" {
 		workflowStore = workflows.NewStore(app.DB, app.Log)
 		workflowEngine = workflows.NewEngine(workflowStore, missionDriver, missionStore, app.Log)
+		workflowEngine.SetRouteForRole(routeForRole)
 		missionDriver.SetOnTerminal(workflowEngine.OnMissionTerminal)
 	}
 	// deliver: chat-facing ad-hoc send to one operator-configured

--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/skills"
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
 	"github.com/SumonMSelim/timothy/internal/brain/tools/builtin"
+	"github.com/SumonMSelim/timothy/internal/brain/workflows"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/ledger"
@@ -284,6 +285,17 @@ func main() {
 	}
 	if missionScheduler != nil && destinationStore != nil {
 		missionScheduler.SetDestinationEnabled(destinationStore.EnabledByID)
+	}
+	// WORKFLOWS_ENABLED gates the orchestration-above-missions layer
+	// (D-070, slice 1): requires missions to already be enabled
+	// (WORKSPACES set), since a workflow step is just a follow-up
+	// mission the engine spawns.
+	var workflowStore *workflows.Store
+	var workflowEngine *workflows.Engine
+	if missionDriver != nil && os.Getenv("WORKFLOWS_ENABLED") != "" {
+		workflowStore = workflows.NewStore(app.DB, app.Log)
+		workflowEngine = workflows.NewEngine(workflowStore, missionDriver, missionStore, app.Log)
+		missionDriver.SetOnTerminal(workflowEngine.OnMissionTerminal)
 	}
 	// deliver: chat-facing ad-hoc send to one operator-configured
 	// destination. Registered here, not inside buildAgent, for the same
@@ -550,7 +562,7 @@ func main() {
 	api.Register(app.Server, svc, store, broker,
 		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, usageDecorator.Decorate, app.Log), flags, fxStore,
 		agentReg, conns, goog, secrets, agent, packs, missionStore, missionDriver, missionNotifier,
-		missionWorkspace, resolveSecret, routeForRole, chat.ClassifyOverGateway(gwc), gwc.ResolveRoute, chat.TitleOverGateway(gwc, app.Log), ledgerAgg.TopModelByMission, missionHub, attachmentStore, &http.Client{}, whisperURL, markitdownURL, token, app.Log, gwc, kbStore, mc, chat.ClassifyCollectionOverGateway(gwc, app.Log), destinationStore, destinationTest)
+		missionWorkspace, resolveSecret, routeForRole, chat.ClassifyOverGateway(gwc), gwc.ResolveRoute, chat.TitleOverGateway(gwc, app.Log), ledgerAgg.TopModelByMission, missionHub, attachmentStore, &http.Client{}, whisperURL, markitdownURL, token, app.Log, gwc, kbStore, mc, chat.ClassifyCollectionOverGateway(gwc, app.Log), destinationStore, destinationTest, workflowStore, workflowEngine)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/session"
 	"github.com/SumonMSelim/timothy/internal/brain/settings"
 	"github.com/SumonMSelim/timothy/internal/brain/skills"
+	"github.com/SumonMSelim/timothy/internal/brain/workflows"
 	"github.com/SumonMSelim/timothy/internal/gateway/ledger"
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
@@ -100,7 +101,7 @@ var memoryRoutePatterns = []string{
 // proxy to the gateway's internal control plane, conns the local
 // connector control plane (nil leaves any of them unmounted).
 // whisperURL empty leaves /v1/transcribe unmounted (WHISPER_URL unset).
-func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, secrets *secretstore.Store, toolset Toolset, packs []skills.Skill, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, markitdownURL string, token string, log *slog.Logger, gwSecrets GatewaySecrets, kbStore *kb.Store, kbIngest kbIngester, kbClassify kbClassifier, destinationStore *destinations.Store, destinationTest destinationTester) {
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, secrets *secretstore.Store, toolset Toolset, packs []skills.Skill, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, markitdownURL string, token string, log *slog.Logger, gwSecrets GatewaySecrets, kbStore *kb.Store, kbIngest kbIngester, kbClassify kbClassifier, destinationStore *destinations.Store, destinationTest destinationTester, workflowStore *workflows.Store, workflowEngine *workflows.Engine) {
 	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log, flags: flags, rates: rates}
 	if kbStore != nil {
 		a.kbCollections = kbStore.ListCollections
@@ -158,6 +159,15 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 		destScheduleRefs = missionStore
 	}
 	a.registerDestinations(srv.Handle, destinationStore, destRefs, destScheduleRefs, destinationTest)
+	// Same nil-box guard as connLister above: a nil *workflows.Engine
+	// boxed straight into workflowStarter would be a non-nil interface
+	// value, breaking registerWorkflows' engine == nil gate on
+	// startRun.
+	var workflowStarterIface workflowStarter
+	if workflowEngine != nil {
+		workflowStarterIface = workflowEngine
+	}
+	a.registerWorkflows(srv.Handle, workflowStore, workflowStarterIface)
 	a.registerEvents(srv.Handle, hub)
 	a.registerTranscribe(srv.Handle, whisperClient, whisperURL)
 	a.registerAttachments(srv.Handle, attachmentStore)

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -146,7 +146,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	if destinationStore != nil {
 		destLookup = destinationStore
 	}
-	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret, routeForRole, missionClassify, codingExecutorDefault, resolveExecutorOptions, nameMission, topModels, conns, missionAttachments, markitdownURL, destLookup)
+	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret, routeForRole, missionClassify, codingExecutorDefault, resolveExecutorOptions, nameMission, topModels, conns, missionAttachments, markitdownURL)
 	a.registerSchedules(srv.Handle, missionStore, destLookup)
 	// destinationRefs/destinationScheduleRefs are *missions.Store itself
 	// (ActiveMissionReferencesDestination / ScheduleReferencingDestinationID) —

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -217,6 +217,8 @@ func failMission(w http.ResponseWriter, err error) {
 		jsonError(w, http.StatusConflict, "already_finished", err.Error())
 	case errors.Is(err, missions.ErrNotTerminal):
 		jsonError(w, http.StatusConflict, "not_terminal", err.Error())
+	case errors.Is(err, missions.ErrInvalidMission):
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 	default:
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 	}
@@ -427,43 +429,21 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "bad_request", "goal is required")
 		return
 	}
-	switch req.Kind {
-	case "":
+	if req.Kind == "" {
 		req.Kind = classifyKind(r.Context(), h.classify, req.Goal)
-	case "coding", "general":
-	default:
-		jsonError(w, http.StatusBadRequest, "bad_request", `kind must be "coding" or "general"`)
-		return
-	}
-	if req.Light && req.Kind != "general" {
-		jsonError(w, http.StatusBadRequest, "bad_request", "light is only valid for kind=general missions")
-		return
 	}
 	if req.Harness == "native" {
 		req.Harness = ""
 	}
-	switch {
-	case req.Kind != "coding" && req.Harness != "":
-		jsonError(w, http.StatusBadRequest, "bad_request", "harness is only valid for kind=coding missions")
-		return
-	case req.Kind == "coding" && req.Harness == "":
-		if h.codingExecutorDefault != nil {
-			req.Harness = h.codingExecutorDefault(r.Context())
-		}
-	case req.Harness != "":
-		if _, ok := executor.Lookup(req.Harness); !ok {
-			jsonError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("unknown harness %q", req.Harness))
-			return
-		}
+	// codingExecutorDefault/environment auto-detect are HTTP-request-time
+	// resolution seams (settings lookup, goal-keyword heuristic) with no
+	// place in ValidateCreate's pure struct-shape rules; the resulting
+	// values still pass through ValidateCreate's kind/harness/environment
+	// checks below via Driver.Create.
+	if req.Kind == "coding" && req.Harness == "" && h.codingExecutorDefault != nil {
+		req.Harness = h.codingExecutorDefault(r.Context())
 	}
-	switch {
-	case req.Kind != "coding" && req.Environment != "":
-		jsonError(w, http.StatusBadRequest, "bad_request", "environment is only valid for kind=coding missions")
-		return
-	case !missions.ValidEnvironment(req.Environment):
-		jsonError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("unknown environment %q", req.Environment))
-		return
-	case req.Kind == "coding" && req.Environment == "":
+	if req.Kind == "coding" && req.Environment == "" {
 		// Auto-detect (D-05x), resolved server-side at create time so
 		// the environment is fixed before the sandbox container is ever
 		// created: no worktree exists yet (it's provisioned after this
@@ -473,17 +453,10 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		// explicit request; "" stays "" (base) when nothing matches.
 		req.Environment, _ = missions.DetectEnvironment("", req.Goal)
 	}
-	switch {
-	case req.RepoURL != "" && req.Kind != "coding":
-		jsonError(w, http.StatusBadRequest, "bad_request", "repo_url is only valid for kind=coding missions")
-		return
-	case req.RepoURL != "" && req.ConnectorID == "":
-		jsonError(w, http.StatusBadRequest, "bad_request", "connector_id is required with repo_url")
-		return
-	case req.RepoURL == "" && req.ConnectorID != "":
-		jsonError(w, http.StatusBadRequest, "bad_request", "connector_id is only valid alongside repo_url")
-		return
-	case req.RepoURL != "":
+	// connector_id existence + kind check is a store lookup ValidateCreate
+	// can't perform (it takes no connectors dependency); repo_url's other
+	// shape rules (coding-only, requires connector_id) are ValidateCreate's.
+	if req.RepoURL != "" {
 		if h.conns == nil {
 			jsonError(w, http.StatusBadRequest, "bad_request", "connectors are not enabled")
 			return
@@ -497,31 +470,6 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 			jsonError(w, http.StatusBadRequest, "bad_request", "connector_id must name a github-kind connector")
 			return
 		}
-	}
-	switch req.OnComplete {
-	case "":
-	case "push", "push_pr":
-		if req.Kind != "coding" || req.RepoURL == "" || req.ConnectorID == "" {
-			jsonError(w, http.StatusBadRequest, "bad_request", "on_complete requires repo_url and connector_id on a kind=coding mission")
-			return
-		}
-	default:
-		jsonError(w, http.StatusBadRequest, "bad_request", `on_complete must be "", "push", or "push_pr"`)
-		return
-	}
-	if req.BranchPattern != "" {
-		if err := missions.ValidateBranchPattern(req.BranchPattern); err != nil {
-			jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
-			return
-		}
-	}
-	if err := missions.ValidateCommitStyle(req.CommitStyle); err != nil {
-		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
-		return
-	}
-	if err := h.validateDestinationIDs(r.Context(), req.DestinationIDs); err != nil {
-		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
-		return
 	}
 	var parentMissionID, parentContext string
 	if req.ParentMissionID != "" {

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -64,11 +64,11 @@ type missionAttachmentStore interface {
 // (not *attachments.Store) so the caller's own nil-box guard (a nil
 // *attachments.Store boxed here would be a non-nil interface value)
 // happens once, at the call site — same shape as chat.Service.SetAttachments.
-func (a *API) registerMissions(handle func(pattern string, h http.Handler), store *missions.Store, driver *missions.Driver, notifier *missions.Notifier, agentReg *agents.Store, workspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, classify agents.Classify, codingExecutorDefault func(context.Context) string, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), conns *connectors.Manager, attachmentStore missionAttachmentStore, markitdownURL string, destinationLookupStore destinationLookup) {
+func (a *API) registerMissions(handle func(pattern string, h http.Handler), store *missions.Store, driver *missions.Driver, notifier *missions.Notifier, agentReg *agents.Store, workspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, classify agents.Classify, codingExecutorDefault func(context.Context) string, resolveExecutorOptions func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), conns *connectors.Manager, attachmentStore missionAttachmentStore, markitdownURL string) {
 	if store == nil {
 		return
 	}
-	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, workspace: workspace, resolveSecret: resolveSecret, routeForRole: routeForRole, classify: classify, codingExecutorDefault: codingExecutorDefault, resolveExecutorOptions: resolveExecutorOptions, nameMission: nameMission, topModels: topModels, conns: conns, perms: a.perms, dir: a.dir, log: a.log, attachments: attachmentStore, markitdownURL: markitdownURL, markitdownHTTP: &http.Client{}, destinations: destinationLookupStore}
+	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, workspace: workspace, resolveSecret: resolveSecret, routeForRole: routeForRole, classify: classify, codingExecutorDefault: codingExecutorDefault, resolveExecutorOptions: resolveExecutorOptions, nameMission: nameMission, topModels: topModels, conns: conns, perms: a.perms, dir: a.dir, log: a.log, attachments: attachmentStore, markitdownURL: markitdownURL, markitdownHTTP: &http.Client{}}
 	handle("GET /v1/missions", a.auth(http.HandlerFunc(h.list)))
 	handle("POST /v1/missions", a.auth(http.HandlerFunc(h.create)))
 	handle("POST /v1/missions/classify", a.auth(http.HandlerFunc(h.classifyGoal)))
@@ -150,14 +150,13 @@ type missionAPI struct {
 	// the operator-owned destinations table (D-061's exfiltration
 	// guard: an id must exist AND be enabled) — nil (destinations
 	// disabled) rejects any non-empty destination_ids.
-	destinations destinationLookup
 }
 
 // destinationLookup is the narrow slice of *destinations.Store the
-// mission create handler needs to validate destination_ids —
-// EnabledByID reports whether id names a real, enabled row (ok=false
-// covers both "unknown id" and "disabled", both rejected identically
-// by validateDestinationIDs below).
+// schedule handlers need to validate destination_ids — EnabledByID
+// reports whether id names a real, enabled row (ok=false covers both
+// "unknown id" and "disabled", both rejected identically). Mission
+// create validation moved into missions.ValidateCreate (D-071).
 type destinationLookup interface {
 	EnabledByID(ctx context.Context, id string) (ok bool, err error)
 }
@@ -176,35 +175,6 @@ func (h *missionAPI) routeExists(ctx context.Context, name string) bool {
 	}
 	_, err := h.resolveExecutorOptions(ctx, name, "")
 	return err == nil
-}
-
-// validateDestinationIDs rejects any id that doesn't name a real,
-// enabled destinations row — the exfiltration guard (D-061): a mission
-// create request only ever attaches operator-owned destinations, never
-// an arbitrary string the model might have supplied. Lists every
-// invalid id in one error, same spirit as an unknown-tool rejection
-// naming what's actually valid.
-func (h *missionAPI) validateDestinationIDs(ctx context.Context, ids []string) error {
-	if len(ids) == 0 {
-		return nil
-	}
-	if h.destinations == nil {
-		return fmt.Errorf("destinations are not enabled")
-	}
-	var invalid []string
-	for _, id := range ids {
-		ok, err := h.destinations.EnabledByID(ctx, id)
-		if err != nil {
-			return fmt.Errorf("destination_ids: %w", err)
-		}
-		if !ok {
-			invalid = append(invalid, id)
-		}
-	}
-	if len(invalid) > 0 {
-		return fmt.Errorf("unknown or disabled destination id(s): %s", strings.Join(invalid, ", "))
-	}
-	return nil
 }
 
 func failMission(w http.ResponseWriter, err error) {

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -119,7 +119,7 @@ func TestMissionsResumeWithAnswerReachesWorker(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/resume", strings.NewReader(`{"answer":"the deploy target is staging"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -187,7 +187,7 @@ func TestMissionsResumeWithoutAnswerLeavesProgressUntouched(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/resume", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -231,7 +231,7 @@ func TestMissionsNoteAppendsEventAndProgressWithoutPhaseChange(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":"focus on the staging config next"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -277,7 +277,7 @@ func TestMissionsNoteUnknownMission(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	req := httptest.NewRequest("POST", "/v1/missions/00000000-0000-0000-0000-000000000000/note", strings.NewReader(`{"text":"hello"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -301,7 +301,7 @@ func TestMissionsNoteEmptyTextRejected(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":""}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -331,7 +331,7 @@ func TestMissionsNoteTerminalMissionRejected(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":"too late"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -355,7 +355,7 @@ func TestMissionsCreateResponseCarriesDetectedEnvironment(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	body := `{"goal":"itest-api-mission write a Go CLI that parses logs","kind":"coding"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -394,7 +394,7 @@ func TestMissionsCreateCarriesPlanRoute(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	body := `{"goal":"itest-api-mission plan route round trip","kind":"general","route":"mini","plan_route":"strong"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -433,7 +433,7 @@ func TestMissionsCreateFollowUp(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	post := func(body string) (int, []byte) {
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -498,7 +498,7 @@ func TestMissionsCreateFollowUpUnknownParent(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	body := `{"goal":"itest-api-mission follow-up unknown parent","kind":"general","parent_mission_id":"00000000-0000-0000-0000-000000000000"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -553,7 +553,7 @@ func TestMissionsCreateWithPDFAttachment(t *testing.T) {
 		defer md.Close()
 
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL)
 
 		code, body := post(m, `{"goal":"itest-api-mission with attachment","kind":"general","attachments":[{"id":"`+att.ID+`","name":"spec.pdf"}]}`)
 		if code != http.StatusCreated {
@@ -618,7 +618,7 @@ func TestMissionsCreateWithPDFAttachment(t *testing.T) {
 		defer md.Close()
 
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL)
 
 		code, body := post(m, `{"goal":"itest-api-mission with huge attachment","kind":"general","attachments":[{"id":"`+att.ID+`"}]}`)
 		if code != http.StatusCreated {
@@ -647,7 +647,7 @@ func TestMissionsCreateWithPDFAttachment(t *testing.T) {
 		defer md.Close()
 
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL)
 
 		code, body := post(m, `{"goal":"itest-api-mission markitdown failure","kind":"general","attachments":[{"id":"`+att.ID+`"}]}`)
 		if code != http.StatusInternalServerError {
@@ -672,7 +672,7 @@ func TestMissionsCreateGeneratesNameAsync(t *testing.T) {
 	nameMission := func(ctx context.Context, goal string) string {
 		return "Parse Logs Utility"
 	}
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "")
 
 	body := `{"goal":"itest-api-mission write a Go CLI that parses logs","kind":"general"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -720,7 +720,7 @@ func TestMissionsCreateNameFallsBackToEmptyOnGenerationFailure(t *testing.T) {
 		defer close(done)
 		return "" // simulates a gateway/timeout failure, same as TitleOverGateway
 	}
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "")
 
 	body := `{"goal":"itest-api-mission a goal whose naming will fail","kind":"general"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -977,7 +977,7 @@ func TestMissionsPushResolvesConnectorToken(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "")
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/push", strings.NewReader(`{}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1049,7 +1049,7 @@ func TestMissionsPushConnectorTable(t *testing.T) {
 
 			a := &API{token: "tok", log: discard()}
 			m := mux(a)
-			a.registerMissions(m.Handle, store, nil, nil, nil, workspace, nil, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil)
+			a.registerMissions(m.Handle, store, nil, nil, nil, workspace, nil, nil, nil, nil, nil, nil, nil, mgr, nil, "")
 
 			req := httptest.NewRequest("POST", "/v1/missions/"+id+"/push", strings.NewReader(`{}`))
 			req.Header.Set("Authorization", "Bearer tok")
@@ -1083,7 +1083,7 @@ func TestMissionsPushExplicitCredentialRefOverridesConnector(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "")
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/push", strings.NewReader(`{"credential_ref":"explicit-ref"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1138,7 +1138,7 @@ func TestMissionsPRHappyPath(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "")
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/pr", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1215,7 +1215,7 @@ func TestMissionsPRAlreadyExistsReturnsExisting(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "")
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/pr", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1249,7 +1249,7 @@ func TestMissionsPRRejectsNonGitHubConnectionMission(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/pr", nil)
 	req.Header.Set("Authorization", "Bearer tok")

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -23,7 +23,7 @@ func TestMissionsEndpointsUnmountedWhenStoreNil(t *testing.T) {
 	t.Parallel()
 	a, _, _ := testAPI(t, "tok", nil)
 	m := mux(a)
-	a.registerMissions(m.Handle, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	for _, req := range []struct{ method, path string }{
 		{"GET", "/v1/missions"},
@@ -62,7 +62,7 @@ func TestMissionsListFilterValidation(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	call := func(path string) int {
 		req := httptest.NewRequest("GET", path, nil)
@@ -110,7 +110,7 @@ func TestMissionsDeleteReachesStore(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	req := httptest.NewRequest("DELETE", "/v1/missions/abc", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -140,7 +140,7 @@ func TestMissionsCreateValidatesHarness(t *testing.T) {
 
 	post := func(codingExecutorDefault func(context.Context) string, body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, codingExecutorDefault, nil, nil, nil, nil, nil, "", nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, codingExecutorDefault, nil, nil, nil, nil, nil, "")
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -201,7 +201,7 @@ func TestMissionsCreateValidatesLight(t *testing.T) {
 
 	post := func(classify func(context.Context, string) (string, error), body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "", nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "")
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -244,7 +244,7 @@ func TestMissionsCreateValidatesRepoURL(t *testing.T) {
 
 	post := func(body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "", nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "")
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -270,7 +270,7 @@ func TestMissionsCreateValidatesRepoURL(t *testing.T) {
 	// No conns wired at all: repo_url is rejected outright rather than
 	// panicking on a nil manager.
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(`{"goal":"g","kind":"coding","repo_url":"https://github.com/o/r","connector_id":"1"}`))
 	req.Header.Set("Authorization", "Bearer tok")
 	w := httptest.NewRecorder()
@@ -295,7 +295,7 @@ func TestMissionsCreateValidatesOnComplete(t *testing.T) {
 
 	post := func(body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "", nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "")
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -334,7 +334,7 @@ func TestMissionsCreateValidatesGitStrategy(t *testing.T) {
 
 	post := func(body string) (int, string) {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -374,7 +374,7 @@ func TestMissionsCreateValidatesParentMission(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(`{"goal":"g","kind":"general","parent_mission_id":"00000000-0000-0000-0000-000000000000"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -449,7 +449,7 @@ func TestMissionsCreateAttachmentsValidation(t *testing.T) {
 		t.Helper()
 		a, _, _ := testAPI(t, "tok", nil)
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, atts, markitdownURL, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, atts, markitdownURL)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -616,7 +616,7 @@ func TestMissionsClassifyEndpoint(t *testing.T) {
 		return "general", nil
 	}
 	m := mux(a)
-	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "")
 
 	call := func(body string) (int, string) {
 		req := httptest.NewRequest("POST", "/v1/missions/classify", strings.NewReader(body))
@@ -649,7 +649,7 @@ func TestMissionsResumeMalformedBodyRejected(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	req := httptest.NewRequest("POST", "/v1/missions/abc/resume", strings.NewReader(`{not json`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -672,7 +672,7 @@ func TestMissionsResumeEmptyBodyUnchanged(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	call := func(body io.Reader) int {
 		req := httptest.NewRequest("POST", "/v1/missions/abc/resume", body)
@@ -703,7 +703,7 @@ func TestMissionsNoteMalformedOrEmptyBodyRejected(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	call := func(body io.Reader) int {
 		req := httptest.NewRequest("POST", "/v1/missions/abc/note", body)
@@ -851,7 +851,7 @@ func TestMissionsCreateKindOptional(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	driver.SetValidateDeps(missions.ValidateDeps{})
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	call := func(body string) (int, string) {
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -888,7 +888,7 @@ func TestPRRejectsNonGitHubConnectionMission(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "")
 
 	// Against a degraded pool, store.Get itself fails before the
 	// connector_id/repo_url gate is ever reached — this test only

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -330,6 +330,7 @@ func TestMissionsCreateValidatesGitStrategy(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	driver.SetValidateDeps(missions.ValidateDeps{})
 
 	post := func(body string) (int, string) {
 		m := mux(a)
@@ -848,6 +849,7 @@ func TestMissionsCreateKindOptional(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	driver.SetValidateDeps(missions.ValidateDeps{})
 	m := mux(a)
 	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
 

--- a/internal/brain/api/workflows.go
+++ b/internal/brain/api/workflows.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/SumonMSelim/timothy/internal/brain/workflows"
+)
+
+// workflowStarter is the narrow slice of *workflows.Engine the API
+// needs to start a run — an interface so this file doesn't force a
+// hard *workflows.Engine dependency shape beyond what's used here.
+type workflowStarter interface {
+	StartRun(ctx context.Context, workflowID string, runContext map[string]string) (string, error)
+}
+
+// registerWorkflows mounts the workflows CRUD + run surface — served
+// locally, WORKFLOWS_ENABLED-gated (nil store leaves it unmounted, same
+// nil-gating pattern as registerDestinations).
+func (a *API) registerWorkflows(handle func(pattern string, h http.Handler), store *workflows.Store, engine workflowStarter) {
+	if store == nil {
+		return
+	}
+	h := &workflowAPI{store: store, engine: engine}
+	handle("GET /v1/admin/workflows", a.auth(http.HandlerFunc(h.list)))
+	handle("POST /v1/admin/workflows", a.auth(http.HandlerFunc(h.create)))
+	handle("GET /v1/admin/workflows/{id}", a.auth(http.HandlerFunc(h.get)))
+	handle("PATCH /v1/admin/workflows/{id}", a.auth(http.HandlerFunc(h.patch)))
+	handle("POST /v1/admin/workflows/{id}/runs", a.auth(http.HandlerFunc(h.startRun)))
+	handle("GET /v1/admin/workflows/{id}/runs", a.auth(http.HandlerFunc(h.listRuns)))
+	handle("GET /v1/admin/workflow-runs/{id}", a.auth(http.HandlerFunc(h.getRun)))
+}
+
+type workflowAPI struct {
+	store  *workflows.Store
+	engine workflowStarter
+}
+
+func failWorkflow(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, workflows.ErrNotFound):
+		jsonError(w, http.StatusNotFound, "not_found", err.Error())
+	case errors.Is(err, workflows.ErrDuplicate):
+		jsonError(w, http.StatusConflict, "duplicate", err.Error())
+	default:
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+	}
+}
+
+func (h *workflowAPI) list(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.store.List(r.Context())
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "workflows_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"workflows": rows})
+}
+
+func (h *workflowAPI) get(w http.ResponseWriter, r *http.Request) {
+	wf, err := h.store.Get(r.Context(), r.PathValue("id"))
+	if err != nil {
+		failWorkflow(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, wf)
+}
+
+type createWorkflowRequest struct {
+	Name       string          `json:"name"`
+	Definition json.RawMessage `json:"definition"`
+}
+
+func (h *workflowAPI) create(w http.ResponseWriter, r *http.Request) {
+	var req createWorkflowRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if req.Name == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "name is required")
+		return
+	}
+	id, err := h.store.Create(r.Context(), req.Name, req.Definition)
+	if err != nil {
+		failWorkflow(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"id": id})
+}
+
+type patchWorkflowRequest struct {
+	Definition json.RawMessage `json:"definition"`
+	Enabled    bool            `json:"enabled"`
+}
+
+func (h *workflowAPI) patch(w http.ResponseWriter, r *http.Request) {
+	var req patchWorkflowRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if err := h.store.Update(r.Context(), r.PathValue("id"), req.Definition, req.Enabled); err != nil {
+		failWorkflow(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type startRunRequest struct {
+	Context map[string]string `json:"context"`
+}
+
+func (h *workflowAPI) startRun(w http.ResponseWriter, r *http.Request) {
+	if h.engine == nil {
+		jsonError(w, http.StatusNotFound, "not_found", "workflows are not enabled")
+		return
+	}
+	var req startRunRequest
+	if r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+	}
+	id, err := h.engine.StartRun(r.Context(), r.PathValue("id"), req.Context)
+	if err != nil {
+		failWorkflow(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"id": id})
+}
+
+func (h *workflowAPI) listRuns(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.store.ListRuns(r.Context(), r.PathValue("id"))
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "workflows_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"runs": rows})
+}
+
+func (h *workflowAPI) getRun(w http.ResponseWriter, r *http.Request) {
+	run, err := h.store.GetRun(r.Context(), r.PathValue("id"))
+	if err != nil {
+		failWorkflow(w, err)
+		return
+	}
+	events, err := h.store.RunEvents(r.Context(), r.PathValue("id"))
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "workflows_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"run": run, "events": events})
+}

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -208,6 +208,13 @@ type Driver struct {
 	// same as SetMemoryExtract does for memoryd.
 	deliverDestinations DestinationDeliver
 
+	// onTerminal wires the workflows engine's reaction to a mission
+	// reaching a terminal phase (see SetOnTerminal / fireOnTerminal) —
+	// nil-safe: unset skips it entirely, same as deliverDestinations. A
+	// func type for the same import-cycle reason: workflows needs
+	// missions.Mission, so missions can't import workflows back.
+	onTerminal OnTerminal
+
 	// gatekeepers holds each mission's in-progress reviewer session
 	// state, keyed by mission id, for the "delta recheck" resume on
 	// rework. Process-local by design: lost on restart is acceptable —
@@ -414,6 +421,43 @@ func (d *Driver) deliverToDestinations(ctx context.Context, id string, terminal 
 	}
 	rctx := context.Background()
 	go d.deliverDestinations(rctx, m, m.DestinationIDs) //nolint:gosec // G118: deliberate — the mission is already terminal, delivery must outlive whatever request/ctx observed that transition
+}
+
+// OnTerminal reacts to a mission reaching a terminal phase —
+// workflows.Engine.OnMissionTerminal satisfies this. Fire-and-forget by
+// contract, same as DestinationDeliver: it must never return an error,
+// block, or affect mission state (the engine only reads terminal
+// missions and creates new ones, never mutates the terminal mission).
+type OnTerminal func(ctx context.Context, m Mission)
+
+// SetOnTerminal wires the workflows engine's reaction hook (see
+// fireOnTerminal) — a setter for the same reason SetDestinationDeliver
+// is. Optional — nil skips it entirely, same as a mission with no
+// workflow_run_id.
+func (d *Driver) SetOnTerminal(fn OnTerminal) {
+	d.onTerminal = fn
+}
+
+// fireOnTerminal fires the workflows engine hook for any mission
+// reaching a terminal phase (done or failed) that names a
+// workflow_run_id — an ordinary mission (workflow_run_id empty) never
+// reaches the engine at all. Detached from ctx like deliverToDestinations:
+// the mission is already terminal, so this must outlive a request that
+// may be winding down.
+func (d *Driver) fireOnTerminal(ctx context.Context, id string) {
+	if d.onTerminal == nil {
+		return
+	}
+	m, err := d.store.Get(ctx, id)
+	if err != nil {
+		d.log.Warn("driver: workflow terminal hook: reload mission failed", "mission_id", id, "error", err)
+		return
+	}
+	if m.WorkflowRunID == "" {
+		return
+	}
+	rctx := context.Background()
+	go d.onTerminal(rctx, m) //nolint:gosec // G118: deliberate — the mission is already terminal, the hook must outlive whatever request/ctx observed that transition
 }
 
 // fireOnComplete runs a mission's recorded on_complete choice
@@ -767,6 +811,7 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 		d.extractMissionMemory(ctx, id, t.Next.Phase, failedReason(t.Events))
 		d.backfillMissionName(ctx, id)
 		d.deliverToDestinations(ctx, id, t.Next.Phase)
+		d.fireOnTerminal(ctx, id)
 	}
 	if t.Next.Phase == PhaseDone {
 		// m is the pre-transition snapshot (re-fetched above, before this
@@ -865,6 +910,7 @@ func (d *Driver) Signal(ctx context.Context, id string, input Input) error {
 		d.extractMissionMemory(ctx, id, t.Next.Phase, failedReason(t.Events))
 		d.backfillMissionName(ctx, id)
 		d.deliverToDestinations(ctx, id, t.Next.Phase)
+		d.fireOnTerminal(ctx, id)
 	}
 	if d.notify != nil {
 		if err := d.notify.OnTransition(ctx, m, before, t.Next.Status, failedReason(t.Events)); err != nil {

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -215,6 +215,15 @@ type Driver struct {
 	// missions.Mission, so missions can't import workflows back.
 	onTerminal OnTerminal
 
+	// validateDeps backs ValidateCreate's store-backed checks (D-071) —
+	// a *ValidateDeps, not a value, so "unset" is distinguishable from
+	// "set to the zero value": nil skips ValidateCreate's call entirely
+	// (existing callers/tests that predate D-071 keep working
+	// unvalidated), while a non-nil ValidateDeps{} runs every
+	// struct-shape check but skips only the dep-backed ones (nil fields
+	// within it). See SetValidateDeps.
+	validateDeps *ValidateDeps
+
 	// gatekeepers holds each mission's in-progress reviewer session
 	// state, keyed by mission id, for the "delta recheck" resume on
 	// rework. Process-local by design: lost on restart is acceptable —
@@ -438,6 +447,16 @@ func (d *Driver) SetOnTerminal(fn OnTerminal) {
 	d.onTerminal = fn
 }
 
+// SetValidateDeps wires the store-backed checks ValidateCreate needs
+// (D-071) — a setter for the same reason SetAgentResolver is: cmd/brain/
+// main.go builds the gateway route resolver and destination store after
+// the Driver. Unset (the default, and every driver_test.go fixture
+// predating D-071) skips Create's ValidateCreate call entirely, so
+// existing tests that build a bare Mission{} keep passing.
+func (d *Driver) SetValidateDeps(deps ValidateDeps) {
+	d.validateDeps = &deps
+}
+
 // fireOnTerminal fires the workflows engine hook for any mission
 // reaching a terminal phase (done or failed) that names a
 // workflow_run_id — an ordinary mission (workflow_run_id empty) never
@@ -515,6 +534,11 @@ func (d *Driver) removeSandbox(id string) {
 // create handler) get the new id back immediately without waiting on
 // the mission to actually run.
 func (d *Driver) Create(ctx context.Context, m Mission) (string, error) {
+	if d.validateDeps != nil {
+		if err := ValidateCreate(ctx, m, *d.validateDeps); err != nil {
+			return "", fmt.Errorf("driver: create: %w", err)
+		}
+	}
 	id, err := d.store.Create(ctx, m)
 	if err != nil {
 		return "", fmt.Errorf("driver: create: %w", err)

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -3,6 +3,7 @@ package missions
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -1157,7 +1158,7 @@ func TestDriverCreateGrantsShellAutoApproveWhenEnabled(t *testing.T) {
 	granter := &fakeGranter{}
 	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, nil, nil, slog.Default())
 
-	id, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: true})
+	id, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "general", Route: "route-x", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: true})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -1179,7 +1180,7 @@ func TestDriverCreateSkipsGrantWhenAutoApproveDisabled(t *testing.T) {
 	granter := &fakeGranter{}
 	d := NewDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}, nil, nil, &fakeSessionCreator{}, granter, nil, nil, slog.Default())
 
-	if _, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: false}); err != nil {
+	if _, err := d.Create(context.Background(), Mission{Goal: "test", Kind: "general", Route: "route-x", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: false}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	if len(granter.calls) != 0 {
@@ -1203,7 +1204,7 @@ func TestDriverCreateGrantsApprovalAllowlist(t *testing.T) {
 	})
 
 	id, err := d.Create(context.Background(), Mission{
-		Goal: "test", Kind: "general", AgentID: "briefing-agent",
+		Goal: "test", Kind: "general", Route: "route-x", AgentID: "briefing-agent",
 		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, AutoApproveSafe: false,
 	})
 	if err != nil {
@@ -1238,13 +1239,54 @@ func TestDriverCreateSkipsAllowlistGrantWhenAgentUnresolved(t *testing.T) {
 	})
 
 	if _, err := d.Create(context.Background(), Mission{
-		Goal: "test", Kind: "general", AutoApproveSafe: false,
+		Goal: "test", Kind: "general", Route: "route-x", AutoApproveSafe: false,
 		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8,
 	}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	if len(granter.calls) != 0 {
 		t.Fatalf("Grant calls = %d, want 0 for an unresolved agent", len(granter.calls))
+	}
+}
+
+// TestDriverCreateRejectsInvalidMissionWhenValidateDepsWired confirms
+// Create runs ValidateCreate (D-071) once SetValidateDeps has been
+// called — closing the gap where only the HTTP create handler used to
+// validate anything, leaving a direct Driver.Create caller (the
+// workflows engine) free to insert a mission the API would 400.
+func TestDriverCreateRejectsInvalidMissionWhenValidateDepsWired(t *testing.T) {
+	store := newFakeStore()
+	d := testDriver(store, &scriptedRunner{})
+	d.SetValidateDeps(ValidateDeps{})
+
+	_, err := d.Create(context.Background(), Mission{
+		Goal: "test", Kind: "coding", Route: "route-x", Light: true, // light is general-only
+		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8,
+	})
+	if err == nil {
+		t.Fatal("Create with light+coding = nil error, want ErrInvalidMission")
+	}
+	if !errors.Is(err, ErrInvalidMission) {
+		t.Fatalf("Create error = %v, want it to wrap ErrInvalidMission", err)
+	}
+	if len(store.missions) != 0 {
+		t.Fatalf("store.missions = %d, want 0: an invalid mission must never reach the store", len(store.missions))
+	}
+}
+
+// TestDriverCreateSkipsValidationWhenDepsUnset confirms a Driver that
+// never calls SetValidateDeps behaves exactly as it did before D-071 —
+// every pre-existing driver_test.go fixture that builds a bare
+// Mission{} (no route) must keep working unvalidated.
+func TestDriverCreateSkipsValidationWhenDepsUnset(t *testing.T) {
+	store := newFakeStore()
+	d := testDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}})
+
+	if _, err := d.Create(context.Background(), Mission{
+		Goal: "test", Kind: "coding", Light: true, // would be rejected if validated
+		Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8,
+	}); err != nil {
+		t.Fatalf("Create with no ValidateDeps wired: %v, want nil (validation skipped)", err)
 	}
 }
 

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -174,6 +174,12 @@ type Mission struct {
 	DestinationIDs []string  `json:"destination_ids,omitempty"`
 	CreatedAt      time.Time `json:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at"`
+	// WorkflowRunID/WorkflowStep name the workflow run and step
+	// (internal/brain/workflows) this mission was spawned as, if any —
+	// empty for an ordinary mission. Set only at create time; the
+	// workflow engine reads terminal missions, it never mutates them.
+	WorkflowRunID string `json:"workflow_run_id,omitempty"`
+	WorkflowStep  string `json:"workflow_step,omitempty"`
 }
 
 // MissionAttachment is one PDF document attached at mission create

--- a/internal/brain/missions/onterminal_test.go
+++ b/internal/brain/missions/onterminal_test.go
@@ -1,0 +1,102 @@
+package missions
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recordingOnTerminal is an OnTerminal fake that records every mission
+// id it's called with, synchronized so tests can assert on it after the
+// driver's dispatching goroutine has had a chance to run (fired via
+// `go` from fireOnTerminal, same as recordingDeliver above).
+type recordingOnTerminal struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (r *recordingOnTerminal) fn() OnTerminal {
+	return func(ctx context.Context, m Mission) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.calls = append(r.calls, m.ID)
+	}
+}
+
+func (r *recordingOnTerminal) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
+}
+
+func waitForOnTerminalCalls(t *testing.T, r *recordingOnTerminal, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if r.count() == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("onTerminal calls = %d, want %d", r.count(), want)
+}
+
+func TestDriverFiresOnTerminalForWorkflowMission(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8, WorkflowRunID: "run-1", WorkflowStep: "step-a"})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner)
+	rec := &recordingOnTerminal{}
+	d.SetOnTerminal(rec.fn())
+
+	driveN(t, d, "m1", 4) // explore -> plan -> execute -> review -> done
+
+	waitForOnTerminalCalls(t, rec, 1)
+	if rec.calls[0] != "m1" {
+		t.Fatalf("onTerminal called with mission %q, want m1", rec.calls[0])
+	}
+}
+
+func TestDriverSkipsOnTerminalWithoutWorkflowRunID(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner)
+	rec := &recordingOnTerminal{}
+	d.SetOnTerminal(rec.fn())
+
+	driveN(t, d, "m1", 4)
+
+	time.Sleep(20 * time.Millisecond)
+	if got := rec.count(); got != 0 {
+		t.Fatalf("onTerminal calls for a mission with no workflow_run_id = %d, want 0", got)
+	}
+}
+
+func TestDriverSkipsOnTerminalWhenNilHook(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8, WorkflowRunID: "run-1"})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner) // no SetOnTerminal call: d.onTerminal stays nil
+
+	// This must not panic — the whole point of the nil-safe field.
+	driveN(t, d, "m1", 4)
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseDone {
+		t.Fatalf("mission phase = %s, want done", m.Phase)
+	}
+}

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -420,6 +420,13 @@ func (s *Scheduler) markSkipped(ctx context.Context, tx pgx.Tx, sc Schedule, now
 // has no session, no workspace, no grants yet — so it is provisioned
 // lazily the first time Advance/Drive touches it (see driver.go's
 // ensureProvisioned).
+// D-071: this inserts directly via SQL rather than Driver.Create, so
+// ValidateCreate never runs against a schedule-fired mission — left as
+// is for this slice. resolveTemplateDefaults (route/harness/environment)
+// and filterDestinationIDs (destination_ids existence) already cover
+// this insert's subset of ValidateCreate's checks; a schedule's own
+// create/patch validation (schedules.go) covers the rest at schedule
+// creation time.
 func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedule) error {
 	t, promptOverlay, knowledge := resolveTemplateDefaults(ctx, sc.MissionTemplate, s.resolve, s.routeForRole, s.routeExists, s.codingExecutorDefault)
 	// destination_ids is NOT NULL; a nil slice binds as a NULL array

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -50,7 +50,8 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 	pending_permission, pending_permission_tool, pending_permission_args,
 	pending_permission_danger, pending_permission_rationale, auto_approve_safe, last_evidence,
 	explore_notes, replan_used, schedule_id, session_id, harness, environment, repo_url, connector_id, on_complete,
-	branch_pattern, commit_style, parent_mission_id, parent_context, attachments, destination_ids, light, final_output, created_at, updated_at`
+	branch_pattern, commit_style, parent_mission_id, parent_context, attachments, destination_ids, light, final_output, created_at, updated_at,
+	workflow_run_id, workflow_step`
 
 // scanMissionWithFailureReason is scanMission plus one extra trailing
 // column: the mission's latest mission.failed event's payload.reason
@@ -65,6 +66,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		pendingPermission                             *string
 		spec, progress, attachmentsRaw, knowledgeRaw  []byte
 		failureReason                                 *string
+		workflowRunID                                 *string
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
@@ -76,6 +78,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &attachmentsRaw,
 		&m.DestinationIDs, &m.Light, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
+		&workflowRunID, &m.WorkflowStep,
 		&failureReason); err != nil {
 		return Mission{}, err
 	}
@@ -94,6 +97,9 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 	}
 	if pendingPermission != nil {
 		m.PendingPermission = *pendingPermission
+	}
+	if workflowRunID != nil {
+		m.WorkflowRunID = *workflowRunID
 	}
 	if failureReason != nil {
 		m.FailureReason = *failureReason
@@ -141,6 +147,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		phase, status                                 string
 		pendingPermission                             *string
 		spec, progress, attachmentsRaw, knowledgeRaw  []byte
+		workflowRunID                                 *string
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
@@ -151,7 +158,8 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &attachmentsRaw,
 		&m.DestinationIDs, &m.Light, &m.FinalOutput,
-		&m.CreatedAt, &m.UpdatedAt); err != nil {
+		&m.CreatedAt, &m.UpdatedAt,
+		&workflowRunID, &m.WorkflowStep); err != nil {
 		return Mission{}, err
 	}
 	_ = json.Unmarshal(knowledgeRaw, &m.Knowledge)
@@ -169,6 +177,9 @@ func scanMission(row pgx.Row) (Mission, error) {
 	}
 	if pendingPermission != nil {
 		m.PendingPermission = *pendingPermission
+	}
+	if workflowRunID != nil {
+		m.WorkflowRunID = *workflowRunID
 	}
 	// Fail-safe degrade: an unrecognized phase/status (e.g. a future
 	// value an older binary doesn't know) loads as paused/infra rather
@@ -244,9 +255,9 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 		phase = PhaseExecute
 	}
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, attachments, destination_ids, light, phase)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NULLIF($15, '')::uuid, $16, $17, $18, $19, $20, $21, $22, $23, NULLIF($24, '')::uuid, $25, $26, $27, $28, $29) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, attachmentsJSON, destinationIDs, m.Light, phase,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, attachments, destination_ids, light, phase, workflow_run_id, workflow_step)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NULLIF($15, '')::uuid, $16, $17, $18, $19, $20, $21, $22, $23, NULLIF($24, '')::uuid, $25, $26, $27, $28, $29, NULLIF($30, '')::uuid, $31) RETURNING id`,
+		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, attachmentsJSON, destinationIDs, m.Light, phase, m.WorkflowRunID, m.WorkflowStep,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)

--- a/internal/brain/missions/validate.go
+++ b/internal/brain/missions/validate.go
@@ -1,0 +1,129 @@
+package missions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions/executor"
+)
+
+// ErrInvalidMission is the sentinel every ValidateCreate rejection
+// wraps — api/missions.go's failMission uses errors.Is against this to
+// map a Driver.Create failure back to 400 instead of 500, the same way
+// it already does for ErrNotFound/ErrBranchConflict/etc.
+var ErrInvalidMission = errors.New("invalid mission")
+
+// ValidateDeps are the store-backed checks ValidateCreate needs beyond
+// the Mission struct itself — each nil-gated: an unset func skips that
+// one check rather than failing closed, same contract as Driver's other
+// optional deps (SetAgentResolver, SetCapacityGate, etc).
+type ValidateDeps struct {
+	// RouteExists reports whether name resolves to a real configured
+	// route. NOT consulted by ValidateCreate: a route name the gateway
+	// doesn't recognize surfaces naturally as a run-time gateway error on
+	// the mission's first turn, same as it always has, and RouteExists'
+	// bool-only signature can't distinguish "unknown route" from "gateway
+	// unreachable" — folding it into create-time validation would risk
+	// rejecting a momentarily-unreachable-but-valid route. Kept on
+	// ValidateDeps (wired the same way DestinationEnabled is) for a
+	// future caller that wants that stricter check.
+	RouteExists func(ctx context.Context, name string) bool
+	// DestinationEnabled reports whether id names a real, enabled
+	// destinations row (destinations.Store.EnabledByID) — nil skips
+	// destination_ids validation entirely (same as api/missions.go's
+	// validateDestinationIDs with h.destinations == nil, except this
+	// degrades to "unchecked" rather than "reject every non-empty list",
+	// since a caller with no destinations wiring has nothing to check
+	// against).
+	DestinationEnabled func(ctx context.Context, id string) (bool, error)
+}
+
+// ValidateCreate enforces the domain rules a mission row must satisfy
+// regardless of which caller is creating it — the HTTP create handler
+// and the workflows engine's spawnStep both call into Driver.Create,
+// and only the HTTP handler used to validate anything (D-071). Callers
+// must resolve their own defaults (kind, route, environment auto-detect)
+// before calling: ValidateCreate rejects an empty route rather than
+// silently picking one, so a caller that wants "the default route"
+// resolves it first.
+//
+// deps may be the zero ValidateDeps{} (every dep-backed check skipped)
+// or have individual fields nil (that check skipped) — never required.
+func ValidateCreate(ctx context.Context, m Mission, deps ValidateDeps) error {
+	switch m.Kind {
+	case "coding", "general":
+	default:
+		return fmt.Errorf(`%w: kind must be "coding" or "general"`, ErrInvalidMission)
+	}
+	if m.Light && m.Kind != "general" {
+		return fmt.Errorf("%w: light is only valid for kind=general missions", ErrInvalidMission)
+	}
+	if m.Kind != "coding" {
+		switch {
+		case m.Harness != "":
+			return fmt.Errorf("%w: harness is only valid for kind=coding missions", ErrInvalidMission)
+		case m.Environment != "":
+			return fmt.Errorf("%w: environment is only valid for kind=coding missions", ErrInvalidMission)
+		case m.RepoURL != "":
+			return fmt.Errorf("%w: repo_url is only valid for kind=coding missions", ErrInvalidMission)
+		case m.BranchPattern != "":
+			return fmt.Errorf("%w: branch_pattern is only valid for kind=coding missions", ErrInvalidMission)
+		case m.CommitStyle != "":
+			return fmt.Errorf("%w: commit_style is only valid for kind=coding missions", ErrInvalidMission)
+		case m.OnComplete != "":
+			return fmt.Errorf("%w: on_complete is only valid for kind=coding missions", ErrInvalidMission)
+		}
+	}
+	if m.Harness != "" {
+		if _, ok := executor.Lookup(m.Harness); !ok {
+			return fmt.Errorf("%w: unknown harness %q", ErrInvalidMission, m.Harness)
+		}
+	}
+	if !ValidEnvironment(m.Environment) {
+		return fmt.Errorf("%w: unknown environment %q", ErrInvalidMission, m.Environment)
+	}
+	switch {
+	case m.RepoURL != "" && m.ConnectorID == "":
+		return fmt.Errorf("%w: connector_id is required with repo_url", ErrInvalidMission)
+	case m.RepoURL == "" && m.ConnectorID != "":
+		return fmt.Errorf("%w: connector_id is only valid alongside repo_url", ErrInvalidMission)
+	}
+	switch m.OnComplete {
+	case "":
+	case "push", "push_pr":
+		if m.RepoURL == "" || m.ConnectorID == "" {
+			return fmt.Errorf("%w: on_complete requires repo_url and connector_id on a kind=coding mission", ErrInvalidMission)
+		}
+	default:
+		return fmt.Errorf(`%w: on_complete must be "", "push", or "push_pr"`, ErrInvalidMission)
+	}
+	if m.BranchPattern != "" {
+		if err := ValidateBranchPattern(m.BranchPattern); err != nil {
+			return fmt.Errorf("%w: %s", ErrInvalidMission, err.Error())
+		}
+	}
+	if err := ValidateCommitStyle(m.CommitStyle); err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidMission, err.Error())
+	}
+	if m.Route == "" {
+		return fmt.Errorf("%w: route is required", ErrInvalidMission)
+	}
+	if deps.DestinationEnabled != nil && len(m.DestinationIDs) > 0 {
+		var invalid []string
+		for _, id := range m.DestinationIDs {
+			ok, err := deps.DestinationEnabled(ctx, id)
+			if err != nil {
+				return fmt.Errorf("%w: destination_ids: %s", ErrInvalidMission, err.Error())
+			}
+			if !ok {
+				invalid = append(invalid, id)
+			}
+		}
+		if len(invalid) > 0 {
+			return fmt.Errorf("%w: unknown or disabled destination id(s): %s", ErrInvalidMission, strings.Join(invalid, ", "))
+		}
+	}
+	return nil
+}

--- a/internal/brain/missions/validate_test.go
+++ b/internal/brain/missions/validate_test.go
@@ -1,0 +1,157 @@
+package missions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// baseValidMission returns a Mission that passes ValidateCreate as-is —
+// each table test case mutates a copy of this to isolate the one rule
+// under test.
+func baseValidMission() Mission {
+	return Mission{Kind: "general", Route: "default"}
+}
+
+func TestValidateCreate(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(m Mission) Mission
+		deps    ValidateDeps
+		wantErr bool
+	}{
+		{"valid general mission", func(m Mission) Mission { return m }, ValidateDeps{}, false},
+		{"valid coding mission", func(m Mission) Mission {
+			m.Kind = "coding"
+			return m
+		}, ValidateDeps{}, false},
+		{"unknown kind", func(m Mission) Mission {
+			m.Kind = "bogus"
+			return m
+		}, ValidateDeps{}, true},
+		{"empty kind", func(m Mission) Mission {
+			m.Kind = ""
+			return m
+		}, ValidateDeps{}, true},
+		{"light on coding", func(m Mission) Mission {
+			m.Kind, m.Light = "coding", true
+			return m
+		}, ValidateDeps{}, true},
+		{"light on general", func(m Mission) Mission {
+			m.Light = true
+			return m
+		}, ValidateDeps{}, false},
+		{"harness on general", func(m Mission) Mission {
+			m.Harness = "claude-cli"
+			return m
+		}, ValidateDeps{}, true},
+		{"unknown harness on coding", func(m Mission) Mission {
+			m.Kind, m.Harness = "coding", "not-a-real-harness"
+			return m
+		}, ValidateDeps{}, true},
+		{"environment on general", func(m Mission) Mission {
+			m.Environment = "go"
+			return m
+		}, ValidateDeps{}, true},
+		{"unknown environment on coding", func(m Mission) Mission {
+			m.Kind, m.Environment = "coding", "bogus"
+			return m
+		}, ValidateDeps{}, true},
+		{"valid environment on coding", func(m Mission) Mission {
+			m.Kind, m.Environment = "coding", "go"
+			return m
+		}, ValidateDeps{}, false},
+		{"repo_url on general", func(m Mission) Mission {
+			m.Kind, m.RepoURL = "general", "https://github.com/o/r"
+			return m
+		}, ValidateDeps{}, true},
+		{"repo_url without connector_id", func(m Mission) Mission {
+			m.Kind, m.RepoURL = "coding", "https://github.com/o/r"
+			return m
+		}, ValidateDeps{}, true},
+		{"connector_id without repo_url", func(m Mission) Mission {
+			m.Kind, m.ConnectorID = "coding", "conn-1"
+			return m
+		}, ValidateDeps{}, true},
+		{"branch_pattern on general", func(m Mission) Mission {
+			m.BranchPattern = "{type}/{slug}"
+			return m
+		}, ValidateDeps{}, true},
+		{"commit_style on general", func(m Mission) Mission {
+			m.CommitStyle = CommitStylePlain
+			return m
+		}, ValidateDeps{}, true},
+		{"on_complete on general", func(m Mission) Mission {
+			m.OnComplete = "push"
+			return m
+		}, ValidateDeps{}, true},
+		{"invalid branch_pattern on coding", func(m Mission) Mission {
+			m.Kind, m.BranchPattern = "coding", "{oops}/{slug}"
+			return m
+		}, ValidateDeps{}, true},
+		{"valid branch_pattern on coding", func(m Mission) Mission {
+			m.Kind, m.BranchPattern = "coding", "{type}/{slug}"
+			return m
+		}, ValidateDeps{}, false},
+		{"invalid commit_style on coding", func(m Mission) Mission {
+			m.Kind, m.CommitStyle = "coding", "loud"
+			return m
+		}, ValidateDeps{}, true},
+		{"valid commit_style on coding", func(m Mission) Mission {
+			m.Kind, m.CommitStyle = "coding", CommitStylePlain
+			return m
+		}, ValidateDeps{}, false},
+		{"on_complete unknown value", func(m Mission) Mission {
+			m.Kind, m.OnComplete = "coding", "bogus"
+			return m
+		}, ValidateDeps{}, true},
+		{"on_complete push without repo/connector", func(m Mission) Mission {
+			m.Kind, m.OnComplete = "coding", "push"
+			return m
+		}, ValidateDeps{}, true},
+		{"on_complete push with repo/connector", func(m Mission) Mission {
+			m.Kind, m.OnComplete = "coding", "push"
+			m.RepoURL, m.ConnectorID = "https://github.com/o/r", "conn-1"
+			return m
+		}, ValidateDeps{}, false},
+		{"empty route", func(m Mission) Mission {
+			m.Route = ""
+			return m
+		}, ValidateDeps{}, true},
+		{"destination_ids all enabled", func(m Mission) Mission {
+			m.DestinationIDs = []string{"d1", "d2"}
+			return m
+		}, ValidateDeps{DestinationEnabled: func(ctx context.Context, id string) (bool, error) {
+			return true, nil
+		}}, false},
+		{"destination_ids one disabled", func(m Mission) Mission {
+			m.DestinationIDs = []string{"d1", "d2"}
+			return m
+		}, ValidateDeps{DestinationEnabled: func(ctx context.Context, id string) (bool, error) {
+			return id == "d1", nil
+		}}, true},
+		{"destination_ids lookup error", func(m Mission) Mission {
+			m.DestinationIDs = []string{"d1"}
+			return m
+		}, ValidateDeps{DestinationEnabled: func(ctx context.Context, id string) (bool, error) {
+			return false, fmt.Errorf("db unavailable")
+		}}, true},
+		{"destination_ids unchecked when dep nil", func(m Mission) Mission {
+			m.DestinationIDs = []string{"d1"}
+			return m
+		}, ValidateDeps{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.mutate(baseValidMission())
+			err := ValidateCreate(context.Background(), m, tc.deps)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateCreate(%+v) error = %v, wantErr %v", m, err, tc.wantErr)
+			}
+			if err != nil && !errors.Is(err, ErrInvalidMission) {
+				t.Fatalf("ValidateCreate error %v does not wrap ErrInvalidMission", err)
+			}
+		})
+	}
+}

--- a/internal/brain/workflows/definition.go
+++ b/internal/brain/workflows/definition.go
@@ -1,0 +1,119 @@
+// Package workflows implements the orchestration layer above missions
+// (D-070): a workflow chains missions together via edges keyed on
+// mission terminal outcomes. Missions stay atoms — this package only
+// reads terminal missions and spawns new ones, never reaches inside a
+// running mission. See docs/2026-08-14-agentic-workflows-plan.md.
+package workflows
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// maxIterations is the HARD Go-side ceiling on any edge's max_iterations
+// — a workflow definition can set a lower cap but never raise it past
+// this, regardless of what the stored jsonb says (safety invariant in
+// code, never data).
+const maxIterations = 10
+
+// endStep is the reserved step name a terminal edge targets to end the
+// run successfully — not a real step, so it (and "done") can never
+// collide with an author-defined step name.
+const endStep = "end"
+
+// Definition is a workflow's data: steps keyed by name, edges between
+// them, and the entry step a new run starts on.
+type Definition struct {
+	Entry string          `json:"entry"`
+	Steps map[string]Step `json:"steps"`
+	Edges []Edge          `json:"edges"`
+}
+
+// Step is a mission template subset: enough to spawn a follow-up
+// mission for this step. Goal may contain {{context.KEY}} and
+// {{outcome}} placeholders, interpolated at spawn time (see
+// interpolate.go).
+type Step struct {
+	Goal           string   `json:"goal"`
+	Kind           string   `json:"kind"` // coding | general
+	Route          string   `json:"route,omitempty"`
+	PlanRoute      string   `json:"plan_route,omitempty"`
+	AgentID        string   `json:"agent_id,omitempty"`
+	OnComplete     string   `json:"on_complete,omitempty"`
+	DestinationIDs []string `json:"destination_ids,omitempty"`
+}
+
+// Edge is one transition: when a step's mission ends with outcome On
+// ("mission.done" or "mission.failed" in slice 1), go to step To ("end"
+// terminates the run). MaxIterations caps how many times this exact
+// edge may fire within one run — clamped to maxIterations regardless of
+// what's stored (see Validate).
+type Edge struct {
+	From          string `json:"from"`
+	On            string `json:"on"`
+	To            string `json:"to"`
+	MaxIterations int    `json:"max_iterations"`
+}
+
+// validOn is the slice-1 event-source allowlist — Go code, not data,
+// same reasoning as the plan's "event-source allowlist are Go code"
+// invariant.
+var validOn = map[string]bool{
+	"mission.done":   true,
+	"mission.failed": true,
+}
+
+// Validate checks a definition's structural integrity and clamps every
+// edge's MaxIterations to the hard ceiling. Mutates d.Edges in place
+// (the clamp), so callers must persist the validated definition, not
+// the one passed in.
+func (d *Definition) Validate() error {
+	if d.Entry == "" {
+		return fmt.Errorf("entry is required")
+	}
+	if _, ok := d.Steps[d.Entry]; !ok {
+		return fmt.Errorf("entry %q does not name a step", d.Entry)
+	}
+	for name := range d.Steps {
+		if name == endStep || name == "done" {
+			return fmt.Errorf("step name %q is reserved", name)
+		}
+		switch d.Steps[name].Kind {
+		case "coding", "general":
+		default:
+			return fmt.Errorf("step %q: kind must be \"coding\" or \"general\"", name)
+		}
+	}
+	for i := range d.Edges {
+		e := &d.Edges[i]
+		if _, ok := d.Steps[e.From]; !ok {
+			return fmt.Errorf("edge %d: from %q does not name a step", i, e.From)
+		}
+		if !validOn[e.On] {
+			return fmt.Errorf("edge %d: on %q is not a supported event", i, e.On)
+		}
+		if e.To != endStep {
+			if _, ok := d.Steps[e.To]; !ok {
+				return fmt.Errorf("edge %d: to %q does not name a step or %q", i, e.To, endStep)
+			}
+		}
+		if e.MaxIterations <= 0 || e.MaxIterations > maxIterations {
+			e.MaxIterations = maxIterations
+		}
+	}
+	return nil
+}
+
+// ParseDefinition unmarshals and validates a stored definition —
+// Store.Create/Update's shared entry point, so no unvalidated
+// definition ever reaches the database.
+func ParseDefinition(raw json.RawMessage) (Definition, error) {
+	var d Definition
+	if err := json.Unmarshal(raw, &d); err != nil {
+		return Definition{}, fmt.Errorf("parse definition: %w", err)
+	}
+	if err := d.Validate(); err != nil {
+		return Definition{}, fmt.Errorf("invalid definition: %w", err)
+	}
+	return d, nil
+}

--- a/internal/brain/workflows/definition.go
+++ b/internal/brain/workflows/definition.go
@@ -83,6 +83,11 @@ func (d *Definition) Validate() error {
 		default:
 			return fmt.Errorf("step %q: kind must be \"coding\" or \"general\"", name)
 		}
+		switch d.Steps[name].OnComplete {
+		case "", "push", "push_pr":
+		default:
+			return fmt.Errorf("step %q: on_complete must be \"\", \"push\", or \"push_pr\"", name)
+		}
 	}
 	for i := range d.Edges {
 		e := &d.Edges[i]

--- a/internal/brain/workflows/definition_test.go
+++ b/internal/brain/workflows/definition_test.go
@@ -1,0 +1,136 @@
+package workflows
+
+import "testing"
+
+func validDefinition() Definition {
+	return Definition{
+		Entry: "coder",
+		Steps: map[string]Step{
+			"coder": {Goal: "write code", Kind: "coding"},
+			"qa":    {Goal: "check {{outcome}}", Kind: "general"},
+		},
+		Edges: []Edge{
+			{From: "coder", On: "mission.done", To: "qa", MaxIterations: 1},
+			{From: "qa", On: "mission.done", To: endStep, MaxIterations: 1},
+		},
+	}
+}
+
+func TestValidateOK(t *testing.T) {
+	d := validDefinition()
+	if err := d.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+}
+
+func TestValidateBadEntry(t *testing.T) {
+	d := validDefinition()
+	d.Entry = "nope"
+	if err := d.Validate(); err == nil {
+		t.Fatal("Validate() = nil, want error for unknown entry")
+	}
+}
+
+func TestValidateEmptyEntry(t *testing.T) {
+	d := validDefinition()
+	d.Entry = ""
+	if err := d.Validate(); err == nil {
+		t.Fatal("Validate() = nil, want error for empty entry")
+	}
+}
+
+func TestValidateDanglingEdgeFrom(t *testing.T) {
+	d := validDefinition()
+	d.Edges = append(d.Edges, Edge{From: "ghost", On: "mission.done", To: "qa", MaxIterations: 1})
+	if err := d.Validate(); err == nil {
+		t.Fatal("Validate() = nil, want error for dangling edge.From")
+	}
+}
+
+func TestValidateDanglingEdgeTo(t *testing.T) {
+	d := validDefinition()
+	d.Edges = append(d.Edges, Edge{From: "coder", On: "mission.failed", To: "ghost", MaxIterations: 1})
+	if err := d.Validate(); err == nil {
+		t.Fatal("Validate() = nil, want error for dangling edge.To")
+	}
+}
+
+func TestValidateEdgeToEndIsAllowed(t *testing.T) {
+	d := validDefinition()
+	if err := d.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil (edge to %q must be allowed)", err, endStep)
+	}
+}
+
+func TestValidateUnsupportedOn(t *testing.T) {
+	d := validDefinition()
+	d.Edges[0].On = "pr.approved"
+	if err := d.Validate(); err == nil {
+		t.Fatal("Validate() = nil, want error for unsupported On in slice 1")
+	}
+}
+
+func TestValidateReservedStepNames(t *testing.T) {
+	for _, name := range []string{"end", "done"} {
+		d := validDefinition()
+		d.Steps[name] = Step{Goal: "x", Kind: "general"}
+		if err := d.Validate(); err == nil {
+			t.Fatalf("Validate() = nil, want error for reserved step name %q", name)
+		}
+	}
+}
+
+func TestValidateBadStepKind(t *testing.T) {
+	d := validDefinition()
+	d.Steps["coder"] = Step{Goal: "write code", Kind: "bogus"}
+	if err := d.Validate(); err == nil {
+		t.Fatal("Validate() = nil, want error for unknown step kind")
+	}
+}
+
+func TestValidateClampsMaxIterations(t *testing.T) {
+	d := validDefinition()
+	d.Edges[0].MaxIterations = 999
+	if err := d.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+	if d.Edges[0].MaxIterations != maxIterations {
+		t.Fatalf("MaxIterations = %d, want clamped to %d", d.Edges[0].MaxIterations, maxIterations)
+	}
+}
+
+func TestValidateClampsZeroOrNegativeMaxIterations(t *testing.T) {
+	for _, in := range []int{0, -1, -100} {
+		d := validDefinition()
+		d.Edges[0].MaxIterations = in
+		if err := d.Validate(); err != nil {
+			t.Fatalf("Validate() = %v, want nil", err)
+		}
+		if d.Edges[0].MaxIterations != maxIterations {
+			t.Fatalf("MaxIterations(%d) = %d, want clamped to %d", in, d.Edges[0].MaxIterations, maxIterations)
+		}
+	}
+}
+
+func TestValidateKeepsLowerMaxIterations(t *testing.T) {
+	d := validDefinition()
+	d.Edges[0].MaxIterations = 3
+	if err := d.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil", err)
+	}
+	if d.Edges[0].MaxIterations != 3 {
+		t.Fatalf("MaxIterations = %d, want unchanged 3 (below the ceiling)", d.Edges[0].MaxIterations)
+	}
+}
+
+func TestParseDefinitionRejectsInvalidJSON(t *testing.T) {
+	if _, err := ParseDefinition([]byte(`{not json`)); err == nil {
+		t.Fatal("ParseDefinition() = nil, want error for invalid JSON")
+	}
+}
+
+func TestParseDefinitionRejectsInvalidDefinition(t *testing.T) {
+	if _, err := ParseDefinition([]byte(`{"entry":"nope","steps":{}}`)); err == nil {
+		t.Fatal("ParseDefinition() = nil, want error for invalid definition")
+	}
+}

--- a/internal/brain/workflows/definition_test.go
+++ b/internal/brain/workflows/definition_test.go
@@ -88,6 +88,26 @@ func TestValidateBadStepKind(t *testing.T) {
 	}
 }
 
+func TestValidateBadStepOnComplete(t *testing.T) {
+	d := validDefinition()
+	d.Steps["coder"] = Step{Goal: "write code", Kind: "coding", OnComplete: "bogus"}
+	if err := d.Validate(); err == nil {
+		t.Fatal("Validate() = nil, want error for unknown on_complete")
+	}
+}
+
+func TestValidateAllowsKnownStepOnComplete(t *testing.T) {
+	for _, oc := range []string{"", "push", "push_pr"} {
+		d := validDefinition()
+		step := d.Steps["coder"]
+		step.OnComplete = oc
+		d.Steps["coder"] = step
+		if err := d.Validate(); err != nil {
+			t.Fatalf("Validate() with on_complete=%q = %v, want nil", oc, err)
+		}
+	}
+}
+
 func TestValidateClampsMaxIterations(t *testing.T) {
 	d := validDefinition()
 	d.Edges[0].MaxIterations = 999

--- a/internal/brain/workflows/engine.go
+++ b/internal/brain/workflows/engine.go
@@ -46,10 +46,27 @@ type Engine struct {
 	spawner missionSpawner
 	events  missionEvents
 	log     *slog.Logger
+
+	// routeForRole resolves a step's default route when it omits one
+	// (see SetRouteForRole / spawnStep) — the same seam missions'
+	// scheduler and api/missions.go's create handler resolve "default"
+	// through, so a workflow step behaves like any other mission create
+	// that doesn't name a route. nil-gated: unset leaves an empty
+	// step.Route empty, which Driver.Create's ValidateCreate (D-071)
+	// then rejects.
+	routeForRole func(ctx context.Context, role string) string
 }
 
 func NewEngine(store engineStore, spawner missionSpawner, events missionEvents, log *slog.Logger) *Engine {
 	return &Engine{store: store, spawner: spawner, events: events, log: log}
+}
+
+// SetRouteForRole wires the default-route resolver spawnStep uses for a
+// step that omits its own route — a setter for the same reason
+// missions.Driver's other optional deps are: cmd/brain/main.go builds
+// the gateway route resolver alongside the Engine itself.
+func (e *Engine) SetRouteForRole(fn func(ctx context.Context, role string) string) {
+	e.routeForRole = fn
 }
 
 // StartRun creates a new run for workflowID and spawns the entry step's
@@ -186,8 +203,12 @@ func (e *Engine) spawnStep(ctx context.Context, runID, stepName string, step Ste
 			e.log.Warn("workflows: spawn step: record unknown placeholder warning failed", "run_id", runID, "key", key, "error", err)
 		}
 	}
+	route := step.Route
+	if route == "" && e.routeForRole != nil {
+		route = e.routeForRole(ctx, "default")
+	}
 	return e.spawner.Create(ctx, missions.Mission{
-		Goal: goal, Kind: step.Kind, Route: step.Route, PlanRoute: step.PlanRoute, AgentID: step.AgentID,
+		Goal: goal, Kind: step.Kind, Route: route, PlanRoute: step.PlanRoute, AgentID: step.AgentID,
 		OnComplete: step.OnComplete, DestinationIDs: step.DestinationIDs,
 		ParentMissionID: parentMissionID, ParentContext: outcome,
 		WorkflowRunID: runID, WorkflowStep: stepName,

--- a/internal/brain/workflows/engine.go
+++ b/internal/brain/workflows/engine.go
@@ -1,0 +1,229 @@
+package workflows
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+// engineStore is the narrow slice of *Store the engine needs — kept as
+// an interface so engine_test.go can fake it without a real Postgres
+// pool, same reasoning as missions.driverStore.
+type engineStore interface {
+	Get(ctx context.Context, id string) (Workflow, error)
+	CreateRun(ctx context.Context, workflowID, currentStep string, runContext map[string]string) (string, error)
+	GetRun(ctx context.Context, id string) (Run, error)
+	ApplyRunTransition(ctx context.Context, id string, t RunTransition) error
+	CountEdgeFirings(ctx context.Context, runID, from, on, to string) (int, error)
+}
+
+// missionSpawner is the narrow slice of *missions.Driver the engine
+// needs to spawn a step's mission — an interface so engine_test.go can
+// fake it without a real Driver. workflows importing missions.Mission
+// directly (not vice versa) is what keeps this acyclic: missions never
+// imports workflows, it only calls back into it through the
+// missions.OnTerminal func type wired by cmd/brain/main.go.
+type missionSpawner interface {
+	Create(ctx context.Context, m missions.Mission) (string, error)
+}
+
+// missionEvents is the narrow slice of *missions.Store the engine needs
+// to assemble a terminal mission's OutcomeDigest for the next step's
+// goal interpolation — *missions.Store satisfies it (Driver has no
+// Events passthrough of its own).
+type missionEvents interface {
+	Events(ctx context.Context, id string) ([]missions.Event, error)
+}
+
+// Engine reacts to mission terminal events and drives workflow runs
+// forward — the orchestration layer above missions (D-070). It never
+// mutates mission state; it only reads terminal missions and creates
+// new ones via spawner.
+type Engine struct {
+	store   engineStore
+	spawner missionSpawner
+	events  missionEvents
+	log     *slog.Logger
+}
+
+func NewEngine(store engineStore, spawner missionSpawner, events missionEvents, log *slog.Logger) *Engine {
+	return &Engine{store: store, spawner: spawner, events: events, log: log}
+}
+
+// StartRun creates a new run for workflowID and spawns the entry step's
+// mission. runContext seeds {{context.KEY}} interpolation for every
+// step in this run.
+func (e *Engine) StartRun(ctx context.Context, workflowID string, runContext map[string]string) (string, error) {
+	wf, err := e.store.Get(ctx, workflowID)
+	if err != nil {
+		return "", fmt.Errorf("workflows start run: %w", err)
+	}
+	if !wf.Enabled {
+		return "", fmt.Errorf("workflow %s is disabled", workflowID)
+	}
+	def, err := ParseDefinition(wf.Definition)
+	if err != nil {
+		return "", fmt.Errorf("workflows start run: %w", err)
+	}
+	runID, err := e.store.CreateRun(ctx, workflowID, def.Entry, runContext)
+	if err != nil {
+		return "", fmt.Errorf("workflows start run: %w", err)
+	}
+	if _, err := e.spawnStep(ctx, runID, def.Entry, def.Steps[def.Entry], runContext, "", ""); err != nil {
+		e.pauseRun(ctx, runID, fmt.Sprintf("spawn entry step %q failed: %s", def.Entry, err.Error()))
+		return runID, fmt.Errorf("workflows start run: spawn entry step: %w", err)
+	}
+	return runID, nil
+}
+
+// OnMissionTerminal reacts to mission m reaching a terminal phase: load
+// its run, find the edge from its step matching the outcome, and either
+// spawn the next step, end the run, pause it, or fail it on cap
+// exceeded. m.WorkflowRunID must be non-empty — the driver's OnTerminal
+// hook already filters for that before calling in. Every decision
+// appends a run event; the engine never mutates the mission itself.
+func (e *Engine) OnMissionTerminal(ctx context.Context, m missions.Mission) {
+	run, err := e.store.GetRun(ctx, m.WorkflowRunID)
+	if err != nil {
+		e.log.Warn("workflows: terminal mission: load run failed", "run_id", m.WorkflowRunID, "mission_id", m.ID, "error", err)
+		return
+	}
+	if run.Status != "running" {
+		// A run already paused/done/failed/cancelled ignores a late
+		// terminal event from a step mission that raced past it (e.g. a
+		// second edge firing while the run was already being cancelled).
+		return
+	}
+	wf, err := e.store.Get(ctx, run.WorkflowID)
+	if err != nil {
+		e.log.Warn("workflows: terminal mission: load workflow failed", "workflow_id", run.WorkflowID, "error", err)
+		return
+	}
+	def, err := ParseDefinition(wf.Definition)
+	if err != nil {
+		e.log.Warn("workflows: terminal mission: parse definition failed", "workflow_id", run.WorkflowID, "error", err)
+		return
+	}
+
+	on := "mission.done"
+	if m.Phase == missions.PhaseFailed {
+		on = "mission.failed"
+	}
+
+	// D-070: match the edge leaving the run's current step on this
+	// mission's outcome kind — the sole decision point for where a run
+	// goes next.
+	var matched *Edge
+	for i := range def.Edges {
+		if def.Edges[i].From == run.CurrentStep && def.Edges[i].On == on {
+			matched = &def.Edges[i]
+			break
+		}
+	}
+	if matched == nil {
+		// mission.failed with no matching edge: pause per the plan's
+		// failure semantics (slice 6 adds notifications). mission.done
+		// with no matching edge is equally a dead end the author likely
+		// forgot to wire — same pause treatment.
+		e.pauseRun(ctx, m.WorkflowRunID, fmt.Sprintf("no matching edge for step %q on %s", run.CurrentStep, on))
+		return
+	}
+
+	firings, err := e.store.CountEdgeFirings(ctx, m.WorkflowRunID, matched.From, matched.On, matched.To)
+	if err != nil {
+		e.log.Warn("workflows: terminal mission: count edge firings failed", "run_id", m.WorkflowRunID, "error", err)
+		return
+	}
+	if firings >= matched.MaxIterations {
+		e.failRun(ctx, m.WorkflowRunID, matched)
+		return
+	}
+
+	if matched.To == endStep {
+		e.endRun(ctx, m.WorkflowRunID, matched)
+		return
+	}
+
+	step, ok := def.Steps[matched.To]
+	if !ok {
+		e.pauseRun(ctx, m.WorkflowRunID, fmt.Sprintf("edge targets unknown step %q", matched.To))
+		return
+	}
+	events, err := e.events.Events(ctx, m.ID)
+	if err != nil {
+		e.pauseRun(ctx, m.WorkflowRunID, fmt.Sprintf("load mission %s events failed: %s", m.ID, err.Error()))
+		return
+	}
+	outcome := missions.OutcomeDigest(m, events, m.Phase, m.FailureReason)
+	if _, err := e.spawnStep(ctx, m.WorkflowRunID, matched.To, step, run.Context, outcome, m.ID); err != nil {
+		e.pauseRun(ctx, m.WorkflowRunID, fmt.Sprintf("spawn step %q failed: %s", matched.To, err.Error()))
+		return
+	}
+	if err := e.store.ApplyRunTransition(ctx, m.WorkflowRunID, RunTransition{
+		Status: "running", CurrentStep: matched.To,
+		Events: []RunTransitionEvent{{Kind: "edge.taken", Payload: map[string]any{
+			"from": matched.From, "on": matched.On, "to": matched.To, "mission_id": m.ID,
+		}}},
+	}); err != nil {
+		e.log.Warn("workflows: terminal mission: advance run failed", "run_id", m.WorkflowRunID, "error", err)
+	}
+}
+
+// spawnStep creates the next mission for step, interpolating its goal
+// from outcome + run context, and appends a run.warning event for any
+// unknown {{context.KEY}} placeholder before creating the mission.
+func (e *Engine) spawnStep(ctx context.Context, runID, stepName string, step Step, runContext map[string]string, outcome, parentMissionID string) (string, error) {
+	goal, unknown := interpolate(step.Goal, outcome, runContext)
+	for _, key := range unknown {
+		if err := e.store.ApplyRunTransition(ctx, runID, RunTransition{
+			Status: "running", CurrentStep: stepName,
+			Events: []RunTransitionEvent{{Kind: "run.warning", Payload: map[string]any{
+				"message": fmt.Sprintf("unknown placeholder {{context.%s}} rendered empty", key), "step": stepName,
+			}}},
+		}); err != nil {
+			e.log.Warn("workflows: spawn step: record unknown placeholder warning failed", "run_id", runID, "key", key, "error", err)
+		}
+	}
+	return e.spawner.Create(ctx, missions.Mission{
+		Goal: goal, Kind: step.Kind, Route: step.Route, PlanRoute: step.PlanRoute, AgentID: step.AgentID,
+		OnComplete: step.OnComplete, DestinationIDs: step.DestinationIDs,
+		ParentMissionID: parentMissionID, ParentContext: outcome,
+		WorkflowRunID: runID, WorkflowStep: stepName,
+	})
+}
+
+func (e *Engine) pauseRun(ctx context.Context, runID, reason string) {
+	run, err := e.store.GetRun(ctx, runID)
+	if err != nil {
+		e.log.Warn("workflows: pause run: reload failed", "run_id", runID, "error", err)
+		return
+	}
+	if err := e.store.ApplyRunTransition(ctx, runID, RunTransition{
+		Status: "paused", CurrentStep: run.CurrentStep,
+		Events: []RunTransitionEvent{{Kind: "run.paused", Payload: map[string]any{"reason": reason}}},
+	}); err != nil {
+		e.log.Warn("workflows: pause run failed", "run_id", runID, "error", err)
+	}
+}
+
+func (e *Engine) failRun(ctx context.Context, runID string, edge *Edge) {
+	if err := e.store.ApplyRunTransition(ctx, runID, RunTransition{
+		Status: "failed", CurrentStep: edge.From,
+		Events: []RunTransitionEvent{{Kind: "run.cap_exceeded", Payload: map[string]any{
+			"from": edge.From, "on": edge.On, "to": edge.To, "max_iterations": edge.MaxIterations,
+		}}},
+	}); err != nil {
+		e.log.Warn("workflows: fail run (cap exceeded) failed", "run_id", runID, "error", err)
+	}
+}
+
+func (e *Engine) endRun(ctx context.Context, runID string, edge *Edge) {
+	if err := e.store.ApplyRunTransition(ctx, runID, RunTransition{
+		Status: "done", CurrentStep: endStep,
+		Events: []RunTransitionEvent{{Kind: "run.done", Payload: map[string]any{"from": edge.From, "on": edge.On}}},
+	}); err != nil {
+		e.log.Warn("workflows: end run failed", "run_id", runID, "error", err)
+	}
+}

--- a/internal/brain/workflows/engine_test.go
+++ b/internal/brain/workflows/engine_test.go
@@ -207,6 +207,52 @@ func TestStartRunRefusesDisabledWorkflow(t *testing.T) {
 	}
 }
 
+// TestStartRunPausesOnSpawnValidationError covers D-071: a step whose
+// spawned mission Driver.Create rejects (here, missions.ErrInvalidMission
+// from an on_complete a workflow step can never satisfy, since Step
+// carries no repo_url/connector_id) must pause the run with the
+// validation error as the reason, not silently create an invalid
+// mission or crash the engine.
+func TestStartRunPausesOnSpawnValidationError(t *testing.T) {
+	def := Definition{
+		Entry: "coder",
+		Steps: map[string]Step{
+			"coder": {Goal: "write the code", Kind: "coding", OnComplete: "push"},
+		},
+	}
+	if err := def.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil (on_complete shape is valid at the definition level)", err)
+	}
+	store := newFakeEngineStore()
+	store.putWorkflow("wf1", def, true)
+	spawner := &fakeSpawner{createErr: fmt.Errorf("driver: create: %w: on_complete requires repo_url and connector_id on a kind=coding mission", missions.ErrInvalidMission)}
+	e := testEngine(store, spawner)
+
+	runID, err := e.StartRun(context.Background(), "wf1", nil)
+	if err == nil {
+		t.Fatal("StartRun() = nil error, want the spawn validation error surfaced")
+	}
+	if spawner.count() != 0 {
+		t.Fatalf("spawned missions = %d, want 0 (Create rejected it)", spawner.count())
+	}
+	run, getErr := store.GetRun(context.Background(), runID)
+	if getErr != nil {
+		t.Fatalf("GetRun: %v", getErr)
+	}
+	if run.Status != "paused" {
+		t.Fatalf("run status = %s, want paused", run.Status)
+	}
+	found := false
+	for _, k := range store.eventKinds(runID) {
+		if k == "run.paused" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("events = %v, want run.paused", store.eventKinds(runID))
+	}
+}
+
 func TestOnMissionTerminalAdvancesToNextStep(t *testing.T) {
 	store := newFakeEngineStore()
 	store.putWorkflow("wf1", coderQADefinition(), true)

--- a/internal/brain/workflows/engine_test.go
+++ b/internal/brain/workflows/engine_test.go
@@ -1,0 +1,383 @@
+package workflows
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+// fakeEngineStore is an in-memory engineStore for scripting Engine
+// scenarios without a real Postgres pool — mirrors missions/driver_test.go's
+// fakeStore approach.
+type fakeEngineStore struct {
+	mu        sync.Mutex
+	workflows map[string]Workflow
+	runs      map[string]Run
+	events    map[string][]RunEvent
+	seq       map[string]int64
+}
+
+func newFakeEngineStore() *fakeEngineStore {
+	return &fakeEngineStore{
+		workflows: map[string]Workflow{},
+		runs:      map[string]Run{},
+		events:    map[string][]RunEvent{},
+		seq:       map[string]int64{},
+	}
+}
+
+func (f *fakeEngineStore) putWorkflow(id string, def Definition, enabled bool) {
+	raw, _ := json.Marshal(def)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.workflows[id] = Workflow{ID: id, Definition: raw, Enabled: enabled}
+}
+
+func (f *fakeEngineStore) Get(ctx context.Context, id string) (Workflow, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	w, ok := f.workflows[id]
+	if !ok {
+		return Workflow{}, ErrNotFound
+	}
+	return w, nil
+}
+
+func (f *fakeEngineStore) CreateRun(ctx context.Context, workflowID, currentStep string, runContext map[string]string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	id := fmt.Sprintf("run-%d", len(f.runs)+1)
+	f.runs[id] = Run{ID: id, WorkflowID: workflowID, Status: "running", CurrentStep: currentStep, Context: runContext}
+	return id, nil
+}
+
+func (f *fakeEngineStore) GetRun(ctx context.Context, id string) (Run, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.runs[id]
+	if !ok {
+		return Run{}, ErrNotFound
+	}
+	return r, nil
+}
+
+func (f *fakeEngineStore) ApplyRunTransition(ctx context.Context, id string, t RunTransition) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.runs[id]
+	if !ok {
+		return ErrNotFound
+	}
+	r.Status, r.CurrentStep = t.Status, t.CurrentStep
+	f.runs[id] = r
+	for _, ev := range t.Events {
+		f.seq[id]++
+		payload, _ := json.Marshal(ev.Payload)
+		f.events[id] = append(f.events[id], RunEvent{RunID: id, Seq: f.seq[id], Kind: ev.Kind, Payload: payload})
+	}
+	return nil
+}
+
+func (f *fakeEngineStore) CountEdgeFirings(ctx context.Context, runID, from, on, to string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, ev := range f.events[runID] {
+		if ev.Kind != "edge.taken" {
+			continue
+		}
+		var p struct {
+			From string `json:"from"`
+			On   string `json:"on"`
+			To   string `json:"to"`
+		}
+		_ = json.Unmarshal(ev.Payload, &p)
+		if p.From == from && p.On == on && p.To == to {
+			n++
+		}
+	}
+	return n, nil
+}
+
+func (f *fakeEngineStore) eventKinds(runID string) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []string
+	for _, ev := range f.events[runID] {
+		out = append(out, ev.Kind)
+	}
+	return out
+}
+
+// fakeSpawner is an in-memory missionSpawner + missionEvents fake.
+type fakeSpawner struct {
+	mu        sync.Mutex
+	missions  []missions.Mission
+	createErr error
+}
+
+func (f *fakeSpawner) Create(ctx context.Context, m missions.Mission) (string, error) {
+	if f.createErr != nil {
+		return "", f.createErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	m.ID = fmt.Sprintf("mission-%d", len(f.missions)+1)
+	f.missions = append(f.missions, m)
+	return m.ID, nil
+}
+
+func (f *fakeSpawner) Events(ctx context.Context, id string) ([]missions.Event, error) {
+	return nil, nil
+}
+
+func (f *fakeSpawner) last() missions.Mission {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.missions[len(f.missions)-1]
+}
+
+func (f *fakeSpawner) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.missions)
+}
+
+func testEngine(store *fakeEngineStore, spawner *fakeSpawner) *Engine {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewEngine(store, spawner, spawner, log)
+}
+
+func coderQADefinition() Definition {
+	d := Definition{
+		Entry: "coder",
+		Steps: map[string]Step{
+			"coder": {Goal: "write the code", Kind: "coding"},
+			"qa":    {Goal: "review {{outcome}}", Kind: "general"},
+		},
+		Edges: []Edge{
+			{From: "coder", On: "mission.done", To: "qa", MaxIterations: 5},
+			{From: "qa", On: "mission.done", To: endStep, MaxIterations: 1},
+		},
+	}
+	_ = d.Validate()
+	return d
+}
+
+func TestStartRunSpawnsEntryStep(t *testing.T) {
+	store := newFakeEngineStore()
+	store.putWorkflow("wf1", coderQADefinition(), true)
+	spawner := &fakeSpawner{}
+	e := testEngine(store, spawner)
+
+	runID, err := e.StartRun(context.Background(), "wf1", map[string]string{"K": "v"})
+	if err != nil {
+		t.Fatalf("StartRun() = %v", err)
+	}
+	if spawner.count() != 1 {
+		t.Fatalf("spawned missions = %d, want 1", spawner.count())
+	}
+	m := spawner.last()
+	if m.Goal != "write the code" || m.WorkflowRunID != runID || m.WorkflowStep != "coder" {
+		t.Fatalf("spawned mission = %+v", m)
+	}
+	run, _ := store.GetRun(context.Background(), runID)
+	if run.Status != "running" || run.CurrentStep != "coder" {
+		t.Fatalf("run = %+v", run)
+	}
+}
+
+func TestStartRunRefusesDisabledWorkflow(t *testing.T) {
+	store := newFakeEngineStore()
+	store.putWorkflow("wf1", coderQADefinition(), false)
+	spawner := &fakeSpawner{}
+	e := testEngine(store, spawner)
+
+	if _, err := e.StartRun(context.Background(), "wf1", nil); err == nil {
+		t.Fatal("StartRun() = nil, want error for disabled workflow")
+	}
+	if spawner.count() != 0 {
+		t.Fatalf("spawned missions = %d, want 0", spawner.count())
+	}
+}
+
+func TestOnMissionTerminalAdvancesToNextStep(t *testing.T) {
+	store := newFakeEngineStore()
+	store.putWorkflow("wf1", coderQADefinition(), true)
+	spawner := &fakeSpawner{}
+	e := testEngine(store, spawner)
+
+	runID, _ := e.StartRun(context.Background(), "wf1", nil)
+	coderMission := spawner.last()
+	coderMission.ID = "coder-mission"
+	coderMission.Phase = missions.PhaseDone
+
+	e.OnMissionTerminal(context.Background(), coderMission)
+
+	if spawner.count() != 2 {
+		t.Fatalf("spawned missions = %d, want 2 (coder + qa)", spawner.count())
+	}
+	qa := spawner.last()
+	if qa.WorkflowStep != "qa" || qa.ParentMissionID != "coder-mission" {
+		t.Fatalf("qa mission = %+v", qa)
+	}
+	run, _ := store.GetRun(context.Background(), runID)
+	if run.CurrentStep != "qa" || run.Status != "running" {
+		t.Fatalf("run = %+v", run)
+	}
+}
+
+func TestOnMissionTerminalEndsRunOnToEnd(t *testing.T) {
+	store := newFakeEngineStore()
+	store.putWorkflow("wf1", coderQADefinition(), true)
+	spawner := &fakeSpawner{}
+	e := testEngine(store, spawner)
+
+	runID, _ := e.StartRun(context.Background(), "wf1", nil)
+	run, _ := store.GetRun(context.Background(), runID)
+	run.CurrentStep = "qa"
+	store.runs[runID] = run
+
+	qaMission := missions.Mission{ID: "qa-mission", WorkflowRunID: runID, WorkflowStep: "qa", Phase: missions.PhaseDone}
+	e.OnMissionTerminal(context.Background(), qaMission)
+
+	run, _ = store.GetRun(context.Background(), runID)
+	if run.Status != "done" {
+		t.Fatalf("run status = %s, want done", run.Status)
+	}
+}
+
+func TestOnMissionTerminalPausesOnNoMatchingEdge(t *testing.T) {
+	store := newFakeEngineStore()
+	store.putWorkflow("wf1", coderQADefinition(), true)
+	spawner := &fakeSpawner{}
+	e := testEngine(store, spawner)
+
+	runID, _ := e.StartRun(context.Background(), "wf1", nil)
+	coderMission := spawner.last()
+	coderMission.ID = "coder-mission"
+	coderMission.Phase = missions.PhaseFailed // no edge wired for coder+mission.failed
+
+	e.OnMissionTerminal(context.Background(), coderMission)
+
+	run, _ := store.GetRun(context.Background(), runID)
+	if run.Status != "paused" {
+		t.Fatalf("run status = %s, want paused", run.Status)
+	}
+	found := false
+	for _, k := range store.eventKinds(runID) {
+		if k == "run.paused" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("events = %v, want run.paused", store.eventKinds(runID))
+	}
+}
+
+func TestOnMissionTerminalCapExceededFailsRun(t *testing.T) {
+	def := coderQADefinition()
+	// Rewrite the coder->qa edge with a cap of 1 for this test.
+	def.Edges[0].MaxIterations = 1
+	store := newFakeEngineStore()
+	store.putWorkflow("wf1", def, true)
+	spawner := &fakeSpawner{}
+	e := testEngine(store, spawner)
+
+	runID, _ := e.StartRun(context.Background(), "wf1", nil)
+
+	// Fire the coder->qa edge once (allowed): advances to qa.
+	coder1 := spawner.last()
+	coder1.ID = "coder-1"
+	coder1.Phase = missions.PhaseDone
+	e.OnMissionTerminal(context.Background(), coder1)
+
+	// Manually rewind the run back to "coder" to simulate a second
+	// coder mission finishing and trying to take the SAME edge again —
+	// this must now exceed the cap of 1.
+	run, _ := store.GetRun(context.Background(), runID)
+	run.CurrentStep = "coder"
+	store.runs[runID] = run
+
+	coder2 := missions.Mission{ID: "coder-2", WorkflowRunID: runID, WorkflowStep: "coder", Phase: missions.PhaseDone}
+	e.OnMissionTerminal(context.Background(), coder2)
+
+	run, _ = store.GetRun(context.Background(), runID)
+	if run.Status != "failed" {
+		t.Fatalf("run status = %s, want failed (cap exceeded)", run.Status)
+	}
+	found := false
+	for _, k := range store.eventKinds(runID) {
+		if k == "run.cap_exceeded" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("events = %v, want run.cap_exceeded", store.eventKinds(runID))
+	}
+}
+
+func TestOnMissionTerminalIgnoresNonRunningRun(t *testing.T) {
+	store := newFakeEngineStore()
+	store.putWorkflow("wf1", coderQADefinition(), true)
+	spawner := &fakeSpawner{}
+	e := testEngine(store, spawner)
+
+	runID, _ := e.StartRun(context.Background(), "wf1", nil)
+	run, _ := store.GetRun(context.Background(), runID)
+	run.Status = "cancelled"
+	store.runs[runID] = run
+
+	coderMission := spawner.last()
+	coderMission.ID = "coder-mission"
+	coderMission.Phase = missions.PhaseDone
+	e.OnMissionTerminal(context.Background(), coderMission)
+
+	if spawner.count() != 1 {
+		t.Fatalf("spawned missions = %d, want 1 (no further spawn on a non-running run)", spawner.count())
+	}
+}
+
+func TestOnMissionTerminalRecordsUnknownPlaceholderWarning(t *testing.T) {
+	def := Definition{
+		Entry: "coder",
+		Steps: map[string]Step{
+			"coder": {Goal: "write code", Kind: "coding"},
+			"qa":    {Goal: "check {{context.MISSING}}", Kind: "general"},
+		},
+		Edges: []Edge{
+			{From: "coder", On: "mission.done", To: "qa", MaxIterations: 1},
+		},
+	}
+	_ = def.Validate()
+	store := newFakeEngineStore()
+	store.putWorkflow("wf1", def, true)
+	spawner := &fakeSpawner{}
+	e := testEngine(store, spawner)
+
+	runID, _ := e.StartRun(context.Background(), "wf1", nil)
+	coderMission := spawner.last()
+	coderMission.ID = "coder-mission"
+	coderMission.Phase = missions.PhaseDone
+	e.OnMissionTerminal(context.Background(), coderMission)
+
+	found := false
+	for _, k := range store.eventKinds(runID) {
+		if k == "run.warning" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("events = %v, want run.warning for unknown placeholder", store.eventKinds(runID))
+	}
+	qa := spawner.last()
+	if qa.Goal != "check " {
+		t.Fatalf("qa goal = %q, want unknown placeholder rendered empty", qa.Goal)
+	}
+}

--- a/internal/brain/workflows/interpolate.go
+++ b/internal/brain/workflows/interpolate.go
@@ -1,0 +1,50 @@
+package workflows
+
+import "strings"
+
+// outcomeTruncateRunes bounds {{outcome}}'s expansion — the same
+// reasoning as missions.OutcomeDigest's own truncation: an unbounded
+// digest could blow out prompt size across every downstream step.
+const outcomeTruncateRunes = 4000
+
+// interpolate replaces {{outcome}} with outcome (truncated) and
+// {{context.KEY}} with context[KEY] in goal. An unknown {{context.KEY}}
+// renders as empty and is reported back via unknown, for the caller to
+// log as a run event warning — slice-1 minimal, no other placeholder
+// forms.
+func interpolate(goal, outcome string, context map[string]string) (rendered string, unknown []string) {
+	truncated := truncateRunes(outcome, outcomeTruncateRunes)
+	rendered = strings.ReplaceAll(goal, "{{outcome}}", truncated)
+
+	var b strings.Builder
+	for {
+		start := strings.Index(rendered, "{{context.")
+		if start == -1 {
+			b.WriteString(rendered)
+			break
+		}
+		end := strings.Index(rendered[start:], "}}")
+		if end == -1 {
+			b.WriteString(rendered)
+			break
+		}
+		end += start
+		key := rendered[start+len("{{context.") : end]
+		b.WriteString(rendered[:start])
+		if v, ok := context[key]; ok {
+			b.WriteString(v)
+		} else {
+			unknown = append(unknown, key)
+		}
+		rendered = rendered[end+len("}}"):]
+	}
+	return b.String(), unknown
+}
+
+func truncateRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n])
+}

--- a/internal/brain/workflows/interpolate_test.go
+++ b/internal/brain/workflows/interpolate_test.go
@@ -1,0 +1,54 @@
+package workflows
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInterpolateOutcome(t *testing.T) {
+	got, unknown := interpolate("review this: {{outcome}}", "the digest", nil)
+	if got != "review this: the digest" {
+		t.Fatalf("got %q", got)
+	}
+	if len(unknown) != 0 {
+		t.Fatalf("unknown = %v, want none", unknown)
+	}
+}
+
+func TestInterpolateContext(t *testing.T) {
+	got, unknown := interpolate("do {{context.TASK}} for {{context.REPO}}", "", map[string]string{"TASK": "fix bug", "REPO": "acme/app"})
+	if got != "do fix bug for acme/app" {
+		t.Fatalf("got %q", got)
+	}
+	if len(unknown) != 0 {
+		t.Fatalf("unknown = %v, want none", unknown)
+	}
+}
+
+func TestInterpolateUnknownContextKeyRendersEmpty(t *testing.T) {
+	got, unknown := interpolate("do {{context.MISSING}} now", "", map[string]string{"OTHER": "x"})
+	if got != "do  now" {
+		t.Fatalf("got %q, want placeholder rendered empty", got)
+	}
+	if len(unknown) != 1 || unknown[0] != "MISSING" {
+		t.Fatalf("unknown = %v, want [MISSING]", unknown)
+	}
+}
+
+func TestInterpolateOutcomeTruncated(t *testing.T) {
+	long := strings.Repeat("x", outcomeTruncateRunes+500)
+	got, _ := interpolate("{{outcome}}", long, nil)
+	if len([]rune(got)) != outcomeTruncateRunes {
+		t.Fatalf("len(got) = %d, want %d", len([]rune(got)), outcomeTruncateRunes)
+	}
+}
+
+func TestInterpolateNoPlaceholders(t *testing.T) {
+	got, unknown := interpolate("plain goal, no placeholders", "outcome", map[string]string{"K": "v"})
+	if got != "plain goal, no placeholders" {
+		t.Fatalf("got %q", got)
+	}
+	if len(unknown) != 0 {
+		t.Fatalf("unknown = %v, want none", unknown)
+	}
+}

--- a/internal/brain/workflows/store.go
+++ b/internal/brain/workflows/store.go
@@ -1,0 +1,394 @@
+package workflows
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+// Sentinel errors the HTTP layer maps onto status codes, mirroring
+// missions.ErrNotFound / ErrTerminal.
+var (
+	ErrNotFound  = errors.New("not found")
+	ErrDuplicate = errors.New("a workflow with this name already exists")
+)
+
+// Workflow is the API/DB shape of one workflows row.
+type Workflow struct {
+	ID         string          `json:"id"`
+	Name       string          `json:"name"`
+	Definition json.RawMessage `json:"definition"`
+	Enabled    bool            `json:"enabled"`
+	CreatedAt  time.Time       `json:"created_at"`
+	UpdatedAt  time.Time       `json:"updated_at"`
+}
+
+// Run is the API/DB shape of one workflow_runs row.
+type Run struct {
+	ID          string            `json:"id"`
+	WorkflowID  string            `json:"workflow_id"`
+	Status      string            `json:"status"` // running | paused | done | failed | cancelled
+	CurrentStep string            `json:"current_step"`
+	Context     map[string]string `json:"context"`
+	CreatedAt   time.Time         `json:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"`
+}
+
+// RunEvent is one row from workflow_run_events.
+type RunEvent struct {
+	ID        int64           `json:"id"`
+	RunID     string          `json:"run_id"`
+	Seq       int64           `json:"seq"`
+	Kind      string          `json:"kind"`
+	Payload   json.RawMessage `json:"payload"`
+	CreatedAt time.Time       `json:"created_at"`
+}
+
+// Store is workflows' + workflow_runs' + workflow_run_events' Postgres
+// access.
+type Store struct {
+	db  *pgpool.Pool
+	log *slog.Logger
+}
+
+func NewStore(db *pgpool.Pool, log *slog.Logger) *Store {
+	return &Store{db: db, log: log}
+}
+
+const workflowColumns = `id, name, definition, enabled, created_at, updated_at`
+
+func scanWorkflow(row pgx.Row) (Workflow, error) {
+	var w Workflow
+	if err := row.Scan(&w.ID, &w.Name, &w.Definition, &w.Enabled, &w.CreatedAt, &w.UpdatedAt); err != nil {
+		return Workflow{}, err
+	}
+	return w, nil
+}
+
+// Create validates the definition and inserts a workflow row.
+func (s *Store) Create(ctx context.Context, name string, definition json.RawMessage) (string, error) {
+	if _, err := ParseDefinition(definition); err != nil {
+		return "", err
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		return "", fmt.Errorf("workflows create: %w", err)
+	}
+	var id string
+	err = db.QueryRow(ctx, `INSERT INTO workflows (name, definition) VALUES ($1, $2) RETURNING id`,
+		name, definition).Scan(&id)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return "", ErrDuplicate
+		}
+		return "", fmt.Errorf("workflows create: %w", err)
+	}
+	return id, nil
+}
+
+// Get returns one workflow by id.
+func (s *Store) Get(ctx context.Context, id string) (Workflow, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return Workflow{}, fmt.Errorf("workflows get: %w", err)
+	}
+	w, err := scanWorkflow(db.QueryRow(ctx, `SELECT `+workflowColumns+` FROM workflows WHERE id = $1`, id))
+	if err != nil {
+		return Workflow{}, fmt.Errorf("workflow %s: %w", id, ErrNotFound)
+	}
+	return w, nil
+}
+
+// List returns every workflow, newest first.
+func (s *Store) List(ctx context.Context) ([]Workflow, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("workflows list: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT `+workflowColumns+` FROM workflows ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("workflows list: %w", err)
+	}
+	defer rows.Close()
+	out := []Workflow{}
+	for rows.Next() {
+		w, err := scanWorkflow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("workflows list: %w", err)
+		}
+		out = append(out, w)
+	}
+	return out, rows.Err()
+}
+
+// Update validates the new definition and replaces it plus enabled.
+func (s *Store) Update(ctx context.Context, id string, definition json.RawMessage, enabled bool) error {
+	if _, err := ParseDefinition(definition); err != nil {
+		return err
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("workflows update: %w", err)
+	}
+	tag, err := db.Exec(ctx, `UPDATE workflows SET definition = $2, enabled = $3, updated_at = now() WHERE id = $1`,
+		id, definition, enabled)
+	if err != nil {
+		return fmt.Errorf("workflows update: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("workflow %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+// SetEnabled flips a workflow's enabled flag without touching its
+// definition — a disabled workflow's StartRun is refused by the API
+// layer, existing runs are unaffected.
+func (s *Store) SetEnabled(ctx context.Context, id string, enabled bool) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("workflows set enabled: %w", err)
+	}
+	tag, err := db.Exec(ctx, `UPDATE workflows SET enabled = $2, updated_at = now() WHERE id = $1`, id, enabled)
+	if err != nil {
+		return fmt.Errorf("workflows set enabled: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("workflow %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+const runColumns = `id, workflow_id, status, current_step, context, created_at, updated_at`
+
+func scanRun(row pgx.Row) (Run, error) {
+	var r Run
+	var contextRaw []byte
+	if err := row.Scan(&r.ID, &r.WorkflowID, &r.Status, &r.CurrentStep, &contextRaw, &r.CreatedAt, &r.UpdatedAt); err != nil {
+		return Run{}, err
+	}
+	_ = json.Unmarshal(contextRaw, &r.Context)
+	if r.Context == nil {
+		r.Context = map[string]string{}
+	}
+	return r, nil
+}
+
+// CreateRun inserts a run row in status=running at currentStep, with
+// the given initial context.
+func (s *Store) CreateRun(ctx context.Context, workflowID, currentStep string, runContext map[string]string) (string, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return "", fmt.Errorf("workflows create run: %w", err)
+	}
+	if runContext == nil {
+		runContext = map[string]string{}
+	}
+	contextJSON, err := json.Marshal(runContext)
+	if err != nil {
+		return "", fmt.Errorf("workflows create run: %w", err)
+	}
+	var id string
+	err = db.QueryRow(ctx, `INSERT INTO workflow_runs (workflow_id, current_step, context) VALUES ($1, $2, $3) RETURNING id`,
+		workflowID, currentStep, contextJSON).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("workflows create run: %w", err)
+	}
+	return id, nil
+}
+
+// GetRun returns one run by id.
+func (s *Store) GetRun(ctx context.Context, id string) (Run, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return Run{}, fmt.Errorf("workflows get run: %w", err)
+	}
+	r, err := scanRun(db.QueryRow(ctx, `SELECT `+runColumns+` FROM workflow_runs WHERE id = $1`, id))
+	if err != nil {
+		return Run{}, fmt.Errorf("workflow run %s: %w", id, ErrNotFound)
+	}
+	return r, nil
+}
+
+// ListRuns returns runs for workflowID, newest first. Empty workflowID
+// lists every run.
+func (s *Store) ListRuns(ctx context.Context, workflowID string) ([]Run, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("workflows list runs: %w", err)
+	}
+	query := `SELECT ` + runColumns + ` FROM workflow_runs`
+	var args []any
+	if workflowID != "" {
+		query += ` WHERE workflow_id = $1`
+		args = append(args, workflowID)
+	}
+	query += ` ORDER BY created_at DESC`
+	rows, err := db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("workflows list runs: %w", err)
+	}
+	defer rows.Close()
+	out := []Run{}
+	for rows.Next() {
+		r, err := scanRun(rows)
+		if err != nil {
+			return nil, fmt.Errorf("workflows list runs: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// RunTransition is the ApplyRunTransition writer's input: the run's new
+// status/current_step plus any events to append in the same
+// transaction — same shape as missions.Transition.
+type RunTransition struct {
+	Status      string
+	CurrentStep string
+	Events      []RunTransitionEvent
+}
+
+type RunTransitionEvent struct {
+	Kind    string
+	Payload map[string]any
+}
+
+// ApplyRunTransition persists a RunTransition atomically: updates the
+// run row and appends its events in order, all in one txn — the ONLY
+// way a run's status/current_step changes after CreateRun, mirroring
+// missions.Store.ApplyTransition's discipline.
+func (s *Store) ApplyRunTransition(ctx context.Context, id string, t RunTransition) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("workflows apply run transition: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("workflows apply run transition begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+
+	var exists bool
+	if err := tx.QueryRow(ctx, `SELECT true FROM workflow_runs WHERE id = $1 FOR UPDATE`, id).Scan(&exists); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("workflow run %s: %w", id, ErrNotFound)
+		}
+		return fmt.Errorf("workflows apply run transition lock: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `UPDATE workflow_runs SET status = $2, current_step = $3, updated_at = now() WHERE id = $1`,
+		id, t.Status, t.CurrentStep); err != nil {
+		return fmt.Errorf("workflows apply run transition update: %w", err)
+	}
+	for _, ev := range t.Events {
+		if err := appendRunEventTx(ctx, tx, id, ev.Kind, ev.Payload); err != nil {
+			return fmt.Errorf("workflows apply run transition event: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("workflows apply run transition commit: %w", err)
+	}
+	return nil
+}
+
+// AppendRunEvent assigns seq under SELECT ... FOR UPDATE on the run row
+// (serializes appends per-run only) and inserts, outside of
+// ApplyRunTransition — for callers that need to log something without a
+// status change.
+func (s *Store) AppendRunEvent(ctx context.Context, id, kind string, payload map[string]any) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("workflows append run event: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("workflows append run event begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+	if err := appendRunEventTx(ctx, tx, id, kind, payload); err != nil {
+		return fmt.Errorf("workflows append run event: %w", err)
+	}
+	return tx.Commit(ctx)
+}
+
+// appendRunEventTx does the actual locked-seq insert within an
+// already-open transaction, shared by ApplyRunTransition and
+// AppendRunEvent — copies missions/store.go's appendEventTx pattern.
+// Append-only: never updated or deleted.
+func appendRunEventTx(ctx context.Context, tx pgx.Tx, runID, kind string, payload map[string]any) error {
+	var exists bool
+	if err := tx.QueryRow(ctx, `SELECT true FROM workflow_runs WHERE id = $1 FOR UPDATE`, runID).Scan(&exists); err != nil {
+		return fmt.Errorf("lock run %s: %w", runID, err)
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO workflow_run_events (run_id, seq, kind, payload)
+		 SELECT $1, COALESCE(MAX(seq), 0) + 1, $2, $3 FROM workflow_run_events WHERE run_id = $1`,
+		runID, kind, data,
+	); err != nil {
+		return fmt.Errorf("insert run event: %w", err)
+	}
+	return nil
+}
+
+// RunEvents returns a run's full event log in seq order.
+func (s *Store) RunEvents(ctx context.Context, runID string) ([]RunEvent, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("workflows run events: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT id, run_id, seq, kind, payload, created_at
+		FROM workflow_run_events WHERE run_id = $1 ORDER BY seq`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("workflows run events: %w", err)
+	}
+	defer rows.Close()
+	out := []RunEvent{}
+	for rows.Next() {
+		var e RunEvent
+		if err := rows.Scan(&e.ID, &e.RunID, &e.Seq, &e.Kind, &e.Payload, &e.CreatedAt); err != nil {
+			return nil, fmt.Errorf("workflows run events: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// CountEdgeFirings counts how many times an edge (identified by its
+// from-step + on-event + to-step) has previously fired for run —
+// Engine's per-edge iteration-cap input. Counts "edge.taken" run events
+// matching all three fields.
+func (s *Store) CountEdgeFirings(ctx context.Context, runID, from, on, to string) (int, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return 0, fmt.Errorf("workflows count edge firings: %w", err)
+	}
+	var n int
+	err = db.QueryRow(ctx, `SELECT count(*) FROM workflow_run_events
+		WHERE run_id = $1 AND kind = 'edge.taken'
+		AND payload->>'from' = $2 AND payload->>'on' = $3 AND payload->>'to' = $4`,
+		runID, from, on, to).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("workflows count edge firings: %w", err)
+	}
+	return n, nil
+}
+
+// isUniqueViolation reports whether err is Postgres's unique_violation
+// (23505) — workflows.name's UNIQUE constraint. Mirrors
+// missions/schedules.go's isUniqueViolation.
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}

--- a/internal/brain/workflows/store_integration_test.go
+++ b/internal/brain/workflows/store_integration_test.go
@@ -1,0 +1,220 @@
+//go:build integration
+
+package workflows
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/SumonMSelim/timothy/internal/platform/migrate"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+	"github.com/SumonMSelim/timothy/migrations"
+)
+
+// marker prefixes every test workflow's name so sweep can find and
+// remove them without touching unrelated rows — mirrors
+// missions/store_integration_test.go's own marker.
+const marker = "itest-workflow-"
+
+func testStore(t *testing.T) *Store {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	sweep(ctx, db)
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer ccancel()
+		conn, err := pgx.Connect(cctx, dsn)
+		if err != nil {
+			t.Logf("teardown sweep skipped: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close(cctx) }()
+		sweep(cctx, conn)
+	})
+	return NewStore(pool, log)
+}
+
+// execer is the shared Exec surface between a pool connection and a
+// one-shot pgx.Conn — mirrors missions/store_integration_test.go's own
+// execer, lets sweep run identically at setup and teardown.
+type execer interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+func sweep(ctx context.Context, db execer) {
+	_, _ = db.Exec(ctx, `DELETE FROM workflow_runs WHERE workflow_id IN (SELECT id FROM workflows WHERE name LIKE $1 || '%')`, marker)
+	_, _ = db.Exec(ctx, `DELETE FROM workflows WHERE name LIKE $1 || '%'`, marker)
+}
+
+func validDef() json.RawMessage {
+	raw, _ := json.Marshal(Definition{
+		Entry: "a",
+		Steps: map[string]Step{"a": {Goal: "do a", Kind: "general"}},
+		Edges: []Edge{{From: "a", On: "mission.done", To: "end", MaxIterations: 1}},
+	})
+	return raw
+}
+
+func TestStoreCreateGetList(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	id, err := s.Create(ctx, marker+"one", validDef())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	wf, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if wf.Name != marker+"one" || !wf.Enabled {
+		t.Fatalf("wf = %+v", wf)
+	}
+	rows, err := s.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	found := false
+	for _, r := range rows {
+		if r.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("List did not include the created workflow")
+	}
+}
+
+func TestStoreCreateRejectsInvalidDefinition(t *testing.T) {
+	s := testStore(t)
+	if _, err := s.Create(context.Background(), marker+"bad", json.RawMessage(`{"entry":"x","steps":{}}`)); err == nil {
+		t.Fatal("Create() = nil, want error for invalid definition")
+	}
+}
+
+func TestStoreCreateRejectsDuplicateName(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	name := marker + "dup"
+	if _, err := s.Create(ctx, name, validDef()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := s.Create(ctx, name, validDef()); err == nil {
+		t.Fatal("Create() = nil, want ErrDuplicate on second create with the same name")
+	}
+}
+
+func TestRunEventsAppendOnlySeq(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	wfID, err := s.Create(ctx, marker+"seq", validDef())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	runID, err := s.CreateRun(ctx, wfID, "a", nil)
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if err := s.AppendRunEvent(ctx, runID, "test.event", map[string]any{"i": i}); err != nil {
+			t.Fatalf("AppendRunEvent(%d): %v", i, err)
+		}
+	}
+	events, err := s.RunEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("RunEvents: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("len(events) = %d, want 3", len(events))
+	}
+	for i, e := range events {
+		if e.Seq != int64(i+1) {
+			t.Fatalf("events[%d].Seq = %d, want %d", i, e.Seq, i+1)
+		}
+	}
+}
+
+func TestApplyRunTransitionUpdatesStatusAndAppendsEvents(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	wfID, err := s.Create(ctx, marker+"transition", validDef())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	runID, err := s.CreateRun(ctx, wfID, "a", nil)
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if err := s.ApplyRunTransition(ctx, runID, RunTransition{
+		Status: "done", CurrentStep: "end",
+		Events: []RunTransitionEvent{{Kind: "run.done", Payload: map[string]any{"from": "a"}}},
+	}); err != nil {
+		t.Fatalf("ApplyRunTransition: %v", err)
+	}
+	run, err := s.GetRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if run.Status != "done" || run.CurrentStep != "end" {
+		t.Fatalf("run = %+v", run)
+	}
+	events, err := s.RunEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("RunEvents: %v", err)
+	}
+	if len(events) != 1 || events[0].Kind != "run.done" {
+		t.Fatalf("events = %+v", events)
+	}
+}
+
+func TestCountEdgeFirings(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+	wfID, err := s.Create(ctx, marker+"firings", validDef())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	runID, err := s.CreateRun(ctx, wfID, "a", nil)
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if err := s.AppendRunEvent(ctx, runID, "edge.taken", map[string]any{"from": "a", "on": "mission.done", "to": "end"}); err != nil {
+			t.Fatalf("AppendRunEvent: %v", err)
+		}
+	}
+	n, err := s.CountEdgeFirings(ctx, runID, "a", "mission.done", "end")
+	if err != nil {
+		t.Fatalf("CountEdgeFirings: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("CountEdgeFirings = %d, want 2", n)
+	}
+	if n, _ := s.CountEdgeFirings(ctx, runID, "a", "mission.failed", "end"); n != 0 {
+		t.Fatalf("CountEdgeFirings (different on) = %d, want 0", n)
+	}
+}

--- a/migrations/0010_missions.sql
+++ b/migrations/0010_missions.sql
@@ -180,7 +180,13 @@ CREATE TABLE IF NOT EXISTS missions (
     -- driver.go's terminal-transition hook). Never model-decided —
     -- api/missions.go's create validates every id against the
     -- operator-owned destinations table before it lands here.
-    destination_ids       uuid[] NOT NULL DEFAULT '{}'
+    destination_ids       uuid[] NOT NULL DEFAULT '{}',
+    -- workflow_run_id/workflow_step name the workflow run and step
+    -- (internal/brain/workflows) this mission was spawned as, if any.
+    -- NULL/'' for an ordinary mission. The workflow engine reads these
+    -- via mission terminal events; it never writes mission state.
+    workflow_run_id        uuid,
+    workflow_step          text NOT NULL DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS missions_status_idx ON missions (status);

--- a/migrations/0015_workflows.sql
+++ b/migrations/0015_workflows.sql
@@ -1,0 +1,56 @@
+-- Agentic workflows: an orchestration layer above missions
+-- (internal/brain/workflows). A workflow is composable data (steps +
+-- edges); missions stay atoms, spawned one at a time by the engine
+-- reacting to mission terminal events. See
+-- docs/2026-08-14-agentic-workflows-plan.md.
+CREATE TABLE IF NOT EXISTS workflows (
+    id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        text UNIQUE NOT NULL,
+    definition  jsonb NOT NULL DEFAULT '{}',
+    enabled     boolean NOT NULL DEFAULT true,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- status is deliberately NOT CHECK-constrained, same reasoning as
+-- missions.phase/status (0010_missions.sql): a future code rollback
+-- that doesn't recognize a newer status must degrade safely in Go, not
+-- have Postgres reject the row.
+CREATE TABLE IF NOT EXISTS workflow_runs (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    workflow_id   uuid NOT NULL REFERENCES workflows(id),
+    status        text NOT NULL DEFAULT 'running', -- running | paused | done | failed | cancelled
+    current_step  text NOT NULL DEFAULT '',
+    context       jsonb NOT NULL DEFAULT '{}',
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS workflow_runs_workflow_idx ON workflow_runs (workflow_id);
+
+-- Append-only event log, same invariant as mission_events: seq is
+-- assigned under a SELECT ... FOR UPDATE on the parent run row, never
+-- updated or deleted.
+CREATE TABLE IF NOT EXISTS workflow_run_events (
+    id          bigserial PRIMARY KEY,
+    run_id      uuid NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+    seq         bigint NOT NULL,
+    kind        text NOT NULL,
+    payload     jsonb NOT NULL DEFAULT '{}',
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (run_id, seq)
+);
+
+-- Deferred FK: a mission may name the workflow run that spawned it.
+-- NOT VALID skips a table scan on possibly-large existing data at
+-- migration time, same pattern as missions_schedule_id_fkey
+-- (0010_missions.sql).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'missions_workflow_run_id_fkey'
+    ) THEN
+        ALTER TABLE missions ADD CONSTRAINT missions_workflow_run_id_fkey
+            FOREIGN KEY (workflow_run_id) REFERENCES workflow_runs(id) NOT VALID;
+    END IF;
+END $$;


### PR DESCRIPTION
Replaces draft #287 (that branch was rebased onto post-light main; force-push is not used in this repo, so this is the same work republished on a fresh branch, plus the validation slice the architecture review demanded).

**Slice 1 of the agentic-workflows plan (D-070)** — see #287's description for the full breakdown: workflows/runs/run_events schema (append-only), definition validation with Go-side iteration cap ≤10, engine reacting to mission terminal transitions and spawning next steps via the follow-up path, nil-safe driver OnTerminal hook, admin API, env-gated behind WORKFLOWS_ENABLED. Statemachine untouched.

**D-071 — missions.ValidateCreate** (review finding H-1): create rules lived only in the HTTP handler while Driver.Create validated nothing, and the workflows engine is now its second caller. Domain rules (kind enum, light⇒general, coding-only fields, on_complete requirements, route required, destination enabled) move into the missions package, called from Driver.Create (nil-gated deps). The handler keeps HTTP concerns and maps ErrInvalidMission to 400. Workflow spawns resolve default routes first; a step failing validation pauses the run with the reason in run.paused.

Tests: 28-case ValidateCreate table, direct Driver.Create rejection, engine pause-on-invalid-step, definition on_complete enum, updated api tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790100055&installation_model_id=431401&pr_number=290&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F290&signature=90983c53e92000e25badaf3a5d4e37a9d5793265bcbd0bc1345a799ed6c77842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->