### PR TITLE
feat: chat follow-up tool and merged-pr worktree base detection

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -319,8 +319,8 @@ func main() {
 	// deliver: chat-facing ad-hoc send to one operator-configured
 	// destination. Registered here, not inside buildAgent, for the same
 	// reason as the mission tools below — destinationStore/Deliverer
-	// don't exist yet at that point. Like missions/mission_push, this
-	// reaches the live tool surface (chat + connector-reload swaps)
+	// don't exist yet at that point. Like list_missions/push_mission_branch,
+	// this reaches the live tool surface (chat + connector-reload swaps)
 	// only, never the BuiltinsOnly base surface a mission worker turn
 	// resolves to: a mission worker must never gain an outward-write
 	// tool the harness itself doesn't grant it (same reasoning as
@@ -340,16 +340,21 @@ func main() {
 	}
 	// Chat-facing mission tools (D-0xx: "is mission X done?" / "push
 	// mission X"): registered here, not inside buildAgent, since both
-	// need missionStore (built above, after buildAgent) and mission_push
-	// additionally needs conns+secrets for its push token resolver.
-	// missionStore nil (WORKSPACES unset) means neither tool is
+	// need missionStore (built above, after buildAgent) and
+	// push_mission_branch additionally needs conns+secrets for its push
+	// token resolver.
+	// missionStore nil (WORKSPACES unset) means none of these tools are
 	// registered at all, matching the nil-gating pattern buildMissions
 	// itself already uses. A recompile+swap applies them to the live
 	// agent immediately rather than waiting for the next connector
 	// reload (which may never come if no connectors are configured).
 	if missionStore != nil {
 		missionAdapter := missionToolStore{missionStore}
-		newTools := []*tools.Tool{builtin.Missions(missionAdapter, missionAdapter)}
+		newTools := []*tools.Tool{
+			builtin.ListMissions(missionAdapter),
+			builtin.GetMission(missionAdapter, missionAdapter),
+			builtin.FollowupMission(missionAdapter, missionFollowUpCreatorAdapter{missionDriver}),
+		}
 		if conns != nil && secrets != nil {
 			resolvePushToken := func(ctx context.Context, connectorID string) (string, error) {
 				c, err := conns.Store().Get(ctx, connectorID)
@@ -359,7 +364,7 @@ func main() {
 				return secrets.Resolve(ctx, c.CredentialRef)
 			}
 			completer := missionCompleterAdapter{missionStore, missions.NewCompleter(missionWorkspace, missionStore, nil, connsPRSource{conns})}
-			newTools = append(newTools, builtin.MissionPush(missionAdapter, completer, resolvePushToken))
+			newTools = append(newTools, builtin.PushMissionBranch(missionAdapter, completer, resolvePushToken))
 		}
 		current := builtinSet.add(newTools...)
 		if conns != nil {
@@ -980,6 +985,14 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 			return result, nil
 		})
 	}
+	if conns != nil {
+		// A follow-up mission's worktree base: detect whether the parent's
+		// PR (if any) was already merged, so the base doesn't point at a
+		// branch GitHub may since have deleted (see followUpBaseRef).
+		driver.SetPRStateResolver(func(ctx context.Context, connectorID, owner, repo string, number int) (bool, error) {
+			return conns.PRMerged(ctx, connectorID, owner, repo, number)
+		})
+	}
 	if conns != nil && secrets != nil {
 		// The auto-fire-on-done hook's push token: resolve connector_id
 		// straight to its credential_ref's secret value, same as the
@@ -1065,10 +1078,10 @@ func toMissionRecord(m missions.Mission) builtin.MissionRecord {
 }
 
 // missionToolStore adapts *missions.Store to the builtin package's
-// missions/mission_push tool interfaces (missionLister,
-// missionEventReader) — a thin translation layer since builtin cannot
-// import missions.Mission/missions.Event directly (import cycle, see
-// MissionRecord's doc comment).
+// list_missions/get_mission/push_mission_branch tool interfaces
+// (missionLister, missionEventReader) — a thin translation layer since
+// builtin cannot import missions.Mission/missions.Event directly
+// (import cycle, see MissionRecord's doc comment).
 type missionToolStore struct {
 	store *missions.Store
 }
@@ -1106,12 +1119,12 @@ func (a missionToolStore) MissionEvents(ctx context.Context, id string) ([]built
 }
 
 // missionCompleterAdapter adapts *missions.Completer to the builtin
-// package's missionCompleter interface — mission_push's push/PR calls
-// go through the exact same Completer the button/auto-fire paths use.
-// It re-Gets the mission by id from the real store before calling
-// Completer, so Completer always acts on the authoritative
-// missions.Mission (worktree, full spec for PRBody, ...) rather than a
-// partial copy shuttled through builtin.MissionRecord.
+// package's missionCompleter interface — push_mission_branch's
+// push/PR calls go through the exact same Completer the button/
+// auto-fire paths use. It re-Gets the mission by id from the real
+// store before calling Completer, so Completer always acts on the
+// authoritative missions.Mission (worktree, full spec for PRBody,
+// ...) rather than a partial copy shuttled through builtin.MissionRecord.
 type missionCompleterAdapter struct {
 	store     *missions.Store
 	completer *missions.Completer
@@ -1131,6 +1144,18 @@ func (a missionCompleterAdapter) OpenMissionPR(ctx context.Context, id, token st
 		return "", 0, fmt.Errorf("no mission found with id %q", id)
 	}
 	return a.completer.OpenPR(ctx, m, token)
+}
+
+// missionFollowUpCreatorAdapter adapts *missions.Driver to the builtin
+// package's missionFollowUpCreator interface — followup_mission's
+// create call goes through the exact same Driver.CreateFollowUp the
+// mission-create API's own ParentMissionID branch uses.
+type missionFollowUpCreatorAdapter struct {
+	driver *missions.Driver
+}
+
+func (a missionFollowUpCreatorAdapter) CreateFollowUpMission(ctx context.Context, parentID, goal string) (string, error) {
+	return a.driver.CreateFollowUp(ctx, parentID, goal)
 }
 
 // credResolveTimeout bounds one credential_ref resolution the delegated

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -880,6 +880,9 @@ func (f *fakeGitHubSource) GetRepo(ctx context.Context, owner, repo string) (con
 func (f *fakeGitHubSource) CreatePR(ctx context.Context, owner, repo, title, head, base, body string) (connectors.GitHubPR, error) {
 	return f.createPRFn(ctx, owner, repo, title, head, base, body)
 }
+func (f *fakeGitHubSource) PRMerged(context.Context, string, string, int) (bool, error) {
+	return false, errors.New("not implemented in fakeGitHubSource")
+}
 
 // testConnectorsManager builds a real *connectors.Manager backed by the
 // same test Postgres pool, with the github builder returning src for

--- a/internal/brain/connectors/github.go
+++ b/internal/brain/connectors/github.go
@@ -255,6 +255,36 @@ func (s *githubSource) CreatePR(ctx context.Context, owner, repo, title, head, b
 	return *existing, nil
 }
 
+// PRMerged resolves the connector's PAT and reports whether owner/repo
+// pull request number has been merged.
+func (s *githubSource) PRMerged(ctx context.Context, owner, repo string, number int) (bool, error) {
+	token, err := s.resolve(ctx, s.credentialRef)
+	if err != nil {
+		return false, fmt.Errorf("resolve credential_ref %q: %w", s.credentialRef, err)
+	}
+	return fetchGitHubPRMerged(ctx, s.client, token, owner, repo, number)
+}
+
+// fetchGitHubPRMerged calls GET /repos/{owner}/{repo}/pulls/{number} and
+// returns its merged field.
+func fetchGitHubPRMerged(ctx context.Context, client *http.Client, token, owner, repo string, number int) (bool, error) {
+	resp, err := githubRequest(ctx, client, token, fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, repo, number))
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("get pull request: %w", githubStatusError(resp))
+	}
+	var pr struct {
+		Merged bool `json:"merged"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&pr); err != nil {
+		return false, fmt.Errorf("get pull request: decode response: %w", err)
+	}
+	return pr.Merged, nil
+}
+
 // fetchGitHubRepo calls GET /repos/{owner}/{repo}.
 func fetchGitHubRepo(ctx context.Context, client *http.Client, token, owner, repo string) (GitHubRepo, error) {
 	resp, err := githubRequest(ctx, client, token, fmt.Sprintf("/repos/%s/%s", owner, repo))

--- a/internal/brain/connectors/github_test.go
+++ b/internal/brain/connectors/github_test.go
@@ -422,6 +422,61 @@ func TestFetchGitHubRepo(t *testing.T) {
 	}
 }
 
+// TestFetchGitHubPRMerged proves GET /repos/{owner}/{repo}/pulls/{number}
+// decodes the merged field, and a non-200 response surfaces as an
+// error.
+func TestFetchGitHubPRMerged(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		handler http.HandlerFunc
+		want    bool
+		wantErr string
+	}{
+		{
+			name: "merged",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/repos/octocat/hello-world/pulls/42" {
+					t.Fatalf("unexpected path %q", r.URL.Path)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"merged": true})
+			},
+			want: true,
+		},
+		{
+			name: "not merged",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{"merged": false})
+			},
+			want: false,
+		},
+		{
+			name: "error status",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_ = json.NewEncoder(w).Encode(map[string]any{"message": "Not Found"})
+			},
+			wantErr: "status 404",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := githubFakeServer(t, tc.handler)
+			got, err := fetchGitHubPRMerged(t.Context(), srv.Client(), "test-token", "octocat", "hello-world", 42)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want it to contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("fetchGitHubPRMerged: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("merged = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestCreateGitHubPR proves POST /repos/{owner}/{repo}/pulls sends the
 // expected body and decodes the created PR.
 func TestCreateGitHubPR(t *testing.T) {

--- a/internal/brain/connectors/manager.go
+++ b/internal/brain/connectors/manager.go
@@ -312,6 +312,7 @@ type repoSource interface {
 	CreateRepo(ctx context.Context, name string, private bool) (GitHubRepo, error)
 	GetRepo(ctx context.Context, owner, repo string) (GitHubRepo, error)
 	CreatePR(ctx context.Context, owner, repo, title, head, base, body string) (GitHubPR, error)
+	PRMerged(ctx context.Context, owner, repo string, number int) (bool, error)
 }
 
 // buildRepoSource resolves connector id, builds it fresh (same shape as
@@ -385,4 +386,15 @@ func (m *Manager) CreatePR(ctx context.Context, id, owner, repo, title, head, ba
 	}
 	defer closeFn()
 	return rs.CreatePR(ctx, owner, repo, title, head, base, body)
+}
+
+// PRMerged reports whether owner/repo pull request number has been
+// merged, through the connector's credential.
+func (m *Manager) PRMerged(ctx context.Context, id, owner, repo string, number int) (bool, error) {
+	rs, closeFn, err := m.buildRepoSource(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	defer closeFn()
+	return rs.PRMerged(ctx, owner, repo, number)
 }

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -258,13 +258,14 @@ type Request struct {
 	// BuiltinsOnly restricts the turn's base tool surface to compiled-in
 	// builtins (calculator, shell, web_search, ...), excluding connector
 	// tools (e.g. a write-capable GitHub MCP token) and the chat-only
-	// mission tools (missions/mission_push). Set by every mission-driven
-	// request (explore/plan/worker/reviewer) — a mission worker must
-	// never side-channel a connector write around the worktree/human-
-	// consented push pipeline, and mission_push is nonsensical inside a
-	// mission turn. Deliberately independent of MissionID (a ledger
-	// attribution tag only) so tool-surface scoping stays an explicit,
-	// intentional choice at each call site rather than inferred.
+	// mission tools (list_missions/get_mission/push_mission_branch). Set by
+	// every mission-driven request (explore/plan/worker/reviewer) — a
+	// mission worker must never side-channel a connector write around
+	// the worktree/human-consented push pipeline, and push_mission_branch
+	// is nonsensical inside a mission turn. Deliberately independent of
+	// MissionID (a ledger attribution tag only) so tool-surface scoping
+	// stays an explicit, intentional choice at each call site rather
+	// than inferred.
 	// ExtraTools still layer on top as normal — missions.nativeRunner's
 	// worker/explore turns use exactly this to add back read-only
 	// connector tools (gmail/calendar reads) that scheduled general

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -364,6 +364,19 @@ func (d *Driver) SetGitBranchPattern(get func(ctx context.Context) string) {
 	d.provision.gitBranchPattern = get
 }
 
+// PRStateResolver resolves whether a github connector's owner/repo pull
+// request number has been merged — connectors.Manager.PRMerged
+// satisfies this. missions has no compile-time dependency on the
+// connectors package, same reasoning as CloneTokenResolver.
+type PRStateResolver func(ctx context.Context, connectorID, owner, repo string, number int) (merged bool, err error)
+
+// SetPRStateResolver wires the resolver followUpBaseRef uses to detect
+// a merged parent PR — a setter (not a NewDriver parameter) for the
+// same reason SetAgentResolver is.
+func (d *Driver) SetPRStateResolver(resolve PRStateResolver) {
+	d.provision.resolvePRState = resolve
+}
+
 // SetGitCommitStyle wires the live settings getter runExecute falls
 // back to when a mission's own CommitStyle is empty — a setter for the
 // same reason SetGitBranchPattern is.

--- a/internal/brain/missions/followup.go
+++ b/internal/brain/missions/followup.go
@@ -1,0 +1,53 @@
+package missions
+
+import (
+	"context"
+	"fmt"
+)
+
+// CreateFollowUp spawns a new mission continuing a terminal parent —
+// the driver-layer counterpart of api/missions.go's create handler's
+// own ParentMissionID branch, reused by builtin.FollowupMission so a
+// chat-triggered follow-up can never diverge in behavior from one
+// created through the mission-create API.
+func (d *Driver) CreateFollowUp(ctx context.Context, parentID, goal string) (string, error) {
+	parent, err := d.store.Get(ctx, parentID)
+	if err != nil {
+		return "", fmt.Errorf("create follow-up: parent mission %s not found: %w", parentID, err)
+	}
+	if !parent.Phase.Terminal() {
+		return "", fmt.Errorf("create follow-up: parent mission %s is not finished (phase %s)", parentID, parent.Phase)
+	}
+	events, err := d.store.Events(ctx, parentID)
+	if err != nil {
+		return "", fmt.Errorf("create follow-up: read parent events: %w", err)
+	}
+	parentContext := OutcomeDigest(parent, events, parent.Phase, parent.FailureReason)
+
+	child := Mission{
+		Goal: goal, Kind: parent.Kind, AgentID: parent.AgentID,
+		Route: parent.Route, ReviewRoute: parent.ReviewRoute, PlanRoute: parent.PlanRoute,
+		EscalationRoute: parent.EscalationRoute, MaxIterations: parent.MaxIterations,
+		BudgetAmount: parent.BudgetAmount, BudgetCurrency: parent.BudgetCurrency,
+		AutoApproveSafe: parent.AutoApproveSafe, PromptOverlay: parent.PromptOverlay,
+		Knowledge: parent.Knowledge, Harness: parent.Harness, Environment: parent.Environment,
+		RepoURL: parent.RepoURL, ConnectorID: parent.ConnectorID,
+		BranchPattern: parent.BranchPattern, CommitStyle: parent.CommitStyle,
+		Light: parent.Light, ParentMissionID: parent.ID, ParentContext: parentContext,
+		// Deliberately NOT copied from parent: OnComplete (push consent is
+		// a per-mission human choice), DestinationIDs (D-061, operator
+		// addresses outputs per mission), Attachments (a follow-up's own
+		// documents, not the parent's).
+	}
+	id, err := d.Create(ctx, child)
+	if err != nil {
+		return "", fmt.Errorf("create follow-up: %w", err)
+	}
+	// Fire-and-forget display name generation, same shape as
+	// api/missions.go's create handler's own generateName — detached
+	// from ctx so a caller winding down doesn't cancel it.
+	if d.nameMission != nil {
+		go d.backfillMissionName(context.Background(), id, goal) //nolint:gosec // G118: deliberate — the naming call must outlive whatever request/ctx triggered create
+	}
+	return id, nil
+}

--- a/internal/brain/missions/followup_test.go
+++ b/internal/brain/missions/followup_test.go
@@ -1,0 +1,119 @@
+package missions
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// followUpBlockedRunner is a scriptedRunner with one entry, shared by
+// every followup test — CreateFollowUp's own Create call kicks off a
+// real Drive goroutine, and "blocked" parks it immediately without
+// needing a real workspace/sandbox.
+func followUpBlockedRunner() *scriptedRunner {
+	return &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
+}
+
+// TestCreateFollowUpRejectsNonTerminalParent proves a parent still
+// mid-flight is refused before any child mission is created.
+func TestCreateFollowUpRejectsNonTerminalParent(t *testing.T) {
+	store := newFakeStore()
+	store.put("parent", Mission{ID: "parent", Goal: "do the thing", Kind: "general", Phase: PhaseExecute, Status: StatusWorking})
+	d := NewDriver(store, followUpBlockedRunner(), nil, nil, &fakeSessionCreator{}, &fakeGranter{}, nil, nil, slog.Default())
+
+	_, err := d.CreateFollowUp(context.Background(), "parent", "do more")
+	if err == nil {
+		t.Fatal("expected an error for a non-terminal parent")
+	}
+	if !strings.Contains(err.Error(), "not finished") {
+		t.Fatalf("error %q should say the parent is not finished", err.Error())
+	}
+}
+
+// TestCreateFollowUpUnknownParent proves an unknown parent id is
+// refused with a clear error.
+func TestCreateFollowUpUnknownParent(t *testing.T) {
+	store := newFakeStore()
+	d := NewDriver(store, followUpBlockedRunner(), nil, nil, &fakeSessionCreator{}, &fakeGranter{}, nil, nil, slog.Default())
+
+	_, err := d.CreateFollowUp(context.Background(), "does-not-exist", "do more")
+	if err == nil {
+		t.Fatal("expected an error for an unknown parent id")
+	}
+}
+
+// TestCreateFollowUpCopiesParentSettings proves the child mission
+// inherits the parent's kind/agent/routes/repo/harness settings, carries
+// a non-empty ParentContext, and does NOT inherit OnComplete or
+// DestinationIDs.
+func TestCreateFollowUpCopiesParentSettings(t *testing.T) {
+	store := newFakeStore()
+	store.put("parent", Mission{
+		ID: "parent", Goal: "fix the login bug", Kind: "coding", Phase: PhaseDone, Status: StatusDone,
+		AgentID: "agent-1", Route: "route-a", ReviewRoute: "route-b", PlanRoute: "route-c",
+		EscalationRoute: "route-d", MaxIterations: 12, BudgetCurrency: "USD",
+		AutoApproveSafe: true, PromptOverlay: "be terse", Knowledge: []string{"kb1"},
+		Harness: "claude-cli", Environment: "node", RepoURL: "https://github.com/o/r.git",
+		ConnectorID: "conn1", BranchPattern: "custom/{slug}", CommitStyle: "conventional",
+		OnComplete: "push_pr", DestinationIDs: []string{"dest-1"},
+	})
+	d := NewDriver(store, followUpBlockedRunner(), nil, nil, &fakeSessionCreator{}, &fakeGranter{}, nil, nil, slog.Default())
+
+	id, err := d.CreateFollowUp(context.Background(), "parent", "now add tests")
+	if err != nil {
+		t.Fatalf("CreateFollowUp: %v", err)
+	}
+	child, err := store.Get(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Get child: %v", err)
+	}
+	if child.Goal != "now add tests" {
+		t.Fatalf("child.Goal = %q, want the follow-up's own goal", child.Goal)
+	}
+	if child.Kind != "coding" || child.AgentID != "agent-1" || child.Route != "route-a" ||
+		child.ReviewRoute != "route-b" || child.PlanRoute != "route-c" || child.EscalationRoute != "route-d" ||
+		child.MaxIterations != 12 || child.AutoApproveSafe != true || child.PromptOverlay != "be terse" ||
+		child.Harness != "claude-cli" || child.Environment != "node" || child.RepoURL != "https://github.com/o/r.git" ||
+		child.ConnectorID != "conn1" || child.BranchPattern != "custom/{slug}" || child.CommitStyle != "conventional" {
+		t.Fatalf("child did not inherit parent settings: %+v", child)
+	}
+	if len(child.Knowledge) != 1 || child.Knowledge[0] != "kb1" {
+		t.Fatalf("child.Knowledge = %v, want inherited from parent", child.Knowledge)
+	}
+	if child.ParentMissionID != "parent" {
+		t.Fatalf("child.ParentMissionID = %q, want %q", child.ParentMissionID, "parent")
+	}
+	if child.ParentContext == "" {
+		t.Fatal("child.ParentContext should carry the parent's outcome digest")
+	}
+	if !strings.Contains(child.ParentContext, "fix the login bug") {
+		t.Fatalf("child.ParentContext = %q, want it to mention the parent's goal", child.ParentContext)
+	}
+	if child.OnComplete != "" {
+		t.Fatalf("child.OnComplete = %q, want empty — push consent is a per-mission choice", child.OnComplete)
+	}
+	if len(child.DestinationIDs) != 0 {
+		t.Fatalf("child.DestinationIDs = %v, want empty — destinations are a per-mission choice", child.DestinationIDs)
+	}
+}
+
+// TestCreateFollowUpAllowsFailedParent proves a failed (not just done)
+// terminal parent is a valid follow-up base too.
+func TestCreateFollowUpAllowsFailedParent(t *testing.T) {
+	store := newFakeStore()
+	store.put("parent", Mission{ID: "parent", Goal: "attempt one", Kind: "general", Phase: PhaseFailed, Status: StatusError})
+	d := NewDriver(store, followUpBlockedRunner(), nil, nil, &fakeSessionCreator{}, &fakeGranter{}, nil, nil, slog.Default())
+
+	id, err := d.CreateFollowUp(context.Background(), "parent", "attempt two")
+	if err != nil {
+		t.Fatalf("CreateFollowUp: %v", err)
+	}
+	child, err := store.Get(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Get child: %v", err)
+	}
+	if child.ParentMissionID != "parent" {
+		t.Fatalf("child.ParentMissionID = %q, want %q", child.ParentMissionID, "parent")
+	}
+}

--- a/internal/brain/missions/provision.go
+++ b/internal/brain/missions/provision.go
@@ -7,6 +7,7 @@ package missions
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -51,6 +52,15 @@ type provisioner struct {
 	// unset falls straight through to Provision's own DefaultBranchPattern
 	// fallback, same as before this setting existed.
 	gitBranchPattern func(ctx context.Context) string
+
+	// resolvePRState resolves whether a github PR has been merged (see
+	// SetPRStateResolver) — consulted by followUpBaseRef when the parent
+	// mission opened a PR, so a follow-up whose parent's branch was
+	// already merged bases on the repo's default branch instead of a
+	// branch GitHub may since have deleted. nil-safe: unset (or any
+	// resolve error) falls straight through to the parent-branch base,
+	// same as before this existed.
+	resolvePRState PRStateResolver
 }
 
 // ensureProvisioned gives a mission everything Create used to set up
@@ -152,7 +162,10 @@ func (p *provisioner) ensureProvisioned(ctx context.Context, m Mission) (Mission
 // general mission, or one cloning a different repo, has no
 // meaningful base to hand Provision. Any failure (parent gone, no
 // branch) degrades to "" (Provision's own default-branch behavior),
-// never fails provisioning.
+// never fails provisioning. When the parent opened a PR and the
+// resolver reports it merged, the parent's branch may already be
+// deleted on the remote — this bases on the repo's default branch
+// instead, same degrade-to-"" path.
 func (p *provisioner) followUpBaseRef(ctx context.Context, m Mission) string {
 	if m.ParentMissionID == "" {
 		return ""
@@ -165,7 +178,59 @@ func (p *provisioner) followUpBaseRef(ctx context.Context, m Mission) string {
 	if parent.Branch == "" || parent.RepoURL != m.RepoURL {
 		return ""
 	}
+	if p.resolvePRState != nil {
+		if merged := p.parentPRMerged(ctx, m, parent); merged {
+			return ""
+		}
+	}
 	return parent.Branch
+}
+
+// followUpPROpenedPayload is the shape of a mission.pr_opened event's
+// payload this package needs — a local struct (not an import of
+// builtin.missionPROpenedPayload) since missions cannot import the
+// builtin package (import cycle, see MissionRecord's doc comment in
+// builtin/missions.go).
+type followUpPROpenedPayload struct {
+	Number int `json:"number"`
+}
+
+// parentPRMerged reports whether the parent mission's latest opened PR
+// has been merged, via resolvePRState — false on any missing event,
+// unparseable repo URL, or resolver error, degrading to the existing
+// parent-branch behavior in every such case.
+func (p *provisioner) parentPRMerged(ctx context.Context, m, parent Mission) bool {
+	events, err := p.store.Events(ctx, parent.ID)
+	if err != nil {
+		p.log.Debug("driver: follow-up base ref: parent events lookup failed", "mission_id", m.ID, "parent_id", parent.ID, "error", err)
+		return false
+	}
+	var number int
+	found := false
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].Kind != "mission.pr_opened" {
+			continue
+		}
+		var payload followUpPROpenedPayload
+		if err := json.Unmarshal(events[i].Payload, &payload); err == nil {
+			number = payload.Number
+			found = true
+		}
+		break
+	}
+	if !found || number == 0 {
+		return false
+	}
+	owner, repo, ok := ParseGitHubRepoURL(parent.RepoURL)
+	if !ok {
+		return false
+	}
+	merged, err := p.resolvePRState(ctx, parent.ConnectorID, owner, repo, number)
+	if err != nil {
+		p.log.Debug("driver: follow-up base ref: pr state resolve failed", "mission_id", m.ID, "parent_id", parent.ID, "error", err)
+		return false
+	}
+	return merged
 }
 
 // grantSessionDefaults pre-authorizes a freshly created hidden session:

--- a/internal/brain/missions/provision_test.go
+++ b/internal/brain/missions/provision_test.go
@@ -1,0 +1,131 @@
+package missions
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+)
+
+// newTestProvisioner builds a bare provisioner over a fakeStore for
+// followUpBaseRef's own unit tests — no workspace/sessions/perms
+// needed, since none of those are on this method's call path.
+func newTestProvisioner(store driverStore) *provisioner {
+	return &provisioner{store: store, log: slog.Default()}
+}
+
+// TestFollowUpBaseRefNoParent proves a mission with no ParentMissionID
+// never looks anything up.
+func TestFollowUpBaseRefNoParent(t *testing.T) {
+	store := newFakeStore()
+	p := newTestProvisioner(store)
+	if got := p.followUpBaseRef(context.Background(), Mission{ID: "m1"}); got != "" {
+		t.Fatalf("base = %q, want empty with no parent", got)
+	}
+}
+
+// TestFollowUpBaseRefUsesParentBranch proves the parent's own branch is
+// returned when the parent has one, shares RepoURL, and no PR resolver
+// is wired.
+func TestFollowUpBaseRefUsesParentBranch(t *testing.T) {
+	store := newFakeStore()
+	store.put("parent", Mission{ID: "parent", Branch: "mission/fix-bug", RepoURL: "https://github.com/o/r.git"})
+	p := newTestProvisioner(store)
+	m := Mission{ID: "m1", ParentMissionID: "parent", RepoURL: "https://github.com/o/r.git"}
+	if got, want := p.followUpBaseRef(context.Background(), m), "mission/fix-bug"; got != want {
+		t.Fatalf("base = %q, want %q", got, want)
+	}
+}
+
+// TestFollowUpBaseRefDifferentRepoDegradesToEmpty proves a follow-up
+// cloning a different repo than its parent gets no base ref.
+func TestFollowUpBaseRefDifferentRepoDegradesToEmpty(t *testing.T) {
+	store := newFakeStore()
+	store.put("parent", Mission{ID: "parent", Branch: "mission/fix-bug", RepoURL: "https://github.com/o/r.git"})
+	p := newTestProvisioner(store)
+	m := Mission{ID: "m1", ParentMissionID: "parent", RepoURL: "https://github.com/o/other.git"}
+	if got := p.followUpBaseRef(context.Background(), m); got != "" {
+		t.Fatalf("base = %q, want empty for a different repo", got)
+	}
+}
+
+// TestFollowUpBaseRefMergedPRDegradesToEmpty proves a merged parent PR
+// makes followUpBaseRef fall through to the repo default branch ("")
+// instead of the parent's own (possibly deleted) branch.
+func TestFollowUpBaseRefMergedPRDegradesToEmpty(t *testing.T) {
+	store := newFakeStore()
+	store.put("parent", Mission{ID: "parent", Branch: "mission/fix-bug", RepoURL: "https://github.com/o/r.git", ConnectorID: "conn1"})
+	if err := store.AppendEvent(context.Background(), "parent", "mission.pr_opened", map[string]any{"url": "https://github.com/o/r/pull/9", "number": 9}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	p := newTestProvisioner(store)
+	p.resolvePRState = func(ctx context.Context, connectorID, owner, repo string, number int) (bool, error) {
+		if connectorID != "conn1" || owner != "o" || repo != "r" || number != 9 {
+			t.Fatalf("resolvePRState called with connectorID=%q owner=%q repo=%q number=%d", connectorID, owner, repo, number)
+		}
+		return true, nil
+	}
+	m := Mission{ID: "m1", ParentMissionID: "parent", RepoURL: "https://github.com/o/r.git"}
+	if got := p.followUpBaseRef(context.Background(), m); got != "" {
+		t.Fatalf("base = %q, want empty when the parent's PR is merged", got)
+	}
+}
+
+// TestFollowUpBaseRefUnmergedPRUsesParentBranch proves an open
+// (unmerged) parent PR still bases the follow-up on the parent's
+// branch.
+func TestFollowUpBaseRefUnmergedPRUsesParentBranch(t *testing.T) {
+	store := newFakeStore()
+	store.put("parent", Mission{ID: "parent", Branch: "mission/fix-bug", RepoURL: "https://github.com/o/r.git", ConnectorID: "conn1"})
+	if err := store.AppendEvent(context.Background(), "parent", "mission.pr_opened", map[string]any{"url": "https://github.com/o/r/pull/9", "number": 9}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	p := newTestProvisioner(store)
+	p.resolvePRState = func(ctx context.Context, connectorID, owner, repo string, number int) (bool, error) {
+		return false, nil
+	}
+	m := Mission{ID: "m1", ParentMissionID: "parent", RepoURL: "https://github.com/o/r.git"}
+	if got, want := p.followUpBaseRef(context.Background(), m), "mission/fix-bug"; got != want {
+		t.Fatalf("base = %q, want %q for an unmerged PR", got, want)
+	}
+}
+
+// TestFollowUpBaseRefResolverErrorFallsBackToParentBranch proves a
+// resolver error degrades to the parent-branch base, never fails
+// provisioning.
+func TestFollowUpBaseRefResolverErrorFallsBackToParentBranch(t *testing.T) {
+	store := newFakeStore()
+	store.put("parent", Mission{ID: "parent", Branch: "mission/fix-bug", RepoURL: "https://github.com/o/r.git", ConnectorID: "conn1"})
+	if err := store.AppendEvent(context.Background(), "parent", "mission.pr_opened", map[string]any{"url": "https://github.com/o/r/pull/9", "number": 9}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+	p := newTestProvisioner(store)
+	p.resolvePRState = func(ctx context.Context, connectorID, owner, repo string, number int) (bool, error) {
+		return false, errors.New("github unreachable")
+	}
+	m := Mission{ID: "m1", ParentMissionID: "parent", RepoURL: "https://github.com/o/r.git"}
+	if got, want := p.followUpBaseRef(context.Background(), m), "mission/fix-bug"; got != want {
+		t.Fatalf("base = %q, want %q when the resolver errors", got, want)
+	}
+}
+
+// TestFollowUpBaseRefNoPROpenedEventUsesParentBranch proves a parent
+// with no recorded PR (never pushed/opened one) still uses its own
+// branch when a resolver is wired — there's simply nothing to check.
+func TestFollowUpBaseRefNoPROpenedEventUsesParentBranch(t *testing.T) {
+	store := newFakeStore()
+	store.put("parent", Mission{ID: "parent", Branch: "mission/fix-bug", RepoURL: "https://github.com/o/r.git", ConnectorID: "conn1"})
+	p := newTestProvisioner(store)
+	calls := 0
+	p.resolvePRState = func(ctx context.Context, connectorID, owner, repo string, number int) (bool, error) {
+		calls++
+		return true, nil
+	}
+	m := Mission{ID: "m1", ParentMissionID: "parent", RepoURL: "https://github.com/o/r.git"}
+	if got, want := p.followUpBaseRef(context.Background(), m), "mission/fix-bug"; got != want {
+		t.Fatalf("base = %q, want %q with no pr_opened event", got, want)
+	}
+	if calls != 0 {
+		t.Fatalf("resolvePRState called %d times, want 0 with no pr_opened event", calls)
+	}
+}

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -1642,7 +1642,7 @@ func TestRunTurnTimesOutOnHungStream(t *testing.T) {
 // every loop.Request the native runner builds — worker, explorer,
 // reviewer, planner — must set BuiltinsOnly, so a mission turn's base
 // tool surface never includes connector tools (e.g. a write-capable
-// GitHub MCP token) or the chat-only mission/mission_push tools. A
+// GitHub MCP token) or the chat-only mission list/get/push tools. A
 // missed phase here would silently reopen the side-channel the fix
 // closes.
 func TestMissionRunnerRequestsAreBuiltinsOnly(t *testing.T) {

--- a/internal/brain/tools/builtin/missions.go
+++ b/internal/brain/tools/builtin/missions.go
@@ -49,16 +49,16 @@ type MissionEvent struct {
 	Payload json.RawMessage
 }
 
-// missionLister is the narrow slice of missions access the missions
-// and mission_push tools need — List and Get, kept as an interface so
+// missionLister is the narrow slice of missions access the list/get
+// and push_mission_branch tools need — List and Get, kept as an interface so
 // tests fake it without a real Postgres pool.
 type missionLister interface {
 	ListMissions(ctx context.Context, limit int) ([]MissionRecord, error)
 	GetMission(ctx context.Context, id string) (MissionRecord, error)
 }
 
-// missionEventReader is the narrow slice of missions access the
-// missions tool needs to find a mission's latest PR URL, if any.
+// missionEventReader is the narrow slice of missions access
+// get_mission needs to find a mission's latest PR URL, if any.
 type missionEventReader interface {
 	MissionEvents(ctx context.Context, id string) ([]MissionEvent, error)
 }
@@ -68,10 +68,13 @@ const (
 	missionsListMaxLimit     = 50
 )
 
-type missionsArgs struct {
+type listMissionsArgs struct {
+	Limit int `json:"limit"`
+}
+
+type getMissionArgs struct {
 	Query string `json:"query"`
 	ID    string `json:"id"`
-	Limit int    `json:"limit"`
 }
 
 // missionPROpenedPayload is the shape of a mission.pr_opened event's
@@ -189,58 +192,34 @@ func findMission(ctx context.Context, store missionLister, id, query string) (Mi
 	}
 }
 
-// Missions is a read-only, permission-exempt tool: pure reads over
-// the missions store, no side effects. Answers "is mission X done?"
-// and similar status questions from real harness data (never the
-// worker/reviewer's own claims — same D-0xx discipline as the harness
-// itself). Registered only when store/events are non-nil (missions
-// engine wired, see cmd/brain/main.go's WORKSPACES gate).
-func Missions(store missionLister, events missionEventReader) *tools.Tool {
+// ListMissions is a read-only, permission-exempt tool: pure reads over
+// the missions store, no side effects. Lists recent missions for
+// questions like "what missions have I run recently?". Registered
+// only when store is non-nil (missions engine wired, see
+// cmd/brain/main.go's WORKSPACES gate).
+func ListMissions(store missionLister) *tools.Tool {
 	return &tools.Tool{
-		Name: "missions",
-		Description: `Reads mission status: answers "is mission X done?", "what's the status of my last mission?", and similar questions from the harness's own records — never the worker/reviewer's claims.
+		Name: "list_missions",
+		Description: `Lists recent missions from the harness's own records — never the worker/reviewer's claims.
 
-Arguments (all optional):
-- id (string): exact mission id — returns that mission's full status snapshot.
-- query (string): a name/goal substring to find a mission by; must
-  match exactly one mission, otherwise you get the list of candidates
-  to disambiguate with id.
-- limit (int): with neither id nor query, lists recent missions
-  (default 10, max 50) with id/name/phase/status/updated_at.
+Arguments (optional):
+- limit (int): max missions to list (default 10, max 50).
 
-A snapshot includes: id, name, goal, kind, phase, status, iteration,
-harness, repo_url, branch, created/updated timestamps, unit pass
-counts, pause reason/message if paused, the latest PR url if one was
-opened, and the on_complete setting.
+Each list item has id/name/phase/status/updated_at. Use get_mission
+with the id to read a full status snapshot.
 
-Example: {"query": "invoice pdf export"} → that mission's snapshot, or
-a disambiguation list if more than one mission matches.
 Example: {} → the 10 most recently updated missions.`,
 		InputSchema: json.RawMessage(`{
 			"type": "object",
 			"properties": {
-				"id": {"type": "string", "description": "Exact mission id"},
-				"query": {"type": "string", "description": "Name/goal substring to find a mission by"},
-				"limit": {"type": "integer", "description": "Max missions to list when neither id nor query is given (default 10, max 50)"}
+				"limit": {"type": "integer", "description": "Max missions to list (default 10, max 50)"}
 			},
 			"additionalProperties": false
 		}`),
 		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
-			var args missionsArgs
+			var args listMissionsArgs
 			if err := json.Unmarshal(raw, &args); err != nil {
 				return "", fmt.Errorf("invalid arguments: %w", err)
-			}
-			if args.ID != "" || args.Query != "" {
-				m, err := findMission(ctx, store, args.ID, args.Query)
-				if err != nil {
-					return "", err
-				}
-				snap := toMissionSnapshot(ctx, events, m)
-				out, err := json.Marshal(snap)
-				if err != nil {
-					return "", fmt.Errorf("encode mission snapshot: %w", err)
-				}
-				return string(out), nil
 			}
 			limit := args.Limit
 			if limit <= 0 {
@@ -266,8 +245,62 @@ Example: {} → the 10 most recently updated missions.`,
 	}
 }
 
+// GetMission is a read-only, permission-exempt tool: pure reads over
+// the missions store, no side effects. Answers "is mission X done?"
+// and similar status questions from real harness data (never the
+// worker/reviewer's own claims — same D-0xx discipline as the harness
+// itself). Registered only when store/events are non-nil (missions
+// engine wired, see cmd/brain/main.go's WORKSPACES gate).
+func GetMission(store missionLister, events missionEventReader) *tools.Tool {
+	return &tools.Tool{
+		Name: "get_mission",
+		Description: `Reads one mission's status: answers "is mission X done?", "what's the status of my last mission?", and similar questions from the harness's own records — never the worker/reviewer's claims.
+
+Arguments (exactly one required):
+- id (string): exact mission id.
+- query (string): a name/goal substring to find a mission by; must
+  match exactly one mission, otherwise you get the list of candidates
+  to disambiguate with id. Use list_missions first if unsure.
+
+Returns a snapshot with: id, name, goal, kind, phase, status,
+iteration, harness, repo_url, branch, created/updated timestamps, unit
+pass counts, pause reason/message if paused, the latest PR url if one
+was opened, and the on_complete setting.
+
+Example: {"query": "invoice pdf export"} → that mission's snapshot, or
+a disambiguation list if more than one mission matches.`,
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"id": {"type": "string", "description": "Exact mission id"},
+				"query": {"type": "string", "description": "Name/goal substring to find a mission by"}
+			},
+			"additionalProperties": false
+		}`),
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
+			var args getMissionArgs
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return "", fmt.Errorf("invalid arguments: %w", err)
+			}
+			if args.ID == "" && args.Query == "" {
+				return "", fmt.Errorf("one of id or query is required")
+			}
+			m, err := findMission(ctx, store, args.ID, args.Query)
+			if err != nil {
+				return "", err
+			}
+			snap := toMissionSnapshot(ctx, events, m)
+			out, err := json.Marshal(snap)
+			if err != nil {
+				return "", fmt.Errorf("encode mission snapshot: %w", err)
+			}
+			return string(out), nil
+		},
+	}
+}
+
 // missionCompleter is the narrow slice of *missions.Completer the
-// mission_push tool needs — pushing (and optionally opening a PR)
+// push_mission_branch tool needs — pushing (and optionally opening a PR)
 // through the SAME code path the button/auto-fire paths use, so a
 // chat-triggered push can never diverge in behavior. Takes the
 // mission id rather than a MissionRecord: the adapter (main.go) re-Gets
@@ -290,8 +323,8 @@ type missionPushArgs struct {
 	OpenPR bool   `json:"open_pr"`
 }
 
-// MissionPush is permission-GATED — it is deliberately left out of
-// Permissions' exempt map (see internal/brain/tools/permissions.go)
+// PushMissionBranch is permission-GATED — it is deliberately left out
+// of Permissions' exempt map (see internal/brain/tools/permissions.go)
 // and never appears in any allowlist grant a chat session's model
 // could pre-authorize itself into, so every call parks on an explicit
 // human approval, matching the "pushes stay human" invariant.
@@ -302,9 +335,9 @@ type missionPushArgs struct {
 // tool is technically reachable from a mission's own turns too, not
 // just chat. Do not "fix" that here; it's explicitly out of scope for
 // this slice.
-func MissionPush(store missionLister, completer missionCompleter, resolveToken missionTokenResolver) *tools.Tool {
+func PushMissionBranch(store missionLister, completer missionCompleter, resolveToken missionTokenResolver) *tools.Tool {
 	return &tools.Tool{
-		Name: "mission_push",
+		Name: "push_mission_branch",
 		Description: `Pushes a mission's branch to GitHub, optionally opening a pull request. Requires explicit human approval every time — this tool is never auto-approved.
 
 Only a github-connection coding mission with a completed worktree can
@@ -365,6 +398,89 @@ a PR, returns the PR url.`,
 				return "", fmt.Errorf("push: %w", err)
 			}
 			return fmt.Sprintf("pushed %s to %s", m.Branch, host), nil
+		},
+	}
+}
+
+// missionTerminalPhases mirrors missions.Phase.Terminal()'s set — kept
+// as a local copy (not an import) for the same import-cycle reason
+// MissionRecord is its own struct: missions imports this package.
+var missionTerminalPhases = map[string]bool{"done": true, "failed": true}
+
+// missionFollowUpCreator is the narrow slice of missions access
+// followup_mission needs — *missions.Driver.CreateFollowUp satisfies
+// it via cmd/brain/main.go's adapter.
+type missionFollowUpCreator interface {
+	CreateFollowUpMission(ctx context.Context, parentID, goal string) (string, error)
+}
+
+type missionFollowupArgs struct {
+	Goal  string `json:"goal"`
+	ID    string `json:"id"`
+	Query string `json:"query"`
+}
+
+// FollowupMission is permission-GATED for the same reason PushMissionBranch
+// is — deliberately left out of Permissions' exempt map (see
+// internal/brain/tools/permissions.go) so spawning a new mission
+// against a finished one always parks on an explicit human approval.
+func FollowupMission(store missionLister, creator missionFollowUpCreator) *tools.Tool {
+	return &tools.Tool{
+		Name: "followup_mission",
+		Description: `Spawns a NEW mission continuing a finished one. Requires explicit human approval every time — this tool is never auto-approved.
+
+The parent mission must already be finished (phase done or failed). The
+new mission carries the parent's outcome summary into its own explore/
+plan/work prompts and inherits the parent's agent, routes, kind, and
+repo settings; for a coding mission, its worktree is based on the
+parent's own branch when reachable. It never inherits the parent's
+push-on-complete choice or destinations — those are per-mission human
+decisions, made fresh for the follow-up.
+
+Arguments:
+- goal (string, required): the follow-up mission's own goal.
+- id (string): exact parent mission id.
+- query (string): a name/goal substring to find the parent mission by;
+  must match exactly one mission, otherwise you get the list of
+  candidates to disambiguate with id.
+
+Exactly one of id/query is required.
+
+Example: {"id": "3fa1...", "goal": "now add tests for the new endpoint"}
+→ creates a follow-up mission of 3fa1..., returns its id.`,
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"goal": {"type": "string", "description": "The follow-up mission's own goal"},
+				"id": {"type": "string", "description": "Exact parent mission id"},
+				"query": {"type": "string", "description": "Name/goal substring to find the parent mission by"}
+			},
+			"required": ["goal"],
+			"additionalProperties": false
+		}`),
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
+			var args missionFollowupArgs
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return "", fmt.Errorf("invalid arguments: %w", err)
+			}
+			if strings.TrimSpace(args.Goal) == "" {
+				return "", fmt.Errorf("goal is required")
+			}
+			if args.ID == "" && args.Query == "" {
+				return "", fmt.Errorf("one of id or query is required")
+			}
+			parent, err := findMission(ctx, store, args.ID, args.Query)
+			if err != nil {
+				return "", err
+			}
+			if !missionTerminalPhases[parent.Phase] {
+				return "", fmt.Errorf("mission %s is not finished (phase %s); follow-ups need a terminal parent", parent.ID, parent.Phase)
+			}
+			childID, err := creator.CreateFollowUpMission(ctx, parent.ID, args.Goal)
+			if err != nil {
+				return "", fmt.Errorf("create follow-up mission: %w", err)
+			}
+			return fmt.Sprintf("created follow-up mission %s of %s: %s", childID, parent.ID, args.Goal), nil
 		},
 	}
 }

--- a/internal/brain/tools/builtin/missions_test.go
+++ b/internal/brain/tools/builtin/missions_test.go
@@ -67,9 +67,9 @@ func mustMarshal(t *testing.T, v any) json.RawMessage {
 	return b
 }
 
-// TestMissionsToolByID proves an id lookup returns that mission's full
+// TestGetMissionByID proves an id lookup returns that mission's full
 // snapshot, including the latest mission.pr_opened event's url.
-func TestMissionsToolByID(t *testing.T) {
+func TestGetMissionByID(t *testing.T) {
 	t.Parallel()
 	store := newFakeMissionStore()
 	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
@@ -82,7 +82,7 @@ func TestMissionsToolByID(t *testing.T) {
 		{Kind: "mission.pr_opened", Payload: mustMarshal(t, map[string]any{"url": "https://github.com/o/r/pull/1", "number": 1})},
 	}
 
-	tool := Missions(store, store)
+	tool := GetMission(store, store)
 	out, err := tool.Execute(context.Background(), mustMarshal(t, map[string]string{"id": "m1"}))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -99,15 +99,15 @@ func TestMissionsToolByID(t *testing.T) {
 	}
 }
 
-// TestMissionsToolByQueryUnique proves a query substring matching
+// TestGetMissionByQueryUnique proves a query substring matching
 // exactly one mission's name/goal resolves to that mission.
-func TestMissionsToolByQueryUnique(t *testing.T) {
+func TestGetMissionByQueryUnique(t *testing.T) {
 	t.Parallel()
 	store := newFakeMissionStore()
 	store.add(MissionRecord{ID: "m1", Name: "Invoice PDF export", Goal: "export invoices as pdf"})
 	store.add(MissionRecord{ID: "m2", Name: "Unrelated mission", Goal: "something else"})
 
-	tool := Missions(store, store)
+	tool := GetMission(store, store)
 	out, err := tool.Execute(context.Background(), mustMarshal(t, map[string]string{"query": "invoice"}))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -121,15 +121,15 @@ func TestMissionsToolByQueryUnique(t *testing.T) {
 	}
 }
 
-// TestMissionsToolByQueryAmbiguous proves a query matching more than
+// TestGetMissionByQueryAmbiguous proves a query matching more than
 // one mission returns a disambiguation list, not a guess.
-func TestMissionsToolByQueryAmbiguous(t *testing.T) {
+func TestGetMissionByQueryAmbiguous(t *testing.T) {
 	t.Parallel()
 	store := newFakeMissionStore()
 	store.add(MissionRecord{ID: "m1", Name: "Export invoices", Goal: "export invoices as pdf"})
 	store.add(MissionRecord{ID: "m2", Name: "Export contacts", Goal: "export contacts as csv"})
 
-	tool := Missions(store, store)
+	tool := GetMission(store, store)
 	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]string{"query": "export"}))
 	if err == nil {
 		t.Fatal("expected an ambiguous-match error")
@@ -139,15 +139,42 @@ func TestMissionsToolByQueryAmbiguous(t *testing.T) {
 	}
 }
 
-// TestMissionsToolListMode proves the no-id/no-query path lists
-// missions with the default limit applied.
-func TestMissionsToolListMode(t *testing.T) {
+// TestGetMissionRequiresIDOrQuery proves neither id nor query is
+// rejected before touching the store at all.
+func TestGetMissionRequiresIDOrQuery(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	tool := GetMission(store, store)
+	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{}))
+	if err == nil {
+		t.Fatal("expected an id-or-query-required error")
+	}
+}
+
+// TestGetMissionUnknownID proves an unknown id returns a clear
+// error rather than a zero-value snapshot.
+func TestGetMissionUnknownID(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	tool := GetMission(store, store)
+	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]string{"id": "does-not-exist"}))
+	if err == nil {
+		t.Fatal("expected an error for an unknown mission id")
+	}
+	if !strings.Contains(err.Error(), "does-not-exist") {
+		t.Fatalf("error %q should name the id", err.Error())
+	}
+}
+
+// TestListMissions proves the list-mode path lists missions with the
+// default limit applied.
+func TestListMissions(t *testing.T) {
 	t.Parallel()
 	store := newFakeMissionStore()
 	for i := 0; i < 3; i++ {
 		store.add(MissionRecord{ID: string(rune('a' + i)), Name: "mission", Phase: "execute", Status: "working"})
 	}
-	tool := Missions(store, store)
+	tool := ListMissions(store)
 	out, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{}))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -161,14 +188,14 @@ func TestMissionsToolListMode(t *testing.T) {
 	}
 }
 
-// TestMissionsToolListModeCapsLimit proves an over-large limit is
-// capped, not passed straight to the store.
-func TestMissionsToolListModeCapsLimit(t *testing.T) {
+// TestListMissionsCapsLimit proves an over-large limit is capped, not
+// passed straight to the store.
+func TestListMissionsCapsLimit(t *testing.T) {
 	t.Parallel()
 	store := newFakeMissionStore()
 	var gotLimit int
 	capping := missionLimitCapture{fakeMissionStore: store, capture: &gotLimit}
-	tool := Missions(capping, store)
+	tool := ListMissions(capping)
 	if _, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"limit": 500})); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -190,23 +217,8 @@ func (c missionLimitCapture) ListMissions(ctx context.Context, limit int) ([]Mis
 	return c.fakeMissionStore.ListMissions(ctx, limit)
 }
 
-// TestMissionsToolUnknownID proves an unknown id returns a clear
-// error rather than a zero-value snapshot.
-func TestMissionsToolUnknownID(t *testing.T) {
-	t.Parallel()
-	store := newFakeMissionStore()
-	tool := Missions(store, store)
-	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]string{"id": "does-not-exist"}))
-	if err == nil {
-		t.Fatal("expected an error for an unknown mission id")
-	}
-	if !strings.Contains(err.Error(), "does-not-exist") {
-		t.Fatalf("error %q should name the id", err.Error())
-	}
-}
-
-// fakeMissionCompleter scripts missionCompleter for mission_push's
-// table tests.
+// fakeMissionCompleter scripts missionCompleter for
+// push_mission_branch's table tests.
 type fakeMissionCompleter struct {
 	pushHost    string
 	pushErr     error
@@ -238,16 +250,16 @@ func pushableRecord() MissionRecord {
 		RepoURL: "https://github.com/o/r.git", ConnectorID: "conn1"}
 }
 
-// TestMissionPushHappyPath proves a pushable mission pushes through
+// TestPushMissionBranchHappyPath proves a pushable mission pushes through
 // the completer and reports the host.
-func TestMissionPushHappyPath(t *testing.T) {
+func TestPushMissionBranchHappyPath(t *testing.T) {
 	t.Parallel()
 	store := newFakeMissionStore()
 	store.add(pushableRecord())
 	completer := &fakeMissionCompleter{pushHost: "github.com"}
 	resolve := func(ctx context.Context, connectorID string) (string, error) { return "tok", nil }
 
-	tool := MissionPush(store, completer, resolve)
+	tool := PushMissionBranch(store, completer, resolve)
 	out, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"id": "m1"}))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -260,16 +272,16 @@ func TestMissionPushHappyPath(t *testing.T) {
 	}
 }
 
-// TestMissionPushOpenPR proves open_pr:true opens a PR instead of a
+// TestPushMissionBranchOpenPR proves open_pr:true opens a PR instead of a
 // plain push, reporting the PR url.
-func TestMissionPushOpenPR(t *testing.T) {
+func TestPushMissionBranchOpenPR(t *testing.T) {
 	t.Parallel()
 	store := newFakeMissionStore()
 	store.add(pushableRecord())
 	completer := &fakeMissionCompleter{prURL: "https://github.com/o/r/pull/2", prNumber: 2}
 	resolve := func(ctx context.Context, connectorID string) (string, error) { return "tok", nil }
 
-	tool := MissionPush(store, completer, resolve)
+	tool := PushMissionBranch(store, completer, resolve)
 	out, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"id": "m1", "open_pr": true}))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -282,10 +294,10 @@ func TestMissionPushOpenPR(t *testing.T) {
 	}
 }
 
-// TestMissionPushNotPushable proves a mission NotPushable flags
+// TestPushMissionBranchNotPushable proves a mission NotPushable flags
 // (precomputed onto the record) is refused before ever calling the
 // completer.
-func TestMissionPushNotPushable(t *testing.T) {
+func TestPushMissionBranchNotPushable(t *testing.T) {
 	t.Parallel()
 	store := newFakeMissionStore()
 	rec := pushableRecord()
@@ -294,7 +306,7 @@ func TestMissionPushNotPushable(t *testing.T) {
 	completer := &fakeMissionCompleter{}
 	resolve := func(ctx context.Context, connectorID string) (string, error) { return "tok", nil }
 
-	tool := MissionPush(store, completer, resolve)
+	tool := PushMissionBranch(store, completer, resolve)
 	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"id": "m1"}))
 	if err == nil {
 		t.Fatal("expected a not-pushable error")
@@ -307,17 +319,17 @@ func TestMissionPushNotPushable(t *testing.T) {
 	}
 }
 
-// TestMissionPushNonGitHubMission proves a mission with no
+// TestPushMissionBranchNonGitHubMission proves a mission with no
 // connector_id/repo_url (never cloned from GitHub) is refused before
 // calling the completer.
-func TestMissionPushNonGitHubMission(t *testing.T) {
+func TestPushMissionBranchNonGitHubMission(t *testing.T) {
 	t.Parallel()
 	store := newFakeMissionStore()
 	store.add(MissionRecord{ID: "m1", Kind: "coding", Branch: "mission/m1"})
 	completer := &fakeMissionCompleter{}
 	resolve := func(ctx context.Context, connectorID string) (string, error) { return "tok", nil }
 
-	tool := MissionPush(store, completer, resolve)
+	tool := PushMissionBranch(store, completer, resolve)
 	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"id": "m1"}))
 	if err == nil {
 		t.Fatal("expected a not-a-github-mission error")
@@ -327,16 +339,16 @@ func TestMissionPushNonGitHubMission(t *testing.T) {
 	}
 }
 
-// TestMissionPushCompleterError proves a completer failure surfaces
+// TestPushMissionBranchCompleterError proves a completer failure surfaces
 // as the tool's own error.
-func TestMissionPushCompleterError(t *testing.T) {
+func TestPushMissionBranchCompleterError(t *testing.T) {
 	t.Parallel()
 	store := newFakeMissionStore()
 	store.add(pushableRecord())
 	completer := &fakeMissionCompleter{pushErr: errors.New("push rejected by remote")}
 	resolve := func(ctx context.Context, connectorID string) (string, error) { return "tok", nil }
 
-	tool := MissionPush(store, completer, resolve)
+	tool := PushMissionBranch(store, completer, resolve)
 	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"id": "m1"}))
 	if err == nil {
 		t.Fatal("expected the completer's push error to surface")
@@ -346,9 +358,9 @@ func TestMissionPushCompleterError(t *testing.T) {
 	}
 }
 
-// TestMissionPushUnknownID proves an unknown mission id is refused
+// TestPushMissionBranchUnknownID proves an unknown mission id is refused
 // before any token resolution or completer call.
-func TestMissionPushUnknownID(t *testing.T) {
+func TestPushMissionBranchUnknownID(t *testing.T) {
 	t.Parallel()
 	store := newFakeMissionStore()
 	completer := &fakeMissionCompleter{}
@@ -358,7 +370,7 @@ func TestMissionPushUnknownID(t *testing.T) {
 		return "tok", nil
 	}
 
-	tool := MissionPush(store, completer, resolve)
+	tool := PushMissionBranch(store, completer, resolve)
 	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"id": "nope"}))
 	if err == nil {
 		t.Fatal("expected an unknown-mission error")
@@ -368,15 +380,163 @@ func TestMissionPushUnknownID(t *testing.T) {
 	}
 }
 
-// TestMissionPushRequiresID proves a missing id is rejected before
+// TestPushMissionBranchRequiresID proves a missing id is rejected before
 // touching the store at all.
-func TestMissionPushRequiresID(t *testing.T) {
+func TestPushMissionBranchRequiresID(t *testing.T) {
 	t.Parallel()
 	store := newFakeMissionStore()
 	completer := &fakeMissionCompleter{}
-	tool := MissionPush(store, completer, nil)
+	tool := PushMissionBranch(store, completer, nil)
 	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{}))
 	if err == nil {
 		t.Fatal("expected an id-required error")
+	}
+}
+
+// fakeMissionFollowUpCreator scripts missionFollowUpCreator for
+// followup_mission's table tests.
+type fakeMissionFollowUpCreator struct {
+	childID string
+	err     error
+	calls   int
+	gotGoal string
+}
+
+func (f *fakeMissionFollowUpCreator) CreateFollowUpMission(ctx context.Context, parentID, goal string) (string, error) {
+	f.calls++
+	f.gotGoal = goal
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.childID, nil
+}
+
+func terminalMissionRecord() MissionRecord {
+	return MissionRecord{ID: "m1", Name: "Fix login bug", Goal: "fix the login bug", Phase: "done"}
+}
+
+// TestFollowupMissionRequiresGoal proves a missing goal is rejected
+// before touching the store at all.
+func TestFollowupMissionRequiresGoal(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	creator := &fakeMissionFollowUpCreator{}
+	tool := FollowupMission(store, creator)
+	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"id": "m1"}))
+	if err == nil {
+		t.Fatal("expected a goal-required error")
+	}
+	if creator.calls != 0 {
+		t.Fatalf("creator called %d times, want 0", creator.calls)
+	}
+}
+
+// TestFollowupMissionRequiresIDOrQuery proves neither id nor query is
+// rejected before touching the store at all.
+func TestFollowupMissionRequiresIDOrQuery(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	creator := &fakeMissionFollowUpCreator{}
+	tool := FollowupMission(store, creator)
+	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"goal": "do more"}))
+	if err == nil {
+		t.Fatal("expected an id-or-query-required error")
+	}
+	if creator.calls != 0 {
+		t.Fatalf("creator called %d times, want 0", creator.calls)
+	}
+}
+
+// TestFollowupMissionAmbiguousQuery proves a query matching more than
+// one mission is refused before the creator is ever called.
+func TestFollowupMissionAmbiguousQuery(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	store.add(MissionRecord{ID: "m1", Name: "Export invoices", Goal: "export invoices as pdf", Phase: "done"})
+	store.add(MissionRecord{ID: "m2", Name: "Export contacts", Goal: "export contacts as csv", Phase: "done"})
+	creator := &fakeMissionFollowUpCreator{}
+	tool := FollowupMission(store, creator)
+	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"goal": "do more", "query": "export"}))
+	if err == nil {
+		t.Fatal("expected an ambiguous-match error")
+	}
+	if creator.calls != 0 {
+		t.Fatalf("creator called %d times, want 0", creator.calls)
+	}
+}
+
+// TestFollowupMissionNonTerminalParent proves a parent still mid-flight
+// is refused before the creator is ever called.
+func TestFollowupMissionNonTerminalParent(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	rec := terminalMissionRecord()
+	rec.Phase = "execute"
+	store.add(rec)
+	creator := &fakeMissionFollowUpCreator{}
+	tool := FollowupMission(store, creator)
+	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"goal": "do more", "id": "m1"}))
+	if err == nil {
+		t.Fatal("expected a not-finished error")
+	}
+	if !strings.Contains(err.Error(), "not finished") {
+		t.Fatalf("error %q should say the parent is not finished", err.Error())
+	}
+	if creator.calls != 0 {
+		t.Fatalf("creator called %d times, want 0", creator.calls)
+	}
+}
+
+// TestFollowupMissionCreatorError proves a creator failure surfaces as
+// the tool's own error.
+func TestFollowupMissionCreatorError(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	store.add(terminalMissionRecord())
+	creator := &fakeMissionFollowUpCreator{err: errors.New("create failed")}
+	tool := FollowupMission(store, creator)
+	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"goal": "do more", "id": "m1"}))
+	if err == nil {
+		t.Fatal("expected the creator's error to surface")
+	}
+	if !strings.Contains(err.Error(), "create failed") {
+		t.Fatalf("error %q should wrap the creator's error", err.Error())
+	}
+}
+
+// TestFollowupMissionHappyPath proves a terminal parent resolved by id
+// creates a follow-up and reports the new mission id.
+func TestFollowupMissionHappyPath(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	store.add(terminalMissionRecord())
+	creator := &fakeMissionFollowUpCreator{childID: "m2"}
+	tool := FollowupMission(store, creator)
+	out, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"goal": "add tests", "id": "m1"}))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if creator.calls != 1 || creator.gotGoal != "add tests" {
+		t.Fatalf("creator calls=%d gotGoal=%q, want 1 call with the follow-up goal", creator.calls, creator.gotGoal)
+	}
+	if !strings.Contains(out, "m2") || !strings.Contains(out, "m1") {
+		t.Fatalf("out = %q, want it to mention both the new and parent mission ids", out)
+	}
+}
+
+// TestFollowupMissionResolvesByQuery proves a query substring matching
+// exactly one terminal mission resolves to that mission as parent.
+func TestFollowupMissionResolvesByQuery(t *testing.T) {
+	t.Parallel()
+	store := newFakeMissionStore()
+	store.add(terminalMissionRecord())
+	creator := &fakeMissionFollowUpCreator{childID: "m2"}
+	tool := FollowupMission(store, creator)
+	_, err := tool.Execute(context.Background(), mustMarshal(t, map[string]any{"goal": "add tests", "query": "login"}))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if creator.calls != 1 {
+		t.Fatalf("creator calls = %d, want 1", creator.calls)
 	}
 }

--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -89,11 +89,13 @@ func NewPermissions(db *pgpool.Pool, workspaceRoot string) *Permissions {
 			// there is nothing for a prompt to guard that the tool
 			// doesn't already enforce harder.
 			"write_file": true,
-			// missions is a pure read over the missions store (status
-			// snapshot / list) — zero side effects, same reasoning as
-			// web_search. mission_push is deliberately NOT here: it must
-			// always ask (see MissionPush's doc comment).
-			"missions": true,
+			// list_missions/get_mission are pure reads over the missions
+			// store (list / status snapshot) — zero side effects, same
+			// reasoning as web_search. push_mission_branch is
+			// deliberately NOT here: it must always ask (see
+			// PushMissionBranch's doc comment).
+			"list_missions": true,
+			"get_mission":   true,
 			// kb_search is a pure read scoped to collections bound in Go
 			// at construction (D-060), never model input — same reasoning
 			// as web_search/missions.

--- a/internal/brain/tools/permissions_integration_test.go
+++ b/internal/brain/tools/permissions_integration_test.go
@@ -59,15 +59,15 @@ func TestResolveNoGrantAsks(t *testing.T) {
 	}
 }
 
-// TestResolveMissionPushAsksWithoutGrant proves mission_push (unlike
-// missions, which is exempt) always falls through to "no standing
-// grant" and asks — it is deliberately absent from Permissions.exempt
-// (see NewPermissions) so a chat session's model can never talk its
-// way into an auto-approved push.
-func TestResolveMissionPushAsksWithoutGrant(t *testing.T) {
+// TestResolvePushMissionBranchAsksWithoutGrant proves push_mission_branch
+// (unlike list_missions/get_mission, which are exempt) always falls
+// through to "no standing grant" and asks — it is deliberately absent
+// from Permissions.exempt (see NewPermissions) so a chat session's
+// model can never talk its way into an auto-approved push.
+func TestResolvePushMissionBranchAsksWithoutGrant(t *testing.T) {
 	p, sid := integrationPermissions(t)
 
-	res, err := p.Resolve(t.Context(), sid, "mission_push", json.RawMessage(`{"id":"m1"}`))
+	res, err := p.Resolve(t.Context(), sid, "push_mission_branch", json.RawMessage(`{"id":"m1"}`))
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}

--- a/internal/brain/tools/permissions_test.go
+++ b/internal/brain/tools/permissions_test.go
@@ -190,19 +190,22 @@ func TestResolveShortCircuits(t *testing.T) {
 		}
 	})
 
-	// missions is a pure read (status snapshot/list) and exempt, same
-	// reasoning as web_search; mission_push must never be exempt (see
-	// TestResolveMissionPushAsksWithoutGrant, the integration
-	// counterpart proving its full no-grant path) — this only pins the
-	// exempt-map membership the short-circuit above depends on.
-	t.Run("missions tool exempt", func(t *testing.T) {
+	// list_missions/get_mission are pure reads (list/status snapshot)
+	// and exempt, same reasoning as web_search; push_mission_branch must
+	// never be exempt (see TestResolvePushMissionBranchAsksWithoutGrant,
+	// the integration counterpart proving its full no-grant path) —
+	// this only pins the exempt-map membership the short-circuit above
+	// depends on.
+	t.Run("list_missions and get_mission tools exempt", func(t *testing.T) {
 		t.Parallel()
-		res, err := p.Resolve(ctx, "s1", "missions", json.RawMessage(`{}`))
-		if err != nil {
-			t.Fatalf("Resolve(missions): %v", err)
-		}
-		if res.Decision != DecisionAllow {
-			t.Fatalf("Resolve(missions) = %+v, want allow", res)
+		for _, tool := range []string{"list_missions", "get_mission"} {
+			res, err := p.Resolve(ctx, "s1", tool, json.RawMessage(`{}`))
+			if err != nil {
+				t.Fatalf("Resolve(%s): %v", tool, err)
+			}
+			if res.Decision != DecisionAllow {
+				t.Fatalf("Resolve(%s) = %+v, want allow", tool, res)
+			}
 		}
 	})
 

--- a/migrations/0009_agents.sql
+++ b/migrations/0009_agents.sql
@@ -57,6 +57,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS agents_one_default
 INSERT INTO agents (name, description, prompt_overlay, route, skills, tools, is_default)
 SELECT 'general', 'Everyday questions and tasks on a strong all-round chain.', '', 'default',
     '["research-brief", "deep-research", "coding", "email-research"]',
-    '["current_time", "convert_time", "calculate", "currency_convert", "web_search", "web_fetch", "remember", "missions", "mission_push", "gmail_search", "gmail_read", "calendar_list_events"]',
+    '["current_time", "convert_time", "calculate", "currency_convert", "web_search", "web_fetch", "remember", "list_missions", "get_mission", "push_mission_branch", "gmail_search", "gmail_read", "calendar_list_events"]',
     NOT EXISTS (SELECT 1 FROM agents WHERE is_default)
 WHERE NOT EXISTS (SELECT 1 FROM agents WHERE name = 'general');


### PR DESCRIPTION
## What

- New permission-gated chat tool `followup_mission`: spawns a follow-up of a terminal mission via `Driver.CreateFollowUp`. Inherits the parent's agent/routes/kind/harness/repo/budget settings and snapshots the parent's outcome digest into `parent_context`. Deliberately does not inherit `on_complete` (push consent stays a per-mission human choice) or `destination_ids` (D-061).
- Merged-PR base detection: `followUpBaseRef` now checks the parent's latest `mission.pr_opened` event against GitHub (`PRMerged`, new connectors method + nil-safe `SetPRStateResolver`). A merged parent PR bases the follow-up worktree on the repo default branch instead of the stale parent branch. Any lookup failure falls back to the previous behavior.
- Verb-first mission tool names: `missions` split into `list_missions` + `get_mission`; `mission_push` renamed to `push_mission_branch` (it pushes the mission's generated code branch, not the mission); new tool named `followup_mission`. Seeded agent tools in 0009 updated in place (pre-release convention).

## Verification

- make build / test / vet / lint green; integration suite green after extending the api test fake with `PRMerged`
- make canary PASS
- Live e2e through the real chat approval flow: parent light mission -> chat turn -> parked `followup_mission` approval -> child created with `parent_mission_id`, inherited kind/light, parent context digest, generated title, ran to done

## Deploy note

Agent tool allowlists reference tool names: existing agents need `missions`/`mission_push` replaced with `list_missions`, `get_mission`, `push_mission_branch` (and `followup_mission` where wanted). Applied to local dev already; remote needs it at next deploy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790208429&installation_model_id=431401&pr_number=326&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F326&signature=58f8dc5b59d59f4421be09db7f46534ffe9f2b90b835cffe8c8fb2514631c5bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->