### PR TITLE
feat: source-aware memory extraction that reinforces duplicates

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -464,7 +464,7 @@ func main() {
 		}
 		ectx, cancel := context.WithTimeout(context.WithoutCancel(ctx), extractBudget)
 		defer cancel()
-		if _, err := mc.Extract(ectx, sessionID, seq, text, route); err != nil {
+		if _, err := mc.Extract(ectx, sessionID, seq, text, route, "chat"); err != nil {
 			app.Log.Warn("turn memory extraction failed", "session_id", sessionID, "error", err)
 		}
 	})
@@ -480,7 +480,7 @@ func main() {
 			}
 			ectx, cancel := context.WithTimeout(context.WithoutCancel(ctx), extractBudget)
 			defer cancel()
-			if _, err := mc.Extract(ectx, sessionID, seq, text, route); err != nil {
+			if _, err := mc.Extract(ectx, sessionID, seq, text, route, "mission"); err != nil {
 				app.Log.Warn("mission memory extraction failed", "session_id", sessionID, "error", err)
 			}
 		})
@@ -493,7 +493,7 @@ func main() {
 		// never starve the summarize that follows it.
 		ectx, cancel := context.WithTimeout(ctx, preCompactExtractBudget)
 		defer cancel()
-		ids, err := mc.Extract(ectx, sessionID, seq, text, route)
+		ids, err := mc.Extract(ectx, sessionID, seq, text, route, "compaction")
 		if err != nil {
 			app.Log.Warn("pre-compaction extraction failed", "session_id", sessionID, "error", err)
 			return nil

--- a/internal/brain/memclient/memclient.go
+++ b/internal/brain/memclient/memclient.go
@@ -32,10 +32,12 @@ func New(baseURL string) *Client {
 // Extract posts one extraction job and returns the inserted memory
 // ids. route overrides memoryd's own side-call route when non-empty —
 // set when the turn/session being extracted executed a sensitive tool
-// and must not fall back to the default side-call route.
-func (c *Client) Extract(ctx context.Context, sessionID string, sourceSeq int64, text, route string) ([]string, error) {
+// and must not fall back to the default side-call route. source names
+// what produced the text ("chat", "mission", "compaction") so memoryd
+// can pick a source-appropriate extraction contract; empty means chat.
+func (c *Client) Extract(ctx context.Context, sessionID string, sourceSeq int64, text, route, source string) ([]string, error) {
 	body, err := json.Marshal(map[string]any{
-		"session_id": sessionID, "source_seq": sourceSeq, "text": text, "route": route,
+		"session_id": sessionID, "source_seq": sourceSeq, "text": text, "route": route, "source": source,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("memclient: marshal: %w", err)

--- a/internal/brain/memclient/memclient_test.go
+++ b/internal/brain/memclient/memclient_test.go
@@ -23,7 +23,7 @@ func TestExtractRoundTrip(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ids, err := New(srv.URL).Extract(t.Context(), "s1", 42, "turn text", "")
+	ids, err := New(srv.URL).Extract(t.Context(), "s1", 42, "turn text", "", "chat")
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestExtractSendsRouteOverride(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := New(srv.URL).Extract(t.Context(), "s1", 1, "x", "local"); err != nil {
+	if _, err := New(srv.URL).Extract(t.Context(), "s1", 1, "x", "local", "chat"); err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
 	if got["route"] != "local" {
@@ -62,7 +62,7 @@ func TestExtractSurfacesHTTPError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := New(srv.URL).Extract(t.Context(), "s1", 1, "x", ""); err == nil {
+	if _, err := New(srv.URL).Extract(t.Context(), "s1", 1, "x", "", ""); err == nil {
 		t.Fatal("Extract succeeded on 502, want error")
 	}
 }

--- a/internal/memory/extract/extract.go
+++ b/internal/memory/extract/extract.go
@@ -67,6 +67,14 @@ const system = `You extract durable facts from a conversation excerpt for an AI 
 [{"type":"episodic|semantic|procedural","content":"one atomic self-contained fact","entities":[{"type":"person|project|service|preference|decision|topic|place","name":"..."}],"confidence":0.0}]
 Rules: each content is ONE fact, self-contained (absolute dates, full names, no "he"/"it"/"this project"). type: episodic = something that happened, semantic = a durable fact or preference, procedural = a how-to. Anything phrased as a rule, requirement, standing instruction, or directive is semantic, NEVER episodic — even when it was stated during an event. confidence in [0,1] reflects how certain the excerpt makes the fact. Skip small talk, transient state, and anything already obvious. Empty array when nothing qualifies.`
 
+// missionSystem is the mission-digest extraction contract. The input
+// is a mission's OutcomeDigest — goal, title, kind, unit statuses —
+// which is a RECORD, not knowledge: everything in its header lines
+// already lives in the missions table. Only deltas qualify.
+const missionSystem = `You extract durable facts from a completed background mission's outcome digest for an AI assistant's long-term memory. Reply with ONLY a JSON array — no prose, no markdown fences:
+[{"type":"episodic|semantic|procedural","content":"one atomic self-contained fact","entities":[{"type":"person|project|service|preference|decision|topic|place","name":"..."}],"confidence":0.0}]
+ONLY these qualify: (a) a user preference or standing instruction the mission revealed, (b) a durable fact about the outside world DISCOVERED during execution (an API's behavior, a service's quirk, a deadline that exists), (c) a lesson from a failure worth avoiding next time. NEVER extract the mission's goal, title, kind, unit statuses, artifact names, or terminal state — those are bookkeeping the system already stores, not knowledge. Each content must be self-contained (absolute dates, full names, no pronouns). Anything phrased as a rule or standing instruction is semantic, never episodic. Most digests contain NOTHING worth remembering: an empty array is the expected common answer.`
+
 // Request is one extraction job: text from a completed turn or from
 // turns about to be compacted away.
 type Request struct {
@@ -79,6 +87,13 @@ type Request struct {
 	// pinned the turn to instead of falling back to sideRoute's cloud
 	// model.
 	Route string `json:"route,omitempty"`
+	// Source names what produced Text: "chat" (default), "mission"
+	// (a terminal mission's OutcomeDigest), or "compaction". Mission
+	// digests get their own extraction contract — the generic prompt
+	// dutifully extracted the digest's own goal/title/kind header
+	// lines as "facts", flooding the confirmation queue with
+	// restatements of things the missions table already records.
+	Source string `json:"source,omitempty"`
 }
 
 // Extractor runs the pipeline.
@@ -119,29 +134,34 @@ func (e *Extractor) Extract(ctx context.Context, req Request) ([]string, error) 
 		vecs = make([][]float32, len(facts))
 	}
 
+	deny := denyText(req)
 	var ids []string
 	for i, f := range facts {
+		if echoesDeny(f.Content, deny) {
+			// The model restated the digest's own goal/title header —
+			// bookkeeping the missions table already records, never a
+			// memory. Code enforces what the prompt asks for (D-011).
+			e.log.Info("memory dropped as source-header echo", "session_id", req.SessionID)
+			continue
+		}
 		emb := store.Vector(vecs[i])
 		if len(emb) > 0 {
 			dupID, sim, found, err := e.store.NearestActive(ctx, emb)
 			if err != nil {
 				return ids, fmt.Errorf("extract: dedup: %w", err)
 			}
-			if found && sim >= exactDupSimilarity {
-				// Dropping the fact would otherwise lose the
-				// confirmation signal entirely; best-effort, never
-				// fails extraction.
+			if found && sim >= nearDupSimilarity {
+				// Exact and near duplicates both reinforce the existing
+				// row instead of inserting: repetition is a confidence
+				// signal, not new knowledge. Inserting near-dups "for
+				// consolidation to merge later" flooded the confirmation
+				// queue with the same fact many times over.
 				if err := e.store.Confirm(ctx, dupID); err != nil {
-					e.log.Warn("confirm on exact duplicate failed; fact still dropped", "of", dupID, "error", err)
+					e.log.Warn("confirm on duplicate failed; fact still dropped", "of", dupID, "error", err)
 				}
-				e.log.Info("memory dropped as exact duplicate",
+				e.log.Info("memory duplicate reinforced existing row",
 					"of", dupID, "similarity", sim, "session_id", req.SessionID)
 				continue
-			}
-			if found && sim >= nearDupSimilarity {
-				// Near-dup: keep it, consolidation merges the group later.
-				e.log.Info("memory near-duplicate kept for consolidation",
-					"of", dupID, "similarity", sim, "session_id", req.SessionID)
 			}
 		}
 
@@ -202,10 +222,14 @@ func (e *Extractor) proposeOnce(ctx context.Context, req Request) (string, error
 	if req.Route != "" {
 		route = req.Route
 	}
+	sys := system
+	if req.Source == "mission" {
+		sys = missionSystem
+	}
 	events, err := e.gw.Stream(ctx, gwclient.StreamRequest{
 		Route: route,
 		Purpose:      "memory-extract",
-		System:       system,
+		System:       sys,
 		Messages:     []provider.Message{{Role: "user", Content: req.Text}},
 		// Reasoning models spend thinking tokens from the same budget
 		// before emitting content; 1000 starved the JSON reply entirely
@@ -318,4 +342,55 @@ func AutoPromote(f Fact) bool {
 		return false
 	}
 	return !sensitive.MatchString(f.Content)
+}
+
+// denyText collects the source-record lines a proposed fact must not
+// restate. Only mission digests carry them: OutcomeDigest's "mission
+// goal:" and "mission title:" headers are bookkeeping, not knowledge,
+// and models reliably extract them as "facts" without this fence.
+func denyText(req Request) []string {
+	if req.Source != "mission" {
+		return nil
+	}
+	var deny []string
+	for _, line := range strings.Split(req.Text, "\n") {
+		for _, prefix := range []string{"mission goal:", "mission title:"} {
+			if rest, ok := strings.CutPrefix(line, prefix); ok {
+				if v := strings.TrimSpace(rest); v != "" {
+					deny = append(deny, strings.ToLower(v))
+				}
+			}
+		}
+	}
+	return deny
+}
+
+// echoesDeny reports whether content substantially restates any deny
+// line: most of the deny line's words (>70%) reappear in the fact.
+// Word-overlap rather than substring, because extraction paraphrases
+// ("The user mandated a mission goal to create...") instead of quoting.
+func echoesDeny(content string, deny []string) bool {
+	if len(deny) == 0 {
+		return false
+	}
+	words := map[string]bool{}
+	for _, w := range strings.Fields(strings.ToLower(content)) {
+		words[strings.Trim(w, ".,;:'\"()")] = true
+	}
+	for _, d := range deny {
+		fields := strings.Fields(d)
+		if len(fields) == 0 {
+			continue
+		}
+		hits := 0
+		for _, w := range fields {
+			if words[strings.Trim(w, ".,;:'\"()")] {
+				hits++
+			}
+		}
+		if float64(hits)/float64(len(fields)) > 0.7 {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/memory/extract/extract_test.go
+++ b/internal/memory/extract/extract_test.go
@@ -245,7 +245,7 @@ func TestExtractDropsExactDuplicate(t *testing.T) {
 	}
 }
 
-func TestExtractKeepsNearDuplicate(t *testing.T) {
+func TestExtractNearDuplicateReinforcesInsteadOfInserting(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGateway{replies: []string{`[{"type":"semantic","content":"User is based in Porto, Portugal.","entities":[],"confidence":0.9}]`}}
 	st := &fakeStore{}
@@ -254,8 +254,44 @@ func TestExtractKeepsNearDuplicate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	if len(ids) != 0 || len(st.inserted) != 0 {
+		t.Fatalf("near dup inserted: ids=%v inserted=%d", ids, len(st.inserted))
+	}
+	if len(st.confirmed) != 1 || st.confirmed[0] != "existing" {
+		t.Fatalf("confirmed = %v, want [existing]", st.confirmed)
+	}
+}
+
+// A mission-source job uses the mission contract and drops facts that
+// merely restate the digest's goal/title header lines.
+func TestExtractMissionSourceFiltersGoalEchoes(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGateway{replies: []string{`[` +
+		`{"type":"semantic","content":"The user mandated a mission goal to create a file named redirects.md explaining 301 302 and 307 redirects in ten lines.","entities":[],"confidence":0.95},` +
+		`{"type":"semantic","content":"The bKash production API rejects requests without an app key header.","entities":[],"confidence":0.9}]`}}
+	st := &fakeStore{}
+	digest := "mission goal: Create a file named redirects.md explaining 301, 302, and 307 redirects in ten lines\n" +
+		"mission title: Understanding Redirects\nmission kind: general\n\nterminal state: done\n"
+	ids, err := New(gw, st, testLog()).Extract(t.Context(), Request{Text: digest, Source: "mission"})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
 	if len(ids) != 1 || len(st.inserted) != 1 {
-		t.Fatalf("near dup dropped: ids=%v inserted=%d", ids, len(st.inserted))
+		t.Fatalf("want the goal echo dropped and the real fact kept: ids=%v inserted=%d", ids, len(st.inserted))
+	}
+	if !strings.Contains(st.inserted[0].Content, "bKash") {
+		t.Fatalf("kept the wrong fact: %q", st.inserted[0].Content)
+	}
+}
+
+func TestEchoesDeny(t *testing.T) {
+	t.Parallel()
+	deny := []string{"create a file named redirects.md explaining 301, 302, and 307 redirects"}
+	if !echoesDeny("The user mandated a mission goal to create a file named redirects.md that explains 301, 302, and 307 redirects.", deny) {
+		t.Fatal("paraphrased goal echo not caught")
+	}
+	if echoesDeny("The bKash production API rejects requests without an app key header.", deny) {
+		t.Fatal("unrelated fact wrongly dropped")
 	}
 }
 


### PR DESCRIPTION
Memory-extraction-v2 plan, slices 1+2 (docs/2026-08-23-memory-extraction-v2-plan.md):

- extraction jobs carry source (chat | mission | compaction); mission digests get a dedicated contract — only revealed preferences, discovered world facts, and failure lessons qualify; goal/title/kind/unit-status restatements are explicitly out, and "empty array" is framed as the expected common answer
- code-side echo fence: proposed facts with >70% word overlap against the digest's own goal/title header lines drop before insert (models paraphrase, so word-overlap, not substring)
- near-duplicates (similarity >= 0.95) now reinforce the existing row via Confirm instead of inserting "for consolidation to merge later" — the policy that flooded the confirmation queue with the same fact repeatedly

No schema changes. Kills the noise class shown in the confirmation-queue screenshot: "The mission title is 'Status Codes 4xx vs 5xx'" et al.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790125715&installation_model_id=431401&pr_number=305&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F305&signature=e73e9f96f6b14fea49a401489e6f4af0e05bbdf681b31ca6d016357c2ee532c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->