### PR TITLE
docs: sync docs with shipped features, user-value README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,16 +40,21 @@ via the existing `--env-file` Make targets.
 
 ## Layout
 
-- `cmd/{brain,gateway,memoryd,skills-validate}`: binaries; all wiring
-  in each `main.go` (nil-able deps, env-gated features).
+- `cmd/{brain,gateway,memoryd,sandboxd,skills-validate}`: binaries;
+  all wiring in each `main.go` (nil-able deps, env-gated features).
 - `internal/brain/`: `api` (HTTP handlers, nil-gated `register*`),
   `loop` (THE tool loop, lives here only), `tools` + `tools/builtin`,
   `chat`, `session`, `agents`, `missions` (agent harness),
-  `connectors`, `gwclient`, `memclient`, `settings`, `skills`.
+  `workflows` (orchestration above missions, env-gated
+  `WORKFLOWS_ENABLED`), `connectors`, `destinations`, `kb`,
+  `attachments`, `gwclient`, `memclient`, `sandboxclient`,
+  `settings`, `skills`.
 - `internal/gateway/`: `provider` (wire adapters only), `router`,
-  `ledger`, `stream`, `admin`, `api`.
+  `catalog`, `ledger`, `stream`, `admin`, `api`.
+- `internal/memory/`: `api`, `store` (pgvector), `chunk`, `extract`
+  (source-aware fact extraction), `retrieval` (hybrid, RRF-fused).
 - `internal/platform/`: shared (`migrate`, `pgpool`, `sse`,
-  `httpserver`, `metrics`, `logging`, `config`, `service`,
+  `httpserver`, `metrics`, `logging`, `config`, `service`, `netguard`,
   `markitdown`, `whisper`).
 - `migrations/`: numbered idempotent SQL, embedded via `embed.go`.
   Pre-release: schema changes edit the original migration in place
@@ -60,7 +65,14 @@ via the existing `--env-file` Make targets.
 
 - `internal/brain/missions/`: `statemachine.go` (pure `Step()`, sole
   transition logic), `store.go` (`ApplyTransition` is the only state
-  writer; append-only `mission_events`), `driver.go`, `runner.go`.
+  writer; append-only `mission_events`), `driver.go`, `runner.go`,
+  `policy.go` (per-kind/light behavior), `provision.go`, `budget.go`,
+  `verifier.go`, `sentinel.go`, `packet.go`, `scheduler.go`.
+- Light missions (kind=general, `light` flag): born in phase=execute,
+  skip explore/plan/review; the worker carries the deliverable in
+  mission_status's `final_output` argument.
+- Worker turns end on successful sentinel execution
+  (`loop.Request.EndTurnTools`); never add a post-sentinel model call.
 - Harness-owned verification: `CheckArtifacts` runs BEFORE any
   model-authored `verify_cmd`; `passes` flags flip only on harness
   evidence, never on model claims.
@@ -83,7 +95,7 @@ via the existing `--env-file` Make targets.
 - Secrets by `credential_ref` name only; raw values never in DB, API,
   logs, or frontend. Never read `.env*`, `~/.ssh`, credentials.
 - Providers are wire adapters; routing/model choice is data
-  (`providers`/`task_routes` rows), not code.
+  (`providers`/`routes` rows), not code.
 - Cost honesty: unknown price recorded as NULL, never guessed.
 - No speculative abstractions: no interface with one implementation,
   no config nothing reads.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,9 @@ First run: `cp deploy/env.example deploy/.env` and set
 - `internal/brain/`: `api` (HTTP handlers, nil-gated `register*`
   pattern), `loop` (THE tool loop, lives here only), `tools` +
   `tools/builtin` (registry, permission chain, builtin tools), `chat`,
-  `session`, `agents`, `missions` (agent harness), `connectors`
+  `session`, `agents`, `missions` (agent harness), `workflows`
+  (orchestration above missions: steps + outcome-driven edges, env-gated
+  `WORKFLOWS_ENABLED`), `connectors`
   (Google/MCP), `destinations` (mission result delivery: email/webhook/
   telegram), `kb` (knowledge-base collections/documents), `attachments`,
   `gwclient`, `memclient`, `sandboxclient`, `settings`, `skills`.
@@ -63,8 +65,9 @@ First run: `cp deploy/env.example deploy/.env` and set
   `catalog` (LiteLLM-synced model/pricing catalog), `ledger`, `stream`,
   `admin`, `api`.
 - `internal/memory/` (memoryd's implementation): `api`, `store`
-  (pgvector), `chunk`, `extract`, `retrieval` (hybrid vector+text+entity,
-  RRF-fused).
+  (pgvector), `chunk`, `extract` (source-aware contracts, echo fence,
+  duplicate reinforcement, `changes_behavior` utility gate), `retrieval`
+  (hybrid vector+text+entity, RRF-fused).
 - `internal/platform/`: shared: `migrate`, `pgpool`, `sse`,
   `httpserver`, `metrics`, `logging`, `config`, `service`, `netguard`
   (SSRF-guarded outbound dialer), `markitdown`, `whisper` (sidecar
@@ -79,10 +82,24 @@ First run: `cp deploy/env.example deploy/.env` and set
 - `internal/brain/missions/`: `statemachine.go` (pure `Step()`, sole
   transition logic), `store.go` (`ApplyTransition` is the only state
   writer; append-only `mission_events`), `driver.go`, `runner.go`
-  (native runner over `loop.Agent`), `worktree.go`, `packet.go`,
-  `sentinel.go`, `review.go`, `verify.go`, `scheduler.go`, `notify.go`,
-  `sweep.go`. Schema: `migrations/0010_missions.sql` (edited in place
+  (native runner over `loop.Agent`), `policy.go` (per-kind/light
+  behavior flags), `provision.go`, `budget.go`, `verifier.go`,
+  `worktree.go`, `packet.go`, `sentinel.go`, `review.go`, `verify.go`,
+  `scheduler.go`, `notify.go`, `sweep.go`, `memory.go`. Schema: `migrations/0010_missions.sql` (edited in place
   pre-release, never new ALTER migrations), attachments in 0011.
+- Light missions (D-069, kind=general only): born in phase=execute,
+  skip explore/plan/review; the deliverable travels in mission_status's
+  `final_output` argument (reasoning models emit tool calls with no
+  plain text). Digest schedules run light.
+- Worker turns END on successful sentinel execution
+  (`loop.Request.EndTurnTools`, D-075): never reintroduce a
+  post-sentinel model call — chat models ramble through it, reasoning
+  models return empty and fail the turn.
+- Mission workers get their agent's skill index in the system prompt
+  (packet `SkillsIndex`, resolved at packet build); delegated CLI
+  packets never include it. Every mission prompt carries the current
+  date via `execEnvironmentNote` — models otherwise anchor on stale
+  dates in tool descriptions.
 - Follow-up missions: a terminal mission spawns a new one via
   `parent_mission_id`; the parent's outcome digest (`OutcomeDigest`,
   shared with memory extraction) is snapshotted into `parent_context`

--- a/README.md
+++ b/README.md
@@ -17,17 +17,22 @@ Self-hosted personal AI assistant: chat, cost tracking, tasks, and agents, runni
 
 Alpha releases with prebuilt images are available on the [Releases page](https://github.com/timothy-agent/timothy/releases); expect rough edges and breaking changes between releases.
 
-## What works today
+## Features
 
-- **Multi-provider chat**: Anthropic, Amazon Bedrock, and any OpenAI-compatible API behind one gateway; providers, models, and per-task routing are database configuration, editable at runtime from the settings panel with hot reload.
-- **Sessions that survive**: every conversation is an append-only event log; kill a container mid-stream and the session resumes and replays exactly.
-- **Tools, permissions, skills**: the agent loop executes tools behind a constraint/permission chain (destructive actions require explicit approval in the UI); skill packs load lazily by task.
-- **Missions**: long-running agent tasks with a pure state machine, harness-owned verification (artifacts must exist before any model claim counts), per-mission sandboxes, budgets, and LLM review; recurring missions fire from cron schedules. Coding missions auto-detect their language environment (Go, Node, Python, Java, PHP) and run in a matching per-language sandbox image, pulled on demand.
-- **Delegated coding harness**: a coding mission can hand its execution to headless Claude Code running inside the mission sandbox — against an Anthropic subscription, or any provider with an Anthropic-compatible endpoint (GLM, local Ollama) — while Timothy keeps verification, review, budgets, and the event timeline; it falls back to the native loop (recorded in the timeline) whenever the harness is unavailable.
-- **Memory-aware scheduling**: before starting a mission, sandboxd checks whether the host can actually afford another sandbox; if not, the mission queues idle and is retried automatically as resources free up.
-- **Long-term memory**: staged fact extraction with a confirmation queue, hybrid pgvector retrieval (vector + text + entity, RRF-fused) under a strict token budget.
-- **Cost accounting**: every request lands in a ledger with honest pricing (unknown price is recorded as null, never guessed); usage dashboard, spend budgets with alerts, Prometheus metrics on every service.
-- **Privacy floor**: tools whose output carries sensitive data (raw email) pin the rest of their turn, and every downstream side-call (memory extraction, compaction), to a dedicated route you can chain to a local model.
+<table>
+<tr><td><b>Use any AI model</b></td><td>Anthropic, OpenAI, Amazon Bedrock, local models via Ollama, or any compatible provider — all behind one interface. Pick which model handles chat, coding, research, or digests, switch anytime from settings, and let Timothy fail over to a backup model when a provider has a bad day.</td></tr>
+<tr><td><b>Give it real work</b></td><td>Hand Timothy a task — research a topic, write a report, fix a bug — and it works unattended: plans, executes, verifies its own output, and shows you the result with a full timeline of what it did. Quick tasks skip the ceremony and just get done.</td></tr>
+<tr><td><b>It writes code safely</b></td><td>Coding tasks run in isolated per-language sandboxes (Go, Node, Python, Java, PHP), on their own git branch, with the work verified before you see it. It can even drive Claude Code or Codex for you while keeping review and budgets in your hands.</td></tr>
+<tr><td><b>Your daily briefings</b></td><td>Schedule digests of your inbox, calendar, and spending — delivered to Telegram, email, or a webhook, in your timezone, saying only what actually needs your attention.</td></tr>
+<tr><td><b>Connected to your life</b></td><td>Gmail, Google Calendar, Docs, Drive, GitHub, and any MCP server. Timothy reads them when a task needs it — and asks before doing anything destructive.</td></tr>
+<tr><td><b>Shape your own assistants</b></td><td>Create named agents with their own personality, model, and exactly the tools and knowledge they should have — a digest agent that only reads mail and calendar, a coder that only touches code.</td></tr>
+<tr><td><b>It remembers you</b></td><td>Preferences, projects, and facts you share carry across conversations. You approve what becomes a standing instruction; noise gets filtered before it ever reaches you.</td></tr>
+<tr><td><b>Your documents, searchable</b></td><td>Drop in files or URLs and Timothy files them into topic collections and uses them to answer questions — your own knowledge base, on your own disk.</td></tr>
+<tr><td><b>Nothing gets lost</b></td><td>Conversations survive restarts, crashes, and upgrades — pick up any session exactly where it left off.</td></tr>
+<tr><td><b>You control the spend</b></td><td>Every model call is priced and logged honestly. Set budgets with alerts, see exactly where the money goes, and route routine work to cheap or free models.</td></tr>
+<tr><td><b>Private by design</b></td><td>Runs entirely on your hardware. Sensitive content like email can be pinned to a local model so it never leaves your network, and API keys live in an encrypted store (or your own Vault / AWS Secrets Manager) — never in logs, never in the UI.</td></tr>
+<tr><td><b>Talk to it</b></td><td>Optional voice input with fully local speech-to-text — audio never leaves your machine.</td></tr>
+</table>
 
 ## Architecture
 
@@ -60,14 +65,12 @@ Sessions are an append-only event log: every turn, tool run, and compaction is a
 
 The fastest way to run Timothy: no Go/Node toolchain, no build step, just Docker and the released images.
 
-1. Make an empty directory and download the installer from the [latest release](https://github.com/timothy-agent/timothy/releases). While Timothy is alpha, every release is marked prerelease, so GitHub's `/releases/latest` redirect doesn't resolve; look up the newest tag instead:
+1. Make an empty directory and download the installer from the [latest release](https://github.com/timothy-agent/timothy/releases). While Timothy is alpha, every release is marked prerelease, so GitHub's `/releases/latest` redirect doesn't resolve; take the newest entry from the releases list instead:
 
    ```sh
    mkdir timothy && cd timothy
    TAG=$(curl -fsSL https://api.github.com/repos/timothy-agent/timothy/releases \
-     | grep -E '"tag_name"|"published_at"' | paste - - \
-     | sed -E 's/.*"tag_name": "([^"]+)".*"published_at": "([^"]+)".*/\2 \1/' \
-     | sort -r | head -1 | awk '{print $2}')
+     | grep -m1 '"tag_name"' | cut -d'"' -f4)
    curl -fsSLo install.sh "https://github.com/timothy-agent/timothy/releases/download/$TAG/install.sh"
    ```
 

--- a/skills/coding/SKILL.md
+++ b/skills/coding/SKILL.md
@@ -1,42 +1,45 @@
 ---
 name: coding
-description: Disciplined software changes: plan first, test first, verify end-to-end. Use when writing, modifying, debugging, or reviewing code, or when a task produces anything a compiler, interpreter, or test suite will judge.
+description: Disciplined software changes: understand the requirement, reproduce failures, make the smallest safe change, and verify it with evidence. Use when writing, modifying, debugging, or reviewing code, or when a task produces anything a compiler, interpreter, linter, or test suite will evaluate.
 ---
 
 # Coding task discipline
 
 ## Rules
 
-- State the plan before the first edit: what changes, where, and how you will know it worked.
-- Write or identify the failing test before writing the fix; a bug you cannot reproduce is a bug you cannot claim to have fixed.
-- Make the smallest change that satisfies the requirement; delete nothing you did not orphan yourself.
-- Build and run the tests after every coherent step, not once at the end: a broken intermediate state with ten changes in flight has ten suspects.
-- Read the actual error message before theorizing; quote it, don't paraphrase it.
-- When a fix doesn't work, revert to the last known-good state before trying the next idea; stacked failed attempts compound.
-- Match the codebase's existing style, naming, and idiom even where you disagree with it.
-- Never weaken an assertion, delete a test, or broaden an exception handler to make a failure go away; make the code satisfy the test or prove the test wrong.
-- Treat compiler warnings and linter findings in changed code as errors.
+- Before editing, inspect the relevant code, tests, configuration, and repository conventions enough to understand the requested change and define success criteria.
+- State the plan before the first edit: what changes, where, and how you will verify them.
+- For bugs, reproduce the failure and write or identify a failing test before fixing it when practical. For other changes, define the verification criteria before editing.
+- Make the smallest change that satisfies the requirement; avoid unrelated cleanup or refactoring.
+- After each coherent change, run the smallest relevant verification available. After completing the coherent unit of work, run broader applicable tests.
+- Read the actual error output before theorizing; quote it rather than paraphrasing it.
+- When a fix fails, return to the last known-good state before trying a different fix, while preserving useful diagnostic instrumentation.
+- Match the codebase's existing style, naming, architecture, and idioms unless the task explicitly requires changing them.
+- Never weaken assertions, delete tests, or broaden exception handling merely to make failures disappear.
+- Treat new compiler warnings and linter findings introduced by the change as errors.
 
 ## Anti-rationalization
 
-| Excuse | Rebuttal |
-|---|---|
-| "Tests slow me down" | Untested code is unfinished code; the time returns on the first regression. |
-| "It's a one-line change, no need to run anything" | One-line changes have shipped outages; the cost of running the suite is minutes. |
-| "The error is probably X, let me just fix that" | Probably is a guess; reproduce first, then fix what actually failed. |
-| "I'll clean this up later" | Later never has more context than now. |
-| "The existing style is bad, I'll improve it while I'm here" | Unrequested churn hides the real change and breaks review. |
+| Excuse                                            | Rebuttal                                                                          |
+|---------------------------------------------------|-----------------------------------------------------------------------------------|
+| "Tests slow me down"                              | Use the smallest relevant verification first; unverified code is unfinished code. |
+| "It's a one-line change, no need to run anything" | Small changes can still cause regressions; run the applicable verification.       |
+| "The error is probably X"                         | Probably is a guess; reproduce and inspect the actual failure first.              |
+| "I'll clean this up while I'm here"               | Unrequested churn hides the real change and increases regression risk.            |
+| "The existing style is bad"                       | Match the repository unless changing it is part of the task.                      |
 
 ## Red flags: stop and re-check
 
-- You are about to change a test's expected value to match new output.
-- You cannot explain why the fix works, only that it does.
+- You are about to change a test expectation to match new output without establishing that the expected behavior should change.
+- You cannot explain why the fix works, only that a test happens to pass.
 - The diff touches files unrelated to the stated task.
-- You are adding a sleep, retry, or timeout to make a test pass.
-- Two consecutive fix attempts failed: stop patching, start reading.
+- You are adding a sleep, retry, timeout, or exception handling solely to make a test pass.
+- Two consecutive fix attempts failed: stop patching and inspect the code, test, and failure more deeply.
+- You cannot distinguish a newly introduced failure from a pre-existing failure.
 
 ## Evidence required
 
-- The failing output before the fix and the passing output after, from the same command.
-- A clean build/lint/test run at the final state, quoted, not summarized.
-- Self-assessment ("looks correct", "should work") counts for nothing.
+- For bug fixes: evidence of the failure before the fix and successful verification after the fix.
+- Applicable verification at the final state: build, lint, tests, type checks, static analysis, or other repository-specific checks.
+- Report actual command results and relevant output rather than claiming that something "looks correct."
+- Distinguish pre-existing failures from regressions introduced by the current change.

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -54,13 +54,13 @@ description: Decomposes a complex research question into independent sub-questio
 
 ## Anti-rationalization
 
-| Excuse | Rebuttal |
-|---|---|
-| "These sub-questions all touch the same topic, I'll merge them" | Same topic doesn't mean same unit; independence is about whether one needs the other's answer. |
-| "The snippet already told me, no need to fetch the page" | A snippet is a lead, not a source; fetch the page, confirm the claim, then cite it. |
-| "The synthesis can just re-search to fill a gap" | Synthesis reads findings files only; a gap found at synthesis time means a findings unit was incomplete, not a license to search again. |
-| "One source is fine, this fact is obviously true" | Obviousness is not verification; decision-driving claims still need two independent sources. |
-| "Close enough to the URL I remember" | The harness matches cited URLs against fetched ones exactly; a remembered or reconstructed URL fails the unit. |
+| Excuse                                                          | Rebuttal                                                                                                                                |
+|-----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| "These sub-questions all touch the same topic, I'll merge them" | Same topic doesn't mean same unit; independence is about whether one needs the other's answer.                                          |
+| "The snippet already told me, no need to fetch the page"        | A snippet is a lead, not a source; fetch the page, confirm the claim, then cite it.                                                     |
+| "The synthesis can just re-search to fill a gap"                | Synthesis reads findings files only; a gap found at synthesis time means a findings unit was incomplete, not a license to search again. |
+| "One source is fine, this fact is obviously true"               | Obviousness is not verification; decision-driving claims still need two independent sources.                                            |
+| "Close enough to the URL I remember"                            | The harness matches cited URLs against fetched ones exactly; a remembered or reconstructed URL fails the unit.                          |
 
 ## Red flags: stop and re-check
 

--- a/skills/email-research/SKILL.md
+++ b/skills/email-research/SKILL.md
@@ -28,14 +28,14 @@ description: Searches, reads, and aggregates Gmail content, finding bookings, co
 
 ## Anti-rationalization
 
-| Excuse | Rebuttal |
-|---|---|
-| "The snippet already shows the amount" | Snippets truncate; gmail_read the message before citing a figure from it. |
-| "I can add these three numbers myself" | Mental arithmetic on amounts you'll report as fact goes through calculate, no exceptions. |
-| "Combining $40 and €40 into one total is close enough" | Different currencies are different totals; report each separately. |
-| "It's from the same sender as the confirmation, so it counts" | Marketing and reminders from that domain are not the transaction; label them separately. |
-| "The user's message implies this year" | Never guess a year: read it from the system prompt's current date. |
-| "No Gmail tool is available, but I probably know the answer" | Say "email not connected"; never answer from assumption when the tool is simply missing. |
+| Excuse                                                        | Rebuttal                                                                                  |
+|---------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| "The snippet already shows the amount"                        | Snippets truncate; gmail_read the message before citing a figure from it.                 |
+| "I can add these three numbers myself"                        | Mental arithmetic on amounts you'll report as fact goes through calculate, no exceptions. |
+| "Combining $40 and €40 into one total is close enough"        | Different currencies are different totals; report each separately.                        |
+| "It's from the same sender as the confirmation, so it counts" | Marketing and reminders from that domain are not the transaction; label them separately.  |
+| "The user's message implies this year"                        | Never guess a year: read it from the system prompt's current date.                        |
+| "No Gmail tool is available, but I probably know the answer"  | Say "email not connected"; never answer from assumption when the tool is simply missing.  |
 
 ## Red flags: stop and re-check
 

--- a/skills/research-brief/SKILL.md
+++ b/skills/research-brief/SKILL.md
@@ -38,11 +38,11 @@ description: Source-grounded research with verification and citations. Use when 
 
 ## Anti-rationalization
 
-| Excuse | Rebuttal |
-|---|---|
-| "I already know this" | Knowledge has a training cutoff; the question is being asked now. |
-| "One good source is enough" | Single sources are wrong often enough that decisions deserve two. |
-| "Citing everything clutters the answer" | An uncited actionable claim is a liability, not a courtesy. |
+| Excuse                                              | Rebuttal                                                             |
+|-----------------------------------------------------|----------------------------------------------------------------------|
+| "I already know this"                               | Knowledge has a training cutoff; the question is being asked now.    |
+| "One good source is enough"                         | Single sources are wrong often enough that decisions deserve two.    |
+| "Citing everything clutters the answer"             | An uncited actionable claim is a liability, not a courtesy.          |
 | "The aggregator summarizes the primary source fine" | Aggregators introduce errors and lag; the primary is one fetch away. |
 
 ## Red flags: stop and re-check


### PR DESCRIPTION
- README: "What works today" -> Features table written for end users (value per row: briefings, safe coding, memory, spend control, privacy); tech detail moved to AGENTS/CLAUDE
- README: TAG lookup simplified to the first tag_name from the releases API (verified live: v0.1.0-alpha.47)
- AGENTS/CLAUDE: layout sync (workflows, kb, destinations, catalog, memory extraction pipeline, mission file split), light missions, EndTurnTools contract, mission skills index, routes table name fix
- skills: reworked coding skill (owner-authored) + table formatting on the other packs; make skills-validate passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790129878&installation_model_id=431401&pr_number=307&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F307&signature=a8b78bd3ed7febc678a89ae508a78e3fa9a5d085d8c1de63fa0fa5b2c044cb04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->