### PR TITLE
feat: generate_pdf builtin tool and single-message pdf export

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -608,6 +608,23 @@ func main() {
 		}
 	}
 
+	// generate_pdf: registered here, not inside buildAgent, since it
+	// needs pdfService (built above, after buildAgent). Nil-gated on
+	// pdfService, which is itself nil-gated on PDFGEN_URL and
+	// attachmentStore — no separate media-saver wiring needed, it rides
+	// the same agent.SetMediaSaver call share_file just made.
+	if pdfService != nil {
+		generatePDFTool := builtin.GeneratePDF(pdfService)
+		current := builtinSet.add(generatePDFTool)
+		if conns != nil {
+			swapAgentTools(agent, current, conns, app.Log, toolCalls)
+		} else if constrained, defs, err := compileToolset(current, nil, app.Log, toolCalls); err != nil {
+			app.Log.Warn("generate_pdf tool registration failed; agent keeps its previous tool surface", "error", err)
+		} else {
+			agent.SwapTools(constrained, defs)
+		}
+	}
+
 	// Mission artifact copy: registered here for the same reason
 	// share_file is — needs attachmentStore, built after buildMissions.
 	// Nil-gated on both attachmentStore (ATTACHMENTS_DIR) and

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -82,6 +82,11 @@ type API struct {
 	// validating a knowledge PUT/chat request's names — nil when KB is
 	// disabled (no kb.Store wired), rejecting any non-empty Knowledge.
 	kbCollections func(ctx context.Context) ([]kb.Collection, error)
+
+	// pdfService backs POST /v1/chat/export-pdf (single assistant
+	// message export, #380) — nil-gated the same way missionAPI's
+	// pdfService is (PDFGEN_URL unset or attachments disabled).
+	pdfService *pdfgen.Service
 }
 
 // memoryRoutePatterns is the EXHAUSTIVE list of memoryd routes brain
@@ -103,7 +108,7 @@ var memoryRoutePatterns = []string{
 // connector control plane (nil leaves any of them unmounted).
 // whisperURL empty leaves /v1/transcribe unmounted (WHISPER_URL unset).
 func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, msft *connectors.Microsoft, secrets *secretstore.Store, toolset Toolset, packs []skills.Skill, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, resolveRoute func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, markitdownURL string, token string, log *slog.Logger, gwSecrets GatewaySecrets, kbStore *kb.Store, kbIngest kbIngester, kbClassify kbClassifier, kbTitle kbTitler, destinationStore *destinations.Store, destinationTest destinationTester, workflowStore *workflows.Store, workflowEngine *workflows.Engine, pdfService *pdfgen.Service) {
-	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log, flags: flags, rates: rates}
+	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log, flags: flags, rates: rates, pdfService: pdfService}
 	if kbStore != nil {
 		a.kbCollections = kbStore.ListCollections
 	}
@@ -193,6 +198,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	srv.Handle("GET /v1/permissions/pending", a.auth(http.HandlerFunc(a.handlePendingPermissions)))
 	// Deprecated shim: same behavior, session_id in the body.
 	srv.Handle("POST /v1/chat", a.auth(http.HandlerFunc(a.handleChatShim)))
+	srv.Handle("POST /v1/chat/export-pdf", a.auth(http.HandlerFunc(a.handleExportMessagePDF)))
 }
 
 // handlePermission answers a parked tool call: {decision: once|session|deny}.

--- a/internal/brain/api/chat_export.go
+++ b/internal/brain/api/chat_export.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/SumonMSelim/timothy/internal/brain/pdfgen"
+	pdfgenclient "github.com/SumonMSelim/timothy/internal/platform/pdfgen"
+)
+
+// handleExportMessagePDF serves POST /v1/chat/export-pdf: renders one
+// already-rendered assistant message (title + markdown content, both
+// supplied by the client — the message never left the transcript the
+// client already holds) into a single-chapter PDF, no cover page or
+// TOC. Returns the rendered attachment id; the client downloads it via
+// GET /v1/attachments/{id}.
+func (a *API) handleExportMessagePDF(w http.ResponseWriter, r *http.Request) {
+	if a.pdfService == nil {
+		jsonError(w, http.StatusServiceUnavailable, "not_enabled", "pdf generation is not enabled")
+		return
+	}
+	var body struct {
+		Title   string `json:"title"`
+		Content string `json:"content"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", "body must be JSON with a content field")
+		return
+	}
+	if body.Content == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "content is empty")
+		return
+	}
+	if len(body.Content) > maxExportMarkdownBytes {
+		jsonError(w, http.StatusRequestEntityTooLarge, "too_large", fmt.Sprintf("content exceeds %d bytes", maxExportMarkdownBytes))
+		return
+	}
+	title := body.Title
+	if title == "" {
+		title = "Message"
+	}
+
+	docs := []pdfgenclient.Document{{Title: title, Content: body.Content}}
+	result, err := a.pdfService.Render(r.Context(), docs, pdfgenclient.Options{})
+	if err != nil {
+		if errors.Is(err, pdfgen.ErrNotEnabled) {
+			jsonError(w, http.StatusServiceUnavailable, "not_enabled", "pdf generation is not enabled")
+			return
+		}
+		jsonError(w, http.StatusBadGateway, "export_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"attachment_id": result.AttachmentID, "cached": result.Cached})
+}

--- a/internal/brain/api/chat_export_test.go
+++ b/internal/brain/api/chat_export_test.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/pdfgen"
+	pdfgenclient "github.com/SumonMSelim/timothy/internal/platform/pdfgen"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+func TestExportMessagePDFNotEnabled(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+
+	w := do(a, a.handleExportMessagePDF, "POST", "/v1/chat/export-pdf", "Bearer tok", `{"title":"Reply","content":"# hi"}`)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("code = %d, want 503", w.Code)
+	}
+	var body struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error != "not_enabled" {
+		t.Fatalf("error = %q, want not_enabled", body.Error)
+	}
+}
+
+func TestExportMessagePDFValidation(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	// A real (non-nil) Service is required so the handler's own content
+	// validation runs before the not_enabled short-circuit; it's never
+	// actually called against the sidecar since every case here is
+	// rejected before Render.
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	a.pdfService = pdfgen.New(pdfgenclient.New("http://invalid"), pool, nil)
+
+	t.Run("bad json", func(t *testing.T) {
+		w := do(a, a.handleExportMessagePDF, "POST", "/v1/chat/export-pdf", "Bearer tok", `{`)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("code = %d, want 400", w.Code)
+		}
+	})
+
+	t.Run("empty content", func(t *testing.T) {
+		w := do(a, a.handleExportMessagePDF, "POST", "/v1/chat/export-pdf", "Bearer tok", `{"title":"Reply"}`)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("code = %d, want 400", w.Code)
+		}
+	})
+
+	t.Run("oversize content", func(t *testing.T) {
+		body := `{"content":"` + strings.Repeat("x", maxExportMarkdownBytes+1) + `"}`
+		w := do(a, a.handleExportMessagePDF, "POST", "/v1/chat/export-pdf", "Bearer tok", body)
+		if w.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("code = %d, want 413", w.Code)
+		}
+	})
+}

--- a/internal/brain/tools/builtin/generatepdf.go
+++ b/internal/brain/tools/builtin/generatepdf.go
@@ -1,0 +1,118 @@
+package builtin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	pdfgenclient "github.com/SumonMSelim/timothy/internal/platform/pdfgen"
+
+	"github.com/SumonMSelim/timothy/internal/brain/pdfgen"
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+type generatePDFDocument struct {
+	Title   string `json:"title"`
+	Content string `json:"content"`
+}
+
+type generatePDFArgs struct {
+	Documents  []generatePDFDocument `json:"documents"`
+	CoverTitle string                `json:"cover_title"`
+	TOC        bool                  `json:"toc"`
+}
+
+// GeneratePDF renders one or more markdown documents into a typeset PDF
+// via the pdfgen sidecar and publishes it to the user as generated
+// media, the same way share_file does. Pass one document for a plain
+// PDF; pass several with toc:true and a cover_title for a book-style
+// merged PDF (one chapter per document).
+func GeneratePDF(svc *pdfgen.Service) *tools.Tool {
+	return &tools.Tool{
+		Name: "generate_pdf",
+		Description: `Renders markdown document(s) into a typeset PDF and publishes it to the user as a downloadable file.
+
+Arguments:
+- documents (array, required): one or more {"title", "content"} pairs,
+  content as markdown. Each document becomes one chapter.
+- cover_title (string, optional): adds a cover page with this title.
+- toc (boolean, optional): adds a table of contents. Meaningful with
+  multiple documents.
+
+Pass a single document for a plain PDF. Pass several with toc:true and
+a cover_title for a book-style merged PDF.
+
+Returns a confirmation naming the stored id. Identical input returns
+the same cached PDF without regenerating it.
+
+Example: {"documents": [{"title": "Report", "content": "# Report\n..."}]}`,
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"documents": {
+					"type": "array",
+					"minItems": 1,
+					"items": {
+						"type": "object",
+						"properties": {
+							"title": {"type": "string"},
+							"content": {"type": "string"}
+						},
+						"required": ["title", "content"],
+						"additionalProperties": false
+					}
+				},
+				"cover_title": {
+					"type": "string",
+					"description": "Optional cover page title"
+				},
+				"toc": {
+					"type": "boolean",
+					"description": "Optional table of contents"
+				}
+			},
+			"required": ["documents"],
+			"additionalProperties": false
+		}`),
+		Execute: func(ctx context.Context, raw json.RawMessage) (string, error) {
+			if svc == nil {
+				return "", fmt.Errorf("generate_pdf is not configured")
+			}
+			var args generatePDFArgs
+			if err := json.Unmarshal(raw, &args); err != nil {
+				return "", fmt.Errorf("invalid arguments: %w", err)
+			}
+			if len(args.Documents) == 0 {
+				return "", fmt.Errorf("documents is empty")
+			}
+			docs := make([]pdfgenclient.Document, len(args.Documents))
+			for i, d := range args.Documents {
+				if d.Content == "" {
+					return "", fmt.Errorf("document %d: content is empty", i)
+				}
+				docs[i] = pdfgenclient.Document{Title: d.Title, Content: d.Content}
+			}
+			opts := pdfgenclient.Options{CoverTitle: args.CoverTitle, TOC: args.TOC}
+
+			result, err := svc.Render(ctx, docs, opts)
+			if err != nil {
+				return "", fmt.Errorf("render pdf: %w", err)
+			}
+
+			collector := tools.CollectorFrom(ctx)
+			if collector == nil {
+				return "", fmt.Errorf("media emission is not configured")
+			}
+			name := args.CoverTitle
+			if name == "" {
+				name = args.Documents[0].Title
+			}
+			ref, err := collector.Emit(ctx, name+".pdf", bytes.NewReader(result.PDF))
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("generated %q as %s (%s)", name, ref.ID, ref.Mime), nil
+		},
+	}
+}

--- a/internal/brain/tools/builtin/generatepdf_integration_test.go
+++ b/internal/brain/tools/builtin/generatepdf_integration_test.go
@@ -1,0 +1,104 @@
+//go:build integration
+
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/attachments"
+	"github.com/SumonMSelim/timothy/internal/brain/pdfgen"
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+	pdfgenclient "github.com/SumonMSelim/timothy/internal/platform/pdfgen"
+	"github.com/SumonMSelim/timothy/internal/platform/migrate"
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+	"github.com/SumonMSelim/timothy/migrations"
+)
+
+func integrationPDFService(t *testing.T) *pdfgen.Service {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	poolCtx, poolCancel := context.WithCancel(context.Background())
+	t.Cleanup(poolCancel)
+	pool := pgpool.New(poolCtx, dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("%PDF-1.4 fake"))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := pdfgenclient.New(srv.URL)
+	att := attachments.New(t.TempDir(), pool)
+	return pdfgen.New(client, pool, att)
+}
+
+func TestGeneratePDFEmitsMediaRef(t *testing.T) {
+	svc := integrationPDFService(t)
+	tool := GeneratePDF(svc)
+
+	collector := tools.NewCollector(func(_ context.Context, r io.Reader) (string, string, error) {
+		data, err := io.ReadAll(r)
+		if err != nil {
+			return "", "", err
+		}
+		return string(data), "application/pdf", nil
+	})
+	ctx := tools.WithCollector(context.Background(), collector)
+
+	args, _ := json.Marshal(generatePDFArgs{
+		Documents: []generatePDFDocument{{Title: "Chapter 1", Content: "# unique-" + t.Name()}},
+	})
+	out, err := tool.Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "Chapter 1") {
+		t.Fatalf("out = %q, want it to name the document", out)
+	}
+
+	refs := collector.Drain()
+	if len(refs) != 1 {
+		t.Fatalf("refs = %d, want 1", len(refs))
+	}
+	if refs[0].Name != "Chapter 1.pdf" {
+		t.Fatalf("ref name = %q, want %q", refs[0].Name, "Chapter 1.pdf")
+	}
+}
+
+func TestGeneratePDFNoCollectorConfigured(t *testing.T) {
+	svc := integrationPDFService(t)
+	tool := GeneratePDF(svc)
+
+	args, _ := json.Marshal(generatePDFArgs{
+		Documents: []generatePDFDocument{{Title: "A", Content: "# unique-" + t.Name()}},
+	})
+	if _, err := tool.Execute(context.Background(), args); err == nil {
+		t.Fatal("missing collector accepted")
+	}
+}

--- a/internal/brain/tools/builtin/generatepdf_test.go
+++ b/internal/brain/tools/builtin/generatepdf_test.go
@@ -1,0 +1,43 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+func TestGeneratePDFNilService(t *testing.T) {
+	tool := GeneratePDF(nil)
+	ctx := tools.WithCollector(context.Background(), tools.NewCollector(fakeSaver(0)))
+	args, _ := json.Marshal(generatePDFArgs{Documents: []generatePDFDocument{{Title: "A", Content: "hello"}}})
+	if _, err := tool.Execute(ctx, args); err == nil {
+		t.Fatal("nil service accepted")
+	}
+}
+
+func TestGeneratePDFValidation(t *testing.T) {
+	tool := GeneratePDF(nil)
+	ctx := tools.WithCollector(context.Background(), tools.NewCollector(fakeSaver(0)))
+
+	t.Run("empty documents", func(t *testing.T) {
+		args, _ := json.Marshal(generatePDFArgs{})
+		if _, err := tool.Execute(ctx, args); err == nil {
+			t.Fatal("empty documents accepted")
+		}
+	})
+
+	t.Run("empty content", func(t *testing.T) {
+		args, _ := json.Marshal(generatePDFArgs{Documents: []generatePDFDocument{{Title: "A", Content: ""}}})
+		if _, err := tool.Execute(ctx, args); err == nil {
+			t.Fatal("empty content accepted")
+		}
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		if _, err := tool.Execute(ctx, json.RawMessage(`{`)); err == nil {
+			t.Fatal("invalid json accepted")
+		}
+	})
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1569,6 +1569,20 @@ export async function downloadMissionPdfExport(attachmentId: string, filename: s
   return fetchBlobDownload(`/v1/attachments/${attachmentId}`, filename)
 }
 
+// exportMessagePDF renders one chat message's already-rendered markdown
+// into a single-chapter PDF via the pdfgen sidecar. The message content
+// travels in the body — it's already in the transcript the client
+// holds, no server-side lookup needed.
+export async function exportMessagePDF(
+  title: string,
+  content: string,
+): Promise<{ attachment_id: string; cached: boolean }> {
+  return request<{ attachment_id: string; cached: boolean }>('/v1/chat/export-pdf', {
+    method: 'POST',
+    body: JSON.stringify({ title, content }),
+  })
+}
+
 // --- schedules (recurring cron triggers that fire mission templates) ---
 
 export interface CreateScheduleInput {

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -6,6 +6,9 @@ import { AssistantMessage, CompactionDivider, ErrorMessage, InterruptedMessage, 
 
 vi.mock('../api/client', () => ({
   fetchAttachmentBlob: vi.fn(),
+  getSettings: vi.fn().mockResolvedValue({ settings: {}, values: {} }),
+  exportMessagePDF: vi.fn(),
+  downloadMissionPdfExport: vi.fn(),
 }))
 
 afterEach(cleanup)
@@ -279,6 +282,54 @@ describe('copy buttons', () => {
     const msg = play([{ type: 'chunk', text: 'partial' }])
     render(<AssistantMessage msg={msg} />)
     expect(screen.queryByTestId('copy-button')).toBeNull()
+  })
+
+  it('hides the export PDF button when pdf export is disabled', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.getSettings).mockResolvedValue({ settings: {}, values: {} })
+    const msg = play([
+      { type: 'chunk', text: 'the answer' },
+      { type: 'meta', session_id: 's' },
+    ])
+    render(<AssistantMessage msg={msg} />)
+    await waitFor(() => expect(client.getSettings).toHaveBeenCalled())
+    expect(screen.queryByTestId('export-pdf-button')).not.toBeInTheDocument()
+  })
+
+  it('shows the export PDF button and downloads the render when pdf export is enabled', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.getSettings).mockResolvedValue({
+      settings: { pdf_export_enabled: true },
+      values: {},
+    })
+    vi.mocked(client.exportMessagePDF).mockResolvedValue({ attachment_id: 'att-1', cached: false })
+    vi.mocked(client.downloadMissionPdfExport).mockResolvedValue(undefined)
+
+    const msg = play([
+      { type: 'chunk', text: 'the answer' },
+      { type: 'meta', session_id: 's' },
+    ])
+    render(<AssistantMessage msg={msg} />)
+
+    const btn = await screen.findByTestId('export-pdf-button')
+    fireEvent.click(btn)
+
+    await waitFor(() => expect(client.exportMessagePDF).toHaveBeenCalledWith('Message', 'the answer'))
+    await waitFor(() =>
+      expect(client.downloadMissionPdfExport).toHaveBeenCalledWith('att-1', 'message.pdf'),
+    )
+  })
+
+  it('hides the export PDF button while streaming even when enabled', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.getSettings).mockResolvedValue({
+      settings: { pdf_export_enabled: true },
+      values: {},
+    })
+    const msg = play([{ type: 'chunk', text: 'partial' }])
+    render(<AssistantMessage msg={msg} />)
+    await waitFor(() => expect(client.getSettings).toHaveBeenCalled())
+    expect(screen.queryByTestId('export-pdf-button')).not.toBeInTheDocument()
   })
 
   it('copies the interrupted partial text', () => {

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -13,12 +13,19 @@ import {
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
-import { fetchAttachmentBlob } from '../api/client'
+import { toast } from 'sonner'
+import {
+  downloadMissionPdfExport,
+  exportMessagePDF,
+  fetchAttachmentBlob,
+  getSettings,
+} from '../api/client'
 import type { ImageRef, MediaRef } from '../api/types'
 import { ActivityLine } from './Activity'
 import { AttachmentViewer, mimeLabel } from './AttachmentViewer'
 import { CodeBlock } from './CodeBlock'
 import { ModelBadge } from './ModelBadge'
+import { errText } from './settings/util'
 import { Badge } from './ui/badge'
 import { collapseRepeatedTail, splitSources } from '../lib/citations'
 import { attachmentURLCache } from '../lib/attachmentCache'
@@ -274,6 +281,33 @@ export function CopyButton({
   )
 }
 
+// ExportPDFButton renders a completed assistant message's markdown as
+// a typeset PDF via the pdfgen sidecar and downloads it. Only mounted
+// when pdf_export_enabled — the caller decides that, this component
+// just renders the button.
+function ExportPDFButton({ text }: { text: string }) {
+  const [exporting, setExporting] = useState(false)
+  const exportPdf = () => {
+    setExporting(true)
+    exportMessagePDF('Message', text)
+      .then((r) => downloadMissionPdfExport(r.attachment_id, 'message.pdf'))
+      .catch((err: unknown) => toast.error('Could not export PDF', { description: errText(err) }))
+      .finally(() => setExporting(false))
+  }
+  return (
+    <button
+      type="button"
+      aria-label="Export PDF"
+      data-testid="export-pdf-button"
+      disabled={exporting}
+      onClick={exportPdf}
+      className="rounded p-1 text-muted-foreground opacity-0 transition hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover/message:opacity-100 disabled:opacity-50"
+    >
+      <HugeiconsIcon icon={exporting ? Loading03Icon : Pdf02Icon} className={cn('size-3.5', exporting && 'animate-spin')} />
+    </button>
+  )
+}
+
 export function UserMessage({
   text,
   images,
@@ -430,6 +464,12 @@ export function AssistantMessage({
   // doesn't render (there's nowhere for it to open).
   onShowActivity?: () => void
 }) {
+  const [pdfExportEnabled, setPdfExportEnabled] = useState(false)
+  useEffect(() => {
+    getSettings()
+      .then((s) => setPdfExportEnabled(s.settings.pdf_export_enabled ?? false))
+      .catch(() => setPdfExportEnabled(false))
+  }, [])
   const tokens = msg.meta?.usage
     ? `${compact(msg.meta.usage.input_tokens)}→${compact(msg.meta.usage.output_tokens)} tok`
     : null
@@ -534,6 +574,7 @@ export function AssistantMessage({
             </div>
           )}
           {msg.text !== '' && <CopyButton text={msg.text} label="Copy reply" />}
+          {msg.text !== '' && pdfExportEnabled && <ExportPDFButton text={msg.text} />}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Why

Closes #381 and #380, the two remaining document-generation tickets after the pdfgen sidecar (#386) and mission export (#389).

## What

- `generate_pdf` builtin tool (`internal/brain/tools/builtin/generatepdf.go`): renders one or more markdown documents via the `internal/brain/pdfgen.Service` (content-hash cache, shared with mission export) and publishes the PDF as generated media through `tools.Collector.Emit`, same wiring as `share_file`. Registered in `cmd/brain/main.go` right after `share_file`, nil-gated on `pdfService`. Rides the normal permission chain (not exempt) — it writes to the attachment store.
- `POST /v1/chat/export-pdf`: renders a single chat message (title + markdown content, both supplied by the client since the message already lives in the transcript) into a single-chapter PDF. No session/event lookup needed.
- Chat UI: "Export PDF" action next to the copy button on completed assistant messages, gated on the existing `pdf_export_enabled` derived setting and hidden while streaming.

## Verification

- `make build test vet lint` — green
- `go vet -tags integration ./...` — green
- New integration tests for `generate_pdf` (real pdfgen.Service against a test Postgres + fake sidecar HTTP server) — not run in this environment (needs `DATABASE_URL`), skip-gated the same way existing pdfgen integration tests are
- `docker compose ... web-dev npm run build && npm run lint && npm test` — green, 946 tests passing

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790681001&installation_model_id=431401&pr_number=398&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F398&signature=3b18e1efea8df6b6c340dfa413cfea8b33a692568f082151de9185fbad61695b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->