### PR TITLE
feat(missions): per-turn tool-call trace events and UI view

### DIFF
--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -23,7 +23,7 @@ import (
 )
 
 // ErrModelFloor reports that a mission turn was served by a model on
-// the runner's deny list — a fallback too weak to drive tool-using
+// the runner's deny list: a fallback too weak to drive tool-using
 // agentic turns. The driver pauses the mission immediately (infra)
 // instead of burning its iteration budget on a model that cannot
 // succeed.
@@ -31,18 +31,18 @@ var ErrModelFloor = errors.New("mission turn served by a below-floor model")
 
 // GatekeeperState is whatever a reviewer session needs to resume
 // in-memory for a delta recheck on rework, instead of cold-reanalyzing
-// from scratch. Acceptable to lose on restart — a cold reviewer just
+// from scratch. Acceptable to lose on restart: a cold reviewer just
 // re-checks everything, which is safe, just slower.
 type GatekeeperState struct {
 	Messages []provider.Message
 }
 
 // Runner executes ONE session (worker turn, reviewer turn, or planner
-// turn) and owns NO state-transition logic — it reports what happened,
+// turn) and owns NO state-transition logic: it reports what happened,
 // Driver decides what it means. A future delegated CLI executor would
 // be an alternate Runner implementation; Phase 1 ships exactly one:
 // nativeRunner, backed by loop.Agent. This interface is kept minimal
-// on purpose — no executor-selection abstraction is built until a
+// on purpose: no executor-selection abstraction is built until a
 // second implementation actually needs one.
 type Runner interface {
 	// RunWorker seeds a FRESH session from packet, runs it to
@@ -52,8 +52,8 @@ type Runner interface {
 	RunWorker(ctx context.Context, m Mission, packet WorkPacket) (WorkerVerdict, string, error)
 
 	// RunReview resumes (or starts, on the first round) the gatekeeper
-	// session, judging the packet — goal, plan, harness-read artifact
-	// contents, diff, evidence — and returns the verdict.
+	// session, judging the packet: goal, plan, harness-read artifact
+	// contents, diff, evidence: and returns the verdict.
 	RunReview(ctx context.Context, m Mission, packet ReviewPacket, gatekeeper *GatekeeperState) (ReviewVerdict, *GatekeeperState, error)
 
 	// PlanSession runs the planning turn that produces a Spec (the list
@@ -62,21 +62,21 @@ type Runner interface {
 
 	// ExploreSession runs the explore turn: a tool-using session that
 	// explores the workspace and (via base tools) the web, ending with an
-	// explore_notes sentinel call. Exploration is advisory — a turn that
+	// explore_notes sentinel call. Exploration is advisory: a turn that
 	// never produces the sentinel degrades to the raw turn text rather
 	// than failing the phase.
 	ExploreSession(ctx context.Context, m Mission) (string, error)
 }
 
 // agentStream is the narrow slice of *loop.Agent nativeRunner actually
-// calls — kept as an interface so tests can fake it without
+// calls: kept as an interface so tests can fake it without
 // constructing a full production Agent (permissions, audit, outputs,
 // event log).
 type agentStream interface {
 	Start(ctx context.Context, req loop.Request) (<-chan stream.StreamEvent, error)
 }
 
-// StorePermissionParker adapts *Store to parkNotifier — the production
+// StorePermissionParker adapts *Store to parkNotifier: the production
 // implementation NewNativeRunner is constructed with. Errors are
 // logged, never returned: a failed park/clear write must not abort the
 // turn it's reporting on.
@@ -105,7 +105,7 @@ func (p *StorePermissionParker) OnPermissionCleared(ctx context.Context, mission
 
 // OnPermissionDenied records that a tool call was denied (D-039: most
 // often the automatic unattended-turn denial, but any denied result
-// qualifies) — best-effort, same stance as OnPermissionParked/Cleared:
+// qualifies): best-effort, same stance as OnPermissionParked/Cleared:
 // a failed append logs and never aborts the turn it's reporting on.
 func (p *StorePermissionParker) OnPermissionDenied(ctx context.Context, missionID, tool, digest string) {
 	if err := p.Store.AppendEvent(ctx, missionID, "mission.permission_denied", map[string]any{
@@ -115,8 +115,21 @@ func (p *StorePermissionParker) OnPermissionDenied(ctx context.Context, missionI
 	}
 }
 
+// OnToolCall records one tool call from a worker/explore/plan/review
+// turn as a mission.tool_call event (issue #369): the UI's per-turn
+// trace reads these back grouped by phase, alongside the mission.turn
+// event the same runTurn call eventually produces. Best-effort like
+// the other parkNotifier methods.
+func (p *StorePermissionParker) OnToolCall(ctx context.Context, missionID, phase, tool, digest, status string, durationMs int64) {
+	if err := p.Store.AppendEvent(ctx, missionID, "mission.tool_call", map[string]any{
+		"phase": phase, "tool": tool, "args_digest": digest, "status": status, "duration_ms": durationMs,
+	}); err != nil {
+		p.Log.Error("mission: record tool call failed", "mission_id", missionID, "error", err)
+	}
+}
+
 // parkNotifier reports a mission turn parking on (and later clearing)
-// a tool-call permission prompt — without this, the same interactive
+// a tool-call permission prompt: without this, the same interactive
 // broker chat sessions use silently strands a mission worker turn for
 // the full 10-minute timeout with nothing telling the UI a decision is
 // needed. Backed by *Store in production (SetPendingPermission /
@@ -128,13 +141,18 @@ type parkNotifier interface {
 	// most often the unattended-turn automatic denial (D-039), but any
 	// denial qualifies. Best-effort like the two methods above.
 	OnPermissionDenied(ctx context.Context, missionID, tool, digest string)
+	// OnToolCall reports every tool call a worker/explore/plan/review
+	// turn made, in call order: the trace the mission detail UI shows
+	// per turn (issue #369). Best-effort, same stance as the methods
+	// above.
+	OnToolCall(ctx context.Context, missionID, phase, tool, digest, status string, durationMs int64)
 }
 
 // sandboxExec is the narrow slice of *sandboxclient.Client nativeRunner
-// needs — kept as a function type (not an import of sandboxclient) so
+// needs: kept as a function type (not an import of sandboxclient) so
 // missions has no compile-time dependency on Docker; the driver wires
 // the real *sandboxclient.Client.Exec in cmd/brain/main.go. environment
-// selects the mission's sandbox image (D-05x) — only matters on the
+// selects the mission's sandbox image (D-05x): only matters on the
 // mission's first exec, since a container's image is fixed once
 // created.
 type sandboxExec func(ctx context.Context, missionID, environment, workdir, command string, timeout time.Duration, out io.Writer) (exitCode int, err error)
@@ -155,19 +173,19 @@ type nativeRunner struct {
 	// Docker container instead of brain's own process.
 	sandbox sandboxExec
 	// kbSearch backs the per-turn search_kb ExtraTool (see kbSearchTool)
-	// — nil means search_kb is never offered on any mission turn,
+	//: nil means search_kb is never offered on any mission turn,
 	// regardless of a mission's own Knowledge snapshot (same "the
 	// dependency's absence turns the feature off entirely" contract as
 	// chat.go's SetKBSearch).
 	kbSearch KBSearchFunc
 
-	// kbRead backs the per-turn read_kb ExtraTool — same nil contract
+	// kbRead backs the per-turn read_kb ExtraTool: same nil contract
 	// as kbSearch.
 	kbRead KBReadFunc
 
 	// connectorReads resolves a mission's agent to the read-only
 	// connector tools (gmail/calendar reads) it may use on worker/explore
-	// turns (see SetConnectorReads) — nil-safe: unset means no connector
+	// turns (see SetConnectorReads): nil-safe: unset means no connector
 	// reads are offered, same as before this existed.
 	connectorReads ConnectorReadsResolver
 
@@ -261,13 +279,13 @@ func countOperatorNotes(notes []ProgressNote) int {
 }
 
 // ConnectorReadsResolver resolves an agent id to the read-only
-// connector tools a mission turn for that agent may use — the
+// connector tools a mission turn for that agent may use: the
 // intersection of the agent's Tools allowlist and every built
 // connector's ReadOnly-marked, non-MCP tools (see
 // connectors.Manager.ReadOnlyTools). Connector WRITES are never
 // included regardless of the allowlist: mission turns stay
 // BuiltinsOnly for the base surface, and this resolver only ever
-// layers reads on top via ExtraTools — a worker can never side-channel
+// layers reads on top via ExtraTools: a worker can never side-channel
 // a connector write around the worktree/human-consented push
 // pipeline. Resolved at DRIVE time (every RunWorker/ExploreSession
 // call), not cached on the mission, so an agent's allowlist or a
@@ -277,7 +295,7 @@ func countOperatorNotes(notes []ProgressNote) int {
 // tools.Permissions' exempt set (same as chat), so an unattended,
 // schedule-fired mission (Unattended: true, D-039) still needs a
 // standing grant or the call fails fast instead of parking. That grant
-// already exists — driver.go's grantSessionDefaults seeds one from the
+// already exists: driver.go's grantSessionDefaults seeds one from the
 // mission's agent's ApprovalAllowlist (a separate field from Tools) at
 // provisioning time, the same path a chat agent's connector-tool
 // grants take. An agent that wants its scheduled missions to actually
@@ -286,26 +304,26 @@ func countOperatorNotes(notes []ProgressNote) int {
 type ConnectorReadsResolver func(ctx context.Context, agentID string) []*tools.Tool
 
 // SetConnectorReads wires the resolver RunWorker/ExploreSession use to
-// layer read-only connector tools onto a mission turn — a setter (not
+// layer read-only connector tools onto a mission turn: a setter (not
 // a NewNativeRunner parameter) because cmd/brain/main.go builds the
 // runner before the connectors.Manager it closes over.
 func (r *nativeRunner) SetConnectorReads(resolve ConnectorReadsResolver) {
 	r.connectorReads = resolve
 }
 
-// KBSearchFunc runs one search_kb call scoped to collectionNames — main
+// KBSearchFunc runs one search_kb call scoped to collectionNames: main
 // curries memclient.Client.KBSearch in, same shape as chat.go's
 // KBSearch type. collectionNames travels on every call (the mission's
 // own Knowledge snapshot), never bound once, since the same func serves
 // every mission.
 type KBSearchFunc func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error)
 
-// KBReadFunc loads one kb document scoped to collectionNames — same
+// KBReadFunc loads one kb document scoped to collectionNames: same
 // travel-on-every-call contract as KBSearchFunc.
 type KBReadFunc func(ctx context.Context, documentID string, collectionNames []string) (builtin.KBDocument, error)
 
 // NewNativeRunner wraps a production *loop.Agent as a Runner. The
-// agent instance is expected to be brain's existing chat agent — a
+// agent instance is expected to be brain's existing chat agent: a
 // mission worker turn is just another loop.Agent caller, not a
 // separate permission/audit/tool-execution stack. parker may be nil
 // (park events are then silently ignored, same as before this existed).
@@ -315,8 +333,8 @@ func NewNativeRunner(agent *loop.Agent, parker parkNotifier, log *slog.Logger) R
 
 // NewNativeRunnerWithFloor is NewNativeRunner plus a model floor deny
 // list (see nativeRunner.modelFloorDeny), a sandbox exec backend (a
-// *sandbox.Manager.Exec closure) — worker and reviewer shell calls
-// route through it instead of brain's own process — and a search_kb
+// *sandbox.Manager.Exec closure): worker and reviewer shell calls
+// route through it instead of brain's own process: and a search_kb
 // backend (nil disables search_kb on every mission turn, matching
 // SetKBSearch's nil-safe contract).
 // The return type is the unexported *nativeRunner, not Runner: callers
@@ -332,7 +350,7 @@ func NewNativeRunnerWithFloor(agent *loop.Agent, parker parkNotifier, floorDeny 
 // backend wired, or the mission's creating agent named no collections
 // (empty Knowledge = no search_kb, same opt-in-only contract as
 // chat.go's kbSearchTool, which this mirrors exactly). A non-nil sink
-// records every returned document at execution time — the harness's
+// records every returned document at execution time: the harness's
 // citation evidence must come from here, not from the rendered tool
 // result: digests cap at digestCeiling and offload past 8KiB, so a
 // full search_kb result never survives into the digest text.
@@ -364,7 +382,7 @@ func (r *nativeRunner) kbReadTool(m Mission) *tools.Tool {
 }
 
 // connectorReadTools resolves m's read-only connector tools (nil
-// resolver or no agent id means none) — appended to worker/explore
+// resolver or no agent id means none): appended to worker/explore
 // ExtraTools so a scheduled mission (daily inbox digest, calendar
 // summary) can read gmail/calendar without the base connector surface
 // (which BuiltinsOnly excludes) ever reopening for a write.
@@ -402,12 +420,12 @@ func (s *kbRefSink) all() []string {
 // a shell that replaces the global workspace-rooted one for the turn —
 // the root cause of a whole failure family was workers writing into
 // the shared root while verify_cmd and the reviewer looked in the
-// per-mission directory — and write_file, so artifact writes never go
+// per-mission directory: and write_file, so artifact writes never go
 // through destructive-classified shell redirects. The shell's Runner
 // routes commands into the mission's own Docker container (see
 // builtin.ShellConfig.Runner) instead of brain's own process.
 // sandboxShellMaxTimeout is the mission shell's timeout ceiling when
-// backed by a sandbox container — 120s (chat's shell ceiling) is far
+// backed by a sandbox container: 120s (chat's shell ceiling) is far
 // too tight for app-development work: package installs, builds, and
 // test suites routinely run longer. The container's own resource caps
 // (memory/CPU/pids) bound the damage a long-running command can do, so
@@ -416,8 +434,8 @@ const sandboxShellMaxTimeout = 15 * time.Minute
 
 // turnTimeout bounds one runTurn call (worker, explore, plan, or
 // review). Without this, a stream that never emits an error or
-// terminal event — no chunk, no EventDone, no EventError, just
-// silence — hangs runTurn's `for ev := range events` forever: nothing
+// terminal event: no chunk, no EventDone, no EventError, just
+// silence: hangs runTurn's `for ev := range events` forever: nothing
 // upstream aborts it, and driveTimeBound (4h) is the mission's own
 // lifetime cap, not a per-turn one. Set above sandboxShellMaxTimeout
 // (15m) plus headroom for a turn issuing several tool calls in
@@ -439,7 +457,7 @@ func (r *nativeRunner) missionTools(m Mission) []*tools.Tool {
 
 // missionShell builds the turn-scoped shell tool rooted in the
 // mission's own directory, routed through the mission's sandbox
-// container — shared by missionTools (worker/reviewer, paired with
+// container: shared by missionTools (worker/reviewer, paired with
 // write_file) and ExploreSession (shell only, read-only exploration:
 // the execute phase does the actual work, so explore never gets
 // write_file). Returns nil when the mission has no work root yet
@@ -477,13 +495,13 @@ func (r *nativeRunner) missionShell(m Mission) *tools.Tool {
 	return builtin.Shell(shellCfg)
 }
 
-// shellOutputCap mirrors builtin.Shell's own output cap — the sandbox
+// shellOutputCap mirrors builtin.Shell's own output cap: the sandbox
 // backend's Runner must behave identically to the in-process path, not
 // let a runaway sandboxed command balloon memory.
 const shellOutputCap = 64 << 10
 
 // cappedStringWriter stops retaining bytes past max (writes still
-// succeed so the underlying exec can finish) — the sandbox-Runner
+// succeed so the underlying exec can finish): the sandbox-Runner
 // analog of builtin.capWriter, kept separate because that type is
 // unexported in the builtin package.
 type cappedStringWriter struct {
@@ -527,20 +545,39 @@ type turnResult struct {
 	finalSeg     string
 }
 
+// toolCallDigestCap bounds a mission.tool_call event's args digest:
+// same 2000-char cap the missions package already applies to other
+// bounded event-payload fields (pending-permission args, progress
+// notes, executor stderr tails; see truncate's other call sites). A
+// tool arg blob can be arbitrarily large; the trace only needs enough
+// to identify what was called, not a byte-for-byte replay.
+const toolCallDigestCap = 2000
+
+// toolCallDigest renders a tool call's raw JSON args as a capped
+// string for the mission.tool_call event: truncate() operates on
+// already-decoded text everywhere else it's used, so raw bytes are
+// converted first.
+func toolCallDigest(args json.RawMessage) string {
+	return truncate(string(args), toolCallDigestCap)
+}
+
 // runTurn drives one loop.Agent session to completion, capturing the
 // text of the sentinel tool call named toolName (if any) alongside the
 // full assistant text. It does not itself decide what a missing
-// sentinel means — that's the caller's job (worker vs review have
-// different enforcement/parsing needs).
+// sentinel means: that's the caller's job (worker vs review have
+// different enforcement/parsing needs). phase tags every mission.tool_call
+// event this turn emits (issue #369), so the UI can group a turn's
+// trace by phase alongside the mission.turn event Advance appends for
+// the same phase run.
 //
 // finalSeg is the assistant text written since the last non-sentinel
-// tool activity (EventToolEnd/EventToolResult) — a session can run
+// tool activity (EventToolEnd/EventToolResult): a session can run
 // several internal tool-calling rounds before its sentinel call, and
 // full is every chunk across all of them (draft narration, tool-retry
 // commentary included), while finalSeg is just what the model wrote
 // right before ending its turn. The sentinel call itself never resets
 // finalSeg (it carries no assistant text of its own to lose).
-func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTool string) (turnResult, error) {
+func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTool string, phase Phase) (turnResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, turnTimeout)
 	defer cancel()
 	// D-075: the sentinel call's successful execution ends the turn —
@@ -554,7 +591,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 	var b, finalB strings.Builder
 	var sentinelArgs json.RawMessage
 	var seenURLs []string
-	// parked tracks in-flight parks by CallID, not a single flag — a
+	// parked tracks in-flight parks by CallID, not a single flag: a
 	// turn can issue concurrent tool calls (executeAll runs up to
 	// maxParallelTools at once), so a sibling call finishing first must
 	// not be mistaken for the still-blocked destructive one resolving.
@@ -565,7 +602,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 	// its terminal (deadline racing a stream cut). Without this check a
 	// silent cut returned a clean empty verdict, which the caller read
 	// as a missing sentinel and burned a recovery re-run plus a forced
-	// retry — two full model turns for one infra failure.
+	// retry: two full model turns for one infra failure.
 	sawTerminal := false
 	for ev := range events {
 		switch ev.Type {
@@ -593,7 +630,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 					ev.Permission.Args, ev.Permission.Danger, ev.Permission.Rationale)
 			}
 		case stream.EventToolResult:
-			// Only the specific call that parked clears it — and only
+			// Only the specific call that parked clears it: and only
 			// once every parked call in this turn has resolved does the
 			// mission stop reporting a pending permission.
 			if ev.ToolResult != nil && parked[ev.ToolResult.ID] {
@@ -602,9 +639,9 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 					r.parker.OnPermissionCleared(ctx, req.MissionID)
 				}
 			}
-			// A denied result — most often the unattended-turn automatic
+			// A denied result: most often the unattended-turn automatic
 			// denial (D-039), which never emits EventPermissionRequest at
-			// all — is otherwise invisible to anything watching the
+			// all: is otherwise invisible to anything watching the
 			// mission; record it as an event.
 			if ev.ToolResult != nil && ev.ToolResult.Status == "denied" && r.parker != nil {
 				r.parker.OnPermissionDenied(ctx, req.MissionID, ev.ToolResult.Name, ev.ToolResult.Digest)
@@ -615,6 +652,15 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if ev.ToolResult != nil && ev.ToolResult.Name != sentinelTool {
 				finalB.Reset()
 			}
+			// mission.tool_call trace (issue #369): one event per finished
+			// tool call, in call order: a post-hoc record only, no bearing
+			// on turn behavior. The permission-denied case above already
+			// records a denial separately with its own digest; this event
+			// records every call's outcome regardless of status.
+			if ev.ToolResult != nil && r.parker != nil {
+				r.parker.OnToolCall(ctx, req.MissionID, string(phase), ev.ToolResult.Name,
+					toolCallDigest(ev.ToolResult.Args), ev.ToolResult.Status, ev.ToolResult.DurationMs)
+			}
 		case stream.EventDone:
 			sawTerminal = true
 			if ev.Meta != nil {
@@ -622,7 +668,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			}
 		case stream.EventIncomplete:
 			// A cut-off stream is an infra failure, not a short clean
-			// answer — without this case it was indistinguishable from
+			// answer: without this case it was indistinguishable from
 			// one and flowed into sentinel parsing. Both this and the
 			// error case return directly, so only done needs to mark
 			// sawTerminal.
@@ -654,7 +700,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 }
 
 // webFetchArgURL extracts the url arg from a fetch_url call's raw
-// input — the exact field name webfetch.go's webFetchArgs decodes
+// input: the exact field name webfetch.go's webFetchArgs decodes
 // (D-059). A malformed input yields nothing rather than an error: this
 // is best-effort evidence collection, not argument validation (the
 // tool's own Execute already rejected a bad call before this point).
@@ -669,13 +715,13 @@ func webFetchArgURL(input json.RawMessage) []string {
 }
 
 // webSearchResultURLs pulls result URLs out of search_web's rendered
-// output — websearch.go's runSearch emits one blank-line-separated
+// output: websearch.go's runSearch emits one blank-line-separated
 // entry per result as "N. title\nurl\nsnippet" (D-059). Line 2 of each
 // three-line group is the URL; anything not matching that shape (the
 // "no results found" sentinel, a truncated tail) is skipped rather
 // than guessed at. Best-effort only: the digest is capped (and big
 // results offload to a stub), so URLs past the cap are lost. That is
-// deliberate lenience on top of the reliable contract — cite what you
+// deliberate lenience on top of the reliable contract: cite what you
 // fetch_url, whose args are never truncated.
 var webSearchResultHeader = regexp.MustCompile(`^\d+\.\s`)
 
@@ -683,7 +729,7 @@ func webSearchResultURLs(digest string) []string {
 	lines := strings.Split(digest, "\n")
 	var urls []string
 	for i := 0; i+1 < len(lines); i++ {
-		// A result's first line is "N. title" — only its second line
+		// A result's first line is "N. title": only its second line
 		// (the URL) is collected.
 		if !webSearchResultHeader.MatchString(lines[i]) {
 			continue
@@ -698,8 +744,8 @@ func webSearchResultURLs(digest string) []string {
 
 // workerRoute picks the route a worker turn runs on. With an
 // escalation route configured, any evidence the current model is not
-// cutting it — a worker failure or a review rework already on the
-// books — switches subsequent worker turns to it. Empty escalation
+// cutting it: a worker failure or a review rework already on the
+// books: switches subsequent worker turns to it. Empty escalation
 // route means the ladder is off and the mission's own route always
 // wins.
 func workerRoute(m Mission) string {
@@ -710,7 +756,7 @@ func workerRoute(m Mission) string {
 }
 
 // oversightRoute picks the route explore/plan/replan turns run on:
-// PlanRoute when set ("GLM plans, local executes" — oversight runs on a
+// PlanRoute when set ("GLM plans, local executes": oversight runs on a
 // stronger route while Route stays the worker's cheap/local route),
 // otherwise Route unchanged (empty PlanRoute is exact current behavior).
 func oversightRoute(m Mission) string {
@@ -732,7 +778,7 @@ func reviewRoute(m Mission) string {
 
 // workerModel is workerRoute's model-pin counterpart (D-078): RouteModel
 // pins execute turns to one chain entry in workerRoute(m). Cleared
-// whenever workerRoute has swapped to EscalationRoute — RouteModel names
+// whenever workerRoute has swapped to EscalationRoute: RouteModel names
 // an entry in the BASE route's chain, not the escalation route's, so
 // carrying it over would pin escalation to a model that may not even be
 // in that chain.
@@ -800,7 +846,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		Steering: r.steeringFor(m.ID, packet.Progress),
 	}
 
-	res, err := r.runTurn(ctx, req, missionStatusToolName)
+	res, err := r.runTurn(ctx, req, missionStatusToolName, PhaseExecute)
 	text, seenURLs := res.text, res.seenURLs
 	if err != nil {
 		return WorkerVerdict{}, text, err
@@ -817,7 +863,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		provider.Message{Role: "assistant", Content: text},
 		provider.Message{Role: "user", Content: "[system] You must end your turn with exactly one mission_status tool call: done, retry, or blocked."},
 	)
-	recoverRes, err := r.runTurn(ctx, recoverReq, missionStatusToolName)
+	recoverRes, err := r.runTurn(ctx, recoverReq, missionStatusToolName, PhaseExecute)
 	recoverText := recoverRes.text
 	seenURLs = append(seenURLs, recoverRes.seenURLs...)
 	if err != nil {
@@ -830,12 +876,12 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 	}
 
 	// Neither turn produced a tool call: before giving up, check whether
-	// the model expressed the sentinel as TEXT instead — observed on
+	// the model expressed the sentinel as TEXT instead: observed on
 	// non-frontier models (GLM-5.2's XML-ish self-closing tag, qwen3:30b's
 	// bare "mission_status" token followed by a JSON object). A text-form
 	// verdict is trust-equivalent to the tool-call form: both are the
 	// model's own self-report, and the harness's own verify_cmd/
-	// CheckArtifacts evidence — never model output — is what actually
+	// CheckArtifacts evidence: never model output: is what actually
 	// gates a unit's Passes flag. This is strictly a fallback: the
 	// tool-call path above always wins when it succeeds.
 	combined := text + "\n" + recoverText
@@ -849,7 +895,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 	}
 
 	// Still missing: bail detection informs the log, but either way this
-	// is a forced retry — detection accuracy never gates the outcome.
+	// is a forced retry: detection accuracy never gates the outcome.
 	if detectBail(combined) {
 		r.log.Warn("mission worker bailed without a sentinel call", "mission_id", m.ID)
 	} else {
@@ -863,7 +909,7 @@ func (r *nativeRunner) tryParseVerdict(args json.RawMessage) (WorkerVerdict, boo
 }
 
 // tryParseWorkerVerdict decodes args into a WorkerVerdict, ok=false on
-// empty input or a missing outcome — shared by nativeRunner's sentinel
+// empty input or a missing outcome: shared by nativeRunner's sentinel
 // ladder and delegatedRunner's result ladder (delegated.go), since both
 // read a mission_status-shaped payload from a text-form sentinel.
 func tryParseWorkerVerdict(args json.RawMessage) (WorkerVerdict, bool) {
@@ -880,7 +926,7 @@ func tryParseWorkerVerdict(args json.RawMessage) (WorkerVerdict, bool) {
 // D-074: forcedRetryVerdict builds the fabricated "retry" verdict every
 // last rung of the worker/executor verdict ladders falls back to when
 // NEITHER a tool call/schema result NOR a text-form sentinel could be
-// read — shared by nativeRunner's sentinel ladder (RunWorker, above)
+// read: shared by nativeRunner's sentinel ladder (RunWorker, above)
 // and delegatedRunner's result ladder (delegated.go's attemptResume,
 // pollToVerdict's idle-kill, finish, finishNoResult), which previously
 // each spelled out WorkerVerdict{Outcome: "retry", Forced: true, ...}
@@ -892,7 +938,7 @@ func forcedRetryVerdict(reason string) WorkerVerdict {
 
 // ExploreSession runs the mission's explore turn: explore the goal
 // before planning commits to a shape. Unlike RunWorker's sentinel
-// ladder, a missing explore_notes call never fails the phase — the
+// ladder, a missing explore_notes call never fails the phase: the
 // findings are advisory input to the planner, not a gate on progress,
 // so the ladder's last resort is the raw turn text rather than a forced
 // failure.
@@ -931,7 +977,7 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 		Unattended:   m.ScheduleID != "",
 	}
 
-	res, err := r.runTurn(ctx, req, exploreNotesToolName)
+	res, err := r.runTurn(ctx, req, exploreNotesToolName, PhaseExplore)
 	text := res.text
 	if err != nil {
 		return "", err
@@ -946,7 +992,7 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 		provider.Message{Role: "assistant", Content: text},
 		provider.Message{Role: "user", Content: "[system] You must end your turn with exactly one explore_notes tool call containing your findings."},
 	)
-	recoverRes, err := r.runTurn(ctx, recoverReq, exploreNotesToolName)
+	recoverRes, err := r.runTurn(ctx, recoverReq, exploreNotesToolName, PhaseExplore)
 	recoverText := recoverRes.text
 	if err != nil {
 		return "", err
@@ -1012,13 +1058,13 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 		BuiltinsOnly: true,
 		Unattended:   m.ScheduleID != "",
 	}
-	res, err := r.runTurn(ctx, req, reviewVerdictToolName)
+	res, err := r.runTurn(ctx, req, reviewVerdictToolName, PhaseReview)
 	text, args := res.text, res.sentinelArgs
 	if err != nil {
 		return ReviewVerdict{}, nil, err
 	}
 	if len(args) == 0 {
-		// Recovery re-run: same one-shot ladder RunWorker uses — a
+		// Recovery re-run: same one-shot ladder RunWorker uses: a
 		// reviewer that ran long on analysis and didn't reach its tool
 		// call gets one more turn demanding it, instead of failing the
 		// whole review round outright.
@@ -1027,20 +1073,20 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 			provider.Message{Role: "assistant", Content: text},
 			provider.Message{Role: "user", Content: "[system] You must end your turn with exactly one review_verdict tool call: approve or rework."},
 		)
-		recoverRes, err := r.runTurn(ctx, recoverReq, reviewVerdictToolName)
+		recoverRes, err := r.runTurn(ctx, recoverReq, reviewVerdictToolName, PhaseReview)
 		recoverText, recoverArgs := recoverRes.text, recoverRes.sentinelArgs
 		if err != nil {
 			return ReviewVerdict{}, nil, err
 		}
 		if len(recoverArgs) == 0 {
 			// Neither turn produced a review_verdict tool call: before
-			// failing the round, check for a text-form verdict — observed
+			// failing the round, check for a text-form verdict: observed
 			// on qwen3:30b reviewers that write prose analysis and never
 			// call the tool. Trust-equivalent to the tool-call form (see
 			// RunWorker's identical fallback above): the harness's own
 			// artifact/diff evidence, not the reviewer's self-report,
 			// decides whether a unit actually holds up. A text-form rework
-			// with no parseable findings is acceptable — GapFingerprint of
+			// with no parseable findings is acceptable: GapFingerprint of
 			// empty findings is empty, which the state machine already
 			// tolerates.
 			combined := text + "\n" + recoverText
@@ -1125,7 +1171,7 @@ func renderReviewContent(p ReviewPacket) string {
 // PlanSession runs the planning turn that produces a Spec from the
 // mission's goal and explore-phase findings. The plan is forced
 // through the submit_plan tool call (mirroring RunWorker/RunReview's
-// sentinel ladder) rather than asked for as bare JSON prose — a model
+// sentinel ladder) rather than asked for as bare JSON prose: a model
 // free to preface its reply with prose was the root cause of a real
 // stuck mission (5 straight "invalid plan JSON" failures, identical
 // each retry since nothing told the model what went wrong).
@@ -1159,8 +1205,8 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 		Messages:  []provider.Message{{Role: "user", Content: user}},
 		// The planner plans; it must not act. No base tool matches this
 		// allowlist (submit_plan/search_kb arrive via ExtraTools, which
-		// bypass it, and search_kb is read-only — never "acting"), so
-		// the turn's only BASE tool is none — a planner that reaches for
+		// bypass it, and search_kb is read-only: never "acting"), so
+		// the turn's only BASE tool is none: a planner that reaches for
 		// shell parked a live canary on the permission gate for ten
 		// minutes trying to do the worker's job in plan phase.
 		ToolAllow:    []string{planToolName},
@@ -1174,7 +1220,7 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 	if len(extra) == 1 {
 		req.ForceTool = planToolName
 	}
-	res, err := r.runTurn(ctx, req, planToolName)
+	res, err := r.runTurn(ctx, req, planToolName, PhasePlan)
 	text, args := res.text, res.sentinelArgs
 	if err != nil {
 		return Spec{}, err
@@ -1186,7 +1232,7 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 	}
 
 	// Recovery re-run: either the tool call was missing entirely, or its
-	// arguments didn't decode as a valid Spec — either way, tell the
+	// arguments didn't decode as a valid Spec: either way, tell the
 	// model exactly what was wrong instead of silently repeating the
 	// identical prompt (which previously produced the identical failure
 	// on every retry).
@@ -1201,7 +1247,7 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 		provider.Message{Role: "assistant", Content: text},
 		provider.Message{Role: "user", Content: "[system] Your last turn did not produce a usable plan: " + recoverReason + ". You must end this turn with exactly one submit_plan tool call."},
 	)
-	recoverRes, err := r.runTurn(ctx, recoverReq, planToolName)
+	recoverRes, err := r.runTurn(ctx, recoverReq, planToolName, PhasePlan)
 	recoverText, recoverArgs := recoverRes.text, recoverRes.sentinelArgs
 	if err != nil {
 		return Spec{}, err
@@ -1219,7 +1265,7 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 }
 
 // execEnvironmentNote tells the planner what execution environment
-// verify_cmd and shell commands actually run in — without this, a
+// verify_cmd and shell commands actually run in: without this, a
 // planner with no sandbox has no way to know whether e.g. python3
 // exists, and can author a verify_cmd for a runtime that was never
 // there (the root cause of a real stuck mission: a plan's verify_cmd
@@ -1234,7 +1280,7 @@ func (r *nativeRunner) execEnvironmentNote(ctx context.Context) string {
 }
 
 // execEnvironmentNote is the shared wording nativeRunner (planner
-// prompt) and Driver (worker packet) both need — kept as one function
+// prompt) and Driver (worker packet) both need: kept as one function
 // so the two prompts never drift out of sync about what's actually
 // available. loc is the operator's configured timezone; nil renders
 // in UTC.
@@ -1243,7 +1289,7 @@ func execEnvironmentNote(loc *time.Location) string {
 		loc = time.UTC
 	}
 	// The date line rides along so every mission prompt (explore, plan,
-	// worker) knows "today" — a model with no other way to know it
+	// worker) knows "today": a model with no other way to know it
 	// anchors on training data or on dated examples in tool descriptions
 	// and mangles date-bounded calls (calendar windows, Gmail
 	// after:/before:). Date only, no clock time, for the same
@@ -1252,7 +1298,7 @@ func execEnvironmentNote(loc *time.Location) string {
 }
 
 // parseSpec decodes the planner's reply strictly: fences stripped,
-// unknown fields rejected — same discipline as loop/turnmemory.go's
+// unknown fields rejected: same discipline as loop/turnmemory.go's
 // distillation parsing.
 func parseSpec(raw string) (Spec, error) {
 	text := strings.TrimSpace(raw)
@@ -1278,7 +1324,7 @@ func parseSpec(raw string) (Spec, error) {
 	if len(spec.Units) == 0 {
 		return Spec{}, fmt.Errorf("mission runner: plan has no units")
 	}
-	// verify_cmd runs through RunVerify (a plain /bin/sh -c) — harness-
+	// verify_cmd runs through RunVerify (a plain /bin/sh -c): harness-
 	// side, outside the permission chain entirely, so D-050's sandbox
 	// relaxation (which only changes how a worker/reviewer's own shell
 	// TOOL CALL is classified) has no bearing here. The rejection below

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -21,11 +21,11 @@ import (
 )
 
 // scriptedAgent is a fake agentStream that replays a fixed sequence of
-// event batches, one batch per call to Start — call N of Start gets
+// event batches, one batch per call to Start: call N of Start gets
 // batch N. Lets a test script "first turn has no sentinel, recovery
 // turn does" without a real gateway. The real loop.Agent guarantees
 // exactly one terminal event before close, so batches that don't end
-// on one get an EventDone appended — a bare close is the abnormal
+// on one get an EventDone appended: a bare close is the abnormal
 // shape runTurn now rejects, and only rawClose tests script it.
 type scriptedAgent struct {
 	batches  [][]stream.StreamEvent
@@ -83,11 +83,20 @@ func newTestRunnerWithParker(agent agentStream, parker parkNotifier) *nativeRunn
 }
 
 // fakeParker records park/clear calls in order for assertion, keyed by
-// mission id — a real parkNotifier for tests, not a mock of one.
+// mission id: a real parkNotifier for tests, not a mock of one.
 type fakeParker struct {
-	parked  []string // "missionID:tool:danger"
-	cleared []string // missionID
-	denied  []string // "missionID:tool:digest"
+	parked    []string // "missionID:tool:danger"
+	cleared   []string // missionID
+	denied    []string // "missionID:tool:digest"
+	toolCalls []toolCallRecord
+}
+
+// toolCallRecord captures one OnToolCall invocation for assertion:
+// order in the slice IS call order, since runTurn appends synchronously
+// off its single event-consuming loop.
+type toolCallRecord struct {
+	missionID, phase, tool, digest, status string
+	durationMs                             int64
 }
 
 func (f *fakeParker) OnPermissionParked(_ context.Context, missionID, _, tool, _, danger, _ string) {
@@ -100,6 +109,10 @@ func (f *fakeParker) OnPermissionCleared(_ context.Context, missionID string) {
 
 func (f *fakeParker) OnPermissionDenied(_ context.Context, missionID, tool, digest string) {
 	f.denied = append(f.denied, missionID+":"+tool+":"+digest)
+}
+
+func (f *fakeParker) OnToolCall(_ context.Context, missionID, phase, tool, digest, status string, durationMs int64) {
+	f.toolCalls = append(f.toolCalls, toolCallRecord{missionID, phase, tool, digest, status, durationMs})
 }
 
 func permissionRequestEvent(id, callID, tool, danger string) stream.StreamEvent {
@@ -115,6 +128,15 @@ func toolResultEvent(id string) stream.StreamEvent {
 func deniedToolResultEvent(id, name, digest string) stream.StreamEvent {
 	return stream.StreamEvent{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{
 		ID: id, Name: name, Status: "denied", Digest: digest,
+	}}
+}
+
+// finishedToolResultEvent builds a fully-populated tool_result event:
+// the shape mission.tool_call's OnToolCall reads from (name, status,
+// args, duration).
+func finishedToolResultEvent(id, name, status, args string, durationMs int64) stream.StreamEvent {
+	return stream.StreamEvent{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{
+		ID: id, Name: name, Status: status, Args: json.RawMessage(args), DurationMs: durationMs,
 	}}
 }
 
@@ -232,7 +254,7 @@ func TestRunWorkerFallsBackToXMLTextSentinel(t *testing.T) {
 	}
 	// The XML form arrived on the FIRST turn (no tool call at all), so the
 	// runner still needs its one recovery re-run before falling back to
-	// text extraction — that ladder order is unchanged by this fix.
+	// text extraction: that ladder order is unchanged by this fix.
 	if agent.call != 2 {
 		t.Fatalf("expected two turns (original + one recovery) before the text fallback kicks in, got %d", agent.call)
 	}
@@ -261,7 +283,7 @@ func TestRunWorkerFallsBackToTokenJSONTextSentinel(t *testing.T) {
 
 func TestRunWorkerIgnoresRepeatSentinelCalls(t *testing.T) {
 	// A worker that calls mission_status twice in one turn: the runner
-	// captures the LAST tool_end for that name in the stream loop — this
+	// captures the LAST tool_end for that name in the stream loop: this
 	// documents that behavior explicitly (loop.Agent itself is what
 	// would reject a genuine repeat via the tool's closure-flag guard in
 	// production; nativeRunner just reads what the stream reports).
@@ -330,7 +352,7 @@ func TestRunReviewRoutePrecedence(t *testing.T) {
 // research-mission review gap: reviewers used to reject every round
 // for "missing goal" / "missing artifact" because neither was in
 // their context. The packet's goal, harness-read artifact contents,
-// and the worker's evidence must all reach the reviewer — and no
+// and the worker's evidence must all reach the reviewer: and no
 // empty "Diff to review" section may appear when there is no diff.
 func TestRunReviewPacketRendersArtifactsGoalAndEvidence(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
@@ -423,7 +445,7 @@ func TestRunReviewFallsBackToTextSentinel(t *testing.T) {
 }
 
 // TestRunReviewFallsBackToTokenJSONTextSentinel mirrors the XML case
-// for the token+JSON text form, on a rework decision — findings are
+// for the token+JSON text form, on a rework decision: findings are
 // empty in the text form (acceptable: GapFingerprint of empty findings
 // is empty, which the state machine already tolerates).
 func TestRunReviewFallsBackToTokenJSONTextSentinel(t *testing.T) {
@@ -472,7 +494,7 @@ func TestPlanSessionParsesSpec(t *testing.T) {
 // TestPlanSessionPromptsLengthAwareSplitting pins that the planner is
 // told to split a unit whose own deliverable demands a long
 // continuous generation (many chapters/sections/files) along its
-// natural boundaries, regardless of the goal's subject matter — a
+// natural boundaries, regardless of the goal's subject matter: a
 // long single-turn stream truncating mid-generation is what a
 // too-few-units plan risks (a real 12-chapter book goal collapsed
 // into one unit and truncated on a long model stream, twice).
@@ -651,7 +673,7 @@ func TestPlanSessionRejectsInfeasibleWithoutReason(t *testing.T) {
 // TestPlanSessionRejectsCommandSubstitution guards parseSpec's
 // determinism rule: verify_cmd runs harness-side via RunVerify,
 // outside the permission chain (D-050's sandbox relaxation for a
-// worker/reviewer shell CALL does not apply here) — a planner-authored
+// worker/reviewer shell CALL does not apply here): a planner-authored
 // verify_cmd containing $(...) is rejected because command
 // substitution undermines a reproducible content check, not because of
 // any permission concern. The plan should be rejected here, at
@@ -711,10 +733,10 @@ func TestPlanSessionRecoversFromCommandSubstitutionFeedback(t *testing.T) {
 }
 
 // TestPlanSessionAcceptsLegitimateVerifyCmd confirms the substitution
-// guard doesn't false-positive on real verification commands — a
+// guard doesn't false-positive on real verification commands: a
 // content-checking verify_cmd (the existing tautology guard's whole
 // point: never a bare echo) and a legitimate input redirect (<, which
-// must stay legal — only substitution is banned) both parse cleanly
+// must stay legal: only substitution is banned) both parse cleanly
 // in a single turn, no recovery needed.
 func TestPlanSessionAcceptsLegitimateVerifyCmd(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
@@ -772,8 +794,8 @@ func TestPlanSessionRejectsUnitWithNoArtifacts(t *testing.T) {
 // regardless of content, which is exactly the shape of the real
 // amazon.nova-2-lite incident (verify_cmd `echo 'Gmail API integration
 // required for actual execution'`, always passing, proving nothing).
-// A command that merely CONTAINS one of those words — as an argument,
-// or after && — must still be accepted; the deny-set only looks at
+// A command that merely CONTAINS one of those words: as an argument,
+// or after &&: must still be accepted; the deny-set only looks at
 // the first token, by design (see the scoping comment in parseSpec).
 func TestPlanSessionRejectsNoOpVerifyCmd(t *testing.T) {
 	cases := []struct {
@@ -805,7 +827,7 @@ func TestPlanSessionRejectsNoOpVerifyCmd(t *testing.T) {
 }
 
 // TestPlanSessionAcceptsVerifyCmdContainingEchoWord confirms the
-// no-op deny-set only inspects the verify_cmd's FIRST shell word — a
+// no-op deny-set only inspects the verify_cmd's FIRST shell word: a
 // real content check that happens to contain the word "echo" as an
 // argument, or a command containing "echo" later after &&, must pass.
 func TestPlanSessionAcceptsVerifyCmdContainingEchoWord(t *testing.T) {
@@ -830,7 +852,7 @@ func TestPlanSessionAcceptsVerifyCmdContainingEchoWord(t *testing.T) {
 
 // TestPlanSessionRejectsUnterminatedQuote guards D-068's POSIX shell
 // syntax gate: verify_cmd is run through the REAL /bin/sh -n (per this
-// repo's real-shell-tests convention — a fake shell would forgive
+// repo's real-shell-tests convention: a fake shell would forgive
 // exactly the quoting bugs this check exists to catch). This mirrors
 // the real amazon.nova-lite incident, whose unterminated quote burned
 // execute iterations before failing at verify time, well after the
@@ -892,7 +914,7 @@ func TestPlanSessionRejectsMalformedJSON(t *testing.T) {
 
 // TestPlanSessionRecoversWithFeedback confirms a missing/invalid
 // submit_plan call on the first turn gets ONE recovery re-run whose
-// injected message names what was wrong — not a byte-identical retry
+// injected message names what was wrong: not a byte-identical retry
 // of the original prompt, which previously produced the same failure
 // every time against a nondeterministic model.
 func TestPlanSessionRecoversWithFeedback(t *testing.T) {
@@ -922,7 +944,7 @@ func TestPlanSessionRecoversWithFeedback(t *testing.T) {
 // criterion: a tool call that parks on an interactive permission
 // prompt must reach the mission row (via parkNotifier), not vanish
 // into runTurn's event drain the way it silently did before this
-// existed — that gap is what stranded a real mission for its full
+// existed: that gap is what stranded a real mission for its full
 // 10-minute timeout with the UI showing nothing.
 func TestRunWorkerReportsPermissionParkAndClear(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{{
@@ -950,7 +972,7 @@ func TestRunWorkerReportsPermissionParkAndClear(t *testing.T) {
 
 // sequencingParker records, at the moment each OnPermissionCleared
 // fires, how many distinct calls had parked vs how many tool results
-// had been delivered so far — the direct signal that distinguishes
+// had been delivered so far: the direct signal that distinguishes
 // "cleared after the right call" from "cleared after the first call
 // resolved regardless of which one" (a plain clear-count is identical
 // in both the buggy and fixed behavior for two concurrent parks).
@@ -970,7 +992,7 @@ func (f *sequencingParker) OnPermissionCleared(ctx context.Context, missionID st
 // destructive tool calls, both parked. Before this fix, runTurn's
 // single shared "parked" bool cleared the mission's pending-permission
 // state as soon as the FIRST call's result arrived, even while the
-// second call was still genuinely blocked awaiting a decision — the
+// second call was still genuinely blocked awaiting a decision: the
 // UI/API then showed nothing pending while a destructive command sat
 // unresolved for up to the full 10-minute timeout.
 func TestRunWorkerConcurrentParksClearOnlyWhenAllResolve(t *testing.T) {
@@ -1007,7 +1029,7 @@ func TestRunWorkerConcurrentParksClearOnlyWhenAllResolve(t *testing.T) {
 }
 
 // countingResultAgent wraps scriptedAgent's fixed batch with a live
-// counter the test parker reads at clear-time — the pre-buffered
+// counter the test parker reads at clear-time: the pre-buffered
 // channel scriptedAgent uses can't otherwise expose "how far the
 // consumer has gotten" to a callback fired mid-drain.
 type countingResultAgent struct {
@@ -1075,7 +1097,7 @@ func TestRunWorkerModelFloor(t *testing.T) {
 }
 
 // TestRunWorkerModelFloorDisabledByDefault: no deny list, any model is
-// fine — the sentinel outcome decides.
+// fine: the sentinel outcome decides.
 func TestRunWorkerModelFloorDisabledByDefault(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ok"}`), doneEvent("amazon.nova-lite-v1:0")},
@@ -1091,7 +1113,7 @@ func TestRunWorkerModelFloorDisabledByDefault(t *testing.T) {
 }
 
 // TestRunWorkerGetsMissionScopedShell: the worker turn must carry a
-// turn-scoped shell tool rooted in the mission's own workspace — the
+// turn-scoped shell tool rooted in the mission's own workspace: the
 // root cause of the workspace-split failure family was workers running
 // shell in the shared global root while verification looked in the
 // per-mission directory.
@@ -1116,7 +1138,7 @@ func TestWorkerRoute(t *testing.T) {
 }
 
 // TestOversightRoute pins explore/plan/replan's route resolution:
-// PlanRoute wins when set, Route otherwise — exact current behavior
+// PlanRoute wins when set, Route otherwise: exact current behavior
 // when PlanRoute is empty.
 func TestOversightRoute(t *testing.T) {
 	tests := []struct {
@@ -1162,7 +1184,7 @@ func TestReviewRoute(t *testing.T) {
 
 // TestWorkerModel pins route_model's precedence: it backs execute
 // exactly like Route, but must NOT carry over once workerRoute has
-// swapped to EscalationRoute — it names an entry in the base route's
+// swapped to EscalationRoute: it names an entry in the base route's
 // chain, not the escalation route's.
 func TestWorkerModel(t *testing.T) {
 	tests := []struct {
@@ -1336,7 +1358,7 @@ func TestRunWorkerOmitsConnectorReadsWhenResolverUnset(t *testing.T) {
 
 // TestExploreSessionIncludesConnectorReadsWhenResolverSet mirrors
 // TestRunWorkerIncludesConnectorReadsWhenResolverSet for the explore
-// phase — scheduled missions may need connector reads before planning
+// phase: scheduled missions may need connector reads before planning
 // too.
 func TestExploreSessionIncludesConnectorReadsWhenResolverSet(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
@@ -1360,7 +1382,7 @@ func TestExploreSessionIncludesConnectorReadsWhenResolverSet(t *testing.T) {
 }
 
 // shellExtraTool pulls the "shell" tool out of a mission's ExtraTools
-// list — helper for tests exercising missionTools' Runner wiring
+// list: helper for tests exercising missionTools' Runner wiring
 // directly, without going through a full RunWorker turn.
 func shellExtraTool(t *testing.T, extras []*tools.Tool) *tools.Tool {
 	t.Helper()
@@ -1421,7 +1443,7 @@ func TestMissionToolsSandboxTimeoutPropagatesAsError(t *testing.T) {
 
 // TestMissionToolsSandboxCapsOutput confirms cappedStringWriter bounds
 // the sandbox Runner's output the same way builtin.Shell's local path
-// caps its own — a runaway sandboxed command must not balloon memory
+// caps its own: a runaway sandboxed command must not balloon memory
 // or context just because the local exec path isn't the one running.
 func TestMissionToolsSandboxCapsOutput(t *testing.T) {
 	r := newTestRunner(&scriptedAgent{})
@@ -1500,10 +1522,66 @@ func TestRunWorkerReportsPermissionDenied(t *testing.T) {
 	}
 }
 
+// TestRunWorkerEmitsToolCallTraceInOrder covers issue #369's acceptance
+// criterion 1: every finished tool call in a worker turn reaches the
+// mission via parkNotifier as a mission.tool_call trace entry, in call
+// order, tagged with the execute phase and the correct outcome
+// classification (ok/denied/error).
+func TestRunWorkerEmitsToolCallTraceInOrder(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{{
+		finishedToolResultEvent("call1", "search_kb", "ok", `{"query":"first"}`, 12),
+		finishedToolResultEvent("call2", "shell", "denied", `{"command":"rm -rf /"}`, 3),
+		finishedToolResultEvent("call3", "write_file", "error", `{"path":"x"}`, 40),
+		toolEndEvent(missionStatusToolName, `{"outcome":"retry","analysis":"blocked"}`),
+	}}}
+	parker := &fakeParker{}
+	r := newTestRunnerWithParker(agent, parker)
+	if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	want := []toolCallRecord{
+		{"m1", "execute", "search_kb", `{"query":"first"}`, "ok", 12},
+		{"m1", "execute", "shell", `{"command":"rm -rf /"}`, "denied", 3},
+		{"m1", "execute", "write_file", `{"path":"x"}`, "error", 40},
+	}
+	if len(parker.toolCalls) != len(want) {
+		t.Fatalf("toolCalls = %+v, want %d entries", parker.toolCalls, len(want))
+	}
+	for i, got := range parker.toolCalls {
+		if got != want[i] {
+			t.Fatalf("toolCalls[%d] = %+v, want %+v", i, got, want[i])
+		}
+	}
+}
+
+// TestToolCallDigestCapsLargeArgs is the digest-capping table test
+// (issue #369's cap requirement): args past toolCallDigestCap bytes are
+// truncated with an ellipsis, never carried whole into the event.
+func TestToolCallDigestCapsLargeArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		want string
+	}{
+		{"empty", "", ""},
+		{"short", `{"a":1}`, `{"a":1}`},
+		{"exactly at cap", strings.Repeat("a", toolCallDigestCap), strings.Repeat("a", toolCallDigestCap)},
+		{"over cap", strings.Repeat("a", toolCallDigestCap+500), strings.Repeat("a", toolCallDigestCap) + "…"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toolCallDigest(json.RawMessage(tt.args))
+			if got != tt.want {
+				t.Fatalf("toolCallDigest(%d bytes) len=%d, want len=%d", len(tt.args), len(got), len(tt.want))
+			}
+		})
+	}
+}
+
 // TestRunTurnBareCloseIsError pins the missions half of D-044: a loop
 // channel that closes with no terminal event at all (every producer
 // lost it to the turn deadline racing a stream cut) must surface as an
-// infra error — previously it returned a clean empty verdict, which
+// infra error: previously it returned a clean empty verdict, which
 // the caller read as a missing sentinel and burned a recovery re-run
 // plus a forced retry for one silent infra failure.
 // TestExploreSessionSentinelPresent mirrors TestRunWorkerSentinelPresent:
@@ -1625,7 +1703,7 @@ func TestExploreSessionRecoversWhenSentinelMissingThenPresent(t *testing.T) {
 
 // TestExploreSessionFallsBackToTextSentinel covers a explore turn
 // that expresses explore_notes as text (XML-ish tag), never as a tool
-// call — same fallback RunWorker/RunReview already rely on.
+// call: same fallback RunWorker/RunReview already rely on.
 func TestExploreSessionFallsBackToTextSentinel(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{textEvent("no tool call here")},
@@ -1643,7 +1721,7 @@ func TestExploreSessionFallsBackToTextSentinel(t *testing.T) {
 
 // TestExploreSessionFallsBackToRawText is the advisory-phase contract:
 // when NEITHER turn produces an explore_notes call in any form, the raw
-// turn text becomes the notes — never an error, since explore findings
+// turn text becomes the notes: never an error, since explore findings
 // are advisory input to the planner, not a gate on mission progress.
 func TestExploreSessionFallsBackToRawText(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
@@ -1679,7 +1757,7 @@ func TestExploreSessionStreamErrorPropagates(t *testing.T) {
 
 // TestExploreSessionGetsShellButNotWriteFile confirms the explore
 // turn's ExtraTools include a mission-scoped shell (for read-only
-// exploration) but never write_file — the execute phase does the
+// exploration) but never write_file: the execute phase does the
 // actual work, explore must not create or modify files.
 func TestExploreSessionGetsShellButNotWriteFile(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
@@ -1713,7 +1791,7 @@ func TestRunTurnBareCloseIsError(t *testing.T) {
 		textEvent("partial work"),
 	}}}
 	r := newTestRunner(agent)
-	res, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName)
+	res, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseExecute)
 	if err == nil || !strings.Contains(err.Error(), "without a terminal event") {
 		t.Fatalf("err = %v, want no-terminal error", err)
 	}
@@ -1723,7 +1801,7 @@ func TestRunTurnBareCloseIsError(t *testing.T) {
 }
 
 // TestRunTurnIncompleteIsError: a cut-off stream (EventIncomplete
-// terminal) is an infra failure, not a short clean answer — it must
+// terminal) is an infra failure, not a short clean answer: it must
 // not flow into sentinel parsing as if the worker finished.
 func TestRunTurnIncompleteIsError(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{{
@@ -1731,7 +1809,7 @@ func TestRunTurnIncompleteIsError(t *testing.T) {
 		{Type: stream.EventIncomplete, Text: "stream ended without a terminal event"},
 	}}}
 	r := newTestRunner(agent)
-	if _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "incomplete stream") {
+	if _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseExecute); err == nil || !strings.Contains(err.Error(), "incomplete stream") {
 		t.Fatalf("err = %v, want incomplete-stream error", err)
 	}
 }
@@ -1744,13 +1822,13 @@ func TestRunTurnNilErrErrorEvent(t *testing.T) {
 		{Type: stream.EventError},
 	}}}
 	r := newTestRunner(agent)
-	if _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName); err == nil || !strings.Contains(err.Error(), "provider stream error") {
+	if _, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseExecute); err == nil || !strings.Contains(err.Error(), "provider stream error") {
 		t.Fatalf("err = %v, want generic provider stream error", err)
 	}
 }
 
 // hangingAgent is a fake agentStream whose Start never sends and never
-// closes its channel on its own — it only closes once ctx is
+// closes its channel on its own: it only closes once ctx is
 // cancelled, modeling a stream that emits no chunk, no terminal, and
 // no error (the observed production hang: a worker turn silently wedged
 // for 35+ minutes with driveTimeBound, at 4h, nowhere near catching it).
@@ -1766,7 +1844,7 @@ func (hangingAgent) Start(ctx context.Context, req loop.Request) (<-chan stream.
 }
 
 // TestRunTurnTimesOutOnHungStream: runTurn must not block forever on a
-// stream that never emits anything — turnTimeout bounds it, and the
+// stream that never emits anything: turnTimeout bounds it, and the
 // resulting bare channel close falls into the same "stream ended
 // without a terminal event" retryable-failure path as a real stream
 // cut, rather than hanging the driver's Drive goroutine.
@@ -1779,7 +1857,7 @@ func TestRunTurnTimesOutOnHungStream(t *testing.T) {
 	done := make(chan struct{})
 	var err error
 	go func() {
-		_, err = r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName)
+		_, err = r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseExecute)
 		close(done)
 	}()
 	select {
@@ -1793,8 +1871,8 @@ func TestRunTurnTimesOutOnHungStream(t *testing.T) {
 }
 
 // TestMissionRunnerRequestsAreBuiltinsOnly guards the security fix:
-// every loop.Request the native runner builds — worker, explorer,
-// reviewer, planner — must set BuiltinsOnly, so a mission turn's base
+// every loop.Request the native runner builds: worker, explorer,
+// reviewer, planner: must set BuiltinsOnly, so a mission turn's base
 // tool surface never includes connector tools (e.g. a write-capable
 // GitHub MCP token) or the chat-only mission list/get/push tools. A
 // missed phase here would silently reopen the side-channel the fix
@@ -1846,7 +1924,7 @@ func TestMissionRunnerRequestsAreBuiltinsOnly(t *testing.T) {
 }
 
 // okToolResultEvent is toolResultEvent's ok-status counterpart with a
-// name and digest — search_web's rendered results ride the digest,
+// name and digest: search_web's rendered results ride the digest,
 // never a separate raw-result field (D-059).
 func okToolResultEvent(id, name, digest string) stream.StreamEvent {
 	return stream.StreamEvent{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{
@@ -1916,7 +1994,7 @@ func TestWebSearchResultURLs(t *testing.T) {
 // end-to-end wiring check (D-059): a worker turn that calls fetch_url
 // and search_web must surface both URLs on the returned verdict, so
 // the driver's citations check has real harness evidence to compare
-// against — never the model's own claim.
+// against: never the model's own claim.
 func TestRunWorkerCollectsSeenURLsFromWebFetchAndWebSearch(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{
@@ -2161,7 +2239,7 @@ func TestSteeringForNilWithoutProgressReader(t *testing.T) {
 
 // TestExecEnvironmentNoteIncludesTimezoneSteer pins that the date line
 // carries the timezone-presentation instruction right after the date,
-// for both an operator location and the nil (UTC) default — a global
+// for both an operator location and the nil (UTC) default: a global
 // harness instruction instead of per-prompt boilerplate.
 func TestExecEnvironmentNoteIncludesTimezoneSteer(t *testing.T) {
 	want := "Present all dates and times in this timezone unless the goal asks otherwise."

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -901,6 +901,20 @@ export interface MissionRetryPayload {
   reason?: string
 }
 
+// MissionToolCallPayload is mission.tool_call's payload (runner.go's
+// runTurn, issue #369): one event per tool call finished during a
+// worker/explore/plan/review turn, in call order. phase matches the
+// mission.turn event for the same turn (explore/plan/execute/review),
+// so the detail page can group a turn's trace. args_digest is capped
+// server-side, never a full args blob.
+export interface MissionToolCallPayload {
+  phase: string
+  tool: string
+  args_digest?: string
+  status: string
+  duration_ms: number
+}
+
 // MissionPermissionDeniedPayload is mission.permission_denied's payload
 // (runner.go's OnPermissionDenied); tool is the denied call, detail is
 // a short digest of why (never the full args/rationale).

--- a/web/src/components/missions/TimelineSection.test.tsx
+++ b/web/src/components/missions/TimelineSection.test.tsx
@@ -88,3 +88,91 @@ describe('TimelineSection', () => {
     expect(screen.getAllByText('1 event')).toHaveLength(1)
   })
 })
+
+// toolCallTraceEvents builds a mission.turn row preceded by three
+// mission.tool_call events, ordered as runner.go's runTurn appends
+// them: the shape a per-turn trace toggle groups (issue #369).
+const toolCallTraceEvents: MissionEvent[] = [
+  {
+    mission_id: 'm1',
+    seq: 1,
+    kind: 'mission.tool_call',
+    payload: { phase: 'execute', tool: 'search_kb', args_digest: '{"query":"first"}', status: 'ok', duration_ms: 12 },
+    provenance: 'harness',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    mission_id: 'm1',
+    seq: 2,
+    kind: 'mission.tool_call',
+    payload: { phase: 'execute', tool: 'shell', args_digest: '{"command":"ls"}', status: 'denied', duration_ms: 3 },
+    provenance: 'harness',
+    created_at: '2026-01-01T00:00:01Z',
+  },
+  {
+    mission_id: 'm1',
+    seq: 3,
+    kind: 'mission.tool_call',
+    payload: { phase: 'execute', tool: 'write_file', args_digest: '{"path":"x"}', status: 'error', duration_ms: 40 },
+    provenance: 'harness',
+    created_at: '2026-01-01T00:00:02Z',
+  },
+  {
+    mission_id: 'm1',
+    seq: 4,
+    kind: 'mission.turn',
+    payload: { phase: 'execute', duration_ms: 500, ok: true, input: 'worker_done' },
+    provenance: 'harness',
+    created_at: '2026-01-01T00:00:03Z',
+  },
+]
+
+describe('TimelineSection tool call trace', () => {
+  it('excludes mission.tool_call events from the plain row count', () => {
+    render(<TimelineSection events={toolCallTraceEvents} />)
+    // Only the mission.turn row counts as an event; its three tool
+    // calls are nested, not separate rows.
+    expect(screen.getAllByText('1 event')).toHaveLength(1)
+  })
+
+  it('shows the trace collapsed by default, with a toggle naming the count', () => {
+    render(<TimelineSection events={toolCallTraceEvents} />)
+    expect(screen.getByText('3 tool calls')).toBeTruthy()
+    expect(screen.queryByText('search_kb')).toBeNull()
+  })
+
+  it('expands to show the ordered tool-call trace with outcome and duration', () => {
+    render(<TimelineSection events={toolCallTraceEvents} />)
+    fireEvent.click(screen.getByText('3 tool calls'))
+
+    const names = screen.getAllByText(/search_kb|shell|write_file/).map((el) => el.textContent)
+    expect(names).toEqual(['search_kb', 'shell', 'write_file'])
+    expect(screen.getByText('{"query":"first"}')).toBeTruthy()
+    expect(screen.getByText('{"command":"ls"}')).toBeTruthy()
+    expect(screen.getByText('{"path":"x"}')).toBeTruthy()
+  })
+
+  it('collapses again on a second toggle click', () => {
+    render(<TimelineSection events={toolCallTraceEvents} />)
+    const toggle = screen.getByText('3 tool calls')
+    fireEvent.click(toggle)
+    expect(screen.getByText('search_kb')).toBeTruthy()
+    fireEvent.click(toggle)
+    expect(screen.queryByText('search_kb')).toBeNull()
+  })
+
+  it('shows no toggle for a turn with no tool calls', () => {
+    const noCalls: MissionEvent[] = [
+      {
+        mission_id: 'm1',
+        seq: 1,
+        kind: 'mission.turn',
+        payload: { phase: 'plan', duration_ms: 200, ok: true, input: 'plan_created' },
+        provenance: 'harness',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ]
+    render(<TimelineSection events={noCalls} />)
+    expect(screen.queryByText(/tool call/)).toBeNull()
+  })
+})

--- a/web/src/components/missions/TimelineSection.tsx
+++ b/web/src/components/missions/TimelineSection.tsx
@@ -1,27 +1,91 @@
-import { ArrowDown01Icon, ArrowUp01Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { ArrowDown01Icon, ArrowRight01Icon, ArrowUp01Icon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
-import { useEffect, useRef } from 'react'
-import type { MissionEvent } from '../../api/types'
+import { useEffect, useRef, useState } from 'react'
+import type { MissionEvent, MissionToolCallPayload } from '../../api/types'
 import { CopyButton } from '../Message'
 import { Button } from '../ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
-import { renderEvent } from './eventRenderers'
+import { renderEvent, toolCallStatusClass } from './eventRenderers'
 import { FullscreenDialog, FullscreenToggle, useFullscreenPanel } from './FullscreenPanel'
+import { formatDuration } from '../../lib/format'
 
 // How close to the bottom (px) counts as "already following the tail"
-// — auto-scroll only kicks in within this margin, so a reader who has
+//: auto-scroll only kicks in within this margin, so a reader who has
 // scrolled up to read history never gets yanked back down by new
 // events arriving from the poll loop.
 const followThresholdPx = 48
 
 // executor.progress fires on every byte the delegated CLI executor
-// writes — rendering one row per event would flood the timeline, so
+// writes: rendering one row per event would flood the timeline, so
 // it's excluded here; MissionDetail's phase header shows the latest
-// one instead as a lightweight live indicator.
-const rowKind = (e: MissionEvent) => e.kind !== 'executor.progress'
+// one instead as a lightweight live indicator. mission.tool_call is
+// excluded the same way: it renders nested under its owning
+// mission.turn row (see turnToolCalls) instead of as its own Timeline
+// line.
+const rowKind = (e: MissionEvent) => e.kind !== 'executor.progress' && e.kind !== 'mission.tool_call'
+
+// turnToolCalls groups every mission.tool_call event by the
+// mission.turn row it belongs to: a turn's tool calls are the
+// mission.tool_call events between the PRECEDING mission.turn event
+// (exclusive) and this one (inclusive), in seq order: matching how
+// runner.go's runTurn appends one mission.tool_call per finished call
+// during the turn, then driver.go's Advance appends the mission.turn
+// summary once the turn (and any recovery re-run) completes. Keyed by
+// the mission.turn event's own seq, since that's a stable per-row key
+// already used elsewhere in this file.
+function turnToolCalls(events: MissionEvent[]): Map<number, MissionEvent[]> {
+  const byTurn = new Map<number, MissionEvent[]>()
+  let pending: MissionEvent[] = []
+  for (const e of events) {
+    if (e.kind === 'mission.tool_call') {
+      pending.push(e)
+    } else if (e.kind === 'mission.turn') {
+      byTurn.set(e.seq, pending)
+      pending = []
+    }
+  }
+  return byTurn
+}
+
+// TurnTraceToggle renders the expand/collapse control and, when
+// expanded, the ordered tool-call trace for one mission.turn row.
+function TurnTraceToggle({ calls }: { calls: MissionEvent[] }) {
+  const [open, setOpen] = useState(false)
+  if (calls.length === 0) return null
+  return (
+    <div className="mt-0.5">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center gap-1 text-zinc-500 hover:text-zinc-300"
+      >
+        <HugeiconsIcon icon={ArrowRight01Icon} className={`size-3 transition-transform ${open ? 'rotate-90' : ''}`} />
+        {calls.length} tool call{calls.length === 1 ? '' : 's'}
+      </button>
+      {open && (
+        <ol className="mt-1 space-y-0.5 border-l border-zinc-800 pl-3">
+          {calls.map((c) => {
+            const { tool, status, duration_ms, args_digest } = c.payload as MissionToolCallPayload
+            return (
+              <li key={c.seq} className="text-zinc-400">
+                <span className={toolCallStatusClass(status)}>{tool}</span> · {status} ·{' '}
+                {formatDuration(duration_ms)}
+                {args_digest && (
+                  <code className="ml-1 block truncate rounded bg-muted/20 px-1 py-0.5 text-[11px] text-zinc-500">
+                    {args_digest}
+                  </code>
+                )}
+              </li>
+            )
+          })}
+        </ol>
+      )}
+    </div>
+  )
+}
 
 // timelineText renders a plain-text version of the timeline for the
-// copy button — one line per row, timestamp plus event kind (the
+// copy button: one line per row, timestamp plus event kind (the
 // short, stable label; renderEvent's JSX detail is skipped, it's
 // styled markup, not plain text).
 function timelineText(rows: MissionEvent[]): string {
@@ -30,6 +94,7 @@ function timelineText(rows: MissionEvent[]): string {
 
 export function TimelineSection({ events }: { events: MissionEvent[] }) {
   const rows = events.filter(rowKind)
+  const toolCallsByTurn = turnToolCalls(events)
   const containerRef = useRef<HTMLDivElement>(null)
   const wasAtBottomRef = useRef(true)
   const { fullscreen, toggle, close } = useFullscreenPanel()
@@ -117,7 +182,10 @@ export function TimelineSection({ events }: { events: MissionEvent[] }) {
                 <span className="w-24 shrink-0 whitespace-nowrap text-zinc-500">
                   {new Date(e.created_at).toLocaleTimeString()}
                 </span>
-                <span className="flex-1 break-words">{renderEvent(e, rows)}</span>
+                <span className="flex-1 break-words">
+                  {renderEvent(e, rows)}
+                  {e.kind === 'mission.turn' && <TurnTraceToggle calls={toolCallsByTurn.get(e.seq) ?? []} />}
+                </span>
               </li>
             ))}
           </ol>

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -11,13 +11,14 @@ import type {
   MissionPROpenedPayload,
   MissionRetryPayload,
   MissionSteeredPayload,
+  MissionToolCallPayload,
   MissionTurnPayload,
 } from '../../api/types'
 import { formatDuration } from '../../lib/format'
 
 // eventRenderers maps a mission_events kind to a short, human-readable
 // summary of its payload. Unrecognized kinds fall back to the generic
-// renderer below — forward-compatible with new event kinds the web
+// renderer below: forward-compatible with new event kinds the web
 // hasn't been updated to render specifically, rather than rendering
 // blank.
 const renderers: Record<string, (payload: unknown) => ReactNode> = {
@@ -61,6 +62,14 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
     return (
       <span className="text-red-400" title={reason}>
         {base}: {truncateForDisplay(reason, 160)}
+      </span>
+    )
+  },
+  'mission.tool_call': (p) => {
+    const { tool, status, duration_ms } = p as MissionToolCallPayload
+    return (
+      <span className={toolCallStatusClass(status)}>
+        {tool} · {status} · {formatDuration(duration_ms)}
       </span>
     )
   },
@@ -195,13 +204,13 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
 
 // formatExecutorCost renders executor.result's usage.cost_usd.
 // cost_usd_billed=true means this figure is the SAME one the cost
-// ledger booked as real spend (Anthropic first-party api_key) — shown
+// ledger booked as real spend (Anthropic first-party api_key): shown
 // as the billed truth, unchanged from before. Everything else is the
 // CLI's own harness-reported figure, never booked as-is: subscription/
 // oauth_token auth (never billed at all) or a non-anthropic provider
-// (priced against Anthropic's table, fiction for that provider — the
+// (priced against Anthropic's table, fiction for that provider: the
 // ledger prices it from that provider's own rows instead, or leaves it
-// unpriced) — labeled so it's never mistaken for real marginal spend.
+// unpriced): labeled so it's never mistaken for real marginal spend.
 // Absent + subscription auth means cost is genuinely untracked (older
 // run, before this CLI reported it); absent otherwise is unreported.
 function formatExecutorCost(costUsd: number | null | undefined, billed: boolean, subscriptionAuth?: boolean): string {
@@ -213,12 +222,22 @@ function formatExecutorCost(costUsd: number | null | undefined, billed: boolean,
   return subscriptionAuth ? 'subscription — cost untracked' : 'cost unreported'
 }
 
+// toolCallStatusClass colors a tool call trace entry by outcome:
+// shared between the plain Timeline row above and TimelineSection's
+// per-turn trace, so a tool call reads the same color wherever it's
+// shown.
+export function toolCallStatusClass(status: string): string {
+  if (status === 'ok') return 'text-green-400'
+  if (status === 'denied') return 'text-amber-400'
+  return 'text-red-400'
+}
+
 function asRecord(v: unknown): Record<string, unknown> {
   return typeof v === 'object' && v !== null ? (v as Record<string, unknown>) : {}
 }
 
 // truncateForDisplay caps an inline Timeline snippet well below the
-// backend's own 2000-char event cap — a full shell command belongs in
+// backend's own 2000-char event cap: a full shell command belongs in
 // the (already truncated) event payload, not a single Timeline row.
 function truncateForDisplay(s: string, n = 200): string {
   return s.length <= n ? s : s.slice(0, n) + '…'
@@ -228,7 +247,7 @@ function truncateForDisplay(s: string, n = 200): string {
 // kinds fall back to the raw kind string rather than rendering blank.
 // allEvents carries the full timeline so executor.result (below) can
 // look back to the run's executor.spawned for context its own payload
-// doesn't repeat (auth_mode) — every other kind ignores it.
+// doesn't repeat (auth_mode): every other kind ignores it.
 export function renderEvent(event: MissionEvent, allEvents: MissionEvent[] = [event]): ReactNode {
   if (event.kind === 'executor.result') return renderExecutorResult(event, allEvents)
   const render = renderers[event.kind]
@@ -237,7 +256,7 @@ export function renderEvent(event: MissionEvent, allEvents: MissionEvent[] = [ev
 }
 
 function renderExecutorResult(event: MissionEvent, allEvents: MissionEvent[]): ReactNode {
-  // denials/usage are omitted from the payload when empty — never
+  // denials/usage are omitted from the payload when empty: never
   // assume presence, a TypeError here blanks the whole detail page.
   const { status, duration_ms, exit_code, denials = [], usage } = event.payload as ExecutorResultPayload
   const spawn = [...allEvents]


### PR DESCRIPTION
## Why

Closes #369. mission_events recorded turn-level entries only; for mission aca04d5d it was impossible to confirm KB usage. Operators need to see how a result was produced to trust it.

## Changes

- `runTurn` (internal/brain/missions/runner.go) already consumes `stream.EventToolResult` per finished tool call; it now reports each through a new `parkNotifier.OnToolCall` method. `StorePermissionParker` appends a `mission.tool_call` event via the existing non-transition `Store.AppendEvent` path (`mission.review_skipped` precedent). Append-only invariant untouched; `ApplyTransition` remains the sole state writer. Zero change to loop execution, permissions, or turn outcomes.
- Payload: `{phase, tool, args_digest, status, duration_ms}`; args digest capped at 2000 chars (existing `truncate` pattern). `runTurn` takes an explicit `Phase` from its call sites (execute/explore/plan/review).
- Web: mission detail timeline groups `mission.tool_call` events under their owning `mission.turn` row by seq range; collapsed-by-default expandable trace showing tool, status, duration, digest preview. Trace events excluded from the plain row count like `executor.progress`.

## Verification

- Go: build, vet, vet -tags integration, `go test -race ./internal/brain/missions/` clean (containerized).
- Web: build clean, TimelineSection tests 12/12 (5 new).
- `make canary`: PASS on the live stack rebuilt with this branch; event counts included `mission.tool_call: 6` across 3 turns.

## Notes

Out of scope per issue: live streaming of tool calls (post-hoc trace only).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790685094&installation_model_id=431401&pr_number=402&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F402&signature=9d00124a053a282ce1160772fdefcf0a73f22db3b5c008d58e1022906d422386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->