### PR TITLE
feat(web): inline pdf preview in mission workspace file viewer

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1518,14 +1518,24 @@ export async function downloadMissionFile(id: string, path: string): Promise<voi
 // back to "download instead" in the UI.
 export const missionFilePreviewCap = 1_000_000
 
+// missionPdfPreviewCap is the same guard, raised for pdf kind: the
+// browser's own PDF plugin renders it, not the tab's JS, so a much
+// larger file is still safe to hand over as a blob URL.
+export const missionPdfPreviewCap = 25_000_000
+
 export class MissionFileTooLargeError extends Error {}
 
 // fetchMissionFileBlob reads a mission file's bytes for in-app
-// preview (image/text/markdown) rather than triggering a save — the
-// server forces Content-Type: application/octet-stream on this route
-// deliberately (a worker-authored file could be arbitrary HTML), so
-// callers must render the bytes themselves, never navigate to the URL.
-export async function fetchMissionFileBlob(id: string, path: string): Promise<Blob> {
+// preview (image/text/markdown/pdf) rather than triggering a save —
+// the server forces Content-Type: application/octet-stream on this
+// route deliberately (a worker-authored file could be arbitrary
+// HTML), so callers must render the bytes themselves, never navigate
+// to the URL.
+export async function fetchMissionFileBlob(
+  id: string,
+  path: string,
+  cap: number = missionFilePreviewCap,
+): Promise<Blob> {
   const res = await fetch(`/v1/missions/${id}/files/${encodeFilePath(path)}`, {
     headers: { Authorization: `Bearer ${getToken()}` },
   })
@@ -1533,11 +1543,11 @@ export async function fetchMissionFileBlob(id: string, path: string): Promise<Bl
     failChat(res.status, `request failed (${res.status})`)
   }
   const len = res.headers.get('Content-Length')
-  if (len && Number(len) > missionFilePreviewCap) {
+  if (len && Number(len) > cap) {
     throw new MissionFileTooLargeError('file too large to preview')
   }
   const blob = await res.blob()
-  if (blob.size > missionFilePreviewCap) {
+  if (blob.size > cap) {
     throw new MissionFileTooLargeError('file too large to preview')
   }
   return blob

--- a/web/src/components/missions/FileViewer.test.tsx
+++ b/web/src/components/missions/FileViewer.test.tsx
@@ -7,6 +7,7 @@ vi.mock('../../api/client', () => ({
   downloadMissionFile: vi.fn(),
   fetchMissionFileBlob: vi.fn(),
   missionFilePreviewCap: 1_000_000,
+  missionPdfPreviewCap: 25_000_000,
   MissionFileTooLargeError: class MissionFileTooLargeError extends Error {},
 }))
 
@@ -52,6 +53,15 @@ describe('FileViewer', () => {
 
     const img = await screen.findByRole('img')
     expect(img.getAttribute('src')).toBe('blob:mock')
+  })
+
+  it('renders pdf files inline in an iframe, retyped as application/pdf', async () => {
+    vi.mocked(fetchMissionFileBlob).mockResolvedValue(new Blob(['%PDF-1.4']))
+    render(<FileViewer missionId="m1" file={file('report.pdf')} />)
+
+    const iframe = (await screen.findByTitle('report.pdf')) as HTMLIFrameElement
+    expect(iframe.getAttribute('src')).toBe('blob:mock')
+    expect(fetchMissionFileBlob).toHaveBeenCalledWith('m1', 'report.pdf', 25_000_000)
   })
 
   it('shows a too-large message without fetching preview content past the cap', async () => {

--- a/web/src/components/missions/FileViewer.tsx
+++ b/web/src/components/missions/FileViewer.tsx
@@ -6,6 +6,7 @@ import {
   downloadMissionFile,
   fetchMissionFileBlob,
   missionFilePreviewCap,
+  missionPdfPreviewCap,
 } from '../../api/client'
 import type { MissionFile } from '../../api/types'
 import { FileCodeBlock, FileMarkdownBlock } from '../FilePreviewBlocks'
@@ -26,6 +27,7 @@ type LoadState =
   | { status: 'too-large' }
   | { status: 'text'; text: string }
   | { status: 'image'; url: string }
+  | { status: 'pdf'; url: string }
 
 export function FileViewer({ missionId, file }: { missionId: string; file: MissionFile }) {
   const [state, setState] = useState<LoadState>({ status: 'loading' })
@@ -41,12 +43,19 @@ export function FileViewer({ missionId, file }: { missionId: string; file: Missi
     }
     let objectUrl: string | undefined
     let cancelled = false
-    fetchMissionFileBlob(missionId, file.path).then(
+    const cap = kind === 'pdf' ? missionPdfPreviewCap : missionFilePreviewCap
+    fetchMissionFileBlob(missionId, file.path, cap).then(
       (blob) => {
         if (cancelled) return
         if (kind === 'image') {
           objectUrl = URL.createObjectURL(blob)
           setState({ status: 'image', url: objectUrl })
+        } else if (kind === 'pdf') {
+          // Server forces Content-Type: application/octet-stream on this
+          // route deliberately — retype the blob client-side so the
+          // iframe's PDF plugin picks it up (see FileViewer.tsx's guard).
+          objectUrl = URL.createObjectURL(new Blob([blob], { type: 'application/pdf' }))
+          setState({ status: 'pdf', url: objectUrl })
         } else {
           blob.text().then((text) => {
             if (!cancelled) setState({ status: 'text', text })
@@ -112,7 +121,7 @@ export function FileViewer({ missionId, file }: { missionId: string; file: Missi
               </Button>
             </>
           )}
-          {state.status === 'image' && (
+          {(state.status === 'image' || state.status === 'pdf') && (
             <Button variant="ghost" size="sm" onClick={() => window.open(state.url, '_blank')}>
               Raw
             </Button>
@@ -129,8 +138,8 @@ export function FileViewer({ missionId, file }: { missionId: string; file: Missi
         )}
         {state.status === 'too-large' && (
           <p className="p-3 text-sm text-muted-foreground">
-            File is larger than {humanSize(missionFilePreviewCap)}, too large to preview.
-            Download it instead.
+            File is larger than {humanSize(kind === 'pdf' ? missionPdfPreviewCap : missionFilePreviewCap)},
+            too large to preview. Download it instead.
           </p>
         )}
         {state.status === 'error' && (
@@ -144,6 +153,9 @@ export function FileViewer({ missionId, file }: { missionId: string; file: Missi
           <div className="flex justify-center p-3">
             <img src={state.url} alt={file.path} className="max-w-full" />
           </div>
+        )}
+        {state.status === 'pdf' && (
+          <iframe src={state.url} title={file.path} className="size-full border-0" />
         )}
         {state.status === 'text' && kind === 'markdown' && (
           <FileMarkdownBlock text={state.text} raw={showRawMarkdown} />

--- a/web/src/components/missions/filePreviewKind.test.ts
+++ b/web/src/components/missions/filePreviewKind.test.ts
@@ -11,6 +11,11 @@ describe('previewKindOf', () => {
     expect(previewKindOf('README.md')).toBe('markdown')
   })
 
+  it('classifies pdf', () => {
+    expect(previewKindOf('report.pdf')).toBe('pdf')
+    expect(previewKindOf('a/b/report.PDF')).toBe('pdf')
+  })
+
   it('classifies known code extensions', () => {
     expect(previewKindOf('main.go')).toBe('code')
     expect(previewKindOf('index.tsx')).toBe('code')

--- a/web/src/components/missions/filePreviewKind.ts
+++ b/web/src/components/missions/filePreviewKind.ts
@@ -1,4 +1,4 @@
-export type PreviewKind = 'image' | 'markdown' | 'code' | 'unsupported'
+export type PreviewKind = 'image' | 'markdown' | 'pdf' | 'code' | 'unsupported'
 
 const imageExts = new Set(['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'ico'])
 const markdownExts = new Set(['md', 'markdown'])
@@ -76,6 +76,7 @@ export function previewKindOf(path: string): PreviewKind {
   const ext = extOf(path)
   if (imageExts.has(ext)) return 'image'
   if (markdownExts.has(ext)) return 'markdown'
+  if (ext === 'pdf') return 'pdf'
   if (baseOf(path) in basenameLanguages) return 'code'
   if (ext in codeLanguages) return 'code'
   return 'unsupported'


### PR DESCRIPTION
FileViewer had no pdf branch, so worker-authored PDFs only offered a download prompt. Adds a pdf preview kind: fetches the bytes (server keeps serving octet-stream + attachment disposition, untouched), retypes the blob as application/pdf client-side, and iframes it — the same pattern AttachmentViewer already uses. The preview cap is raised for this kind (the browser's PDF plugin renders it, not the tab's JS).

Tested: web build, lint, full vitest suite; new cases for the pdf branch, the raised cap, and previewKindOf classification.

Closes #364

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790628671&installation_model_id=431401&pr_number=384&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F384&signature=f1febb732a191a6982183d6c825114351effdd556c0d328413dfca4f7e0de7ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->