### PR TITLE
fix: stop nagging to migrate the vault bootstrap credential

### DIFF
--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -193,8 +193,19 @@ func (a *Admin) MigrateAllSecrets(ctx context.Context, targetBackend string) ([]
 	if err != nil {
 		return nil, err
 	}
+	bootstrap, err := a.secrets.BootstrapRefs(ctx)
+	if err != nil {
+		return nil, err
+	}
 	out := make([]SecretMigrationResult, 0, len(refs))
 	for _, r := range refs {
+		// A backend's own bootstrap credential can never migrate
+		// (Migrate refuses it) — skip it up front instead of reporting
+		// the refusal as a batch failure.
+		if bootstrap[r.RefName] != "" {
+			out = append(out, SecretMigrationResult{Name: r.RefName, Skipped: true})
+			continue
+		}
 		configured, backend, err := a.secrets.Status(ctx, r.RefName)
 		if err != nil {
 			out = append(out, SecretMigrationResult{Name: r.RefName, Error: err.Error()})

--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -1208,6 +1208,8 @@ func TestMigrateAllSecretsBulkPartialFailure(t *testing.T) {
 		switch {
 		case r.URL.Path == "/v1/auth/token/lookup-self":
 			w.Write([]byte(`{}`))
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "migrate-all-fail"):
+			w.WriteHeader(http.StatusInternalServerError)
 		case r.Method == http.MethodPost:
 			w.Write([]byte(`{}`))
 		default:
@@ -1239,8 +1241,17 @@ func TestMigrateAllSecretsBulkPartialFailure(t *testing.T) {
 		t.Fatalf("pre-migrate refSkip: %v", err)
 	}
 
+	// refFail: db-backed, but the fake vault 500s its write — the batch
+	// must record the error and keep going.
+	refFail := adminMarker + "migrate-all-fail"
+	if err := adm.SetSecret(ctx, refFail, "sk-c"); err != nil {
+		t.Fatalf("SetSecret refFail: %v", err)
+	}
+
 	// refBootstrap: the vault backend's own token_ref, db-backed. The
-	// bulk migrate must record it as an error, never abort the batch.
+	// bulk migrate must skip it up front (it can never migrate; reporting
+	// the refusal as a failure made the UI nag forever), never abort the
+	// batch.
 	refBootstrap := refOK + "_TOKEN"
 
 	results, err := adm.MigrateAllSecrets(ctx, "vault")
@@ -1258,11 +1269,11 @@ func TestMigrateAllSecretsBulkPartialFailure(t *testing.T) {
 		t.Fatalf("refSkip result = %+v, want skipped (already on vault)", byName[refSkip])
 	}
 	bootstrapResult := byName[refBootstrap]
-	if bootstrapResult.Migrated || bootstrapResult.Skipped || bootstrapResult.Error == "" {
-		t.Fatalf("refBootstrap result = %+v, want error only", bootstrapResult)
+	if !bootstrapResult.Skipped || bootstrapResult.Migrated || bootstrapResult.Error != "" {
+		t.Fatalf("refBootstrap result = %+v, want skipped only", bootstrapResult)
 	}
-	if !strings.Contains(bootstrapResult.Error, "bootstrap credential") {
-		t.Fatalf("refBootstrap error = %q, want it to mention bootstrap credential", bootstrapResult.Error)
+	if byName[refFail].Error == "" || byName[refFail].Migrated || byName[refFail].Skipped {
+		t.Fatalf("refFail result = %+v, want error only", byName[refFail])
 	}
 
 	// An unknown target backend fails validation before touching any ref.

--- a/web/src/components/settings/CredentialsTab.test.tsx
+++ b/web/src/components/settings/CredentialsTab.test.tsx
@@ -127,6 +127,15 @@ describe('CredentialsTab', () => {
     expect(screen.queryByRole('button', { name: /Migrate all to/ })).not.toBeInTheDocument()
   })
 
+  it('hides the migrate-all banner when only a system ref lives off the default backend', async () => {
+    vi.mocked(useDefaultSecretBackend).mockReturnValue('vault')
+    vi.mocked(listSecretRefs).mockResolvedValue([systemRef, { ...orphaned, backend: 'vault' }])
+    render(<CredentialsTab />)
+
+    await screen.findByText('VAULT_TOKEN')
+    expect(screen.queryByRole('button', { name: /Migrate all to/ })).not.toBeInTheDocument()
+  })
+
   it('shows migrate-all when the default backend is external and a ref lives elsewhere', async () => {
     vi.mocked(useDefaultSecretBackend).mockReturnValue('vault')
     vi.mocked(listSecretRefs).mockResolvedValue([{ ...orphaned, backend: 'db' }])

--- a/web/src/components/settings/CredentialsTab.tsx
+++ b/web/src/components/settings/CredentialsTab.tsx
@@ -58,8 +58,10 @@ export function CredentialsTab() {
 
   // Migrate all: only offered once an external backend is the default
   // (moving everything back to "db" isn't this button's job) and at
-  // least one ref still lives elsewhere.
-  const elsewhereCount = refs.filter((r) => r.backend !== defaultBackend).length
+  // least one ref still lives elsewhere. System refs (a backend's own
+  // bootstrap credential) don't count — they can never migrate, so
+  // counting them left the banner nagging forever.
+  const elsewhereCount = refs.filter((r) => r.backend !== defaultBackend && !r.system).length
   const showMigrateAll = defaultBackend !== 'db' && elsewhereCount > 0
 
   const migrateAll = async () => {


### PR DESCRIPTION
MigrateAllSecrets skips bootstrap refs (they can never migrate; the refusal surfaced as a permanent 'Migrated 0, 1 failed' toast) and the credentials page excludes system refs from the not-yet-in-Vault count, so the banner disappears once every migratable ref is on the target backend. Integration test updated to the skip contract with a restored genuine-failure leg.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790119485&installation_model_id=431401&pr_number=300&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F300&signature=9ca5af201d94241e9f598fc0ed6b7b49fc6484bfc43ab7a1bf887669180d88e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->