### PR TITLE
feat: operator timezone setting and single-shot telegram delivery

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -202,7 +202,7 @@ func main() {
 	fxStore := fxrates.NewStore(app.DB)
 	go fxrates.NewFetcher(fxStore, settings.AllowedCurrencies(), app.Log).Run(ctx)
 
-	agent, broker, outputs, builtins, chatPerms, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, markitdownURL, packs, flags.SkillAllowed, mc.Add, app.Log, toolCalls, sensitiveRoute, fxStore)
+	agent, broker, outputs, builtins, chatPerms, buildErr := buildAgent(gwc, store, app.DB, workspace, searxngURL, markitdownURL, packs, flags.SkillAllowed, flags.Location, mc.Add, app.Log, toolCalls, sensitiveRoute, fxStore)
 	if buildErr != nil {
 		fmt.Fprintln(os.Stderr, buildErr)
 		os.Exit(1)
@@ -423,7 +423,7 @@ func main() {
 
 	svc := chat.New(turnRouter{agent: agent, gw: gwc, flags: flags}, store, distill,
 		gatedCompactor{inner: compactor, flags: flags}, budgetFn, packs, flags.SkillAllowed,
-		agentReg.Resolve, app.Log)
+		flags.Location, agentReg.Resolve, app.Log)
 	svc.SetAutoDispatch(agentReg.Enabled, chat.ClassifyOverGateway(gwc))
 	svc.SetSensitiveTools(sensitiveTools)
 	// TURN_TIMEOUT raises the detached-turn ceiling above the compiled
@@ -698,7 +698,7 @@ func buildDestinations(db *pgpool.Pool, conns *connectors.Manager, goog *connect
 	if secrets != nil {
 		telegram = &destinations.TelegramAdapter{ResolveToken: secrets.Resolve}
 	}
-	deliverer := destinations.NewDeliverer(store, missionStore, email, webhook, telegram, flags.WebBaseURL, log)
+	deliverer := destinations.NewDeliverer(store, missionStore, email, webhook, telegram, flags.WebBaseURL, flags.Location, log)
 	return store, deliverer
 }
 
@@ -894,6 +894,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 		nativeRunner.SetConnectorReads(missionConnectorReadsResolver(agentReg, conns))
 	}
 	nativeRunner.SetProgressReader(store)
+	nativeRunner.SetLocation(flags.Location)
 	// The delegated runner wraps native with D-051/D-052's CLI-executor
 	// dispatch — resolve a worker route's chain via the gateway, spawn a
 	// harness entry's CLI detached in the mission's own sandbox container,
@@ -914,6 +915,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	driver.SetCapacityGate(sandboxMgr)
 	driver.SetGitBranchPattern(flags.GitBranchPattern)
 	driver.SetGitCommitStyle(flags.GitCommitStyle)
+	driver.SetLocation(flags.Location)
 	resolveAgent := missionAgentResolver(agentReg)
 	driver.SetAgentResolver(resolveAgent)
 	driver.SetNameMission(chat.TitleOverGateway(gwc, log))
@@ -1009,6 +1011,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 		return err == nil
 	}
 	scheduler := missions.NewScheduler(db, store, resolveAgent, schedulerEnabled, routeForRole, routeExists, flags.CodingExecutor, nil, log)
+	scheduler.SetLocation(flags.Location)
 	go scheduler.Run(ctx)
 	return store, driver, notifier, workspace, hub, scheduler
 }
@@ -1271,10 +1274,10 @@ func (r turnRouter) RouteForRole(ctx context.Context, role string) (string, bool
 // buildAgent assembles the compiled-in tool registry and its guard
 // rails (D-009, D-010). The returned builtin set is the fixed half of
 // the tool surface; connector tools join it via swapAgentTools.
-func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, workspace, searxngURL, markitdownURL string, packs []skills.Skill, skillAllow func(context.Context, string) bool, remember builtin.RememberFunc, log *slog.Logger, toolCalls *prometheus.CounterVec, sensitiveRoute func(context.Context) string, fxStore *fxrates.Store) (*loop.Agent, *loop.PermBroker, *tools.Outputs, []*tools.Tool, *tools.Permissions, error) {
+func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, workspace, searxngURL, markitdownURL string, packs []skills.Skill, skillAllow func(context.Context, string) bool, defaultLoc func(context.Context) *time.Location, remember builtin.RememberFunc, log *slog.Logger, toolCalls *prometheus.CounterVec, sensitiveRoute func(context.Context) string, fxStore *fxrates.Store) (*loop.Agent, *loop.PermBroker, *tools.Outputs, []*tools.Tool, *tools.Permissions, error) {
 	outputs := tools.NewOutputs(db)
 	set := []*tools.Tool{
-		builtin.CurrentTime(time.Now),
+		builtin.CurrentTime(time.Now, defaultLoc),
 		builtin.ConvertTime(),
 		builtin.Calculator(),
 		builtin.WebFetch(builtin.WebFetchConfig{MarkitdownURL: markitdownURL}),

--- a/internal/brain/api/api_test.go
+++ b/internal/brain/api/api_test.go
@@ -282,7 +282,7 @@ func testAPI(t *testing.T, token string, events []stream.StreamEvent) (*API, *me
 	t.Helper()
 	dir := newMemDir()
 	gw := &fakeGateway{events: events}
-	svc := chat.New(gw, dir, nil, nil, staticBudget(60_000), nil, nil, nil, discard())
+	svc := chat.New(gw, dir, nil, nil, staticBudget(60_000), nil, nil, nil, nil, discard())
 	return &API{svc: svc, dir: dir, token: token, log: discard()}, dir, gw
 }
 
@@ -908,7 +908,7 @@ func TestChatErrorCarriesSessionID(t *testing.T) {
 	id, _ := dir.Create(t.Context(), "t")
 	// gateway with error
 	gw := &fakeGateway{err: context.DeadlineExceeded}
-	a.svc = chat.New(gw, dir, nil, nil, staticBudget(60_000), nil, nil, nil, discard())
+	a.svc = chat.New(gw, dir, nil, nil, staticBudget(60_000), nil, nil, nil, nil, discard())
 
 	w := doMux(a, http.MethodPost, "/v1/sessions/"+id+"/messages", `{"message":"hi"}`)
 	if w.Code != http.StatusBadGateway {

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -141,16 +141,17 @@ type Service struct {
 	classify       agents.Classify // nil: auto-dispatch falls back to default
 	budget         func(context.Context) int
 	packs          []skills.Skill
-	skillAllow     func(context.Context, string) bool // nil: all packs allowed
-	skillBodies    map[string]string                  // name -> full pack body, for skill_hint
-	flushEvery     time.Duration                      // pending-state flush cadence mid-stream
-	turnTimeout    time.Duration                      // detached-turn ceiling; defaults to the turnTimeout const, overridable in tests
-	sensitive      *session.SensitiveTools            // nil: no sensitive-tool route pin for side-calls
-	attachments    AttachmentStore                    // nil: attachments disabled (ATTACHMENTS_DIR unset)
-	markitdownURL  string                             // "": pdf attachments disabled (MARKITDOWN_URL unset)
-	markitdownHTTP *http.Client                       // shared client for the markitdown sidecar call
-	kbSearch       KBSearch                           // nil: kb_search never offered, regardless of agent config
-	kbRead         KBRead                             // nil: kb_read never offered, regardless of agent config
+	skillAllow     func(context.Context, string) bool   // nil: all packs allowed
+	location       func(context.Context) *time.Location // nil: date line renders in UTC
+	skillBodies    map[string]string                    // name -> full pack body, for skill_hint
+	flushEvery     time.Duration                        // pending-state flush cadence mid-stream
+	turnTimeout    time.Duration                        // detached-turn ceiling; defaults to the turnTimeout const, overridable in tests
+	sensitive      *session.SensitiveTools              // nil: no sensitive-tool route pin for side-calls
+	attachments    AttachmentStore                      // nil: attachments disabled (ATTACHMENTS_DIR unset)
+	markitdownURL  string                               // "": pdf attachments disabled (MARKITDOWN_URL unset)
+	markitdownHTTP *http.Client                         // shared client for the markitdown sidecar call
+	kbSearch       KBSearch                             // nil: kb_search never offered, regardless of agent config
+	kbRead         KBRead                               // nil: kb_read never offered, regardless of agent config
 	logger         *slog.Logger
 
 	grants Granter // nil: chat never seeds standing grants (today's behavior)
@@ -370,7 +371,7 @@ type AgentResolver func(ctx context.Context, name string) (agents.Agent, bool)
 // back to the default agent.
 type AgentCandidates func(ctx context.Context) []agents.Agent
 
-func New(gw Gateway, log SessionLog, distill Distill, compactor Compactor, budget func(context.Context) int, packs []skills.Skill, skillAllow func(context.Context, string) bool, resolver AgentResolver, logger *slog.Logger) *Service {
+func New(gw Gateway, log SessionLog, distill Distill, compactor Compactor, budget func(context.Context) int, packs []skills.Skill, skillAllow func(context.Context, string) bool, location func(context.Context) *time.Location, resolver AgentResolver, logger *slog.Logger) *Service {
 	logger.Info("chat service ready", "system_prompt_version", systemPromptVersion)
 	bodies := make(map[string]string, len(packs))
 	for _, p := range packs {
@@ -380,6 +381,7 @@ func New(gw Gateway, log SessionLog, distill Distill, compactor Compactor, budge
 		gw: gw, log: log, distill: distill, compactor: compactor, budget: budget,
 		packs:       packs,
 		skillAllow:  skillAllow,
+		location:    location,
 		agents:      resolver,
 		skillBodies: bodies,
 		flushEvery:  2 * time.Second, turnTimeout: turnTimeout, logger: logger,
@@ -1138,7 +1140,11 @@ func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, 
 	// (D-011 poisoning defense); the skill body is instructions the
 	// user explicitly selected, deterministically loaded rather than
 	// left to the model's load_skill judgment.
-	system := assembleSystem(skills.Index(s.allowedPacks(turnCtx, profile)), time.Now())
+	var loc *time.Location
+	if s.location != nil {
+		loc = s.location(turnCtx)
+	}
+	system := assembleSystem(skills.Index(s.allowedPacks(turnCtx, profile)), time.Now(), loc)
 	// The agent overlay is stable for a given agent, so it sits ahead
 	// of the per-turn tail and stays inside the cacheable prefix.
 	if profile.PromptOverlay != "" {

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -30,7 +30,6 @@ func staticBudget(n int) func(context.Context) int {
 	return func(context.Context) int { return n }
 }
 
-
 // fakeLog is an in-memory SessionLog.
 type fakeLog struct {
 	mu        sync.Mutex
@@ -208,7 +207,7 @@ func okEvents(text string) []stream.StreamEvent {
 }
 
 func newService(gw Gateway, log SessionLog) *Service {
-	return New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, discard())
+	return New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, nil, discard())
 }
 
 func drain(t *testing.T, ch <-chan stream.StreamEvent) []stream.StreamEvent {
@@ -853,7 +852,7 @@ func TestChatSkillHintInjectsBodyDeterministically(t *testing.T) {
 	}
 	s := New(gw, newFakeLog(), nil, nil, staticBudget(60_000), []skills.Skill{
 		{Name: "travel-planning", Description: "Use when planning a trip", Body: "Ask about dates, budget, destination."},
-	}, nil, resolver, discard())
+	}, nil, nil, resolver, discard())
 
 	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "Tokyo, 5 days", SkillHint: "travel-planning"})
 	if err != nil {
@@ -893,7 +892,7 @@ func TestKBToolsOfferedFromSessionKnowledgeAlone(t *testing.T) {
 	resolver := func(context.Context, string) (agents.Agent, bool) {
 		return agents.Agent{Memory: true}, true // empty Knowledge
 	}
-	s := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	s := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 	s.SetKBSearch(func(context.Context, string, []string, string, int) ([]builtin.KBSearchHit, error) {
 		return nil, nil
 	})
@@ -971,7 +970,7 @@ func TestKBToolsUnionDedupesAgentAndSessionCollections(t *testing.T) {
 	resolver := func(context.Context, string) (agents.Agent, bool) {
 		return agents.Agent{Memory: true, Knowledge: []string{"a"}}, true
 	}
-	s := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	s := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 
 	var gotCollections []string
 	s.SetKBSearch(func(_ context.Context, _ string, collections []string, _ string, _ int) ([]builtin.KBSearchHit, error) {
@@ -1004,7 +1003,7 @@ func TestKBToolsFallBackOnSessionKnowledgeLookupFailure(t *testing.T) {
 	resolver := func(context.Context, string) (agents.Agent, bool) {
 		return agents.Agent{Memory: true, Knowledge: []string{"docs"}}, true
 	}
-	s := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	s := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 	s.SetKBSearch(func(context.Context, string, []string, string, int) ([]builtin.KBSearchHit, error) {
 		return nil, nil
 	})
@@ -1062,7 +1061,7 @@ func TestChatSkillAllowlistGatesIndexAndHint(t *testing.T) {
 	resolver := func(context.Context, string) (agents.Agent, bool) {
 		return agents.Agent{Memory: true, Skills: []string{"allowed-skill", "blocked-skill"}}, true
 	}
-	s := New(gw, newFakeLog(), nil, nil, staticBudget(60_000), packs, allow, resolver, discard())
+	s := New(gw, newFakeLog(), nil, nil, staticBudget(60_000), packs, allow, nil, resolver, discard())
 
 	if _, _, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "hi", SkillHint: "blocked-skill"}); err == nil {
 		t.Fatal("skill_hint for a disallowed pack accepted")
@@ -1100,7 +1099,7 @@ func TestChatEmptySkillsAllowlistDeniesEveryPack(t *testing.T) {
 	resolver := func(context.Context, string) (agents.Agent, bool) {
 		return agents.Agent{Memory: true}, true // Skills left empty
 	}
-	s := New(gw, newFakeLog(), nil, nil, staticBudget(60_000), packs, nil, resolver, discard())
+	s := New(gw, newFakeLog(), nil, nil, staticBudget(60_000), packs, nil, nil, resolver, discard())
 
 	// skill_hint naming a pack the (empty) allowlist doesn't list must
 	// be refused, same as an unknown skill — a denied hint is never
@@ -1132,7 +1131,7 @@ func TestChatNonEmptySkillsAllowlistAdmitsOnlyListedPacks(t *testing.T) {
 	resolver := func(context.Context, string) (agents.Agent, bool) {
 		return agents.Agent{Memory: true, Skills: []string{"listed-skill"}}, true
 	}
-	s := New(gw, newFakeLog(), nil, nil, staticBudget(60_000), packs, nil, resolver, discard())
+	s := New(gw, newFakeLog(), nil, nil, staticBudget(60_000), packs, nil, nil, resolver, discard())
 
 	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "hi"})
 	if err != nil {
@@ -1205,7 +1204,7 @@ func TestChatEmptyToolsAllowlistStillOffersRetrieveOutput(t *testing.T) {
 	resolver := func(context.Context, string) (agents.Agent, bool) {
 		return agents.Agent{Memory: true}, true // Tools left empty
 	}
-	s := New(gw, newFakeLog(), nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	s := New(gw, newFakeLog(), nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 
 	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "hi"})
 	if err != nil {
@@ -1254,7 +1253,7 @@ func TestChatCompactsBeforeSend(t *testing.T) {
 	log := newFakeLog()
 	order := &orderCompactor{}
 	gw := &gwAfterCompact{fakeGW: &fakeGW{events: okEvents("hi")}, order: order}
-	svc := New(gw, log, nil, order, staticBudget(60_000), nil, nil, nil, discard())
+	svc := New(gw, log, nil, order, staticBudget(60_000), nil, nil, nil, nil, discard())
 
 	_, ch, err := svc.Chat(t.Context(), Request{Message: "hello"})
 	if err != nil {
@@ -1303,7 +1302,7 @@ func TestChatSendsCompactedContext(t *testing.T) {
 	}
 
 	gw := &fakeGW{events: okEvents("fresh reply")}
-	svc := New(gw, log, nil, &compactingLog{log: log}, staticBudget(60_000), nil, nil, nil, discard())
+	svc := New(gw, log, nil, &compactingLog{log: log}, staticBudget(60_000), nil, nil, nil, nil, discard())
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "new question"})
 	if err != nil {
@@ -1354,7 +1353,7 @@ func TestFollowUpSeesCompletedTurnWhileDistillRuns(t *testing.T) {
 		}
 		return &session.TurnMemory{KeyFindings: []string{"late residue"}}
 	}
-	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
+	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, nil, discard())
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "first question"})
 	if err != nil {
@@ -1416,7 +1415,7 @@ func TestMemoryExtractGetsUserTextAndResidue(t *testing.T) {
 	distill := func(context.Context, string, string, string) *session.TurnMemory {
 		return &session.TurnMemory{KeyFindings: []string{"user moved to Porto"}}
 	}
-	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
+	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, nil, discard())
 
 	type call struct {
 		sessionID string
@@ -1538,7 +1537,7 @@ func TestMemoryRetrieveEmptyLeavesSystemUntouched(t *testing.T) {
 	drain(t, ch)
 
 	got := chatRequest(t, gw).System
-	want := assembleSystem(skills.Index(svc.allowedPacks(t.Context(), agents.Agent{Memory: true})), time.Now())
+	want := assembleSystem(skills.Index(svc.allowedPacks(t.Context(), agents.Agent{Memory: true})), time.Now(), nil)
 	if got != want {
 		t.Fatalf("system modified on empty recall:\n%q\nvs\n%q", got, want)
 	}
@@ -1622,7 +1621,7 @@ func TestChatAutoDispatchesAgent(t *testing.T) {
 			return agents.Agent{}, false
 		}
 	}
-	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 	candidates := []agents.Agent{
 		{Name: "general", Description: "everyday tasks"},
 		{Name: "researcher", Description: "consults sources"},
@@ -1672,7 +1671,7 @@ func TestChatAutoWithoutDispatchWiredFallsBackToDefault(t *testing.T) {
 		}
 		return agents.Agent{}, false
 	}
-	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "hi", Agent: autoAgentName})
 	if err != nil {
@@ -1707,7 +1706,7 @@ func TestAgentProfileShapesTurn(t *testing.T) {
 			return agents.Agent{}, false
 		}
 	}
-	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 	recalled := false
 	svc.SetMemoryRetrieve(func(context.Context, string, string) string {
 		recalled = true
@@ -2373,7 +2372,7 @@ func TestChatSeedsApprovalAllowlistAsStandingGrant(t *testing.T) {
 		return agents.Agent{ID: "agent-1", Name: "scheduler", Memory: true,
 			ApprovalAllowlist: []string{"calendar_list_events"}}, true
 	}
-	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 	granter := &fakeGranter{}
 	svc.SetApprovalGrants(granter)
 
@@ -2400,7 +2399,7 @@ func TestChatWithoutAllowlistGrantsNothing(t *testing.T) {
 	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
 		return agents.Agent{ID: "agent-2", Name: "plain", Memory: true}, true
 	}
-	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 	granter := &fakeGranter{}
 	svc.SetApprovalGrants(granter)
 
@@ -2427,7 +2426,7 @@ func TestChatSeedsApprovalAllowlistOnceIdempotent(t *testing.T) {
 		return agents.Agent{ID: "agent-1", Name: "scheduler", Memory: true,
 			ApprovalAllowlist: []string{"calendar_list_events"}}, true
 	}
-	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 	granter := &fakeGranter{}
 	svc.SetApprovalGrants(granter)
 
@@ -2471,7 +2470,7 @@ func TestChatAgentSwitchGrantsNewAllowlist(t *testing.T) {
 			return agents.Agent{}, false
 		}
 	}
-	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 	granter := &fakeGranter{}
 	svc.SetApprovalGrants(granter)
 
@@ -2514,7 +2513,7 @@ func TestDistillUsesSensitiveRouteWhenTurnRanSensitiveTool(t *testing.T) {
 		got <- route
 		return nil
 	}
-	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
+	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, nil, discard())
 	svc.SetSensitiveTools(&session.SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize my inbox"})
@@ -2550,7 +2549,7 @@ func TestDistillUsesEmptyRouteWhenTurnDidNotRunSensitiveTool(t *testing.T) {
 		got <- route
 		return nil
 	}
-	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
+	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, nil, discard())
 	svc.SetSensitiveTools(&session.SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 
 	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "run a shell command"})
@@ -2718,7 +2717,7 @@ func TestPersistTurnPinsSideCallsWhenSessionPreviouslySensitive(t *testing.T) {
 		distillRoute <- route
 		return nil
 	}
-	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, discard())
+	svc := New(gw, log, distill, nil, staticBudget(60_000), nil, nil, nil, nil, discard())
 	svc.SetSensitiveTools(&session.SensitiveTools{ConnectorNames: func(context.Context) []string { return []string{"personal"} }, Route: func(context.Context) string { return "local" }})
 
 	extractRoute := make(chan string, 1)
@@ -3090,7 +3089,7 @@ func TestChatAutoDispatchFallsBackWhenClassifyErrors(t *testing.T) {
 			return agents.Agent{}, false
 		}
 	}
-	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, resolver, discard())
+	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 	candidates := []agents.Agent{
 		{Name: "general", Description: "everyday tasks"},
 		{Name: "researcher", Description: "consults sources"},

--- a/internal/brain/chat/systemprompt.go
+++ b/internal/brain/chat/systemprompt.go
@@ -32,9 +32,13 @@ const systemPromptClose = `Be concise; do not restate context or repeat the ques
 // data and mangles date-bounded tool calls (e.g. Gmail after:/before:
 // operators). Date only, no clock time: a timestamp would bust the
 // provider prompt cache's tail every single request, where a date
-// busts it once per day (D-018) — acceptable.
-func assembleSystem(skillsIndex string, now time.Time) string {
-	dateLine := "Today is " + now.UTC().Format("Monday, 2006-01-02") + " (UTC)."
+// busts it once per day (D-018), acceptable. loc is the operator's
+// configured timezone; nil renders in UTC.
+func assembleSystem(skillsIndex string, now time.Time, loc *time.Location) string {
+	if loc == nil {
+		loc = time.UTC
+	}
+	dateLine := "Today is " + now.In(loc).Format("Monday, 2006-01-02 (MST).")
 	if skillsIndex == "" {
 		return systemPrompt + "\n\n" + dateLine + "\n\n" + systemPromptClose
 	}

--- a/internal/brain/chat/systemprompt_test.go
+++ b/internal/brain/chat/systemprompt_test.go
@@ -9,7 +9,7 @@ import (
 func TestAssembleSystemDateLine(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, time.July, 28, 15, 4, 5, 0, time.UTC)
-	got := assembleSystem("", now)
+	got := assembleSystem("", now, nil)
 
 	want := "Today is Tuesday, 2026-07-28 (UTC)."
 	if !strings.Contains(got, want) {
@@ -20,15 +20,30 @@ func TestAssembleSystemDateLine(t *testing.T) {
 	}
 }
 
-func TestAssembleSystemDateLineNonUTCInputNormalized(t *testing.T) {
+func TestAssembleSystemDateLineNilLocationIsUTC(t *testing.T) {
 	t.Parallel()
 	loc := time.FixedZone("UTC-5", -5*60*60)
 	// 2026-07-28 23:30 UTC-5 == 2026-07-29 04:30 UTC.
 	now := time.Date(2026, time.July, 28, 23, 30, 0, 0, loc)
-	got := assembleSystem("", now)
+	got := assembleSystem("", now, nil)
 
 	if !strings.Contains(got, "Today is Wednesday, 2026-07-29 (UTC).") {
 		t.Fatalf("date line not normalized to UTC:\n%s", got)
+	}
+}
+
+func TestAssembleSystemDateLineOperatorLocation(t *testing.T) {
+	t.Parallel()
+	loc, err := time.LoadLocation("Europe/Amsterdam")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	// 2026-07-28 23:30 UTC == 2026-07-29 01:30 CEST.
+	now := time.Date(2026, time.July, 28, 23, 30, 0, 0, time.UTC)
+	got := assembleSystem("", now, loc)
+
+	if !strings.Contains(got, "Today is Wednesday, 2026-07-29 (CEST).") {
+		t.Fatalf("date line not rendered in operator location:\n%s", got)
 	}
 }
 
@@ -37,7 +52,7 @@ func TestAssembleSystemCloseStaysLast(t *testing.T) {
 	now := time.Date(2026, time.July, 28, 0, 0, 0, 0, time.UTC)
 
 	for _, skillsIndex := range []string{"", "# Skills\n\n- foo: does foo"} {
-		got := assembleSystem(skillsIndex, now)
+		got := assembleSystem(skillsIndex, now, nil)
 		if !strings.HasSuffix(got, systemPromptClose) {
 			t.Fatalf("close steer not last line (skillsIndex=%q):\n%s", skillsIndex, got)
 		}
@@ -47,8 +62,8 @@ func TestAssembleSystemCloseStaysLast(t *testing.T) {
 func TestAssembleSystemStablePrefixUnchangedByDate(t *testing.T) {
 	t.Parallel()
 	skillsIndex := "# Skills\n\n- foo: does foo"
-	day1 := assembleSystem(skillsIndex, time.Date(2026, time.July, 28, 0, 0, 0, 0, time.UTC))
-	day2 := assembleSystem(skillsIndex, time.Date(2026, time.July, 29, 0, 0, 0, 0, time.UTC))
+	day1 := assembleSystem(skillsIndex, time.Date(2026, time.July, 28, 0, 0, 0, 0, time.UTC), nil)
+	day2 := assembleSystem(skillsIndex, time.Date(2026, time.July, 29, 0, 0, 0, 0, time.UTC), nil)
 
 	prefix := systemPrompt + "\n\n" + skillsIndex
 	if !strings.HasPrefix(day1, prefix) || !strings.HasPrefix(day2, prefix) {

--- a/internal/brain/destinations/adapters.go
+++ b/internal/brain/destinations/adapters.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 )
@@ -13,6 +15,30 @@ import (
 // own webhookTimeout for the same reasoning (a slow/unreachable
 // receiver must never stall the caller).
 const webhookTimeout = 10 * time.Second
+
+// errMaybeDelivered means the request may have reached the provider: a
+// retry can duplicate an already-sent message. deliverOne (deliver.go)
+// stops its retry loop on this, unlike a dial/connection-setup failure
+// (nothing left the machine, safe to retry).
+var errMaybeDelivered = errors.New("delivery status unknown, request may have been received")
+
+// classifySendErr sorts one HTTP client Do() error into retry-safe or
+// errMaybeDelivered. A dial/connection-setup failure (DNS, refused,
+// no route) never reached the peer, so a retry cannot duplicate
+// anything. Everything else, a timeout, a canceled context, any other
+// transport error, may have reached the peer after the client gave up
+// waiting, so it wraps errMaybeDelivered.
+func classifySendErr(err error) error {
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr.Op == "dial" {
+		return err
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return err
+	}
+	return fmt.Errorf("%w: %w", errMaybeDelivered, err)
+}
 
 // Adapter delivers one rendered Payload to a destination's config.
 // credentialRef is the destination's stored credential_ref name (never
@@ -120,11 +146,14 @@ func (a *WebhookAdapter) Deliver(ctx context.Context, config json.RawMessage, _ 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("webhook adapter: post: %w", err)
+		return fmt.Errorf("webhook adapter: post: %w", classifySendErr(err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
-		return fmt.Errorf("webhook adapter: status %d", resp.StatusCode)
+		// A non-2xx response was definitely processed by the receiver; a
+		// retry cannot un-process it, and for a 5xx may cause a duplicate
+		// side effect, so this counts as maybe-delivered too.
+		return fmt.Errorf("webhook adapter: %w: status %d", errMaybeDelivered, resp.StatusCode)
 	}
 	return nil
 }

--- a/internal/brain/destinations/deliver.go
+++ b/internal/brain/destinations/deliver.go
@@ -3,6 +3,7 @@ package destinations
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -39,6 +40,7 @@ type Deliverer struct {
 	events   eventRecorder
 	adapters map[string]Adapter
 	webURL   func(ctx context.Context) string
+	location func(ctx context.Context) *time.Location
 	log      *slog.Logger
 }
 
@@ -49,8 +51,9 @@ type Deliverer struct {
 // leaves that kind unregistered in adapters — deliverOne's map lookup
 // then reports "no adapter for kind" rather than boxing a nil adapter
 // as a non-nil Adapter (which would panic on first field access
-// inside Deliver).
-func NewDeliverer(store destinationStore, events eventRecorder, email *EmailAdapter, webhook *WebhookAdapter, telegram *TelegramAdapter, webURL func(ctx context.Context) string, log *slog.Logger) *Deliverer {
+// inside Deliver). location follows the same fresh-read pattern as
+// webURL; nil (or a nil *time.Location it returns) defaults to UTC.
+func NewDeliverer(store destinationStore, events eventRecorder, email *EmailAdapter, webhook *WebhookAdapter, telegram *TelegramAdapter, webURL func(ctx context.Context) string, location func(ctx context.Context) *time.Location, log *slog.Logger) *Deliverer {
 	adapters := map[string]Adapter{"webhook": webhook}
 	if email != nil {
 		adapters["email"] = email
@@ -63,6 +66,7 @@ func NewDeliverer(store destinationStore, events eventRecorder, email *EmailAdap
 		events:   events,
 		adapters: adapters,
 		webURL:   webURL,
+		location: location,
 		log:      log,
 	}
 }
@@ -101,7 +105,13 @@ func (d *Deliverer) Deliver(ctx context.Context, m missions.Mission, destination
 	if d.webURL != nil {
 		webBaseURL = d.webURL(ctx)
 	}
-	payload := Render(m, webBaseURL, events)
+	loc := time.UTC
+	if d.location != nil {
+		if l := d.location(ctx); l != nil {
+			loc = l
+		}
+	}
+	payload := Render(m, webBaseURL, events, loc)
 
 	for _, id := range destinationIDs {
 		if already[id] {
@@ -146,6 +156,12 @@ func (d *Deliverer) deliverOne(ctx context.Context, missionID, destinationID str
 			return
 		}
 		d.log.Warn("destinations: delivery attempt failed", "mission_id", missionID, "destination_id", destinationID, "attempt", i+1, "error", lastErr)
+		if errors.Is(lastErr, errMaybeDelivered) {
+			// The request may have already reached the provider: retrying
+			// risks sending the same message twice, so stop here rather than
+			// continue the schedule.
+			break
+		}
 	}
 	d.recordOutcome(ctx, missionID, destinationID, dest.Name, false, lastErr.Error())
 }

--- a/internal/brain/destinations/deliver_test.go
+++ b/internal/brain/destinations/deliver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -75,6 +76,27 @@ func (f *fakeAdapter) callCount() int {
 	return f.calls
 }
 
+// maybeDeliveredAdapter always fails with errMaybeDelivered: the
+// "the request may have reached the provider" case deliverOne must
+// never retry.
+type maybeDeliveredAdapter struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (f *maybeDeliveredAdapter) Deliver(_ context.Context, _ json.RawMessage, _ string, _ Payload) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return fmt.Errorf("timeout: %w", errMaybeDelivered)
+}
+
+func (f *maybeDeliveredAdapter) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
 func withFastBackoff(t *testing.T) {
 	t.Helper()
 	orig := deliverBackoff
@@ -85,7 +107,7 @@ func withFastBackoff(t *testing.T) {
 func TestDeliverZeroDestinationsNoop(t *testing.T) {
 	destStore := &fakeDestStore{rows: map[string]Destination{}}
 	eventStore := &fakeEventStore{}
-	d := NewDeliverer(destStore, eventStore, nil, &WebhookAdapter{}, nil, nil, discardLog())
+	d := NewDeliverer(destStore, eventStore, nil, &WebhookAdapter{}, nil, nil, nil, discardLog())
 
 	d.Deliver(t.Context(), missions.Mission{ID: "m1"}, nil)
 
@@ -126,6 +148,29 @@ func TestDeliverRetryExhaustedThenFail(t *testing.T) {
 
 	if adapter.callCount() != 3 {
 		t.Fatalf("expected 3 attempts (1 + 2 retries), got %d", adapter.callCount())
+	}
+	if len(eventStore.events) != 1 || eventStore.events[0].Kind != eventDeliveryFailed {
+		t.Fatalf("expected one mission.delivery_failed event, got %+v", eventStore.events)
+	}
+}
+
+// TestDeliverStopsRetryingOnMaybeDelivered covers the fix: an error
+// wrapping errMaybeDelivered (the request may have already reached the
+// provider) must stop the retry loop after the first attempt, unlike a
+// plain failure which retries the full schedule.
+func TestDeliverStopsRetryingOnMaybeDelivered(t *testing.T) {
+	withFastBackoff(t)
+	adapter := &maybeDeliveredAdapter{}
+	destStore := &fakeDestStore{rows: map[string]Destination{
+		"d1": {ID: "d1", Name: "telegram-1", Kind: "telegram", Enabled: true, Config: json.RawMessage(`{"chat_id":"1"}`)},
+	}}
+	eventStore := &fakeEventStore{}
+	d := &Deliverer{store: destStore, events: eventStore, adapters: map[string]Adapter{"telegram": adapter}, log: discardLog()}
+
+	d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"d1"})
+
+	if adapter.callCount() != 1 {
+		t.Fatalf("expected exactly 1 attempt (no retry on errMaybeDelivered), got %d", adapter.callCount())
 	}
 	if len(eventStore.events) != 1 || eventStore.events[0].Kind != eventDeliveryFailed {
 		t.Fatalf("expected one mission.delivery_failed event, got %+v", eventStore.events)

--- a/internal/brain/destinations/render.go
+++ b/internal/brain/destinations/render.go
@@ -23,9 +23,10 @@ type Payload struct {
 	// of its mission-derived default when non-empty.
 	Subject string `json:"subject,omitempty"`
 	Body    string `json:"body"`
-	// CompletedAt is the mission's terminal-transition time, UTC. Zero
-	// for the ad-hoc deliver tool (no mission behind it) — adapters
-	// render nothing when zero, never a guessed "now".
+	// CompletedAt is the mission's terminal-transition time, in the
+	// operator's configured timezone (Render's loc argument). Zero for
+	// the ad-hoc deliver tool (no mission behind it): adapters render
+	// nothing when zero, never a guessed "now".
 	CompletedAt time.Time `json:"completed_at,omitempty"`
 	Links       []string  `json:"links"`
 	Files       []File    `json:"-"`
@@ -41,14 +42,14 @@ type Payload struct {
 // mission's generated output, not the goal/plan/review process digest.
 // missions.OutcomeDigest keeps serving memory extraction and follow-up
 // parent_context, both untouched by this. CompletedAt is the mission's
-// terminal-transition timestamp (UpdatedAt), UTC — never a guessed
-// local timezone, since destinations carry no per-mission timezone
-// setting. links is the mission detail URL (built from webBaseURL when
+// terminal-transition timestamp (UpdatedAt) converted into loc, the
+// operator's configured timezone (settings.Store.Location), UTC when
+// unset. links is the mission detail URL (built from webBaseURL when
 // non-empty) plus branch/PR URL when the mission has them.
 // Files/TextArtifacts/OversizeFiles come from the mission's declared
 // plan-unit artifacts, read from its workspace (resolveArtifactFiles) —
 // exactly what CheckArtifacts already verified exists.
-func Render(m missions.Mission, webBaseURL string, events []missions.Event) Payload {
+func Render(m missions.Mission, webBaseURL string, events []missions.Event, loc *time.Location) Payload {
 	name := m.Name
 	if name == "" {
 		name = m.Goal
@@ -76,7 +77,7 @@ func Render(m missions.Mission, webBaseURL string, events []missions.Event) Payl
 		Name:          name,
 		Goal:          m.Goal,
 		Body:          body,
-		CompletedAt:   m.UpdatedAt.UTC(),
+		CompletedAt:   m.UpdatedAt.In(loc),
 		Links:         links,
 		Files:         files,
 		TextArtifacts: texts,

--- a/internal/brain/destinations/render_test.go
+++ b/internal/brain/destinations/render_test.go
@@ -14,7 +14,7 @@ func TestRender(t *testing.T) {
 	m := missions.Mission{ID: "m1", Goal: "ship the thing", Name: "Ship it"}
 
 	t.Run("no web base url, no branch, no pr", func(t *testing.T) {
-		p := Render(m, "", nil)
+		p := Render(m, "", nil, time.UTC)
 		if p.MissionID != "m1" || p.Name != "Ship it" || p.Goal != "ship the thing" || p.Body != "Mission complete: Ship it" {
 			t.Fatalf("unexpected payload: %+v", p)
 		}
@@ -24,7 +24,7 @@ func TestRender(t *testing.T) {
 	})
 
 	t.Run("with web base url", func(t *testing.T) {
-		p := Render(m, "https://timothy.example.lan/", nil)
+		p := Render(m, "https://timothy.example.lan/", nil, time.UTC)
 		if len(p.Links) != 1 || p.Links[0] != "https://timothy.example.lan/missions/m1" {
 			t.Fatalf("unexpected links: %v", p.Links)
 		}
@@ -33,7 +33,7 @@ func TestRender(t *testing.T) {
 	t.Run("with branch", func(t *testing.T) {
 		coding := m
 		coding.Branch = "feat/ship-it"
-		p := Render(coding, "", nil)
+		p := Render(coding, "", nil, time.UTC)
 		if len(p.Links) != 1 || p.Links[0] != "branch: feat/ship-it" {
 			t.Fatalf("unexpected links: %v", p.Links)
 		}
@@ -42,7 +42,7 @@ func TestRender(t *testing.T) {
 	t.Run("with pr opened event", func(t *testing.T) {
 		payload, _ := json.Marshal(map[string]any{"url": "https://github.com/org/repo/pull/1", "number": 1})
 		events := []missions.Event{{Kind: "mission.pr_opened", Payload: payload}}
-		p := Render(m, "", events)
+		p := Render(m, "", events, time.UTC)
 		if len(p.Links) != 1 || p.Links[0] != "https://github.com/org/repo/pull/1" {
 			t.Fatalf("unexpected links: %v", p.Links)
 		}
@@ -53,7 +53,7 @@ func TestRender(t *testing.T) {
 		coding.Branch = "feat/ship-it"
 		payload, _ := json.Marshal(map[string]any{"url": "https://github.com/org/repo/pull/1"})
 		events := []missions.Event{{Kind: "mission.pr_opened", Payload: payload}}
-		p := Render(coding, "https://timothy.example.lan", events)
+		p := Render(coding, "https://timothy.example.lan", events, time.UTC)
 		want := []string{
 			"https://timothy.example.lan/missions/m1",
 			"branch: feat/ship-it",
@@ -72,7 +72,7 @@ func TestRender(t *testing.T) {
 	t.Run("falls back to goal when name empty", func(t *testing.T) {
 		noName := m
 		noName.Name = ""
-		p := Render(noName, "", nil)
+		p := Render(noName, "", nil, time.UTC)
 		if p.Name != "ship the thing" {
 			t.Fatalf("Name = %q, want fallback to goal", p.Name)
 		}
@@ -89,7 +89,7 @@ func TestRender(t *testing.T) {
 		withArtifact := m
 		withArtifact.Workspace = root
 		withArtifact.Spec = missions.Spec{Units: []missions.PlanUnit{{Artifacts: []string{"report.md"}}}}
-		p := Render(withArtifact, "", nil)
+		p := Render(withArtifact, "", nil, time.UTC)
 		if len(p.Files) != 0 {
 			t.Fatalf("expected report.md NOT attached as a file, got %+v", p.Files)
 		}
@@ -106,7 +106,7 @@ func TestRender(t *testing.T) {
 		withArtifact := m
 		withArtifact.Workspace = root
 		withArtifact.Spec = missions.Spec{Units: []missions.PlanUnit{{Artifacts: []string{"data.csv"}}}}
-		p := Render(withArtifact, "", nil)
+		p := Render(withArtifact, "", nil, time.UTC)
 		if len(p.TextArtifacts) != 0 {
 			t.Fatalf("expected data.csv NOT rendered inline, got %+v", p.TextArtifacts)
 		}
@@ -119,7 +119,7 @@ func TestRender(t *testing.T) {
 		light := m
 		light.Light = true
 		light.FinalOutput = "here is the complete deliverable"
-		p := Render(light, "", nil)
+		p := Render(light, "", nil, time.UTC)
 		if p.Body != "here is the complete deliverable" {
 			t.Fatalf("Body = %q, want the light mission's final output", p.Body)
 		}
@@ -128,7 +128,7 @@ func TestRender(t *testing.T) {
 	t.Run("light mission with no final output falls back to the completion line", func(t *testing.T) {
 		light := m
 		light.Light = true
-		p := Render(light, "", nil)
+		p := Render(light, "", nil, time.UTC)
 		if p.Body != "Mission complete: Ship it" {
 			t.Fatalf("Body = %q, want the completion-line fallback", p.Body)
 		}
@@ -141,12 +141,29 @@ func TestRender(t *testing.T) {
 			t.Fatalf("parse fixture time: %v", err)
 		}
 		withTime.UpdatedAt = parsed
-		p := Render(withTime, "", nil)
+		p := Render(withTime, "", nil, time.UTC)
 		if p.CompletedAt.IsZero() {
 			t.Fatal("CompletedAt is zero, want the mission's UpdatedAt")
 		}
 		if got, want := p.CompletedAt.UTC().Format("2006-01-02T15:04:05Z"), "2026-08-21T18:30:00Z"; got != want {
 			t.Fatalf("CompletedAt = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("CompletedAt converts into the given non-UTC location", func(t *testing.T) {
+		withTime := m
+		parsed, err := time.Parse(time.RFC3339, "2026-08-21T20:30:00Z")
+		if err != nil {
+			t.Fatalf("parse fixture time: %v", err)
+		}
+		withTime.UpdatedAt = parsed
+		loc, err := time.LoadLocation("Europe/Amsterdam")
+		if err != nil {
+			t.Fatalf("LoadLocation: %v", err)
+		}
+		p := Render(withTime, "", nil, loc)
+		if got, want := p.CompletedAt.Format("2006-01-02T15:04:05 MST"), "2026-08-21T22:30:00 CEST"; got != want {
+			t.Fatalf("CompletedAt = %q, want %q (converted into Europe/Amsterdam)", got, want)
 		}
 	})
 }

--- a/internal/brain/destinations/telegram.go
+++ b/internal/brain/destinations/telegram.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -13,8 +14,10 @@ import (
 )
 
 // telegramTimeout bounds one Telegram Bot API call — same reasoning as
-// webhookTimeout.
-const telegramTimeout = 10 * time.Second
+// webhookTimeout. 30s, not 10s: a slow path to api.telegram.org (seen
+// on the homelab VM) hit 10s AFTER Telegram had already accepted the
+// send, so every retry re-sent an already-delivered message.
+const telegramTimeout = 30 * time.Second
 
 // telegramMessageLimit is the Bot API's sendMessage text cap. A
 // message over this is truncated with a notice + mission link
@@ -145,7 +148,9 @@ const telegramCaptionLimit = 1024
 // renderTelegramCaption builds the bold title + completion date shown
 // above the first attached file — MarkdownV2, escaped. CompletedAt
 // zero (the ad-hoc deliver tool's payload, which never sets it) omits
-// the date line rather than guessing "now".
+// the date line rather than guessing "now"; otherwise it renders in
+// whatever location Render already converted it into, "MST" showing
+// that zone's abbreviation instead of a hardcoded "UTC".
 func renderTelegramCaption(p Payload) string {
 	var b strings.Builder
 	b.WriteString("*")
@@ -153,7 +158,7 @@ func renderTelegramCaption(p Payload) string {
 	b.WriteString("*")
 	if !p.CompletedAt.IsZero() {
 		b.WriteString("\n")
-		b.WriteString(escapeMarkdownV2(p.CompletedAt.Format("2 Jan 2006, 15:04 UTC")))
+		b.WriteString(escapeMarkdownV2(p.CompletedAt.Format("2 Jan 2006, 15:04 MST")))
 	}
 	full := b.String()
 	if len(full) <= telegramCaptionLimit {
@@ -271,31 +276,62 @@ func (a *TelegramAdapter) sendDocument(ctx context.Context, token, chatID string
 }
 
 // call POSTs one Bot API method and treats any non-2xx status or
-// {"ok": false} response body as failure.
+// {"ok": false} response body as failure. Every returned error is
+// redacted (redactToken) before it leaves this function: url embeds
+// the bot token, and a *url.Error from http.Client.Do carries the full
+// request URL verbatim, so an unredacted error would leak the token
+// into WARN logs.
 func (a *TelegramAdapter) call(ctx context.Context, token, method, contentType string, body io.Reader) error {
 	cctx, cancel := context.WithTimeout(ctx, telegramTimeout)
 	defer cancel()
 	url := a.apiBase() + "/bot" + token + "/" + method
 	req, err := http.NewRequestWithContext(cctx, http.MethodPost, url, body)
 	if err != nil {
-		return fmt.Errorf("request: %w", err)
+		return redactToken(fmt.Errorf("request: %w", err), token)
 	}
 	req.Header.Set("Content-Type", contentType)
 	resp, err := a.client().Do(req)
 	if err != nil {
-		return fmt.Errorf("post: %w", err)
+		return redactToken(fmt.Errorf("post: %w", classifySendErr(err)), token)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if resp.StatusCode >= 300 {
-		return fmt.Errorf("api status %d: %s", resp.StatusCode, string(data))
+		// A non-2xx response was definitely processed by Telegram; retrying
+		// a rejection is pointless and a 5xx may still have side effects.
+		return redactToken(fmt.Errorf("api status %d: %s: %w", resp.StatusCode, string(data), errMaybeDelivered), token)
 	}
 	var result struct {
 		OK          bool   `json:"ok"`
 		Description string `json:"description"`
 	}
 	if err := json.Unmarshal(data, &result); err == nil && !result.OK {
-		return fmt.Errorf("api error: %s", result.Description)
+		return redactToken(fmt.Errorf("api error: %s: %w", result.Description, errMaybeDelivered), token)
 	}
 	return nil
 }
+
+// redactToken rebuilds err with every occurrence of token in its
+// message replaced by "REDACTED". errors.Is(err, errMaybeDelivered)
+// still holds afterwards (wrapped via %w against the already-redacted
+// text, never re-appending the sentinel's own message) since deliver.go's
+// retry loop classifies on the returned error.
+func redactToken(err error, token string) error {
+	if err == nil || token == "" {
+		return err
+	}
+	msg := strings.ReplaceAll(err.Error(), token, "REDACTED")
+	if errors.Is(err, errMaybeDelivered) {
+		return fmt.Errorf("%w", redactedMaybeDelivered{msg})
+	}
+	return errors.New(msg)
+}
+
+// redactedMaybeDelivered carries a redacted message while still
+// satisfying errors.Is(err, errMaybeDelivered) via Unwrap, needed
+// because the original message (with the token already replaced) must
+// not be reconstructed by re-wrapping errMaybeDelivered's own text.
+type redactedMaybeDelivered struct{ msg string }
+
+func (e redactedMaybeDelivered) Error() string { return e.msg }
+func (e redactedMaybeDelivered) Unwrap() error { return errMaybeDelivered }

--- a/internal/brain/destinations/telegram_test.go
+++ b/internal/brain/destinations/telegram_test.go
@@ -360,3 +360,83 @@ func TestTelegramAdapterDeliverBadConfig(t *testing.T) {
 		t.Fatal("expected error for malformed config")
 	}
 }
+
+// TestTelegramAdapterDeliverNeverLeaksTokenOnTimeout covers the token
+// leak: call() builds its request URL with the raw token, and a
+// *url.Error from http.Client.Do embeds that URL verbatim. A server
+// that never responds forces a client timeout so Do returns exactly
+// that shape of error.
+func TestTelegramAdapterDeliverNeverLeaksTokenOnTimeout(t *testing.T) {
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+	}))
+	// Defers run LIFO: srv.Close() (declared second, runs first) would
+	// otherwise block forever waiting for the still-blocked handler, so
+	// close(block) must be declared AFTER srv.Close() to run BEFORE it.
+	defer srv.Close()
+	defer close(block)
+
+	const token = "123456:super-secret-bot-token"
+	a := &TelegramAdapter{
+		ResolveToken: fakeTokenResolver("TG_BOT_TOKEN", token),
+		APIBase:      srv.URL,
+		HTTP:         &http.Client{Timeout: 50 * time.Millisecond},
+	}
+	err := a.Deliver(t.Context(), json.RawMessage(`{"chat_id":"123"}`), "TG_BOT_TOKEN", Payload{Body: "hi"})
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("error leaks the bot token: %q", err.Error())
+	}
+	if !errors.Is(err, errMaybeDelivered) {
+		t.Fatalf("expected errMaybeDelivered for a client timeout, got %v", err)
+	}
+}
+
+// TestTelegramAdapterDeliverNeverLeaksTokenOn500 covers the same
+// redaction requirement on the non-2xx response path, and asserts the
+// response is treated as maybe-delivered (retrying a processed request
+// is pointless and a 5xx may still have side effects).
+func TestTelegramAdapterDeliverNeverLeaksTokenOn500(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	const token = "123456:super-secret-bot-token"
+	a := &TelegramAdapter{ResolveToken: fakeTokenResolver("TG_BOT_TOKEN", token), APIBase: srv.URL}
+	err := a.Deliver(t.Context(), json.RawMessage(`{"chat_id":"123"}`), "TG_BOT_TOKEN", Payload{Body: "hi"})
+	if err == nil {
+		t.Fatal("expected an error for a 500 response")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("error leaks the bot token: %q", err.Error())
+	}
+	if !errors.Is(err, errMaybeDelivered) {
+		t.Fatalf("expected errMaybeDelivered for a non-2xx response, got %v", err)
+	}
+}
+
+// TestTelegramAdapterDeliverDialFailureIsSafeToRetry covers the other
+// leg of classifySendErr: a connection that never got established
+// (dialing a closed port) must NOT be errMaybeDelivered, since nothing
+// left the machine and a retry cannot duplicate anything.
+func TestTelegramAdapterDeliverDialFailureIsSafeToRetry(t *testing.T) {
+	// A server that's immediately closed leaves its port refusing
+	// connections, forcing a dial failure rather than any response.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	closedURL := srv.URL
+	srv.Close()
+
+	a := &TelegramAdapter{ResolveToken: fakeTokenResolver("TG_BOT_TOKEN", "secret-token"), APIBase: closedURL}
+	err := a.Deliver(t.Context(), json.RawMessage(`{"chat_id":"123"}`), "TG_BOT_TOKEN", Payload{Body: "hi"})
+	if err == nil {
+		t.Fatal("expected an error dialing a closed port")
+	}
+	if errors.Is(err, errMaybeDelivered) {
+		t.Fatalf("expected a dial failure to be safe-to-retry, got errMaybeDelivered: %v", err)
+	}
+}

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -159,6 +159,11 @@ type Driver struct {
 	// to CommitMessage's own conventional-style default.
 	gitCommitStyle func(ctx context.Context) string
 
+	// location resolves the operator's configured timezone for the
+	// worker packet's exec-environment note and progress-note timestamps
+	// (see SetLocation), nil-safe: unset renders both in UTC.
+	location func(ctx context.Context) *time.Location
+
 	// completer runs a mission's recorded on_complete choice
 	// (push/push_pr) once it reaches phase=done (see SetCompleter,
 	// fireOnComplete) — nil-safe: unset (no connectors/secrets wired)
@@ -364,6 +369,13 @@ func (d *Driver) SetGitBranchPattern(get func(ctx context.Context) string) {
 // same reason SetGitBranchPattern is.
 func (d *Driver) SetGitCommitStyle(get func(ctx context.Context) string) {
 	d.gitCommitStyle = get
+}
+
+// SetLocation wires the operator timezone accessor used for worker
+// packet date/timestamp rendering, a setter for the same reason
+// SetGitCommitStyle is.
+func (d *Driver) SetLocation(loc func(ctx context.Context) *time.Location) {
+	d.location = loc
 }
 
 // SetCompleter wires the Completer the driver's auto-fire-on-done hook
@@ -1268,11 +1280,15 @@ func (d *Driver) packet(ctx context.Context, m Mission) (WorkPacket, error) {
 	if m.Worktree != "" {
 		gitLog, _ = gitLogSince(ctx, m.Worktree, m.BaseCommit)
 	}
+	var loc *time.Location
+	if d.location != nil {
+		loc = d.location(ctx)
+	}
 	p := WorkPacket{
 		Goal: m.Goal, Kind: m.Kind, Spec: m.Spec, Progress: m.Progress,
 		GitLog: gitLog, Iteration: m.Iteration, PromptOverlay: m.PromptOverlay,
-		ExecEnvironmentNote: execEnvironmentNote(), ParentContext: m.ParentContext, Attachments: m.Attachments,
-		Light: missionPolicyFor(m).skipsPlanning,
+		ExecEnvironmentNote: execEnvironmentNote(loc), ParentContext: m.ParentContext, Attachments: m.Attachments,
+		Light: missionPolicyFor(m).skipsPlanning, Location: loc,
 	}
 	if d.skillsIndex != nil && m.AgentID != "" {
 		p.SkillsIndex = d.skillsIndex(ctx, m.AgentID)

--- a/internal/brain/missions/packet.go
+++ b/internal/brain/missions/packet.go
@@ -3,6 +3,7 @@ package missions
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // gitLogCap bounds how much committed history a fresh worker sees —
@@ -58,6 +59,9 @@ type WorkPacket struct {
 	// Render uses lightSystemPreamble instead of nativeSystemPreamble,
 	// and Spec is always empty so the Plan block never renders.
 	Light bool
+	// Location is the operator's configured timezone, used to render
+	// progress-note timestamps; nil renders in UTC.
+	Location *time.Location
 }
 
 // toolDisciplineNote is the tool-loop stop-rule contract shared by the
@@ -141,6 +145,10 @@ func (p WorkPacket) render(preamble string) (system, user string) {
 	}
 
 	if len(p.Progress) > 0 {
+		loc := p.Location
+		if loc == nil {
+			loc = time.UTC
+		}
 		b.WriteString("Progress so far:\n")
 		notes := p.Progress
 		if len(notes) > progressRenderCap {
@@ -148,7 +156,7 @@ func (p WorkPacket) render(preamble string) (system, user string) {
 			notes = notes[len(notes)-progressRenderCap:]
 		}
 		for _, n := range notes {
-			fmt.Fprintf(&b, "- %s: %s\n", n.At.Format("2006-01-02 15:04"), NeutralizeSlot(n.Note))
+			fmt.Fprintf(&b, "- %s: %s\n", n.At.In(loc).Format("2006-01-02 15:04 MST"), NeutralizeSlot(n.Note))
 		}
 		b.WriteString("\n")
 	}

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -176,6 +176,10 @@ type nativeRunner struct {
 	// means a worker turn's Steering func is never wired, matching
 	// today's behavior (a note only reaches the NEXT worker turn).
 	progressReader ProgressReader
+
+	// location resolves the operator's configured timezone for the
+	// explore/plan prompts' date line; nil means UTC.
+	location func(ctx context.Context) *time.Location
 }
 
 // ProgressReader re-reads one mission's progress notes mid-run, the
@@ -191,6 +195,14 @@ type ProgressReader interface {
 // alongside, same pattern as SetConnectorReads.
 func (r *nativeRunner) SetProgressReader(pr ProgressReader) {
 	r.progressReader = pr
+}
+
+// SetLocation wires the operator timezone accessor used for the
+// explore/plan prompts' date line, same setter pattern as
+// SetProgressReader (cmd/brain/main.go holds the *settings.Store the
+// runner is built alongside).
+func (r *nativeRunner) SetLocation(loc func(ctx context.Context) *time.Location) {
+	r.location = loc
 }
 
 // operatorNotePrefix marks a progress note as operator-authored
@@ -850,7 +862,7 @@ func forcedRetryVerdict(reason string) WorkerVerdict {
 // so the ladder's last resort is the raw turn text rather than a forced
 // failure.
 func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, error) {
-	system := "You are exploring one mission before it is planned. Investigate the goal: explore the workspace with shell (read-only — do not create or modify files; the execute phase does the actual work), and use web search/fetch tools if available and relevant to the goal. If the goal is self-contained and needs no exploration, say so briefly. End your turn with exactly one explore_notes tool call whose findings field contains everything the planner needs: what exists, what's relevant, constraints, gotchas, unknowns." + toolDisciplineNote + execEnvironmentNote()
+	system := "You are exploring one mission before it is planned. Investigate the goal: explore the workspace with shell (read-only — do not create or modify files; the execute phase does the actual work), and use web search/fetch tools if available and relevant to the goal. If the goal is self-contained and needs no exploration, say so briefly. End your turn with exactly one explore_notes tool call whose findings field contains everything the planner needs: what exists, what's relevant, constraints, gotchas, unknowns." + toolDisciplineNote + r.execEnvironmentNote(ctx)
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if m.ParentContext != "" {
 		user += "\n\nPrevious mission outcome:\n" + NeutralizeSlot(m.ParentContext)
@@ -1078,7 +1090,7 @@ func renderReviewContent(p ReviewPacket) string {
 // stuck mission (5 straight "invalid plan JSON" failures, identical
 // each retry since nothing told the model what went wrong).
 func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes string) (Spec, error) {
-	system := "You are planning one mission. Break the goal into the SMALLEST ordered list of verifiable units that achieves it — one unit is correct for a simple goal; never pad the plan. Every unit must list at least one artifact — the workspace-relative file(s) the unit must produce (for a report-style goal, the report file itself is the artifact); the harness itself checks each exists and is non-empty, so name the real deliverables. verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory — it must be a real POSIX shell command (using binaries like grep, test, wc — NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Never use command substitution ($(...) or backticks) in verify_cmd — write the direct command instead; for a line-count check use awk, e.g. `awk 'END{exit NR<10}' report.md`, NEVER `test $(wc -l ...)`. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. End your turn with exactly one submit_plan tool call." + r.execEnvironmentNote()
+	system := "You are planning one mission. Break the goal into the SMALLEST ordered list of verifiable units that achieves it — one unit is correct for a simple goal; never pad the plan. Every unit must list at least one artifact — the workspace-relative file(s) the unit must produce (for a report-style goal, the report file itself is the artifact); the harness itself checks each exists and is non-empty, so name the real deliverables. verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory — it must be a real POSIX shell command (using binaries like grep, test, wc — NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Never use command substitution ($(...) or backticks) in verify_cmd — write the direct command instead; for a line-count check use awk, e.g. `awk 'END{exit NR<10}' report.md`, NEVER `test $(wc -l ...)`. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. End your turn with exactly one submit_plan tool call." + r.execEnvironmentNote(ctx)
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if exploreNotes != "" {
 		user += "\n\nExploration findings:\n" + NeutralizeSlot(exploreNotes)
@@ -1169,22 +1181,30 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 // there (the root cause of a real stuck mission: a plan's verify_cmd
 // assumed Python in an environment that had none). WorkPacket.Render
 // carries the same text to the worker via ExecEnvironmentNote.
-func (r *nativeRunner) execEnvironmentNote() string {
-	return execEnvironmentNote()
+func (r *nativeRunner) execEnvironmentNote(ctx context.Context) string {
+	var loc *time.Location
+	if r.location != nil {
+		loc = r.location(ctx)
+	}
+	return execEnvironmentNote(loc)
 }
 
 // execEnvironmentNote is the shared wording nativeRunner (planner
 // prompt) and Driver (worker packet) both need — kept as one function
 // so the two prompts never drift out of sync about what's actually
-// available.
-func execEnvironmentNote() string {
+// available. loc is the operator's configured timezone; nil renders
+// in UTC.
+func execEnvironmentNote(loc *time.Location) string {
+	if loc == nil {
+		loc = time.UTC
+	}
 	// The date line rides along so every mission prompt (explore, plan,
 	// worker) knows "today" — a model with no other way to know it
 	// anchors on training data or on dated examples in tool descriptions
 	// and mangles date-bounded calls (calendar windows, Gmail
 	// after:/before:). Date only, no clock time, for the same
 	// prompt-cache reason as chat's date line (D-018).
-	return " Commands run inside an isolated Linux container with python3, node, git, and standard POSIX/coreutils tools available; each mission gets its own container, state persists across your commands within the mission. Today is " + time.Now().UTC().Format("Monday, 2006-01-02") + " (UTC)."
+	return " Commands run inside an isolated Linux container with python3, node, git, and standard POSIX/coreutils tools available; each mission gets its own container, state persists across your commands within the mission. Today is " + time.Now().In(loc).Format("Monday, 2006-01-02 (MST).")
 }
 
 // parseSpec decodes the planner's reply strictly: fences stripped,

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -153,6 +153,13 @@ type Scheduler struct {
 	codingExecutorDefault func(context.Context) string
 	destinationEnabled    DestinationEnabled
 	log                   *slog.Logger
+
+	// location resolves the operator's configured timezone: cron
+	// expressions are evaluated in this zone (schedule.Next reads the
+	// wall-clock fields of the time it's given), UTC when unset or
+	// unwired. This is a deliberate behavior change from the prior
+	// always-UTC evaluation (see SetLocation).
+	location func(ctx context.Context) *time.Location
 }
 
 // NewScheduler wires the scheduler with the agent resolver
@@ -185,6 +192,13 @@ func NewScheduler(db *pgpool.Pool, missions *Store, resolve AgentResolver, enabl
 // buildMissions), same late-wiring shape as Driver.SetDestinationDeliver.
 func (s *Scheduler) SetDestinationEnabled(fn DestinationEnabled) {
 	s.destinationEnabled = fn
+}
+
+// SetLocation wires the operator timezone accessor cron expressions
+// are evaluated against, a setter for the same reason
+// SetDestinationEnabled is.
+func (s *Scheduler) SetLocation(loc func(ctx context.Context) *time.Location) {
+	s.location = loc
 }
 
 // Run ticks forever until ctx is done. Double-fire protection across
@@ -220,7 +234,11 @@ const (
 // last run, now, grace), decide fire/skip/backfill-skip. Kept separate
 // from tick's I/O so it's unit-testable without a Store. anchor is
 // lastRun if set, else the schedule's created-at equivalent — callers
-// pass whichever applies.
+// pass whichever applies. The cron expression fires in whatever
+// location anchor/now carry (schedule.Next reads their wall-clock
+// fields): fireOne converts both into the operator's configured
+// timezone before calling this, so cron fires in the operator
+// timezone, UTC when unset.
 func dueDecision(cronExpr string, anchor, now time.Time, grace time.Duration) (decision, error) {
 	schedule, err := cron.ParseStandard(cronExpr)
 	if err != nil {
@@ -305,7 +323,17 @@ func (s *Scheduler) fireOne(ctx context.Context, tx pgx.Tx, sc Schedule, now tim
 		anchor = *sc.LastRun
 	}
 
-	dec, err := dueDecision(sc.Cron, anchor, now, misfireGrace)
+	// Cron expressions are evaluated in the operator's configured
+	// timezone (UTC when unset), not the container's local time: only
+	// dueDecision's inputs change here, last_run/last_skipped_at below
+	// still store the original instant.
+	loc := time.UTC
+	if s.location != nil {
+		if l := s.location(ctx); l != nil {
+			loc = l
+		}
+	}
+	dec, err := dueDecision(sc.Cron, anchor.In(loc), now.In(loc), misfireGrace)
 	if err != nil {
 		return err
 	}

--- a/internal/brain/missions/scheduler_test.go
+++ b/internal/brain/missions/scheduler_test.go
@@ -90,6 +90,40 @@ func TestDueDecision(t *testing.T) {
 	}
 }
 
+// TestDueDecisionNonUTCLocation proves cron evaluates against whatever
+// location anchor/now carry, not the process's local time: "0 8 * * *"
+// fires at 08:00 Europe/Amsterdam, which is 06:00 UTC in August (CEST,
+// UTC+2), a caller (fireOne) that passed the raw UTC instants instead
+// would see the boundary two hours late.
+func TestDueDecisionNonUTCLocation(t *testing.T) {
+	loc, err := time.LoadLocation("Europe/Amsterdam")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	const dailyAt8 = "0 8 * * *"
+	anchor := time.Date(2026, 8, 1, 8, 0, 0, 0, loc)
+
+	// 06:00 UTC == 08:00 CEST: due.
+	now := time.Date(2026, 8, 2, 6, 0, 0, 0, time.UTC).In(loc)
+	got, err := dueDecision(dailyAt8, anchor, now, time.Hour)
+	if err != nil {
+		t.Fatalf("dueDecision: %v", err)
+	}
+	if got != decisionFire {
+		t.Fatalf("dueDecision = %v, want decisionFire (08:00 CEST boundary)", got)
+	}
+
+	// 06:00 UTC == 07:00 CEST-equivalent wall clock one hour early: not yet due.
+	early := time.Date(2026, 8, 2, 5, 0, 0, 0, time.UTC).In(loc)
+	got, err = dueDecision(dailyAt8, anchor, early, time.Hour)
+	if err != nil {
+		t.Fatalf("dueDecision: %v", err)
+	}
+	if got != decisionSkip {
+		t.Fatalf("dueDecision = %v, want decisionSkip (07:00 CEST, before boundary)", got)
+	}
+}
+
 func TestResolveTemplateDefaults(t *testing.T) {
 	t.Parallel()
 	budget := 5.0

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -76,6 +76,10 @@ const (
 	// in destination deliveries (destinations/render.go); "" omits the
 	// link entirely rather than guessing a LAN address.
 	ValueWebBaseURL = "web_base_url"
+	// ValueTimezone is the operator's IANA timezone name (e.g.
+	// "Europe/Amsterdam"), used to render delivery timestamps
+	// (destinations/render.go); "" defers to time.UTC.
+	ValueTimezone = "timezone"
 )
 
 var knownValueKeys = map[string]bool{
@@ -84,7 +88,7 @@ var knownValueKeys = map[string]bool{
 	ValueSensitiveToolRoute: true, ValueDefaultCurrency: true,
 	ValueCodingExecutor:   true,
 	ValueGitBranchPattern: true, ValueGitCommitStyle: true,
-	ValueWebBaseURL: true,
+	ValueWebBaseURL: true, ValueTimezone: true,
 }
 
 // allowedCurrencies is the flat, fixed list of ISO 4217 codes the
@@ -196,6 +200,22 @@ func (s *Store) GitCommitStyle(ctx context.Context) string {
 // mission link) when unset.
 func (s *Store) WebBaseURL(ctx context.Context) string {
 	return s.Value(ctx, ValueWebBaseURL)
+}
+
+// Location returns the operator's configured timezone, time.UTC when
+// unset or when the stored value fails to load (SetValue already
+// rejects a non-IANA value at write time, so a load failure here means
+// stale data, not a fresh mistake).
+func (s *Store) Location(ctx context.Context) *time.Location {
+	v := s.Value(ctx, ValueTimezone)
+	if v == "" {
+		return time.UTC
+	}
+	loc, err := time.LoadLocation(v)
+	if err != nil {
+		return time.UTC
+	}
+	return loc
 }
 
 // SkillAllowed reports whether the allowlist admits a pack name;
@@ -315,6 +335,11 @@ func (s *Store) SetValue(ctx context.Context, key, value string) error {
 	if key == ValueGitCommitStyle && value != "" {
 		if err := missions.ValidateCommitStyle(value); err != nil {
 			return fmt.Errorf("%s: %w", key, err)
+		}
+	}
+	if key == ValueTimezone && value != "" {
+		if _, err := time.LoadLocation(value); err != nil {
+			return fmt.Errorf("%s: unknown IANA timezone %q", key, value)
 		}
 	}
 	return s.write(ctx, key, s.Value(ctx, key), value)

--- a/internal/brain/settings/settings_integration_test.go
+++ b/internal/brain/settings/settings_integration_test.go
@@ -269,3 +269,34 @@ func TestGitStrategySettings(t *testing.T) {
 		t.Fatal("unknown commit style accepted")
 	}
 }
+
+// TestTimezoneSetting covers Location's fallback to UTC (unset, and a
+// stale/invalid stored value) and its use of the stored IANA name once
+// validated on write.
+func TestTimezoneSetting(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	if got := s.Location(ctx); got != time.UTC {
+		t.Fatalf("Location default = %v, want time.UTC", got)
+	}
+
+	if err := s.SetValue(ctx, ValueTimezone, "Not/AZone"); err == nil {
+		t.Fatal("unknown IANA timezone accepted")
+	}
+
+	if err := s.SetValue(ctx, ValueTimezone, "Europe/Amsterdam"); err != nil {
+		t.Fatalf("SetValue Europe/Amsterdam: %v", err)
+	}
+	loc := s.Location(ctx)
+	if loc == nil || loc.String() != "Europe/Amsterdam" {
+		t.Fatalf("Location after set = %v, want Europe/Amsterdam", loc)
+	}
+
+	if err := s.SetValue(ctx, ValueTimezone, ""); err != nil {
+		t.Fatalf("SetValue clear: %v", err)
+	}
+	if got := s.Location(ctx); got != time.UTC {
+		t.Fatalf("Location after clear = %v, want time.UTC", got)
+	}
+}

--- a/internal/brain/tools/builtin/time.go
+++ b/internal/brain/tools/builtin/time.go
@@ -18,11 +18,15 @@ import (
 // Clock returns the current time; injectable for tests.
 type Clock func() time.Time
 
+// LocationFunc returns the operator's configured timezone (UTC when
+// unset); injectable for tests. Matches settings.Store.Location.
+type LocationFunc func(context.Context) *time.Location
+
 type currentTimeArgs struct {
 	Timezone string `json:"timezone"`
 }
 
-func CurrentTime(now Clock) *tools.Tool {
+func CurrentTime(now Clock, defaultLoc LocationFunc) *tools.Tool {
 	return &tools.Tool{
 		Name: "current_time",
 		Description: `Returns the current date and time.
@@ -32,8 +36,9 @@ somewhere, day of week, or anything relative to the present.
 
 Arguments:
 - timezone (string, optional): IANA timezone name, e.g. "Africa/Nairobi",
-  "America/New_York", "UTC". Defaults to UTC. Abbreviations like "EST"
-  or offsets like "+03:00" are NOT accepted — use the IANA name.
+  "America/New_York", "UTC". Defaults to the configured operator
+  timezone, UTC when unset. Abbreviations like "EST" or offsets like
+  "+03:00" are NOT accepted, use the IANA name.
 
 Returns the time in RFC 3339 format plus a human-readable line with
 the weekday.
@@ -45,17 +50,22 @@ Example: {"timezone": "Asia/Dhaka"} →
 			"properties": {
 				"timezone": {
 					"type": "string",
-					"description": "IANA timezone name (e.g. Africa/Nairobi). Defaults to UTC."
+					"description": "IANA timezone name (e.g. Africa/Nairobi). Defaults to the configured operator timezone, UTC when unset."
 				}
 			},
 			"additionalProperties": false
 		}`),
-		Execute: func(_ context.Context, raw json.RawMessage) (string, error) {
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
 			var args currentTimeArgs
 			if err := json.Unmarshal(raw, &args); err != nil {
 				return "", fmt.Errorf("invalid arguments: %w", err)
 			}
 			loc := time.UTC
+			if defaultLoc != nil {
+				if l := defaultLoc(ctx); l != nil {
+					loc = l
+				}
+			}
 			if args.Timezone != "" {
 				l, err := time.LoadLocation(args.Timezone)
 				if err != nil {

--- a/internal/brain/tools/builtin/time_test.go
+++ b/internal/brain/tools/builtin/time_test.go
@@ -19,7 +19,7 @@ func fixedClock(t *testing.T, rfc3339 string) Clock {
 
 func TestCurrentTime(t *testing.T) {
 	t.Parallel()
-	tool := CurrentTime(fixedClock(t, "2026-07-11T03:15:00Z"))
+	tool := CurrentTime(fixedClock(t, "2026-07-11T03:15:00Z"), nil)
 
 	tests := []struct {
 		name    string
@@ -27,7 +27,7 @@ func TestCurrentTime(t *testing.T) {
 		want    string
 		wantErr string
 	}{
-		{name: "defaults to UTC", args: `{}`, want: "2026-07-11T03:15:00Z"},
+		{name: "defaults to UTC when no location func wired", args: `{}`, want: "2026-07-11T03:15:00Z"},
 		{name: "IANA zone", args: `{"timezone":"Asia/Dhaka"}`, want: "2026-07-11T09:15:00+06:00"},
 		{name: "weekday present", args: `{"timezone":"Asia/Dhaka"}`, want: "Saturday"},
 		{name: "unknown zone", args: `{"timezone":"EST5"}`, wantErr: "unknown timezone"},
@@ -49,6 +49,32 @@ func TestCurrentTime(t *testing.T) {
 				t.Fatalf("result %q does not contain %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestCurrentTimeDefaultsToOperatorLocation(t *testing.T) {
+	t.Parallel()
+	loc, err := time.LoadLocation("Asia/Dhaka")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+	tool := CurrentTime(fixedClock(t, "2026-07-11T03:15:00Z"), func(context.Context) *time.Location { return loc })
+
+	got, err := tool.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(got, "2026-07-11T09:15:00+06:00") {
+		t.Fatalf("result %q did not default to the wired operator location", got)
+	}
+
+	// An explicit timezone argument still overrides the default.
+	got, err = tool.Execute(context.Background(), json.RawMessage(`{"timezone":"UTC"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(got, "2026-07-11T03:15:00Z") {
+		t.Fatalf("explicit timezone argument was overridden by the default: %q", got)
 	}
 }
 

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -1,82 +1,60 @@
 ---
 name: deep-research
-description: Decomposes a complex research question into independent sub-questions, researches each in its own unit, then synthesizes a cited report. Use when a question needs multiple independent angles of investigation. Never use when a single search answers the question.
+description: Decomposes complex research questions into independent sub-questions, researches each in its own unit, then synthesizes a cited report. Use when a question requires multiple independent angles of investigation. Do not use when a single research path is sufficient to answer the question.
 ---
 
 # Deep research discipline
 
 ## Rules
 
-- Decompose the goal into 2-4 independent sub-questions during explore. A
-  sub-question is independent only if it can be researched without knowing
-  the answer to another one; questions that depend on each other's results
-  stay together in one unit, they do not get split for the sake of
-  splitting.
-- Scout each sub-question with 1-2 web_search calls before locking the plan:
-  confirm it is actually answerable and roughly how much material exists.
-  This is reconnaissance, not the research itself.
-- If a kb_search tool is available, search the knowledge base before the
-  web and cite kb sources by their kb:// ref.
-- One plan unit per sub-question. Each unit declares exactly one artifact,
-  `findings-<slug>.md`, created with write_file. Each findings file has:
-  the answer to that sub-question, key facts with an inline citation and
-  date on each, and a closing `## Sources` section listing only URLs
-  fetched or seen in that unit.
-- Close every findings file with `## Sources`: numbered list, one line
-  each, `1. [Title](URL)`. No dates or notes on that line. A source in the
-  list that the body never cites is not a citation.
-- Two independent sources for any fact the report will treat as a
-  decision-driving claim; one source is enough for background color.
-  Prefer the primary source (the vendor, the filing, the paper) over an
-  aggregator repeating it.
-- Label inference explicitly: "Inference: ..." for anything reasoned from
-  sources rather than stated by one. Never blur the line between the two.
-- Cite only URLs you fetched with web_fetch this unit. A search snippet
-  is a lead, not a source: fetch the page before citing it. The harness
-  checks cited URLs against ones actually retrieved and fails the unit on
-  a mismatch, so an invented or remembered URL is not a shortcut, it is a
-  failed unit.
-- Stop searching a sub-question once it has an answer backed by adequate
-  sources. If a query line goes nowhere, note the dead end in one line and
-  try a different angle, don't repeat the same query hoping for a
-  different result.
-- The final unit is synthesis only: read every findings-*.md file, do not
-  run new web_search calls. Write `report.md` with write_file: a section
-  per sub-question plus an overview, every claim citing a source drawn
-  from a findings file's Sources section, closing with one consolidated
-  `## Sources` list merged from all findings files.
-- Verify each research unit's artifact with a verify_cmd that greps the
-  findings file for a `## Sources` heading and at least one `https://`
-  URL. Verify the synthesis unit's verify_cmd checks report.md exists and
-  contains a `## Sources` heading.
-- Conflicting sources get reported as a conflict in both the findings file
-  and, if load-bearing, the report. Do not silently pick a side.
+- Determine whether the task genuinely requires multi-angle research. When multiple independent angles are required, decompose the goal into 2-4 independent sub-questions during explore. A sub-question is independent only if it can be researched without knowing the answer to another one; questions that depend on each other's results stay together in one unit.
+- Scout each sub-question with 1-2 web_search calls before locking the plan: confirm it is actually answerable and roughly how much material exists. This is reconnaissance, not the research itself.
+- If a kb_search tool is available, search the knowledge base before the web and cite kb sources by their kb:// ref.
+- Use one research unit per independent sub-question. Each unit declares exactly one artifact, `findings-<slug>.md`, created with write_file. Each findings file contains:
+  - the answer to that sub-question
+  - key supporting facts with inline citations
+  - relevant dates for time-sensitive facts
+  - a closing `## Sources` section listing only sources actually retrieved or seen in that unit
+- Close every findings file with `## Sources`: numbered list, one line each, `1. [Title](URL)`. Do not add dates or notes to those lines. A source listed there must be cited in the body.
+- For any decision-driving claim, seek two genuinely independent corroborating sources when practical. Syndicated copies, reposts, or sources clearly relying on the same underlying material do not count as independent. One authoritative source is sufficient for background information when additional corroboration would not materially improve confidence.
+- Prefer primary sources such as official documentation, vendor statements, filings, standards, or original papers over secondary sources repeating them.
+- Label reasoning explicitly as `Inference: ...` whenever it goes beyond what a source directly states. Never blur sourced facts and inference.
+- Cite only sources actually retrieved during the research unit. A search snippet is a lead, not evidence: retrieve the underlying page before citing it. Never invent, reconstruct, or rely on remembered URLs.
+- Stop researching a sub-question once it has an adequately supported answer. If a query goes nowhere, note the dead end briefly and try a materially different research angle rather than repeating the same query.
+- The final unit is synthesis only: read every `findings-*.md` file and do not perform new web research. Write `report.md` with an overview plus a section per sub-question, using claims supported by the findings files. If synthesis discovers a material evidence gap, return it to the appropriate research unit rather than silently filling it.
+- Close `report.md` with one consolidated `## Sources` list merged from the findings files. Every substantive factual claim in the report must be traceable to a cited source in those findings files; analytical conclusions should be clearly identified as inference when appropriate.
+- Verify each research unit's artifact with a verify_cmd that confirms the findings file exists, contains a `## Sources` heading, and contains at least one retrieved source URL. Verify the synthesis unit's verify_cmd confirms `report.md` exists and contains a `## Sources` heading.
+- Conflicting credible sources must be reported explicitly as a conflict in both the relevant findings file and, when load-bearing, the final report. Do not silently pick a side.
 
 ## Anti-rationalization
 
-| Excuse                                                          | Rebuttal                                                                                                                                |
-|-----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| "These sub-questions all touch the same topic, I'll merge them" | Same topic doesn't mean same unit; independence is about whether one needs the other's answer.                                          |
-| "The snippet already told me, no need to fetch the page"        | A snippet is a lead, not a source; fetch the page, confirm the claim, then cite it.                                                     |
-| "The synthesis can just re-search to fill a gap"                | Synthesis reads findings files only; a gap found at synthesis time means a findings unit was incomplete, not a license to search again. |
-| "One source is fine, this fact is obviously true"               | Obviousness is not verification; decision-driving claims still need two independent sources.                                            |
-| "Close enough to the URL I remember"                            | The harness matches cited URLs against fetched ones exactly; a remembered or reconstructed URL fails the unit.                          |
+| Excuse                                                                          | Rebuttal                                                                                                                  |
+|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| "These sub-questions all touch the same topic, I'll merge them"                 | Same topic does not mean same unit; independence is determined by whether one answer is required to research another.     |
+| "The snippet already told me, no need to fetch the page"                        | A snippet is a lead, not evidence; retrieve the source, confirm the claim, then cite it.                                  |
+| "The synthesis can just re-search to fill a gap"                                | Synthesis is evidence assembly, not new research. A material gap means the appropriate research unit is incomplete.       |
+| "One source is fine, this fact is obviously true"                               | Obviousness is not verification; decision-driving claims require independent corroboration when practical.                |
+| "These two articles count as independent sources"                               | Not if they merely repeat the same underlying source or reporting.                                                        |
+| "Close enough to the URL I remember"                                            | Cite only a source actually retrieved during the research unit; reconstructed or remembered URLs are not evidence.        |
+| "All the useful sources are from the same domain, so the research must be weak" | Domain diversity is not required when a source is authoritative and independence would not materially improve confidence. |
 
 ## Red flags: stop and re-check
 
-- A sub-question depends on another sub-question's answer but got its own
-  parallel unit anyway.
-- A findings file cites a URL that was never fetched with web_fetch in
-  that unit.
-- The synthesis unit is making a web_search or fetch call.
-- report.md contains a claim with no traceable source in any findings
-  file's Sources section.
-- Every source in a findings file's Sources list is the same domain.
+- A sub-question depends on another sub-question's answer but was split into its own parallel unit.
+- A research unit cites a URL that was never actually retrieved in that unit.
+- A search snippet is being cited as evidence without retrieving the underlying source.
+- The synthesis unit is making new web_search or fetch calls.
+- A material claim in `report.md` has no traceable source in the findings files.
+- A decision-driving claim relies on a single non-authoritative source when independent corroboration is reasonably available.
+- Two supposedly independent sources clearly derive from the same underlying material.
+- A conflict between credible sources is being silently resolved.
+- A research unit is repeating unsuccessful searches without changing the research angle.
 
 ## Evidence required
 
-- Each findings-<slug>.md: answer, cited facts with dates, `## Sources`
-  listing only URLs actually retrieved that unit.
-- report.md: every claim traceable to a findings file's Sources section,
-  closing with a consolidated `## Sources` list.
-- Conflicts between sources surfaced explicitly, never silently resolved.
+- Each `findings-<slug>.md` contains the answer, supporting cited facts, relevant dates for time-sensitive claims, and a `## Sources` section listing only sources actually retrieved in that unit.
+- Every cited source in a findings file is traceable to a source actually retrieved during that unit.
+- Decision-driving claims have independent corroboration when practical, with primary sources preferred.
+- `report.md` contains an overview, a section per research unit, and claims traceable to sources recorded in the findings files.
+- `report.md` closes with a consolidated `## Sources` list.
+- Conflicts between credible sources are surfaced explicitly rather than silently resolved.

--- a/skills/research-brief/SKILL.md
+++ b/skills/research-brief/SKILL.md
@@ -1,59 +1,55 @@
 ---
 name: research-brief
-description: Source-grounded research with verification and citations. Use when a question needs facts you must look up: current events, prices, specifications, laws, schedules, or any claim the user will act on.
+description: Source-grounded factual research with verification and citations. Use when a question requires current or externally verifiable facts and a single research path is sufficient. Use deep-research when multiple independent research angles are required.
 ---
 
 # Research brief discipline
 
 ## Rules
 
-- Retrieve before you write: every load-bearing claim needs a source you actually fetched this turn, not trained recall.
+- Retrieve before you write: every load-bearing factual claim must be supported by a source actually retrieved this turn, not by trained recall.
 - If a kb_search tool is available, search the knowledge base before the web and cite kb sources by their kb:// ref.
-- Two independent sources for any claim that drives a decision; one source for background color.
-- Record where each fact came from; a source mentioned only in the trailing list without ever being referenced in the body is not a citation, it is decoration.
-- Distinguish plainly between what a source states and what you infer from it; label inference as inference.
-- Prefer primary sources (the vendor's page, the law's text, the paper) over aggregators repeating them.
-- Note the date on every time-sensitive fact; an undated price or version number is a trap for the reader.
-- When sources conflict, report the conflict; do not silently pick one.
-- If retrieval fails or the fact cannot be found, say so; a stated gap beats a confident guess.
-- End with the answer to the actual question asked, not a survey of everything found.
-- Close every answer with a `## Sources` section: a numbered markdown
-  list, one fetched source per line, formatted exactly as
-  `1. [Title](URL)`. Nothing else on that line: no dates, no notes,
-  no extra prose. Every URL listed must be one you actually fetched or
-  searched this turn.
-- Write arithmetic in plain text or inline code, never LaTeX or math
-  notation (`\frac`, `\times`, `\text`, `$...$`); the interface does
-  not render it.
-- Before a tool call, write at most one short line saying what you are
-  checking, never the answer itself. The answer comes only after all
-  tool results are in.
-- State the final answer exactly once. Never repeat a sentence or
-  paragraph you already wrote this turn, and do not add an `## Answer`
-  heading.
-- When comparing a number against a limit or allowance, write the
-  comparison out explicitly (`184,320 < 400,000: under the limit`)
-  before concluding. When pricing usage that has a free allowance,
-  subtract the allowance first and price only the remainder.
+- Use two genuinely independent sources for any claim that drives a decision when practical. Syndicated copies, reposts, or sources relying on the same underlying material do not count as independent. One authoritative source is sufficient for background information when additional corroboration would not materially improve confidence.
+- Record where each important fact came from. A source mentioned only in the trailing list without being referenced in the body is not a citation.
+- Distinguish clearly between what a source states and what you infer from it. Label inference explicitly as `Inference: ...`.
+- Prefer primary sources such as official documentation, vendor pages, laws, filings, standards, and original papers over aggregators or secondary sources repeating them.
+- Include the relevant publication, effective, event, or access date for time-sensitive facts such as prices, versions, laws, schedules, and availability.
+- When credible sources conflict, report the conflict and explain the difference when possible. Do not silently choose one.
+- If retrieval fails or a fact cannot be verified, say so. A stated evidence gap is better than a confident guess.
+- Answer the actual question asked. Do not turn a focused research request into a broad survey unless the additional information materially helps answer it.
+- Close every answer with a `## Sources` section containing a numbered markdown list, one fetched source per line, formatted exactly as:
+  `1. [Title](URL)`
+  Nothing else on the line. Every listed URL must be a source actually retrieved this turn.
+- When comparing a value against a limit or allowance, explicitly show the comparison before stating the conclusion.
+- When pricing usage with a free allowance, subtract the allowance before calculating the billable remainder.
 
 ## Anti-rationalization
 
-| Excuse                                              | Rebuttal                                                             |
-|-----------------------------------------------------|----------------------------------------------------------------------|
-| "I already know this"                               | Knowledge has a training cutoff; the question is being asked now.    |
-| "One good source is enough"                         | Single sources are wrong often enough that decisions deserve two.    |
-| "Citing everything clutters the answer"             | An uncited actionable claim is a liability, not a courtesy.          |
-| "The aggregator summarizes the primary source fine" | Aggregators introduce errors and lag; the primary is one fetch away. |
+| Excuse                                                     | Rebuttal                                                                                                               |
+|------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| "I already know this"                                      | The question requires current or externally verifiable information; use retrieved evidence rather than trained recall. |
+| "One good source is enough"                                | Decision-driving claims deserve independent corroboration when practical.                                              |
+| "Citing everything clutters the answer"                    | Important actionable claims need traceable evidence.                                                                   |
+| "The aggregator summarizes the primary source fine"        | Prefer the primary source when it is available and materially relevant.                                                |
+| "Two articles say the same thing, so they are independent" | Not if they rely on the same underlying source or report.                                                              |
+| "The source could not be fetched, but I know the URL"      | An unverified or remembered URL is not evidence.                                                                       |
+| "I can infer the missing value"                            | Label an inference explicitly; never present an unsupported inference as a sourced fact.                               |
 
 ## Red flags: stop and re-check
 
-- You are writing a number, date, or name you did not see in a fetched source this turn.
-- Every citation points at the same domain.
-- The answer contradicts something a source said and you haven't explained why.
-- You are about to answer without having made a single retrieval call.
+- You are writing a material number, date, name, price, version, or legal claim that you did not verify from a retrieved source this turn.
+- A decision-driving claim has only one weak or non-independent source despite reasonable corroboration being available.
+- All citations come from the same domain even though the claim requires independent corroboration.
+- The answer contradicts a retrieved source without explaining the discrepancy.
+- You are about to answer without making the required retrieval call.
+- A source is being cited because a search snippet mentioned it, but the underlying source was never retrieved.
+- A retrieved source is being presented as authoritative when it is actually an aggregator or secondary copy of a more authoritative source.
 
 ## Evidence required
 
-- Each key claim traceable to a fetched source (URL and access date).
-- Conflicts between sources surfaced explicitly.
-- "I'm confident" is not evidence; a quote from the source is.
+- Every important factual claim is traceable to a source retrieved this turn.
+- Time-sensitive claims include the relevant date.
+- Decision-driving claims have independent corroboration when practical.
+- Conflicts between credible sources are surfaced explicitly.
+- Inferences are clearly distinguished from sourced facts.
+- `## Sources` contains only sources actually retrieved this turn.

--- a/web/src/components/icons/TelegramIcon.tsx
+++ b/web/src/components/icons/TelegramIcon.tsx
@@ -1,0 +1,13 @@
+// TelegramIcon renders Telegram's official circular paper-plane
+// logomark via currentColor. Inline SVG only: CSP forbids fetching an
+// external asset. Path is the standard 24x24 logomark geometry.
+export function TelegramIcon({ className = 'size-3.5' }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={`${className} shrink-0`} aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"
+      />
+    </svg>
+  )
+}

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -1020,7 +1020,7 @@ export function MissionForm({
                       value={expiresAtToTime(expiresAt)}
                       onChange={(e) => pickExpiresTime(e.target.value)}
                       disabled={!expiresAt}
-                      className="flex-1"
+                      className="h-8.5 flex-1"
                     />
                     <Button variant="outline" size="sm" onClick={() => setExpiresAt('')}>
                       Clear

--- a/web/src/components/settings/CredentialRefPicker.tsx
+++ b/web/src/components/settings/CredentialRefPicker.tsx
@@ -28,9 +28,14 @@ function managedRoleSuffix(ref: SecretRefEntry): string | null {
 export function CredentialModeToggle({
   mode,
   onChange,
+  labels,
 }: {
   mode: CredentialMode
   onChange: (mode: CredentialMode) => void
+  // labels override the segment text where "New credential" would
+  // mislead (e.g. rotating a token writes the current ref's value,
+  // it never creates a credential).
+  labels?: { new: string; existing: string }
 }) {
   return (
     <div className="inline-flex rounded-lg border border-border p-0.5 text-sm">
@@ -43,7 +48,7 @@ export function CredentialModeToggle({
             mode === m ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'
           }`}
         >
-          {m === 'new' ? 'New credential' : 'Use existing'}
+          {m === 'new' ? (labels?.new ?? 'New credential') : (labels?.existing ?? 'Use existing')}
         </button>
       ))}
     </div>

--- a/web/src/components/settings/DestinationEdit.tsx
+++ b/web/src/components/settings/DestinationEdit.tsx
@@ -266,19 +266,31 @@ export function DestinationEdit() {
           <div className="space-y-3 rounded-xl border border-border p-4">
             <div className="flex items-center justify-between">
               <span className="text-sm font-medium text-foreground">Rotate bot token</span>
-              <CredentialModeToggle mode={botTokenMode} onChange={setBotTokenMode} />
+              <CredentialModeToggle
+                mode={botTokenMode}
+                onChange={(m) => {
+                  setBotTokenMode(m)
+                  if (m === 'existing' && !existingBotTokenRef) setExistingBotTokenRef(destination.credential_ref)
+                }}
+                labels={{ new: 'New token', existing: 'Different credential' }}
+              />
             </div>
             {botTokenMode === 'existing' ? (
               <Field label="Existing credential">
                 <ExistingCredentialSelect value={existingBotTokenRef} onChange={setExistingBotTokenRef} />
               </Field>
             ) : (
-              <Input
-                value={botToken}
-                onChange={(e) => setBotToken(e.target.value)}
-                placeholder="123456:ABC-DEF..."
-                className="h-10"
-              />
+              <div className="space-y-1.5">
+                <Input
+                  value={botToken}
+                  onChange={(e) => setBotToken(e.target.value)}
+                  placeholder="123456:ABC-DEF..."
+                  className="h-10"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Replaces the stored value of {destination.credential_ref}.
+                </p>
+              </div>
             )}
             <Button
               size="sm"

--- a/web/src/components/settings/DestinationsList.tsx
+++ b/web/src/components/settings/DestinationsList.tsx
@@ -1,5 +1,6 @@
-import { Mail01Icon, GlobalIcon, TelegramIcon } from '@hugeicons-pro/core-stroke-rounded'
+import { Mail01Icon, GlobalIcon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
+import { TelegramIcon } from '@/components/icons/TelegramIcon'
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
@@ -16,7 +17,7 @@ import {
 import { Toggle } from './shared'
 import { errText } from './util'
 
-const kindIcon = { email: Mail01Icon, webhook: GlobalIcon, telegram: TelegramIcon } as const
+const kindIcon = { email: Mail01Icon, webhook: GlobalIcon } as const
 
 export function DestinationsList() {
   const [destinations, setDestinations] = useState<Destination[]>([])
@@ -93,7 +94,7 @@ export function DestinationsList() {
             onClick={() => navigate('/settings/destinations/new/telegram')}
             className="flex items-center gap-3 rounded-xl border border-dashed border-border p-4 text-left transition hover:border-brand hover:bg-muted/50"
           >
-            <HugeiconsIcon icon={TelegramIcon} className="size-9" />
+            <TelegramIcon className="size-9" />
             <span className="min-w-0">
               <span className="block text-sm font-semibold">Telegram</span>
               <span className="block truncate text-sm text-muted-foreground">
@@ -153,7 +154,11 @@ function DestinationCard({
   return (
     <div className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 shadow-sm transition hover:shadow-md">
       <div className="flex items-center gap-3">
-        <HugeiconsIcon icon={kindIcon[destination.kind]} className="size-9" />
+        {destination.kind === 'telegram' ? (
+          <TelegramIcon className="size-9" />
+        ) : (
+          <HugeiconsIcon icon={kindIcon[destination.kind]} className="size-9" />
+        )}
         <div className="min-w-0 flex-1">
           <div className="truncate text-sm font-semibold">{destination.name}</div>
           <div className="text-xs text-muted-foreground uppercase">{destination.kind}</div>

--- a/web/src/components/settings/FeaturesTab.tsx
+++ b/web/src/components/settings/FeaturesTab.tsx
@@ -1,13 +1,42 @@
 import { useCallback, useEffect, useState } from 'react'
+import { ChevronDownIcon } from 'lucide-react'
 import { getSettings, listRoutes, patchSettings, patchSettingValues } from '../../api/client'
 import type { AdminRoute } from '../../api/types'
 import { CURRENCIES } from '../../lib/currencies'
 import { getNotificationSoundEnabled, setNotificationSoundEnabled } from '../../lib/sound'
 import { Button } from '../ui/button'
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '../ui/command'
 import { Input } from '../ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { ErrorBanner, Toggle } from './shared'
 import { errText } from './util'
+
+// FALLBACK_TIMEZONES stands in for Intl.supportedValuesOf('timeZone')
+// when that API is unavailable (older test environments): a short,
+// common list, not an attempt to cover every IANA zone.
+const FALLBACK_TIMEZONES = [
+  'UTC',
+  'Europe/Amsterdam',
+  'Europe/London',
+  'Europe/Berlin',
+  'America/New_York',
+  'America/Los_Angeles',
+  'America/Chicago',
+  'Asia/Kolkata',
+  'Asia/Dhaka',
+  'Asia/Tokyo',
+  'Asia/Shanghai',
+  'Australia/Sydney',
+]
+
+function listTimezones(): string[] {
+  try {
+    return Intl.supportedValuesOf('timeZone')
+  } catch {
+    return FALLBACK_TIMEZONES
+  }
+}
 
 const featureCopy: Record<string, { label: string; description: string }> = {
   tools_enabled: {
@@ -69,6 +98,7 @@ export function FeaturesTab() {
         </div>
       ))}
       {values && <SensitiveRouteCard values={values} onError={setError} onSaved={refresh} />}
+      {values && <TimezoneCard values={values} onError={setError} onSaved={refresh} />}
       {values && <DefaultCurrencyCard values={values} onError={setError} onSaved={refresh} />}
       {values && <DefaultCodingExecutorCard values={values} onError={setError} onSaved={refresh} />}
       {values && <GitBranchPatternCard values={values} onError={setError} onSaved={refresh} />}
@@ -260,7 +290,7 @@ function GitBranchPatternCard({
             value={pattern}
             onChange={(e) => setPattern(e.target.value)}
             placeholder="{type}/{slug}"
-            className="w-72"
+            className="h-10 w-72"
             aria-label="Default branch pattern"
           />
         </label>
@@ -398,7 +428,7 @@ function SensitiveRouteCard({
               value={route}
               onChange={(e) => setRoute(e.target.value)}
               placeholder="empty = off"
-              className="w-56"
+              className="h-10 w-56"
               aria-label="Sensitive tool route"
             />
           </label>
@@ -415,3 +445,95 @@ function SensitiveRouteCard({
   )
 }
 
+// TimezoneCard picks the IANA timezone destination deliveries (email,
+// telegram) render completion timestamps in: mirrors KnowledgePicker's
+// combobox-with-typeahead shape (Command + Popover), single-select
+// instead of multi. Empty means UTC (settings.Store.Location's
+// fallback).
+function TimezoneCard({
+  values,
+  onError,
+  onSaved,
+}: {
+  values: Record<string, string>
+  onError: (msg: string) => void
+  onSaved: () => void
+}) {
+  const [timezone, setTimezone] = useState(values.timezone ?? '')
+  const [saved, setSaved] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [zones] = useState(listTimezones)
+
+  const save = (next: string) => {
+    setSaved(false)
+    patchSettingValues({ timezone: next })
+      .then(() => {
+        setSaved(true)
+        onSaved()
+      })
+      .catch((err: unknown) => onError(errText(err)))
+  }
+
+  const choose = (zone: string) => {
+    setTimezone(zone)
+    setOpen(false)
+    save(zone)
+  }
+
+  return (
+    <div className="rounded-xl border border-border p-4">
+      <div className="text-sm font-medium">Timezone</div>
+      <div className="mt-3 flex flex-wrap items-end gap-3">
+        <div className="grid gap-1 text-xs text-muted-foreground">
+          <span>Zone</span>
+          <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                role="combobox"
+                aria-expanded={open}
+                aria-label="Timezone"
+                className="h-10 w-56 justify-between font-normal"
+              >
+                <span className="truncate text-left">{timezone || 'UTC (default)'}</span>
+                <ChevronDownIcon className="size-4 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-[min(92vw,20rem)] p-0" align="start">
+              <Command>
+                <CommandInput placeholder="Search timezones…" />
+                <CommandList>
+                  <CommandEmpty>No timezone matches.</CommandEmpty>
+                  <CommandGroup>
+                    <CommandItem
+                      value="UTC (default)"
+                      data-checked={timezone === '' || undefined}
+                      onSelect={() => choose('')}
+                    >
+                      UTC (default)
+                    </CommandItem>
+                    {zones.map((z) => (
+                      <CommandItem
+                        key={z}
+                        value={z}
+                        data-checked={timezone === z || undefined}
+                        onSelect={() => choose(z)}
+                      >
+                        {z}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+        </div>
+        {saved && <span className="text-xs text-muted-foreground">Saved.</span>}
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Dates and times everywhere follow this timezone: delivery timestamps, schedule cron
+        times, and the current date shown to models. Empty defaults to UTC.
+      </p>
+    </div>
+  )
+}

--- a/web/src/components/settings/RoutesList.tsx
+++ b/web/src/components/settings/RoutesList.tsx
@@ -126,14 +126,14 @@ export function RoutesList() {
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
                 placeholder="my-route"
-                className="w-40"
+                className="h-10 w-40"
                 aria-label="New route name"
               />
             </label>
             <label className="grid gap-1 text-xs text-muted-foreground">
               Capability
               <Select value={newCapability} onValueChange={setNewCapability}>
-                <SelectTrigger className="h-9 w-32" aria-label="New route capability">
+                <SelectTrigger className="h-10 w-32" aria-label="New route capability">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/web/src/pages/Memory.tsx
+++ b/web/src/pages/Memory.tsx
@@ -202,13 +202,14 @@ function Browser() {
 
   return (
     <div className="space-y-6">
-      <div className="flex gap-2">
+      <div className="flex items-center gap-2">
         <Input
           placeholder="Search memories…"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && search()}
           data-testid="memory-search"
+          className="h-10"
         />
         <Button onClick={search} disabled={busy}>
           Search
@@ -272,16 +273,17 @@ function Browser() {
 
       <div className="space-y-2">
         <h3 className="text-sm font-medium text-muted-foreground">Remember something</h3>
-        <div className="flex gap-2">
+        <div className="flex items-center gap-2">
           <Input
             placeholder="Timothy, remember…"
             value={newFact}
             onChange={(e) => setNewFact(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && add()}
             data-testid="manual-add"
+            className="h-10"
           />
           <Select value={newType} onValueChange={setNewType}>
-            <SelectTrigger className="w-36">
+            <SelectTrigger className="h-10 w-36">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -170,6 +170,59 @@ describe('Features tab sensitive tool route', () => {
   })
 })
 
+describe('Features tab timezone', () => {
+  beforeEach(() => {
+    vi.mocked(getSettings).mockResolvedValue({
+      settings: { tools_enabled: true },
+      values: { timezone: '' },
+    })
+    vi.mocked(usageBudget).mockResolvedValue({
+      day: { currency: '', limit: null, spend: 0, over: false },
+      month: { currency: '', limit: null, spend: 0, over: false },
+    })
+    vi.mocked(patchSettingValues).mockResolvedValue()
+    vi.mocked(listRoutes).mockResolvedValue([])
+  })
+
+  it('shows the UTC default placeholder when unset', async () => {
+    renderPage('/settings/features')
+    expect(await screen.findByRole('combobox', { name: 'Timezone' })).toHaveTextContent(
+      'UTC (default)',
+    )
+  })
+
+  it('filters by typeahead and patches the chosen zone', async () => {
+    renderPage('/settings/features')
+    const trigger = await screen.findByRole('combobox', { name: 'Timezone' })
+    fireEvent.click(trigger)
+
+    const search = await screen.findByPlaceholderText('Search timezones…')
+    fireEvent.change(search, { target: { value: 'amster' } })
+
+    fireEvent.click(await screen.findByText('Europe/Amsterdam'))
+
+    await waitFor(() =>
+      expect(patchSettingValues).toHaveBeenCalledWith({ timezone: 'Europe/Amsterdam' }),
+    )
+  })
+
+  it('clears back to UTC default', async () => {
+    vi.mocked(getSettings).mockResolvedValue({
+      settings: { tools_enabled: true },
+      values: { timezone: 'Europe/Amsterdam' },
+    })
+
+    renderPage('/settings/features')
+    const trigger = await screen.findByRole('combobox', { name: 'Timezone' })
+    expect(trigger).toHaveTextContent('Europe/Amsterdam')
+    fireEvent.click(trigger)
+
+    fireEvent.click(await screen.findByText('UTC (default)'))
+
+    await waitFor(() => expect(patchSettingValues).toHaveBeenCalledWith({ timezone: '' }))
+  })
+})
+
 describe('Secrets tab default backend', () => {
   it('shows the built-in storage card carrying the default badge', async () => {
     renderPage('/settings/secrets')


### PR DESCRIPTION
Telegram digests arrived in triplicate: a slow path to api.telegram.org tripped the 10s timeout after Telegram had already accepted the send, and the blind retry loop re-sent the same message. Ambiguous outcomes (timeout, non-2xx, ok:false) now stop retrying; only dial/DNS failures retry. Timeout raised to 30s. Telegram adapter errors embedded the bot token via url.Error into WARN logs; all errors are now redacted.

New operator timezone setting (IANA name, typeahead combobox in Settings, UTC when unset) drives delivery timestamps, chat and mission prompt date lines, steering-note timestamps, the current_time tool default, and schedule cron evaluation. Behavior change: cron expressions fire in the operator timezone once set.

Also: rotate-bot-token UX now updates the current ref in place with honest labels, official Telegram icon on destination cards, input/button height alignment across inline form rows, and tightened research skill instructions.

Verified: Go build/vet/tests green, web build/lint/tests green (766 tests), tested live against local stack.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790198687&installation_model_id=431401&pr_number=323&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F323&signature=c2b5ef915c54182edb58b62b7ef4fdfa0728ace76a9146f42d0ed7a27123c25c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->