### PR TITLE
feat: light workflow steps

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -120,6 +120,9 @@ services:
       # alongside a slow provider's request_timeout so the two
       # deadlines never land at the same instant.
       TURN_TIMEOUT: ${TURN_TIMEOUT:-}
+      # Non-empty enables the agentic workflows layer (D-070):
+      # orchestration above missions. Off by default.
+      WORKFLOWS_ENABLED: ${WORKFLOWS_ENABLED:-}
       # Compose-internal only: the model never sees this address.
       SEARXNG_URL: http://searxng:8080
       # Converts Gmail attachments (PDFs) and HTML-only email bodies to

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -36,6 +36,11 @@ TIMOTHY_PUBLIC_URL=http://localhost:3300
 # the two deadlines never collide.
 TURN_TIMEOUT=
 
+# --- Workflows ---
+# Non-empty enables the agentic workflows layer (orchestration above
+# missions). Off by default.
+WORKFLOWS_ENABLED=
+
 # --- Third-party services ---
 # npm auth token for HugeIcons Pro packages (from your hugeicons.com account)
 HUGEICONS_TOKEN=

--- a/internal/brain/workflows/definition.go
+++ b/internal/brain/workflows/definition.go
@@ -36,6 +36,7 @@ type Definition struct {
 type Step struct {
 	Goal           string   `json:"goal"`
 	Kind           string   `json:"kind"` // coding | general
+	Light          bool     `json:"light,omitempty"` // D-069 light mission; general only
 	Route          string   `json:"route,omitempty"`
 	PlanRoute      string   `json:"plan_route,omitempty"`
 	AgentID        string   `json:"agent_id,omitempty"`
@@ -87,6 +88,9 @@ func (d *Definition) Validate() error {
 		case "", "push", "push_pr":
 		default:
 			return fmt.Errorf("step %q: on_complete must be \"\", \"push\", or \"push_pr\"", name)
+		}
+		if d.Steps[name].Light && d.Steps[name].Kind != "general" {
+			return fmt.Errorf("step %q: light is only valid for kind=general", name)
 		}
 	}
 	for i := range d.Edges {

--- a/internal/brain/workflows/definition_test.go
+++ b/internal/brain/workflows/definition_test.go
@@ -154,3 +154,19 @@ func TestParseDefinitionRejectsInvalidDefinition(t *testing.T) {
 		t.Fatal("ParseDefinition() = nil, want error for invalid definition")
 	}
 }
+
+func TestValidateRejectsLightOnCoding(t *testing.T) {
+	d := validDefinition()
+	d.Steps["coder"] = Step{Goal: "write code", Kind: "coding", Light: true}
+	if err := d.Validate(); err == nil {
+		t.Fatal("Validate() = nil, want error for light on kind=coding")
+	}
+}
+
+func TestValidateAllowsLightOnGeneral(t *testing.T) {
+	d := validDefinition()
+	d.Steps["coder"] = Step{Goal: "summarize", Kind: "general", Light: true}
+	if err := d.Validate(); err != nil {
+		t.Fatalf("Validate() = %v, want nil for light on kind=general", err)
+	}
+}

--- a/internal/brain/workflows/engine.go
+++ b/internal/brain/workflows/engine.go
@@ -208,7 +208,7 @@ func (e *Engine) spawnStep(ctx context.Context, runID, stepName string, step Ste
 		route = e.routeForRole(ctx, "default")
 	}
 	return e.spawner.Create(ctx, missions.Mission{
-		Goal: goal, Kind: step.Kind, Route: route, PlanRoute: step.PlanRoute, AgentID: step.AgentID,
+		Goal: goal, Kind: step.Kind, Light: step.Light, Route: route, PlanRoute: step.PlanRoute, AgentID: step.AgentID,
 		OnComplete: step.OnComplete, DestinationIDs: step.DestinationIDs,
 		ParentMissionID: parentMissionID, ParentContext: outcome,
 		WorkflowRunID: runID, WorkflowStep: stepName,


### PR DESCRIPTION
Review follow-up: `workflows.Step` had no `light` field, so workflow steps silently could not be light — exactly the read→synthesize→deliver composition light mode (D-069) exists for. `Step.Light` now passes through `spawnStep` to the mission; `Validate()` rejects light on non-general steps (same rule as `ValidateCreate`, which also still guards the spawn path). Tests for both.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790105347&installation_model_id=431401&pr_number=295&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F295&signature=a0c33af9d2e60e25e361a643006ee6f538b76e62f51f2bc69412ca8e59cb72cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->