### PR TITLE
feat(attachments): viewer modal, video/audio uploads, name threading

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -560,6 +560,9 @@ func main() {
 	if markitdownURL != "" {
 		svc.SetMarkitdown(markitdownURL)
 	}
+	if whisperURL != "" {
+		svc.SetWhisper(whisperURL)
+	}
 
 	// kb_search: nil-safe wiring, same shape as memory retrieve/extract
 	// above — mc satisfies IngestDocument/KBSearch unconditionally, so

--- a/internal/brain/api/attachments.go
+++ b/internal/brain/api/attachments.go
@@ -30,6 +30,8 @@ func failAttachment(w http.ResponseWriter, err error) {
 		jsonError(w, http.StatusNotFound, "not_found", "attachment not found")
 	case errors.Is(err, attachments.ErrUnsupportedMIME):
 		jsonError(w, http.StatusBadRequest, "unsupported_mime", err.Error())
+	case errors.Is(err, attachments.ErrTooLarge):
+		jsonError(w, http.StatusBadRequest, "too_large", err.Error())
 	default:
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 	}
@@ -48,7 +50,7 @@ type attachmentView struct {
 func (h *attachmentAPI) upload(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, attachments.MaxSizeBytes)
 	if err := r.ParseMultipartForm(attachments.MaxSizeBytes); err != nil { //nolint:gosec // G120: r.Body is already MaxBytesReader-capped above at the same limit
-		jsonError(w, http.StatusBadRequest, "too_large", "file exceeds the 10MB limit")
+		jsonError(w, http.StatusBadRequest, "too_large", "file exceeds the maximum upload size")
 		return
 	}
 	file, _, err := r.FormFile("file")

--- a/internal/brain/attachments/attachments.go
+++ b/internal/brain/attachments/attachments.go
@@ -1,7 +1,8 @@
-// Package attachments stores user-uploaded images and PDFs
-// content-addressed on a local volume, with metadata only in Postgres
-// — binaries never enter the database (D-045). ATTACHMENTS_DIR unset
-// means the feature is off: callers nil-gate on a nil *Store.
+// Package attachments stores user-uploaded images, documents, video
+// and audio content-addressed on a local volume, with metadata only
+// in Postgres — binaries never enter the database (D-045).
+// ATTACHMENTS_DIR unset means the feature is off: callers nil-gate on
+// a nil *Store.
 package attachments
 
 import (
@@ -14,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -22,20 +24,37 @@ import (
 )
 
 // MaxSizeBytes caps a single attachment upload; enforced by the caller
-// via http.MaxBytesReader before Save ever sees the body.
-const MaxSizeBytes = 10 << 20 // 10MB
+// via http.MaxBytesReader before Save ever sees the body. This is the
+// largest per-type cap (video) — the HTTP layer must accept up to this
+// many bytes since the real type isn't known until Save sniffs it;
+// Save itself rejects a file over its own type's cap once sniffed.
+const MaxSizeBytes = maxVideoBytes
+
+// Per-type caps: video is the largest, audio bounded by the whisper
+// sidecar's body limit, everything else stays the original 10MB.
+const (
+	maxDefaultBytes = 10 << 20  // 10MB: images, pdf, text
+	maxVideoBytes   = 100 << 20 // 100MB
+	maxAudioBytes   = 25 << 20  // 25MB: whisper sidecar body cap
+)
 
 // ErrUnsupportedMIME reports a sniffed content type outside the
 // allowlist — decided server-side (http.DetectContentType), never
 // trusting the client-supplied header.
 var ErrUnsupportedMIME = errors.New("attachments: unsupported mime type")
 
+// ErrTooLarge reports a file over its sniffed type's size cap.
+var ErrTooLarge = errors.New("attachments: file too large for its type")
+
 // ErrNotFound reports an id with no matching row.
 var ErrNotFound = errors.New("attachments: not found")
 
-// allowedExt maps the sniffed MIME type (bare, parameters stripped) to
-// its stored file extension. Only these six are accepted; anything
-// else is ErrUnsupportedMIME.
+// allowedExt maps the canonical MIME type to its stored file
+// extension. Only these are accepted; anything else is
+// ErrUnsupportedMIME. Canonical mimes are reached via
+// normalizeSniffedMime, since http.DetectContentType's raw sniff
+// values don't always match the wire-standard type string (e.g. WAV
+// sniffs as "audio/wave").
 var allowedExt = map[string]string{
 	"image/png":       ".png",
 	"image/jpeg":      ".jpg",
@@ -43,6 +62,42 @@ var allowedExt = map[string]string{
 	"image/gif":       ".gif",
 	"application/pdf": ".pdf",
 	"text/plain":      ".txt",
+	"video/mp4":       ".mp4",
+	"video/webm":      ".webm",
+	"audio/mpeg":      ".mp3",
+	"audio/wav":       ".wav",
+	"audio/ogg":       ".ogg",
+}
+
+// maxBytesFor returns the size cap for a canonical mime type.
+func maxBytesFor(mime string) int64 {
+	switch {
+	case strings.HasPrefix(mime, "video/"):
+		return maxVideoBytes
+	case strings.HasPrefix(mime, "audio/"):
+		return maxAudioBytes
+	default:
+		return maxDefaultBytes
+	}
+}
+
+// normalizeSniffedMime maps http.DetectContentType's raw output to the
+// canonical mime allowedExt keys on. DetectContentType returns
+// non-standard values for some of these types: "audio/wave" for WAV
+// (not "audio/wav"), "application/ogg" for an Ogg container (not
+// "audio/ogg"). m4a is not sniffable reliably (its ftyp brand overlaps
+// with mp4/video, and some encoders' output sniffs as
+// application/octet-stream) so it is not supported — see the package
+// report for the sniff investigation.
+func normalizeSniffedMime(bare string) string {
+	switch bare {
+	case "audio/wave", "audio/x-wav", "audio/wav":
+		return "audio/wav"
+	case "application/ogg":
+		return "audio/ogg"
+	default:
+		return bare
+	}
 }
 
 // Attachment is one stored image's metadata.
@@ -100,9 +155,13 @@ func (s *Store) Save(ctx context.Context, r io.Reader) (Attachment, error) {
 	if parsed, _, err := mime.ParseMediaType(sniffedMime); err == nil {
 		bareMime = parsed
 	}
+	bareMime = normalizeSniffedMime(bareMime)
 	ext, ok := allowedExt[bareMime]
 	if !ok {
 		return Attachment{}, fmt.Errorf("attachments: save: mime %q: %w", sniffedMime, ErrUnsupportedMIME)
+	}
+	if size > maxBytesFor(bareMime) {
+		return Attachment{}, fmt.Errorf("attachments: save: %d bytes exceeds the %q cap: %w", size, bareMime, ErrTooLarge)
 	}
 
 	id := fmt.Sprintf("%x", h.Sum(nil))

--- a/internal/brain/attachments/sniff_test.go
+++ b/internal/brain/attachments/sniff_test.go
@@ -1,0 +1,113 @@
+package attachments
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// Fixtures use real magic bytes for each format so the assertions
+// exercise the actual http.DetectContentType behavior, not a guess at
+// it. Padded to a comfortable length past each signature's own
+// look-ahead requirement (e.g. the mp4 ftyp box needs its full boxSize
+// available in the sniffed buffer).
+
+var pngBytes = []byte{
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+	0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89,
+}
+
+func mp4Fixture() []byte {
+	// ftyp box: size(24) + "ftyp" + major brand(4, unchecked) +
+	// minor version(4, skipped by the sniffer) + compatible brand
+	// "mp42"(4, matched) + padding so len(data) >= boxSize.
+	b := []byte{0, 0, 0, 24}
+	b = append(b, []byte("ftyp")...)
+	b = append(b, []byte("isom")...)
+	b = append(b, 0, 0, 0, 0)
+	b = append(b, []byte("mp42")...)
+	return append(b, make([]byte, 32)...)
+}
+
+func webmFixture() []byte {
+	return []byte{0x1A, 0x45, 0xDF, 0xA3, 0x9F, 0x42, 0x86, 0x81, 0x01, 0x42, 0xF7, 0x81}
+}
+
+func mp3Fixture() []byte {
+	// ID3v2 header: Go's sniffer only recognizes the "ID3" tag, not a
+	// raw MPEG frame sync — real-world mp3 uploads carry ID3 tags.
+	return append([]byte("ID3\x03\x00\x00\x00\x00\x00\x00"), make([]byte, 16)...)
+}
+
+func wavFixture() []byte {
+	b := []byte("RIFF")
+	b = append(b, 0, 0, 0, 0) // chunk size, masked out by the sniffer
+	b = append(b, []byte("WAVEfmt ")...)
+	return b
+}
+
+func oggFixture() []byte {
+	return append([]byte("OggS\x00"), make([]byte, 8)...)
+}
+
+func TestSniffAndNormalize(t *testing.T) {
+	cases := []struct {
+		name string
+		data []byte
+		want string
+	}{
+		{"png", pngBytes, "image/png"},
+		{"mp4", mp4Fixture(), "video/mp4"},
+		{"webm", webmFixture(), "video/webm"},
+		{"mp3", mp3Fixture(), "audio/mpeg"},
+		{"wav", wavFixture(), "audio/wav"},
+		{"ogg", oggFixture(), "audio/ogg"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sniffed := http.DetectContentType(tc.data)
+			got := normalizeSniffedMime(sniffed)
+			if got != tc.want {
+				t.Fatalf("normalizeSniffedMime(DetectContentType(%s)) = %q (raw sniff %q), want %q", tc.name, got, sniffed, tc.want)
+			}
+			if _, ok := allowedExt[got]; !ok {
+				t.Fatalf("%q missing from allowedExt", got)
+			}
+		})
+	}
+}
+
+func TestMaxBytesFor(t *testing.T) {
+	cases := []struct {
+		mime string
+		want int64
+	}{
+		{"image/png", maxDefaultBytes},
+		{"application/pdf", maxDefaultBytes},
+		{"text/plain", maxDefaultBytes},
+		{"video/mp4", maxVideoBytes},
+		{"video/webm", maxVideoBytes},
+		{"audio/mpeg", maxAudioBytes},
+		{"audio/wav", maxAudioBytes},
+		{"audio/ogg", maxAudioBytes},
+	}
+	for _, tc := range cases {
+		if got := maxBytesFor(tc.mime); got != tc.want {
+			t.Fatalf("maxBytesFor(%q) = %d, want %d", tc.mime, got, tc.want)
+		}
+	}
+}
+
+func TestSaveRejectsOversizeForType(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	s := &Store{dir: dir} // db unused: rejection happens before any query
+	oversized := bytes.Repeat([]byte{0}, int(maxDefaultBytes)+1)
+	oversized = append(pngBytes, oversized...)
+	_, err := s.Save(t.Context(), bytes.NewReader(oversized))
+	if !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("Save err = %v, want ErrTooLarge", err)
+	}
+}

--- a/internal/brain/attachments/sniff_test.go
+++ b/internal/brain/attachments/sniff_test.go
@@ -13,7 +13,7 @@ import (
 // look-ahead requirement (e.g. the mp4 ftyp box needs its full boxSize
 // available in the sniffed buffer).
 
-var pngBytes = []byte{
+var sniffPNGBytes = []byte{
 	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
 	0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
 	0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89,
@@ -58,7 +58,7 @@ func TestSniffAndNormalize(t *testing.T) {
 		data []byte
 		want string
 	}{
-		{"png", pngBytes, "image/png"},
+		{"png", sniffPNGBytes, "image/png"},
 		{"mp4", mp4Fixture(), "video/mp4"},
 		{"webm", webmFixture(), "video/webm"},
 		{"mp3", mp3Fixture(), "audio/mpeg"},
@@ -105,7 +105,7 @@ func TestSaveRejectsOversizeForType(t *testing.T) {
 	dir := t.TempDir()
 	s := &Store{dir: dir} // db unused: rejection happens before any query
 	oversized := bytes.Repeat([]byte{0}, int(maxDefaultBytes)+1)
-	oversized = append(pngBytes, oversized...)
+	oversized = append(sniffPNGBytes, oversized...)
 	_, err := s.Save(t.Context(), bytes.NewReader(oversized))
 	if !errors.Is(err, ErrTooLarge) {
 		t.Fatalf("Save err = %v, want ErrTooLarge", err)

--- a/internal/brain/chat/attachments_test.go
+++ b/internal/brain/chat/attachments_test.go
@@ -60,7 +60,7 @@ func TestChatAcceptsAttachmentOnlyMessage(t *testing.T) {
 	fa.seed("abc123", "image/png", []byte("fake-png-bytes"))
 	svc.SetAttachments(fa)
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Attachments: []string{"abc123"}})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Attachments: []AttachmentRef{{ID: "abc123"}}})
 	if err != nil {
 		t.Fatalf("Chat with no text but an attachment: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestChatRejectsUnknownAttachmentBeforeAnyAppend(t *testing.T) {
 	svc := newService(&fakeGW{}, log)
 	svc.SetAttachments(newFakeAttachments()) // enabled, but "missing" is unseeded
 
-	_, _, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "look", Attachments: []string{"missing"}})
+	_, _, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "look", Attachments: []AttachmentRef{{ID: "missing"}}})
 	if !errors.Is(err, ErrBadRequest) {
 		t.Fatalf("err = %v, want ErrBadRequest", err)
 	}
@@ -104,7 +104,7 @@ func TestChatRejectsAttachmentsWhenDisabled(t *testing.T) {
 	t.Parallel()
 	svc := newService(&fakeGW{}, newFakeLog())
 	// SetAttachments never called: s.attachments stays nil.
-	_, _, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "look", Attachments: []string{"x"}})
+	_, _, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "look", Attachments: []AttachmentRef{{ID: "x"}}})
 	if !errors.Is(err, ErrBadRequest) {
 		t.Fatalf("err = %v, want ErrBadRequest", err)
 	}
@@ -123,7 +123,7 @@ func TestChatImageRefsLandInUserMessageEvent(t *testing.T) {
 	fa.seed("img1", "image/png", []byte("raw-bytes"))
 	svc.SetAttachments(fa)
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what is this?", Attachments: []string{"img1"}})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what is this?", Attachments: []AttachmentRef{{ID: "img1"}}})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestRetryReplaysImageRefs(t *testing.T) {
 	fa.seed("img1", "image/webp", []byte("webp-data"))
 	svc.SetAttachments(fa)
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "q", Attachments: []string{"img1"}})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "q", Attachments: []AttachmentRef{{ID: "img1"}}})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestChatImageMessageAutoFlipsToVisionRoute(t *testing.T) {
 	fa.seed("img1", "image/png", []byte("bytes"))
 	svc.SetAttachments(fa)
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what is this?", Attachments: []string{"img1"}})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what is this?", Attachments: []AttachmentRef{{ID: "img1"}}})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestChatImageMessageWithExplicitRouteIsHonored(t *testing.T) {
 	svc.SetAttachments(fa)
 
 	_, ch, err := svc.Chat(t.Context(), Request{
-		SessionID: "s1", Message: "what is this?", Attachments: []string{"img1"}, Route: "research",
+		SessionID: "s1", Message: "what is this?", Attachments: []AttachmentRef{{ID: "img1"}}, Route: "research",
 	})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
@@ -269,7 +269,7 @@ func TestChatImageMessageOnSensitivePinnedSessionKeepsPinnedRoute(t *testing.T) 
 	fa.seed("img1", "image/png", []byte("bytes"))
 	svc.SetAttachments(fa)
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what is this?", Attachments: []string{"img1"}})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what is this?", Attachments: []AttachmentRef{{ID: "img1"}}})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -314,7 +314,7 @@ func TestRetryOfImageTurnStaysOnVisionRoute(t *testing.T) {
 	fa.seed("img1", "image/png", []byte("bytes"))
 	svc.SetAttachments(fa)
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what is this?", Attachments: []string{"img1"}})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "what is this?", Attachments: []AttachmentRef{{ID: "img1"}}})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -369,7 +369,7 @@ func TestChatPDFAttachmentConvertsToDocument(t *testing.T) {
 	md := fakeMarkitdown(t, "# Converted Title")
 	svc.SetMarkitdown(md.URL)
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []string{"doc1"}})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []AttachmentRef{{ID: "doc1"}}})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -404,7 +404,7 @@ func TestChatPDFAttachmentWithoutMarkitdownIsBadRequest(t *testing.T) {
 	svc.SetAttachments(fa)
 	// SetMarkitdown intentionally not called.
 
-	_, _, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []string{"doc1"}})
+	_, _, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []AttachmentRef{{ID: "doc1"}}})
 	if !errors.Is(err, ErrBadRequest) {
 		t.Fatalf("err = %v, want ErrBadRequest", err)
 	}
@@ -435,7 +435,7 @@ func TestChatPDFAttachmentTruncatesOversizedMarkdown(t *testing.T) {
 	md := fakeMarkitdown(t, huge)
 	svc.SetMarkitdown(md.URL)
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []string{"doc1"}})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []AttachmentRef{{ID: "doc1"}}})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -473,7 +473,7 @@ func TestChatTextAttachmentConvertsToDocument(t *testing.T) {
 	svc.SetAttachments(fa)
 	// SetMarkitdown intentionally not called: text must not require it.
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []string{"txt1"}})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []AttachmentRef{{ID: "txt1"}}})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -506,7 +506,7 @@ func TestChatTextAttachmentTruncatesOversizedContent(t *testing.T) {
 	fa.seed("txt1", "text/plain", []byte(huge))
 	svc.SetAttachments(fa)
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []string{"txt1"}})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []AttachmentRef{{ID: "txt1"}}})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -543,7 +543,7 @@ func TestChatDocumentsOnlyMessageDoesNotFlipToVisionRoute(t *testing.T) {
 	md := fakeMarkitdown(t, "converted text")
 	svc.SetMarkitdown(md.URL)
 
-	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []string{"doc1"}})
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "summarize", Attachments: []AttachmentRef{{ID: "doc1"}}})
 	if err != nil {
 		t.Fatalf("Chat: %v", err)
 	}
@@ -552,5 +552,190 @@ func TestChatDocumentsOnlyMessageDoesNotFlipToVisionRoute(t *testing.T) {
 	sent := gw.lastChatRequest()
 	if sent.Route != "default" {
 		t.Fatalf("route = %q, want %q (documents-only message, no vision flip)", sent.Route, "default")
+	}
+}
+
+// fakeWhisper stands in for the whisper sidecar: POST /transcribe
+// replies with a fixed transcript, same wire shape whisper.Transcribe
+// expects.
+func fakeWhisper(t *testing.T, text string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body, err := json.Marshal(map[string]string{"text": text})
+		if err != nil {
+			t.Fatalf("marshal fake whisper response: %v", err)
+		}
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestChatAudioAttachmentTranscribesToDocument confirms an audio
+// attachment ref is transcribed through the whisper sidecar exactly
+// once at send time and lands as a DocumentRef on the persisted
+// user_message, name threaded through.
+func TestChatAudioAttachmentTranscribesToDocument(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("heard your note")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("aud1", "audio/mpeg", []byte("fake-mp3-bytes"))
+	svc.SetAttachments(fa)
+	ws := fakeWhisper(t, "buy some milk")
+	svc.SetWhisper(ws.URL)
+
+	_, ch, err := svc.Chat(t.Context(), Request{
+		SessionID: "s1", Message: "summarize", Attachments: []AttachmentRef{{ID: "aud1", Name: "note.mp3"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+
+	events, _ := log.Events(t.Context(), "s1")
+	var um session.UserMessage
+	if err := json.Unmarshal(events[1].Payload, &um); err != nil {
+		t.Fatalf("decode user_message: %v", err)
+	}
+	if len(um.Documents) != 1 || um.Documents[0].ID != "aud1" || um.Documents[0].Mime != "audio/mpeg" {
+		t.Fatalf("documents = %+v, want one ref to aud1/audio/mpeg", um.Documents)
+	}
+	if um.Documents[0].Markdown != "buy some milk" {
+		t.Fatalf("markdown = %q, want transcript", um.Documents[0].Markdown)
+	}
+	if um.Documents[0].Name != "note.mp3" {
+		t.Fatalf("name = %q, want note.mp3", um.Documents[0].Name)
+	}
+}
+
+// TestChatAudioAttachmentWithoutWhisperAttachesOnly confirms an audio
+// ref is kept (never rejected) when whisper isn't configured, with an
+// empty transcript rather than a 400.
+func TestChatAudioAttachmentWithoutWhisperAttachesOnly(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("ok")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("aud1", "audio/wav", []byte("fake-wav-bytes"))
+	svc.SetAttachments(fa)
+	// SetWhisper intentionally not called.
+
+	_, ch, err := svc.Chat(t.Context(), Request{SessionID: "s1", Message: "hi", Attachments: []AttachmentRef{{ID: "aud1"}}})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+
+	events, _ := log.Events(t.Context(), "s1")
+	var um session.UserMessage
+	if err := json.Unmarshal(events[1].Payload, &um); err != nil {
+		t.Fatalf("decode user_message: %v", err)
+	}
+	if len(um.Documents) != 1 || um.Documents[0].Markdown != "" {
+		t.Fatalf("documents = %+v, want one ref with empty markdown", um.Documents)
+	}
+}
+
+// TestChatVideoAttachmentNeverConvertsContent confirms a video
+// attachment lands as a DocumentRef with an empty Markdown — never
+// sent to any sidecar, never carrying content.
+func TestChatVideoAttachmentNeverConvertsContent(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("ok")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("vid1", "video/mp4", []byte("fake-mp4-bytes"))
+	svc.SetAttachments(fa)
+
+	_, ch, err := svc.Chat(t.Context(), Request{
+		SessionID: "s1", Message: "watch this", Attachments: []AttachmentRef{{ID: "vid1", Name: "clip.mp4"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+
+	events, _ := log.Events(t.Context(), "s1")
+	var um session.UserMessage
+	if err := json.Unmarshal(events[1].Payload, &um); err != nil {
+		t.Fatalf("decode user_message: %v", err)
+	}
+	if len(um.Documents) != 1 || um.Documents[0].Markdown != "" || um.Documents[0].Mime != "video/mp4" {
+		t.Fatalf("documents = %+v, want one video ref with empty markdown", um.Documents)
+	}
+	if um.Documents[0].Name != "clip.mp4" {
+		t.Fatalf("name = %q, want clip.mp4", um.Documents[0].Name)
+	}
+
+	sent := gw.lastChatRequest()
+	last := sent.Messages[len(sent.Messages)-1]
+	if !strings.Contains(last.Content, "not viewable by the model") {
+		t.Fatalf("prompt content = %q, want the neutralized attach-only note", last.Content)
+	}
+}
+
+// TestChatAudioAndVideoDoNotFlipToVisionRoute confirms the D-046
+// vision auto-flip stays keyed on images alone: audio/video attachments
+// never ride the vision chain, same as PDF/text documents.
+func TestChatAudioAndVideoDoNotFlipToVisionRoute(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("ok")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("aud1", "audio/mpeg", []byte("fake-mp3-bytes"))
+	fa.seed("vid1", "video/webm", []byte("fake-webm-bytes"))
+	svc.SetAttachments(fa)
+
+	_, ch, err := svc.Chat(t.Context(), Request{
+		SessionID: "s1", Message: "look and listen",
+		Attachments: []AttachmentRef{{ID: "aud1"}, {ID: "vid1"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	sent := gw.lastChatRequest()
+	if sent.Route != "default" {
+		t.Fatalf("route = %q, want %q (audio/video attachments, no vision flip)", sent.Route, "default")
+	}
+}
+
+// TestChatImageNameThreadsToPersistedRef confirms the client-supplied
+// filename lands on the persisted ImageRef.
+func TestChatImageNameThreadsToPersistedRef(t *testing.T) {
+	t.Parallel()
+	log := newFakeLog()
+	gw := &fakeGW{events: okEvents("described")}
+	svc := newService(gw, log)
+	fa := newFakeAttachments()
+	fa.seed("img1", "image/png", []byte("bytes"))
+	svc.SetAttachments(fa)
+
+	_, ch, err := svc.Chat(t.Context(), Request{
+		SessionID: "s1", Message: "what is this?", Attachments: []AttachmentRef{{ID: "img1", Name: "photo.png"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 })
+
+	events, _ := log.Events(t.Context(), "s1")
+	var um session.UserMessage
+	if err := json.Unmarshal(events[1].Payload, &um); err != nil {
+		t.Fatalf("decode user_message: %v", err)
+	}
+	if len(um.Images) != 1 || um.Images[0].Name != "photo.png" {
+		t.Fatalf("images = %+v, want name photo.png", um.Images)
 	}
 }

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -31,6 +31,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 	"github.com/SumonMSelim/timothy/internal/gateway/stream"
 	"github.com/SumonMSelim/timothy/internal/platform/markitdown"
+	"github.com/SumonMSelim/timothy/internal/platform/whisper"
 )
 
 const (
@@ -150,6 +151,8 @@ type Service struct {
 	attachments    AttachmentStore                      // nil: attachments disabled (ATTACHMENTS_DIR unset)
 	markitdownURL  string                               // "": pdf attachments disabled (MARKITDOWN_URL unset)
 	markitdownHTTP *http.Client                         // shared client for the markitdown sidecar call
+	whisperURL     string                               // "": audio attachments attach without a transcript (WHISPER_URL unset)
+	whisperHTTP    *http.Client                         // shared client for the whisper sidecar call
 	kbSearch       KBSearch                             // nil: kb_search never offered, regardless of agent config
 	kbRead         KBRead                               // nil: kb_read never offered, regardless of agent config
 	logger         *slog.Logger
@@ -241,6 +244,16 @@ func (s *Service) SetMarkitdown(url string) {
 	s.markitdownURL = url
 	if s.markitdownHTTP == nil {
 		s.markitdownHTTP = &http.Client{}
+	}
+}
+
+// SetWhisper wires the whisper sidecar's base URL for audio attachment
+// transcription. Optional — empty (WHISPER_URL unset) attaches audio
+// with no transcript rather than rejecting it (attach-only fallback).
+func (s *Service) SetWhisper(url string) {
+	s.whisperURL = url
+	if s.whisperHTTP == nil {
+		s.whisperHTTP = &http.Client{}
 	}
 }
 
@@ -755,6 +768,14 @@ func resolveToolAllow(profile agents.Agent) []string {
 	return allow
 }
 
+// AttachmentRef names one already-uploaded attachment to resolve for a
+// turn; Name is display-only (the store itself doesn't carry a
+// filename), mirrors missionAttachmentInput's shape.
+type AttachmentRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 // Request is one chat turn.
 type Request struct {
 	SessionID string `json:"session_id,omitempty"`
@@ -769,10 +790,12 @@ type Request struct {
 	// skip: the pack's body is in the system prompt before the first
 	// token streams.
 	SkillHint string `json:"skill_hint,omitempty"`
-	// Attachments are attachment ids (internal/brain/attachments)
-	// the user attached to this message — refs only, resolved into
-	// base64 at request-build time (D-045).
-	Attachments []string `json:"attachments,omitempty"`
+	// Attachments name already-uploaded attachments (internal/brain/
+	// attachments) the user attached to this message — refs only,
+	// resolved into base64 (images) or transcript/markdown text
+	// (documents) at request-build time (D-045). Name is the original
+	// filename, display-only: the store itself doesn't carry one.
+	Attachments []AttachmentRef `json:"attachments,omitempty"`
 	// Knowledge names kb collections the user pinned to this turn's
 	// session (composer # mentions) — unioned into the session's
 	// stored knowledge list before the turn runs.
@@ -938,19 +961,19 @@ func (s *Service) readAttachment(ctx context.Context, id string) (string, error)
 // validateAttachments checks every id exists in the attachment store
 // BEFORE the turn's exclusivity is won or anything is appended (D-042:
 // store lookups are read-only and safe before turnBegin, but a bad ref
-// must 400 before even the user_message persists). Empty ids returns
+// must 400 before even the user_message persists). Empty refs returns
 // nil, nil, nil without touching the store — attachments stay off when
 // unconfigured, and a message with none never needs it wired.
 //
-// PDFs are converted to markdown here, once, at send time (not lazily
-// per turn like images): re-converting on every turn would re-call the
-// markitdown sidecar every turn, and any output drift would rewrite an
-// earlier projected message — breaking LLMContext's prefix stability
-// that provider prompt caches depend on. A conversion failure is the
-// sidecar's fault, not the client's, so it returns a plain wrapped
-// error rather than ErrBadRequest.
-func (s *Service) validateAttachments(ctx context.Context, ids []string) ([]session.ImageRef, []session.DocumentRef, error) {
-	if len(ids) == 0 {
+// PDFs/text/audio are converted to markdown (or transcript) here,
+// once, at send time (not lazily per turn like images): re-converting
+// on every turn would re-call the sidecar every turn, and any output
+// drift would rewrite an earlier projected message — breaking
+// LLMContext's prefix stability that provider prompt caches depend on.
+// A conversion failure is the sidecar's fault, not the client's, so it
+// returns a plain wrapped error rather than ErrBadRequest.
+func (s *Service) validateAttachments(ctx context.Context, refs []AttachmentRef) ([]session.ImageRef, []session.DocumentRef, error) {
+	if len(refs) == 0 {
 		return nil, nil, nil
 	}
 	if s.attachments == nil {
@@ -958,48 +981,83 @@ func (s *Service) validateAttachments(ctx context.Context, ids []string) ([]sess
 	}
 	var images []session.ImageRef
 	var documents []session.DocumentRef
-	for _, id := range ids {
-		att, err := s.attachments.Get(ctx, id)
+	for _, ref := range refs {
+		att, err := s.attachments.Get(ctx, ref.ID)
 		if err != nil {
-			return nil, nil, fmt.Errorf("chat: %w: attachment %q: %v", ErrBadRequest, id, err)
+			return nil, nil, fmt.Errorf("chat: %w: attachment %q: %v", ErrBadRequest, ref.ID, err)
 		}
 		switch {
 		case strings.HasPrefix(att.Mime, "image/"):
-			images = append(images, session.ImageRef{ID: att.ID, Mime: att.Mime})
+			images = append(images, session.ImageRef{ID: att.ID, Mime: att.Mime, Name: ref.Name})
 		case att.Mime == "application/pdf":
 			if s.markitdownURL == "" {
 				return nil, nil, fmt.Errorf("chat: %w: pdf attachments require the markitdown sidecar (MARKITDOWN_URL)", ErrBadRequest)
 			}
-			r, _, err := s.attachments.Open(ctx, att.ID)
+			raw, err := s.readAttachmentBytes(ctx, att.ID)
 			if err != nil {
-				return nil, nil, fmt.Errorf("chat: %w: attachment %q: %v", ErrBadRequest, id, err)
-			}
-			raw, err := io.ReadAll(r)
-			_ = r.Close()
-			if err != nil {
-				return nil, nil, fmt.Errorf("chat: read attachment %q: %w", id, err)
+				return nil, nil, err
 			}
 			md, err := markitdown.Convert(ctx, s.markitdownHTTP, s.markitdownURL, att.ID+".pdf", att.Mime, raw)
 			if err != nil {
-				return nil, nil, fmt.Errorf("chat: convert attachment %q: %w", id, err)
+				return nil, nil, fmt.Errorf("chat: convert attachment %q: %w", ref.ID, err)
 			}
-			documents = append(documents, session.DocumentRef{ID: att.ID, Mime: att.Mime, Markdown: markitdown.TruncateMarkdown(md)})
+			documents = append(documents, session.DocumentRef{ID: att.ID, Mime: att.Mime, Markdown: markitdown.TruncateMarkdown(md), Name: ref.Name})
 		case att.Mime == "text/plain":
-			r, _, err := s.attachments.Open(ctx, att.ID)
+			raw, err := s.readAttachmentBytes(ctx, att.ID)
 			if err != nil {
-				return nil, nil, fmt.Errorf("chat: %w: attachment %q: %v", ErrBadRequest, id, err)
+				return nil, nil, err
 			}
-			raw, err := io.ReadAll(r)
-			_ = r.Close()
+			documents = append(documents, session.DocumentRef{ID: att.ID, Mime: att.Mime, Markdown: markitdown.TruncateMarkdown(string(raw)), Name: ref.Name})
+		case strings.HasPrefix(att.Mime, "audio/"):
+			doc, err := s.transcribeAudioAttachment(ctx, att, ref.Name)
 			if err != nil {
-				return nil, nil, fmt.Errorf("chat: read attachment %q: %w", id, err)
+				return nil, nil, err
 			}
-			documents = append(documents, session.DocumentRef{ID: att.ID, Mime: att.Mime, Markdown: markitdown.TruncateMarkdown(string(raw))})
+			documents = append(documents, doc)
+		case strings.HasPrefix(att.Mime, "video/"):
+			// Never converted or sent as content — projection.go renders
+			// an empty-markdown document as a neutralized attach-only
+			// note instead.
+			documents = append(documents, session.DocumentRef{ID: att.ID, Mime: att.Mime, Name: ref.Name})
 		default:
-			return nil, nil, fmt.Errorf("chat: %w: attachment %q: unsupported mime %q", ErrBadRequest, id, att.Mime)
+			return nil, nil, fmt.Errorf("chat: %w: attachment %q: unsupported mime %q", ErrBadRequest, ref.ID, att.Mime)
 		}
 	}
 	return images, documents, nil
+}
+
+// readAttachmentBytes opens and fully reads one attachment's bytes.
+func (s *Service) readAttachmentBytes(ctx context.Context, id string) ([]byte, error) {
+	r, _, err := s.attachments.Open(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("chat: %w: attachment %q: %v", ErrBadRequest, id, err)
+	}
+	defer func() { _ = r.Close() }()
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("chat: read attachment %q: %w", id, err)
+	}
+	return raw, nil
+}
+
+// transcribeAudioAttachment sends an audio attachment's bytes through
+// the whisper sidecar and returns a DocumentRef carrying the
+// transcript. When whisper isn't configured (WHISPER_URL unset), the
+// attachment is kept but with no transcript — attach-only, never
+// silently dropped.
+func (s *Service) transcribeAudioAttachment(ctx context.Context, att attachments.Attachment, name string) (session.DocumentRef, error) {
+	if s.whisperURL == "" {
+		return session.DocumentRef{ID: att.ID, Mime: att.Mime, Name: name}, nil
+	}
+	raw, err := s.readAttachmentBytes(ctx, att.ID)
+	if err != nil {
+		return session.DocumentRef{}, err
+	}
+	text, err := whisper.Transcribe(ctx, s.whisperHTTP, s.whisperURL, raw, "")
+	if err != nil {
+		return session.DocumentRef{}, fmt.Errorf("chat: transcribe attachment %q: %w", att.ID, err)
+	}
+	return session.DocumentRef{ID: att.ID, Mime: att.Mime, Markdown: markitdown.TruncateMarkdown(text), Name: name}, nil
 }
 
 // pinSensitiveRoute promotes the session-wide privacy floor above the

--- a/internal/brain/session/events.go
+++ b/internal/brain/session/events.go
@@ -67,20 +67,27 @@ type UserMessage struct {
 
 // ImageRef points at a stored attachment; Mime rides alongside so
 // projections and drivers can build a data: URL without a store
-// round-trip.
+// round-trip. Name is the original filename, additive: events
+// persisted before D-0xx filename threading omit it, and the UI falls
+// back to its existing short-hash label in that case.
 type ImageRef struct {
 	ID   string `json:"id"`
 	Mime string `json:"mime"`
+	Name string `json:"name,omitempty"`
 }
 
-// DocumentRef points at a stored PDF attachment; Markdown is its
-// converted text, persisted so projection is deterministic and the
-// markitdown sidecar is called exactly once per attach (see
-// UserMessage.Documents).
+// DocumentRef points at a stored document attachment (PDF, text,
+// audio, video); Markdown is its converted text or transcript,
+// persisted so projection is deterministic and the markitdown/whisper
+// sidecar is called exactly once per attach (see UserMessage.Documents).
+// Video attachments and audio attachments with no transcript (whisper
+// unconfigured) carry an empty Markdown — never sent to the model as
+// content, see projection.go. Name is additive, same as ImageRef.
 type DocumentRef struct {
 	ID       string `json:"id"`
 	Mime     string `json:"mime"`
 	Markdown string `json:"markdown"`
+	Name     string `json:"name,omitempty"`
 }
 
 // UIBlock is one renderable piece of an assistant turn.

--- a/internal/brain/session/projection.go
+++ b/internal/brain/session/projection.go
@@ -83,10 +83,23 @@ func LLMContext(events []Event, budget int) ([]provider.Message, error) {
 			// Documents carry their markdown already converted and
 			// persisted (chat.Chat, at send time) — projection just
 			// appends it as ordinary text, no store round-trip and no
-			// sidecar call. PDFs never flip the vision route; only
-			// images do.
+			// sidecar call. PDFs/audio/video never flip the vision
+			// route; only images do. A document with no markdown
+			// (video, or audio with no whisper configured) renders as
+			// a one-line neutralized note instead of the usual block —
+			// the model is told it exists but never asked to read
+			// content that isn't there.
 			for _, doc := range m.Documents {
-				block := fmt.Sprintf("[attached document %s (%s)]\n%s", doc.ID, doc.Mime, doc.Markdown)
+				var block string
+				if doc.Markdown == "" {
+					label := doc.Name
+					if label == "" {
+						label = doc.ID
+					}
+					block = fmt.Sprintf("[attached file: %s (%s), not viewable by the model]", label, doc.Mime)
+				} else {
+					block = fmt.Sprintf("[attached document %s (%s)]\n%s", doc.ID, doc.Mime, doc.Markdown)
+				}
 				if msg.Content == "" {
 					msg.Content = block
 				} else {
@@ -246,7 +259,7 @@ func UITranscript(events []Event) ([]TranscriptItem, error) {
 			}
 			item.Kind, item.Text, item.Images = "user", m.Text, m.Images
 			for _, doc := range m.Documents {
-				item.Documents = append(item.Documents, ImageRef{ID: doc.ID, Mime: doc.Mime})
+				item.Documents = append(item.Documents, ImageRef{ID: doc.ID, Mime: doc.Mime, Name: doc.Name})
 			}
 		case KindAssistantTurn:
 			var t AssistantTurn

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -101,7 +101,9 @@ export interface ChatRequest {
   route?: string
   model_hint?: string
   skill_hint?: string
-  attachments?: string[]
+  // attachments name already-uploaded attachments; name is the
+  // original filename, display-only.
+  attachments?: { id: string; name?: string }[]
   // knowledge is the set of kb collection names pinned for this turn;
   // the server unions them into the session's knowledge list.
   knowledge?: string[]
@@ -127,10 +129,13 @@ export interface UIBlock {
 }
 
 // ImageRef is one attachment carried by a user transcript item — the
-// attachment's id (content hash) and MIME type, never the bytes.
+// attachment's id (content hash) and MIME type, never the bytes. name
+// is the original filename; absent on events persisted before
+// filename threading shipped.
 export interface ImageRef {
   id: string
   mime: string
+  name?: string
 }
 
 // One executed tool call in the replay projection (digest only).

--- a/web/src/components/AttachmentViewer.test.tsx
+++ b/web/src/components/AttachmentViewer.test.tsx
@@ -1,0 +1,153 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AttachmentViewer } from './AttachmentViewer'
+
+vi.mock('../api/client', () => ({
+  fetchAttachmentBlob: vi.fn(),
+}))
+
+import { fetchAttachmentBlob } from '../api/client'
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  URL.createObjectURL = vi.fn(() => 'blob:mock')
+  URL.revokeObjectURL = vi.fn()
+})
+
+describe('AttachmentViewer', () => {
+  it('renders nothing when no attachment is given', () => {
+    render(<AttachmentViewer open={false} onOpenChange={() => {}} attachment={null} />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders an image lightbox for image/*', async () => {
+    vi.mocked(fetchAttachmentBlob).mockResolvedValue(new Blob(['x'], { type: 'image/png' }))
+    render(
+      <AttachmentViewer
+        open
+        onOpenChange={() => {}}
+        attachment={{ id: 'img1', mime: 'image/png', name: 'photo.png' }}
+      />,
+    )
+    const img = await screen.findByRole('img', { name: 'photo.png' })
+    expect(img.getAttribute('src')).toBe('blob:mock')
+  })
+
+  it('renders a video element with controls for video/*', async () => {
+    vi.mocked(fetchAttachmentBlob).mockResolvedValue(new Blob(['x'], { type: 'video/mp4' }))
+    render(
+      <AttachmentViewer
+        open
+        onOpenChange={() => {}}
+        attachment={{ id: 'vid1', mime: 'video/mp4', name: 'clip.mp4' }}
+      />,
+    )
+    // Dialog content portals to document.body, not the render container.
+    const video = await waitFor(() => {
+      const el = document.body.querySelector('video')
+      if (!el) throw new Error('video not rendered yet')
+      return el
+    })
+    expect(video.getAttribute('src')).toBe('blob:mock')
+    expect(video.hasAttribute('controls')).toBe(true)
+  })
+
+  it('renders an audio element with controls for audio/*', async () => {
+    vi.mocked(fetchAttachmentBlob).mockResolvedValue(new Blob(['x'], { type: 'audio/mpeg' }))
+    render(
+      <AttachmentViewer
+        open
+        onOpenChange={() => {}}
+        attachment={{ id: 'aud1', mime: 'audio/mpeg', name: 'note.mp3' }}
+      />,
+    )
+    const audio = await waitFor(() => {
+      const el = document.body.querySelector('audio')
+      if (!el) throw new Error('audio not rendered yet')
+      return el
+    })
+    expect(audio.getAttribute('src')).toBe('blob:mock')
+    expect(audio.hasAttribute('controls')).toBe(true)
+  })
+
+  it('renders a full-size iframe for application/pdf', async () => {
+    vi.mocked(fetchAttachmentBlob).mockResolvedValue(new Blob(['x'], { type: 'application/pdf' }))
+    render(
+      <AttachmentViewer
+        open
+        onOpenChange={() => {}}
+        attachment={{ id: 'doc1', mime: 'application/pdf', name: 'report.pdf' }}
+      />,
+    )
+    const frame = await screen.findByTitle('report.pdf')
+    expect(frame.tagName).toBe('IFRAME')
+    expect(frame.getAttribute('src')).toBe('blob:mock')
+  })
+
+  it('renders markdown for text/markdown with a Source/Rendered toggle', async () => {
+    vi.mocked(fetchAttachmentBlob).mockResolvedValue(new Blob(['# Hello'], { type: 'text/markdown' }))
+    render(
+      <AttachmentViewer
+        open
+        onOpenChange={() => {}}
+        attachment={{ id: 'md1', mime: 'text/markdown', name: 'notes.md' }}
+      />,
+    )
+    expect(await screen.findByRole('heading', { name: 'Hello' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Source' })).toBeInTheDocument()
+  })
+
+  it('renders plain text for text/plain with a Copy button, no Source toggle', async () => {
+    vi.mocked(fetchAttachmentBlob).mockResolvedValue(new Blob(['plain body'], { type: 'text/plain' }))
+    render(
+      <AttachmentViewer
+        open
+        onOpenChange={() => {}}
+        attachment={{ id: 'txt1', mime: 'text/plain', name: 'notes.txt' }}
+      />,
+    )
+    expect(await screen.findByText('plain body')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Source' })).not.toBeInTheDocument()
+  })
+
+  it('falls back to a type label + short hash when no name is present', async () => {
+    vi.mocked(fetchAttachmentBlob).mockResolvedValue(new Blob(['x'], { type: 'application/pdf' }))
+    render(
+      <AttachmentViewer
+        open
+        onOpenChange={() => {}}
+        attachment={{ id: 'abcdefgh12345678', mime: 'application/pdf' }}
+      />,
+    )
+    expect(await screen.findByText('PDF (abcdefgh)')).toBeInTheDocument()
+  })
+
+  it('renders exactly one close control, in the header row, not the default overlapping one', async () => {
+    vi.mocked(fetchAttachmentBlob).mockResolvedValue(new Blob(['x'], { type: 'application/pdf' }))
+    render(
+      <AttachmentViewer
+        open
+        onOpenChange={() => {}}
+        attachment={{ id: 'doc1', mime: 'application/pdf', name: 'report.pdf' }}
+      />,
+    )
+    await screen.findByText('Download')
+    expect(screen.getAllByRole('button', { name: 'Close' })).toHaveLength(1)
+  })
+
+  it('uses the given localUrl directly without fetching', () => {
+    render(
+      <AttachmentViewer
+        open
+        onOpenChange={() => {}}
+        attachment={{ id: 'img1', mime: 'image/png', name: 'photo.png' }}
+        localUrl="blob:local-preview"
+      />,
+    )
+    expect(fetchAttachmentBlob).not.toHaveBeenCalled()
+    const img = screen.getByRole('img', { name: 'photo.png' }) as HTMLImageElement
+    expect(img.src).toBe('blob:local-preview')
+  })
+})

--- a/web/src/components/AttachmentViewer.tsx
+++ b/web/src/components/AttachmentViewer.tsx
@@ -1,0 +1,207 @@
+import {
+  Cancel01Icon,
+  Copy01Icon,
+  Download04Icon,
+  ImageNotFound01Icon,
+  Loading03Icon,
+  Tick02Icon,
+} from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useEffect, useState } from 'react'
+import { fetchAttachmentBlob } from '../api/client'
+import { attachmentURLCache } from '../lib/attachmentCache'
+import { FileCodeBlock, FileMarkdownBlock } from './FilePreviewBlocks'
+import { Button } from './ui/button'
+import { Dialog, DialogClose, DialogContent, DialogTitle } from './ui/dialog'
+
+// AttachmentViewer is a fullscreen modal for one chat attachment,
+// dispatching on mime: images get a lightbox, video/audio get native
+// controls, PDFs render in an iframe, and text/markdown reuse
+// FileViewer's reader halves (FilePreviewBlocks.tsx). Reuses
+// Message.tsx's attachmentURLCache so an already-rendered thumbnail's
+// blob URL is never refetched.
+export function AttachmentViewer({
+  open,
+  onOpenChange,
+  attachment,
+  localUrl,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  attachment: { id: string; mime: string; name?: string } | null
+  // An optimistic item's own object URL from the composer, used
+  // directly instead of fetching.
+  localUrl?: string
+}) {
+  const [url, setUrl] = useState<string | undefined>(undefined)
+  const [text, setText] = useState<string | undefined>(undefined)
+  const [failed, setFailed] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const [showRaw, setShowRaw] = useState(false)
+
+  const id = attachment?.id
+  const mime = attachment?.mime ?? ''
+  const isText = mime === 'text/plain' || mime === 'text/markdown'
+
+  useEffect(() => {
+    setFailed(false)
+    setText(undefined)
+    setShowRaw(false)
+    if (!open || !id) {
+      setUrl(undefined)
+      return
+    }
+    const cached = localUrl ?? attachmentURLCache.get(id)
+    if (cached) {
+      setUrl(cached)
+      if (isText) {
+        fetch(cached)
+          .then((r) => r.text())
+          .then(setText)
+          .catch(() => setFailed(true))
+      }
+      return
+    }
+    let stale = false
+    fetchAttachmentBlob(id)
+      .then(async (blob) => {
+        if (stale) return
+        const objectUrl = URL.createObjectURL(blob)
+        attachmentURLCache.set(id, objectUrl)
+        setUrl(objectUrl)
+        if (isText) setText(await blob.text())
+      })
+      .catch(() => {
+        if (!stale) setFailed(true)
+      })
+    return () => {
+      stale = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- isText derives from mime, which is stable per attachment id
+  }, [open, id, localUrl])
+
+  if (!attachment) return null
+
+  const label = mimeLabel(mime)
+  const displayName = attachment.name ?? `${label} (${attachment.id.slice(0, 8)})`
+
+  const copyText = async () => {
+    if (text === undefined) return
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard unavailable: no-op.
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="flex h-[calc(100vh-4rem)] max-w-[calc(100vw-4rem)] flex-col p-0 sm:max-w-[calc(100vw-4rem)]"
+        aria-describedby={undefined}
+      >
+        <div className="flex items-center justify-between gap-3 border-b border-border bg-muted/50 px-4 py-2.5">
+          <div className="min-w-0 flex-1">
+            <DialogTitle className="truncate text-sm font-medium">{displayName}</DialogTitle>
+            <p className="text-xs text-muted-foreground">{mime}</p>
+          </div>
+          <div className="flex items-center gap-1.5">
+            {isText && text !== undefined && (
+              <>
+                {mime === 'text/markdown' && (
+                  <Button variant="outline" size="sm" onClick={() => setShowRaw((v) => !v)}>
+                    {showRaw ? 'Rendered' : 'Source'}
+                  </Button>
+                )}
+                <Button variant="ghost" size="sm" onClick={() => void copyText()}>
+                  <HugeiconsIcon icon={copied ? Tick02Icon : Copy01Icon} />
+                  {copied ? 'Copied' : 'Copy'}
+                </Button>
+              </>
+            )}
+            {url && (
+              <Button variant="ghost" size="sm" asChild>
+                <a href={url} download={attachment.name || attachment.id}>
+                  <HugeiconsIcon icon={Download04Icon} />
+                  Download
+                </a>
+              </Button>
+            )}
+            {/* DialogContent's built-in close X is suppressed
+                (showCloseButton={false}) since it's absolutely
+                positioned top-right and collided with Download above —
+                this sits in-flow in the header row instead, same fix
+                FullscreenDialog uses for its own header controls. */}
+            <DialogClose asChild>
+              <Button variant="ghost" size="icon-sm" aria-label="Close">
+                <HugeiconsIcon icon={Cancel01Icon} />
+              </Button>
+            </DialogClose>
+          </div>
+        </div>
+        <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto bg-zinc-950/2 dark:bg-black/40">
+          {failed && (
+            <div className="flex flex-col items-center gap-2 text-muted-foreground">
+              <HugeiconsIcon icon={ImageNotFound01Icon} className="size-8" />
+              <p className="text-sm">Could not load this attachment.</p>
+            </div>
+          )}
+          {!failed && !url && (
+            <HugeiconsIcon icon={Loading03Icon} className="size-6 animate-spin text-muted-foreground" />
+          )}
+          {!failed && url && mime.startsWith('image/') && (
+            <img src={url} alt={displayName} className="max-h-full max-w-full object-contain" />
+          )}
+          {!failed && url && mime.startsWith('video/') && (
+            // eslint-disable-next-line jsx-a11y/media-has-caption -- attachment source carries no caption track
+            <video src={url} controls className="max-h-full max-w-full" />
+          )}
+          {!failed && url && mime.startsWith('audio/') && (
+            // eslint-disable-next-line jsx-a11y/media-has-caption -- audio has no caption track
+            <audio src={url} controls className="w-full max-w-md" />
+          )}
+          {!failed && url && mime === 'application/pdf' && (
+            <iframe src={url} title={displayName} className="size-full border-0" />
+          )}
+          {!failed && isText && text !== undefined && (
+            <div className="size-full overflow-auto">
+              {mime === 'text/markdown' ? (
+                <FileMarkdownBlock text={text} raw={showRaw} />
+              ) : (
+                <FileCodeBlock code={text} path={attachment.name ?? 'file.txt'} />
+              )}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// mimeLabel is the short type label used in headers/chips when no
+// filename is present.
+export function mimeLabel(mime: string): string {
+  switch (mime) {
+    case 'application/pdf':
+      return 'PDF'
+    case 'text/markdown':
+      return 'MD'
+    case 'text/plain':
+      return 'TXT'
+    case 'video/mp4':
+      return 'MP4'
+    case 'video/webm':
+      return 'WEBM'
+    case 'audio/mpeg':
+      return 'MP3'
+    case 'audio/wav':
+      return 'WAV'
+    case 'audio/ogg':
+      return 'OGG'
+    default:
+      return mime.split('/')[1]?.toUpperCase() ?? 'FILE'
+  }
+}

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -398,6 +398,96 @@ describe('Composer attachments', () => {
     expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled()
   })
 
+  it('uploads a selected video file and adds a document chip on success', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.uploadAttachment).mockResolvedValue({
+      id: 'att-vid',
+      mime: 'video/mp4',
+      size_bytes: 2048,
+    })
+    const onAttachments = vi.fn()
+    const { rerender } = render(
+      <Composer {...baseProps()} attachments={[]} onAttachments={onAttachments} />,
+    )
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const video = makeImageFile('clip.mp4', 'video/mp4', 2048)
+    fireEvent.change(input, { target: { files: [video] } })
+
+    await waitFor(() => expect(client.uploadAttachment).toHaveBeenCalledWith(video))
+    await waitFor(() =>
+      expect(onAttachments).toHaveBeenLastCalledWith([
+        expect.objectContaining({ id: 'att-vid', mime: 'video/mp4', uploading: false }),
+      ]),
+    )
+
+    const [[chips]] = onAttachments.mock.calls.slice(-1)
+    rerender(<Composer {...baseProps()} attachments={chips} onAttachments={onAttachments} />)
+    expect(screen.getByText('clip.mp4')).toBeTruthy()
+  })
+
+  it('uploads a selected audio file and adds a document chip on success', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.uploadAttachment).mockResolvedValue({
+      id: 'att-aud',
+      mime: 'audio/mpeg',
+      size_bytes: 512,
+    })
+    const onAttachments = vi.fn()
+    const { rerender } = render(
+      <Composer {...baseProps()} attachments={[]} onAttachments={onAttachments} />,
+    )
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const audio = makeImageFile('note.mp3', 'audio/mpeg', 512)
+    fireEvent.change(input, { target: { files: [audio] } })
+
+    await waitFor(() => expect(client.uploadAttachment).toHaveBeenCalledWith(audio))
+    await waitFor(() =>
+      expect(onAttachments).toHaveBeenLastCalledWith([
+        expect.objectContaining({ id: 'att-aud', mime: 'audio/mpeg', uploading: false }),
+      ]),
+    )
+
+    const [[chips]] = onAttachments.mock.calls.slice(-1)
+    rerender(<Composer {...baseProps()} attachments={chips} onAttachments={onAttachments} />)
+    expect(screen.getByText('note.mp3')).toBeTruthy()
+  })
+
+  it('allows a video file under the 100MB cap but rejects one over it', async () => {
+    const client = await import('../api/client')
+    const { toast } = await import('sonner')
+    const onAttachments = vi.fn()
+    render(<Composer {...baseProps()} onAttachments={onAttachments} />)
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const big = makeImageFile('huge.mp4', 'video/mp4', 101 * 1024 * 1024)
+    fireEvent.change(input, { target: { files: [big] } })
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('huge.mp4: exceeds the 100MB limit'),
+    )
+    expect(client.uploadAttachment).not.toHaveBeenCalled()
+    expect(onAttachments).not.toHaveBeenCalled()
+  })
+
+  it('rejects an audio file over the 25MB cap', async () => {
+    const client = await import('../api/client')
+    const { toast } = await import('sonner')
+    const onAttachments = vi.fn()
+    render(<Composer {...baseProps()} onAttachments={onAttachments} />)
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+    const big = makeImageFile('huge.mp3', 'audio/mpeg', 26 * 1024 * 1024)
+    fireEvent.change(input, { target: { files: [big] } })
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('huge.mp3: exceeds the 25MB limit'),
+    )
+    expect(client.uploadAttachment).not.toHaveBeenCalled()
+    expect(onAttachments).not.toHaveBeenCalled()
+  })
+
   it('uploads a pasted image from the clipboard', async () => {
     const client = await import('../api/client')
     vi.mocked(client.uploadAttachment).mockResolvedValue({

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -3,6 +3,8 @@ import {
   ArrowDown01Icon,
   ArrowUp01Icon,
   Cancel01Icon,
+  FileMusicIcon,
+  FileVideoIcon,
   Loading03Icon,
   Mic01Icon,
   Pdf02Icon,
@@ -48,11 +50,34 @@ const allowedMimes = [
   'application/pdf',
   'text/plain',
   'text/markdown',
+  'video/mp4',
+  'video/webm',
+  'audio/mpeg',
+  'audio/wav',
+  'audio/ogg',
 ]
 // Exported: MissionAttachments.tsx reuses the same caps for its own
 // document upload flow.
 export const maxAttachmentBytes = 10 * 1024 * 1024
+export const maxVideoBytes = 100 * 1024 * 1024
+export const maxAudioBytes = 25 * 1024 * 1024
 export const maxAttachments = 8
+
+// maxBytesFor mirrors the server's per-type size caps (internal/brain/
+// attachments) so an oversize file is rejected client-side before an
+// upload round-trip.
+function maxBytesFor(mime: string): number {
+  if (mime.startsWith('video/')) return maxVideoBytes
+  if (mime.startsWith('audio/')) return maxAudioBytes
+  return maxAttachmentBytes
+}
+
+// documentChipIcon picks the composer's pending-chip icon by mime.
+function documentChipIcon(mime: string) {
+  if (mime.startsWith('video/')) return FileVideoIcon
+  if (mime.startsWith('audio/')) return FileMusicIcon
+  return Pdf02Icon
+}
 
 // isAllowedFile accepts a file when its reported type is in
 // allowedMimes, or (for .md/.txt) by extension — browsers report
@@ -64,17 +89,29 @@ export function isAllowedFile(file: File): boolean {
 }
 
 // isDocumentFile is isAllowedFile narrowed to document types (PDF,
-// Markdown, text) — used where images aren't accepted, e.g. mission
-// attachments.
+// Markdown, text) — used where only documents are accepted, e.g.
+// mission attachments. Video/audio are chat-only (explicit decision):
+// excluded here even though allowedMimes carries them for the composer.
 export function isDocumentFile(file: File): boolean {
-  return isAllowedFile(file) && !file.type.startsWith('image/')
+  return (
+    isAllowedFile(file) &&
+    !file.type.startsWith('image/') &&
+    !file.type.startsWith('video/') &&
+    !file.type.startsWith('audio/')
+  )
 }
 
 // isDocumentAttachment mirrors the server's document (non-image)
-// attachments: PDF and text/markdown files render as a document chip
-// rather than an image thumbnail.
+// attachments: PDF, text/markdown, video and audio files render as a
+// document chip rather than an image thumbnail.
 export function isDocumentAttachment(mime: string): boolean {
-  return mime === 'application/pdf' || mime === 'text/plain' || mime === 'text/markdown'
+  return (
+    mime === 'application/pdf' ||
+    mime === 'text/plain' ||
+    mime === 'text/markdown' ||
+    mime.startsWith('video/') ||
+    mime.startsWith('audio/')
+  )
 }
 
 // Composer is the one message box: the chat page's docked input and
@@ -355,8 +392,9 @@ export function Composer({
         toast.error(`${file.name || 'file'}: unsupported file type`)
         continue
       }
-      if (file.size > maxAttachmentBytes) {
-        toast.error(`${file.name || 'file'}: exceeds the 10MB limit`)
+      const cap = maxBytesFor(file.type)
+      if (file.size > cap) {
+        toast.error(`${file.name || 'file'}: exceeds the ${Math.round(cap / (1024 * 1024))}MB limit`)
         continue
       }
       if (attachmentsRef.current.length >= maxAttachments) {
@@ -479,7 +517,7 @@ export function Composer({
             >
               {isDocumentAttachment(a.mime) ? (
                 <div className="flex size-full flex-col items-center justify-center gap-0.5 bg-zinc-100 text-zinc-500 dark:bg-zinc-700 dark:text-zinc-400">
-                  <HugeiconsIcon icon={Pdf02Icon} className="size-4" />
+                  <HugeiconsIcon icon={documentChipIcon(a.mime)} className="size-4" />
                   <span className="max-w-full truncate px-1 text-[9px]">{a.name ?? 'Document'}</span>
                 </div>
               ) : (
@@ -554,7 +592,7 @@ export function Composer({
               <input
                 ref={fileInputRef}
                 type="file"
-                accept="image/png,image/jpeg,image/webp,image/gif,application/pdf,.md,.txt,text/plain,text/markdown"
+                accept="image/png,image/jpeg,image/webp,image/gif,application/pdf,.md,.txt,text/plain,text/markdown,video/mp4,video/webm,audio/mpeg,audio/wav,audio/ogg"
                 multiple
                 className="hidden"
                 onChange={(e) => {

--- a/web/src/components/FilePreviewBlocks.tsx
+++ b/web/src/components/FilePreviewBlocks.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from 'react'
+import hljs from 'highlight.js'
+import ReactMarkdown from 'react-markdown'
+import rehypeHighlight from 'rehype-highlight'
+import remarkGfm from 'remark-gfm'
+import { codeLanguageOf } from './missions/filePreviewKind'
+import 'highlight.js/styles/github-dark.css'
+
+// FileCodeBlock highlights plain (non-markdown) text/code files
+// directly with highlight.js — hljs escapes the source itself before
+// wrapping it in span tags, the same trust model rehype-highlight
+// already uses for markdown, so the resulting HTML is safe to inject.
+// A line-number gutter runs alongside it, GitHub-style: one row per
+// source line, select-none so copying the code never grabs the numbers.
+// Shared by missions/FileViewer.tsx and AttachmentViewer.tsx — named
+// distinctly from the top-level CodeBlock.tsx (shiki, for chat markdown
+// `pre` blocks), which this is unrelated to.
+export function FileCodeBlock({ code, path }: { code: string; path: string }) {
+  const html = useMemo(() => {
+    const lang = codeLanguageOf(path)
+    const result = lang
+      ? hljs.highlight(code, { language: lang, ignoreIllegals: true })
+      : hljs.highlightAuto(code)
+    return result.value
+  }, [code, path])
+  const lineCount = useMemo(() => code.split('\n').length, [code])
+  return (
+    <div className="flex overflow-x-auto p-3 font-mono text-xs leading-5">
+      <div aria-hidden="true" className="select-none pr-3 text-right text-muted-foreground">
+        {Array.from({ length: lineCount }, (_, i) => (
+          <div key={i}>{i + 1}</div>
+        ))}
+      </div>
+      <pre className="min-w-0 flex-1 font-mono text-xs leading-5">
+        <code
+          className="hljs !bg-transparent !p-0 font-mono text-xs leading-5"
+          // eslint-disable-next-line react/no-danger -- hljs escapes `code` itself; see FileCodeBlock comment above.
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </pre>
+    </div>
+  )
+}
+
+// FileMarkdownBlock renders markdown text, or its raw source through
+// FileCodeBlock when `raw` is toggled (the Source/Rendered switch).
+export function FileMarkdownBlock({ text, raw }: { text: string; raw: boolean }) {
+  if (raw) return <FileCodeBlock code={text} path="file.md" />
+  return (
+    <div className="prose prose-sm max-w-none p-3 dark:prose-invert prose-pre:bg-zinc-900">
+      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+        {text}
+      </ReactMarkdown>
+    </div>
+  )
+}

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -575,7 +575,7 @@ describe('UserMessage attachments', () => {
     expect(screen.queryByRole('img')).not.toBeInTheDocument()
   })
 
-  it('renders a non-clickable chip per attached document, never fetching it', async () => {
+  it('renders a chip per attached document, labeled by mime, without fetching it up front', async () => {
     const client = await import('../api/client')
 
     render(
@@ -593,5 +593,46 @@ describe('UserMessage attachments', () => {
   it('renders no document chips when the message carries none', () => {
     render(<UserMessage text="plain text" />)
     expect(screen.queryByText('PDF')).not.toBeInTheDocument()
+  })
+
+  it('shows the filename on a document chip when present, falling back to the mime label', () => {
+    render(
+      <UserMessage
+        text="summarize this"
+        documents={[
+          { id: 'doc-1', mime: 'application/pdf', name: 'quarterly-report.pdf' },
+          { id: 'doc-2', mime: 'audio/mpeg' },
+        ]}
+      />,
+    )
+    expect(screen.getByText('quarterly-report.pdf')).toBeInTheDocument()
+    expect(screen.getByText('MP3')).toBeInTheDocument()
+  })
+
+  it('opens the AttachmentViewer modal when a document chip is clicked', async () => {
+    render(
+      <UserMessage
+        text="summarize this"
+        documents={[{ id: 'doc-1', mime: 'application/pdf', name: 'report.pdf' }]}
+      />,
+    )
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('report.pdf'))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('application/pdf')).toBeInTheDocument()
+  })
+
+  it('opens the AttachmentViewer modal when an image thumbnail is clicked', async () => {
+    const localUrls = new Map([['att-1', 'blob:local-preview']])
+    render(
+      <UserMessage
+        text="sending…"
+        images={[{ id: 'att-1', mime: 'image/png', name: 'photo.png' }]}
+        localUrls={localUrls}
+      />,
+    )
+    fireEvent.click(screen.getByRole('img'))
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('photo.png')).toBeInTheDocument()
   })
 })

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -1,5 +1,8 @@
 import {
   Copy01Icon,
+  File01Icon,
+  FileMusicIcon,
+  FileVideoIcon,
   ImageNotFound01Icon,
   Link04Icon,
   Loading03Icon,
@@ -14,29 +17,37 @@ import remarkGfm from 'remark-gfm'
 import { fetchAttachmentBlob } from '../api/client'
 import type { ImageRef } from '../api/types'
 import { ActivityLine } from './Activity'
+import { AttachmentViewer, mimeLabel } from './AttachmentViewer'
 import { CodeBlock } from './CodeBlock'
 import { ModelBadge } from './ModelBadge'
 import { Badge } from './ui/badge'
 import { collapseRepeatedTail, splitSources } from '../lib/citations'
+import { attachmentURLCache } from '../lib/attachmentCache'
 import type { AssistantState } from '../lib/chat'
 import { compact, formatDuration, money } from '../lib/format'
 import { cn } from '../lib/utils'
-
-// Object URLs fetched per attachment id, cached module-level: an
-// attachment is content-addressed and immutable (D-045), so replaying
-// the same transcript (reload, resumed session) never refetches it.
-const attachmentURLCache = new Map<string, string>()
 
 // AuthedImage renders one attachment thumbnail. GET
 // /v1/attachments/{id} requires the bearer header, so a bare <img
 // src> can't fetch it directly — this fetches the bytes through the
 // authed client and renders them as a blob object URL, with a loading
 // shimmer while in flight and a broken-image fallback on failure.
-// Click opens the same resolved blob URL in a new tab — a raw
-// /v1/attachments/{id} href would 401 without the bearer header.
+// Click opens the AttachmentViewer modal on the same resolved blob URL
+// — a raw /v1/attachments/{id} href would 401 without the bearer
+// header, and a new tab loses the app's own reader/download chrome.
 // `localUrl`, when given (an optimistic item's own object URL from
 // the composer), is used directly and never fetched.
-function AuthedImage({ id, mime, localUrl }: { id: string; mime: string; localUrl?: string }) {
+function AuthedImage({
+  id,
+  mime,
+  localUrl,
+  onOpen,
+}: {
+  id: string
+  mime: string
+  localUrl?: string
+  onOpen: () => void
+}) {
   const [url, setUrl] = useState<string | undefined>(localUrl ?? attachmentURLCache.get(id))
   const [failed, setFailed] = useState(false)
 
@@ -85,7 +96,7 @@ function AuthedImage({ id, mime, localUrl }: { id: string; mime: string; localUr
     <img
       src={url}
       alt={mime}
-      onClick={() => window.open(url, '_blank')}
+      onClick={onOpen}
       className="max-h-50 max-w-full cursor-pointer rounded-lg object-cover"
     />
   )
@@ -94,33 +105,57 @@ function AuthedImage({ id, mime, localUrl }: { id: string; mime: string; localUr
 // ImageGrid renders a user message's attached images above the text.
 // Optimistic items carry their own local object URL (localUrls keyed
 // by id) so the just-sent thumbnail never round-trips the network.
-function ImageGrid({ images, localUrls }: { images: ImageRef[]; localUrls?: Map<string, string> }) {
+function ImageGrid({
+  images,
+  localUrls,
+  onOpen,
+}: {
+  images: ImageRef[]
+  localUrls?: Map<string, string>
+  onOpen: (img: ImageRef) => void
+}) {
   return (
     <div className="flex max-w-2xl flex-wrap justify-end gap-1.5">
       {images.map((img) => (
-        <AuthedImage key={img.id} id={img.id} mime={img.mime} localUrl={localUrls?.get(img.id)} />
+        <AuthedImage
+          key={img.id}
+          id={img.id}
+          mime={img.mime}
+          localUrl={localUrls?.get(img.id)}
+          onOpen={() => onOpen(img)}
+        />
       ))}
     </div>
   )
 }
 
-// DocumentChips renders a user message's attached PDFs as small,
-// non-clickable chips — unlike images there is no thumbnail to show
-// and no authed fetch to make (the converted markdown already rode
-// the turn server-side); this is just an acknowledgment of what was
-// attached.
-function DocumentChips({ documents }: { documents: ImageRef[] }) {
+// documentChipIcon picks a chip's icon by mime — PDF, video, audio, or
+// plain text/markdown all get a distinct glyph.
+function documentChipIcon(mime: string) {
+  if (mime.startsWith('video/')) return FileVideoIcon
+  if (mime.startsWith('audio/')) return FileMusicIcon
+  if (mime === 'text/plain' || mime === 'text/markdown') return File01Icon
+  return Pdf02Icon
+}
+
+// DocumentChips renders a user message's attached documents (PDF,
+// text, markdown, video, audio) as small clickable chips that open the
+// AttachmentViewer modal — labeled by mime, showing the original
+// filename when present.
+function DocumentChips({ documents, onOpen }: { documents: ImageRef[]; onOpen: (doc: ImageRef) => void }) {
   return (
     <div className="flex max-w-2xl flex-wrap justify-end gap-1.5">
       {documents.map((doc) => (
-        <div
+        <button
           key={doc.id}
-          title={doc.id.slice(0, 8)}
-          className="flex items-center gap-1 rounded-lg border border-zinc-950/10 bg-zinc-100 px-2 py-1 text-xs text-zinc-500 dark:border-white/10 dark:bg-zinc-800 dark:text-zinc-400"
+          type="button"
+          title={doc.name ?? doc.id.slice(0, 8)}
+          onClick={() => onOpen(doc)}
+          className="flex items-center gap-1 rounded-lg border border-zinc-950/10 bg-zinc-100 px-2 py-1 text-xs text-zinc-500 transition hover:bg-zinc-200 dark:border-white/10 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
         >
-          <HugeiconsIcon icon={Pdf02Icon} className="size-3.5" />
-          PDF
-        </div>
+          <HugeiconsIcon icon={documentChipIcon(doc.mime)} className="size-3.5" />
+          {doc.name ?? mimeLabel(doc.mime)}
+        </button>
       ))}
     </div>
   )
@@ -211,8 +246,8 @@ export function UserMessage({
   // Attached images (transcript's Images, or the live turn's own
   // optimistic list) — thumbnails render above the text bubble.
   images?: ImageRef[]
-  // Attached PDFs (transcript's Documents, or the live turn's own
-  // optimistic list) — rendered as small chips, never fetched.
+  // Attached documents (transcript's Documents, or the live turn's own
+  // optimistic list) — rendered as small clickable chips.
   documents?: ImageRef[]
   // Optimistic-send local object URLs keyed by attachment id, so a
   // just-sent message's thumbnails render instantly without
@@ -223,10 +258,24 @@ export function UserMessage({
   // component just renders whatever it's handed.
   onRetry?: () => void
 }) {
+  const [viewerAttachment, setViewerAttachment] = useState<ImageRef | null>(null)
+  const openAttachment = (ref: ImageRef) => setViewerAttachment(ref)
   return (
     <div className="flex flex-col items-end gap-1">
-      {images && images.length > 0 && <ImageGrid images={images} localUrls={localUrls} />}
-      {documents && documents.length > 0 && <DocumentChips documents={documents} />}
+      {images && images.length > 0 && (
+        <ImageGrid images={images} localUrls={localUrls} onOpen={openAttachment} />
+      )}
+      {documents && documents.length > 0 && (
+        <DocumentChips documents={documents} onOpen={openAttachment} />
+      )}
+      <AttachmentViewer
+        open={viewerAttachment !== null}
+        onOpenChange={(open) => {
+          if (!open) setViewerAttachment(null)
+        }}
+        attachment={viewerAttachment}
+        localUrl={viewerAttachment ? localUrls?.get(viewerAttachment.id) : undefined}
+      />
       <div className="group/message flex items-end justify-end gap-1">
         <CopyButton text={text} label="Copy message" />
         {text !== '' && (

--- a/web/src/components/missions/FileViewer.tsx
+++ b/web/src/components/missions/FileViewer.tsx
@@ -1,10 +1,6 @@
 import { Download04Icon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
-import hljs from 'highlight.js'
-import { useEffect, useMemo, useState } from 'react'
-import ReactMarkdown from 'react-markdown'
-import rehypeHighlight from 'rehype-highlight'
-import remarkGfm from 'remark-gfm'
+import { useEffect, useState } from 'react'
 import {
   MissionFileTooLargeError,
   downloadMissionFile,
@@ -12,63 +8,16 @@ import {
   missionFilePreviewCap,
 } from '../../api/client'
 import type { MissionFile } from '../../api/types'
+import { FileCodeBlock, FileMarkdownBlock } from '../FilePreviewBlocks'
 import { CopyButton } from '../Message'
 import { errText } from '../settings/util'
 import { Button } from '../ui/button'
-import { codeLanguageOf, previewKindOf } from './filePreviewKind'
-import 'highlight.js/styles/github-dark.css'
+import { previewKindOf } from './filePreviewKind'
 
 function humanSize(n: number): string {
   if (n < 1024) return `${n} B`
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
   return `${(n / 1024 / 1024).toFixed(1)} MB`
-}
-
-// CodeBlock highlights plain (non-markdown) text/code files directly
-// with highlight.js — hljs escapes the source itself before wrapping
-// it in span tags, the same trust model rehype-highlight already uses
-// for markdown in Message.tsx, so the resulting HTML is safe to inject.
-// A line-number gutter runs alongside it, GitHub-style: one row per
-// source line, select-none so copying the code never grabs the numbers.
-function CodeBlock({ code, path }: { code: string; path: string }) {
-  const html = useMemo(() => {
-    const lang = codeLanguageOf(path)
-    const result = lang
-      ? hljs.highlight(code, { language: lang, ignoreIllegals: true })
-      : hljs.highlightAuto(code)
-    return result.value
-  }, [code, path])
-  const lineCount = useMemo(() => code.split('\n').length, [code])
-  return (
-    <div className="flex overflow-x-auto p-3 font-mono text-xs leading-5">
-      <div
-        aria-hidden="true"
-        className="select-none pr-3 text-right text-muted-foreground"
-      >
-        {Array.from({ length: lineCount }, (_, i) => (
-          <div key={i}>{i + 1}</div>
-        ))}
-      </div>
-      <pre className="min-w-0 flex-1 font-mono text-xs leading-5">
-        <code
-          className="hljs !bg-transparent !p-0 font-mono text-xs leading-5"
-          // eslint-disable-next-line react/no-danger -- hljs escapes `code` itself; see CodeBlock comment above.
-          dangerouslySetInnerHTML={{ __html: html }}
-        />
-      </pre>
-    </div>
-  )
-}
-
-function MarkdownBlock({ text, raw }: { text: string; raw: boolean }) {
-  if (raw) return <CodeBlock code={text} path="file.md" />
-  return (
-    <div className="prose prose-sm max-w-none p-3 dark:prose-invert prose-pre:bg-zinc-900">
-      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-        {text}
-      </ReactMarkdown>
-    </div>
-  )
 }
 
 type LoadState =
@@ -197,10 +146,10 @@ export function FileViewer({ missionId, file }: { missionId: string; file: Missi
           </div>
         )}
         {state.status === 'text' && kind === 'markdown' && (
-          <MarkdownBlock text={state.text} raw={showRawMarkdown} />
+          <FileMarkdownBlock text={state.text} raw={showRawMarkdown} />
         )}
         {state.status === 'text' && kind === 'code' && (
-          <CodeBlock code={state.text} path={file.path} />
+          <FileCodeBlock code={state.text} path={file.path} />
         )}
       </div>
     </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -200,3 +200,23 @@
 .dark .shiki-container .shiki span {
   color: var(--shiki-dark);
 }
+
+/* GitHub-style inline code chips in prose bodies (Message.tsx). Kills
+   the typography plugin's backtick pseudo-content and gives inline
+   code a translucent neutral background instead. Excludes fenced
+   code (pre code, .shiki-container code), which CodeBlock renders. */
+.prose :where(code):not(:where(pre code, .shiki-container code))::before,
+.prose :where(code):not(:where(pre code, .shiki-container code))::after {
+  content: none;
+}
+.prose :where(code):not(:where(pre code, .shiki-container code)) {
+  padding: 0.2em 0.4em;
+  border-radius: 6px;
+  font-size: 85%;
+  font-weight: inherit;
+  background-color: rgba(0, 0, 0, 0.06);
+}
+.dark .prose :where(code):not(:where(pre code, .shiki-container code)),
+.prose-invert :where(code):not(:where(pre code, .shiki-container code)) {
+  background-color: rgba(255, 255, 255, 0.12);
+}

--- a/web/src/lib/attachmentCache.ts
+++ b/web/src/lib/attachmentCache.ts
@@ -1,0 +1,7 @@
+// Object URLs fetched per attachment id, cached module-level: an
+// attachment is content-addressed and immutable (D-045), so replaying
+// the same transcript (reload, resumed session) or reopening the
+// viewer for a thumbnail already shown never refetches it. Shared by
+// Message.tsx (thumbnails) and AttachmentViewer.tsx (the fullscreen
+// modal) so the two never double-fetch the same id.
+export const attachmentURLCache = new Map<string, string>()

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -15,7 +15,7 @@ import {
 import type { ChatEvent } from '../api/types'
 import { ActivityPanel } from '../components/Activity'
 import { useAgents } from '../components/AgentPicker'
-import { Composer, type PendingAttachment } from '../components/Composer'
+import { Composer, isDocumentAttachment, type PendingAttachment } from '../components/Composer'
 import { AssistantMessage, CompactionDivider, ErrorMessage, InterruptedMessage, UserMessage } from '../components/Message'
 import { PermissionModal } from '../components/PermissionModal'
 import { Sheet } from '../components/ui/sheet'
@@ -361,16 +361,21 @@ export function Chat({
       localUrlsRef.current.set(userItemId, new Map(ready.map((a) => [a.id, a.previewUrl])))
     }
     const readyImages = ready.filter((a) => a.mime.startsWith('image/'))
-    const readyDocuments = ready.filter((a) => a.mime === 'application/pdf')
+    const readyDocuments = ready.filter((a) => isDocumentAttachment(a.mime))
     setItems((prev) => [
       ...prev,
       {
         id: userItemId,
         role: 'user',
         text: message,
-        images: readyImages.length > 0 ? readyImages.map((a) => ({ id: a.id, mime: a.mime })) : undefined,
+        images:
+          readyImages.length > 0
+            ? readyImages.map((a) => ({ id: a.id, mime: a.mime, name: a.name }))
+            : undefined,
         documents:
-          readyDocuments.length > 0 ? readyDocuments.map((a) => ({ id: a.id, mime: a.mime })) : undefined,
+          readyDocuments.length > 0
+            ? readyDocuments.map((a) => ({ id: a.id, mime: a.mime, name: a.name }))
+            : undefined,
       },
       { id: crypto.randomUUID(), role: 'assistant', ...emptyAssistant() },
     ])
@@ -394,7 +399,8 @@ export function Chat({
           agent: agentName,
           route: routeName || undefined,
           skill_hint: hint,
-          attachments: ready.length > 0 ? ready.map((a) => a.id) : undefined,
+          attachments:
+            ready.length > 0 ? ready.map((a) => ({ id: a.id, name: a.name })) : undefined,
           knowledge: sentKnowledge.length > 0 ? sentKnowledge : undefined,
         },
         (ev: ChatEvent) => {


### PR DESCRIPTION
## What

- Attachment viewer modal in chat: click any thumbnail or document chip to open it. Mime-dispatched: image lightbox, native video/audio players, PDF iframe, source/rendered reader for md/txt (FileViewer's reader blocks extracted into shared FilePreviewBlocks; FileViewer behavior unchanged). Header shows filename, mime, Copy (text kinds), Download, explicit close button.
- Video/audio uploads (chat only): mp4, webm, mp3, wav, ogg. Server-side sniff with normalization of Go's nonstandard DetectContentType outputs (audio/wave -> audio/wav, application/ogg -> audio/ogg). Per-type caps: video 100MB, audio 25MB, others 10MB. Audio is transcribed via the whisper sidecar at send when configured, attach-only otherwise; video is always attach-only and renders a neutralized note into the prompt. Vision-route flip stays images-only (tested). m4a not supported: DetectContentType cannot sniff it reliably and client mime is never trusted.
- Filename threading: upload -> ChatRequest.attachments {id, name} -> session ImageRef/DocumentRef.Name -> projection -> web types. Chips and viewer show real names; pre-existing events fall back to type label + short hash. Additive optional field only, append-only stores untouched.
- Inline markdown code in chat now renders as GitHub-style chips (kills the typography plugin's literal backtick pseudo-content; fenced/shiki blocks excluded).

## Why

Attachments were dead ends: images opened a bare browser tab, chips were inert and all said PDF, and nothing in the transcript knew a file's real name. Media files had no pipeline at all.

## Verification

- `make build test vet lint` green
- web build + lint (0 errors) + 886/886 tests via compose web-dev
- New tests: magic-byte sniff/normalize/cap table tests, whisper-faked audio + video validateAttachments, no-vision-flip assertions, AttachmentViewer per-mime dispatch, clickable chips + name fallback, per-type client caps, close/Download collision regression

Follow-up tracked in #345 (assistant-generated media in responses and mission results).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790517655&installation_model_id=431401&pr_number=346&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F346&signature=ae01d20a9b67d3446cca2a9f593cb3972f594f5318c65611535c375fbabf5771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->