### PR TITLE
fix(web): markdown raw html, explicit-only budgets, execution plan branding

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -871,7 +871,7 @@ const missionWorkSlotMax = 4
 
 // missionAgentResolver adapts agentReg.ResolveByID to scheduler.go's
 // AgentResolver / driver.go's SetAgentResolver shape — both need the
-// SAME resolution (route/review_route/budget/prompt_overlay/
+// SAME resolution (route/review_route/prompt_overlay/
 // approval_allowlist/harness from an agents row), just at different
 // moments (schedule fire time vs mission provisioning time), so one
 // adapter serves both call sites.
@@ -883,8 +883,8 @@ func missionAgentResolver(agentReg *agents.Store) missions.AgentResolver {
 		}
 		return missions.AgentDefaults{
 			Route: a.Route, ReviewRoute: a.ReviewRoute, PromptOverlay: a.PromptOverlay,
-			BudgetAmount: a.BudgetUSD, ApprovalAllowlist: a.ApprovalAllowlist,
-			Knowledge: a.Knowledge, Harness: a.Harness,
+			ApprovalAllowlist: a.ApprovalAllowlist,
+			Knowledge:         a.Knowledge, Harness: a.Harness,
 		}, true
 	}
 }

--- a/internal/brain/agents/agents.go
+++ b/internal/brain/agents/agents.go
@@ -27,10 +27,10 @@ import (
 // output and, when Skills is non-empty, load_skill stay available
 // regardless); empty Route means the default route.
 //
-// ReviewRoute and BudgetUSD are meaningless to a chat-only agent and
-// stay at their zero values for one; a mission-capable agent
-// (internal/brain/missions) sets both — missions reference this table
-// directly rather than a parallel agent_profiles table. ApprovalAllowlist
+// ReviewRoute is meaningless to a chat-only agent and stays at its
+// zero value for one; a mission-capable agent (internal/brain/missions)
+// sets it — missions reference this table directly rather than a
+// parallel agent_profiles table. ApprovalAllowlist
 // applies to both: missions grant it at provisioning time
 // (missions/driver.go), chat seeds the same session_grants rows on a
 // session's first turn under the agent (chat.Service.SetApprovalGrants).
@@ -46,7 +46,6 @@ type Agent struct {
 	IsDefault         bool     `json:"is_default"`
 	Enabled           bool     `json:"enabled"`
 	ReviewRoute       string   `json:"review_route"`
-	BudgetUSD         *float64 `json:"budget_usd,omitempty"`
 	ApprovalAllowlist []string `json:"approval_allowlist"`
 	// Harness is the coding executor this agent's missions delegate
 	// to when the mission itself leaves harness empty (mission.harness
@@ -102,7 +101,7 @@ func NewStore(db *pgpool.Pool, log *slog.Logger) *Store {
 	return &Store{db: db, log: log}
 }
 
-const agentColumns = `id, name, description, prompt_overlay, route, skills, tools, memory, is_default, enabled, review_route, budget_usd, approval_allowlist, knowledge, harness`
+const agentColumns = `id, name, description, prompt_overlay, route, skills, tools, memory, is_default, enabled, review_route, approval_allowlist, knowledge, harness`
 
 func scanAgent(row pgx.Row) (Agent, error) {
 	var (
@@ -111,7 +110,7 @@ func scanAgent(row pgx.Row) (Agent, error) {
 	)
 	if err := row.Scan(&a.ID, &a.Name, &a.Description, &a.PromptOverlay, &a.Route,
 		&skills, &tools, &a.Memory, &a.IsDefault, &a.Enabled,
-		&a.ReviewRoute, &a.BudgetUSD, &appr, &knowledge, &a.Harness); err != nil {
+		&a.ReviewRoute, &appr, &knowledge, &a.Harness); err != nil {
 		return Agent{}, err
 	}
 	_ = json.Unmarshal(skills, &a.Skills)
@@ -266,10 +265,10 @@ func (s *Store) Create(ctx context.Context, a Agent) (string, error) {
 	var id string
 	err = db.QueryRow(ctx, `INSERT INTO agents
 			(name, description, prompt_overlay, route, skills, tools, memory, enabled,
-			 review_route, budget_usd, approval_allowlist, knowledge, harness)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING id`,
+			 review_route, approval_allowlist, knowledge, harness)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING id`,
 		a.Name, a.Description, a.PromptOverlay, a.Route, skills, tools, a.Memory, a.Enabled,
-		a.ReviewRoute, a.BudgetUSD, appr, knowledge, a.Harness).Scan(&id)
+		a.ReviewRoute, appr, knowledge, a.Harness).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("agents create: %w", err)
 	}
@@ -289,7 +288,6 @@ type Patch struct {
 	Memory            *bool     `json:"memory"`
 	Enabled           *bool     `json:"enabled"`
 	ReviewRoute       *string   `json:"review_route"`
-	BudgetUSD         *float64  `json:"budget_usd"`
 	ApprovalAllowlist *[]string `json:"approval_allowlist"`
 	Knowledge         *[]string `json:"knowledge"`
 	Harness           *string   `json:"harness"`
@@ -344,9 +342,6 @@ func (s *Store) Patch(ctx context.Context, id string, p Patch) error {
 	if p.ReviewRoute != nil {
 		after.ReviewRoute = *p.ReviewRoute
 	}
-	if p.BudgetUSD != nil {
-		after.BudgetUSD = p.BudgetUSD
-	}
 	if p.ApprovalAllowlist != nil {
 		after.ApprovalAllowlist = *p.ApprovalAllowlist
 	}
@@ -358,12 +353,12 @@ func (s *Store) Patch(ctx context.Context, id string, p Patch) error {
 	}
 	if _, err := tx.Exec(ctx, `UPDATE agents SET description = $2, prompt_overlay = $3,
 			route = $4, skills = $5, tools = $6, memory = $7, enabled = $8,
-			review_route = $9, budget_usd = $10, approval_allowlist = $11, knowledge = $12,
-			harness = $13, updated_at = now()
+			review_route = $9, approval_allowlist = $10, knowledge = $11,
+			harness = $12, updated_at = now()
 		WHERE id = $1`,
 		id, after.Description, after.PromptOverlay, after.Route,
 		jsonArr(after.Skills), jsonArr(after.Tools), after.Memory, after.Enabled,
-		after.ReviewRoute, after.BudgetUSD, jsonArr(after.ApprovalAllowlist), jsonArr(after.Knowledge),
+		after.ReviewRoute, jsonArr(after.ApprovalAllowlist), jsonArr(after.Knowledge),
 		after.Harness); err != nil {
 		return fmt.Errorf("agents patch: %w", err)
 	}

--- a/internal/brain/agents/agents_integration_test.go
+++ b/internal/brain/agents/agents_integration_test.go
@@ -165,35 +165,33 @@ func TestAgentCRUDAndResolve(t *testing.T) {
 
 // TestAgentMissionColumns covers the columns missions (internal/brain/
 // missions) rely on: a chat-only agent leaves them at their zero
-// values, a mission-capable agent round-trips all three through
+// values, a mission-capable agent round-trips all of them through
 // Create, Resolve, and Patch.
 func TestAgentMissionColumns(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
 
 	name := marker + "mission-capable"
-	budget := 5.5
 	id, err := s.Create(ctx, Agent{
 		Name: name, Route: "default", Enabled: true,
-		ReviewRoute: "research", BudgetUSD: &budget,
+		ReviewRoute:       "research",
 		ApprovalAllowlist: []string{"shell_exec"}, Harness: "claude-cli",
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	a, ok := s.Resolve(ctx, name)
-	if !ok || a.ReviewRoute != "research" || a.BudgetUSD == nil || *a.BudgetUSD != budget ||
+	if !ok || a.ReviewRoute != "research" ||
 		len(a.ApprovalAllowlist) != 1 || a.ApprovalAllowlist[0] != "shell_exec" || a.Harness != "claude-cli" {
 		t.Fatalf("Resolve = %+v ok=%v, want mission columns round-tripped", a, ok)
 	}
 
-	newBudget := 9.0
 	reviewRoute := "default"
 	newHarness := "codex-cli"
-	if err := s.Patch(ctx, id, Patch{ReviewRoute: &reviewRoute, BudgetUSD: &newBudget, Harness: &newHarness}); err != nil {
+	if err := s.Patch(ctx, id, Patch{ReviewRoute: &reviewRoute, Harness: &newHarness}); err != nil {
 		t.Fatalf("Patch: %v", err)
 	}
-	if a, _ := s.Resolve(ctx, name); a.ReviewRoute != "default" || a.BudgetUSD == nil || *a.BudgetUSD != newBudget || a.Harness != "codex-cli" {
+	if a, _ := s.Resolve(ctx, name); a.ReviewRoute != "default" || a.Harness != "codex-cli" {
 		t.Fatalf("patched mission columns = %+v (cache must invalidate)", a)
 	}
 
@@ -204,7 +202,7 @@ func TestAgentMissionColumns(t *testing.T) {
 	if _, err := s.Create(ctx, Agent{Name: chatOnly, Enabled: true}); err != nil {
 		t.Fatalf("Create chat-only: %v", err)
 	}
-	if a, _ := s.Resolve(ctx, chatOnly); a.ReviewRoute != "" || a.BudgetUSD != nil || len(a.ApprovalAllowlist) != 0 || a.Harness != "" {
+	if a, _ := s.Resolve(ctx, chatOnly); a.ReviewRoute != "" || len(a.ApprovalAllowlist) != 0 || a.Harness != "" {
 		t.Fatalf("chat-only agent mission columns = %+v, want all zero", a)
 	}
 

--- a/internal/brain/api/kb.go
+++ b/internal/brain/api/kb.go
@@ -313,13 +313,15 @@ func (h *kbAPI) finishIngest(w http.ResponseWriter, r *http.Request, collectionI
 		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
 		return
 	}
-	h.startIngest(docID, title)
-
+	// Read the document back before kicking off ingestion so the
+	// response deterministically reports the created "pending" state
+	// instead of racing the background ingest goroutine.
 	doc, err := h.store.GetDocument(r.Context(), docID)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
 		return
 	}
+	h.startIngest(docID, title)
 	writeJSON(w, http.StatusCreated, sanitizeDocument(doc))
 }
 
@@ -438,12 +440,12 @@ func (h *kbAPI) refreshOrCreate(w http.ResponseWriter, r *http.Request, resolveC
 			failKB(w, err)
 			return
 		}
-		h.startIngest(existing.ID, title)
 		doc, err := h.store.GetDocument(r.Context(), existing.ID)
 		if err != nil {
 			jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
 			return
 		}
+		h.startIngest(existing.ID, title)
 		writeJSON(w, http.StatusOK, sanitizeDocument(doc))
 	}
 }
@@ -598,12 +600,12 @@ func (h *kbAPI) clipDocument(w http.ResponseWriter, r *http.Request) {
 			jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
 			return
 		}
-		h.startIngest(docID, title)
 		doc, err := h.store.GetDocument(r.Context(), docID)
 		if err != nil {
 			jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
 			return
 		}
+		h.startIngest(docID, title)
 		writeJSON(w, http.StatusAccepted, sanitizeDocument(doc))
 	case err != nil:
 		jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
@@ -615,12 +617,12 @@ func (h *kbAPI) clipDocument(w http.ResponseWriter, r *http.Request) {
 			failKB(w, err)
 			return
 		}
-		h.startIngest(existing.ID, title)
 		doc, err := h.store.GetDocument(r.Context(), existing.ID)
 		if err != nil {
 			jsonError(w, http.StatusInternalServerError, "kb_failed", err.Error())
 			return
 		}
+		h.startIngest(existing.ID, title)
 		writeJSON(w, http.StatusAccepted, sanitizeDocument(doc))
 	}
 }

--- a/internal/brain/api/kb_integration_test.go
+++ b/internal/brain/api/kb_integration_test.go
@@ -60,12 +60,17 @@ func testKBStore(t *testing.T) *kb.Store {
 		t.Skip("DATABASE_URL not set; skipping integration test")
 	}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
-	// Background, not t.Context(): the pool closes its connections the
-	// moment its context is Done — the cleanup delete below would
-	// silently no-op, leaking itest-% collections that collide across
-	// tests sharing fixedClassifier's name. Same reasoning as
-	// testMissionStore's pool.
-	pool := pgpool.New(context.Background(), dsn, log)
+	// The pool must outlive t.Context(), which is already done when
+	// t.Cleanup fires — a t.Context()-scoped pool silently no-ops the
+	// cleanup delete below, leaking itest-% collections that collide
+	// across tests sharing fixedClassifier's name. A plain Background
+	// pool leaks connections instead (pgpool has no Close), so use a
+	// cancelable context released by the LAST cleanup: t.Cleanup runs
+	// LIFO, so registering the cancel before the delete keeps the pool
+	// alive for the delete and closes it right after.
+	poolCtx, poolCancel := context.WithCancel(context.Background())
+	t.Cleanup(poolCancel)
+	pool := pgpool.New(poolCtx, dsn, log)
 	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 	defer cancel()
 	if err := pool.WaitHealthy(ctx); err != nil {

--- a/internal/brain/api/kb_integration_test.go
+++ b/internal/brain/api/kb_integration_test.go
@@ -60,7 +60,12 @@ func testKBStore(t *testing.T) *kb.Store {
 		t.Skip("DATABASE_URL not set; skipping integration test")
 	}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
-	pool := pgpool.New(t.Context(), dsn, log)
+	// Background, not t.Context(): the pool closes its connections the
+	// moment its context is Done — the cleanup delete below would
+	// silently no-op, leaking itest-% collections that collide across
+	// tests sharing fixedClassifier's name. Same reasoning as
+	// testMissionStore's pool.
+	pool := pgpool.New(context.Background(), dsn, log)
 	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 	defer cancel()
 	if err := pool.WaitHealthy(ctx); err != nil {
@@ -76,7 +81,9 @@ func testKBStore(t *testing.T) *kb.Store {
 	t.Cleanup(func() {
 		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer ccancel()
-		_, _ = db.Exec(cctx, `DELETE FROM kb_collections WHERE name LIKE 'itest-%'`)
+		if _, err := db.Exec(cctx, `DELETE FROM kb_collections WHERE name LIKE 'itest-%'`); err != nil {
+			t.Logf("cleanup kb collections: %v", err)
+		}
 	})
 	return kb.New(pool)
 }

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -546,9 +546,6 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 			if req.ReviewRoute == "" {
 				req.ReviewRoute = a.ReviewRoute
 			}
-			if req.BudgetAmount == nil {
-				req.BudgetAmount = a.BudgetUSD
-			}
 			promptOverlay = a.PromptOverlay
 			knowledge = a.Knowledge
 		}
@@ -907,6 +904,9 @@ func (h *missionAPI) executorOptions(w http.ResponseWriter, r *http.Request) {
 // is usable).
 type executionPlanEntry struct {
 	ProviderName string              `json:"provider_name"`
+	Driver       string              `json:"driver"`
+	Kind         string              `json:"kind"`
+	BaseURL      string              `json:"base_url"`
 	Model        string              `json:"model"`
 	Usable       bool                `json:"usable"`
 	SkipReason   string              `json:"skip_reason"`
@@ -1000,6 +1000,9 @@ func (h *missionAPI) resolveEntries(ctx context.Context, route, harness, modelPi
 	for i, e := range resolved.Entries {
 		entries[i] = executionPlanEntry{
 			ProviderName: e.ProviderName,
+			Driver:       e.Driver,
+			Kind:         e.Kind,
+			BaseURL:      e.BaseURL,
 			Model:        e.Model,
 			Usable:       e.Usable,
 			SkipReason:   e.SkipReason,

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -64,12 +64,16 @@ func testMissionStore(t *testing.T) *missions.Store {
 		t.Skip("DATABASE_URL not set; skipping integration test")
 	}
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
-	// context.Background(), not t.Context(): t.Context() cancels BEFORE
-	// t.Cleanup callbacks run, and the pool closes its connection the
-	// moment its context is Done — the cleanup delete below would
-	// silently no-op (it did, leaking itest mission rows on every run).
-	// Same reasoning as testConnectorsManager's pool.
-	pool := pgpool.New(context.Background(), dsn, log)
+	// The pool must outlive t.Context(), which cancels BEFORE t.Cleanup
+	// callbacks run — a t.Context()-scoped pool silently no-ops the
+	// cleanup delete below (it did, leaking itest mission rows on every
+	// run). A plain Background pool never releases its connections
+	// (pgpool has no Close) and exhausts Postgres across many tests, so
+	// use a cancelable context released by the LAST cleanup (t.Cleanup
+	// runs LIFO: delete first, then cancel).
+	poolCtx, poolCancel := context.WithCancel(context.Background())
+	t.Cleanup(poolCancel)
+	pool := pgpool.New(poolCtx, dsn, log)
 	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 	defer cancel()
 	if err := pool.WaitHealthy(ctx); err != nil {

--- a/internal/brain/api/schedules.go
+++ b/internal/brain/api/schedules.go
@@ -169,7 +169,7 @@ type patchScheduleRequest struct {
 	Enabled         *bool                     `json:"enabled"`
 	// ExpiresAt: nil (omitted OR explicit null — encoding/json can't
 	// tell those apart through a single pointer) means "leave
-	// unchanged," same convention as agents.Patch.BudgetUSD. Clearing an
+	// unchanged," same convention as agents.Patch.ReviewRoute. Clearing an
 	// expiry entirely is not reachable through this endpoint in v1 —
 	// delete and recreate the schedule instead.
 	ExpiresAt *time.Time `json:"expires_at"`

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -106,14 +106,9 @@ type MissionTemplate struct {
 // api/missions.go's create-handler resolution so a scheduler-fired
 // mission gets the same defaults a UI-created one would.
 type AgentDefaults struct {
-	Route         string
-	ReviewRoute   string
-	PromptOverlay string
-	// BudgetAmount is a plain fallback number: an agent-level default
-	// carries no currency of its own, it always inherits whatever
-	// currency the firing mission/request resolves to (request's
-	// explicit budget_currency, or "USD" if that's also empty).
-	BudgetAmount      *float64
+	Route             string
+	ReviewRoute       string
+	PromptOverlay     string
 	ApprovalAllowlist []string
 	// Knowledge is the agent's kb_collections allowlist, snapshotted
 	// onto the mission the same way PromptOverlay is (see
@@ -549,9 +544,6 @@ func resolveTemplateDefaults(ctx context.Context, t MissionTemplate, resolve Age
 			}
 			if t.ReviewRoute == "" {
 				t.ReviewRoute = defaults.ReviewRoute
-			}
-			if t.BudgetAmount == nil {
-				t.BudgetAmount = defaults.BudgetAmount
 			}
 			promptOverlay = defaults.PromptOverlay
 			knowledge = defaults.Knowledge

--- a/internal/brain/missions/scheduler_test.go
+++ b/internal/brain/missions/scheduler_test.go
@@ -126,7 +126,6 @@ func TestDueDecisionNonUTCLocation(t *testing.T) {
 
 func TestResolveTemplateDefaults(t *testing.T) {
 	t.Parallel()
-	budget := 5.0
 
 	cases := []struct {
 		name          string
@@ -137,7 +136,6 @@ func TestResolveTemplateDefaults(t *testing.T) {
 		wantRoute     string
 		wantReview    string
 		wantPlanRoute string
-		wantBudget    *float64
 		wantOverlay   string
 		wantHarness   string
 		wantKnowledge []string
@@ -200,11 +198,10 @@ func TestResolveTemplateDefaults(t *testing.T) {
 			name:     "empty template fields fill from resolved agent",
 			template: MissionTemplate{Goal: "g", AgentID: "briefing"},
 			resolve: func(ctx context.Context, agentID string) (AgentDefaults, bool) {
-				return AgentDefaults{Route: "fast", ReviewRoute: "careful", BudgetAmount: &budget, PromptOverlay: "overlay text"}, true
+				return AgentDefaults{Route: "fast", ReviewRoute: "careful", PromptOverlay: "overlay text"}, true
 			},
 			wantRoute:   "fast",
 			wantReview:  "careful",
-			wantBudget:  &budget,
 			wantOverlay: "overlay text",
 		},
 		{
@@ -306,11 +303,6 @@ func TestResolveTemplateDefaults(t *testing.T) {
 			}
 			if got.PlanRoute != tc.wantPlanRoute {
 				t.Errorf("PlanRoute = %q, want %q", got.PlanRoute, tc.wantPlanRoute)
-			}
-			if (got.BudgetAmount == nil) != (tc.wantBudget == nil) {
-				t.Errorf("BudgetAmount = %v, want %v", got.BudgetAmount, tc.wantBudget)
-			} else if got.BudgetAmount != nil && *got.BudgetAmount != *tc.wantBudget {
-				t.Errorf("BudgetAmount = %v, want %v", *got.BudgetAmount, *tc.wantBudget)
 			}
 			if overlay != tc.wantOverlay {
 				t.Errorf("overlay = %q, want %q", overlay, tc.wantOverlay)

--- a/migrations/0009_agents.sql
+++ b/migrations/0009_agents.sql
@@ -17,14 +17,13 @@ CREATE TABLE IF NOT EXISTS agents (
     enabled        boolean NOT NULL DEFAULT true,
     -- Missions reuse the agents table (missions.agent_id -> agents.id)
     -- rather than a parallel agent_profiles table: a mission-serving
-    -- agent is still "who serves this," same as chat. These four
-    -- columns are meaningless to a chat-only agent and stay at their
-    -- defaults for one; a mission-capable agent sets what it needs.
-    -- harness is the coding executor a mission delegates to (mission.
-    -- harness -> agent.harness -> settings.coding_executor -> native);
-    -- empty means inherit.
+    -- agent is still "who serves this," same as chat. These columns
+    -- are meaningless to a chat-only agent and stay at their defaults
+    -- for one; a mission-capable agent sets what it needs. harness is
+    -- the coding executor a mission delegates to (mission.harness ->
+    -- agent.harness -> settings.coding_executor -> native); empty
+    -- means inherit.
     review_route       text NOT NULL DEFAULT '',
-    budget_usd         numeric(12,2),
     approval_allowlist jsonb NOT NULL DEFAULT '[]',
     harness            text NOT NULL DEFAULT '',
     -- Knowledge collections (kb_collections.name) this agent may search

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -28,6 +28,8 @@
         "react-markdown": "^10.1.0",
         "react-router": "^8.3.0",
         "rehype-highlight": "^7.0.2",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.19.0",
         "shiki": "^4.4.3",
@@ -6949,6 +6951,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
@@ -6956,6 +6978,83 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-raw/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7012,6 +7111,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-text": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
@@ -7035,6 +7153,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10230,6 +10365,35 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -11605,6 +11769,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -12058,6 +12236,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/webidl-conversions": {

--- a/web/package.json
+++ b/web/package.json
@@ -31,6 +31,8 @@
     "react-markdown": "^10.1.0",
     "react-router": "^8.3.0",
     "rehype-highlight": "^7.0.2",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.19.0",
     "shiki": "^4.4.3",

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -585,7 +585,6 @@ export interface AdminAgent {
   // since most call sites (chat agent picker etc.) never populate
   // them.
   review_route?: string
-  budget_usd?: number
   approval_allowlist?: string[]
   // Harness this agent's coding missions delegate to when the mission
   // itself leaves harness empty (mission.harness -> agent.harness ->
@@ -1044,6 +1043,9 @@ export interface ExecutionPlanPrices {
 // entry only; nothing is selected if none are usable.
 export interface ExecutionPlanEntry {
   provider_name: string
+  driver: string
+  kind: string
+  base_url: string
   model: string
   usable: boolean
   skip_reason: string

--- a/web/src/components/FilePreviewBlocks.tsx
+++ b/web/src/components/FilePreviewBlocks.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react'
 import hljs from 'highlight.js'
 import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import { CodeBlock } from './CodeBlock'
+import { rehypePlugins, remarkPlugins } from '../lib/markdown'
 import { codeLanguageOf } from './missions/filePreviewKind'
 import 'highlight.js/styles/github-dark.css'
 
@@ -48,7 +48,11 @@ export function FileMarkdownBlock({ text, raw }: { text: string; raw: boolean })
   if (raw) return <FileCodeBlock code={text} path="file.md" />
   return (
     <div className="prose prose-sm max-w-none p-3 dark:prose-invert">
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ pre: CodeBlock }}>
+      <ReactMarkdown
+        remarkPlugins={remarkPlugins}
+        rehypePlugins={rehypePlugins}
+        components={{ pre: CodeBlock }}
+      >
         {text}
       </ReactMarkdown>
     </div>

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -13,7 +13,6 @@ import {
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import { fetchAttachmentBlob } from '../api/client'
 import type { ImageRef, MediaRef } from '../api/types'
 import { ActivityLine } from './Activity'
@@ -25,6 +24,7 @@ import { collapseRepeatedTail, splitSources } from '../lib/citations'
 import { attachmentURLCache } from '../lib/attachmentCache'
 import type { AssistantState } from '../lib/chat'
 import { compact, formatDuration, money } from '../lib/format'
+import { rehypePlugins, remarkPlugins } from '../lib/markdown'
 import { cn } from '../lib/utils'
 
 // AuthedImage renders one attachment thumbnail. GET
@@ -319,7 +319,9 @@ export function UserMessage({
         <CopyButton text={text} label="Copy message" />
         {text !== '' && (
           <div className="prose prose-sm prose-invert max-w-2xl rounded-2xl bg-blue-600 px-4 py-2.5 text-sm/6 text-white prose-pre:bg-blue-700">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
+              {text}
+            </ReactMarkdown>
           </div>
         )}
       </div>
@@ -360,7 +362,11 @@ export function InterruptedMessage({ text }: { text: string }) {
   return (
     <div className="group/message flex w-full flex-col items-start gap-2" data-testid="interrupted">
       <div className="prose prose-sm w-full max-w-none dark:prose-invert">
-        <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ pre: CodeBlock }}>
+        <ReactMarkdown
+          remarkPlugins={remarkPlugins}
+          rehypePlugins={rehypePlugins}
+          components={{ pre: CodeBlock }}
+        >
           {text}
         </ReactMarkdown>
       </div>
@@ -467,7 +473,11 @@ export function AssistantMessage({
       )}
 
       <div className="prose prose-sm w-full max-w-none dark:prose-invert">
-        <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ pre: CodeBlock }}>
+        <ReactMarkdown
+          remarkPlugins={remarkPlugins}
+          rehypePlugins={rehypePlugins}
+          components={{ pre: CodeBlock }}
+        >
           {body}
         </ReactMarkdown>
         {msg.streaming && msg.permissions.length === 0 && <span className="animate-pulse">▍</span>}

--- a/web/src/components/missions/ExploreSection.tsx
+++ b/web/src/components/missions/ExploreSection.tsx
@@ -1,7 +1,7 @@
 import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import { CodeBlock } from '../CodeBlock'
 import { CopyButton } from '../Message'
+import { rehypePlugins, remarkPlugins } from '../../lib/markdown'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 
@@ -33,7 +33,11 @@ export function ExploreSection({ notes }: { notes: string }) {
               </Tooltip>
             </div>
             <div className="prose prose-sm max-h-64 max-w-none overflow-y-auto p-3 pt-1 dark:prose-invert">
-              <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ pre: CodeBlock }}>
+              <ReactMarkdown
+                remarkPlugins={remarkPlugins}
+                rehypePlugins={rehypePlugins}
+                components={{ pre: CodeBlock }}
+              >
                 {notes}
               </ReactMarkdown>
             </div>

--- a/web/src/components/missions/GoalSection.tsx
+++ b/web/src/components/missions/GoalSection.tsx
@@ -1,7 +1,7 @@
 import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import { CodeBlock } from '../CodeBlock'
 import { CopyButton } from '../Message'
+import { rehypePlugins, remarkPlugins } from '../../lib/markdown'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 
@@ -31,7 +31,11 @@ export function GoalSection({ goal }: { goal: string }) {
               </Tooltip>
             </div>
             <div className="prose prose-sm max-h-64 max-w-none overflow-y-auto p-3 pt-1 dark:prose-invert">
-              <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ pre: CodeBlock }}>
+              <ReactMarkdown
+                remarkPlugins={remarkPlugins}
+                rehypePlugins={rehypePlugins}
+                components={{ pre: CodeBlock }}
+              >
                 {goal}
               </ReactMarkdown>
             </div>

--- a/web/src/components/missions/MissionExecutionPlan.tsx
+++ b/web/src/components/missions/MissionExecutionPlan.tsx
@@ -1,6 +1,8 @@
 import type { ExecutionPlanEntry, ExecutionPlanPhase } from '../../api/types'
 import { executorChoices } from './MissionForm'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { matchPreset } from '../settings/presets'
+import { ProviderLogo } from '../settings/ProviderLogo'
 
 // MODEL_AUTO is the select's sentinel for "no pin" — Radix Select
 // rejects an empty-string item value, same convention MissionForm's
@@ -173,10 +175,12 @@ function PhaseRow({
           entries={phase.entries}
           pin={modelPinFor(phaseKey, props)}
           onChange={onChange}
+          selected={selected}
         />
       ) : selected ? (
-        <span className="font-medium">
-          {selected.provider_name} {selected.model}
+        <span className="flex items-center gap-1.5 font-medium">
+          <ProviderLogo preset={matchPreset(selected)} className="size-4" />
+          {selected.model}
         </span>
       ) : phase.entries.length > 0 ? (
         <span className="text-muted-foreground" title={phase.entries[0]?.skip_reason || undefined}>
@@ -193,20 +197,23 @@ function PhaseRow({
 }
 
 // ModelPinSelect is the resolved-model cell for a pinnable phase: a
-// select over that phase's entries, "Auto (first usable)" plus every
-// entry — unusable ones stay listed and disabled with their skip_reason
-// as a tooltip, same pattern PhaseRow already used for display-only
-// unusable counts.
+// select over that phase's entries, "Auto" plus every entry — unusable
+// ones stay listed and disabled with their skip_reason as a tooltip,
+// same pattern PhaseRow already used for display-only unusable counts.
+// The Auto item names the entry it actually resolves to when one is
+// selected and usable, so "Auto" isn't a mystery next to a picked model.
 function ModelPinSelect({
   label,
   entries,
   pin,
   onChange,
+  selected,
 }: {
   label: string
   entries: ExecutionPlanEntry[]
   pin: string
   onChange: (v: string) => void
+  selected: ExecutionPlanEntry | undefined
 }) {
   return (
     <Select
@@ -217,12 +224,23 @@ function ModelPinSelect({
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value={MODEL_AUTO}>Auto (first usable)</SelectItem>
+        <SelectItem value={MODEL_AUTO}>
+          {selected && selected.usable ? (
+            <>
+              Auto
+              <ProviderLogo preset={matchPreset(selected)} className="size-4" />
+              {selected.model}
+            </>
+          ) : (
+            'Auto (first usable)'
+          )}
+        </SelectItem>
         {entries.map((entry) => {
           const value = pinValue(entry)
           return (
             <SelectItem key={value} value={value} disabled={!entry.usable} title={entry.skip_reason || undefined}>
-              {entry.provider_name} {entry.model}
+              <ProviderLogo preset={matchPreset(entry)} className="size-4" />
+              {entry.model}
               {!entry.usable && entry.skip_reason ? ` - ${entry.skip_reason}` : ''}
             </SelectItem>
           )

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -1308,6 +1308,9 @@ const fivePhases: ExecutionPlanPhase[] = [
     entries: [
       {
         provider_name: 'GLM (Z.ai)',
+        driver: 'openaicompat',
+        kind: 'chat',
+        base_url: 'https://api.z.ai/api/paas/v4',
         model: 'glm-5.3',
         usable: true,
         skip_reason: '',
@@ -1325,6 +1328,9 @@ const fivePhases: ExecutionPlanPhase[] = [
     entries: [
       {
         provider_name: 'Anthropic',
+        driver: 'anthropic',
+        kind: 'chat',
+        base_url: '',
         model: 'sonnet-5',
         usable: true,
         skip_reason: '',
@@ -1345,15 +1351,15 @@ describe('MissionForm — execution plan', () => {
 
     expect(await screen.findByText('This mission will run')).toBeInTheDocument()
     expect(screen.getByText('Claude Code')).toBeInTheDocument()
-    // No pin set on either phase: the select shows "Auto (first usable)"
-    // regardless of which entry the server marked selected.
-    expect(screen.getByLabelText('Explore model')).toHaveTextContent('Auto (first usable)')
-    expect(screen.getByLabelText('Execute model')).toHaveTextContent('Auto (first usable)')
+    // No pin set on either phase: the select shows "Auto" naming the
+    // entry the server marked selected.
+    expect(screen.getByLabelText('Explore model')).toHaveTextContent('Autoglm-5.3')
+    expect(screen.getByLabelText('Execute model')).toHaveTextContent('Autosonnet-5')
     fireEvent.click(screen.getByLabelText('Explore model'))
-    expect(await screen.findByRole('option', { name: 'GLM (Z.ai) glm-5.3' })).toBeInTheDocument()
+    expect(await screen.findByRole('option', { name: 'glm-5.3' })).toBeInTheDocument()
     fireEvent.click(screen.getByLabelText('Explore model'))
     fireEvent.click(screen.getByLabelText('Execute model'))
-    expect(await screen.findByRole('option', { name: 'Anthropic sonnet-5' })).toBeInTheDocument()
+    expect(await screen.findByRole('option', { name: 'sonnet-5' })).toBeInTheDocument()
     expect(screen.getByText('$0.60/$2.20 per Mtok')).toBeInTheDocument()
     expect(screen.getByText('Naming and memory extraction use the summarize route.')).toBeInTheDocument()
   })
@@ -1378,6 +1384,9 @@ describe('MissionForm — execution plan', () => {
             entries: [
               {
                 provider_name: 'OpenAI',
+                driver: 'openaicompat',
+                kind: 'chat',
+                base_url: 'https://api.openai.com/v1',
                 model: 'gpt-5-mini',
                 usable: false,
                 skip_reason: 'cooling down',
@@ -1394,7 +1403,7 @@ describe('MissionForm — execution plan', () => {
 
     expect(await screen.findByLabelText('Explore model')).toHaveTextContent('Auto (first usable)')
     fireEvent.click(screen.getByLabelText('Explore model'))
-    const option = await screen.findByRole('option', { name: /OpenAI gpt-5-mini - cooling down/ })
+    const option = await screen.findByRole('option', { name: /gpt-5-mini - cooling down/ })
     expect(option).toHaveAttribute('aria-disabled', 'true')
   })
 
@@ -1422,8 +1431,8 @@ describe('MissionForm — execution plan', () => {
     await screen.findByLabelText('Execute model')
 
     fireEvent.click(screen.getByLabelText('Execute model'))
-    fireEvent.click(await screen.findByRole('option', { name: 'Anthropic sonnet-5' }))
-    expect(screen.getByLabelText('Execute model')).toHaveTextContent('Anthropic sonnet-5')
+    fireEvent.click(await screen.findByRole('option', { name: 'sonnet-5' }))
+    expect(screen.getByLabelText('Execute model')).toHaveTextContent('sonnet-5')
 
     fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
     await waitFor(() =>
@@ -1455,12 +1464,12 @@ describe('MissionForm — execution plan', () => {
     await screen.findByLabelText('Execute model')
 
     fireEvent.click(screen.getByLabelText('Execute model'))
-    fireEvent.click(await screen.findByRole('option', { name: 'Anthropic sonnet-5' }))
-    expect(screen.getByLabelText('Execute model')).toHaveTextContent('Anthropic sonnet-5')
+    fireEvent.click(await screen.findByRole('option', { name: 'sonnet-5' }))
+    expect(screen.getByLabelText('Execute model')).toHaveTextContent('sonnet-5')
 
     fireEvent.click(screen.getByLabelText('Execute model'))
-    fireEvent.click(await screen.findByRole('option', { name: 'Auto (first usable)' }))
-    expect(screen.getByLabelText('Execute model')).toHaveTextContent('Auto (first usable)')
+    fireEvent.click(await screen.findByRole('option', { name: 'Autosonnet-5' }))
+    expect(screen.getByLabelText('Execute model')).toHaveTextContent('Autosonnet-5')
   })
 
   it('shows live default labels for plan, review, and escalation route selects', async () => {

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -605,7 +605,6 @@ export function MissionForm({
     const agent = agents.find((a) => a.id === id)
     if (agent) {
       setReviewRoute(agent.review_route ?? '')
-      if (agent.budget_usd != null) setBudget(String(agent.budget_usd))
     }
   }
 

--- a/web/src/components/missions/ResultSection.tsx
+++ b/web/src/components/missions/ResultSection.tsx
@@ -1,7 +1,7 @@
 import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import { CodeBlock } from '../CodeBlock'
 import { CopyButton } from '../Message'
+import { rehypePlugins, remarkPlugins } from '../../lib/markdown'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 
 // Uses CodeBlock (not the plain MarkdownPre) so fenced code gets the
@@ -21,7 +21,11 @@ export function ResultSection({ evidence }: { evidence: string }) {
           </Tooltip>
         </div>
         <div className="prose prose-sm max-w-none p-3 pt-1 dark:prose-invert">
-          <ReactMarkdown remarkPlugins={[remarkGfm]} components={{ pre: CodeBlock }}>
+          <ReactMarkdown
+            remarkPlugins={remarkPlugins}
+            rehypePlugins={rehypePlugins}
+            components={{ pre: CodeBlock }}
+          >
             {evidence}
           </ReactMarkdown>
         </div>

--- a/web/src/components/settings/presets.ts
+++ b/web/src/components/settings/presets.ts
@@ -213,10 +213,16 @@ export const providerPresets: ProviderPreset[] = [
   },
 ]
 
+// MatchPresetSource is the subset of a provider row matchPreset reads -
+// widened so it also accepts an ExecutionPlanEntry, which carries the
+// same driver/kind/base_url fields trimmed from the gateway resolve
+// response.
+export type MatchPresetSource = Pick<AdminProvider, 'kind' | 'driver' | 'base_url'>
+
 // matchPreset finds the preset a configured provider was (probably)
 // created from, for card branding: exact drivers first, then base_url
 // host, then the custom fallback.
-export function matchPreset(p: AdminProvider): ProviderPreset {
+export function matchPreset(p: MatchPresetSource): ProviderPreset {
   const custom = providerPresets.find((x) => x.id === 'custom')!
   // kind='cli' rows (D-051) are subscription auth, not a separate
   // preset per driver; branding folds into the matching CLI card

--- a/web/src/lib/markdown.test.tsx
+++ b/web/src/lib/markdown.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import ReactMarkdown from 'react-markdown'
+import { afterEach, describe, expect, it } from 'vitest'
+import { rehypePlugins, remarkPlugins } from './markdown'
+
+afterEach(cleanup)
+
+function renderMarkdown(text: string) {
+  return render(
+    <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
+      {text}
+    </ReactMarkdown>,
+  )
+}
+
+describe('shared markdown config', () => {
+  it('renders raw HTML img tags', () => {
+    renderMarkdown('<img src="https://example.com/x.png" alt="x">')
+    const img = screen.getByAltText('x')
+    expect(img).toHaveAttribute('src', 'https://example.com/x.png')
+  })
+
+  it('strips script tags', () => {
+    const { container } = renderMarkdown('<script>alert(1)</script>')
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  it('strips event handler attributes like onerror', () => {
+    const { container } = renderMarkdown('<img src=x onerror="alert(1)">')
+    const img = container.querySelector('img')
+    expect(img).not.toBeNull()
+    expect(img?.getAttribute('onerror')).toBeNull()
+  })
+
+  it('strips javascript: hrefs', () => {
+    const { container } = renderMarkdown('[click me](javascript:alert(1))')
+    const link = container.querySelector('a')
+    expect(link).not.toBeNull()
+    expect(link?.getAttribute('href')).toBeNull()
+  })
+
+  it('still tags fenced code blocks with a language-* className', () => {
+    const { container } = renderMarkdown('```typescript\nconst x = 1\n```')
+    const code = container.querySelector('code')
+    expect(code?.className).toContain('language-typescript')
+  })
+})

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -1,0 +1,20 @@
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
+import type { Options as SanitizeSchema } from 'rehype-sanitize'
+import remarkGfm from 'remark-gfm'
+import type { PluggableList } from 'unified'
+
+// Shared ReactMarkdown plugin config, used by every markdown call site.
+// rehypeRaw parses raw HTML nodes into the tree (react-markdown skips
+// them by default); rehypeSanitize then strips anything dangerous
+// (script tags, event handler attributes, javascript: URLs) before render.
+//
+// defaultSchema already covers what this app's markdown needs: `align`
+// and `width`/`height` are allowed on all elements (including p/img/td/th),
+// `code` keeps its `language-*` className (CodeBlock/mermaid detection
+// depends on this), and img `src` is restricted to http/https. Used as-is,
+// no extension needed.
+const schema: SanitizeSchema = defaultSchema
+
+export const remarkPlugins: PluggableList = [remarkGfm]
+export const rehypePlugins: PluggableList = [rehypeRaw, [rehypeSanitize, schema]]

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -175,6 +175,38 @@ describe('MissionDetail spend', () => {
     )
   })
 
+  it('uses the converted figure for budget percent when spend is in another currency', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, budget_amount: 2, budget_currency: 'BDT' })
+    vi.mocked(missionUsage).mockResolvedValue({
+      mission_id: 'm1',
+      cost_by_currency: { USD: 0.5 },
+      converted_cost_by_currency: { BDT: 1 },
+      input_tokens: 0,
+      output_tokens: 0,
+      requests: 7,
+      unpriced_requests: 0,
+      models: [],
+    })
+    renderPage()
+    expect(await screen.findByText('50% of budget')).toBeTruthy()
+  })
+
+  it('hides the budget badge when spend exists only in other currencies with no converted figure', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, budget_amount: 2, budget_currency: 'BDT' })
+    vi.mocked(missionUsage).mockResolvedValue({
+      mission_id: 'm1',
+      cost_by_currency: { USD: 0.5 },
+      input_tokens: 0,
+      output_tokens: 0,
+      requests: 7,
+      unpriced_requests: 0,
+      models: [],
+    })
+    renderPage()
+    await screen.findByText('7 calls')
+    expect(screen.queryByText(/% of budget/)).toBeNull()
+  })
+
   it('omits the provider brand mark for an unrecognized provider name', async () => {
     vi.mocked(missionUsage).mockResolvedValue({
       mission_id: 'm1',

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -70,6 +70,24 @@ function unbilledTooltipLine(usage: MissionUsage, currency: string): string | nu
   return `+${money(amount, currency)} unbilled`
 }
 
+// budgetPercentSpent figures the "% of budget" badge value in the
+// mission's own budget currency — prefers the currency-converted spend
+// figure (matching how the cost pills already display), falling back
+// to the raw same-currency amount. Returns null when spend in the
+// budget currency can't be stated at all (no converted figure and the
+// raw bucket is zero while spend exists in other currencies) — showing
+// 0% there would be dishonest, not just imprecise.
+function budgetPercentSpent(usage: MissionUsage, budgetCurrency: string, budgetAmount: number): number | null {
+  const converted = usage.converted_cost_by_currency?.[budgetCurrency]
+  const raw = usage.cost_by_currency[budgetCurrency]
+  const amount = converted ?? raw
+  const hasOtherSpend = Object.entries(usage.cost_by_currency).some(
+    ([currency, cost]) => currency !== budgetCurrency && cost > 0,
+  )
+  if ((amount == null || amount === 0) && hasOtherSpend) return null
+  return Math.round(((amount ?? 0) / budgetAmount) * 100)
+}
+
 function formatDate(v?: string): string {
   if (!v) return 'N/A'
   return new Date(v).toLocaleString()
@@ -766,16 +784,12 @@ export function MissionDetail() {
                   {usage.unpriced_requests} unpriced call{usage.unpriced_requests === 1 ? '' : 's'}
                 </Badge>
               )}
-              {mission.budget_amount != null && mission.budget_amount > 0 && (
-                <Badge variant="secondary">
-                  {Math.round(
-                    ((usage.cost_by_currency[mission.budget_currency ?? 'USD'] ?? 0) /
-                      mission.budget_amount) *
-                      100,
-                  )}
-                  % of budget
-                </Badge>
-              )}
+              {mission.budget_amount != null &&
+                mission.budget_amount > 0 &&
+                (() => {
+                  const pct = budgetPercentSpent(usage, mission.budget_currency ?? 'USD', mission.budget_amount)
+                  return pct == null ? null : <Badge variant="secondary">{pct}% of budget</Badge>
+                })()}
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary

- Raw HTML inside markdown (README-style img tags) now renders, sanitized, via one shared plugin config across all seven ReactMarkdown call sites (rehype-raw + rehype-sanitize; scripts, event handlers, and javascript: URLs stripped).
- Mission budgets apply only when set explicitly: the form no longer copies an agent's USD default into whatever currency is selected, and the server/scheduler fallbacks plus the agents.budget_usd field are removed end to end (0009 edited in place, pre-release convention).
- The % of budget badge prefers converted spend and hides instead of showing a false 0% when spend cannot be stated in the budget currency.
- Execution plan model selects show the provider mark plus model name (entries expose driver/kind/base_url from the gateway resolve); the Auto option shows what it currently resolves to.

Closes #390
Closes #391
Closes #392
Closes #393
Closes #394

## Test plan

- New unit tests: sanitized markdown rendering (img kept, script/onerror/javascript: stripped), budget percent conversion + hidden-badge case, empty budget on agent pick, Auto label fallback.
- `make build test vet lint` clean; web build/lint/test clean (943 tests).
- Verified locally against the failed BDT-budget mission and a README with inline HTML.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790645119&installation_model_id=431401&pr_number=395&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F395&signature=cfde9620efcfb2ff79ffd2dfef179e95afc302d23eac26ea00e8c85128f02b84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->