### PR TITLE
feat: usage-driven decay for unused pending memories

### DIFF
--- a/cmd/memoryd/main.go
+++ b/cmd/memoryd/main.go
@@ -61,6 +61,7 @@ func main() {
 			"Near-duplicate merges rejected by reason.", "reason"),
 		Archived: app.Metrics.NewCounter("memory_archived_total", "Stale episodic memories archived."),
 		Decayed:  app.Metrics.NewCounter("memory_decayed_total", "Stale semantic facts decayed and queued for reconfirmation."),
+		Demoted:  app.Metrics.NewCounter("memory_demoted_total", "Unused pending memories demoted by the usage-driven decay pass."),
 	})
 	consolidator.SetReflector(extractor)
 	kbStore := store.NewKBStore(app.DB)

--- a/internal/memory/api/consolidate.go
+++ b/internal/memory/api/consolidate.go
@@ -25,6 +25,7 @@ func (a *API) handleConsolidate(w http.ResponseWriter, r *http.Request) {
 		"rejected": summary.Rejected,
 		"archived": summary.Archived,
 		"decayed":  summary.Decayed,
+		"demoted":  summary.Demoted,
 	}
 	if err != nil {
 		a.log.Warn("consolidation pass failed", "error", err)

--- a/internal/memory/extract/consolidate.go
+++ b/internal/memory/extract/consolidate.go
@@ -38,6 +38,15 @@ const (
 	reflectMaxEpisodics = 200
 	reflectWindow       = 7 * 24 * time.Hour
 
+	// unusedDemoteAfter: pending memories never retrieved and never
+	// confirmed are noise past this age (memory-extraction-v2 slice 5).
+	unusedDemoteAfter = 60 * 24 * time.Hour
+	// unusedDemoteConfidence: only low-confidence pendings demote - a
+	// high-confidence fact still unconfirmed is a queue-hygiene problem
+	// (slice 3's TTL), not a usage problem.
+	unusedDemoteConfidence = autoPromoteConfidence
+	demoteBatch            = 50 // stalest per run; a queue, not a flood
+
 	// mergeGuard thresholds. A guard false positive only keeps a
 	// near-dup group as-is (extraction already tolerates that state)
 	// and retries next pass with a fresh LLM sample; a false negative
@@ -60,6 +69,7 @@ type ConsolidateStore interface {
 	ArchiveStaleEpisodic(ctx context.Context, olderThan time.Time) (int64, error)
 	DecayStaleSemantic(ctx context.Context, olderThan time.Time, factor float64, limit int) ([]string, error)
 	RecentEpisodic(ctx context.Context, since time.Time, limit int) ([]store.Memory, error)
+	DemoteUnused(ctx context.Context, olderThan time.Time, confidenceBelow float64, limit int) ([]string, error)
 }
 
 // Metrics counts every consolidation action; any counter may be nil
@@ -69,6 +79,7 @@ type Metrics struct {
 	Rejects  *prometheus.CounterVec // reason: token_loss|shrink|bloat|conflict|error
 	Archived prometheus.Counter
 	Decayed  prometheus.Counter
+	Demoted  prometheus.Counter
 }
 
 // Summary counts one Run pass. RunLoop discards it; the manual
@@ -79,11 +90,12 @@ type Summary struct {
 	Archived  int `json:"archived"`
 	Decayed   int `json:"decayed"`
 	Reflected int `json:"reflected"`
+	Demoted   int `json:"demoted"`
 }
 
 // Consolidator is the daily lifecycle job (D-011): merge near-dup
 // groups, archive unused episodic memories, decay unconfirmed
-// semantic facts.
+// semantic facts, demote unused pending memories.
 type Consolidator struct {
 	gw      Gateway
 	store   ConsolidateStore
@@ -158,6 +170,12 @@ func (c *Consolidator) Run(ctx context.Context) (Summary, error) {
 
 	reflected, err := c.reflect(ctx)
 	summary.Reflected = reflected
+	if err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	demoted, err := c.demoteUnused(ctx)
+	summary.Demoted = demoted
 	if err != nil {
 		errs = append(errs, err.Error())
 	}
@@ -446,6 +464,25 @@ func (c *Consolidator) decayStale(ctx context.Context) (int, error) {
 		c.log.Info("stale semantic facts decayed; queued for reconfirmation", "count", len(ids))
 		if c.metrics.Decayed != nil {
 			c.metrics.Decayed.Add(float64(len(ids)))
+		}
+	}
+	return len(ids), nil
+}
+
+// demoteUnused closes out pending memories nobody ever retrieved or
+// confirmed (memory-extraction-v2 slice 5): retrieval usage, not
+// extraction confidence, is what proves a memory's value. Reinforced
+// or ever-retrieved memories are immune - the store query filters on
+// retrieval_hits and status directly.
+func (c *Consolidator) demoteUnused(ctx context.Context) (int, error) {
+	ids, err := c.store.DemoteUnused(ctx, time.Now().Add(-unusedDemoteAfter), unusedDemoteConfidence, demoteBatch)
+	if err != nil {
+		return 0, err
+	}
+	if len(ids) > 0 {
+		c.log.Info("unused pending memories demoted", "count", len(ids))
+		if c.metrics.Demoted != nil {
+			c.metrics.Demoted.Add(float64(len(ids)))
 		}
 	}
 	return len(ids), nil

--- a/internal/memory/extract/consolidate_test.go
+++ b/internal/memory/extract/consolidate_test.go
@@ -50,10 +50,15 @@ type consolidateStore struct {
 	pairs    [][2]string
 	archived int64
 	decayed  []string
+	demoted  []string
 
 	applyMergeErr  error
 	superseded     map[string]string
 	recentEpisodic []store.Memory
+}
+
+func (s *consolidateStore) DemoteUnused(context.Context, time.Time, float64, int) ([]string, error) {
+	return s.demoted, nil
 }
 
 func (s *consolidateStore) RecentEpisodic(context.Context, time.Time, int) ([]store.Memory, error) {
@@ -343,5 +348,37 @@ func TestConsolidatorReflect(t *testing.T) {
 	c3 := NewConsolidator(gw2, st, testLog(), Metrics{})
 	if s, err := c3.Run(t.Context()); err != nil || s.Reflected != 0 {
 		t.Fatalf("unwired reflector: %+v err=%v", s, err)
+	}
+}
+
+// TestConsolidateDemotesUnused checks that Run surfaces whatever the
+// store's DemoteUnused selects into Summary.Demoted - the selection
+// logic itself (eligible vs immune rows) lives in the store's own
+// query and is covered by the store integration test.
+func TestConsolidateDemotesUnused(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGateway{}
+	st := &consolidateStore{demoted: []string{"m1", "m2"}}
+	c := NewConsolidator(gw, st, testLog(), Metrics{})
+	summary, err := c.Run(t.Context())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.Demoted != 2 {
+		t.Fatalf("Demoted = %d, want 2", summary.Demoted)
+	}
+}
+
+func TestConsolidateDemotesNothing(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGateway{}
+	st := &consolidateStore{}
+	c := NewConsolidator(gw, st, testLog(), Metrics{})
+	summary, err := c.Run(t.Context())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.Demoted != 0 {
+		t.Fatalf("Demoted = %d, want 0", summary.Demoted)
 	}
 }

--- a/internal/memory/retrieval/search.go
+++ b/internal/memory/retrieval/search.go
@@ -175,9 +175,12 @@ func (s *Searcher) leg(ctx context.Context, name, sql string, args []any, types 
 	return rows.Err()
 }
 
-// MarkRetrieved stamps last_retrieved_at on the returned memories so
-// the consolidation job can see what is actually used. Deliberately
-// NOT last_confirmed_at (D-011). Failures only log — retrieval
+// MarkRetrieved stamps last_retrieved_at and bumps retrieval_hits on
+// the returned memories so the consolidation job can see what is
+// actually used (archival window and usage-driven decay,
+// memory-extraction-v2 slice 5). This is metadata bookkeeping,
+// deliberately NOT a supersede or last_confirmed_at bump (D-011);
+// memory content stays supersede-only. Failures only log — retrieval
 // already succeeded.
 func (s *Searcher) MarkRetrieved(ctx context.Context, ids []string) {
 	if len(ids) == 0 {
@@ -189,7 +192,9 @@ func (s *Searcher) MarkRetrieved(ctx context.Context, ids []string) {
 		return
 	}
 	if _, err := db.Exec(ctx,
-		`UPDATE memories SET last_retrieved_at = now() WHERE id = ANY($1)`, ids); err != nil {
+		`UPDATE memories SET last_retrieved_at = now(),
+			retrieval_hits = retrieval_hits + 1
+			WHERE id = ANY($1)`, ids); err != nil {
 		s.log.Warn("mark retrieved failed", "error", err, "ids", strings.Join(ids, ","))
 	}
 }

--- a/internal/memory/store/models.go
+++ b/internal/memory/store/models.go
@@ -49,6 +49,7 @@ type Memory struct {
 	SupersededBy    string
 	Status          Status
 	Confidence      float32
+	RetrievalHits   int
 }
 
 // Entity is a named thing memories can reference. MemoryCount is the

--- a/internal/memory/store/store.go
+++ b/internal/memory/store/store.go
@@ -34,7 +34,7 @@ func New(db *pgpool.Pool, log *slog.Logger) *Store {
 const memoryColumns = `id, type, content, entity_refs, ` +
 	`COALESCE(source_session::text, ''), COALESCE(source_seq, 0), actor, ` +
 	`created_at, last_confirmed_at, COALESCE(superseded_by::text, ''), ` +
-	`status, COALESCE(confidence, 0)`
+	`status, COALESCE(confidence, 0), retrieval_hits`
 
 // Insert stores a new memory and returns its id. Status is derived,
 // not caller-chosen: user-explicit memories activate immediately,
@@ -340,6 +340,41 @@ func (s *Store) Confirm(ctx context.Context, id string) error {
 	return nil
 }
 
+// DemoteUnused archives pending memories that were never retrieved,
+// never confirmed (still pending: confirmation is Promote to active),
+// low confidence, and older than the cutoff. The last_retrieved_at
+// IS NULL guard keeps rows retrieved before retrieval_hits existed
+// immune despite their zero counter. This never overwrites content,
+// only closes the row out (D-011). Returns the demoted ids.
+func (s *Store) DemoteUnused(ctx context.Context, olderThan time.Time, confidenceBelow float64, limit int) ([]string, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("demote unused: %w", err)
+	}
+	rows, err := db.Query(ctx, `UPDATE memories SET status = $1
+		WHERE id IN (
+			SELECT id FROM memories
+			WHERE status = $2 AND retrieval_hits = 0 AND last_retrieved_at IS NULL
+			  AND confidence < $3 AND created_at < $4
+			ORDER BY created_at
+			LIMIT $5)
+		RETURNING id`,
+		StatusArchived, StatusPending, confidenceBelow, olderThan, limit)
+	if err != nil {
+		return nil, fmt.Errorf("demote unused: %w", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("demote unused: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 // ArchiveStaleEpisodic retires active episodic memories neither
 // retrieved nor created within the window. Returns how many.
 func (s *Store) ArchiveStaleEpisodic(ctx context.Context, olderThan time.Time) (int64, error) {
@@ -398,7 +433,7 @@ func scanMemory(r rowScanner) (Memory, error) {
 	var m Memory
 	err := r.Scan(&m.ID, &m.Type, &m.Content, &m.EntityRefs, &m.SourceSession,
 		&m.SourceSeq, &m.Actor, &m.CreatedAt, &m.LastConfirmedAt,
-		&m.SupersededBy, &m.Status, &m.Confidence)
+		&m.SupersededBy, &m.Status, &m.Confidence, &m.RetrievalHits)
 	return m, err
 }
 

--- a/internal/memory/store/store_integration_test.go
+++ b/internal/memory/store/store_integration_test.go
@@ -763,6 +763,94 @@ func TestDecayStaleSemantic(t *testing.T) {
 	}
 }
 
+func TestDemoteUnused(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	backdate := func(id string) {
+		if _, err := db.Exec(ctx,
+			"UPDATE memories SET created_at = now() - interval '90 days' WHERE id = $1", id); err != nil {
+			t.Fatalf("backdate: %v", err)
+		}
+	}
+
+	eligible := mem("stale unused pending fact")
+	eligible.Confidence = 0.5
+	eligibleID, _ := s.Insert(ctx, eligible)
+	backdate(eligibleID)
+
+	retrieved := mem("stale but retrieved pending fact")
+	retrieved.Confidence = 0.5
+	retrievedID, _ := s.Insert(ctx, retrieved)
+	backdate(retrievedID)
+	if _, err := db.Exec(ctx,
+		"UPDATE memories SET retrieval_hits = 1, last_retrieved_at = now() WHERE id = $1", retrievedID); err != nil {
+		t.Fatalf("mark retrieved: %v", err)
+	}
+
+	// Retrieved before retrieval_hits existed: zero counter but a
+	// non-null last_retrieved_at, must stay immune.
+	legacy := mem("stale pending fact retrieved pre-counter")
+	legacy.Confidence = 0.5
+	legacyID, _ := s.Insert(ctx, legacy)
+	backdate(legacyID)
+	if _, err := db.Exec(ctx,
+		"UPDATE memories SET last_retrieved_at = now() WHERE id = $1", legacyID); err != nil {
+		t.Fatalf("mark legacy retrieved: %v", err)
+	}
+
+	confirmed := mem("stale but confirmed fact")
+	confirmed.Confidence = 0.5
+	confirmedID, _ := s.Insert(ctx, confirmed)
+	backdate(confirmedID)
+	if err := s.Promote(ctx, confirmedID); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+
+	highConfidence := mem("stale high-confidence pending fact")
+	highConfidence.Confidence = 0.95
+	highConfidenceID, _ := s.Insert(ctx, highConfidence)
+	backdate(highConfidenceID)
+
+	fresh := mem("recent unused pending fact")
+	fresh.Confidence = 0.5
+	freshID, _ := s.Insert(ctx, fresh)
+
+	ids, err := s.DemoteUnused(ctx, time.Now().Add(-60*24*time.Hour), 0.8, 10)
+	if err != nil {
+		t.Fatalf("DemoteUnused: %v", err)
+	}
+	demoted := map[string]bool{}
+	for _, id := range ids {
+		demoted[id] = true
+	}
+	if !demoted[eligibleID] {
+		t.Fatalf("eligible memory not demoted: %v", ids)
+	}
+	for name, id := range map[string]string{
+		"retrieved": retrievedID, "confirmed": confirmedID,
+		"high-confidence": highConfidenceID, "fresh": freshID,
+		"legacy-retrieved": legacyID,
+	} {
+		if demoted[id] {
+			t.Fatalf("%s memory wrongly demoted", name)
+		}
+	}
+
+	if got, _ := s.Get(ctx, eligibleID); got.Status != StatusArchived {
+		t.Fatalf("eligible status = %s, want archived", got.Status)
+	}
+	if got, _ := s.Get(ctx, retrievedID); got.Status != StatusPending {
+		t.Fatalf("retrieved status = %s, want still pending", got.Status)
+	}
+	if got, _ := s.Get(ctx, confirmedID); got.Status != StatusActive {
+		t.Fatalf("confirmed status = %s, want still active", got.Status)
+	}
+}
+
 // rawDB opens a direct connection for tests that must corrupt state in
 // ways the store API forbids.
 func rawDB(t *testing.T) *pgxpool.Pool {

--- a/migrations/0005_memory.sql
+++ b/migrations/0005_memory.sql
@@ -25,7 +25,12 @@ CREATE TABLE IF NOT EXISTS memories (
     -- memories unretrieved for 180d) — this is NOT last_confirmed_at,
     -- which only explicit confirmation or re-extraction may bump
     -- (D-011).
-    last_retrieved_at timestamptz
+    last_retrieved_at timestamptz,
+    -- Usage-driven decay bookkeeping (memory-extraction-v2 slice 5):
+    -- how many times retrieval has returned this memory. Metadata
+    -- bookkeeping, not a fact UPDATE (D-011); memory content stays
+    -- supersede-only.
+    retrieval_hits    integer NOT NULL DEFAULT 0
 );
 
 -- m/ef_construction over pgvector defaults (16/64): better recall at


### PR DESCRIPTION
## What

Memory extraction v2 slice 5: usage-driven decay. Closes the loop where memory value is measured by use, not extraction confidence.

- `memories` gains a `retrieval_hits` counter (migration 0005 edited in place per pre-release policy). `MarkRetrieved` bumps it in the same fire-and-forget UPDATE that already stamps `last_retrieved_at`; metadata bookkeeping only, memory content stays supersede-only (D-011).
- The daily consolidation job gains a demote stage: pending memories never retrieved (`retrieval_hits = 0 AND last_retrieved_at IS NULL`), confidence below the auto-promote threshold, older than 60 days, are archived in batches of 50, oldest first. Confirmed, reinforced, or ever-retrieved memories are immune; the `last_retrieved_at IS NULL` guard also keeps rows retrieved before the counter existed immune.
- Demote count surfaces in the consolidation summary, the manual-trigger API response, and a new `memory_demoted_total` counter.

## Why

Extraction confidence is a guess at write time; retrieval is evidence. Without decay the pending queue accumulates plausible-but-never-used facts forever, and the confirmation queue rots.

## Deploy note

Instances that already ran 0005 need:

```sql
ALTER TABLE memories ADD COLUMN IF NOT EXISTS retrieval_hits integer NOT NULL DEFAULT 0;
```

## Tests

`go build`, `go vet`, `go test -race ./internal/memory/...` pass. New DB-backed table test for demote selection (eligible vs immune rows incl. legacy-retrieved case) and consolidator wiring tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790138322&installation_model_id=431401&pr_number=314&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F314&signature=3e2d03e746e3d05fd49b76ca19fb5fd601e2fe04d002adacd4471041941408ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->