### PR TITLE
feat(media): assistant-generated files in chat and mission results

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
@@ -562,6 +563,37 @@ func main() {
 	}
 	if whisperURL != "" {
 		svc.SetWhisper(whisperURL)
+	}
+
+	// share_file: registered here, not inside buildAgent, since it
+	// needs attachmentStore (built above, after buildAgent). Nil-gated
+	// the same way attachments-dependent wiring above is: no
+	// ATTACHMENTS_DIR means no media emission at all.
+	if attachmentStore != nil {
+		agent.SetMediaSaver(func(ctx context.Context, r io.Reader) (string, string, error) {
+			a, err := attachmentStore.Save(ctx, r)
+			if err != nil {
+				return "", "", err
+			}
+			return a.ID, a.Mime, nil
+		})
+		shareFileTool := builtin.ShareFile(builtin.ShareFileConfig{Root: workspace})
+		current := builtinSet.add(shareFileTool)
+		if conns != nil {
+			swapAgentTools(agent, current, conns, app.Log, toolCalls)
+		} else if constrained, defs, err := compileToolset(current, nil, app.Log, toolCalls); err != nil {
+			app.Log.Warn("share_file tool registration failed; agent keeps its previous tool surface", "error", err)
+		} else {
+			agent.SwapTools(constrained, defs)
+		}
+	}
+
+	// Mission artifact copy: registered here for the same reason
+	// share_file is — needs attachmentStore, built after buildMissions.
+	// Nil-gated on both attachmentStore (ATTACHMENTS_DIR) and
+	// missionDriver (WORKSPACES).
+	if attachmentStore != nil && missionDriver != nil {
+		missionDriver.SetArtifactCopy(destinations.CopyArtifacts(attachmentStore, app.Log))
 	}
 
 	// kb_search: nil-safe wiring, same shape as memory retrieve/extract

--- a/internal/brain/attachments/sniff_test.go
+++ b/internal/brain/attachments/sniff_test.go
@@ -3,6 +3,7 @@ package attachments
 import (
 	"bytes"
 	"errors"
+	"mime"
 	"net/http"
 	"testing"
 )
@@ -71,6 +72,40 @@ func TestSniffAndNormalize(t *testing.T) {
 			got := normalizeSniffedMime(sniffed)
 			if got != tc.want {
 				t.Fatalf("normalizeSniffedMime(DetectContentType(%s)) = %q (raw sniff %q), want %q", tc.name, got, sniffed, tc.want)
+			}
+			if _, ok := allowedExt[got]; !ok {
+				t.Fatalf("%q missing from allowedExt", got)
+			}
+		})
+	}
+}
+
+// TestSniffTextVariantsAllowedAsPlainText confirms csv/json/md content
+// all sniff as text/plain (Go's DetectContentType has no dedicated
+// signature for any of them) and are accepted under the existing
+// text/plain allowlist entry — no new allowedExt types needed for
+// share_file to publish these.
+func TestSniffTextVariantsAllowedAsPlainText(t *testing.T) {
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{"csv", []byte("name,age\nAda,36\n")},
+		{"json", []byte(`{"key":"value"}`)},
+		{"markdown", []byte("# Title\n\nBody text.\n")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mirrors Save's own pipeline: DetectContentType, strip
+			// params via ParseMediaType, then normalize.
+			sniffed := http.DetectContentType(tc.data)
+			bare := sniffed
+			if parsed, _, err := mime.ParseMediaType(sniffed); err == nil {
+				bare = parsed
+			}
+			got := normalizeSniffedMime(bare)
+			if got != "text/plain" {
+				t.Fatalf("normalize(%s) = %q (raw sniff %q), want text/plain", tc.name, got, sniffed)
 			}
 			if _, ok := allowedExt[got]; !ok {
 				t.Fatalf("%q missing from allowedExt", got)

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -1328,6 +1328,10 @@ func (s *Service) relay(reqCtx context.Context, sessionID, userText, route strin
 	// flag a turn whose answer is entirely tool/reasoning traffic with
 	// no text.
 	ranTool := false
+	// mediaRefs accumulates every media ref a tool call emitted this
+	// turn (in call-result order), rendered as a trailing UIBlock at
+	// persist time — see noteToolResult below.
+	var mediaRefs []session.MediaRef
 	// failure captures a terminal EventError/EventIncomplete's code and
 	// message (D-044): the relay used to just drop these on the floor
 	// after streaming them to the client, leaving a turn with nothing
@@ -1362,6 +1366,9 @@ func (s *Service) relay(reqCtx context.Context, sessionID, userText, route strin
 				return
 			}
 			ranTool = true
+			for _, m := range ev.ToolResult.Media {
+				mediaRefs = append(mediaRefs, session.MediaRef{ID: m.ID, Mime: m.Mime, Name: m.Name})
+			}
 			if s.sensitive.Matches(reqCtx, ev.ToolResult.Name, ev.ToolResult.Args) {
 				turnSensitive = true
 			}
@@ -1463,7 +1470,7 @@ func (s *Service) relay(reqCtx context.Context, sessionID, userText, route strin
 			notePermission(ev)
 			bc.publish(ev)
 		}
-		s.persistTurn(sessionID, userText, route, profile, needsTitle, text.String(), segmentStarts, reasoning.String(), meta, usage, sawDone, flushed, turnSensitive || sessionSensitive, failure, ranTool)
+		s.persistTurn(sessionID, userText, route, profile, needsTitle, text.String(), segmentStarts, reasoning.String(), meta, usage, sawDone, flushed, turnSensitive || sessionSensitive, failure, ranTool, mediaRefs)
 		// Terminal persist is now durable: free the broadcaster (closes
 		// every live /live subscriber) and push the session signal, in
 		// that order — mirrors missions.Store's own "publish only after
@@ -1533,7 +1540,7 @@ func stampDuration(base *stream.Meta, start time.Time) *stream.Meta {
 	return &m
 }
 
-func (s *Service) persistTurn(sessionID, userText, route string, profile agents.Agent, needsTitle bool, text string, segmentStarts []int, reasoning string, meta *stream.Meta, usage *stream.Usage, sawDone bool, flushed int, sensitive bool, failure *session.TurnFailed, ranTool bool) {
+func (s *Service) persistTurn(sessionID, userText, route string, profile agents.Agent, needsTitle bool, text string, segmentStarts []int, reasoning string, meta *stream.Meta, usage *stream.Usage, sawDone bool, flushed int, sensitive bool, failure *session.TurnFailed, ranTool bool, mediaRefs []session.MediaRef) {
 	if !sawDone {
 		// Abnormal end: keep the partial durable; the projection
 		// splices it into the next request. Skip when the periodic
@@ -1623,6 +1630,9 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 		if seg := text[start:]; seg != "" {
 			turn.UI.Blocks = append(turn.UI.Blocks, session.UIBlock{Type: "text", Text: seg})
 		}
+	}
+	if len(mediaRefs) > 0 {
+		turn.UI.Blocks = append(turn.UI.Blocks, session.UIBlock{Type: "media", Media: mediaRefs})
 	}
 	if meta != nil {
 		turn.Provider, turn.Model, turn.LedgerID = meta.Provider, meta.Model, meta.LedgerID

--- a/internal/brain/connectors/google_test.go
+++ b/internal/brain/connectors/google_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -769,6 +770,45 @@ func TestGmailReadListsAttachmentsAndReadAttachmentUsesMarkItDown(t *testing.T) 
 	}
 	if !strings.Contains(out, "converted(filename=receipt.pdf") {
 		t.Fatalf("read_attachment = %q, want it routed through markitdown with the given filename", out)
+	}
+}
+
+func TestGmailReadAttachmentEmitsMedia(t *testing.T) {
+	t.Parallel()
+	f := &fakeGoogle{}
+	src, _ := connectedSource(t, f)
+
+	collector := tools.NewCollector(func(_ context.Context, r io.Reader) (string, string, error) {
+		_, _ = io.ReadAll(r)
+		return "att-1", "application/pdf", nil
+	})
+	ctx := tools.WithCollector(t.Context(), collector)
+	if _, err := toolByName(t, src, "mail_read_attachment").Execute(ctx,
+		json.RawMessage(`{"message_id":"m3","filename":"receipt.pdf"}`)); err != nil {
+		t.Fatalf("read_attachment: %v", err)
+	}
+	refs := collector.Drain()
+	if len(refs) != 1 || refs[0].ID != "att-1" || refs[0].Name != "receipt.pdf" {
+		t.Fatalf("refs = %+v, want one media ref for receipt.pdf", refs)
+	}
+}
+
+func TestGmailReadAttachmentEmitFailureDoesNotFailTool(t *testing.T) {
+	t.Parallel()
+	f := &fakeGoogle{}
+	src, _ := connectedSource(t, f)
+
+	collector := tools.NewCollector(func(context.Context, io.Reader) (string, string, error) {
+		return "", "", errors.New("save failed")
+	})
+	ctx := tools.WithCollector(t.Context(), collector)
+	out, err := toolByName(t, src, "mail_read_attachment").Execute(ctx,
+		json.RawMessage(`{"message_id":"m3","filename":"receipt.pdf"}`))
+	if err != nil {
+		t.Fatalf("read_attachment: %v, want the markdown conversion to still succeed", err)
+	}
+	if !strings.Contains(out, "converted(filename=receipt.pdf") {
+		t.Fatalf("out = %q, want it routed through markitdown despite media emit failure", out)
 	}
 }
 

--- a/internal/brain/connectors/google_tools.go
+++ b/internal/brain/connectors/google_tools.go
@@ -1,6 +1,7 @@
 package connectors
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -470,6 +471,14 @@ func (s *googleSource) gmailReadAttachment() *tools.Tool {
 			raw, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(strings.TrimRight(att.Data, "="))
 			if err != nil {
 				return "", fmt.Errorf("decode attachment: %w", err)
+			}
+			// Best-effort: the raw bytes exist here before markitdown
+			// conversion discards them — emit them as media too, but a
+			// failure (unconfigured, unsupported mime, oversize) must
+			// never fail the tool; the markdown conversion below is the
+			// call's actual contract.
+			if collector := tools.CollectorFrom(ctx); collector != nil {
+				_, _ = collector.Emit(ctx, in.Filename, bytes.NewReader(raw))
 			}
 			return markitdown.Convert(ctx, s.g.Client, s.g.MarkItDownURL, in.Filename, "", raw)
 		},

--- a/internal/brain/connectors/imap_test.go
+++ b/internal/brain/connectors/imap_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -269,6 +270,61 @@ func TestIMAPMailReadAttachmentUsesMarkItDown(t *testing.T) {
 	}
 	if !strings.Contains(out, "converted(filename=receipt.pdf, mimetype=application/pdf)") {
 		t.Fatalf("out = %q, want it routed through markitdown", out)
+	}
+}
+
+func TestIMAPMailReadAttachmentEmitsMedia(t *testing.T) {
+	t.Parallel()
+	srv := markitdownStub(t)
+
+	sess := &fakeIMAPSession{attachments: map[imap.UID]map[string]struct {
+		raw []byte
+		ct  string
+	}{
+		9: {"receipt.pdf": {raw: []byte("pdf bytes"), ct: "application/pdf"}},
+	}}
+	src, _ := testIMAPSource(t, imapRow(""), sess)
+	src.markItDownURL = srv.URL
+
+	collector := tools.NewCollector(func(_ context.Context, r io.Reader) (string, string, error) {
+		_, _ = io.ReadAll(r)
+		return "att-1", "application/pdf", nil
+	})
+	ctx := tools.WithCollector(t.Context(), collector)
+	if _, err := imapToolByName(t, src, "mail_read_attachment").Execute(ctx,
+		json.RawMessage(`{"message_id":"9","filename":"receipt.pdf"}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	refs := collector.Drain()
+	if len(refs) != 1 || refs[0].ID != "att-1" || refs[0].Name != "receipt.pdf" {
+		t.Fatalf("refs = %+v, want one media ref for receipt.pdf", refs)
+	}
+}
+
+func TestIMAPMailReadAttachmentEmitFailureDoesNotFailTool(t *testing.T) {
+	t.Parallel()
+	srv := markitdownStub(t)
+
+	sess := &fakeIMAPSession{attachments: map[imap.UID]map[string]struct {
+		raw []byte
+		ct  string
+	}{
+		9: {"receipt.pdf": {raw: []byte("pdf bytes"), ct: "application/pdf"}},
+	}}
+	src, _ := testIMAPSource(t, imapRow(""), sess)
+	src.markItDownURL = srv.URL
+
+	collector := tools.NewCollector(func(context.Context, io.Reader) (string, string, error) {
+		return "", "", errors.New("save failed")
+	})
+	ctx := tools.WithCollector(t.Context(), collector)
+	out, err := imapToolByName(t, src, "mail_read_attachment").Execute(ctx,
+		json.RawMessage(`{"message_id":"9","filename":"receipt.pdf"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v, want the markdown conversion to still succeed", err)
+	}
+	if !strings.Contains(out, "converted(filename=receipt.pdf, mimetype=application/pdf)") {
+		t.Fatalf("out = %q, want it routed through markitdown despite media emit failure", out)
 	}
 }
 

--- a/internal/brain/connectors/imap_tools.go
+++ b/internal/brain/connectors/imap_tools.go
@@ -517,6 +517,14 @@ func (s *imapSource) mailReadAttachment() *tools.Tool {
 			if err != nil {
 				return "", err
 			}
+			// Best-effort: the raw bytes exist here before markitdown
+			// conversion discards them — emit them as media too, but a
+			// failure (unconfigured, unsupported mime, oversize) must
+			// never fail the tool; the markdown conversion below is the
+			// call's actual contract.
+			if collector := tools.CollectorFrom(ctx); collector != nil {
+				_, _ = collector.Emit(ctx, in.Filename, bytes.NewReader(raw))
+			}
 			return markitdown.Convert(ctx, s.client, s.markItDownURL, in.Filename, contentType, raw)
 		},
 	}

--- a/internal/brain/destinations/adapters_test.go
+++ b/internal/brain/destinations/adapters_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
 )
 
 type fakeMailSender struct {
@@ -133,6 +135,32 @@ func TestWebhookAdapterJSONNeverIncludesFiles(t *testing.T) {
 	}
 	if strings.Contains(gotBody, "secret.txt") || strings.Contains(gotBody, "should never appear") {
 		t.Fatalf("webhook JSON body leaked file content: %q", gotBody)
+	}
+}
+
+func TestWebhookAdapterJSONIncludesArtifactRefs(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		gotBody = string(buf)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	a := &WebhookAdapter{}
+	payload := Payload{
+		Body:         "digest",
+		ArtifactRefs: []missions.ArtifactRef{{ID: "att-1", Mime: "text/markdown", Name: "report.md"}},
+	}
+	cfg, _ := json.Marshal(WebhookConfig{URL: srv.URL, Format: "json"})
+	if err := a.Deliver(t.Context(), cfg, "", payload); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	for _, want := range []string{"att-1", "text/markdown", "report.md"} {
+		if !strings.Contains(gotBody, want) {
+			t.Fatalf("webhook JSON body = %q, want it to include %q", gotBody, want)
+		}
 	}
 }
 

--- a/internal/brain/destinations/artifacts_copy.go
+++ b/internal/brain/destinations/artifacts_copy.go
@@ -1,0 +1,48 @@
+package destinations
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+
+	"github.com/SumonMSelim/timothy/internal/brain/attachments"
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+// artifactSaver is the slice of *attachments.Store CopyArtifacts
+// needs — mirrors chat.AttachmentStore's own narrow interface, kept
+// local rather than depending on the concrete *attachments.Store type.
+type artifactSaver interface {
+	Save(ctx context.Context, r io.Reader) (attachments.Attachment, error)
+}
+
+// CopyArtifacts best-effort copies a terminal mission's declared
+// artifact files (the same set resolveArtifactFiles reads for
+// delivery) into the attachment store, returning the resulting refs.
+// A vanished/oversize/disallowed-mime file is silently skipped — see
+// resolveArtifactFiles's own doc comment for that contract; this adds
+// no further failure mode of its own besides the store's Save call,
+// which is likewise skipped on error rather than aborting the rest.
+// Never errors and never fails the mission's terminal transition.
+func CopyArtifacts(saver artifactSaver, log *slog.Logger) missions.ArtifactCopy {
+	return func(ctx context.Context, m missions.Mission) []missions.ArtifactRef {
+		files, texts, _ := resolveArtifactFiles(m)
+		var refs []missions.ArtifactRef
+		save := func(name string, data []byte) {
+			a, err := saver.Save(ctx, bytes.NewReader(data))
+			if err != nil {
+				log.Warn("mission artifact copy skipped", "mission_id", m.ID, "name", name, "error", err)
+				return
+			}
+			refs = append(refs, missions.ArtifactRef{ID: a.ID, Mime: a.Mime, Name: name})
+		}
+		for _, f := range files {
+			save(f.Name, f.Data)
+		}
+		for _, t := range texts {
+			save(t.Name, []byte(t.Content))
+		}
+		return refs
+	}
+}

--- a/internal/brain/destinations/artifacts_copy_test.go
+++ b/internal/brain/destinations/artifacts_copy_test.go
@@ -1,0 +1,91 @@
+package destinations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/attachments"
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+// fakeSaver stubs artifactSaver: every save gets a sequential id, or
+// errors for a name in reject.
+type fakeSaver struct {
+	n      int
+	reject map[string]bool
+}
+
+func (f *fakeSaver) Save(_ context.Context, r io.Reader) (attachments.Attachment, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return attachments.Attachment{}, err
+	}
+	if f.reject[string(data)] {
+		return attachments.Attachment{}, errors.New("unsupported mime")
+	}
+	f.n++
+	return attachments.Attachment{ID: fmt.Sprintf("id-%d", f.n), Mime: "text/plain"}, nil
+}
+
+func TestCopyArtifactsHappyPath(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "out.md"), []byte("report body"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "data.csv"), []byte("a,b\n1,2\n"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	m := missions.Mission{ID: "m1", Workspace: root, Spec: missions.Spec{Units: []missions.PlanUnit{
+		{Artifacts: []string{"out.md", "data.csv"}},
+	}}}
+
+	saver := &fakeSaver{}
+	refs := CopyArtifacts(saver, slog.Default())(t.Context(), m)
+	if len(refs) != 2 {
+		t.Fatalf("refs = %+v, want 2", refs)
+	}
+	names := map[string]bool{}
+	for _, r := range refs {
+		names[r.Name] = true
+		if r.ID == "" || r.Mime == "" {
+			t.Fatalf("ref missing id/mime: %+v", r)
+		}
+	}
+	if !names["out.md"] || !names["data.csv"] {
+		t.Fatalf("refs = %+v, want out.md and data.csv", refs)
+	}
+}
+
+func TestCopyArtifactsSkipsSaveFailure(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "ok.md"), []byte("fine"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "bad.html"), []byte("<html>rejected</html>"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	m := missions.Mission{ID: "m1", Workspace: root, Spec: missions.Spec{Units: []missions.PlanUnit{
+		{Artifacts: []string{"ok.md", "bad.html"}},
+	}}}
+
+	saver := &fakeSaver{reject: map[string]bool{"<html>rejected</html>": true}}
+	refs := CopyArtifacts(saver, slog.Default())(t.Context(), m)
+	if len(refs) != 1 || refs[0].Name != "ok.md" {
+		t.Fatalf("refs = %+v, want only ok.md (bad.html's save failure must not fail the copy)", refs)
+	}
+}
+
+func TestCopyArtifactsNothingDeclared(t *testing.T) {
+	m := missions.Mission{ID: "m1"}
+	saver := &fakeSaver{}
+	refs := CopyArtifacts(saver, slog.Default())(t.Context(), m)
+	if len(refs) != 0 {
+		t.Fatalf("refs = %+v, want none", refs)
+	}
+}

--- a/internal/brain/destinations/render.go
+++ b/internal/brain/destinations/render.go
@@ -35,6 +35,12 @@ type Payload struct {
 	// attached — see resolveArtifactFiles.
 	TextArtifacts []TextArtifact `json:"-"`
 	OversizeFiles []string       `json:"-"`
+	// ArtifactRefs are the mission's artifact-store refs (id/mime/name,
+	// never bytes — D-045), copied in by the terminal-transition
+	// artifact-copy hook before Render runs. Unlike Files/TextArtifacts,
+	// these DO serialize: webhook's JSON body is the only delivery kind
+	// with no other way to reference an artifact's content.
+	ArtifactRefs []missions.ArtifactRef `json:"artifact_refs,omitempty"`
 }
 
 // Render builds a mission's delivery Payload: body is a short
@@ -82,6 +88,7 @@ func Render(m missions.Mission, webBaseURL string, events []missions.Event, loc 
 		Files:         files,
 		TextArtifacts: texts,
 		OversizeFiles: oversize,
+		ArtifactRefs:  m.ArtifactRefs,
 	}
 }
 

--- a/internal/brain/destinations/render_test.go
+++ b/internal/brain/destinations/render_test.go
@@ -23,6 +23,15 @@ func TestRender(t *testing.T) {
 		}
 	})
 
+	t.Run("carries artifact refs from the mission", func(t *testing.T) {
+		withRefs := m
+		withRefs.ArtifactRefs = []missions.ArtifactRef{{ID: "att-1", Mime: "text/markdown", Name: "report.md"}}
+		p := Render(withRefs, "", nil, time.UTC)
+		if len(p.ArtifactRefs) != 1 || p.ArtifactRefs[0] != withRefs.ArtifactRefs[0] {
+			t.Fatalf("ArtifactRefs = %+v, want %+v", p.ArtifactRefs, withRefs.ArtifactRefs)
+		}
+	})
+
 	t.Run("with web base url", func(t *testing.T) {
 		p := Render(m, "https://timothy.example.lan/", nil, time.UTC)
 		if len(p.Links) != 1 || p.Links[0] != "https://timothy.example.lan/missions/m1" {

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -149,6 +149,12 @@ type Agent struct {
 	// main.go wires it, and always a no-op once the manager is ready
 	// (the hook should return instantly by then).
 	waitToolsReady func(context.Context)
+
+	// mediaSaver persists media a tool emits during its call (see
+	// tools.Collector). nil (the default) leaves media emission
+	// unconfigured — a tool's Emit call then always errors, same as
+	// ATTACHMENTS_DIR unset gates chat's own attachment upload path.
+	mediaSaver tools.SaveFunc
 }
 
 func NewAgent(gw Gateway, exec Executor, perms Permissioner, outputs OutputSink, audit AuditSink, events EventAppender, broker *PermBroker, defs []provider.ToolDef, logger *slog.Logger) *Agent {
@@ -243,6 +249,14 @@ func (a *Agent) SetForceRouteByConnector(names func(context.Context) []string, r
 
 // SetWaitToolsReady registers the turn-entry readiness hook (see the
 // waitToolsReady field doc). Startup-time only.
+// SetMediaSaver wires the media-emission collector's save backend
+// (see tools.Collector, tools.SaveFunc). Optional — nil (the default)
+// leaves media emission unconfigured, same nil-gate shape as
+// SetForceRoute and friends.
+func (a *Agent) SetMediaSaver(fn tools.SaveFunc) {
+	a.mediaSaver = fn
+}
+
 func (a *Agent) SetWaitToolsReady(fn func(context.Context)) {
 	a.waitToolsReady = fn
 }
@@ -727,6 +741,11 @@ func (a *Agent) executeAll(ctx context.Context, exec Executor, sessionID string,
 
 func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string, call provider.ToolCall, toolNames map[string]bool, unattended bool, emit func(stream.StreamEvent)) provider.ToolResult {
 	start := time.Now()
+	// A fresh collector per call: media a tool emits during THIS
+	// Execute rides on ctx, drained right below, never leaking into a
+	// concurrent sibling call's result.
+	collector := tools.NewCollector(a.mediaSaver)
+	ctx = tools.WithCollector(ctx, collector)
 	// A panicking tool must become feedback the model can read (D-009),
 	// never a process crash: executeOne runs inside an errgroup worker,
 	// and an unrecovered panic there takes down the whole brain — every
@@ -741,6 +760,14 @@ func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string,
 		return a.resolveAndRun(ctx, exec, sessionID, call, toolNames, unattended, emit)
 	}()
 	isError := status != "ok"
+	media := collector.Drain()
+	if len(media) > tools.MaxMediaPerCall {
+		media = media[:tools.MaxMediaPerCall]
+	}
+	streamMedia := make([]stream.MediaRef, len(media))
+	for i, m := range media {
+		streamMedia[i] = stream.MediaRef{ID: m.ID, Mime: m.Mime, Name: m.Name}
+	}
 
 	if status == "ok" {
 		offloaded, err := a.offloadIfBig(ctx, sessionID, call.Name, content)
@@ -793,6 +820,7 @@ func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string,
 	emit(stream.StreamEvent{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{
 		ID: call.ID, Name: call.Name, Status: status,
 		Digest: digest, DurationMs: duration.Milliseconds(), Args: call.Input,
+		Media: streamMedia,
 	}})
 
 	return provider.ToolResult{ID: call.ID, Content: content, IsError: isError}

--- a/internal/brain/missions/artifact_copy_test.go
+++ b/internal/brain/missions/artifact_copy_test.go
@@ -1,0 +1,91 @@
+package missions
+
+import (
+	"context"
+	"testing"
+)
+
+// TestDriverCopiesArtifactsBeforeDestinationDelivery covers copyArtifacts'
+// ordering guarantee: the artifact-copy hook runs and its refs are
+// persisted BEFORE destinations delivery sees the mission, so a
+// webhook payload built from the same reloaded Mission can include
+// them.
+func TestDriverCopiesArtifactsBeforeDestinationDelivery(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8, DestinationIDs: []string{"d1"}})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner)
+	wantRefs := []ArtifactRef{{ID: "att-1", Mime: "text/plain", Name: "out.md"}}
+	d.SetArtifactCopy(func(ctx context.Context, m Mission) []ArtifactRef {
+		return wantRefs
+	})
+	deliverRec := &recordingDeliver{}
+	d.SetDestinationDeliver(deliverRec.fn())
+
+	driveN(t, d, "m1", 4) // explore -> plan -> execute -> review -> done
+
+	waitForDeliverCalls(t, deliverRec, 1)
+	got := deliverRec.calls[0].mission.ArtifactRefs
+	if len(got) != 1 || got[0] != wantRefs[0] {
+		t.Fatalf("destination delivery saw ArtifactRefs = %+v, want %+v", got, wantRefs)
+	}
+
+	m, _ := store.Get(context.Background(), "m1")
+	if len(m.ArtifactRefs) != 1 || m.ArtifactRefs[0] != wantRefs[0] {
+		t.Fatalf("persisted mission ArtifactRefs = %+v, want %+v", m.ArtifactRefs, wantRefs)
+	}
+}
+
+// TestDriverSkipsArtifactCopyOnFailed covers the same done-only gate
+// deliverToDestinations already has: a mission that fails must not run
+// the artifact-copy hook.
+func TestDriverSkipsArtifactCopyOnFailed(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 1})
+	runner := &scriptedRunner{
+		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "nope"}},
+	}
+	d := testDriver(store, runner)
+	called := false
+	d.SetArtifactCopy(func(ctx context.Context, m Mission) []ArtifactRef {
+		called = true
+		return nil
+	})
+
+	driveN(t, d, "m1", 1)
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseFailed {
+		t.Fatalf("mission phase = %s, want failed", m.Phase)
+	}
+	if called {
+		t.Fatal("artifact copy hook must not run on a failed transition")
+	}
+}
+
+// TestDriverSkipsArtifactCopyWhenNilHook confirms the nil-safe default
+// never panics and leaves ArtifactRefs empty.
+func TestDriverSkipsArtifactCopyWhenNilHook(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner) // no SetArtifactCopy call: d.artifactCopy stays nil
+
+	driveN(t, d, "m1", 4)
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseDone {
+		t.Fatalf("mission phase = %s, want done", m.Phase)
+	}
+	if len(m.ArtifactRefs) != 0 {
+		t.Fatalf("ArtifactRefs = %+v, want none", m.ArtifactRefs)
+	}
+}

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -75,6 +75,7 @@ type driverStore interface {
 	SetFinalOutput(ctx context.Context, id, text string) error
 	SetExploreNotes(ctx context.Context, id, notes string) error
 	SetNameIfEmpty(ctx context.Context, id, name string) error
+	SetArtifactRefs(ctx context.Context, id string, refs []ArtifactRef) error
 	AppendProgress(ctx context.Context, id, note string) error
 	Spend(ctx context.Context, missionID string) (MissionSpend, error)
 }
@@ -197,6 +198,15 @@ type Driver struct {
 	// would cycle; cmd/brain/main.go's wiring closure bridges the two,
 	// same as SetMemoryExtract does for memoryd.
 	deliverDestinations DestinationDeliver
+
+	// artifactCopy wires the best-effort copy of declared artifact
+	// files into the attachment store on a mission's terminal done
+	// transition (see SetArtifactCopy / copyArtifacts) — nil-safe:
+	// unset leaves ArtifactRefs empty, same as before this existed. A
+	// func type for the same import-cycle reason as deliverDestinations:
+	// the copy needs the attachment store and destinations' own
+	// artifact-path resolution, both out of missions' reach.
+	artifactCopy ArtifactCopy
 
 	// onTerminal wires the workflows engine's reaction to a mission
 	// reaching a terminal phase (see SetOnTerminal / fireOnTerminal) —
@@ -456,6 +466,46 @@ func (d *Driver) deliverToDestinations(m Mission, terminal Phase) {
 	go d.deliverDestinations(rctx, m, m.DestinationIDs) //nolint:gosec // G118: deliberate — the mission is already terminal, delivery must outlive whatever request/ctx observed that transition
 }
 
+// ArtifactCopy best-effort copies a terminal mission's declared
+// artifact files into the attachment store and returns the resulting
+// refs — destinations.CopyArtifacts satisfies this signature. Must
+// never error or block indefinitely: a vanished/oversize/disallowed-
+// mime file is simply skipped, never fails the transition.
+type ArtifactCopy func(ctx context.Context, m Mission) []ArtifactRef
+
+// SetArtifactCopy wires the artifact-copy hook fired on a mission's
+// terminal done transition (see copyArtifacts) — a setter for the same
+// reason SetDestinationDeliver is. Optional — nil leaves ArtifactRefs
+// empty, same as a mission with no declared artifacts.
+func (d *Driver) SetArtifactCopy(fn ArtifactCopy) {
+	d.artifactCopy = fn
+}
+
+// copyArtifacts runs the artifact-copy hook exactly on a transition
+// into phase=done (mirrors deliverToDestinations) and persists the
+// resulting refs onto the mission row — SYNCHRONOUS, unlike delivery/
+// memory extraction below, so deliverToDestinations' webhook payload
+// (built from the same reloaded Mission) can include them. Bounded so
+// a slow attachment store never stalls the terminal-transition path
+// indefinitely.
+func (d *Driver) copyArtifacts(ctx context.Context, id string, m Mission, terminal Phase) Mission {
+	if d.artifactCopy == nil || terminal != PhaseDone {
+		return m
+	}
+	cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	refs := d.artifactCopy(cctx, m)
+	if len(refs) == 0 {
+		return m
+	}
+	if err := d.store.SetArtifactRefs(ctx, id, refs); err != nil {
+		d.log.Warn("driver: persist artifact refs failed", "mission_id", id, "error", err)
+		return m
+	}
+	m.ArtifactRefs = refs
+	return m
+}
+
 // OnTerminal reacts to a mission reaching a terminal phase —
 // workflows.Engine.OnMissionTerminal satisfies this. Fire-and-forget by
 // contract, same as DestinationDeliver: it must never return an error,
@@ -534,9 +584,13 @@ func (d *Driver) fireOnComplete(ctx context.Context, id string, m Mission) {
 //  3. name backfill (SYNCHRONOUS — see backfillMissionName)
 //  4. one mission reload, AFTER the backfill above, so every hook past
 //     this point sees a stable, already-backfilled name
-//  5. memory extraction, destinations delivery, workflow onTerminal —
-//     each handed the SAME reloaded Mission, no hook reloads on its own
-//  6. fireOnComplete, done transitions only
+//  5. artifact copy (SYNCHRONOUS, done transitions only — see
+//     copyArtifacts) — runs BEFORE the hooks below so destinations
+//     delivery's webhook payload can include the resulting refs
+//  6. memory extraction, destinations delivery, workflow onTerminal —
+//     each handed the SAME reloaded (and artifact-copy-updated)
+//     Mission, no hook reloads on its own
+//  7. fireOnComplete, done transitions only
 //
 // Each hook may still dispatch its own goroutine (memory/destinations/
 // workflow all remain fire-and-forget past this function returning) —
@@ -569,6 +623,7 @@ func (d *Driver) runTerminalHooks(ctx context.Context, id string, terminal Phase
 		d.log.Warn("driver: terminal hooks: reload mission failed", "mission_id", id, "error", err)
 		return
 	}
+	m = d.copyArtifacts(ctx, id, m, terminal)
 	d.extractMissionMemory(ctx, m, terminal, reason)
 	d.deliverToDestinations(m, terminal)
 	d.fireOnTerminal(m)

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -187,6 +187,15 @@ func (f *fakeStore) SetNameIfEmpty(ctx context.Context, id, name string) error {
 	return nil
 }
 
+func (f *fakeStore) SetArtifactRefs(ctx context.Context, id string, refs []ArtifactRef) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	m := f.missions[id]
+	m.ArtifactRefs = refs
+	f.missions[id] = m
+	return nil
+}
+
 func (f *fakeStore) AppendProgress(ctx context.Context, id, note string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -33,7 +33,7 @@ type Mission struct {
 	// Empty means kb_search is never offered on this mission's turns.
 	Knowledge []string `json:"knowledge,omitempty"`
 	Phase     Phase    `json:"phase"`
-	Status        Status `json:"status"`
+	Status    Status   `json:"status"`
 	// FailureReason is derived (no column) from this mission's latest
 	// mission.failed event's payload.reason — "cancelled" or
 	// "max_iterations" (statemachine.go) — set only by Store.List/Get for
@@ -192,6 +192,22 @@ type Mission struct {
 	// workflow engine reads terminal missions, it never mutates them.
 	WorkflowRunID string `json:"workflow_run_id,omitempty"`
 	WorkflowStep  string `json:"workflow_step,omitempty"`
+	// ArtifactRefs are this mission's declared artifact files, best-
+	// effort copied into the attachment store on the terminal done
+	// transition (driver.go's copyArtifacts) — survive workspace
+	// deletion, unlike the live-workspace files ArtifactsSection
+	// browses. Empty until that copy runs, or if it finds nothing to
+	// copy.
+	ArtifactRefs []ArtifactRef `json:"artifact_refs,omitempty"`
+}
+
+// ArtifactRef is one mission artifact file copied into the attachment
+// store at terminal done — id names an attachments-store row, mirrors
+// MissionAttachment's shape (id/mime/name, never bytes — D-045).
+type ArtifactRef struct {
+	ID   string `json:"id"`
+	Mime string `json:"mime"`
+	Name string `json:"name,omitempty"`
 }
 
 // MissionAttachment is one PDF document attached at mission create

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -51,7 +51,7 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 	pending_permission_danger, pending_permission_rationale, auto_approve_safe, last_evidence,
 	explore_notes, replan_used, schedule_id, session_id, harness, environment, repo_url, connector_id, on_complete,
 	branch_pattern, commit_style, parent_mission_id, parent_context, attachments, destination_ids, light, final_output, created_at, updated_at,
-	workflow_run_id, workflow_step`
+	workflow_run_id, workflow_step, artifact_refs`
 
 // scanMissionWithFailureReason is scanMission plus one extra trailing
 // column: the mission's latest mission.failed event's payload.reason
@@ -60,13 +60,13 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 // web UI's mission list/detail views read.
 func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 	var (
-		m                                             Mission
-		agentID, scheduleID, sessionID, parentMission *string
-		phase, status                                 string
-		pendingPermission                             *string
-		spec, progress, attachmentsRaw, knowledgeRaw  []byte
-		failureReason                                 *string
-		workflowRunID                                 *string
+		m                                                             Mission
+		agentID, scheduleID, sessionID, parentMission                 *string
+		phase, status                                                 string
+		pendingPermission                                             *string
+		spec, progress, attachmentsRaw, knowledgeRaw, artifactRefsRaw []byte
+		failureReason                                                 *string
+		workflowRunID                                                 *string
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
@@ -78,11 +78,12 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &attachmentsRaw,
 		&m.DestinationIDs, &m.Light, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
-		&workflowRunID, &m.WorkflowStep,
+		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw,
 		&failureReason); err != nil {
 		return Mission{}, err
 	}
 	_ = json.Unmarshal(knowledgeRaw, &m.Knowledge)
+	_ = json.Unmarshal(artifactRefsRaw, &m.ArtifactRefs)
 	if agentID != nil {
 		m.AgentID = *agentID
 	}
@@ -142,12 +143,12 @@ const failureReasonJoin = `
 
 func scanMission(row pgx.Row) (Mission, error) {
 	var (
-		m                                             Mission
-		agentID, scheduleID, sessionID, parentMission *string
-		phase, status                                 string
-		pendingPermission                             *string
-		spec, progress, attachmentsRaw, knowledgeRaw  []byte
-		workflowRunID                                 *string
+		m                                                             Mission
+		agentID, scheduleID, sessionID, parentMission                 *string
+		phase, status                                                 string
+		pendingPermission                                             *string
+		spec, progress, attachmentsRaw, knowledgeRaw, artifactRefsRaw []byte
+		workflowRunID                                                 *string
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
@@ -159,10 +160,11 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &attachmentsRaw,
 		&m.DestinationIDs, &m.Light, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
-		&workflowRunID, &m.WorkflowStep); err != nil {
+		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw); err != nil {
 		return Mission{}, err
 	}
 	_ = json.Unmarshal(knowledgeRaw, &m.Knowledge)
+	_ = json.Unmarshal(artifactRefsRaw, &m.ArtifactRefs)
 	if agentID != nil {
 		m.AgentID = *agentID
 	}
@@ -383,6 +385,28 @@ func (s *Store) SetSpec(ctx context.Context, id string, spec Spec) error {
 	}
 	if _, err := db.Exec(ctx, `UPDATE missions SET spec = $2, updated_at = now() WHERE id = $1`, id, data); err != nil {
 		return fmt.Errorf("missions set spec: %w", err)
+	}
+	return nil
+}
+
+// SetArtifactRefs persists the mission's artifact-store refs (see
+// driver.go's copyArtifacts) — bypasses the state machine, same as
+// SetSpec, since it runs from a terminal-transition hook rather than
+// an Advance step.
+func (s *Store) SetArtifactRefs(ctx context.Context, id string, refs []ArtifactRef) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("missions set artifact refs: %w", err)
+	}
+	if refs == nil {
+		refs = []ArtifactRef{}
+	}
+	data, err := json.Marshal(refs)
+	if err != nil {
+		return fmt.Errorf("missions set artifact refs: %w", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE missions SET artifact_refs = $2, updated_at = now() WHERE id = $1`, id, data); err != nil {
+		return fmt.Errorf("missions set artifact refs: %w", err)
 	}
 	return nil
 }

--- a/internal/brain/session/events.go
+++ b/internal/brain/session/events.go
@@ -92,9 +92,23 @@ type DocumentRef struct {
 
 // UIBlock is one renderable piece of an assistant turn.
 type UIBlock struct {
-	Type string         `json:"type"` // text | reasoning | tool_call | meta
+	Type string         `json:"type"` // text | reasoning | tool_call | meta | media
 	Text string         `json:"text,omitempty"`
 	Meta map[string]any `json:"meta,omitempty"`
+	// Media carries refs only (never bytes, D-045) for a "media" block
+	// — content a tool call generated during the turn (share_file,
+	// mail_read_attachment). Additive: absent on every block type that
+	// predates this.
+	Media []MediaRef `json:"media,omitempty"`
+}
+
+// MediaRef points at one attachment-store item a tool generated during
+// a turn — id, mime, and an optional display name, never bytes
+// (D-045). Mirrors stream.MediaRef; converted at the chat.go boundary.
+type MediaRef struct {
+	ID   string `json:"id"`
+	Mime string `json:"mime"`
+	Name string `json:"name,omitempty"`
 }
 
 // TurnMemory is the structured residue distilled from a turn's raw

--- a/internal/brain/session/projection.go
+++ b/internal/brain/session/projection.go
@@ -178,15 +178,34 @@ func livePendingSeq(events []Event) int64 {
 	return -1
 }
 
-// renderAssistant serializes a turn for the LLM: the message plus,
-// for events written before turn_memory became its own kind, the
-// embedded residue block.
+// renderAssistant serializes a turn for the LLM: the message, a
+// one-line note per generated media block (never inline content —
+// D-045), plus, for events written before turn_memory became its own
+// kind, the embedded residue block.
 func renderAssistant(t AssistantTurn) string {
+	msg := t.LLM.Message
+	for _, b := range t.UI.Blocks {
+		if b.Type != "media" {
+			continue
+		}
+		for _, m := range b.Media {
+			label := m.Name
+			if label == "" {
+				label = m.ID
+			}
+			note := fmt.Sprintf("[generated file: %s (%s)]", label, m.Mime)
+			if msg == "" {
+				msg = note
+			} else {
+				msg += "\n\n" + note
+			}
+		}
+	}
 	block := renderTurnMemory(t.LLM.TurnMemory)
 	if block == "" {
-		return t.LLM.Message
+		return msg
 	}
-	return t.LLM.Message + "\n\n" + block
+	return msg + "\n\n" + block
 }
 
 // renderTurnMemory serializes residue into its compact deterministic

--- a/internal/brain/tools/builtin/sharefile.go
+++ b/internal/brain/tools/builtin/sharefile.go
@@ -1,0 +1,106 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// ShareFileConfig fixes the directory share_file may read from.
+type ShareFileConfig struct {
+	Root string
+}
+
+type shareFileArgs struct {
+	Path string `json:"path"`
+	Name string `json:"name"`
+}
+
+// ShareFile reads a file from the workspace and publishes it to the
+// user-facing transcript as generated media — the way an assistant
+// turn hands back an image, document, or other file it produced, as
+// opposed to write_file's plain confirmation text. The attachment
+// store's own allowlist and per-type size caps are the only limits
+// (tools.Collector.Emit -> the wired SaveFunc); a rejected type or an
+// oversize file comes back as a clear tool error, nothing is silently
+// dropped.
+func ShareFile(cfg ShareFileConfig) *tools.Tool {
+	return &tools.Tool{
+		Name: "share_file",
+		Description: `Publishes a file from the workspace to the user as generated media (an image, document, or other file the turn produced).
+
+Arguments:
+- path (string, required): workspace-relative file path, e.g.
+  "chart.png" or "reports/summary.pdf". Absolute paths and paths
+  containing ".." are rejected.
+- name (string, optional): a display name shown to the user; defaults
+  to the file's base name.
+
+Returns a confirmation naming the stored id and detected mime type.
+Rejected file types (e.g. HTML) come back as a clear error instead of
+publishing anything.
+
+Example: {"path": "chart.png"}`,
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"path": {
+					"type": "string",
+					"description": "Workspace-relative file path to share"
+				},
+				"name": {
+					"type": "string",
+					"description": "Optional display name; defaults to the file's base name"
+				}
+			},
+			"required": ["path"],
+			"additionalProperties": false
+		}`),
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
+			var args shareFileArgs
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return "", fmt.Errorf("invalid arguments: %w", err)
+			}
+			if cfg.Root == "" {
+				return "", fmt.Errorf("share_file is not configured with a workspace")
+			}
+			if args.Path == "" {
+				return "", fmt.Errorf("path is empty")
+			}
+			if filepath.IsAbs(args.Path) {
+				return "", fmt.Errorf("path must be workspace-relative, got an absolute path")
+			}
+			cleaned := filepath.Clean(args.Path)
+			target := filepath.Join(cfg.Root, cleaned)
+			if err := tools.WithinRoot(cfg.Root, target); err != nil {
+				return "", err
+			}
+			f, err := os.Open(target) //nolint:gosec // G304: path is root-confined by WithinRoot above
+			if err != nil {
+				if os.IsNotExist(err) {
+					return "", fmt.Errorf("no file at %q", cleaned)
+				}
+				return "", fmt.Errorf("open file: %w", err)
+			}
+			defer func() { _ = f.Close() }()
+
+			name := args.Name
+			if name == "" {
+				name = filepath.Base(cleaned)
+			}
+			collector := tools.CollectorFrom(ctx)
+			if collector == nil {
+				return "", fmt.Errorf("media emission is not configured")
+			}
+			ref, err := collector.Emit(ctx, name, f)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("shared %q as %s (%s)", name, ref.ID, ref.Mime), nil
+		},
+	}
+}

--- a/internal/brain/tools/builtin/sharefile_test.go
+++ b/internal/brain/tools/builtin/sharefile_test.go
@@ -1,0 +1,129 @@
+package builtin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// fakeSaver stubs tools.SaveFunc: every save gets a sequential id and
+// echoes back a fixed mime, or errors when maxBytes is exceeded.
+func fakeSaver(maxBytes int) tools.SaveFunc {
+	n := 0
+	return func(_ context.Context, r io.Reader) (string, string, error) {
+		data, err := io.ReadAll(r)
+		if err != nil {
+			return "", "", err
+		}
+		if maxBytes > 0 && len(data) > maxBytes {
+			return "", "", errors.New("file too large for its type")
+		}
+		n++
+		return fmt.Sprintf("id-%d", n), "image/png", nil
+	}
+}
+
+func TestShareFile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "chart.png"), []byte("fake-png-bytes"), 0o644); err != nil { //nolint:gosec // test fixture
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "reports"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "reports", "big.png"), bytes.Repeat([]byte("x"), 100), 0o644); err != nil { //nolint:gosec // test fixture
+		t.Fatal(err)
+	}
+	outsideDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outsideDir, "secret.png"), []byte("nope"), 0o644); err != nil { //nolint:gosec // test fixture
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideDir, filepath.Join(root, "escape")); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+
+	call := func(tool *tools.Tool, ctx context.Context, path, name string) (string, error) {
+		args, _ := json.Marshal(shareFileArgs{Path: path, Name: name})
+		return tool.Execute(ctx, args)
+	}
+
+	t.Run("happy path", func(t *testing.T) {
+		tool := ShareFile(ShareFileConfig{Root: root})
+		ctx := tools.WithCollector(context.Background(), tools.NewCollector(fakeSaver(0)))
+		out, err := call(tool, ctx, "chart.png", "")
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if !strings.Contains(out, "id-1") || !strings.Contains(out, "image/png") {
+			t.Fatalf("out = %q", out)
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		tool := ShareFile(ShareFileConfig{Root: root})
+		ctx := tools.WithCollector(context.Background(), tools.NewCollector(fakeSaver(0)))
+		if _, err := call(tool, ctx, "nope.png", ""); err == nil {
+			t.Fatal("missing file accepted")
+		}
+	})
+
+	t.Run("oversize file", func(t *testing.T) {
+		tool := ShareFile(ShareFileConfig{Root: root})
+		ctx := tools.WithCollector(context.Background(), tools.NewCollector(fakeSaver(10)))
+		if _, err := call(tool, ctx, "reports/big.png", ""); err == nil {
+			t.Fatal("oversize file accepted")
+		}
+	})
+
+	t.Run("rejects absolute path", func(t *testing.T) {
+		tool := ShareFile(ShareFileConfig{Root: root})
+		ctx := tools.WithCollector(context.Background(), tools.NewCollector(fakeSaver(0)))
+		if _, err := call(tool, ctx, "/etc/passwd", ""); err == nil {
+			t.Fatal("absolute path accepted")
+		}
+	})
+
+	t.Run("rejects escape via ..", func(t *testing.T) {
+		tool := ShareFile(ShareFileConfig{Root: root})
+		ctx := tools.WithCollector(context.Background(), tools.NewCollector(fakeSaver(0)))
+		if _, err := call(tool, ctx, "../outside.png", ""); err == nil {
+			t.Fatal(".. escape accepted")
+		}
+	})
+
+	t.Run("rejects symlink escape", func(t *testing.T) {
+		tool := ShareFile(ShareFileConfig{Root: root})
+		ctx := tools.WithCollector(context.Background(), tools.NewCollector(fakeSaver(0)))
+		if _, err := call(tool, ctx, "escape/secret.png", ""); err == nil {
+			t.Fatal("symlink escape accepted")
+		}
+	})
+
+	t.Run("rejects empty path and unconfigured root", func(t *testing.T) {
+		tool := ShareFile(ShareFileConfig{Root: root})
+		ctx := tools.WithCollector(context.Background(), tools.NewCollector(fakeSaver(0)))
+		if _, err := call(tool, ctx, "", ""); err == nil {
+			t.Fatal("empty path accepted")
+		}
+		bare := ShareFile(ShareFileConfig{})
+		if _, err := call(bare, ctx, "chart.png", ""); err == nil {
+			t.Fatal("unconfigured root accepted")
+		}
+	})
+
+	t.Run("no collector configured", func(t *testing.T) {
+		tool := ShareFile(ShareFileConfig{Root: root})
+		if _, err := call(tool, context.Background(), "chart.png", ""); err == nil {
+			t.Fatal("missing collector accepted")
+		}
+	})
+}

--- a/internal/brain/tools/media.go
+++ b/internal/brain/tools/media.go
@@ -1,0 +1,100 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// MediaRef points at one piece of media a tool emitted during its
+// Execute call — an id in the attachment store plus the metadata a UI
+// needs to render it, never bytes (D-045).
+type MediaRef struct {
+	ID   string
+	Mime string
+	Name string
+}
+
+// MaxMediaPerCall caps how many media items one tool call may emit;
+// beyond this Emit returns an error instead of silently truncating, so
+// the tool's own text feedback can tell the model what happened.
+const MaxMediaPerCall = 4
+
+// SaveFunc persists r's bytes and returns the stored id and sniffed
+// mime type — attachments.Store.Save's shape, defined locally so tools
+// doesn't import the attachments package (would cycle through
+// builtin's callers).
+type SaveFunc func(ctx context.Context, r io.Reader) (id, mime string, err error)
+
+// Collector accumulates media a single tool call emits. One Collector
+// is attached to the context per Execute call by the loop, then
+// drained after Execute returns.
+type Collector struct {
+	saver SaveFunc
+	mu    sync.Mutex
+	refs  []MediaRef
+}
+
+// NewCollector returns a Collector backed by saver. saver nil means
+// media emission is unconfigured; Emit then always errors.
+func NewCollector(saver SaveFunc) *Collector {
+	return &Collector{saver: saver}
+}
+
+// Emit saves r's content and records it as one of this call's media
+// refs. Beyond MaxMediaPerCall, or after Execute already returned an
+// error, this cannot be avoided without either failing the whole tool
+// call or the caller checking length after the fact — the error return
+// lets the tool decide.
+func (c *Collector) Emit(ctx context.Context, name string, r io.Reader) (MediaRef, error) {
+	if c == nil || c.saver == nil {
+		return MediaRef{}, fmt.Errorf("media emission is not configured")
+	}
+	c.mu.Lock()
+	if len(c.refs) >= MaxMediaPerCall {
+		c.mu.Unlock()
+		return MediaRef{}, fmt.Errorf("this call already emitted the maximum of %d media items", MaxMediaPerCall)
+	}
+	c.mu.Unlock()
+
+	id, mime, err := c.saver(ctx, r)
+	if err != nil {
+		return MediaRef{}, fmt.Errorf("save media: %w", err)
+	}
+	ref := MediaRef{ID: id, Mime: mime, Name: name}
+
+	c.mu.Lock()
+	c.refs = append(c.refs, ref)
+	c.mu.Unlock()
+	return ref, nil
+}
+
+// Drain returns every ref emitted so far and clears the collector.
+func (c *Collector) Drain() []MediaRef {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	refs := c.refs
+	c.refs = nil
+	return refs
+}
+
+// collectorCtxKey is the context key a Collector rides on.
+type collectorCtxKey struct{}
+
+// WithCollector attaches c to ctx for the duration of one tool Execute
+// call.
+func WithCollector(ctx context.Context, c *Collector) context.Context {
+	return context.WithValue(ctx, collectorCtxKey{}, c)
+}
+
+// CollectorFrom returns the Collector attached to ctx, or nil if none
+// — a tool built before media emission existed, or a call context the
+// loop never attached one to.
+func CollectorFrom(ctx context.Context) *Collector {
+	c, _ := ctx.Value(collectorCtxKey{}).(*Collector)
+	return c
+}

--- a/internal/gateway/stream/events.go
+++ b/internal/gateway/stream/events.go
@@ -56,11 +56,25 @@ type ToolResultEvent struct {
 	Status     string `json:"status"`
 	Digest     string `json:"digest,omitempty"`
 	DurationMs int64  `json:"duration_ms"`
+	// Media is any media the tool emitted during this call (refs only,
+	// never bytes — D-045), additive: empty on every call that emits
+	// none.
+	Media []MediaRef `json:"media,omitempty"`
 	// Args is the call's own input, brain-internal only (json:"-": never
 	// reaches the client wire); chat's sensitivity check needs it to
 	// resolve which account a unified aggregate tool call (e.g.
 	// mail_search) actually routed to (session.SensitiveTools.Matches).
 	Args json.RawMessage `json:"-"`
+}
+
+// MediaRef points at one attachment-store item a tool generated during
+// its call — id, mime, and an optional display name, never bytes
+// (D-045). Mirrors tools.MediaRef; defined here (not imported from
+// tools) since stream sits lower in the import graph.
+type MediaRef struct {
+	ID   string `json:"id"`
+	Mime string `json:"mime"`
+	Name string `json:"name,omitempty"`
 }
 
 // PermissionRequestEvent tells the client the turn parked waiting for

--- a/migrations/0010_missions.sql
+++ b/migrations/0010_missions.sql
@@ -202,7 +202,14 @@ CREATE TABLE IF NOT EXISTS missions (
     -- NULL/'' for an ordinary mission. The workflow engine reads these
     -- via mission terminal events; it never writes mission state.
     workflow_run_id        uuid,
-    workflow_step          text NOT NULL DEFAULT ''
+    workflow_step          text NOT NULL DEFAULT '',
+    -- ArtifactRefs: this mission's declared artifact files, best-effort
+    -- copied into the attachment store on the terminal done transition
+    -- (driver.go's copyArtifacts) — a jsonb array of {id, mime, name},
+    -- mirroring attachments' own shape. Never bytes (D-045). Lets a
+    -- mission's result artifacts survive workspace deletion, unlike the
+    -- live-workspace files ArtifactsSection browses.
+    artifact_refs          jsonb NOT NULL DEFAULT '[]'
 );
 
 CREATE INDEX IF NOT EXISTS missions_status_idx ON missions (status);

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -14,12 +14,21 @@ export interface ToolCallEvent {
   input?: unknown
 }
 
+// MediaRef points at one attachment-store item a tool generated during
+// a call — id, mime, and an optional display name, never bytes.
+export interface MediaRef {
+  id: string
+  mime: string
+  name?: string
+}
+
 export interface ToolResultEvent {
   id: string
   name: string
   status: 'ok' | 'error' | 'denied'
   digest?: string
   duration_ms: number
+  media?: MediaRef[]
 }
 
 export interface PermissionRequestEvent {
@@ -124,8 +133,9 @@ export interface SessionMeta {
 }
 
 export interface UIBlock {
-  type: 'text' | 'reasoning'
-  text: string
+  type: 'text' | 'reasoning' | 'media'
+  text?: string
+  media?: MediaRef[]
 }
 
 // ImageRef is one attachment carried by a user transcript item — the
@@ -771,6 +781,11 @@ export interface Mission {
   // MissionDetail.tsx's mutually exclusive light/!light Result blocks).
   light?: boolean
   final_output?: string
+  // artifact_refs are this mission's declared artifact files, best-
+  // effort copied into the attachment store on the terminal done
+  // transition — survive workspace deletion, unlike the live-workspace
+  // files ArtifactsSection browses. Absent/empty until that copy runs.
+  artifact_refs?: MediaRef[]
   created_at: string
   updated_at: string
 }

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -151,6 +151,26 @@ describe('AssistantMessage', () => {
     )
   })
 
+  it('renders a document chip for generated media from a live tool_result', () => {
+    const msg = play([
+      { type: 'chunk', text: 'Here is the file.' },
+      {
+        type: 'tool_result',
+        tool_result: {
+          id: 'call-1',
+          name: 'share_file',
+          status: 'ok',
+          duration_ms: 5,
+          media: [{ id: 'att-1', mime: 'application/pdf', name: 'report.pdf' }],
+        },
+      },
+      { type: 'meta', session_id: 's' },
+    ])
+    render(<AssistantMessage msg={msg} />)
+
+    expect(screen.getByText('report.pdf')).toBeInTheDocument()
+  })
+
   it('renders errors as errors', () => {
     const msg = play([
       { type: 'error', error: { code: 'chain_exhausted', message: 'all failed', retryable: false } },

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -15,7 +15,7 @@ import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { fetchAttachmentBlob } from '../api/client'
-import type { ImageRef } from '../api/types'
+import type { ImageRef, MediaRef } from '../api/types'
 import { ActivityLine } from './Activity'
 import { AttachmentViewer, mimeLabel } from './AttachmentViewer'
 import { CodeBlock } from './CodeBlock'
@@ -102,20 +102,24 @@ function AuthedImage({
   )
 }
 
-// ImageGrid renders a user message's attached images above the text.
-// Optimistic items carry their own local object URL (localUrls keyed
-// by id) so the just-sent thumbnail never round-trips the network.
+// ImageGrid renders a set of image attachments (a user message's
+// attached images, or an assistant turn's generated media) above the
+// text. Optimistic items carry their own local object URL (localUrls
+// keyed by id) so the just-sent thumbnail never round-trips the
+// network.
 function ImageGrid({
   images,
   localUrls,
   onOpen,
+  align = 'end',
 }: {
-  images: ImageRef[]
+  images: (ImageRef | MediaRef)[]
   localUrls?: Map<string, string>
-  onOpen: (img: ImageRef) => void
+  onOpen: (img: ImageRef | MediaRef) => void
+  align?: 'start' | 'end'
 }) {
   return (
-    <div className="flex max-w-2xl flex-wrap justify-end gap-1.5">
+    <div className={cn('flex max-w-2xl flex-wrap gap-1.5', align === 'end' ? 'justify-end' : 'justify-start')}>
       {images.map((img) => (
         <AuthedImage
           key={img.id}
@@ -138,13 +142,21 @@ function documentChipIcon(mime: string) {
   return Pdf02Icon
 }
 
-// DocumentChips renders a user message's attached documents (PDF,
-// text, markdown, video, audio) as small clickable chips that open the
-// AttachmentViewer modal — labeled by mime, showing the original
-// filename when present.
-function DocumentChips({ documents, onOpen }: { documents: ImageRef[]; onOpen: (doc: ImageRef) => void }) {
+// DocumentChips renders a set of non-image attachments (a user
+// message's documents, or an assistant turn's generated media) as
+// small clickable chips that open the AttachmentViewer modal — labeled
+// by mime, showing the original filename when present.
+function DocumentChips({
+  documents,
+  onOpen,
+  align = 'end',
+}: {
+  documents: (ImageRef | MediaRef)[]
+  onOpen: (doc: ImageRef | MediaRef) => void
+  align?: 'start' | 'end'
+}) {
   return (
-    <div className="flex max-w-2xl flex-wrap justify-end gap-1.5">
+    <div className={cn('flex max-w-2xl flex-wrap gap-1.5', align === 'end' ? 'justify-end' : 'justify-start')}>
       {documents.map((doc) => (
         <button
           key={doc.id}
@@ -157,6 +169,33 @@ function DocumentChips({ documents, onOpen }: { documents: ImageRef[]; onOpen: (
           {doc.name ?? mimeLabel(doc.mime)}
         </button>
       ))}
+    </div>
+  )
+}
+
+// GeneratedMedia renders an assistant turn's tool-generated media
+// (share_file, mail_read_attachment): image mimes as thumbnails via
+// AuthedImage, everything else as a chip — same rendering the user
+// message's own attachments use, opening the same AttachmentViewer.
+function GeneratedMedia({ media }: { media: MediaRef[] }) {
+  const [viewerAttachment, setViewerAttachment] = useState<MediaRef | null>(null)
+  const images = media.filter((m) => m.mime.startsWith('image/'))
+  const documents = media.filter((m) => !m.mime.startsWith('image/'))
+  return (
+    <div className="flex flex-col items-start gap-1.5">
+      {images.length > 0 && (
+        <ImageGrid images={images} align="start" onOpen={(img) => setViewerAttachment(img)} />
+      )}
+      {documents.length > 0 && (
+        <DocumentChips documents={documents} align="start" onOpen={(doc) => setViewerAttachment(doc)} />
+      )}
+      <AttachmentViewer
+        open={viewerAttachment !== null}
+        onOpenChange={(open) => {
+          if (!open) setViewerAttachment(null)
+        }}
+        attachment={viewerAttachment}
+      />
     </div>
   )
 }
@@ -433,6 +472,8 @@ export function AssistantMessage({
         </ReactMarkdown>
         {msg.streaming && msg.permissions.length === 0 && <span className="animate-pulse">▍</span>}
       </div>
+
+      {msg.media.length > 0 && <GeneratedMedia media={msg.media} />}
 
       {citations.length > 0 && <SourcesPanel citations={citations} />}
 

--- a/web/src/components/missions/ArtifactRefsSection.test.tsx
+++ b/web/src/components/missions/ArtifactRefsSection.test.tsx
@@ -1,0 +1,39 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MediaRef } from '../../api/types'
+import { ArtifactRefsSection } from './ArtifactRefsSection'
+
+vi.mock('../../api/client', () => ({
+  fetchAttachmentBlob: vi.fn(),
+}))
+
+import { fetchAttachmentBlob } from '../../api/client'
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.mocked(fetchAttachmentBlob).mockResolvedValue(new Blob(['hello']))
+})
+
+describe('ArtifactRefsSection', () => {
+  it('renders nothing when there are no refs', () => {
+    const { container } = render(<ArtifactRefsSection refs={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a chip per ref, labeled by name or the mime label', () => {
+    const refs: MediaRef[] = [
+      { id: 'att-1', mime: 'text/markdown', name: 'report.md' },
+      { id: 'att-2', mime: 'application/pdf' },
+    ]
+    render(<ArtifactRefsSection refs={refs} />)
+    expect(screen.getByText('report.md')).toBeInTheDocument()
+    expect(screen.getByText('PDF')).toBeInTheDocument()
+  })
+
+  it('opens the viewer when a chip is clicked', () => {
+    const refs: MediaRef[] = [{ id: 'att-1', mime: 'text/markdown', name: 'report.md' }]
+    render(<ArtifactRefsSection refs={refs} />)
+    fireEvent.click(screen.getByText('report.md'))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/missions/ArtifactRefsSection.tsx
+++ b/web/src/components/missions/ArtifactRefsSection.tsx
@@ -1,0 +1,50 @@
+import { File01Icon, FileMusicIcon, FileVideoIcon, Pdf02Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import { useState } from 'react'
+import type { MediaRef } from '../../api/types'
+import { AttachmentViewer, mimeLabel } from '../AttachmentViewer'
+
+// artifactChipIcon picks a chip's icon by mime, same mapping as
+// Message.tsx's documentChipIcon.
+function artifactChipIcon(mime: string) {
+  if (mime.startsWith('video/')) return FileVideoIcon
+  if (mime.startsWith('audio/')) return FileMusicIcon
+  if (mime === 'text/plain' || mime === 'text/markdown') return File01Icon
+  return Pdf02Icon
+}
+
+// ArtifactRefsSection renders a terminal mission's artifact-store refs
+// (mission.artifact_refs) as clickable chips through AttachmentViewer —
+// unlike ArtifactsSection (which browses the live workspace and
+// disappears once it's deleted), these refs are durable copies that
+// keep working after mission/workspace cleanup.
+export function ArtifactRefsSection({ refs }: { refs: MediaRef[] }) {
+  const [viewerAttachment, setViewerAttachment] = useState<MediaRef | null>(null)
+  if (refs.length === 0) return null
+  return (
+    <section>
+      <h2 className="mb-2 text-sm font-semibold tracking-tight">Artifacts</h2>
+      <div className="flex flex-wrap gap-1.5">
+        {refs.map((ref) => (
+          <button
+            key={ref.id}
+            type="button"
+            title={ref.name ?? ref.id.slice(0, 8)}
+            onClick={() => setViewerAttachment(ref)}
+            className="flex items-center gap-1 rounded-lg border border-zinc-950/10 bg-zinc-100 px-2 py-1 text-xs text-zinc-500 transition hover:bg-zinc-200 dark:border-white/10 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+          >
+            <HugeiconsIcon icon={artifactChipIcon(ref.mime)} className="size-3.5" />
+            {ref.name ?? mimeLabel(ref.mime)}
+          </button>
+        ))}
+      </div>
+      <AttachmentViewer
+        open={viewerAttachment !== null}
+        onOpenChange={(open) => {
+          if (!open) setViewerAttachment(null)
+        }}
+        attachment={viewerAttachment}
+      />
+    </section>
+  )
+}

--- a/web/src/lib/chat.ts
+++ b/web/src/lib/chat.ts
@@ -1,4 +1,4 @@
-import type { ChatEvent, PermissionRequestEvent, Usage } from '../api/types'
+import type { ChatEvent, MediaRef, PermissionRequestEvent, Usage } from '../api/types'
 
 // ToolRun is one tool call's lifecycle inside a live turn.
 export interface ToolRun {
@@ -19,6 +19,9 @@ export interface AssistantState {
   notices: string[]
   tools: ToolRun[]
   permissions: PermissionRequestEvent[]
+  // media accumulates every ref a tool call emitted this turn, in
+  // call-result order.
+  media: MediaRef[]
   error?: string
   meta?: {
     provider?: string
@@ -35,7 +38,7 @@ export interface AssistantState {
 }
 
 export function emptyAssistant(): AssistantState {
-  return { text: '', reasoning: '', notices: [], tools: [], permissions: [], streaming: true }
+  return { text: '', reasoning: '', notices: [], tools: [], permissions: [], media: [], streaming: true }
 }
 
 // applyEvent folds one SSE event into the assistant message state.
@@ -75,6 +78,7 @@ export function applyEvent(msg: AssistantState, ev: ChatEvent): AssistantState {
         // Clear only the prompt tied to THIS call; other parallel
         // calls may still be parked awaiting their own decision.
         permissions: msg.permissions.filter((p) => p.call_id !== r.id),
+        media: r.media && r.media.length > 0 ? [...msg.media, ...r.media] : msg.media,
       }
     }
     case 'permission_request': {

--- a/web/src/lib/transcript.test.ts
+++ b/web/src/lib/transcript.test.ts
@@ -65,6 +65,25 @@ describe('fromTranscript', () => {
     expect(items[0]).toMatchObject({ role: 'assistant', text: 'part one\n\npart two' })
   })
 
+  it('replays a media block into the assistant item', () => {
+    const items = fromTranscript([
+      {
+        seq: 1,
+        kind: 'assistant',
+        blocks: [
+          { type: 'text', text: 'here you go' },
+          { type: 'media', media: [{ id: 'att-1', mime: 'image/png', name: 'chart.png' }] },
+        ],
+        created_at: at,
+      },
+    ])
+    expect(items[0]).toMatchObject({
+      role: 'assistant',
+      text: 'here you go',
+      media: [{ id: 'att-1', mime: 'image/png', name: 'chart.png' }],
+    })
+  })
+
   it('omits meta when the turn has no provider attribution', () => {
     const items = fromTranscript([
       { seq: 1, kind: 'assistant', blocks: [{ type: 'text', text: 'x' }], created_at: at },

--- a/web/src/lib/transcript.ts
+++ b/web/src/lib/transcript.ts
@@ -58,6 +58,7 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
       notices: [],
       tools,
       permissions,
+      media: [],
       streaming: false,
       meta: undefined,
     })
@@ -87,11 +88,13 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
       case 'assistant': {
         let text = ''
         let reasoning = ''
+        let media: NonNullable<(typeof item)['blocks']>[number]['media'] = undefined
         for (const b of item.blocks ?? []) {
           // An empty block serializes without its text key (omitempty);
           // naive concat would render a literal "undefined".
           if (b.type === 'text') text += (text && b.text ? '\n\n' : '') + (b.text ?? '')
           else if (b.type === 'reasoning') reasoning += b.text ?? ''
+          else if (b.type === 'media' && b.media) media = [...(media ?? []), ...b.media]
         }
         const tools = pendingTools.map((p) => toToolRun(p.tool))
         const permissions = pendingPermissions.map((p) => p.permission)
@@ -105,6 +108,7 @@ export function fromTranscript(items: TranscriptItem[]): ChatItem[] {
           notices: [],
           tools,
           permissions,
+          media: media ?? [],
           streaming: false,
           meta: item.provider
             ? {

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -23,6 +23,7 @@ vi.mock('../api/client', () => ({
   downloadMissionArchive: vi.fn(),
   pushMission: vi.fn(),
   openMissionPR: vi.fn(),
+  fetchAttachmentBlob: vi.fn(),
 }))
 
 import {
@@ -545,6 +546,23 @@ describe('MissionDetail', () => {
 
     fireEvent.click(screen.getByText('Show exploration'))
     expect(screen.getByText('three').tagName).toBe('STRONG')
+  })
+
+  it('omits the Artifacts refs section when artifact_refs is absent', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(screen.queryByText('att-1')).toBeNull()
+  })
+
+  it('renders artifact ref chips when artifact_refs is set', async () => {
+    vi.mocked(getMission).mockResolvedValue({
+      ...baseMission,
+      artifact_refs: [{ id: 'att-1', mime: 'text/markdown', name: 'report.md' }],
+    })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+
+    expect(screen.getByText('report.md')).toBeInTheDocument()
   })
 
   it('shows the permission banner with tool detail when pending_permission is set', async () => {

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -24,6 +24,7 @@ import {
   sendMissionNote,
 } from '../api/client'
 import type { Mission, MissionEvent, MissionPROpenedPayload, MissionUsage, Schedule } from '../api/types'
+import { ArtifactRefsSection } from '../components/missions/ArtifactRefsSection'
 import { ArtifactsSection } from '../components/missions/ArtifactsSection'
 import { PermissionBanner } from '../components/missions/PermissionBanner'
 import { PlanSection } from '../components/missions/PlanSection'
@@ -823,6 +824,8 @@ export function MissionDetail() {
             />
           </section>
         )}
+
+      <ArtifactRefsSection refs={mission.artifact_refs ?? []} />
 
       <ArtifactsSection missionId={id} phase={mission.phase} workspace={mission.workspace} />
 


### PR DESCRIPTION
## What

**Chat media**: tools can now hand the user files. A turn-scoped collector rides the context (no Execute signature change, cap 4 per call); emitted files save into the content-addressed attachment store, travel as refs on the tool result, persist as a new `media` UIBlock, stream over SSE, and render as chips/thumbnails opening in the attachment viewer (#346). LLM context gets a one-line generated-file note, never bytes.

Producers:
- New `share_file` builtin: publishes a workspace file (WithinRoot containment, store allowlist/caps, permission-gated, not exempt)
- `mail_read_attachment`: additionally emits the original attachment bytes as media (best-effort; markdown return unchanged)

**Mission artifacts**: at the terminal done transition, declared artifacts copy best-effort into the attachment store (before delivery) and persist as `artifact_refs` on the mission row, surviving workspace deletion. Mission detail gets a durable artifact-chips section alongside the live file browser; webhook payloads now carry artifact refs (previously none).

**Security**: text/html stays rejected by the attachment allowlist. The download route serves stored mime without nosniff; model/worker-authored HTML rendering same-origin is the XSS path the mission files route already closed. Caps and allowlists remain Go code.

## Schema

`migrations/0010_missions.sql` edited in place (pre-release convention): `missions.artifact_refs jsonb NOT NULL DEFAULT '[]'`. Deployed instances need the pre-flight ALTER before the next release deploy.

## Verification

- `make build test vet lint` green; `go vet -tags integration ./internal/...` clean
- Web build + lint (0 errors) + 893/893 tests
- Live smoke: chat turn shell -> share_file -> media block streamed + persisted, bytes exact via GET /v1/attachments
- `make canary` PASS; canary artifact confirmed copied into the attachment store at terminal transition

Closes #345.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790529063&installation_model_id=431401&pr_number=347&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F347&signature=a744ed5b71981ba404a2638cf13e3174615147cf73c24f45257557497542e35b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->