### PR TITLE
test: freeze clock in relativeTimeUntil specs

### DIFF
--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   compact,
   formatDuration,
@@ -126,6 +126,16 @@ describe('relativeTime', () => {
 })
 
 describe('relativeTimeUntil', () => {
+  // Freeze the clock: these offsets sit exactly on unit boundaries, and
+  // any real ms elapsing between the test's Date.now() and the
+  // function's floors the result into the unit below.
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('renders under a minute as "due now"', () => {
     expect(relativeTimeUntil(new Date(Date.now() + 10_000).toISOString())).toBe('due now')
   })


### PR DESCRIPTION
## What

The relativeTimeUntil specs use offsets that sit exactly on unit boundaries (2 days, 5 minutes, 3 hours). Any real milliseconds elapsing between the test's Date.now() and the function's floors the result into the unit below, which surfaced in CI as expected 'in 2d', got 'in 1d'. Fake timers freeze the clock for the block so both calls see the same instant.

## Tests

format.test.ts 28/28 green in the node:24 container.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790186230&installation_model_id=431401&pr_number=322&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F322&signature=9656a11781322cd205739f7d124fdb13864fd4cb04b18d36f5259e9814c1b315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->