### PR TITLE
fix: architecture-review small-items batch

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -692,11 +692,58 @@ func classifyLight(ctx context.Context, classify agents.Classify, goal string) b
 	return strings.Contains(reply, "yes") && !strings.Contains(reply, "no")
 }
 
+// classifyKindAndLight answers both classifyKind and classifyLight's
+// questions in one model call — used only by the preview endpoint
+// (classifyGoal), which needs both on every debounced keystroke and
+// would otherwise pay for two full LLM turns per preview. create()'s
+// fallback path keeps using classifyKind/classifyLight separately,
+// since it only ever needs light after kind is already known to be
+// general. Parsing is defensive: any reply shape other than exactly
+// "coding"/"general" followed by "light"/"full" (case-insensitive,
+// separated by whitespace) falls back to kind=coding, light=false —
+// the same safe-side bias classifyKind/classifyLight each apply alone.
+func classifyKindAndLight(ctx context.Context, classify agents.Classify, goal string) (kind string, light bool) {
+	if classify == nil {
+		return "coding", false
+	}
+	prompt := "Classify this mission goal along two independent axes.\n" +
+		"Axis 1 — coding or general: coding means creating or modifying code, scripts, or configuration in a project/repository; general means everything else (documents, analysis, data gathering, operations).\n" +
+		"Axis 2 — light or full: light means the goal is a single-pass task deliverable in one response (a read, summary, lookup, or short write-up with no multi-step plan or file artifacts); full means it needs a plan and artifacts.\n" +
+		"Answer with exactly two words separated by a space: first coding or general, then light or full.\n\n" +
+		"Goal: " + goal
+	reply, err := classify(ctx, prompt)
+	if err != nil {
+		return "coding", false
+	}
+	fields := strings.Fields(strings.ToLower(reply))
+	if len(fields) != 2 {
+		return "coding", false
+	}
+	switch fields[0] {
+	case "general":
+		kind = "general"
+	case "coding":
+		kind = "coding"
+	default:
+		return "coding", false
+	}
+	switch fields[1] {
+	case "light":
+		light = true
+	case "full":
+		light = false
+	default:
+		return "coding", false
+	}
+	return kind, kind == "general" && light
+}
+
 // classifyGoal serves POST /v1/missions/classify: the same
 // classification create() falls back to when kind is omitted, exposed
 // standalone so the web UI's chip preview can show a mission's inferred
 // kind (and, for a general goal, a light suggestion) before submit
-// without actually creating anything.
+// without actually creating anything. Uses classifyKindAndLight's
+// single-call form since every debounced keystroke hits this endpoint.
 func (h *missionAPI) classifyGoal(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Goal string `json:"goal"`
@@ -709,8 +756,7 @@ func (h *missionAPI) classifyGoal(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "bad_request", "goal is required")
 		return
 	}
-	kind := classifyKind(r.Context(), h.classify, req.Goal)
-	light := kind == missions.KindGeneral && classifyLight(r.Context(), h.classify, req.Goal)
+	kind, light := classifyKindAndLight(r.Context(), h.classify, req.Goal)
 	writeJSON(w, http.StatusOK, map[string]any{"kind": kind, "light": light})
 }
 

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -602,6 +602,86 @@ func TestClassifyLight(t *testing.T) {
 	}
 }
 
+// TestClassifyKindAndLight exercises the merged single-call classifier
+// classifyGoal uses: happy paths for both axes, and every ambiguous or
+// malformed reply shape falling back to kind=coding light=false, the
+// same safe-side bias classifyKind/classifyLight apply separately.
+func TestClassifyKindAndLight(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		classify  func(ctx context.Context, prompt string) (string, error)
+		wantKind  string
+		wantLight bool
+	}{
+		{"nil classify defaults to coding/full", nil, "coding", false},
+		{
+			"general + light", func(context.Context, string) (string, error) {
+				return "general light", nil
+			}, "general", true,
+		},
+		{
+			"general + full", func(context.Context, string) (string, error) {
+				return "general full", nil
+			}, "general", false,
+		},
+		{
+			"coding + light is never light (light only applies to general)", func(context.Context, string) (string, error) {
+				return "coding light", nil
+			}, "coding", false,
+		},
+		{
+			"coding + full", func(context.Context, string) (string, error) {
+				return "Coding Full", nil
+			}, "coding", false,
+		},
+		{
+			"extra whitespace still parses", func(context.Context, string) (string, error) {
+				return "  general   light  ", nil
+			}, "general", true,
+		},
+		{
+			"single word reply falls back", func(context.Context, string) (string, error) {
+				return "general", nil
+			}, "coding", false,
+		},
+		{
+			"three word reply falls back", func(context.Context, string) (string, error) {
+				return "general light extra", nil
+			}, "coding", false,
+		},
+		{
+			"garbage first word falls back", func(context.Context, string) (string, error) {
+				return "banana light", nil
+			}, "coding", false,
+		},
+		{
+			"garbage second word falls back", func(context.Context, string) (string, error) {
+				return "general banana", nil
+			}, "coding", false,
+		},
+		{
+			"empty reply falls back", func(context.Context, string) (string, error) {
+				return "", nil
+			}, "coding", false,
+		},
+		{
+			"classify error falls back", func(context.Context, string) (string, error) {
+				return "", errors.New("gateway down")
+			}, "coding", false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotKind, gotLight := classifyKindAndLight(context.Background(), tc.classify, "some goal")
+			if gotKind != tc.wantKind || gotLight != tc.wantLight {
+				t.Fatalf("classifyKindAndLight() = (%q, %v), want (%q, %v)", gotKind, gotLight, tc.wantKind, tc.wantLight)
+			}
+		})
+	}
+}
+
 // TestMissionsClassifyEndpoint covers POST /v1/missions/classify: the
 // happy path returning the classifier's verdict (kind and light), and
 // the empty-goal 400 — this endpoint has no store/driver dependency, so
@@ -610,10 +690,7 @@ func TestMissionsClassifyEndpoint(t *testing.T) {
 	t.Parallel()
 	a, _, _ := testAPI(t, "tok", nil)
 	classify := func(ctx context.Context, prompt string) (string, error) {
-		if strings.Contains(prompt, "single-pass") {
-			return "yes", nil
-		}
-		return "general", nil
+		return "general light", nil
 	}
 	m := mux(a)
 	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "")

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -1235,7 +1235,7 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 			if err := d.store.SetFinalOutput(ctx, m.ID, finalOutput); err != nil {
 				d.log.Warn("driver: record final output failed", "mission_id", m.ID, "error", err)
 			}
-			if err := d.store.AppendEvent(ctx, m.ID, "mission.review_skipped", map[string]any{"reason": "light"}); err != nil {
+			if err := d.store.AppendEvent(ctx, m.ID, "mission.review_skipped", map[string]any{"reason": "light", "verified": false}); err != nil {
 				d.log.Warn("driver: record review skip failed", "mission_id", m.ID, "error", err)
 			}
 			return StepInput{Input: InputReviewApprove}, nil
@@ -1322,6 +1322,13 @@ func (d *Driver) checkRegressions(ctx context.Context, m Mission) (StepInput, bo
 		d.log.Warn("driver: regression check reload failed", "mission_id", m.ID, "error", err)
 		return StepInput{}, false
 	}
+	// Deliberately omits verifyCurrentUnit's CheckCitations step: that
+	// check validates URLs against seenURLs, which only ever holds the
+	// citations from the turn that just produced the current unit's
+	// output (runExecute's live evidence). A regression recheck has no
+	// such turn — it's re-verifying units OTHER than the one just
+	// worked — so seenURLs would be empty here and CheckCitations would
+	// false-fail every already-passed unit on every regression pass.
 	workRoot := fresh.WorkRoot()
 	for i, u := range fresh.Spec.Units {
 		if !u.Passes {

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -428,6 +428,17 @@ func (r *nativeRunner) belowFloor(model string) bool {
 	return false
 }
 
+// turnResult is runTurn's outcome: the full assistant text, the
+// sentinel tool call's raw arguments (if any), URLs the turn's
+// web_search/web_fetch calls saw, and the final assistant segment
+// (see finalSeg's doc below, formerly a bare 5th return value).
+type turnResult struct {
+	text         string
+	sentinelArgs json.RawMessage
+	seenURLs     []string
+	finalSeg     string
+}
+
 // runTurn drives one loop.Agent session to completion, capturing the
 // text of the sentinel tool call named toolName (if any) alongside the
 // full assistant text. It does not itself decide what a missing
@@ -441,14 +452,16 @@ func (r *nativeRunner) belowFloor(model string) bool {
 // commentary included), while finalSeg is just what the model wrote
 // right before ending its turn. The sentinel call itself never resets
 // finalSeg (it carries no assistant text of its own to lose).
-func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTool string) (full string, sentinelArgs json.RawMessage, seenURLs []string, finalSeg string, err error) {
+func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTool string) (turnResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, turnTimeout)
 	defer cancel()
 	events, err := r.agent.Start(ctx, req)
 	if err != nil {
-		return "", nil, nil, "", err
+		return turnResult{}, err
 	}
 	var b, finalB strings.Builder
+	var sentinelArgs json.RawMessage
+	var seenURLs []string
 	// parked tracks in-flight parks by CallID, not a single flag — a
 	// turn can issue concurrent tool calls (executeAll runs up to
 	// maxParallelTools at once), so a sibling call finishing first must
@@ -524,7 +537,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if len(parked) > 0 && r.parker != nil {
 				r.parker.OnPermissionCleared(ctx, req.MissionID)
 			}
-			return b.String(), sentinelArgs, seenURLs, finalB.String(), fmt.Errorf("mission runner: incomplete stream: %s", ev.Text)
+			return turnResult{b.String(), sentinelArgs, seenURLs, finalB.String()}, fmt.Errorf("mission runner: incomplete stream: %s", ev.Text)
 		case stream.EventError:
 			if len(parked) > 0 && r.parker != nil {
 				r.parker.OnPermissionCleared(ctx, req.MissionID)
@@ -533,19 +546,19 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if ev.Err != nil {
 				msg = ev.Err.Message
 			}
-			return b.String(), sentinelArgs, seenURLs, finalB.String(), fmt.Errorf("mission runner: %s", msg)
+			return turnResult{b.String(), sentinelArgs, seenURLs, finalB.String()}, fmt.Errorf("mission runner: %s", msg)
 		}
 	}
 	if !sawTerminal {
 		if len(parked) > 0 && r.parker != nil {
 			r.parker.OnPermissionCleared(ctx, req.MissionID)
 		}
-		return b.String(), sentinelArgs, seenURLs, finalB.String(), fmt.Errorf("mission runner: stream ended without a terminal event")
+		return turnResult{b.String(), sentinelArgs, seenURLs, finalB.String()}, fmt.Errorf("mission runner: stream ended without a terminal event")
 	}
 	if servedModel != "" && r.belowFloor(servedModel) {
-		return b.String(), sentinelArgs, seenURLs, finalB.String(), fmt.Errorf("%w: %s", ErrModelFloor, servedModel)
+		return turnResult{b.String(), sentinelArgs, seenURLs, finalB.String()}, fmt.Errorf("%w: %s", ErrModelFloor, servedModel)
 	}
-	return b.String(), sentinelArgs, seenURLs, finalB.String(), nil
+	return turnResult{b.String(), sentinelArgs, seenURLs, finalB.String()}, nil
 }
 
 // webFetchArgURL extracts the url arg from a web_fetch call's raw
@@ -657,13 +670,14 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		Unattended: m.ScheduleID != "",
 	}
 
-	text, args, seenURLs, finalSeg, err := r.runTurn(ctx, req, missionStatusToolName)
+	res, err := r.runTurn(ctx, req, missionStatusToolName)
+	text, seenURLs := res.text, res.seenURLs
 	if err != nil {
 		return WorkerVerdict{}, text, err
 	}
-	if v, ok := r.tryParseVerdict(args); ok {
+	if v, ok := r.tryParseVerdict(res.sentinelArgs); ok {
 		v.SeenURLs = append(seenURLs, kbSeen.all()...)
-		v.FinalMessage = finalSeg
+		v.FinalMessage = res.finalSeg
 		return v, text, nil
 	}
 
@@ -673,14 +687,15 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		provider.Message{Role: "assistant", Content: text},
 		provider.Message{Role: "user", Content: "[system] You must end your turn with exactly one mission_status tool call: done, retry, or blocked."},
 	)
-	recoverText, recoverArgs, recoverSeenURLs, recoverFinalSeg, err := r.runTurn(ctx, recoverReq, missionStatusToolName)
-	seenURLs = append(seenURLs, recoverSeenURLs...)
+	recoverRes, err := r.runTurn(ctx, recoverReq, missionStatusToolName)
+	recoverText := recoverRes.text
+	seenURLs = append(seenURLs, recoverRes.seenURLs...)
 	if err != nil {
 		return WorkerVerdict{}, text + "\n" + recoverText, err
 	}
-	if v, ok := r.tryParseVerdict(recoverArgs); ok {
+	if v, ok := r.tryParseVerdict(recoverRes.sentinelArgs); ok {
 		v.SeenURLs = append(seenURLs, kbSeen.all()...)
-		v.FinalMessage = recoverFinalSeg
+		v.FinalMessage = recoverRes.finalSeg
 		return v, text + "\n" + recoverText, nil
 	}
 
@@ -698,7 +713,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		if v, ok := r.tryParseVerdict(raw); ok {
 			r.log.Warn("mission worker expressed mission_status as text, not a tool call", "mission_id", m.ID)
 			v.SeenURLs = append(seenURLs, kbSeen.all()...)
-			v.FinalMessage = recoverFinalSeg
+			v.FinalMessage = recoverRes.finalSeg
 			return v, combined, nil
 		}
 	}
@@ -769,11 +784,12 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 		Unattended:   m.ScheduleID != "",
 	}
 
-	text, args, _, _, err := r.runTurn(ctx, req, exploreNotesToolName)
+	res, err := r.runTurn(ctx, req, exploreNotesToolName)
+	text := res.text
 	if err != nil {
 		return "", err
 	}
-	if notes, ok := tryParseFindings(args); ok {
+	if notes, ok := tryParseFindings(res.sentinelArgs); ok {
 		return notes, nil
 	}
 
@@ -783,11 +799,12 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 		provider.Message{Role: "assistant", Content: text},
 		provider.Message{Role: "user", Content: "[system] You must end your turn with exactly one explore_notes tool call containing your findings."},
 	)
-	recoverText, recoverArgs, _, _, err := r.runTurn(ctx, recoverReq, exploreNotesToolName)
+	recoverRes, err := r.runTurn(ctx, recoverReq, exploreNotesToolName)
+	recoverText := recoverRes.text
 	if err != nil {
 		return "", err
 	}
-	if notes, ok := tryParseFindings(recoverArgs); ok {
+	if notes, ok := tryParseFindings(recoverRes.sentinelArgs); ok {
 		return notes, nil
 	}
 
@@ -847,7 +864,8 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 		BuiltinsOnly: true,
 		Unattended:   m.ScheduleID != "",
 	}
-	text, args, _, _, err := r.runTurn(ctx, req, reviewVerdictToolName)
+	res, err := r.runTurn(ctx, req, reviewVerdictToolName)
+	text, args := res.text, res.sentinelArgs
 	if err != nil {
 		return ReviewVerdict{}, nil, err
 	}
@@ -861,7 +879,8 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 			provider.Message{Role: "assistant", Content: text},
 			provider.Message{Role: "user", Content: "[system] You must end your turn with exactly one review_verdict tool call: approve or rework."},
 		)
-		recoverText, recoverArgs, _, _, err := r.runTurn(ctx, recoverReq, reviewVerdictToolName)
+		recoverRes, err := r.runTurn(ctx, recoverReq, reviewVerdictToolName)
+		recoverText, recoverArgs := recoverRes.text, recoverRes.sentinelArgs
 		if err != nil {
 			return ReviewVerdict{}, nil, err
 		}
@@ -993,7 +1012,8 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 	if len(extra) == 1 {
 		req.ForceTool = planToolName
 	}
-	text, args, _, _, err := r.runTurn(ctx, req, planToolName)
+	res, err := r.runTurn(ctx, req, planToolName)
+	text, args := res.text, res.sentinelArgs
 	if err != nil {
 		return Spec{}, err
 	}
@@ -1019,7 +1039,8 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 		provider.Message{Role: "assistant", Content: text},
 		provider.Message{Role: "user", Content: "[system] Your last turn did not produce a usable plan: " + recoverReason + ". You must end this turn with exactly one submit_plan tool call."},
 	)
-	recoverText, recoverArgs, _, _, err := r.runTurn(ctx, recoverReq, planToolName)
+	recoverRes, err := r.runTurn(ctx, recoverReq, planToolName)
+	recoverText, recoverArgs := recoverRes.text, recoverRes.sentinelArgs
 	if err != nil {
 		return Spec{}, err
 	}

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -1517,12 +1517,12 @@ func TestRunTurnBareCloseIsError(t *testing.T) {
 		textEvent("partial work"),
 	}}}
 	r := newTestRunner(agent)
-	text, _, _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName)
+	res, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName)
 	if err == nil || !strings.Contains(err.Error(), "without a terminal event") {
 		t.Fatalf("err = %v, want no-terminal error", err)
 	}
-	if text != "partial work" {
-		t.Fatalf("text = %q, want the partial preserved", text)
+	if res.text != "partial work" {
+		t.Fatalf("text = %q, want the partial preserved", res.text)
 	}
 }
 
@@ -1535,7 +1535,7 @@ func TestRunTurnIncompleteIsError(t *testing.T) {
 		{Type: stream.EventIncomplete, Text: "stream ended without a terminal event"},
 	}}}
 	r := newTestRunner(agent)
-	if _, _, _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "incomplete stream") {
+	if _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "incomplete stream") {
 		t.Fatalf("err = %v, want incomplete-stream error", err)
 	}
 }
@@ -1548,7 +1548,7 @@ func TestRunTurnNilErrErrorEvent(t *testing.T) {
 		{Type: stream.EventError},
 	}}}
 	r := newTestRunner(agent)
-	if _, _, _, _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "provider stream error") {
+	if _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "provider stream error") {
 		t.Fatalf("err = %v, want generic provider stream error", err)
 	}
 }
@@ -1583,7 +1583,7 @@ func TestRunTurnTimesOutOnHungStream(t *testing.T) {
 	done := make(chan struct{})
 	var err error
 	go func() {
-		_, _, _, _, err = r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName)
+		_, err = r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName)
 		close(done)
 	}()
 	select {

--- a/internal/brain/missions/sentinel.go
+++ b/internal/brain/missions/sentinel.go
@@ -217,6 +217,20 @@ var sentinelDiscriminatorValues = map[string]map[string]bool{
 	reviewVerdictToolName: {"approve": true, "rework": true},
 }
 
+// init guards the three maps' convention: every tool named in
+// sentinelDiscriminator must also have an entry in sentinelAttrs, or
+// extractTextSentinel bails silently for that tool with no signal a
+// tool was ever added incompletely. sentinelDiscriminatorValues is
+// deliberately NOT checked the same way — explore_notes has no enum
+// (see its doc comment above) and is expected to be absent from it.
+func init() {
+	for tool := range sentinelDiscriminator {
+		if _, ok := sentinelAttrs[tool]; !ok {
+			panic(fmt.Sprintf("sentinel.go: %q registered in sentinelDiscriminator but missing from sentinelAttrs", tool))
+		}
+	}
+}
+
 // xmlTagPattern matches an XML-ish sentinel tag: <toolName attr="val"
 // attr2='val2' ... /> or <toolName ...>, attribute values in either
 // quote style, attributes in any order. %s is the exact tool name —

--- a/internal/brain/missions/sentinel_test.go
+++ b/internal/brain/missions/sentinel_test.go
@@ -6,6 +6,33 @@ import (
 	"testing"
 )
 
+// TestSentinelDiscriminatorKeysHaveAttrs guards the convention the
+// package init() enforces at load time: every tool named in
+// sentinelDiscriminator must also appear in sentinelAttrs, since
+// extractTextSentinel silently returns ok=false for a tool missing
+// from sentinelAttrs (knownAttrs would be empty). This test exercises
+// the same check standalone so a future map edit that broke the
+// invariant fails a normal `go test` run, not just a process boot.
+func TestSentinelDiscriminatorKeysHaveAttrs(t *testing.T) {
+	for tool := range sentinelDiscriminator {
+		if _, ok := sentinelAttrs[tool]; !ok {
+			t.Errorf("tool %q is in sentinelDiscriminator but missing from sentinelAttrs", tool)
+		}
+	}
+}
+
+// TestSentinelDiscriminatorValuesOmitsExploreNotes documents the one
+// deliberate exception to "all three maps stay in sync": explore_notes
+// has a free-text discriminator (findings), not an enum, so it must
+// NOT appear in sentinelDiscriminatorValues. If this ever starts
+// failing because explore_notes gained an entry, the accompanying doc
+// comment on sentinelDiscriminatorValues needs updating too.
+func TestSentinelDiscriminatorValuesOmitsExploreNotes(t *testing.T) {
+	if _, ok := sentinelDiscriminatorValues[exploreNotesToolName]; ok {
+		t.Fatalf("sentinelDiscriminatorValues unexpectedly has an entry for %q, want it absent (free-text discriminator)", exploreNotesToolName)
+	}
+}
+
 func TestDetectBail(t *testing.T) {
 	positive := []string{
 		"I've made the changes. This is ready for review.",

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -32,11 +32,12 @@ func nextPhase(p Phase) (Phase, bool) {
 	return "", false
 }
 
-// parsePhase never rejects: an unrecognized value degrades to a safe
-// fallback rather than the caller treating the row as unreadable —
-// corruption-safety over strictness (a future rollback that doesn't
-// recognize a newer phase must still load the mission as paused, not
-// fail to load it at all).
+// parsePhase reports whether raw is a recognized Phase; on an
+// unrecognized value it returns ("", false) and leaves degrading to
+// the caller (e.g. scanMission treats it as failed; ApplyTransition's
+// terminal re-check treats it as terminal) — corruption-safety over
+// strictness, each call site choosing the safe fallback for its own
+// context.
 func parsePhase(raw string) (Phase, bool) {
 	switch Phase(raw) {
 	case PhaseExplore, PhasePlan, PhaseExecute, PhaseReview, PhaseDone, PhaseFailed:
@@ -305,8 +306,8 @@ func stepPhaseComplete(s StepState) Transition {
 }
 
 // stepWorkerFailed counts consecutive failures toward the backoff
-// brake; a fresh success (any non-failed input) resets the counter
-// elsewhere (the driver clears ConsecutiveFailures on progress).
+// brake; progress resets the counter elsewhere in this file
+// (stepPhaseComplete, stepWorkerRetry, stepReviewApprove all zero it).
 //
 // The MaxIterations ceiling is checked before the backoff pause: it is
 // a hard stop, and a backoff pause must only ever happen below the
@@ -395,7 +396,10 @@ func stepReviewApprove(s StepState) Transition {
 	if s.LastUnit {
 		s.Phase = PhaseDone
 		s.Status = StatusDone
-		return Transition{Next: s, Events: []EventDraft{{Kind: "mission.done"}}}
+		// verified: false for light missions, which reach done with zero
+		// harness verification (no spec units, no CheckArtifacts/RunVerify) —
+		// distinguishes that in the event log from a harness-verified done.
+		return Transition{Next: s, Events: []EventDraft{{Kind: "mission.done", Payload: map[string]any{"verified": !s.Light}}}}
 	}
 	s.Phase = PhaseExecute
 	s.Status = StatusIdle

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -361,7 +361,10 @@ func TestStepReplanEmitsReasonAndUsesReplanOnlyOnce(t *testing.T) {
 
 // TestStepLightApproveGoesDone confirms a light mission (born in
 // PhaseExecute, empty spec so LastUnit is always true) reaches done on
-// review_approve exactly like a coding/general mission's last unit.
+// review_approve exactly like a coding/general mission's last unit,
+// and that its mission.done event carries verified=false — a light
+// mission has no spec units, so it reaches done with zero harness
+// verification and the event log must say so.
 func TestStepLightApproveGoesDone(t *testing.T) {
 	got := Step(
 		StepState{Phase: PhaseExecute, Status: StatusWorking, Light: true, LastUnit: true},
@@ -370,6 +373,29 @@ func TestStepLightApproveGoesDone(t *testing.T) {
 	)
 	if got.Next.Phase != PhaseDone || got.Next.Status != StatusDone {
 		t.Fatalf("Step(light approve) = %+v, want phase=done status=done", got.Next)
+	}
+	if len(got.Events) != 1 || got.Events[0].Kind != "mission.done" {
+		t.Fatalf("Events = %+v, want exactly one mission.done event", got.Events)
+	}
+	if verified, ok := got.Events[0].Payload["verified"].(bool); !ok || verified {
+		t.Fatalf("light mission.done payload = %+v, want verified=false", got.Events[0].Payload)
+	}
+}
+
+// TestStepNonLightApproveDoneIsVerified confirms a mission that reaches
+// its last unit via harness/review checks (not light) gets
+// verified=true on mission.done.
+func TestStepNonLightApproveDoneIsVerified(t *testing.T) {
+	got := Step(
+		StepState{Phase: PhaseReview, Status: StatusWorking, Light: false, LastUnit: true},
+		StepInput{Input: InputReviewApprove},
+		DefaultConfig,
+	)
+	if len(got.Events) != 1 || got.Events[0].Kind != "mission.done" {
+		t.Fatalf("Events = %+v, want exactly one mission.done event", got.Events)
+	}
+	if verified, ok := got.Events[0].Payload["verified"].(bool); !ok || !verified {
+		t.Fatalf("non-light mission.done payload = %+v, want verified=true", got.Events[0].Payload)
 	}
 }
 

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -686,7 +686,11 @@ func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) er
 		}
 		return fmt.Errorf("missions apply transition lock: %w", err)
 	}
-	if phase, ok := parsePhase(currentPhase); ok && phase.Terminal() {
+	// An unrecognized phase is treated as terminal, not writable: unlike
+	// scanMission's read path (which must always return something),
+	// corruption discovered here should freeze the mission and refuse
+	// the write rather than let stale code overwrite an unreadable row.
+	if phase, ok := parsePhase(currentPhase); !ok || phase.Terminal() {
 		return ErrTerminal
 	}
 

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -792,6 +792,46 @@ func TestApplyTransitionRejectsWriteOnTerminalMission(t *testing.T) {
 	}
 }
 
+// TestApplyTransitionRejectsWriteOnUnrecognizedPhase reproduces a
+// corrupted row: a phase value no running binary recognizes (e.g. a
+// column mangled out of band, or a future phase an older binary
+// doesn't know). ApplyTransition must treat that as terminal and
+// refuse the write, freezing the mission rather than letting stale
+// code overwrite an unreadable row.
+func TestApplyTransitionRejectsWriteOnUnrecognizedPhase(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{Goal: marker + "unknown-phase-guard", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE missions SET phase = 'quantum' WHERE id = $1`, id); err != nil {
+		t.Fatalf("corrupt phase: %v", err)
+	}
+
+	err = s.ApplyTransition(ctx, id, Transition{
+		Next:   StepState{Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8},
+		Events: []EventDraft{{Kind: "mission.turn", Payload: map[string]any{"phase": "execute"}}},
+	})
+	if !errors.Is(err, ErrTerminal) {
+		t.Fatalf("ApplyTransition (unrecognized phase) err = %v, want ErrTerminal", err)
+	}
+
+	events, err := s.Events(ctx, id)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("Events = %+v, want none appended on rejected write", events)
+	}
+}
+
 // TestApplyTransitionCancelThenDoubleCancel exercises the two ends of
 // the cancel path around the new guard: a cancel applied to a live
 // mission still writes normally, and a second cancel on the

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -746,6 +746,9 @@ export interface Mission {
   // kind=general only, born in phase=execute, one bare worker turn.
   // final_output is that worker's verbatim final message — the
   // deliverable itself, absent/empty until the mission reaches done.
+  // Invariant: final_output is only ever populated when light is true;
+  // a non-light mission's Result comes from last_evidence instead (see
+  // MissionDetail.tsx's mutually exclusive light/!light Result blocks).
   light?: boolean
   final_output?: string
   created_at: string


### PR DESCRIPTION
Eight independent fixes from the mission harness review:

- `verified` on terminal events: `mission.done` carries `{verified: !light}`, light's `mission.review_skipped` carries `verified: false` — unverified completions are now distinguishable in the event log
- `ApplyTransition` refuses writes on an unrecognized phase (was: treated as writable non-terminal while scanMission treated the same corruption as failed)
- sentinel map sync (`sentinelAttrs`/`sentinelDiscriminator`) enforced at init; deliberate `explore_notes` omission documented
- `runTurn` returns one `turnResult` struct instead of five values threaded through 8 call sites
- preview classify endpoint uses a single kind+light LLM call instead of two sequential ones (create()'s fallback path untouched)
- stale "driver clears ConsecutiveFailures" comment corrected; missing checkRegressions-skips-citations rationale added (verified against the code first)
- `light`/`final_output` invariant documented in web types (full discriminated union judged not worth the ripple — one guarded call site)

Rebased on D-072. Go suite + web build/lint/test green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790102464&installation_model_id=431401&pr_number=292&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F292&signature=64e74efe2a2950139e5c4969a6651392932f8f5e1c6cbd399874fcb01be866f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->