### PR TITLE
feat: terminal hook runner and coherent failure policy (D-073)

### DIFF
--- a/internal/brain/missions/destination_deliver_test.go
+++ b/internal/brain/missions/destination_deliver_test.go
@@ -16,6 +16,7 @@ type recordingDeliver struct {
 	calls []struct {
 		missionID string
 		destIDs   []string
+		mission   Mission
 	}
 }
 
@@ -26,7 +27,8 @@ func (r *recordingDeliver) fn() DestinationDeliver {
 		r.calls = append(r.calls, struct {
 			missionID string
 			destIDs   []string
-		}{m.ID, destinationIDs})
+			mission   Mission
+		}{m.ID, destinationIDs, m})
 	}
 }
 
@@ -109,6 +111,33 @@ func TestDriverSkipsDeliveryWhenNoDestinations(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 	if got := rec.count(); got != 0 {
 		t.Fatalf("deliver calls for a mission with no destination_ids = %d, want 0", got)
+	}
+}
+
+// TestDriverBackfillsNameBeforeDestinationDelivery covers D-073's
+// ordering guarantee: runTerminalHooks backfills a missing name and
+// reloads the mission BEFORE handing it to the destinations hook, so a
+// mission that reached done with no name still delivers with the
+// backfilled one rather than empty.
+func TestDriverBackfillsNameBeforeDestinationDelivery(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8, DestinationIDs: []string{"d1"}})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner)
+	nameRec := &recordingNameMission{name: "Backfilled Name"}
+	d.SetNameMission(nameRec.fn())
+	deliverRec := &recordingDeliver{}
+	d.SetDestinationDeliver(deliverRec.fn())
+
+	driveN(t, d, "m1", 4) // explore -> plan -> execute -> review -> done
+
+	waitForDeliverCalls(t, deliverRec, 1)
+	if got := deliverRec.calls[0].mission.Name; got != "Backfilled Name" {
+		t.Fatalf("destination delivery saw mission name = %q, want %q (backfilled before delivery)", got, "Backfilled Name")
 	}
 }
 

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -262,6 +262,14 @@ func NewDriver(store driverStore, runner Runner, workspace *Workspace, notify no
 // a failing model at ~1/sec until the backoff pause finally kicks in —
 // this ladder slows that down without changing when the pause itself
 // fires (stepWorkerFailed's cfg.BackoffFailures ceiling is unchanged).
+// This is the in-band ladder: it paces retries WITHIN a live Drive loop,
+// seconds apart, while the mission is still working. Its counterpart is
+// sweep.go's autoResumeBackoffDelays/autoResumeInfraDelays, which pace
+// resuming a mission that already paused — minutes apart, run from the
+// periodic sweep rather than inline in Advance. The split exists because
+// the two problems are different: this ladder slows a mission that is
+// still actively (if unsuccessfully) making attempts; the sweep's
+// ladders self-heal a mission that has already stopped and gone quiet.
 var workerFailedRetryDelays = [...]time.Duration{5 * time.Second, 15 * time.Second, 45 * time.Second}
 
 // retryDelay maps a post-transition ConsecutiveFailures count to a
@@ -412,20 +420,14 @@ func (d *Driver) SetDestinationDeliver(fn DestinationDeliver) {
 // deliverToDestinations fires the destinations delivery hook exactly
 // on a transition into phase=done (never phase=failed — v1 doesn't
 // deliver on failure, the notifier already covers failure alerts) and
-// only when the mission actually has destination_ids attached.
-// Detached from ctx like fireOnComplete: the mission is already
-// terminal, so delivery must outlive a request that may be winding
-// down.
-func (d *Driver) deliverToDestinations(ctx context.Context, id string, terminal Phase) {
-	if d.deliverDestinations == nil || terminal != PhaseDone {
-		return
-	}
-	m, err := d.store.Get(ctx, id)
-	if err != nil {
-		d.log.Warn("driver: destination delivery: reload mission failed", "mission_id", id, "error", err)
-		return
-	}
-	if len(m.DestinationIDs) == 0 {
+// only when the mission actually has destination_ids attached. m is
+// the terminal-transition's own reload (onTerminal's single Get,
+// after backfillMissionName) — this no longer reloads itself, so
+// delivery always sees the backfilled name. Detached from ctx like
+// fireOnComplete: the mission is already terminal, so delivery must
+// outlive a request that may be winding down.
+func (d *Driver) deliverToDestinations(m Mission, terminal Phase) {
+	if d.deliverDestinations == nil || terminal != PhaseDone || len(m.DestinationIDs) == 0 {
 		return
 	}
 	rctx := context.Background()
@@ -460,19 +462,11 @@ func (d *Driver) SetValidateDeps(deps ValidateDeps) {
 // fireOnTerminal fires the workflows engine hook for any mission
 // reaching a terminal phase (done or failed) that names a
 // workflow_run_id — an ordinary mission (workflow_run_id empty) never
-// reaches the engine at all. Detached from ctx like deliverToDestinations:
-// the mission is already terminal, so this must outlive a request that
-// may be winding down.
-func (d *Driver) fireOnTerminal(ctx context.Context, id string) {
-	if d.onTerminal == nil {
-		return
-	}
-	m, err := d.store.Get(ctx, id)
-	if err != nil {
-		d.log.Warn("driver: workflow terminal hook: reload mission failed", "mission_id", id, "error", err)
-		return
-	}
-	if m.WorkflowRunID == "" {
+// reaches the engine at all. m is onTerminal's single reload, same as
+// deliverToDestinations. Detached from ctx: the mission is already
+// terminal, so this must outlive a request that may be winding down.
+func (d *Driver) fireOnTerminal(m Mission) {
+	if d.onTerminal == nil || m.WorkflowRunID == "" {
 		return
 	}
 	rctx := context.Background()
@@ -502,6 +496,62 @@ func (d *Driver) fireOnComplete(ctx context.Context, id string, m Mission) {
 		if d.notifyPushFailed != nil {
 			d.notifyPushFailed(rctx, id, fmt.Sprintf("mission %s: automatic %s failed: %s", id, m.OnComplete, err.Error()))
 		}
+	}
+}
+
+// D-073: runTerminalHooks is the single place Advance and Signal fire
+// every terminal-transition hook, replacing what used to be a verbatim block
+// duplicated in both (and had already drifted: Signal's copy omitted
+// fireOnComplete, benign only because Signal never produces a done
+// transition today — cancel always fails a mission, never completes
+// it).
+//
+// Fixed order:
+//  1. gatekeeper state drop (in-process only, no I/O)
+//  2. sandbox container removal (async, best-effort)
+//  3. name backfill (SYNCHRONOUS — see backfillMissionName)
+//  4. one mission reload, AFTER the backfill above, so every hook past
+//     this point sees a stable, already-backfilled name
+//  5. memory extraction, destinations delivery, workflow onTerminal —
+//     each handed the SAME reloaded Mission, no hook reloads on its own
+//  6. fireOnComplete, done transitions only
+//
+// Each hook may still dispatch its own goroutine (memory/destinations/
+// workflow all remain fire-and-forget past this function returning) —
+// the order guarantee above only covers the synchronous portion: it
+// guarantees WHAT each hook is handed, not when its own background work
+// finishes. notify.OnTransition is deliberately NOT one of these hooks:
+// it fires on every transition, not just terminal ones, so callers keep
+// invoking it separately.
+//
+// A hook failure is logged by the hook itself and never stops the rest
+// of the sequence — one hook's trouble (a dead memoryd, a bad
+// destination) must never suppress another's.
+func (d *Driver) runTerminalHooks(ctx context.Context, id string, terminal Phase, events []EventDraft) {
+	delete(d.gatekeepers, id)
+	d.removeSandbox(id)
+
+	reason := failedReason(events)
+	if d.nameMission != nil {
+		if pre, err := d.store.Get(ctx, id); err == nil && pre.Name == "" {
+			// Synchronous but bounded: the backfill is an LLM call, and
+			// a wedged provider must not stall the drive loop past this.
+			nctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+			d.backfillMissionName(nctx, id, pre.Goal)
+			cancel()
+		}
+	}
+
+	m, err := d.store.Get(ctx, id)
+	if err != nil {
+		d.log.Warn("driver: terminal hooks: reload mission failed", "mission_id", id, "error", err)
+		return
+	}
+	d.extractMissionMemory(ctx, m, terminal, reason)
+	d.deliverToDestinations(m, terminal)
+	d.fireOnTerminal(m)
+	if terminal == PhaseDone {
+		d.fireOnComplete(ctx, id, m)
 	}
 }
 
@@ -830,19 +880,7 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 		return false, fmt.Errorf("driver advance: apply transition: %w", err)
 	}
 	if t.Next.Phase.Terminal() {
-		delete(d.gatekeepers, id)
-		d.removeSandbox(id)
-		d.extractMissionMemory(ctx, id, t.Next.Phase, failedReason(t.Events))
-		d.backfillMissionName(ctx, id)
-		d.deliverToDestinations(ctx, id, t.Next.Phase)
-		d.fireOnTerminal(ctx, id)
-	}
-	if t.Next.Phase == PhaseDone {
-		// m is the pre-transition snapshot (re-fetched above, before this
-		// round's ApplyTransition) — RepoURL/ConnectorID/OnComplete/
-		// Branch/Worktree never change after create, so it's safe to
-		// reuse here rather than a third Get.
-		d.fireOnComplete(ctx, id, m)
+		d.runTerminalHooks(ctx, id, t.Next.Phase, t.Events)
 	}
 	if d.notify != nil {
 		if err := d.notify.OnTransition(ctx, m, before, t.Next.Status, failedReason(t.Events)); err != nil {
@@ -929,12 +967,7 @@ func (d *Driver) Signal(ctx context.Context, id string, input Input) error {
 		return fmt.Errorf("driver: signal: apply transition: %w", err)
 	}
 	if t.Next.Phase.Terminal() {
-		delete(d.gatekeepers, id)
-		d.removeSandbox(id)
-		d.extractMissionMemory(ctx, id, t.Next.Phase, failedReason(t.Events))
-		d.backfillMissionName(ctx, id)
-		d.deliverToDestinations(ctx, id, t.Next.Phase)
-		d.fireOnTerminal(ctx, id)
+		d.runTerminalHooks(ctx, id, t.Next.Phase, t.Events)
 	}
 	if d.notify != nil {
 		if err := d.notify.OnTransition(ctx, m, before, t.Next.Status, failedReason(t.Events)); err != nil {

--- a/internal/brain/missions/memory.go
+++ b/internal/brain/missions/memory.go
@@ -56,29 +56,22 @@ func alreadyExtracted(events []Event) bool {
 }
 
 // extractMissionMemory runs the mission's one terminal extraction pass:
-// called by Advance/Signal exactly when a transition's Next.Phase is
-// terminal (done or failed). Nil memory client, or a mission with no
+// called by onTerminal for every transition whose Next.Phase is
+// terminal (done or failed). m is onTerminal's single reload — this no
+// longer reloads itself. Nil memory client, or a mission with no
 // hidden session, skips silently — matching the nil-gated dependency
 // pattern the rest of the driver's optional hooks use (fireOnComplete,
 // notify). Extraction failures can never fail or block the mission
 // transition: MemoryExtract's own contract (see its doc comment) is
 // fire-and-forget, so nothing here can return an error to the caller
 // even in principle.
-func (d *Driver) extractMissionMemory(ctx context.Context, id string, terminal Phase, failureReason string) {
-	if d.memory == nil {
+func (d *Driver) extractMissionMemory(ctx context.Context, m Mission, terminal Phase, failureReason string) {
+	if d.memory == nil || m.SessionID == "" {
 		return
 	}
-	m, err := d.store.Get(ctx, id)
+	events, err := d.store.Events(ctx, m.ID)
 	if err != nil {
-		d.log.Warn("driver: memory extraction: reload mission failed", "mission_id", id, "error", err)
-		return
-	}
-	if m.SessionID == "" {
-		return
-	}
-	events, err := d.store.Events(ctx, id)
-	if err != nil {
-		d.log.Warn("driver: memory extraction: load events failed", "mission_id", id, "error", err)
+		d.log.Warn("driver: memory extraction: load events failed", "mission_id", m.ID, "error", err)
 		return
 	}
 	if alreadyExtracted(events) {
@@ -92,8 +85,8 @@ func (d *Driver) extractMissionMemory(ctx context.Context, id string, terminal P
 	// between dispatch and a not-yet-appended event would fire a second
 	// pass. Marking the attempt (not "succeeded") is the same commitment
 	// AppendEvent's other bookkeeping-only callers make.
-	if err := d.store.AppendEvent(ctx, id, memoryExtractedKind, map[string]any{"terminal": string(terminal)}); err != nil {
-		d.log.Warn("driver: memory extraction: record event failed", "mission_id", id, "error", err)
+	if err := d.store.AppendEvent(ctx, m.ID, memoryExtractedKind, map[string]any{"terminal": string(terminal)}); err != nil {
+		d.log.Warn("driver: memory extraction: record event failed", "mission_id", m.ID, "error", err)
 		return
 	}
 	go d.memory(context.Background(), m.SessionID, 0, digest, "") //nolint:gosec // G118: deliberate — the mission is already terminal, extraction must outlive whatever request/ctx observed that transition
@@ -102,27 +95,24 @@ func (d *Driver) extractMissionMemory(ctx context.Context, id string, terminal P
 // backfillMissionName regenerates a missing display name when a mission
 // reaches a terminal phase — the create-time naming call is best-effort
 // and a failure there would otherwise be permanent. Best-effort itself:
-// never blocks or fails the transition. SetNameIfEmpty's guard makes a
-// late create-time call racing this one harmless.
-func (d *Driver) backfillMissionName(ctx context.Context, id string) {
+// never fails the transition (any error is logged and swallowed). Runs
+// synchronously (D-073), unlike the rest of the terminal hooks: onTerminal
+// reloads the mission right after this returns, and that reload is what
+// destinations/workflow hooks see, so the name must already be persisted
+// by the time this call returns. SetNameIfEmpty's guard makes a late
+// create-time call racing this one harmless.
+func (d *Driver) backfillMissionName(ctx context.Context, id, goal string) {
 	if d.nameMission == nil {
 		return
 	}
-	m, err := d.store.Get(ctx, id)
-	if err != nil || m.Name != "" {
+	name := d.nameMission(ctx, goal)
+	if name == "" {
+		d.log.Warn("mission: name backfill returned empty", "mission_id", id)
 		return
 	}
-	goal := m.Goal
-	go func() { //nolint:gosec // G118: deliberate — the mission is already terminal, naming must outlive whatever request/ctx observed that transition
-		name := d.nameMission(context.Background(), goal)
-		if name == "" {
-			d.log.Warn("mission: name backfill returned empty", "mission_id", id)
-			return
-		}
-		if err := d.store.SetNameIfEmpty(context.Background(), id, name); err != nil {
-			d.log.Warn("mission: name backfill save failed", "mission_id", id, "error", err)
-		}
-	}()
+	if err := d.store.SetNameIfEmpty(ctx, id, name); err != nil {
+		d.log.Warn("mission: name backfill save failed", "mission_id", id, "error", err)
+	}
 }
 
 // OutcomeDigest assembles the curated extraction input: goal, title,

--- a/internal/brain/missions/memory_test.go
+++ b/internal/brain/missions/memory_test.go
@@ -241,10 +241,11 @@ func TestDriverExtractsMemoryOnceOnRedrive(t *testing.T) {
 	rec := &recordingExtract{}
 	d.SetMemoryExtract(rec.fn())
 
-	d.extractMissionMemory(context.Background(), "m1", PhaseDone, "")
+	m, _ := store.Get(context.Background(), "m1")
+	d.extractMissionMemory(context.Background(), m, PhaseDone, "")
 	waitForCalls(t, rec, 1)
 
-	d.extractMissionMemory(context.Background(), "m1", PhaseDone, "")
+	d.extractMissionMemory(context.Background(), m, PhaseDone, "")
 	time.Sleep(20 * time.Millisecond)
 	if got := rec.count(); got != 1 {
 		t.Fatalf("extraction calls after re-drive = %d, want 1 (idempotency guard must suppress the second attempt)", got)
@@ -310,7 +311,8 @@ func TestDriverSkipsExtractionWhenNoSession(t *testing.T) {
 	rec := &recordingExtract{}
 	d.SetMemoryExtract(rec.fn())
 
-	d.extractMissionMemory(context.Background(), "m1", PhaseDone, "")
+	m, _ := store.Get(context.Background(), "m1")
+	d.extractMissionMemory(context.Background(), m, PhaseDone, "")
 	time.Sleep(20 * time.Millisecond)
 	if got := rec.count(); got != 0 {
 		t.Fatalf("extraction calls with no hidden session = %d, want 0", got)
@@ -341,21 +343,9 @@ func (r *recordingNameMission) count() int {
 	return len(r.calls)
 }
 
-// waitForNameCalls polls count() until it reaches want or the deadline
-// passes — the backfill dispatch is `go d.nameMission(...)`, same
-// allowance waitForCalls gives extraction's own dispatch goroutine.
-func waitForNameCalls(t *testing.T, r *recordingNameMission, want int) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if r.count() == want {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatalf("nameMission calls = %d, want %d", r.count(), want)
-}
-
+// TestBackfillMissionNameFillsEmptyName covers backfillMissionName
+// itself (D-073: now synchronous — runTerminalHooks is what decides
+// whether a mission needs naming; backfillMissionName just does it).
 func TestBackfillMissionNameFillsEmptyName(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{ID: "m1", Goal: "add a widget", Phase: PhaseDone, Status: StatusDone})
@@ -363,28 +353,28 @@ func TestBackfillMissionNameFillsEmptyName(t *testing.T) {
 	rec := &recordingNameMission{name: "Nice Name"}
 	d.SetNameMission(rec.fn())
 
-	d.backfillMissionName(context.Background(), "m1")
-	waitForNameCalls(t, rec, 1)
+	d.backfillMissionName(context.Background(), "m1", "add a widget")
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if m, _ := store.Get(context.Background(), "m1"); m.Name == "Nice Name" {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
+	if rec.count() != 1 {
+		t.Fatalf("nameMission calls = %d, want 1", rec.count())
 	}
-	t.Fatal("mission name was never backfilled")
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Name != "Nice Name" {
+		t.Fatalf("mission name = %q, want %q", m.Name, "Nice Name")
+	}
 }
 
-func TestBackfillMissionNameSkipsWhenAlreadyNamed(t *testing.T) {
+// TestRunTerminalHooksSkipsNamingWhenAlreadyNamed covers the
+// already-named guard, which now lives in runTerminalHooks rather than
+// backfillMissionName itself.
+func TestRunTerminalHooksSkipsNamingWhenAlreadyNamed(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{ID: "m1", Goal: "add a widget", Name: "Already Named", Phase: PhaseDone, Status: StatusDone})
 	d := testDriver(store, &scriptedRunner{})
 	rec := &recordingNameMission{name: "Nice Name"}
 	d.SetNameMission(rec.fn())
 
-	d.backfillMissionName(context.Background(), "m1")
-	time.Sleep(20 * time.Millisecond)
+	d.runTerminalHooks(context.Background(), "m1", PhaseDone, nil)
 	if got := rec.count(); got != 0 {
 		t.Fatalf("nameMission calls for an already-named mission = %d, want 0", got)
 	}
@@ -395,8 +385,7 @@ func TestBackfillMissionNameSkipsWhenNilFn(t *testing.T) {
 	store.put("m1", Mission{ID: "m1", Goal: "add a widget", Phase: PhaseDone, Status: StatusDone})
 	d := testDriver(store, &scriptedRunner{}) // no SetNameMission call: d.nameMission stays nil
 
-	d.backfillMissionName(context.Background(), "m1")
-	time.Sleep(20 * time.Millisecond)
+	d.backfillMissionName(context.Background(), "m1", "add a widget")
 
 	m, _ := store.Get(context.Background(), "m1")
 	if m.Name != "" {
@@ -411,10 +400,11 @@ func TestBackfillMissionNameSkipsSaveWhenGenerationEmpty(t *testing.T) {
 	rec := &recordingNameMission{name: ""} // simulates a generation failure
 	d.SetNameMission(rec.fn())
 
-	d.backfillMissionName(context.Background(), "m1")
-	waitForNameCalls(t, rec, 1)
+	d.backfillMissionName(context.Background(), "m1", "add a widget")
 
-	time.Sleep(20 * time.Millisecond)
+	if rec.count() != 1 {
+		t.Fatalf("nameMission calls = %d, want 1", rec.count())
+	}
 	m, _ := store.Get(context.Background(), "m1")
 	if m.Name != "" {
 		t.Fatalf("mission name = %q, want empty (empty generation must not write)", m.Name)

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -384,6 +384,11 @@ func replanTransition(s StepState, in StepInput) Transition {
 	s.StallCount = 0
 	s.LastGapFingerprint = ""
 	s.Iteration = 0
+	// A replan is a fresh start, same as any other stepPhaseComplete
+	// transition into a new phase — leaving ConsecutiveFailures set would
+	// arrive at planning already one failure from a backoff pause despite
+	// having made no failed attempt yet in the new phase.
+	s.ConsecutiveFailures = 0
 	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.replan", Payload: map[string]any{"reason": in.Reason}}}}
 }
 

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -250,6 +250,19 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhasePlan, Status: StatusIdle, MaxIterations: 8, ReplanUsed: true},
 		},
 		{
+			// A mission can carry ConsecutiveFailures into a stall (e.g. one
+			// worker_failed round before the stall's own worker_retry
+			// rounds) — replanning must clear it same as any other fresh
+			// phase start (stepPhaseComplete), or the replanned mission
+			// arrives at planning one failure from a backoff pause despite
+			// having made no failed attempt yet in the new phase.
+			name:  "worker_retry stall replan clears ConsecutiveFailures",
+			state: StepState{Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8, StallCount: 1, LastGapFingerprint: "verify_failed:unit_0", ConsecutiveFailures: 2},
+			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "verify_failed:unit_0", Reason: "same failure again"},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhasePlan, Status: StatusIdle, MaxIterations: 8, ReplanUsed: true},
+		},
+		{
 			name:  "review_infra_failure pauses with infra reason",
 			state: StepState{Phase: PhaseReview, Status: StatusWorking},
 			input: StepInput{Input: InputReviewInfraFailure},

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -1072,9 +1072,9 @@ func (s *Store) Spend(ctx context.Context, missionID string) (MissionSpend, erro
 	return out, rows.Err()
 }
 
-// BackoffPausedMission is BackoffPaused's row: just enough to drive the
-// auto-resume ladder (sweep.go's autoResumeBackoff) without the cost of
-// a full Mission scan.
+// BackoffPausedMission is PausedByReason's row: just enough to drive
+// the auto-resume ladders (sweep.go's autoResumeBackoff and
+// autoResumeInfra) without the cost of a full Mission scan.
 type BackoffPausedMission struct {
 	ID        string
 	UpdatedAt time.Time
@@ -1083,20 +1083,27 @@ type BackoffPausedMission struct {
 // BackoffPaused returns every mission currently paused with
 // pause_reason='backoff' — autoResumeBackoff's input.
 func (s *Store) BackoffPaused(ctx context.Context) ([]BackoffPausedMission, error) {
+	return s.PausedByReason(ctx, string(PauseBackoff))
+}
+
+// PausedByReason returns every mission currently paused with the given
+// pause_reason — shared by autoResumeBackoff (reason="backoff") and
+// autoResumeInfra (reason="infra").
+func (s *Store) PausedByReason(ctx context.Context, reason string) ([]BackoffPausedMission, error) {
 	db, err := s.db.Get()
 	if err != nil {
-		return nil, fmt.Errorf("missions backoff paused: %w", err)
+		return nil, fmt.Errorf("missions paused by reason: %w", err)
 	}
-	rows, err := db.Query(ctx, `SELECT id, updated_at FROM missions WHERE status = 'paused' AND pause_reason = 'backoff'`)
+	rows, err := db.Query(ctx, `SELECT id, updated_at FROM missions WHERE status = 'paused' AND pause_reason = $1`, reason)
 	if err != nil {
-		return nil, fmt.Errorf("missions backoff paused: %w", err)
+		return nil, fmt.Errorf("missions paused by reason: %w", err)
 	}
 	defer rows.Close()
 	out := []BackoffPausedMission{}
 	for rows.Next() {
 		var m BackoffPausedMission
 		if err := rows.Scan(&m.ID, &m.UpdatedAt); err != nil {
-			return nil, fmt.Errorf("missions backoff paused: %w", err)
+			return nil, fmt.Errorf("missions paused by reason: %w", err)
 		}
 		out = append(out, m)
 	}
@@ -1107,15 +1114,23 @@ func (s *Store) BackoffPaused(ctx context.Context) ([]BackoffPausedMission, erro
 // paused for backoff (mission.paused events with reason=backoff) —
 // autoResumeBackoff's input to the resume ladder.
 func (s *Store) CountBackoffPauses(ctx context.Context, missionID string) (int, error) {
+	return s.CountPausesByReason(ctx, missionID, string(PauseBackoff))
+}
+
+// CountPausesByReason counts how many times missionID has previously
+// paused for the given reason (mission.paused events with a matching
+// payload reason) — shared by autoResumeBackoff and autoResumeInfra's
+// resume ladders.
+func (s *Store) CountPausesByReason(ctx context.Context, missionID, reason string) (int, error) {
 	db, err := s.db.Get()
 	if err != nil {
-		return 0, fmt.Errorf("missions count backoff pauses: %w", err)
+		return 0, fmt.Errorf("missions count pauses by reason: %w", err)
 	}
 	var n int
 	err = db.QueryRow(ctx, `SELECT count(*) FROM mission_events
-		WHERE mission_id = $1 AND kind = 'mission.paused' AND payload->>'reason' = 'backoff'`, missionID).Scan(&n)
+		WHERE mission_id = $1 AND kind = 'mission.paused' AND payload->>'reason' = $2`, missionID, reason).Scan(&n)
 	if err != nil {
-		return 0, fmt.Errorf("missions count backoff pauses: %w", err)
+		return 0, fmt.Errorf("missions count pauses by reason: %w", err)
 	}
 	return n, nil
 }

--- a/internal/brain/missions/sweep.go
+++ b/internal/brain/missions/sweep.go
@@ -15,11 +15,13 @@ import (
 const workSlotSweepInterval = 30 * time.Second
 
 // staleWorkingAfter bounds how long a 'working' mission may go without a
-// turn before the periodic sweep re-Drives it — well above any observed
-// legit single-turn duration (the slowest logged this project: ~9.4min,
-// a remote-model turn), so this never fires on a mission genuinely
-// mid-turn, only one whose Drive loop has actually stopped.
-const staleWorkingAfter = 15 * time.Minute
+// turn before the periodic sweep re-Drives it. Invariant: staleWorkingAfter
+// > turnTimeout (runner.go) — otherwise this sweep can re-Drive a mission
+// still genuinely mid-turn (only claimDriving's no-op saves it from a
+// second concurrent Drive loop). Derived from turnTimeout plus margin
+// rather than a bare constant so that invariant can't silently drift out
+// of sync if turnTimeout ever changes.
+var staleWorkingAfter = turnTimeout + 5*time.Minute
 
 // recoverWorkingRetries and recoverWorkingRetryDelay bound the boot
 // recovery pass's tolerance for Postgres not yet accepting connections
@@ -64,6 +66,15 @@ type backoffStore interface {
 	CountBackoffPauses(ctx context.Context, missionID string) (int, error)
 }
 
+// pausedByReasonStore is the narrow slice of *Store autoResumeInfra
+// needs — the reason-parameterized counterpart of backoffStore, kept
+// separate rather than folded into it since autoResumeBackoff's own
+// existing tests fake backoffStore's fixed-reason shape.
+type pausedByReasonStore interface {
+	PausedByReason(ctx context.Context, reason string) ([]BackoffPausedMission, error)
+	CountPausesByReason(ctx context.Context, missionID, reason string) (int, error)
+}
+
 // signaler is the narrow slice of *Driver autoResumeBackoff needs to
 // resume a mission — an interface so the ladder logic is testable
 // against a fake capturing Signal calls without a real Store/Runner.
@@ -76,13 +87,35 @@ type signaler interface {
 // again, indexed by prior-backoff-pause count (1st, 2nd, 3rd). A
 // mission that has paused for backoff 4 or more times has a persistent
 // problem, not a transient outage, and needs a human — see
-// autoResumeBackoff.
+// autoResumeBackoff. This is the post-pause ladder: it paces resuming a
+// mission the sweep finds already stopped, minutes apart. Its
+// counterpart is driver.go's workerFailedRetryDelays, which paces
+// retries WITHIN a live Drive loop, seconds apart, before a pause ever
+// happens — see that ladder's own comment for the split's rationale.
 var autoResumeBackoffDelays = [...]time.Duration{5 * time.Minute, 15 * time.Minute, 60 * time.Minute}
 
 // autoResumeExhaustedAfter is the prior-backoff-pause count at and
 // above which autoResumeBackoff stops resuming a mission and instead
 // notifies once and leaves it paused for a human.
 const autoResumeExhaustedAfter = 4
+
+// autoResumeInfraDelays ladders how long an infra-paused mission waits
+// before autoResumeInfra resumes it again, indexed by prior-infra-pause
+// count (1st, 2nd, 3rd) — its own, shorter ladder than
+// autoResumeBackoffDelays: infra failures (a gateway blip, a docker
+// hiccup) are usually transient and worth retrying sooner, while a
+// genuinely permanent one (a missing image) re-pauses immediately and
+// hits autoResumeInfraExhaustedAfter fast regardless of how short the
+// ladder is.
+var autoResumeInfraDelays = [...]time.Duration{2 * time.Minute, 10 * time.Minute, 30 * time.Minute}
+
+// autoResumeInfraExhaustedAfter is the prior-infra-pause count at and
+// above which autoResumeInfra stops resuming a mission and instead
+// notifies once and leaves it paused for a human — deliberately lower
+// than autoResumeExhaustedAfter's 4: a repeatedly failing infra
+// dependency needs a human sooner than a repeatedly failing model call
+// does.
+const autoResumeInfraExhaustedAfter = 3
 
 // admitWork reports whether the host can afford claiming another work
 // slot right now (D-056). A nil gate always admits (tests, and any
@@ -192,6 +225,7 @@ func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurren
 			sweepOrphanSandboxes(ctx, store, sandbox, log)
 			reDriveStaleWorking(ctx, d, store, log)
 			autoResumeBackoff(ctx, d, store, notify, log)
+			autoResumeInfra(ctx, d, store, notify, log)
 			// D-056: skip the claim entirely this tick if the host can't
 			// afford another working mission — the mission stays idle,
 			// and this same sweep retries it in workSlotSweepInterval; that
@@ -289,6 +323,59 @@ func autoResumeBackoff(ctx context.Context, d signaler, store backoffStore, noti
 		log.Info("auto-resume backoff sweep: resuming a backoff-paused mission", "mission_id", m.ID, "prior_pauses", n)
 		if err := d.Signal(ctx, m.ID, InputResume); err != nil {
 			log.Error("auto-resume backoff sweep: signal failed", "mission_id", m.ID, "error", err)
+		}
+	}
+}
+
+// autoResumeInfra self-heals missions paused for infra failure
+// (PauseInfra: gateway blip, docker hiccup, harness/reviewer/driver
+// error) without a human hitting resume every time — same ladder shape
+// as autoResumeBackoff, but its own shorter delays
+// (autoResumeInfraDelays) and its own lower cap
+// (autoResumeInfraExhaustedAfter): infra failures are usually transient
+// and worth retrying sooner than a repeatedly-failing model call, while
+// a genuinely permanent infra failure (a missing image) re-pauses
+// immediately and hits the cap fast regardless.
+//
+// A resumed mission still hitting the same (or a different) pause
+// condition re-pauses with whatever reason applies (statemachine.go's
+// checks run before the input switch) — it naturally leaves
+// PausedByReason's result set on the very next tick if that reason
+// isn't 'infra', no special case needed here.
+func autoResumeInfra(ctx context.Context, d signaler, store pausedByReasonStore, notify messageNotifier, log *slog.Logger) {
+	missions, err := store.PausedByReason(ctx, string(PauseInfra))
+	if err != nil {
+		log.Error("auto-resume infra sweep: list failed", "error", err)
+		return
+	}
+	for _, m := range missions {
+		n, err := store.CountPausesByReason(ctx, m.ID, string(PauseInfra))
+		if err != nil {
+			log.Error("auto-resume infra sweep: count pauses failed", "mission_id", m.ID, "error", err)
+			continue
+		}
+		if n <= 0 {
+			continue // no recorded infra pause yet — nothing to ladder from
+		}
+		if n >= autoResumeInfraExhaustedAfter {
+			if notify != nil {
+				msg := fmt.Sprintf("this mission has paused for infra failure %d times and will not auto-resume again — it needs a human look", n)
+				if err := notify.NotifyMessage(ctx, m.ID, "auto_resume_exhausted", msg); err != nil {
+					log.Warn("auto-resume infra sweep: notify failed", "mission_id", m.ID, "error", err)
+				}
+			}
+			continue
+		}
+		idx := n - 1
+		if idx >= len(autoResumeInfraDelays) {
+			idx = len(autoResumeInfraDelays) - 1
+		}
+		if time.Since(m.UpdatedAt) < autoResumeInfraDelays[idx] {
+			continue // not due yet
+		}
+		log.Info("auto-resume infra sweep: resuming an infra-paused mission", "mission_id", m.ID, "prior_pauses", n)
+		if err := d.Signal(ctx, m.ID, InputResume); err != nil {
+			log.Error("auto-resume infra sweep: signal failed", "mission_id", m.ID, "error", err)
 		}
 	}
 }

--- a/internal/brain/missions/sweep_test.go
+++ b/internal/brain/missions/sweep_test.go
@@ -161,3 +161,100 @@ func TestAutoResumeBackoffNilNotifierSafe(t *testing.T) {
 		t.Fatal("exhausted mission must never be resumed")
 	}
 }
+
+// fakePausedByReasonStore scripts PausedByReason/CountPausesByReason
+// for autoResumeInfra tests without a real Postgres pool — the
+// reason-parameterized counterpart of fakeBackoffStore.
+type fakePausedByReasonStore struct {
+	paused []BackoffPausedMission
+	counts map[string]int
+}
+
+func (f fakePausedByReasonStore) PausedByReason(ctx context.Context, reason string) ([]BackoffPausedMission, error) {
+	return f.paused, nil
+}
+
+func (f fakePausedByReasonStore) CountPausesByReason(ctx context.Context, missionID, reason string) (int, error) {
+	return f.counts[missionID], nil
+}
+
+// TestAutoResumeInfraLadder covers autoResumeInfra's own, shorter
+// ladder ({2m, 10m, 30m}) and lower cap (3 prior pauses) — mirrors
+// TestAutoResumeBackoffLadder's boundary structure.
+func TestAutoResumeInfraLadder(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	now := time.Now()
+
+	cases := []struct {
+		name       string
+		n          int
+		since      time.Duration
+		wantResume bool
+		wantNotify bool
+	}{
+		{"n=1 just before 2m due", 1, 2*time.Minute - time.Second, false, false},
+		{"n=1 just after 2m due", 1, 2*time.Minute + time.Second, true, false},
+		{"n=2 just before 10m due", 2, 10*time.Minute - time.Second, false, false},
+		{"n=2 just after 10m due", 2, 10*time.Minute + time.Second, true, false},
+		{"n=3 exhausted, never resumes", 3, 999 * time.Hour, false, true},
+		{"n=4 exhausted, never resumes", 4, 999 * time.Hour, false, true},
+		{"n=0 no recorded pause yet, skipped", 0, 999 * time.Hour, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := fakePausedByReasonStore{
+				paused: []BackoffPausedMission{{ID: "m1", UpdatedAt: now.Add(-tc.since)}},
+				counts: map[string]int{"m1": tc.n},
+			}
+			signaler := &fakeSignaler{}
+			notifier := &fakeMessageNotifier{}
+			autoResumeInfra(context.Background(), signaler, store, notifier, log)
+
+			if resumed := len(signaler.signaled) == 1; resumed != tc.wantResume {
+				t.Fatalf("signaled = %v, want resume=%v", signaler.signaled, tc.wantResume)
+			}
+			if notified := len(notifier.notified) == 1; notified != tc.wantNotify {
+				t.Fatalf("notified = %v, want notify=%v", notifier.notified, tc.wantNotify)
+			}
+		})
+	}
+}
+
+// TestAutoResumeInfraNotifiesOncePerTick confirms the exhausted path
+// notifies exactly once per sweep tick (NotifyMessage's own dedupe in
+// notify.go covers repeat ticks) — mirrors the backoff sweep's
+// single-notify-per-call behavior already covered by the ladder table
+// above; this test isolates it explicitly for the infra ladder's own
+// (lower) cap.
+func TestAutoResumeInfraNotifiesOncePerTick(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := fakePausedByReasonStore{
+		paused: []BackoffPausedMission{{ID: "m1", UpdatedAt: time.Now().Add(-999 * time.Hour)}},
+		counts: map[string]int{"m1": 3},
+	}
+	signaler := &fakeSignaler{}
+	notifier := &fakeMessageNotifier{}
+	autoResumeInfra(context.Background(), signaler, store, notifier, log)
+	if len(notifier.notified) != 1 {
+		t.Fatalf("notified = %d, want 1", len(notifier.notified))
+	}
+	if len(signaler.signaled) != 0 {
+		t.Fatal("exhausted mission must never be resumed")
+	}
+}
+
+// TestAutoResumeInfraNilNotifierSafe confirms a nil notifier never
+// panics on the exhausted path — same nil-safe contract as
+// autoResumeBackoff.
+func TestAutoResumeInfraNilNotifierSafe(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := fakePausedByReasonStore{
+		paused: []BackoffPausedMission{{ID: "m1", UpdatedAt: time.Now().Add(-999 * time.Hour)}},
+		counts: map[string]int{"m1": 3},
+	}
+	signaler := &fakeSignaler{}
+	autoResumeInfra(context.Background(), signaler, store, nil, log)
+	if len(signaler.signaled) != 0 {
+		t.Fatal("exhausted mission must never be resumed")
+	}
+}


### PR DESCRIPTION
Review findings M-2 and MED-HIGH failure-taxonomy, roadmap steps 3+4:

**Terminal hook runner** — one `runTerminalHooks` replaces the verbatim-duplicated blocks in Advance/Signal: defined order (gatekeeper → sandbox → name backfill → single reload → memory/destinations/workflow → on_complete on done), one detach pattern, every hook handed the same preloaded row (was: three redundant reloads, delivered name order-dependent). Name backfill is synchronous for the ordering guarantee but ctx-bounded at 20s so a wedged provider can't stall the drive loop. Signal's missing `fireOnComplete` included (latent, unreachable today).

**Failure policy**
- infra pauses auto-resume on their own ladder (2m/10m/30m, cap 3, notify-once on exhaustion) — was: a gateway blip waited for a human forever while 3× worker failures self-healed in 5m (inverted). Budget/mixed-currency/no-progress stay manual.
- `replanTransition` clears ConsecutiveFailures (was: stalled-after-2-failures entered planning one failure from a backoff pause)
- `staleWorkingAfter = turnTimeout + 5m` (was 15m vs 20m — sweep could re-drive a still-running turn)
- cross-referencing comments on the two retry ladders (in-band vs post-pause)

Tests: infra ladder/cap/notify-once, ConsecutiveFailures reset, hook-order (backfilled name reaches delivery), adapted terminal-hook suites. Green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790104081&installation_model_id=431401&pr_number=293&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F293&signature=9c784687232d28046547e94b77a0b64bc33c042cda9eac4a726231317f14d676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->