### PR TITLE
fix: neutral oauth banner copy and google identity on test

### DIFF
--- a/internal/brain/connectors/google_test.go
+++ b/internal/brain/connectors/google_test.go
@@ -156,6 +156,10 @@ func (f *fakeGoogle) server(t *testing.T) *httptest.Server {
 		data := base64.URLEncoding.EncodeToString(raw)
 		_, _ = fmt.Fprintf(w, `{"size":%d,"data":%q}`, len(raw), data)
 	})
+	mux.HandleFunc("GET /gmail/v1/users/me/profile", func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		_, _ = w.Write([]byte(`{"emailAddress":"ada@example.com"}`))
+	})
 	mux.HandleFunc("POST /gmail/v1/users/me/messages/send", func(w http.ResponseWriter, r *http.Request) {
 		record(r)
 		var in struct {
@@ -167,6 +171,10 @@ func (f *fakeGoogle) server(t *testing.T) *httptest.Server {
 		f.gmailSent = append(f.gmailSent, string(raw))
 		f.mu.Unlock()
 		_, _ = w.Write([]byte(`{"id":"sent-1"}`))
+	})
+	mux.HandleFunc("GET /calendars/primary", func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		_, _ = w.Write([]byte(`{"id":"ada@example.com"}`))
 	})
 	mux.HandleFunc("GET /calendars/primary/events", func(w http.ResponseWriter, r *http.Request) {
 		record(r)
@@ -181,6 +189,10 @@ func (f *fakeGoogle) server(t *testing.T) *httptest.Server {
 		f.events = append(f.events, ev)
 		f.mu.Unlock()
 		_, _ = w.Write([]byte(`{"id":"ev-1","htmlLink":"https://cal/ev-1"}`))
+	})
+	mux.HandleFunc("GET /about", func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		_, _ = w.Write([]byte(`{"user":{"displayName":"Ada Lovelace","emailAddress":"ada@example.com"}}`))
 	})
 	mux.HandleFunc("GET /files", func(w http.ResponseWriter, r *http.Request) {
 		record(r)
@@ -1021,6 +1033,135 @@ func TestGoogleAPIErrorMapping(t *testing.T) {
 				t.Fatalf("googleAPIError = %q, want %q", err.Error(), tc.want)
 			}
 		})
+	}
+}
+
+// TestGoogleIdentityUsesGmailProfile pins the gmail-scoped path:
+// Identity resolves the account email via Gmail's own profile
+// endpoint, first match wins over drive/calendar.
+func TestGoogleIdentityUsesGmailProfile(t *testing.T) {
+	t.Parallel()
+	f := &fakeGoogle{}
+	src, _ := connectedSource(t, f) // bothScopes: gmail + calendar
+
+	gs, ok := src.(*googleSource)
+	if !ok {
+		t.Fatalf("src is %T, want *googleSource", src)
+	}
+	identity, err := gs.Identity(t.Context())
+	if err != nil {
+		t.Fatalf("Identity: %v", err)
+	}
+	if identity.Login != "ada@example.com" || identity.Email != "ada@example.com" {
+		t.Fatalf("identity = %+v", identity)
+	}
+	if identity.Scopes != strings.Join(gs.cfg.Scopes, ", ") {
+		t.Fatalf("identity.Scopes = %q", identity.Scopes)
+	}
+}
+
+// TestGoogleIdentityUsesDriveAboutForReadonlyScope pins the
+// drive.readonly-only path: Identity falls back to Drive's about
+// endpoint and surfaces the displayName.
+func TestGoogleIdentityUsesDriveAboutForReadonlyScope(t *testing.T) {
+	t.Parallel()
+	f := &fakeGoogle{}
+	row := googleRow(`["https://www.googleapis.com/auth/drive.readonly"]`)
+	g, secrets := testGoogle(t, f, row)
+	//nolint:gosec // G117: fake token fixture.
+	live, _ := json.Marshal(tokenBundle{AccessToken: "at-live", Expiry: time.Now().Add(time.Hour)})
+	_ = secrets.Set(t.Context(), "PERSONAL_GOOGLE_OAUTH", string(live))
+	src, err := g.Builder()(t.Context(), row, nil)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	gs := src.(*googleSource)
+	identity, err := gs.Identity(t.Context())
+	if err != nil {
+		t.Fatalf("Identity: %v", err)
+	}
+	if identity.Email != "ada@example.com" || identity.Name != "Ada Lovelace" {
+		t.Fatalf("identity = %+v", identity)
+	}
+}
+
+// TestGoogleIdentityUsesDriveAboutForDocsScopes pins that the docs
+// preset (documents + drive.file, no drive.readonly) also resolves via
+// Drive's about endpoint — proving the drive.file path works, not just
+// drive.readonly.
+func TestGoogleIdentityUsesDriveAboutForDocsScopes(t *testing.T) {
+	t.Parallel()
+	f := &fakeGoogle{}
+	row := googleRow(`["https://www.googleapis.com/auth/documents","https://www.googleapis.com/auth/drive.file"]`)
+	g, secrets := testGoogle(t, f, row)
+	//nolint:gosec // G117: fake token fixture.
+	live, _ := json.Marshal(tokenBundle{AccessToken: "at-live", Expiry: time.Now().Add(time.Hour)})
+	_ = secrets.Set(t.Context(), "PERSONAL_GOOGLE_OAUTH", string(live))
+	src, err := g.Builder()(t.Context(), row, nil)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	gs := src.(*googleSource)
+	identity, err := gs.Identity(t.Context())
+	if err != nil {
+		t.Fatalf("Identity: %v", err)
+	}
+	if identity.Email != "ada@example.com" || identity.Name != "Ada Lovelace" {
+		t.Fatalf("identity = %+v", identity)
+	}
+}
+
+// TestGoogleIdentityUsesCalendarPrimaryID pins the calendar-only path:
+// with no gmail or drive scope, Identity falls back to the primary
+// calendar's id, which for the primary calendar IS the account email.
+func TestGoogleIdentityUsesCalendarPrimaryID(t *testing.T) {
+	t.Parallel()
+	f := &fakeGoogle{}
+	row := googleRow(`["https://www.googleapis.com/auth/calendar"]`)
+	g, secrets := testGoogle(t, f, row)
+	//nolint:gosec // G117: fake token fixture.
+	live, _ := json.Marshal(tokenBundle{AccessToken: "at-live", Expiry: time.Now().Add(time.Hour)})
+	_ = secrets.Set(t.Context(), "PERSONAL_GOOGLE_OAUTH", string(live))
+	src, err := g.Builder()(t.Context(), row, nil)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	gs := src.(*googleSource)
+	identity, err := gs.Identity(t.Context())
+	if err != nil {
+		t.Fatalf("Identity: %v", err)
+	}
+	if identity.Login != "ada@example.com" || identity.Email != "ada@example.com" {
+		t.Fatalf("identity = %+v", identity)
+	}
+}
+
+// TestManagerTestIdentityReturnsGoogleIdentity mirrors
+// TestManagerTestIdentityReturnsGitHubIdentity (github_test.go): a
+// google-kind connector resolved through Manager.TestIdentity returns
+// a non-nil identity, proving the identifier type assertion picks up
+// googleSource too.
+func TestManagerTestIdentityReturnsGoogleIdentity(t *testing.T) {
+	t.Parallel()
+	f := &fakeGoogle{}
+	row := googleRow(bothScopes)
+	g, secrets := testGoogle(t, f, row)
+	//nolint:gosec // G117: fake token fixture.
+	live, _ := json.Marshal(tokenBundle{AccessToken: "at-live", Expiry: time.Now().Add(time.Hour)})
+	_ = secrets.Set(t.Context(), "PERSONAL_GOOGLE_OAUTH", string(live))
+
+	m := testManager(fakeRows{rows: []Connector{row}})
+	m.RegisterBuilder("google", g.Builder())
+
+	identity, err := m.TestIdentity(t.Context(), row.ID)
+	if err != nil {
+		t.Fatalf("TestIdentity: %v", err)
+	}
+	if identity == nil || identity.Email != "ada@example.com" {
+		t.Fatalf("identity = %+v", identity)
 	}
 }
 

--- a/internal/brain/connectors/google_tools.go
+++ b/internal/brain/connectors/google_tools.go
@@ -66,6 +66,63 @@ func (s *googleSource) Test(ctx context.Context) error {
 
 func (s *googleSource) Close() error { return nil }
 
+// Identity resolves the connected account's email — the panel's
+// evidence a working credential was configured, same role as
+// githubSource.Identity and microsoftSource.Identity. Reuses
+// GitHubIdentity's shape rather than adding a parallel one. Tries
+// whichever consented scope can report an email, cheapest/most direct
+// first: Gmail's own profile, then Drive's about endpoint (reachable
+// with either drive.readonly or the narrower drive.file scope Docs
+// grants), then the primary Calendar's id (which for the primary
+// calendar IS the account email).
+func (s *googleSource) Identity(ctx context.Context) (GitHubIdentity, error) {
+	scopes := strings.Join(s.cfg.Scopes, ", ")
+	switch {
+	case s.hasScope("gmail"):
+		var profile struct {
+			EmailAddress string `json:"emailAddress"`
+		}
+		if err := s.api(ctx, http.MethodGet,
+			s.g.GmailBase+"/gmail/v1/users/me/profile", nil, &profile); err != nil {
+			return GitHubIdentity{}, err
+		}
+		return GitHubIdentity{Login: profile.EmailAddress, Email: profile.EmailAddress, Scopes: scopes}, nil
+	case s.hasScope("drive"):
+		var about struct {
+			User struct {
+				DisplayName  string `json:"displayName"`
+				EmailAddress string `json:"emailAddress"`
+			} `json:"user"`
+		}
+		if err := s.api(ctx, http.MethodGet,
+			s.g.DriveBase+"/about?fields=user", nil, &about); err != nil {
+			return GitHubIdentity{}, err
+		}
+		return GitHubIdentity{
+			Login: about.User.EmailAddress, Name: about.User.DisplayName,
+			Email: about.User.EmailAddress, Scopes: scopes,
+		}, nil
+	case s.hasScope("calendar"):
+		var cal struct {
+			ID string `json:"id"`
+		}
+		if err := s.api(ctx, http.MethodGet,
+			s.g.CalendarBase+"/calendars/primary", nil, &cal); err != nil {
+			return GitHubIdentity{}, err
+		}
+		return GitHubIdentity{Login: cal.ID, Email: cal.ID, Scopes: scopes}, nil
+	default:
+		// Defensive: the builder rejects a connector with no known
+		// scopes, so every built googleSource has at least one of the
+		// above. Fall back to Test's connectivity check with a zero
+		// identity so the caller still learns whether the credential works.
+		if err := s.Test(ctx); err != nil {
+			return GitHubIdentity{}, err
+		}
+		return GitHubIdentity{}, fmt.Errorf("google connector has no identity-capable scope (gmail, drive, or calendar)")
+	}
+}
+
 func (s *googleSource) hasScope(service string) bool {
 	for _, sc := range s.cfg.Scopes {
 		if strings.Contains(sc, service) {

--- a/internal/brain/connectors/manager.go
+++ b/internal/brain/connectors/manager.go
@@ -261,7 +261,8 @@ func (m *Manager) Test(ctx context.Context, id string) error {
 }
 
 // identifier is the optional Source capability that reports who a
-// credential authenticates as (github- and microsoft-kind today).
+// credential authenticates as (github-, microsoft-, and google-kind
+// today).
 // Type-asserted so kinds without an identity concept (mcp) are
 // untouched. microsoftSource reuses GitHubIdentity's shape rather than
 // a parallel type (see its Identity method).
@@ -270,7 +271,7 @@ type identifier interface {
 }
 
 // TestIdentity is Test plus, for a kind that can report one (github,
-// microsoft), the resolved identity — the evidence a working
+// microsoft, google), the resolved identity — the evidence a working
 // credential was configured, since a github connector serves no tools
 // to prove itself with otherwise (microsoft's tools require a scope
 // the operator may not have granted, so the identity check is useful

--- a/web/src/components/settings/ConnectorAdd.tsx
+++ b/web/src/components/settings/ConnectorAdd.tsx
@@ -18,7 +18,7 @@ import { connectorPresets } from './connectorPresets'
 import { CredentialModeToggle, ExistingCredentialSelect, type CredentialMode } from './CredentialRefPicker'
 import { Field } from './shared'
 import { useDefaultSecretBackend } from './useDefaultSecretBackend'
-import { errText, isTimothyAuthError, secretDestination } from './util'
+import { connectedAs, errText, isTimothyAuthError, secretDestination } from './util'
 
 // slugify turns a display name into a connector name (tool-name
 // prefix): lowercase slug, the backend rejects anything else.
@@ -384,8 +384,8 @@ export function ConnectorAdd() {
                 {busy
                   ? 'Testing connection…'
                   : tested
-                    ? isGitHub && test?.identity
-                      ? `Connected as ${test.identity.login} (${test.identity.email}), ${test.identity.scopes}.`
+                    ? test?.identity
+                      ? `${connectedAs(test.identity)}, ${test.identity.scopes}.`
                       : 'Connection OK, tools are servable.'
                     : test && !test.ok
                       ? `Connection failed: ${test.error}. The connector was saved disabled, fix and retry.`

--- a/web/src/components/settings/ConnectorEdit.tsx
+++ b/web/src/components/settings/ConnectorEdit.tsx
@@ -24,7 +24,7 @@ import { Input } from '../ui/input'
 import { ConnectorLogo } from './ConnectorLogo'
 import { connectorPresets, unknownPreset } from './connectorPresets'
 import { Field, Toggle } from './shared'
-import { errText, isTimothyAuthError } from './util'
+import { connectedAs, errText, isTimothyAuthError } from './util'
 
 // oauthProviderLabel names the OAuth provider for a connector kind —
 // both google and microsoft share the same reconnect/test UI shape.
@@ -198,8 +198,8 @@ export function ConnectorEdit() {
             {testing
               ? 'Testing connection…'
               : test?.ok
-                ? (connector.kind === 'github' || connector.kind === 'microsoft') && test.identity
-                  ? `Connected as ${test.identity.login} (${test.identity.email}), ${test.identity.scopes}.`
+                ? test.identity
+                  ? `${connectedAs(test.identity)}, ${test.identity.scopes}.`
                   : 'Connection OK, tools are servable.'
                 : test && !test.ok
                   ? `Failed: ${test.error}`

--- a/web/src/components/settings/ConnectorsList.tsx
+++ b/web/src/components/settings/ConnectorsList.tsx
@@ -7,7 +7,7 @@ import { Button } from '../ui/button'
 import { ConnectorLogo } from './ConnectorLogo'
 import { connectorPresets, unknownPreset } from './connectorPresets'
 import { Toggle } from './shared'
-import { errText, isTimothyAuthError } from './util'
+import { connectedAs, errText, isTimothyAuthError } from './util'
 
 export function ConnectorsList() {
   const [connectors, setConnectors] = useState<AdminConnector[]>([])
@@ -30,7 +30,7 @@ export function ConnectorsList() {
     <div className="mt-6 space-y-8">
       {oauthConnected && (
         <div className="flex items-center gap-3 rounded-xl border border-good/30 bg-good-soft p-3 text-sm text-good">
-          <span>Google account connected to “{oauthConnected}”. Enable it below to serve tools.</span>
+          <span>Account connected to “{oauthConnected}”. Enable it below to serve tools.</span>
           <button type="button" onClick={clearOAuthParams} className="ml-auto text-sm underline-offset-2 hover:underline">
             dismiss
           </button>
@@ -38,7 +38,7 @@ export function ConnectorsList() {
       )}
       {oauthError && (
         <div className="flex items-center gap-3 rounded-xl border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-          <span>Google connection failed: {oauthError}</span>
+          <span>Connection failed: {oauthError}</span>
           <button type="button" onClick={clearOAuthParams} className="ml-auto text-sm underline-offset-2 hover:underline">
             dismiss
           </button>
@@ -168,7 +168,7 @@ function ConnectorCard({
         >
           {test.ok
             ? test.identity
-              ? `Connected as ${test.identity.login} (${test.identity.email})`
+              ? connectedAs(test.identity)
               : 'Connection OK'
             : `Failed: ${test.error}`}
         </div>

--- a/web/src/components/settings/ConnectorsTab.test.tsx
+++ b/web/src/components/settings/ConnectorsTab.test.tsx
@@ -209,11 +209,11 @@ describe('Connectors tab', () => {
 
   it('shows the OAuth outcome banners from the callback redirect', async () => {
     renderTab('/settings/connectors?oauth_connected=personal')
-    expect(await screen.findByText(/Google account connected to “personal”/)).toBeTruthy()
+    expect(await screen.findByText(/Account connected to “personal”/)).toBeTruthy()
 
     cleanup()
     renderTab('/settings/connectors?oauth_error=access_denied')
-    expect(await screen.findByText(/Google connection failed: access_denied/)).toBeTruthy()
+    expect(await screen.findByText(/Connection failed: access_denied/)).toBeTruthy()
   })
 
   it('adds an MCP connector: secret, create disabled, test, enable', async () => {

--- a/web/src/components/settings/util.ts
+++ b/web/src/components/settings/util.ts
@@ -116,6 +116,16 @@ export function humanizeProbeDetail(detail: string): string {
   return detail
 }
 
+// connectedAs labels a test-connection identity, skipping the email
+// when it repeats the login (google/microsoft report the same address
+// for both).
+export function connectedAs(identity: { login: string; email: string }): string {
+  if (identity.email && identity.email !== identity.login) {
+    return `Connected as ${identity.login} (${identity.email})`
+  }
+  return `Connected as ${identity.login}`
+}
+
 // stripPaste removes whitespace and zero-width characters that ride
 // along when a key is copied out of wrapped text.
 export function stripPaste(v: string): string {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -23,7 +23,7 @@ export const settingsAreas = [
   {
     key: 'connectors',
     label: 'Connectors',
-    description: 'External services Timothy can act on, like Google or MCP servers.',
+    description: 'External services Timothy can act on, like Google, Outlook, or MCP servers.',
     render: ConnectorsTab,
   },
   {


### PR DESCRIPTION
- OAuth outcome banners and the connectors settings description no longer hardcode Google (a connected Outlook showed "Google account connected").
- Google-kind connectors implement the `identifier` capability: Test connection now reports the connected account, resolved from the first identity-capable consented scope (gmail profile, drive `about` for drive.readonly/drive.file, or the primary calendar id). Previously google tests showed only "Connection OK".
- Shared `connectedAs` label skips the parenthesized email when it repeats the login (google/microsoft report the same address for both).

No schema changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790212662&installation_model_id=431401&pr_number=328&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F328&signature=2ec7aeab84ef4ac99cda01e29ddf2928bbae6253a015b1dd79501a554c7a51c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->