### PR TITLE
fix: agent prompt overlay editor matches the mission goal textarea

### DIFF
--- a/web/src/components/settings/AgentForm.tsx
+++ b/web/src/components/settings/AgentForm.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Input } from '../ui/input'
+import { Textarea } from '../ui/textarea'
 import {
   Select,
   SelectContent,
@@ -126,13 +127,13 @@ export function AgentForm({
         />
       </Field>
       <Field label="Prompt overlay" hint="appended to the system prompt">
-        <textarea
+        <Textarea
           value={fields.overlay}
           onChange={(e) => fields.setOverlay(e.target.value)}
           aria-label="Prompt overlay"
           rows={5}
-          placeholder="Instructions, persona, house rules…"
-          className="mt-1.5 w-full rounded-lg border border-input bg-transparent p-3 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+          placeholder="Instructions, persona, house rules… Markdown supported."
+          className="mt-1.5 min-h-32 resize-y text-sm"
         />
       </Field>
       <div className="grid gap-5 sm:grid-cols-2">


### PR DESCRIPTION
Shared ui/Textarea (auto-grow via field-sizing-content, resize-y, min-h-32) replaces the raw fixed textarea; placeholder notes markdown support. Behavior now identical to the mission goal editor; newline preservation was already end-to-end.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790123519&installation_model_id=431401&pr_number=303&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F303&signature=4677bbf478e129536a9ca8f6a3918659a995b54de2846ce9ef075a52d40397a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->