### PR TITLE
feat(connectors): rename, unified mcp tools, verb-first tool naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ PostgreSQL database + React web UI, run via Docker Compose
 | `memoryd`    | Internal memory service: pgvector recall                                |
 | `sandboxd`   | Holds the Docker socket; per-mission sandbox containers                 |
 | `web`        | React UI (:3300)                                                        |
-| `searxng`    | Metasearch backend for web_search                                       |
+| `searxng`    | Metasearch backend for search_web                                       |
 | `markitdown` | Python sidecar: file → markdown                                         |
 | `whisper`    | Python sidecar: local speech-to-text                                    |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ PostgreSQL database + React web UI, run via Docker Compose
 | `memoryd`      | Internal memory service: pgvector recall                                                                       |
 | `sandboxd`     | Internal service holding the Docker socket: per-mission sandbox containers, brain calls it via `sandboxclient` |
 | `web`          | React UI (:3300)                                                                                               |
-| `searxng`      | Internal metasearch backend for the web_search tool                                                            |
+| `searxng`      | Internal metasearch backend for the search_web tool                                                            |
 | `markitdown`   | Internal Python sidecar (`markitdown-svc/`): file→markdown                                                     |
 | `whisper`      | Internal Python sidecar (`whisper-svc/`): local speech-to-text                                                 |
 | (local models) | Native host Ollama at host.docker.internal:11434, registered as openaicompat provider                          |
@@ -59,8 +59,8 @@ First run: `cp deploy/env.example deploy/.env` and set
   (orchestration above missions: steps + outcome-driven edges, env-gated
   `WORKFLOWS_ENABLED`), `connectors`
   (google/microsoft/github/mcp/imap/caldav, unified capability tools:
-  `mail_search`, `mail_read`, `mail_send`, `calendar_list_events`,
-  `calendar_create_event` route to the right connector/account via an
+  `search_mail`, `read_mail`, `send_mail`, `list_calendar_events`,
+  `create_calendar_event` route to the right connector/account via an
   `account` parameter — see `manager.go`'s `aggregateTools`),
   `destinations` (mission result delivery: email/webhook/
   telegram), `kb` (knowledge-base collections/documents), `attachments`,

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Go microservices behind a single public API, one PostgreSQL database, React web 
 | `memoryd`    | Internal memory service: pgvector-backed recall                                               |
 | `sandboxd`   | Internal service holding the Docker socket: per-mission sandbox containers                    |
 | `web`        | React + Tailwind interface: chat, missions, usage, settings                                   |
-| `searxng`    | Internal metasearch backend for the web_search tool                                           |
+| `searxng`    | Internal metasearch backend for the search_web tool                                           |
 | `markitdown` | Internal Python sidecar: file→markdown conversion                                             |
 | `whisper`    | Internal Python sidecar: local speech-to-text for the web mic button (opt-in, off by default) |
 

--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -1446,10 +1446,18 @@ func compileToolset(builtins, connectorTools []*tools.Tool, log *slog.Logger, to
 }
 
 // swapAgentTools recompiles builtin + connector tools and swaps them
-// into the agent. A compile failure keeps the previous surface — a
-// broken connector schema must not take down the builtins.
+// into the agent. builtins' own names are passed to conns.Tools as the
+// reserved set: a connector tool (MCP raw names now included, see
+// Manager.Tools) never aggregates under a name the agent already has
+// from somewhere else, so it stays namespaced instead of shadowing it.
+// A compile failure keeps the previous surface — a broken connector
+// schema must not take down the builtins.
 func swapAgentTools(agent *loop.Agent, builtins []*tools.Tool, conns *connectors.Manager, log *slog.Logger, toolCalls *prometheus.CounterVec) {
-	constrained, defs, err := compileToolset(builtins, conns.Tools(), log, toolCalls)
+	reserved := make(map[string]bool, len(builtins))
+	for _, t := range builtins {
+		reserved[t.Name] = true
+	}
+	constrained, defs, err := compileToolset(builtins, conns.Tools(reserved), log, toolCalls)
 	if err != nil {
 		log.Warn("connector toolset compile failed; keeping previous tools", "error", err)
 		return

--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -197,7 +197,7 @@ func main() {
 		return flags.Value(ctx, settings.ValueSensitiveToolRoute)
 	}
 	// fxStore backs both the daily rate fetch (below) and
-	// currency_convert's table-first lookup (buildAgent) — one fetch,
+	// convert_currency's table-first lookup (buildAgent) — one fetch,
 	// one table, shared by the live tool and by display conversion
 	// (Analytics, mission usage) elsewhere in this file.
 	fxStore := fxrates.NewStore(app.DB)
@@ -410,7 +410,7 @@ func main() {
 	}
 
 	// sensitiveAccountConnector resolves a unified aggregate tool call
-	// (e.g. mail_search) to the connector name its account actually
+	// (e.g. search_mail) to the connector name its account actually
 	// routed to: the unified surface's counterpart to
 	// sensitiveConnectorNames' MCP-prefix matching, since an aggregate
 	// tool's own name carries no connector name to prefix-match against.
@@ -596,7 +596,7 @@ func main() {
 		missionDriver.SetArtifactCopy(destinations.CopyArtifacts(attachmentStore, app.Log))
 	}
 
-	// kb_search: nil-safe wiring, same shape as memory retrieve/extract
+	// search_kb: nil-safe wiring, same shape as memory retrieve/extract
 	// above — mc satisfies IngestDocument/KBSearch unconditionally, so
 	// this always wires (memoryd unreachable surfaces as a per-call
 	// error, not a nil-gate, since MEMORYD_URL always resolves to a
@@ -667,7 +667,7 @@ func main() {
 // so it's built once here rather than each caller decoding the master
 // key independently. A nil return (with an error to log) means an
 // unusable master key or init failure; callers nil-gate on it.
-// kbReadFromStore builds the kb_read backing lookup: the full stored
+// kbReadFromStore builds the read_kb backing lookup: the full stored
 // markdown straight from brain's own kb store — no memoryd round trip.
 // A document outside the caller's allowed collections reads as not
 // found (never "forbidden": the distinction would leak that the id
@@ -739,7 +739,7 @@ func buildConnectors(db *pgpool.Pool, secrets *secretstore.Store, log *slog.Logg
 		goog.MarkItDownURL = markItDownURL
 		msft.MarkItDownURL = markItDownURL
 	} else {
-		log.Warn("MARKITDOWN_URL not set; gmail_read/mail_read fall back to a snippet or are unavailable for attachments")
+		log.Warn("MARKITDOWN_URL not set; read_mail falls back to a snippet or is unavailable for attachments")
 	}
 	return mgr, goog, msft, markItDownURL
 }
@@ -874,10 +874,10 @@ func missionAgentResolver(agentReg *agents.Store) missions.AgentResolver {
 // intersected with every built connector's ReadOnly-marked, non-MCP
 // tools (connectors.Manager.ReadOnlyTools already excludes MCP and
 // non-read-only tools, and aggregates the rest into one unified tool
-// per capability, e.g. "mail_search" regardless of how many accounts
+// per capability, e.g. "search_mail" regardless of how many accounts
 // serve it. tools.ToolMatches is the same rule filterDefs/matchGrant
 // use: its exact-match branch is what actually fires here, since an
-// allowlist entry like "mail_search" IS the aggregated tool's own name,
+// allowlist entry like "search_mail" IS the aggregated tool's own name,
 // with no connector-prefix suffix to resolve.
 func missionConnectorReadsResolver(agentReg *agents.Store, conns *connectors.Manager) missions.ConnectorReadsResolver {
 	return func(ctx context.Context, agentID string) []*tools.Tool {
@@ -949,7 +949,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	// sandboxMgr routes model-authored command execution (the
 	// worker/reviewer shell, verify_cmd) OUT of brain's own process,
 	// through sandboxd, into a per-mission Docker container.
-	// kb_search: nil-safe (mc is never nil, MEMORYD_URL always resolves
+	// search_kb: nil-safe (mc is never nil, MEMORYD_URL always resolves
 	// to a default), same shape as chat's own SetKBSearch wiring — the
 	// mission's OWN Knowledge snapshot (never a live agent lookup)
 	// scopes collections per turn (missions.nativeRunner.kbSearchTool).

--- a/cmd/brain/main_test.go
+++ b/cmd/brain/main_test.go
@@ -14,7 +14,7 @@ import (
 func TestIntersectReadOnlyConnectorToolsMatchesAllowlist(t *testing.T) {
 	available := []*tools.Tool{
 		{Name: "gmail_gmail_search", ReadOnly: true},
-		{Name: "google-calendar_calendar_list_events", ReadOnly: true},
+		{Name: "google-calendar_list_calendar_events", ReadOnly: true},
 		{Name: "gmail_gmail_send"}, // not read-only; ReadOnlyTools would never hand this in, but the matcher must not care
 	}
 
@@ -31,13 +31,13 @@ func TestIntersectReadOnlyConnectorToolsMatchesAllowlist(t *testing.T) {
 		t.Fatalf("empty allowlist = %v, want nil", got)
 	}
 
-	got = intersectReadOnlyConnectorTools([]string{"calendar_list_events", "gmail_search"}, available)
+	got = intersectReadOnlyConnectorTools([]string{"list_calendar_events", "gmail_search"}, available)
 	names = nil
 	for _, tl := range got {
 		names = append(names, tl.Name)
 	}
 	slices.Sort(names)
-	want := []string{"gmail_gmail_search", "google-calendar_calendar_list_events"}
+	want := []string{"gmail_gmail_search", "google-calendar_list_calendar_events"}
 	slices.Sort(want)
 	if !slices.Equal(names, want) {
 		t.Fatalf("intersect = %v, want %v", names, want)

--- a/internal/brain/agents/agents.go
+++ b/internal/brain/agents/agents.go
@@ -54,7 +54,7 @@ type Agent struct {
 	// means inherit from settings; meaningless outside kind=coding.
 	Harness string `json:"harness"`
 	// Knowledge names the kb_collections this agent may search with
-	// kb_search (D-060) — empty means none (opt-in only, same as
+	// search_kb (D-060) — empty means none (opt-in only, same as
 	// Skills/Tools). Collection scoping is enforced in Go at the tool
 	// call, never left to a prompt.
 	Knowledge []string `json:"knowledge"`

--- a/internal/brain/agents/agents_integration_test.go
+++ b/internal/brain/agents/agents_integration_test.go
@@ -66,7 +66,7 @@ func TestAgentCRUDAndResolve(t *testing.T) {
 	id, err := s.Create(ctx, Agent{
 		Name: name, Description: "d", PromptOverlay: "overlay",
 		Route: "research", Skills: []string{"research-task"},
-		Tools: []string{"web_search"}, Memory: true, Enabled: true,
+		Tools: []string{"search_web"}, Memory: true, Enabled: true,
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)

--- a/internal/brain/api/connectors.go
+++ b/internal/brain/api/connectors.go
@@ -110,6 +110,8 @@ func failConnector(w http.ResponseWriter, err error) {
 		jsonError(w, http.StatusNotFound, "not_found", err.Error())
 	case errors.Is(err, connectors.ErrUnsupported):
 		jsonError(w, http.StatusUnprocessableEntity, "unsupported", err.Error())
+	case errors.Is(err, connectors.ErrNameConflict):
+		jsonError(w, http.StatusConflict, "name_conflict", err.Error())
 	default:
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 	}

--- a/internal/brain/api/tools_test.go
+++ b/internal/brain/api/tools_test.go
@@ -17,7 +17,7 @@ func TestToolsEndpointListsLiveSurface(t *testing.T) {
 	a, _, _ := testAPI(t, "tok", nil)
 	m := mux(a)
 	a.registerTools(m.Handle, stubToolset{defs: []provider.ToolDef{
-		{Name: "web_search", Description: "Search the web", InputSchema: []byte(`{}`)},
+		{Name: "search_web", Description: "Search the web", InputSchema: []byte(`{}`)},
 		{Name: "github_create_issue", Description: "Create a GitHub issue", InputSchema: []byte(`{}`)},
 	}})
 
@@ -30,7 +30,7 @@ func TestToolsEndpointListsLiveSurface(t *testing.T) {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
 	body := decodeToolsBody(t, w.Body.Bytes())
-	if len(body.Tools) != 2 || body.Tools[0].Name != "web_search" || body.Tools[1].Name != "github_create_issue" {
+	if len(body.Tools) != 2 || body.Tools[0].Name != "search_web" || body.Tools[1].Name != "github_create_issue" {
 		t.Fatalf("tools = %+v", body.Tools)
 	}
 	// Only name/description are exposed — never the input schema

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -153,8 +153,8 @@ type Service struct {
 	markitdownHTTP *http.Client                         // shared client for the markitdown sidecar call
 	whisperURL     string                               // "": audio attachments attach without a transcript (WHISPER_URL unset)
 	whisperHTTP    *http.Client                         // shared client for the whisper sidecar call
-	kbSearch       KBSearch                             // nil: kb_search never offered, regardless of agent config
-	kbRead         KBRead                               // nil: kb_read never offered, regardless of agent config
+	kbSearch       KBSearch                             // nil: search_kb never offered, regardless of agent config
+	kbRead         KBRead                               // nil: read_kb never offered, regardless of agent config
 	logger         *slog.Logger
 
 	grants Granter // nil: chat never seeds standing grants (today's behavior)
@@ -264,15 +264,15 @@ func (s *Service) SetWhisper(url string) {
 // Knowledge list (D-060: enforced here in Go, never a prompt).
 type KBSearch func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error)
 
-// SetKBSearch wires the kb_search tool's backing search call. Optional
-// — nil means kb_search is never offered on any turn, regardless of an
+// SetKBSearch wires the search_kb tool's backing search call. Optional
+// — nil means search_kb is never offered on any turn, regardless of an
 // agent's Knowledge list (same "the dependency's absence turns the
 // feature off entirely" contract as SetMemoryRetrieve/SetAttachments).
 func (s *Service) SetKBSearch(fn KBSearch) { s.kbSearch = fn }
 
-// kbSearchTool builds this turn's kb_search ExtraTool bound to
+// kbSearchTool builds this turn's search_kb ExtraTool bound to
 // collections (the serving agent's Knowledge unioned with the
-// session's own pinned list), or nil when kb_search must not be
+// session's own pinned list), or nil when search_kb must not be
 // offered: no backing search call wired, or collections is empty
 // (opt-in-only, same contract as Skills/Tools — this is the "exclude
 // from the turn" choice, matching load_skill's precedent of leaving a
@@ -293,11 +293,11 @@ func (s *Service) kbSearchTool(collections []string) *tools.Tool {
 // is the serving agent's own Knowledge list.
 type KBRead func(ctx context.Context, documentID string, collectionNames []string) (builtin.KBDocument, error)
 
-// SetKBRead wires the kb_read tool's backing lookup. Optional — same
+// SetKBRead wires the read_kb tool's backing lookup. Optional — same
 // nil contract as SetKBSearch.
 func (s *Service) SetKBRead(fn KBRead) { s.kbRead = fn }
 
-// kbReadTool builds this turn's kb_read ExtraTool, gated exactly like
+// kbReadTool builds this turn's read_kb ExtraTool, gated exactly like
 // kbSearchTool: no backend or empty collections means the tool is not
 // offered.
 func (s *Service) kbReadTool(collections []string) *tools.Tool {
@@ -1247,12 +1247,12 @@ func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, 
 	}
 
 	// A pinned collection is an explicit user signal to search it, not
-	// just a passive tool grant — but only when kb_search will actually
+	// just a passive tool grant — but only when search_kb will actually
 	// be offered (skErr nil, s.kbSearch wired, union non-empty): a
 	// pinned name with no backend must never promise a tool that isn't
 	// there.
 	if skErr == nil && len(sk) > 0 && s.kbSearch != nil && len(collections) > 0 {
-		system += "\n\n# Pinned knowledge\n\nThe user pinned these knowledge collections to this session: " + strings.Join(sk, ", ") + ". This is an explicit signal: when a question could plausibly be answered by their content, call kb_search first and ground the answer in what it returns, rather than answering from general knowledge alone."
+		system += "\n\n# Pinned knowledge\n\nThe user pinned these knowledge collections to this session: " + strings.Join(sk, ", ") + ". This is an explicit signal: when a question could plausibly be answered by their content, call search_kb first and ground the answer in what it returns, rather than answering from general knowledge alone."
 	}
 
 	var extraTools []*tools.Tool

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -283,7 +283,7 @@ func TestChatSegmentsTextAcrossToolActivity(t *testing.T) {
 	log := newFakeLog()
 	gw := &fakeGW{events: []stream.StreamEvent{
 		{Type: stream.EventChunk, Text: "exact nature area."},
-		{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{ID: "call_1", Name: "web_search", Status: "ok"}},
+		{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{ID: "call_1", Name: "search_web", Status: "ok"}},
 		{Type: stream.EventChunk, Text: "I'm searching for"},
 		{Type: stream.EventDone, Meta: &stream.Meta{Provider: "prov", Model: "mod", LedgerID: "led"}},
 	}}
@@ -872,7 +872,7 @@ func TestChatSkillHintInjectsBodyDeterministically(t *testing.T) {
 }
 
 // extraToolNames returns the ExtraTools names on req, for asserting
-// which turn-only tools (kb_search, kb_read) were offered.
+// which turn-only tools (search_kb, read_kb) were offered.
 func extraToolNames(req gwclient.StreamRequest) []string {
 	var names []string
 	for _, t := range req.ExtraTools {
@@ -882,7 +882,7 @@ func extraToolNames(req gwclient.StreamRequest) []string {
 }
 
 // TestKBToolsOfferedFromSessionKnowledgeAlone pins the union contract:
-// an agent with an empty Knowledge list still gets kb_search/kb_read
+// an agent with an empty Knowledge list still gets search_kb/read_kb
 // offered when the session itself has pinned collections.
 func TestKBToolsOfferedFromSessionKnowledgeAlone(t *testing.T) {
 	t.Parallel()
@@ -907,8 +907,8 @@ func TestKBToolsOfferedFromSessionKnowledgeAlone(t *testing.T) {
 	drain(t, ch)
 
 	names := extraToolNames(chatRequest(t, gw))
-	if !slices.Contains(names, "kb_search") || !slices.Contains(names, "kb_read") {
-		t.Fatalf("extra tools = %v, want kb_search and kb_read from session knowledge alone", names)
+	if !slices.Contains(names, "search_kb") || !slices.Contains(names, "read_kb") {
+		t.Fatalf("extra tools = %v, want search_kb and read_kb from session knowledge alone", names)
 	}
 }
 
@@ -993,7 +993,7 @@ func TestKBToolsUnionDedupesAgentAndSessionCollections(t *testing.T) {
 
 // TestKBToolsFallBackOnSessionKnowledgeLookupFailure pins the
 // best-effort contract: s.log.Knowledge erroring must not kill the
-// turn. kb_search still gets offered from the agent's own Knowledge
+// turn. search_kb still gets offered from the agent's own Knowledge
 // list, but the "Pinned knowledge" block is skipped since skErr != nil.
 func TestKBToolsFallBackOnSessionKnowledgeLookupFailure(t *testing.T) {
 	t.Parallel()
@@ -1016,8 +1016,8 @@ func TestKBToolsFallBackOnSessionKnowledgeLookupFailure(t *testing.T) {
 
 	req := chatRequest(t, gw)
 	names := extraToolNames(req)
-	if !slices.Contains(names, "kb_search") {
-		t.Fatalf("extra tools = %v, want kb_search from agent knowledge alone", names)
+	if !slices.Contains(names, "search_kb") {
+		t.Fatalf("extra tools = %v, want search_kb from agent knowledge alone", names)
 	}
 	if strings.Contains(req.System, "Pinned knowledge") {
 		t.Fatalf("system prompt has pinned knowledge block despite session knowledge lookup failure:\n%s", req.System)
@@ -1174,9 +1174,9 @@ func TestResolveToolAllowEmptyToolsWithSkillsAlsoGrantsLoadSkill(t *testing.T) {
 
 func TestResolveToolAllowNonEmptyToolsGainsInfraExemptions(t *testing.T) {
 	t.Parallel()
-	profile := agents.Agent{Tools: []string{"web_search", "current_time"}, Skills: []string{"some-skill"}}
+	profile := agents.Agent{Tools: []string{"search_web", "get_current_time"}, Skills: []string{"some-skill"}}
 	got := resolveToolAllow(profile)
-	want := []string{"web_search", "current_time", "retrieve_output", "load_skill"}
+	want := []string{"search_web", "get_current_time", "retrieve_output", "load_skill"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("resolveToolAllow(non-empty) = %v, want %v", got, want)
 	}
@@ -1699,7 +1699,7 @@ func TestAgentProfileShapesTurn(t *testing.T) {
 			return agents.Agent{
 				Name: "researcher", Route: "research",
 				PromptOverlay: "Consult sources before answering.",
-				Tools:         []string{"web_search"},
+				Tools:         []string{"search_web"},
 				Memory:        false,
 			}, true
 		default:
@@ -1727,7 +1727,7 @@ func TestAgentProfileShapesTurn(t *testing.T) {
 	if sent.Route != "research" || sent.Agent != "researcher" {
 		t.Fatalf("route/agent = %s/%s, want research/researcher", sent.Route, sent.Agent)
 	}
-	if !slices.Equal(sent.ToolAllow, []string{"web_search", "retrieve_output"}) {
+	if !slices.Equal(sent.ToolAllow, []string{"search_web", "retrieve_output"}) {
 		t.Fatalf("tool allowlist = %v, want authored list plus retrieve_output", sent.ToolAllow)
 	}
 	if !strings.Contains(sent.System, "Consult sources before answering.") {
@@ -2370,7 +2370,7 @@ func TestChatSeedsApprovalAllowlistAsStandingGrant(t *testing.T) {
 	log := newFakeLog()
 	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
 		return agents.Agent{ID: "agent-1", Name: "scheduler", Memory: true,
-			ApprovalAllowlist: []string{"calendar_list_events"}}, true
+			ApprovalAllowlist: []string{"list_calendar_events"}}, true
 	}
 	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 	granter := &fakeGranter{}
@@ -2383,8 +2383,8 @@ func TestChatSeedsApprovalAllowlistAsStandingGrant(t *testing.T) {
 	drain(t, ch)
 
 	got := granter.grantedTools("s1")
-	if len(got) != 1 || got[0] != "calendar_list_events" {
-		t.Fatalf("granted tools = %v, want [calendar_list_events]", got)
+	if len(got) != 1 || got[0] != "list_calendar_events" {
+		t.Fatalf("granted tools = %v, want [list_calendar_events]", got)
 	}
 }
 
@@ -2424,7 +2424,7 @@ func TestChatSeedsApprovalAllowlistOnceIdempotent(t *testing.T) {
 	log := newFakeLog()
 	resolver := func(_ context.Context, name string) (agents.Agent, bool) {
 		return agents.Agent{ID: "agent-1", Name: "scheduler", Memory: true,
-			ApprovalAllowlist: []string{"calendar_list_events"}}, true
+			ApprovalAllowlist: []string{"list_calendar_events"}}, true
 	}
 	svc := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 	granter := &fakeGranter{}
@@ -2462,7 +2462,7 @@ func TestChatAgentSwitchGrantsNewAllowlist(t *testing.T) {
 		switch name {
 		case "scheduler":
 			return agents.Agent{ID: "agent-1", Name: "scheduler", Memory: true,
-				ApprovalAllowlist: []string{"calendar_list_events"}}, true
+				ApprovalAllowlist: []string{"list_calendar_events"}}, true
 		case "mailer":
 			return agents.Agent{ID: "agent-2", Name: "mailer", Memory: true,
 				ApprovalAllowlist: []string{"gmail_search"}}, true
@@ -2490,7 +2490,7 @@ func TestChatAgentSwitchGrantsNewAllowlist(t *testing.T) {
 	drain(t, ch)
 
 	got := granter.grantedTools("s1")
-	want := []string{"calendar_list_events", "gmail_search"}
+	want := []string{"list_calendar_events", "gmail_search"}
 	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
 		t.Fatalf("granted tools = %v, want %v (both agents' allowlists)", got, want)
 	}

--- a/internal/brain/chat/systemprompt.go
+++ b/internal/brain/chat/systemprompt.go
@@ -24,6 +24,12 @@ A message block starting with "[attached document <id> (<mime>)]" is followed by
 // the assembled prompt (D-018).
 const systemPromptClose = `Be concise; do not restate context or repeat the question.`
 
+// timezoneSteer follows the date line, telling the model to present
+// dates/times in the operator's configured timezone rather than
+// whatever a tool result happens to carry. A constant, not built from
+// loc, so it never varies request to request (D-018).
+const timezoneSteer = " Present all dates and times in this timezone unless the user asks otherwise."
+
 // assembleSystem builds the full system prompt: identity, then the
 // optional per-deploy skills index, then a current-date line, then the
 // closing steer. now must be evaluated at request time (never cached
@@ -38,7 +44,7 @@ func assembleSystem(skillsIndex string, now time.Time, loc *time.Location) strin
 	if loc == nil {
 		loc = time.UTC
 	}
-	dateLine := "Today is " + now.In(loc).Format("Monday, 2006-01-02 (MST).")
+	dateLine := "Today is " + now.In(loc).Format("Monday, 2006-01-02 (MST).") + timezoneSteer
 	if skillsIndex == "" {
 		return systemPrompt + "\n\n" + dateLine + "\n\n" + systemPromptClose
 	}

--- a/internal/brain/chat/systemprompt.go
+++ b/internal/brain/chat/systemprompt.go
@@ -3,7 +3,7 @@ package chat
 import "time"
 
 // systemPromptVersion increments with any change to the prompt text.
-const systemPromptVersion = 5
+const systemPromptVersion = 6
 
 // systemPrompt is Timothy's identity. Additions APPEND after the
 // existing text and the terseness steer stays the LAST line: the
@@ -18,7 +18,7 @@ Answer from knowledge when confident; say plainly when you are unsure or lack ac
 
 Before a tool call, write at most one short line saying what you are checking — never the answer itself; the answer comes only after the tool results are in. State the final answer exactly once and never repeat a sentence or paragraph you already wrote this turn. Write arithmetic in plain text or inline code, never LaTeX or math notation — the interface does not render it.
 
-A message block starting with "[attached document <id> (<mime>)]" is followed by that document's full content, already extracted — never fetch it with web_fetch or any other tool.`
+A message block starting with "[attached document <id> (<mime>)]" is followed by that document's full content, already extracted — never fetch it with fetch_url or any other tool.`
 
 // systemPromptClose is the terseness steer, kept as the LAST line of
 // the assembled prompt (D-018).

--- a/internal/brain/chat/systemprompt_test.go
+++ b/internal/brain/chat/systemprompt_test.go
@@ -47,6 +47,35 @@ func TestAssembleSystemDateLineOperatorLocation(t *testing.T) {
 	}
 }
 
+// TestAssembleSystemDateLineIncludesTimezoneSteer pins that the date
+// line carries the timezone-presentation instruction (timezoneSteer)
+// right after the date, both for an operator location and for the nil
+// (UTC) default — a global harness instruction instead of per-prompt
+// boilerplate.
+func TestAssembleSystemDateLineIncludesTimezoneSteer(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.July, 28, 15, 4, 5, 0, time.UTC)
+	want := "Present all dates and times in this timezone"
+
+	t.Run("nil location (UTC)", func(t *testing.T) {
+		got := assembleSystem("", now, nil)
+		if !strings.Contains(got, want) {
+			t.Fatalf("timezone steer missing:\n%s\nwant substring:\n%s", got, want)
+		}
+	})
+
+	t.Run("operator location", func(t *testing.T) {
+		loc, err := time.LoadLocation("Europe/Amsterdam")
+		if err != nil {
+			t.Fatalf("load location: %v", err)
+		}
+		got := assembleSystem("", now, loc)
+		if !strings.Contains(got, want) {
+			t.Fatalf("timezone steer missing:\n%s\nwant substring:\n%s", got, want)
+		}
+	})
+}
+
 func TestAssembleSystemCloseStaysLast(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, time.July, 28, 0, 0, 0, 0, time.UTC)

--- a/internal/brain/connectors/aggregate_test.go
+++ b/internal/brain/connectors/aggregate_test.go
@@ -45,7 +45,7 @@ func TestAggregateSingleAccountDefaultsWithoutAccountArg(t *testing.T) {
 		"gmail": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("gmail", true)}}, kind: "google"},
 	}
 
-	tl := toolNamed(t, m.Tools(), "mail_search")
+	tl := toolNamed(t, m.Tools(nil), "mail_search")
 	var schema map[string]any
 	if err := json.Unmarshal(tl.InputSchema, &schema); err != nil {
 		t.Fatal(err)
@@ -74,7 +74,7 @@ func TestAggregateMultiAccountRequiresAccount(t *testing.T) {
 		"work":     &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("work", true)}}, kind: "microsoft", email: "me@work.com"},
 	}
 
-	tl := toolNamed(t, m.Tools(), "mail_search")
+	tl := toolNamed(t, m.Tools(nil), "mail_search")
 	var schema map[string]any
 	if err := json.Unmarshal(tl.InputSchema, &schema); err != nil {
 		t.Fatal(err)
@@ -119,7 +119,7 @@ func TestAggregateUnknownAccountErrors(t *testing.T) {
 		"work":     &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("work", true)}}, kind: "microsoft"},
 	}
 
-	tl := toolNamed(t, m.Tools(), "mail_search")
+	tl := toolNamed(t, m.Tools(nil), "mail_search")
 	_, err := tl.Execute(t.Context(), json.RawMessage(`{"query":"x","account":"nope"}`))
 	if err == nil || !strings.Contains(err.Error(), "nope") ||
 		!strings.Contains(err.Error(), "personal") || !strings.Contains(err.Error(), "work") {
@@ -139,7 +139,7 @@ func TestAggregateDescriptionListsConnectedAccounts(t *testing.T) {
 		"work":     &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("work", true)}}, kind: "microsoft"},
 	}
 
-	desc := toolNamed(t, m.Tools(), "mail_search").Description
+	desc := toolNamed(t, m.Tools(nil), "mail_search").Description
 	for _, want := range []string{
 		"Search mail.", "personal", "me@personal.com", "google",
 		"work", "microsoft", "For google accounts", "Gmail search syntax",
@@ -162,7 +162,7 @@ func TestAggregateDescriptionKindGuidanceOnlyForContributingKinds(t *testing.T) 
 		"personal": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("personal", true)}}, kind: "google"},
 	}
 
-	desc := toolNamed(t, m.Tools(), "mail_search").Description
+	desc := toolNamed(t, m.Tools(nil), "mail_search").Description
 	if !strings.Contains(desc, "For google accounts") {
 		t.Fatalf("description = %q, want the google guidance block", desc)
 	}
@@ -183,7 +183,7 @@ func TestAggregateIMAPContributesToMailSearch(t *testing.T) {
 		"mailbox": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("mailbox", true)}}, kind: "imap"},
 	}
 
-	desc := toolNamed(t, m.Tools(), "mail_search").Description
+	desc := toolNamed(t, m.Tools(nil), "mail_search").Description
 	if !strings.Contains(desc, "For imap accounts") {
 		t.Fatalf("description = %q, want the imap guidance block", desc)
 	}
@@ -191,7 +191,7 @@ func TestAggregateIMAPContributesToMailSearch(t *testing.T) {
 		t.Fatalf("description = %q, must not contain google/microsoft guidance with no such account connected", desc)
 	}
 
-	out, err := toolNamed(t, m.Tools(), "mail_search").Execute(t.Context(), json.RawMessage(`{"query":"x"}`))
+	out, err := toolNamed(t, m.Tools(nil), "mail_search").Execute(t.Context(), json.RawMessage(`{"query":"x"}`))
 	if err != nil || out != "ran on mailbox" {
 		t.Fatalf("Execute = (%q, %v), want ran on mailbox", out, err)
 	}
@@ -208,7 +208,7 @@ func TestAggregateReadOnlyRequiresAllAccountsReadOnly(t *testing.T) {
 		"b": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("b", false)}}, kind: "microsoft"},
 	}
 
-	tl := toolNamed(t, m.Tools(), "mail_search")
+	tl := toolNamed(t, m.Tools(nil), "mail_search")
 	if tl.ReadOnly {
 		t.Fatal("aggregate ReadOnly=true, want false when any contributing account's tool is not ReadOnly")
 	}
@@ -223,29 +223,161 @@ func TestAggregateReadOnlyRequiresAllAccountsReadOnly(t *testing.T) {
 	}
 }
 
-// TestAggregateMCPPassthroughUnaffected pins that MCP sources keep
-// their existing "<connector>_<tool>" namespacing, appended alongside
-// the aggregated non-MCP surface: MCP tool names are external and
-// can't be unified.
-func TestAggregateMCPPassthroughUnaffected(t *testing.T) {
+// TestAggregateMCPJoinsUnifiedSurfaceAlongsideNonMCP pins that an MCP
+// source with no colliding raw name merges into the unified surface
+// right alongside non-MCP aggregates, un-namespaced: MCP tools are no
+// longer treated differently from any other source once their raw name
+// is free to merge (see groupByRawName).
+func TestAggregateMCPJoinsUnifiedSurfaceAlongsideNonMCP(t *testing.T) {
 	t.Parallel()
 	m := testManager(fakeRows{})
 	m.sources = map[string]Source{
 		"gmail": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("gmail", true)}}, kind: "google"},
-		"slack": &mcpSource{name: "slack", toolList: []*tools.Tool{{Name: "read_channel", ReadOnly: true}}},
+		"slack": &mcpSource{name: "slack", toolList: []*tools.Tool{
+			{Name: "read_channel", ReadOnly: true, InputSchema: json.RawMessage(`{"type":"object"}`)},
+		}},
 	}
 
 	names := map[string]bool{}
-	for _, tl := range m.Tools() {
+	for _, tl := range m.Tools(nil) {
 		names[tl.Name] = true
 	}
 	if !names["mail_search"] {
 		t.Fatal("aggregated mail_search missing")
 	}
-	if !names["slack_read_channel"] {
-		t.Fatal("MCP tool must keep its connector-prefixed name")
+	if !names["read_channel"] {
+		t.Fatal("MCP tool with no name collision must merge un-namespaced")
 	}
-	if names["read_channel"] {
-		t.Fatal("MCP tool must not also appear un-namespaced")
+	if names["slack_read_channel"] {
+		t.Fatal("MCP tool must not also appear namespaced once merged")
+	}
+}
+
+// TestAggregateTwoMCPConnectorsSameToolIdenticalSchemaMerge pins the
+// multi-MCP-connector case: two MCP connectors serving the same raw
+// tool name with an identical schema merge into one tool, "account"
+// required same as any other multi-account aggregate.
+func TestAggregateTwoMCPConnectorsSameToolIdenticalSchemaMerge(t *testing.T) {
+	t.Parallel()
+	schema := json.RawMessage(`{"type":"object","properties":{"query":{"type":"string"}},"required":["query"],"additionalProperties":false}`)
+	m := testManager(fakeRows{})
+	m.sources = map[string]Source{
+		"linear": &mcpSource{name: "linear", toolList: []*tools.Tool{
+			{Name: "search", InputSchema: schema, Execute: func(context.Context, json.RawMessage) (string, error) { return "ran on linear", nil }},
+		}},
+		"jira": &mcpSource{name: "jira", toolList: []*tools.Tool{
+			{Name: "search", InputSchema: schema, Execute: func(context.Context, json.RawMessage) (string, error) { return "ran on jira", nil }},
+		}},
+	}
+
+	tl := toolNamed(t, m.Tools(nil), "search")
+	var s map[string]any
+	if err := json.Unmarshal(tl.InputSchema, &s); err != nil {
+		t.Fatal(err)
+	}
+	req, _ := s["required"].([]any)
+	var hasAccount bool
+	for _, r := range req {
+		if r == "account" {
+			hasAccount = true
+		}
+	}
+	if !hasAccount {
+		t.Fatal("account must be required once two MCP connectors share a raw name")
+	}
+	out, err := tl.Execute(t.Context(), json.RawMessage(`{"query":"x","account":"jira"}`))
+	if err != nil || out != "ran on jira" {
+		t.Fatalf("Execute(account=jira) = (%q, %v), want ran on jira", out, err)
+	}
+
+	names := map[string]bool{}
+	for _, tl := range m.Tools(nil) {
+		names[tl.Name] = true
+	}
+	if names["linear_search"] || names["jira_search"] {
+		t.Fatalf("tools = %v, must not also appear namespaced once merged", names)
+	}
+}
+
+// TestAggregateTwoMCPConnectorsSameToolSchemaMismatchStaysNamespaced
+// pins Guard B: two MCP connectors serving the same raw tool name with
+// DIFFERENT schemas must never merge — unlike non-MCP sources sharing a
+// raw name (Timothy's own code, schema-identical by construction), an
+// external MCP server's schema can't be assumed to match. Both stay
+// namespaced instead.
+func TestAggregateTwoMCPConnectorsSameToolSchemaMismatchStaysNamespaced(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{})
+	m.sources = map[string]Source{
+		"linear": &mcpSource{name: "linear", toolList: []*tools.Tool{
+			{Name: "search", InputSchema: json.RawMessage(`{"type":"object","properties":{"query":{"type":"string"}}}`)},
+		}},
+		"jira": &mcpSource{name: "jira", toolList: []*tools.Tool{
+			{Name: "search", InputSchema: json.RawMessage(`{"type":"object","properties":{"jql":{"type":"string"}}}`)},
+		}},
+	}
+
+	names := map[string]bool{}
+	for _, tl := range m.Tools(nil) {
+		names[tl.Name] = true
+	}
+	if names["search"] {
+		t.Fatalf("tools = %v, schema-mismatched MCP tools must not merge", names)
+	}
+	if !names["linear_search"] || !names["jira_search"] {
+		t.Fatalf("tools = %v, want both to stay namespaced", names)
+	}
+}
+
+// TestAccountConnectorResolvesMergedMCPTool is the safety-invariant
+// test for the raw-name refactor: a sensitive MCP connector's tool,
+// once merged under its raw name, must still resolve back to that
+// connector through AccountConnector — the path
+// session.SensitiveTools.Matches falls back to once its own namespace-
+// prefix check no longer fires (the tool has no prefix any more). This
+// pins that the safety property survives the refactor at the layer
+// that actually implements it.
+func TestAccountConnectorResolvesMergedMCPTool(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{})
+	m.sources = map[string]Source{
+		"internal-crm": &mcpSource{name: "internal-crm", toolList: []*tools.Tool{
+			{Name: "lookup_customer", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		}},
+	}
+
+	// The tool merged un-namespaced (lone contributor, no collision).
+	tl := toolNamed(t, m.Tools(nil), "lookup_customer")
+	if tl.Name != "lookup_customer" {
+		t.Fatalf("tool name = %q, want lookup_customer", tl.Name)
+	}
+
+	// AccountConnector must still resolve the raw-named call back to
+	// the connector — the fact a name merged doesn't erase which
+	// connector actually served it.
+	if got := m.AccountConnector("lookup_customer", nil); got != "internal-crm" {
+		t.Fatalf("AccountConnector(lookup_customer) = %q, want internal-crm", got)
+	}
+}
+
+// TestAccountConnectorLeavesNamespacedMCPToolUnresolved pins the other
+// half: a tool that stayed namespaced (Guard A/B) is never resolvable
+// under its RAW name through AccountConnector, since it isn't exposed
+// that way — session.SensitiveTools.Matches instead catches it via its
+// own namespace-prefix check, which still fires for a namespaced tool.
+func TestAccountConnectorLeavesNamespacedMCPToolUnresolved(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{})
+	m.sources = map[string]Source{
+		"internal-crm": &mcpSource{name: "internal-crm", toolList: []*tools.Tool{
+			{Name: "lookup_customer", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		}},
+	}
+
+	if got := m.AccountConnector("lookup_customer", nil); got == "" {
+		t.Fatal("sanity check: lookup_customer should resolve before reserving it")
+	}
+	if got := m.AccountConnector("internal-crm_lookup_customer", nil); got != "" {
+		t.Fatalf("AccountConnector(namespaced name) = %q, want empty (never exposed under that name here)", got)
 	}
 }

--- a/internal/brain/connectors/aggregate_test.go
+++ b/internal/brain/connectors/aggregate_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
 )
 
-// searchTool builds a minimal mail_search-shaped tool whose Execute
+// searchTool builds a minimal search_mail-shaped tool whose Execute
 // reports which account (by connector name) actually ran it, so a test
 // can assert routing without a real Google/Microsoft source.
 func searchTool(connector string, readOnly bool) *tools.Tool {
 	return &tools.Tool{
-		Name:        "mail_search",
+		Name:        "search_mail",
 		ReadOnly:    readOnly,
 		Description: "Search mail.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{"query":{"type":"string"}},"required":["query"],"additionalProperties":false}`),
@@ -45,7 +45,7 @@ func TestAggregateSingleAccountDefaultsWithoutAccountArg(t *testing.T) {
 		"gmail": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("gmail", true)}}, kind: "google"},
 	}
 
-	tl := toolNamed(t, m.Tools(nil), "mail_search")
+	tl := toolNamed(t, m.Tools(nil), "search_mail")
 	var schema map[string]any
 	if err := json.Unmarshal(tl.InputSchema, &schema); err != nil {
 		t.Fatal(err)
@@ -74,7 +74,7 @@ func TestAggregateMultiAccountRequiresAccount(t *testing.T) {
 		"work":     &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("work", true)}}, kind: "microsoft", email: "me@work.com"},
 	}
 
-	tl := toolNamed(t, m.Tools(nil), "mail_search")
+	tl := toolNamed(t, m.Tools(nil), "search_mail")
 	var schema map[string]any
 	if err := json.Unmarshal(tl.InputSchema, &schema); err != nil {
 		t.Fatal(err)
@@ -119,7 +119,7 @@ func TestAggregateUnknownAccountErrors(t *testing.T) {
 		"work":     &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("work", true)}}, kind: "microsoft"},
 	}
 
-	tl := toolNamed(t, m.Tools(nil), "mail_search")
+	tl := toolNamed(t, m.Tools(nil), "search_mail")
 	_, err := tl.Execute(t.Context(), json.RawMessage(`{"query":"x","account":"nope"}`))
 	if err == nil || !strings.Contains(err.Error(), "nope") ||
 		!strings.Contains(err.Error(), "personal") || !strings.Contains(err.Error(), "work") {
@@ -129,7 +129,7 @@ func TestAggregateUnknownAccountErrors(t *testing.T) {
 
 // TestAggregateDescriptionListsConnectedAccounts pins the description
 // shape: base description plus one line per account naming the
-// connector, its email when known, its kind, and mail_search's
+// connector, its email when known, its kind, and search_mail's
 // provider-specific syntax hint.
 func TestAggregateDescriptionListsConnectedAccounts(t *testing.T) {
 	t.Parallel()
@@ -139,7 +139,7 @@ func TestAggregateDescriptionListsConnectedAccounts(t *testing.T) {
 		"work":     &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("work", true)}}, kind: "microsoft"},
 	}
 
-	desc := toolNamed(t, m.Tools(nil), "mail_search").Description
+	desc := toolNamed(t, m.Tools(nil), "search_mail").Description
 	for _, want := range []string{
 		"Search mail.", "personal", "me@personal.com", "google",
 		"work", "microsoft", "For google accounts", "Gmail search syntax",
@@ -152,7 +152,7 @@ func TestAggregateDescriptionListsConnectedAccounts(t *testing.T) {
 }
 
 // TestAggregateDescriptionKindGuidanceOnlyForContributingKinds pins
-// that a kind's mail_search guidance block only renders when that kind
+// that a kind's search_mail guidance block only renders when that kind
 // actually contributes an account: a google-only deployment must never
 // see microsoft's Graph $search note, and vice versa.
 func TestAggregateDescriptionKindGuidanceOnlyForContributingKinds(t *testing.T) {
@@ -162,7 +162,7 @@ func TestAggregateDescriptionKindGuidanceOnlyForContributingKinds(t *testing.T) 
 		"personal": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("personal", true)}}, kind: "google"},
 	}
 
-	desc := toolNamed(t, m.Tools(nil), "mail_search").Description
+	desc := toolNamed(t, m.Tools(nil), "search_mail").Description
 	if !strings.Contains(desc, "For google accounts") {
 		t.Fatalf("description = %q, want the google guidance block", desc)
 	}
@@ -172,8 +172,8 @@ func TestAggregateDescriptionKindGuidanceOnlyForContributingKinds(t *testing.T) 
 }
 
 // TestAggregateIMAPContributesToMailSearch pins that an imap-kind
-// fakeAccountSource joins the unified mail_search surface exactly like
-// google/microsoft, and that its mail_search guidance block only
+// fakeAccountSource joins the unified search_mail surface exactly like
+// google/microsoft, and that its search_mail guidance block only
 // renders when an imap account actually contributes — mirroring
 // TestAggregateDescriptionKindGuidanceOnlyForContributingKinds.
 func TestAggregateIMAPContributesToMailSearch(t *testing.T) {
@@ -183,7 +183,7 @@ func TestAggregateIMAPContributesToMailSearch(t *testing.T) {
 		"mailbox": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("mailbox", true)}}, kind: "imap"},
 	}
 
-	desc := toolNamed(t, m.Tools(nil), "mail_search").Description
+	desc := toolNamed(t, m.Tools(nil), "search_mail").Description
 	if !strings.Contains(desc, "For imap accounts") {
 		t.Fatalf("description = %q, want the imap guidance block", desc)
 	}
@@ -191,7 +191,7 @@ func TestAggregateIMAPContributesToMailSearch(t *testing.T) {
 		t.Fatalf("description = %q, must not contain google/microsoft guidance with no such account connected", desc)
 	}
 
-	out, err := toolNamed(t, m.Tools(nil), "mail_search").Execute(t.Context(), json.RawMessage(`{"query":"x"}`))
+	out, err := toolNamed(t, m.Tools(nil), "search_mail").Execute(t.Context(), json.RawMessage(`{"query":"x"}`))
 	if err != nil || out != "ran on mailbox" {
 		t.Fatalf("Execute = (%q, %v), want ran on mailbox", out, err)
 	}
@@ -208,7 +208,7 @@ func TestAggregateReadOnlyRequiresAllAccountsReadOnly(t *testing.T) {
 		"b": &fakeAccountSource{fakeSource: fakeSource{tools: []*tools.Tool{searchTool("b", false)}}, kind: "microsoft"},
 	}
 
-	tl := toolNamed(t, m.Tools(nil), "mail_search")
+	tl := toolNamed(t, m.Tools(nil), "search_mail")
 	if tl.ReadOnly {
 		t.Fatal("aggregate ReadOnly=true, want false when any contributing account's tool is not ReadOnly")
 	}
@@ -217,8 +217,8 @@ func TestAggregateReadOnlyRequiresAllAccountsReadOnly(t *testing.T) {
 	// is ReadOnly, but the unified tool covers both accounts and can't
 	// selectively deny "b" mid-call.
 	for _, tl := range m.ReadOnlyTools() {
-		if tl.Name == "mail_search" {
-			t.Fatal("ReadOnlyTools must not include mail_search when one account's tool is not ReadOnly")
+		if tl.Name == "search_mail" {
+			t.Fatal("ReadOnlyTools must not include search_mail when one account's tool is not ReadOnly")
 		}
 	}
 }
@@ -242,8 +242,8 @@ func TestAggregateMCPJoinsUnifiedSurfaceAlongsideNonMCP(t *testing.T) {
 	for _, tl := range m.Tools(nil) {
 		names[tl.Name] = true
 	}
-	if !names["mail_search"] {
-		t.Fatal("aggregated mail_search missing")
+	if !names["search_mail"] {
+		t.Fatal("aggregated search_mail missing")
 	}
 	if !names["read_channel"] {
 		t.Fatal("MCP tool with no name collision must merge un-namespaced")

--- a/internal/brain/connectors/caldav.go
+++ b/internal/brain/connectors/caldav.go
@@ -107,7 +107,7 @@ type caldavSource struct {
 	client        *http.Client
 }
 
-// Tools returns calendar_list_events and calendar_create_event, always
+// Tools returns list_calendar_events and create_calendar_event, always
 // (caldav has no scope concept to gate on).
 func (s *caldavSource) Tools() []*tools.Tool {
 	return []*tools.Tool{s.calendarListEvents(), s.calendarCreateEvent()}

--- a/internal/brain/connectors/caldav_test.go
+++ b/internal/brain/connectors/caldav_test.go
@@ -204,7 +204,7 @@ func TestCalDAVListEventsDefaultWindow(t *testing.T) {
 	srv := caldavTestServer(t, nil)
 	src := testCalDAVSource(t, srv.URL)
 
-	out, err := caldavToolByName(t, src, "calendar_list_events").Execute(t.Context(), json.RawMessage(`{}`))
+	out, err := caldavToolByName(t, src, "list_calendar_events").Execute(t.Context(), json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -221,7 +221,7 @@ func TestCalDAVListEventsExplicitTimeRangeInReportBody(t *testing.T) {
 	srv := caldavTestServer(t, state)
 	src := testCalDAVSource(t, srv.URL)
 
-	_, err := caldavToolByName(t, src, "calendar_list_events").Execute(t.Context(),
+	_, err := caldavToolByName(t, src, "list_calendar_events").Execute(t.Context(),
 		json.RawMessage(`{"time_min":"2026-08-01T00:00:00Z","time_max":"2026-08-02T00:00:00Z"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -240,7 +240,7 @@ func TestCalDAVListEventsMaxResultsCap(t *testing.T) {
 	srv := caldavTestServer(t, nil)
 	src := testCalDAVSource(t, srv.URL)
 
-	out, err := caldavToolByName(t, src, "calendar_list_events").Execute(t.Context(), json.RawMessage(`{"max_results":2}`))
+	out, err := caldavToolByName(t, src, "list_calendar_events").Execute(t.Context(), json.RawMessage(`{"max_results":2}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -254,7 +254,7 @@ func TestCalDAVListEventsFormatsLines(t *testing.T) {
 	srv := caldavTestServer(t, nil)
 	src := testCalDAVSource(t, srv.URL)
 
-	out, err := caldavToolByName(t, src, "calendar_list_events").Execute(t.Context(), json.RawMessage(`{}`))
+	out, err := caldavToolByName(t, src, "list_calendar_events").Execute(t.Context(), json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -273,7 +273,7 @@ func TestCalDAVListEventsFallsBackWhenExpandUnsupported(t *testing.T) {
 	// dates: the fallback path now filters non-recurring events to the
 	// window (finding 4), so relying on the default now-relative window
 	// would make this test's fixture data go stale.
-	out, err := caldavToolByName(t, src, "calendar_list_events").Execute(t.Context(),
+	out, err := caldavToolByName(t, src, "list_calendar_events").Execute(t.Context(),
 		json.RawMessage(`{"time_min":"2026-07-20T00:00:00Z","time_max":"2026-07-26T00:00:00Z"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -298,7 +298,7 @@ func TestCalDAVCreateEventPutsExpectedBody(t *testing.T) {
 	srv := caldavTestServer(t, state)
 	src := testCalDAVSource(t, srv.URL)
 
-	out, err := caldavToolByName(t, src, "calendar_create_event").Execute(t.Context(), json.RawMessage(
+	out, err := caldavToolByName(t, src, "create_calendar_event").Execute(t.Context(), json.RawMessage(
 		`{"summary":"1:1","start":"2026-07-23T10:00:00Z","end":"2026-07-23T10:30:00Z","location":"zoom","attendees":["b@y.com"]}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -330,7 +330,7 @@ func TestCalDAVCreateEventGeneratesUniqueUID(t *testing.T) {
 	src := testCalDAVSource(t, srv.URL)
 
 	for i := 0; i < 2; i++ {
-		_, err := caldavToolByName(t, src, "calendar_create_event").Execute(t.Context(), json.RawMessage(
+		_, err := caldavToolByName(t, src, "create_calendar_event").Execute(t.Context(), json.RawMessage(
 			fmt.Sprintf(`{"summary":"e%d","start":"2026-07-23T10:00:00Z","end":"2026-07-23T10:30:00Z"}`, i)))
 		if err != nil {
 			t.Fatalf("Execute: %v", err)
@@ -483,7 +483,7 @@ func TestCalDAVQueryEventsServerError(t *testing.T) {
 	srv := caldavTestServer(t, state)
 	src := testCalDAVSource(t, srv.URL)
 
-	_, err := caldavToolByName(t, src, "calendar_list_events").Execute(t.Context(), json.RawMessage(`{}`))
+	_, err := caldavToolByName(t, src, "list_calendar_events").Execute(t.Context(), json.RawMessage(`{}`))
 	if err == nil || !strings.Contains(err.Error(), "status 500") {
 		t.Fatalf("err = %v, want a caldavStatusError naming status 500", err)
 	}
@@ -580,7 +580,7 @@ func TestCalDAVListEventsTimeMinInvalidErrors(t *testing.T) {
 	srv := caldavTestServer(t, nil)
 	src := testCalDAVSource(t, srv.URL)
 
-	_, err := caldavToolByName(t, src, "calendar_list_events").Execute(t.Context(),
+	_, err := caldavToolByName(t, src, "list_calendar_events").Execute(t.Context(),
 		json.RawMessage(`{"time_min":"not-a-timestamp"}`))
 	if err == nil || !strings.Contains(err.Error(), "time_min must be RFC3339") {
 		t.Fatalf("err = %v, want a time_min RFC3339 error", err)
@@ -592,7 +592,7 @@ func TestCalDAVListEventsTimeMaxInvalidErrors(t *testing.T) {
 	srv := caldavTestServer(t, nil)
 	src := testCalDAVSource(t, srv.URL)
 
-	_, err := caldavToolByName(t, src, "calendar_list_events").Execute(t.Context(),
+	_, err := caldavToolByName(t, src, "list_calendar_events").Execute(t.Context(),
 		json.RawMessage(`{"time_max":"not-a-timestamp"}`))
 	if err == nil || !strings.Contains(err.Error(), "time_max must be RFC3339") {
 		t.Fatalf("err = %v, want a time_max RFC3339 error", err)

--- a/internal/brain/connectors/caldav_tools.go
+++ b/internal/brain/connectors/caldav_tools.go
@@ -18,7 +18,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
 )
 
-// caldavListDefault mirrors microsoft's calendar_list_events default
+// caldavListDefault mirrors microsoft's list_calendar_events default
 // max_results.
 const caldavListDefault = 20
 
@@ -32,7 +32,7 @@ type caldavEvent struct {
 
 func (s *caldavSource) calendarListEvents() *tools.Tool {
 	return &tools.Tool{
-		Name:        "calendar_list_events",
+		Name:        "list_calendar_events",
 		ReadOnly:    true,
 		Description: "List events from the connected calendar in a time window. Omit time_min/time_max for the default window, the next 7 days from now; set them (RFC3339 UTC) only when the goal needs a different window, computed from today's actual date. Returns start, end, title, and location per event.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
@@ -337,7 +337,7 @@ func rfc3339FromICal(v string) string {
 
 func (s *caldavSource) calendarCreateEvent() *tools.Tool {
 	return &tools.Tool{
-		Name:        "calendar_create_event",
+		Name:        "create_calendar_event",
 		Description: "Create an event on the connected account's primary calendar. start and end are RFC3339 timestamps with offset, e.g. 2026-07-22T15:00:00+02:00. Use only when the user asked for an event; depending on the provider, attendees may be notified immediately.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"summary":{"type":"string","description":"event title"},

--- a/internal/brain/connectors/connectors.go
+++ b/internal/brain/connectors/connectors.go
@@ -43,7 +43,7 @@ type Connector struct {
 	// Sensitive marks the WHOLE connector as sensitive. Most of a
 	// connector's tools — MCP included, unless a name collision or
 	// schema mismatch keeps them namespaced (see Manager.groupByRawName)
-	// — aggregate into unified, un-namespaced tools (mail_search,
+	// — aggregate into unified, un-namespaced tools (search_mail,
 	// create_issue, etc.); session.SensitiveTools.Matches catches those
 	// via Manager.AccountConnector resolving a call's account back to
 	// this connector's name. A tool that DID stay namespaced

--- a/internal/brain/connectors/connectors.go
+++ b/internal/brain/connectors/connectors.go
@@ -9,11 +9,13 @@ package connectors
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
 )
@@ -38,21 +40,22 @@ type Connector struct {
 	Config        json.RawMessage `json:"config"`
 	CredentialRef string          `json:"credential_ref"`
 	Enabled       bool            `json:"enabled"`
-	// Sensitive marks the WHOLE connector as sensitive: an MCP
-	// connector's tools are namespaced "<name>_<tool>" (see
-	// Manager.Tools), so its own name is a PREFIX of every tool it
-	// serves, and session.SensitiveTools.Matches checks this prefix. A
-	// non-MCP connector's tools instead aggregate into unified,
-	// un-namespaced tools (mail_search etc.); Matches catches those via
-	// AccountConnector resolving a call's account back to this
-	// connector's name.
+	// Sensitive marks the WHOLE connector as sensitive. Most of a
+	// connector's tools — MCP included, unless a name collision or
+	// schema mismatch keeps them namespaced (see Manager.groupByRawName)
+	// — aggregate into unified, un-namespaced tools (mail_search,
+	// create_issue, etc.); session.SensitiveTools.Matches catches those
+	// via Manager.AccountConnector resolving a call's account back to
+	// this connector's name. A tool that DID stay namespaced
+	// "<name>_<tool>" (Manager.Tools) has its own name as a PREFIX,
+	// which Matches also checks directly, no account resolution needed.
 	Sensitive bool `json:"sensitive"`
 }
 
-// namePattern keeps connector names usable both as MCP tool-name
-// prefixes ("<name>_<tool>") and as a unified aggregate tool's
-// "account" argument value (see Manager.aggregateTools): lowercase
-// slug, no spaces.
+// namePattern keeps connector names usable both as a namespaced tool's
+// prefix ("<name>_<tool>", for whatever fails to unify — see
+// Manager.groupByRawName) and as a unified aggregate tool's "account"
+// argument value: lowercase slug, no spaces.
 var namePattern = regexp.MustCompile(`^[a-z0-9]+(?:[-_][a-z0-9]+)*$`)
 
 func validate(c Connector) error {
@@ -155,17 +158,27 @@ func (s *Store) Create(ctx context.Context, c Connector) (string, error) {
 	return id, nil
 }
 
-// Patch applies a partial update. Name and kind are immutable: the
-// name prefixes served tool names and the kind picks the builder —
-// changing either mid-flight would silently re-identify every tool.
+// Patch applies a partial update. Kind is immutable: it picks the
+// builder, and changing it mid-flight would silently re-identify every
+// tool. Name is patchable — it prefixes MCP tool names and serves as a
+// unified aggregate tool's account argument, but renaming takes effect
+// on the next reload same as any other config change.
 type Patch struct {
+	Name          *string          `json:"name"`
 	Config        *json.RawMessage `json:"config"`
 	CredentialRef *string          `json:"credential_ref"`
 	Enabled       *bool            `json:"enabled"`
 	Sensitive     *bool            `json:"sensitive"`
 }
 
+// ErrNameConflict is the sentinel error the HTTP layer maps onto 409,
+// mirroring missions.ErrScheduleNameConflict.
+var ErrNameConflict = fmt.Errorf("a connector with this name already exists")
+
 func (s *Store) Patch(ctx context.Context, id string, patch Patch) error {
+	if patch.Name != nil && !namePattern.MatchString(*patch.Name) {
+		return fmt.Errorf("name must be a lowercase slug (a-z, 0-9, - or _), it prefixes MCP tool names and is used as an account argument")
+	}
 	if patch.CredentialRef != nil && !credentialRefPattern.MatchString(*patch.CredentialRef) {
 		return fmt.Errorf("credential_ref must be a name or path, never a secret value")
 	}
@@ -190,6 +203,9 @@ func (s *Store) Patch(ctx context.Context, id string, patch Patch) error {
 		return err
 	}
 	after := before
+	if patch.Name != nil {
+		after.Name = *patch.Name
+	}
 	if patch.Config != nil {
 		after.Config = *patch.Config
 	}
@@ -203,9 +219,12 @@ func (s *Store) Patch(ctx context.Context, id string, patch Patch) error {
 		after.Sensitive = *patch.Sensitive
 	}
 
-	if _, err := tx.Exec(ctx, `UPDATE connectors SET config = $2, credential_ref = $3,
-			enabled = $4, sensitive = $5, updated_at = now() WHERE id = $1`,
-		id, after.Config, after.CredentialRef, after.Enabled, after.Sensitive); err != nil {
+	if _, err := tx.Exec(ctx, `UPDATE connectors SET name = $2, config = $3, credential_ref = $4,
+			enabled = $5, sensitive = $6, updated_at = now() WHERE id = $1`,
+		id, after.Name, after.Config, after.CredentialRef, after.Enabled, after.Sensitive); err != nil {
+		if isUniqueViolation(err) {
+			return ErrNameConflict
+		}
 		return fmt.Errorf("connectors patch: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
@@ -214,6 +233,11 @@ func (s *Store) Patch(ctx context.Context, id string, patch Patch) error {
 	s.audit(ctx, "update", id, before, after)
 	s.onChange(ctx)
 	return nil
+}
+
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
 }
 
 // Delete removes a connector; its tools vanish on the next reload.

--- a/internal/brain/connectors/connectors_integration_test.go
+++ b/internal/brain/connectors/connectors_integration_test.go
@@ -5,6 +5,7 @@ package connectors
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -140,6 +141,51 @@ func TestConnectorCRUDAuditsAndNotifies(t *testing.T) {
 	}
 	if audits != 3 {
 		t.Fatalf("audit rows = %d, want 3 (create, update, delete)", audits)
+	}
+}
+
+func TestConnectorPatchRename(t *testing.T) {
+	store, _ := testStore(t)
+	ctx := t.Context()
+
+	name := marker + "rename-a"
+	id, err := store.Create(ctx, Connector{Name: name, Kind: "mcp"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	other := marker + "rename-b"
+	otherID, err := store.Create(ctx, Connector{Name: other, Kind: "mcp"})
+	if err != nil {
+		t.Fatalf("Create other: %v", err)
+	}
+
+	t.Run("valid slug renames", func(t *testing.T) {
+		newName := marker + "renamed"
+		if err := store.Patch(ctx, id, Patch{Name: &newName}); err != nil {
+			t.Fatalf("Patch: %v", err)
+		}
+		got, err := store.Get(ctx, id)
+		if err != nil || got.Name != newName {
+			t.Fatalf("Get after rename = %+v, err = %v, want name %s", got, err, newName)
+		}
+	})
+
+	t.Run("invalid slug rejected", func(t *testing.T) {
+		bad := "Has Spaces"
+		if err := store.Patch(ctx, id, Patch{Name: &bad}); err == nil {
+			t.Fatal("invalid slug accepted")
+		}
+	})
+
+	t.Run("duplicate name rejected", func(t *testing.T) {
+		if err := store.Patch(ctx, id, Patch{Name: &other}); !errors.Is(err, ErrNameConflict) {
+			t.Fatalf("Patch error = %v, want ErrNameConflict", err)
+		}
+	})
+
+	if err := store.Delete(ctx, otherID); err != nil {
+		t.Fatalf("Delete other: %v", err)
 	}
 }
 

--- a/internal/brain/connectors/google_test.go
+++ b/internal/brain/connectors/google_test.go
@@ -275,7 +275,7 @@ func (f *fakeGoogle) server(t *testing.T) *httptest.Server {
 	})
 	// Fakes the markitdown sidecar: echoes back a recognizable marker
 	// plus the filename/mimetype headers it was called with, so tests
-	// can assert gmail_read/gmail_read_attachment actually reached it
+	// can assert read_mail/read_mail_attachment actually reached it
 	// (rather than asserting real markitdown behavior — that's covered
 	// by the sidecar's own build/run, not this Go test).
 	mux.HandleFunc("POST /convert", func(w http.ResponseWriter, r *http.Request) {
@@ -484,10 +484,10 @@ func TestGoogleReadOnlyToolsPinned(t *testing.T) {
 	}
 
 	want := map[string]bool{
-		"mail_search":          true,
-		"mail_read":            true,
-		"mail_read_attachment": true,
-		"calendar_list_events": true,
+		"search_mail":          true,
+		"read_mail":            true,
+		"read_mail_attachment": true,
+		"list_calendar_events": true,
 	}
 	got := map[string]bool{}
 	for _, tl := range src.Tools() {
@@ -553,15 +553,15 @@ func TestGmailToolsRoundTrip(t *testing.T) {
 	f := &fakeGoogle{}
 	src, _ := connectedSource(t, f)
 
-	out, err := toolByName(t, src, "mail_search").Execute(t.Context(), json.RawMessage(`{"query":"is:unread"}`))
+	out, err := toolByName(t, src, "search_mail").Execute(t.Context(), json.RawMessage(`{"query":"is:unread"}`))
 	if err != nil || !strings.Contains(out, "subject: hi") {
 		t.Fatalf("search = (%q, %v)", out, err)
 	}
-	out, err = toolByName(t, src, "mail_read").Execute(t.Context(), json.RawMessage(`{"id":"m1"}`))
+	out, err = toolByName(t, src, "read_mail").Execute(t.Context(), json.RawMessage(`{"id":"m1"}`))
 	if err != nil || !strings.Contains(out, "hello body") {
 		t.Fatalf("read = (%q, %v)", out, err)
 	}
-	out, err = toolByName(t, src, "mail_send").Execute(t.Context(),
+	out, err = toolByName(t, src, "send_mail").Execute(t.Context(),
 		json.RawMessage(`{"to":"b@y","subject":"re: hi","body":"on my way"}`))
 	if err != nil || !strings.Contains(out, "sent-1") {
 		t.Fatalf("send = (%q, %v)", out, err)
@@ -705,7 +705,7 @@ func TestGmailSearchZeroResultsSuggestsBroadening(t *testing.T) {
 	f := &fakeGoogle{}
 	src, _ := connectedSource(t, f)
 
-	out, err := toolByName(t, src, "mail_search").Execute(t.Context(),
+	out, err := toolByName(t, src, "search_mail").Execute(t.Context(),
 		json.RawMessage(`{"query":"from:nowhere.invalid"}`))
 	if err != nil {
 		t.Fatalf("search: %v", err)
@@ -716,7 +716,7 @@ func TestGmailSearchZeroResultsSuggestsBroadening(t *testing.T) {
 }
 
 // TestGmailReadFallsBackToMarkItDownForHTMLOnlyBody pins the fix for
-// HTML-only mail (booking confirmations, receipts): gmail_read used to
+// HTML-only mail (booking confirmations, receipts): read_mail used to
 // fall back to the truncated snippet whenever a message had no
 // text/plain part. It must now hand the text/html part to markitdown
 // instead — asserted here against the fake sidecar (real conversion
@@ -726,7 +726,7 @@ func TestGmailReadFallsBackToMarkItDownForHTMLOnlyBody(t *testing.T) {
 	f := &fakeGoogle{}
 	src, _ := connectedSource(t, f)
 
-	out, err := toolByName(t, src, "mail_read").Execute(t.Context(), json.RawMessage(`{"id":"m2"}`))
+	out, err := toolByName(t, src, "read_mail").Execute(t.Context(), json.RawMessage(`{"id":"m2"}`))
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
@@ -743,8 +743,8 @@ func TestGmailReadFallsBackToMarkItDownForHTMLOnlyBody(t *testing.T) {
 
 // TestGmailReadListsAttachmentsAndReadAttachmentUsesMarkItDown pins the
 // fix for PDF-only receipts (a Kiwi/Agoda-style booking whose amount
-// lives only in a PDF attachment): gmail_read must surface the
-// attachment filename, and gmail_read_attachment must look up the real
+// lives only in a PDF attachment): read_mail must surface the
+// attachment filename, and read_mail_attachment must look up the real
 // (long, opaque) Gmail attachment id itself — the model only ever
 // supplies the short, copyable filename.
 func TestGmailReadListsAttachmentsAndReadAttachmentUsesMarkItDown(t *testing.T) {
@@ -752,7 +752,7 @@ func TestGmailReadListsAttachmentsAndReadAttachmentUsesMarkItDown(t *testing.T) 
 	f := &fakeGoogle{}
 	src, _ := connectedSource(t, f)
 
-	out, err := toolByName(t, src, "mail_read").Execute(t.Context(), json.RawMessage(`{"id":"m3"}`))
+	out, err := toolByName(t, src, "read_mail").Execute(t.Context(), json.RawMessage(`{"id":"m3"}`))
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
@@ -763,7 +763,7 @@ func TestGmailReadListsAttachmentsAndReadAttachmentUsesMarkItDown(t *testing.T) 
 		t.Fatalf("read = %q, want the raw attachment id kept out of what the model sees", out)
 	}
 
-	out, err = toolByName(t, src, "mail_read_attachment").Execute(t.Context(),
+	out, err = toolByName(t, src, "read_mail_attachment").Execute(t.Context(),
 		json.RawMessage(`{"message_id":"m3","filename":"receipt.pdf"}`))
 	if err != nil {
 		t.Fatalf("read_attachment: %v", err)
@@ -783,7 +783,7 @@ func TestGmailReadAttachmentEmitsMedia(t *testing.T) {
 		return "att-1", "application/pdf", nil
 	})
 	ctx := tools.WithCollector(t.Context(), collector)
-	if _, err := toolByName(t, src, "mail_read_attachment").Execute(ctx,
+	if _, err := toolByName(t, src, "read_mail_attachment").Execute(ctx,
 		json.RawMessage(`{"message_id":"m3","filename":"receipt.pdf"}`)); err != nil {
 		t.Fatalf("read_attachment: %v", err)
 	}
@@ -802,7 +802,7 @@ func TestGmailReadAttachmentEmitFailureDoesNotFailTool(t *testing.T) {
 		return "", "", errors.New("save failed")
 	})
 	ctx := tools.WithCollector(t.Context(), collector)
-	out, err := toolByName(t, src, "mail_read_attachment").Execute(ctx,
+	out, err := toolByName(t, src, "read_mail_attachment").Execute(ctx,
 		json.RawMessage(`{"message_id":"m3","filename":"receipt.pdf"}`))
 	if err != nil {
 		t.Fatalf("read_attachment: %v, want the markdown conversion to still succeed", err)
@@ -817,7 +817,7 @@ func TestGmailReadAttachmentRejectsUnknownFilename(t *testing.T) {
 	f := &fakeGoogle{}
 	src, _ := connectedSource(t, f)
 
-	_, err := toolByName(t, src, "mail_read_attachment").Execute(t.Context(),
+	_, err := toolByName(t, src, "read_mail_attachment").Execute(t.Context(),
 		json.RawMessage(`{"message_id":"m3","filename":"nope.pdf"}`))
 	if err == nil {
 		t.Fatal("expected an error for an unknown attachment filename")
@@ -843,11 +843,11 @@ func TestCalendarToolsRoundTrip(t *testing.T) {
 	f := &fakeGoogle{}
 	src, _ := connectedSource(t, f)
 
-	out, err := toolByName(t, src, "calendar_list_events").Execute(t.Context(), json.RawMessage(`{}`))
+	out, err := toolByName(t, src, "list_calendar_events").Execute(t.Context(), json.RawMessage(`{}`))
 	if err != nil || !strings.Contains(out, "standup") || !strings.Contains(out, "zoom") {
 		t.Fatalf("list = (%q, %v)", out, err)
 	}
-	out, err = toolByName(t, src, "calendar_create_event").Execute(t.Context(), json.RawMessage(
+	out, err = toolByName(t, src, "create_calendar_event").Execute(t.Context(), json.RawMessage(
 		`{"summary":"1:1","start":"2026-07-23T10:00:00Z","end":"2026-07-23T10:30:00Z","attendees":["b@y"]}`))
 	if err != nil || !strings.Contains(out, "https://cal/ev-1") {
 		t.Fatalf("create = (%q, %v)", out, err)
@@ -862,7 +862,7 @@ func TestDriveSearchHappyPath(t *testing.T) {
 	f := &fakeGoogle{}
 	src, _ := connectedDriveDocsSource(t, f)
 
-	out, err := toolByName(t, src, "drive_search").Execute(t.Context(), json.RawMessage(`{"query":"budget"}`))
+	out, err := toolByName(t, src, "search_drive").Execute(t.Context(), json.RawMessage(`{"query":"budget"}`))
 	if err != nil {
 		t.Fatalf("search: %v", err)
 	}
@@ -871,7 +871,7 @@ func TestDriveSearchHappyPath(t *testing.T) {
 		t.Fatalf("search = %q", out)
 	}
 
-	out, err = toolByName(t, src, "drive_search").Execute(t.Context(), json.RawMessage(`{"query":"nothing-matches"}`))
+	out, err = toolByName(t, src, "search_drive").Execute(t.Context(), json.RawMessage(`{"query":"nothing-matches"}`))
 	if err != nil || !strings.Contains(out, "no files matched") {
 		t.Fatalf("empty search = (%q, %v)", out, err)
 	}
@@ -886,7 +886,7 @@ func TestDriveReadExportsGoogleNativeFile(t *testing.T) {
 	f := &fakeGoogle{}
 	src, _ := connectedDriveDocsSource(t, f)
 
-	out, err := toolByName(t, src, "drive_read").Execute(t.Context(), json.RawMessage(`{"id":"d1"}`))
+	out, err := toolByName(t, src, "read_drive_file").Execute(t.Context(), json.RawMessage(`{"id":"d1"}`))
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
@@ -898,13 +898,13 @@ func TestDriveReadExportsGoogleNativeFile(t *testing.T) {
 
 // TestDriveReadDownloadsAndConvertsBinaryFile pins the non-native path:
 // a binary file (PDF) is downloaded via alt=media and handed to
-// markitdown, same as gmail_read_attachment's PDF handling.
+// markitdown, same as read_mail_attachment's PDF handling.
 func TestDriveReadDownloadsAndConvertsBinaryFile(t *testing.T) {
 	t.Parallel()
 	f := &fakeGoogle{}
 	src, _ := connectedDriveDocsSource(t, f)
 
-	out, err := toolByName(t, src, "drive_read").Execute(t.Context(), json.RawMessage(`{"id":"bin1"}`))
+	out, err := toolByName(t, src, "read_drive_file").Execute(t.Context(), json.RawMessage(`{"id":"bin1"}`))
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
@@ -919,7 +919,7 @@ func TestDocsReadFlattensBodyToText(t *testing.T) {
 	f := &fakeGoogle{}
 	src, _ := connectedDriveDocsSource(t, f)
 
-	out, err := toolByName(t, src, "docs_read").Execute(t.Context(), json.RawMessage(`{"id":"doc1"}`))
+	out, err := toolByName(t, src, "read_doc").Execute(t.Context(), json.RawMessage(`{"id":"doc1"}`))
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
@@ -934,7 +934,7 @@ func TestDocsCreateWithInitialBody(t *testing.T) {
 	f := &fakeGoogle{}
 	src, _ := connectedDriveDocsSource(t, f)
 
-	out, err := toolByName(t, src, "docs_create").Execute(t.Context(),
+	out, err := toolByName(t, src, "create_doc").Execute(t.Context(),
 		json.RawMessage(`{"title":"New Doc","body":"hello world"}`))
 	if err != nil {
 		t.Fatalf("create: %v", err)
@@ -955,7 +955,7 @@ func TestDocsAppendInsertsAtEndIndex(t *testing.T) {
 	f := &fakeGoogle{}
 	src, _ := connectedDriveDocsSource(t, f)
 
-	out, err := toolByName(t, src, "docs_append").Execute(t.Context(),
+	out, err := toolByName(t, src, "append_doc").Execute(t.Context(),
 		json.RawMessage(`{"id":"doc1","text":"more text"}`))
 	if err != nil {
 		t.Fatalf("append: %v", err)

--- a/internal/brain/connectors/google_tools.go
+++ b/internal/brain/connectors/google_tools.go
@@ -294,11 +294,11 @@ func htmlPart(parts []gmailPart) []byte {
 
 func (s *googleSource) gmailSearch() *tools.Tool {
 	return &tools.Tool{
-		Name:     "mail_search",
+		Name:     "search_mail",
 		ReadOnly: true,
 		Description: `Search a connected mail account. Returns up to max_results
 (default 10) messages as id, date, from, subject, snippet. Use
-mail_read with an id for the full body. See the tool description's
+read_mail with an id for the full body. See the tool description's
 Connected accounts list for this account's query syntax.`,
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"query":{"type":"string","description":"search query"},
@@ -347,7 +347,7 @@ Connected accounts list for this account's query syntax.`,
 }
 
 // gmailAttachment names one attachment found while walking a message's
-// MIME tree, ready to hand to gmail_read_attachment.
+// MIME tree, ready to hand to read_mail_attachment.
 type gmailAttachment struct {
 	Filename     string
 	AttachmentID string
@@ -356,7 +356,7 @@ type gmailAttachment struct {
 // attachments walks the MIME tree collecting every part that names a
 // file AND carries an attachment id — inline images with no filename,
 // and body parts with data inlined directly rather than referenced by
-// id, are not attachments in the sense gmail_read_attachment needs.
+// id, are not attachments in the sense read_mail_attachment needs.
 func attachments(parts []gmailPart) []gmailAttachment {
 	var out []gmailAttachment
 	for _, p := range parts {
@@ -369,7 +369,7 @@ func attachments(parts []gmailPart) []gmailAttachment {
 }
 
 // findAttachment returns the attachment id for a given filename.
-// gmail_read_attachment takes a filename, never the raw Gmail
+// read_mail_attachment takes a filename, never the raw Gmail
 // attachment id: that id is a 300-400+ char opaque token, and models
 // reliably truncate it when copying it into a tool call — every
 // real-world attempt failed with "Invalid attachment token" before
@@ -387,9 +387,9 @@ func findAttachment(parts []gmailPart, filename string) (string, bool) {
 
 func (s *googleSource) gmailRead() *tools.Tool {
 	return &tools.Tool{
-		Name:        "mail_read",
+		Name:        "read_mail",
 		ReadOnly:    true,
-		Description: "Read one email's full content by message id (from mail_search). Returns headers and the body as readable text, plus a list of attachment filenames, if any. Use mail_read_attachment with the message id and a filename from that list to read an attachment's content.",
+		Description: "Read one email's full content by message id (from search_mail). Returns headers and the body as readable text, plus a list of attachment filenames, if any. Use read_mail_attachment with the message id and a filename from that list to read an attachment's content.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"id":{"type":"string","description":"message id"}
 		},"required":["id"],"additionalProperties":false}`),
@@ -434,12 +434,12 @@ func (s *googleSource) gmailRead() *tools.Tool {
 
 func (s *googleSource) gmailReadAttachment() *tools.Tool {
 	return &tools.Tool{
-		Name:        "mail_read_attachment",
+		Name:        "read_mail_attachment",
 		ReadOnly:    true,
-		Description: "Reads an attachment's content as markdown/text, given a message id and the attachment's filename (both from mail_read's attachments list). Handles PDFs, Office documents, and other common formats.",
+		Description: "Reads an attachment's content as markdown/text, given a message id and the attachment's filename (both from read_mail's attachments list). Handles PDFs, Office documents, and other common formats.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"message_id":{"type":"string","description":"message id"},
-			"filename":{"type":"string","description":"Attachment filename from mail_read's attachments list"}
+			"filename":{"type":"string","description":"Attachment filename from read_mail's attachments list"}
 		},"required":["message_id","filename"],"additionalProperties":false}`),
 		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
 			var in struct {
@@ -460,7 +460,7 @@ func (s *googleSource) gmailReadAttachment() *tools.Tool {
 			}
 			attachmentID, ok := findAttachment(msg.Payload.Parts, in.Filename)
 			if !ok {
-				return "", fmt.Errorf("no attachment named %q on this message; check mail_read's attachments list", in.Filename)
+				return "", fmt.Errorf("no attachment named %q on this message; check read_mail's attachments list", in.Filename)
 			}
 			var att gmailBody
 			if err := s.api(ctx, http.MethodGet,
@@ -487,7 +487,7 @@ func (s *googleSource) gmailReadAttachment() *tools.Tool {
 
 func (s *googleSource) gmailSend() *tools.Tool {
 	return &tools.Tool{
-		Name:        "mail_send",
+		Name:        "send_mail",
 		Description: "Send an email from a connected mail account. Plain text only. Use only when the user asked for an email to be sent; the recipient sees it immediately.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"to":{"type":"string","description":"recipient address(es), comma-separated"},
@@ -526,7 +526,7 @@ func (s *googleSource) gmailSend() *tools.Tool {
 
 func (s *googleSource) calendarListEvents() *tools.Tool {
 	return &tools.Tool{
-		Name:        "calendar_list_events",
+		Name:        "list_calendar_events",
 		ReadOnly:    true,
 		Description: "List events from the connected calendar in a time window. Omit time_min/time_max for the default window, the next 7 days from now; set them (RFC3339 UTC) only when the goal needs a different window, computed from today's actual date. Returns start, end, title, and location per event.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
@@ -597,7 +597,7 @@ func (s *googleSource) calendarListEvents() *tools.Tool {
 
 func (s *googleSource) calendarCreateEvent() *tools.Tool {
 	return &tools.Tool{
-		Name:        "calendar_create_event",
+		Name:        "create_calendar_event",
 		Description: "Create an event on the connected account's primary calendar. start and end are RFC3339 timestamps with offset, e.g. 2026-07-22T15:00:00+02:00. Use only when the user asked for an event; depending on the provider, attendees may be notified immediately.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"summary":{"type":"string","description":"event title"},
@@ -648,7 +648,7 @@ func (s *googleSource) calendarCreateEvent() *tools.Tool {
 
 // --- Drive ---
 
-// driveReadMaxResult bounds drive_read's returned text — Drive
+// driveReadMaxResult bounds read_drive_file's returned text — Drive
 // documents and downloaded/converted files have no inherent size
 // cap, and an unbounded file could blow the loop's context budget.
 // Same convention as webFetchMaxResult.
@@ -665,12 +665,12 @@ var driveExportMimeTypes = map[string]string{
 
 func (s *googleSource) driveSearch() *tools.Tool {
 	return &tools.Tool{
-		Name: "drive_search",
+		Name: "search_drive",
 		Description: `Search Google Drive by file name or content. query is matched
 against file names and, for supported formats, document content
 (Drive's "fullText contains" search). Returns up to max_results
 (default 20) files as id, name, mimeType, modifiedTime, webViewLink.
-Use drive_read with an id to read a file's content.`,
+Use read_drive_file with an id to read a file's content.`,
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"query":{"type":"string","description":"words to match against file name and content"},
 			"max_results":{"type":"integer","minimum":1,"maximum":50}
@@ -721,8 +721,8 @@ Use drive_read with an id to read a file's content.`,
 
 func (s *googleSource) driveRead() *tools.Tool {
 	return &tools.Tool{
-		Name:        "drive_read",
-		Description: "Read a Drive file's content by id (from drive_search). Google Docs/Sheets/Slides export to text/markdown/CSV; other formats (PDF, Office documents, ...) download and convert to markdown. Long content is truncated.",
+		Name:        "read_drive_file",
+		Description: "Read a Drive file's content by id (from search_drive). Google Docs/Sheets/Slides export to text/markdown/CSV; other formats (PDF, Office documents, ...) download and convert to markdown. Long content is truncated.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"id":{"type":"string","description":"Drive file id"}
 		},"required":["id"],"additionalProperties":false}`),
@@ -781,7 +781,7 @@ func (s *googleSource) driveRead() *tools.Tool {
 
 // --- Docs ---
 
-// docsReadMaxResult bounds docs_read's returned text, same convention
+// docsReadMaxResult bounds read_doc's returned text, same convention
 // as driveReadMaxResult.
 const docsReadMaxResult = 64 << 10
 
@@ -812,8 +812,8 @@ type docsStructuralElement struct {
 
 func (s *googleSource) docsRead() *tools.Tool {
 	return &tools.Tool{
-		Name:        "docs_read",
-		Description: "Read a Google Doc's content by id (from drive_search, or a doc's id from its URL/docs_create's result). Returns the document title and body as plain text. Long documents are truncated.",
+		Name:        "read_doc",
+		Description: "Read a Google Doc's content by id (from search_drive, or a doc's id from its URL/create_doc's result). Returns the document title and body as plain text. Long documents are truncated.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"id":{"type":"string","description":"Google Doc id"}
 		},"required":["id"],"additionalProperties":false}`),
@@ -849,7 +849,7 @@ func (s *googleSource) docsRead() *tools.Tool {
 
 func (s *googleSource) docsCreate() *tools.Tool {
 	return &tools.Tool{
-		Name:        "docs_create",
+		Name:        "create_doc",
 		Description: "Create a new Google Doc with a title and initial body text. Returns the new doc's id and webViewLink. Use only when the user asked for a new document.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"title":{"type":"string"},
@@ -891,7 +891,7 @@ func (s *googleSource) docsCreate() *tools.Tool {
 
 func (s *googleSource) docsAppend() *tools.Tool {
 	return &tools.Tool{
-		Name:        "docs_append",
+		Name:        "append_doc",
 		Description: "Append text to the end of an existing Google Doc. Use only when the user asked to add to a document; the change is immediate and visible to anyone viewing it.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"id":{"type":"string","description":"Google Doc id"},

--- a/internal/brain/connectors/imap.go
+++ b/internal/brain/connectors/imap.go
@@ -20,7 +20,7 @@ import (
 // password lives in the connector's credential_ref (secret store),
 // never here. Port defaults to 993 (implicit TLS); port 143 selects
 // STARTTLS instead. AccountEmail defaults to Username when unset.
-// SMTPHost is optional and gates whether mail_send is served at all;
+// SMTPHost is optional and gates whether send_mail is served at all;
 // SMTPPort defaults to 587 (STARTTLS), port 465 selects implicit TLS.
 type IMAPConfig struct {
 	Host         string `json:"host"`
@@ -82,7 +82,7 @@ func imapConfig(c Connector) (IMAPConfig, error) {
 // IMAPBuilder returns the Builder for kind='imap'. client is used for
 // markitdown's HTTP call (attachment conversion); a nil client
 // defaults inside markitdown.Convert. markItDownURL is the markitdown
-// sidecar's base address; empty disables mail_read_attachment with a
+// sidecar's base address; empty disables read_mail_attachment with a
 // clear per-call error, same convention as Microsoft.MarkItDownURL.
 func IMAPBuilder(client *http.Client, markItDownURL string) Builder {
 	return func(_ context.Context, c Connector, resolve Resolve) (Source, error) {
@@ -126,8 +126,8 @@ type imapSource struct {
 	send func(ctx context.Context, cfg IMAPConfig, password string, recipients []string, message []byte) error
 }
 
-// Tools returns mail_search/mail_read/mail_read_attachment always,
-// plus mail_send only when SMTPHost is configured.
+// Tools returns search_mail/read_mail/read_mail_attachment always,
+// plus send_mail only when SMTPHost is configured.
 func (s *imapSource) Tools() []*tools.Tool {
 	out := []*tools.Tool{s.mailSearch(), s.mailRead(), s.mailReadAttachment()}
 	if s.cfg.SMTPHost != "" {

--- a/internal/brain/connectors/imap_test.go
+++ b/internal/brain/connectors/imap_test.go
@@ -72,7 +72,7 @@ func (f *fakeIMAPSession) FetchAttachment(_ context.Context, uid imap.UID, filen
 	}
 	a, ok := byName[filename]
 	if !ok {
-		return nil, "", fmt.Errorf("no attachment named %q on this message; check mail_read's attachments list", filename)
+		return nil, "", fmt.Errorf("no attachment named %q on this message; check read_mail's attachments list", filename)
 	}
 	return a.raw, a.ct, nil
 }
@@ -140,7 +140,7 @@ func imapToolByName(t *testing.T, src *imapSource, name string) *tools.Tool {
 }
 
 // markitdownStub serves the same /convert response shape
-// microsoft_test.go's fakeMicrosoft uses, so mail_read_attachment's
+// microsoft_test.go's fakeMicrosoft uses, so read_mail_attachment's
 // markitdown round trip can be asserted without a real sidecar.
 func markitdownStub(t *testing.T) *httptest.Server {
 	t.Helper()
@@ -163,7 +163,7 @@ func TestIMAPMailSearchFormatsResults(t *testing.T) {
 	}}
 	src, _ := testIMAPSource(t, imapRow(""), sess)
 
-	out, err := imapToolByName(t, src, "mail_search").Execute(t.Context(), json.RawMessage(`{"query":"hi"}`))
+	out, err := imapToolByName(t, src, "search_mail").Execute(t.Context(), json.RawMessage(`{"query":"hi"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestIMAPMailSearchFormatsResults(t *testing.T) {
 		}
 	}
 	if !sess.closed {
-		t.Fatal("session not closed after mail_search")
+		t.Fatal("session not closed after search_mail")
 	}
 }
 
@@ -182,7 +182,7 @@ func TestIMAPMailSearchNoResults(t *testing.T) {
 	sess := &fakeIMAPSession{}
 	src, _ := testIMAPSource(t, imapRow(""), sess)
 
-	out, err := imapToolByName(t, src, "mail_search").Execute(t.Context(), json.RawMessage(`{"query":"nowhere"}`))
+	out, err := imapToolByName(t, src, "search_mail").Execute(t.Context(), json.RawMessage(`{"query":"nowhere"}`))
 	if err != nil || out != "no messages matched" {
 		t.Fatalf("Execute = (%q, %v)", out, err)
 	}
@@ -198,7 +198,7 @@ func TestIMAPMailSearchMaxResultsDefaultAndCap(t *testing.T) {
 	src, _ := testIMAPSource(t, imapRow(""), sess)
 
 	// Default (no max_results): capped at imapSearchDefault (10).
-	out, err := imapToolByName(t, src, "mail_search").Execute(t.Context(), json.RawMessage(`{"query":"m"}`))
+	out, err := imapToolByName(t, src, "search_mail").Execute(t.Context(), json.RawMessage(`{"query":"m"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestIMAPMailSearchMaxResultsDefaultAndCap(t *testing.T) {
 	}
 
 	// Explicit max_results above imapSearchMax (25): capped at 25.
-	out, err = imapToolByName(t, src, "mail_search").Execute(t.Context(), json.RawMessage(`{"query":"m","max_results":1000}`))
+	out, err = imapToolByName(t, src, "search_mail").Execute(t.Context(), json.RawMessage(`{"query":"m","max_results":1000}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -223,7 +223,7 @@ func TestIMAPMailReadPrefersPlainTextOverHTML(t *testing.T) {
 	}}
 	src, _ := testIMAPSource(t, imapRow(""), sess)
 
-	out, err := imapToolByName(t, src, "mail_read").Execute(t.Context(), json.RawMessage(`{"id":"7"}`))
+	out, err := imapToolByName(t, src, "read_mail").Execute(t.Context(), json.RawMessage(`{"id":"7"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestIMAPMailReadListsAttachments(t *testing.T) {
 	}}
 	src, _ := testIMAPSource(t, imapRow(""), sess)
 
-	out, err := imapToolByName(t, src, "mail_read").Execute(t.Context(), json.RawMessage(`{"id":"9"}`))
+	out, err := imapToolByName(t, src, "read_mail").Execute(t.Context(), json.RawMessage(`{"id":"9"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -263,7 +263,7 @@ func TestIMAPMailReadAttachmentUsesMarkItDown(t *testing.T) {
 	src, _ := testIMAPSource(t, imapRow(""), sess)
 	src.markItDownURL = srv.URL
 
-	out, err := imapToolByName(t, src, "mail_read_attachment").Execute(t.Context(),
+	out, err := imapToolByName(t, src, "read_mail_attachment").Execute(t.Context(),
 		json.RawMessage(`{"message_id":"9","filename":"receipt.pdf"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -291,7 +291,7 @@ func TestIMAPMailReadAttachmentEmitsMedia(t *testing.T) {
 		return "att-1", "application/pdf", nil
 	})
 	ctx := tools.WithCollector(t.Context(), collector)
-	if _, err := imapToolByName(t, src, "mail_read_attachment").Execute(ctx,
+	if _, err := imapToolByName(t, src, "read_mail_attachment").Execute(ctx,
 		json.RawMessage(`{"message_id":"9","filename":"receipt.pdf"}`)); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestIMAPMailReadAttachmentEmitFailureDoesNotFailTool(t *testing.T) {
 		return "", "", errors.New("save failed")
 	})
 	ctx := tools.WithCollector(t.Context(), collector)
-	out, err := imapToolByName(t, src, "mail_read_attachment").Execute(ctx,
+	out, err := imapToolByName(t, src, "read_mail_attachment").Execute(ctx,
 		json.RawMessage(`{"message_id":"9","filename":"receipt.pdf"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v, want the markdown conversion to still succeed", err)
@@ -336,7 +336,7 @@ func TestIMAPMailReadAttachmentUnknownName(t *testing.T) {
 	}{9: {}}}
 	src, _ := testIMAPSource(t, imapRow(""), sess)
 
-	_, err := imapToolByName(t, src, "mail_read_attachment").Execute(t.Context(),
+	_, err := imapToolByName(t, src, "read_mail_attachment").Execute(t.Context(),
 		json.RawMessage(`{"message_id":"9","filename":"nope.pdf"}`))
 	if err == nil {
 		t.Fatal("expected an error for an unknown attachment name")
@@ -347,8 +347,8 @@ func TestIMAPMailSendAbsentWithoutSMTPHost(t *testing.T) {
 	t.Parallel()
 	src, _ := testIMAPSource(t, imapRow(""), &fakeIMAPSession{})
 	for _, tl := range src.Tools() {
-		if tl.Name == "mail_send" {
-			t.Fatal("mail_send must not be present without smtp_host configured")
+		if tl.Name == "send_mail" {
+			t.Fatal("send_mail must not be present without smtp_host configured")
 		}
 	}
 }
@@ -358,12 +358,12 @@ func TestIMAPMailSendPresentWithSMTPHost(t *testing.T) {
 	src, _ := testIMAPSource(t, imapRow("smtp.example.com"), &fakeIMAPSession{})
 	found := false
 	for _, tl := range src.Tools() {
-		if tl.Name == "mail_send" {
+		if tl.Name == "send_mail" {
 			found = true
 		}
 	}
 	if !found {
-		t.Fatal("mail_send must be present when smtp_host is configured")
+		t.Fatal("send_mail must be present when smtp_host is configured")
 	}
 }
 
@@ -371,7 +371,7 @@ func TestIMAPMailSendAssemblesMessage(t *testing.T) {
 	t.Parallel()
 	src, sent := testIMAPSource(t, imapRow("smtp.example.com"), &fakeIMAPSession{})
 
-	out, err := imapToolByName(t, src, "mail_send").Execute(t.Context(),
+	out, err := imapToolByName(t, src, "send_mail").Execute(t.Context(),
 		json.RawMessage(`{"to":"b@y.com","cc":"c@z.com","subject":"hi there","body":"the body"}`))
 	if err != nil || out != "sent" {
 		t.Fatalf("Execute = (%q, %v)", out, err)
@@ -398,7 +398,7 @@ func TestIMAPMailSendDisplayNameRecipient(t *testing.T) {
 	t.Parallel()
 	src, sent := testIMAPSource(t, imapRow("smtp.example.com"), &fakeIMAPSession{})
 
-	out, err := imapToolByName(t, src, "mail_send").Execute(t.Context(),
+	out, err := imapToolByName(t, src, "send_mail").Execute(t.Context(),
 		json.RawMessage(`{"to":"Bob Jones <b@y.com>","subject":"hi","body":"b"}`))
 	if err != nil || out != "sent" {
 		t.Fatalf("Execute = (%q, %v)", out, err)
@@ -417,7 +417,7 @@ func TestIMAPMailSendQuotedDisplayNameWithComma(t *testing.T) {
 	t.Parallel()
 	src, sent := testIMAPSource(t, imapRow("smtp.example.com"), &fakeIMAPSession{})
 
-	out, err := imapToolByName(t, src, "mail_send").Execute(t.Context(),
+	out, err := imapToolByName(t, src, "send_mail").Execute(t.Context(),
 		json.RawMessage(`{"to":"\"Jones, Bob\" <b@y.com>","subject":"hi","body":"b"}`))
 	if err != nil || out != "sent" {
 		t.Fatalf("Execute = (%q, %v)", out, err)
@@ -434,7 +434,7 @@ func TestIMAPMailSendUnparseableAddressErrors(t *testing.T) {
 	t.Parallel()
 	src, sent := testIMAPSource(t, imapRow("smtp.example.com"), &fakeIMAPSession{})
 
-	_, err := imapToolByName(t, src, "mail_send").Execute(t.Context(),
+	_, err := imapToolByName(t, src, "send_mail").Execute(t.Context(),
 		json.RawMessage(`{"to":"not an address","subject":"hi","body":"b"}`))
 	if err == nil {
 		t.Fatal("expected an error for an unparseable to address")
@@ -448,7 +448,7 @@ func TestIMAPMailSendEncodesNonASCIISubject(t *testing.T) {
 	t.Parallel()
 	src, sent := testIMAPSource(t, imapRow("smtp.example.com"), &fakeIMAPSession{})
 
-	out, err := imapToolByName(t, src, "mail_send").Execute(t.Context(),
+	out, err := imapToolByName(t, src, "send_mail").Execute(t.Context(),
 		json.RawMessage(`{"to":"b@y.com","subject":"héllo","body":"b"}`))
 	if err != nil || out != "sent" {
 		t.Fatalf("Execute = (%q, %v)", out, err)
@@ -476,7 +476,7 @@ func TestIMAPMailSendRejectsHeaderInjection(t *testing.T) {
 		{"newline in cc", `{"to":"b@y.com","cc":"c@z.com\nBcc: evil@x.com","subject":"hi","body":"b"}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := imapToolByName(t, src, "mail_send").Execute(t.Context(), json.RawMessage(tc.args))
+			_, err := imapToolByName(t, src, "send_mail").Execute(t.Context(), json.RawMessage(tc.args))
 			if err == nil {
 				t.Fatal("expected an error for a header value containing a newline")
 			}

--- a/internal/brain/connectors/imap_tools.go
+++ b/internal/brain/connectors/imap_tools.go
@@ -24,14 +24,14 @@ import (
 	"github.com/SumonMSelim/timothy/internal/platform/markitdown"
 )
 
-// imapSearchDefault/imapSearchMax mirror microsoft/google's mail_search
+// imapSearchDefault/imapSearchMax mirror microsoft/google's search_mail
 // max_results default and cap.
 const (
 	imapSearchDefault = 10
 	imapSearchMax     = 25
 )
 
-// imapMessageSummary is one mail_search result: envelope plus a best-
+// imapMessageSummary is one search_mail result: envelope plus a best-
 // effort snippet.
 type imapMessageSummary struct {
 	UID     imap.UID
@@ -42,13 +42,13 @@ type imapMessageSummary struct {
 }
 
 // imapAttachment names one attachment found in a parsed message, ready
-// to hand to mail_read_attachment.
+// to hand to read_mail_attachment.
 type imapAttachment struct {
 	Filename    string
 	ContentType string
 }
 
-// imapMessage is one mail_read result: headers, body text, and
+// imapMessage is one read_mail result: headers, body text, and
 // attachment metadata.
 type imapMessage struct {
 	From, To, Date, Subject string
@@ -116,7 +116,7 @@ func (s *imapConn) Search(ctx context.Context, words []string, max int) ([]imapM
 	return out, nil
 }
 
-// buildSummary builds one mail_search result's envelope fields from a
+// buildSummary builds one search_mail result's envelope fields from a
 // fetched message's UID/INTERNALDATE/ENVELOPE, pure so it's testable
 // without a live IMAP session. Date defaults to internalDate and is
 // only overwritten by the envelope's own Date when that's non-zero: a
@@ -267,7 +267,7 @@ func (s *imapConn) Close() error {
 }
 
 // formatEnvelopeAddresses renders envelope From addresses the same
-// "Name <addr>" shape microsoft/google's mail_search uses.
+// "Name <addr>" shape microsoft/google's search_mail uses.
 func formatEnvelopeAddresses(addrs []imap.Address) string {
 	parts := make([]string, 0, len(addrs))
 	for _, a := range addrs {
@@ -373,11 +373,11 @@ func findIMAPAttachment(raw []byte, filename string) ([]byte, string, error) {
 		}
 		return body, ct, nil
 	}
-	return nil, "", fmt.Errorf("no attachment named %q on this message; check mail_read's attachments list", filename)
+	return nil, "", fmt.Errorf("no attachment named %q on this message; check read_mail's attachments list", filename)
 }
 
 // joinAddresses renders a net/mail address list the same "Name <addr>"
-// shape microsoft/google's mail_read uses.
+// shape microsoft/google's read_mail uses.
 func joinAddresses(addrs []*mail.Address) string {
 	parts := make([]string, 0, len(addrs))
 	for _, a := range addrs {
@@ -388,11 +388,11 @@ func joinAddresses(addrs []*mail.Address) string {
 
 func (s *imapSource) mailSearch() *tools.Tool {
 	return &tools.Tool{
-		Name:     "mail_search",
+		Name:     "search_mail",
 		ReadOnly: true,
 		Description: `Search a connected mail account. Returns up to max_results
 (default 10) messages as id, date, from, subject, snippet. Use
-mail_read with an id for the full body. See the tool description's
+read_mail with an id for the full body. See the tool description's
 Connected accounts list for this account's query syntax.`,
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"query":{"type":"string","description":"search query"},
@@ -442,9 +442,9 @@ Connected accounts list for this account's query syntax.`,
 
 func (s *imapSource) mailRead() *tools.Tool {
 	return &tools.Tool{
-		Name:        "mail_read",
+		Name:        "read_mail",
 		ReadOnly:    true,
-		Description: "Read one email's full content by message id (from mail_search). Returns headers and the body as readable text, plus a list of attachment filenames, if any. Use mail_read_attachment with the message id and a filename from that list to read an attachment's content.",
+		Description: "Read one email's full content by message id (from search_mail). Returns headers and the body as readable text, plus a list of attachment filenames, if any. Use read_mail_attachment with the message id and a filename from that list to read an attachment's content.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"id":{"type":"string","description":"message id"}
 		},"required":["id"],"additionalProperties":false}`),
@@ -487,12 +487,12 @@ func (s *imapSource) mailRead() *tools.Tool {
 
 func (s *imapSource) mailReadAttachment() *tools.Tool {
 	return &tools.Tool{
-		Name:        "mail_read_attachment",
+		Name:        "read_mail_attachment",
 		ReadOnly:    true,
-		Description: "Reads an attachment's content as markdown/text, given a message id and the attachment's filename (both from mail_read's attachments list). Handles PDFs, Office documents, and other common formats.",
+		Description: "Reads an attachment's content as markdown/text, given a message id and the attachment's filename (both from read_mail's attachments list). Handles PDFs, Office documents, and other common formats.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"message_id":{"type":"string","description":"message id"},
-			"filename":{"type":"string","description":"Attachment filename from mail_read's attachments list"}
+			"filename":{"type":"string","description":"Attachment filename from read_mail's attachments list"}
 		},"required":["message_id","filename"],"additionalProperties":false}`),
 		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
 			var in struct {
@@ -532,7 +532,7 @@ func (s *imapSource) mailReadAttachment() *tools.Tool {
 
 func (s *imapSource) mailSend() *tools.Tool {
 	return &tools.Tool{
-		Name:        "mail_send",
+		Name:        "send_mail",
 		Description: "Send an email from a connected mail account. Plain text only. Use only when the user asked for an email to be sent; the recipient sees it immediately.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"to":{"type":"string","description":"recipient address(es), comma-separated"},
@@ -584,7 +584,7 @@ func (s *imapSource) mailSend() *tools.Tool {
 	}
 }
 
-// parseIMAPUID parses a mail_search-returned id string back into a UID.
+// parseIMAPUID parses a search_mail-returned id string back into a UID.
 func parseIMAPUID(id string) (imap.UID, error) {
 	n, err := strconv.ParseUint(id, 10, 32)
 	if err != nil {

--- a/internal/brain/connectors/manager.go
+++ b/internal/brain/connectors/manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -145,22 +146,22 @@ func (m *Manager) Reload(ctx context.Context) error {
 // toolNameSanitizer strips characters providers reject in tool names.
 var toolNameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
 
-// Tools returns the agent's whole non-MCP tool surface aggregated one
-// tool per raw name (see aggregateTools), plus every MCP source's
-// tools individually namespaced "<connector>_<tool>" as before: MCP
-// servers are external, their names can't be unified.
-func (m *Manager) Tools() []*tools.Tool {
+// Tools returns the agent's whole tool surface: every source (MCP
+// included) joins the raw-name aggregation aggregateTools performs,
+// with an "account" argument selecting the connector once more than
+// one contributes the same raw name — same as the unified mail/
+// calendar surface. reserved names (the agent's non-connector tools,
+// e.g. builtins) never aggregate under their raw form: a connector
+// tool sharing one falls back to "<connector>_<tool>" instead, so a
+// remote MCP server can never shadow a tool the operator didn't wire
+// through a connector. Two MCP connectors serving the same raw name
+// with non-identical schemas also fall back to namespaced form for
+// that name (see aggregateTools): unlike Timothy's own connector
+// kinds, an external MCP server's schema can't be assumed to match.
+func (m *Manager) Tools(reserved map[string]bool) []*tools.Tool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	out := aggregateTools(m.sources, false)
-	for name, src := range m.sources {
-		mcp, isMCP := src.(*mcpSource)
-		if !isMCP {
-			continue
-		}
-		out = append(out, namespacedTools(name, mcp.Tools())...)
-	}
-	return out
+	return aggregateTools(m.sources, false, reserved)
 }
 
 // ReadOnlyTools returns the aggregated ReadOnly-marked non-MCP tool
@@ -174,7 +175,7 @@ func (m *Manager) Tools() []*tools.Tool {
 func (m *Manager) ReadOnlyTools() []*tools.Tool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return aggregateTools(m.sources, true)
+	return aggregateTools(m.sources, true, nil)
 }
 
 // AccountConnector resolves which connector name a unified tool call
@@ -182,30 +183,25 @@ func (m *Manager) ReadOnlyTools() []*tools.Tool {
 // resolution aggregateTool's Execute applies, exposed standalone so
 // callers that only need to know WHICH connector a call touches (e.g.
 // connector-level sensitivity, session.SensitiveTools) don't have to
-// re-run the call to find out. Returns "" when toolName isn't a
-// currently aggregated non-MCP tool, or when args' account doesn't
-// resolve (missing-but-required, or unknown); callers fall back to
-// their own default in that case, same as any non-connector tool call.
+// re-run the call to find out. Every source, MCP included, contributes
+// here through groupByRawName's SAME merge decision Tools uses: an MCP
+// tool that actually merged into the raw-name surface routes through
+// account resolution, so a sensitive MCP connector's raw-named tool
+// call still resolves back to it; an MCP tool that stayed namespaced
+// (Guard A/B) never reaches here under its raw name, since it isn't
+// exposed that way. reserved is nil: sensitivity resolution runs after
+// the agent's tool surface is already fixed, so it only needs to know
+// what's ACTUALLY unified, which groupByRawName reports regardless of
+// reserved (a nil reserved set only affects the split, never whether a
+// name that did merge is resolvable). Returns "" when toolName isn't a
+// currently aggregated tool, or when args' account doesn't resolve
+// (missing-but-required, or unknown); callers fall back to their own
+// default in that case, same as any non-connector tool call.
 func (m *Manager) AccountConnector(toolName string, args json.RawMessage) string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	byName := map[string][]toolAccount{}
-	for name, src := range m.sources {
-		if _, isMCP := src.(*mcpSource); isMCP {
-			continue
-		}
-		var kind, email string
-		if info, ok := src.(accountInfo); ok {
-			kind, email = info.AccountInfo()
-		}
-		for _, t := range src.Tools() {
-			if t.Name != toolName {
-				continue
-			}
-			byName[t.Name] = append(byName[t.Name], toolAccount{connector: name, kind: kind, email: email, tool: t})
-		}
-	}
-	accounts, ok := byName[toolName]
+	merged, _ := groupByRawName(m.sources, nil)
+	accounts, ok := merged[toolName]
 	if !ok {
 		return ""
 	}
@@ -217,7 +213,8 @@ func (m *Manager) AccountConnector(toolName string, args json.RawMessage) string
 }
 
 // namespacedTools clones ts renamed "<name>_<tool>", sanitized and
-// length-capped: MCP's tool-naming scheme, unchanged by unification.
+// length-capped: MCP's tool-naming scheme, kept for a name that stays
+// split (see groupByRawName).
 func namespacedTools(name string, ts []*tools.Tool) []*tools.Tool {
 	out := make([]*tools.Tool, 0, len(ts))
 	for _, t := range ts {
@@ -235,16 +232,15 @@ func namespacedTools(name string, ts []*tools.Tool) []*tools.Tool {
 // accountInfo is the optional Source capability that reports the
 // source's kind and connected account email (google-, microsoft-kind
 // today): the input aggregateTools groups tools around. A source that
-// doesn't implement it (mcp) is never aggregated; Tools/ReadOnlyTools
-// handle mcp separately.
+// doesn't implement it (mcp included) reports empty kind/email but
+// still joins the raw-name grouping.
 type accountInfo interface {
 	AccountInfo() (kind, email string)
 }
 
-// toolAccount is one accountInfo-capable source's contribution to an
-// aggregated tool: its connector name/kind/email (for account matching
-// and the description's connected-accounts list) plus its own
-// (un-namespaced) tool.
+// toolAccount is one source's contribution to an aggregated tool: its
+// connector name/kind/email (for account matching and the description's
+// connected-accounts list) plus its own (un-namespaced) tool.
 type toolAccount struct {
 	connector string
 	kind      string
@@ -252,48 +248,185 @@ type toolAccount struct {
 	tool      *tools.Tool
 }
 
-// aggregateTools groups every non-MCP source's tools by their RAW
-// (un-namespaced) name and returns one aggregate tool per name, giving
-// the unified mail surface: "mail_search" once, regardless of how many
-// accounts or connector kinds serve it. A future connector kind joins
-// this surface automatically just by giving its tools the same raw
-// names; accountInfo is read opportunistically for kind/email metadata
-// (empty when a source doesn't implement it) and never gates whether a
-// source's tools aggregate. readOnlyOnly mirrors the old ReadOnlyTools'
-// filter: a WHOLE aggregate is dropped unless every contributing
-// account's tool is ReadOnly. Contributing accounts on one capability
-// should always agree (see aggregateTool's ReadOnly), so this only ever
-// matters if that invariant is somehow violated, in which case the
-// safer behavior is to withhold the capability entirely rather than
-// silently narrow it to a subset of accounts.
-func aggregateTools(sources map[string]Source, readOnlyOnly bool) []*tools.Tool {
+// groupByRawName is the merge decision Tools, ReadOnlyTools, and
+// AccountConnector all share: every source's tools grouped by their
+// RAW (un-namespaced) name, split into what actually aggregates under
+// that name and what must stay namespaced. Two guards pull a name (or
+// one connector's copy of it) out of the merged set and into split:
+//
+//   - reserved: a name the agent could already have from somewhere
+//     else (builtins, chat-only mission tools) never aggregates,
+//     regardless of source — a connector must never shadow a tool the
+//     operator didn't wire through a connector. nil means nothing is
+//     reserved (safe default for callers, like AccountConnector, that
+//     run after the actual surface is already fixed).
+//   - schema mismatch among MCP contributors: non-MCP sources sharing a
+//     raw name are Timothy's own code and assumed schema-identical by
+//     construction (TestGoogleMicrosoftSharedToolSchemasMatch); an
+//     external MCP server can't be trusted the same way. If any two
+//     MCP connectors serving the same raw name (or an MCP connector and
+//     a non-MCP one already occupying that name) disagree on
+//     InputSchema, every MCP contributor at that name splits instead of
+//     merging — the non-MCP contributors, if any, still merge among
+//     themselves.
+//
+// A name with zero merged contributors after splitting simply doesn't
+// appear in merged; its split contributors still get their namespaced
+// form from the caller.
+func groupByRawName(sources map[string]Source, reserved map[string]bool) (merged map[string][]toolAccount, split map[string][]toolAccount) {
 	byName := map[string][]toolAccount{}
-	var order []string
 	for name, src := range sources {
-		if _, isMCP := src.(*mcpSource); isMCP {
-			continue
-		}
 		var kind, email string
 		if info, ok := src.(accountInfo); ok {
 			kind, email = info.AccountInfo()
 		}
 		for _, t := range src.Tools() {
-			if _, seen := byName[t.Name]; !seen {
-				order = append(order, t.Name)
-			}
 			byName[t.Name] = append(byName[t.Name], toolAccount{connector: name, kind: kind, email: email, tool: t})
 		}
+	}
+
+	merged = map[string][]toolAccount{}
+	split = map[string][]toolAccount{}
+	for name, accounts := range byName {
+		if reserved[name] {
+			split[name] = accounts
+			continue
+		}
+		mcpSchemasMatch := true
+		var mcpSchema json.RawMessage
+		for _, a := range accounts {
+			if _, isMCP := sources[a.connector].(*mcpSource); !isMCP {
+				continue
+			}
+			if mcpSchema == nil {
+				mcpSchema = a.tool.InputSchema
+				continue
+			}
+			if !schemasEqual(mcpSchema, a.tool.InputSchema) {
+				mcpSchemasMatch = false
+				break
+			}
+		}
+		// An MCP contributor also has to match a non-MCP occupant of the
+		// same name, not just other MCP contributors, or joining would
+		// silently pick whichever schema aggregateTool happens to render.
+		if mcpSchemasMatch && mcpSchema != nil {
+			for _, a := range accounts {
+				if _, isMCP := sources[a.connector].(*mcpSource); isMCP {
+					continue
+				}
+				if !schemasEqual(mcpSchema, a.tool.InputSchema) {
+					mcpSchemasMatch = false
+					break
+				}
+			}
+		}
+		if mcpSchemasMatch {
+			merged[name] = accounts
+			continue
+		}
+		// Mismatch: only the MCP contributors split off; any non-MCP
+		// tool at this name is Timothy's own code and keeps merging.
+		for _, a := range accounts {
+			if _, isMCP := sources[a.connector].(*mcpSource); isMCP {
+				split[name] = append(split[name], a)
+			} else {
+				merged[name] = append(merged[name], a)
+			}
+		}
+	}
+	return merged, split
+}
+
+// schemasEqual reports whether two tool input schemas are the same
+// JSON value, ignoring key order — an MCP server's exact byte
+// formatting is never guaranteed to match another's or to be stable
+// build to build.
+func schemasEqual(a, b json.RawMessage) bool {
+	var av, bv any
+	if json.Unmarshal(a, &av) != nil || json.Unmarshal(b, &bv) != nil {
+		return false
+	}
+	return reflect.DeepEqual(av, bv)
+}
+
+// aggregateTools groups every source's tools by their RAW (un-
+// namespaced) name and returns one tool per name for whatever merges
+// (see groupByRawName), plus "<connector>_<tool>" for whatever splits.
+// A future connector kind (or a raw-named MCP tool) joins the unified
+// surface automatically just by giving its tools the same raw name;
+// accountInfo is read opportunistically for kind/email metadata (empty
+// when a source doesn't implement it, mcp included) and never gates
+// whether a source's tools can merge. readOnlyOnly mirrors the old
+// ReadOnlyTools' filter: a WHOLE merged aggregate is dropped unless
+// every contributing account's tool is ReadOnly, and every split (MCP)
+// tool is dropped outright — a remote MCP server's ReadOnly claim can't
+// be verified, unlike google/microsoft's tool constructors, which are
+// Timothy's own code.
+func aggregateTools(sources map[string]Source, readOnlyOnly bool, reserved map[string]bool) []*tools.Tool {
+	merged, split := groupByRawName(sources, reserved)
+
+	if readOnlyOnly {
+		// MCP never contributes to ReadOnlyTools, merged or not: a
+		// remote server's ReadOnly claim can't be verified, unlike
+		// google/microsoft's tool constructors (Timothy's own code).
+		// Strip MCP accounts out of each merged group rather than
+		// trusting groupByRawName's ordinary merge/split split, which
+		// answers a different question (does this name unify safely),
+		// not this one (is this account's claim trustworthy).
+		filtered := map[string][]toolAccount{}
+		for name, accounts := range merged {
+			var kept []toolAccount
+			for _, a := range accounts {
+				if _, isMCP := sources[a.connector].(*mcpSource); !isMCP {
+					kept = append(kept, a)
+				}
+			}
+			if len(kept) > 0 {
+				filtered[name] = kept
+			}
+		}
+		merged = filtered
+	}
+
+	order := make([]string, 0, len(merged))
+	for name := range merged {
+		order = append(order, name)
 	}
 	sort.Strings(order)
 	out := make([]*tools.Tool, 0, len(order))
 	for _, name := range order {
-		accounts := byName[name]
+		accounts := merged[name]
 		sort.Slice(accounts, func(i, j int) bool { return accounts[i].connector < accounts[j].connector })
 		agg := aggregateTool(name, accounts)
 		if readOnlyOnly && !agg.ReadOnly {
 			continue
 		}
 		out = append(out, agg)
+	}
+	if readOnlyOnly {
+		return out
+	}
+
+	splitNames := make([]string, 0, len(split))
+	for name := range split {
+		splitNames = append(splitNames, name)
+	}
+	sort.Strings(splitNames)
+	for _, name := range splitNames {
+		accounts := split[name]
+		sort.Slice(accounts, func(i, j int) bool { return accounts[i].connector < accounts[j].connector })
+		byConnector := map[string][]*tools.Tool{}
+		var connectorOrder []string
+		for _, a := range accounts {
+			if _, seen := byConnector[a.connector]; !seen {
+				connectorOrder = append(connectorOrder, a.connector)
+			}
+			byConnector[a.connector] = append(byConnector[a.connector], a.tool)
+		}
+		for _, connector := range connectorOrder {
+			out = append(out, namespacedTools(connector, byConnector[connector])...)
+		}
 	}
 	return out
 }

--- a/internal/brain/connectors/manager.go
+++ b/internal/brain/connectors/manager.go
@@ -461,7 +461,7 @@ func aggregateTool(name string, accounts []toolAccount) *tools.Tool {
 // account's copy is schema-identical by construction, see
 // TestGoogleMicrosoftSharedToolSchemasMatch) plus a connected-accounts
 // list naming which account argument reaches which connector, its
-// kind, its email when known, and, for mail_search specifically, the
+// kind, its email when known, and, for search_mail specifically, the
 // provider's query syntax, since that's where google and microsoft
 // diverge and the shared schema has nowhere else to say so.
 func aggregateDescription(accounts []toolAccount) string {
@@ -480,13 +480,13 @@ func aggregateDescription(accounts []toolAccount) string {
 	} else {
 		b.WriteString("\naccount is required: pass one of the connector names or emails above.")
 	}
-	if accounts[0].tool.Name == "mail_search" {
+	if accounts[0].tool.Name == "search_mail" {
 		b.WriteString(mailSearchKindGuidance(accounts))
 	}
 	return strings.TrimRight(b.String(), "\n")
 }
 
-// mailSearchGuidanceByKind holds mail_search's per-provider query
+// mailSearchGuidanceByKind holds search_mail's per-provider query
 // syntax guidance, rendered by mailSearchKindGuidance only for kinds
 // actually contributing an account. Keyed by accountInfo's kind
 // string. The google entry keeps the zero-result broaden-retry
@@ -671,7 +671,7 @@ func (m *Manager) Names() []string {
 // "personal-gmail" joins the set, caught either via Matches' namespace-
 // prefix check (an MCP tool actually namespaced that way) or via
 // AccountConnector resolving a unified aggregate call's account (e.g.
-// mail_search) to that same connector name. Reads rows fresh each call
+// search_mail) to that same connector name. Reads rows fresh each call
 // (no restart needed for a settings toggle to take effect), same
 // reasoning as sensitiveRoute.
 func (m *Manager) SensitiveNames(ctx context.Context) ([]string, error) {

--- a/internal/brain/connectors/mcp_test.go
+++ b/internal/brain/connectors/mcp_test.go
@@ -248,24 +248,57 @@ func TestMCPStatusErrorNeverLeaksRawJSON(t *testing.T) {
 	}
 }
 
-// TestManagerNamespacesMCPTools pins that only MCP sources still get
-// the "<connector>_<tool>" prefix (external names can't be unified);
-// a real *mcpSource is used since Manager's MCP exclusion in
-// aggregateTools type-asserts against it specifically.
-func TestManagerNamespacesMCPTools(t *testing.T) {
+// TestManagerMergesLoneMCPToolUnderRawName pins the raw-name refactor's
+// default case: a single MCP connector with no reserved-name collision
+// and nothing else sharing its tools' raw names joins the unified
+// surface exactly like any other source (see groupByRawName) — no
+// prefix, "account" left off the schema since there's only one
+// contributor.
+func TestManagerMergesLoneMCPToolUnderRawName(t *testing.T) {
 	t.Parallel()
 	m := testManager(fakeRows{})
 	m.sources = map[string]Source{
 		"github": &mcpSource{name: "github", toolList: []*tools.Tool{
-			{Name: "create_issue"},
-			{Name: "search code"}, // space sanitized
+			{Name: "create_issue", InputSchema: json.RawMessage(`{"type":"object"}`)},
 		}},
 	}
 	names := map[string]bool{}
-	for _, tl := range m.Tools() {
+	for _, tl := range m.Tools(nil) {
 		names[tl.Name] = true
 	}
-	if !names["github_create_issue"] || !names["github_search_code"] {
-		t.Fatalf("namespaced tools = %v", names)
+	if !names["create_issue"] {
+		t.Fatalf("tools = %v, want create_issue un-namespaced", names)
+	}
+	if names["github_create_issue"] {
+		t.Fatalf("tools = %v, must not also appear namespaced", names)
+	}
+}
+
+// TestManagerNamespacesMCPToolReservedByBuiltin pins Guard A: a raw
+// name in the reserved set (the agent's non-connector tools) never
+// merges, MCP included — an MCP tool sharing that name falls back to
+// "<connector>_<tool>" (namespacedTools' sanitizer intact, hence the
+// space in "search code") instead of shadowing the reserved tool.
+func TestManagerNamespacesMCPToolReservedByBuiltin(t *testing.T) {
+	t.Parallel()
+	m := testManager(fakeRows{})
+	m.sources = map[string]Source{
+		"github": &mcpSource{name: "github", toolList: []*tools.Tool{
+			{Name: "create_issue", InputSchema: json.RawMessage(`{"type":"object"}`)},
+			{Name: "search code", InputSchema: json.RawMessage(`{"type":"object"}`)}, // space sanitized
+		}},
+	}
+	names := map[string]bool{}
+	for _, tl := range m.Tools(map[string]bool{"search code": true}) {
+		names[tl.Name] = true
+	}
+	if !names["create_issue"] {
+		t.Fatalf("tools = %v, want unreserved create_issue un-namespaced", names)
+	}
+	if !names["github_search_code"] {
+		t.Fatalf("tools = %v, want the reserved name namespaced", names)
+	}
+	if names["search code"] {
+		t.Fatalf("tools = %v, reserved raw name must never be served directly", names)
 	}
 }

--- a/internal/brain/connectors/microsoft_test.go
+++ b/internal/brain/connectors/microsoft_test.go
@@ -69,7 +69,7 @@ func (f *fakeMicrosoft) server(t *testing.T) *httptest.Server {
 	mux.HandleFunc("GET /me/messages/{id}", func(w http.ResponseWriter, r *http.Request) {
 		record(r)
 		if got := r.Header.Get("Prefer"); got != `outlook.body-content-type="text"` {
-			t.Fatalf("mail_read missing Prefer text header: %q", got)
+			t.Fatalf("read_mail missing Prefer text header: %q", got)
 		}
 		id := r.PathValue("id")
 		switch id {
@@ -323,7 +323,7 @@ func TestMicrosoftBuilderScopeGating(t *testing.T) {
 
 // TestMicrosoftNoSendScopeMeansNoSendTool pins the scope-gating matrix
 // entry the task calls out explicitly: Mail.Read alone must never
-// surface mail_send.
+// surface send_mail.
 func TestMicrosoftNoSendScopeMeansNoSendTool(t *testing.T) {
 	t.Parallel()
 	f := &fakeMicrosoft{}
@@ -334,8 +334,8 @@ func TestMicrosoftNoSendScopeMeansNoSendTool(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, tl := range src.Tools() {
-		if tl.Name == "mail_send" {
-			t.Fatal("mail_send must not be present without Mail.Send scope")
+		if tl.Name == "send_mail" {
+			t.Fatal("send_mail must not be present without Mail.Send scope")
 		}
 	}
 }
@@ -372,21 +372,21 @@ func TestOutlookMailToolsRoundTrip(t *testing.T) {
 	f := &fakeMicrosoft{}
 	src, _ := connectedMicrosoftSource(t, f)
 
-	out, err := microsoftToolByName(t, src, "mail_search").Execute(t.Context(), json.RawMessage(`{"query":"hi"}`))
+	out, err := microsoftToolByName(t, src, "search_mail").Execute(t.Context(), json.RawMessage(`{"query":"hi"}`))
 	if err != nil || !strings.Contains(out, "subject: hi") {
 		t.Fatalf("search = (%q, %v)", out, err)
 	}
-	out, err = microsoftToolByName(t, src, "mail_search").Execute(t.Context(), json.RawMessage(`{"query":"nowhere"}`))
+	out, err = microsoftToolByName(t, src, "search_mail").Execute(t.Context(), json.RawMessage(`{"query":"nowhere"}`))
 	if err != nil || !strings.Contains(out, "no messages matched") {
 		t.Fatalf("empty search = (%q, %v)", out, err)
 	}
 
-	out, err = microsoftToolByName(t, src, "mail_read").Execute(t.Context(), json.RawMessage(`{"id":"m1"}`))
+	out, err = microsoftToolByName(t, src, "read_mail").Execute(t.Context(), json.RawMessage(`{"id":"m1"}`))
 	if err != nil || !strings.Contains(out, "hello body") {
 		t.Fatalf("read = (%q, %v)", out, err)
 	}
 
-	out, err = microsoftToolByName(t, src, "mail_send").Execute(t.Context(),
+	out, err = microsoftToolByName(t, src, "send_mail").Execute(t.Context(),
 		json.RawMessage(`{"to":"b@y","subject":"re: hi","body":"on my way"}`))
 	if err != nil || out != "sent" {
 		t.Fatalf("send = (%q, %v)", out, err)
@@ -411,7 +411,7 @@ func TestOutlookMailReadListsAttachmentsAndReadAttachmentUsesMarkItDown(t *testi
 	f := &fakeMicrosoft{}
 	src, _ := connectedMicrosoftSource(t, f)
 
-	out, err := microsoftToolByName(t, src, "mail_read").Execute(t.Context(), json.RawMessage(`{"id":"m2"}`))
+	out, err := microsoftToolByName(t, src, "read_mail").Execute(t.Context(), json.RawMessage(`{"id":"m2"}`))
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
@@ -419,7 +419,7 @@ func TestOutlookMailReadListsAttachmentsAndReadAttachmentUsesMarkItDown(t *testi
 		t.Fatalf("read = %q, want it to list the attachment name", out)
 	}
 
-	out, err = microsoftToolByName(t, src, "mail_read_attachment").Execute(t.Context(),
+	out, err = microsoftToolByName(t, src, "read_mail_attachment").Execute(t.Context(),
 		json.RawMessage(`{"message_id":"m2","filename":"receipt.pdf"}`))
 	if err != nil {
 		t.Fatalf("read_attachment: %v", err)
@@ -434,7 +434,7 @@ func TestOutlookMailReadAttachmentRejectsUnknownName(t *testing.T) {
 	f := &fakeMicrosoft{}
 	src, _ := connectedMicrosoftSource(t, f)
 
-	_, err := microsoftToolByName(t, src, "mail_read_attachment").Execute(t.Context(),
+	_, err := microsoftToolByName(t, src, "read_mail_attachment").Execute(t.Context(),
 		json.RawMessage(`{"message_id":"m2","filename":"nope.pdf"}`))
 	if err == nil {
 		t.Fatal("expected an error for an unknown attachment name")
@@ -446,7 +446,7 @@ func TestOutlookCalendarListEvents(t *testing.T) {
 	f := &fakeMicrosoft{}
 	src, _ := connectedMicrosoftSource(t, f)
 
-	out, err := microsoftToolByName(t, src, "calendar_list_events").Execute(t.Context(), json.RawMessage(`{}`))
+	out, err := microsoftToolByName(t, src, "list_calendar_events").Execute(t.Context(), json.RawMessage(`{}`))
 	if err != nil || !strings.Contains(out, "standup") || !strings.Contains(out, "zoom") ||
 		!strings.Contains(out, "Boss") {
 		t.Fatalf("list = (%q, %v)", out, err)

--- a/internal/brain/connectors/microsoft_tools.go
+++ b/internal/brain/connectors/microsoft_tools.go
@@ -210,11 +210,11 @@ func (r outlookRecipient) String() string {
 
 func (s *microsoftSource) mailSearch() *tools.Tool {
 	return &tools.Tool{
-		Name:     "mail_search",
+		Name:     "search_mail",
 		ReadOnly: true,
 		Description: `Search a connected mail account. Returns up to max_results
 (default 10) messages as id, date, from, subject, snippet. Use
-mail_read with an id for the full body. See the tool description's
+read_mail with an id for the full body. See the tool description's
 Connected accounts list for this account's query syntax.`,
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"query":{"type":"string","description":"search query"},
@@ -258,9 +258,9 @@ Connected accounts list for this account's query syntax.`,
 
 func (s *microsoftSource) mailRead() *tools.Tool {
 	return &tools.Tool{
-		Name:        "mail_read",
+		Name:        "read_mail",
 		ReadOnly:    true,
-		Description: "Read one email's full content by message id (from mail_search). Returns headers and the body as readable text, plus a list of attachment filenames, if any. Use mail_read_attachment with the message id and a filename from that list to read an attachment's content.",
+		Description: "Read one email's full content by message id (from search_mail). Returns headers and the body as readable text, plus a list of attachment filenames, if any. Use read_mail_attachment with the message id and a filename from that list to read an attachment's content.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"id":{"type":"string","description":"message id"}
 		},"required":["id"],"additionalProperties":false}`),
@@ -315,8 +315,8 @@ type outlookAttachment struct {
 
 // listAttachments fetches one message's attachment metadata (id, name,
 // contentType), without the (potentially large) contentBytes field —
-// mail_read_attachment fetches one attachment's bytes separately, by
-// name, mirroring gmail_read_attachment's filename-lookup shape.
+// read_mail_attachment fetches one attachment's bytes separately, by
+// name, mirroring read_mail_attachment's filename-lookup shape.
 func (s *microsoftSource) listAttachments(ctx context.Context, messageID string) ([]outlookAttachment, error) {
 	var list struct {
 		Value []outlookAttachment `json:"value"`
@@ -331,12 +331,12 @@ func (s *microsoftSource) listAttachments(ctx context.Context, messageID string)
 
 func (s *microsoftSource) mailReadAttachment() *tools.Tool {
 	return &tools.Tool{
-		Name:        "mail_read_attachment",
+		Name:        "read_mail_attachment",
 		ReadOnly:    true,
-		Description: "Reads an attachment's content as markdown/text, given a message id and the attachment's filename (both from mail_read's attachments list). Handles PDFs, Office documents, and other common formats.",
+		Description: "Reads an attachment's content as markdown/text, given a message id and the attachment's filename (both from read_mail's attachments list). Handles PDFs, Office documents, and other common formats.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"message_id":{"type":"string","description":"message id"},
-			"filename":{"type":"string","description":"Attachment filename from mail_read's attachments list"}
+			"filename":{"type":"string","description":"Attachment filename from read_mail's attachments list"}
 		},"required":["message_id","filename"],"additionalProperties":false}`),
 		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
 			var in struct {
@@ -358,7 +358,7 @@ func (s *microsoftSource) mailReadAttachment() *tools.Tool {
 				}
 			}
 			if attachmentID == "" {
-				return "", fmt.Errorf("no attachment named %q on this message; check mail_read's attachments list", in.Filename)
+				return "", fmt.Errorf("no attachment named %q on this message; check read_mail's attachments list", in.Filename)
 			}
 			var full outlookAttachment
 			if err := s.api(ctx, http.MethodGet,
@@ -377,7 +377,7 @@ func (s *microsoftSource) mailReadAttachment() *tools.Tool {
 
 func (s *microsoftSource) mailSend() *tools.Tool {
 	return &tools.Tool{
-		Name:        "mail_send",
+		Name:        "send_mail",
 		Description: "Send an email from a connected mail account. Plain text only. Use only when the user asked for an email to be sent; the recipient sees it immediately.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{
 			"to":{"type":"string","description":"recipient address(es), comma-separated"},
@@ -454,7 +454,7 @@ type outlookEvent struct {
 
 func (s *microsoftSource) calendarListEvents() *tools.Tool {
 	return &tools.Tool{
-		Name:        "calendar_list_events",
+		Name:        "list_calendar_events",
 		ReadOnly:    true,
 		Description: "List events from the connected calendar in a time window. Omit time_min/time_max for the default window, the next 7 days from now; set them (RFC3339 UTC) only when the goal needs a different window, computed from today's actual date. Returns start, end, title, and location per event.",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{

--- a/internal/brain/connectors/unified_tools_test.go
+++ b/internal/brain/connectors/unified_tools_test.go
@@ -5,8 +5,8 @@ import (
 )
 
 // TestSharedToolSchemasMatchAcrossKinds pins the unified mail surface's
-// precondition: every kind serving a raw tool name (mail_search,
-// mail_read, ...) serves the SAME input schema (property names, types,
+// precondition: every kind serving a raw tool name (search_mail,
+// read_mail, ...) serves the SAME input schema (property names, types,
 // required) AND the SAME Description as every other kind serving that
 // same name, so Manager's aggregation can offer one schema and one
 // base description per capability regardless of which account answers

--- a/internal/brain/fxrates/rates.go
+++ b/internal/brain/fxrates/rates.go
@@ -6,7 +6,7 @@
 // provider actually billed).
 //
 // Source: open.er-api.com, not frankfurter.app (the source
-// internal/brain/tools/builtin/currency.go's live currency_convert tool
+// internal/brain/tools/builtin/currency.go's live convert_currency tool
 // used before this package existed, now sharing this same source and
 // parser). frankfurter.app publishes ECB reference rates, which do not
 // cover several currencies in settings.allowedCurrencies (BDT, AED,

--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -32,7 +32,7 @@ type StreamRequest struct {
 	Agent     string   `json:"agent,omitempty"`
 	ToolAllow []string `json:"-"`
 	// ExtraTools are turn-only tool defs layered on top of the shared
-	// base set (loop.Request.ExtraTools) — chat's per-agent kb_search
+	// base set (loop.Request.ExtraTools) — chat's per-agent search_kb
 	// binding is the only caller today. Loop-internal, never
 	// serialized, same as ToolAllow.
 	ExtraTools []*tools.Tool      `json:"-"`

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -129,7 +129,7 @@ type Agent struct {
 	// ConnectorNames), not just a single named tool. Two ways a call can
 	// match: an MCP-style namespaced name ("<connector-name>_<tool-
 	// name>") where the connector's own name is a PREFIX; or, for a
-	// unified aggregate tool (connectors.Manager's mail_search etc.,
+	// unified aggregate tool (connectors.Manager's search_mail etc.,
 	// which carries no connector name in its own name)
 	// forceRouteByAccountConnector resolving the call's actual account
 	// to a sensitive connector. A single dynamic name-list func rather
@@ -234,7 +234,7 @@ func (a *Agent) SetForceRoute(suffix string, route func(context.Context) string)
 // connector marked sensitive (as opposed to one hardcoded tool name):
 // once any tool call matching a name currently in names(ctx) runs
 // (either an MCP-style "<name>_"-prefixed tool, or a unified aggregate
-// tool such as mail_search whose call resolves to that connector via
+// tool such as search_mail whose call resolves to that connector via
 // accountConnector), the rest of the turn pins to route(ctx), same
 // sticky/settings-live semantics as SetForceRoute. names, route, and
 // accountConnector are all re-resolved at flip/call time, so toggling a
@@ -278,7 +278,7 @@ type Request struct {
 	MissionID string // ledger tag: set when this turn serves a mission, not chat
 
 	// BuiltinsOnly restricts the turn's base tool surface to compiled-in
-	// builtins (calculator, shell, web_search, ...), excluding connector
+	// builtins (calculator, shell, search_web, ...), excluding connector
 	// tools (e.g. a write-capable GitHub MCP token) and the chat-only
 	// mission tools (list_missions/get_mission/push_mission_branch). Set by
 	// every mission-driven request (explore/plan/worker/reviewer) — a

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -472,7 +472,7 @@ func TestAgentStepCeilingForcesSynthesis(t *testing.T) {
 }
 
 // TestAgentForcesSynthesisOnRepeatedIdenticalCalls reproduces a live
-// loop: a model retrying the exact same tool call (e.g. web_search
+// loop: a model retrying the exact same tool call (e.g. search_web
 // hoping a later attempt "books" something it structurally cannot)
 // must be cut off well before the full step ceiling, not burn all
 // DefaultMaxSteps steps first.
@@ -1370,17 +1370,17 @@ func TestForceRouteByConnectorIgnoresUnlistedConnector(t *testing.T) {
 
 // TestForceRouteByConnectorMatchesUnifiedToolViaAccountConnector pins
 // the unified-tool path: a call to a name carrying no connector prefix
-// (e.g. mail_search) still pins the route once accountConnector
+// (e.g. search_mail) still pins the route once accountConnector
 // resolves the call to a name in the sensitive list: the account the
 // call actually routed to, not the tool's own name, decides the flip.
 func TestForceRouteByConnectorMatchesUnifiedToolViaAccountConnector(t *testing.T) {
 	t.Parallel()
 	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
-		toolCallStep([2]string{"mail_search", `{"account":"work-outlook"}`}),
+		toolCallStep([2]string{"search_mail", `{"account":"work-outlook"}`}),
 		finalStep("done"),
 	}}
 	search := &tools.Tool{
-		Name:        "mail_search",
+		Name:        "search_mail",
 		Description: "searches connected mail",
 		InputSchema: json.RawMessage(`{"type":"object","properties":{"account":{"type":"string"}},"additionalProperties":false}`),
 		Execute: func(context.Context, json.RawMessage) (string, error) {
@@ -1392,7 +1392,7 @@ func TestForceRouteByConnectorMatchesUnifiedToolViaAccountConnector(t *testing.T
 		func(context.Context) []string { return []string{"work-outlook"} },
 		func(context.Context) string { return "local" },
 		func(_ context.Context, toolName string, args json.RawMessage) string {
-			if toolName == "mail_search" && strings.Contains(string(args), "work-outlook") {
+			if toolName == "search_mail" && strings.Contains(string(args), "work-outlook") {
 				return "work-outlook"
 			}
 			return ""
@@ -1413,7 +1413,7 @@ func TestForceRouteByConnectorMatchesUnifiedToolViaAccountConnector(t *testing.T
 		t.Fatalf("step 1 route = %q, want default (before the sensitive account's tool ran)", gw.requests[0].Route)
 	}
 	if gw.requests[1].Route != "local" {
-		t.Fatalf("step 2 route = %q, want local (forced after mail_search resolved to work-outlook)", gw.requests[1].Route)
+		t.Fatalf("step 2 route = %q, want local (forced after search_mail resolved to work-outlook)", gw.requests[1].Route)
 	}
 }
 
@@ -1702,9 +1702,9 @@ func TestFilterDefs(t *testing.T) {
 	}{
 		{
 			name:  "empty allow keeps everything",
-			defs:  []string{"web_search", "shell"},
+			defs:  []string{"search_web", "shell"},
 			allow: nil,
-			want:  []string{"web_search", "shell"},
+			want:  []string{"search_web", "shell"},
 		},
 		{
 			name:  "exact name still matches",
@@ -1719,21 +1719,21 @@ func TestFilterDefs(t *testing.T) {
 			want:  []string{"gmail_gmail_search"},
 		},
 		{
-			name:  "calendar_list_events allows google-calendar_calendar_list_events",
-			defs:  []string{"google-calendar_calendar_list_events"},
-			allow: []string{"calendar_list_events"},
-			want:  []string{"google-calendar_calendar_list_events"},
+			name:  "list_calendar_events allows google-calendar_list_calendar_events",
+			defs:  []string{"google-calendar_list_calendar_events"},
+			allow: []string{"list_calendar_events"},
+			want:  []string{"google-calendar_list_calendar_events"},
 		},
 		{
-			name:  "search matches web_search under the same suffix rule as matchGrant",
-			defs:  []string{"web_search"},
-			allow: []string{"search"},
-			want:  []string{"web_search"},
+			name:  "search matches search_web under the same suffix rule as matchGrant",
+			defs:  []string{"search_web"},
+			allow: []string{"web"},
+			want:  []string{"search_web"},
 		},
 		{
 			name:  "no underscore boundary rejected",
-			defs:  []string{"notcalendar_list_events"},
-			allow: []string{"calendar_list_events"},
+			defs:  []string{"notlist_calendar_events"},
+			allow: []string{"list_calendar_events"},
 			want:  nil,
 		},
 		{

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -30,7 +30,7 @@ type Mission struct {
 	PromptOverlay string `json:"prompt_overlay,omitempty"`
 	// Knowledge is a snapshot of the creating agent's kb_collections
 	// allowlist at create time, same reasoning as PromptOverlay above.
-	// Empty means kb_search is never offered on this mission's turns.
+	// Empty means search_kb is never offered on this mission's turns.
 	Knowledge []string `json:"knowledge,omitempty"`
 	Phase     Phase    `json:"phase"`
 	Status    Status   `json:"status"`

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -1242,7 +1242,7 @@ func execEnvironmentNote(loc *time.Location) string {
 	// and mangles date-bounded calls (calendar windows, Gmail
 	// after:/before:). Date only, no clock time, for the same
 	// prompt-cache reason as chat's date line (D-018).
-	return " Commands run inside an isolated Linux container with python3, node, git, and standard POSIX/coreutils tools available; each mission gets its own container, state persists across your commands within the mission. Today is " + time.Now().In(loc).Format("Monday, 2006-01-02 (MST).")
+	return " Commands run inside an isolated Linux container with python3, node, git, and standard POSIX/coreutils tools available; each mission gets its own container, state persists across your commands within the mission. Today is " + time.Now().In(loc).Format("Monday, 2006-01-02 (MST).") + " Present all dates and times in this timezone unless the goal asks otherwise."
 }
 
 // parseSpec decodes the planner's reply strictly: fences stripped,

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -154,14 +154,14 @@ type nativeRunner struct {
 	// sandbox executes worker/reviewer shell commands in a per-mission
 	// Docker container instead of brain's own process.
 	sandbox sandboxExec
-	// kbSearch backs the per-turn kb_search ExtraTool (see kbSearchTool)
-	// — nil means kb_search is never offered on any mission turn,
+	// kbSearch backs the per-turn search_kb ExtraTool (see kbSearchTool)
+	// — nil means search_kb is never offered on any mission turn,
 	// regardless of a mission's own Knowledge snapshot (same "the
 	// dependency's absence turns the feature off entirely" contract as
 	// chat.go's SetKBSearch).
 	kbSearch KBSearchFunc
 
-	// kbRead backs the per-turn kb_read ExtraTool — same nil contract
+	// kbRead backs the per-turn read_kb ExtraTool — same nil contract
 	// as kbSearch.
 	kbRead KBReadFunc
 
@@ -293,7 +293,7 @@ func (r *nativeRunner) SetConnectorReads(resolve ConnectorReadsResolver) {
 	r.connectorReads = resolve
 }
 
-// KBSearchFunc runs one kb_search call scoped to collectionNames — main
+// KBSearchFunc runs one search_kb call scoped to collectionNames — main
 // curries memclient.Client.KBSearch in, same shape as chat.go's
 // KBSearch type. collectionNames travels on every call (the mission's
 // own Knowledge snapshot), never bound once, since the same func serves
@@ -316,8 +316,8 @@ func NewNativeRunner(agent *loop.Agent, parker parkNotifier, log *slog.Logger) R
 // NewNativeRunnerWithFloor is NewNativeRunner plus a model floor deny
 // list (see nativeRunner.modelFloorDeny), a sandbox exec backend (a
 // *sandbox.Manager.Exec closure) — worker and reviewer shell calls
-// route through it instead of brain's own process — and a kb_search
-// backend (nil disables kb_search on every mission turn, matching
+// route through it instead of brain's own process — and a search_kb
+// backend (nil disables search_kb on every mission turn, matching
 // SetKBSearch's nil-safe contract).
 // The return type is the unexported *nativeRunner, not Runner: callers
 // that need to wire SetConnectorReads (cmd/brain/main.go) must hold the
@@ -327,15 +327,15 @@ func NewNativeRunnerWithFloor(agent *loop.Agent, parker parkNotifier, floorDeny 
 	return &nativeRunner{agent: agent, parker: parker, modelFloorDeny: floorDeny, sandbox: sandbox, kbSearch: kbSearch, kbRead: kbRead, log: log}
 }
 
-// kbSearchTool builds this turn's kb_search ExtraTool bound to m's own
-// Knowledge snapshot, or nil when kb_search must not be offered: no
+// kbSearchTool builds this turn's search_kb ExtraTool bound to m's own
+// Knowledge snapshot, or nil when search_kb must not be offered: no
 // backend wired, or the mission's creating agent named no collections
-// (empty Knowledge = no kb_search, same opt-in-only contract as
+// (empty Knowledge = no search_kb, same opt-in-only contract as
 // chat.go's kbSearchTool, which this mirrors exactly). A non-nil sink
 // records every returned document at execution time — the harness's
 // citation evidence must come from here, not from the rendered tool
 // result: digests cap at digestCeiling and offload past 8KiB, so a
-// full kb_search result never survives into the digest text.
+// full search_kb result never survives into the digest text.
 func (r *nativeRunner) kbSearchTool(m Mission, sink *kbRefSink) *tools.Tool {
 	if r.kbSearch == nil || len(m.Knowledge) == 0 {
 		return nil
@@ -350,7 +350,7 @@ func (r *nativeRunner) kbSearchTool(m Mission, sink *kbRefSink) *tools.Tool {
 	})
 }
 
-// kbReadTool builds this turn's kb_read ExtraTool, gated exactly like
+// kbReadTool builds this turn's read_kb ExtraTool, gated exactly like
 // kbSearchTool: no backend, or an empty Knowledge snapshot, means the
 // tool is not offered.
 func (r *nativeRunner) kbReadTool(m Mission) *tools.Tool {
@@ -375,7 +375,7 @@ func (r *nativeRunner) connectorReadTools(ctx context.Context, m Mission) []*too
 	return r.connectorReads(ctx, m.AgentID)
 }
 
-// kbRefSink accumulates the kb:// refs of documents kb_search actually
+// kbRefSink accumulates the kb:// refs of documents search_kb actually
 // returned across a worker run's turns. Guarded because the loop may
 // execute tool calls concurrently within a turn.
 type kbRefSink struct {
@@ -518,7 +518,7 @@ func (r *nativeRunner) belowFloor(model string) bool {
 
 // turnResult is runTurn's outcome: the full assistant text, the
 // sentinel tool call's raw arguments (if any), URLs the turn's
-// web_search/web_fetch calls saw, and the final assistant segment
+// search_web/fetch_url calls saw, and the final assistant segment
 // (see finalSeg's doc below, formerly a bare 5th return value).
 type turnResult struct {
 	text         string
@@ -576,7 +576,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if ev.ToolCall != nil && ev.ToolCall.Name == sentinelTool {
 				sentinelArgs = ev.ToolCall.Input
 			}
-			if ev.ToolCall != nil && ev.ToolCall.Name == "web_fetch" {
+			if ev.ToolCall != nil && ev.ToolCall.Name == "fetch_url" {
 				seenURLs = append(seenURLs, webFetchArgURL(ev.ToolCall.Input)...)
 			}
 			// Any tool call OTHER than the sentinel is mid-turn activity —
@@ -609,7 +609,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if ev.ToolResult != nil && ev.ToolResult.Status == "denied" && r.parker != nil {
 				r.parker.OnPermissionDenied(ctx, req.MissionID, ev.ToolResult.Name, ev.ToolResult.Digest)
 			}
-			if ev.ToolResult != nil && ev.ToolResult.Status == "ok" && ev.ToolResult.Name == "web_search" {
+			if ev.ToolResult != nil && ev.ToolResult.Status == "ok" && ev.ToolResult.Name == "search_web" {
 				seenURLs = append(seenURLs, webSearchResultURLs(ev.ToolResult.Digest)...)
 			}
 			if ev.ToolResult != nil && ev.ToolResult.Name != sentinelTool {
@@ -653,7 +653,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 	return turnResult{b.String(), sentinelArgs, seenURLs, finalB.String()}, nil
 }
 
-// webFetchArgURL extracts the url arg from a web_fetch call's raw
+// webFetchArgURL extracts the url arg from a fetch_url call's raw
 // input — the exact field name webfetch.go's webFetchArgs decodes
 // (D-059). A malformed input yields nothing rather than an error: this
 // is best-effort evidence collection, not argument validation (the
@@ -668,7 +668,7 @@ func webFetchArgURL(input json.RawMessage) []string {
 	return []string{args.URL}
 }
 
-// webSearchResultURLs pulls result URLs out of web_search's rendered
+// webSearchResultURLs pulls result URLs out of search_web's rendered
 // output — websearch.go's runSearch emits one blank-line-separated
 // entry per result as "N. title\nurl\nsnippet" (D-059). Line 2 of each
 // three-line group is the URL; anything not matching that shape (the
@@ -676,7 +676,7 @@ func webFetchArgURL(input json.RawMessage) []string {
 // than guessed at. Best-effort only: the digest is capped (and big
 // results offload to a stub), so URLs past the cap are lost. That is
 // deliberate lenience on top of the reliable contract — cite what you
-// web_fetch, whose args are never truncated.
+// fetch_url, whose args are never truncated.
 var webSearchResultHeader = regexp.MustCompile(`^\d+\.\s`)
 
 func webSearchResultURLs(digest string) []string {
@@ -1152,8 +1152,8 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 		System:    system,
 		Messages:  []provider.Message{{Role: "user", Content: user}},
 		// The planner plans; it must not act. No base tool matches this
-		// allowlist (submit_plan/kb_search arrive via ExtraTools, which
-		// bypass it, and kb_search is read-only — never "acting"), so
+		// allowlist (submit_plan/search_kb arrive via ExtraTools, which
+		// bypass it, and search_kb is read-only — never "acting"), so
 		// the turn's only BASE tool is none — a planner that reaches for
 		// shell parked a live canary on the permission gate for ten
 		// minutes trying to do the worker's job in plan phase.
@@ -1163,7 +1163,7 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 		Unattended:   m.ScheduleID != "",
 	}
 	// Force submit_plan only when it is the turn's sole tool (D-063):
-	// a KB-attached mission also offers kb_search/kb_read here, and a
+	// a KB-attached mission also offers search_kb/read_kb here, and a
 	// forced choice would make consulting them impossible.
 	if len(extra) == 1 {
 		req.ForceTool = planToolName

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -485,7 +485,7 @@ func TestPlanSessionForcesPlanTool(t *testing.T) {
 }
 
 // TestPlanSessionNoForceToolWithKB pins the D-063 carve-out: a
-// KB-attached mission also offers kb_search/kb_read on the planning
+// KB-attached mission also offers search_kb/read_kb on the planning
 // turn, so forcing submit_plan would make consulting them impossible.
 func TestPlanSessionNoForceToolWithKB(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
@@ -1639,7 +1639,7 @@ func TestExploreSessionGetsShellButNotWriteFile(t *testing.T) {
 		t.Fatalf("explore ExtraTools = %v, want the explore_notes sentinel", names)
 	}
 	if agent.requests[0].ToolAllow != nil {
-		t.Fatalf("explore ToolAllow = %v, want nil so base tools (web_search/web_fetch) stay available", agent.requests[0].ToolAllow)
+		t.Fatalf("explore ToolAllow = %v, want nil so base tools (search_web/fetch_url) stay available", agent.requests[0].ToolAllow)
 	}
 }
 
@@ -1781,7 +1781,7 @@ func TestMissionRunnerRequestsAreBuiltinsOnly(t *testing.T) {
 }
 
 // okToolResultEvent is toolResultEvent's ok-status counterpart with a
-// name and digest — web_search's rendered results ride the digest,
+// name and digest — search_web's rendered results ride the digest,
 // never a separate raw-result field (D-059).
 func okToolResultEvent(id, name, digest string) stream.StreamEvent {
 	return stream.StreamEvent{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{
@@ -1848,17 +1848,17 @@ func TestWebSearchResultURLs(t *testing.T) {
 }
 
 // TestRunWorkerCollectsSeenURLsFromWebFetchAndWebSearch is the
-// end-to-end wiring check (D-059): a worker turn that calls web_fetch
-// and web_search must surface both URLs on the returned verdict, so
+// end-to-end wiring check (D-059): a worker turn that calls fetch_url
+// and search_web must surface both URLs on the returned verdict, so
 // the driver's citations check has real harness evidence to compare
 // against — never the model's own claim.
 func TestRunWorkerCollectsSeenURLsFromWebFetchAndWebSearch(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{
-			toolEndEvent("web_fetch", `{"url":"https://example.com/fetched"}`),
-			okToolResultEvent("call-1", "web_fetch", "fetched content"),
-			toolEndEvent("web_search", `{"query":"golang release notes"}`),
-			okToolResultEvent("call-2", "web_search", "1. Release notes\nhttps://example.com/searched\nsnippet"),
+			toolEndEvent("fetch_url", `{"url":"https://example.com/fetched"}`),
+			okToolResultEvent("call-1", "fetch_url", "fetched content"),
+			toolEndEvent("search_web", `{"query":"golang release notes"}`),
+			okToolResultEvent("call-2", "search_web", "1. Release notes\nhttps://example.com/searched\nsnippet"),
 			toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"researched"}`),
 		},
 	}}
@@ -1876,7 +1876,7 @@ func TestRunWorkerCollectsSeenURLsFromWebFetchAndWebSearch(t *testing.T) {
 // TestKBSearchToolRecordsRefsInSink covers the execution-time harvest
 // (the digest is capped/offloaded past digestCeiling, so citation
 // evidence must be recorded when the tool RUNS, never parsed from the
-// rendered result): executing the worker's kb_search tool must land
+// rendered result): executing the worker's search_kb tool must land
 // every returned document's kb:// ref in the sink, and a nil sink
 // (explore/plan turns) must stay safe.
 func TestKBSearchToolRecordsRefsInSink(t *testing.T) {
@@ -1954,7 +1954,7 @@ func TestRunWorkerSurfacesKBSinkRefsOnVerdict(t *testing.T) {
 }
 
 // kbExecutingAgent stands in for the loop actually running the offered
-// kb_search tool mid-turn: Start executes it for real (so the tool's
+// search_kb tool mid-turn: Start executes it for real (so the tool's
 // closure records into the worker's sink) before replaying the
 // scripted events.
 type kbExecutingAgent struct {
@@ -1963,7 +1963,7 @@ type kbExecutingAgent struct {
 
 func (a *kbExecutingAgent) Start(ctx context.Context, req loop.Request) (<-chan stream.StreamEvent, error) {
 	for _, tool := range req.ExtraTools {
-		if tool.Name == "kb_search" {
+		if tool.Name == "search_kb" {
 			if _, err := tool.Execute(ctx, json.RawMessage(`{"query":"q"}`)); err != nil {
 				return nil, err
 			}
@@ -1974,13 +1974,13 @@ func (a *kbExecutingAgent) Start(ctx context.Context, req loop.Request) (<-chan 
 
 // TestRunWorkerOffersKBSearchOnlyWhenMissionHasKnowledge covers
 // kbSearchTool's opt-in-only contract: no backend wired, or a mission
-// with an empty Knowledge snapshot, must never put kb_search on the
+// with an empty Knowledge snapshot, must never put search_kb on the
 // turn's offered tool surface (chat.go's kbSearchTool mirrors this
 // exactly on the chat side).
 func TestRunWorkerOffersKBSearchOnlyWhenMissionHasKnowledge(t *testing.T) {
 	hasKBSearch := func(req loop.Request) bool {
 		for _, tool := range req.ExtraTools {
-			if tool.Name == "kb_search" {
+			if tool.Name == "search_kb" {
 				return true
 			}
 		}
@@ -1995,7 +1995,7 @@ func TestRunWorkerOffersKBSearchOnlyWhenMissionHasKnowledge(t *testing.T) {
 			t.Fatalf("RunWorker: %v", err)
 		}
 		if hasKBSearch(agent.requests[0]) {
-			t.Fatal("kb_search offered with no backend wired")
+			t.Fatal("search_kb offered with no backend wired")
 		}
 	})
 
@@ -2009,7 +2009,7 @@ func TestRunWorkerOffersKBSearchOnlyWhenMissionHasKnowledge(t *testing.T) {
 			t.Fatalf("RunWorker: %v", err)
 		}
 		if hasKBSearch(agent.requests[0]) {
-			t.Fatal("kb_search offered with empty mission Knowledge")
+			t.Fatal("search_kb offered with empty mission Knowledge")
 		}
 	})
 
@@ -2023,7 +2023,7 @@ func TestRunWorkerOffersKBSearchOnlyWhenMissionHasKnowledge(t *testing.T) {
 			t.Fatalf("RunWorker: %v", err)
 		}
 		if !hasKBSearch(agent.requests[0]) {
-			t.Fatal("kb_search not offered despite backend wired and non-empty Knowledge")
+			t.Fatal("search_kb not offered despite backend wired and non-empty Knowledge")
 		}
 	})
 }

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -2094,6 +2094,35 @@ func TestSteeringForNilWithoutProgressReader(t *testing.T) {
 	}
 }
 
+// TestExecEnvironmentNoteIncludesTimezoneSteer pins that the date line
+// carries the timezone-presentation instruction right after the date,
+// for both an operator location and the nil (UTC) default — a global
+// harness instruction instead of per-prompt boilerplate.
+func TestExecEnvironmentNoteIncludesTimezoneSteer(t *testing.T) {
+	want := "Present all dates and times in this timezone unless the goal asks otherwise."
+
+	t.Run("nil location (UTC)", func(t *testing.T) {
+		note := execEnvironmentNote(nil)
+		if !strings.Contains(note, want) {
+			t.Fatalf("timezone steer missing:\n%s\nwant substring:\n%s", note, want)
+		}
+		if i, j := strings.Index(note, "Today is"), strings.Index(note, want); i == -1 || j <= i {
+			t.Fatalf("timezone steer must follow the date: %s", note)
+		}
+	})
+
+	t.Run("operator location", func(t *testing.T) {
+		loc, err := time.LoadLocation("Europe/Amsterdam")
+		if err != nil {
+			t.Fatalf("load location: %v", err)
+		}
+		note := execEnvironmentNote(loc)
+		if !strings.Contains(note, want) {
+			t.Fatalf("timezone steer missing:\n%s\nwant substring:\n%s", note, want)
+		}
+	})
+}
+
 // TestRunWorkerWiresSteeringFromProgressReader confirms RunWorker's
 // loop.Request actually carries a non-nil Steering func end-to-end when
 // a ProgressReader is wired, and that the request has none when it

--- a/internal/brain/missions/sentinel.go
+++ b/internal/brain/missions/sentinel.go
@@ -182,7 +182,7 @@ type WorkerVerdict struct {
 	// the tool.
 	Forced bool
 	// SeenURLs is every URL the worker actually observed this turn via
-	// web_fetch/web_search (D-059) — nativeRunner's own runTurn evidence,
+	// fetch_url/search_web (D-059) — nativeRunner's own runTurn evidence,
 	// never model-reported. Empty for the delegated (CLI harness) path,
 	// which has no stream to observe; citations verification is native-
 	// runner-only for now.

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -335,7 +335,7 @@ func TestMissionKnowledgeRoundTrips(t *testing.T) {
 		t.Fatalf("Knowledge = %v, want it to round-trip unchanged", m.Knowledge)
 	}
 
-	// Absent means "kb_search never offered" — must stay empty, not some
+	// Absent means "search_kb never offered" — must stay empty, not some
 	// driver default.
 	id2, err := s.Create(ctx, Mission{Goal: marker + "no-knowledge", Kind: "general", Route: "default"})
 	if err != nil {

--- a/internal/brain/missions/verifier.go
+++ b/internal/brain/missions/verifier.go
@@ -44,7 +44,7 @@ func (e *verifyFailure) Error() string {
 // harness-run evidence may flip a unit's Passes flag, never model
 // output. Declared artifacts are checked first (exists, non-empty),
 // then (general missions only, D-059) that every URL cited in those
-// artifacts was actually seen by the worker via web_fetch/web_search
+// artifacts was actually seen by the worker via fetch_url/search_web
 // this turn — a tautological verify_cmd cannot pass a unit whose
 // artifact was never written, or whose citations were invented.
 // seenURLs is only ever populated by the caller right after the

--- a/internal/brain/missions/verify.go
+++ b/internal/brain/missions/verify.go
@@ -189,8 +189,8 @@ func NormalizeURL(raw string) string {
 
 // CheckCitations verifies every http(s) URL and kb:// reference cited
 // in a unit's declared artifacts was actually seen by the worker this
-// turn — via web_fetch's url arg, a web_search result URL, or a
-// kb_search result's kb:// ref — never merely claimed. Scoped to
+// turn — via fetch_url's url arg, a search_web result URL, or a
+// search_kb result's kb:// ref — never merely claimed. Scoped to
 // "general" missions only (D-059): coding missions cite source, not
 // the web/knowledge base. seenURLs empty and the artifact cites
 // nothing passes trivially; seenURLs empty with citations present
@@ -256,9 +256,9 @@ func unknownCitationSummary(unknown []string) string {
 	case hasKB && hasURL:
 		return "cited URL(s)/kb reference(s) never seen this turn: " + strings.Join(unknown, ", ")
 	case hasKB:
-		return "cited kb reference(s) never seen via kb_search this turn: " + strings.Join(unknown, ", ")
+		return "cited kb reference(s) never seen via search_kb this turn: " + strings.Join(unknown, ", ")
 	default:
-		return "cited URL(s) never seen via web_fetch/web_search this turn: " + strings.Join(unknown, ", ")
+		return "cited URL(s) never seen via fetch_url/search_web this turn: " + strings.Join(unknown, ", ")
 	}
 }
 
@@ -275,10 +275,10 @@ func unknownCitationFix(unknown []string) string {
 	}
 	switch {
 	case hasKB && hasURL:
-		return "fetch a source with web_fetch, or search for it with kb_search, before citing it"
+		return "fetch a source with fetch_url, or search for it with search_kb, before citing it"
 	case hasKB:
-		return "search for it with kb_search before citing it"
+		return "search for it with search_kb before citing it"
 	default:
-		return "fetch a source with web_fetch before citing it"
+		return "fetch a source with fetch_url before citing it"
 	}
 }

--- a/internal/brain/session/events.go
+++ b/internal/brain/session/events.go
@@ -97,7 +97,7 @@ type UIBlock struct {
 	Meta map[string]any `json:"meta,omitempty"`
 	// Media carries refs only (never bytes, D-045) for a "media" block
 	// — content a tool call generated during the turn (share_file,
-	// mail_read_attachment). Additive: absent on every block type that
+	// read_mail_attachment). Additive: absent on every block type that
 	// predates this.
 	Media []MediaRef `json:"media,omitempty"`
 }

--- a/internal/brain/session/sensitive.go
+++ b/internal/brain/session/sensitive.go
@@ -16,13 +16,15 @@ import (
 // content (e.g. email text) to a cloud model. ConnectorNames is the
 // user-controlled input (a connector's own "sensitive" flag, set from
 // the connectors settings UI). Two ways a tool call can be covered:
-// suffix+"_" prefix against an MCP-style namespaced name
-// ("<connector-name>_<tool-name>", connectors.Manager.Tools' MCP
-// passthrough), or, for a unified aggregate tool (connectors.Manager's
-// mail_search etc., which carries no connector name in its own name),
-// AccountConnector resolving the call's actual account to a sensitive
-// connector. AccountConnector is nil-safe (not every caller wires it,
-// and non-connector tools never resolve). All three funcs re-resolve on
+// suffix+"_" prefix against a namespaced name ("<connector-name>_<tool-
+// name>", connectors.Manager.Tools' fallback for a name that can't
+// unify — a builtin collision or, MCP-only, a schema mismatch across
+// connectors), or, for a unified tool (most connector tools, MCP
+// included, once merged under their raw name — mail_search etc. carry
+// no connector name in their own name), AccountConnector resolving the
+// call's actual account to a sensitive connector. AccountConnector is
+// nil-safe (not every caller wires it, and non-connector tools never
+// resolve). All three funcs re-resolve on
 // every call, not cached, so toggling a connector's sensitive flag (or
 // the configured route) applies to the next side-call without a
 // restart; an empty Route result means the feature is currently off

--- a/internal/brain/session/sensitive.go
+++ b/internal/brain/session/sensitive.go
@@ -20,7 +20,7 @@ import (
 // name>", connectors.Manager.Tools' fallback for a name that can't
 // unify — a builtin collision or, MCP-only, a schema mismatch across
 // connectors), or, for a unified tool (most connector tools, MCP
-// included, once merged under their raw name — mail_search etc. carry
+// included, once merged under their raw name — search_mail etc. carry
 // no connector name in their own name), AccountConnector resolving the
 // call's actual account to a sensitive connector. AccountConnector is
 // nil-safe (not every caller wires it, and non-connector tools never

--- a/internal/brain/session/sensitive_test.go
+++ b/internal/brain/session/sensitive_test.go
@@ -32,7 +32,7 @@ func TestSensitiveToolsMatchesConnectorPrefix(t *testing.T) {
 	}{
 		{name: "connector-prefixed tool", tool: "slack_read_channel", want: true},
 		{name: "another tool under the same sensitive connector", tool: "slack_send_message", want: true},
-		{name: "unrelated connector", tool: "calendar_list_events", want: false},
+		{name: "unrelated connector", tool: "list_calendar_events", want: false},
 		{name: "connector name embedded but not as a namespace boundary", tool: "backslack_read", want: false},
 	}
 	for _, tc := range tests {
@@ -58,7 +58,7 @@ func TestSensitiveToolsMatchesConnectorNamesNil(t *testing.T) {
 }
 
 // TestSensitiveToolsMatchesAccountConnector pins the unified-tool path:
-// a call to a name carrying no connector prefix (e.g. "mail_search")
+// a call to a name carrying no connector prefix (e.g. "search_mail")
 // still matches once AccountConnector resolves it to a name in
 // ConnectorNames: the account the call actually routed to, not the
 // tool's own name, decides sensitivity here.
@@ -67,17 +67,17 @@ func TestSensitiveToolsMatchesAccountConnector(t *testing.T) {
 	s := &SensitiveTools{
 		ConnectorNames: func(context.Context) []string { return []string{"work-outlook"} },
 		AccountConnector: func(_ context.Context, toolName string, args json.RawMessage) string {
-			if toolName == "mail_search" && string(args) == `{"account":"work-outlook"}` {
+			if toolName == "search_mail" && string(args) == `{"account":"work-outlook"}` {
 				return "work-outlook"
 			}
 			return "personal-gmail"
 		},
 		Route: func(context.Context) string { return "local" },
 	}
-	if !s.Matches(context.Background(), "mail_search", json.RawMessage(`{"account":"work-outlook"}`)) {
+	if !s.Matches(context.Background(), "search_mail", json.RawMessage(`{"account":"work-outlook"}`)) {
 		t.Fatal("Matches false for a call AccountConnector resolves to a sensitive connector, want true")
 	}
-	if s.Matches(context.Background(), "mail_search", json.RawMessage(`{"account":"other"}`)) {
+	if s.Matches(context.Background(), "search_mail", json.RawMessage(`{"account":"other"}`)) {
 		t.Fatal("Matches true for a call resolving to a non-sensitive connector, want false")
 	}
 }
@@ -91,7 +91,7 @@ func TestSensitiveToolsMatchesAccountConnectorNil(t *testing.T) {
 		ConnectorNames: func(context.Context) []string { return []string{"work-outlook"} },
 		Route:          func(context.Context) string { return "local" },
 	}
-	if s.Matches(context.Background(), "mail_search", json.RawMessage(`{"account":"work-outlook"}`)) {
+	if s.Matches(context.Background(), "search_mail", json.RawMessage(`{"account":"work-outlook"}`)) {
 		t.Fatal("Matches true with nil AccountConnector, want false (no prefix match either)")
 	}
 }

--- a/internal/brain/tools/builtin/currency.go
+++ b/internal/brain/tools/builtin/currency.go
@@ -25,7 +25,7 @@ type currencyConvertArgs struct {
 // CurrencyLookup answers "what is from->to today" from the fx_rates
 // table (internal/brain/fxrates.Store.LatestUSDRate, composed for a
 // direct pair by CurrencyLookupFromStore below) — the primary path a
-// live turn's currency_convert call takes. ok is false when the table
+// live turn's convert_currency call takes. ok is false when the table
 // has no usable rate for this pair (missing, or older than the store's
 // own staleness bound), in which case the tool falls back to a live
 // fetch rather than guess. asOf is formatted "2006-01-02".
@@ -73,7 +73,7 @@ func ConvertCurrency(lookup CurrencyLookup) *tools.Tool {
 // fallback at a stub server instead of the live exchange-rate service.
 func newCurrencyConverter(lookup CurrencyLookup, client *http.Client, baseURL string) *tools.Tool {
 	return &tools.Tool{
-		Name: "currency_convert",
+		Name: "convert_currency",
 		Description: `Converts an amount from one currency to another using
 daily USD-base reference exchange rates (open.er-api.com, updated
 daily; falls back to a live lookup when no stored rate is available).

--- a/internal/brain/tools/builtin/kbread.go
+++ b/internal/brain/tools/builtin/kbread.go
@@ -9,7 +9,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/tools"
 )
 
-// KBDocument is one full document as kb_read returns it.
+// KBDocument is one full document as read_kb returns it.
 type KBDocument struct {
 	Title     string
 	SourceRef string
@@ -28,22 +28,22 @@ type kbReadArgs struct {
 }
 
 // KBRead lets the model read a knowledge-base document in full after
-// kb_search surfaced an excerpt from it. read is built per-agent,
+// search_kb surfaced an excerpt from it. read is built per-agent,
 // per-turn with the collection set already bound — this constructor
 // never sees or accepts collection names itself.
 func KBRead(read KBReadFunc) *tools.Tool {
 	return &tools.Tool{
-		Name: "kb_read",
+		Name: "read_kb",
 		Description: `Reads a full knowledge-base document by its kb:// reference.
 
-Use after kb_search when the returned passages are not enough — to see
+Use after search_kb when the returned passages are not enough — to see
 a passage's surrounding context, or to read the whole document a hit
 came from. Only documents in this agent's knowledge base collections
 are readable.
 
 Arguments:
 - ref (string, required): the "kb://<document-id>" reference from a
-  kb_search result's "Source:" line (the bare document id also works).
+  search_kb result's "Source:" line (the bare document id also works).
 
 Returns the document's title, source reference, and full markdown
 content. When citing it to the user, use the document title — never
@@ -53,7 +53,7 @@ the kb:// reference.`,
 			"properties": {
 				"ref": {
 					"type": "string",
-					"description": "kb:// reference (or bare document id) from a kb_search result."
+					"description": "kb:// reference (or bare document id) from a search_kb result."
 				}
 			},
 			"required": ["ref"],
@@ -62,15 +62,15 @@ the kb:// reference.`,
 		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
 			var args kbReadArgs
 			if err := json.Unmarshal(raw, &args); err != nil {
-				return "", fmt.Errorf("kb_read: invalid arguments: %w", err)
+				return "", fmt.Errorf("read_kb: invalid arguments: %w", err)
 			}
 			id := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(args.Ref), "kb://"))
 			if id == "" {
-				return "", fmt.Errorf("kb_read: ref must be a kb:// reference or document id")
+				return "", fmt.Errorf("read_kb: ref must be a kb:// reference or document id")
 			}
 			doc, err := read(ctx, id)
 			if err != nil {
-				return "", fmt.Errorf("kb_read: %w", err)
+				return "", fmt.Errorf("read_kb: %w", err)
 			}
 			var b strings.Builder
 			b.WriteString(doc.Title)

--- a/internal/brain/tools/builtin/kbsearch.go
+++ b/internal/brain/tools/builtin/kbsearch.go
@@ -47,7 +47,7 @@ type kbSearchArgs struct {
 // accepts collection names itself.
 func KBSearch(search KBSearchFunc) *tools.Tool {
 	return &tools.Tool{
-		Name: "kb_search",
+		Name: "search_kb",
 		Description: `Searches this agent's knowledge base collections and returns matching passages with their source.
 
 Use when the user asks about something that might be documented in the
@@ -63,7 +63,7 @@ Arguments:
 Returns numbered passages, each with its document title, section
 breadcrumb, source reference, and content, plus a "Source:" line giving
 a stable kb:// reference. The kb:// reference is internal plumbing —
-pass it to kb_read to load the full document, but never show it to the
+pass it to read_kb to load the full document, but never show it to the
 user; when answering from a result, cite the document by its title.`,
 		InputSchema: json.RawMessage(`{
 			"type": "object",
@@ -90,24 +90,24 @@ user; when answering from a result, cite the document by its title.`,
 		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
 			var args kbSearchArgs
 			if err := json.Unmarshal(raw, &args); err != nil {
-				return "", fmt.Errorf("kb_search: invalid arguments: %w", err)
+				return "", fmt.Errorf("search_kb: invalid arguments: %w", err)
 			}
 			if strings.TrimSpace(args.Query) == "" {
-				return "", fmt.Errorf("kb_search: query must not be empty")
+				return "", fmt.Errorf("search_kb: query must not be empty")
 			}
 			if args.Mode != "" && !kbSearchModes[args.Mode] {
-				return "", fmt.Errorf("kb_search: mode must be hybrid, semantic, or keyword, got %q", args.Mode)
+				return "", fmt.Errorf("search_kb: mode must be hybrid, semantic, or keyword, got %q", args.Mode)
 			}
 			k := kbSearchDefaultK
 			if args.K != nil {
 				k = *args.K
 				if k < 1 || k > kbSearchMaxK {
-					return "", fmt.Errorf("kb_search: k must be between 1 and %d, got %d", kbSearchMaxK, k)
+					return "", fmt.Errorf("search_kb: k must be between 1 and %d, got %d", kbSearchMaxK, k)
 				}
 			}
 			hits, err := search(ctx, args.Query, args.Mode, k)
 			if err != nil {
-				return "", fmt.Errorf("kb_search: %w", err)
+				return "", fmt.Errorf("search_kb: %w", err)
 			}
 			return formatKBHits(hits), nil
 		},

--- a/internal/brain/tools/builtin/time.go
+++ b/internal/brain/tools/builtin/time.go
@@ -28,7 +28,7 @@ type currentTimeArgs struct {
 
 func CurrentTime(now Clock, defaultLoc LocationFunc) *tools.Tool {
 	return &tools.Tool{
-		Name: "current_time",
+		Name: "get_current_time",
 		Description: `Returns the current date and time.
 
 Use when the answer depends on "now": today's date, the current time
@@ -95,7 +95,7 @@ func ConvertTime() *tools.Tool {
 
 Use when the user gives a time in one zone and needs it in another
 ("3pm New York time in Dhaka?"). Resolve the source time to RFC 3339
-with its offset first (use current_time if you need today's date).
+with its offset first (use get_current_time if you need today's date).
 
 Arguments:
 - time (string, required): RFC 3339 timestamp including offset,

--- a/internal/brain/tools/builtin/webfetch.go
+++ b/internal/brain/tools/builtin/webfetch.go
@@ -54,7 +54,7 @@ func WebFetch(cfg WebFetchConfig) *tools.Tool {
 		},
 	}
 	return &tools.Tool{
-		Name: "web_fetch",
+		Name: "fetch_url",
 		Description: `Fetches a public web page and returns its readable text.
 
 Use to read the content of a specific URL the user gave you or one you

--- a/internal/brain/tools/builtin/websearch.go
+++ b/internal/brain/tools/builtin/websearch.go
@@ -50,18 +50,18 @@ func WebSearch(baseURL string) *tools.Tool {
 	endpoint := strings.TrimRight(baseURL, "/") + "/search"
 
 	return &tools.Tool{
-		Name: "web_search",
+		Name: "search_web",
 		Description: `Searches the web and returns a list of matching pages.
 
 Use when the user needs current information you don't have — news,
 prices, recent releases, anything past your knowledge — or asks you to
 "search the internet". Returns titles, URLs, and short snippets, not
-full page text; call web_fetch on a promising URL to read further.
+full page text; call fetch_url on a promising URL to read further.
 
 This is read-only lookup, never a transaction: it cannot book a
 flight, reserve a hotel, purchase anything, or fill in a form. If the
 user asks you to "book" or "buy" something, use this tool (and
-web_fetch) to find options and prices, then tell the user what you
+fetch_url) to find options and prices, then tell the user what you
 found and that they need to complete the booking themselves — do not
 retry the search hoping for a different kind of result.
 

--- a/internal/brain/tools/constraints_test.go
+++ b/internal/brain/tools/constraints_test.go
@@ -286,13 +286,13 @@ func TestRepeatGuard(t *testing.T) {
 	t.Run("same call three times in a row trips", func(t *testing.T) {
 		t.Parallel()
 		var g RepeatGuard
-		if g.Record([]provider.ToolCall{call("web_search", `{"query":"book hotel in Nairobi"}`)}) {
+		if g.Record([]provider.ToolCall{call("search_web", `{"query":"book hotel in Nairobi"}`)}) {
 			t.Fatal("tripped on first occurrence")
 		}
-		if g.Record([]provider.ToolCall{call("web_search", `{"query":"book hotel in Nairobi"}`)}) {
+		if g.Record([]provider.ToolCall{call("search_web", `{"query":"book hotel in Nairobi"}`)}) {
 			t.Fatal("tripped on second occurrence")
 		}
-		if !g.Record([]provider.ToolCall{call("web_search", `{"query":"book hotel in Nairobi"}`)}) {
+		if !g.Record([]provider.ToolCall{call("search_web", `{"query":"book hotel in Nairobi"}`)}) {
 			t.Fatal("did not trip on third identical occurrence")
 		}
 	})
@@ -300,9 +300,9 @@ func TestRepeatGuard(t *testing.T) {
 	t.Run("different args resets the run", func(t *testing.T) {
 		t.Parallel()
 		var g RepeatGuard
-		g.Record([]provider.ToolCall{call("web_search", `{"query":"a"}`)})
-		g.Record([]provider.ToolCall{call("web_search", `{"query":"a"}`)})
-		if g.Record([]provider.ToolCall{call("web_search", `{"query":"b"}`)}) {
+		g.Record([]provider.ToolCall{call("search_web", `{"query":"a"}`)})
+		g.Record([]provider.ToolCall{call("search_web", `{"query":"a"}`)})
+		if g.Record([]provider.ToolCall{call("search_web", `{"query":"b"}`)}) {
 			t.Fatal("tripped after a genuinely different call broke the run")
 		}
 	})
@@ -311,10 +311,10 @@ func TestRepeatGuard(t *testing.T) {
 		t.Parallel()
 		var g RepeatGuard
 		for range 5 {
-			if g.Record([]provider.ToolCall{call("web_search", `{"query":"a"}`)}) {
+			if g.Record([]provider.ToolCall{call("search_web", `{"query":"a"}`)}) {
 				t.Fatal("tripped despite alternating calls")
 			}
-			if g.Record([]provider.ToolCall{call("web_fetch", `{"url":"https://example.com"}`)}) {
+			if g.Record([]provider.ToolCall{call("fetch_url", `{"url":"https://example.com"}`)}) {
 				t.Fatal("tripped despite alternating calls")
 			}
 		}

--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -65,13 +65,13 @@ func NewPermissions(db *pgpool.Pool, workspaceRoot string) *Permissions {
 		db:            db,
 		workspaceRoot: workspaceRoot,
 		exempt: map[string]bool{
-			"current_time":    true,
-			"convert_time":    true,
-			"calculate":       true,
-			"web_fetch":       true,
-			"web_search":      true,
-			"retrieve_output": true,
-			"load_skill":      true,
+			"get_current_time": true,
+			"convert_time":     true,
+			"calculate":        true,
+			"fetch_url":        true,
+			"search_web":       true,
+			"retrieve_output":  true,
+			"load_skill":       true,
 			// remember fires only on the user's explicit ask — a
 			// prompt would demand consent for consent. The write is
 			// visible and reversible in the memory browser.
@@ -91,18 +91,18 @@ func NewPermissions(db *pgpool.Pool, workspaceRoot string) *Permissions {
 			"write_file": true,
 			// list_missions/get_mission are pure reads over the missions
 			// store (list / status snapshot) — zero side effects, same
-			// reasoning as web_search. push_mission_branch is
+			// reasoning as search_web. push_mission_branch is
 			// deliberately NOT here: it must always ask (see
 			// PushMissionBranch's doc comment).
 			"list_missions": true,
 			"get_mission":   true,
-			// kb_search is a pure read scoped to collections bound in Go
+			// search_kb is a pure read scoped to collections bound in Go
 			// at construction (D-060), never model input — same reasoning
-			// as web_search/missions.
-			"kb_search": true,
-			// kb_read is the same pure read, one document at a time,
+			// as search_web/missions.
+			"search_kb": true,
+			// read_kb is the same pure read, one document at a time,
 			// with the collection allowlist bound the same way.
-			"kb_read": true,
+			"read_kb": true,
 		},
 	}
 }
@@ -273,9 +273,9 @@ func (p *Permissions) Grant(ctx context.Context, sessionID, tool, pattern string
 // D-036: a grant row's tool also matches when the call's tool name
 // ENDS WITH "_"+rowTool — connector tools are namespaced
 // "<connector-name>_<tool-name>" (connectors.Manager.Tools), so an
-// allowlist entry like "calendar_list_events" (agent-authored, before
+// allowlist entry like "list_calendar_events" (agent-authored, before
 // any connector name is known) still hits
-// "google-calendar_calendar_list_events" at call time. Same suffix
+// "google-calendar_list_calendar_events" at call time. Same suffix
 // semantics as loop.Agent.SetForceRoute, for the same reason. The
 // SandboxGrantTool sentinel ("__sandbox__") is excluded — it is never
 // a real tool call, only a stored sandbox root, and its leading "__"
@@ -352,7 +352,7 @@ func callSubject(tool string, args json.RawMessage) string {
 		if c, ok := m["command"].(string); ok {
 			return c
 		}
-	case "web_fetch":
+	case "fetch_url":
 		if u, ok := m["url"].(string); ok {
 			return u
 		}
@@ -380,7 +380,7 @@ var guardPatterns = []struct {
 var AllowedAbsPrefixes = []string{"/dev/null", "/dev/stdin", "/dev/stdout", "/dev/stderr"}
 
 // guardSubject applies the policy guard to shell commands. Other
-// tools have no path-bearing arguments yet; web_fetch has its own
+// tools have no path-bearing arguments yet; fetch_url has its own
 // network guard.
 func guardSubject(root, tool, subject string) string {
 	if tool != "shell" {

--- a/internal/brain/tools/permissions_test.go
+++ b/internal/brain/tools/permissions_test.go
@@ -75,7 +75,7 @@ func TestGuardSubject(t *testing.T) {
 	}
 
 	// The guard only applies to shell.
-	if got := guardSubject(root, "web_fetch", "https://example.com/.env"); got != "" {
+	if got := guardSubject(root, "fetch_url", "https://example.com/.env"); got != "" {
 		t.Fatalf("non-shell tool guarded: %q", got)
 	}
 }
@@ -88,7 +88,7 @@ func TestCallSubject(t *testing.T) {
 		want string
 	}{
 		{tool: "shell", args: `{"command":"ls -la"}`, want: "ls -la"},
-		{tool: "web_fetch", args: `{"url":"https://example.com"}`, want: "https://example.com"},
+		{tool: "fetch_url", args: `{"url":"https://example.com"}`, want: "https://example.com"},
 		{tool: "calculate", args: `{"expression":"1+1"}`, want: "calculate"},
 		{tool: "shell", args: `not json`, want: "shell"},
 	}
@@ -129,13 +129,13 @@ func TestToolMatches(t *testing.T) {
 		want          bool
 	}{
 		{name: "exact match", tool: "gmail_search", rowTool: "gmail_search", want: true},
-		{name: "connector suffix match", tool: "google-calendar_calendar_list_events", rowTool: "calendar_list_events", want: true},
+		{name: "connector suffix match", tool: "google-calendar_list_calendar_events", rowTool: "list_calendar_events", want: true},
 		{name: "connector suffix match gmail", tool: "gmail_gmail_search", rowTool: "gmail_search", want: true},
 		{name: "sandbox sentinel never suffix-matches", tool: "foo___sandbox__", rowTool: SandboxGrantTool, want: false},
 		{name: "sandbox sentinel exact still matches", tool: SandboxGrantTool, rowTool: SandboxGrantTool, want: true},
-		{name: "no underscore boundary rejected", tool: "notcalendar_list_events", rowTool: "calendar_list_events", want: false},
-		{name: "trailing extra text rejected", tool: "calendar_list_events_extra", rowTool: "calendar_list_events", want: false},
-		{name: "unrelated tool", tool: "shell", rowTool: "calendar_list_events", want: false},
+		{name: "no underscore boundary rejected", tool: "notlist_calendar_events", rowTool: "list_calendar_events", want: false},
+		{name: "trailing extra text rejected", tool: "list_calendar_events_extra", rowTool: "list_calendar_events", want: false},
+		{name: "unrelated tool", tool: "shell", rowTool: "list_calendar_events", want: false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -191,7 +191,7 @@ func TestResolveShortCircuits(t *testing.T) {
 	})
 
 	// list_missions/get_mission are pure reads (list/status snapshot)
-	// and exempt, same reasoning as web_search; push_mission_branch must
+	// and exempt, same reasoning as search_web; push_mission_branch must
 	// never be exempt (see TestResolvePushMissionBranchAsksWithoutGrant,
 	// the integration counterpart proving its full no-grant path) —
 	// this only pins the exempt-map membership the short-circuit above

--- a/internal/gateway/provider/toolwire_test.go
+++ b/internal/gateway/provider/toolwire_test.go
@@ -10,7 +10,7 @@ func toolLoopMessages() []Message {
 	return []Message{
 		{Role: "user", Content: "what time is it in Nairobi?"},
 		{Role: "assistant", Content: "Checking.", ToolCalls: []ToolCall{
-			{ID: "call_1", Name: "current_time", Input: json.RawMessage(`{"timezone":"Africa/Nairobi"}`)},
+			{ID: "call_1", Name: "get_current_time", Input: json.RawMessage(`{"timezone":"Africa/Nairobi"}`)},
 			{ID: "call_2", Name: "calculate", Input: json.RawMessage(`{"expression":"19*23"}`)},
 		}},
 		{Role: "tool", ToolResult: &ToolResult{ID: "call_1", Content: "2026-07-11T09:00:00+03:00"}},
@@ -36,7 +36,7 @@ func TestAnthropicMessagesToolRoundTrip(t *testing.T) {
 	if blocks[0].Type != "text" || blocks[0].Text != "Checking." {
 		t.Fatalf("text block = %+v", blocks[0])
 	}
-	if blocks[1].Type != "tool_use" || blocks[1].ID != "call_1" || blocks[1].Name != "current_time" {
+	if blocks[1].Type != "tool_use" || blocks[1].ID != "call_1" || blocks[1].Name != "get_current_time" {
 		t.Fatalf("tool_use block = %+v", blocks[1])
 	}
 
@@ -63,7 +63,7 @@ func TestAnthropicMessagesToolRoundTrip(t *testing.T) {
 func TestAnthropicMessagesEmptyToolInput(t *testing.T) {
 	t.Parallel()
 	msgs := anthropicMessages([]Message{
-		{Role: "assistant", ToolCalls: []ToolCall{{ID: "c", Name: "current_time"}}},
+		{Role: "assistant", ToolCalls: []ToolCall{{ID: "c", Name: "get_current_time"}}},
 	})
 	blocks := msgs[0].Content.([]anthropicContentBlock)
 	if string(blocks[0].Input) != "{}" {
@@ -108,7 +108,7 @@ func TestOpenAICompatToolRoundTrip(t *testing.T) {
 		t.Fatalf("got %d messages, want 4", len(req.Messages))
 	}
 	asst := req.Messages[1]
-	if len(asst.ToolCalls) != 2 || asst.ToolCalls[0].Function.Name != "current_time" {
+	if len(asst.ToolCalls) != 2 || asst.ToolCalls[0].Function.Name != "get_current_time" {
 		t.Fatalf("assistant tool_calls = %+v", asst.ToolCalls)
 	}
 	if asst.ToolCalls[0].Function.Arguments != `{"timezone":"Africa/Nairobi"}` {

--- a/internal/gateway/stream/events.go
+++ b/internal/gateway/stream/events.go
@@ -63,7 +63,7 @@ type ToolResultEvent struct {
 	// Args is the call's own input, brain-internal only (json:"-": never
 	// reaches the client wire); chat's sensitivity check needs it to
 	// resolve which account a unified aggregate tool call (e.g.
-	// mail_search) actually routed to (session.SensitiveTools.Matches).
+	// search_mail) actually routed to (session.SensitiveTools.Matches).
 	Args json.RawMessage `json:"-"`
 }
 

--- a/migrations/0009_agents.sql
+++ b/migrations/0009_agents.sql
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS agents (
     approval_allowlist jsonb NOT NULL DEFAULT '[]',
     harness            text NOT NULL DEFAULT '',
     -- Knowledge collections (kb_collections.name) this agent may search
-    -- with kb_search (D-060) — empty means none, same opt-in semantics
+    -- with search_kb (D-060) — empty means none, same opt-in semantics
     -- as skills/tools: an agent must name a collection explicitly.
     knowledge      jsonb NOT NULL DEFAULT '[]',
     created_at     timestamptz NOT NULL DEFAULT now(),
@@ -50,7 +50,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS agents_one_default
 -- Tool names are the compiled-in builtins' exact registered names
 -- (internal/brain/tools/builtin/*.go) plus the unified connector
 -- capability names (connectors.Manager.Tools aggregates every
--- connected account behind one name per capability, e.g. "mail_search"
+-- connected account behind one name per capability, e.g. "search_mail"
 -- covers every connected google/microsoft mail account); an allowlist
 -- entry here is agent-authored before any connector even exists, and
 -- covers every current and future account serving that capability.
@@ -59,6 +59,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS agents_one_default
 INSERT INTO agents (name, description, prompt_overlay, route, skills, tools, is_default)
 SELECT 'general', 'Everyday questions and tasks on a strong all-round chain.', '', 'default',
     '["research-brief", "deep-research", "coding", "email-research"]',
-    '["current_time", "convert_time", "calculate", "currency_convert", "web_search", "web_fetch", "remember", "list_missions", "get_mission", "push_mission_branch", "followup_mission", "mail_search", "mail_read", "mail_read_attachment", "mail_send", "calendar_list_events", "calendar_create_event"]',
+    '["get_current_time", "convert_time", "calculate", "convert_currency", "search_web", "fetch_url", "remember", "list_missions", "get_mission", "push_mission_branch", "followup_mission", "search_mail", "read_mail", "read_mail_attachment", "send_mail", "list_calendar_events", "create_calendar_event"]',
     NOT EXISTS (SELECT 1 FROM agents WHERE is_default)
 WHERE NOT EXISTS (SELECT 1 FROM agents WHERE name = 'general');

--- a/migrations/0010_missions.sql
+++ b/migrations/0010_missions.sql
@@ -88,9 +88,9 @@ CREATE TABLE IF NOT EXISTS missions (
     prompt_overlay        text NOT NULL DEFAULT '',
     -- Knowledge snapshots the creating agent's kb_collections allowlist
     -- at create time, same reasoning as prompt_overlay above — a
-    -- mission outlives the request that made it, so kb_search's
+    -- mission outlives the request that made it, so search_kb's
     -- collection scoping can't re-resolve a live agent lookup later.
-    -- Empty array means kb_search is never offered on this mission's
+    -- Empty array means search_kb is never offered on this mission's
     -- turns, regardless of what the agent row says today.
     knowledge             jsonb NOT NULL DEFAULT '[]',
     -- Harness snapshots the operator's execution-strategy choice for a

--- a/migrations/0012_knowledge.sql
+++ b/migrations/0012_knowledge.sql
@@ -1,5 +1,5 @@
 -- Knowledge base: named collections of ingested documents an agent can
--- search with kb_search (D-060). Unlike memories, KB content is
+-- search with search_kb (D-060). Unlike memories, KB content is
 -- MUTABLE reference data — external documentation the operator curates,
 -- not something Timothy observed. Re-ingesting a document deletes its
 -- existing chunks and rewrites them; there is no supersede chain here.

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -8,8 +8,8 @@ description: Decomposes complex research questions into independent sub-question
 ## Rules
 
 - Determine whether the task genuinely requires multi-angle research. When multiple independent angles are required, decompose the goal into 2-4 independent sub-questions during explore. A sub-question is independent only if it can be researched without knowing the answer to another one; questions that depend on each other's results stay together in one unit.
-- Scout each sub-question with 1-2 web_search calls before locking the plan: confirm it is actually answerable and roughly how much material exists. This is reconnaissance, not the research itself.
-- If a kb_search tool is available, search the knowledge base before the web and cite kb sources by their kb:// ref.
+- Scout each sub-question with 1-2 search_web calls before locking the plan: confirm it is actually answerable and roughly how much material exists. This is reconnaissance, not the research itself.
+- If a search_kb tool is available, search the knowledge base before the web and cite kb sources by their kb:// ref.
 - Use one research unit per independent sub-question. Each unit declares exactly one artifact, `findings-<slug>.md`, created with write_file. Each findings file contains:
   - the answer to that sub-question
   - key supporting facts with inline citations
@@ -43,7 +43,7 @@ description: Decomposes complex research questions into independent sub-question
 - A sub-question depends on another sub-question's answer but was split into its own parallel unit.
 - A research unit cites a URL that was never actually retrieved in that unit.
 - A search snippet is being cited as evidence without retrieving the underlying source.
-- The synthesis unit is making new web_search or fetch calls.
+- The synthesis unit is making new search_web or fetch calls.
 - A material claim in `report.md` has no traceable source in the findings files.
 - A decision-driving claim relies on a single non-authoritative source when independent corroboration is reasonably available.
 - Two supposedly independent sources clearly derive from the same underlying material.

--- a/skills/email-research/SKILL.md
+++ b/skills/email-research/SKILL.md
@@ -7,7 +7,7 @@ description: Searches, reads, and aggregates Gmail content, finding bookings, co
 
 ## Rules
 
-- Gmail query operators (mail_search's Google accounts; a Microsoft/Outlook account takes a plain keyword query instead: see the tool's own description for which accounts are connected), used correctly:
+- Gmail query operators (search_mail's Google accounts; a Microsoft/Outlook account takes a plain keyword query instead: see the tool's own description for which accounts are connected), used correctly:
   - Quote multi-word phrases: `subject:"booking confirmation"`, not `subject:booking confirmation` (the latter only matches the first word as the operator's argument).
   - `from:`/`to:` take an address or domain: `from:noreply@airline.com`, `from:airline.com`.
   - OR grouping: `{from:a@x.com from:b@x.com}` or `(from:a@x.com OR from:b@x.com)`; bare `OR` between terms with no parens/braces is parsed unreliably, always group it explicitly.
@@ -15,7 +15,7 @@ description: Searches, reads, and aggregates Gmail content, finding bookings, co
   - `has:attachment`, `label:`, `category:`, `is:unread`, `is:read`.
 - Date bounds MUST be derived from the current date in the system prompt, never a guessed or recalled year. If a search built from a "today" you assumed returns nothing, re-derive the bound from the actual system-prompt date before concluding the mail isn't there.
 - Pipeline discipline: start broad (wide date range, no subject/keyword narrowing), then narrow iteratively; a `from:` combined with subject/keyword terms narrows twice and a near-miss becomes a zero-result search.
-- A `mail_search` result (subjects, senders, snippets) is a digest, not content. Before citing or aggregating what is "in" any message, `mail_read` it: snippets truncate and routinely omit the amount, date, or detail you need.
+- A `search_mail` result (subjects, senders, snippets) is a digest, not content. Before citing or aggregating what is "in" any message, `read_mail` it: snippets truncate and routinely omit the amount, date, or detail you need.
 - Extract every amount together with its currency (`$42.50`, `€19`, `12.00 USD`): a bare number is not usable in a total.
 - All arithmetic (sums, counts, averages) goes through the `calculate` tool; never add or estimate in your head. Show the expression you evaluated.
 - Any total or aggregate figure shows its per-item breakdown (each item's amount and source email) alongside the total, not the total alone.
@@ -30,7 +30,7 @@ description: Searches, reads, and aggregates Gmail content, finding bookings, co
 
 | Excuse                                                        | Rebuttal                                                                                  |
 |---------------------------------------------------------------|-------------------------------------------------------------------------------------------|
-| "The snippet already shows the amount"                        | Snippets truncate; mail_read the message before citing a figure from it.                 |
+| "The snippet already shows the amount"                        | Snippets truncate; read_mail the message before citing a figure from it.                 |
 | "I can add these three numbers myself"                        | Mental arithmetic on amounts you'll report as fact goes through calculate, no exceptions. |
 | "Combining $40 and €40 into one total is close enough"        | Different currencies are different totals; report each separately.                        |
 | "It's from the same sender as the confirmation, so it counts" | Marketing and reminders from that domain are not the transaction; label them separately.  |
@@ -42,13 +42,13 @@ description: Searches, reads, and aggregates Gmail content, finding bookings, co
 - An amount is being reported without its currency.
 - A total appears with no per-item breakdown, or was computed without calculate.
 - A date bound (`after:`/`before:`) was written without checking the system prompt's current date first.
-- A claim about a message's content is being made from a search snippet alone, with no mail_read call this turn.
+- A claim about a message's content is being made from a search snippet alone, with no read_mail call this turn.
 - Two different currencies are being added into a single total.
 - A privacy refusal ("I can't access your email") is about to be given while mail tools are present in this turn's tool list.
 
 ## Evidence required
 
-- Every cited message actually opened with mail_read this turn (or mail_read_attachment, for attachment content).
+- Every cited message actually opened with read_mail this turn (or read_mail_attachment, for attachment content).
 - Every amount paired with its currency and its source message.
 - Every total accompanied by the calculate expression used and the per-item breakdown it was built from.
 - Confirmations distinguished from marketing/reminders explicitly, not merged by sender domain alone.

--- a/skills/research-brief/SKILL.md
+++ b/skills/research-brief/SKILL.md
@@ -8,7 +8,7 @@ description: Source-grounded factual research with verification and citations. U
 ## Rules
 
 - Retrieve before you write: every load-bearing factual claim must be supported by a source actually retrieved this turn, not by trained recall.
-- If a kb_search tool is available, search the knowledge base before the web and cite kb sources by their kb:// ref.
+- If a search_kb tool is available, search the knowledge base before the web and cite kb sources by their kb:// ref.
 - Use two genuinely independent sources for any claim that drives a decision when practical. Syndicated copies, reposts, or sources relying on the same underlying material do not count as independent. One authoritative source is sufficient for background information when additional corroboration would not materially improve confidence.
 - Record where each important fact came from. A source mentioned only in the trailing list without being referenced in the body is not a citation.
 - Distinguish clearly between what a source states and what you infer from it. Label inference explicitly as `Inference: ...`.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -932,7 +932,7 @@ export async function deleteAgent(id: string): Promise<void> {
   await request<void>(`/v1/admin/agents/${id}`, { method: 'DELETE' })
 }
 
-// --- knowledge (RAG collections agents search with kb_search) ---
+// --- knowledge (RAG collections agents search with search_kb) ---
 
 export async function listKbCollections(): Promise<KbCollection[]> {
   const { collections } = await request<{ collections: KbCollection[] }>('/v1/admin/kb/collections')

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1066,7 +1066,7 @@ export async function createConnector(c: Partial<AdminConnector>): Promise<strin
 
 export async function patchConnector(
   id: string,
-  patch: Partial<Pick<AdminConnector, 'config' | 'credential_ref' | 'enabled' | 'sensitive'>>,
+  patch: Partial<Pick<AdminConnector, 'name' | 'config' | 'credential_ref' | 'enabled' | 'sensitive'>>,
 ): Promise<void> {
   await request<void>(`/v1/admin/connectors/${id}`, {
     method: 'PATCH',

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -585,7 +585,7 @@ export interface AdminAgent {
   memory: boolean
   is_default: boolean
   enabled: boolean
-  // Knowledge collections this agent can search with kb_search.
+  // Knowledge collections this agent can search with search_kb.
   // Optional: the backend doesn't send it yet, so callers default to
   // [] when absent.
   knowledge?: string[]
@@ -619,7 +619,7 @@ export interface AdminSkill {
 }
 
 // KbCollection is one document collection agents can search with
-// kb_search — a named group of ingested documents.
+// search_kb — a named group of ingested documents.
 export interface KbCollection {
   id: string
   name: string

--- a/web/src/components/Activity.test.tsx
+++ b/web/src/components/Activity.test.tsx
@@ -62,11 +62,11 @@ describe('summarizeTools', () => {
   it('dedupes by first appearance and counts repeats', () => {
     expect(
       summarizeTools([
-        { id: 'c1', name: 'web_search', status: 'ok' },
-        { id: 'c2', name: 'web_search', status: 'ok' },
-        { id: 'c3', name: 'web_fetch', status: 'ok' },
+        { id: 'c1', name: 'search_web', status: 'ok' },
+        { id: 'c2', name: 'search_web', status: 'ok' },
+        { id: 'c3', name: 'fetch_url', status: 'ok' },
       ]),
-    ).toBe('2× web_search, web_fetch')
+    ).toBe('2× search_web, fetch_url')
   })
 
   it('caps at three names and folds the rest into a "+N more"', () => {
@@ -252,10 +252,10 @@ describe('ActivityPanel', () => {
     const msg = play([
       { type: 'tool_start', tool_call: { id: 'c1', name: 'shell' } },
       { type: 'tool_result', tool_result: { id: 'c1', name: 'shell', status: 'ok', duration_ms: 42 } },
-      { type: 'tool_start', tool_call: { id: 'c2', name: 'web_search' } },
+      { type: 'tool_start', tool_call: { id: 'c2', name: 'search_web' } },
       {
         type: 'tool_result',
-        tool_result: { id: 'c2', name: 'web_search', status: 'ok', duration_ms: 58 },
+        tool_result: { id: 'c2', name: 'search_web', status: 'ok', duration_ms: 58 },
       },
       { type: 'meta', session_id: 's' },
     ])

--- a/web/src/components/Activity.tsx
+++ b/web/src/components/Activity.tsx
@@ -25,7 +25,7 @@ export function totalDuration(tools: ToolRun[]): number {
 
 // summarizeTools names what a turn did, deduped by first appearance
 // and capped so a turn with a dozen tool calls still reads as one
-// line: "web_search, 2× web_fetch, +2 more".
+// line: "search_web, 2× fetch_url, +2 more".
 export function summarizeTools(tools: ToolRun[]): string {
   const order: string[] = []
   const counts = new Map<string, number>()

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -356,9 +356,9 @@ describe('tool calls', () => {
   })
 
   it('shows a running tool while streaming', () => {
-    const msg = play([{ type: 'tool_start', tool_call: { id: 'c1', name: 'web_fetch' } }])
+    const msg = play([{ type: 'tool_start', tool_call: { id: 'c1', name: 'fetch_url' } }])
     render(<AssistantMessage msg={msg} onShowActivity={vi.fn()} />)
-    expect(screen.getByTestId('activity-line')).toHaveTextContent('Running web_fetch…')
+    expect(screen.getByTestId('activity-line')).toHaveTextContent('Running fetch_url…')
   })
 
   it('parks visibly while a permission request is pending', () => {

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -174,7 +174,7 @@ function DocumentChips({
 }
 
 // GeneratedMedia renders an assistant turn's tool-generated media
-// (share_file, mail_read_attachment): image mimes as thumbnails via
+// (share_file, read_mail_attachment): image mimes as thumbnails via
 // AuthedImage, everything else as a chip — same rendering the user
 // message's own attachments use, opening the same AttachmentViewer.
 function GeneratedMedia({ media }: { media: MediaRef[] }) {

--- a/web/src/components/knowledge/KnowledgeCollectionAdd.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionAdd.tsx
@@ -42,7 +42,7 @@ export function KnowledgeCollectionAdd() {
       <div className="border-b border-border pb-6">
         <h1 className="text-xl font-semibold tracking-tight">New collection</h1>
         <p className="text-sm text-muted-foreground">
-          A named group of documents agents can search with kb_search.
+          A named group of documents agents can search with search_kb.
         </p>
       </div>
 

--- a/web/src/components/knowledge/KnowledgeCollectionsList.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionsList.tsx
@@ -23,7 +23,7 @@ export function KnowledgeCollectionsList() {
   return (
     <div className="mt-6 space-y-6">
       <p className="text-sm text-muted-foreground">
-        Collections group documents an agent can search with kb_search for grounded answers.
+        Collections group documents an agent can search with search_kb for grounded answers.
         Upload files to a collection, then allow an agent to search it from the agent's own
         settings.
       </p>

--- a/web/src/components/settings/AgentForm.tsx
+++ b/web/src/components/settings/AgentForm.tsx
@@ -193,7 +193,7 @@ export function AgentForm({
       <Field label="Tools allowlist" hint="pick from the live tool surface; empty = none">
         <ToolsPicker value={fields.tools} onChange={fields.setTools} />
       </Field>
-      <Field label="Knowledge allowlist" hint="collections this agent can search with kb_search; empty = none">
+      <Field label="Knowledge allowlist" hint="collections this agent can search with search_kb; empty = none">
         <KnowledgePicker value={fields.knowledge} onChange={fields.setKnowledge} />
       </Field>
     </div>

--- a/web/src/components/settings/ConnectorEdit.tsx
+++ b/web/src/components/settings/ConnectorEdit.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft01Icon, Delete02Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { ArrowLeft01Icon, Delete02Icon, PencilEdit01Icon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useCallback, useEffect, useState } from 'react'
 import { Link, Navigate, useNavigate, useParams } from 'react-router'
@@ -21,6 +21,7 @@ import {
   DialogTitle,
 } from '../ui/dialog'
 import { Input } from '../ui/input'
+import { slugify } from './AgentForm'
 import { ConnectorLogo } from './ConnectorLogo'
 import { connectorPresets, unknownPreset } from './connectorPresets'
 import { Field, Toggle } from './shared'
@@ -45,6 +46,8 @@ export function ConnectorEdit() {
   const [token, setToken] = useState('')
   const [savingToken, setSavingToken] = useState(false)
   const [oauthBusy, setOAuthBusy] = useState(false)
+  const [renaming, setRenaming] = useState(false)
+  const [name, setName] = useState('')
 
   const refresh = useCallback(() => {
     listConnectors()
@@ -134,6 +137,25 @@ export function ConnectorEdit() {
     toast.success('Public key copied')
   }
 
+  const startRename = () => {
+    if (!connector) return
+    setName(connector.name)
+    setRenaming(true)
+  }
+
+  const commitRename = async () => {
+    const slug = slugify(name)
+    setRenaming(false)
+    if (!connector || slug === '' || slug === connector.name) return
+    try {
+      await patchConnector(connector.id, { name: slug })
+      toast.success('Connector renamed')
+      refresh()
+    } catch (err) {
+      toast.error('Could not rename connector', { description: errText(err) })
+    }
+  }
+
   const reconnectOAuth = async () => {
     if (!connector) return
     setOAuthBusy(true)
@@ -164,7 +186,32 @@ export function ConnectorEdit() {
       <div className="flex items-center gap-4 border-b border-border pb-6">
         <ConnectorLogo preset={preset} className="size-12" />
         <div className="min-w-0 flex-1">
-          <h1 className="truncate text-xl font-semibold tracking-tight">{connector.name}</h1>
+          {renaming ? (
+            <Input
+              aria-label="Connector name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onBlur={() => void commitRename()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') e.currentTarget.blur()
+                if (e.key === 'Escape') setRenaming(false)
+              }}
+              autoFocus
+              className="h-8 max-w-sm text-xl font-semibold tracking-tight"
+            />
+          ) : (
+            <div className="flex items-center gap-1.5">
+              <h1 className="truncate text-xl font-semibold tracking-tight">{connector.name}</h1>
+              <button
+                type="button"
+                aria-label="Rename connector"
+                onClick={startRename}
+                className="shrink-0 text-muted-foreground hover:text-foreground"
+              >
+                <HugeiconsIcon icon={PencilEdit01Icon} className="size-4" />
+              </button>
+            </div>
+          )}
           <p className="text-sm text-muted-foreground uppercase">{connector.kind}</p>
         </div>
         <Button variant="destructive" onClick={() => setConfirmDelete(true)}>

--- a/web/src/components/settings/ConnectorsList.tsx
+++ b/web/src/components/settings/ConnectorsList.tsx
@@ -51,7 +51,7 @@ export function ConnectorsList() {
         </h2>
         <p className="text-sm text-muted-foreground">
           Integrations the agent can use as tools. A tool appears to the model once per capability
-          (e.g. <span className="font-mono text-xs">mail_search</span>) with an{' '}
+          (e.g. <span className="font-mono text-xs">search_mail</span>) with an{' '}
           <span className="font-mono text-xs">account</span> argument routing to the right
           connector when more than one serves it; a name that would otherwise collide (with a
           built-in tool, or across two MCP servers with different schemas) keeps its{' '}

--- a/web/src/components/settings/ConnectorsList.tsx
+++ b/web/src/components/settings/ConnectorsList.tsx
@@ -50,12 +50,13 @@ export function ConnectorsList() {
           {connectors.length > 0 ? `Your connectors · ${connectors.length}` : 'Your connectors'}
         </h2>
         <p className="text-sm text-muted-foreground">
-          Integrations the agent can use as tools. Mail/calendar tools appear to the model once
-          per capability (e.g. <span className="font-mono text-xs">mail_search</span>) with an{' '}
+          Integrations the agent can use as tools. A tool appears to the model once per capability
+          (e.g. <span className="font-mono text-xs">mail_search</span>) with an{' '}
           <span className="font-mono text-xs">account</span> argument routing to the right
-          connected account; MCP connectors&apos; tools still appear as{' '}
-          <span className="font-mono text-xs">name_tool</span>. Either way, tool calls go through
-          the same permission prompts as everything else.
+          connector when more than one serves it; a name that would otherwise collide (with a
+          built-in tool, or across two MCP servers with different schemas) keeps its{' '}
+          <span className="font-mono text-xs">name_tool</span> form instead. Either way, tool
+          calls go through the same permission prompts as everything else.
         </p>
         {connectors.length === 0 ? (
           <div className="rounded-xl border border-dashed border-border p-10 text-center text-sm text-muted-foreground">

--- a/web/src/components/settings/ConnectorsTab.test.tsx
+++ b/web/src/components/settings/ConnectorsTab.test.tsx
@@ -104,6 +104,35 @@ describe('Connectors tab', () => {
     )
   })
 
+  it('renames a connector: pencil click, edit, Enter saves the slugified name', async () => {
+    vi.mocked(patchConnector).mockResolvedValue()
+    renderTab(`/settings/connectors/${calendarConnector.id}`)
+    await screen.findByRole('heading', { name: 'google-calendar' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename connector' }))
+    const input = screen.getByRole('textbox', { name: 'Connector name' })
+    fireEvent.change(input, { target: { value: 'New Calendar' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() =>
+      expect(patchConnector).toHaveBeenCalledWith(calendarConnector.id, { name: 'new-calendar' }),
+    )
+  })
+
+  it('cancels a connector rename on Escape without calling patchConnector', async () => {
+    renderTab(`/settings/connectors/${calendarConnector.id}`)
+    await screen.findByRole('heading', { name: 'google-calendar' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename connector' }))
+    const input = screen.getByRole('textbox', { name: 'Connector name' })
+    fireEvent.change(input, { target: { value: 'New Calendar' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(screen.queryByRole('textbox', { name: 'Connector name' })).toBeNull()
+    expect(screen.getByRole('heading', { name: 'google-calendar' })).toBeTruthy()
+    expect(patchConnector).not.toHaveBeenCalled()
+  })
+
   it('renders a Reconnect button and the failure message for a failed google test', async () => {
     vi.mocked(testConnector).mockResolvedValue({
       ok: false,

--- a/web/src/components/settings/DestinationsList.tsx
+++ b/web/src/components/settings/DestinationsList.tsx
@@ -14,10 +14,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../ui/dialog'
-import { Toggle } from './shared'
+import { DestinationKindIcon, Toggle } from './shared'
 import { errText } from './util'
-
-const kindIcon = { email: Mail01Icon, webhook: GlobalIcon } as const
 
 export function DestinationsList() {
   const [destinations, setDestinations] = useState<Destination[]>([])
@@ -154,11 +152,7 @@ function DestinationCard({
   return (
     <div className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 shadow-sm transition hover:shadow-md">
       <div className="flex items-center gap-3">
-        {destination.kind === 'telegram' ? (
-          <TelegramIcon className="size-9" />
-        ) : (
-          <HugeiconsIcon icon={kindIcon[destination.kind]} className="size-9" />
-        )}
+        <DestinationKindIcon kind={destination.kind} className="size-9" />
         <div className="min-w-0 flex-1">
           <div className="truncate text-sm font-semibold">{destination.name}</div>
           <div className="text-xs text-muted-foreground uppercase">{destination.kind}</div>

--- a/web/src/components/settings/ToolsPicker.tsx
+++ b/web/src/components/settings/ToolsPicker.tsx
@@ -65,7 +65,7 @@ export function ToolsPicker({
               .filter(Boolean),
           )
         }
-        placeholder="web_search, web_fetch, shell"
+        placeholder="search_web, fetch_url, shell"
         className="mt-1.5 flex h-10 w-full rounded-lg border border-input bg-transparent px-3 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
       />
     )

--- a/web/src/components/settings/shared.tsx
+++ b/web/src/components/settings/shared.tsx
@@ -1,4 +1,24 @@
+import { Mail01Icon, GlobalIcon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
 import type { ReactNode } from 'react'
+import { TelegramIcon } from '@/components/icons/TelegramIcon'
+import type { Destination } from '../../api/types'
+
+const destinationKindIcon = { email: Mail01Icon, webhook: GlobalIcon } as const
+
+// DestinationKindIcon renders the small glyph identifying a
+// destination's kind — shared by the settings destinations list and
+// the automations pages' destination badges.
+export function DestinationKindIcon({
+  kind,
+  className = 'size-3.5',
+}: {
+  kind: Destination['kind']
+  className?: string
+}) {
+  if (kind === 'telegram') return <TelegramIcon className={className} />
+  return <HugeiconsIcon icon={destinationKindIcon[kind]} className={className} />
+}
 
 // Toggle is a dependency-free switch that reads in both themes.
 export function Toggle({

--- a/web/src/lib/transcript.test.ts
+++ b/web/src/lib/transcript.test.ts
@@ -115,13 +115,13 @@ describe('fromTranscript', () => {
       {
         seq: 1,
         kind: 'tool',
-        tool: { call_id: 'c1', name: 'web_search', status: 'ok', duration_ms: 10 },
+        tool: { call_id: 'c1', name: 'search_web', status: 'ok', duration_ms: 10 },
         created_at: at,
       },
       {
         seq: 2,
         kind: 'tool',
-        tool: { call_id: 'c2', name: 'web_fetch', status: 'ok', duration_ms: 20 },
+        tool: { call_id: 'c2', name: 'fetch_url', status: 'ok', duration_ms: 20 },
         created_at: at,
       },
       { seq: 3, kind: 'assistant', blocks: [{ type: 'text', text: 'done' }], created_at: at },

--- a/web/src/pages/Analytics.test.tsx
+++ b/web/src/pages/Analytics.test.tsx
@@ -304,7 +304,7 @@ describe('Analytics chart legend selection', () => {
     )
     renderPage()
 
-    const chart = (await screen.findByText('Spend over time')).closest('section')
+    const chart = (await screen.findByText('Spend by provider')).closest('section')
     if (!chart) throw new Error('chart section not found')
     // StatsLegend renders the series name as a plain text node with no
     // className, distinct from the "By provider"-style breakdown table
@@ -326,7 +326,7 @@ describe('Analytics chart legend selection', () => {
 
   it('ctrl-click toggles just that entry, independent of other legends', async () => {
     renderPage()
-    const chart = (await screen.findByText('Tokens in / out')).closest('section')
+    const chart = (await screen.findByText('Token consumption')).closest('section')
     if (!chart) throw new Error('chart section not found')
     const inputEntry = (await within(chart).findAllByText('input')).find((el) => el.className === '')
     if (!inputEntry) throw new Error('legend entry not found')
@@ -368,7 +368,7 @@ describe('Analytics bars/lines view toggle', () => {
       group === 'provider' ? [providerTotal] : [],
     )
     renderPage()
-    const chart = (await screen.findByText('Spend over time')).closest('section')
+    const chart = (await screen.findByText('Spend by provider')).closest('section')
     if (!chart) throw new Error('chart section not found')
     const lastOption = await findChartOptionGetter(chart)
     await waitFor(() => expect((lastOption().series as Array<{ type: string }>)[0]?.type).toBe('line'))
@@ -379,7 +379,7 @@ describe('Analytics bars/lines view toggle', () => {
 
   it('defaults to lines and switches the tokens-in/out chart to bars on click', async () => {
     renderPage()
-    const chart = (await screen.findByText('Tokens in / out')).closest('section')
+    const chart = (await screen.findByText('Token consumption')).closest('section')
     if (!chart) throw new Error('chart section not found')
     const lastOption = await findChartOptionGetter(chart)
     await waitFor(() => expect((lastOption().series as Array<{ type: string }>)[0]?.type).toBe('line'))
@@ -412,16 +412,16 @@ describe('Analytics bars/lines view toggle', () => {
 })
 
 describe('Analytics panel layout', () => {
-  it('orders chart panels: spend, tokens, cost by model, tokens per model, latency/spend share, requests & errors', async () => {
+  it('orders chart panels: spend by provider, spend by model, tokens per model, token consumption, latency/spend share, requests & errors', async () => {
     renderPage()
     const headings = (await screen.findAllByRole('heading', { level: 2 })).map((h) => h.textContent)
     const chartHeadings = [
-      'Spend over time',
-      'Tokens in / out',
-      'Cost by model',
+      'Spend by provider',
+      'Spend by model',
       'Tokens per model',
+      'Token consumption',
       'Latency per provider',
-      'Spend share',
+      'Spend share by provider',
       'Requests & errors over time',
     ]
     const positions = chartHeadings.map((h) => headings.indexOf(h))
@@ -489,7 +489,7 @@ describe('Analytics zero-cost exclusion', () => {
     )
     renderPage()
 
-    const modelCostChart = (await screen.findByText('Cost by model')).closest('section')
+    const modelCostChart = (await screen.findByText('Spend by model')).closest('section')
     if (!modelCostChart) throw new Error('model cost chart section not found')
     expect(await within(modelCostChart).findByText('gpt-5.6-sol')).toBeInTheDocument()
     expect(within(modelCostChart).queryByText('local-llama')).toBeNull()

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -395,7 +395,7 @@ export function Analytics() {
   const budgetHint = (w?: { limit: { amount: number; currency: string } | null }) =>
     w?.limit != null ? `of ${money(w.limit.amount, w.limit.currency)} budget` : undefined
   const spendLabel =
-    range === 'today' ? 'Spend today' : range === '7d' ? 'Spend this week' : 'Spend this month'
+    range === 'today' ? 'Spend today' : range === '7d' ? 'Spend this week' : range === '30d' ? 'Spend this month' : 'Spend this quarter'
   const spendHint = range === 'today' ? budgetHint(budget?.day) : range === '30d' ? budgetHint(budget?.month) : undefined
   const spendOriginal = s ? secondaryMoney(s, s.cost) : undefined
   // unbilledAnnotation is the muted "+amount" note beside the spend
@@ -542,7 +542,7 @@ export function Analytics() {
 
         <section className="mt-6 rounded-xl border border-border p-4">
           <div className="flex items-center justify-between">
-            <h2 className="text-sm font-medium">Spend over time</h2>
+            <h2 className="text-sm font-medium">Spend by provider</h2>
             <ViewToggle view={costView} onChange={setCostView} />
           </div>
           <div className="mt-3">
@@ -569,34 +569,7 @@ export function Analytics() {
 
         <section className="mt-6 rounded-xl border border-border p-4">
           <div className="flex items-center justify-between">
-            <h2 className="text-sm font-medium">Tokens in / out</h2>
-            <ViewToggle view={tokensView} onChange={setTokensView} />
-          </div>
-          <div className="mt-3">
-            <EChart
-              option={(tokensView === 'bars' ? stackedBarsOption : areaLinesOption)(
-                tokens as unknown as Record<string, number | string>[],
-                ['input', 'output'],
-                tokensLegend.hidden,
-                (g) => (g === 'input' ? palette[0] : palette[2]),
-                (v) => bucketLabel(v, bucket),
-                compact,
-              )}
-            />
-          </div>
-          <StatsLegend
-            rows={tokens as unknown as Record<string, number | string>[]}
-            groups={['input', 'output']}
-            colorOf={(g) => (g === 'input' ? palette[0] : palette[2])}
-            hidden={tokensLegend.hidden}
-            onSelect={tokensLegend.onSelect}
-            valueLabel={compact}
-          />
-        </section>
-
-        <section className="mt-6 rounded-xl border border-border p-4">
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-medium">Cost by model</h2>
+            <h2 className="text-sm font-medium">Spend by model</h2>
             <ViewToggle view={modelCostView} onChange={setModelCostView} />
           </div>
           <div className="mt-3">
@@ -653,6 +626,33 @@ export function Analytics() {
           />
         </section>
 
+        <section className="mt-6 rounded-xl border border-border p-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-medium">Token consumption</h2>
+            <ViewToggle view={tokensView} onChange={setTokensView} />
+          </div>
+          <div className="mt-3">
+            <EChart
+              option={(tokensView === 'bars' ? stackedBarsOption : areaLinesOption)(
+                tokens as unknown as Record<string, number | string>[],
+                ['input', 'output'],
+                tokensLegend.hidden,
+                (g) => (g === 'input' ? palette[0] : palette[2]),
+                (v) => bucketLabel(v, bucket),
+                compact,
+              )}
+            />
+          </div>
+          <StatsLegend
+            rows={tokens as unknown as Record<string, number | string>[]}
+            groups={['input', 'output']}
+            colorOf={(g) => (g === 'input' ? palette[0] : palette[2])}
+            hidden={tokensLegend.hidden}
+            onSelect={tokensLegend.onSelect}
+            valueLabel={compact}
+          />
+        </section>
+
         <div className="mt-6 grid gap-6 lg:grid-cols-2">
           <section className="flex flex-col rounded-xl border border-border p-4">
             <h2 className="text-sm font-medium">Latency per provider</h2>
@@ -673,7 +673,7 @@ export function Analytics() {
           </section>
 
           <section className="flex flex-col rounded-xl border border-border p-4">
-            <h2 className="text-sm font-medium">Spend share</h2>
+            <h2 className="text-sm font-medium">Spend share by provider</h2>
             <div className="mt-3 min-h-[240px] flex-1">
               <EChart
                 fill

--- a/web/src/pages/AutomationDetail.test.tsx
+++ b/web/src/pages/AutomationDetail.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { createMemoryRouter, RouterProvider } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Destination, Mission, Schedule } from '../api/types'
@@ -8,9 +8,12 @@ vi.mock('../api/client', () => ({
   listSchedules: vi.fn(),
   listMissions: vi.fn(),
   listDestinations: vi.fn(),
+  patchSchedule: vi.fn(),
 }))
 
-import { listDestinations, listMissions, listSchedules } from '../api/client'
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+import { listDestinations, listMissions, listSchedules, patchSchedule } from '../api/client'
 
 const schedule: Schedule = {
   id: 's1',
@@ -109,5 +112,34 @@ describe('AutomationDetail', () => {
     renderAt('s1')
     await screen.findByText('weekly-digest')
     expect(screen.queryByText('ops-inbox')).toBeNull()
+  })
+
+  it('renames the automation: pencil click, edit, Enter saves the slugified name', async () => {
+    vi.mocked(listSchedules).mockResolvedValue([schedule])
+    vi.mocked(patchSchedule).mockResolvedValue({ ...schedule, name: 'new-name' })
+    renderAt('s1')
+    await screen.findByText('weekly-digest')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename automation' }))
+    const input = screen.getByRole('textbox', { name: 'Automation name' })
+    fireEvent.change(input, { target: { value: 'New Name' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(patchSchedule).toHaveBeenCalledWith('s1', { name: 'new-name' }))
+  })
+
+  it('cancels the rename on Escape without calling patchSchedule', async () => {
+    vi.mocked(listSchedules).mockResolvedValue([schedule])
+    renderAt('s1')
+    await screen.findByText('weekly-digest')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename automation' }))
+    const input = screen.getByRole('textbox', { name: 'Automation name' })
+    fireEvent.change(input, { target: { value: 'New Name' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(screen.queryByRole('textbox', { name: 'Automation name' })).toBeNull()
+    expect(screen.getByText('weekly-digest')).toBeTruthy()
+    expect(patchSchedule).not.toHaveBeenCalled()
   })
 })

--- a/web/src/pages/AutomationDetail.tsx
+++ b/web/src/pages/AutomationDetail.tsx
@@ -1,10 +1,17 @@
+import { PencilEdit01Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
 import { useCallback, useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router'
-import { listDestinations, listMissions, listSchedules } from '../api/client'
+import { toast } from 'sonner'
+import { listDestinations, listMissions, listSchedules, patchSchedule } from '../api/client'
 import type { Destination, Mission, Schedule } from '../api/types'
+import { slugify } from '../components/settings/AgentForm'
 import { MissionCard } from '../components/missions/MissionCard'
+import { DestinationKindIcon } from '../components/settings/shared'
+import { errText } from '../components/settings/util'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
+import { Input } from '../components/ui/input'
 import { describeCron } from '../lib/schedules'
 import { relativeTime, relativeTimeUntil } from '../lib/format'
 
@@ -17,6 +24,8 @@ export function AutomationDetail() {
   const [schedule, setSchedule] = useState<Schedule | null>(null)
   const [loading, setLoading] = useState(true)
   const [missions, setMissions] = useState<Mission[]>([])
+  const [renaming, setRenaming] = useState(false)
+  const [name, setName] = useState('')
   // Destinations fetched once per page, just to resolve
   // destination_ids into display names for the badges below.
   const [destinations, setDestinations] = useState<Destination[]>([])
@@ -41,6 +50,25 @@ export function AutomationDetail() {
   }, [id])
 
   useEffect(refresh, [refresh])
+
+  const startRename = () => {
+    if (!schedule) return
+    setName(schedule.name)
+    setRenaming(true)
+  }
+
+  const commitRename = async () => {
+    const slug = slugify(name)
+    setRenaming(false)
+    if (!schedule || slug === '' || slug === schedule.name) return
+    try {
+      await patchSchedule(schedule.id, { name: slug })
+      toast.success('Automation renamed')
+      refresh()
+    } catch (err) {
+      toast.error('Could not rename automation', { description: errText(err) })
+    }
+  }
 
   if (!id) return null
 
@@ -69,7 +97,32 @@ export function AutomationDetail() {
     <div className="mx-auto w-full max-w-full px-8 py-6">
       <div className="flex items-center justify-between gap-4">
         <div className="min-w-0">
-          <h1 className="truncate text-xl font-semibold tracking-tight">{schedule.name}</h1>
+          {renaming ? (
+            <Input
+              aria-label="Automation name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onBlur={() => void commitRename()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') e.currentTarget.blur()
+                if (e.key === 'Escape') setRenaming(false)
+              }}
+              autoFocus
+              className="h-8 max-w-sm text-xl font-semibold tracking-tight"
+            />
+          ) : (
+            <div className="flex items-center gap-1.5">
+              <h1 className="truncate text-xl font-semibold tracking-tight">{schedule.name}</h1>
+              <button
+                type="button"
+                aria-label="Rename automation"
+                onClick={startRename}
+                className="shrink-0 text-muted-foreground hover:text-foreground"
+              >
+                <HugeiconsIcon icon={PencilEdit01Icon} className="size-4" />
+              </button>
+            </div>
+          )}
           <p className="line-clamp-1 text-sm text-muted-foreground">{schedule.mission_template.goal}</p>
           <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
             <span>{describeCron(schedule.cron)}</span>
@@ -84,6 +137,7 @@ export function AutomationDetail() {
                   const d = destinations.find((d) => d.id === did)
                   return (
                     <Badge key={did} variant="outline" className="text-xs">
+                      {d && <DestinationKindIcon kind={d.kind} />}
                       {d?.name ?? did}
                     </Badge>
                   )

--- a/web/src/pages/Automations.test.tsx
+++ b/web/src/pages/Automations.test.tsx
@@ -111,6 +111,16 @@ describe('Automations page', () => {
     expect(await screen.findByText('ops-inbox')).toBeTruthy()
   })
 
+  it('shows the destination kind icon inside the badge alongside the name', async () => {
+    vi.mocked(listDestinations).mockResolvedValue([destination])
+    vi.mocked(listSchedules).mockResolvedValue([
+      { ...schedule, mission_template: { ...schedule.mission_template, destination_ids: ['d1'] } },
+    ])
+    renderPage()
+    const badge = await screen.findByText('ops-inbox')
+    expect(badge.closest('span')?.querySelector('svg')).toBeInTheDocument()
+  })
+
   it('shows no destination badges when the schedule has none attached', async () => {
     vi.mocked(listDestinations).mockResolvedValue([destination])
     vi.mocked(listSchedules).mockResolvedValue([schedule])

--- a/web/src/pages/Automations.tsx
+++ b/web/src/pages/Automations.tsx
@@ -16,7 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../components/ui/dialog'
-import { Toggle } from '../components/settings/shared'
+import { DestinationKindIcon, Toggle } from '../components/settings/shared'
 import { errText } from '../components/settings/util'
 
 // Automations lists every recurring schedule as a card, folding in what
@@ -97,6 +97,7 @@ export function Automations() {
                     const d = destinations.find((d) => d.id === id)
                     return (
                       <Badge key={id} variant="outline" className="text-xs">
+                        {d && <DestinationKindIcon kind={d.kind} />}
                         {d?.name ?? id}
                       </Badge>
                     )

--- a/web/src/pages/EditSchedule.test.tsx
+++ b/web/src/pages/EditSchedule.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Schedule } from '../api/types'
+import { EditSchedule } from './EditSchedule'
+
+vi.mock('../api/client', () => ({
+  listSchedules: vi.fn(),
+}))
+
+// The page's own concerns (heading, back link, not-found/loading
+// states) don't need MissionForm's real dependency graph — stubbed the
+// same way a page test isolates a heavy child component.
+vi.mock('../components/missions/MissionForm', () => ({
+  MissionForm: () => <div>mission form</div>,
+}))
+
+import { listSchedules } from '../api/client'
+
+const schedule: Schedule = {
+  id: 's1',
+  name: 'weekly-digest',
+  cron: '0 8 * * 1-5',
+  mission_template: { goal: 'Summarize the week', kind: 'general', auto_approve_safe: true },
+  enabled: true,
+  next_run: '2026-07-27T08:00:00Z',
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+  pending_fire: false,
+}
+
+function renderAt(id: string) {
+  const router = createMemoryRouter(
+    [{ path: '/automations/:id/edit', element: <EditSchedule /> }],
+    { initialEntries: [`/automations/${id}/edit`] },
+  )
+  return render(<RouterProvider router={router} />)
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(listSchedules).mockResolvedValue([])
+})
+
+describe('EditSchedule', () => {
+  it('shows the "Edit automation" heading and a back link to the automation detail page', async () => {
+    vi.mocked(listSchedules).mockResolvedValue([schedule])
+    renderAt('s1')
+
+    expect(await screen.findByRole('heading', { name: 'Edit automation' })).toBeTruthy()
+    const back = screen.getByRole('link', { name: /Automation/ })
+    expect(back.getAttribute('href')).toBe('/automations/s1')
+  })
+
+  it('shows a not-found message for an unknown schedule', async () => {
+    renderAt('missing')
+    expect(await screen.findByText('Schedule not found.')).toBeTruthy()
+  })
+})

--- a/web/src/pages/EditSchedule.tsx
+++ b/web/src/pages/EditSchedule.tsx
@@ -1,3 +1,5 @@
+import { ArrowLeft01Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router'
 import { listSchedules } from '../api/client'
@@ -49,8 +51,16 @@ export function EditSchedule() {
 
   return (
     <div className="mx-auto w-full max-w-full px-8 py-6">
-      <div>
-        <h1 className="text-xl font-semibold tracking-tight">Edit schedule</h1>
+      <Link
+        to={`/automations/${id}`}
+        className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"
+      >
+        <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+        Automation
+      </Link>
+
+      <div className="mt-6">
+        <h1 className="text-xl font-semibold tracking-tight">Edit automation</h1>
         <p className="text-sm text-muted-foreground">
           A recurring mission that fires on the cron below.
         </p>

--- a/web/src/pages/Research.tsx
+++ b/web/src/pages/Research.tsx
@@ -3,7 +3,7 @@ import { Chat } from './Chat'
 // Research is a dedicated, single-purpose entry point: the
 // research-brief skill is pinned for every turn (not removable, not
 // picked from a chip) so every answer follows the same source-grounded
-// discipline — web_search + web_fetch, cited claims, a structured
+// discipline — search_web + fetch_url, cited claims, a structured
 // Sources list the UI renders as its own panel.
 export function Research({ onNeedToken }: { onNeedToken: () => void }) {
   return (


### PR DESCRIPTION
## What

- Connector and automation rename: PATCH accepts a slug-validated unique name (409 name_conflict); inline pencil rename on the connector edit and automation detail pages.
- MCP tools drop the `<connector>_<tool>` namespace and join the unified raw-name aggregate with the existing `account` parameter. Namespacing remains only as a fallback for builtin-reserved names and cross-server schema mismatches. Sensitive MCP connectors are detected via account resolution instead of the name prefix.
- Verb-first tool naming convention: 17 tools renamed (search_mail, read_mail, send_mail, list_calendar_events, create_calendar_event, search_drive, read_drive_file, read_doc, create_doc, append_doc, read_mail_attachment, search_web, fetch_url, search_kb, read_kb, convert_currency, get_current_time). Seed migration edited in place per pre-release policy; existing agent rows migrate via an idempotent script (dry-run verified locally).
- Global timezone steer: mission and chat prompts instruct the model to present dates and times in the operator timezone, replacing per-goal boilerplate.
- Web polish: destination kind icons in automation badges, "Edit automation" heading, back link on the edit page, analytics panel renames and the 90 day spend label fix.

## Why

Connector names were immutable, yet for unified tools the name is only the account key; MCP was the lone consumer of name-derived tool names, blocking rename and diverging from the aggregate design. Tool naming mixed resource-first and verb-first forms; the pre-release window is the cheap time to converge on the verb-first convention. Timezone context was restated in every schedule goal although the operator setting already exists.

## Tests

- New: connector rename store tests, seven MCP aggregation tests (merge, account routing, reserved-name and schema-mismatch fallbacks, sensitive detection pair), timezone steer assertions for both injection points, web tests for rename flows, edit page, and badge icons.
- make build test vet lint clean; integration suites ok; web 66 files / 900 tests pass.
- make canary PASS after the rename sweep (296s, 4 harness-verified units, zero permission parks).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790563575&installation_model_id=431401&pr_number=348&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F348&signature=74cc47ed43b59a8755a302e144234a24bf15f9efc4fdf4240ba881cb5b3ca6c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->