### PR TITLE
docs: list all connector kinds and unified tool routing in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,11 @@ First run: `cp deploy/env.example deploy/.env` and set
   `session`, `agents`, `missions` (agent harness), `workflows`
   (orchestration above missions: steps + outcome-driven edges, env-gated
   `WORKFLOWS_ENABLED`), `connectors`
-  (Google/MCP), `destinations` (mission result delivery: email/webhook/
+  (google/microsoft/github/mcp/imap/caldav, unified capability tools:
+  `mail_search`, `mail_read`, `mail_send`, `calendar_list_events`,
+  `calendar_create_event` route to the right connector/account via an
+  `account` parameter — see `manager.go`'s `aggregateTools`),
+  `destinations` (mission result delivery: email/webhook/
   telegram), `kb` (knowledge-base collections/documents), `attachments`,
   `gwclient`, `memclient`, `sandboxclient`, `settings`, `skills`.
 - `internal/gateway/`: `provider` (wire adapters only), `router`,


### PR DESCRIPTION
## Summary
- CLAUDE.md's layout section still said connectors were "Google/MCP" only, stale since #327 (microsoft) and #330 (imap/caldav)
- Added a note on the unified capability-tool routing pattern (mail_search/mail_read/etc.) shipped in #329

## Test plan
- [x] Docs-only change, no code affected

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790288136&installation_model_id=431401&pr_number=331&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F331&signature=c89f08d5395222757c8f233bd3cb166776a5253fd1c36b0ff9c313b946a282a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->