### PR TITLE
fix(web): analytics currency honesty and panel cleanup

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -37,7 +37,6 @@ import type {
   RetrievedMemory,
   Schedule,
   SessionMeta,
-  SessionUsage,
   TestResult,
   Transcript,
   UnpricedGroup,
@@ -575,13 +574,6 @@ export async function usageUnpriced(from: Date, to: Date): Promise<UnpricedGroup
     `/v1/admin/usage/unpriced?${rangeParams(from, to)}`,
   )
   return groups ?? []
-}
-
-export async function usageSessions(from: Date, to: Date, limit = 10): Promise<SessionUsage[]> {
-  const { sessions } = await request<{ sessions: SessionUsage[] }>(
-    `/v1/admin/usage/sessions?${rangeParams(from, to, { limit: String(limit) })}`,
-  )
-  return sessions ?? []
 }
 
 export async function usageLatency(from: Date, to: Date): Promise<LatencyRow[]> {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -378,15 +378,6 @@ export interface MissionUsage {
   models: ModelUsed[]
 }
 
-export interface SessionUsage extends ConvertedMoney {
-  session_id: string
-  currency: string
-  cost: number
-  input_tokens: number
-  output_tokens: number
-  requests: number
-}
-
 export interface LatencyRow {
   provider: string
   p50_ms: number

--- a/web/src/components/charts/StatsLegend.test.tsx
+++ b/web/src/components/charts/StatsLegend.test.tsx
@@ -22,15 +22,20 @@ describe('StatsLegend', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('computes mean/last/max per group', () => {
+  it('computes mean/max/total per group under matching headers', () => {
     render(
       <StatsLegend rows={rows} groups={groups} colorOf={colorOf} hidden={new Set()} onSelect={vi.fn()} valueLabel={valueLabel} />,
     )
-    // openai: mean (2+4+9)/3 = 5, last 9, max 9
+    expect(screen.getByText('Mean')).toBeInTheDocument()
+    expect(screen.getByText('Max')).toBeInTheDocument()
+    expect(screen.getByText('Total')).toBeInTheDocument()
+    expect(screen.queryByText('Min')).toBeNull()
+    expect(screen.queryByText('Last')).toBeNull()
+    // openai: mean (2+4+9)/3 = 5, max 9, total 15
     const row = screen.getByText('openai').closest('tr')
     expect(row).not.toBeNull()
-    expect(row).toHaveTextContent('5.0')
-    expect(row).toHaveTextContent('9.0')
+    const cells = [...row!.querySelectorAll('td')].slice(1).map((td) => td.textContent)
+    expect(cells).toEqual(['5.0', '9.0', '15.0'])
   })
 
   it('clicking a name calls onSelect non-additively and shows strikethrough when hidden', () => {
@@ -77,9 +82,10 @@ describe('StatsLegend', () => {
     render(
       <StatsLegend rows={rows} groups={groups} colorOf={colorOf} hidden={new Set()} onSelect={vi.fn()} valueLabel={valueLabel} />,
     )
-    // anthropic: (10+0+5)/3 = 5, last 5, max 10
+    // anthropic: mean (10+0+5)/3 = 5, max 10, total 15
     const row = screen.getByText('anthropic').closest('tr')
-    expect(row).toHaveTextContent('10.0')
+    const cells = [...row!.querySelectorAll('td')].slice(1).map((td) => td.textContent)
+    expect(cells).toEqual(['5.0', '10.0', '15.0'])
   })
 
   it('renders a fractional mean rounded, never at raw float precision, when fed the compact formatter', () => {

--- a/web/src/components/charts/StatsLegend.tsx
+++ b/web/src/components/charts/StatsLegend.tsx
@@ -1,18 +1,17 @@
 import type { Row } from './options'
 
-// statsFor computes mean/last/max for one group across the visible
+// statsFor computes mean/max/total for one group across the visible
 // rows — "visible" here means the rows fed to the chart, not filtered
 // by hidden (a hidden series still shows its stats, struck through).
-function statsFor(rows: Row[], group: string): { mean: number; last: number; max: number } {
+function statsFor(rows: Row[], group: string): { mean: number; max: number; total: number } {
   const values = rows.map((r) => Number(r[group]) || 0)
-  const sum = values.reduce((n, v) => n + v, 0)
-  const mean = values.length > 0 ? sum / values.length : 0
-  const last = values.length > 0 ? values[values.length - 1] : 0
+  const total = values.reduce((n, v) => n + v, 0)
+  const mean = values.length > 0 ? total / values.length : 0
   const max = values.length > 0 ? Math.max(...values) : 0
-  return { mean, last, max }
+  return { mean, max, total }
 }
 
-// Grafana-style legend: color swatch, series name, Mean/Last/Max
+// Grafana-style legend: color swatch, series name, Mean/Max/Total
 // columns computed from rows. Plain click isolates that series;
 // ctrl/cmd-click toggles it in/out of the visible set (name renders
 // plain text so tests/click targets select by it).
@@ -39,8 +38,8 @@ export function StatsLegend({
           <tr className="text-left text-muted-foreground">
             <th className="pb-1 font-medium">Series</th>
             <th className="pb-1 pl-3 text-right font-medium">Mean</th>
-            <th className="pb-1 pl-3 text-right font-medium">Last</th>
             <th className="pb-1 pl-3 text-right font-medium">Max</th>
+            <th className="pb-1 pl-3 text-right font-medium">Total</th>
           </tr>
         </thead>
         <tbody>
@@ -61,8 +60,8 @@ export function StatsLegend({
                   </span>
                 </td>
                 <td className="py-0.5 pl-3 text-right text-muted-foreground">{valueLabel(s.mean)}</td>
-                <td className="py-0.5 pl-3 text-right text-muted-foreground">{valueLabel(s.last)}</td>
                 <td className="py-0.5 pl-3 text-right text-muted-foreground">{valueLabel(s.max)}</td>
+                <td className="py-0.5 pl-3 text-right text-muted-foreground">{valueLabel(s.total)}</td>
               </tr>
             )
           })}

--- a/web/src/components/charts/options.test.ts
+++ b/web/src/components/charts/options.test.ts
@@ -140,6 +140,28 @@ describe('donutOption', () => {
     const series = opt.series as Array<{ center: [string, string] }>
     expect(series[0].center).toEqual(['50%', '50%'])
   })
+
+  it("tooltips a row's own label when given, falling back to valueLabel", () => {
+    const rows = [
+      { group: 'glm', cost: 0.859, label: '৳0.86' },
+      { group: 'openai', cost: 10 },
+    ]
+    const opt = donutOption(rows, colorOf, money)
+    const formatter = (opt.tooltip as { formatter: (p: unknown) => string }).formatter
+    expect(formatter({ name: 'glm', value: 0.859, percent: 7.9 })).toBe('glm<br/>৳0.86 (7.9%)')
+    expect(formatter({ name: 'openai', value: 10, percent: 92.1 })).toBe('openai<br/>$10 (92.1%)')
+  })
+
+  it('labels the "other" bucket with valueLabel, never a folded row\'s label', () => {
+    const rows = Array.from({ length: 10 }, (_, i) => ({
+      group: `p${i}`,
+      cost: 10 - i,
+      label: `L${i}`,
+    }))
+    const opt = donutOption(rows, colorOf, money)
+    const formatter = (opt.tooltip as { formatter: (p: unknown) => string }).formatter
+    expect(formatter({ name: 'other', value: 3, percent: 5 })).toBe('other<br/>$3 (5%)')
+  })
 })
 
 describe('latencyBarsOption', () => {

--- a/web/src/components/charts/options.ts
+++ b/web/src/components/charts/options.ts
@@ -189,8 +189,11 @@ export function requestsErrorsOption(
 // slice labels (name + percent) outside with label lines. Caps at 8
 // slices, folding overflow into "other". Plain pie (no hole), centered
 // in the panel — no legend needed since every slice is direct-labeled.
+// A row may carry its own tooltip `label` (a slice whose amount stayed
+// in a foreign currency shows that currency, not the chart's); rows
+// without one, and the "other" bucket, fall back to valueLabel.
 export function donutOption(
-  rows: { group: string; cost: number }[],
+  rows: { group: string; cost: number; label?: string }[],
   colorOf: (g: string) => string,
   valueLabel: (v: number) => string,
 ): EChartsOption {
@@ -199,6 +202,7 @@ export function donutOption(
   const top = sorted.slice(0, 8)
   const rest = sorted.slice(8)
   const restTotal = rest.reduce((n, r) => n + r.cost, 0)
+  const labels = new Map(top.filter((r) => r.label).map((r) => [r.group, r.label as string]))
   const data = top.map((r) => ({ name: r.group, value: r.cost, itemStyle: { color: colorOf(r.group) } }))
   if (restTotal > 0) data.push({ name: 'other', value: restTotal, itemStyle: { color: 'var(--muted-foreground)' } })
 
@@ -209,7 +213,8 @@ export function donutOption(
       ...theme.tooltip,
       formatter: (p) => {
         const param = p as { name: string; value: number; percent: number }
-        return `${param.name}<br/>${valueLabel(param.value)} (${param.percent}%)`
+        const label = labels.get(param.name) ?? valueLabel(param.value)
+        return `${param.name}<br/>${label} (${param.percent}%)`
       },
     },
     series: [

--- a/web/src/pages/Analytics.test.tsx
+++ b/web/src/pages/Analytics.test.tsx
@@ -11,7 +11,6 @@ vi.mock('../api/client', () => ({
   usageCache: vi.fn(),
   usageLatency: vi.fn(),
   usageSeries: vi.fn(),
-  usageSessions: vi.fn(),
   usageSummary: vi.fn(),
   usageTotals: vi.fn(),
   usageUnpriced: vi.fn(),
@@ -47,7 +46,6 @@ import {
   usageCache,
   usageLatency,
   usageSeries,
-  usageSessions,
   usageSummary,
   usageTotals,
   usageUnpriced,
@@ -87,7 +85,6 @@ beforeEach(() => {
   vi.mocked(usageSummary).mockResolvedValue([summary])
   vi.mocked(usageSeries).mockResolvedValue([])
   vi.mocked(usageTotals).mockResolvedValue([])
-  vi.mocked(usageSessions).mockResolvedValue([])
   vi.mocked(usageLatency).mockResolvedValue([])
   vi.mocked(usageCache).mockResolvedValue([])
   vi.mocked(usageBudget).mockResolvedValue(calmBudget)
@@ -326,7 +323,7 @@ describe('Analytics chart legend selection', () => {
 
   it('ctrl-click toggles just that entry, independent of other legends', async () => {
     renderPage()
-    const chart = (await screen.findByText('Token consumption')).closest('section')
+    const chart = (await screen.findByText('Tokens consumption')).closest('section')
     if (!chart) throw new Error('chart section not found')
     const inputEntry = (await within(chart).findAllByText('input')).find((el) => el.className === '')
     if (!inputEntry) throw new Error('legend entry not found')
@@ -379,7 +376,7 @@ describe('Analytics bars/lines view toggle', () => {
 
   it('defaults to lines and switches the tokens-in/out chart to bars on click', async () => {
     renderPage()
-    const chart = (await screen.findByText('Token consumption')).closest('section')
+    const chart = (await screen.findByText('Tokens consumption')).closest('section')
     if (!chart) throw new Error('chart section not found')
     const lastOption = await findChartOptionGetter(chart)
     await waitFor(() => expect((lastOption().series as Array<{ type: string }>)[0]?.type).toBe('line'))
@@ -404,7 +401,7 @@ describe('Analytics bars/lines view toggle', () => {
 
   it('has no toggle on the requests & errors panel', async () => {
     renderPage()
-    const chart = (await screen.findByText('Requests & errors over time')).closest('section')
+    const chart = (await screen.findByText('Requests & error rate')).closest('section')
     if (!chart) throw new Error('chart section not found')
     expect(within(chart).queryByText('Bars')).toBeNull()
     expect(within(chart).queryByText('Lines')).toBeNull()
@@ -412,23 +409,23 @@ describe('Analytics bars/lines view toggle', () => {
 })
 
 describe('Analytics panel layout', () => {
-  it('orders chart panels: spend by provider, spend by model, tokens per model, token consumption, latency/spend share, requests & errors', async () => {
+  it('orders chart panels: spend by provider, spend by model, tokens per model, tokens consumption, latency/spend share, requests & errors', async () => {
     renderPage()
     const headings = (await screen.findAllByRole('heading', { level: 2 })).map((h) => h.textContent)
     const chartHeadings = [
       'Spend by provider',
       'Spend by model',
       'Tokens per model',
-      'Token consumption',
+      'Tokens consumption',
       'Latency per provider',
       'Spend share by provider',
-      'Requests & errors over time',
+      'Requests & error rate',
     ]
     const positions = chartHeadings.map((h) => headings.indexOf(h))
     expect(positions.every((p) => p >= 0)).toBe(true)
     expect(positions).toEqual([...positions].sort((a, b) => a - b))
     // Requests & errors is the last chart panel, ahead of the budget/table sections.
-    expect(headings.indexOf('Requests & errors over time')).toBeGreaterThan(headings.indexOf('Latency per provider'))
+    expect(headings.indexOf('Requests & error rate')).toBeGreaterThan(headings.indexOf('Latency per provider'))
   })
 })
 
@@ -468,7 +465,7 @@ describe('Analytics zero-cost exclusion', () => {
     )
     renderPage()
 
-    const providerTable = (await screen.findByText('Provider cost breakdown')).closest('section')
+    const providerTable = (await screen.findByText('Cost breakdown by provider')).closest('section')
     if (!providerTable) throw new Error('provider cost table not found')
     expect(await within(providerTable).findByText('openai')).toBeInTheDocument()
     expect(within(providerTable).queryByText('local-llama')).toBeNull()

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Link } from 'react-router'
 import { EChart } from '../components/charts/EChart'
 import { StatsLegend } from '../components/charts/StatsLegend'
 import {
@@ -18,7 +17,6 @@ import {
   usageCache,
   usageLatency,
   usageSeries,
-  usageSessions,
   usageSummary,
   usageTotals,
   usageUnpriced,
@@ -29,7 +27,6 @@ import type {
   CatalogPrice,
   GroupTotal,
   LatencyRow,
-  SessionUsage,
   UnpricedGroup,
   UsagePoint,
   UsageSummary,
@@ -92,7 +89,6 @@ interface Loaded {
   byModel: UsagePoint[]
   providerTotals: GroupTotal[]
   modelTotals: GroupTotal[]
-  sessions: SessionUsage[]
   latency: LatencyRow[]
   cache: CacheRow[]
   budget: BudgetStatus | null
@@ -241,7 +237,6 @@ export function Analytics() {
       usageSeries(from, to, bucket, 'model'),
       usageTotals(from, to, 'provider'),
       usageTotals(from, to, 'model'),
-      usageSessions(from, to, 10),
       usageLatency(from, to),
       usageCache(from, to),
       usageBudget(),
@@ -259,12 +254,11 @@ export function Analytics() {
         byModel: val(results[2], []),
         providerTotals: val(results[3], []),
         modelTotals: val(results[4], []),
-        sessions: val(results[5], []),
-        latency: val(results[6], []),
-        cache: val(results[7], []),
-        budget: val<BudgetStatus | null>(results[8], null),
+        latency: val(results[5], []),
+        cache: val(results[6], []),
+        budget: val<BudgetStatus | null>(results[7], null),
       })
-      setUnpriced(val<UnpricedGroup[]>(results[9], []))
+      setUnpriced(val<UnpricedGroup[]>(results[8], []))
     })
     return () => {
       live = false
@@ -628,7 +622,7 @@ export function Analytics() {
 
         <section className="mt-6 rounded-xl border border-border p-4">
           <div className="flex items-center justify-between">
-            <h2 className="text-sm font-medium">Token consumption</h2>
+            <h2 className="text-sm font-medium">Tokens consumption</h2>
             <ViewToggle view={tokensView} onChange={setTokensView} />
           </div>
           <div className="mt-3">
@@ -678,7 +672,18 @@ export function Analytics() {
               <EChart
                 fill
                 option={donutOption(
-                  (data?.providerTotals ?? []).filter((g) => g.cost > 0),
+                  // Converted-first, same as the bar chart's chartCost:
+                  // slices plot the default-currency figure when a rate
+                  // exists; a slice with no stored rate keeps its raw
+                  // amount and labels it in its OWN currency (D-013:
+                  // never mislabel one currency's amount as another's).
+                  (data?.providerTotals ?? [])
+                    .filter((g) => (g.converted_amount ?? g.cost) > 0)
+                    .map((g) => ({
+                      group: g.group,
+                      cost: g.converted_amount ?? g.cost,
+                      label: money(g.converted_amount ?? g.cost, g.converted_currency ?? g.currency),
+                    })),
                   (g) => colorOf(g, cost.groups),
                   chartMoney,
                 )}
@@ -691,7 +696,7 @@ export function Analytics() {
         </div>
 
         <section className="mt-6 rounded-xl border border-border p-4">
-          <h2 className="text-sm font-medium">Requests &amp; errors over time</h2>
+          <h2 className="text-sm font-medium">Requests &amp; error rate</h2>
           <div className="mt-3">
             <EChart
               option={requestsErrorsOption(
@@ -745,44 +750,9 @@ export function Analytics() {
 
         <div className="mt-6 grid gap-6 lg:grid-cols-2">
           <ProviderCostTable rows={data?.providerTotals ?? []} />
-          <BreakdownTable title="By model" rows={data ? totals(data.byModel) : []} estimates={estimates} />
+          <BreakdownTable title="Cost breakdown by model" rows={data ? totals(data.byModel) : []} estimates={estimates} />
         </div>
 
-        <section className="mt-6 rounded-xl border border-border p-4">
-          <h2 className="text-sm font-medium">Top sessions by cost</h2>
-          <table className="mt-3 w-full text-sm">
-            <tbody>
-              {(data?.sessions ?? []).map((sess) => (
-                <tr key={sess.session_id} className="border-t border-border/60">
-                  <td className="py-2 pr-2">
-                    <Link
-                      to={`/chat/${sess.session_id}`}
-                      className="block max-w-40 truncate text-blue-600 hover:underline dark:text-blue-400"
-                    >
-                      {sess.session_id.slice(0, 8)}…
-                    </Link>
-                  </td>
-                  <td className="py-2 text-right text-muted-foreground">{sess.requests} req</td>
-                  <td className="py-2 text-right font-medium">
-                    {primaryMoney(sess, sess.cost)}
-                    {secondaryMoney(sess, sess.cost) && (
-                      <span className="ml-1 text-xs font-normal text-muted-foreground">
-                        ({secondaryMoney(sess, sess.cost)})
-                      </span>
-                    )}
-                  </td>
-                </tr>
-              ))}
-              {data && data.sessions.length === 0 && (
-                <tr>
-                  <td className="py-6 text-center text-muted-foreground">
-                    No session spend in range.
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </section>
       </div>
     </div>
   )
@@ -876,7 +846,7 @@ function ProviderCostTable({ rows }: { rows: GroupTotal[] }) {
 
   return (
     <section className="rounded-xl border border-border p-4">
-      <h2 className="text-sm font-medium">Provider cost breakdown</h2>
+      <h2 className="text-sm font-medium">Cost breakdown by provider</h2>
       <table className="mt-3 w-full text-sm">
         <thead>
           <tr className="text-left text-xs text-muted-foreground">


### PR DESCRIPTION
The Spend share by provider donut passed raw GroupTotal costs into donutOption and formatted every slice with the chart-wide currency, so a provider billed in BDT showed its raw amount under another currency's label. Slices now plot converted_amount when a stored rate exists (matching the bar chart), and a slice with no rate keeps its raw amount labeled in its own currency (D-013: never mislabel one currency's amount as another's).

Also, per review of the page:
- series legends show Mean/Max/Total (Last dropped)
- headings renamed for consistency: "Requests & error rate", "Cost breakdown by provider", "Cost breakdown by model"
- Top sessions section removed, along with the now-dead usageSessions client function and SessionUsage type

Tested: web build, lint, full vitest suite; new donut per-row-label tests, legend and heading tests updated.

Closes #377

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790628673&installation_model_id=431401&pr_number=385&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F385&signature=a803afecd0f057df57c89aa90dfb44269f81faf39a135ff6af0c65a3430d6fd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->