### PR TITLE
feat(web): composer # references with autocomplete and chips

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -34,6 +34,7 @@ import type {
   Notification,
   PendingPermission,
   ProviderHealth,
+  ReferenceKind,
   RetrievedMemory,
   Schedule,
   SessionMeta,
@@ -107,7 +108,7 @@ export function createSSEParser<T = ChatEvent>(onEvent: (ev: T) => void) {
 
 // ChatError is a structured request failure: match on status/code, not
 // message text. sessionId is present when brain already created a
-// session row — reuse it on retry instead of orphaning it.
+// session row: reuse it on retry instead of orphaning it.
 export class ChatError extends Error {
   readonly status: number
   readonly code?: string
@@ -192,7 +193,7 @@ export async function chatStream(
 
 // retryStream re-runs a session's last (failed) turn: the session
 // already carries the dangling user message server-side, so this
-// posts no body — retry has nothing new to say, just "try again".
+// posts no body: retry has nothing new to say, just "try again".
 export async function retryStream(
   sessionId: string,
   onEvent: (ev: ChatEvent) => void,
@@ -203,7 +204,7 @@ export async function retryStream(
 
 // stopTurn cancels a session's in-flight turn server-side: the turn now
 // runs detached from the request that started it, so aborting the
-// local fetch (AbortController) no longer stops it — this is the only
+// local fetch (AbortController) no longer stops it: this is the only
 // thing that does. A 404 (no turn running, or it already finished) is
 // a benign race from the caller's point of view, same as streamLive's.
 export async function stopTurn(sessionId: string): Promise<void> {
@@ -213,8 +214,8 @@ export async function stopTurn(sessionId: string): Promise<void> {
 // streamLive reattaches to a session's in-flight turn (Tier 2 of live
 // reattach): GET .../live replays whatever the turn already emitted
 // then follows it live until the terminal, wire-identical to
-// chatStream/retryStream's SSE frames — same createSSEParser, same
-// ChatEvent shape, same terminal meta contract — so a caller feeds
+// chatStream/retryStream's SSE frames: same createSSEParser, same
+// ChatEvent shape, same terminal meta contract: so a caller feeds
 // events through the exact same applyEvent reducer regardless of
 // which of the three started the stream. Throws ChatError(404,
 // 'no_active_turn') when nothing is running; the caller's fallback is
@@ -366,7 +367,7 @@ export async function answerPermission(
 }
 
 // listPendingPermissions returns every permission ask still awaiting a
-// decision across every session with a currently active turn — the
+// decision across every session with a currently active turn: the
 // global badge/toast's data source.
 export async function listPendingPermissions(): Promise<PendingPermission[]> {
   const { pending } = await request<{ pending: PendingPermission[] }>('/v1/permissions/pending')
@@ -394,7 +395,7 @@ export async function setSessionKnowledge(id: string, collections: string[]): Pr
 
 // transcribe posts a recorded audio clip (from the mic button) to
 // brain's local speech-to-text proxy and returns the transcript.
-// Raw bytes, not JSON — the body IS the audio, so this bypasses
+// Raw bytes, not JSON: the body IS the audio, so this bypasses
 // request()'s JSON content type. language is an optional ISO 639-1
 // code (e.g. "bn"); omitted lets the sidecar auto-detect.
 export async function transcribe(blob: Blob, language?: string): Promise<string> {
@@ -430,7 +431,7 @@ export interface AttachmentUpload {
 
 // uploadAttachment posts one file to /v1/attachments (multipart field
 // "file") and returns its stored id/mime/size. Raw multipart, not
-// JSON — same bypass of request()'s JSON content type as transcribe.
+// JSON: same bypass of request()'s JSON content type as transcribe.
 export async function uploadAttachment(file: File): Promise<AttachmentUpload> {
   const form = new FormData()
   form.append('file', file)
@@ -454,7 +455,7 @@ export async function uploadAttachment(file: File): Promise<AttachmentUpload> {
 }
 
 // fetchAttachmentBlob reads an uploaded attachment's bytes for inline
-// rendering (AuthedImage) — GET /v1/attachments/{id} requires the
+// rendering (AuthedImage): GET /v1/attachments/{id} requires the
 // bearer header, so a bare <img src> cannot fetch it directly.
 export async function fetchAttachmentBlob(id: string): Promise<Blob> {
   const res = await fetch(`/v1/attachments/${id}`, {
@@ -533,7 +534,7 @@ function rangeParams(from: Date, to: Date, extra: Record<string, string> = {}): 
 }
 
 // usageSummary returns one row per billing currency present in the
-// range — never summed together (D-013's spend-side sibling: no FX
+// range: never summed together (D-013's spend-side sibling: no FX
 // conversion anywhere in this codebase).
 export async function usageSummary(from: Date, to: Date): Promise<UsageSummary[]> {
   const { summaries } = await request<{ summaries: UsageSummary[] }>(
@@ -566,7 +567,7 @@ export async function usageTotals(
 }
 
 // usageUnpriced returns the (provider, model) pairs with unpriced usage
-// (cost NULL) in range — the pairs Analytics' catalog estimate needs to
+// (cost NULL) in range: the pairs Analytics' catalog estimate needs to
 // price, kept per-provider so catalogPrices resolves each pair against
 // that provider's own catalog candidates only.
 export async function usageUnpriced(from: Date, to: Date): Promise<UnpricedGroup[]> {
@@ -643,7 +644,7 @@ export async function testProvider(id: string, model?: string): Promise<TestResu
 }
 
 // validateProvider probes an UNSAVED provider config with a one-token
-// completion — the add dialog's validate-on-create. Probe failures come
+// completion: the add dialog's validate-on-create. Probe failures come
 // back as { ok: false, detail }; only invalid configs throw.
 export async function validateProvider(
   p: Partial<AdminProvider>,
@@ -657,7 +658,7 @@ export async function validateProvider(
 
 // availableModels proxies the provider's own model-listing endpoint.
 // Throws ChatError with status 422 when the driver cannot list models
-// (bedrock) — callers fall back to manual entry.
+// (bedrock): callers fall back to manual entry.
 export async function availableModels(id: string): Promise<AvailableModel[]> {
   const { models } = await request<{ models: AvailableModel[] }>(
     `/v1/admin/providers/${id}/models`,
@@ -697,7 +698,7 @@ export async function searchCatalog(
 // catalogModelsForProvider searches the synced catalog restricted to a
 // provider's candidate litellm_provider(s) (derived server-side from
 // its driver/base_url, or "anthropic" for a kind='cli' claude-cli row)
-// — the model id picker's live suggestion source, and the provider
+//: the model id picker's live suggestion source, and the provider
 // detail page's read-only Models list. q filters case-insensitive
 // substring on model_key; omitted fetches the provider's whole
 // candidate pool. limit defaults to the server's normal cap (50);
@@ -717,7 +718,7 @@ export async function catalogModelsForProvider(
 
 // catalogPrices resolves each (provider, model) pair within that
 // PROVIDER's own catalog candidates only (Analytics' unpriced-call
-// estimate) — never the whole catalog, so a model name that collides
+// estimate): never the whole catalog, so a model name that collides
 // with another vendor's catalog entry can never borrow that vendor's
 // price. price is null when the provider name is unknown or the model
 // has no match within its candidates.
@@ -759,7 +760,7 @@ export async function deleteSecret(refName: string): Promise<void> {
 }
 
 // migrateSecret moves one stored ref's value onto backend, wiping its
-// old storage — used to re-home a credential after Vault/ASM is set up.
+// old storage: used to re-home a credential after Vault/ASM is set up.
 export async function migrateSecret(refName: string, backend: string): Promise<void> {
   await request<void>(`/v1/admin/secrets/${encodeURIComponent(refName)}/migrate`, {
     method: 'POST',
@@ -786,7 +787,7 @@ export async function migrateAllSecrets(backend: string): Promise<SecretMigratio
 }
 
 // SecretReference is one provider or connector naming a credential ref
-// as its credential_ref — the credentials panel's used-by chips.
+// as its credential_ref: the credentials panel's used-by chips.
 export interface SecretReference {
   kind: 'provider' | 'connector'
   name: string
@@ -795,9 +796,9 @@ export interface SecretReference {
 
 // SecretRefEntry is one stored secret's directory entry: name,
 // timestamps (when the row has them), and every referent across both
-// providers and connectors. Never a value — the credentials panel is a
+// providers and connectors. Never a value: the credentials panel is a
 // directory, not a vault viewer. system marks a configured secret
-// backend's own bootstrap credential (e.g. the vault token) — the
+// backend's own bootstrap credential (e.g. the vault token): the
 // gateway refuses to delete these regardless, but the panel hides the
 // delete action for them up front.
 export interface SecretRefEntry {
@@ -964,8 +965,17 @@ export async function listKbDocuments(collectionId: string): Promise<KbDocument[
   return documents ?? []
 }
 
+// searchKbDocuments is the cross-collection title search (the composer
+// #-mention "type to find a kb document" search): an empty q returns
+// every document.
+export async function searchKbDocuments(q = ''): Promise<KbDocument[]> {
+  const qs = q ? `?q=${encodeURIComponent(q)}` : ''
+  const { documents } = await request<{ documents: KbDocument[] }>(`/v1/admin/kb/documents${qs}`)
+  return documents ?? []
+}
+
 // uploadKbDocument posts one file to a collection (multipart field
-// "file") — same bypass of request()'s JSON content type as
+// "file"): same bypass of request()'s JSON content type as
 // uploadAttachment, since the body is the file, not JSON.
 export async function uploadKbDocument(collectionId: string, file: File): Promise<KbDocument> {
   const form = new FormData()
@@ -1081,7 +1091,7 @@ export async function testConnector(
 
 // listConnectorRepos lists every repo a github-kind connector's PAT
 // can see (owner, collaborator, or org member), most recently pushed
-// first — the mission create form's repo picker.
+// first: the mission create form's repo picker.
 export async function listConnectorRepos(id: string): Promise<GitHubRepo[]> {
   const { repos } = await request<{ repos: GitHubRepo[] }>(`/v1/admin/connectors/${id}/repos`)
   return repos ?? []
@@ -1182,7 +1192,7 @@ export async function setRouteRole(name: string, role: string): Promise<void> {
 
 export interface AdminSettings {
   // Feature switches, plus the read-only derived transcribe_enabled
-  // key (true when WHISPER_URL is configured server-side) — the
+  // key (true when WHISPER_URL is configured server-side): the
   // Composer mic button hides itself when it's false.
   settings: Record<string, boolean>
   // Typed runtime settings; empty string means the built-in default.
@@ -1219,12 +1229,12 @@ export interface CreateMissionInput {
   route?: string
   review_route?: string
   // plan_route, when set, is the route explore/plan/replan/review run
-  // on instead of route — omit (or "") to use route for everything.
+  // on instead of route: omit (or "") to use route for everything.
   plan_route?: string
   escalation_route?: string
   // route_model/plan_route_model/review_route_model pin one phase axis
   // to one exact chain entry ("provider name/model") in the route it
-  // would otherwise resolve — omit (or "") to keep the first-usable
+  // would otherwise resolve: omit (or "") to keep the first-usable
   // walk. See ExecutionPlanEntry's provider_name+model for the pair a
   // pin names.
   route_model?: string
@@ -1235,12 +1245,12 @@ export interface CreateMissionInput {
   budget_currency?: string
   auto_approve_safe?: boolean
   // harness names the delegated coding-CLI executor a coding mission
-  // runs under — omit (or "") to apply the settings default,
+  // runs under: omit (or "") to apply the settings default,
   // "native" to force the built-in agent loop. Only valid when
   // kind === 'coding'.
   harness?: string
   // environment selects the sandbox image key (D-05x) a coding
-  // mission's container runs — omit (or "") to auto-detect (repo
+  // mission's container runs: omit (or "") to auto-detect (repo
   // markers, then a goal-keyword heuristic, falling back to base).
   // Only valid when kind === 'coding'.
   environment?: string
@@ -1268,7 +1278,7 @@ export interface CreateMissionInput {
   // outcome digest is carried into this mission's prompts.
   parent_mission_id?: string
   // attachments name already-uploaded PDFs (POST /v1/attachments) to
-  // convert to markdown once at create time — PDF only, up to 8.
+  // convert to markdown once at create time: PDF only, up to 8.
   attachments?: { id: string; name: string }[]
   // destination_ids names operator-created destinations to deliver this
   // mission's outcome digest to on the terminal done transition; omit
@@ -1278,10 +1288,13 @@ export interface CreateMissionInput {
   // single worker turn, final message delivered as the result. Only
   // valid when kind === 'general'.
   light?: boolean
+  // references name composer #-mention picks (missions/chats/kb docs)
+  // to resolve at create time into ReferencedContext.
+  references?: { kind: ReferenceKind; id: string }[]
 }
 
 // ExecutorOption is one registered harness's usability on a given
-// route (GET /v1/missions/executor-options) — usable ones carry the
+// route (GET /v1/missions/executor-options): usable ones carry the
 // provider/model they'd resolve to, unusable ones a reason why not.
 export interface ExecutorOption {
   harness: string
@@ -1336,14 +1349,17 @@ export async function getMissionExecutionPlan(params: {
 }
 
 // listMissions returns every mission by default; opts narrows to one
-// schedule's fire history (scheduleId) and/or caps the result count
-// (limit) — both map directly to the server's optional query params.
+// schedule's fire history (scheduleId), a text search (query, the
+// composer #-mention mission search), and/or caps the result count
+// (limit): all map directly to the server's optional query params.
 export async function listMissions(opts?: {
   scheduleId?: string
+  query?: string
   limit?: number
 }): Promise<Mission[]> {
   const params = new URLSearchParams()
   if (opts?.scheduleId) params.set('schedule_id', opts.scheduleId)
+  if (opts?.query) params.set('q', opts.query)
   if (opts?.limit) params.set('limit', String(opts.limit))
   const qs = params.size > 0 ? `?${params.toString()}` : ''
   const { missions } = await request<{ missions: Mission[] }>(`/v1/missions${qs}`)
@@ -1351,8 +1367,8 @@ export async function listMissions(opts?: {
 }
 
 // createMission returns the full created mission (not just its id) so
-// a server-resolved field decided at create time — e.g. auto-detected
-// environment (D-05x) — is available without a follow-up GET.
+// a server-resolved field decided at create time: e.g. auto-detected
+// environment (D-05x): is available without a follow-up GET.
 export async function createMission(input: CreateMissionInput): Promise<Mission> {
   return request<Mission>('/v1/missions', {
     method: 'POST',
@@ -1362,7 +1378,7 @@ export async function createMission(input: CreateMissionInput): Promise<Mission>
 
 // classifyMission previews the kind create() would infer for goal, and
 // (for a general goal) whether it looks like a single-pass light
-// mission — the same classifyKind/classifyLight logic the server falls
+// mission: the same classifyKind/classifyLight logic the server falls
 // back to/suggests, exposed standalone for the create form's live chip
 // and light toggle default. light is only ever a suggestion; create()
 // still requires the operator's explicit flag.
@@ -1397,7 +1413,7 @@ export async function cancelMission(id: string): Promise<void> {
 }
 
 // sendMissionNote injects operator guidance into a running mission via
-// the progress-note pipeline — no state transition, picked up by the
+// the progress-note pipeline: no state transition, picked up by the
 // next worker turn's own packet.
 export async function sendMissionNote(id: string, text: string): Promise<void> {
   await request<void>(`/v1/missions/${id}/note`, {
@@ -1435,7 +1451,7 @@ export async function pushMission(
 }
 
 // openMissionPR pushes (idempotent re-push) then opens a pull request
-// for a github-connection mission — or returns the existing open PR
+// for a github-connection mission: or returns the existing open PR
 // for the same head if GitHub reports one already exists.
 export async function openMissionPR(id: string): Promise<{ url: string; number: number }> {
   return request<{ url: string; number: number }>(`/v1/missions/${id}/pr`, { method: 'POST' })
@@ -1462,7 +1478,7 @@ export async function listMissionFiles(
 }
 
 // fetchBlobDownload fetches an authenticated binary response and saves
-// it via a programmatic anchor click — plain hrefs can't carry the
+// it via a programmatic anchor click: plain hrefs can't carry the
 // bearer token from localStorage.
 async function fetchBlobDownload(path: string, fallbackName: string): Promise<void> {
   const res = await fetch(path, {
@@ -1518,7 +1534,7 @@ export const missionPdfPreviewCap = 25_000_000
 export class MissionFileTooLargeError extends Error {}
 
 // fetchMissionFileBlob reads a mission file's bytes for in-app
-// preview (image/text/markdown/pdf) rather than triggering a save —
+// preview (image/text/markdown/pdf) rather than triggering a save:
 // the server forces Content-Type: application/octet-stream on this
 // route deliberately (a worker-authored file could be arbitrary
 // HTML), so callers must render the bytes themselves, never navigate
@@ -1571,7 +1587,7 @@ export async function downloadMissionPdfExport(attachmentId: string, filename: s
 
 // exportMessagePDF renders one chat message's already-rendered markdown
 // into a single-chapter PDF via the pdfgen sidecar. The message content
-// travels in the body — it's already in the transcript the client
+// travels in the body: it's already in the transcript the client
 // holds, no server-side lookup needed.
 export async function exportMessagePDF(
   title: string,

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1,5 +1,5 @@
 // Mirrors the brain's SSE wire contract: normalized gateway events
-// followed by exactly one terminal meta event — read until meta.
+// followed by exactly one terminal meta event: read until meta.
 
 export interface Usage {
   input_tokens: number
@@ -15,7 +15,7 @@ export interface ToolCallEvent {
 }
 
 // MediaRef points at one attachment-store item a tool generated during
-// a call — id, mime, and an optional display name, never bytes.
+// a call: id, mime, and an optional display name, never bytes.
 export interface MediaRef {
   id: string
   mime: string
@@ -87,7 +87,7 @@ export interface MetaEvent {
   ledger_id?: string
   duration_ms?: number
   // cost is null/absent when the gateway had no price for the serving
-  // model — unknown price is never guessed (D-013); currency is blank
+  // model: unknown price is never guessed (D-013); currency is blank
   // in that case too.
   cost?: number | null
   currency?: string
@@ -116,6 +116,21 @@ export interface ChatRequest {
   // knowledge is the set of kb collection names pinned for this turn;
   // the server unions them into the session's knowledge list.
   knowledge?: string[]
+  // references name individual missions/chats/kb documents picked via
+  // composer # mentions, resolved server-side into this turn's
+  // documents (generalizes knowledge, which only covers collections).
+  references?: { kind: ReferenceKind; id: string }[]
+}
+
+// ReferenceKind names what a composer #-mention reference points at.
+export type ReferenceKind = 'mission' | 'session' | 'kb_doc'
+
+// Reference is one composer #-mention pick, kept client-side as chip
+// state: name is display-only, never sent to the server.
+export interface Reference {
+  kind: ReferenceKind
+  id: string
+  name: string
 }
 
 // --- session management (mirrors brain's /v1/sessions surface) ---
@@ -138,7 +153,7 @@ export interface UIBlock {
   media?: MediaRef[]
 }
 
-// ImageRef is one attachment carried by a user transcript item — the
+// ImageRef is one attachment carried by a user transcript item: the
 // attachment's id (content hash) and MIME type, never the bytes. name
 // is the original filename; absent on events persisted before
 // filename threading shipped.
@@ -168,7 +183,7 @@ export interface TranscriptItem {
   text?: string
   blocks?: UIBlock[]
   images?: ImageRef[]
-  // documents are attached PDFs, refs only (id+mime) — the converted
+  // documents are attached PDFs, refs only (id+mime): the converted
   // markdown never rides this payload.
   documents?: ImageRef[]
   tool?: ToolExecution
@@ -178,7 +193,7 @@ export interface TranscriptItem {
   usage?: Usage
   duration_ms?: number
   // cost is null/absent when the gateway had no price for the serving
-  // model — unknown price is never guessed (D-013); currency is blank
+  // model: unknown price is never guessed (D-013); currency is blank
   // in that case too.
   cost?: number | null
   currency?: string
@@ -194,13 +209,13 @@ export interface Transcript {
   session: SessionMeta
   items: TranscriptItem[]
   // Whether a turn is currently streaming for this session server-side
-  // — sourced from chat.Service's own turn registry, not a client
+  //: sourced from chat.Service's own turn registry, not a client
   // guess. Lets a tab that opens a session mid-turn know to attach
   // streamLive instead of rendering the last event as stale/interrupted.
   turn_active: boolean
 }
 
-// One unresolved permission ask, from GET /v1/permissions/pending —
+// One unresolved permission ask, from GET /v1/permissions/pending:
 // scoped server-side to sessions with a currently active turn.
 export interface PendingPermission {
   session_id: string
@@ -258,14 +273,14 @@ export interface EntityGraphData {
 // present only when a stored fx rate exists for the row's currency
 // (never a guess) and it differs from the target. The original
 // cost/currency fields are always left exactly as the ledger recorded
-// them (D-013) — these are purely additive display fields.
+// them (D-013): these are purely additive display fields.
 export interface ConvertedMoney {
   converted_amount?: number
   converted_currency?: string
   rate_as_of?: string
 }
 
-// Usage aggregates served by /v1/admin/usage/* — chart-ready, never
+// Usage aggregates served by /v1/admin/usage/*: chart-ready, never
 // raw ledger rows. Money fields are grouped by billing currency (no FX
 // conversion anywhere): a range spanning more than one currency comes
 // back as multiple rows, one per currency, never summed together.
@@ -273,11 +288,11 @@ export interface UsageSummary extends ConvertedMoney {
   currency: string
   cost: number
   // unbilled_cost is the metered-price equivalent of spend billed
-  // through a subscription/oauth_token executor (D-051) — real spend
+  // through a subscription/oauth_token executor (D-051): real spend
   // was $0, excluded from cost, never folded into it.
   unbilled_cost: number
   // converted_unbilled_cost mirrors converted_amount, same mechanism
-  // (usage.go's decorator), for unbilled_cost specifically — present
+  // (usage.go's decorator), for unbilled_cost specifically: present
   // only when a stored fx rate exists and unbilled_cost is nonzero.
   converted_unbilled_cost?: number
   input_tokens: number
@@ -296,7 +311,7 @@ export interface UsagePoint extends ConvertedMoney {
   group: string
   currency: string
   cost: number
-  // unbilled_cost mirrors UsageSummary's field — excluded from cost.
+  // unbilled_cost mirrors UsageSummary's field: excluded from cost.
   unbilled_cost: number
   // converted_unbilled_cost mirrors UsageSummary's field.
   converted_unbilled_cost?: number
@@ -308,7 +323,7 @@ export interface UsagePoint extends ConvertedMoney {
   unpriced_output_tokens: number
 }
 
-// GroupTotal is one group's totals over a whole range — the
+// GroupTotal is one group's totals over a whole range: the
 // non-time-bucketed sibling of UsagePoint, for tables/charts that rank
 // groups rather than plot them over time.
 export interface GroupTotal extends ConvertedMoney {
@@ -323,7 +338,7 @@ export interface GroupTotal extends ConvertedMoney {
 }
 
 // UnpricedGroup is one (provider, model) pair's unpriced-token totals
-// over a range (GET /v1/admin/usage/unpriced) — grouped by provider
+// over a range (GET /v1/admin/usage/unpriced): grouped by provider
 // alongside model so the catalog estimate (catalogPrices) can resolve
 // each pair against that provider's own catalog candidates only.
 export interface UnpricedGroup {
@@ -334,13 +349,13 @@ export interface UnpricedGroup {
 }
 
 // One mission's total ledger footprint. unpriced_requests counts turns
-// whose cost is unknown (NULL in the ledger) — cost_by_currency is
+// whose cost is unknown (NULL in the ledger): cost_by_currency is
 // then a floor per currency, not the whole bill.
 export interface ModelUsed {
   provider: string
   model: string
   // harness is true when this row is the delegated CLI executor's own
-  // calls (purpose='executor', D-051) rather than brain's direct ones —
+  // calls (purpose='executor', D-051) rather than brain's direct ones:
   // a model used by both sides yields two separate rows.
   harness: boolean
   requests: number
@@ -349,13 +364,13 @@ export interface ModelUsed {
 
 export interface MissionUsage {
   mission_id: string
-  // cost_by_currency is billed spend only — unbilled (subscription-
+  // cost_by_currency is billed spend only: unbilled (subscription-
   // billed) rows are excluded, so this is the mission's true bill.
   // Equals billed_brain_by_currency + billed_harness_by_currency.
   cost_by_currency: Record<string, number>
   // converted_cost_by_currency mirrors cost_by_currency, converted into
   // default_currency, present only when at least one entry had a
-  // usable stored fx rate — an entry with no rate is simply omitted,
+  // usable stored fx rate: an entry with no rate is simply omitted,
   // so this map's total can be a floor, not the whole bill.
   converted_cost_by_currency?: Record<string, number>
   // billed_brain_by_currency/billed_harness_by_currency split billed
@@ -365,7 +380,7 @@ export interface MissionUsage {
   billed_brain_by_currency?: Record<string, number>
   billed_harness_by_currency?: Record<string, number>
   // unbilled_cost_by_currency is the API-equivalent price of rows
-  // billed through a subscription/oauth_token executor (D-051) —
+  // billed through a subscription/oauth_token executor (D-051):
   // real spend was $0, this is what the same work would have cost
   // metered.
   unbilled_cost_by_currency?: Record<string, number>
@@ -414,15 +429,15 @@ export interface BudgetStatus {
 }
 
 // Control-plane shapes (/v1/admin/*). credential_ref is a NAME the
-// secret is stored under (in whichever backend is default) — secret
+// secret is stored under (in whichever backend is default): secret
 // values never travel.
 
 // CatalogModel is one model_catalog row (GET /v1/admin/catalog/models)
-// — LiteLLM's synced pricing/context data. Prices are per MILLION
+//: LiteLLM's synced pricing/context data. Prices are per MILLION
 // tokens (Timothy's convention); absent means unknown, never guessed.
 // id is the id the provider's own API actually accepts: model_key with
 // LiteLLM's namespacing provider prefix stripped server-side
-// (gateway/catalog.StripOwnPrefix) — model_key is kept alongside for
+// (gateway/catalog.StripOwnPrefix): model_key is kept alongside for
 // reference/debug, but a picker must display and commit id, never
 // model_key.
 export interface CatalogModel {
@@ -439,7 +454,7 @@ export interface CatalogModel {
 }
 
 // CatalogPriceQuery is one (provider, model) pair POST
-// /v1/admin/catalog/prices resolves — provider is a providers row's
+// /v1/admin/catalog/prices resolves: provider is a providers row's
 // name exactly as recorded in cost_ledger.provider (UnpricedGroup's own
 // field), so a caller reading unpriced usage can pass its rows straight
 // through.
@@ -449,7 +464,7 @@ export interface CatalogPriceQuery {
 }
 
 // CatalogPrice is one requested (provider, model) pair's resolved
-// catalog price from POST /v1/admin/catalog/prices — provider/model
+// catalog price from POST /v1/admin/catalog/prices: provider/model
 // echo the request pair back; price is null when the provider name is
 // unknown or the model has no match within that provider's catalog
 // candidates (never matched against another vendor's catalog rows).
@@ -495,11 +510,11 @@ export interface ChainEntry {
 // RouteEntryStatus is the router's live view of one chain entry: the
 // usability gate verdict plus the ledger stats and normalized factors
 // behind scored strategies. Numeric fields are absent when the ledger
-// has no data (or the model is unpriced) — never a guessed 0.
+// has no data (or the model is unpriced): never a guessed 0.
 export interface RouteEntryStatus {
   provider_id: string
   provider_name?: string
-  // provider_kind is 'api' | 'cli' — 'cli' rows are mission-only
+  // provider_kind is 'api' | 'cli': 'cli' rows are mission-only
   // executor providers (D-051), never built into a chat client.
   provider_kind?: string
   model: string
@@ -529,7 +544,7 @@ export interface AdminRoute {
   // work: 'default' | 'embedding' | 'vision' | 'summarize'. Absent for
   // a plain, user-owned route.
   role?: string
-  // Router try order with live stats — present for enabled routes once
+  // Router try order with live stats: present for enabled routes once
   // a snapshot is loaded. serving is the first usable resolved entry.
   resolved?: RouteEntryStatus[]
   serving?: ChainEntry
@@ -549,7 +564,7 @@ export interface TestResult {
   model: string
   detail?: string
   // responses_ok: whether the endpoint serves POST /responses (the
-  // OpenAI Responses API codex-cli requires) — absent when unprobed or
+  // OpenAI Responses API codex-cli requires): absent when unprobed or
   // the probe outcome was ambiguous, never affects ok.
   responses_ok?: boolean
 }
@@ -580,7 +595,7 @@ export interface AdminAgent {
   // Optional: the backend doesn't send it yet, so callers default to
   // [] when absent.
   knowledge?: string[]
-  // Mission-only fields (internal/brain/missions) — meaningless to a
+  // Mission-only fields (internal/brain/missions): meaningless to a
   // chat-only agent, absent or at zero values for one. Optional here
   // since most call sites (chat agent picker etc.) never populate
   // them.
@@ -593,14 +608,14 @@ export interface AdminAgent {
 }
 
 // AdminTool is one entry of the live tool surface (builtins +
-// connector tools) — feeds the agent editor's tools allowlist picker
+// connector tools): feeds the agent editor's tools allowlist picker
 // so a name is chosen from what actually exists, never typed blind.
 export interface AdminTool {
   name: string
   description: string
 }
 
-// AdminSkill is one loaded skill pack — feeds the agent editor's
+// AdminSkill is one loaded skill pack: feeds the agent editor's
 // skills allowlist picker so a name is chosen from what actually
 // exists, never typed blind.
 export interface AdminSkill {
@@ -609,7 +624,7 @@ export interface AdminSkill {
 }
 
 // KbCollection is one document collection agents can search with
-// search_kb — a named group of ingested documents.
+// search_kb: a named group of ingested documents.
 export interface KbCollection {
   id: string
   name: string
@@ -661,7 +676,7 @@ export interface Mission {
   id: string
   goal: string
   // name is a short display name generated once from goal, the same
-  // way a chat session's title is — empty until generation lands (or
+  // way a chat session's title is: empty until generation lands (or
   // for a mission predating this field); the UI falls back to a
   // truncated goal.
   name?: string
@@ -670,8 +685,8 @@ export interface Mission {
   phase: 'explore' | 'plan' | 'execute' | 'review' | 'done' | 'failed'
   status: 'idle' | 'working' | 'waiting_for_input' | 'paused' | 'done' | 'error'
   // failure_reason is derived server-side (Store.List/Get) from this
-  // mission's latest mission.failed event's payload.reason —
-  // "cancelled" or "max_iterations" — set only when phase is 'failed'.
+  // mission's latest mission.failed event's payload.reason:
+  // "cancelled" or "max_iterations": set only when phase is 'failed'.
   failure_reason?: string
   pause_reason?: 'backoff' | 'no_progress' | 'infra' | 'budget' | 'mixed_currency' | ''
   pause_message?: string
@@ -680,7 +695,7 @@ export interface Mission {
   branch?: string
   base_commit?: string
   // repo_url is the GitHub repo this coding mission was cloned from
-  // (https clone URL) — absent means the self-init'd empty repo.
+  // (https clone URL): absent means the self-init'd empty repo.
   // connector_id names the github-kind connector whose PAT
   // authenticated the clone; only present alongside repo_url.
   repo_url?: string
@@ -691,7 +706,7 @@ export interface Mission {
   // pull request. Only ever set at create time, never by the model.
   on_complete?: '' | 'push' | 'push_pr'
   // explore_notes is set once, at the end of the explore phase
-  // (driver.go's runExplore) — absent/empty for a mission created
+  // (driver.go's runExplore): absent/empty for a mission created
   // before the explore phase existed, or one that hasn't reached it
   // yet.
   explore_notes?: string
@@ -707,12 +722,12 @@ export interface Mission {
   route: string
   review_route: string
   // plan_route, when set, is the route explore/plan/replan/review run
-  // on instead of route — "" means route covers everything.
+  // on instead of route: "" means route covers everything.
   plan_route?: string
   escalation_route?: string
   // route_model/plan_route_model/review_route_model pin one phase axis
   // to one exact chain entry ("provider name/model") in the route it
-  // would otherwise resolve — "" or absent keeps the first-usable walk.
+  // would otherwise resolve: "" or absent keeps the first-usable walk.
   // Precedence mirrors the route fields: route_model backs execute,
   // plan_route_model backs explore/plan, review_route_model falls back
   // review_route_model > plan_route_model > route_model.
@@ -727,7 +742,7 @@ export interface Mission {
   last_evidence?: string
   auto_approve_safe: boolean
   // environment is the sandbox image key (D-05x) this coding mission's
-  // container runs — "" means base, resolved server-side at create
+  // container runs: "" means base, resolved server-side at create
   // time (explicit request > repo markers > goal keyword > base).
   // General missions never set this.
   environment?: string
@@ -743,28 +758,28 @@ export interface Mission {
   commit_style?: string
   // top_model/top_model_provider are decorated onto the list/get
   // response from the cost ledger's top-served-model-per-mission
-  // lookup (internal/brain/api/missions.go's decorateTopModels) — the
+  // lookup (internal/brain/api/missions.go's decorateTopModels): the
   // model that actually served this mission, by request count. Absent
   // for a mission with no ledger rows yet.
   top_model?: string
   top_model_provider?: string
   schedule_id?: string
   // parent_mission_id names the terminal mission this one follows up
-  // on — absent for an ordinary mission. parent_context is that
+  // on: absent for an ordinary mission. parent_context is that
   // parent's outcome digest, snapshotted at follow-up create time.
   parent_mission_id?: string
   parent_context?: string
-  // attachments are PDF documents attached at create time — markdown is
+  // attachments are PDF documents attached at create time: markdown is
   // never sent over the wire (see api/missions.go's sanitizeMission).
   attachments?: { id: string; mime: string; name?: string }[]
   // destination_ids names operator-created destinations (email,
   // webhook) this mission delivers its outcome digest to on the
   // terminal done transition. Validated against the destinations table
-  // at create time — never model-decided.
+  // at create time: never model-decided.
   destination_ids?: string[]
   // light marks a mission that skips explore/plan/review (D-069):
   // kind=general only, born in phase=execute, one bare worker turn.
-  // final_output is that worker's verbatim final message — the
+  // final_output is that worker's verbatim final message: the
   // deliverable itself, absent/empty until the mission reaches done.
   // Invariant: final_output is only ever populated when light is true;
   // a non-light mission's Result comes from last_evidence instead (see
@@ -773,7 +788,7 @@ export interface Mission {
   final_output?: string
   // artifact_refs are this mission's declared artifact files, best-
   // effort copied into the attachment store on the terminal done
-  // transition — survive workspace deletion, unlike the live-workspace
+  // transition: survive workspace deletion, unlike the live-workspace
   // files ArtifactsSection browses. Absent/empty until that copy runs.
   artifact_refs?: MediaRef[]
   created_at: string
@@ -781,7 +796,7 @@ export interface Mission {
 }
 
 // Destination is one operator-created outbound sink for mission
-// results (internal/brain/destinations.Destination) — Settings →
+// results (internal/brain/destinations.Destination): Settings →
 // Destinations CRUD, and the mission form's destinations multi-select.
 export interface Destination {
   id: string
@@ -806,13 +821,13 @@ export interface MissionEvent {
 
 // ExecutorUsage is executor.result's token/cost usage block. cost_usd
 // is null when the run authenticated via a subscription or oauth_token
-// (no per-call price) rather than metered API billing — never a
+// (no per-call price) rather than metered API billing: never a
 // guessed 0 (D-013). cost_usd_billed is true only when cost_usd is the
 // SAME figure the cost ledger booked as real spend (Anthropic
-// first-party api_key) — false whenever cost_usd is merely the CLI's
+// first-party api_key): false whenever cost_usd is merely the CLI's
 // own harness-reported figure: subscription/oauth_token (never billed)
 // or a non-anthropic provider (priced against Anthropic's table, which
-// is fiction for that provider — the ledger prices it separately from
+// is fiction for that provider: the ledger prices it separately from
 // that provider's own rows, or leaves it unpriced).
 export interface ExecutorUsage {
   input_tokens: number
@@ -875,7 +890,7 @@ export interface ExecutorSkippedPayload {
   skip_reasons?: string[]
 }
 
-// MissionSteeredPayload is mission.steered's payload — operator
+// MissionSteeredPayload is mission.steered's payload: operator
 // guidance injected into a running mission via POST .../note.
 export interface MissionSteeredPayload {
   note: string
@@ -909,7 +924,7 @@ export interface MissionPermissionDeniedPayload {
   detail?: string
 }
 
-// MissionPROpenedPayload is mission.pr_opened's payload — recorded by
+// MissionPROpenedPayload is mission.pr_opened's payload: recorded by
 // POST .../pr once a pull request is opened (or an existing one for
 // the same head is found instead).
 export interface MissionPROpenedPayload {
@@ -937,8 +952,8 @@ export interface Notification {
 }
 
 // AdminConnector is one third-party integration the agent can call as
-// tools (MCP server, Google account, or Microsoft account), or — for
-// kind 'github' — an identity/credential connector with no tools of
+// tools (MCP server, Google account, or Microsoft account), or: for
+// kind 'github': an identity/credential connector with no tools of
 // its own (mission flows and Settings resolve a GitHub identity from
 // its PAT; chat tools stay on the MCP-based GitHub connector). config
 // is kind-specific; the credential_ref names where its secret/tokens live.
@@ -951,7 +966,7 @@ export interface AdminConnector {
   enabled: boolean
   // sensitive pins every tool this connector serves onto the
   // privacy-floor route (session.SensitiveTools), same as gmail_read
-  // is pinned today — additive, connector-wide, no code change needed.
+  // is pinned today: additive, connector-wide, no code change needed.
   sensitive: boolean
 }
 
@@ -965,7 +980,7 @@ export interface GitHubIdentity {
 }
 
 // GitHubRepo is one repo a github-kind connector's PAT can see or
-// create (GET/POST /v1/admin/connectors/:id/repos) — the mission
+// create (GET/POST /v1/admin/connectors/:id/repos): the mission
 // create form's repo picker/create-new flow.
 export interface GitHubRepo {
   full_name: string
@@ -977,7 +992,7 @@ export interface GitHubRepo {
 }
 
 // MissionTemplate is the frozen mission-creation payload a schedule
-// fires at each tick (internal/brain/missions.MissionTemplate) — same
+// fires at each tick (internal/brain/missions.MissionTemplate): same
 // shape as CreateMissionInput.
 export interface MissionTemplate {
   goal: string
@@ -986,7 +1001,7 @@ export interface MissionTemplate {
   route?: string
   review_route?: string
   // plan_route, when set, is the route explore/plan/replan/review run
-  // on instead of route — "" means route covers everything.
+  // on instead of route: "" means route covers everything.
   plan_route?: string
   max_iterations?: number
   budget_amount?: number
@@ -998,7 +1013,7 @@ export interface MissionTemplate {
   commit_style?: string
   // destination_ids names operator-created destinations this template's
   // fired missions deliver their outcome digest to. Re-validated at
-  // fire time — a destination deleted or disabled since the schedule
+  // fire time: a destination deleted or disabled since the schedule
   // was created is dropped silently rather than failing the fire.
   destination_ids?: string[]
   // light marks a mission that skips explore/plan/review (D-069);

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useState } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Reference } from '../api/types'
 import { Composer, type PendingAttachment } from './Composer'
 
 vi.mock('../api/client', () => ({
@@ -10,6 +11,9 @@ vi.mock('../api/client', () => ({
   uploadAttachment: vi.fn(),
   getSettings: vi.fn().mockResolvedValue({ settings: { transcribe_enabled: true }, values: {} }),
   listKbCollections: vi.fn().mockResolvedValue([]),
+  listMissions: vi.fn().mockResolvedValue([]),
+  listSessions: vi.fn().mockResolvedValue([]),
+  searchKbDocuments: vi.fn().mockResolvedValue([]),
 }))
 
 vi.mock('sonner', () => ({
@@ -751,5 +755,143 @@ describe('Composer agent-bound knowledge chips', () => {
     // Only the removable violet chip renders, not a second muted one.
     expect(screen.getByRole('button', { name: 'Remove runbooks knowledge' })).toBeTruthy()
     expect(screen.getAllByText('#runbooks')).toHaveLength(1)
+  })
+})
+
+// StatefulComposerWithReferences owns draft/references state itself,
+// same rationale as StatefulComposer above: a test drives real typing
+// and sees the popup/chips update.
+function StatefulComposerWithReferences({ onSend = vi.fn() }: { onSend?: () => void }) {
+  const [draft, setDraft] = useState('')
+  const [references, setReferences] = useState<Reference[]>([])
+  return (
+    <Composer
+      {...baseProps()}
+      draft={draft}
+      onDraft={setDraft}
+      onSend={onSend}
+      references={references}
+      onReferences={setReferences}
+    />
+  )
+}
+
+describe('Composer reference mentions', () => {
+  it('does not show a popup when onReferences is omitted', async () => {
+    render(<Composer {...baseProps()} draft="#fix" />)
+    const input = screen.getByRole('textbox', { name: 'Message' })
+    fireEvent.change(input, { target: { value: '#fix' } })
+    await new Promise((r) => setTimeout(r, 300))
+    expect(screen.queryByText('Missions')).toBeNull()
+  })
+
+  it('debounces the search and fires it once per pause in typing', async () => {
+    const client = await import('../api/client')
+    render(<StatefulComposerWithReferences />)
+    const input = screen.getByRole('textbox', { name: 'Message' })
+
+    fireEvent.change(input, { target: { value: '#f' } })
+    fireEvent.change(input, { target: { value: '#fi' } })
+    fireEvent.change(input, { target: { value: '#fix' } })
+
+    await new Promise((r) => setTimeout(r, 100))
+    expect(client.listMissions).not.toHaveBeenCalled()
+
+    await waitFor(() => expect(client.listMissions).toHaveBeenCalledTimes(1))
+    expect(client.listMissions).toHaveBeenCalledWith({ query: 'fix', limit: 8 })
+  })
+
+  it('shows a grouped popup, picks an entry, and strips the token', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.listMissions).mockResolvedValue([
+      { id: 'mi1', name: 'Fix the bug', goal: 'Fix the bug' } as never,
+    ])
+    render(<StatefulComposerWithReferences />)
+    const input = screen.getByRole('textbox', { name: 'Message' }) as HTMLTextAreaElement
+
+    fireEvent.change(input, { target: { value: 'please #fix' } })
+
+    await screen.findByText('Missions')
+    fireEvent.click(screen.getByText('Fix the bug'))
+
+    expect(input.value).toBe('please ')
+    expect(screen.queryByText('Missions')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Remove Fix the bug reference' })).toBeTruthy()
+  })
+
+  it('removes a reference chip via its remove button', () => {
+    const onReferences = vi.fn()
+    render(
+      <Composer
+        {...baseProps()}
+        draft=""
+        references={[{ kind: 'mission', id: 'mi1', name: 'Fix the bug' }]}
+        onReferences={onReferences}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Fix the bug reference' }))
+    expect(onReferences).toHaveBeenCalledWith([])
+  })
+
+  it('sends payload-shaped references (kind/id only rides the wire, name is chip-only)', () => {
+    const references: Reference[] = [{ kind: 'kb_doc', id: 'd1', name: 'Runbook' }]
+    render(<Composer {...baseProps()} draft="" references={references} onReferences={vi.fn()} />)
+    expect(screen.getByText(/Runbook/)).toBeTruthy()
+  })
+
+  it('does not add a reference past the cap of 8', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.listMissions).mockResolvedValue([
+      { id: 'mi9', name: 'Ninth mission', goal: 'Ninth mission' } as never,
+    ])
+    const eight: Reference[] = Array.from({ length: 8 }, (_, i) => ({
+      kind: 'mission' as const,
+      id: `m${i}`,
+      name: `Mission ${i}`,
+    }))
+    const onReferences = vi.fn()
+    function StatefulAtCap() {
+      const [draft, setDraft] = useState('')
+      return (
+        <Composer
+          {...baseProps()}
+          draft={draft}
+          onDraft={setDraft}
+          references={eight}
+          onReferences={onReferences}
+        />
+      )
+    }
+    render(<StatefulAtCap />)
+    const input = screen.getByRole('textbox', { name: 'Message' })
+
+    fireEvent.change(input, { target: { value: '#ninth' } })
+    await new Promise((r) => setTimeout(r, 300))
+
+    expect(screen.queryByText('Missions')).toBeNull()
+    expect(onReferences).not.toHaveBeenCalled()
+  })
+
+  it('cycles the highlighted option with ArrowDown/ArrowUp across groups', async () => {
+    const client = await import('../api/client')
+    vi.mocked(client.listMissions).mockResolvedValue([
+      { id: 'mi1', name: 'Fix the bug', goal: 'Fix the bug' } as never,
+    ])
+    vi.mocked(client.listSessions).mockResolvedValue([
+      { id: 'se1', title: 'Old chat', archived: false, created_at: '', updated_at: '' },
+    ])
+    render(<StatefulComposerWithReferences />)
+    const input = screen.getByRole('textbox', { name: 'Message' })
+
+    fireEvent.change(input, { target: { value: '#' } })
+    await screen.findByText('Fix the bug')
+    await screen.findByText('Old chat')
+
+    const highlighted = () =>
+      screen.getByText('Fix the bug').className.includes('bg-zinc-100') ? 'mission' : 'chat'
+    expect(highlighted()).toBe('mission')
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    expect(highlighted()).toBe('chat')
   })
 })

--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -12,11 +12,19 @@ import {
   Tick02Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
-import type { ClipboardEvent, DragEvent, KeyboardEvent } from 'react'
+import type { ClipboardEvent, DragEvent, KeyboardEvent, ReactNode } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { getSettings, listKbCollections, transcribe, uploadAttachment } from '../api/client'
-import type { KbCollection } from '../api/types'
+import type { KbCollection, Reference } from '../api/types'
+import {
+  addReference,
+  groupReferenceOptions,
+  maxReferences,
+  referenceKindLabel,
+  removeReference,
+  useReferenceSearch,
+} from '../lib/references'
 import { skillLabels } from '../lib/skills'
 import {
   getTranscribeLanguage,
@@ -33,7 +41,7 @@ import {
 
 // PendingAttachment is one upload in flight or done, owned by the
 // page (same pattern as `draft`) so the send flow can read and clear
-// it. previewUrl is a local object URL — revoked on removal/send.
+// it. previewUrl is a local object URL: revoked on removal/send.
 export interface PendingAttachment {
   id: string
   mime: string
@@ -80,7 +88,7 @@ function documentChipIcon(mime: string) {
 }
 
 // isAllowedFile accepts a file when its reported type is in
-// allowedMimes, or (for .md/.txt) by extension — browsers report
+// allowedMimes, or (for .md/.txt) by extension: browsers report
 // markdown files inconsistently: empty type, text/markdown, or
 // text/plain depending on OS/browser.
 export function isAllowedFile(file: File): boolean {
@@ -89,7 +97,7 @@ export function isAllowedFile(file: File): boolean {
 }
 
 // isDocumentFile is isAllowedFile narrowed to document types (PDF,
-// Markdown, text) — used where only documents are accepted, e.g.
+// Markdown, text): used where only documents are accepted, e.g.
 // mission attachments. Video/audio are chat-only (explicit decision):
 // excluded here even though allowedMimes carries them for the composer.
 export function isDocumentFile(file: File): boolean {
@@ -138,6 +146,8 @@ export function Composer({
   knowledge,
   onKnowledge,
   agentKnowledge,
+  references,
+  onReferences,
 }: {
   draft: string
   onDraft: (v: string) => void
@@ -151,7 +161,7 @@ export function Composer({
   onRemoveSkillHint?: () => void
   disabled?: boolean
   // streaming/onStop swap the send button for a stop control while a
-  // turn is in flight — the turn now runs detached server-side (see
+  // turn is in flight: the turn now runs detached server-side (see
   // chat.Service.StopTurn), so unmounting or navigating away no longer
   // stops it; this is the explicit way to.
   streaming?: boolean
@@ -166,9 +176,15 @@ export function Composer({
   knowledge?: string[]
   onKnowledge?: (next: string[]) => void
   // Collections the serving agent always searches (agents' `knowledge`
-  // field) — shown as muted, non-removable chips and excluded from the
+  // field): shown as muted, non-removable chips and excluded from the
   // mention popup since pinning them is redundant.
   agentKnowledge?: string[]
+  // references/onReferences enable `#mission`/`#chat`/`#document`
+  // mentions alongside `#collection` in the same popup: picking one
+  // inserts a removable chip, capped at maxReferences. Omitting them
+  // disables reference mentions for that composer instance.
+  references?: Reference[]
+  onReferences?: (next: Reference[]) => void
 }) {
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -176,7 +192,7 @@ export function Composer({
   const chunksRef = useRef<BlobPart[]>([])
   // The attachments array is owned by the page, but the upload flow
   // needs the latest value inside async callbacks that started before
-  // a later render — same stale-closure guard as draftRef below.
+  // a later render: same stale-closure guard as draftRef below.
   const attachmentsRef = useRef(attachments)
   attachmentsRef.current = attachments
   // The recorder's onstop closure outlives renders; read the draft
@@ -205,7 +221,7 @@ export function Composer({
   const [mentionQuery, setMentionQuery] = useState<string | null>(null)
   const [mentionOptions, setMentionOptions] = useState<KbCollection[]>([])
   const [mentionIndex, setMentionIndex] = useState(0)
-  // The knowledge array the mention popup filters against — read
+  // The knowledge array the mention popup filters against: read
   // through a ref so the async collections fetch and keydown handler
   // (closures that can outlive a render) see the latest chip list.
   const knowledgeRef = useRef(knowledge ?? [])
@@ -220,7 +236,29 @@ export function Composer({
   // (retry on the next `#`) without also racing a second fetch.
   const collectionsFetchingRef = useRef(false)
 
+  // #mission/#chat/#document reference mention state: generalizes the
+  // collection mention above onto individual missions/chats/kb
+  // documents (D-069-style additive feature, same `#` trigger, same
+  // popup). referenceQuery mirrors mentionQuery but debounced through
+  // useReferenceSearch, since these hit three list/search endpoints
+  // per keystroke pause rather than one cached-after-first-fetch list.
+  const [referenceQuery, setReferenceQuery] = useState<string | null>(null)
+  const referenceOptionsRaw = useReferenceSearch(onReferences ? referenceQuery : null)
+  const referencesRef = useRef(references ?? [])
+  referencesRef.current = references ?? []
+  const referenceOptions = referenceOptionsRaw.filter(
+    (o) => !referencesRef.current.some((r) => r.kind === o.kind && r.id === o.id),
+  )
+  const referenceGroups = groupReferenceOptions(referenceOptions)
+  const atCap = (references ?? []).length >= maxReferences
+
   const mentionRe = /(^|\s)#([a-zA-Z0-9_-]*)$/
+
+  function optionClassName(highlighted: boolean): string {
+    return highlighted
+      ? 'block w-full truncate px-3 py-1.5 text-left text-sm bg-zinc-100 text-zinc-900 dark:bg-zinc-700 dark:text-white'
+      : 'block w-full truncate px-3 py-1.5 text-left text-sm text-zinc-700 hover:bg-zinc-50 dark:text-zinc-200 dark:hover:bg-zinc-700/50'
+  }
 
   function filterOptions(cols: KbCollection[], query: string): KbCollection[] {
     return cols.filter(
@@ -232,19 +270,22 @@ export function Composer({
   }
 
   // updateMention re-derives the popup from the text before the caret
-  // on every draft/selection change. Only active when onKnowledge is
-  // given — mentions are opt-in per composer instance.
+  // on every draft/selection change. Only active when onKnowledge or
+  // onReferences is given: mentions are opt-in per composer instance.
   function updateMention(text: string, caret: number) {
-    if (!onKnowledge) return
+    if (!onKnowledge && !onReferences) return
     const before = text.slice(0, caret)
     const match = mentionRe.exec(before)
     if (!match) {
       setMentionQuery(null)
+      setReferenceQuery(null)
       return
     }
     const query = match[2].toLowerCase()
-    setMentionQuery(query)
     setMentionIndex(0)
+    if (onReferences) setReferenceQuery(query)
+    if (!onKnowledge) return
+    setMentionQuery(query)
     if (collectionsRef.current === null) {
       if (collectionsFetchingRef.current) return
       collectionsFetchingRef.current = true
@@ -267,47 +308,129 @@ export function Composer({
     setMentionOptions(filterOptions(collectionsRef.current, query))
   }
 
-  // selectMention strips the `#prefix` token from the draft and adds
-  // the collection name as a chip.
-  function selectMention(name: string) {
+  // clearMentionToken strips the `#prefix` token from the draft and
+  // closes both popups: shared by selectMention and selectReference.
+  function clearMentionToken(): boolean {
     const el = inputRef.current
-    if (!el || !onKnowledge) return
+    if (!el) return false
     const caret = el.selectionStart ?? draft.length
     const before = draft.slice(0, caret)
     const match = mentionRe.exec(before)
-    if (!match) return
+    if (!match) return false
     const start = caret - match[2].length - 1
     const next = draft.slice(0, start) + draft.slice(caret)
     onDraft(next)
     setMentionQuery(null)
-    if (!(knowledge ?? []).includes(name)) onKnowledge([...(knowledge ?? []), name])
+    setReferenceQuery(null)
     requestAnimationFrame(() => el.setSelectionRange(start, start))
+    return true
+  }
+
+  // selectMention strips the `#prefix` token from the draft and adds
+  // the collection name as a chip.
+  function selectMention(name: string) {
+    if (!onKnowledge) return
+    if (!clearMentionToken()) return
+    if (!(knowledge ?? []).includes(name)) onKnowledge([...(knowledge ?? []), name])
   }
 
   function removeKnowledge(name: string) {
     onKnowledge?.((knowledge ?? []).filter((n) => n !== name))
   }
 
+  // selectReference adds a mission/chat/document reference chip, no-op
+  // past maxReferences (the popup already hides options at the cap, so
+  // this only guards a race).
+  function selectReference(option: { kind: Reference['kind']; id: string; name: string }) {
+    if (!onReferences || atCap) return
+    if (!clearMentionToken()) return
+    onReferences(addReference(references ?? [], option))
+  }
+
+  function removeReferenceChip(kind: Reference['kind'], id: string) {
+    onReferences?.(removeReference(references ?? [], kind, id))
+  }
+
+  // combinedOptions flattens the collection list and the grouped
+  // reference lists into one selectable sequence, collections first:
+  // ArrowUp/ArrowDown, Enter/Tab, and Escape all operate on this single
+  // index regardless of which source an option came from. header is
+  // set on a group's first row only, so the popup can render a section
+  // label without breaking the flat index math keyboard nav relies on.
+  const combinedOptions: {
+    select: () => void
+    header?: string
+    render: (highlighted: boolean) => ReactNode
+  }[] = []
+  if (onKnowledge) {
+    for (const c of mentionOptions) {
+      combinedOptions.push({
+        select: () => selectMention(c.name),
+        render: (highlighted) => (
+          <button
+            type="button"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => selectMention(c.name)}
+            className={optionClassName(highlighted)}
+          >
+            #{c.name}
+          </button>
+        ),
+      })
+    }
+  }
+  if (onReferences && !atCap) {
+    for (const group of referenceGroups) {
+      group.options.forEach((o, i) => {
+        combinedOptions.push({
+          select: () => selectReference(o),
+          header: i === 0 ? referenceKindLabel[group.kind] : undefined,
+          render: (highlighted) => (
+            <button
+              type="button"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => selectReference(o)}
+              className={optionClassName(highlighted)}
+            >
+              {o.name}
+            </button>
+          ),
+        })
+      })
+    }
+  }
+
+  const popupOpen = combinedOptions.length > 0 && (mentionQuery !== null || referenceQuery !== null)
+
   function handleMentionKeyDown(e: KeyboardEvent<HTMLTextAreaElement>): boolean {
-    if (mentionQuery === null || mentionOptions.length === 0) return false
+    if (!popupOpen) {
+      if (e.key === 'Escape' && (mentionQuery !== null || referenceQuery !== null)) {
+        e.preventDefault()
+        setMentionQuery(null)
+        setReferenceQuery(null)
+        return true
+      }
+      return false
+    }
     if (e.key === 'ArrowDown') {
       e.preventDefault()
-      setMentionIndex((i) => (i + 1) % mentionOptions.length)
+      setMentionIndex((i) => (i + 1) % combinedOptions.length)
       return true
     }
     if (e.key === 'ArrowUp') {
       e.preventDefault()
-      setMentionIndex((i) => (i - 1 + mentionOptions.length) % mentionOptions.length)
+      setMentionIndex((i) => (i - 1 + combinedOptions.length) % combinedOptions.length)
       return true
     }
     if (e.key === 'Enter' || e.key === 'Tab') {
       e.preventDefault()
-      selectMention(mentionOptions[mentionIndex].name)
+      combinedOptions[Math.min(mentionIndex, combinedOptions.length - 1)].select()
       return true
     }
     if (e.key === 'Escape') {
       e.preventDefault()
       setMentionQuery(null)
+      setReferenceQuery(null)
       return true
     }
     return false
@@ -376,14 +499,14 @@ export function Composer({
   }
 
   // Stop cleanly if the composer unmounts mid-recording (e.g. route
-  // change) — the MediaRecorder and its track must not keep running.
+  // change): the MediaRecorder and its track must not keep running.
   useEffect(() => () => recorderRef.current?.stop(), [])
 
   // uploadFiles validates each file client-side (type, size, cap) then
   // uploads it, adding a chip immediately in an "uploading" state so
   // the spinner overlay has something to render, and swapping it for
   // the real id on success or dropping it on failure. previewUrl uses
-  // the local file directly — no need to round-trip through the
+  // the local file directly: no need to round-trip through the
   // server just to show a thumbnail.
   async function uploadFiles(files: File[]) {
     if (!onAttachments) return
@@ -449,7 +572,7 @@ export function Composer({
   }
 
   // Muted chips: agent-bound collections not already pinned by the
-  // user. A name in both wins as the removable violet chip only — no
+  // user. A name in both wins as the removable violet chip only: no
   // duplicate muted chip alongside it.
   const agentOnlyKnowledge = (agentKnowledge ?? []).filter((name) => !(knowledge ?? []).includes(name))
 
@@ -459,22 +582,17 @@ export function Composer({
       onDrop={handleDrop}
       className="relative rounded-2xl border border-zinc-950/10 bg-white shadow-sm transition focus-within:border-blue-500/50 focus-within:ring-4 focus-within:ring-blue-500/10 dark:border-white/10 dark:bg-zinc-800/60 dark:focus-within:border-blue-400/40"
     >
-      {onKnowledge && mentionQuery !== null && mentionOptions.length > 0 && (
-        <div className="absolute bottom-full left-2 z-10 mb-1 w-56 overflow-hidden rounded-lg border border-zinc-950/10 bg-white py-1 shadow-lg dark:border-white/10 dark:bg-zinc-800">
-          {mentionOptions.map((c, i) => (
-            <button
-              key={c.id}
-              type="button"
-              onMouseDown={(e) => e.preventDefault()} // keep textarea focus
-              onClick={() => selectMention(c.name)}
-              className={
-                i === mentionIndex
-                  ? 'block w-full truncate px-3 py-1.5 text-left text-sm bg-zinc-100 text-zinc-900 dark:bg-zinc-700 dark:text-white'
-                  : 'block w-full truncate px-3 py-1.5 text-left text-sm text-zinc-700 hover:bg-zinc-50 dark:text-zinc-200 dark:hover:bg-zinc-700/50'
-              }
-            >
-              #{c.name}
-            </button>
+      {popupOpen && (
+        <div className="absolute bottom-full left-2 z-10 mb-1 max-h-72 w-64 overflow-y-auto rounded-lg border border-zinc-950/10 bg-white py-1 shadow-lg dark:border-white/10 dark:bg-zinc-800">
+          {combinedOptions.map((opt, i) => (
+            <div key={i}>
+              {opt.header && (
+                <div className="px-3 pt-1.5 pb-0.5 text-[10px] font-semibold tracking-wider text-zinc-400 uppercase dark:text-zinc-500">
+                  {opt.header}
+                </div>
+              )}
+              {opt.render(i === mentionIndex)}
+            </div>
           ))}
         </div>
       )}
@@ -500,6 +618,28 @@ export function Composer({
                 onClick={() => removeKnowledge(name)}
                 aria-label={`Remove ${name} knowledge`}
                 className="flex size-4 items-center justify-center rounded-full text-violet-700/70 hover:bg-violet-100 hover:text-violet-900 dark:text-violet-300/70 dark:hover:bg-violet-500/20 dark:hover:text-violet-100"
+              >
+                <HugeiconsIcon icon={Cancel01Icon} className="size-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      {references && references.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1 px-3 pt-2.5">
+          {references.map((r) => (
+            <span
+              key={`${r.kind}-${r.id}`}
+              className="inline-flex max-w-48 items-center gap-1 rounded-full bg-blue-50 py-1 pr-1.5 pl-2.5 text-xs font-medium text-blue-700 dark:bg-blue-500/10 dark:text-blue-300"
+            >
+              <span className="truncate">
+                {referenceKindLabel[r.kind].replace(/s$/, '')}: {r.name}
+              </span>
+              <button
+                type="button"
+                onClick={() => removeReferenceChip(r.kind, r.id)}
+                aria-label={`Remove ${r.name} reference`}
+                className="flex size-4 shrink-0 items-center justify-center rounded-full text-blue-700/70 hover:bg-blue-100 hover:text-blue-900 dark:text-blue-300/70 dark:hover:bg-blue-500/20 dark:hover:text-blue-100"
               >
                 <HugeiconsIcon icon={Cancel01Icon} className="size-3" />
               </button>

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -20,6 +20,9 @@ vi.mock('../../api/client', () => ({
   testConnector: vi.fn().mockResolvedValue({ ok: true }),
   uploadAttachment: vi.fn(),
   listDestinations: vi.fn().mockResolvedValue([]),
+  listMissions: vi.fn().mockResolvedValue([]),
+  listSessions: vi.fn().mockResolvedValue([]),
+  searchKbDocuments: vi.fn().mockResolvedValue([]),
 }))
 
 import {
@@ -34,13 +37,16 @@ import {
   listConnectorRepos,
   listConnectors,
   listDestinations,
+  listMissions,
   listRoutes,
+  listSessions,
   patchSchedule,
+  searchKbDocuments,
   uploadAttachment,
 } from '../../api/client'
 import type { Destination, ExecutionPlanPhase } from '../../api/types'
 
-// renderForm wraps MissionForm in a MemoryRouter — the repository
+// renderForm wraps MissionForm in a MemoryRouter: the repository
 // section's "no connectors" hint links to Settings → Connectors, which
 // needs router context even when that section never renders.
 function renderForm(el: React.ReactElement) {
@@ -139,7 +145,7 @@ beforeEach(() => {
   vi.mocked(listConnectors).mockResolvedValue([])
 })
 
-describe('MissionForm — create mode, one-off mission', () => {
+describe('MissionForm: create mode, one-off mission', () => {
   it('submits a general mission with the entered goal', async () => {
     vi.mocked(createMission).mockResolvedValue({ id: 'm2' } as Mission)
     const onDone = vi.fn()
@@ -278,6 +284,121 @@ describe('MissionForm — create mode, one-off mission', () => {
   })
 })
 
+describe('MissionForm: # references', () => {
+  it('opens a grouped picker on #, picks a mission, and strips the token', async () => {
+    vi.mocked(listMissions).mockResolvedValue([
+      { id: 'mi1', name: 'Fix the flaky test', goal: 'Fix the flaky test' } as Mission,
+    ])
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    const goal = screen.getByLabelText('Goal') as HTMLTextAreaElement
+    fireEvent.change(goal, { target: { value: 'See #fix' } })
+
+    await screen.findByText('Missions')
+    const option = await screen.findByText('Fix the flaky test')
+    fireEvent.click(option)
+
+    expect(goal.value).toBe('See ')
+    expect(screen.getByText('Mission: Fix the flaky test')).toBeTruthy()
+    expect(screen.queryByText('Fix the flaky test', { selector: 'button' })).toBeNull()
+  })
+
+  it('submits the picked references on create', async () => {
+    vi.mocked(listMissions).mockResolvedValue([
+      { id: 'mi1', name: 'Fix the flaky test', goal: 'Fix the flaky test' } as Mission,
+    ])
+    vi.mocked(createMission).mockResolvedValue({ id: 'm9' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    const goal = screen.getByLabelText('Goal') as HTMLTextAreaElement
+    fireEvent.change(goal, { target: { value: 'See #fix' } })
+    fireEvent.click(await screen.findByText('Fix the flaky test'))
+    fireEvent.change(goal, { target: { value: `${goal.value}more context` } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(
+        expect.objectContaining({ references: [{ kind: 'mission', id: 'mi1' }] }),
+      ),
+    )
+  })
+
+  it('removes a reference chip via its remove button', async () => {
+    vi.mocked(listMissions).mockResolvedValue([
+      { id: 'mi1', name: 'Fix the flaky test', goal: 'Fix the flaky test' } as Mission,
+    ])
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    const goal = screen.getByLabelText('Goal') as HTMLTextAreaElement
+    fireEvent.change(goal, { target: { value: '#fix' } })
+    fireEvent.click(await screen.findByText('Fix the flaky test'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Fix the flaky test reference' }))
+    expect(screen.queryByText('Mission: Fix the flaky test')).toBeNull()
+  })
+
+  it('groups mission, chat, and document results under separate headers', async () => {
+    vi.mocked(listMissions).mockResolvedValue([{ id: 'mi1', name: 'A mission', goal: 'A mission' } as Mission])
+    vi.mocked(listSessions).mockResolvedValue([
+      { id: 'se1', title: 'A chat', archived: false, created_at: '', updated_at: '' },
+    ])
+    vi.mocked(searchKbDocuments).mockResolvedValue([
+      {
+        id: 'd1',
+        collection_id: 'c1',
+        title: 'A document',
+        source_type: 'file',
+        source_ref: '',
+        status: 'ready',
+        error: '',
+        chunk_count: 1,
+        bytes: 10,
+        ingested_at: null,
+        created_at: '',
+      },
+    ])
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: '#a' } })
+
+    await screen.findByText('Missions')
+    expect(screen.getByText('Chats')).toBeTruthy()
+    expect(screen.getByText('Documents')).toBeTruthy()
+    expect(screen.getByText('A mission')).toBeTruthy()
+    expect(screen.getByText('A chat')).toBeTruthy()
+    expect(screen.getByText('A document')).toBeTruthy()
+  })
+
+  it('disables adding a 9th reference at the cap', async () => {
+    const missions = Array.from({ length: 9 }, (_, i) => ({
+      id: `mi${i}`,
+      name: `mission${i}`,
+      goal: `mission${i}`,
+    })) as Mission[]
+    vi.mocked(listMissions).mockImplementation((opts) =>
+      Promise.resolve(missions.filter((m) => !opts?.query || m.name?.includes(opts.query))),
+    )
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    const countChips = () =>
+      screen.getAllByRole('button', { name: /^Remove mission\d reference$/ }).length
+
+    const goal = screen.getByLabelText('Goal') as HTMLTextAreaElement
+    for (let i = 0; i < 8; i++) {
+      fireEvent.change(goal, { target: { value: `#mission${i}` } })
+      fireEvent.click(await screen.findByText(`mission${i}`))
+      await waitFor(() => expect(countChips()).toBe(i + 1))
+    }
+
+    fireEvent.change(goal, { target: { value: '#mission8' } })
+    await new Promise((r) => setTimeout(r, 300))
+    expect(screen.queryByText('Missions')).toBeNull()
+    expect(screen.queryByText('mission8', { selector: 'button' })).toBeNull()
+    expect(countChips()).toBe(8)
+  })
+})
+
 const destinations: Destination[] = [
   {
     id: 'd1',
@@ -301,7 +422,7 @@ const destinations: Destination[] = [
   },
 ]
 
-describe('MissionForm — destinations multi-select', () => {
+describe('MissionForm: destinations multi-select', () => {
   it('hides the section when there are no destinations', async () => {
     vi.mocked(listDestinations).mockResolvedValue([])
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
@@ -397,7 +518,7 @@ describe('MissionForm — destinations multi-select', () => {
   })
 })
 
-describe('MissionForm — follow-up', () => {
+describe('MissionForm: follow-up', () => {
   it('submits parent_mission_id when given, and seeds kind from initial without locking goal', async () => {
     vi.mocked(createMission).mockResolvedValue({ id: 'm-followup' } as Mission)
     renderForm(
@@ -440,7 +561,7 @@ describe('MissionForm — follow-up', () => {
   })
 })
 
-describe('MissionForm — kind chip', () => {
+describe('MissionForm: kind chip', () => {
   beforeEach(() => {
     vi.useFakeTimers()
   })
@@ -512,7 +633,7 @@ describe('MissionForm — kind chip', () => {
   })
 })
 
-describe('MissionForm — harness select placement', () => {
+describe('MissionForm: harness select placement', () => {
   it('shows the harness select in the main form body for a coding mission, without expanding Advanced', async () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
@@ -548,7 +669,7 @@ describe('MissionForm — harness select placement', () => {
   })
 })
 
-describe('MissionForm — environment select', () => {
+describe('MissionForm: environment select', () => {
   it('shows the environment select for a coding mission, defaulted to Auto-detect', async () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
@@ -596,7 +717,7 @@ describe('MissionForm — environment select', () => {
   })
 })
 
-describe('MissionForm — light mission toggle', () => {
+describe('MissionForm: light mission toggle', () => {
   it('shows the light toggle for a general mission', async () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
@@ -632,7 +753,7 @@ describe('MissionForm — light mission toggle', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'summarize this' } })
-    // Explicitly check it, then immediately uncheck it — the operator's
+    // Explicitly check it, then immediately uncheck it: the operator's
     // deliberate final choice is false, which must survive the classify
     // preview resolving to light: true.
     fireEvent.click(screen.getByLabelText(/Light mission/))
@@ -672,7 +793,7 @@ describe('MissionForm — light mission toggle', () => {
   })
 })
 
-describe('MissionForm — git strategy overrides', () => {
+describe('MissionForm: git strategy overrides', () => {
   it('shows branch pattern and commit style in Advanced for a coding mission', async () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
@@ -770,7 +891,7 @@ async function toCodingMission() {
   expect(screen.getByText('Coding · branches from repo')).toBeInTheDocument()
 }
 
-describe('MissionForm — repository source', () => {
+describe('MissionForm: repository source', () => {
   it('defaults to None and omits repo_url/connector_id from the create payload', async () => {
     vi.mocked(createMission).mockResolvedValue({ id: 'm8' } as Mission)
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
@@ -916,7 +1037,7 @@ describe('MissionForm — repository source', () => {
   })
 })
 
-describe('MissionForm — deployment (on_complete)', () => {
+describe('MissionForm: deployment (on_complete)', () => {
   it('hides the Deployment section until a repo (or new-repo name) is chosen', async () => {
     vi.mocked(listConnectors).mockResolvedValue([githubConnector])
     vi.mocked(listConnectorRepos).mockResolvedValue(repos)
@@ -985,7 +1106,7 @@ describe('MissionForm — deployment (on_complete)', () => {
   })
 })
 
-describe('MissionForm — create mode, repeat on schedule', () => {
+describe('MissionForm: create mode, repeat on schedule', () => {
   it('submits a schedule with the slugified default name, preset cron, and general kind', async () => {
     vi.mocked(createSchedule).mockResolvedValue({ id: 'sc1' })
     const onDone = vi.fn()
@@ -1130,7 +1251,7 @@ describe('MissionForm — create mode, repeat on schedule', () => {
   })
 })
 
-describe('MissionForm — plan route', () => {
+describe('MissionForm: plan route', () => {
   it('renders the Plan route select in Advanced, defaulted to "Same as execute route"', async () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
@@ -1208,7 +1329,7 @@ describe('MissionForm — plan route', () => {
   })
 })
 
-describe('MissionForm — edit mode', () => {
+describe('MissionForm: edit mode', () => {
   it('prefills from the schedule, chip locked to the template kind', async () => {
     renderForm(<MissionForm mode="edit" schedule={schedule} onDone={vi.fn()} onCancel={vi.fn()} />)
 
@@ -1342,7 +1463,7 @@ const fivePhases: ExecutionPlanPhase[] = [
   makePhase({ phase: 'escalate', route: '', route_source: 'off', skipped: true, skip_reason: '' }),
 ]
 
-describe('MissionForm — execution plan', () => {
+describe('MissionForm: execution plan', () => {
   it('renders the execution plan table with a harness phase label and prices', async () => {
     vi.mocked(getMissionExecutionPlan).mockResolvedValue(fivePhases)
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -25,6 +25,7 @@ import type {
   ExecutionPlanPhase,
   GitHubIdentity,
   GitHubRepo,
+  Reference,
   Schedule,
 } from '../../api/types'
 import { useAgents, useRoutes } from '../AgentPicker'
@@ -45,6 +46,7 @@ import { errText } from '../settings/util'
 import { envIcon } from '../icons/EnvIcons'
 import { type PendingAttachment } from '../Composer'
 import { MissionAttachments } from './MissionAttachments'
+import { GoalTextarea } from './MissionReferences'
 import { MissionExecutionPlan } from './MissionExecutionPlan'
 
 type RepoSource = 'none' | 'github'
@@ -53,7 +55,7 @@ type Kind = 'coding' | 'general'
 
 type OnComplete = '' | 'push' | 'push_pr'
 
-// Sentinel for the Deployment Select — Radix Select.Item rejects an
+// Sentinel for the Deployment Select: Radix Select.Item rejects an
 // empty string value, so the "do nothing" choice (the wire value '')
 // is represented by this sentinel on the Select itself.
 const ON_COMPLETE_NONE = '__none__'
@@ -66,7 +68,7 @@ const onCompleteChoices: { value: string; label: string }[] = [
 
 // repoFromCloneURL rebuilds a minimal GitHubRepo from a parent
 // mission's stored clone URL (mirrors MissionDetail.tsx's
-// githubFullName) — a follow-up seeds the repo picker with the
+// githubFullName): a follow-up seeds the repo picker with the
 // parent's repo, but the mission row only ever stored the clone URL,
 // not repos.list's other fields (private/default_branch/etc), which
 // this form's fields never read for an already-selected repo.
@@ -87,7 +89,7 @@ const kindCopy: Record<Kind, string> = {
 }
 
 // A schedule's mission_template carries route/review_route as explicit
-// undefined when unset (see types.ts) — "non-default" means any of
+// undefined when unset (see types.ts): "non-default" means any of
 // them, or a non-default agent, actually has a value. Budget and
 // auto-approve are always visible now, so they never force the
 // advanced section open.
@@ -132,7 +134,7 @@ export function defaultRouteLabel(
 }
 
 // resolvedDefaultRoute is defaultRouteLabel's same precedence, but
-// returns the route name (or '' when none resolves — matches the
+// returns the route name (or '' when none resolves: matches the
 // server's own '' == "no real route, gateway default chain" case)
 // instead of a display label. Used to fetch executor-options against
 // the route a create would actually use, not always the system
@@ -148,13 +150,13 @@ function resolvedDefaultRoute(
 }
 
 // Sentinel for the executor Select's "apply the settings default"
-// choice — wire value stays '' (omit harness from the create payload)
+// choice: wire value stays '' (omit harness from the create payload)
 // to match the API's own empty-means-default semantics. Exported so
 // AgentForm's Harness select can reuse the same sentinel/choice list
 // for its own "inherit" option.
 export const EXECUTOR_DEFAULT = '__default__'
 
-// executorChoices maps a harness Select value to its label — easy to
+// executorChoices maps a harness Select value to its label: easy to
 // extend as more harnesses register. Exported so MissionExecutionPlan
 // can reuse the same harness->label mapping for the axis column.
 export const executorChoices: { value: string; label: string }[] = [
@@ -168,7 +170,7 @@ export const executorChoices: { value: string; label: string }[] = [
 ]
 
 // defaultHarnessLabel names what the Harness select's "Default" choice
-// actually resolves to — mirrors defaultRouteLabel's job for Route —
+// actually resolves to: mirrors defaultRouteLabel's job for Route:
 // so an operator can tell what runs without opening Settings. Falls
 // back to the plain choice when defaultHarnessName is empty (fetch
 // failed) or names a harness not in executorChoices (native, or one
@@ -180,7 +182,7 @@ function defaultHarnessLabel(defaultHarnessName: string): string {
 }
 
 // defaultPlanRouteLabel names what leaving Plan route on "Default"
-// resolves to, read from the execution plan response's plan phase —
+// resolves to, read from the execution plan response's plan phase:
 // never recomputed client-side. Falls back to the plain hardcoded
 // string before the plan has loaded.
 function defaultPlanRouteLabel(plan: ExecutionPlanPhase[] | null): string {
@@ -190,7 +192,7 @@ function defaultPlanRouteLabel(plan: ExecutionPlanPhase[] | null): string {
 }
 
 // defaultReviewRouteLabel names what leaving Review route on
-// "Default" resolves to — either the plan or the execute route,
+// "Default" resolves to: either the plan or the execute route,
 // whichever the review phase actually inherited from.
 function defaultReviewRouteLabel(plan: ExecutionPlanPhase[] | null): string {
   const phase = plan?.find((p) => p.phase === 'review')
@@ -206,12 +208,12 @@ function defaultEscalationRouteLabel(): string {
   return 'Off (no escalation on failure)'
 }
 
-// Sentinel for the environment Select's "auto-detect" choice — wire
+// Sentinel for the environment Select's "auto-detect" choice: wire
 // value stays '' (omit environment from the create payload) to match
 // the API's own empty-means-auto-detect semantics (D-05x).
 const ENVIRONMENT_AUTO = '__auto__'
 
-// environmentChoices maps an environment Select value to its label —
+// environmentChoices maps an environment Select value to its label:
 // mirrors sandboxd's image allowlist (internal/sandboxd/manager.go).
 const environmentChoices: { value: string; label: string }[] = [
   { value: ENVIRONMENT_AUTO, label: 'Auto-detect' },
@@ -224,7 +226,7 @@ const environmentChoices: { value: string; label: string }[] = [
 ]
 
 // Sentinel for the commit-style Select's "apply the settings default"
-// choice — wire value stays '' (omit commit_style from the create
+// choice: wire value stays '' (omit commit_style from the create
 // payload) to match the API's own empty-means-default semantics.
 const COMMIT_STYLE_DEFAULT = '__default__'
 
@@ -270,7 +272,7 @@ function formatExpiresAt(v: string): string {
 // the edit-schedule page. In 'create' mode it submits a one-off
 // mission or, with "Repeat on schedule" on, a new schedule. In 'edit'
 // mode it always patches the given schedule and locks out run-once,
-// coding, and the escalation route — the same constraints
+// coding, and the escalation route: the same constraints
 // NewMissionDialog/ScheduleDialog enforced.
 export function MissionForm({
   mode,
@@ -283,12 +285,12 @@ export function MissionForm({
   mode: 'create' | 'edit'
   schedule?: Schedule
   // initial seeds the form's create-mode state from a parent mission
-  // (a follow-up) — everything except goal, which is left empty for
+  // (a follow-up): everything except goal, which is left empty for
   // the user to type. Read only once, in the useState initializers
   // below, so the caller must render this component only once initial
   // is settled (e.g. after an async parent fetch resolves).
   initial?: Partial<CreateMissionInput>
-  // parentMissionId, when set, is included on the create payload —
+  // parentMissionId, when set, is included on the create payload:
   // makes this a follow-up mission (see CreateMissionInput).
   parentMissionId?: string
   onDone: (result: { kind: 'mission' | 'schedule'; id: string }) => void
@@ -302,14 +304,17 @@ export function MissionForm({
     () => (goal.trim() === '' ? 0 : goal.trim().split(/\s+/).length),
     [goal],
   )
-  // attachments, like goal, is never seeded from initial — a follow-up
+  // attachments, like goal, is never seeded from initial: a follow-up
   // carries the parent's outcome digest as prompt context, not its
   // documents; each new mission attaches its own.
   const [attachments, setAttachments] = useState<PendingAttachment[]>([])
+  // references picked via the goal field's # mentions: component
+  // state only, resolved server-side at create time.
+  const [references, setReferences] = useState<Reference[]>([])
   const [kind, setKind] = useState<Kind>(initial?.kind ?? 'general')
   // kindLocked freezes kind against further auto-classify calls once
   // the user has explicitly chosen it (chip click, or the repeat-mode
-  // general override below) — cleared when the goal is emptied, which
+  // general override below): cleared when the goal is emptied, which
   // resets to auto-detect for whatever's typed next. A follow-up's
   // seeded kind counts as an explicit choice too.
   const [kindLocked, setKindLocked] = useState(!!initial?.kind)
@@ -319,9 +324,9 @@ export function MissionForm({
   const [light, setLight] = useState(initial?.light ?? false)
   const [lightTouched, setLightTouched] = useState(!!initial?.light)
   const [agentID, setAgentID] = useState(initial?.agent_id ?? '')
-  // Destinations multi-select — visible, not advanced; default is
+  // Destinations multi-select: visible, not advanced; default is
   // empty (deliver nowhere). Offered for a one-off create, a new
-  // schedule (repeat on), and editing an existing schedule — fetched
+  // schedule (repeat on), and editing an existing schedule: fetched
   // once per form regardless of mode.
   const [destinations, setDestinations] = useState<Destination[] | null>(null)
   const [destinationIDs, setDestinationIDs] = useState<string[]>([])
@@ -352,7 +357,7 @@ export function MissionForm({
   const [executionPlan, setExecutionPlan] = useState<ExecutionPlanPhase[] | null>(null)
   // defaultHarnessName is settings' coding_executor value (the harness
   // a create actually runs when the Harness select is left on
-  // "Default") — fetched once so that choice can say what it resolves
+  // "Default"): fetched once so that choice can say what it resolves
   // to, the same way the Route select's "Default" already names the
   // route it resolves to (defaultRouteLabel).
   const [defaultHarnessName, setDefaultHarnessName] = useState('')
@@ -377,7 +382,7 @@ export function MissionForm({
   const [newRepoName, setNewRepoName] = useState('')
   const [newRepoPrivate, setNewRepoPrivate] = useState(true)
 
-  // Consent-at-create for the mission's auto-completion action —
+  // Consent-at-create for the mission's auto-completion action:
   // resets whenever the GitHub source is unpicked, since on_complete is
   // only ever valid alongside repo_url/connector_id.
   const [onComplete, setOnComplete] = useState<OnComplete>(initial?.on_complete ?? '')
@@ -386,7 +391,7 @@ export function MissionForm({
   }, [repoSource])
 
   // Fetch github-kind connectors once the operator picks the GitHub
-  // source — most missions never touch this, so it's not loaded
+  // source: most missions never touch this, so it's not loaded
   // upfront with agents/routes.
   useEffect(() => {
     if (repoSource !== 'github' || githubConnectors !== null) return
@@ -395,7 +400,7 @@ export function MissionForm({
       .catch(() => setGithubConnectors([]))
   }, [repoSource, githubConnectors])
 
-  // Fetch the connector's repo list whenever it changes — best-effort,
+  // Fetch the connector's repo list whenever it changes: best-effort,
   // an error surfaces inline rather than blocking the form.
   useEffect(() => {
     if (repoSource !== 'github' || !connectorID) {
@@ -411,7 +416,7 @@ export function MissionForm({
   }, [repoSource, connectorID])
 
   // Resolve the connection's GitHub identity so the Deployment section
-  // can say who commits and PRs will be authored as — best-effort, an
+  // can say who commits and PRs will be authored as: best-effort, an
   // unresolved identity just hides the line.
   useEffect(() => {
     if (repoSource !== 'github' || !connectorID) {
@@ -434,9 +439,9 @@ export function MissionForm({
   // whenever the kind flips to coding or the route selection (explicit
   // or resolved default) changes. An explicit route override wins;
   // otherwise this asks about the same route a create would actually
-  // resolve to (resolvedDefaultRoute), not always the system default —
+  // resolve to (resolvedDefaultRoute), not always the system default:
   // else a "coding" route's own chain never gets previewed. Best-effort
-  // — a failed fetch degrades to a plain, fully-enabled select with no
+  //: a failed fetch degrades to a plain, fully-enabled select with no
   // live info, the server validates on submit anyway.
   useEffect(() => {
     if (kind !== 'coding') {
@@ -451,7 +456,7 @@ export function MissionForm({
 
   // Live execution plan: the server-resolved read-out of what each
   // phase actually runs, keyed on every field that affects resolution.
-  // Best-effort — a failed fetch just hides the table, the server is
+  // Best-effort: a failed fetch just hides the table, the server is
   // still the source of truth at create time.
   useEffect(() => {
     getMissionExecutionPlan({
@@ -484,7 +489,7 @@ export function MissionForm({
   ])
 
   // Pre-select the settings page's configured default currency for a
-  // fresh create — edit mode below overwrites this with the schedule's
+  // fresh create: edit mode below overwrites this with the schedule's
   // own saved currency once it loads.
   useEffect(() => {
     if (mode !== 'create') return
@@ -500,7 +505,7 @@ export function MissionForm({
 
   // Read-only, both modes: names the harness the settings-page
   // coding_executor value resolves to, purely for the Harness select's
-  // "Default" label. Best-effort — an empty value just shows the plain
+  // "Default" label. Best-effort: an empty value just shows the plain
   // "Default (from settings)" fallback.
   useEffect(() => {
     getSettings()
@@ -510,7 +515,7 @@ export function MissionForm({
       })
   }, [])
 
-  // Repeat-on-schedule fields — read/submitted whenever repeat is on
+  // Repeat-on-schedule fields: read/submitted whenever repeat is on
   // (create mode) or always (edit mode, which only ever edits a
   // schedule).
   const [repeat, setRepeat] = useState(mode === 'edit')
@@ -561,7 +566,7 @@ export function MissionForm({
   // Live kind inference: debounced 600ms after goal edits, skipped
   // once the user has locked a manual choice or the goal is empty.
   // Unlocking on an emptied goal happens in the textarea's onChange
-  // below (a direct user edit), not here — this effect also runs on
+  // below (a direct user edit), not here: this effect also runs on
   // mount/schedule-load with the PREVIOUS render's goal, and clearing
   // the lock from here would race the schedule-seed effect's own
   // setKindLocked(true) and stomp it back to false.
@@ -573,7 +578,7 @@ export function MissionForm({
         .then((r) => {
           setKind(r.kind)
           // light only ever defaults the toggle, never overrides an
-          // operator's own choice (lightTouched) — and only makes sense
+          // operator's own choice (lightTouched): and only makes sense
           // once the goal actually classified as general.
           if (!lightTouched) setLight(r.kind === 'general' && r.light)
         })
@@ -624,7 +629,7 @@ export function MissionForm({
     setExpiresAt(dateAndTimeToExpiresAt(date, time))
   }
 
-  // A client-side 5-field shape check only — the server is the
+  // A client-side 5-field shape check only: the server is the
   // authoritative cron validator (robfig/cron), this just catches
   // obvious typos before a round trip.
   const validCronShape = (v: string) => v.trim().split(/\s+/).length === 5
@@ -685,6 +690,8 @@ export function MissionForm({
         attachments.length > 0 ? attachments.map((a) => ({ id: a.id, name: a.name ?? '' })) : undefined,
       destination_ids: destinationIDs.length > 0 ? destinationIDs : undefined,
       light: kind === 'general' ? light : undefined,
+      references:
+        references.length > 0 ? references.map((r) => ({ kind: r.kind, id: r.id })) : undefined,
     })
     toast.success('Mission created')
     onDone({ kind: 'mission', id })
@@ -786,16 +793,31 @@ export function MissionForm({
             What should this mission accomplish{repeat ? ' each time it fires' : ''}?
           </p>
         </div>
-        <Textarea
-          id="mission-goal"
-          aria-label="Goal"
-          value={goal}
-          onChange={(e) => onGoalChange(e.target.value)}
-          placeholder="What should this mission accomplish? Markdown supported."
-          rows={10}
-          autoFocus
-          className="min-h-60 resize-y text-base"
-        />
+        {mode === 'create' && !repeat ? (
+          <GoalTextarea
+            id="mission-goal"
+            aria-label="Goal"
+            value={goal}
+            onChange={onGoalChange}
+            references={references}
+            onReferences={setReferences}
+            placeholder="What should this mission accomplish? Markdown supported. Type # to reference a mission, chat, or document."
+            rows={10}
+            autoFocus
+            className="min-h-60 resize-y text-base"
+          />
+        ) : (
+          <Textarea
+            id="mission-goal"
+            aria-label="Goal"
+            value={goal}
+            onChange={(e) => onGoalChange(e.target.value)}
+            placeholder="What should this mission accomplish? Markdown supported."
+            rows={10}
+            autoFocus
+            className="min-h-60 resize-y text-base"
+          />
+        )}
         <p className="text-right text-xs text-muted-foreground">
           {goalWordCount} {goalWordCount === 1 ? 'word' : 'words'}
         </p>

--- a/web/src/components/missions/MissionReferences.tsx
+++ b/web/src/components/missions/MissionReferences.tsx
@@ -1,0 +1,177 @@
+import { Cancel01Icon } from '@hugeicons-pro/core-stroke-rounded'
+import { HugeiconsIcon } from '@hugeicons/react'
+import type { ComponentProps, KeyboardEvent } from 'react'
+import { useRef, useState } from 'react'
+import type { Reference } from '../../api/types'
+import {
+  addReference,
+  groupReferenceOptions,
+  maxReferences,
+  referenceKindLabel,
+  removeReference,
+  useReferenceSearch,
+} from '../../lib/references'
+import { Textarea } from '../ui/textarea'
+
+const mentionRe = /(^|\s)#([a-zA-Z0-9_-]*)$/
+
+// GoalTextarea is the mission-create form's goal input with a `#`
+// reference picker attached: typing `#` opens an autocomplete over
+// missions/chats/kb documents (same mechanism as Composer.tsx's own
+// #-mention, built fresh here since the goal field never had one) —
+// picking an entry inserts a removable chip and strips the `#query`
+// token from the goal text.
+export function GoalTextarea({
+  value,
+  onChange,
+  references,
+  onReferences,
+  ...textareaProps
+}: {
+  value: string
+  onChange: (v: string) => void
+  references: Reference[]
+  onReferences: (next: Reference[]) => void
+} & Omit<ComponentProps<typeof Textarea>, 'value' | 'onChange'>) {
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+  const [query, setQuery] = useState<string | null>(null)
+  const [index, setIndex] = useState(0)
+  const rawOptions = useReferenceSearch(query)
+  const options = rawOptions.filter(
+    (o) => !references.some((r) => r.kind === o.kind && r.id === o.id),
+  )
+  const groups = groupReferenceOptions(options)
+  const atCap = references.length >= maxReferences
+  const flat = atCap ? [] : groups.flatMap((g) => g.options)
+  const open = query !== null && flat.length > 0
+
+  function updateQuery(text: string, caret: number) {
+    const before = text.slice(0, caret)
+    const match = mentionRe.exec(before)
+    if (!match) {
+      setQuery(null)
+      return
+    }
+    setIndex(0)
+    setQuery(match[2].toLowerCase())
+  }
+
+  function clearToken(): boolean {
+    const el = inputRef.current
+    if (!el) return false
+    const caret = el.selectionStart ?? value.length
+    const before = value.slice(0, caret)
+    const match = mentionRe.exec(before)
+    if (!match) return false
+    const start = caret - match[2].length - 1
+    onChange(value.slice(0, start) + value.slice(caret))
+    setQuery(null)
+    requestAnimationFrame(() => el.setSelectionRange(start, start))
+    return true
+  }
+
+  function pick(option: { kind: Reference['kind']; id: string; name: string }) {
+    if (atCap) return
+    if (!clearToken()) return
+    onReferences(addReference(references, option))
+  }
+
+  function remove(kind: Reference['kind'], id: string) {
+    onReferences(removeReference(references, kind, id))
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (!open) return
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setIndex((i) => (i + 1) % flat.length)
+      return
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setIndex((i) => (i - 1 + flat.length) % flat.length)
+      return
+    }
+    if (e.key === 'Enter' || e.key === 'Tab') {
+      e.preventDefault()
+      pick(flat[Math.min(index, flat.length - 1)])
+      return
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      setQuery(null)
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="relative">
+        {open && (
+          <div className="absolute bottom-full left-0 z-10 mb-1 max-h-72 w-72 overflow-y-auto rounded-lg border border-border bg-popover py-1 shadow-lg">
+            {groups.map((group) => (
+              <div key={group.kind}>
+                <div className="px-3 pt-1.5 pb-0.5 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase">
+                  {referenceKindLabel[group.kind]}
+                </div>
+                {group.options.map((o) => {
+                  const i = flat.findIndex((f) => f.kind === o.kind && f.id === o.id)
+                  return (
+                    <button
+                      key={`${o.kind}-${o.id}`}
+                      type="button"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => pick(o)}
+                      className={
+                        i === index
+                          ? 'block w-full truncate px-3 py-1.5 text-left text-sm bg-muted text-foreground'
+                          : 'block w-full truncate px-3 py-1.5 text-left text-sm text-foreground hover:bg-muted/60'
+                      }
+                    >
+                      {o.name}
+                    </button>
+                  )
+                })}
+              </div>
+            ))}
+          </div>
+        )}
+        <Textarea
+          ref={inputRef}
+          value={value}
+          onChange={(e) => {
+            onChange(e.target.value)
+            updateQuery(e.target.value, e.target.selectionStart ?? e.target.value.length)
+          }}
+          onSelect={(e) => {
+            const el = e.currentTarget
+            updateQuery(el.value, el.selectionStart ?? el.value.length)
+          }}
+          onKeyDown={handleKeyDown}
+          {...textareaProps}
+        />
+      </div>
+      {references.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {references.map((r) => (
+            <span
+              key={`${r.kind}-${r.id}`}
+              className="inline-flex max-w-56 items-center gap-1.5 rounded-lg border border-border bg-muted/30 py-1 pr-1.5 pl-2 text-xs"
+            >
+              <span className="truncate">
+                {referenceKindLabel[r.kind].replace(/s$/, '')}: {r.name}
+              </span>
+              <button
+                type="button"
+                onClick={() => remove(r.kind, r.id)}
+                aria-label={`Remove ${r.name} reference`}
+                className="flex size-3.5 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:text-foreground"
+              >
+                <HugeiconsIcon icon={Cancel01Icon} className="size-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/lib/references.test.ts
+++ b/web/src/lib/references.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import type { Reference } from '../api/types'
+import { addReference, groupReferenceOptions, maxReferences, removeReference } from './references'
+
+describe('addReference', () => {
+  it('appends a new reference', () => {
+    const refs: Reference[] = []
+    const next = addReference(refs, { kind: 'mission', id: 'm1', name: 'Mission one' })
+    expect(next).toEqual([{ kind: 'mission', id: 'm1', name: 'Mission one' }])
+  })
+
+  it('dedupes by kind+id', () => {
+    const refs: Reference[] = [{ kind: 'mission', id: 'm1', name: 'Mission one' }]
+    const next = addReference(refs, { kind: 'mission', id: 'm1', name: 'Mission one' })
+    expect(next).toBe(refs)
+  })
+
+  it('refuses to add past maxReferences', () => {
+    const refs: Reference[] = Array.from({ length: maxReferences }, (_, i) => ({
+      kind: 'mission' as const,
+      id: `m${i}`,
+      name: `Mission ${i}`,
+    }))
+    const next = addReference(refs, { kind: 'session', id: 's1', name: 'A chat' })
+    expect(next).toBe(refs)
+    expect(next).toHaveLength(maxReferences)
+  })
+})
+
+describe('removeReference', () => {
+  it('removes only the matching kind+id', () => {
+    const refs: Reference[] = [
+      { kind: 'mission', id: 'm1', name: 'Mission one' },
+      { kind: 'session', id: 'm1', name: 'Same id, different kind' },
+    ]
+    const next = removeReference(refs, 'mission', 'm1')
+    expect(next).toEqual([{ kind: 'session', id: 'm1', name: 'Same id, different kind' }])
+  })
+})
+
+describe('groupReferenceOptions', () => {
+  it('groups by kind in a fixed order, omitting empty groups', () => {
+    const groups = groupReferenceOptions([
+      { kind: 'kb_doc', id: 'd1', name: 'Doc' },
+      { kind: 'mission', id: 'm1', name: 'Mission' },
+    ])
+    expect(groups.map((g) => g.kind)).toEqual(['mission', 'kb_doc'])
+  })
+})

--- a/web/src/lib/references.ts
+++ b/web/src/lib/references.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from 'react'
+import { listMissions, listSessions, searchKbDocuments } from '../api/client'
+import type { Reference, ReferenceKind } from '../api/types'
+
+// maxReferences mirrors the server's cap (internal/brain/chat/
+// references.go's maxReferences) so the UI disables adding beyond it
+// rather than letting a request get rejected.
+export const maxReferences = 8
+
+// referenceSearchDebounceMs matches the model catalog search's own
+// debounce (ModelInput.tsx's useCatalogSearch) — one request per pause
+// in typing, not per keystroke.
+const referenceSearchDebounceMs = 250
+
+// ReferenceOption is one row of the # picker's results, grouped by
+// kind for the popup's section headers.
+export interface ReferenceOption {
+  kind: ReferenceKind
+  id: string
+  name: string
+}
+
+// searchReferences runs the three lookups in parallel and returns
+// whatever each yields as its own group — a failed lookup degrades to
+// an empty group rather than failing the whole search. Missions and
+// sessions are already newest-first from their list endpoints, so an
+// empty query still returns a usable "recent" list; kb documents
+// require at least one character (searchKbDocuments with no query
+// would return every document across every collection).
+async function searchReferences(q: string): Promise<ReferenceOption[]> {
+  const trimmed = q.trim()
+  const [missions, sessions, docs] = await Promise.all([
+    listMissions({ query: trimmed, limit: 8 }).catch(() => []),
+    listSessions(trimmed).catch(() => []),
+    trimmed ? searchKbDocuments(trimmed).catch(() => []) : Promise.resolve([]),
+  ])
+  return [
+    ...missions.map((m) => ({ kind: 'mission' as const, id: m.id, name: m.name || m.goal })),
+    ...sessions.map((s) => ({ kind: 'session' as const, id: s.id, name: s.title || s.id })),
+    ...docs.map((d) => ({ kind: 'kb_doc' as const, id: d.id, name: d.title })),
+  ]
+}
+
+// useReferenceSearch debounces q and fires searchReferences, guarding
+// against out-of-order responses with a request-sequence counter (same
+// pattern as useCatalogSearch) — active only while q is non-null (the
+// picker is open).
+export function useReferenceSearch(q: string | null): ReferenceOption[] {
+  const [options, setOptions] = useState<ReferenceOption[]>([])
+  const seq = useRef(0)
+
+  useEffect(() => {
+    if (q === null) {
+      setOptions([])
+      return
+    }
+    const mySeq = ++seq.current
+    const t = setTimeout(() => {
+      searchReferences(q).then(
+        (result) => {
+          if (mySeq === seq.current) setOptions(result)
+        },
+        () => {
+          if (mySeq === seq.current) setOptions([])
+        },
+      )
+    }, referenceSearchDebounceMs)
+    return () => clearTimeout(t)
+  }, [q])
+
+  return options
+}
+
+// referenceKindLabel names each group's section header in the popup.
+export const referenceKindLabel: Record<ReferenceKind, string> = {
+  mission: 'Missions',
+  session: 'Chats',
+  kb_doc: 'Documents',
+}
+
+export function groupReferenceOptions(
+  options: ReferenceOption[],
+): { kind: ReferenceKind; options: ReferenceOption[] }[] {
+  return (['mission', 'session', 'kb_doc'] as ReferenceKind[])
+    .map((kind) => ({ kind, options: options.filter((o) => o.kind === kind) }))
+    .filter((g) => g.options.length > 0)
+}
+
+// addReference appends a picked option as a reference chip, deduped by
+// kind+id and capped at maxReferences — a no-op past the cap (the
+// caller disables the option in the UI, this is the belt-and-suspenders
+// guard for a click that raced past it).
+export function addReference(refs: Reference[], picked: ReferenceOption): Reference[] {
+  if (refs.some((r) => r.kind === picked.kind && r.id === picked.id)) return refs
+  if (refs.length >= maxReferences) return refs
+  return [...refs, picked]
+}
+
+export function removeReference(refs: Reference[], kind: ReferenceKind, id: string): Reference[] {
+  return refs.filter((r) => !(r.kind === kind && r.id === id))
+}

--- a/web/src/pages/Chat.test.tsx
+++ b/web/src/pages/Chat.test.tsx
@@ -28,6 +28,9 @@ vi.mock('../api/client', () => ({
   getSettings: vi.fn().mockResolvedValue({ settings: { transcribe_enabled: false }, values: {} }),
   listKbCollections: vi.fn().mockResolvedValue([]),
   setSessionKnowledge: vi.fn().mockResolvedValue(undefined),
+  listMissions: vi.fn().mockResolvedValue([]),
+  listSessions: vi.fn().mockResolvedValue([]),
+  searchKbDocuments: vi.fn().mockResolvedValue([]),
 }))
 
 vi.mock('../lib/events', () => ({ subscribeEvents: vi.fn() }))
@@ -40,6 +43,7 @@ import {
   chatStream,
   getTranscript,
   listAgents,
+  listMissions,
   listRoutes,
   setSessionKnowledge,
   stopTurn,
@@ -50,7 +54,7 @@ import { toast } from 'sonner'
 
 // captureSubscribe grabs the onSignal callback subscribeEvents was
 // last called with, so a test can fire a "session" signal directly
-// instead of driving a real SSE stream — same helper shape as
+// instead of driving a real SSE stream: same helper shape as
 // Missions.test.tsx's own captureSubscribe.
 function captureSubscribe() {
   return {
@@ -237,7 +241,7 @@ describe('live reattach', () => {
       turn_active: true,
     })
     // A real streamLive's promise stays pending until the stream
-    // actually ends (terminal meta) — resolve it ourselves once the
+    // actually ends (terminal meta): resolve it ourselves once the
     // test feeds that terminal event, matching that lifecycle instead
     // of settling immediately like a bare mock would.
     let feed!: (ev: ChatEvent) => void
@@ -268,7 +272,7 @@ describe('live reattach', () => {
 
     feed({ type: 'meta', session_id: 's1' })
     resolveStream()
-    // Terminal meta clears streaming — same reducer/finalization path a
+    // Terminal meta clears streaming: same reducer/finalization path a
     // locally-started turn goes through.
     await waitFor(() => expect(screen.queryByText('▍')).not.toBeInTheDocument())
   })
@@ -328,7 +332,7 @@ describe('live reattach', () => {
 
     await waitFor(() => expect(toast.info).toHaveBeenCalled())
     await waitFor(() => expect(streamLive).toHaveBeenCalled())
-    // No generic failure state rendered — the in-flight turn's own
+    // No generic failure state rendered: the in-flight turn's own
     // stream (fed below) is what populates the answer.
     expect(screen.queryByText(/turn already in flight/)).not.toBeInTheDocument()
 
@@ -341,7 +345,7 @@ describe('live reattach', () => {
   })
 
   it('reattaches via streamLive instead of showing an error on a dropped connection', async () => {
-    // A plain TypeError (network cut, proxy timeout) — not a ChatError,
+    // A plain TypeError (network cut, proxy timeout): not a ChatError,
     // so there's no definite server response to treat as a real failure.
     // Needs an already-adopted session (sessionRef populated from the
     // route param), since a transport failure carries no session_id to
@@ -407,7 +411,7 @@ describe('live reattach', () => {
 
 describe('stop turn', () => {
   it('calls stopTurn when the Stop button is clicked mid-stream', async () => {
-    // A chatStream that never resolves on its own — the turn is still
+    // A chatStream that never resolves on its own: the turn is still
     // "streaming" from the page's point of view until the test clicks
     // Stop, mirroring a real in-flight turn.
     let released!: () => void
@@ -433,7 +437,7 @@ describe('stop turn', () => {
     released() // let the pending chatStream settle so the test can end cleanly
   })
 
-  it('does NOT call stopTurn on unmount — only the local fetch is aborted', async () => {
+  it('does NOT call stopTurn on unmount: only the local fetch is aborted', async () => {
     let released!: () => void
     vi.mocked(chatStream).mockImplementation(
       async (_req: ChatRequest, onEvent: (ev: ChatEvent) => void, opts: ChatStreamOptions = {}) => {
@@ -618,5 +622,34 @@ describe('session knowledge', () => {
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Could not update knowledge'))
     await screen.findByText('#observability')
+  })
+})
+
+describe('composer references', () => {
+  it('picks a mission via # and includes it in the send request, then clears the chip', async () => {
+    vi.mocked(listMissions).mockResolvedValue([
+      { id: 'mi1', name: 'Fix the flaky test', goal: 'Fix the flaky test' } as never,
+    ])
+    renderChat()
+
+    const input = screen.getByLabelText('Message')
+    fireEvent.change(input, { target: { value: 'about #fix' } })
+
+    await screen.findByText('Missions')
+    fireEvent.click(screen.getByText('Fix the flaky test'))
+    expect((input as HTMLTextAreaElement).value).toBe('about ')
+
+    fireEvent.change(input, { target: { value: 'about the fix' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() =>
+      expect(chatStream).toHaveBeenCalledWith(
+        expect.objectContaining({ references: [{ kind: 'mission', id: 'mi1' }] }),
+        expect.anything(),
+        expect.anything(),
+      ),
+    )
+    // The chip strip clears after send, same as attachments/knowledge.
+    expect(screen.queryByText(/Fix the flaky test/)).toBeNull()
   })
 })

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -12,7 +12,7 @@ import {
   stopTurn,
   streamLive,
 } from '../api/client'
-import type { ChatEvent } from '../api/types'
+import type { ChatEvent, Reference } from '../api/types'
 import { ActivityPanel } from '../components/Activity'
 import { useAgents } from '../components/AgentPicker'
 import { Composer, isDocumentAttachment, type PendingAttachment } from '../components/Composer'
@@ -43,11 +43,11 @@ export function Chat({
 }: {
   onNeedToken: () => void
   // Route prefix for session-id adoption (e.g. "/research" for the
-  // locked research page) — kept in sync with the <Route> that mounts
+  // locked research page): kept in sync with the <Route> that mounts
   // this component so mid-stream URL adoption lands on the right page.
   basePath?: string
   // When set, the skill is pinned for every turn and cannot be
-  // removed or overridden by a home-screen intent — a dedicated,
+  // removed or overridden by a home-screen intent: a dedicated,
   // single-purpose page rather than general chat with a chip.
   lockedSkillHint?: string
   emptyHeading?: string
@@ -65,11 +65,11 @@ export function Chat({
   // Optimistic sends' local object URLs, keyed by chat item id, so a
   // just-sent message's thumbnails render instantly (UserMessage's
   // localUrls prop) without round-tripping through AuthedImage's
-  // authed fetch — cleared per item only on unmount of the page, since
+  // authed fetch: cleared per item only on unmount of the page, since
   // a resumed/replayed session recreates items server-side anyway.
   const localUrlsRef = useRef(new Map<string, Map<string, string>>())
   // Locked pages fix their own agent and never touch the shared
-  // localStorage preference — a research page reading (or clobbering)
+  // localStorage preference: a research page reading (or clobbering)
   // whatever agent general chat last used would be a leak either
   // direction. Empty string = the server-side default agent, the only
   // seeded one; its skills allowlist covers every shipped pack, so a
@@ -92,7 +92,11 @@ export function Chat({
   // session's `knowledge` on load; local-only until the first send on
   // a brand-new chat (no session id yet).
   const [knowledge, setKnowledge] = useState<string[]>([])
-  // The serving agent's own bound collections — always searched, never
+  // Mission/chat/document references picked via #mention chips:
+  // component state only, never persisted (unlike knowledge): cleared
+  // on send, same as attachments.
+  const [references, setReferences] = useState<Reference[]>([])
+  // The serving agent's own bound collections: always searched, never
   // pinned by the user. Re-derived from the live agent selection (not
   // snapshotted) so switching agents mid-session updates the chips.
   // Same fallback as AgentRoutePicker: an empty/unmatched agent name
@@ -121,7 +125,7 @@ export function Chat({
   // Cancel any in-flight stream when the page unmounts (route change).
   useEffect(() => () => abortRef.current?.abort(), [])
 
-  // Revoke every optimistic-send object URL when the page unmounts —
+  // Revoke every optimistic-send object URL when the page unmounts:
   // they only exist to make a just-sent thumbnail instant, and a
   // route change means AuthedImage's authed fetch takes over on
   // remount (resume replays the transcript from scratch either way).
@@ -142,7 +146,7 @@ export function Chat({
       return // our own mid-stream URL adoption, not a navigation
     }
     // Real navigation: a stream still running belongs to the previous
-    // session — kill it before it writes into this one's transcript.
+    // session: kill it before it writes into this one's transcript.
     if (abortRef.current) {
       abortRef.current.abort()
       abortRef.current = null
@@ -179,14 +183,14 @@ export function Chat({
       stale = true
     }
     // attachLive is stable across renders in effect (closes over setters
-    // only) but isn't itself memoized — omitted deliberately, same
+    // only) but isn't itself memoized: omitted deliberately, same
     // pattern as the intent-consuming effect below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [routeSession, onNeedToken])
 
   // Tier 1 fallback: while NOT attached to a live stream for the open
   // session, a "session" signal means some turn elsewhere finished (or
-  // this tab missed the transition) — refetch the transcript so a tab
+  // this tab missed the transition): refetch the transcript so a tab
   // that never got to attach live still catches up promptly instead of
   // waiting on the next navigation. Attached tabs skip this: they're
   // already getting every event live, and a mid-stream refetch would
@@ -213,7 +217,7 @@ export function Chat({
 
   // updateKnowledge handles both the mention popup's add (local only,
   // rides the next send) and a chip's remove button. A removal on an
-  // existing session also persists immediately via PUT — the chip
+  // existing session also persists immediately via PUT: the chip
   // otherwise reappears next time the session is opened.
   const updateKnowledge = (next: string[]) => {
     const removed = next.length < knowledge.length
@@ -249,7 +253,7 @@ export function Chat({
   // attachLive reattaches to a turn that was already streaming when
   // this tab opened the session (turn_active from getTranscript): a
   // trailing 'interrupted' item is the server's replay of a mid-turn
-  // pending_state checkpoint — without this it would sit there forever
+  // pending_state checkpoint: without this it would sit there forever
   // looking dead. Replacing it with a live streaming assistant item and
   // feeding streamLive's events through the SAME applyEvent reducer
   // sendMessage uses makes a reattached turn indistinguishable from one
@@ -258,7 +262,7 @@ export function Chat({
   // every chunk that built up the interrupted partial, so the new item
   // starts empty rather than double-seeding with the persisted text.
   // maxLiveReconnects caps how many times a single dropped connection
-  // retries attachLive before giving up — a turn genuinely gone (not
+  // retries attachLive before giving up: a turn genuinely gone (not
   // just this subscriber's connection) would otherwise loop forever.
   const maxLiveReconnects = 5
 
@@ -291,7 +295,7 @@ export function Chat({
         if (controller.signal.aborted) return
         // The live stream can end without a terminal meta event if this
         // subscriber got dropped for lagging (turnBroadcaster's
-        // drop-on-full) rather than the turn actually finishing — a
+        // drop-on-full) rather than the turn actually finishing: a
         // one-shot refetch recovers either way: either it shows the
         // now-completed turn, or it shows the turn still running and
         // the next session signal (Tier 1) prompts another refetch.
@@ -306,7 +310,7 @@ export function Chat({
         if (controller.signal.aborted) return
         if (err instanceof ChatError) {
           // A 404 (no_active_turn) means the turn finished in the gap
-          // between getTranscript and this attach — refetch once to pick
+          // between getTranscript and this attach: refetch once to pick
           // up the now-completed transcript rather than leaving the
           // freshly-blanked item stuck empty.
           getTranscript(sessionId)
@@ -316,7 +320,7 @@ export function Chat({
           return
         }
         // A transport-level failure (dropped connection, proxy timeout)
-        // rather than a definite server response — the turn is very
+        // rather than a definite server response: the turn is very
         // likely still running server-side (D-042), so reattach instead
         // of treating this as final. abortRef must point at the retry's
         // own controller, not get cleared by this attempt's finally.
@@ -345,15 +349,17 @@ export function Chat({
     routeName = route,
     sentAttachments: PendingAttachment[] = [],
     sentKnowledge = knowledge,
+    sentReferences = references,
   ) => {
     const message = text.trim()
-    // Uploads still in flight aren't sendable ids yet — only completed
+    // Uploads still in flight aren't sendable ids yet: only completed
     // ones ride the request; the composer's cap+toast already stops a
     // user from expecting an in-flight one to count.
     const ready = sentAttachments.filter((a) => !a.uploading)
     if ((!message && ready.length === 0) || streaming) return
     setDraft('')
     setAttachments([])
+    setReferences([])
     setStreaming(true)
     pinnedRef.current = true // sending always re-follows the answer
     const userItemId = crypto.randomUUID()
@@ -387,7 +393,7 @@ export function Chat({
       sessionRef.current = id
       adoptedRef.current = id
       // Same route pattern serves basePath and basePath/:id, so this
-      // only re-renders — the live stream keeps its component state.
+      // only re-renders: the live stream keeps its component state.
       navigate(`${basePath}/${id}`, { replace: true })
     }
     let handedOffToLive = false
@@ -402,6 +408,10 @@ export function Chat({
           attachments:
             ready.length > 0 ? ready.map((a) => ({ id: a.id, name: a.name })) : undefined,
           knowledge: sentKnowledge.length > 0 ? sentKnowledge : undefined,
+          references:
+            sentReferences.length > 0
+              ? sentReferences.map((r) => ({ kind: r.kind, id: r.id }))
+              : undefined,
         },
         (ev: ChatEvent) => {
           if (ev.type === 'meta') adoptSession(ev.session_id)
@@ -423,7 +433,7 @@ export function Chat({
           updateLast((m) => ({ ...m, streaming: false, error: errorText(err) }))
         } else if (err.status === 409 && err.code === 'turn_in_flight') {
           // Lost the race to a turn already running elsewhere (another
-          // tab, a retry) — not a failure, just attach to it like a
+          // tab, a retry): not a failure, just attach to it like a
           // page reload mid-turn would. attachLive owns streaming/abort
           // state from here, so the finally below must not touch it.
           toast.info('A reply is already in progress, reattaching')
@@ -432,7 +442,7 @@ export function Chat({
         } else updateLast((m) => ({ ...m, streaming: false, error: err.message }))
       } else if (sessionRef.current) {
         // A transport-level failure (dropped connection, proxy timeout,
-        // laptop sleep) throws a plain error, not ChatError — the turn
+        // laptop sleep) throws a plain error, not ChatError: the turn
         // itself runs detached from this request (D-042), so it's very
         // likely still alive server-side. Reattach via /live instead of
         // surfacing a false "failed" state; attachLive's own error path
@@ -454,11 +464,12 @@ export function Chat({
     }
   }
 
-  const send = () => void sendMessage(draft, agent, skillHint, route, attachments, knowledge)
+  const send = () =>
+    void sendMessage(draft, agent, skillHint, route, attachments, knowledge, references)
 
   // stop asks the server to cancel the in-flight turn (chat.Service now
   // runs it detached from this request, so abortRef.current?.abort()
-  // alone only stops this tab's rendering, never the turn itself — see
+  // alone only stops this tab's rendering, never the turn itself: see
   // stopTurn's doc comment). Fire-and-forget: the turn's abnormal-end
   // persistence and the local abort together already leave the UI in a
   // sane state regardless of whether this call lands.
@@ -507,7 +518,7 @@ export function Chat({
           updateLast((m) => ({ ...m, streaming: false, error: errorText(err) }))
         } else if (err.status === 409 && err.code === 'turn_in_flight') {
           // Same handoff as sendMessage: a turn is already running
-          // (another tab's send/retry won the race) — attach to it
+          // (another tab's send/retry won the race): attach to it
           // instead of showing a failure. attachLive owns
           // streaming/abort state from here.
           toast.info('A reply is already in progress, reattaching')
@@ -516,7 +527,7 @@ export function Chat({
         } else updateLast((m) => ({ ...m, streaming: false, error: err.message }))
       } else {
         // A transport-level failure (dropped connection, proxy timeout,
-        // laptop sleep) throws a plain error, not ChatError — the turn
+        // laptop sleep) throws a plain error, not ChatError: the turn
         // itself runs detached from this request (D-042), so it's very
         // likely still alive server-side. Reattach via /live instead of
         // surfacing a false "failed" state.
@@ -538,7 +549,7 @@ export function Chat({
   // Consume a home-screen intent exactly once: `send` fires the
   // message immediately, `draft` prefills the composer, `skillHint`
   // pins the chip. sendMessage takes hint explicitly here rather than
-  // relying on the skillHint state landing before the call — setState
+  // relying on the skillHint state landing before the call: setState
   // doesn't take effect until the next render.
   useEffect(() => {
     if (lockedSkillHint || intentConsumedRef.current) return
@@ -588,7 +599,7 @@ export function Chat({
     updateLast((m) => clearPermission(m, id))
     answerPermission(id, decision).catch((err: unknown) => {
       // A replayed ask whose turn died (brain restart) answers 404
-      // "unknown or already-answered" — the prompt is already gone
+      // "unknown or already-answered": the prompt is already gone
       // locally (above), so just tell the user why nothing happened.
       // Any other error is the same 10-minute-timeout-resolves-as-deny
       // case as before: nothing useful to render.
@@ -634,7 +645,7 @@ export function Chat({
                   documents={item.documents}
                   localUrls={localUrlsRef.current.get(item.id)}
                   // A trailing user message means the turn died before any
-                  // assistant event reached the transcript — retry re-runs
+                  // assistant event reached the transcript: retry re-runs
                   // it server-side, same trailing-only condition as above.
                   onRetry={i === items.length - 1 && !streaming ? retryLast : undefined}
                 />
@@ -650,7 +661,7 @@ export function Chat({
                   text={item.text}
                   // Same trailing-only condition as user/assistant items:
                   // a failed turn had no way back into the UI at all
-                  // without this — the user had to type the message again.
+                  // without this: the user had to type the message again.
                   onRetry={i === items.length - 1 && !streaming ? retryLast : undefined}
                 />
               )
@@ -660,7 +671,7 @@ export function Chat({
                   key={item.id}
                   msg={item}
                   // Retry only ever targets the trailing dangling turn
-                  // (the session's last event server-side) — never a
+                  // (the session's last event server-side): never a
                   // mid-transcript message.
                   onRetry={i === items.length - 1 && !streaming ? retryLast : undefined}
                   onShowActivity={() => setActivityId(item.id)}
@@ -698,6 +709,8 @@ export function Chat({
           knowledge={knowledge}
           onKnowledge={updateKnowledge}
           agentKnowledge={agentKnowledge}
+          references={references}
+          onReferences={setReferences}
         />
         <p className="mt-2 text-center text-xs text-zinc-400 dark:text-zinc-500">
           Enter to send · Shift+Enter for a new line


### PR DESCRIPTION
## Why

Closes #371, closes #376. Frontend for the composer `#` reference feature over the #375 backend (#401): pin known-relevant context explicitly instead of relying on automatic retrieval.

## Changes

- Typing `#` in the chat composer or mission-create goal field opens the mention popup with matches grouped: existing kb-collection matches (unchanged), then Missions, Chats, Documents. Debounced 250ms (existing `useCatalogSearch` pattern), three searches in parallel (`listMissions?q=`, `listSessions?query=`, new `searchKbDocuments`); missions/chats show recent items on empty query, kb documents need 1+ chars.
- Picking inserts a `Kind: name` chip with a remove control and strips the `#query` token; ArrowUp/Down/Enter/Tab/Escape across the combined list.
- Submit sends `references: [{kind, id}]` on chat requests and mission create. Cap of 8 mirrors the server ceiling (`lib/references.ts`); collections unaffected by the cap.
- Chat composer's existing hand-rolled `#collection` popup extended in place, no parallel dropdown; its 40 existing tests pass verbatim. Mission form gets `MissionReferences.tsx`'s `GoalTextarea` sharing the same logic. Recurring schedules keep the plain textarea (no `references` on schedule fires server-side).

## Tests

18 new: `lib/references.test.ts` (5), Composer (+7: debounce, pick+strip, remove, payload, cap, cross-group keyboard nav), MissionForm (+5), Chat end-to-end (+1).

## Verification

Containerized: build clean (tsc + vite), lint 0 errors (no new warnings from touched files), tests 963/964 with the single failure being the known pre-existing `AgentRoutePicker` timing flake under parallel load (file untouched, 9/9 in isolation).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790686204&installation_model_id=431401&pr_number=403&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F403&signature=7fb094beda8d1cbe9d7396b865488247eb62557688bccb8234fce014f6fba6b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->