### PR TITLE
fix(web): native-platform vite build stage, pdfgen docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ PostgreSQL database + React web UI, run via Docker Compose
 | `searxng`    | Metasearch backend for search_web                                       |
 | `markitdown` | Python sidecar: file → markdown                                         |
 | `whisper`    | Python sidecar: local speech-to-text                                    |
+| `pdfgen`     | Python sidecar: markdown → PDF via Typst (mission export)               |
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ PostgreSQL database + React web UI, run via Docker Compose
 | `searxng`      | Internal metasearch backend for the search_web tool                                                            |
 | `markitdown`   | Internal Python sidecar (`markitdown-svc/`): file→markdown                                                     |
 | `whisper`      | Internal Python sidecar (`whisper-svc/`): local speech-to-text                                                 |
+| `pdfgen`       | Internal Python sidecar (`pdfgen-svc/`): markdown→PDF via Typst                                                |
 | (local models) | Native host Ollama at host.docker.internal:11434, registered as openaicompat provider                          |
 
 ## Commands
@@ -74,8 +75,8 @@ First run: `cp deploy/env.example deploy/.env` and set
   (hybrid vector+text+entity, RRF-fused).
 - `internal/platform/`: shared: `migrate`, `pgpool`, `sse`,
   `httpserver`, `metrics`, `logging`, `config`, `service`, `netguard`
-  (SSRF-guarded outbound dialer), `markitdown`, `whisper` (sidecar
-  clients).
+  (SSRF-guarded outbound dialer), `markitdown`, `whisper`, `pdfgen`
+  (sidecar clients).
 - `migrations/`: numbered idempotent SQL, embedded via `embed.go`;
   never edit an applied migration.
 - `skills/`: skill packs baked into the brain image.
@@ -114,6 +115,12 @@ First run: `cp deploy/env.example deploy/.env` and set
   cache stability), markdown stored in the `attachments` jsonb column,
   rendered neutralized into every prompt; capped at 8; API responses
   strip the markdown. Images/audio unsupported.
+- PDF export: POST /v1/missions/{id}/export-pdf renders workspace
+  markdown (single file, or all files merged book-style) through
+  `internal/brain/pdfgen`, which caches by content hash in
+  `pdf_renders` and stores output via the attachment store; enabled
+  only when PDFGEN_URL is set (derived read-only setting
+  `pdf_export_enabled`).
 - Mission display names: generated fire-and-forget at create
   (`chat.TitleOverGateway`), backfilled once at terminal transition
   (`Driver.SetNameMission`) if still empty.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Go microservices behind a single public API, one PostgreSQL database, React web 
 | `searxng`    | Internal metasearch backend for the search_web tool                                           |
 | `markitdown` | Internal Python sidecar: file→markdown conversion                                             |
 | `whisper`    | Internal Python sidecar: local speech-to-text for the web mic button (opt-in, off by default) |
+| `pdfgen`     | Internal Python sidecar: markdown→PDF via Typst, powers mission PDF export                    |
 
 Plus Postgres (18 + pgvector), internal only, no host port. Migrations are embedded in each Go binary and applied automatically at startup; there's no separate migrate command. Every Go service exposes `GET /health` and `GET /metrics`.
 
@@ -161,7 +162,7 @@ make logs    # follow logs for all services
 Rebuild and restart a single service after a code change:
 
 ```sh
-make brain      # or gateway, memoryd, web, markitdown, whisper, sandboxd
+make brain      # or gateway, memoryd, web, markitdown, whisper, pdfgen, sandboxd
 ```
 
 ### Backups
@@ -206,4 +207,4 @@ Design decisions are documented as `D-0XX` markers in code comments next to the 
 
 ## License
 
-[AGPL-3.0](LICENSE).
+[AGPL-3.0](LICENSE)

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -2,7 +2,11 @@
 # Production web image: Vite build served by unprivileged nginx.
 # The HugeIcons Pro registry token is consumed as a BuildKit secret so
 # it never lands in an image layer or the build history.
-FROM node:24.18.0-alpine AS build
+# --platform=$BUILDPLATFORM: the Vite dist output is arch-independent,
+# so the build stage always runs natively. Running node under qemu for
+# the arm64 leg crashed with illegal-instruction core dumps and hung
+# release builds for hours.
+FROM --platform=$BUILDPLATFORM node:24.18.0-alpine AS build
 ARG GIT_SHA
 ARG APP_VERSION
 ENV GIT_SHA=${GIT_SHA}


### PR DESCRIPTION
## Summary

- The arm64 web image leg ran node under qemu and crashed with illegal-instruction core dumps during npm ci, hanging release builds until the 6h workflow timeout (both alpha.62 attempts). Vite's dist output is arch-independent, so the build stage now pins `--platform=$BUILDPLATFORM` and only the nginx stage varies per arch.
- Adds the pdfgen sidecar to the service tables in README/CLAUDE.md/AGENTS.md and documents the mission PDF export flow.

## Test plan

- Local `docker build` of web/ passes with the pinned build stage.
- Real proof is the release workflow on the re-tagged v0.1.0-alpha.62 after merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790677238&installation_model_id=431401&pr_number=397&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F397&signature=03ab7b67b57d1628c8c7cc0d1f2f806cc229be3e0714219b01c56ca7e79a713c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->