### PR TITLE
fix: executor-options route preview, harness default label, pending-memory dedup

### DIFF
--- a/cmd/memoryd/main.go
+++ b/cmd/memoryd/main.go
@@ -62,6 +62,8 @@ func main() {
 		Archived: app.Metrics.NewCounter("memory_archived_total", "Stale episodic memories archived."),
 		Decayed:  app.Metrics.NewCounter("memory_decayed_total", "Stale semantic facts decayed and queued for reconfirmation."),
 		Demoted:  app.Metrics.NewCounter("memory_demoted_total", "Unused pending memories demoted by the usage-driven decay pass."),
+		PendingDeduped: app.Metrics.NewCounter("memory_pending_deduped_total",
+			"Pending memories rejected as a near-duplicate of another still-pending proposal."),
 	})
 	consolidator.SetReflector(extractor)
 	kbStore := store.NewKBStore(app.DB)

--- a/internal/memory/extract/consolidate.go
+++ b/internal/memory/extract/consolidate.go
@@ -64,6 +64,8 @@ const mergeSystem = `You merge near-duplicate memory entries into ONE canonical 
 // needs.
 type ConsolidateStore interface {
 	NearDupPairs(ctx context.Context, threshold float64) ([][2]string, error)
+	RedundantPendingPairs(ctx context.Context, threshold float64) ([][2]string, error)
+	Reject(ctx context.Context, id string) error
 	Get(ctx context.Context, id string) (store.Memory, error)
 	ApplyMerge(ctx context.Context, m store.Memory, memberIDs []string) (string, error)
 	ArchiveStaleEpisodic(ctx context.Context, olderThan time.Time) (int64, error)
@@ -75,22 +77,24 @@ type ConsolidateStore interface {
 // Metrics counts every consolidation action; any counter may be nil
 // (tests).
 type Metrics struct {
-	Merges   prometheus.Counter
-	Rejects  *prometheus.CounterVec // reason: token_loss|shrink|bloat|conflict|error
-	Archived prometheus.Counter
-	Decayed  prometheus.Counter
-	Demoted  prometheus.Counter
+	Merges         prometheus.Counter
+	Rejects        *prometheus.CounterVec // reason: token_loss|shrink|bloat|conflict|error
+	Archived       prometheus.Counter
+	Decayed        prometheus.Counter
+	Demoted        prometheus.Counter
+	PendingDeduped prometheus.Counter
 }
 
 // Summary counts one Run pass. RunLoop discards it; the manual
 // trigger endpoint returns it.
 type Summary struct {
-	Merged    int `json:"merged"`
-	Rejected  int `json:"rejected"`
-	Archived  int `json:"archived"`
-	Decayed   int `json:"decayed"`
-	Reflected int `json:"reflected"`
-	Demoted   int `json:"demoted"`
+	Merged         int `json:"merged"`
+	Rejected       int `json:"rejected"`
+	Archived       int `json:"archived"`
+	Decayed        int `json:"decayed"`
+	Reflected      int `json:"reflected"`
+	Demoted        int `json:"demoted"`
+	PendingDeduped int `json:"pending_deduped"`
 }
 
 // Consolidator is the daily lifecycle job (D-011): merge near-dup
@@ -156,6 +160,12 @@ func (c *Consolidator) Run(ctx context.Context) (Summary, error) {
 		errs = append(errs, err.Error())
 	}
 
+	pendingDeduped, err := c.dedupePending(ctx)
+	summary.PendingDeduped = pendingDeduped
+	if err != nil {
+		errs = append(errs, err.Error())
+	}
+
 	archived, err := c.archiveStale(ctx)
 	summary.Archived = archived
 	if err != nil {
@@ -184,6 +194,41 @@ func (c *Consolidator) Run(ctx context.Context) (Summary, error) {
 		return summary, fmt.Errorf("consolidate: %s", strings.Join(errs, "; "))
 	}
 	return summary, nil
+}
+
+// dedupePending rejects the newer half of every pending-pending
+// near-duplicate pair: two still-unconfirmed proposals restating the
+// same fact in different wording (extraction's own dedup only compares
+// a new candidate against what's already committed, so two proposals
+// from different runs can both queue before either lands). Neither
+// side is confirmed knowledge, so there's nothing to merge - the
+// older proposal is simply kept and the newer one rejected outright.
+// A pair whose older half a concurrent Confirm/Reject already moved
+// out of pending fails Reject's status-guarded transition; that's
+// logged and skipped, never an error - the queue is already correct
+// by the time this pass would have acted.
+func (c *Consolidator) dedupePending(ctx context.Context) (deduped int, err error) {
+	pairs, err := c.store.RedundantPendingPairs(ctx, nearDupSimilarity)
+	if err != nil {
+		return 0, err
+	}
+	seen := make(map[string]bool, len(pairs))
+	for _, pair := range pairs {
+		newer := pair[1]
+		if seen[newer] {
+			continue
+		}
+		if err := c.store.Reject(ctx, newer); err != nil {
+			c.log.Warn("pending duplicate reject failed; left in queue", "id", newer, "error", err)
+			continue
+		}
+		seen[newer] = true
+		deduped++
+		if c.metrics.PendingDeduped != nil {
+			c.metrics.PendingDeduped.Inc()
+		}
+	}
+	return deduped, nil
 }
 
 // mergeNearDups groups pairwise near-duplicates (union-find over the

--- a/internal/memory/extract/consolidate_test.go
+++ b/internal/memory/extract/consolidate_test.go
@@ -55,6 +55,22 @@ type consolidateStore struct {
 	applyMergeErr  error
 	superseded     map[string]string
 	recentEpisodic []store.Memory
+
+	pendingPairs [][2]string
+	rejectErr    error
+	rejected     []string
+}
+
+func (s *consolidateStore) RedundantPendingPairs(context.Context, float64) ([][2]string, error) {
+	return s.pendingPairs, nil
+}
+
+func (s *consolidateStore) Reject(_ context.Context, id string) error {
+	if s.rejectErr != nil {
+		return s.rejectErr
+	}
+	s.rejected = append(s.rejected, id)
+	return nil
 }
 
 func (s *consolidateStore) DemoteUnused(context.Context, time.Time, float64, int) ([]string, error) {
@@ -151,6 +167,42 @@ func TestConsolidateMergesGroup(t *testing.T) {
 	mergedID := "mem-1"
 	if len(st.superseded) != 2 || st.superseded["m1"] != mergedID || st.superseded["m2"] != mergedID {
 		t.Fatalf("superseded = %v", st.superseded)
+	}
+}
+
+func TestConsolidateDedupesPendingPairs(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGateway{}
+	st := &consolidateStore{
+		pendingPairs: [][2]string{{"p1", "p2"}},
+	}
+	c := NewConsolidator(gw, st, testLog(), Metrics{})
+	summary, err := c.Run(t.Context())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.PendingDeduped != 1 {
+		t.Fatalf("summary.PendingDeduped = %d, want 1", summary.PendingDeduped)
+	}
+	if len(st.rejected) != 1 || st.rejected[0] != "p2" {
+		t.Fatalf("rejected = %v, want [p2] (the newer half kept, p1 untouched)", st.rejected)
+	}
+}
+
+func TestConsolidateDedupesPendingPairsSkipsRejectError(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGateway{}
+	st := &consolidateStore{
+		pendingPairs: [][2]string{{"p1", "p2"}},
+		rejectErr:    errors.New("already confirmed"),
+	}
+	c := NewConsolidator(gw, st, testLog(), Metrics{})
+	summary, err := c.Run(t.Context())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if summary.PendingDeduped != 0 {
+		t.Fatalf("summary.PendingDeduped = %d, want 0 (reject failed, queue left as-is)", summary.PendingDeduped)
 	}
 }
 

--- a/internal/memory/store/store.go
+++ b/internal/memory/store/store.go
@@ -273,6 +273,42 @@ func (s *Store) NearDupPairs(ctx context.Context, threshold float64) ([][2]strin
 	return pairs, rows.Err()
 }
 
+// RedundantPendingPairs returns every pair of pending embedded
+// memories of the same type whose cosine similarity meets the
+// threshold, older id first: unlike NearDupPairs (active-only, feeds
+// the LLM merge path), this catches two still-unconfirmed proposals
+// restating the same fact in different words before either reaches
+// the confirm queue twice. No LLM merge needed here - neither side is
+// confirmed knowledge yet, so the consolidator just rejects the newer
+// half of each pair outright.
+func (s *Store) RedundantPendingPairs(ctx context.Context, threshold float64) ([][2]string, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("redundant pending pairs: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT a.id, b.id
+		FROM memories a
+		JOIN memories b ON a.created_at < b.created_at
+		WHERE a.status = $1 AND b.status = $1
+		  AND a.type = b.type
+		  AND a.embedding IS NOT NULL AND b.embedding IS NOT NULL
+		  AND 1 - (a.embedding <=> b.embedding) >= $2`,
+		StatusPending, threshold)
+	if err != nil {
+		return nil, fmt.Errorf("redundant pending pairs: %w", err)
+	}
+	defer rows.Close()
+	var pairs [][2]string
+	for rows.Next() {
+		var p [2]string
+		if err := rows.Scan(&p[0], &p[1]); err != nil {
+			return nil, fmt.Errorf("redundant pending pairs: %w", err)
+		}
+		pairs = append(pairs, p)
+	}
+	return pairs, rows.Err()
+}
+
 // ApplyMerge inserts the consolidator's merged fact and supersedes
 // every member in a single transaction: a crash mid-sequence can no
 // longer leave the merged row active alongside still-active members

--- a/internal/memory/store/store_integration_test.go
+++ b/internal/memory/store/store_integration_test.go
@@ -509,6 +509,72 @@ func TestNearDupPairs(t *testing.T) {
 	}
 }
 
+// TestRedundantPendingPairs proves two still-pending near-duplicate
+// proposals surface as a pair, older id first, and that Promoting one
+// (moving it out of pending) drops the pair on the next call.
+func TestRedundantPendingPairs(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	near := func(dim int, delta float32) Vector {
+		v := make(Vector, 1024)
+		v[dim] = 1
+		v[dim+1] = delta
+		return v
+	}
+	older := mem("timezone preference set to Europe/Amsterdam")
+	older.Embedding = near(400, 0)
+	newer := mem("user timezone preference is Europe/Amsterdam")
+	newer.Embedding = near(400, 0.1) // cosine ~0.995 with older
+	unrelated := mem("unrelated pending fact")
+	unrelated.Embedding = near(500, 0)
+
+	olderID, err := s.Insert(ctx, older)
+	if err != nil {
+		t.Fatalf("Insert older: %v", err)
+	}
+	newerID, err := s.Insert(ctx, newer)
+	if err != nil {
+		t.Fatalf("Insert newer: %v", err)
+	}
+	if _, err := s.Insert(ctx, unrelated); err != nil {
+		t.Fatalf("Insert unrelated: %v", err)
+	}
+
+	pairs, err := s.RedundantPendingPairs(ctx, 0.95)
+	if err != nil {
+		t.Fatalf("RedundantPendingPairs: %v", err)
+	}
+	found := false
+	for _, p := range pairs {
+		if p[0] == olderID && p[1] == newerID {
+			found = true
+		}
+		if p[0] == unrelated.ID || p[1] == unrelated.ID {
+			t.Fatalf("unrelated memory in a pair: %v", p)
+		}
+	}
+	if !found {
+		t.Fatalf("redundant pending pair (older, newer) not found in %v", pairs)
+	}
+
+	// Promoting the older half moves it out of pending; the pair must
+	// no longer surface (mirrors NearDupPairs' active-only scope, just
+	// the pending mirror of it).
+	if err := s.Promote(ctx, olderID); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+	pairs, err = s.RedundantPendingPairs(ctx, 0.95)
+	if err != nil {
+		t.Fatalf("RedundantPendingPairs after promote: %v", err)
+	}
+	for _, p := range pairs {
+		if p[0] == olderID || p[1] == olderID {
+			t.Fatalf("promoted memory still in a pending pair: %v", p)
+		}
+	}
+}
+
 // TestNearDupPairsCrossTypeExcluded proves a semantic+episodic pair
 // never surfaces as a near-dup edge even at near-identical embeddings
 // — merging across types would silently collapse a durable fact into

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -128,6 +128,22 @@ export function defaultRouteLabel(
   return 'Default'
 }
 
+// resolvedDefaultRoute is defaultRouteLabel's same precedence, but
+// returns the route name (or '' when none resolves — matches the
+// server's own '' == "no real route, gateway default chain" case)
+// instead of a display label. Used to fetch executor-options against
+// the route a create would actually use, not always the system
+// default.
+function resolvedDefaultRoute(
+  kind: Kind,
+  agent: AdminAgent | undefined,
+  routes: AdminRoute[] | null,
+): string {
+  if (agent?.route) return agent.route
+  if (kind === 'coding' && routes?.some((r) => r.name === 'coding')) return 'coding'
+  return routes?.find((r) => r.role === 'default')?.name ?? ''
+}
+
 // Sentinel for the executor Select's "apply the settings default"
 // choice — wire value stays '' (omit harness from the create payload)
 // to match the API's own empty-means-default semantics.
@@ -360,18 +376,23 @@ export function MissionForm({
   }, [repos, repoQuery])
 
   // Live executor pairing/usability preview: coding-only, refetched
-  // whenever the kind flips to coding or the route selection changes.
-  // Best-effort — a failed fetch degrades to a plain, fully-enabled
-  // select with no live info, the server validates on submit anyway.
+  // whenever the kind flips to coding or the route selection (explicit
+  // or resolved default) changes. An explicit route override wins;
+  // otherwise this asks about the same route a create would actually
+  // resolve to (resolvedDefaultRoute), not always the system default —
+  // else a "coding" route's own chain never gets previewed. Best-effort
+  // — a failed fetch degrades to a plain, fully-enabled select with no
+  // live info, the server validates on submit anyway.
   useEffect(() => {
     if (kind !== 'coding') {
       setExecutorOptions(null)
       return
     }
-    getMissionExecutorOptions(route || undefined)
+    const effectiveRoute = route || resolvedDefaultRoute(kind, agents.find((a) => a.id === agentID), routes)
+    getMissionExecutorOptions(effectiveRoute || undefined)
       .then(setExecutorOptions)
       .catch(() => setExecutorOptions(null))
-  }, [kind, route])
+  }, [kind, route, agentID, agents, routes])
 
   // Pre-select the settings page's configured default currency for a
   // fresh create — edit mode below overwrites this with the schedule's

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -161,6 +161,18 @@ const executorChoices: { value: string; label: string }[] = [
   { value: 'cursor-cli', label: 'Cursor CLI' },
 ]
 
+// defaultHarnessLabel names what the Harness select's "Default" choice
+// actually resolves to — mirrors defaultRouteLabel's job for Route —
+// so an operator can tell what runs without opening Settings. Falls
+// back to the plain choice when defaultHarnessName is empty (fetch
+// failed) or names a harness not in executorChoices (native, or one
+// not yet in this list).
+function defaultHarnessLabel(defaultHarnessName: string): string {
+  if (!defaultHarnessName) return 'Default (from settings)'
+  const known = executorChoices.find((c) => c.value === defaultHarnessName)
+  return `Default (${known?.label ?? defaultHarnessName})`
+}
+
 // Sentinel for the environment Select's "auto-detect" choice — wire
 // value stays '' (omit environment from the create payload) to match
 // the API's own empty-means-auto-detect semantics (D-05x).
@@ -301,6 +313,12 @@ export function MissionForm({
   const [branchPattern, setBranchPattern] = useState(initial?.branch_pattern ?? '')
   const [commitStyle, setCommitStyle] = useState(initial?.commit_style ?? '')
   const [executorOptions, setExecutorOptions] = useState<ExecutorOption[] | null>(null)
+  // defaultHarnessName is settings' coding_executor value (the harness
+  // a create actually runs when the Harness select is left on
+  // "Default") — fetched once so that choice can say what it resolves
+  // to, the same way the Route select's "Default" already names the
+  // route it resolves to (defaultRouteLabel).
+  const [defaultHarnessName, setDefaultHarnessName] = useState('')
   const [busy, setBusy] = useState(false)
 
   // Repository source: 'none' self-initializes an empty repo (the
@@ -408,6 +426,18 @@ export function MissionForm({
         // Best-effort: falls back to the USD default already set.
       })
   }, [mode])
+
+  // Read-only, both modes: names the harness the settings-page
+  // coding_executor value resolves to, purely for the Harness select's
+  // "Default" label. Best-effort — an empty value just shows the plain
+  // "Default (from settings)" fallback.
+  useEffect(() => {
+    getSettings()
+      .then((s) => setDefaultHarnessName(s.values.coding_executor ?? ''))
+      .catch(() => {
+        // Best-effort: falls back to the plain "Default" label.
+      })
+  }, [])
 
   // Repeat-on-schedule fields — read/submitted whenever repeat is on
   // (create mode) or always (edit mode, which only ever edits a
@@ -1096,6 +1126,7 @@ export function MissionForm({
                 {executorChoices.map((c) => {
                   const opt = executorOptions?.find((o) => o.harness === c.value)
                   const disabled = !!opt && !opt.usable
+                  const label = c.value === EXECUTOR_DEFAULT ? defaultHarnessLabel(defaultHarnessName) : c.label
                   return (
                     <SelectItem
                       key={c.value}
@@ -1103,7 +1134,7 @@ export function MissionForm({
                       disabled={disabled}
                       title={disabled ? opt?.reason : undefined}
                     >
-                      {c.label}
+                      {label}
                     </SelectItem>
                   )
                 })}


### PR DESCRIPTION
## Summary

**1. MissionForm executor-options preview used the wrong route.** Always queried the system default route unless the operator set an explicit Route override, ignoring the agent's own route and the `coding` route preference create() itself applies (`missions.DefaultCodingRoute`). Result: a coding mission's harness preview/usability check showed the default route's chain (e.g. OpenAI gpt-5-mini) instead of the coding route's chain, disabling harnesses (Claude Code) that were actually usable there. Added `resolvedDefaultRoute`, mirroring `defaultRouteLabel`'s precedence (agent route -> "coding" route -> default role route).

Verified against the live gateway: `coding` route resolves claude-cli usable=true (Anthropic subscription row), `default` route resolves claude-cli usable=false on every entry (wire-incompatible) - matches the reported symptom exactly.

**2. Harness select's "Default" choice named nothing.** Unlike Route's own default label, it just said "Default (from settings)" with no indication which harness that resolves to. Added `defaultHarnessLabel`, fetching the settings-page `coding_executor` value once to name it.

**3. Memory dedup missed pending-pending duplicates.** memoryd's dedup (`NearestActive`) only compares a new extraction candidate against already-committed memories; two independent extraction runs can each propose the same fact in different wording before either reaches confirmation, landing both in the pending queue with no dedup between them (reproduced: two near-identical "user timezone is Europe/Amsterdam" proposals both queued). Added `RedundantPendingPairs` (pending-pending near-dup query, mirrors `NearDupPairs`' active-only one) and a consolidator pass (`dedupePending`) that rejects the newer half of each pair outright - no LLM merge needed since neither side is confirmed knowledge yet.

## Test plan
- [x] `tsc -b` clean
- [x] `npm run lint` - 0 errors (pre-existing warnings only)
- [x] `MissionForm.test.tsx` - 67/67 passing
- [x] `go vet ./...`, `golangci-lint run` - 0 issues
- [x] `go test -race ./internal/memory/...` - passing, incl. new unit tests (`TestConsolidateDedupesPendingPairs`, reject-error path)
- [x] `make test-integration` - full suite green, incl. new `TestRedundantPendingPairs` against live pgvector