### PR TITLE
feat: mission workers get their agent's skill index

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -275,7 +275,7 @@ func main() {
 		}
 		return name
 	}
-	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub, missionScheduler := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, fxStore, gwc, secrets, conns, mc, app.Log)
+	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub, missionScheduler := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, fxStore, gwc, secrets, conns, mc, packs, app.Log)
 	if missionDriver != nil {
 		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, missionNotifier, app.Log)
 	}
@@ -844,7 +844,7 @@ func intersectReadOnlyConnectorTools(allow []string, available []*tools.Tool) []
 // time) so an agent edited after the fact still applies. The hub
 // lives inside the same gate as everything else here — no missions,
 // no push events either.
-func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, agentReg *agents.Store, routeForRole func(context.Context, string) string, fxStore *fxrates.Store, gwc *gwclient.Client, secrets *secretstore.Store, conns *connectors.Manager, mc *memclient.Client, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace, *missions.Hub, *missions.Scheduler) {
+func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, agentReg *agents.Store, routeForRole func(context.Context, string) string, fxStore *fxrates.Store, gwc *gwclient.Client, secrets *secretstore.Store, conns *connectors.Manager, mc *memclient.Client, packs []skills.Skill, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace, *missions.Hub, *missions.Scheduler) {
 	root := os.Getenv("WORKSPACES")
 	if root == "" {
 		log.Info("WORKSPACES not set; missions disabled")
@@ -916,6 +916,18 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	resolveAgent := missionAgentResolver(agentReg)
 	driver.SetAgentResolver(resolveAgent)
 	driver.SetNameMission(chat.TitleOverGateway(gwc, log))
+	// Mission workers see the same per-agent skill index chat sessions
+	// get (skills.Index over the agent's allowlist), resolved at packet
+	// build so agent edits apply on the next turn. The load_skill tool
+	// is already in the mission builtin set; this makes the packs
+	// discoverable there.
+	driver.SetSkillsIndex(func(ctx context.Context, agentID string) string {
+		a, ok := agentReg.ResolveByID(ctx, agentID)
+		if !ok {
+			return ""
+		}
+		return skills.Index(skills.Allowed(packs, a.Skills))
+	})
 	if conns != nil && secrets != nil {
 		// A repo_url mission's clone token: resolve connector_id straight
 		// to its credential_ref's secret value, same as resolveSecret does

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -118,6 +118,10 @@ type Driver struct {
 	sandboxExec   sandboxExec
 	sandboxRemove sandboxRemover
 
+	// skillsIndex renders the mission agent's skill index for worker
+	// prompts (SetSkillsIndex) — nil means workers get no index.
+	skillsIndex func(ctx context.Context, agentID string) string
+
 	// provision holds the mission-provisioning slice split out into its
 	// own type (D-074): ensureProvisioned, grantSessionDefaults,
 	// followUpBaseRef and their resolver deps. Driver's Set* setters
@@ -278,6 +282,15 @@ func retryDelay(consecutiveFailures int) time.Duration {
 // closes over.
 func (d *Driver) SetAgentResolver(resolve AgentResolver) {
 	d.provision.resolveAgent = resolve
+}
+
+// SetSkillsIndex wires the resolver packet() uses to render the
+// mission agent's skill index into worker prompts — a setter for the
+// same construction-order reason SetAgentResolver is. nil (unwired)
+// means workers see no skill index, matching every other nil-gated
+// optional dependency.
+func (d *Driver) SetSkillsIndex(fn func(ctx context.Context, agentID string) string) {
+	d.skillsIndex = fn
 }
 
 // SetFXRates wires the stored USD-base rate table the budget brake
@@ -1255,12 +1268,16 @@ func (d *Driver) packet(ctx context.Context, m Mission) (WorkPacket, error) {
 	if m.Worktree != "" {
 		gitLog, _ = gitLogSince(ctx, m.Worktree, m.BaseCommit)
 	}
-	return WorkPacket{
+	p := WorkPacket{
 		Goal: m.Goal, Kind: m.Kind, Spec: m.Spec, Progress: m.Progress,
 		GitLog: gitLog, Iteration: m.Iteration, PromptOverlay: m.PromptOverlay,
 		ExecEnvironmentNote: execEnvironmentNote(), ParentContext: m.ParentContext, Attachments: m.Attachments,
 		Light: missionPolicyFor(m).skipsPlanning,
-	}, nil
+	}
+	if d.skillsIndex != nil && m.AgentID != "" {
+		p.SkillsIndex = d.skillsIndex(ctx, m.AgentID)
+	}
+	return p, nil
 }
 
 func (d *Driver) recordProgress(ctx context.Context, id, text string) error {

--- a/internal/brain/missions/packet.go
+++ b/internal/brain/missions/packet.go
@@ -46,6 +46,14 @@ type WorkPacket struct {
 	// every worker turn via Render, including a delegated executor's
 	// turn (executor packets also go through Render).
 	Attachments []MissionAttachment
+	// SkillsIndex is the rendered skill index for the mission's agent
+	// (skills.Index over the agent's allowlist), resolved at packet
+	// build time like the scheduler's other agent defaults — an agent
+	// edited mid-mission applies on the next turn. Empty when the
+	// mission has no agent, the agent lists no skills, or the driver's
+	// resolver is unwired. Native workers only: a delegated CLI has no
+	// load_skill tool, so RenderForDelegated never includes it.
+	SkillsIndex string
 	// Light marks a mission that skips explore/plan/review (D-069) —
 	// Render uses lightSystemPreamble instead of nativeSystemPreamble,
 	// and Spec is always empty so the Plan block never renders.
@@ -96,6 +104,11 @@ func (p WorkPacket) RenderForDelegated() (system, user string) {
 
 func (p WorkPacket) render(preamble string) (system, user string) {
 	system = preamble + p.ExecEnvironmentNote
+	if preamble != "" && p.SkillsIndex != "" {
+		// preamble=="" is the delegated path (RenderForDelegated) —
+		// no load_skill tool there, so the index would only mislead.
+		system += "\n\n" + p.SkillsIndex
+	}
 	if p.PromptOverlay != "" {
 		// Operator-authored config, not model output — unlike Progress/
 		// GitLog below, this never passes through NeutralizeSlot.

--- a/internal/brain/missions/packet_test.go
+++ b/internal/brain/missions/packet_test.go
@@ -254,3 +254,17 @@ func TestWorkPacketRenderCarriesToolDiscipline(t *testing.T) {
 		}
 	}
 }
+
+// The agent's skill index reaches native worker prompts but never the
+// delegated path — a delegated CLI has no load_skill tool.
+func TestWorkPacketRenderSkillsIndex(t *testing.T) {
+	p := WorkPacket{Goal: "g", SkillsIndex: "Skills available via the load_skill tool:\n- email-research: gmail discipline"}
+	system, _ := p.Render()
+	if !strings.Contains(system, "email-research") {
+		t.Fatal("native render missing skills index")
+	}
+	system, _ = p.RenderForDelegated()
+	if strings.Contains(system, "email-research") {
+		t.Fatal("delegated render must not carry the skills index")
+	}
+}

--- a/internal/brain/skills/skills.go
+++ b/internal/brain/skills/skills.go
@@ -134,6 +134,26 @@ func isKebab(s string) bool {
 
 // Index renders the one-line-per-skill system prompt section. Bodies
 // never appear here — that is the entire point.
+// Allowed filters packs to those named in names — the per-agent skill
+// allowlist semantics (empty means none, opt-in only, same contract as
+// agents.Agent.Tools). Order follows packs, not names.
+func Allowed(packs []Skill, names []string) []Skill {
+	if len(names) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(names))
+	for _, n := range names {
+		set[n] = true
+	}
+	out := make([]Skill, 0, len(names))
+	for _, p := range packs {
+		if set[p.Name] {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 func Index(skills []Skill) string {
 	if len(skills) == 0 {
 		return ""

--- a/internal/brain/skills/skills_test.go
+++ b/internal/brain/skills/skills_test.go
@@ -168,3 +168,14 @@ func TestRepoSkillsAreValid(t *testing.T) {
 		}
 	}
 }
+
+func TestAllowedFiltersOptIn(t *testing.T) {
+	packs := []Skill{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+	if got := Allowed(packs, nil); got != nil {
+		t.Fatalf("empty allowlist must admit nothing, got %v", got)
+	}
+	got := Allowed(packs, []string{"c", "a", "nope"})
+	if len(got) != 2 || got[0].Name != "a" || got[1].Name != "c" {
+		t.Fatalf("Allowed = %v, want [a c] in pack order", got)
+	}
+}


### PR DESCRIPTION
- skills.Allowed: opt-in filter over loaded packs (empty allowlist = none, same contract as agent Tools)
- WorkPacket.SkillsIndex rendered into the native worker system prompt after the preamble; RenderForDelegated never includes it (no load_skill there)
- Driver.SetSkillsIndex nil-gated resolver, wired in buildMissions from agentReg + packs; resolved per packet build so agent edits apply next turn
- Unblocks email-research for digest missions, coding/research-brief/deep-research for their mission kinds

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790124981&installation_model_id=431401&pr_number=304&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F304&signature=3b471615d8199f26197b165c57d59623f938d7e8131a28733cda79bab0590f45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->