### PR TITLE
feat: inject operator steering notes into in-flight worker turns

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -893,6 +893,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	if conns != nil {
 		nativeRunner.SetConnectorReads(missionConnectorReadsResolver(agentReg, conns))
 	}
+	nativeRunner.SetProgressReader(store)
 	// The delegated runner wraps native with D-051/D-052's CLI-executor
 	// dispatch — resolve a worker route's chain via the gateway, spawn a
 	// harness entry's CLI detached in the mission's own sandbox container,

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -296,6 +296,15 @@ type Request struct {
 	// answers everything the turn needed; empty means today's behavior
 	// (always continue).
 	EndTurnTools []string
+
+	// Steering, when set, is polled once per iteration at the top of
+	// every model round after the first; each returned string is
+	// appended to Messages as a user-role message before that round's
+	// call. Lets an operator note posted while a turn is mid-flight
+	// reach the SAME turn instead of only the next one. Empty result is
+	// a no-op. nil for every caller but mission worker turns: the loop
+	// itself knows nothing about missions.
+	Steering func(ctx context.Context) []string
 }
 
 // Start launches the loop and returns its event stream. The channel
@@ -412,6 +421,11 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 	hint := req.ModelHint
 
 	for step := 1; ; step++ {
+		if step > 1 && req.Steering != nil {
+			for _, note := range req.Steering(ctx) {
+				msgs = append(msgs, provider.Message{Role: "user", Content: note})
+			}
+		}
 		directive := tools.CeilingFor(step, a.maxSteps)
 		// A model retrying the same call over and over (e.g. hoping a
 		// search tool will "book" something on a later attempt) forces

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -913,6 +913,82 @@ func (g *grantRecordingPerms) Grant(ctx context.Context, sid, tool, pattern stri
 	return g.rec.Grant(ctx, sid, tool, pattern, ttl)
 }
 
+// TestAgentSteeringInjectsMidTurn pins the Steering seam: a note
+// returned by Request.Steering must land as a user message on the
+// SECOND model call of a turn (never the first, which has nothing to
+// steer), and steering must not fire again once the model stops
+// calling tools.
+func TestAgentSteeringInjectsMidTurn(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"echo", `{"text":"hi"}`}),
+		finalStep("done"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	var calls int
+	steering := func(context.Context) []string {
+		calls++
+		return []string{"operator says hurry up"}
+	}
+
+	ch, err := a.Start(t.Context(), Request{
+		SessionID: "s1", Route: "coding",
+		Messages: []provider.Message{{Role: "user", Content: "go"}},
+		Steering: steering,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	if len(gw.requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(gw.requests))
+	}
+	if calls != 1 {
+		t.Fatalf("steering called %d times, want exactly 1 (never on step 1)", calls)
+	}
+	var sawFirst bool
+	for _, m := range gw.requests[0].Messages {
+		if strings.Contains(m.Content, "operator says hurry up") {
+			sawFirst = true
+		}
+	}
+	if sawFirst {
+		t.Fatal("steering note leaked into the first model call")
+	}
+	var sawSecond bool
+	for _, m := range gw.requests[1].Messages {
+		if m.Role == "user" && strings.Contains(m.Content, "operator says hurry up") {
+			sawSecond = true
+		}
+	}
+	if !sawSecond {
+		t.Fatalf("steering note missing from second call: %+v", gw.requests[1].Messages)
+	}
+}
+
+// TestAgentNilSteeringIsNoop pins that a nil Steering (every existing
+// caller) never changes behavior: the loop must not even attempt to
+// call it.
+func TestAgentNilSteeringIsNoop(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"echo", `{"text":"hi"}`}),
+		finalStep("done"),
+	}}
+	a, _, _, _ := testAgent(t, gw)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding", Messages: []provider.Message{{Role: "user", Content: "go"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs := collect(t, ch)
+	if len(ofType(evs, stream.EventDone)) != 1 {
+		t.Fatal("must still finish cleanly with nil Steering")
+	}
+}
+
 func TestAgentResearchCoercion(t *testing.T) {
 	t.Parallel()
 	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -1173,7 +1173,7 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 	workRoot := m.WorkRoot()
 	packet := ReviewPacket{
 		Goal: m.Goal, Plan: m.Spec, Diff: diff, Evidence: m.LastEvidence,
-		Listing: ListWorkspace(workRoot),
+		Listing: ListWorkspace(workRoot), Progress: m.Progress,
 	}
 	if unit, _ := currentUnit(m.Spec); unit != nil {
 		packet.UnitTitle = unit.Title

--- a/internal/brain/missions/review.go
+++ b/internal/brain/missions/review.go
@@ -49,6 +49,11 @@ type ReviewPacket struct {
 	// artifacts.
 	Listing  string
 	Evidence string
+	// Progress is the mission's progress log, rendered so an operator
+	// steering note posted mid-mission reaches the reviewer too: a
+	// rework-triggering note ("skip the CSS polish") must not be invisible
+	// to the round deciding whether the unit passes.
+	Progress []ProgressNote
 }
 
 // ReadArtifacts reads each declared artifact from workRoot, capped at

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -170,6 +170,82 @@ type nativeRunner struct {
 	// turns (see SetConnectorReads) — nil-safe: unset means no connector
 	// reads are offered, same as before this existed.
 	connectorReads ConnectorReadsResolver
+
+	// progressReader reads back a mission's live progress log: backs
+	// mid-run steering note delivery (see steeringFor). nil-safe: unset
+	// means a worker turn's Steering func is never wired, matching
+	// today's behavior (a note only reaches the NEXT worker turn).
+	progressReader ProgressReader
+}
+
+// ProgressReader re-reads one mission's progress notes mid-run, the
+// minimal slice of *Store nativeRunner needs for steering, so runner.go
+// never depends on Store's full surface (query shape, transactions).
+type ProgressReader interface {
+	Progress(ctx context.Context, missionID string) ([]ProgressNote, error)
+}
+
+// SetProgressReader wires the reader RunWorker uses to poll for
+// mid-turn operator notes: a setter (not a NewNativeRunner parameter)
+// so cmd/brain/main.go can pass the same *Store it builds the runner
+// alongside, same pattern as SetConnectorReads.
+func (r *nativeRunner) SetProgressReader(pr ProgressReader) {
+	r.progressReader = pr
+}
+
+// operatorNotePrefix marks a progress note as operator-authored
+// steering (api/missions.go's note handler writes exactly this prefix);
+// steeringFor only ever redelivers notes carrying it.
+const operatorNotePrefix = "Operator note: "
+
+// D-076: steeringFor builds a worker turn's loop.Request.Steering
+// closure: the watermark starts at the count of operator notes already
+// present in the packet the worker was seeded with, so those never
+// redeliver; each poll re-reads the mission's live progress log, takes
+// operator notes past the watermark, and advances it by however many it
+// found. A poll error logs and returns nil rather than failing the
+// turn: steering is a best-effort mid-run nicety, not load-bearing.
+func (r *nativeRunner) steeringFor(missionID string, seeded []ProgressNote) func(ctx context.Context) []string {
+	if r.progressReader == nil {
+		return nil
+	}
+	watermark := countOperatorNotes(seeded)
+	return func(ctx context.Context) []string {
+		notes, err := r.progressReader.Progress(ctx, missionID)
+		if err != nil {
+			r.log.Warn("mission worker: poll steering notes failed", "mission_id", missionID, "error", err)
+			return nil
+		}
+		var operator []string
+		for _, n := range notes {
+			if strings.HasPrefix(n.Note, operatorNotePrefix) {
+				operator = append(operator, strings.TrimPrefix(n.Note, operatorNotePrefix))
+			}
+		}
+		if watermark >= len(operator) {
+			return nil
+		}
+		fresh := operator[watermark:]
+		watermark = len(operator)
+		out := make([]string, len(fresh))
+		for i, note := range fresh {
+			out[i] = "Operator steering note (mid-run): " + note
+		}
+		return out
+	}
+}
+
+// countOperatorNotes counts how many of notes are operator-authored
+// steering notes: the watermark's starting point, so a note already
+// rendered into the worker's seed packet is never redelivered mid-turn.
+func countOperatorNotes(notes []ProgressNote) int {
+	n := 0
+	for _, note := range notes {
+		if strings.HasPrefix(note.Note, operatorNotePrefix) {
+			n++
+		}
+	}
+	return n
 }
 
 // ConnectorReadsResolver resolves an agent id to the read-only
@@ -672,6 +748,9 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		// with feedback instead of parking (D-039). UI-created missions
 		// (ScheduleID empty) keep the park-and-answer flow.
 		Unattended: m.ScheduleID != "",
+		// Only the worker turn gets mid-run steering (D-076): explore/
+		// plan/review turns are unaffected.
+		Steering: r.steeringFor(m.ID, packet.Progress),
 	}
 
 	res, err := r.runTurn(ctx, req, missionStatusToolName)
@@ -972,6 +1051,16 @@ func renderReviewContent(p ReviewPacket) string {
 		b.WriteString("\nDiff to review:\n")
 		b.WriteString(p.Diff)
 		b.WriteString("\n")
+	}
+	if len(p.Progress) > 0 {
+		notes := p.Progress
+		if len(notes) > progressRenderCap {
+			notes = notes[len(notes)-progressRenderCap:]
+		}
+		b.WriteString("\nRecent progress (includes any operator steering notes):\n")
+		for _, n := range notes {
+			fmt.Fprintf(&b, "- %s\n", NeutralizeSlot(n.Note))
+		}
 	}
 	if p.Evidence != "" {
 		b.WriteString("\nWorker's own report (verify against the artifacts above, do not take at face value):\n")

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -1902,3 +1902,100 @@ func TestRunWorkerOffersKBSearchOnlyWhenMissionHasKnowledge(t *testing.T) {
 		}
 	})
 }
+
+// fakeProgressReader is a ProgressReader backed by an in-memory slice,
+// mutable between polls so tests can simulate a note posted mid-turn.
+type fakeProgressReader struct {
+	notes []ProgressNote
+}
+
+func (f *fakeProgressReader) Progress(_ context.Context, _ string) ([]ProgressNote, error) {
+	return f.notes, nil
+}
+
+// TestSteeringForSkipsNotesSeededInPacket pins the watermark's starting
+// point: operator notes already rendered into the worker's seed packet
+// (WorkPacket.Progress) must never be redelivered as mid-turn steering.
+func TestSteeringForSkipsNotesSeededInPacket(t *testing.T) {
+	seeded := []ProgressNote{{Note: "Operator note: already seen"}}
+	reader := &fakeProgressReader{notes: seeded}
+	r := &nativeRunner{log: slog.Default(), progressReader: reader}
+
+	steer := r.steeringFor("m1", seeded)
+	if steer == nil {
+		t.Fatal("steeringFor returned nil with a progressReader wired")
+	}
+	if got := steer(context.Background()); got != nil {
+		t.Fatalf("steering = %v, want nil (note already in the seed packet)", got)
+	}
+}
+
+// TestSteeringForDeliversNoteExactlyOnce pins the core contract: a note
+// appended to the store mid-turn is delivered on the next poll, and
+// never again on a later poll once the watermark has advanced.
+func TestSteeringForDeliversNoteExactlyOnce(t *testing.T) {
+	reader := &fakeProgressReader{}
+	r := &nativeRunner{log: slog.Default(), progressReader: reader}
+	steer := r.steeringFor("m1", nil)
+
+	if got := steer(context.Background()); got != nil {
+		t.Fatalf("steering before any note = %v, want nil", got)
+	}
+
+	reader.notes = append(reader.notes, ProgressNote{Note: "Operator note: hurry up"})
+	got := steer(context.Background())
+	if len(got) != 1 || got[0] != "Operator steering note (mid-run): hurry up" {
+		t.Fatalf("steering after note posted = %v, want one formatted note", got)
+	}
+
+	if got := steer(context.Background()); got != nil {
+		t.Fatalf("steering re-delivered the same note: %v", got)
+	}
+
+	reader.notes = append(reader.notes, ProgressNote{Note: "not an operator note"})
+	if got := steer(context.Background()); got != nil {
+		t.Fatalf("steering delivered a non-operator progress note: %v", got)
+	}
+}
+
+// TestSteeringForNilWithoutProgressReader pins that RunWorker's Steering
+// wiring degrades to a no-op when no ProgressReader was ever set
+// (SetProgressReader unwired): the pre-existing behavior everywhere
+// this feature isn't configured.
+func TestSteeringForNilWithoutProgressReader(t *testing.T) {
+	r := &nativeRunner{log: slog.Default()}
+	if steer := r.steeringFor("m1", nil); steer != nil {
+		t.Fatal("steeringFor should return nil with no progressReader wired")
+	}
+}
+
+// TestRunWorkerWiresSteeringFromProgressReader confirms RunWorker's
+// loop.Request actually carries a non-nil Steering func end-to-end when
+// a ProgressReader is wired, and that the request has none when it
+// isn't: the seam other packages (loop.Agent) rely on.
+func TestRunWorkerWiresSteeringFromProgressReader(t *testing.T) {
+	doneBatch := [][]stream.StreamEvent{{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ok"}`)}}
+
+	t.Run("wired", func(t *testing.T) {
+		agent := &scriptedAgent{batches: doneBatch}
+		r := newTestRunner(agent)
+		r.SetProgressReader(&fakeProgressReader{})
+		if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"}); err != nil {
+			t.Fatalf("RunWorker: %v", err)
+		}
+		if agent.requests[0].Steering == nil {
+			t.Fatal("Steering not wired on the worker request despite a ProgressReader")
+		}
+	})
+
+	t.Run("unwired", func(t *testing.T) {
+		agent := &scriptedAgent{batches: doneBatch}
+		r := newTestRunner(agent)
+		if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"}); err != nil {
+			t.Fatalf("RunWorker: %v", err)
+		}
+		if agent.requests[0].Steering != nil {
+			t.Fatal("Steering wired despite no ProgressReader")
+		}
+	})
+}

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -418,6 +418,26 @@ func (s *Store) AppendProgress(ctx context.Context, id, note string) error {
 	return tx.Commit(ctx)
 }
 
+// Progress reads back one mission's live progress log: a narrower
+// query than Get (just the progress column), used by nativeRunner's
+// mid-run steering poll (missions.ProgressReader) so an in-flight
+// worker turn can see an operator note posted after it started.
+func (s *Store) Progress(ctx context.Context, id string) ([]ProgressNote, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("missions progress: %w", err)
+	}
+	var raw []byte
+	if err := db.QueryRow(ctx, `SELECT progress FROM missions WHERE id = $1`, id).Scan(&raw); err != nil {
+		return nil, fmt.Errorf("missions progress: %w", err)
+	}
+	var notes []ProgressNote
+	if err := json.Unmarshal(raw, &notes); err != nil {
+		return nil, fmt.Errorf("missions progress: %w", err)
+	}
+	return notes, nil
+}
+
 // SetPendingPermission records a mission's turn parking on a tool-call
 // permission prompt (loop.PermBroker id plus the detail the UI needs
 // to render a real decision, not a bare "waiting" banner). Independent


### PR DESCRIPTION
## What

Mid-run steering-note injection (D-076). An operator note posted while a native worker turn is executing now reaches that same turn at the next tool-loop iteration boundary, instead of waiting for the next worker turn.

- `loop.Request` gains an optional `Steering func(ctx) []string`, polled once per model round after the first; returned strings are appended as user messages before the round's call. Nil for every existing caller, zero behavior change; the loop knows nothing about missions.
- `nativeRunner` wires it for worker turns only, via a watermark closure over operator-prefixed progress notes: notes already rendered into the seed packet never redeliver, each new note is delivered exactly once, poll errors log and never fail the turn.
- Reviewer gap fixed: `ReviewPacket` never saw progress notes, so the review turn was blind to operator steering. It now renders recent progress notes (capped, neutralized) after the diff section; delegated-worker missions get this too since their review goes through the native path.

## Why

Steering shipped in #196 but only landed on the NEXT worker turn; a long-running turn ignored notes entirely, and the reviewer never saw them at all.

## Tests

`go build`, `go vet`, `go test -race ./internal/brain/loop/... ./internal/brain/missions/...` pass. Loop tests for injection on the second model call and nil no-op; runner tests for watermark seeding, exactly-once delivery, nil without a reader, and RunWorker wiring. Canary run against the local stack before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790138336&installation_model_id=431401&pr_number=315&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F315&signature=7924e3a5a5f2d8ea3bf41218cbc8b23f4f02e8db6f4fbcbec89b102227b85f68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->