### PR TITLE
feat(attachments): accept markdown and text files in chat and missions

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -619,8 +619,8 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, sanitizeMission(created))
 }
 
-// resolveAttachments validates and converts a create request's PDF
-// refs into MissionAttachments — writes any error response itself and
+// resolveAttachments validates and converts a create request's PDF and
+// text refs into MissionAttachments — writes any error response itself and
 // returns ok=false, mirroring chat.validateAttachments' shape but as a
 // method so it can write directly (create()'s other validation blocks
 // use jsonError+return rather than a returned error). Empty input
@@ -638,21 +638,33 @@ func (h *missionAPI) resolveAttachments(w http.ResponseWriter, ctx context.Conte
 		jsonError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("too many attachments (max %d)", maxMissionAttachments))
 		return nil, false
 	}
-	if h.markitdownURL == "" {
-		jsonError(w, http.StatusBadRequest, "bad_request", "pdf attachments require the markitdown sidecar (MARKITDOWN_URL)")
-		return nil, false
-	}
-	out := make([]missions.MissionAttachment, 0, len(in))
-	for _, input := range in {
+	// Fetch and validate mime up front so the markitdown-sidecar check
+	// below only fires when a PDF actually needs conversion — text
+	// attachments must succeed with no sidecar configured.
+	atts := make([]attachments.Attachment, len(in))
+	needsMarkitdown := false
+	for i, input := range in {
 		att, err := h.attachments.Get(ctx, input.ID)
 		if err != nil {
 			jsonError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("attachment %q not found", input.ID))
 			return nil, false
 		}
-		if att.Mime != "application/pdf" {
+		if att.Mime != "application/pdf" && att.Mime != "text/plain" {
 			jsonError(w, http.StatusBadRequest, "bad_request", "only document attachments are supported for missions")
 			return nil, false
 		}
+		if att.Mime == "application/pdf" {
+			needsMarkitdown = true
+		}
+		atts[i] = att
+	}
+	if needsMarkitdown && h.markitdownURL == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "pdf attachments require the markitdown sidecar (MARKITDOWN_URL)")
+		return nil, false
+	}
+	out := make([]missions.MissionAttachment, 0, len(in))
+	for i, input := range in {
+		att := atts[i]
 		r, _, err := h.attachments.Open(ctx, att.ID)
 		if err != nil {
 			jsonError(w, http.StatusInternalServerError, "internal_error", err.Error())
@@ -664,10 +676,15 @@ func (h *missionAPI) resolveAttachments(w http.ResponseWriter, ctx context.Conte
 			jsonError(w, http.StatusInternalServerError, "internal_error", err.Error())
 			return nil, false
 		}
-		md, err := markitdown.Convert(ctx, h.markitdownHTTP, h.markitdownURL, att.ID+".pdf", att.Mime, raw)
-		if err != nil {
-			jsonError(w, http.StatusInternalServerError, "internal_error", err.Error())
-			return nil, false
+		var md string
+		if att.Mime == "application/pdf" {
+			md, err = markitdown.Convert(ctx, h.markitdownHTTP, h.markitdownURL, att.ID+".pdf", att.Mime, raw)
+			if err != nil {
+				jsonError(w, http.StatusInternalServerError, "internal_error", err.Error())
+				return nil, false
+			}
+		} else {
+			md = string(raw)
 		}
 		out = append(out, missions.MissionAttachment{
 			ID: att.ID, Mime: att.Mime, Name: input.Name, Markdown: markitdown.TruncateMarkdown(md),

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -439,8 +439,12 @@ func TestMissionsCreateAttachmentsValidation(t *testing.T) {
 		byID: map[string]attachments.Attachment{
 			"doc1": {ID: "doc1", Mime: "application/pdf"},
 			"img1": {ID: "img1", Mime: "image/png"},
+			"txt1": {ID: "txt1", Mime: "text/plain"},
 		},
-		data: map[string][]byte{"doc1": []byte("%PDF-1.4")},
+		data: map[string][]byte{
+			"doc1": []byte("%PDF-1.4"),
+			"txt1": []byte("plain text notes"),
+		},
 	}
 	md := fakeMarkitdownServer(t, "# converted")
 
@@ -496,6 +500,25 @@ func TestMissionsCreateAttachmentsValidation(t *testing.T) {
 		code, body := post(t, fa, md.URL, `{"goal":"g","kind":"general","attachments":[{"id":"img1"}]}`)
 		if code != 400 || !strings.Contains(body, "only document attachments are supported") {
 			t.Fatalf("code=%d body=%q, want 400 unsupported-mime", code, body)
+		}
+	})
+
+	// The remaining two cases exercise resolveAttachments past all its
+	// own 400 paths — the fake pool has no live database, so create()
+	// itself then fails past validation; asserting the failure is the
+	// (unrelated) store error, not a resolveAttachments 400, confirms
+	// text/plain cleared validation.
+	t.Run("text/plain attachment accepted with markitdown configured", func(t *testing.T) {
+		code, body := post(t, fa, md.URL, `{"goal":"g","kind":"general","attachments":[{"id":"txt1"}]}`)
+		if code != 400 || !strings.Contains(body, "database unavailable") {
+			t.Fatalf("code=%d body=%q, want a store error (validation passed)", code, body)
+		}
+	})
+
+	t.Run("text-only attachment succeeds with no markitdownURL configured", func(t *testing.T) {
+		code, body := post(t, fa, "", `{"goal":"g","kind":"general","attachments":[{"id":"txt1"}]}`)
+		if code != 400 || !strings.Contains(body, "database unavailable") {
+			t.Fatalf("code=%d body=%q, want a store error (text attachments don't need the sidecar)", code, body)
 		}
 	})
 }

--- a/internal/brain/attachments/attachments.go
+++ b/internal/brain/attachments/attachments.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -32,14 +33,16 @@ var ErrUnsupportedMIME = errors.New("attachments: unsupported mime type")
 // ErrNotFound reports an id with no matching row.
 var ErrNotFound = errors.New("attachments: not found")
 
-// allowedExt maps the sniffed MIME type to its stored file extension.
-// Only these five are accepted; anything else is ErrUnsupportedMIME.
+// allowedExt maps the sniffed MIME type (bare, parameters stripped) to
+// its stored file extension. Only these six are accepted; anything
+// else is ErrUnsupportedMIME.
 var allowedExt = map[string]string{
 	"image/png":       ".png",
 	"image/jpeg":      ".jpg",
 	"image/webp":      ".webp",
 	"image/gif":       ".gif",
 	"application/pdf": ".pdf",
+	"text/plain":      ".txt",
 }
 
 // Attachment is one stored image's metadata.
@@ -92,10 +95,14 @@ func (s *Store) Save(ctx context.Context, r io.Reader) (Attachment, error) {
 		return Attachment{}, fmt.Errorf("attachments: save: close: %w", err)
 	}
 
-	mime := http.DetectContentType(sniffBuf[:sniffed])
-	ext, ok := allowedExt[mime]
+	sniffedMime := http.DetectContentType(sniffBuf[:sniffed])
+	bareMime := sniffedMime
+	if parsed, _, err := mime.ParseMediaType(sniffedMime); err == nil {
+		bareMime = parsed
+	}
+	ext, ok := allowedExt[bareMime]
 	if !ok {
-		return Attachment{}, fmt.Errorf("attachments: save: mime %q: %w", mime, ErrUnsupportedMIME)
+		return Attachment{}, fmt.Errorf("attachments: save: mime %q: %w", sniffedMime, ErrUnsupportedMIME)
 	}
 
 	id := fmt.Sprintf("%x", h.Sum(nil))
@@ -113,7 +120,7 @@ func (s *Store) Save(ctx context.Context, r io.Reader) (Attachment, error) {
 	// likewise a same-content overwrite of itself.
 	if _, err := db.Exec(ctx,
 		"INSERT INTO attachments (id, mime, size_bytes) VALUES ($1, $2, $3) ON CONFLICT (id) DO NOTHING",
-		id, mime, size,
+		id, bareMime, size,
 	); err != nil {
 		return Attachment{}, fmt.Errorf("attachments: save: insert: %w", err)
 	}
@@ -124,7 +131,7 @@ func (s *Store) Save(ctx context.Context, r io.Reader) (Attachment, error) {
 		return Attachment{}, fmt.Errorf("attachments: save: read back: %w", err)
 	}
 
-	return Attachment{ID: id, Mime: mime, SizeBytes: size, CreatedAt: createdAt}, nil
+	return Attachment{ID: id, Mime: bareMime, SizeBytes: size, CreatedAt: createdAt}, nil
 }
 
 // copyAndSniff copies r into w while hashing every byte and capturing

--- a/internal/brain/attachments/attachments_integration_test.go
+++ b/internal/brain/attachments/attachments_integration_test.go
@@ -71,6 +71,31 @@ func TestStoreSavePDF(t *testing.T) {
 	}
 }
 
+func TestStoreSaveText(t *testing.T) {
+	s := integrationStore(t)
+
+	// http.DetectContentType returns "text/plain; charset=utf-8" for
+	// both .txt and .md content — normalized to the bare "text/plain".
+	att, err := s.Save(t.Context(), bytes.NewReader([]byte("# Notes\n\nplain text content")))
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if att.Mime != "text/plain" {
+		t.Fatalf("Mime = %q, want text/plain", att.Mime)
+	}
+	if _, err := os.Stat(filepath.Join(s.dir, att.ID+".txt")); err != nil {
+		t.Fatalf("expected %s.txt on disk: %v", att.ID, err)
+	}
+
+	got, err := s.Get(t.Context(), att.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Mime != "text/plain" {
+		t.Fatalf("stored Mime = %q, want text/plain (parameters stripped)", got.Mime)
+	}
+}
+
 func TestStoreSaveDedup(t *testing.T) {
 	s := integrationStore(t)
 
@@ -105,10 +130,13 @@ func TestStoreSaveDedup(t *testing.T) {
 func TestStoreSaveRejectsFakeExtension(t *testing.T) {
 	s := integrationStore(t)
 
-	// A .png-looking upload that is actually plain text must be rejected
-	// by magic-byte sniffing, not the (absent, since we don't trust it)
-	// client-declared type.
-	_, err := s.Save(t.Context(), bytes.NewReader([]byte("not actually an image, just text")))
+	// A .png-looking upload that is actually a zip must be rejected by
+	// magic-byte sniffing, not the (absent, since we don't trust it)
+	// client-declared type. Plain text now sniffs to the allowed
+	// text/plain, so this uses zip's magic bytes instead to stay
+	// genuinely unsupported.
+	zipBytes := []byte{0x50, 0x4b, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00}
+	_, err := s.Save(t.Context(), bytes.NewReader(zipBytes))
 	if !errors.Is(err, ErrUnsupportedMIME) {
 		t.Fatalf("Save err = %v, want ErrUnsupportedMIME", err)
 	}

--- a/internal/brain/chat/attachments_test.go
+++ b/internal/brain/chat/attachments_test.go
@@ -460,6 +460,74 @@ func TestChatPDFAttachmentTruncatesOversizedMarkdown(t *testing.T) {
 	}
 }
 
+// TestChatTextAttachmentConvertsToDocument confirms a text/plain
+// attachment lands as a DocumentRef with its raw content inline,
+// without calling the markitdown sidecar.
+func TestChatTextAttachmentConvertsToDocument(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("read your notes")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("txt1", "text/plain", []byte("meeting notes: ship it"))
+	svc.SetAttachments(fa)
+	// SetMarkitdown intentionally not called: text must not require it.
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []string{"txt1"}})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+
+	events, _ := log.Events(t.Context(), "s1")
+	var um session.UserMessage
+	if err := json.Unmarshal(events[1].Payload, &um); err != nil {
+		t.Fatalf("decode user_message: %v", err)
+	}
+	if len(um.Documents) != 1 || um.Documents[0].ID != "txt1" || um.Documents[0].Mime != "text/plain" {
+		t.Fatalf("documents = %+v, want one ref to txt1/text/plain", um.Documents)
+	}
+	if um.Documents[0].Markdown != "meeting notes: ship it" {
+		t.Fatalf("markdown = %q, want raw text content", um.Documents[0].Markdown)
+	}
+}
+
+// TestChatTextAttachmentTruncatesOversizedContent confirms an
+// oversized text attachment is cut at markitdown.TruncateMarkdown's
+// cap, same as an oversized converted PDF.
+func TestChatTextAttachmentTruncatesOversizedContent(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("read your huge notes")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	huge := strings.Repeat("a", docMarkdownCap+1024)
+	fa.seed("txt1", "text/plain", []byte(huge))
+	svc.SetAttachments(fa)
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []string{"txt1"}})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+
+	events, _ := log.Events(t.Context(), "s1")
+	var um session.UserMessage
+	if err := json.Unmarshal(events[1].Payload, &um); err != nil {
+		t.Fatalf("decode user_message: %v", err)
+	}
+	if len(um.Documents) != 1 {
+		t.Fatalf("documents = %+v, want one", um.Documents)
+	}
+	got := um.Documents[0].Markdown
+	const truncatedMarker = "\n\n[document truncated: markdown exceeded 128KB]"
+	if !strings.HasSuffix(got, truncatedMarker) {
+		t.Fatalf("markdown does not end with truncation marker: %q", got[max(0, len(got)-60):])
+	}
+}
+
 // TestChatDocumentsOnlyMessageDoesNotFlipToVisionRoute confirms the
 // D-046 vision auto-flip stays keyed on images alone: a message
 // carrying only a PDF (converted to plain text) never rides the

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -984,6 +984,17 @@ func (s *Service) validateAttachments(ctx context.Context, ids []string) ([]sess
 				return nil, nil, fmt.Errorf("chat: convert attachment %q: %w", id, err)
 			}
 			documents = append(documents, session.DocumentRef{ID: att.ID, Mime: att.Mime, Markdown: markitdown.TruncateMarkdown(md)})
+		case att.Mime == "text/plain":
+			r, _, err := s.attachments.Open(ctx, att.ID)
+			if err != nil {
+				return nil, nil, fmt.Errorf("chat: %w: attachment %q: %v", ErrBadRequest, id, err)
+			}
+			raw, err := io.ReadAll(r)
+			_ = r.Close()
+			if err != nil {
+				return nil, nil, fmt.Errorf("chat: read attachment %q: %w", id, err)
+			}
+			documents = append(documents, session.DocumentRef{ID: att.ID, Mime: att.Mime, Markdown: markitdown.TruncateMarkdown(string(raw))})
 		default:
 			return nil, nil, fmt.Errorf("chat: %w: attachment %q: unsupported mime %q", ErrBadRequest, id, att.Mime)
 		}

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -282,14 +282,59 @@ describe('Composer attachments', () => {
     render(<Composer {...baseProps()} onAttachments={onAttachments} />)
 
     const input = document.querySelector('input[type="file"]') as HTMLInputElement
-    const bogus = makeImageFile('notes.txt', 'text/plain')
+    const bogus = makeImageFile('archive.zip', 'application/zip')
     fireEvent.change(input, { target: { files: [bogus] } })
 
     await waitFor(() =>
-      expect(toast.error).toHaveBeenCalledWith('notes.txt: unsupported file type'),
+      expect(toast.error).toHaveBeenCalledWith('archive.zip: unsupported file type'),
     )
     expect(client.uploadAttachment).not.toHaveBeenCalled()
     expect(onAttachments).not.toHaveBeenCalled()
+  })
+
+  it('uploads a selected .txt file and adds a file chip on success', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.uploadAttachment).mockResolvedValue({
+      id: 'att-txt',
+      mime: 'text/plain',
+      size_bytes: 20,
+    })
+    const onAttachments = vi.fn()
+    const { rerender } = render(
+      <Composer {...baseProps()} attachments={[]} onAttachments={onAttachments} />,
+    )
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const txt = makeImageFile('notes.txt', 'text/plain')
+    fireEvent.change(input, { target: { files: [txt] } })
+
+    await waitFor(() => expect(client.uploadAttachment).toHaveBeenCalledWith(txt))
+    await waitFor(() =>
+      expect(onAttachments).toHaveBeenLastCalledWith([
+        expect.objectContaining({ id: 'att-txt', mime: 'text/plain', uploading: false }),
+      ]),
+    )
+
+    const [[chips]] = onAttachments.mock.calls.slice(-1)
+    rerender(<Composer {...baseProps()} attachments={chips} onAttachments={onAttachments} />)
+    expect(screen.getByText('notes.txt')).toBeTruthy()
+  })
+
+  it('accepts a .md file with an empty reported type, by extension', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.uploadAttachment).mockResolvedValue({
+      id: 'att-md',
+      mime: 'text/plain',
+      size_bytes: 20,
+    })
+    const onAttachments = vi.fn()
+    render(<Composer {...baseProps()} attachments={[]} onAttachments={onAttachments} />)
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const md = makeImageFile('README.md', '')
+    fireEvent.change(input, { target: { files: [md] } })
+
+    await waitFor(() => expect(client.uploadAttachment).toHaveBeenCalledWith(md))
   })
 
   it('uploads a selected PDF and adds a file chip on success', async () => {

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -40,11 +40,42 @@ export interface PendingAttachment {
   uploading?: boolean
 }
 
-const allowedMimes = ['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'application/pdf']
+const allowedMimes = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+  'application/pdf',
+  'text/plain',
+  'text/markdown',
+]
 // Exported: MissionAttachments.tsx reuses the same caps for its own
-// PDF-only upload flow.
+// document upload flow.
 export const maxAttachmentBytes = 10 * 1024 * 1024
 export const maxAttachments = 8
+
+// isAllowedFile accepts a file when its reported type is in
+// allowedMimes, or (for .md/.txt) by extension — browsers report
+// markdown files inconsistently: empty type, text/markdown, or
+// text/plain depending on OS/browser.
+export function isAllowedFile(file: File): boolean {
+  if (allowedMimes.includes(file.type)) return true
+  return /\.(md|txt)$/i.test(file.name)
+}
+
+// isDocumentFile is isAllowedFile narrowed to document types (PDF,
+// Markdown, text) — used where images aren't accepted, e.g. mission
+// attachments.
+export function isDocumentFile(file: File): boolean {
+  return isAllowedFile(file) && !file.type.startsWith('image/')
+}
+
+// isDocumentAttachment mirrors the server's document (non-image)
+// attachments: PDF and text/markdown files render as a document chip
+// rather than an image thumbnail.
+export function isDocumentAttachment(mime: string): boolean {
+  return mime === 'application/pdf' || mime === 'text/plain' || mime === 'text/markdown'
+}
 
 // Composer is the one message box: the chat page's docked input and
 // the home page's hero input are the same component so behavior
@@ -320,7 +351,7 @@ export function Composer({
   async function uploadFiles(files: File[]) {
     if (!onAttachments) return
     for (const file of files) {
-      if (!allowedMimes.includes(file.type)) {
+      if (!isAllowedFile(file)) {
         toast.error(`${file.name || 'file'}: unsupported file type`)
         continue
       }
@@ -446,10 +477,10 @@ export function Composer({
               className="group relative size-12 shrink-0 overflow-hidden rounded-lg border border-zinc-950/10 dark:border-white/10"
               title={a.name}
             >
-              {a.mime === 'application/pdf' ? (
+              {isDocumentAttachment(a.mime) ? (
                 <div className="flex size-full flex-col items-center justify-center gap-0.5 bg-zinc-100 text-zinc-500 dark:bg-zinc-700 dark:text-zinc-400">
                   <HugeiconsIcon icon={Pdf02Icon} className="size-4" />
-                  <span className="max-w-full truncate px-1 text-[9px]">{a.name ?? 'PDF'}</span>
+                  <span className="max-w-full truncate px-1 text-[9px]">{a.name ?? 'Document'}</span>
                 </div>
               ) : (
                 <img src={a.previewUrl} alt={a.name ?? 'attachment'} className="size-full object-cover" />
@@ -523,7 +554,7 @@ export function Composer({
               <input
                 ref={fileInputRef}
                 type="file"
-                accept="image/png,image/jpeg,image/webp,image/gif,application/pdf"
+                accept="image/png,image/jpeg,image/webp,image/gif,application/pdf,.md,.txt,text/plain,text/markdown"
                 multiple
                 className="hidden"
                 onChange={(e) => {

--- a/web/src/components/missions/MissionAttachments.tsx
+++ b/web/src/components/missions/MissionAttachments.tsx
@@ -3,14 +3,20 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import { useRef } from 'react'
 import { toast } from 'sonner'
 import { uploadAttachment } from '../../api/client'
-import { maxAttachmentBytes, maxAttachments, type PendingAttachment } from '../Composer'
+import {
+  isDocumentFile,
+  maxAttachmentBytes,
+  maxAttachments,
+  type PendingAttachment,
+} from '../Composer'
 import { Button } from '../ui/button'
 
-// MissionAttachments is the mission-create form's PDF-only attachment
-// picker: an "Attach PDF" button plus a chip strip (name, uploading
-// spinner, remove button) — a simplified variant of Composer.tsx's
-// uploadFiles/removeAttachment flow with no paste/drag support, since
-// a mission's create form isn't a message box.
+// MissionAttachments is the mission-create form's document attachment
+// picker (PDF, Markdown, text): an "Attach file" button plus a chip
+// strip (name, uploading spinner, remove button) — a simplified
+// variant of Composer.tsx's uploadFiles/removeAttachment flow with no
+// paste/drag support, since a mission's create form isn't a message
+// box.
 export function MissionAttachments({
   attachments,
   onChange,
@@ -22,8 +28,8 @@ export function MissionAttachments({
 
   async function uploadFiles(files: File[]) {
     for (const file of files) {
-      if (file.type !== 'application/pdf') {
-        toast.error(`${file.name || 'file'}: only PDF attachments are supported`)
+      if (!isDocumentFile(file)) {
+        toast.error(`${file.name || 'file'}: only PDF, Markdown, and text attachments are supported`)
         continue
       }
       if (file.size > maxAttachmentBytes) {
@@ -67,7 +73,7 @@ export function MissionAttachments({
       <input
         ref={inputRef}
         type="file"
-        accept="application/pdf"
+        accept="application/pdf,.md,.txt,text/plain,text/markdown"
         multiple
         className="hidden"
         onChange={(e) => {
@@ -78,7 +84,7 @@ export function MissionAttachments({
       />
       <Button type="button" variant="outline" size="sm" onClick={() => inputRef.current?.click()}>
         <HugeiconsIcon icon={Attachment02Icon} className="size-4" />
-        Attach PDF
+        Attach file
       </Button>
       {attachments.length > 0 && (
         <div className="flex flex-wrap gap-2">
@@ -88,7 +94,7 @@ export function MissionAttachments({
               className="group relative flex items-center gap-1.5 rounded-lg border border-border bg-muted/30 py-1 pr-1.5 pl-2 text-xs"
             >
               <HugeiconsIcon icon={Pdf02Icon} className="size-3.5 text-muted-foreground" />
-              <span className="max-w-40 truncate">{a.name ?? 'PDF'}</span>
+              <span className="max-w-40 truncate">{a.name ?? 'Document'}</span>
               {a.uploading ? (
                 <HugeiconsIcon icon={Loading03Icon} className="size-3 animate-spin text-muted-foreground" />
               ) : (

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -225,6 +225,36 @@ describe('MissionForm — create mode, one-off mission', () => {
     )
   })
 
+  it('attaching a .txt file renders a chip and submits it on the payload', async () => {
+    vi.mocked(uploadAttachment).mockResolvedValue({ id: 'att2', mime: 'text/plain', size_bytes: 20 })
+    vi.mocked(createMission).mockResolvedValue({ id: 'm3' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Summarize the attached notes' } })
+    const file = new File(['some notes'], 'notes.txt', { type: 'text/plain' })
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(input, { target: { files: [file] } })
+
+    await screen.findByText('notes.txt')
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(
+        expect.objectContaining({ attachments: [{ id: 'att2', name: 'notes.txt' }] }),
+      ),
+    )
+  })
+
+  it('rejects an image attachment on the mission form', async () => {
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    const file = new File(['fake'], 'photo.png', { type: 'image/png' })
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(input, { target: { files: [file] } })
+
+    expect(uploadAttachment).not.toHaveBeenCalled()
+  })
+
   it('disables submit while an attachment is uploading', async () => {
     let resolveUpload: (v: { id: string; mime: string; size_bytes: number }) => void = () => {}
     vi.mocked(uploadAttachment).mockReturnValue(


### PR DESCRIPTION
## Why

Only PDFs were accepted as document attachments in chat and missions, forcing users to convert plain notes before attaching them. Markdown and text files are already text, so they can be inlined directly without the markitdown sidecar.

## What

- Blob store: sniffed MIME normalized (parameters stripped) before the allowlist lookup; `text/plain` allowed. Both `.md` and `.txt` sniff as text/plain, filename is preserved by callers.
- Chat: text attachments become inline documents (128KB truncate) without calling markitdown; works with the sidecar unconfigured; no vision-route flip.
- Missions: PDF or text accepted; the sidecar-required check fires only when a PDF is actually present, so text-only attachments work without markitdown.
- Web: Composer and MissionAttachments accept `.md`/`.txt` via a mime-or-extension check (browsers report `.md` types inconsistently); UI copy updated.
- Tests across all layers; two pre-existing negative tests switched their "unsupported" fixture from plain text (now legal) to zip.

## Verify

- `make build test vet lint` clean
- `make test-integration` exit 0
- Web: build clean, lint 0 errors, 821/821 tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790471889&installation_model_id=431401&pr_number=343&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F343&signature=dc1cfaa5a421132be95c9d8e8a472f619feef41af215c8688e952094fac3564c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->