### PR TITLE
feat: one-command install and upgrade via installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Alpha releases with prebuilt images are available on the [Releases page](https:/
 |---|---|
 | **One assistant, every model** | Anthropic, OpenAI, Amazon Bedrock, local models via Ollama, or any compatible provider, all behind one interface. Pick which model handles chat, coding, research, or briefings, and let Timothy fail over to a backup when a provider has a bad day. |
 | **Give it real work** | Hand Timothy a task (research a topic, write a report, fix a bug) and it works unattended: plans, executes, verifies its own output, and shows you the result with a full timeline of what it did. Quick tasks skip the ceremony and just get done. |
+| **Results find you** | Any task or schedule can deliver its result to Telegram, email, or a webhook the moment it finishes, files attached. No checking a dashboard: the answer lands where you already are. |
 | **It writes code safely** | Coding tasks run in isolated per-language sandboxes (Go, Node, Python, Java, PHP), on their own git branch, with the work verified before you see it. It can even drive Claude Code or Codex for you while keeping review and budgets in your hands. |
 | **Your daily briefings** | Wake up to a digest of your inbox, calendar, and spending, delivered to Telegram or email in your timezone, saying only what actually needs your attention. Schedule any task to run on your clock. |
 | **Connected to your life** | Gmail, Google Calendar, Docs, Drive, GitHub, and any MCP server. Timothy reads them when a task needs it, and asks before doing anything destructive. |
@@ -81,37 +82,23 @@ Sessions are an append-only event log: every turn, tool run, and compaction is a
 
 The fastest way to run Timothy: no Go/Node toolchain, no build step, just Docker and the released images.
 
-1. Make an empty directory and download the installer from the [latest release](https://github.com/timothy-agent/timothy/releases). While Timothy is alpha, every release is marked prerelease, so GitHub's `/releases/latest` redirect doesn't resolve; take the newest entry from the releases list instead:
+```sh
+curl -fsSL https://raw.githubusercontent.com/timothy-agent/timothy/main/deploy/release/install.sh | sh
+```
 
-   ```sh
-   mkdir timothy && cd timothy
-   TAG=$(curl -fsSL https://api.github.com/repos/timothy-agent/timothy/releases \
-     | grep -m1 '"tag_name"' | cut -d'"' -f4)
-   curl -fsSLo install.sh "https://github.com/timothy-agent/timothy/releases/download/$TAG/install.sh"
-   ```
+The installer resolves the newest release, installs into `~/timothy` (override with `TIMOTHY_HOME=/some/dir`), generates a `.env` with fresh secrets (`POSTGRES_PASSWORD`, `TIMOTHY_MASTER_KEY`, `TIMOTHY_API_TOKEN`), pulls the images, starts the stack, and prints a magic sign-in link once the web UI is up. Open the link: the web UI signs in automatically.
 
-2. Read `install.sh` before running it. Then run it:
+Prefer to inspect scripts before running them? Every release also ships `install.sh` as an asset: download it from the [releases page](https://github.com/timothy-agent/timothy/releases), read it, then `sh install.sh`.
 
-   ```sh
-   sh install.sh
-   ```
+### Upgrading
 
-   It downloads `docker-compose.yml` and `env.example`, generates a `.env` with fresh secrets (`POSTGRES_PASSWORD`, `TIMOTHY_MASTER_KEY`, `TIMOTHY_API_TOKEN`), pulls the images, starts the stack, and prints a magic sign-in link once the web UI is up.
+Run the exact same command again:
 
-3. Open the printed link: the web UI signs in automatically from the token in the URL.
+```sh
+curl -fsSL https://raw.githubusercontent.com/timothy-agent/timothy/main/deploy/release/install.sh | sh
+```
 
-To upgrade later, in this order:
-
-1. Download the new release's `docker-compose.yml` (it changes between releases; the old one may reference services or settings the new images don't expect):
-
-   ```sh
-   curl -fsSLo docker-compose.yml "https://github.com/timothy-agent/timothy/releases/download/<new-tag>/docker-compose.yml"
-   ```
-
-2. Set `TIMOTHY_VERSION` in `.env` to the new tag (without the `v` prefix).
-3. `docker compose pull && docker compose up -d`
-
-Or bump `TIMOTHY_VERSION` in `.env` and re-run the new release's `install.sh`, which handles the rest (it leaves an existing `.env` untouched, refreshes `docker-compose.yml` and the searxng config, and pre-pulls the mission sandbox image). Sandbox images (base and the per-language variants) are otherwise pulled on demand by sandboxd the first time a mission needs them.
+The installer finds your existing install (`~/timothy`, `TIMOTHY_HOME`, or the directory you run it from), keeps all your secrets, bumps `TIMOTHY_VERSION` to the newest release, refreshes `docker-compose.yml` and the searxng config, pulls the new images (including the mission sandbox), and restarts the stack. Your data lives in Docker volumes and your secrets in `.env`; neither is touched. Database migrations run automatically when the new version starts. Downgrading is not supported once a newer version's migrations have run.
 
 The rest of this README covers building and running from source instead.
 
@@ -187,7 +174,7 @@ docker compose -f deploy/docker-compose.yml exec postgres pg_dump -U timothy tim
 
 A full backup is the `pgdata` volume plus `deploy/.env`: without `TIMOTHY_MASTER_KEY`, the encrypted secrets in that dump are unrecoverable.
 
-### Upgrading
+### Upgrading a source build
 
 ```sh
 git pull

--- a/deploy/release/install.sh
+++ b/deploy/release/install.sh
@@ -4,8 +4,6 @@
 set -eu
 
 TAG="__TIMOTHY_TAG__"
-RELEASE_TAG="v${TAG}"
-BASE_URL="https://github.com/timothy-agent/timothy/releases/download/${RELEASE_TAG}"
 
 fail() {
   echo "error: $1" >&2
@@ -21,6 +19,26 @@ fetch() {
   fi
 }
 
+# Release assets ship with TAG baked in. When this script is fetched
+# straight from the repo instead, the placeholder is still present
+# (the case pattern is a prefix so the release sed leaves it alone);
+# resolve the newest release tag from the GitHub API.
+case "$TAG" in
+__TIMOTHY*)
+  if command -v curl >/dev/null 2>&1; then
+    releases=$(curl -fsSL "https://api.github.com/repos/timothy-agent/timothy/releases?per_page=1")
+  else
+    releases=$(wget -qO- "https://api.github.com/repos/timothy-agent/timothy/releases?per_page=1")
+  fi
+  TAG=$(printf '%s' "$releases" | grep -m1 '"tag_name"' | cut -d'"' -f4)
+  TAG=${TAG#v}
+  [ -n "$TAG" ] || fail "could not determine the latest release tag"
+  ;;
+esac
+
+RELEASE_TAG="v${TAG}"
+BASE_URL="https://github.com/timothy-agent/timothy/releases/download/${RELEASE_TAG}"
+
 echo "Timothy installer (${RELEASE_TAG})"
 
 # --- Preflight ---
@@ -29,6 +47,19 @@ docker compose version >/dev/null 2>&1 || fail "'docker compose' plugin not avai
 command -v openssl >/dev/null 2>&1 || fail "openssl not found on PATH. Install it to generate secrets."
 if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
   fail "neither curl nor wget found on PATH."
+fi
+
+# --- Install directory ---
+# Operate in the current directory when it already holds a Timothy
+# install (in-place upgrade); otherwise use TIMOTHY_HOME (default
+# ~/timothy) so the one-liner works from anywhere.
+if [ -f .env ] && [ -f docker-compose.yml ]; then
+  echo "Existing install detected in $(pwd)."
+else
+  TIMOTHY_HOME="${TIMOTHY_HOME:-$HOME/timothy}"
+  mkdir -p "$TIMOTHY_HOME"
+  cd "$TIMOTHY_HOME"
+  echo "Installing into ${TIMOTHY_HOME}"
 fi
 
 # --- Download assets ---
@@ -40,7 +71,8 @@ fetch "${BASE_URL}/searxng-settings.yml" searxng/settings.yml
 
 # --- .env ---
 if [ -f .env ]; then
-  echo "Existing .env found — leaving it untouched (upgrade path)."
+  echo "Existing .env found (upgrade path): keeping your secrets, bumping TIMOTHY_VERSION to ${TAG}."
+  sed -i.bak "s#^TIMOTHY_VERSION=.*#TIMOTHY_VERSION=${TAG}#" .env && rm -f .env.bak
 else
   echo "Generating .env with fresh secrets..."
   cp env.example .env
@@ -76,10 +108,8 @@ docker compose pull
 
 # compose pull only covers services; the mission sandbox image is an
 # env var handed to sandboxd (which pulls per-mission containers via
-# the Docker socket, not through compose), so pull it explicitly here —
-# same TIMOTHY_VERSION tag as everything else, read back from .env so
-# an upgrade (TIMOTHY_VERSION bumped by hand, .env otherwise untouched)
-# pulls the matching sandbox tag too.
+# the Docker socket, not through compose), so pull it explicitly here,
+# same TIMOTHY_VERSION tag as everything else, read back from .env.
 timothy_version=$(sed -n 's/^TIMOTHY_VERSION=//p' .env | head -n1)
 echo "Pulling mission sandbox image..."
 docker pull "ghcr.io/timothy-agent/timothy-sandbox:${timothy_version}"
@@ -107,6 +137,8 @@ api_token=$(sed -n 's/^TIMOTHY_API_TOKEN=//p' .env | head -n1)
 echo ""
 echo "================================================================"
 echo " Timothy is up."
+echo ""
+echo " Install dir: $(pwd)"
 echo ""
 echo " Sign in:  http://localhost:${web_port}/#token=${api_token}"
 echo " (this magic link signs the web UI in automatically)"


### PR DESCRIPTION
## What

- `install.sh` resolves the newest release tag from the GitHub API when fetched straight from the repo (release assets still ship with the tag baked in).
- Installer owns its directory: installs into `TIMOTHY_HOME` (default `~/timothy`) unless run inside an existing install (`.env` + `docker-compose.yml` present), which upgrades in place.
- Upgrade path bumps `TIMOTHY_VERSION` in the existing `.env` automatically; secrets untouched.
- Final banner prints the install directory.
- README: quick start and upgrade are now the same one-liner runnable from anywhere; added destinations (Telegram/email/webhook delivery) to the features table.

## Why

Installing required a manual tag lookup (which even misbehaved with grep -m1 closing curl's pipe), and upgrading required hand-editing `TIMOTHY_VERSION`. Now both are a single command:

```sh
curl -fsSL https://raw.githubusercontent.com/timothy-agent/timothy/main/deploy/release/install.sh | sh
```

## Verification

- `sh -n` syntax check.
- Release sed round-trip: fallback case pattern survives `s/__TIMOTHY_TAG__/x/g` and stops matching after substitution.
- Live API tag resolution returns `0.1.0-alpha.48`.
- Directory logic round-tripped in real `/bin/sh`: fresh dir installs into `TIMOTHY_HOME`, existing install dir upgrades in place, default lands in `~/timothy`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790134839&installation_model_id=431401&pr_number=313&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F313&signature=bb2a90cabbc25c56e45e15762cd65ece1e5eb37469d0901b69ad37497aef9411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->