### PR TITLE
test(api): use errRunner in resumable-mission resume tests

### DIFF
--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -129,7 +129,11 @@ func TestMissionsResumeWithAnswerReachesWorker(t *testing.T) {
 		t.Fatalf("ApplyTransition: %v", err)
 	}
 
-	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	// Signal(InputResume) below fires Drive in a background goroutine
+	// that outlives this test; a nil runner panics there once it
+	// reaches runExecute, surfacing as an async crash during package
+	// teardown instead of a normal test failure.
+	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
 	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
@@ -197,7 +201,9 @@ func TestMissionsResumeWithoutAnswerLeavesProgressUntouched(t *testing.T) {
 		t.Fatalf("ApplyTransition: %v", err)
 	}
 
-	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	// Signal(InputResume) fires Drive in a background goroutine that
+	// outlives this test (same reason as TestMissionsResumeWithAnswerReachesWorker).
+	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
 	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)


### PR DESCRIPTION
## Why

Closes #396.

The audit of all 30 `pgpool.New(t.Context())` sites in `internal/` found every DB-writing cleanup already migrated by the prior fixes (#389, #395 and incremental commits), using one of three safe patterns: one-shot `pgx.Connect(context.Background())` inside the cleanup, `defer` while the pool is still alive, or no DB-writing cleanup at all. No pool changes needed.

The remaining defect was the nil-runner panic observed during api package teardown: `Driver.Signal(InputResume)` fires `Drive` in a detached goroutine that outlives the test, and `runExecute` calls `d.runner.RunWorker` unconditionally. Two resume tests parked a mission in a resumable state with a nil runner instead of the file's established `errRunner{}` fake, so the panic surfaced asynchronously during teardown instead of as a test failure.

## Changes

- `internal/brain/api/missions_integration_test.go`: both resume tests now build the driver with `errRunner{}`, matching the seven sibling tests in the same file.

## Verification

- `go build ./...`, `go vet ./...`, `go vet -tags integration ./...` all clean (containerized golang:1.26.6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790683487&installation_model_id=431401&pr_number=399&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F399&signature=56cb3e53990b35c64d3dbdb0564d19c525a28081ea0d79c138193c5d9413355b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->