### PR TITLE
fix: end mission turns on sentinel execution (D-075)

### DIFF
--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -288,6 +288,14 @@ type Request struct {
 	// step (D-063). Only set by callers whose turn ends on that tool
 	// (mission sentinel turns). Empty means auto, today's behavior.
 	ForceTool string
+
+	// EndTurnTools names offered tools whose successful EXECUTION ends
+	// the turn immediately — no further model call to react to the
+	// result. Set by mission sentinel turns (mission_status/
+	// explore_notes/submit_plan/review_verdict), whose call already
+	// answers everything the turn needed; empty means today's behavior
+	// (always continue).
+	EndTurnTools []string
 }
 
 // Start launches the loop and returns its event stream. The channel
@@ -373,6 +381,10 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 	forceTool := req.ForceTool
 	if forceTool != "" && !toolNames[forceTool] {
 		forceTool = ""
+	}
+	endTurnTools := make(map[string]bool, len(req.EndTurnTools))
+	for _, name := range req.EndTurnTools {
+		endTurnTools[name] = true
 	}
 	msgs := append([]provider.Message(nil), req.Messages...)
 	total := stream.Usage{}
@@ -598,6 +610,28 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 		for i := range results {
 			msgs = append(msgs, provider.Message{Role: "tool", ToolResult: &results[i]})
 		}
+
+		// D-075: a sentinel call's successful execution already answers
+		// everything the turn needed (mission_status/explore_notes/
+		// submit_plan/review_verdict) — sending its result back for
+		// another completion just burns a model call, and on reasoning
+		// models over openai-responses that pointless continuation
+		// returns empty output and fails the whole turn (D-063). An
+		// errored/denied sentinel result still needs the model to see
+		// it and retry, so only a clean result ends the turn here.
+		endTurn := false
+		for i, c := range calls {
+			if endTurnTools[c.Name] && !results[i].IsError {
+				endTurn = true
+				break
+			}
+		}
+		if endTurn {
+			emitFinal(stream.StreamEvent{Type: stream.EventUsage, Usage: &total})
+			emitFinal(stream.StreamEvent{Type: stream.EventDone, Meta: lastMeta})
+			return
+		}
+
 		effort = EffortFor(results)
 	}
 }

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -2147,3 +2147,89 @@ func TestWaitToolsReadyTimeoutStillProceeds(t *testing.T) {
 	}
 }
 
+// TestAgentEndTurnToolsEndsAfterSentinel pins D-075: a tool named in
+// EndTurnTools that executes cleanly ends the turn right there — no
+// second model call to react to a result nobody asked for. Only one
+// gateway request must fire, and the assistant+tool-result messages
+// still land in the round-trip (session persistence must see them
+// exactly as if the turn had continued).
+func TestAgentEndTurnToolsEndsAfterSentinel(t *testing.T) {
+	t.Parallel()
+	sentinel := &tools.Tool{
+		Name:        "mission_status",
+		Description: "reports mission status",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"outcome":{"type":"string"}},"required":["outcome"],"additionalProperties":false}`),
+		Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+			return "recorded", nil
+		},
+	}
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"mission_status", `{"outcome":"done"}`}),
+	}}
+	a, _, events, _ := testAgent(t, gw, sentinel)
+
+	ch, err := a.Start(t.Context(), Request{
+		SessionID:    "s1",
+		Route:        "coding",
+		Messages:     []provider.Message{{Role: "user", Content: "go"}},
+		EndTurnTools: []string{"mission_status"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	if len(gw.requests) != 1 {
+		t.Fatalf("gateway requests = %d, want exactly 1 (no continuation call)", len(gw.requests))
+	}
+	if got := ofType(evs, stream.EventDone); len(got) != 1 {
+		t.Fatalf("done events = %d, want exactly 1", len(got))
+	}
+	usage := ofType(evs, stream.EventUsage)
+	if len(usage) != 1 || usage[0].Usage.InputTokens != 10 || usage[0].Usage.OutputTokens != 5 {
+		t.Fatalf("usage = %+v, want the sentinel step's own usage (10/5)", usage)
+	}
+	if len(events.kinds) != 1 || events.kinds[0] != "tool_execution" {
+		t.Fatalf("session events = %v, want the sentinel's tool_execution persisted", events.kinds)
+	}
+}
+
+// TestAgentEndTurnToolsErrorContinues pins the D-075 carve-out: an
+// EndTurnTools call that comes back as an error/denial does NOT end
+// the turn — the model must see the failure and get a chance to
+// retry, exactly like today's behavior for every other tool.
+func TestAgentEndTurnToolsErrorContinues(t *testing.T) {
+	t.Parallel()
+	sentinel := &tools.Tool{
+		Name:        "mission_status",
+		Description: "reports mission status",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`),
+		Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+			panic("bad args")
+		},
+	}
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"mission_status", `{}`}),
+		finalStep("retried"),
+	}}
+	a, _, _, _ := testAgent(t, gw, sentinel)
+
+	ch, err := a.Start(t.Context(), Request{
+		SessionID:    "s1",
+		Route:        "coding",
+		Messages:     []provider.Message{{Role: "user", Content: "go"}},
+		EndTurnTools: []string{"mission_status"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+
+	if len(gw.requests) != 2 {
+		t.Fatalf("gateway requests = %d, want 2 (error result must still get a continuation)", len(gw.requests))
+	}
+	if got := ofType(evs, stream.EventDone); len(got) != 1 {
+		t.Fatalf("done events = %d, want exactly 1", len(got))
+	}
+}
+

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -455,6 +455,10 @@ type turnResult struct {
 func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTool string) (turnResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, turnTimeout)
 	defer cancel()
+	// D-075: the sentinel call's successful execution ends the turn —
+	// every mission phase (worker/explore/plan/review) goes through
+	// this one call site.
+	req.EndTurnTools = []string{sentinelTool}
 	events, err := r.agent.Start(ctx, req)
 	if err != nil {
 		return turnResult{}, err

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -136,6 +136,12 @@ func TestRunWorkerSentinelPresent(t *testing.T) {
 	if agent.call != 1 {
 		t.Fatalf("expected exactly one turn when the sentinel is present, got %d", agent.call)
 	}
+	// D-075: the worker turn must tell loop.Agent its sentinel ends the
+	// turn, so a clean mission_status call never triggers a pointless
+	// continuation call.
+	if len(agent.requests) != 1 || len(agent.requests[0].EndTurnTools) != 1 || agent.requests[0].EndTurnTools[0] != missionStatusToolName {
+		t.Fatalf("EndTurnTools = %+v, want [%q]", agent.requests[0].EndTurnTools, missionStatusToolName)
+	}
 }
 
 // TestRunWorkerFinalMessageExcludesPriorToolRoundNarration guards D-069's


### PR DESCRIPTION
Failure-capture diagnosis (D-066) of the remaining reasoning-model `empty_output` failures: the loop ALWAYS sent the sentinel's tool result back for one more completion. Chat models rambled (masking it — and wasting one model call on EVERY mission turn); reasoning models over openai-responses correctly returned empty → D-063 failed the attempt → the turn errored after its sentinel had already succeeded. Ledger fingerprint: `output_tokens=4`, captured request tail = sentinel call + its result.

- `loop.Request.EndTurnTools`: turn ends cleanly (same usage/done terminal as the natural exit) after a NON-error execution of a named tool; errored sentinel results continue as today so the model sees the failure
- `runner.runTurn` sets it to each session's sentinel (mission_status / explore_notes / submit_plan / review_verdict)
- chat unaffected (doesn't set it); delegated path bypasses the loop entirely

Side effect: every mission turn on every model saves one model call. Live matrix rerun on luna/terra/gpt-5.4/5.4-mini follows before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790106512&installation_model_id=431401&pr_number=296&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F296&signature=0152f36593bd9d9900ed931589fce6f8d9417b21d2c92bbccf4c74eb2bf46c7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->