### PR TITLE
feat: operator price overrides for uncatalogued models

### DIFF
--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"regexp"
 	"sort"
@@ -404,15 +405,15 @@ func (a *Admin) PatchBudget(ctx context.Context, patch map[string]*ledger.Budget
 // NAME (env var / Vault path / AWS profile) — secret values are never
 // stored or returned anywhere in this system.
 type Provider struct {
-	ID            string             `json:"id"`
-	Name          string             `json:"name"`
-	Kind          string             `json:"kind"`
-	Driver        string             `json:"driver"`
-	BaseURL       string             `json:"base_url"`
-	DefaultModel  string             `json:"default_model"`
-	CredentialRef string             `json:"credential_ref"`
-	Headers       map[string]string  `json:"headers"`
-	Enabled       bool               `json:"enabled"`
+	ID            string            `json:"id"`
+	Name          string            `json:"name"`
+	Kind          string            `json:"kind"`
+	Driver        string            `json:"driver"`
+	BaseURL       string            `json:"base_url"`
+	DefaultModel  string            `json:"default_model"`
+	CredentialRef string            `json:"credential_ref"`
+	Headers       map[string]string `json:"headers"`
+	Enabled       bool              `json:"enabled"`
 	// ExcludeFromBootstrap opts this provider out of auto-fallback fill
 	// on the shared default/summarize/embedding routes — for local/dev
 	// providers (e.g. Ollama) that should never silently serve
@@ -534,6 +535,40 @@ func validateLitellmProvider(opts map[string]string) error {
 	}
 	if !litellmProviderPattern.MatchString(raw) {
 		return fmt.Errorf("options.litellm_provider %q must be a non-empty printable token", raw)
+	}
+	return nil
+}
+
+// validatePricesByModel rejects an operator-declared price map that
+// would corrupt cost records (D-079). Checked here as well as at config
+// load so a bad value fails the admin write that introduced it, rather
+// than surfacing later as a failed reload far from the operator.
+func validatePricesByModel(opts map[string]string) error {
+	raw, ok := opts["prices_by_model"]
+	if !ok || raw == "" {
+		return nil
+	}
+	var prices map[string]router.ModelPrices
+	if err := json.Unmarshal([]byte(raw), &prices); err != nil {
+		return fmt.Errorf("options.prices_by_model must be a JSON object of model -> prices: %w", err)
+	}
+	for model, p := range prices {
+		for _, f := range []struct {
+			name string
+			val  float64
+		}{
+			{"input_per_mtok", p.InputPerMTok},
+			{"output_per_mtok", p.OutputPerMTok},
+			{"cache_read_per_mtok", p.CacheReadPerMTok},
+			{"cache_write_per_mtok", p.CacheWritePerMTok},
+		} {
+			if math.IsNaN(f.val) || math.IsInf(f.val, 0) {
+				return fmt.Errorf("options.prices_by_model %q: %s is not a finite number", model, f.name)
+			}
+			if f.val < 0 {
+				return fmt.Errorf("options.prices_by_model %q: %s is negative (%v)", model, f.name, f.val)
+			}
+		}
 	}
 	return nil
 }
@@ -737,6 +772,9 @@ func (a *Admin) Patch(ctx context.Context, id string, patch ProviderPatch) error
 			return err
 		}
 		if err := validateLitellmProvider(*patch.Options); err != nil {
+			return err
+		}
+		if err := validatePricesByModel(*patch.Options); err != nil {
 			return err
 		}
 		if err := validateOpenAIResponses(*patch.Options); err != nil {

--- a/internal/gateway/admin/admin_options_test.go
+++ b/internal/gateway/admin/admin_options_test.go
@@ -288,3 +288,45 @@ func TestProbeTimeout(t *testing.T) {
 		t.Fatalf("probeTimeout(invalid) = %v, want default %v", got, testTimeout)
 	}
 }
+
+// TestValidatePricesByModel covers the admin-write guard on
+// operator-declared prices (D-079). These numbers are recorded as real
+// spend, so a malformed or nonsensical rate must fail the write that
+// introduced it rather than surfacing later as a failed config reload.
+func TestValidatePricesByModel(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "absent is fine"},
+		{name: "empty is fine", value: ""},
+		{
+			name:  "a real price set passes",
+			value: `{"glm-5.3":{"input_per_mtok":1.4,"output_per_mtok":4.4,"cache_read_per_mtok":0.26}}`,
+		},
+		{name: "zero is legal", value: `{"free-model":{"input_per_mtok":0,"output_per_mtok":0}}`},
+		{name: "malformed json fails", value: `not json`, wantErr: true},
+		{name: "a bare number is not an object", value: `42`, wantErr: true},
+		{name: "negative input fails", value: `{"m":{"input_per_mtok":-1}}`, wantErr: true},
+		{name: "negative output fails", value: `{"m":{"output_per_mtok":-0.5}}`, wantErr: true},
+		{name: "negative cache read fails", value: `{"m":{"cache_read_per_mtok":-2}}`, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			opts := map[string]string{}
+			if tt.value != "" {
+				opts["prices_by_model"] = tt.value
+			}
+			err := validatePricesByModel(opts)
+			if tt.wantErr && err == nil {
+				t.Fatalf("validatePricesByModel(%q): want error, got nil", tt.value)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("validatePricesByModel(%q): %v", tt.value, err)
+			}
+		})
+	}
+}

--- a/internal/gateway/router/router.go
+++ b/internal/gateway/router/router.go
@@ -81,6 +81,17 @@ type ProviderRow struct {
 	// same provider row have no such restriction — a single scalar
 	// override can't express that.
 	ReasoningEffortByModel map[string]string
+	// PricesByModel comes from options.prices_by_model — operator-declared
+	// per-model prices for models the synced catalog has no entry for.
+	// LiteLLM's per-vendor buckets lag: a vendor that does not upstream
+	// its own pricing leaves its newest models unpriced indefinitely,
+	// and cost honesty (D-013) then records NULL rather than a guess,
+	// which makes real spend invisible. An operator transcribing the
+	// vendor's published rate is not a guess, so these are treated as
+	// real prices. They win over the catalog (D-079) so a wrong catalog
+	// entry can be corrected, which also means a stale override outlives
+	// a later-correct catalog price until someone removes it.
+	PricesByModel map[string]ModelPrices
 }
 
 // reasoningEffortFor resolves model's effective reasoning_effort
@@ -989,6 +1000,12 @@ func (s *Snapshot) Prices(providerName, model string) *ModelPrices {
 	row, ok := s.byName[providerName]
 	if !ok {
 		return nil
+	}
+	// Operator-declared prices win over the catalog (D-079): the catalog
+	// is a synced third-party snapshot, an override is a deliberate
+	// statement about this row.
+	if p, ok := row.PricesByModel[model]; ok {
+		return &p
 	}
 	m, ok := s.catalogModel(row, model)
 	if !ok || (m.InputPerMTok == nil && m.OutputPerMTok == nil) {

--- a/internal/gateway/router/router_test.go
+++ b/internal/gateway/router/router_test.go
@@ -1620,3 +1620,41 @@ func TestResolveRouteSelfPairedMultipleRowsSortedByName(t *testing.T) {
 		t.Fatalf("entries not sorted by provider name: %+v", entries)
 	}
 }
+
+// TestPricesOperatorOverride covers D-079: an operator-declared price
+// fills a catalog gap, and wins over the catalog when both have one.
+// Precedence matters because the catalog is a synced third-party
+// snapshot while an override is a deliberate statement about this row
+// — including a correction of a wrong catalog entry.
+func TestPricesOperatorOverride(t *testing.T) {
+	t.Parallel()
+	provRows := []ProviderRow{
+		{
+			ID: "p1", Name: "anthropic", Kind: "api", Driver: "anthropic",
+			DefaultModel: "sonnet", CredentialRef: "A_KEY", Enabled: true,
+			PricesByModel: map[string]ModelPrices{
+				// "sonnet" has no catalog entry: the gap-filling case.
+				"sonnet": {InputPerMTok: 3, OutputPerMTok: 15},
+				// "opus" IS in the catalog at 15/75: the correction case.
+				"opus": {InputPerMTok: 1, OutputPerMTok: 2},
+			},
+		},
+	}
+	cat := &fakeCatalog{pool: []catalog.Model{catModel("opus", "chat", fp(15))}}
+	cat.pool[0].OutputPerMTok = fp(75)
+	snap, _ := BuildSnapshot(provRows, nil, func(string) string { return "sk-a" }, cat)
+
+	p := snap.Prices("anthropic", "sonnet")
+	if p == nil || p.InputPerMTok != 3 || p.OutputPerMTok != 15 {
+		t.Fatalf("Prices(anthropic, sonnet) = %+v, want the override 3/15 filling the catalog gap", p)
+	}
+
+	p = snap.Prices("anthropic", "opus")
+	if p == nil || p.InputPerMTok != 1 || p.OutputPerMTok != 2 {
+		t.Fatalf("Prices(anthropic, opus) = %+v, want the override 1/2 to beat the catalog's 15/75", p)
+	}
+
+	if p := snap.Prices("anthropic", "haiku"); p != nil {
+		t.Fatalf("Prices(anthropic, haiku) = %+v, want nil (no override, no catalog entry)", p)
+	}
+}

--- a/internal/gateway/router/store.go
+++ b/internal/gateway/router/store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math"
 	"sync/atomic"
 	"time"
 
@@ -170,8 +171,9 @@ func (s *Store) Load(ctx context.Context) error {
 
 // applyProviderOptions decodes a providers row's options jsonb into row.
 // Only reasoning_effort, reasoning_effort_by_model, request_timeout,
-// region, anthropic_base_url, and openai_responses are recognized today
-// (D-040, D-041, D-048, D-051); unknown keys are ignored silently. An unparseable
+// region, anthropic_base_url, openai_responses, litellm_provider, and
+// prices_by_model are recognized today
+// (D-040, D-041, D-048, D-051, D-079); unknown keys are ignored silently. An unparseable
 // request_timeout fails the load outright — config honesty, never a
 // silent fallback to the driver default. region gets no such
 // validation beyond being present: AWS region ids change over time, so
@@ -184,7 +186,35 @@ func (s *Store) Load(ctx context.Context) error {
 // (e.g. `"{\"gpt-5.6-luna\":\"none\"}"`), not a nested object — options
 // stays map[string]string end to end through the admin write path
 // (ProviderPatch), so a per-model override rides inside a flat string
-// value instead of widening that type.
+// value instead of widening that type. prices_by_model is encoded the
+// same way (e.g. `"{\"glm-5.3\":{\"input_per_mtok\":1.4}}"`), and its
+// numbers are validated on load: a negative or non-finite rate fails
+// outright rather than silently producing wrong costs, since these
+// prices are recorded as real spend (D-079).
+// validateModelPrices rejects an operator-declared price that could
+// only corrupt cost records: a negative rate, or a NaN/Inf that would
+// propagate through every cost sum touching it. Zero is legitimate
+// (genuinely free models exist, e.g. glm-4.7-flash).
+func validateModelPrices(p ModelPrices) error {
+	for _, f := range []struct {
+		name string
+		val  float64
+	}{
+		{"input_per_mtok", p.InputPerMTok},
+		{"output_per_mtok", p.OutputPerMTok},
+		{"cache_read_per_mtok", p.CacheReadPerMTok},
+		{"cache_write_per_mtok", p.CacheWritePerMTok},
+	} {
+		if math.IsNaN(f.val) || math.IsInf(f.val, 0) {
+			return fmt.Errorf("%s is not a finite number", f.name)
+		}
+		if f.val < 0 {
+			return fmt.Errorf("%s is negative (%v)", f.name, f.val)
+		}
+	}
+	return nil
+}
+
 func applyProviderOptions(row *ProviderRow, optionsJSON []byte) error {
 	var opts struct {
 		ReasoningEffort        string `json:"reasoning_effort"`
@@ -194,6 +224,7 @@ func applyProviderOptions(row *ProviderRow, optionsJSON []byte) error {
 		AnthropicBaseURL       string `json:"anthropic_base_url"`
 		OpenAIResponses        string `json:"openai_responses"`
 		LitellmProvider        string `json:"litellm_provider"`
+		PricesByModel          string `json:"prices_by_model"`
 	}
 	if err := json.Unmarshal(optionsJSON, &opts); err != nil {
 		return err
@@ -207,6 +238,16 @@ func applyProviderOptions(row *ProviderRow, optionsJSON []byte) error {
 	row.Region = opts.Region
 	row.AnthropicBaseURL = opts.AnthropicBaseURL
 	row.LitellmProvider = opts.LitellmProvider
+	if opts.PricesByModel != "" {
+		if err := json.Unmarshal([]byte(opts.PricesByModel), &row.PricesByModel); err != nil {
+			return fmt.Errorf("prices_by_model: %w", err)
+		}
+		for model, p := range row.PricesByModel {
+			if err := validateModelPrices(p); err != nil {
+				return fmt.Errorf("prices_by_model %q: %w", model, err)
+			}
+		}
+	}
 	if opts.RequestTimeout != "" {
 		d, err := time.ParseDuration(opts.RequestTimeout)
 		if err != nil {

--- a/internal/gateway/router/store_test.go
+++ b/internal/gateway/router/store_test.go
@@ -122,3 +122,73 @@ func TestApplyProviderOptionsOpenAIResponses(t *testing.T) {
 }
 
 func boolPtr(b bool) *bool { return &b }
+
+// TestApplyProviderOptionsPricesByModel covers operator-declared prices
+// (D-079): the value is a JSON-encoded object string like its
+// reasoning_effort_by_model sibling, and every rate is validated on
+// load because these numbers are recorded as real spend. Zero stays
+// legal — genuinely free models exist.
+func TestApplyProviderOptionsPricesByModel(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		options string
+		wantErr bool
+		check   func(*testing.T, ProviderRow)
+	}{
+		{
+			name:    "full price set decodes",
+			options: `{"prices_by_model": "{\"glm-5.3\":{\"input_per_mtok\":1.4,\"output_per_mtok\":4.4,\"cache_read_per_mtok\":0.26}}"}`,
+			check: func(t *testing.T, row ProviderRow) {
+				p, ok := row.PricesByModel["glm-5.3"]
+				if !ok {
+					t.Fatal("glm-5.3 missing from PricesByModel")
+				}
+				if p.InputPerMTok != 1.4 || p.OutputPerMTok != 4.4 || p.CacheReadPerMTok != 0.26 {
+					t.Fatalf("prices = %+v, want 1.4/4.4/0.26", p)
+				}
+			},
+		},
+		{
+			name:    "zero is a legal price",
+			options: `{"prices_by_model": "{\"glm-4.7-flash\":{\"input_per_mtok\":0,\"output_per_mtok\":0}}"}`,
+			check: func(t *testing.T, row ProviderRow) {
+				if _, ok := row.PricesByModel["glm-4.7-flash"]; !ok {
+					t.Fatal("glm-4.7-flash missing from PricesByModel")
+				}
+			},
+		},
+		{
+			name:    "absent leaves the map nil",
+			options: `{"reasoning_effort": "low"}`,
+			check: func(t *testing.T, row ProviderRow) {
+				if row.PricesByModel != nil {
+					t.Fatalf("PricesByModel = %v, want nil when unset", row.PricesByModel)
+				}
+			},
+		},
+		{name: "malformed json fails", options: `{"prices_by_model": "not json"}`, wantErr: true},
+		{
+			name:    "negative price fails",
+			options: `{"prices_by_model": "{\"m\":{\"input_per_mtok\":-1}}"}`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var row ProviderRow
+			err := applyProviderOptions(&row, []byte(tt.options))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("applyProviderOptions: want error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("applyProviderOptions: %v", err)
+			}
+			tt.check(t, row)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- LiteLLM's synced catalog lags per-vendor pricing; glm-5.3 currently records $0 cost across 120 calls / 195k tokens because no catalog entry exists
- Adds `prices_by_model` to provider options (JSON-encoded string, following `reasoning_effort_by_model`'s convention) so an operator can declare real per-model prices
- Overrides win over the catalog (D-079): a wrong catalog entry can be corrected, at the cost of a stale override outliving a later-correct catalog price until removed
- Validates negative/non-finite rates at both admin write and config load; zero stays legal for genuinely free models

## Test plan
- [x] `make build test vet lint` — 0 issues
- [x] Verified locally: `/v1/routes/{route}/resolve` shows glm-5.3 priced at $1.40/$4.40/$0.26 per mtok after setting the override

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790369289&installation_model_id=431401&pr_number=334&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F334&signature=ead773d7914571c681dec80b20c198a4775ab58ce68c0c0bb2abc254460327c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->