### PR TITLE
fix(memory): gate extraction against rejected, transient, and system-owned facts

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -482,13 +482,25 @@ func main() {
 	// visible to that exact chain, not a parallel grant store.
 	svc.SetApprovalGrants(chatPerms)
 	compactor.SetSensitiveTools(sensitiveTools)
+	// extractDeny fetches system-owned values a proposed fact must not
+	// restate (currently just the operator's timezone). Read per-call,
+	// not once at wiring time: settings can change at runtime, and
+	// extraction is already off the hot path, so the extra DB/cache
+	// read is cheap here.
+	extractDeny := func(ctx context.Context) []string {
+		if tz := flags.Value(ctx, settings.ValueTimezone); tz != "" {
+			return []string{tz}
+		}
+		return nil
+	}
 	svc.SetMemoryExtract(func(ctx context.Context, sessionID string, seq int64, text, route string) {
 		if !flags.Enabled(ctx, settings.KeyMemoryExtraction) {
 			return
 		}
+		deny := extractDeny(ctx)
 		ectx, cancel := context.WithTimeout(context.WithoutCancel(ctx), extractBudget)
 		defer cancel()
-		if _, err := mc.Extract(ectx, sessionID, seq, text, route, "chat"); err != nil {
+		if _, err := mc.Extract(ectx, sessionID, seq, text, route, "chat", deny); err != nil {
 			app.Log.Warn("turn memory extraction failed", "session_id", sessionID, "error", err)
 		}
 	})
@@ -502,9 +514,10 @@ func main() {
 			if !flags.Enabled(ctx, settings.KeyMemoryExtraction) {
 				return
 			}
+			deny := extractDeny(ctx)
 			ectx, cancel := context.WithTimeout(context.WithoutCancel(ctx), extractBudget)
 			defer cancel()
-			if _, err := mc.Extract(ectx, sessionID, seq, text, route, "mission"); err != nil {
+			if _, err := mc.Extract(ectx, sessionID, seq, text, route, "mission", deny); err != nil {
 				app.Log.Warn("mission memory extraction failed", "session_id", sessionID, "error", err)
 			}
 		})
@@ -513,11 +526,12 @@ func main() {
 		if !flags.Enabled(ctx, settings.KeyMemoryExtraction) {
 			return nil
 		}
+		deny := extractDeny(ctx)
 		// Own deadline WITHIN the compaction budget: extraction must
 		// never starve the summarize that follows it.
 		ectx, cancel := context.WithTimeout(ctx, preCompactExtractBudget)
 		defer cancel()
-		ids, err := mc.Extract(ectx, sessionID, seq, text, route, "compaction")
+		ids, err := mc.Extract(ectx, sessionID, seq, text, route, "compaction", deny)
 		if err != nil {
 			app.Log.Warn("pre-compaction extraction failed", "session_id", sessionID, "error", err)
 			return nil

--- a/internal/brain/memclient/memclient.go
+++ b/internal/brain/memclient/memclient.go
@@ -35,9 +35,11 @@ func New(baseURL string) *Client {
 // and must not fall back to the default side-call route. source names
 // what produced the text ("chat", "mission", "compaction") so memoryd
 // can pick a source-appropriate extraction contract; empty means chat.
-func (c *Client) Extract(ctx context.Context, sessionID string, sourceSeq int64, text, route, source string) ([]string, error) {
+// deny lists system-owned values (e.g. the operator's timezone) a
+// proposed fact must not restate; nil when there is nothing to deny.
+func (c *Client) Extract(ctx context.Context, sessionID string, sourceSeq int64, text, route, source string, deny []string) ([]string, error) {
 	body, err := json.Marshal(map[string]any{
-		"session_id": sessionID, "source_seq": sourceSeq, "text": text, "route": route, "source": source,
+		"session_id": sessionID, "source_seq": sourceSeq, "text": text, "route": route, "source": source, "deny": deny,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("memclient: marshal: %w", err)

--- a/internal/brain/memclient/memclient_test.go
+++ b/internal/brain/memclient/memclient_test.go
@@ -23,7 +23,7 @@ func TestExtractRoundTrip(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	ids, err := New(srv.URL).Extract(t.Context(), "s1", 42, "turn text", "", "chat")
+	ids, err := New(srv.URL).Extract(t.Context(), "s1", 42, "turn text", "", "chat", nil)
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
@@ -32,6 +32,27 @@ func TestExtractRoundTrip(t *testing.T) {
 	}
 	if got["session_id"] != "s1" || got["source_seq"] != float64(42) || got["text"] != "turn text" {
 		t.Fatalf("request body = %v", got)
+	}
+}
+
+// TestExtractSendsDeny pins the deny pass-through: system-owned values
+// (e.g. the operator's timezone) reach the wire so memoryd can fence
+// them out of proposed facts.
+func TestExtractSendsDeny(t *testing.T) {
+	t.Parallel()
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		_ = json.NewEncoder(w).Encode(map[string]any{"memory_ids": []string{}})
+	}))
+	defer srv.Close()
+
+	if _, err := New(srv.URL).Extract(t.Context(), "s1", 1, "x", "", "chat", []string{"Europe/Amsterdam"}); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	deny, _ := got["deny"].([]any)
+	if len(deny) != 1 || deny[0] != "Europe/Amsterdam" {
+		t.Fatalf("request body deny = %v, want [Europe/Amsterdam]", got["deny"])
 	}
 }
 
@@ -47,7 +68,7 @@ func TestExtractSendsRouteOverride(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := New(srv.URL).Extract(t.Context(), "s1", 1, "x", "local", "chat"); err != nil {
+	if _, err := New(srv.URL).Extract(t.Context(), "s1", 1, "x", "local", "chat", nil); err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
 	if got["route"] != "local" {
@@ -62,7 +83,7 @@ func TestExtractSurfacesHTTPError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := New(srv.URL).Extract(t.Context(), "s1", 1, "x", "", ""); err == nil {
+	if _, err := New(srv.URL).Extract(t.Context(), "s1", 1, "x", "", "", nil); err == nil {
 		t.Fatal("Extract succeeded on 502, want error")
 	}
 }

--- a/internal/memory/extract/extract.go
+++ b/internal/memory/extract/extract.go
@@ -66,7 +66,7 @@ const (
 // dates, no pronouns that need surrounding context.
 const system = `You extract durable facts from a conversation excerpt for an AI assistant's long-term memory. Reply with ONLY a JSON array - no prose, no markdown fences:
 [{"type":"episodic|semantic|procedural","content":"one atomic self-contained fact","entities":[{"type":"person|project|service|preference|decision|topic|place","name":"..."}],"confidence":0.0,"changes_behavior":true}]
-Rules: each content is ONE fact, self-contained (absolute dates, full names, no "he"/"it"/"this project"). type: episodic = something that happened, semantic = a durable fact or preference, procedural = a how-to. Anything phrased as a rule, requirement, standing instruction, or directive is semantic, NEVER episodic - even when it was stated during an event. confidence in [0,1] reflects how certain the excerpt makes the fact. changes_behavior: true only when knowing this fact would change how the assistant acts or answers in a FUTURE conversation - facts about the user, their preferences, their projects, their world. General knowledge the excerpt happened to discuss (documentation facts, quiz answers, how a technology works) is false. Skip small talk, transient state, and anything already obvious. Also skip filesystem paths, directory/file permissions and ownership, container or sandbox environment details, UUIDs and other identifiers, and any other machine-state observations - these are transient environment facts, not durable knowledge about the user. Empty array when nothing qualifies.`
+Rules: each content is ONE fact, self-contained (absolute dates, full names, no "he"/"it"/"this project"). type: episodic = something that happened, semantic = a durable fact or preference, procedural = a how-to. Anything phrased as a rule, requirement, standing instruction, or directive is semantic, NEVER episodic - even when it was stated during an event. confidence in [0,1] reflects how certain the excerpt makes the fact. changes_behavior is REQUIRED on every fact: true only when knowing this fact would change how the assistant acts or answers in a FUTURE conversation - facts about the user, their preferences, their projects, their world. General knowledge the excerpt happened to discuss is false - for example, "The capital of the Netherlands is Amsterdam" or "HTTP 429 means rate limiting" are general knowledge, not facts about the user. Skip small talk, transient state, and anything already obvious. Also skip filesystem paths, directory/file permissions and ownership, container or sandbox environment details, UUIDs and other identifiers, and any other machine-state observations - these are transient environment facts, not durable knowledge about the user. Empty array when nothing qualifies.`
 
 // missionSystem is the mission-digest extraction contract. The input
 // is a mission's OutcomeDigest - goal, title, kind, unit statuses -
@@ -74,7 +74,7 @@ Rules: each content is ONE fact, self-contained (absolute dates, full names, no 
 // already lives in the missions table. Only deltas qualify.
 const missionSystem = `You extract durable facts from a completed background mission's outcome digest for an AI assistant's long-term memory. Reply with ONLY a JSON array - no prose, no markdown fences:
 [{"type":"episodic|semantic|procedural","content":"one atomic self-contained fact","entities":[{"type":"person|project|service|preference|decision|topic|place","name":"..."}],"confidence":0.0,"changes_behavior":true}]
-Set changes_behavior true only when knowing the fact would change how the assistant acts in a future conversation. ONLY these qualify: (a) a user preference or standing instruction the mission revealed, (b) a durable fact about the outside world DISCOVERED during execution (an API's behavior, a service's quirk, a deadline that exists), (c) a lesson from a failure worth avoiding next time. NEVER extract the mission's goal, title, kind, unit statuses, artifact names, or terminal state - those are bookkeeping the system already stores, not knowledge. Each content must be self-contained (absolute dates, full names, no pronouns). Anything phrased as a rule or standing instruction is semantic, never episodic. Most digests contain NOTHING worth remembering: an empty array is the expected common answer.`
+Set changes_behavior true only when knowing the fact would change how the assistant acts in a future conversation. ONLY these qualify: (a) a user preference or standing instruction the mission revealed, (b) a durable fact about the outside world DISCOVERED during execution (an API's behavior, a service's quirk, a deadline that exists), (c) a lesson from a failure worth avoiding next time. NEVER extract the mission's goal, title, kind, unit statuses, artifact names, or terminal state - those are bookkeeping the system already stores, not knowledge. NEVER extract execution-environment observations - installed packages, library or tool availability or versions, filesystem paths, file or directory permissions and ownership, container or sandbox details, absence of files in a repository, or any other machine-state observation; these describe the sandbox, not the world. A summary of what a scan, search, or inbox check found during one run is a transient result, not a durable fact - do not extract it; only a durable fact it revealed (for example a deadline that exists) qualifies, stated on its own with absolute dates. Each content must be self-contained (absolute dates, full names, no pronouns). Anything phrased as a rule or standing instruction is semantic, never episodic. changes_behavior is REQUIRED on every fact. Most digests contain NOTHING worth remembering: an empty array is the expected common answer.`
 
 // reflectionSystem is the consolidation reflection contract: distill
 // recurring patterns across recent episodic memories into rare,
@@ -83,7 +83,7 @@ Set changes_behavior true only when knowing the fact would change how the assist
 // episodics themselves stay; this only proposes what they add up to.
 const reflectionSystem = `You are reviewing an AI assistant's recent episodic memories (things that happened) to distill durable insights for long-term memory. Reply with ONLY a JSON array - no prose, no markdown fences:
 [{"type":"semantic","content":"one atomic self-contained insight","entities":[{"type":"person|project|service|preference|decision|topic|place","name":"..."}],"confidence":0.0,"changes_behavior":true}]
-An insight qualifies ONLY when a RECURRING pattern across several distinct episodes reveals something durable no single episode states: a habit, a recurring problem, a stable preference, a relationship between things the user deals with repeatedly. Propose at most 3 insights per review, each grounded in at least 2 separate episodes. Never restate a single episode, never summarize the list, never propose general knowledge. An empty array is the expected common answer.`
+An insight qualifies ONLY when a RECURRING pattern across several distinct episodes reveals something durable no single episode states: a habit, a recurring problem, a stable preference, a relationship between things the user deals with repeatedly. Propose at most 3 insights per review, each grounded in at least 2 separate episodes. Never restate a single episode, never summarize the list, never propose general knowledge. changes_behavior is REQUIRED on every insight. An empty array is the expected common answer.`
 
 // Request is one extraction job: text from a completed turn or from
 // turns about to be compacted away.
@@ -104,6 +104,11 @@ type Request struct {
 	// lines as "facts", flooding the confirmation queue with
 	// restatements of things the missions table already records.
 	Source string `json:"source,omitempty"`
+	// Deny lists values a fact must not restate: system-owned
+	// knowledge (operator settings like timezone) that the model
+	// otherwise re-extracts as if it were a discovered fact about the
+	// user.
+	Deny []string `json:"deny,omitempty"`
 }
 
 // Extractor runs the pipeline.
@@ -162,6 +167,15 @@ func (e *Extractor) Extract(ctx context.Context, req Request) ([]string, error) 
 			e.log.Info("memory dropped as source-header echo", "session_id", req.SessionID)
 			continue
 		}
+		if f.Type != string(store.TypeEpisodic) && boundedWindow(f.Content) {
+			// A semantic or procedural fact phrased as a bounded
+			// observation window ("last 24 hours", "currently") describes
+			// one run's result, not a durable fact. Episodic facts keep -
+			// something that happened IS time-scoped. Code enforces what
+			// the prompt asks for (D-011).
+			e.log.Info("memory dropped as bounded-window observation", "session_id", req.SessionID)
+			continue
+		}
 		emb := store.Vector(vecs[i])
 		if len(emb) > 0 {
 			// Intra-batch dedup: one extraction run can propose the same
@@ -177,6 +191,14 @@ func (e *Extractor) Extract(ctx context.Context, req Request) ([]string, error) 
 				return ids, fmt.Errorf("extract: dedup: %w", err)
 			}
 			if found && sim >= nearDupSimilarity {
+				if status == store.StatusRejected {
+					// The user already rejected this fact once; rejection
+					// is a durable teaching signal, so the candidate is
+					// dropped instead of re-proposed forever.
+					e.log.Info("memory dropped as near-duplicate of rejected fact",
+						"of", dupID, "similarity", sim, "session_id", req.SessionID)
+					continue
+				}
 				if status == store.StatusPending {
 					// A pending row already carries this fact awaiting
 					// confirmation; Confirm's UPDATE is active-only and
@@ -297,9 +319,10 @@ type Fact struct {
 	Entities   []FactEntity `json:"entities"`
 	Confidence float32      `json:"confidence"`
 	// ChangesBehavior is the utility gate: the model's own answer to
-	// "would knowing this change a future turn?". Pointer so an older
-	// model reply that omits the field keeps the fact (nil = keep);
-	// only an explicit false drops it.
+	// "would knowing this change a future turn?". Required on every
+	// fact - ParseFacts rejects a fact where it's nil (missing from the
+	// reply), triggering propose()'s retry instead of silently keeping
+	// an unjudged fact.
 	ChangesBehavior *bool `json:"changes_behavior,omitempty"`
 }
 
@@ -347,6 +370,9 @@ func ParseFacts(raw string) ([]Fact, error) {
 		if f.Confidence < 0 || f.Confidence > 1 {
 			return nil, fmt.Errorf("fact %d: confidence %v out of range", i, f.Confidence)
 		}
+		if f.ChangesBehavior == nil {
+			return nil, fmt.Errorf("fact %d: missing changes_behavior", i)
+		}
 		for j, ent := range f.Entities {
 			if !validEntityTypes[ent.Type] {
 				return nil, fmt.Errorf("fact %d entity %d: invalid type %q", i, j, ent.Type)
@@ -357,6 +383,25 @@ func ParseFacts(raw string) ([]Fact, error) {
 		}
 	}
 	return facts, nil
+}
+
+// boundedWindowPattern catches bounded-time-window phrasing: a
+// semantic or procedural fact phrased this way describes what was
+// true during one observation window, not a durable fact about the
+// world. "as of" is deliberately excluded - the extraction contract
+// demands absolute dates and legitimate facts use exactly that
+// phrasing (e.g. "as of 2026-08-24 the user works at Cielara").
+var boundedWindowPattern = regexp.MustCompile(`(?i)\b(` +
+	`(?:last|past)\s+(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|twelve|twenty[- ]four)\s+(?:hours?|days?|weeks?|months?)|` +
+	`today|yesterday|tonight|` +
+	`this\s+(?:morning|afternoon|evening|week|month)|` +
+	`currently|right now|at the moment|so far` +
+	`)\b`)
+
+// boundedWindow reports whether content describes a bounded
+// observation window rather than a durable fact.
+func boundedWindow(content string) bool {
+	return boundedWindowPattern.MatchString(content)
 }
 
 // sensitive marks content that must never skip the confirmation queue
@@ -388,22 +433,26 @@ func AutoPromote(f Fact) bool {
 }
 
 // denyText collects the source-record lines a proposed fact must not
-// restate. Only mission digests carry them: OutcomeDigest's "mission
-// goal:" and "mission title:" headers are bookkeeping, not knowledge,
-// and models reliably extract them as "facts" without this fence.
+// restate. Mission digests contribute OutcomeDigest's "mission goal:"
+// and "mission title:" headers - bookkeeping, not knowledge, that
+// models reliably extract as "facts" without this fence. req.Deny
+// contributes system-owned knowledge (operator settings) regardless
+// of source.
 func denyText(req Request) []string {
-	if req.Source != "mission" {
-		return nil
-	}
 	var deny []string
-	for _, line := range strings.Split(req.Text, "\n") {
-		for _, prefix := range []string{"mission goal:", "mission title:"} {
-			if rest, ok := strings.CutPrefix(line, prefix); ok {
-				if v := strings.TrimSpace(rest); v != "" {
-					deny = append(deny, strings.ToLower(v))
+	if req.Source == "mission" {
+		for _, line := range strings.Split(req.Text, "\n") {
+			for _, prefix := range []string{"mission goal:", "mission title:"} {
+				if rest, ok := strings.CutPrefix(line, prefix); ok {
+					if v := strings.TrimSpace(rest); v != "" {
+						deny = append(deny, strings.ToLower(v))
+					}
 				}
 			}
 		}
+	}
+	for _, v := range req.Deny {
+		deny = append(deny, strings.ToLower(v))
 	}
 	return deny
 }

--- a/internal/memory/extract/extract_test.go
+++ b/internal/memory/extract/extract_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestParseFacts(t *testing.T) {
 	t.Parallel()
-	valid := `[{"type":"semantic","content":"User lives in Porto.","entities":[{"type":"place","name":"Porto"}],"confidence":0.9}]`
+	valid := `[{"type":"semantic","content":"User lives in Porto.","entities":[{"type":"place","name":"Porto"}],"confidence":0.9,"changes_behavior":true}]`
 	tests := []struct {
 		name    string
 		raw     string
@@ -26,13 +26,14 @@ func TestParseFacts(t *testing.T) {
 		{name: "fenced", raw: "```json\n" + valid + "\n```", wantN: 1},
 		{name: "empty array", raw: "[]", wantN: 0},
 		{name: "prose", raw: "Here are the facts: " + valid, wantErr: true},
-		{name: "bad fact type", raw: `[{"type":"opinion","content":"x","entities":[],"confidence":0.5}]`, wantErr: true},
-		{name: "empty content", raw: `[{"type":"semantic","content":"  ","entities":[],"confidence":0.5}]`, wantErr: true},
-		{name: "confidence out of range", raw: `[{"type":"semantic","content":"x","entities":[],"confidence":1.5}]`, wantErr: true},
-		{name: "bad entity type", raw: `[{"type":"semantic","content":"x","entities":[{"type":"animal","name":"cat"}],"confidence":0.5}]`, wantErr: true},
-		{name: "empty entity name", raw: `[{"type":"semantic","content":"x","entities":[{"type":"person","name":""}],"confidence":0.5}]`, wantErr: true},
-		{name: "unknown field", raw: `[{"type":"semantic","content":"x","entities":[],"confidence":0.5,"extra":1}]`, wantErr: true},
+		{name: "bad fact type", raw: `[{"type":"opinion","content":"x","entities":[],"confidence":0.5,"changes_behavior":true}]`, wantErr: true},
+		{name: "empty content", raw: `[{"type":"semantic","content":"  ","entities":[],"confidence":0.5,"changes_behavior":true}]`, wantErr: true},
+		{name: "confidence out of range", raw: `[{"type":"semantic","content":"x","entities":[],"confidence":1.5,"changes_behavior":true}]`, wantErr: true},
+		{name: "bad entity type", raw: `[{"type":"semantic","content":"x","entities":[{"type":"animal","name":"cat"}],"confidence":0.5,"changes_behavior":true}]`, wantErr: true},
+		{name: "empty entity name", raw: `[{"type":"semantic","content":"x","entities":[{"type":"person","name":""}],"confidence":0.5,"changes_behavior":true}]`, wantErr: true},
+		{name: "unknown field", raw: `[{"type":"semantic","content":"x","entities":[],"confidence":0.5,"extra":1,"changes_behavior":true}]`, wantErr: true},
 		{name: "object not array", raw: `{"type":"semantic","content":"x"}`, wantErr: true},
+		{name: "missing changes_behavior", raw: `[{"type":"semantic","content":"x","entities":[],"confidence":0.5}]`, wantErr: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -56,7 +57,7 @@ func TestParseFacts(t *testing.T) {
 
 func TestParseFactsCapsCount(t *testing.T) {
 	t.Parallel()
-	one := `{"type":"episodic","content":"fact","entities":[],"confidence":0.9}`
+	one := `{"type":"episodic","content":"fact","entities":[],"confidence":0.9,"changes_behavior":true}`
 	raw := "[" + strings.Repeat(one+",", 30) + one + "]"
 	facts, err := ParseFacts(raw)
 	if err != nil {
@@ -93,6 +94,52 @@ func TestAutoPromote(t *testing.T) {
 				t.Fatalf("AutoPromote(%+v) = %v, want %v", tc.f, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestBoundedWindow(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "gmail 24h scan", content: "In the Gmail inbox over the last 24 hours there were no spending emails.", want: true},
+		{name: "absolute deadline", content: "User's AWS Skill Builder renewal of $29 is due on 1 September 2026.", want: false},
+		{name: "as of phrasing kept", content: "As of 2026-08-24 the user works at Cielara.", want: false},
+		{name: "currently phrasing", content: "The user currently prefers dark mode.", want: true},
+		{name: "today bare word", content: "The user finished the report today.", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := boundedWindow(tc.content); got != tc.want {
+				t.Fatalf("boundedWindow(%q) = %v, want %v", tc.content, got, tc.want)
+			}
+		})
+	}
+}
+
+// The bounded-window gate drops semantic facts but keeps episodic ones
+// (something that happened IS time-scoped) and absolute-dated facts.
+func TestExtractDropsBoundedWindowSemanticFacts(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGateway{replies: []string{`[` +
+		`{"type":"semantic","content":"In the Gmail inbox over the last 24 hours there were no spending emails.","entities":[],"confidence":0.8,"changes_behavior":true},` +
+		`{"type":"semantic","content":"User's AWS Skill Builder renewal of $29 is due on 1 September 2026.","entities":[],"confidence":0.9,"changes_behavior":true},` +
+		`{"type":"episodic","content":"User finished the quarterly report today.","entities":[],"confidence":0.9,"changes_behavior":true}]`}}
+	st := &fakeStore{}
+	ids, err := New(gw, st, testLog()).Extract(t.Context(), Request{Text: "x"})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if len(ids) != 2 || len(st.inserted) != 2 {
+		t.Fatalf("want bounded-window semantic dropped, absolute-dated semantic and episodic kept: ids=%v inserted=%d", ids, len(st.inserted))
+	}
+	for _, m := range st.inserted {
+		if strings.Contains(m.Content, "last 24 hours") {
+			t.Fatalf("bounded-window fact inserted: %q", m.Content)
+		}
 	}
 }
 
@@ -189,8 +236,8 @@ func testLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, ni
 func TestExtractInsertsAndPromotes(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGateway{replies: []string{`[
-		{"type":"episodic","content":"Deployed v2 on 2026-07-11.","entities":[{"type":"project","name":"v2"}],"confidence":0.9},
-		{"type":"semantic","content":"User lives in Porto.","entities":[{"type":"place","name":"Porto"}],"confidence":0.9}
+		{"type":"episodic","content":"Deployed v2 on 2026-07-11.","entities":[{"type":"project","name":"v2"}],"confidence":0.9,"changes_behavior":true},
+		{"type":"semantic","content":"User lives in Porto.","entities":[{"type":"place","name":"Porto"}],"confidence":0.9,"changes_behavior":true}
 	]`}}
 	st := &fakeStore{}
 	ids, err := New(gw, st, testLog()).Extract(t.Context(), Request{SessionID: "11111111-1111-1111-1111-111111111111", SourceSeq: 7, Text: "turn text"})
@@ -227,7 +274,7 @@ func TestExtractInsertsAndPromotes(t *testing.T) {
 // pinned a sensitive turn/session to.
 func TestExtractUsesRequestRouteOverride(t *testing.T) {
 	t.Parallel()
-	gw := &fakeGateway{replies: []string{`[{"type":"semantic","content":"User lives in Porto.","entities":[],"confidence":0.9}]`}}
+	gw := &fakeGateway{replies: []string{`[{"type":"semantic","content":"User lives in Porto.","entities":[],"confidence":0.9,"changes_behavior":true}]`}}
 	st := &fakeStore{}
 	_, err := New(gw, st, testLog()).Extract(t.Context(), Request{Text: "x", Route: "local"})
 	if err != nil {
@@ -240,7 +287,7 @@ func TestExtractUsesRequestRouteOverride(t *testing.T) {
 
 func TestExtractDropsExactDuplicate(t *testing.T) {
 	t.Parallel()
-	gw := &fakeGateway{replies: []string{`[{"type":"semantic","content":"User lives in Porto.","entities":[],"confidence":0.9}]`}}
+	gw := &fakeGateway{replies: []string{`[{"type":"semantic","content":"User lives in Porto.","entities":[],"confidence":0.9,"changes_behavior":true}]`}}
 	st := &fakeStore{}
 	st.nearest.id, st.nearest.sim, st.nearest.ok = "existing", 0.995, true
 	ids, err := New(gw, st, testLog()).Extract(t.Context(), Request{Text: "x"})
@@ -258,7 +305,7 @@ func TestExtractDropsExactDuplicate(t *testing.T) {
 
 func TestExtractNearDuplicateReinforcesInsteadOfInserting(t *testing.T) {
 	t.Parallel()
-	gw := &fakeGateway{replies: []string{`[{"type":"semantic","content":"User is based in Porto, Portugal.","entities":[],"confidence":0.9}]`}}
+	gw := &fakeGateway{replies: []string{`[{"type":"semantic","content":"User is based in Porto, Portugal.","entities":[],"confidence":0.9,"changes_behavior":true}]`}}
 	st := &fakeStore{}
 	st.nearest.id, st.nearest.sim, st.nearest.ok = "existing", 0.96, true
 	ids, err := New(gw, st, testLog()).Extract(t.Context(), Request{Text: "x"})
@@ -278,7 +325,7 @@ func TestExtractNearDuplicateReinforcesInsteadOfInserting(t *testing.T) {
 // silently no-op on a pending row.
 func TestExtractPendingDuplicateSkipsWithoutConfirm(t *testing.T) {
 	t.Parallel()
-	gw := &fakeGateway{replies: []string{`[{"type":"semantic","content":"User is based in Porto, Portugal.","entities":[],"confidence":0.9}]`}}
+	gw := &fakeGateway{replies: []string{`[{"type":"semantic","content":"User is based in Porto, Portugal.","entities":[],"confidence":0.9,"changes_behavior":true}]`}}
 	st := &fakeStore{}
 	st.nearest.id, st.nearest.sim, st.nearest.status, st.nearest.ok = "existing-pending", 0.96, store.StatusPending, true
 	ids, err := New(gw, st, testLog()).Extract(t.Context(), Request{Text: "x"})
@@ -297,7 +344,7 @@ func TestExtractPendingDuplicateSkipsWithoutConfirm(t *testing.T) {
 // (unchanged behavior, pinned against the status-branch refactor).
 func TestExtractActiveDuplicateStillConfirms(t *testing.T) {
 	t.Parallel()
-	gw := &fakeGateway{replies: []string{`[{"type":"semantic","content":"User is based in Porto, Portugal.","entities":[],"confidence":0.9}]`}}
+	gw := &fakeGateway{replies: []string{`[{"type":"semantic","content":"User is based in Porto, Portugal.","entities":[],"confidence":0.9,"changes_behavior":true}]`}}
 	st := &fakeStore{}
 	st.nearest.id, st.nearest.sim, st.nearest.status, st.nearest.ok = "existing-active", 0.96, store.StatusActive, true
 	ids, err := New(gw, st, testLog()).Extract(t.Context(), Request{Text: "x"})
@@ -312,14 +359,33 @@ func TestExtractActiveDuplicateStillConfirms(t *testing.T) {
 	}
 }
 
+// A near-dup match against a rejected row drops the candidate outright:
+// rejection is a durable teaching signal, so no Confirm and no Insert.
+func TestExtractRejectedDuplicateDropped(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGateway{replies: []string{`[{"type":"semantic","content":"User is based in Porto, Portugal.","entities":[],"confidence":0.9,"changes_behavior":true}]`}}
+	st := &fakeStore{}
+	st.nearest.id, st.nearest.sim, st.nearest.status, st.nearest.ok = "existing-rejected", 0.96, store.StatusRejected, true
+	ids, err := New(gw, st, testLog()).Extract(t.Context(), Request{Text: "x"})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if len(ids) != 0 || len(st.inserted) != 0 {
+		t.Fatalf("rejected dup inserted: ids=%v inserted=%d", ids, len(st.inserted))
+	}
+	if len(st.confirmed) != 0 {
+		t.Fatalf("confirmed = %v, want none (rejection is not reinforced)", st.confirmed)
+	}
+}
+
 // Two near-identical facts proposed in the same run must dedup against
 // each other before either reaches the DB or NearestActive.
 func TestExtractIntraBatchNearDuplicateSkipped(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGateway{
 		replies: []string{`[
-			{"type":"semantic","content":"User timezone preference is Europe/Amsterdam.","entities":[],"confidence":0.9},
-			{"type":"semantic","content":"All times should be interpreted in Europe/Amsterdam.","entities":[],"confidence":0.9}
+			{"type":"semantic","content":"User timezone preference is Europe/Amsterdam.","entities":[],"confidence":0.9,"changes_behavior":true},
+			{"type":"semantic","content":"All times should be interpreted in Europe/Amsterdam.","entities":[],"confidence":0.9,"changes_behavior":true}
 		]`},
 		embeds: [][]float32{{1, 0, 0}, {0.999, 0.001, 0}},
 	}
@@ -338,8 +404,8 @@ func TestExtractIntraBatchNearDuplicateSkipped(t *testing.T) {
 func TestExtractMissionSourceFiltersGoalEchoes(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGateway{replies: []string{`[` +
-		`{"type":"semantic","content":"The user mandated a mission goal to create a file named redirects.md explaining 301 302 and 307 redirects in ten lines.","entities":[],"confidence":0.95},` +
-		`{"type":"semantic","content":"The bKash production API rejects requests without an app key header.","entities":[],"confidence":0.9}]`}}
+		`{"type":"semantic","content":"The user mandated a mission goal to create a file named redirects.md explaining 301 302 and 307 redirects in ten lines.","entities":[],"confidence":0.95,"changes_behavior":true},` +
+		`{"type":"semantic","content":"The bKash production API rejects requests without an app key header.","entities":[],"confidence":0.9,"changes_behavior":true}]`}}
 	st := &fakeStore{}
 	digest := "mission goal: Create a file named redirects.md explaining 301, 302, and 307 redirects in ten lines\n" +
 		"mission title: Understanding Redirects\nmission kind: general\n\nterminal state: done\n"
@@ -351,6 +417,27 @@ func TestExtractMissionSourceFiltersGoalEchoes(t *testing.T) {
 		t.Fatalf("want the goal echo dropped and the real fact kept: ids=%v inserted=%d", ids, len(st.inserted))
 	}
 	if !strings.Contains(st.inserted[0].Content, "bKash") {
+		t.Fatalf("kept the wrong fact: %q", st.inserted[0].Content)
+	}
+}
+
+// A Deny value from the operator's settings (e.g. timezone) fences out
+// a fact restating it, regardless of source; an unrelated fact
+// mentioning a similar-looking but distinct token still inserts.
+func TestExtractDenyFencesSettingsValue(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGateway{replies: []string{`[` +
+		`{"type":"semantic","content":"User timezone preference is Europe/Amsterdam; interpret all times in Europe/Amsterdam.","entities":[],"confidence":0.9,"changes_behavior":true},` +
+		`{"type":"semantic","content":"User is attending a concert in Amsterdam on 5 September 2026.","entities":[],"confidence":0.9,"changes_behavior":true}]`}}
+	st := &fakeStore{}
+	ids, err := New(gw, st, testLog()).Extract(t.Context(), Request{Text: "x", Deny: []string{"Europe/Amsterdam"}})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if len(ids) != 1 || len(st.inserted) != 1 {
+		t.Fatalf("want timezone echo dropped, concert fact kept: ids=%v inserted=%d", ids, len(st.inserted))
+	}
+	if !strings.Contains(st.inserted[0].Content, "concert") {
 		t.Fatalf("kept the wrong fact: %q", st.inserted[0].Content)
 	}
 }
@@ -370,7 +457,7 @@ func TestExtractRetriesOnInvalidJSON(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGateway{replies: []string{
 		"sorry, here are the facts...",
-		`[{"type":"episodic","content":"Fixed the build on 2026-07-11.","entities":[],"confidence":0.9}]`,
+		`[{"type":"episodic","content":"Fixed the build on 2026-07-11.","entities":[],"confidence":0.9,"changes_behavior":true}]`,
 	}}
 	st := &fakeStore{}
 	ids, err := New(gw, st, testLog()).Extract(t.Context(), Request{Text: "x"})
@@ -443,7 +530,7 @@ func (g *embedlessGateway) Embed(context.Context, []string, string) ([][]float32
 func TestExtractDegradesWithoutEmbeddings(t *testing.T) {
 	t.Parallel()
 	gw := &embedlessGateway{fakeGateway{replies: []string{
-		`[{"type":"episodic","content":"Deployed v2 on 2026-07-11.","entities":[],"confidence":0.9}]`,
+		`[{"type":"episodic","content":"Deployed v2 on 2026-07-11.","entities":[],"confidence":0.9,"changes_behavior":true}]`,
 	}}}
 	st := &fakeStore{}
 	ids, err := New(gw, st, testLog()).Extract(t.Context(), Request{Text: "x"})
@@ -469,7 +556,7 @@ func TestExtractUtilityGateDropsExplicitFalseOnly(t *testing.T) {
 	gw := &fakeGateway{replies: []string{`[` +
 		`{"type":"semantic","content":"DynamoDB local secondary indexes are defined at table creation.","entities":[],"confidence":0.9,"changes_behavior":false},` +
 		`{"type":"semantic","content":"The user prefers explanations with code examples.","entities":[],"confidence":0.9,"changes_behavior":true},` +
-		`{"type":"semantic","content":"The user is based in Purmerend.","entities":[],"confidence":0.9}]`}}
+		`{"type":"semantic","content":"The user is based in Purmerend.","entities":[],"confidence":0.9,"changes_behavior":true}]`}}
 	st := &fakeStore{}
 	ids, err := New(gw, st, testLog()).Extract(t.Context(), Request{Text: "x"})
 	if err != nil {

--- a/internal/memory/store/store.go
+++ b/internal/memory/store/store.go
@@ -210,14 +210,17 @@ func (s *Store) UpsertEntity(ctx context.Context, typ, name string) (string, err
 	return id, nil
 }
 
-// NearestActive returns the closest active-or-pending memory to the
-// embedding by cosine similarity, or ok=false when no such memory has
-// an embedding. Pending rows must be visible too: dedup used to only
-// see active rows, so a fact re-extracted before its first proposal
-// was confirmed or promoted never found its match and near-duplicates
-// piled up in the confirmation queue. status tells the caller which
-// branch applies - only an active match can be Confirmed (Confirm's
-// UPDATE is active-only).
+// NearestActive returns the closest active, pending, or rejected
+// memory to the embedding by cosine similarity, or ok=false when no
+// such memory has an embedding. Pending rows must be visible too:
+// dedup used to only see active rows, so a fact re-extracted before
+// its first proposal was confirmed or promoted never found its match
+// and near-duplicates piled up in the confirmation queue. Rejected
+// rows must be visible for the same reason in the other direction:
+// rejection is a durable teaching signal, so a candidate matching a
+// rejected row is dropped instead of re-proposed forever. status
+// tells the caller which branch applies - only an active match can be
+// Confirmed (Confirm's UPDATE is active-only).
 func (s *Store) NearestActive(ctx context.Context, embedding Vector) (id string, similarity float64, status Status, ok bool, err error) {
 	db, err := s.db.Get()
 	if err != nil {
@@ -225,9 +228,9 @@ func (s *Store) NearestActive(ctx context.Context, embedding Vector) (id string,
 	}
 	err = db.QueryRow(ctx, `SELECT id, 1 - (embedding <=> $1::vector), status
 		FROM memories
-		WHERE status IN ($2, $3) AND embedding IS NOT NULL
+		WHERE status IN ($2, $3, $4) AND embedding IS NOT NULL
 		ORDER BY embedding <=> $1::vector
-		LIMIT 1`, embedding.String(), StatusActive, StatusPending).Scan(&id, &similarity, &status)
+		LIMIT 1`, embedding.String(), StatusActive, StatusPending, StatusRejected).Scan(&id, &similarity, &status)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return "", 0, "", false, nil
 	}

--- a/internal/memory/store/store_integration_test.go
+++ b/internal/memory/store/store_integration_test.go
@@ -430,6 +430,35 @@ func TestNearestActive(t *testing.T) {
 	}
 }
 
+// A rejected memory stays visible to NearestActive: rejection is a
+// durable teaching signal, so a matching candidate must find it and
+// get dropped instead of re-proposed forever.
+func TestNearestActiveSeesRejected(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	base := make(Vector, 1024)
+	base[0], base[1] = 0.6, 0.8
+
+	m := mem("rejected target fact")
+	m.Embedding = base
+	id, err := s.Insert(ctx, m)
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if err := s.Reject(ctx, id); err != nil {
+		t.Fatalf("Reject: %v", err)
+	}
+
+	gotID, _, status, ok, err := s.NearestActive(ctx, base)
+	if err != nil {
+		t.Fatalf("NearestActive: %v", err)
+	}
+	if !ok || gotID != id || status != StatusRejected {
+		t.Fatalf("NearestActive = (%s, status=%s, ok=%v), want (%s, rejected, true)", gotID, status, ok, id)
+	}
+}
+
 func TestListByStatusFiltersTypes(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()


### PR DESCRIPTION
## Problem

The memory confirmation queue kept surfacing redundant and useless suggestions:

- Facts the user rejected were re-proposed forever: embedding dedupe (`NearestActive`) only saw active and pending rows, so rejection taught nothing.
- Mission-digest extraction produced sandbox environment facts ("python-docx installed", workspace permissions) - the chat prompt has a machine-state skip list, `missionSystem` did not. All 12 rejected rows in the local DB are this class.
- One-run scan summaries stored as semantic facts ("In the Gmail inbox over the last 24 hours there were no spending emails...").
- The operator timezone, already a setting (`ValueTimezone`), re-extracted as a discovered fact.
- General knowledge leaked past the utility gate ("The capital of the Netherlands is Amsterdam" sat active).

## Changes

1. **Rejected suppression**: `NearestActive` status filter now includes `rejected`; a candidate matching a rejected row at >=0.95 similarity drops silently. Rejection becomes a durable teaching signal.
2. **Mission skip list**: `missionSystem` forbids execution-environment observations and transient scan/search/inbox results; a durable fact a scan revealed (a deadline that exists) still qualifies, stated standalone with absolute dates.
3. **Bounded-window code gate**: semantic/procedural facts phrased as a bounded observation window ("last 24 hours", "today", "currently", "so far") drop in code. Episodic keeps - something that happened is time-scoped. "as of" deliberately excluded: the contract demands absolute dates and legitimate facts use it.
4. **Settings deny fence**: `extract.Request` gains `Deny []string`; brain wiring passes the operator timezone per call (chat, mission, and compaction closures in `main.go` - no signature change to `chat.MemoryExtract`/`missions.MemoryExtract`). `echoesDeny` drops facts restating a deny value.
5. **Utility gate hardening**: `changes_behavior` is now required - a fact missing it fails `ParseFacts` and triggers the existing retry instead of being kept unjudged. Both extraction prompts carry the observed leak examples as negatives.

## Verification

- `make build vet lint test`: clean, all packages ok with `-race`
- `make test-integration`: all ok, including new `TestNearestActiveSeesRejected`
- New unit tests: rejected-dup drop, bounded-window table, deny fence (timezone dropped, "concert in Amsterdam" kept), missing `changes_behavior` parse rejection

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790461533&installation_model_id=431401&pr_number=341&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F341&signature=2ff82ce0672b05553521f814e84495659c4c60804a12bf436623ab0dcd95ef8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->