### PR TITLE
refactor: mission policy table for kind/light behavior (D-072)

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -410,10 +410,10 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 	// place in ValidateCreate's pure struct-shape rules; the resulting
 	// values still pass through ValidateCreate's kind/harness/environment
 	// checks below via Driver.Create.
-	if req.Kind == "coding" && req.Harness == "" && h.codingExecutorDefault != nil {
+	if req.Kind == missions.KindCoding && req.Harness == "" && h.codingExecutorDefault != nil {
 		req.Harness = h.codingExecutorDefault(r.Context())
 	}
-	if req.Kind == "coding" && req.Environment == "" {
+	if req.Kind == missions.KindCoding && req.Environment == "" {
 		// Auto-detect (D-05x), resolved server-side at create time so
 		// the environment is fixed before the sandbox container is ever
 		// created: no worktree exists yet (it's provisioned after this
@@ -501,7 +501,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		defaultRoute = h.routeForRole(r.Context(), "default")
 	}
 	if req.Route == "" {
-		if req.Kind == "coding" {
+		if req.Kind == missions.KindCoding {
 			req.Route = missions.DefaultCodingRoute(r.Context(), h.routeExists, defaultRoute)
 		} else {
 			req.Route = defaultRoute
@@ -710,7 +710,7 @@ func (h *missionAPI) classifyGoal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	kind := classifyKind(r.Context(), h.classify, req.Goal)
-	light := kind == "general" && classifyLight(r.Context(), h.classify, req.Goal)
+	light := kind == missions.KindGeneral && classifyLight(r.Context(), h.classify, req.Goal)
 	writeJSON(w, http.StatusOK, map[string]any{"kind": kind, "light": light})
 }
 

--- a/internal/brain/api/schedules.go
+++ b/internal/brain/api/schedules.go
@@ -67,7 +67,7 @@ func (h *scheduleAPI) validateDestinationIDs(ctx context.Context, ids []string) 
 // kind=coding — light (D-069) only makes sense for a kind=general
 // mission, same rule create() enforces for a one-off mission.
 func validateLightTemplate(t missions.MissionTemplate) error {
-	if t.Light && t.Kind != "general" {
+	if t.Light && t.Kind != missions.KindGeneral {
 		return fmt.Errorf("mission_template.light is only valid for kind=general")
 	}
 	return nil

--- a/internal/brain/missions/complete.go
+++ b/internal/brain/missions/complete.go
@@ -90,7 +90,7 @@ func NewCompleter(workspace *Workspace, store eventAppender, resolveToken PushTo
 // diverge on what counts as pushable.
 func NotPushable(m Mission) string {
 	switch {
-	case m.Kind != "coding":
+	case !missionPolicyFor(m).canPush:
 		return "only coding missions can be pushed"
 	case m.Branch == "":
 		return "mission has no branch"

--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -186,6 +186,15 @@ func (r *delegatedRunner) RunWorker(ctx context.Context, m Mission, packet WorkP
 	if m.Harness == "" {
 		return r.native.RunWorker(ctx, m, packet)
 	}
+	if !missionPolicyFor(m).canDelegate {
+		// D-072: enforces the documented coding-only harness rule
+		// in-package — ValidateCreate already rejects a non-coding
+		// mission with harness set, so this only fires for a row that
+		// predates that check or was inserted around it.
+		r.log.Warn("delegated runner: harness not allowed for kind; falling back to native", "mission_id", m.ID, "kind", m.Kind, "harness", m.Harness)
+		r.recordSkipped(ctx, m.ID, m.Harness, "harness not allowed for kind", nil)
+		return r.native.RunWorker(ctx, m, packet)
+	}
 	adapter, ok := executor.Lookup(m.Harness)
 	if !ok {
 		r.log.Warn("delegated runner: unknown harness; falling back to native", "mission_id", m.ID, "harness", m.Harness)

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -1281,6 +1281,47 @@ func TestDelegatedRunWorker_Dispatch_UnknownHarnessFallsBackToNative(t *testing.
 	}
 }
 
+// D-072: a general mission with Harness set (a row predating
+// ValidateCreate's coding-only rule, or inserted around it) must fall
+// back to native and record why — enforces the coding-only harness
+// rule in-package instead of trusting the caller already checked it.
+func TestDelegatedRunWorker_Dispatch_HarnessOnGeneralFallsBackToNative(t *testing.T) {
+	native := &fakeNative{verdict: WorkerVerdict{Outcome: "done"}}
+	resolveCalled := false
+	resolve := func(ctx context.Context, name, harness string) (*gwclient.ResolvedRoute, error) {
+		resolveCalled = true
+		return nil, nil
+	}
+	sandbox := newFakeSandbox()
+	events := &fakeEventSink{}
+
+	r := newTestDelegatedRunner(native, resolve, scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+	m.Kind = "general"
+
+	if _, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if native.callCount() != 1 {
+		t.Fatalf("native call count = %d, want 1", native.callCount())
+	}
+	if resolveCalled {
+		t.Fatal("resolveRoute called for a harness-not-allowed mission; want it skipped entirely")
+	}
+	if events.count("executor.skipped") != 1 {
+		t.Fatalf("executor.skipped count = %d, want 1", events.count("executor.skipped"))
+	}
+	skipped, _ := events.last("executor.skipped")
+	var skippedPayload map[string]any
+	_ = json.Unmarshal(skipped.Payload, &skippedPayload)
+	if skippedPayload["reason"] != "harness not allowed for kind" {
+		t.Fatalf("executor.skipped reason = %v, want %q", skippedPayload["reason"], "harness not allowed for kind")
+	}
+	if skippedPayload["harness"] != m.Harness {
+		t.Fatalf("executor.skipped harness = %v, want %q", skippedPayload["harness"], m.Harness)
+	}
+}
+
 func TestDelegatedRunWorker_Dispatch_ResolveErrorFallsBackToNative(t *testing.T) {
 	native := &fakeNative{verdict: WorkerVerdict{Outcome: "done"}}
 	sandbox := newFakeSandbox()

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -621,7 +621,7 @@ func (d *Driver) ensureProvisioned(ctx context.Context, m Mission) (Mission, err
 			return m, err
 		}
 		m.Workspace, m.Worktree, m.Branch, m.BaseCommit = workspace, worktree, branch, baseCommit
-		if m.ParentMissionID != "" && m.Kind == "coding" {
+		if m.ParentMissionID != "" && missionPolicyFor(m).needsWorktree {
 			ref := baseUsed
 			if ref == "" {
 				ref = "the repo's default branch (parent branch unreachable)"
@@ -1277,7 +1277,7 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 // existence checks can't see. Units with no declared artifacts always
 // review too — there is no harness evidence to stand on.
 func (d *Driver) trySkipReview(ctx context.Context, m Mission, seenURLs []string) (StepInput, bool) {
-	if m.Kind == "coding" {
+	if missionPolicyFor(m).alwaysReview {
 		return StepInput{}, false
 	}
 	unit, idx := currentUnit(m.Spec)
@@ -1524,7 +1524,7 @@ func (d *Driver) verifyCurrentUnit(ctx context.Context, m Mission, seenURLs []st
 			}
 			return &verifyFailure{unit: i, excerpt: excerpt}
 		}
-		if m.Kind == "general" {
+		if missionPolicyFor(m).checksCitations {
 			if problems := CheckCitations(workRoot, u.Artifacts, seenURLs); len(problems) > 0 {
 				excerpt := "citation check failed:\n" + strings.Join(problems, "\n")
 				if err := d.store.AppendEvent(ctx, m.ID, "mission.unit_verified", map[string]any{
@@ -1578,7 +1578,7 @@ func (d *Driver) packet(ctx context.Context, m Mission) (WorkPacket, error) {
 		Goal: m.Goal, Kind: m.Kind, Spec: m.Spec, Progress: m.Progress,
 		GitLog: gitLog, Iteration: m.Iteration, PromptOverlay: m.PromptOverlay,
 		ExecEnvironmentNote: execEnvironmentNote(), ParentContext: m.ParentContext, Attachments: m.Attachments,
-		Light: m.Light,
+		Light: missionPolicyFor(m).skipsPlanning,
 	}, nil
 }
 

--- a/internal/brain/missions/policy.go
+++ b/internal/brain/missions/policy.go
@@ -1,0 +1,80 @@
+package missions
+
+// KindCoding and KindGeneral are the two mission kinds — see
+// Mission.Kind.
+const (
+	KindCoding  = "coding"
+	KindGeneral = "general"
+)
+
+// missionPolicy derives every kind/light-dependent behavior once
+// (D-072) — call sites consult the table instead of re-testing
+// Kind/Light strings.
+type missionPolicy struct {
+	needsWorktree   bool // clone/branch/rollback machinery
+	alwaysReview    bool // LLM review round can never be skipped
+	checksCitations bool // CheckCitations on verify
+	canDelegate     bool // harness (delegated CLI executor) allowed
+	skipsPlanning   bool // born in execute; no explore/plan/review
+	canPush         bool // on_complete push/push_pr allowed
+}
+
+// policyFor derives kind's policy, then folds in light's effect
+// (general only, D-069). An unknown kind gets the general-shaped
+// policy with alwaysReview forced true — fail conservative: a kind
+// this table doesn't recognize must never silently skip review.
+//
+// D-072: the single source of behavior-by-kind; every call site that
+// used to test Kind/Light directly now derives it from here instead.
+func policyFor(kind string, light bool) missionPolicy {
+	switch kind {
+	case KindCoding:
+		return missionPolicy{
+			needsWorktree:   true,
+			alwaysReview:    true,
+			checksCitations: false,
+			canDelegate:     true,
+			skipsPlanning:   false,
+			canPush:         true,
+		}
+	case KindGeneral:
+		p := missionPolicy{
+			needsWorktree:   false,
+			alwaysReview:    false,
+			checksCitations: true,
+			canDelegate:     false,
+			skipsPlanning:   false,
+			canPush:         false,
+		}
+		if light {
+			p.skipsPlanning = true
+		}
+		return p
+	default:
+		return missionPolicy{
+			needsWorktree:   false,
+			alwaysReview:    true,
+			checksCitations: true,
+			canDelegate:     false,
+			skipsPlanning:   false,
+			canPush:         false,
+		}
+	}
+}
+
+// missionPolicyFor is policyFor over a live Mission row.
+func missionPolicyFor(m Mission) missionPolicy {
+	return policyFor(m.Kind, m.Light)
+}
+
+// initialPhase is the phase a newly created mission row starts in:
+// PhaseExecute for a light mission (D-069, skips explore/plan),
+// PhaseExplore otherwise. Shared by store.go's Create and
+// scheduler.go's createFromTemplate, which both used to duplicate
+// this check inline.
+func initialPhase(kind string, light bool) Phase {
+	if policyFor(kind, light).skipsPlanning {
+		return PhaseExecute
+	}
+	return PhaseExplore
+}

--- a/internal/brain/missions/policy_test.go
+++ b/internal/brain/missions/policy_test.go
@@ -1,0 +1,81 @@
+package missions
+
+import "testing"
+
+func TestPolicyFor(t *testing.T) {
+	cases := []struct {
+		name  string
+		kind  string
+		light bool
+		want  missionPolicy
+	}{
+		{
+			name: "coding",
+			kind: KindCoding,
+			want: missionPolicy{needsWorktree: true, alwaysReview: true, checksCitations: false, canDelegate: true, skipsPlanning: false, canPush: true},
+		},
+		{
+			name: "coding light is meaningless but still coding-shaped",
+			kind: KindCoding, light: true,
+			want: missionPolicy{needsWorktree: true, alwaysReview: true, checksCitations: false, canDelegate: true, skipsPlanning: false, canPush: true},
+		},
+		{
+			name: "general",
+			kind: KindGeneral,
+			want: missionPolicy{needsWorktree: false, alwaysReview: false, checksCitations: true, canDelegate: false, skipsPlanning: false, canPush: false},
+		},
+		{
+			name: "general light",
+			kind: KindGeneral, light: true,
+			want: missionPolicy{needsWorktree: false, alwaysReview: false, checksCitations: true, canDelegate: false, skipsPlanning: true, canPush: false},
+		},
+		{
+			name: "unknown kind fails conservative",
+			kind: "bogus",
+			want: missionPolicy{needsWorktree: false, alwaysReview: true, checksCitations: true, canDelegate: false, skipsPlanning: false, canPush: false},
+		},
+		{
+			name: "unknown kind with light stays conservative, ignores light",
+			kind: "bogus", light: true,
+			want: missionPolicy{needsWorktree: false, alwaysReview: true, checksCitations: true, canDelegate: false, skipsPlanning: false, canPush: false},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := policyFor(tc.kind, tc.light)
+			if got != tc.want {
+				t.Fatalf("policyFor(%q, %v) = %+v, want %+v", tc.kind, tc.light, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMissionPolicyFor(t *testing.T) {
+	m := Mission{Kind: KindGeneral, Light: true}
+	got := missionPolicyFor(m)
+	want := policyFor(KindGeneral, true)
+	if got != want {
+		t.Fatalf("missionPolicyFor(%+v) = %+v, want %+v", m, got, want)
+	}
+}
+
+func TestInitialPhase(t *testing.T) {
+	cases := []struct {
+		name  string
+		kind  string
+		light bool
+		want  Phase
+	}{
+		{name: "coding starts at explore", kind: KindCoding, want: PhaseExplore},
+		{name: "general starts at explore", kind: KindGeneral, want: PhaseExplore},
+		{name: "light general starts at execute", kind: KindGeneral, light: true, want: PhaseExecute},
+		{name: "unknown kind starts at explore even if light requested", kind: "bogus", light: true, want: PhaseExplore},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := initialPhase(tc.kind, tc.light); got != tc.want {
+				t.Fatalf("initialPhase(%q, %v) = %v, want %v", tc.kind, tc.light, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -451,10 +451,7 @@ func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedu
 	if name == "" {
 		name = sc.Name
 	}
-	phase := PhaseExplore
-	if t.Light {
-		phase = PhaseExecute
-	}
+	phase := initialPhase(t.Kind, t.Light)
 	_, err = tx.Exec(ctx, `INSERT INTO missions
 			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, knowledge, auto_approve_safe, spec, schedule_id, harness, environment, destination_ids, light, phase)
 		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)`,
@@ -523,12 +520,13 @@ func resolveTemplateDefaults(ctx context.Context, t MissionTemplate, resolve Age
 			knowledge = defaults.Knowledge
 		}
 	}
+	policy := policyFor(t.Kind, t.Light)
 	defaultRoute := ""
 	if routeForRole != nil {
 		defaultRoute = routeForRole(ctx, "default")
 	}
 	if t.Route == "" {
-		if t.Kind == "coding" {
+		if t.Kind == KindCoding {
 			t.Route = DefaultCodingRoute(ctx, routeExists, defaultRoute)
 		} else {
 			t.Route = defaultRoute
@@ -543,14 +541,14 @@ func resolveTemplateDefaults(ctx context.Context, t MissionTemplate, resolve Age
 			t.ReviewRoute = defaultRoute
 		}
 	}
-	if t.Kind == "coding" && t.Harness == "" && codingExecutorDefault != nil {
+	if policy.canDelegate && t.Harness == "" && codingExecutorDefault != nil {
 		t.Harness = codingExecutorDefault(ctx)
 	}
 	// Environment (D-05x): no settings default (unlike Harness above) —
 	// an omitted template auto-detects from the goal at fire time. No
 	// worktree exists yet, so only the goal-keyword heuristic can fire;
 	// repo-marker detection has nothing to check.
-	if t.Kind == "coding" && t.Environment == "" {
+	if policy.needsWorktree && t.Environment == "" {
 		t.Environment, _ = DetectEnvironment("", t.Goal)
 	}
 	return t, promptOverlay, knowledge

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -250,10 +250,7 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	if destinationIDs == nil {
 		destinationIDs = []string{}
 	}
-	phase := PhaseExplore
-	if m.Light {
-		phase = PhaseExecute
-	}
+	phase := initialPhase(m.Kind, m.Light)
 	err = db.QueryRow(ctx, `INSERT INTO missions
 			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, attachments, destination_ids, light, phase, workflow_run_id, workflow_step)
 		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NULLIF($15, '')::uuid, $16, $17, $18, $19, $20, $21, $22, $23, NULLIF($24, '')::uuid, $25, $26, $27, $28, $29, NULLIF($30, '')::uuid, $31) RETURNING id`,

--- a/internal/brain/missions/validate.go
+++ b/internal/brain/missions/validate.go
@@ -53,14 +53,14 @@ type ValidateDeps struct {
 // or have individual fields nil (that check skipped) — never required.
 func ValidateCreate(ctx context.Context, m Mission, deps ValidateDeps) error {
 	switch m.Kind {
-	case "coding", "general":
+	case KindCoding, KindGeneral:
 	default:
 		return fmt.Errorf(`%w: kind must be "coding" or "general"`, ErrInvalidMission)
 	}
-	if m.Light && m.Kind != "general" {
+	if m.Light && m.Kind != KindGeneral {
 		return fmt.Errorf("%w: light is only valid for kind=general missions", ErrInvalidMission)
 	}
-	if m.Kind != "coding" {
+	if !missionPolicyFor(m).canDelegate {
 		switch {
 		case m.Harness != "":
 			return fmt.Errorf("%w: harness is only valid for kind=coding missions", ErrInvalidMission)

--- a/internal/brain/missions/worktree.go
+++ b/internal/brain/missions/worktree.go
@@ -80,7 +80,7 @@ func (w *Workspace) Provision(ctx context.Context, missionID, goal, kind, repoUR
 		return "", "", "", "", "", fmt.Errorf("worktree: provision: mkdir %s: %w", workspace, err)
 	}
 
-	if kind != "coding" {
+	if !policyFor(kind, false).needsWorktree {
 		return workspace, "", "", "", "", nil
 	}
 
@@ -406,7 +406,7 @@ func CommitMessage(unitTitle, goal, body, style string) string {
 // Rollback discards uncommitted work: `git checkout -- .` + `git clean
 // -fd` for coding missions, no-op otherwise.
 func (w *Workspace) Rollback(ctx context.Context, worktree, kind string) error {
-	if kind != "coding" || worktree == "" {
+	if !policyFor(kind, false).needsWorktree || worktree == "" {
 		return nil
 	}
 	cctx, cancel := context.WithTimeout(ctx, rollbackTimeout)


### PR DESCRIPTION
Architecture-review finding: behavior-by-kind lived in 9 scattered bare-string `Kind` conditionals + 8 `.Light` sites; `!= "coding"` sites would silently give any future kind non-coding behavior; harness was documented coding-only but unenforced in-package.

- `policy.go`: `policyFor(kind, light)` → `{needsWorktree, alwaysReview, checksCitations, canDelegate, skipsPlanning, canPush}`; unknown kind = general-shaped with `alwaysReview` forced (fail conservative). `KindCoding`/`KindGeneral` constants replace bare literals.
- All call sites converted behavior-identically (worktree provision/rollback, pushability, review skip, citation check, scheduler defaults, ValidateCreate).
- `initialPhase` deduplicates the light→execute birth-phase logic from store.Create + scheduler.
- One intentional enforcement change: delegated dispatch now gates on `canDelegate` — a harness on a non-coding row logs + records `executor.skipped {reason: harness not allowed for kind}` and runs native. ValidateCreate already blocks such rows at create; this covers pre-existing/out-of-band rows.

A new kind is now one table row instead of nine re-decisions. Full policy/initialPhase table tests + delegated fallback test; suite green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790102064&installation_model_id=431401&pr_number=291&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F291&signature=eea93123b9b8d75aff5d6f396ed57caab18f20d05b7513acc3ea831d7d319639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->