### PR TITLE
fix(web): merge duplicate artifacts sections on mission detail

### DIFF
--- a/web/src/components/missions/ArtifactRefChips.test.tsx
+++ b/web/src/components/missions/ArtifactRefChips.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { MediaRef } from '../../api/types'
-import { ArtifactRefsSection } from './ArtifactRefsSection'
+import { ArtifactRefChips } from './ArtifactRefsSection'
 
 vi.mock('../../api/client', () => ({
   fetchAttachmentBlob: vi.fn(),
@@ -14,9 +14,9 @@ beforeEach(() => {
   vi.mocked(fetchAttachmentBlob).mockResolvedValue(new Blob(['hello']))
 })
 
-describe('ArtifactRefsSection', () => {
+describe('ArtifactRefChips', () => {
   it('renders nothing when there are no refs', () => {
-    const { container } = render(<ArtifactRefsSection refs={[]} />)
+    const { container } = render(<ArtifactRefChips refs={[]} />)
     expect(container.firstChild).toBeNull()
   })
 
@@ -25,14 +25,14 @@ describe('ArtifactRefsSection', () => {
       { id: 'att-1', mime: 'text/markdown', name: 'report.md' },
       { id: 'att-2', mime: 'application/pdf' },
     ]
-    render(<ArtifactRefsSection refs={refs} />)
+    render(<ArtifactRefChips refs={refs} />)
     expect(screen.getByText('report.md')).toBeInTheDocument()
     expect(screen.getByText('PDF')).toBeInTheDocument()
   })
 
   it('opens the viewer when a chip is clicked', () => {
     const refs: MediaRef[] = [{ id: 'att-1', mime: 'text/markdown', name: 'report.md' }]
-    render(<ArtifactRefsSection refs={refs} />)
+    render(<ArtifactRefChips refs={refs} />)
     fireEvent.click(screen.getByText('report.md'))
     expect(screen.getByRole('dialog')).toBeInTheDocument()
   })

--- a/web/src/components/missions/ArtifactRefsSection.tsx
+++ b/web/src/components/missions/ArtifactRefsSection.tsx
@@ -13,17 +13,16 @@ function artifactChipIcon(mime: string) {
   return Pdf02Icon
 }
 
-// ArtifactRefsSection renders a terminal mission's artifact-store refs
+// ArtifactRefChips renders a terminal mission's artifact-store refs
 // (mission.artifact_refs) as clickable chips through AttachmentViewer —
-// unlike ArtifactsSection (which browses the live workspace and
-// disappears once it's deleted), these refs are durable copies that
-// keep working after mission/workspace cleanup.
-export function ArtifactRefsSection({ refs }: { refs: MediaRef[] }) {
+// durable copies that keep working after mission/workspace cleanup,
+// integrated into ArtifactsSection's panel (or rendered alone when the
+// workspace is gone).
+export function ArtifactRefChips({ refs }: { refs: MediaRef[] }) {
   const [viewerAttachment, setViewerAttachment] = useState<MediaRef | null>(null)
   if (refs.length === 0) return null
   return (
-    <section>
-      <h2 className="mb-2 text-sm font-semibold tracking-tight">Artifacts</h2>
+    <>
       <div className="flex flex-wrap gap-1.5">
         {refs.map((ref) => (
           <button
@@ -45,6 +44,6 @@ export function ArtifactRefsSection({ refs }: { refs: MediaRef[] }) {
         }}
         attachment={viewerAttachment}
       />
-    </section>
+    </>
   )
 }

--- a/web/src/components/missions/ArtifactsSection.test.tsx
+++ b/web/src/components/missions/ArtifactsSection.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { MissionFile } from '../../api/types'
+import type { MediaRef, MissionFile } from '../../api/types'
 import { ArtifactsSection } from './ArtifactsSection'
 
 vi.mock('../../api/client', () => ({
@@ -8,18 +8,22 @@ vi.mock('../../api/client', () => ({
   downloadMissionFile: vi.fn(),
   downloadMissionArchive: vi.fn(),
   fetchMissionFileBlob: vi.fn(),
+  fetchAttachmentBlob: vi.fn(),
   missionFilePreviewCap: 1_000_000,
   MissionFileTooLargeError: class MissionFileTooLargeError extends Error {},
 }))
 
-import { fetchMissionFileBlob, listMissionFiles } from '../../api/client'
+import { fetchAttachmentBlob, fetchMissionFileBlob, listMissionFiles } from '../../api/client'
 
 afterEach(cleanup)
 beforeEach(() => {
   vi.clearAllMocks()
   vi.mocked(listMissionFiles).mockResolvedValue({ files: [], truncated: false })
   vi.mocked(fetchMissionFileBlob).mockResolvedValue(new Blob(['hello']))
+  vi.mocked(fetchAttachmentBlob).mockResolvedValue(new Blob(['hello']))
 })
+
+const refs: MediaRef[] = [{ id: 'att-1', mime: 'text/markdown', name: 'report.md' }]
 
 const files: MissionFile[] = [
   { path: 'src/a.txt', size: 512, mtime: '2026-01-01T00:00:00Z', declared: false },
@@ -101,5 +105,34 @@ describe('ArtifactsSection', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Exit fullscreen' }))
     expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('renders refs chips alone when the workspace is gone', () => {
+    render(<ArtifactsSection missionId="m1" phase="terminal" workspace={undefined} refs={refs} />)
+    expect(screen.getByText('Artifacts')).toBeInTheDocument()
+    expect(screen.getByText('report.md')).toBeInTheDocument()
+    expect(listMissionFiles).not.toHaveBeenCalled()
+  })
+
+  it('integrates refs chips into the workspace panel header', async () => {
+    vi.mocked(listMissionFiles).mockResolvedValue({ files, truncated: false })
+    render(<ArtifactsSection missionId="m1" phase="execute" workspace="ws-1" refs={refs} />)
+    await screen.findByText('big.bin')
+    expect(screen.getAllByText('Artifacts')).toHaveLength(1)
+    expect(screen.getByText('report.md')).toBeInTheDocument()
+  })
+
+  it('shows chips even when the workspace has no files', async () => {
+    render(<ArtifactsSection missionId="m1" phase="execute" workspace="ws-1" refs={refs} />)
+    await waitFor(() => expect(vi.mocked(listMissionFiles)).toHaveBeenCalled())
+    expect(screen.getByText('Artifacts')).toBeInTheDocument()
+    expect(screen.getByText('report.md')).toBeInTheDocument()
+  })
+
+  it('renders nothing when there is no workspace and no refs', () => {
+    const { container } = render(
+      <ArtifactsSection missionId="m1" phase="execute" workspace={undefined} refs={[]} />,
+    )
+    expect(container.firstChild).toBeNull()
   })
 })

--- a/web/src/components/missions/ArtifactsSection.tsx
+++ b/web/src/components/missions/ArtifactsSection.tsx
@@ -3,9 +3,10 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { downloadMissionArchive, listMissionFiles } from '../../api/client'
-import type { MissionFile } from '../../api/types'
+import type { MediaRef, MissionFile } from '../../api/types'
 import { errText } from '../settings/util'
 import { Button } from '../ui/button'
+import { ArtifactRefChips } from './ArtifactRefsSection'
 import { buildFileTree, type FileTreeNode } from './fileTree'
 import { FileTreeView } from './FileTreeView'
 import { FileViewer } from './FileViewer'
@@ -15,10 +16,12 @@ export function ArtifactsSection({
   missionId,
   phase,
   workspace,
+  refs = [],
 }: {
   missionId: string
   phase: string
   workspace?: string
+  refs?: MediaRef[]
 }) {
   const [files, setFiles] = useState<MissionFile[]>([])
   const [truncated, setTruncated] = useState(false)
@@ -40,11 +43,12 @@ export function ArtifactsSection({
 
   const tree = useMemo(() => buildFileTree(files), [files])
 
-  // No workspace, or a workspace with nothing in it (and no fetch error
-  // worth surfacing): the whole section disappears rather than showing
-  // an empty shell.
-  if (!workspace) return null
-  if (files.length === 0 && !error) return null
+  // No workspace and no refs, or a workspace with nothing in it and no
+  // refs (and no fetch error worth surfacing): the whole section
+  // disappears rather than showing an empty shell.
+  const hasWorkspace = Boolean(workspace)
+  if (!hasWorkspace && refs.length === 0) return null
+  if (hasWorkspace && files.length === 0 && !error && refs.length === 0) return null
 
   const downloadAll = () => {
     downloadMissionArchive(missionId).catch((err: unknown) =>
@@ -54,6 +58,16 @@ export function ArtifactsSection({
 
   const selectNode = (node: FileTreeNode) => {
     if (node.file) setSelected(node.file)
+  }
+
+  // No live workspace: render the refs chips alone, no panel chrome.
+  if (!hasWorkspace) {
+    return (
+      <section>
+        <h2 className="mb-2 text-sm font-semibold tracking-tight">Artifacts</h2>
+        <ArtifactRefChips refs={refs} />
+      </section>
+    )
   }
 
   const panel = (
@@ -76,6 +90,11 @@ export function ArtifactsSection({
           <FullscreenToggle fullscreen={fullscreen} onToggle={toggle} />
         </div>
       </div>
+      {refs.length > 0 && (
+        <div className="border-b border-border px-3 py-2">
+          <ArtifactRefChips refs={refs} />
+        </div>
+      )}
       {files.length === 0 ? (
         <p className="p-3 text-sm text-muted-foreground">No files yet.</p>
       ) : (

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -24,7 +24,6 @@ import {
   sendMissionNote,
 } from '../api/client'
 import type { Mission, MissionEvent, MissionPROpenedPayload, MissionUsage, Schedule } from '../api/types'
-import { ArtifactRefsSection } from '../components/missions/ArtifactRefsSection'
 import { ArtifactsSection } from '../components/missions/ArtifactsSection'
 import { PermissionBanner } from '../components/missions/PermissionBanner'
 import { PlanSection } from '../components/missions/PlanSection'
@@ -825,9 +824,12 @@ export function MissionDetail() {
           </section>
         )}
 
-      <ArtifactRefsSection refs={mission.artifact_refs ?? []} />
-
-      <ArtifactsSection missionId={id} phase={mission.phase} workspace={mission.workspace} />
+      <ArtifactsSection
+        missionId={id}
+        phase={mission.phase}
+        workspace={mission.workspace}
+        refs={mission.artifact_refs ?? []}
+      />
 
       <section>
         <h2 className="mb-2 text-sm font-semibold tracking-tight">Timeline</h2>


### PR DESCRIPTION
Folds the artifact-ref chips into ArtifactsSection's workspace panel so the page shows exactly one Artifacts heading. Chips render alone (no panel chrome) once the workspace is cleaned up; a mission with neither shows no section.

Both data sources stay per the issue: refs survive workspace cleanup, the browser dies with the workspace.

Tested: web build, lint, full vitest suite; new cases for refs-alone, refs+workspace, and neither.

Closes #363

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790628666&installation_model_id=431401&pr_number=382&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F382&signature=66ad49dbefa8dd003ee2ad3d1261f463c1e53d5253f56c38157b89a43b8333eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->