### PR TITLE
feat(kb): clip endpoint, url dedup, source tooltips, classify granularity

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -654,7 +654,7 @@ func main() {
 	api.Register(app.Server, svc, store, broker,
 		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, usageDecorator.Decorate, app.Log), flags, fxStore,
 		agentReg, conns, goog, msft, secrets, agent, packs, missionStore, missionDriver, missionNotifier,
-		missionWorkspace, resolveSecret, routeForRole, chat.ClassifyOverGateway(gwc), gwc.ResolveRoute, chat.TitleOverGateway(gwc, app.Log), ledgerAgg.TopModelByMission, missionHub, attachmentStore, &http.Client{}, whisperURL, markitdownURL, token, app.Log, gwc, kbStore, mc, chat.ClassifyCollectionOverGateway(gwc, app.Log), destinationStore, destinationTest, workflowStore, workflowEngine)
+		missionWorkspace, resolveSecret, routeForRole, chat.ClassifyOverGateway(gwc), gwc.ResolveRoute, chat.TitleOverGateway(gwc, app.Log), ledgerAgg.TopModelByMission, missionHub, attachmentStore, &http.Client{}, whisperURL, markitdownURL, token, app.Log, gwc, kbStore, mc, chat.ClassifyCollectionOverGateway(gwc, app.Log), chat.TitleOverGateway(gwc, app.Log), destinationStore, destinationTest, workflowStore, workflowEngine)
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -101,7 +101,7 @@ var memoryRoutePatterns = []string{
 // proxy to the gateway's internal control plane, conns the local
 // connector control plane (nil leaves any of them unmounted).
 // whisperURL empty leaves /v1/transcribe unmounted (WHISPER_URL unset).
-func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, msft *connectors.Microsoft, secrets *secretstore.Store, toolset Toolset, packs []skills.Skill, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, resolveRoute func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, markitdownURL string, token string, log *slog.Logger, gwSecrets GatewaySecrets, kbStore *kb.Store, kbIngest kbIngester, kbClassify kbClassifier, destinationStore *destinations.Store, destinationTest destinationTester, workflowStore *workflows.Store, workflowEngine *workflows.Engine) {
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, msft *connectors.Microsoft, secrets *secretstore.Store, toolset Toolset, packs []skills.Skill, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, resolveRoute func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, markitdownURL string, token string, log *slog.Logger, gwSecrets GatewaySecrets, kbStore *kb.Store, kbIngest kbIngester, kbClassify kbClassifier, kbTitle kbTitler, destinationStore *destinations.Store, destinationTest destinationTester, workflowStore *workflows.Store, workflowEngine *workflows.Engine) {
 	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log, flags: flags, rates: rates}
 	if kbStore != nil {
 		a.kbCollections = kbStore.ListCollections
@@ -133,7 +133,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	a.registerConnectors(srv.Handle, conns, goog, msft, secrets)
 	a.registerTools(srv.Handle, toolset)
 	a.registerSkills(srv.Handle, packs)
-	a.registerKB(srv.Handle, kbStore, kbIngest, markitdownURL, kbClassify)
+	a.registerKB(srv.Handle, kbStore, kbIngest, markitdownURL, kbClassify, kbTitle)
 	var codingExecutorDefault func(context.Context) string
 	if flags != nil {
 		codingExecutorDefault = flags.CodingExecutor

--- a/internal/brain/api/kb.go
+++ b/internal/brain/api/kb.go
@@ -23,6 +23,18 @@ import (
 // maxKBUploadBytes caps a single knowledge-base document upload.
 const maxKBUploadBytes = 32 << 20 // 32MiB
 
+// maxClipMarkdownBytes caps a browser-extension clip's markdown,
+// mirroring markitdown's own output cap (markitdown.TruncateMarkdown).
+const maxClipMarkdownBytes = 128 << 10 // 128KiB
+
+// clipTitleInputRunes bounds how much markdown a clip with no title
+// feeds to the titler; clipTitleMaxRunes bounds the generated title
+// itself.
+const (
+	clipTitleInputRunes = 2000
+	clipTitleMaxRunes   = 200
+)
+
 // kbAllowedExt names the file extensions kb document upload accepts.
 // .md/.txt skip markitdown entirely (already markdown/plain text);
 // everything else converts through the sidecar.
@@ -44,14 +56,19 @@ type kbIngester interface {
 // classifier itself): a document must always resolve to some choice.
 type kbClassifier func(ctx context.Context, docTitle, docText string, collections []kb.Collection) chat.CollectionChoice
 
+// kbTitler generates a document title from a markdown excerpt —
+// chat.TitleOverGateway in production, faked in tests. Never errors;
+// an empty return means the caller falls back to titleFromURL.
+type kbTitler func(ctx context.Context, input string) string
+
 // registerKB mounts the knowledge-base admin surface (D-060). Nil
 // store leaves it unmounted, same nil-gate pattern as agents/skills.
-func (a *API) registerKB(handle func(pattern string, h http.Handler), store *kb.Store, ingest kbIngester, markitdownURL string, classify kbClassifier) {
+func (a *API) registerKB(handle func(pattern string, h http.Handler), store *kb.Store, ingest kbIngester, markitdownURL string, classify kbClassifier, title kbTitler) {
 	if store == nil {
 		return
 	}
 	h := &kbAPI{
-		store: store, ingest: ingest, markitdownURL: markitdownURL, classify: classify,
+		store: store, ingest: ingest, markitdownURL: markitdownURL, classify: classify, title: title,
 		markitdownHTTP: &http.Client{},
 		fetchHTTP:      &http.Client{Timeout: kbURLFetchTimeout, Transport: kbFetchTransport},
 		log:            a.log,
@@ -66,6 +83,7 @@ func (a *API) registerKB(handle func(pattern string, h http.Handler), store *kb.
 	handle("POST /v1/admin/kb/collections/{id}/documents/url", a.auth(http.HandlerFunc(h.addDocumentFromURL)))
 	handle("POST /v1/admin/kb/documents", a.auth(http.HandlerFunc(h.uploadDocumentAuto)))
 	handle("POST /v1/admin/kb/documents/url", a.auth(http.HandlerFunc(h.addDocumentFromURLAuto)))
+	handle("POST /v1/admin/kb/documents/clip", a.auth(http.HandlerFunc(h.clipDocument)))
 	handle("DELETE /v1/admin/kb/documents/{id}", a.auth(http.HandlerFunc(h.deleteDocument)))
 	handle("POST /v1/admin/kb/documents/{id}/reingest", a.auth(http.HandlerFunc(h.reingestDocument)))
 }
@@ -74,6 +92,7 @@ type kbAPI struct {
 	store          *kb.Store
 	ingest         kbIngester
 	classify       kbClassifier
+	title          kbTitler
 	markitdownURL  string
 	markitdownHTTP *http.Client
 	// fetchHTTP fetches user-supplied URLs; production wires it through
@@ -436,6 +455,141 @@ func (h *kbAPI) addDocumentFromURLAuto(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	h.finishIngest(w, r, collectionID, d.title, "url", d.url, d.markdown, d.rawBytes)
+}
+
+// kbClipRequest is a browser-extension clip: the extension converts the
+// page to markdown client-side, so this path never fetches or converts
+// anything itself.
+type kbClipRequest struct {
+	URL          string `json:"url"`
+	Title        string `json:"title"`
+	Markdown     string `json:"markdown"`
+	CollectionID string `json:"collection_id"`
+}
+
+// normalizeClipURL is the clip dedup key: fragment dropped, and
+// tracking query parameters (fbclid, gclid, utm_*) stripped. The
+// extension already strips these client-side; this re-strips as
+// defense so a stray tracking param never splits one page into two
+// documents.
+func normalizeClipURL(u *url.URL) string {
+	out := *u
+	out.Fragment = ""
+	q := out.Query()
+	for key := range q {
+		lower := strings.ToLower(key)
+		if lower == "fbclid" || lower == "gclid" || strings.HasPrefix(lower, "utm_") {
+			q.Del(key)
+		}
+	}
+	out.RawQuery = q.Encode()
+	return out.String()
+}
+
+// truncateRunes cuts s to at most n runes, not bytes (titles and
+// markdown excerpts can carry multi-byte UTF-8).
+func truncateRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n])
+}
+
+// clipDocument ingests a browser-extension clip: the extension sends
+// pre-converted markdown, so this handler validates and stores it
+// directly, with no fetch and no markitdown conversion. Re-clipping an
+// already-known URL (by source_type=clip, source_ref=normalized URL)
+// refreshes the existing document in place rather than creating a
+// duplicate.
+func (h *kbAPI) clipDocument(w http.ResponseWriter, r *http.Request) {
+	var req kbClipRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+
+	u, err := url.Parse(strings.TrimSpace(req.URL))
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "url must be a full http:// or https:// URL")
+		return
+	}
+	u.User = nil
+
+	markdownText := strings.TrimSpace(req.Markdown)
+	if markdownText == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "markdown is required")
+		return
+	}
+	if len(req.Markdown) > maxClipMarkdownBytes {
+		jsonError(w, http.StatusRequestEntityTooLarge, "too_large", "markdown exceeds the 128KiB limit")
+		return
+	}
+
+	collectionID := strings.TrimSpace(req.CollectionID)
+	if collectionID != "" {
+		if _, err := h.store.GetCollection(r.Context(), collectionID); err != nil {
+			failKB(w, err)
+			return
+		}
+	}
+
+	// Sanitize the same as every other ingest path: converted (or here,
+	// extension-supplied) markdown can carry NUL bytes or invalid UTF-8,
+	// which Postgres text columns reject (22021).
+	markdownText = strings.ToValidUTF8(strings.ReplaceAll(req.Markdown, "\x00", ""), "�")
+
+	title := strings.TrimSpace(req.Title)
+	if title == "" {
+		if h.title != nil {
+			title = truncateRunes(strings.TrimSpace(h.title(r.Context(), truncateRunes(markdownText, clipTitleInputRunes))), clipTitleMaxRunes)
+		}
+		if title == "" {
+			title = titleFromURL(u)
+		}
+	}
+
+	sourceRef := normalizeClipURL(u)
+	existing, err := h.store.FindDocumentBySource(r.Context(), "clip", sourceRef)
+	switch {
+	case errors.Is(err, kb.ErrNotFound):
+		if collectionID == "" {
+			collectionID, err = h.resolveCollection(r.Context(), title, markdownText)
+			if err != nil {
+				jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
+				return
+			}
+		}
+		docID, err := h.store.CreateDocument(r.Context(), collectionID, title, "clip", sourceRef, markdownText, int64(len(markdownText)))
+		if err != nil {
+			jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
+			return
+		}
+		h.startIngest(docID, title)
+		doc, err := h.store.GetDocument(r.Context(), docID)
+		if err != nil {
+			jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
+			return
+		}
+		writeJSON(w, http.StatusAccepted, sanitizeDocument(doc))
+	case err != nil:
+		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
+	default:
+		// Re-clip: refresh the existing document rather than duplicate
+		// it. startIngest's memoryd call deletes the old chunks before
+		// writing the new set (same as reingestDocument).
+		if err := h.store.ReplaceDocumentContent(r.Context(), existing.ID, title, markdownText, int64(len(markdownText)), collectionID); err != nil {
+			failKB(w, err)
+			return
+		}
+		h.startIngest(existing.ID, title)
+		doc, err := h.store.GetDocument(r.Context(), existing.ID)
+		if err != nil {
+			jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
+			return
+		}
+		writeJSON(w, http.StatusAccepted, sanitizeDocument(doc))
+	}
 }
 
 // fetchURL GETs u, capping the body at maxKBUploadBytes, and returns

--- a/internal/brain/api/kb.go
+++ b/internal/brain/api/kb.go
@@ -413,11 +413,45 @@ func (h *kbAPI) decodeURL(w http.ResponseWriter, r *http.Request, req kbURLReque
 	if title == "" {
 		title = titleFromURL(u)
 	}
-	return decodedURL{title: title, url: u.String(), markdown: markdownText, rawBytes: int64(len(body))}, true
+	return decodedURL{title: title, url: normalizeSourceURL(u), markdown: markdownText, rawBytes: int64(len(body))}, true
+}
+
+// refreshOrCreate looks up an existing document by (sourceType,
+// sourceRef). On a hit it refreshes the row in place (200 OK), moving
+// it to moveTo ("" keeps the current collection). On a miss it calls
+// resolveCollectionID to pick a collection (classifying or using the
+// caller's choice) and creates a new document (201 Created).
+func (h *kbAPI) refreshOrCreate(w http.ResponseWriter, r *http.Request, resolveCollectionID func() (string, error), moveTo, title, sourceType, sourceRef, markdownText string, size int64) {
+	existing, err := h.store.FindDocumentBySource(r.Context(), sourceType, sourceRef)
+	switch {
+	case errors.Is(err, kb.ErrNotFound):
+		collectionID, err := resolveCollectionID()
+		if err != nil {
+			jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
+			return
+		}
+		h.finishIngest(w, r, collectionID, title, sourceType, sourceRef, markdownText, size)
+	case err != nil:
+		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
+	default:
+		if err := h.store.ReplaceDocumentContent(r.Context(), existing.ID, title, markdownText, size, moveTo); err != nil {
+			failKB(w, err)
+			return
+		}
+		h.startIngest(existing.ID, title)
+		doc, err := h.store.GetDocument(r.Context(), existing.ID)
+		if err != nil {
+			jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, sanitizeDocument(doc))
+	}
 }
 
 // addDocumentFromURL fetches a user-supplied URL into a caller-chosen
-// collection.
+// collection. Re-adding an already-known URL (by source_type=url,
+// source_ref=normalized URL) refreshes the existing document in place,
+// moving it to collectionID since the operator explicitly chose it.
 func (h *kbAPI) addDocumentFromURL(w http.ResponseWriter, r *http.Request) {
 	collectionID := r.PathValue("id")
 	if _, err := h.store.GetCollection(r.Context(), collectionID); err != nil {
@@ -433,12 +467,15 @@ func (h *kbAPI) addDocumentFromURL(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	h.finishIngest(w, r, collectionID, d.title, "url", d.url, d.markdown, d.rawBytes)
+	resolve := func() (string, error) { return collectionID, nil }
+	h.refreshOrCreate(w, r, resolve, collectionID, d.title, "url", d.url, d.markdown, d.rawBytes)
 }
 
 // addDocumentFromURLAuto fetches a user-supplied URL with no collection
 // chosen: the document is classified against existing collections (or
-// files into a newly proposed one) before ingest.
+// files into a newly proposed one) before ingest. Re-adding an
+// already-known URL refreshes it in place and keeps its current
+// collection, skipping the classifier.
 func (h *kbAPI) addDocumentFromURLAuto(w http.ResponseWriter, r *http.Request) {
 	var req kbURLRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -449,12 +486,8 @@ func (h *kbAPI) addDocumentFromURLAuto(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	collectionID, err := h.resolveCollection(r.Context(), d.title, d.markdown)
-	if err != nil {
-		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
-		return
-	}
-	h.finishIngest(w, r, collectionID, d.title, "url", d.url, d.markdown, d.rawBytes)
+	resolve := func() (string, error) { return h.resolveCollection(r.Context(), d.title, d.markdown) }
+	h.refreshOrCreate(w, r, resolve, "", d.title, "url", d.url, d.markdown, d.rawBytes)
 }
 
 // kbClipRequest is a browser-extension clip: the extension converts the
@@ -467,12 +500,12 @@ type kbClipRequest struct {
 	CollectionID string `json:"collection_id"`
 }
 
-// normalizeClipURL is the clip dedup key: fragment dropped, and
-// tracking query parameters (fbclid, gclid, utm_*) stripped. The
+// normalizeSourceURL is the url/clip dedup key: fragment dropped, and
+// tracking query parameters (fbclid, gclid, utm_*) stripped. The clip
 // extension already strips these client-side; this re-strips as
 // defense so a stray tracking param never splits one page into two
 // documents.
-func normalizeClipURL(u *url.URL) string {
+func normalizeSourceURL(u *url.URL) string {
 	out := *u
 	out.Fragment = ""
 	q := out.Query()
@@ -549,7 +582,7 @@ func (h *kbAPI) clipDocument(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	sourceRef := normalizeClipURL(u)
+	sourceRef := normalizeSourceURL(u)
 	existing, err := h.store.FindDocumentBySource(r.Context(), "clip", sourceRef)
 	switch {
 	case errors.Is(err, kb.ErrNotFound):

--- a/internal/brain/api/kb_integration_test.go
+++ b/internal/brain/api/kb_integration_test.go
@@ -394,6 +394,233 @@ func TestKBDocumentFromURLIngestsFetchedMarkdown(t *testing.T) {
 	}
 }
 
+// TestKBDocumentFromURLScopedReAddRefreshesInPlace covers the scoped
+// route's dedup: re-adding the same URL updates the existing row (200,
+// same id, no second row) instead of duplicating it.
+func TestKBDocumentFromURLScopedReAddRefreshesInPlace(t *testing.T) {
+	store := testKBStore(t)
+	ingester := &fakeIngester{}
+
+	body := "# Fetched\nversion one"
+	page := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer page.Close()
+
+	saved := kbFetchTransport
+	kbFetchTransport = http.DefaultTransport
+	defer func() { kbFetchTransport = saved }()
+
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
+
+	collID, err := store.CreateCollection(context.Background(), "itest-url-readd", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	post := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest("POST", "/v1/admin/kb/collections/"+collID+"/documents/url",
+			strings.NewReader(`{"url":"`+page.URL+`/page","title":""}`))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w
+	}
+
+	first := post()
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first status = %d body %s", first.Code, first.Body)
+	}
+	var firstDoc struct {
+		ID string `json:"id"`
+	}
+	if err := decodeBody(t, first.Body.Bytes(), &firstDoc); err != nil {
+		t.Fatal(err)
+	}
+
+	body = "# Fetched\nversion two"
+	second := post()
+	if second.Code != http.StatusOK {
+		t.Fatalf("second status = %d, want 200 body %s", second.Code, second.Body)
+	}
+	var secondDoc struct {
+		ID string `json:"id"`
+	}
+	if err := decodeBody(t, second.Body.Bytes(), &secondDoc); err != nil {
+		t.Fatal(err)
+	}
+	if secondDoc.ID != firstDoc.ID {
+		t.Fatalf("second add created a new document %q, want the same id %q", secondDoc.ID, firstDoc.ID)
+	}
+
+	rows, err := store.ListDocuments(context.Background(), collID)
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("found %d documents, want exactly 1 (no duplicate)", len(rows))
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if ingester.callCount() >= 2 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	final, err := store.GetDocument(context.Background(), firstDoc.ID)
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if final.Markdown != "# Fetched\nversion two" {
+		t.Fatalf("stored markdown = %q, want the refreshed body", final.Markdown)
+	}
+}
+
+// TestKBDocumentFromURLAutoReAddSkipsClassifierKeepsCollection covers
+// the unscoped route's dedup: re-adding the same URL must not
+// re-consult the classifier and must keep the document in its current
+// collection.
+func TestKBDocumentFromURLAutoReAddSkipsClassifierKeepsCollection(t *testing.T) {
+	store := testKBStore(t)
+	ingester := &fakeIngester{}
+
+	body := "# Fetched\nversion one"
+	page := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer page.Close()
+
+	saved := kbFetchTransport
+	kbFetchTransport = http.DefaultTransport
+	defer func() { kbFetchTransport = saved }()
+
+	classifyCalls := 0
+	classify := func(ctx context.Context, docTitle, docText string, collections []kb.Collection) chat.CollectionChoice {
+		classifyCalls++
+		return chat.CollectionChoice{NewName: "itest-url-auto-readd"}
+	}
+
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, ingester, "", classify, nil)
+
+	post := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest("POST", "/v1/admin/kb/documents/url",
+			strings.NewReader(`{"url":"`+page.URL+`/auto-page","title":""}`))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w
+	}
+
+	first := post()
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first status = %d body %s", first.Code, first.Body)
+	}
+	var firstDoc struct {
+		ID           string `json:"id"`
+		CollectionID string `json:"collection_id"`
+	}
+	if err := decodeBody(t, first.Body.Bytes(), &firstDoc); err != nil {
+		t.Fatal(err)
+	}
+	if classifyCalls != 1 {
+		t.Fatalf("classifyCalls after first add = %d, want 1", classifyCalls)
+	}
+
+	body = "# Fetched\nversion two"
+	second := post()
+	if second.Code != http.StatusOK {
+		t.Fatalf("second status = %d, want 200 body %s", second.Code, second.Body)
+	}
+	var secondDoc struct {
+		ID           string `json:"id"`
+		CollectionID string `json:"collection_id"`
+	}
+	if err := decodeBody(t, second.Body.Bytes(), &secondDoc); err != nil {
+		t.Fatal(err)
+	}
+	if secondDoc.ID != firstDoc.ID {
+		t.Fatalf("second add created a new document %q, want the same id %q", secondDoc.ID, firstDoc.ID)
+	}
+	if secondDoc.CollectionID != firstDoc.CollectionID {
+		t.Fatalf("collection_id = %q, want unchanged %q", secondDoc.CollectionID, firstDoc.CollectionID)
+	}
+	if classifyCalls != 1 {
+		t.Fatalf("classifyCalls after re-add = %d, want still 1 (not re-consulted)", classifyCalls)
+	}
+}
+
+// TestKBDocumentFromURLDifferentURLStillCreates confirms dedup keys on
+// the normalized URL, not the collection or title: a distinct URL
+// always creates a second document.
+func TestKBDocumentFromURLDifferentURLStillCreates(t *testing.T) {
+	store := testKBStore(t)
+	ingester := &fakeIngester{}
+
+	page := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+		_, _ = w.Write([]byte("# Fetched\nbody"))
+	}))
+	defer page.Close()
+
+	saved := kbFetchTransport
+	kbFetchTransport = http.DefaultTransport
+	defer func() { kbFetchTransport = saved }()
+
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
+
+	collID, err := store.CreateCollection(context.Background(), "itest-url-distinct", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	post := func(path string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest("POST", "/v1/admin/kb/collections/"+collID+"/documents/url",
+			strings.NewReader(`{"url":"`+page.URL+path+`","title":""}`))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w
+	}
+
+	first := post("/page-a")
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first status = %d body %s", first.Code, first.Body)
+	}
+	second := post("/page-b")
+	if second.Code != http.StatusCreated {
+		t.Fatalf("second status = %d, want 201 body %s", second.Code, second.Body)
+	}
+	var firstDoc, secondDoc struct {
+		ID string `json:"id"`
+	}
+	if err := decodeBody(t, first.Body.Bytes(), &firstDoc); err != nil {
+		t.Fatal(err)
+	}
+	if err := decodeBody(t, second.Body.Bytes(), &secondDoc); err != nil {
+		t.Fatal(err)
+	}
+	if firstDoc.ID == secondDoc.ID {
+		t.Fatal("distinct URLs must not collapse into the same document")
+	}
+
+	rows, err := store.ListDocuments(context.Background(), collID)
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("found %d documents, want 2", len(rows))
+	}
+}
+
 // TestKBDocumentUploadAutoCreatesNewCollection exercises the unscoped
 // upload route: no collection is chosen up front, so the classifier's
 // proposed new collection (fixedClassifier) must be created and the

--- a/internal/brain/api/kb_integration_test.go
+++ b/internal/brain/api/kb_integration_test.go
@@ -118,7 +118,7 @@ func TestKBCollectionsCRUD(t *testing.T) {
 	store := testKBStore(t)
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
 
 	create := httptest.NewRequest("POST", "/v1/admin/kb/collections", strings.NewReader(`{"name":"itest-docs","description":"test collection"}`))
 	create.Header.Set("Authorization", "Bearer tok")
@@ -203,7 +203,7 @@ func TestKBDocumentUploadSkipsMarkitdownForMarkdown(t *testing.T) {
 	ingester := &fakeIngester{}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", fixedClassifier)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-upload", "")
 	if err != nil {
@@ -267,7 +267,7 @@ func TestKBDocumentUploadStripsNULAndInvalidUTF8(t *testing.T) {
 	ingester := &fakeIngester{}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", fixedClassifier)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-nul", "")
 	if err != nil {
@@ -305,7 +305,7 @@ func TestKBDocumentUploadRejectsUnsupportedType(t *testing.T) {
 	store := testKBStore(t)
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-upload-bad", "")
 	if err != nil {
@@ -341,7 +341,7 @@ func TestKBDocumentFromURLIngestsFetchedMarkdown(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", fixedClassifier)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-url", "")
 	if err != nil {
@@ -403,7 +403,7 @@ func TestKBDocumentUploadAutoCreatesNewCollection(t *testing.T) {
 	ingester := &fakeIngester{}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", fixedClassifier)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
 
 	body, contentType := multipartFile(t, "file", "notes.md", []byte("# Title\nsome content"))
 	req := httptest.NewRequest("POST", "/v1/admin/kb/documents", body)
@@ -458,7 +458,7 @@ func TestKBDocumentFromURLAutoUsesExistingCollection(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", matchExisting)
+	a.registerKB(m.Handle, store, ingester, "", matchExisting, nil)
 
 	req := httptest.NewRequest("POST", "/v1/admin/kb/documents/url",
 		strings.NewReader(`{"url":"`+page.URL+`/notes.md","title":""}`))
@@ -541,11 +541,382 @@ func TestKBSweepStaleFailsStuckDocuments(t *testing.T) {
 	}
 }
 
+// clipRequest builds a valid clip JSON body, letting each test override
+// individual fields via the returned map before marshaling.
+func clipRequest(overrides map[string]any) string {
+	body := map[string]any{
+		"url":         "https://example.com/article",
+		"title":       "Article title",
+		"markdown":    "# Article title\n\nsome content",
+	}
+	for k, v := range overrides {
+		if v == nil {
+			delete(body, k)
+			continue
+		}
+		body[k] = v
+	}
+	raw, _ := json.Marshal(body)
+	return string(raw)
+}
+
+func postClip(t *testing.T, m *http.ServeMux, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/v1/admin/kb/documents/clip", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	return w
+}
+
+func TestKBClipValidation(t *testing.T) {
+	store := testKBStore(t)
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
+
+	tests := []struct {
+		name       string
+		overrides  map[string]any
+		wantStatus int
+		wantCode   string
+	}{
+		{"missing url", map[string]any{"url": nil}, http.StatusBadRequest, "bad_request"},
+		{"invalid url scheme", map[string]any{"url": "ftp://example.com/x"}, http.StatusBadRequest, "bad_request"},
+		{"empty markdown", map[string]any{"markdown": "  "}, http.StatusBadRequest, "bad_request"},
+		{"oversize markdown", map[string]any{"markdown": strings.Repeat("a", (128<<10)+1)}, http.StatusRequestEntityTooLarge, "too_large"},
+		{"unknown collection_id", map[string]any{"collection_id": "00000000-0000-0000-0000-000000000000"}, http.StatusNotFound, "not_found"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := postClip(t, m, clipRequest(tc.overrides))
+			if w.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d body %s", w.Code, tc.wantStatus, w.Body)
+			}
+			var resp struct {
+				Error string `json:"error"`
+			}
+			if err := decodeBody(t, w.Body.Bytes(), &resp); err != nil {
+				t.Fatal(err)
+			}
+			if resp.Error != tc.wantCode {
+				t.Fatalf("error code = %q, want %q", resp.Error, tc.wantCode)
+			}
+		})
+	}
+}
+
+// TestKBClipNewDocumentAutoClassifiesAndNormalizesURL exercises the
+// happy path with no collection_id: the classifier is consulted, the
+// document lands with source_type clip, and the stored source_ref has
+// tracking params stripped but real params kept.
+func TestKBClipNewDocumentAutoClassifiesAndNormalizesURL(t *testing.T) {
+	store := testKBStore(t)
+	ingester := &fakeIngester{}
+	classified := false
+	classify := func(ctx context.Context, docTitle, docText string, collections []kb.Collection) chat.CollectionChoice {
+		classified = true
+		return chat.CollectionChoice{NewName: "itest-clip-auto", NewDesc: "auto"}
+	}
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, ingester, "", classify, nil)
+
+	body := clipRequest(map[string]any{"url": "https://example.com/article?utm_source=x&x=1#frag"})
+	w := postClip(t, m, body)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body %s", w.Code, w.Body)
+	}
+	if !classified {
+		t.Fatal("classifier was not consulted for a new clip with no collection_id")
+	}
+	if strings.Contains(w.Body.String(), "some content") {
+		t.Fatal("response must not include markdown")
+	}
+
+	var doc struct {
+		ID           string `json:"id"`
+		CollectionID string `json:"collection_id"`
+		SourceType   string `json:"source_type"`
+		SourceRef    string `json:"source_ref"`
+		Status       string `json:"status"`
+	}
+	if err := decodeBody(t, w.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.SourceType != "clip" {
+		t.Fatalf("source_type = %q, want clip", doc.SourceType)
+	}
+	if doc.SourceRef != "https://example.com/article?x=1" {
+		t.Fatalf("source_ref = %q, want tracking params stripped and fragment dropped", doc.SourceRef)
+	}
+	coll, err := store.GetCollection(context.Background(), doc.CollectionID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	if coll.Name != "itest-clip-auto" {
+		t.Fatalf("collection name = %q, want the classifier's proposed itest-clip-auto", coll.Name)
+	}
+}
+
+func TestKBClipNewDocumentWithCollectionSkipsClassifier(t *testing.T) {
+	store := testKBStore(t)
+	classified := false
+	classify := func(ctx context.Context, docTitle, docText string, collections []kb.Collection) chat.CollectionChoice {
+		classified = true
+		return chat.CollectionChoice{NewName: "should-not-be-created"}
+	}
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", classify, nil)
+
+	collID, err := store.CreateCollection(context.Background(), "itest-clip-target", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	w := postClip(t, m, clipRequest(map[string]any{"collection_id": collID}))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body %s", w.Code, w.Body)
+	}
+	if classified {
+		t.Fatal("classifier must not be consulted when collection_id is given")
+	}
+
+	var doc struct {
+		CollectionID string `json:"collection_id"`
+	}
+	if err := decodeBody(t, w.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.CollectionID != collID {
+		t.Fatalf("collection_id = %q, want %q", doc.CollectionID, collID)
+	}
+}
+
+// TestKBClipReClipRefreshesInPlace covers the dedup path: posting the
+// same normalized URL twice must update the existing row, not create a
+// second one, and must not re-consult the classifier.
+func TestKBClipReClipRefreshesInPlace(t *testing.T) {
+	store := testKBStore(t)
+	classifyCalls := 0
+	classify := func(ctx context.Context, docTitle, docText string, collections []kb.Collection) chat.CollectionChoice {
+		classifyCalls++
+		return chat.CollectionChoice{NewName: "itest-clip-reclip"}
+	}
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", classify, nil)
+
+	first := postClip(t, m, clipRequest(map[string]any{"url": "https://example.com/reclip?utm_source=a#x"}))
+	if first.Code != http.StatusAccepted {
+		t.Fatalf("first clip status = %d body %s", first.Code, first.Body)
+	}
+	var firstDoc struct {
+		ID           string `json:"id"`
+		CollectionID string `json:"collection_id"`
+	}
+	if err := decodeBody(t, first.Body.Bytes(), &firstDoc); err != nil {
+		t.Fatal(err)
+	}
+	if classifyCalls != 1 {
+		t.Fatalf("classifyCalls after first clip = %d, want 1", classifyCalls)
+	}
+
+	second := postClip(t, m, clipRequest(map[string]any{
+		"url":      "https://example.com/reclip?utm_source=b#y",
+		"title":    "Updated title",
+		"markdown": "# Updated title\n\nnew content",
+	}))
+	if second.Code != http.StatusAccepted {
+		t.Fatalf("second clip status = %d body %s", second.Code, second.Body)
+	}
+	var secondDoc struct {
+		ID           string `json:"id"`
+		Title        string `json:"title"`
+		CollectionID string `json:"collection_id"`
+		Status       string `json:"status"`
+	}
+	if err := decodeBody(t, second.Body.Bytes(), &secondDoc); err != nil {
+		t.Fatal(err)
+	}
+	if secondDoc.ID != firstDoc.ID {
+		t.Fatalf("second clip created a new document %q, want the same id %q", secondDoc.ID, firstDoc.ID)
+	}
+	if secondDoc.Title != "Updated title" {
+		t.Fatalf("title = %q, want updated", secondDoc.Title)
+	}
+	if secondDoc.Status != "pending" {
+		t.Fatalf("status = %q, want pending", secondDoc.Status)
+	}
+	if secondDoc.CollectionID != firstDoc.CollectionID {
+		t.Fatalf("collection_id changed to %q without collection_id in the request, want unchanged %q", secondDoc.CollectionID, firstDoc.CollectionID)
+	}
+	if classifyCalls != 1 {
+		t.Fatalf("classifyCalls after re-clip = %d, want still 1 (not re-consulted)", classifyCalls)
+	}
+
+	final, err := store.GetDocument(context.Background(), firstDoc.ID)
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if final.Markdown != "# Updated title\n\nnew content" {
+		t.Fatalf("stored markdown = %q, want updated", final.Markdown)
+	}
+	if final.Bytes != int64(len(final.Markdown)) {
+		t.Fatalf("bytes = %d, want %d", final.Bytes, len(final.Markdown))
+	}
+
+	rows, err := store.ListDocuments(context.Background(), firstDoc.CollectionID)
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	count := 0
+	for _, d := range rows {
+		if d.ID == firstDoc.ID {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("found %d rows for the re-clipped document, want exactly 1 (no duplicate)", count)
+	}
+}
+
+func TestKBClipReClipMovesCollection(t *testing.T) {
+	store := testKBStore(t)
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
+
+	origID, err := store.CreateCollection(context.Background(), "itest-clip-orig", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	newID, err := store.CreateCollection(context.Background(), "itest-clip-new", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	first := postClip(t, m, clipRequest(map[string]any{"url": "https://example.com/move", "collection_id": origID}))
+	if first.Code != http.StatusAccepted {
+		t.Fatalf("first clip status = %d body %s", first.Code, first.Body)
+	}
+
+	second := postClip(t, m, clipRequest(map[string]any{"url": "https://example.com/move", "collection_id": newID}))
+	if second.Code != http.StatusAccepted {
+		t.Fatalf("second clip status = %d body %s", second.Code, second.Body)
+	}
+	var doc struct {
+		CollectionID string `json:"collection_id"`
+	}
+	if err := decodeBody(t, second.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.CollectionID != newID {
+		t.Fatalf("collection_id = %q, want moved to %q", doc.CollectionID, newID)
+	}
+}
+
+func TestKBClipStripsNULBytes(t *testing.T) {
+	store := testKBStore(t)
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
+
+	w := postClip(t, m, clipRequest(map[string]any{"markdown": "clean\x00 text \xff here"}))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body %s", w.Code, w.Body)
+	}
+	var doc struct {
+		ID string `json:"id"`
+	}
+	if err := decodeBody(t, w.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	final, err := store.GetDocument(context.Background(), doc.ID)
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if final.Markdown != "clean text � here" {
+		t.Fatalf("stored markdown = %q, want NUL stripped and invalid UTF-8 replaced", final.Markdown)
+	}
+}
+
+func TestKBClipEmptyTitleUsesGeneratedTitle(t *testing.T) {
+	store := testKBStore(t)
+	titler := func(ctx context.Context, input string) string { return "Generated Title" }
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, titler)
+
+	w := postClip(t, m, clipRequest(map[string]any{"title": ""}))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body %s", w.Code, w.Body)
+	}
+	var doc struct {
+		Title string `json:"title"`
+	}
+	if err := decodeBody(t, w.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.Title != "Generated Title" {
+		t.Fatalf("title = %q, want the titler's Generated Title", doc.Title)
+	}
+}
+
+func TestKBClipEmptyTitleFallsBackToURLWhenTitlerEmpty(t *testing.T) {
+	store := testKBStore(t)
+	titler := func(ctx context.Context, input string) string { return "" }
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, titler)
+
+	body := clipRequest(map[string]any{"title": "", "url": "https://example.com/docs/getting-started.html"})
+	w := postClip(t, m, body)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body %s", w.Code, w.Body)
+	}
+	var doc struct {
+		Title string `json:"title"`
+	}
+	if err := decodeBody(t, w.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.Title != "getting-started" {
+		t.Fatalf("title = %q, want titleFromURL's derivation getting-started", doc.Title)
+	}
+}
+
+func TestKBClipExplicitTitleSkipsTitler(t *testing.T) {
+	store := testKBStore(t)
+	titler := func(ctx context.Context, input string) string {
+		t.Fatal("titler must not be consulted when title is non-empty")
+		return ""
+	}
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, titler)
+
+	w := postClip(t, m, clipRequest(map[string]any{"title": "Explicit Title"}))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body %s", w.Code, w.Body)
+	}
+	var doc struct {
+		Title string `json:"title"`
+	}
+	if err := decodeBody(t, w.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.Title != "Explicit Title" {
+		t.Fatalf("title = %q, want Explicit Title", doc.Title)
+	}
+}
+
 func TestKBDocumentFromURLRejectsBadURL(t *testing.T) {
 	store := testKBStore(t)
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-url-bad", "")
 	if err != nil {
@@ -569,7 +940,7 @@ func TestKBDocumentFromURLBlocksLocalAddresses(t *testing.T) {
 	m := mux(a)
 	// Real guarded transport: the loopback httptest server must be
 	// refused at dial time.
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
 
 	page := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("secret internal page"))
@@ -596,7 +967,7 @@ func TestKBDocumentReingestFailureSetsFailedStatus(t *testing.T) {
 	ingester := &fakeIngester{err: errors.New("memoryd unreachable")}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", fixedClassifier)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-reingest", "")
 	if err != nil {

--- a/internal/brain/api/kb_url_test.go
+++ b/internal/brain/api/kb_url_test.go
@@ -70,7 +70,7 @@ func TestFetchURLBlockedStatus(t *testing.T) {
 	}
 }
 
-func TestNormalizeClipURL(t *testing.T) {
+func TestNormalizeSourceURL(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name string
@@ -91,8 +91,8 @@ func TestNormalizeClipURL(t *testing.T) {
 				t.Fatalf("parse %s: %v", tc.url, err)
 			}
 			u.User = nil
-			if got := normalizeClipURL(u); got != tc.want {
-				t.Fatalf("normalizeClipURL(%s) = %q, want %q", tc.url, got, tc.want)
+			if got := normalizeSourceURL(u); got != tc.want {
+				t.Fatalf("normalizeSourceURL(%s) = %q, want %q", tc.url, got, tc.want)
 			}
 		})
 	}

--- a/internal/brain/api/kb_url_test.go
+++ b/internal/brain/api/kb_url_test.go
@@ -70,6 +70,34 @@ func TestFetchURLBlockedStatus(t *testing.T) {
 	}
 }
 
+func TestNormalizeClipURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"fragment dropped", "https://example.com/a#section-2", "https://example.com/a"},
+		{"mixed tracking and real params", "https://example.com/a?utm_source=x&x=1&fbclid=abc&gclid=def", "https://example.com/a?x=1"},
+		{"no params unchanged", "https://example.com/a", "https://example.com/a"},
+		{"all params stripped drops the question mark", "https://example.com/a?utm_source=x&utm_medium=y", "https://example.com/a"},
+		{"credentials cleared", "https://user:pass@example.com/a", "https://example.com/a"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			u, err := url.Parse(tc.url)
+			if err != nil {
+				t.Fatalf("parse %s: %v", tc.url, err)
+			}
+			u.User = nil
+			if got := normalizeClipURL(u); got != tc.want {
+				t.Fatalf("normalizeClipURL(%s) = %q, want %q", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestConvertFetched(t *testing.T) {
 	t.Parallel()
 	markitdown := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -634,11 +634,11 @@ func ClassifyCollectionOverGateway(gw Gateway, log *slog.Logger) func(ctx contex
 			list.WriteString("No collections exist yet.")
 		} else {
 			for _, c := range collections {
-				fmt.Fprintf(&list, "%s: %s — %s\n", c.ID, c.Name, c.Description)
+				fmt.Fprintf(&list, "%s: %s (%d docs) - %s\n", c.ID, c.Name, c.DocCount, c.Description)
 			}
 		}
 
-		const classifySystem = `You file documents into a knowledge base. Given a document and a list of existing collections, reply with exactly one line: either the bare id of the best-matching existing collection, or "NEW: <name> | <description>" to propose a new collection when nothing fits. Prefer an existing collection whenever the document broadly belongs to its topic — an imperfect match beats a new collection. A new collection's name must be a SHORT GENERIC TOPIC CATEGORY of 1-3 words (like "AI Agents", "Scalability", "Code Review", "CVs") that many future documents could belong to — never a title describing this specific document. The description should state the topic's scope broadly. No other text.`
+		const classifySystem = `You file documents into a knowledge base. Given a document and a list of existing collections, reply with exactly one line: either the bare id of the best-matching existing collection, or "NEW: <name> | <description>" to propose a new collection when nothing fits. Prefer the MOST SPECIFIC existing collection that fits the document's primary topic; propose NEW only when the primary topic is clearly narrower than every existing collection and is a topic more future documents could join. A broad collection is the wrong pick when a narrower on-topic one already exists, or when the document's topic deserves its own collection - do not use a catch-all just because it is easy. A new collection's name must be a SHORT GENERIC TOPIC CATEGORY of 1-3 words (like "AI Agents", "Scalability", "Code Review", "CVs") that many future documents could belong to, never a title describing this specific document. The description should state the topic's scope broadly. No other text.`
 		route, ok, err := gw.RouteForRole(ctx, "summarize")
 		if err != nil || !ok {
 			route, ok, err = gw.RouteForRole(ctx, "default")

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -2070,6 +2070,24 @@ func TestClassifyCollectionOverGatewayProposesNewCollection(t *testing.T) {
 	}
 }
 
+// TestClassifyCollectionOverGatewayListsDocCounts confirms the
+// collection list sent to the model includes each collection's
+// document count, so the model can judge how established a collection
+// already is.
+func TestClassifyCollectionOverGatewayListsDocCounts(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGW{events: okEvents("col-1")}
+	ClassifyCollectionOverGateway(gw, discard())(context.Background(), "Q3 Invoice", "some invoice text",
+		[]kb.Collection{{ID: "col-1", Name: "Finance", Description: "money stuff", DocCount: 7}})
+
+	gw.mu.Lock()
+	defer gw.mu.Unlock()
+	user := fmt.Sprint(gw.requests[0].Messages)
+	if !strings.Contains(user, "col-1: Finance (7 docs) - money stuff") {
+		t.Fatalf("user message missing doc count in the collection list:\n%s", user)
+	}
+}
+
 // TestClassifyCollectionOverGatewayFallsBackToUnsortedOnGatewayError
 // confirms the best-effort contract: any Stream error resolves to the
 // Unsorted fallback rather than propagating.

--- a/internal/brain/kb/kb.go
+++ b/internal/brain/kb/kb.go
@@ -287,6 +287,48 @@ func (s *Store) SetFailed(ctx context.Context, id, errMsg string) error {
 	return nil
 }
 
+// FindDocumentBySource looks up a document by its dedup key
+// (source_type, source_ref) — used by clip ingestion to tell a fresh
+// clip from a re-clip of the same URL.
+func (s *Store) FindDocumentBySource(ctx context.Context, sourceType, sourceRef string) (Document, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return Document{}, fmt.Errorf("kb document by source: %w", err)
+	}
+	d, err := scanDocument(db.QueryRow(ctx,
+		`SELECT `+documentColumns+` FROM kb_documents WHERE source_type = $1 AND source_ref = $2`,
+		sourceType, sourceRef))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Document{}, fmt.Errorf("document %s %s: %w", sourceType, sourceRef, ErrNotFound)
+	}
+	if err != nil {
+		return Document{}, fmt.Errorf("kb document by source: %w", err)
+	}
+	return d, nil
+}
+
+// ReplaceDocumentContent overwrites a document's content on a re-clip:
+// title, markdown, and bytes are replaced, status resets to pending for
+// a fresh ingest, and any error is cleared. collectionID moves the
+// document only when non-empty, leaving it in place otherwise.
+func (s *Store) ReplaceDocumentContent(ctx context.Context, id, title, markdown string, bytes int64, collectionID string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("kb document %s replace: %w", id, err)
+	}
+	tag, err := db.Exec(ctx, `UPDATE kb_documents
+		SET title = $2, markdown = $3, bytes = $4, status = 'pending', error = '',
+			collection_id = COALESCE(NULLIF($5, '')::uuid, collection_id), updated_at = now()
+		WHERE id = $1`, id, title, markdown, bytes, collectionID)
+	if err != nil {
+		return fmt.Errorf("kb document %s replace: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("document %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
 // DeleteDocument removes a document; ON DELETE CASCADE takes its
 // chunks with it.
 func (s *Store) DeleteDocument(ctx context.Context, id string) error {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -640,7 +640,7 @@ export interface KbDocument {
   id: string
   collection_id: string
   title: string
-  source_type: 'file' | 'notion' | 'wiki' | 'url'
+  source_type: 'file' | 'notion' | 'wiki' | 'url' | 'clip'
   source_ref: string
   status: 'pending' | 'ingesting' | 'ready' | 'failed'
   error: string

--- a/web/src/components/knowledge/KnowledgeCollectionDetail.test.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionDetail.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { KbDocument } from '../../api/types'
+import { TooltipProvider } from '../ui/tooltip'
+import { SourceBadge } from './KnowledgeCollectionDetail'
+
+afterEach(cleanup)
+
+const baseDoc: KbDocument = {
+  id: 'd1',
+  collection_id: 'c1',
+  title: 'notes',
+  source_type: 'file',
+  source_ref: 'notes.md',
+  status: 'pending',
+  error: '',
+  chunk_count: 0,
+  bytes: 12,
+  ingested_at: null,
+  created_at: '2026-07-01T00:00:00Z',
+}
+
+function renderBadge(doc: KbDocument) {
+  return render(
+    <TooltipProvider>
+      <SourceBadge doc={doc} />
+    </TooltipProvider>,
+  )
+}
+
+describe('SourceBadge', () => {
+  it('links a url document to its source_ref in a new tab', () => {
+    const doc: KbDocument = { ...baseDoc, source_type: 'url', source_ref: 'https://example.com/a' }
+    renderBadge(doc)
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', 'https://example.com/a')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('links a clip document to its source_ref in a new tab', () => {
+    const doc: KbDocument = { ...baseDoc, source_type: 'clip', source_ref: 'https://example.com/b' }
+    renderBadge(doc)
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', 'https://example.com/b')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders a file document as a plain badge with no link', () => {
+    renderBadge(baseDoc)
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+    expect(screen.getByText('file')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
@@ -34,7 +34,37 @@ import {
 } from '../ui/dialog'
 import { errText } from '../settings/util'
 import { Input } from '../ui/input'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import { KbUploadForm } from './KbUploadForm'
+
+const linkedSourceTypes = new Set<KbDocument['source_type']>(['url', 'clip'])
+
+export function SourceBadge({ doc }: { doc: KbDocument }) {
+  const badge = (
+    <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase text-muted-foreground">
+      {doc.source_type}
+    </span>
+  )
+  const content = linkedSourceTypes.has(doc.source_type) ? (
+    <a
+      href={doc.source_ref}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="hover:text-foreground"
+    >
+      {badge}
+    </a>
+  ) : (
+    badge
+  )
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{content}</TooltipTrigger>
+      <TooltipContent>{doc.source_ref}</TooltipContent>
+    </Tooltip>
+  )
+}
 
 const statusStyle: Record<KbDocument['status'], string> = {
   pending: 'bg-muted text-muted-foreground',
@@ -197,62 +227,62 @@ export function KnowledgeCollectionDetail() {
       {documents.length === 0 ? (
         <p className="text-sm text-muted-foreground">No documents yet.</p>
       ) : (
-        <div className="overflow-x-auto rounded-xl border border-border">
-          <table className="w-full text-sm">
-            <thead className="border-b border-border bg-muted/50 text-left text-xs uppercase tracking-wide text-muted-foreground">
-              <tr>
-                <th className="px-3 py-2">Title</th>
-                <th className="px-3 py-2">Source</th>
-                <th className="px-3 py-2">Status</th>
-                <th className="px-3 py-2">Chunks</th>
-                <th className="px-3 py-2">Size</th>
-                <th className="px-3 py-2">Ingested</th>
-                <th className="px-3 py-2" />
-              </tr>
-            </thead>
-            <tbody>
-              {documents.map((doc) => (
-                <tr key={doc.id} className="border-b border-border last:border-0">
-                  <td className="flex items-center gap-2 px-3 py-2">
-                    <HugeiconsIcon icon={File02Icon} className="size-4 shrink-0 text-muted-foreground" />
-                    <span className="truncate">{doc.title}</span>
-                  </td>
-                  <td className="px-3 py-2">
-                    <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase text-muted-foreground">
-                      {doc.source_type}
-                    </span>
-                  </td>
-                  <td className="px-3 py-2">
-                    <StatusBadge doc={doc} />
-                  </td>
-                  <td className="px-3 py-2">{doc.chunk_count}</td>
-                  <td className="px-3 py-2">{humanBytes(doc.bytes)}</td>
-                  <td className="px-3 py-2">{doc.ingested_at ? relativeTime(doc.ingested_at) : '—'}</td>
-                  <td className="px-3 py-2">
-                    <div className="flex items-center justify-end gap-2">
-                      <button
-                        type="button"
-                        aria-label={`Re-ingest ${doc.title}`}
-                        onClick={() => void reingest(doc)}
-                        className="text-muted-foreground hover:text-foreground"
-                      >
-                        <HugeiconsIcon icon={ReloadIcon} className="size-4" />
-                      </button>
-                      <button
-                        type="button"
-                        aria-label={`Delete ${doc.title}`}
-                        onClick={() => setConfirmDeleteDoc(doc)}
-                        className="text-muted-foreground hover:text-destructive"
-                      >
-                        <HugeiconsIcon icon={Delete02Icon} className="size-4" />
-                      </button>
-                    </div>
-                  </td>
+        <TooltipProvider>
+          <div className="overflow-x-auto rounded-xl border border-border">
+            <table className="w-full text-sm">
+              <thead className="border-b border-border bg-muted/50 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <tr>
+                  <th className="px-3 py-2">Title</th>
+                  <th className="px-3 py-2">Source</th>
+                  <th className="px-3 py-2">Status</th>
+                  <th className="px-3 py-2">Chunks</th>
+                  <th className="px-3 py-2">Size</th>
+                  <th className="px-3 py-2">Ingested</th>
+                  <th className="px-3 py-2" />
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {documents.map((doc) => (
+                  <tr key={doc.id} className="border-b border-border last:border-0">
+                    <td className="flex items-center gap-2 px-3 py-2">
+                      <HugeiconsIcon icon={File02Icon} className="size-4 shrink-0 text-muted-foreground" />
+                      <span className="truncate">{doc.title}</span>
+                    </td>
+                    <td className="px-3 py-2">
+                      <SourceBadge doc={doc} />
+                    </td>
+                    <td className="px-3 py-2">
+                      <StatusBadge doc={doc} />
+                    </td>
+                    <td className="px-3 py-2">{doc.chunk_count}</td>
+                    <td className="px-3 py-2">{humanBytes(doc.bytes)}</td>
+                    <td className="px-3 py-2">{doc.ingested_at ? relativeTime(doc.ingested_at) : '—'}</td>
+                    <td className="px-3 py-2">
+                      <div className="flex items-center justify-end gap-2">
+                        <button
+                          type="button"
+                          aria-label={`Re-ingest ${doc.title}`}
+                          onClick={() => void reingest(doc)}
+                          className="text-muted-foreground hover:text-foreground"
+                        >
+                          <HugeiconsIcon icon={ReloadIcon} className="size-4" />
+                        </button>
+                        <button
+                          type="button"
+                          aria-label={`Delete ${doc.title}`}
+                          onClick={() => setConfirmDeleteDoc(doc)}
+                          className="text-muted-foreground hover:text-destructive"
+                        >
+                          <HugeiconsIcon icon={Delete02Icon} className="size-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </TooltipProvider>
       )}
 
       <Dialog open={editing} onOpenChange={setEditing}>


### PR DESCRIPTION
Four ingestion improvements for the knowledge base.

**Clip endpoint** (`POST /v1/admin/kb/documents/clip`): the browser extension (Pounce) converts the rendered page to markdown client-side and posts it, reaching pages server-side fetch cannot (logins, paywalls, bot walls). Validates and stores without fetching or converting; markdown capped at 128KiB (413 above). Re-clipping a known URL refreshes the document in place instead of duplicating. Empty title is generated over the gateway with a URL-derived fallback.

**URL dedup on existing ingest paths**: re-adding a URL previously created a duplicate document with duplicate chunks. Both URL handlers now normalize the URL (fragment and utm_*/fbclid/gclid stripped) as source_ref and refresh in place on re-add (200) instead of creating (201).

**Source tooltip in the UI**: the source badge on knowledge documents now shows the full source_ref in a tooltip, and url/clip badges link to the source, so it is visible which URL was ingested.

**Classify granularity**: the collection classifier preferred broad existing collections, piling everything infra-flavored into one catch-all. The prompt now prefers the most specific fitting collection, warns against catch-all filing, and sees per-collection document counts.

All handler behavior covered by integration tests (run against a live stack), URL normalization unit-tested, UI change component-tested. Full go test/vet/lint and web build/lint/test green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790572380&installation_model_id=431401&pr_number=351&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F351&signature=c45fe57f74961d7b2486b1433a84b01a4aab926c26f37f1743cd9784055fcad7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->