### PR TITLE
ci: move workflows to github-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   # Workflow-file changes always mark everything relevant: CI's own
   # logic must run its full suite against itself.
   changes:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     # paths-filter needs this to list a PR's changed files via the API
     # when the local checkout doesn't have enough history for a git
     # diff — scoped to this job only, not the workflow-wide grant.
@@ -60,7 +60,7 @@ jobs:
   go-test:
     needs: changes
     if: needs.changes.outputs.go == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -89,7 +89,7 @@ jobs:
   go-integration:
     needs: changes
     if: needs.changes.outputs.go == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: pgvector/pgvector:0.8.4-pg18-trixie
@@ -120,7 +120,7 @@ jobs:
   lint:
     needs: changes
     if: needs.changes.outputs.go == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
@@ -133,7 +133,7 @@ jobs:
   web:
     needs: changes
     if: needs.changes.outputs.web == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     env:
       # HugeIcons Pro registry auth (web/.npmrc references it by name)
       HUGEICONS_TOKEN: ${{ secrets.HUGEICONS_TOKEN }}
@@ -183,7 +183,7 @@ jobs:
     # fork-triggered runs — the empty token fails npm auth (broke PR
     # #248). Same-repo pushes and PRs still build it, and the release
     # workflow builds it again at tag time, so nothing ships unbuilt.
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         service: [brain, gateway, memoryd, sandboxd, web]
@@ -230,7 +230,7 @@ jobs:
   sandbox-image:
     needs: changes
     if: needs.changes.outputs.sandbox == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - name: Build base image
@@ -260,7 +260,7 @@ jobs:
   # needs, the old blocklist missed it, and auto-merge fired on red
   # jobs — path-awareness must not reopen that hole.)
   ci-ok:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: [changes, go-test, go-integration, lint, web, images, sandbox-image]
     if: always()
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
   # it, or a real change could be missed. First-ever release (no
   # previous tag) marks everything changed.
   diff:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       brain: ${{ steps.diff.outputs.brain }}
       gateway: ${{ steps.diff.outputs.gateway }}
@@ -69,7 +69,7 @@ jobs:
 
   images:
     needs: diff
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       packages: write
     strategy:
@@ -119,8 +119,8 @@ jobs:
         if: fromJSON(needs.diff.outputs[matrix.name])
       # Always set up buildx: the copy-forward step below (unchanged
       # images) also needs it for `docker buildx imagetools create`.
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v2
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -128,7 +128,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         if: fromJSON(needs.diff.outputs[matrix.name])
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -189,7 +189,7 @@ jobs:
   # dangling and break the first mission of each environment.
   sandbox-images:
     needs: diff
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       packages: write
     steps:
@@ -200,9 +200,9 @@ jobs:
         run: echo "short=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-qemu-action@v4
         if: fromJSON(needs.diff.outputs.sandbox)
-      - name: Setup Blacksmith Builder
+      - name: Setup Docker Buildx
         if: fromJSON(needs.diff.outputs.sandbox)
-        uses: useblacksmith/setup-docker-builder@v2
+        uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -220,7 +220,7 @@ jobs:
           done
       - name: Build and push base
         if: fromJSON(needs.diff.outputs.sandbox)
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: deploy/sandbox-base.Dockerfile
@@ -250,7 +250,7 @@ jobs:
   release:
     needs: [images, sandbox-images]
     if: needs.images.result == 'success' && needs.sandbox-images.result == 'success'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Replaces blacksmith runners with ubuntu-latest and swaps useblacksmith/setup-docker-builder + build-push-action for the stock docker/setup-buildx-action@v3 + docker/build-push-action@v6. No workflow logic changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790115681&installation_model_id=431401&pr_number=299&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F299&signature=ca560fbff949ed97dc259c49ff97e9b7ec50579b16d2c4bc6ce4293ac3a7814b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->