### PR TITLE
feat: tool-loop discipline rules in mission prompts

### DIFF
--- a/internal/brain/missions/packet.go
+++ b/internal/brain/missions/packet.go
@@ -52,16 +52,23 @@ type WorkPacket struct {
 	Light bool
 }
 
+// toolDisciplineNote is the tool-loop stop-rule contract shared by the
+// explore prompt (runner.go) and both worker preambles: without it,
+// models repeat failed tool calls verbatim and burn iterations
+// (observed on glm-5.3 and the nova family), and fill gaps with
+// plausible guesses instead of naming what's missing.
+const toolDisciplineNote = " Tool discipline: before each tool call, know what you still need; after each result, judge whether it answered that. Never repeat a failed call unchanged — vary the approach or move on. If information cannot be found after a few attempts, continue with what you have and state what is missing rather than guessing."
+
 // nativeSystemPreamble is the mission_status/write_file contract a
 // native (in-process loop.Agent) worker turn must follow — meaningless
 // to a delegated CLI, which has neither tool (RenderForDelegated uses
 // delegatedSystemPreamble instead).
-const nativeSystemPreamble = "You are executing one unit of a plan. Work toward the goal, then end your turn with exactly one mission_status tool call: done (with evidence), retry (with analysis), or blocked (with a question). Create or update files ONLY with the write_file tool using workspace-relative paths — never shell redirects (>, >>) or heredocs, which classify as writes requiring interactive approval and will stall you; artifact tracking depends on write_file being the only way files get created. Use shell for reading and checking, not writing. The harness verifies your declared artifacts exist on disk; describing a file is not producing it. When you end with retry or blocked, include a handoff note summarizing state, remaining work, and gotchas — the next session starts fresh and sees only your handoff, the plan, and the git log."
+const nativeSystemPreamble = "You are executing one unit of a plan. Work toward the goal, then end your turn with exactly one mission_status tool call: done (with evidence), retry (with analysis), or blocked (with a question). Create or update files ONLY with the write_file tool using workspace-relative paths — never shell redirects (>, >>) or heredocs, which classify as writes requiring interactive approval and will stall you; artifact tracking depends on write_file being the only way files get created. Use shell for reading and checking, not writing. The harness verifies your declared artifacts exist on disk; describing a file is not producing it. When you end with retry or blocked, include a handoff note summarizing state, remaining work, and gotchas — the next session starts fresh and sees only your handoff, the plan, and the git log." + toolDisciplineNote
 
 // lightSystemPreamble is nativeSystemPreamble's counterpart for a light
 // mission (D-069): single pass, no plan, no artifact check — the
 // worker's final message is delivered to the user verbatim.
-const lightSystemPreamble = "You are completing this goal in a single pass. Work toward the goal, then end your turn with exactly one mission_status tool call: done (with evidence), retry (with analysis), or blocked (with a question). On done, put the COMPLETE final deliverable text in the mission_status call's final_output argument — it is delivered to the user verbatim as the result, so it must be the deliverable itself, never a summary of work done. Create or update files ONLY with the write_file tool using workspace-relative paths — never shell redirects (>, >>) or heredocs, which classify as writes requiring interactive approval and will stall you. Use shell for reading and checking, not writing. When you end with retry or blocked, include a handoff note summarizing state, remaining work, and gotchas — the next session starts fresh and sees only your handoff and the git log."
+const lightSystemPreamble = "You are completing this goal in a single pass. Work toward the goal, then end your turn with exactly one mission_status tool call: done (with evidence), retry (with analysis), or blocked (with a question). On done, put the COMPLETE final deliverable text in the mission_status call's final_output argument — it is delivered to the user verbatim as the result, so it must be the deliverable itself, never a summary of work done. Create or update files ONLY with the write_file tool using workspace-relative paths — never shell redirects (>, >>) or heredocs, which classify as writes requiring interactive approval and will stall you. Use shell for reading and checking, not writing. When you end with retry or blocked, include a handoff note summarizing state, remaining work, and gotchas — the next session starts fresh and sees only your handoff and the git log." + toolDisciplineNote
 
 // Render turns the packet into the system/user message a native
 // worker session's first turn receives. Progress notes and git log

--- a/internal/brain/missions/packet_test.go
+++ b/internal/brain/missions/packet_test.go
@@ -242,3 +242,15 @@ func TestWorkPacketRenderNeutralizesAttachmentMarkdown(t *testing.T) {
 		t.Fatal("Render did not neutralize an injected framing sequence in attachment markdown")
 	}
 }
+
+// Both worker preambles carry the tool-discipline stop rules — the
+// contract that stops models from repeating failed tool calls verbatim.
+func TestWorkPacketRenderCarriesToolDiscipline(t *testing.T) {
+	for _, light := range []bool{false, true} {
+		p := WorkPacket{Goal: "g", Light: light}
+		system, _ := p.Render()
+		if !strings.Contains(system, "Never repeat a failed call unchanged") {
+			t.Fatalf("light=%v: system prompt missing tool discipline note", light)
+		}
+	}
+}

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -771,7 +771,7 @@ func forcedRetryVerdict(reason string) WorkerVerdict {
 // so the ladder's last resort is the raw turn text rather than a forced
 // failure.
 func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, error) {
-	system := "You are exploring one mission before it is planned. Investigate the goal: explore the workspace with shell (read-only — do not create or modify files; the execute phase does the actual work), and use web search/fetch tools if available and relevant to the goal. If the goal is self-contained and needs no exploration, say so briefly. End your turn with exactly one explore_notes tool call whose findings field contains everything the planner needs: what exists, what's relevant, constraints, gotchas, unknowns." + execEnvironmentNote()
+	system := "You are exploring one mission before it is planned. Investigate the goal: explore the workspace with shell (read-only — do not create or modify files; the execute phase does the actual work), and use web search/fetch tools if available and relevant to the goal. If the goal is self-contained and needs no exploration, say so briefly. End your turn with exactly one explore_notes tool call whose findings field contains everything the planner needs: what exists, what's relevant, constraints, gotchas, unknowns." + toolDisciplineNote + execEnvironmentNote()
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if m.ParentContext != "" {
 		user += "\n\nPrevious mission outcome:\n" + NeutralizeSlot(m.ParentContext)


### PR DESCRIPTION
Shared toolDisciplineNote appended to nativeSystemPreamble, lightSystemPreamble, and the explore prompt: state what you still need before each tool call, judge each result, never repeat a failed call unchanged, and report missing information instead of guessing. Directly targets the repeated-identical-call and gap-guessing failure modes observed in this week's model bake-offs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790121893&installation_model_id=431401&pr_number=302&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F302&signature=c1cb1ed5b04900a327893286563823d7be661b36328d9ba7e68593d8b2f96339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->