### PR TITLE
feat: rename knowledge collections and classify into generic topics

### DIFF
--- a/internal/brain/api/kb.go
+++ b/internal/brain/api/kb.go
@@ -59,6 +59,7 @@ func (a *API) registerKB(handle func(pattern string, h http.Handler), store *kb.
 	handle("GET /v1/admin/kb/collections", a.auth(http.HandlerFunc(h.listCollections)))
 	handle("POST /v1/admin/kb/collections", a.auth(http.HandlerFunc(h.createCollection)))
 	handle("GET /v1/admin/kb/collections/{id}", a.auth(http.HandlerFunc(h.getCollection)))
+	handle("PATCH /v1/admin/kb/collections/{id}", a.auth(http.HandlerFunc(h.updateCollection)))
 	handle("DELETE /v1/admin/kb/collections/{id}", a.auth(http.HandlerFunc(h.deleteCollection)))
 	handle("GET /v1/admin/kb/collections/{id}/documents", a.auth(http.HandlerFunc(h.listDocuments)))
 	handle("POST /v1/admin/kb/collections/{id}/documents", a.auth(http.HandlerFunc(h.uploadDocument)))
@@ -159,6 +160,38 @@ func (h *kbAPI) createCollection(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *kbAPI) getCollection(w http.ResponseWriter, r *http.Request) {
+	c, err := h.store.GetCollection(r.Context(), r.PathValue("id"))
+	if err != nil {
+		failKB(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, c)
+}
+
+// updateCollection renames a collection and/or replaces its
+// description — absent fields stay untouched (pointer-decoded PATCH,
+// same shape the settings handlers use).
+func (h *kbAPI) updateCollection(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Name        *string `json:"name"`
+		Description *string `json:"description"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if req.Name == nil && req.Description == nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", "nothing to update")
+		return
+	}
+	if req.Name != nil && strings.TrimSpace(*req.Name) == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "name must not be empty")
+		return
+	}
+	if err := h.store.UpdateCollection(r.Context(), r.PathValue("id"), req.Name, req.Description); err != nil {
+		failKB(w, err)
+		return
+	}
 	c, err := h.store.GetCollection(r.Context(), r.PathValue("id"))
 	if err != nil {
 		failKB(w, err)

--- a/internal/brain/api/kb_integration_test.go
+++ b/internal/brain/api/kb_integration_test.go
@@ -142,6 +142,32 @@ func TestKBCollectionsCRUD(t *testing.T) {
 		t.Fatalf("list status = %d body %s", w.Code, w.Body)
 	}
 
+	// PATCH renames without touching the description; empty-name and
+	// empty-body PATCHes are rejected.
+	patch := httptest.NewRequest("PATCH", "/v1/admin/kb/collections/"+created.ID, strings.NewReader(`{"name":"itest-docs-renamed"}`))
+	patch.Header.Set("Authorization", "Bearer tok")
+	w = httptest.NewRecorder()
+	m.ServeHTTP(w, patch)
+	if w.Code != http.StatusOK {
+		t.Fatalf("patch status = %d body %s", w.Code, w.Body)
+	}
+	renamed, err := store.GetCollection(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetCollection after rename: %v", err)
+	}
+	if renamed.Name != "itest-docs-renamed" || renamed.Description != "test collection" {
+		t.Fatalf("after rename: name=%q description=%q", renamed.Name, renamed.Description)
+	}
+	for _, body := range []string{`{}`, `{"name":"  "}`} {
+		bad := httptest.NewRequest("PATCH", "/v1/admin/kb/collections/"+created.ID, strings.NewReader(body))
+		bad.Header.Set("Authorization", "Bearer tok")
+		w = httptest.NewRecorder()
+		m.ServeHTTP(w, bad)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("patch %s status = %d, want 400", body, w.Code)
+		}
+	}
+
 	// A failed document counts toward failed_count but not the base
 	// doc/chunk story — GetCollection picks it up via collectionColumns.
 	docID, err := store.CreateDocument(context.Background(), created.ID, "Doc", "file", "doc.md", "content", 7)

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -623,7 +623,7 @@ func ClassifyCollectionOverGateway(gw Gateway, log *slog.Logger) func(ctx contex
 			}
 		}
 
-		const classifySystem = `You file documents into a knowledge base. Given a document and a list of existing collections, reply with exactly one line: either the bare id of the best-matching existing collection, or "NEW: <name> | <description>" to propose a new collection when nothing fits. No other text.`
+		const classifySystem = `You file documents into a knowledge base. Given a document and a list of existing collections, reply with exactly one line: either the bare id of the best-matching existing collection, or "NEW: <name> | <description>" to propose a new collection when nothing fits. Prefer an existing collection whenever the document broadly belongs to its topic — an imperfect match beats a new collection. A new collection's name must be a SHORT GENERIC TOPIC CATEGORY of 1-3 words (like "AI Agents", "Scalability", "Code Review", "CVs") that many future documents could belong to — never a title describing this specific document. The description should state the topic's scope broadly. No other text.`
 		route, ok, err := gw.RouteForRole(ctx, "summarize")
 		if err != nil || !ok {
 			route, ok, err = gw.RouteForRole(ctx, "default")

--- a/internal/brain/kb/kb.go
+++ b/internal/brain/kb/kb.go
@@ -130,6 +130,26 @@ func (s *Store) CreateCollection(ctx context.Context, name, description string) 
 	return id, nil
 }
 
+// UpdateCollection renames a collection and/or replaces its
+// description. nil leaves a field unchanged, so a bare rename never
+// clobbers the description the classifier matches against.
+func (s *Store) UpdateCollection(ctx context.Context, id string, name, description *string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("kb collections update: %w", err)
+	}
+	tag, err := db.Exec(ctx, `UPDATE kb_collections
+		SET name = COALESCE($2, name), description = COALESCE($3, description), updated_at = now()
+		WHERE id = $1`, id, name, description)
+	if err != nil {
+		return fmt.Errorf("kb collections update: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("collection %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
 // DeleteCollection removes a collection; ON DELETE CASCADE takes its
 // documents and chunks with it.
 func (s *Store) DeleteCollection(ctx context.Context, id string) error {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -950,6 +950,16 @@ export async function createKbCollection(c: { name: string; description: string 
   return id
 }
 
+export async function updateKbCollection(
+  id: string,
+  patch: { name?: string; description?: string },
+): Promise<KbCollection> {
+  return request<KbCollection>(`/v1/admin/kb/collections/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(patch),
+  })
+}
+
 export async function deleteKbCollection(id: string): Promise<void> {
   await request<void>(`/v1/admin/kb/collections/${id}`, { method: 'DELETE' })
 }

--- a/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
@@ -2,6 +2,7 @@ import {
   ArrowLeft01Icon,
   CancelCircleIcon,
   Delete02Icon,
+  Edit01Icon,
   File02Icon,
   Loading03Icon,
   ReloadIcon,
@@ -18,6 +19,7 @@ import {
   getKbCollection,
   listKbDocuments,
   reingestKbDocument,
+  updateKbCollection,
   uploadKbDocument,
 } from '../../api/client'
 import type { KbCollection, KbDocument } from '../../api/types'
@@ -31,6 +33,7 @@ import {
   DialogTitle,
 } from '../ui/dialog'
 import { errText } from '../settings/util'
+import { Input } from '../ui/input'
 import { KbUploadForm } from './KbUploadForm'
 
 const statusStyle: Record<KbDocument['status'], string> = {
@@ -71,6 +74,9 @@ export function KnowledgeCollectionDetail() {
   const [collection, setCollection] = useState<KbCollection | null | undefined>(undefined)
   const [documents, setDocuments] = useState<KbDocument[]>([])
   const [confirmDeleteCollection, setConfirmDeleteCollection] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const [editName, setEditName] = useState('')
+  const [editDesc, setEditDesc] = useState('')
   const [confirmDeleteDoc, setConfirmDeleteDoc] = useState<KbDocument | null>(null)
 
   const refresh = useCallback(() => {
@@ -98,6 +104,18 @@ export function KnowledgeCollectionDetail() {
 
   if (collection === null) return <Navigate to="/knowledge" replace />
   if (collection === undefined || !id) return null
+
+  const saveEdit = async () => {
+    if (!id || editName.trim() === '') return
+    try {
+      const updated = await updateKbCollection(id, { name: editName.trim(), description: editDesc })
+      setCollection(updated)
+      setEditing(false)
+      toast.success('Collection updated')
+    } catch (err) {
+      toast.error('Could not update collection', { description: errText(err) })
+    }
+  }
 
   const removeCollection = async () => {
     try {
@@ -151,10 +169,23 @@ export function KnowledgeCollectionDetail() {
             <p className="text-sm text-muted-foreground">{collection.description}</p>
           )}
         </div>
-        <Button variant="destructive" onClick={() => setConfirmDeleteCollection(true)}>
-          <HugeiconsIcon icon={Delete02Icon} />
-          Delete collection
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            onClick={() => {
+              setEditName(collection.name)
+              setEditDesc(collection.description ?? '')
+              setEditing(true)
+            }}
+          >
+            <HugeiconsIcon icon={Edit01Icon} />
+            Rename
+          </Button>
+          <Button variant="destructive" onClick={() => setConfirmDeleteCollection(true)}>
+            <HugeiconsIcon icon={Delete02Icon} />
+            Delete collection
+          </Button>
+        </div>
       </div>
 
       <KbUploadForm
@@ -223,6 +254,36 @@ export function KnowledgeCollectionDetail() {
           </table>
         </div>
       )}
+
+      <Dialog open={editing} onOpenChange={setEditing}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rename collection</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Input
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              placeholder="Collection name"
+              aria-label="Collection name"
+            />
+            <Input
+              value={editDesc}
+              onChange={(e) => setEditDesc(e.target.value)}
+              placeholder="Description"
+              aria-label="Collection description"
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditing(false)}>
+              Cancel
+            </Button>
+            <Button disabled={editName.trim() === ''} onClick={() => void saveEdit()}>
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={confirmDeleteCollection} onOpenChange={setConfirmDeleteCollection}>
         <DialogContent>

--- a/web/src/pages/Knowledge.test.tsx
+++ b/web/src/pages/Knowledge.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../api/client', () => ({
   getKbCollection: vi.fn(),
   createKbCollection: vi.fn(),
   deleteKbCollection: vi.fn(),
+  updateKbCollection: vi.fn(),
   listKbDocuments: vi.fn(),
   uploadKbDocument: vi.fn(),
   deleteKbDocument: vi.fn(),
@@ -29,6 +30,7 @@ import {
   listKbCollections,
   listKbDocuments,
   reingestKbDocument,
+  updateKbCollection,
   uploadKbDocument,
 } from '../api/client'
 
@@ -88,6 +90,26 @@ beforeEach(() => {
 })
 
 describe('Knowledge page', () => {
+  it('renames a collection from the detail header', async () => {
+    vi.mocked(getKbCollection).mockResolvedValue(productDocs)
+    vi.mocked(listKbDocuments).mockResolvedValue([readyDoc])
+    vi.mocked(updateKbCollection).mockResolvedValue({ ...productDocs, name: 'Scalability' })
+    renderPage('/knowledge/c1')
+
+    fireEvent.click(await screen.findByRole('button', { name: /Rename/ }))
+    const nameInput = await screen.findByLabelText('Collection name')
+    fireEvent.change(nameInput, { target: { value: 'Scalability' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() =>
+      expect(updateKbCollection).toHaveBeenCalledWith('c1', {
+        name: 'Scalability',
+        description: 'Product documentation for support agents.',
+      }),
+    )
+    expect(await screen.findByText('Scalability')).toBeInTheDocument()
+  })
+
   it('renders the page header and collections with doc and chunk counts', async () => {
     renderPage()
     expect(screen.getByRole('heading', { name: 'Knowledge' })).toBeTruthy()


### PR DESCRIPTION
- kb store: UpdateCollection (COALESCE partial update, ErrNotFound on missing)
- api: PATCH /v1/admin/kb/collections/{id} — name and/or description, 400 on empty name or empty patch; integration test extended
- classifier prompt: new collections must be short generic topic categories (e.g. "AI Agents", "Scalability", "CVs"), never document titles; prefer imperfect existing matches
- web: Rename dialog on collection detail (name + description), updateKbCollection client fn, tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790119901&installation_model_id=431401&pr_number=301&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F301&signature=fbfa82cbcf8e96e91bdc8cd3bbc406505c39567a3c3ec67fa7cba1abf5ff2efb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->