### PR TITLE
feat: unified connector capability tools with account routing

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -406,6 +406,19 @@ func main() {
 		return names
 	}
 
+	// sensitiveAccountConnector resolves a unified aggregate tool call
+	// (e.g. mail_search) to the connector name its account actually
+	// routed to: the unified surface's counterpart to
+	// sensitiveConnectorNames' MCP-prefix matching, since an aggregate
+	// tool's own name carries no connector name to prefix-match against.
+	// conns nil (connector surface disabled) means every call resolves
+	// to "", never sensitive, same degrade as sensitiveConnectorNames.
+	sensitiveAccountConnector := func(_ context.Context, toolName string, args json.RawMessage) string {
+		if conns == nil {
+			return ""
+		}
+		return conns.AccountConnector(toolName, args)
+	}
 	// Single source of truth for "this turn/session executed a sensitive
 	// tool": a connector's own "sensitive" flag (set from the connectors
 	// settings UI) and the same sensitiveRoute resolver drive both the
@@ -416,8 +429,9 @@ func main() {
 	// resolving to "" at call time means the feature is currently off,
 	// same as before, but now editable at runtime from the settings UI.
 	sensitiveTools := &session.SensitiveTools{
-		ConnectorNames: sensitiveConnectorNames,
-		Route:          sensitiveRoute,
+		ConnectorNames:   sensitiveConnectorNames,
+		AccountConnector: sensitiveAccountConnector,
+		Route:            sensitiveRoute,
 	}
 	// Connector-level sensitivity's in-turn counterpart: a whole
 	// connector flagged sensitive must pin the SAME turn that calls its
@@ -427,7 +441,7 @@ func main() {
 	// session is sensitive, one turn too late for whatever content that
 	// tool just pulled into context. Wired here, after conns exists,
 	// rather than inside buildAgent (which runs before conns is built).
-	agent.SetForceRouteByConnector(sensitiveConnectorNames, sensitiveRoute)
+	agent.SetForceRouteByConnector(sensitiveConnectorNames, sensitiveRoute, sensitiveAccountConnector)
 
 	svc := chat.New(turnRouter{agent: agent, gw: gwc, flags: flags}, store, distill,
 		gatedCompactor{inner: compactor, flags: flags}, budgetFn, packs, flags.SkillAllowed,
@@ -807,10 +821,12 @@ func missionAgentResolver(agentReg *agents.Store) missions.AgentResolver {
 // missions.ConnectorReadsResolver: an agent's Tools allowlist
 // intersected with every built connector's ReadOnly-marked, non-MCP
 // tools (connectors.Manager.ReadOnlyTools already excludes MCP and
-// non-read-only tools). tools.ToolMatches is the same suffix rule
-// filterDefs/matchGrant use, so an allowlist entry authored before any
-// connector name is known (e.g. "gmail_search") still matches the
-// namespaced tool at resolve time.
+// non-read-only tools, and aggregates the rest into one unified tool
+// per capability, e.g. "mail_search" regardless of how many accounts
+// serve it. tools.ToolMatches is the same rule filterDefs/matchGrant
+// use: its exact-match branch is what actually fires here, since an
+// allowlist entry like "mail_search" IS the aggregated tool's own name,
+// with no connector-prefix suffix to resolve.
 func missionConnectorReadsResolver(agentReg *agents.Store, conns *connectors.Manager) missions.ConnectorReadsResolver {
 	return func(ctx context.Context, agentID string) []*tools.Tool {
 		a, ok := agentReg.ResolveByID(ctx, agentID)

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -1293,7 +1293,7 @@ func (s *Service) relay(reqCtx context.Context, sessionID, userText, route strin
 				return
 			}
 			ranTool = true
-			if s.sensitive.Matches(reqCtx, ev.ToolResult.Name) {
+			if s.sensitive.Matches(reqCtx, ev.ToolResult.Name, ev.ToolResult.Args) {
 				turnSensitive = true
 			}
 		}

--- a/internal/brain/connectors/aggregate_test.go
+++ b/internal/brain/connectors/aggregate_test.go
@@ -1,0 +1,225 @@
+package connectors
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// searchTool builds a minimal mail_search-shaped tool whose Execute
+// reports which account (by connector name) actually ran it, so a test
+// can assert routing without a real Google/Microsoft source.
+func searchTool(connector string, readOnly bool) *tools.Tool {
+	return &tools.Tool{
+		Name:        "mail_search",
+		ReadOnly:    readOnly,
+		Description: "Search mail.",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"query":{"type":"string"}},"required":["query"],"additionalProperties":false}`),
+		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
+			return "ran on " + connector, nil
+		},
+	}
+}
+
+func toolNamed(t *testing.T, ts []*tools.Tool, name string) *tools.Tool {
+	t.Helper()
+	for _, tl := range ts {
+		if tl.Name == name {
+			return tl
+		}
+	}
+	t.Fatalf("no aggregated tool named %q in %v", name, ts)
+	return nil
+}
+
+// TestAggregateSingleAccountDefaultsWithoutAccountArg pins the single-
+// account case: account is optional in the schema, and omitting it
+// routes to the lone account.
+func TestAggregateSingleAccountDefaultsWithoutAccountArg(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{})
+	m.sources = map[string]Source{
+		"gmail": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("gmail", true)}}, kind: "google"},
+	}
+
+	tl := toolNamed(t, m.Tools(), "mail_search")
+	var schema map[string]any
+	if err := json.Unmarshal(tl.InputSchema, &schema); err != nil {
+		t.Fatal(err)
+	}
+	req, _ := schema["required"].([]any)
+	for _, r := range req {
+		if r == "account" {
+			t.Fatal("account must not be required with a single account")
+		}
+	}
+
+	out, err := tl.Execute(t.Context(), json.RawMessage(`{"query":"x"}`))
+	if err != nil || out != "ran on gmail" {
+		t.Fatalf("Execute = (%q, %v), want ran on gmail", out, err)
+	}
+}
+
+// TestAggregateMultiAccountRequiresAccount pins the multi-account case:
+// account becomes required in the schema, and a call with no account
+// errors listing the valid options.
+func TestAggregateMultiAccountRequiresAccount(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{})
+	m.sources = map[string]Source{
+		"personal": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("personal", true)}}, kind: "google", email: "me@personal.com"},
+		"work":     &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("work", true)}}, kind: "microsoft", email: "me@work.com"},
+	}
+
+	tl := toolNamed(t, m.Tools(), "mail_search")
+	var schema map[string]any
+	if err := json.Unmarshal(tl.InputSchema, &schema); err != nil {
+		t.Fatal(err)
+	}
+	req, _ := schema["required"].([]any)
+	var hasAccount bool
+	for _, r := range req {
+		if r == "account" {
+			hasAccount = true
+		}
+	}
+	if !hasAccount {
+		t.Fatal("account must be required with several accounts")
+	}
+
+	if _, err := tl.Execute(t.Context(), json.RawMessage(`{"query":"x"}`)); err == nil {
+		t.Fatal("missing account with several candidates: want an error")
+	} else if !strings.Contains(err.Error(), "personal") || !strings.Contains(err.Error(), "work") {
+		t.Fatalf("error = %v, want it to list both accounts", err)
+	}
+
+	out, err := tl.Execute(t.Context(), json.RawMessage(`{"query":"x","account":"work"}`))
+	if err != nil || out != "ran on work" {
+		t.Fatalf("Execute(account=work) = (%q, %v), want ran on work", out, err)
+	}
+
+	// Matching by email, case-insensitively.
+	out, err = tl.Execute(t.Context(), json.RawMessage(`{"query":"x","account":"ME@PERSONAL.COM"}`))
+	if err != nil || out != "ran on personal" {
+		t.Fatalf("Execute(account=email) = (%q, %v), want ran on personal", out, err)
+	}
+}
+
+// TestAggregateUnknownAccountErrors pins that an account naming
+// neither a connector nor a known email errors, listing the valid
+// options.
+func TestAggregateUnknownAccountErrors(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{})
+	m.sources = map[string]Source{
+		"personal": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("personal", true)}}, kind: "google"},
+		"work":     &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("work", true)}}, kind: "microsoft"},
+	}
+
+	tl := toolNamed(t, m.Tools(), "mail_search")
+	_, err := tl.Execute(t.Context(), json.RawMessage(`{"query":"x","account":"nope"}`))
+	if err == nil || !strings.Contains(err.Error(), "nope") ||
+		!strings.Contains(err.Error(), "personal") || !strings.Contains(err.Error(), "work") {
+		t.Fatalf("Execute(unknown account) = %v, want an error naming nope and listing personal/work", err)
+	}
+}
+
+// TestAggregateDescriptionListsConnectedAccounts pins the description
+// shape: base description plus one line per account naming the
+// connector, its email when known, its kind, and mail_search's
+// provider-specific syntax hint.
+func TestAggregateDescriptionListsConnectedAccounts(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{})
+	m.sources = map[string]Source{
+		"personal": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("personal", true)}}, kind: "google", email: "me@personal.com"},
+		"work":     &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("work", true)}}, kind: "microsoft"},
+	}
+
+	desc := toolNamed(t, m.Tools(), "mail_search").Description
+	for _, want := range []string{
+		"Search mail.", "personal", "me@personal.com", "google",
+		"work", "microsoft", "For google accounts", "Gmail search syntax",
+		"For microsoft accounts", "Graph's $search",
+	} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("description = %q, want it to contain %q", desc, want)
+		}
+	}
+}
+
+// TestAggregateDescriptionKindGuidanceOnlyForContributingKinds pins
+// that a kind's mail_search guidance block only renders when that kind
+// actually contributes an account: a google-only deployment must never
+// see microsoft's Graph $search note, and vice versa.
+func TestAggregateDescriptionKindGuidanceOnlyForContributingKinds(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{})
+	m.sources = map[string]Source{
+		"personal": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("personal", true)}}, kind: "google"},
+	}
+
+	desc := toolNamed(t, m.Tools(), "mail_search").Description
+	if !strings.Contains(desc, "For google accounts") {
+		t.Fatalf("description = %q, want the google guidance block", desc)
+	}
+	if strings.Contains(desc, "For microsoft accounts") {
+		t.Fatalf("description = %q, must not contain microsoft guidance with no microsoft account connected", desc)
+	}
+}
+
+// TestAggregateReadOnlyRequiresAllAccountsReadOnly pins the ReadOnly
+// AND-across-accounts rule: one account's write-marked tool makes the
+// aggregate not ReadOnly, even though the other account's tool is.
+func TestAggregateReadOnlyRequiresAllAccountsReadOnly(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{})
+	m.sources = map[string]Source{
+		"a": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("a", true)}}, kind: "google"},
+		"b": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("b", false)}}, kind: "microsoft"},
+	}
+
+	tl := toolNamed(t, m.Tools(), "mail_search")
+	if tl.ReadOnly {
+		t.Fatal("aggregate ReadOnly=true, want false when any contributing account's tool is not ReadOnly")
+	}
+
+	// ReadOnlyTools must also drop the whole aggregate: only "a"'s copy
+	// is ReadOnly, but the unified tool covers both accounts and can't
+	// selectively deny "b" mid-call.
+	for _, tl := range m.ReadOnlyTools() {
+		if tl.Name == "mail_search" {
+			t.Fatal("ReadOnlyTools must not include mail_search when one account's tool is not ReadOnly")
+		}
+	}
+}
+
+// TestAggregateMCPPassthroughUnaffected pins that MCP sources keep
+// their existing "<connector>_<tool>" namespacing, appended alongside
+// the aggregated non-MCP surface: MCP tool names are external and
+// can't be unified.
+func TestAggregateMCPPassthroughUnaffected(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{})
+	m.sources = map[string]Source{
+		"gmail": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("gmail", true)}}, kind: "google"},
+		"slack": &mcpSource{name: "slack", toolList: []*tools.Tool{{Name: "read_channel", ReadOnly: true}}},
+	}
+
+	names := map[string]bool{}
+	for _, tl := range m.Tools() {
+		names[tl.Name] = true
+	}
+	if !names["mail_search"] {
+		t.Fatal("aggregated mail_search missing")
+	}
+	if !names["slack_read_channel"] {
+		t.Fatal("MCP tool must keep its connector-prefixed name")
+	}
+	if names["read_channel"] {
+		t.Fatal("MCP tool must not also appear un-namespaced")
+	}
+}

--- a/internal/brain/connectors/connectors.go
+++ b/internal/brain/connectors/connectors.go
@@ -38,22 +38,26 @@ type Connector struct {
 	Config        json.RawMessage `json:"config"`
 	CredentialRef string          `json:"credential_ref"`
 	Enabled       bool            `json:"enabled"`
-	// Sensitive marks the WHOLE connector as sensitive: every tool it
-	// serves is namespaced "<name>_<tool>" (see Manager.Tools), so the
-	// connector's own name is a PREFIX of every tool it serves —
-	// session.SensitiveTools.Matches checks this prefix in addition to
-	// its existing per-tool suffix rule (D-036), catching all of a
-	// sensitive connector's tools via its name alone.
+	// Sensitive marks the WHOLE connector as sensitive: an MCP
+	// connector's tools are namespaced "<name>_<tool>" (see
+	// Manager.Tools), so its own name is a PREFIX of every tool it
+	// serves, and session.SensitiveTools.Matches checks this prefix. A
+	// non-MCP connector's tools instead aggregate into unified,
+	// un-namespaced tools (mail_search etc.); Matches catches those via
+	// AccountConnector resolving a call's account back to this
+	// connector's name.
 	Sensitive bool `json:"sensitive"`
 }
 
-// namePattern keeps connector names usable as tool-name prefixes
-// (tools surface as "<name>_<tool>"): lowercase slug, no spaces.
+// namePattern keeps connector names usable both as MCP tool-name
+// prefixes ("<name>_<tool>") and as a unified aggregate tool's
+// "account" argument value (see Manager.aggregateTools): lowercase
+// slug, no spaces.
 var namePattern = regexp.MustCompile(`^[a-z0-9]+(?:[-_][a-z0-9]+)*$`)
 
 func validate(c Connector) error {
 	if !namePattern.MatchString(c.Name) {
-		return fmt.Errorf("name must be a lowercase slug (a-z, 0-9, - or _), it prefixes the connector's tool names")
+		return fmt.Errorf("name must be a lowercase slug (a-z, 0-9, - or _), it prefixes MCP tool names and is used as an account argument")
 	}
 	if !kinds[c.Kind] {
 		return fmt.Errorf("unknown kind %q", c.Kind)

--- a/internal/brain/connectors/google.go
+++ b/internal/brain/connectors/google.go
@@ -24,6 +24,12 @@ type GoogleConfig struct {
 	ClientID        string   `json:"client_id"`
 	ClientSecretRef string   `json:"client_secret_ref"`
 	Scopes          []string `json:"scopes"`
+	// AccountEmail is the connected account's email, resolved and
+	// persisted once at connect time (see HandleCallback), read back
+	// by Manager's aggregation for account matching/descriptions
+	// without an API call per Tools(). Empty until resolved or if
+	// resolution failed; that never fails the connect.
+	AccountEmail string `json:"account_email,omitempty"`
 }
 
 // tokenBundle is what the OAuth dance stores at the connector's
@@ -205,7 +211,45 @@ func (g *Google) HandleCallback(ctx context.Context, state, code string) (string
 	if err := g.storeBundle(ctx, c.CredentialRef, bundle); err != nil {
 		return "", err
 	}
+	g.persistAccountEmail(ctx, c, cfg)
 	return c.Name, nil
+}
+
+// rowPatcher is the optional Rows capability that lets HandleCallback
+// persist the resolved account email into config.account_email: a
+// bare rowSource (as tests pass) has no Patch, so persistence is
+// skipped there rather than required.
+type rowPatcher interface {
+	Patch(ctx context.Context, id string, patch Patch) error
+}
+
+// persistAccountEmail resolves the just-connected account's email and
+// writes it to config.account_email so Manager's aggregation can build
+// account-matching and descriptions without an API call per Tools().
+// Best-effort: identity resolution or the patch failing only logs;
+// the connect itself already succeeded, and the email simply stays
+// unknown until the next successful resolution (e.g. a later Test).
+func (g *Google) persistAccountEmail(ctx context.Context, c Connector, cfg GoogleConfig) {
+	patcher, ok := g.Rows.(rowPatcher)
+	if !ok {
+		return
+	}
+	src := &googleSource{g: g, cfg: cfg, ref: c.CredentialRef}
+	identity, err := src.Identity(ctx)
+	if err != nil || identity.Email == "" {
+		g.Log.Warn("could not resolve google account email at connect", "connector", c.Name, "error", err)
+		return
+	}
+	cfg.AccountEmail = identity.Email
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		g.Log.Warn("could not encode google config with account email", "connector", c.Name, "error", err)
+		return
+	}
+	rawMsg := json.RawMessage(raw)
+	if err := patcher.Patch(ctx, c.ID, Patch{Config: &rawMsg}); err != nil {
+		g.Log.Warn("could not persist google account email", "connector", c.Name, "error", err)
+	}
 }
 
 // exchange posts to the token endpoint with client credentials and

--- a/internal/brain/connectors/google_test.go
+++ b/internal/brain/connectors/google_test.go
@@ -483,10 +483,10 @@ func TestGoogleReadOnlyToolsPinned(t *testing.T) {
 	}
 
 	want := map[string]bool{
-		"gmail_search":          true,
-		"gmail_read":            true,
-		"gmail_read_attachment": true,
-		"calendar_list_events":  true,
+		"mail_search":          true,
+		"mail_read":            true,
+		"mail_read_attachment": true,
+		"calendar_list_events": true,
 	}
 	got := map[string]bool{}
 	for _, tl := range src.Tools() {
@@ -552,15 +552,15 @@ func TestGmailToolsRoundTrip(t *testing.T) {
 	f := &fakeGoogle{}
 	src, _ := connectedSource(t, f)
 
-	out, err := toolByName(t, src, "gmail_search").Execute(t.Context(), json.RawMessage(`{"query":"is:unread"}`))
+	out, err := toolByName(t, src, "mail_search").Execute(t.Context(), json.RawMessage(`{"query":"is:unread"}`))
 	if err != nil || !strings.Contains(out, "subject: hi") {
 		t.Fatalf("search = (%q, %v)", out, err)
 	}
-	out, err = toolByName(t, src, "gmail_read").Execute(t.Context(), json.RawMessage(`{"id":"m1"}`))
+	out, err = toolByName(t, src, "mail_read").Execute(t.Context(), json.RawMessage(`{"id":"m1"}`))
 	if err != nil || !strings.Contains(out, "hello body") {
 		t.Fatalf("read = (%q, %v)", out, err)
 	}
-	out, err = toolByName(t, src, "gmail_send").Execute(t.Context(),
+	out, err = toolByName(t, src, "mail_send").Execute(t.Context(),
 		json.RawMessage(`{"to":"b@y","subject":"re: hi","body":"on my way"}`))
 	if err != nil || !strings.Contains(out, "sent-1") {
 		t.Fatalf("send = (%q, %v)", out, err)
@@ -704,7 +704,7 @@ func TestGmailSearchZeroResultsSuggestsBroadening(t *testing.T) {
 	f := &fakeGoogle{}
 	src, _ := connectedSource(t, f)
 
-	out, err := toolByName(t, src, "gmail_search").Execute(t.Context(),
+	out, err := toolByName(t, src, "mail_search").Execute(t.Context(),
 		json.RawMessage(`{"query":"from:nowhere.invalid"}`))
 	if err != nil {
 		t.Fatalf("search: %v", err)
@@ -725,7 +725,7 @@ func TestGmailReadFallsBackToMarkItDownForHTMLOnlyBody(t *testing.T) {
 	f := &fakeGoogle{}
 	src, _ := connectedSource(t, f)
 
-	out, err := toolByName(t, src, "gmail_read").Execute(t.Context(), json.RawMessage(`{"id":"m2"}`))
+	out, err := toolByName(t, src, "mail_read").Execute(t.Context(), json.RawMessage(`{"id":"m2"}`))
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
@@ -751,7 +751,7 @@ func TestGmailReadListsAttachmentsAndReadAttachmentUsesMarkItDown(t *testing.T) 
 	f := &fakeGoogle{}
 	src, _ := connectedSource(t, f)
 
-	out, err := toolByName(t, src, "gmail_read").Execute(t.Context(), json.RawMessage(`{"id":"m3"}`))
+	out, err := toolByName(t, src, "mail_read").Execute(t.Context(), json.RawMessage(`{"id":"m3"}`))
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
@@ -762,7 +762,7 @@ func TestGmailReadListsAttachmentsAndReadAttachmentUsesMarkItDown(t *testing.T) 
 		t.Fatalf("read = %q, want the raw attachment id kept out of what the model sees", out)
 	}
 
-	out, err = toolByName(t, src, "gmail_read_attachment").Execute(t.Context(),
+	out, err = toolByName(t, src, "mail_read_attachment").Execute(t.Context(),
 		json.RawMessage(`{"message_id":"m3","filename":"receipt.pdf"}`))
 	if err != nil {
 		t.Fatalf("read_attachment: %v", err)
@@ -777,7 +777,7 @@ func TestGmailReadAttachmentRejectsUnknownFilename(t *testing.T) {
 	f := &fakeGoogle{}
 	src, _ := connectedSource(t, f)
 
-	_, err := toolByName(t, src, "gmail_read_attachment").Execute(t.Context(),
+	_, err := toolByName(t, src, "mail_read_attachment").Execute(t.Context(),
 		json.RawMessage(`{"message_id":"m3","filename":"nope.pdf"}`))
 	if err == nil {
 		t.Fatal("expected an error for an unknown attachment filename")

--- a/internal/brain/connectors/google_tools.go
+++ b/internal/brain/connectors/google_tools.go
@@ -66,6 +66,14 @@ func (s *googleSource) Test(ctx context.Context) error {
 
 func (s *googleSource) Close() error { return nil }
 
+// AccountInfo reports this source's kind and connected account email
+// (the accountInfo capability, see manager.go's aggregation); email is
+// whatever HandleCallback persisted at connect time, empty if
+// resolution failed or the connector predates it.
+func (s *googleSource) AccountInfo() (kind, email string) {
+	return "google", s.cfg.AccountEmail
+}
+
 // Identity resolves the connected account's email — the panel's
 // evidence a working credential was configured, same role as
 // githubSource.Identity and microsoftSource.Identity. Reuses
@@ -285,28 +293,14 @@ func htmlPart(parts []gmailPart) []byte {
 
 func (s *googleSource) gmailSearch() *tools.Tool {
 	return &tools.Tool{
-		Name:     "gmail_search",
+		Name:     "mail_search",
 		ReadOnly: true,
-		Description: `Search the connected Gmail account. query uses Gmail search syntax
-(from:, subject:, is:unread, newer_than:7d, after:YYYY/MM/DD, ...).
-Returns up to max_results (default 10) messages as id, date, from,
-subject, snippet. Use gmail_read with an id for the full body.
-
-A zero-result search does NOT mean the email doesn't exist — Gmail's
-from: matching is stricter than it looks, and a query combining from:
-with keyword/subject terms narrows twice, compounding a near-miss into
-zero. If a targeted search returns nothing, retry BROADER before
-concluding the email isn't there:
-1. Drop keyword/subject filters, keep only from: and a date range.
-2. If from: with a bare domain (e.g. from:example.com) misses, try
-   the FULL sender address you're looking for, or a shorter substring
-   of the domain, or just the company name as a plain keyword with no
-   from: operator at all.
-3. Widen the date range (after:/before:/newer_than:) — a mistaken
-   assumption about when an email arrived is a common miss.
-4. Try in:anywhere if you suspect it's archived or in another label.`,
+		Description: `Search a connected mail account. Returns up to max_results
+(default 10) messages as id, date, from, subject, snippet. Use
+mail_read with an id for the full body. See the tool description's
+Connected accounts list for this account's query syntax.`,
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
-			"query":{"type":"string","description":"Gmail search query"},
+			"query":{"type":"string","description":"search query"},
 			"max_results":{"type":"integer","minimum":1,"maximum":25}
 		},"required":["query"],"additionalProperties":false}`),
 		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
@@ -392,11 +386,11 @@ func findAttachment(parts []gmailPart, filename string) (string, bool) {
 
 func (s *googleSource) gmailRead() *tools.Tool {
 	return &tools.Tool{
-		Name:        "gmail_read",
+		Name:        "mail_read",
 		ReadOnly:    true,
-		Description: "Read one email's full content by message id (from gmail_search). Returns headers and the body — plain text when available, otherwise the HTML body rendered to readable text (common for booking confirmations and receipts) — plus a list of attachment filenames, if any. Use gmail_read_attachment with the message id and a filename from that list to read an attachment's content.",
+		Description: "Read one email's full content by message id (from mail_search). Returns headers and the body as readable text, plus a list of attachment filenames, if any. Use mail_read_attachment with the message id and a filename from that list to read an attachment's content.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
-			"id":{"type":"string","description":"Gmail message id"}
+			"id":{"type":"string","description":"message id"}
 		},"required":["id"],"additionalProperties":false}`),
 		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
 			var in struct {
@@ -439,12 +433,12 @@ func (s *googleSource) gmailRead() *tools.Tool {
 
 func (s *googleSource) gmailReadAttachment() *tools.Tool {
 	return &tools.Tool{
-		Name:        "gmail_read_attachment",
+		Name:        "mail_read_attachment",
 		ReadOnly:    true,
-		Description: "Reads an attachment's content as markdown/text, given a message id and the attachment's filename (both from gmail_read's attachments list). Handles PDFs, Office documents, and other common formats.",
+		Description: "Reads an attachment's content as markdown/text, given a message id and the attachment's filename (both from mail_read's attachments list). Handles PDFs, Office documents, and other common formats.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
-			"message_id":{"type":"string","description":"Gmail message id"},
-			"filename":{"type":"string","description":"Attachment filename from gmail_read's attachments list"}
+			"message_id":{"type":"string","description":"message id"},
+			"filename":{"type":"string","description":"Attachment filename from mail_read's attachments list"}
 		},"required":["message_id","filename"],"additionalProperties":false}`),
 		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
 			var in struct {
@@ -465,7 +459,7 @@ func (s *googleSource) gmailReadAttachment() *tools.Tool {
 			}
 			attachmentID, ok := findAttachment(msg.Payload.Parts, in.Filename)
 			if !ok {
-				return "", fmt.Errorf("no attachment named %q on this message; check gmail_read's attachments list", in.Filename)
+				return "", fmt.Errorf("no attachment named %q on this message; check mail_read's attachments list", in.Filename)
 			}
 			var att gmailBody
 			if err := s.api(ctx, http.MethodGet,
@@ -484,8 +478,8 @@ func (s *googleSource) gmailReadAttachment() *tools.Tool {
 
 func (s *googleSource) gmailSend() *tools.Tool {
 	return &tools.Tool{
-		Name:        "gmail_send",
-		Description: "Send an email from the connected Gmail account. Plain text only. Use only when the user asked for an email to be sent; the recipient sees it immediately.",
+		Name:        "mail_send",
+		Description: "Send an email from a connected mail account. Plain text only. Use only when the user asked for an email to be sent; the recipient sees it immediately.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"to":{"type":"string","description":"recipient address(es), comma-separated"},
 			"subject":{"type":"string"},
@@ -525,7 +519,7 @@ func (s *googleSource) calendarListEvents() *tools.Tool {
 	return &tools.Tool{
 		Name:        "calendar_list_events",
 		ReadOnly:    true,
-		Description: "List events from the connected Google Calendar (primary calendar). Omit time_min/time_max for the default window — the next 7 days from now; set them (RFC3339 UTC) only when the goal needs a different window, computed from today's actual date. Returns start, end, summary, and location per event.",
+		Description: "List events from the connected calendar in a time window. Omit time_min/time_max for the default window, the next 7 days from now; set them (RFC3339 UTC) only when the goal needs a different window, computed from today's actual date. Returns start, end, title, and location per event.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"time_min":{"type":"string","description":"RFC3339 UTC timestamp; omit for the default window"},
 			"time_max":{"type":"string","description":"RFC3339 UTC timestamp; omit for the default window"},

--- a/internal/brain/connectors/manager.go
+++ b/internal/brain/connectors/manager.go
@@ -2,9 +2,12 @@ package connectors
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"regexp"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -142,57 +145,349 @@ func (m *Manager) Reload(ctx context.Context) error {
 // toolNameSanitizer strips characters providers reject in tool names.
 var toolNameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
 
-// Tools returns every built connector's tools, each renamed to
-// "<connector>_<tool>" so names never collide across connectors or
-// with the builtin set. The clones share the source's Execute.
+// Tools returns the agent's whole non-MCP tool surface aggregated one
+// tool per raw name (see aggregateTools), plus every MCP source's
+// tools individually namespaced "<connector>_<tool>" as before: MCP
+// servers are external, their names can't be unified.
 func (m *Manager) Tools() []*tools.Tool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	var out []*tools.Tool
+	out := aggregateTools(m.sources, false)
 	for name, src := range m.sources {
-		for _, t := range src.Tools() {
-			full := toolNameSanitizer.ReplaceAllString(name+"_"+t.Name, "_")
-			if len(full) > 128 {
-				full = full[:128]
-			}
-			clone := *t
-			clone.Name = full
-			out = append(out, &clone)
+		mcp, isMCP := src.(*mcpSource)
+		if !isMCP {
+			continue
 		}
+		out = append(out, namespacedTools(name, mcp.Tools())...)
 	}
 	return out
 }
 
-// ReadOnlyTools returns every built connector's ReadOnly-marked tools,
-// namespaced exactly like Tools — for mission turns, which must see
-// connector reads (gmail search, calendar list) despite BuiltinsOnly
-// but never connector writes (see missions.nativeRunner's connector
-// reads resolver). MCP sources are excluded unconditionally, marker or
-// not: a remote MCP server's tool can change behavior between builds,
-// and nothing here can verify a "read-only" claim actually holds —
-// unlike google's tool constructors, which are Timothy's own code.
+// ReadOnlyTools returns the aggregated ReadOnly-marked non-MCP tool
+// surface, for mission turns, which must see connector reads (mail
+// search, calendar list) despite BuiltinsOnly but never connector
+// writes (see missions.nativeRunner's connector reads resolver). MCP
+// sources are excluded unconditionally, marker or not: a remote MCP
+// server's tool can change behavior between builds, and nothing here
+// can verify a "read-only" claim actually holds, unlike google/
+// microsoft's tool constructors, which are Timothy's own code.
 func (m *Manager) ReadOnlyTools() []*tools.Tool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	var out []*tools.Tool
+	return aggregateTools(m.sources, true)
+}
+
+// AccountConnector resolves which connector name a unified tool call
+// (toolName plus its args) would actually route to: the same account
+// resolution aggregateTool's Execute applies, exposed standalone so
+// callers that only need to know WHICH connector a call touches (e.g.
+// connector-level sensitivity, session.SensitiveTools) don't have to
+// re-run the call to find out. Returns "" when toolName isn't a
+// currently aggregated non-MCP tool, or when args' account doesn't
+// resolve (missing-but-required, or unknown); callers fall back to
+// their own default in that case, same as any non-connector tool call.
+func (m *Manager) AccountConnector(toolName string, args json.RawMessage) string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	byName := map[string][]toolAccount{}
 	for name, src := range m.sources {
 		if _, isMCP := src.(*mcpSource); isMCP {
 			continue
 		}
+		var kind, email string
+		if info, ok := src.(accountInfo); ok {
+			kind, email = info.AccountInfo()
+		}
 		for _, t := range src.Tools() {
-			if !t.ReadOnly {
+			if t.Name != toolName {
 				continue
 			}
-			full := toolNameSanitizer.ReplaceAllString(name+"_"+t.Name, "_")
-			if len(full) > 128 {
-				full = full[:128]
-			}
-			clone := *t
-			clone.Name = full
-			out = append(out, &clone)
+			byName[t.Name] = append(byName[t.Name], toolAccount{connector: name, kind: kind, email: email, tool: t})
 		}
 	}
+	accounts, ok := byName[toolName]
+	if !ok {
+		return ""
+	}
+	acc, _, err := resolveAccount(accounts, args)
+	if err != nil {
+		return ""
+	}
+	return acc.connector
+}
+
+// namespacedTools clones ts renamed "<name>_<tool>", sanitized and
+// length-capped: MCP's tool-naming scheme, unchanged by unification.
+func namespacedTools(name string, ts []*tools.Tool) []*tools.Tool {
+	out := make([]*tools.Tool, 0, len(ts))
+	for _, t := range ts {
+		full := toolNameSanitizer.ReplaceAllString(name+"_"+t.Name, "_")
+		if len(full) > 128 {
+			full = full[:128]
+		}
+		clone := *t
+		clone.Name = full
+		out = append(out, &clone)
+	}
 	return out
+}
+
+// accountInfo is the optional Source capability that reports the
+// source's kind and connected account email (google-, microsoft-kind
+// today): the input aggregateTools groups tools around. A source that
+// doesn't implement it (mcp) is never aggregated; Tools/ReadOnlyTools
+// handle mcp separately.
+type accountInfo interface {
+	AccountInfo() (kind, email string)
+}
+
+// toolAccount is one accountInfo-capable source's contribution to an
+// aggregated tool: its connector name/kind/email (for account matching
+// and the description's connected-accounts list) plus its own
+// (un-namespaced) tool.
+type toolAccount struct {
+	connector string
+	kind      string
+	email     string
+	tool      *tools.Tool
+}
+
+// aggregateTools groups every non-MCP source's tools by their RAW
+// (un-namespaced) name and returns one aggregate tool per name, giving
+// the unified mail surface: "mail_search" once, regardless of how many
+// accounts or connector kinds serve it. A future connector kind joins
+// this surface automatically just by giving its tools the same raw
+// names; accountInfo is read opportunistically for kind/email metadata
+// (empty when a source doesn't implement it) and never gates whether a
+// source's tools aggregate. readOnlyOnly mirrors the old ReadOnlyTools'
+// filter: a WHOLE aggregate is dropped unless every contributing
+// account's tool is ReadOnly. Contributing accounts on one capability
+// should always agree (see aggregateTool's ReadOnly), so this only ever
+// matters if that invariant is somehow violated, in which case the
+// safer behavior is to withhold the capability entirely rather than
+// silently narrow it to a subset of accounts.
+func aggregateTools(sources map[string]Source, readOnlyOnly bool) []*tools.Tool {
+	byName := map[string][]toolAccount{}
+	var order []string
+	for name, src := range sources {
+		if _, isMCP := src.(*mcpSource); isMCP {
+			continue
+		}
+		var kind, email string
+		if info, ok := src.(accountInfo); ok {
+			kind, email = info.AccountInfo()
+		}
+		for _, t := range src.Tools() {
+			if _, seen := byName[t.Name]; !seen {
+				order = append(order, t.Name)
+			}
+			byName[t.Name] = append(byName[t.Name], toolAccount{connector: name, kind: kind, email: email, tool: t})
+		}
+	}
+	sort.Strings(order)
+	out := make([]*tools.Tool, 0, len(order))
+	for _, name := range order {
+		accounts := byName[name]
+		sort.Slice(accounts, func(i, j int) bool { return accounts[i].connector < accounts[j].connector })
+		agg := aggregateTool(name, accounts)
+		if readOnlyOnly && !agg.ReadOnly {
+			continue
+		}
+		out = append(out, agg)
+	}
+	return out
+}
+
+// aggregateTool builds one aggregated tool from every account serving
+// raw name: the model sees exactly this shape regardless of which or
+// how many connectors/kinds contribute.
+func aggregateTool(name string, accounts []toolAccount) *tools.Tool {
+	readOnly := true
+	for _, a := range accounts {
+		if !a.tool.ReadOnly {
+			readOnly = false
+			break
+		}
+	}
+	return &tools.Tool{
+		Name:        name,
+		ReadOnly:    readOnly,
+		Description: aggregateDescription(accounts),
+		InputSchema: injectAccountProperty(accounts[0].tool.InputSchema, len(accounts) > 1),
+		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
+			acc, stripped, err := resolveAccount(accounts, args)
+			if err != nil {
+				return "", err
+			}
+			return acc.tool.Execute(ctx, stripped)
+		},
+	}
+}
+
+// aggregateDescription is the shared tool's own description (every
+// account's copy is schema-identical by construction, see
+// TestGoogleMicrosoftSharedToolSchemasMatch) plus a connected-accounts
+// list naming which account argument reaches which connector, its
+// kind, its email when known, and, for mail_search specifically, the
+// provider's query syntax, since that's where google and microsoft
+// diverge and the shared schema has nowhere else to say so.
+func aggregateDescription(accounts []toolAccount) string {
+	var b strings.Builder
+	b.WriteString(accounts[0].tool.Description)
+	b.WriteString("\n\nConnected accounts:\n")
+	for _, a := range accounts {
+		fmt.Fprintf(&b, "- %s", a.connector)
+		if a.email != "" {
+			fmt.Fprintf(&b, " (%s)", a.email)
+		}
+		fmt.Fprintf(&b, ": %s\n", a.kind)
+	}
+	if len(accounts) == 1 {
+		fmt.Fprintf(&b, "\naccount is optional here, omit it to use %s.", accounts[0].connector)
+	} else {
+		b.WriteString("\naccount is required: pass one of the connector names or emails above.")
+	}
+	if accounts[0].tool.Name == "mail_search" {
+		b.WriteString(mailSearchKindGuidance(accounts))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// mailSearchGuidanceByKind holds mail_search's per-provider query
+// syntax guidance, rendered by mailSearchKindGuidance only for kinds
+// actually contributing an account. Keyed by accountInfo's kind
+// string. The google entry keeps the zero-result broaden-retry
+// heuristics: they are valuable operational guidance, scoped here to
+// the accounts they actually apply to instead of living in the base,
+// provider-neutral tool description.
+var mailSearchGuidanceByKind = map[string]string{
+	"google": `
+For google accounts: query uses Gmail search syntax (from:, subject:,
+is:unread, newer_than:7d, after:YYYY/MM/DD, ...).
+
+A zero-result search does NOT mean the email doesn't exist: Gmail's
+from: matching is stricter than it looks, and a query combining from:
+with keyword/subject terms narrows twice, compounding a near-miss into
+zero. If a targeted search returns nothing, retry BROADER before
+concluding the email isn't there:
+1. Drop keyword/subject filters, keep only from: and a date range.
+2. If from: with a bare domain (e.g. from:example.com) misses, try
+   the FULL sender address you're looking for, or a shorter substring
+   of the domain, or just the company name as a plain keyword with no
+   from: operator at all.
+3. Widen the date range (after:/before:/newer_than:), a mistaken
+   assumption about when an email arrived is a common miss.
+4. Try in:anywhere if you suspect it's archived or in another label.`,
+	"microsoft": `
+For microsoft accounts: query matches subject, body, and sender across
+messages (Graph's $search); plain keywords, no operator syntax.`,
+}
+
+// mailSearchKindGuidance renders one guidance block per KIND actually
+// contributing an account to accounts, in a fixed order (google, then
+// microsoft) so the description is stable regardless of map iteration
+// or account sort order.
+func mailSearchKindGuidance(accounts []toolAccount) string {
+	seen := map[string]bool{}
+	for _, a := range accounts {
+		seen[a.kind] = true
+	}
+	var b strings.Builder
+	for _, kind := range []string{"google", "microsoft"} {
+		if !seen[kind] {
+			continue
+		}
+		b.WriteString("\n")
+		b.WriteString(mailSearchGuidanceByKind[kind])
+	}
+	return b.String()
+}
+
+// injectAccountProperty adds an "account" string property to base (a
+// tool's InputSchema, always {"type":"object","properties":{...},
+// "required":[...],"additionalProperties":false} by construction, see
+// tools.Tool's builtin/connector constructors); required only when
+// several accounts serve the capability, since a lone account has an
+// unambiguous default.
+func injectAccountProperty(base json.RawMessage, accountRequired bool) json.RawMessage {
+	var schema map[string]any
+	// The base schema is always valid JSON built by our own tool
+	// constructors; a decode failure here would be a programming error,
+	// not a runtime condition to recover from gracefully. Fall back to
+	// returning base unmodified rather than panicking.
+	if err := json.Unmarshal(base, &schema); err != nil {
+		return base
+	}
+	props, _ := schema["properties"].(map[string]any)
+	if props == nil {
+		props = map[string]any{}
+	}
+	props["account"] = map[string]any{
+		"type":        "string",
+		"description": "which connected account to use: a connector name or its email (see the tool description's Connected accounts list)",
+	}
+	schema["properties"] = props
+	if accountRequired {
+		req, _ := schema["required"].([]any)
+		schema["required"] = append(req, "account")
+	}
+	out, err := json.Marshal(schema)
+	if err != nil {
+		return base
+	}
+	return out
+}
+
+// resolveAccount picks which account's tool serves one call: args'
+// "account" (connector name or email, case-insensitive) when several
+// accounts are available, or the sole account by default when there's
+// only one. Returns args with "account" stripped, since the underlying
+// tool's own schema never declared that property. An unknown or
+// missing (when required) account errors listing the valid names.
+func resolveAccount(accounts []toolAccount, args json.RawMessage) (toolAccount, json.RawMessage, error) {
+	var in map[string]json.RawMessage
+	if len(args) > 0 {
+		if err := json.Unmarshal(args, &in); err != nil {
+			return toolAccount{}, nil, err
+		}
+	}
+	var account string
+	if raw, ok := in["account"]; ok {
+		if err := json.Unmarshal(raw, &account); err != nil {
+			return toolAccount{}, nil, fmt.Errorf("account must be a string")
+		}
+		delete(in, "account")
+	}
+	stripped, err := json.Marshal(in)
+	if err != nil {
+		return toolAccount{}, nil, err
+	}
+	if account == "" {
+		if len(accounts) == 1 {
+			return accounts[0], stripped, nil
+		}
+		return toolAccount{}, nil, fmt.Errorf("account is required (%d connected accounts): %s", len(accounts), accountNames(accounts))
+	}
+	for _, a := range accounts {
+		if strings.EqualFold(a.connector, account) || (a.email != "" && strings.EqualFold(a.email, account)) {
+			return a, stripped, nil
+		}
+	}
+	return toolAccount{}, nil, fmt.Errorf("unknown account %q; valid accounts: %s", account, accountNames(accounts))
+}
+
+// accountNames renders every account's connector name (plus email when
+// known) for an error message's option list.
+func accountNames(accounts []toolAccount) string {
+	names := make([]string, 0, len(accounts))
+	for _, a := range accounts {
+		if a.email != "" {
+			names = append(names, fmt.Sprintf("%s (%s)", a.connector, a.email))
+		} else {
+			names = append(names, a.connector)
+		}
+	}
+	return strings.Join(names, ", ")
 }
 
 // SetOnReload registers a hook that fires after every successful
@@ -232,12 +527,14 @@ func (m *Manager) Names() []string {
 }
 
 // SensitiveNames returns the names of every enabled connector marked
-// sensitive — the sole input to session.SensitiveTools.ConnectorNames
-// (D-036): a connector named "gmail" being sensitive means "gmail"
-// joins the set, and Matches' namespace-prefix check catches
-// gmail_search/gmail_read/etc. at once. Reads rows fresh each call (no
-// restart needed for a settings toggle to take effect), same reasoning
-// as sensitiveRoute.
+// sensitive: the input to session.SensitiveTools.ConnectorNames
+// (D-036): a connector named "personal-gmail" being sensitive means
+// "personal-gmail" joins the set, caught either via Matches' namespace-
+// prefix check (an MCP tool actually namespaced that way) or via
+// AccountConnector resolving a unified aggregate call's account (e.g.
+// mail_search) to that same connector name. Reads rows fresh each call
+// (no restart needed for a settings toggle to take effect), same
+// reasoning as sensitiveRoute.
 func (m *Manager) SensitiveNames(ctx context.Context) ([]string, error) {
 	rows, err := m.rows.List(ctx)
 	if err != nil {

--- a/internal/brain/connectors/manager_test.go
+++ b/internal/brain/connectors/manager_test.go
@@ -34,9 +34,20 @@ type fakeSource struct {
 	tested  bool
 }
 
-func (f *fakeSource) Tools() []*tools.Tool        { return f.tools }
-func (f *fakeSource) Test(context.Context) error  { f.tested = true; return f.testErr }
-func (f *fakeSource) Close() error                { f.closed = true; return nil }
+func (f *fakeSource) Tools() []*tools.Tool       { return f.tools }
+func (f *fakeSource) Test(context.Context) error { f.tested = true; return f.testErr }
+func (f *fakeSource) Close() error               { f.closed = true; return nil }
+
+// fakeAccountSource is a fakeSource that also implements accountInfo:
+// google/microsoft's role in aggregation tests, without the real
+// OAuth/API machinery.
+type fakeAccountSource struct {
+	fakeSource
+	kind  string
+	email string
+}
+
+func (f *fakeAccountSource) AccountInfo() (string, string) { return f.kind, f.email }
 
 func testManager(rows rowSource) *Manager {
 	return &Manager{
@@ -100,6 +111,7 @@ func TestReloadSkipsFailedBuildAndClosesOld(t *testing.T) {
 // filter: only ReadOnly-marked tools, and never from an MCP source —
 // even one whose tool happens to carry ReadOnly, since a remote MCP
 // server's claim can't be verified (see ReadOnlyTools' doc comment).
+// Non-MCP tools aggregate un-namespaced (see aggregateTools).
 func TestReadOnlyToolsExcludesWritesAndMCP(t *testing.T) {
 	t.Parallel()
 	m := testManager(fakeRows{})
@@ -117,8 +129,8 @@ func TestReadOnlyToolsExcludesWritesAndMCP(t *testing.T) {
 	for _, t := range m.ReadOnlyTools() {
 		got[t.Name] = true
 	}
-	want := map[string]bool{"gmail_search": true}
-	if len(got) != len(want) || !got["gmail_search"] {
+	want := map[string]bool{"search": true}
+	if len(got) != len(want) || !got["search"] {
 		t.Fatalf("ReadOnlyTools = %v, want %v", got, want)
 	}
 }

--- a/internal/brain/connectors/mcp_test.go
+++ b/internal/brain/connectors/mcp_test.go
@@ -248,11 +248,15 @@ func TestMCPStatusErrorNeverLeaksRawJSON(t *testing.T) {
 	}
 }
 
-func TestManagerNamespacesTools(t *testing.T) {
+// TestManagerNamespacesMCPTools pins that only MCP sources still get
+// the "<connector>_<tool>" prefix (external names can't be unified);
+// a real *mcpSource is used since Manager's MCP exclusion in
+// aggregateTools type-asserts against it specifically.
+func TestManagerNamespacesMCPTools(t *testing.T) {
 	t.Parallel()
 	m := testManager(fakeRows{})
 	m.sources = map[string]Source{
-		"github": &fakeSource{tools: []*tools.Tool{
+		"github": &mcpSource{name: "github", toolList: []*tools.Tool{
 			{Name: "create_issue"},
 			{Name: "search code"}, // space sanitized
 		}},

--- a/internal/brain/connectors/microsoft.go
+++ b/internal/brain/connectors/microsoft.go
@@ -23,6 +23,10 @@ type MicrosoftConfig struct {
 	ClientID        string   `json:"client_id"`
 	ClientSecretRef string   `json:"client_secret_ref"`
 	Scopes          []string `json:"scopes"`
+	// AccountEmail is the connected account's email, resolved and
+	// persisted once at connect time (see HandleCallback), same role as
+	// GoogleConfig.AccountEmail.
+	AccountEmail string `json:"account_email,omitempty"`
 }
 
 const (
@@ -175,7 +179,36 @@ func (m *Microsoft) HandleCallback(ctx context.Context, state, code string) (str
 	if err := m.storeBundle(ctx, c.CredentialRef, bundle); err != nil {
 		return "", err
 	}
+	m.persistAccountEmail(ctx, c, cfg)
 	return c.Name, nil
+}
+
+// persistAccountEmail resolves the just-connected account's email and
+// writes it to config.account_email, same role as
+// Google.persistAccountEmail, same best-effort semantics (identity
+// resolution or the patch failing only logs; the connect already
+// succeeded).
+func (m *Microsoft) persistAccountEmail(ctx context.Context, c Connector, cfg MicrosoftConfig) {
+	patcher, ok := m.Rows.(rowPatcher)
+	if !ok {
+		return
+	}
+	src := &microsoftSource{m: m, cfg: cfg, ref: c.CredentialRef}
+	identity, err := src.Identity(ctx)
+	if err != nil || identity.Email == "" {
+		m.Log.Warn("could not resolve microsoft account email at connect", "connector", c.Name, "error", err)
+		return
+	}
+	cfg.AccountEmail = identity.Email
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		m.Log.Warn("could not encode microsoft config with account email", "connector", c.Name, "error", err)
+		return
+	}
+	rawMsg := json.RawMessage(raw)
+	if err := patcher.Patch(ctx, c.ID, Patch{Config: &rawMsg}); err != nil {
+		m.Log.Warn("could not persist microsoft account email", "connector", c.Name, "error", err)
+	}
 }
 
 // exchange posts to the token endpoint with client credentials and

--- a/internal/brain/connectors/microsoft_test.go
+++ b/internal/brain/connectors/microsoft_test.go
@@ -420,7 +420,7 @@ func TestOutlookMailReadListsAttachmentsAndReadAttachmentUsesMarkItDown(t *testi
 	}
 
 	out, err = microsoftToolByName(t, src, "mail_read_attachment").Execute(t.Context(),
-		json.RawMessage(`{"message_id":"m2","name":"receipt.pdf"}`))
+		json.RawMessage(`{"message_id":"m2","filename":"receipt.pdf"}`))
 	if err != nil {
 		t.Fatalf("read_attachment: %v", err)
 	}
@@ -435,7 +435,7 @@ func TestOutlookMailReadAttachmentRejectsUnknownName(t *testing.T) {
 	src, _ := connectedMicrosoftSource(t, f)
 
 	_, err := microsoftToolByName(t, src, "mail_read_attachment").Execute(t.Context(),
-		json.RawMessage(`{"message_id":"m2","name":"nope.pdf"}`))
+		json.RawMessage(`{"message_id":"m2","filename":"nope.pdf"}`))
 	if err == nil {
 		t.Fatal("expected an error for an unknown attachment name")
 	}

--- a/internal/brain/connectors/microsoft_tools.go
+++ b/internal/brain/connectors/microsoft_tools.go
@@ -64,6 +64,12 @@ func (s *microsoftSource) Test(ctx context.Context) error {
 
 func (s *microsoftSource) Close() error { return nil }
 
+// AccountInfo reports this source's kind and connected account email,
+// same role as googleSource.AccountInfo.
+func (s *microsoftSource) AccountInfo() (kind, email string) {
+	return "microsoft", s.cfg.AccountEmail
+}
+
 // hasScope reports whether one of the connector's granted scopes is
 // exactly want. Graph scopes never share substrings the way Google's
 // drive.readonly/drive.file do, so an exact match is enough (unlike
@@ -206,12 +212,12 @@ func (s *microsoftSource) mailSearch() *tools.Tool {
 	return &tools.Tool{
 		Name:     "mail_search",
 		ReadOnly: true,
-		Description: `Search the connected Outlook mailbox. query matches subject, body,
-and sender across messages (Graph's $search). Returns up to
-max_results (default 10) messages as id, date, from, subject,
-bodyPreview. Use mail_read with an id for the full body.`,
+		Description: `Search a connected mail account. Returns up to max_results
+(default 10) messages as id, date, from, subject, snippet. Use
+mail_read with an id for the full body. See the tool description's
+Connected accounts list for this account's query syntax.`,
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
-			"query":{"type":"string","description":"search text"},
+			"query":{"type":"string","description":"search query"},
 			"max_results":{"type":"integer","minimum":1,"maximum":25}
 		},"required":["query"],"additionalProperties":false}`),
 		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
@@ -254,9 +260,9 @@ func (s *microsoftSource) mailRead() *tools.Tool {
 	return &tools.Tool{
 		Name:        "mail_read",
 		ReadOnly:    true,
-		Description: "Read one email's full content by message id (from mail_search). Returns headers and the plain-text body. Reports whether the message has attachments; use mail_read_attachment with the message id and an attachment name to read one.",
+		Description: "Read one email's full content by message id (from mail_search). Returns headers and the body as readable text, plus a list of attachment filenames, if any. Use mail_read_attachment with the message id and a filename from that list to read an attachment's content.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
-			"id":{"type":"string","description":"Outlook message id"}
+			"id":{"type":"string","description":"message id"}
 		},"required":["id"],"additionalProperties":false}`),
 		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
 			var in struct {
@@ -327,15 +333,15 @@ func (s *microsoftSource) mailReadAttachment() *tools.Tool {
 	return &tools.Tool{
 		Name:        "mail_read_attachment",
 		ReadOnly:    true,
-		Description: "Reads an attachment's content as markdown/text, given a message id and the attachment's name (both from mail_read's attachments list). Handles PDFs, Office documents, and other common formats.",
+		Description: "Reads an attachment's content as markdown/text, given a message id and the attachment's filename (both from mail_read's attachments list). Handles PDFs, Office documents, and other common formats.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
-			"message_id":{"type":"string","description":"Outlook message id"},
-			"name":{"type":"string","description":"Attachment name from mail_read's attachments list"}
-		},"required":["message_id","name"],"additionalProperties":false}`),
+			"message_id":{"type":"string","description":"message id"},
+			"filename":{"type":"string","description":"Attachment filename from mail_read's attachments list"}
+		},"required":["message_id","filename"],"additionalProperties":false}`),
 		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
 			var in struct {
 				MessageID string `json:"message_id"`
-				Name      string `json:"name"`
+				Filename  string `json:"filename"`
 			}
 			if err := json.Unmarshal(args, &in); err != nil {
 				return "", err
@@ -346,13 +352,13 @@ func (s *microsoftSource) mailReadAttachment() *tools.Tool {
 			}
 			var attachmentID, contentType string
 			for _, a := range atts {
-				if a.Name == in.Name {
+				if a.Name == in.Filename {
 					attachmentID, contentType = a.ID, a.ContentType
 					break
 				}
 			}
 			if attachmentID == "" {
-				return "", fmt.Errorf("no attachment named %q on this message; check mail_read's attachments list", in.Name)
+				return "", fmt.Errorf("no attachment named %q on this message; check mail_read's attachments list", in.Filename)
 			}
 			var full outlookAttachment
 			if err := s.api(ctx, http.MethodGet,
@@ -364,7 +370,7 @@ func (s *microsoftSource) mailReadAttachment() *tools.Tool {
 			if err != nil {
 				return "", fmt.Errorf("decode attachment: %w", err)
 			}
-			return markitdown.Convert(ctx, s.m.Client, s.m.MarkItDownURL, in.Name, contentType, raw)
+			return markitdown.Convert(ctx, s.m.Client, s.m.MarkItDownURL, in.Filename, contentType, raw)
 		},
 	}
 }
@@ -372,38 +378,33 @@ func (s *microsoftSource) mailReadAttachment() *tools.Tool {
 func (s *microsoftSource) mailSend() *tools.Tool {
 	return &tools.Tool{
 		Name:        "mail_send",
-		Description: "Send an email from the connected Outlook account. Plain text only. Use only when the user asked for an email to be sent; the recipient sees it immediately.",
+		Description: "Send an email from a connected mail account. Plain text only. Use only when the user asked for an email to be sent; the recipient sees it immediately.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"to":{"type":"string","description":"recipient address(es), comma-separated"},
 			"subject":{"type":"string"},
-			"body":{"type":"string","description":"plain-text message body"}
+			"body":{"type":"string","description":"plain-text message body"},
+			"cc":{"type":"string","description":"optional cc address(es), comma-separated"}
 		},"required":["to","subject","body"],"additionalProperties":false}`),
 		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
 			var in struct {
-				To, Subject, Body string
+				To, Subject, Body, CC string
 			}
 			if err := json.Unmarshal(args, &in); err != nil {
 				return "", err
 			}
-			var toRecipients []map[string]any
-			for _, addr := range strings.Split(in.To, ",") {
-				addr = strings.TrimSpace(addr)
-				if addr == "" {
-					continue
-				}
-				toRecipients = append(toRecipients, map[string]any{
-					"emailAddress": map[string]string{"address": addr},
-				})
+			message := map[string]any{
+				"subject": in.Subject,
+				"body": map[string]string{
+					"contentType": "Text",
+					"content":     in.Body,
+				},
+				"toRecipients": outlookRecipientList(in.To),
+			}
+			if cc := outlookRecipientList(in.CC); cc != nil {
+				message["ccRecipients"] = cc
 			}
 			payload := map[string]any{
-				"message": map[string]any{
-					"subject": in.Subject,
-					"body": map[string]string{
-						"contentType": "Text",
-						"content":     in.Body,
-					},
-					"toRecipients": toRecipients,
-				},
+				"message":         message,
 				"saveToSentItems": true,
 			}
 			if err := s.api(ctx, http.MethodPost, s.m.GraphBase+"/me/sendMail", payload, nil); err != nil {
@@ -412,6 +413,23 @@ func (s *microsoftSource) mailSend() *tools.Tool {
 			return "sent", nil
 		},
 	}
+}
+
+// outlookRecipientList splits a comma-separated address list into
+// Graph's recipient shape; empty input yields nil so an omitted cc
+// list is left off the payload's ccRecipients rather than sent empty.
+func outlookRecipientList(addrs string) []map[string]any {
+	var out []map[string]any
+	for _, addr := range strings.Split(addrs, ",") {
+		addr = strings.TrimSpace(addr)
+		if addr == "" {
+			continue
+		}
+		out = append(out, map[string]any{
+			"emailAddress": map[string]string{"address": addr},
+		})
+	}
+	return out
 }
 
 // --- Calendar ---
@@ -438,30 +456,36 @@ func (s *microsoftSource) calendarListEvents() *tools.Tool {
 	return &tools.Tool{
 		Name:        "calendar_list_events",
 		ReadOnly:    true,
-		Description: "List events from the connected Outlook calendar in a time window. Omit start_time/end_time for the default window — the next 7 days from now; set them (RFC3339 UTC) only when the goal needs a different window, computed from today's actual date. Returns start, end, subject, location, and organizer per event.",
+		Description: "List events from the connected calendar in a time window. Omit time_min/time_max for the default window, the next 7 days from now; set them (RFC3339 UTC) only when the goal needs a different window, computed from today's actual date. Returns start, end, title, and location per event.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
-			"start_time":{"type":"string","description":"RFC3339 UTC timestamp; omit for the default window"},
-			"end_time":{"type":"string","description":"RFC3339 UTC timestamp; omit for the default window"}
+			"time_min":{"type":"string","description":"RFC3339 UTC timestamp; omit for the default window"},
+			"time_max":{"type":"string","description":"RFC3339 UTC timestamp; omit for the default window"},
+			"max_results":{"type":"integer","minimum":1,"maximum":50}
 		},"additionalProperties":false}`),
 		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
 			var in struct {
-				StartTime string `json:"start_time"`
-				EndTime   string `json:"end_time"`
+				TimeMin    string `json:"time_min"`
+				TimeMax    string `json:"time_max"`
+				MaxResults int    `json:"max_results"`
 			}
 			if err := json.Unmarshal(args, &in); err != nil {
 				return "", err
 			}
-			if in.StartTime == "" {
-				in.StartTime = time.Now().Format("2006-01-02T15:04:05Z07:00")
+			if in.TimeMin == "" {
+				in.TimeMin = time.Now().Format("2006-01-02T15:04:05Z07:00")
 			}
-			if in.EndTime == "" {
-				in.EndTime = time.Now().AddDate(0, 0, 7).Format("2006-01-02T15:04:05Z07:00")
+			if in.TimeMax == "" {
+				in.TimeMax = time.Now().AddDate(0, 0, 7).Format("2006-01-02T15:04:05Z07:00")
+			}
+			if in.MaxResults <= 0 {
+				in.MaxResults = 20
 			}
 			q := url.Values{
-				"startDateTime": {in.StartTime},
-				"endDateTime":   {in.EndTime},
+				"startDateTime": {in.TimeMin},
+				"endDateTime":   {in.TimeMax},
 				"$orderby":      {"start/dateTime"},
 				"$select":       {"subject,start,end,location,organizer"},
+				"$top":          {fmt.Sprint(in.MaxResults)},
 			}
 			var res struct {
 				Value []outlookEvent `json:"value"`

--- a/internal/brain/connectors/unified_tools_test.go
+++ b/internal/brain/connectors/unified_tools_test.go
@@ -1,0 +1,64 @@
+package connectors
+
+import (
+	"testing"
+)
+
+// TestGoogleMicrosoftSharedToolSchemasMatch pins the unified mail
+// surface's precondition: google and microsoft serve the SAME input
+// schema (property names, types, required) AND the SAME Description
+// for every tool name they both expose, so Manager's aggregation can
+// offer one schema and one base description per capability regardless
+// of which account answers it. Provider-specific query syntax belongs
+// in the aggregate's per-kind description blocks (see
+// mailSearchGuidanceByKind), never in a diverging base schema or
+// description.
+func TestGoogleMicrosoftSharedToolSchemasMatch(t *testing.T) {
+	t.Parallel()
+	fg := &fakeGoogle{}
+	gRow := googleRow(bothScopes)
+	g, _ := testGoogle(t, fg, gRow)
+	gSrc, err := g.Builder()(t.Context(), gRow, nil)
+	if err != nil {
+		t.Fatalf("google build: %v", err)
+	}
+
+	fm := &fakeMicrosoft{}
+	mRow := microsoftRow(microsoftAllScopes)
+	m, _ := testMicrosoft(t, fm, mRow)
+	mSrc, err := m.Builder()(t.Context(), mRow, nil)
+	if err != nil {
+		t.Fatalf("microsoft build: %v", err)
+	}
+
+	type toolShape struct {
+		schema string
+		desc   string
+	}
+	gByName := map[string]toolShape{}
+	for _, tl := range gSrc.Tools() {
+		gByName[tl.Name] = toolShape{schema: string(tl.InputSchema), desc: tl.Description}
+	}
+	mByName := map[string]toolShape{}
+	for _, tl := range mSrc.Tools() {
+		mByName[tl.Name] = toolShape{schema: string(tl.InputSchema), desc: tl.Description}
+	}
+
+	var shared int
+	for name, gShape := range gByName {
+		mShape, ok := mByName[name]
+		if !ok {
+			continue
+		}
+		shared++
+		if gShape.schema != mShape.schema {
+			t.Errorf("tool %s: schemas differ\n google: %s\n msft:   %s", name, gShape.schema, mShape.schema)
+		}
+		if gShape.desc != mShape.desc {
+			t.Errorf("tool %s: descriptions differ\n google: %s\n msft:   %s", name, gShape.desc, mShape.desc)
+		}
+	}
+	if shared == 0 {
+		t.Fatal("no shared tool names found between google and microsoft: test setup is broken")
+	}
+}

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -126,17 +126,21 @@ type Agent struct {
 
 	// forceRouteByConnectorNames/forceRouteByConnectorRoute cover a
 	// WHOLE connector marked sensitive in settings (session.SensitiveTools'
-	// ConnectorNames), not just a single named tool: connector tools are
-	// namespaced "<connector-name>_<tool-name>", so the connector's own
-	// name is a PREFIX match, never a suffix — its own field/rule rather
-	// than folding into forceRouteBySuffix. A single dynamic name-list
-	// func rather than a map, since the caller (main.go) already
-	// resolves the live sensitive-connector list as one query; each
-	// name shares the one route resolver (same sensitiveRoute the
-	// static suffix floor uses). Both nil-safe: a turn with no
-	// connectors flagged sensitive just never flips this way.
-	forceRouteByConnectorNames func(context.Context) []string
-	forceRouteByConnectorRoute func(context.Context) string
+	// ConnectorNames), not just a single named tool. Two ways a call can
+	// match: an MCP-style namespaced name ("<connector-name>_<tool-
+	// name>") where the connector's own name is a PREFIX; or, for a
+	// unified aggregate tool (connectors.Manager's mail_search etc.,
+	// which carries no connector name in its own name)
+	// forceRouteByAccountConnector resolving the call's actual account
+	// to a sensitive connector. A single dynamic name-list func rather
+	// than a map, since the caller (main.go) already resolves the live
+	// sensitive-connector list as one query; each name shares the one
+	// route resolver (same sensitiveRoute the static suffix floor
+	// uses). All nil-safe: a turn with no connectors flagged sensitive
+	// (or no AccountConnector resolver wired) just never flips this way.
+	forceRouteByConnectorNames   func(context.Context) []string
+	forceRouteByConnectorRoute   func(context.Context) string
+	forceRouteByAccountConnector func(ctx context.Context, toolName string, args json.RawMessage) string
 
 	// waitToolsReady, if set, runs at the start of every turn before the
 	// tool snapshot (D-043): it lets main.go block briefly on the
@@ -222,15 +226,19 @@ func (a *Agent) SetForceRoute(suffix string, route func(context.Context) string)
 
 // SetForceRouteByConnector is SetForceRoute's counterpart for a WHOLE
 // connector marked sensitive (as opposed to one hardcoded tool name):
-// once any tool whose name starts with "<name>_" for a name currently
-// in names(ctx) is called, the rest of the turn pins to route(ctx),
-// same sticky/settings-live semantics as SetForceRoute. names and
-// route are both re-resolved at flip time, so toggling a connector's
-// sensitive flag (or the configured route) takes effect on the very
-// next tool call, no restart.
-func (a *Agent) SetForceRouteByConnector(names func(context.Context) []string, route func(context.Context) string) {
+// once any tool call matching a name currently in names(ctx) runs
+// (either an MCP-style "<name>_"-prefixed tool, or a unified aggregate
+// tool such as mail_search whose call resolves to that connector via
+// accountConnector), the rest of the turn pins to route(ctx), same
+// sticky/settings-live semantics as SetForceRoute. names, route, and
+// accountConnector are all re-resolved at flip/call time, so toggling a
+// connector's sensitive flag (or the configured route) takes effect on
+// the very next tool call, no restart. accountConnector may be nil (no
+// unified tool surface wired); the MCP-prefix path still works either way.
+func (a *Agent) SetForceRouteByConnector(names func(context.Context) []string, route func(context.Context) string, accountConnector func(ctx context.Context, toolName string, args json.RawMessage) string) {
 	a.forceRouteByConnectorNames = names
 	a.forceRouteByConnectorRoute = route
+	a.forceRouteByAccountConnector = accountConnector
 }
 
 // SetWaitToolsReady registers the turn-entry readiness hook (see the
@@ -606,13 +614,27 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 				}
 			}
 			if a.forceRouteByConnectorNames != nil {
-				for _, name := range a.forceRouteByConnectorNames(ctx) {
+				sensitiveNames := a.forceRouteByConnectorNames(ctx)
+				matched := false
+				for _, name := range sensitiveNames {
 					if strings.HasPrefix(c.Name, name+"_") {
-						if forced := a.forceRouteByConnectorRoute(ctx); forced != "" {
-							route = forced
-							hint = ""
-						}
+						matched = true
 						break
+					}
+				}
+				if !matched && a.forceRouteByAccountConnector != nil {
+					connector := a.forceRouteByAccountConnector(ctx, c.Name, c.Input)
+					for _, name := range sensitiveNames {
+						if name == connector {
+							matched = true
+							break
+						}
+					}
+				}
+				if matched {
+					if forced := a.forceRouteByConnectorRoute(ctx); forced != "" {
+						route = forced
+						hint = ""
 					}
 				}
 			}
@@ -770,7 +792,7 @@ func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string,
 
 	emit(stream.StreamEvent{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{
 		ID: call.ID, Name: call.Name, Status: status,
-		Digest: digest, DurationMs: duration.Milliseconds(),
+		Digest: digest, DurationMs: duration.Milliseconds(), Args: call.Input,
 	}})
 
 	return provider.ToolResult{ID: call.ID, Content: content, IsError: isError}

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -1307,6 +1307,7 @@ func TestForceRouteByConnectorSwitchesRouteAfterMatchingTool(t *testing.T) {
 	a.SetForceRouteByConnector(
 		func(context.Context) []string { return []string{"gmail"} },
 		func(context.Context) string { return "local" },
+		nil,
 	)
 
 	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "default",
@@ -1350,6 +1351,7 @@ func TestForceRouteByConnectorIgnoresUnlistedConnector(t *testing.T) {
 	a.SetForceRouteByConnector(
 		func(context.Context) []string { return []string{"gmail"} },
 		func(context.Context) string { return "local" },
+		nil,
 	)
 
 	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "default",
@@ -1363,6 +1365,55 @@ func TestForceRouteByConnectorIgnoresUnlistedConnector(t *testing.T) {
 		if req.Route != "default" {
 			t.Fatalf("request %d route = %q, want default (gmailbox_search must not prefix-match \"gmail\")", i, req.Route)
 		}
+	}
+}
+
+// TestForceRouteByConnectorMatchesUnifiedToolViaAccountConnector pins
+// the unified-tool path: a call to a name carrying no connector prefix
+// (e.g. mail_search) still pins the route once accountConnector
+// resolves the call to a name in the sensitive list: the account the
+// call actually routed to, not the tool's own name, decides the flip.
+func TestForceRouteByConnectorMatchesUnifiedToolViaAccountConnector(t *testing.T) {
+	t.Parallel()
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"mail_search", `{"account":"work-outlook"}`}),
+		finalStep("done"),
+	}}
+	search := &tools.Tool{
+		Name:        "mail_search",
+		Description: "searches connected mail",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"account":{"type":"string"}},"additionalProperties":false}`),
+		Execute: func(context.Context, json.RawMessage) (string, error) {
+			return "search results", nil
+		},
+	}
+	a, _, _, _ := testAgent(t, gw, search)
+	a.SetForceRouteByConnector(
+		func(context.Context) []string { return []string{"work-outlook"} },
+		func(context.Context) string { return "local" },
+		func(_ context.Context, toolName string, args json.RawMessage) string {
+			if toolName == "mail_search" && strings.Contains(string(args), "work-outlook") {
+				return "work-outlook"
+			}
+			return ""
+		},
+	)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "default",
+		Messages: []provider.Message{{Role: "user", Content: "search my email"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	collect(t, ch)
+
+	if len(gw.requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(gw.requests))
+	}
+	if gw.requests[0].Route != "default" {
+		t.Fatalf("step 1 route = %q, want default (before the sensitive account's tool ran)", gw.requests[0].Route)
+	}
+	if gw.requests[1].Route != "local" {
+		t.Fatalf("step 2 route = %q, want local (forced after mail_search resolved to work-outlook)", gw.requests[1].Route)
 	}
 }
 

--- a/internal/brain/session/sensitive.go
+++ b/internal/brain/session/sensitive.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 )
 
@@ -14,26 +15,47 @@ import (
 // same floor the in-turn steps already honor and ship raw sensitive
 // content (e.g. email text) to a cloud model. ConnectorNames is the
 // user-controlled input (a connector's own "sensitive" flag, set from
-// the connectors settings UI): connectors are namespaced
-// "<connector-name>_<tool-name>" (connectors.Manager.Tools), so a
-// connector's own name is the PREFIX of every tool it serves. Both
-// ConnectorNames and Route are funcs, not static values, so toggling a
-// connector's sensitive flag (or the configured route) applies to the
-// next side-call without a restart; an empty Route result means the
-// feature is currently off (callers keep their own default route).
+// the connectors settings UI). Two ways a tool call can be covered:
+// suffix+"_" prefix against an MCP-style namespaced name
+// ("<connector-name>_<tool-name>", connectors.Manager.Tools' MCP
+// passthrough), or, for a unified aggregate tool (connectors.Manager's
+// mail_search etc., which carries no connector name in its own name),
+// AccountConnector resolving the call's actual account to a sensitive
+// connector. AccountConnector is nil-safe (not every caller wires it,
+// and non-connector tools never resolve). All three funcs re-resolve on
+// every call, not cached, so toggling a connector's sensitive flag (or
+// the configured route) applies to the next side-call without a
+// restart; an empty Route result means the feature is currently off
+// (callers keep their own default route).
 type SensitiveTools struct {
-	ConnectorNames func(context.Context) []string
-	Route          func(context.Context) string
+	ConnectorNames   func(context.Context) []string
+	AccountConnector func(ctx context.Context, toolName string, args json.RawMessage) string
+	Route            func(context.Context) string
 }
 
-// Matches reports whether toolName is covered: suffix+"_" prefix (a
-// whole connector's namespace) against ConnectorNames.
-func (s *SensitiveTools) Matches(ctx context.Context, toolName string) bool {
+// Matches reports whether a call to toolName (with args, for unified
+// aggregate tools' account resolution) is covered: suffix+"_" prefix
+// against ConnectorNames, or AccountConnector resolving the call to a
+// name in ConnectorNames.
+func (s *SensitiveTools) Matches(ctx context.Context, toolName string, args json.RawMessage) bool {
 	if s == nil || s.ConnectorNames == nil {
 		return false
 	}
-	for _, name := range s.ConnectorNames(ctx) {
+	names := s.ConnectorNames(ctx)
+	for _, name := range names {
 		if strings.HasPrefix(toolName, name+"_") {
+			return true
+		}
+	}
+	if s.AccountConnector == nil {
+		return false
+	}
+	connector := s.AccountConnector(ctx, toolName, args)
+	if connector == "" {
+		return false
+	}
+	for _, name := range names {
+		if name == connector {
 			return true
 		}
 	}
@@ -60,7 +82,7 @@ func (s *SensitiveTools) SessionSensitive(ctx context.Context, events []Event) b
 		if decode(ev, &te) != nil {
 			continue
 		}
-		if s.Matches(ctx, te.Name) {
+		if s.Matches(ctx, te.Name, json.RawMessage(te.Args)) {
 			return true
 		}
 	}

--- a/internal/brain/session/sensitive_test.go
+++ b/internal/brain/session/sensitive_test.go
@@ -2,13 +2,14 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 )
 
 func TestSensitiveToolsMatchesNilReceiver(t *testing.T) {
 	t.Parallel()
 	var s *SensitiveTools
-	if s.Matches(context.Background(), "gmail_read") {
+	if s.Matches(context.Background(), "gmail_read", nil) {
 		t.Fatal("nil SensitiveTools matched a tool, want false (feature off)")
 	}
 }
@@ -37,7 +38,7 @@ func TestSensitiveToolsMatchesConnectorPrefix(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := s.Matches(context.Background(), tc.tool); got != tc.want {
+			if got := s.Matches(context.Background(), tc.tool, nil); got != tc.want {
 				t.Fatalf("Matches(%q) = %v, want %v", tc.tool, got, tc.want)
 			}
 		})
@@ -51,8 +52,47 @@ func TestSensitiveToolsMatchesConnectorNamesNil(t *testing.T) {
 	s := &SensitiveTools{
 		Route: func(context.Context) string { return "local" },
 	}
-	if s.Matches(context.Background(), "slack_read_channel") {
+	if s.Matches(context.Background(), "slack_read_channel", nil) {
 		t.Fatal("Matches true with nil ConnectorNames, want false")
+	}
+}
+
+// TestSensitiveToolsMatchesAccountConnector pins the unified-tool path:
+// a call to a name carrying no connector prefix (e.g. "mail_search")
+// still matches once AccountConnector resolves it to a name in
+// ConnectorNames: the account the call actually routed to, not the
+// tool's own name, decides sensitivity here.
+func TestSensitiveToolsMatchesAccountConnector(t *testing.T) {
+	t.Parallel()
+	s := &SensitiveTools{
+		ConnectorNames: func(context.Context) []string { return []string{"work-outlook"} },
+		AccountConnector: func(_ context.Context, toolName string, args json.RawMessage) string {
+			if toolName == "mail_search" && string(args) == `{"account":"work-outlook"}` {
+				return "work-outlook"
+			}
+			return "personal-gmail"
+		},
+		Route: func(context.Context) string { return "local" },
+	}
+	if !s.Matches(context.Background(), "mail_search", json.RawMessage(`{"account":"work-outlook"}`)) {
+		t.Fatal("Matches false for a call AccountConnector resolves to a sensitive connector, want true")
+	}
+	if s.Matches(context.Background(), "mail_search", json.RawMessage(`{"account":"other"}`)) {
+		t.Fatal("Matches true for a call resolving to a non-sensitive connector, want false")
+	}
+}
+
+// TestSensitiveToolsMatchesAccountConnectorNil pins that a nil
+// AccountConnector (not every caller wires it) never panics and simply
+// falls back to the prefix rule alone.
+func TestSensitiveToolsMatchesAccountConnectorNil(t *testing.T) {
+	t.Parallel()
+	s := &SensitiveTools{
+		ConnectorNames: func(context.Context) []string { return []string{"work-outlook"} },
+		Route:          func(context.Context) string { return "local" },
+	}
+	if s.Matches(context.Background(), "mail_search", json.RawMessage(`{"account":"work-outlook"}`)) {
+		t.Fatal("Matches true with nil AccountConnector, want false (no prefix match either)")
 	}
 }
 
@@ -75,12 +115,12 @@ func TestSensitiveToolsMatchesDynamicConnectorNames(t *testing.T) {
 		Route: func(context.Context) string { return "local" },
 	}
 
-	if s.Matches(context.Background(), "slack_read_channel") {
+	if s.Matches(context.Background(), "slack_read_channel", nil) {
 		t.Fatal("Matches true before connector marked sensitive, want false")
 	}
 
 	sensitiveConnector = true
-	if !s.Matches(context.Background(), "slack_read_channel") {
+	if !s.Matches(context.Background(), "slack_read_channel", nil) {
 		t.Fatal("Matches false after connector marked sensitive, want true")
 	}
 

--- a/internal/gateway/stream/events.go
+++ b/internal/gateway/stream/events.go
@@ -56,6 +56,11 @@ type ToolResultEvent struct {
 	Status     string `json:"status"`
 	Digest     string `json:"digest,omitempty"`
 	DurationMs int64  `json:"duration_ms"`
+	// Args is the call's own input, brain-internal only (json:"-": never
+	// reaches the client wire); chat's sensitivity check needs it to
+	// resolve which account a unified aggregate tool call (e.g.
+	// mail_search) actually routed to (session.SensitiveTools.Matches).
+	Args json.RawMessage `json:"-"`
 }
 
 // PermissionRequestEvent tells the client the turn parked waiting for

--- a/migrations/0009_agents.sql
+++ b/migrations/0009_agents.sql
@@ -44,19 +44,17 @@ CREATE UNIQUE INDEX IF NOT EXISTS agents_one_default
 -- listed tool schema rides every turn's prompt.
 --
 -- Tool names are the compiled-in builtins' exact registered names
--- (internal/brain/tools/builtin/*.go) plus connector tools by their
--- bare, connector-unprefixed name ("gmail_search", not "gmail_
--- gmail_search") — matchGrant's/filterDefs' suffix rule (D-036,
--- internal/brain/tools/permissions.go) matches these against the
--- runtime-namespaced tool name a connector actually registers, so
--- this works regardless of which connector serves gmail/calendar.
--- gmail_send is deliberately left off: sending mail is a deliberate
--- per-agent opt-in, not a default. Guarded both ways for is_default:
--- if any default agent already exists, this seed must not attempt to
--- set is_default=true.
+-- (internal/brain/tools/builtin/*.go) plus the unified connector
+-- capability names (connectors.Manager.Tools aggregates every
+-- connected account behind one name per capability, e.g. "mail_search"
+-- covers every connected google/microsoft mail account); an allowlist
+-- entry here is agent-authored before any connector even exists, and
+-- covers every current and future account serving that capability.
+-- Guarded both ways for is_default: if any default agent already
+-- exists, this seed must not attempt to set is_default=true.
 INSERT INTO agents (name, description, prompt_overlay, route, skills, tools, is_default)
 SELECT 'general', 'Everyday questions and tasks on a strong all-round chain.', '', 'default',
     '["research-brief", "deep-research", "coding", "email-research"]',
-    '["current_time", "convert_time", "calculate", "currency_convert", "web_search", "web_fetch", "remember", "list_missions", "get_mission", "push_mission_branch", "gmail_search", "gmail_read", "calendar_list_events"]',
+    '["current_time", "convert_time", "calculate", "currency_convert", "web_search", "web_fetch", "remember", "list_missions", "get_mission", "push_mission_branch", "followup_mission", "mail_search", "mail_read", "mail_read_attachment", "mail_send", "calendar_list_events", "calendar_create_event"]',
     NOT EXISTS (SELECT 1 FROM agents WHERE is_default)
 WHERE NOT EXISTS (SELECT 1 FROM agents WHERE name = 'general');

--- a/skills/email-research/SKILL.md
+++ b/skills/email-research/SKILL.md
@@ -7,7 +7,7 @@ description: Searches, reads, and aggregates Gmail content, finding bookings, co
 
 ## Rules
 
-- Gmail query operators, used correctly:
+- Gmail query operators (mail_search's Google accounts; a Microsoft/Outlook account takes a plain keyword query instead: see the tool's own description for which accounts are connected), used correctly:
   - Quote multi-word phrases: `subject:"booking confirmation"`, not `subject:booking confirmation` (the latter only matches the first word as the operator's argument).
   - `from:`/`to:` take an address or domain: `from:noreply@airline.com`, `from:airline.com`.
   - OR grouping: `{from:a@x.com from:b@x.com}` or `(from:a@x.com OR from:b@x.com)`; bare `OR` between terms with no parens/braces is parsed unreliably, always group it explicitly.
@@ -15,7 +15,7 @@ description: Searches, reads, and aggregates Gmail content, finding bookings, co
   - `has:attachment`, `label:`, `category:`, `is:unread`, `is:read`.
 - Date bounds MUST be derived from the current date in the system prompt, never a guessed or recalled year. If a search built from a "today" you assumed returns nothing, re-derive the bound from the actual system-prompt date before concluding the mail isn't there.
 - Pipeline discipline: start broad (wide date range, no subject/keyword narrowing), then narrow iteratively; a `from:` combined with subject/keyword terms narrows twice and a near-miss becomes a zero-result search.
-- A `gmail_search` result (subjects, senders, snippets) is a digest, not content. Before citing or aggregating what is "in" any message, `gmail_read` it: snippets truncate and routinely omit the amount, date, or detail you need.
+- A `mail_search` result (subjects, senders, snippets) is a digest, not content. Before citing or aggregating what is "in" any message, `mail_read` it: snippets truncate and routinely omit the amount, date, or detail you need.
 - Extract every amount together with its currency (`$42.50`, `€19`, `12.00 USD`): a bare number is not usable in a total.
 - All arithmetic (sums, counts, averages) goes through the `calculate` tool; never add or estimate in your head. Show the expression you evaluated.
 - Any total or aggregate figure shows its per-item breakdown (each item's amount and source email) alongside the total, not the total alone.
@@ -30,25 +30,25 @@ description: Searches, reads, and aggregates Gmail content, finding bookings, co
 
 | Excuse                                                        | Rebuttal                                                                                  |
 |---------------------------------------------------------------|-------------------------------------------------------------------------------------------|
-| "The snippet already shows the amount"                        | Snippets truncate; gmail_read the message before citing a figure from it.                 |
+| "The snippet already shows the amount"                        | Snippets truncate; mail_read the message before citing a figure from it.                 |
 | "I can add these three numbers myself"                        | Mental arithmetic on amounts you'll report as fact goes through calculate, no exceptions. |
 | "Combining $40 and €40 into one total is close enough"        | Different currencies are different totals; report each separately.                        |
 | "It's from the same sender as the confirmation, so it counts" | Marketing and reminders from that domain are not the transaction; label them separately.  |
 | "The user's message implies this year"                        | Never guess a year: read it from the system prompt's current date.                        |
-| "No Gmail tool is available, but I probably know the answer"  | Say "email not connected"; never answer from assumption when the tool is simply missing.  |
+| "No mail tool is available, but I probably know the answer"   | Say "email not connected"; never answer from assumption when the tool is simply missing.  |
 
 ## Red flags: stop and re-check
 
 - An amount is being reported without its currency.
 - A total appears with no per-item breakdown, or was computed without calculate.
 - A date bound (`after:`/`before:`) was written without checking the system prompt's current date first.
-- A claim about a message's content is being made from a search snippet alone, with no gmail_read call this turn.
+- A claim about a message's content is being made from a search snippet alone, with no mail_read call this turn.
 - Two different currencies are being added into a single total.
-- A privacy refusal ("I can't access your email") is about to be given while gmail tools are present in this turn's tool list.
+- A privacy refusal ("I can't access your email") is about to be given while mail tools are present in this turn's tool list.
 
 ## Evidence required
 
-- Every cited message actually opened with gmail_read this turn (or gmail_read_attachment, for attachment content).
+- Every cited message actually opened with mail_read this turn (or mail_read_attachment, for attachment content).
 - Every amount paired with its currency and its source message.
 - Every total accompanied by the calculate expression used and the per-item breakdown it was built from.
 - Confirmations distinguished from marketing/reminders explicitly, not merged by sender domain alone.

--- a/web/src/components/settings/ConnectorsList.tsx
+++ b/web/src/components/settings/ConnectorsList.tsx
@@ -50,9 +50,12 @@ export function ConnectorsList() {
           {connectors.length > 0 ? `Your connectors · ${connectors.length}` : 'Your connectors'}
         </h2>
         <p className="text-sm text-muted-foreground">
-          Integrations the agent can use as tools, each connector&apos;s tools appear to the
-          model as <span className="font-mono text-xs">name_tool</span> and go through the same
-          permission prompts as everything else.
+          Integrations the agent can use as tools. Mail/calendar tools appear to the model once
+          per capability (e.g. <span className="font-mono text-xs">mail_search</span>) with an{' '}
+          <span className="font-mono text-xs">account</span> argument routing to the right
+          connected account; MCP connectors&apos; tools still appear as{' '}
+          <span className="font-mono text-xs">name_tool</span>. Either way, tool calls go through
+          the same permission prompts as everything else.
         </p>
         {connectors.length === 0 ? (
           <div className="rounded-xl border border-dashed border-border p-10 text-center text-sm text-muted-foreground">


### PR DESCRIPTION
Replaces per-connector prefixed chat tools with one tool per capability across all connected accounts.

- `Manager.Tools()`/`ReadOnlyTools()` aggregate non-MCP sources' tools by raw name: `mail_search`, `mail_read`, `mail_read_attachment`, `mail_send`, `calendar_list_events`, `calendar_create_event`, `drive_*`, `docs_*`. The aggregation is generic: a future connector kind joins a capability by serving a tool with the same raw name.
- `account` parameter: optional with one account (defaults), required with several (schema reflects it; unknown/missing errors list valid accounts). Matches connector name or connected email, case-insensitive.
- google's gmail_* tools renamed to mail_*; google/microsoft same-named tools now have identical schemas and provider-neutral identical descriptions (pinned by test). Provider-specific query syntax and Gmail retry heuristics render in the aggregate description once per contributing kind.
- OAuth callback persists `config.account_email` (best-effort) for email addressing and the accounts list.
- Sensitive-connector routing (chat sensitivity + in-turn route pin) resolves unified calls to their connector via call args; MCP prefix matching unchanged.
- Agent allowlists now grant capability names once; seeds updated in 0009 (in place, pre-release policy). Existing agent rows need a post-deploy tools patch.
- MCP connectors keep `<connector>_<tool>` naming.

Gates: go build/test/vet/lint green, web 767/767, canary PASS.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790247419&installation_model_id=431401&pr_number=329&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F329&signature=4b408dd922d9e3888a2f417000b5b150bf2ed6c5e8278e4050d335864a603f49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->