### PR TITLE
feat(kb): whole-kb search by default, collections become ranking boost

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -14,7 +14,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -61,7 +60,7 @@ const defaultTokenBudget = 60_000
 // returns: the connector reload goroutine reads it (via
 // conns.SetOnReload's closure) on its own timer, concurrently with
 // main()'s later append of the mission tools once missionStore is
-// built — a plain slice variable shared across those two goroutines
+// built: a plain slice variable shared across those two goroutines
 // would race on that append. add appends under lock and returns the
 // current snapshot for the caller to pass straight to swapAgentTools.
 type builtinToolSet struct {
@@ -92,7 +91,7 @@ const (
 	// extractBudget bounds the fire-and-forget turn-end extraction:
 	// one memoryd round trip (LLM + embed) plus slack.
 	extractBudget = 90 * time.Second
-	// retrieveBudget sits ON the turn's critical path — one embed +
+	// retrieveBudget sits ON the turn's critical path: one embed +
 	// three SQL legs, so tight.
 	retrieveBudget = 10 * time.Second
 	// preCompactExtractBudget bounds the extraction INSIDE the
@@ -100,7 +99,7 @@ const (
 	// instead of starving the summarize.
 	preCompactExtractBudget = 45 * time.Second
 	// connectorReadyWait bounds how long a turn waits at entry for the
-	// first connector load (D-043) — long enough to absorb the DB pool
+	// first connector load (D-043): long enough to absorb the DB pool
 	// warming at boot, short enough that a turn never meaningfully hangs
 	// on it.
 	connectorReadyWait = 15 * time.Second
@@ -203,7 +202,7 @@ func main() {
 		return flags.Value(ctx, settings.ValueSensitiveToolRoute)
 	}
 	// fxStore backs both the daily rate fetch (below) and
-	// convert_currency's table-first lookup (buildAgent) — one fetch,
+	// convert_currency's table-first lookup (buildAgent): one fetch,
 	// one table, shared by the live tool and by display conversion
 	// (Analytics, mission usage) elsewhere in this file.
 	fxStore := fxrates.NewStore(app.DB)
@@ -252,7 +251,7 @@ func main() {
 		})
 		// Only the first turn after boot pays this: once conns.Ready()
 		// closes, WaitReady returns instantly on every later call. Bounded
-		// so a turn NEVER blocks indefinitely — a slow/never-ready load
+		// so a turn NEVER blocks indefinitely: a slow/never-ready load
 		// degrades to builtins-only instead of hanging the turn.
 		agent.SetWaitToolsReady(func(ctx context.Context) {
 			wctx, cancel := context.WithTimeout(ctx, connectorReadyWait)
@@ -266,7 +265,7 @@ func main() {
 	// Mission shell/verify_cmd execution always runs sandboxed via
 	// sandboxd (it holds the Docker socket, brain no longer touches it
 	// directly). Brain doesn't fail closed if sandboxd itself is
-	// unreachable at boot — that surfaces as a degraded health check
+	// unreachable at boot: that surfaces as a degraded health check
 	// below, with missions failing as infra at exec time instead.
 	sandboxdURL := os.Getenv("SANDBOXD_URL")
 	if sandboxdURL == "" {
@@ -330,7 +329,7 @@ func main() {
 	}
 	// deliver: chat-facing ad-hoc send to one operator-configured
 	// destination. Registered here, not inside buildAgent, for the same
-	// reason as the mission tools below — destinationStore/Deliverer
+	// reason as the mission tools below: destinationStore/Deliverer
 	// don't exist yet at that point. Like list_missions/push_mission_branch,
 	// this reaches the live tool surface (chat + connector-reload swaps)
 	// only, never the BuiltinsOnly base surface a mission worker turn
@@ -400,7 +399,7 @@ func main() {
 	// rule) since "<connector-name>_<tool-name>" puts the connector's own
 	// name in front of every tool it serves. Computed fresh each call,
 	// not cached, so toggling a connector's sensitive flag takes effect
-	// on the next side-call without a restart — same reasoning as
+	// on the next side-call without a restart: same reasoning as
 	// sensitiveRoute above. conns is nil when the connector surface
 	// itself is disabled (no secret store).
 	sensitiveConnectorNames := func(ctx context.Context) []string {
@@ -434,7 +433,7 @@ func main() {
 	// loop's in-turn SetForceRouteByConnector pin below and this
 	// SensitiveTools value, so side-calls (extraction, compaction
 	// summarize) honor the same route floor the tool loop already
-	// pinned the turn to. Wired unconditionally — sensitiveRoute
+	// pinned the turn to. Wired unconditionally: sensitiveRoute
 	// resolving to "" at call time means the feature is currently off,
 	// same as before, but now editable at runtime from the settings UI.
 	sensitiveTools := &session.SensitiveTools{
@@ -444,7 +443,7 @@ func main() {
 	}
 	// Connector-level sensitivity's in-turn counterpart: a whole
 	// connector flagged sensitive must pin the SAME turn that calls its
-	// tool, not just every turn after (chat.pinSensitiveRoute) — without
+	// tool, not just every turn after (chat.pinSensitiveRoute): without
 	// this, a search/read tool's own results ride the turn's ORIGINAL
 	// route (e.g. a cloud default) until the NEXT turn notices the
 	// session is sensitive, one turn too late for whatever content that
@@ -458,7 +457,7 @@ func main() {
 	svc.SetAutoDispatch(agentReg.Enabled, chat.ClassifyOverGateway(gwc))
 	svc.SetSensitiveTools(sensitiveTools)
 	// TURN_TIMEOUT raises the detached-turn ceiling above the compiled
-	// 30m default — needed when a route serves a slow CPU-only backend
+	// 30m default: needed when a route serves a slow CPU-only backend
 	// whose provider request_timeout (D-041) would otherwise collide
 	// with the brain ceiling and manufacture a deadline-vs-terminal
 	// race at the exact same instant. Env-gated feature, default off.
@@ -485,7 +484,7 @@ func main() {
 		})
 	}
 	// Same Permissions instance (and session_grants table) the chat
-	// agent loop's own Resolve chain reads from — seeding here is
+	// agent loop's own Resolve chain reads from: seeding here is
 	// visible to that exact chain, not a parallel grant store.
 	svc.SetApprovalGrants(chatPerms)
 	compactor.SetSensitiveTools(sensitiveTools)
@@ -514,7 +513,7 @@ func main() {
 	if missionDriver != nil {
 		// Same mc.Extract entry point chat's own MemoryExtract rides,
 		// fed the mission's curated digest instead of a chat turn's
-		// residue — missions/memory.go builds the digest, this closure
+		// residue: missions/memory.go builds the digest, this closure
 		// only owns the flag gate, timeout, and error logging, exactly
 		// like chat's own wiring above.
 		missionDriver.SetMemoryExtract(func(ctx context.Context, sessionID string, seq int64, text, route string) {
@@ -559,7 +558,7 @@ func main() {
 	attachmentStore := buildAttachments(app.DB, app.Log)
 	// Nil-safe: a nil *attachments.Store boxed into the AttachmentStore
 	// interface would be a non-nil interface value, breaking chat.go's
-	// `s.attachments == nil` gate — so this only wires when non-nil,
+	// `s.attachments == nil` gate: so this only wires when non-nil,
 	// same guard shape as the missionHub check above.
 	if attachmentStore != nil {
 		svc.SetAttachments(attachmentStore)
@@ -572,7 +571,7 @@ func main() {
 	}
 
 	// pdfService is nil-gated on both PDFGEN_URL and attachmentStore
-	// (ATTACHMENTS_DIR) — backs POST /v1/missions/{id}/export-pdf (#379)
+	// (ATTACHMENTS_DIR): backs POST /v1/missions/{id}/export-pdf (#379)
 	// and the derived pdf_export_enabled setting.
 	var pdfService *pdfgen.Service
 	if pdfgenURL != "" && attachmentStore != nil {
@@ -611,7 +610,7 @@ func main() {
 	// generate_pdf: registered here, not inside buildAgent, since it
 	// needs pdfService (built above, after buildAgent). Nil-gated on
 	// pdfService, which is itself nil-gated on PDFGEN_URL and
-	// attachmentStore — no separate media-saver wiring needed, it rides
+	// attachmentStore: no separate media-saver wiring needed, it rides
 	// the same agent.SetMediaSaver call share_file just made.
 	if pdfService != nil {
 		generatePDFTool := builtin.GeneratePDF(pdfService)
@@ -626,7 +625,7 @@ func main() {
 	}
 
 	// Mission artifact copy: registered here for the same reason
-	// share_file is — needs attachmentStore, built after buildMissions.
+	// share_file is: needs attachmentStore, built after buildMissions.
 	// Nil-gated on both attachmentStore (ATTACHMENTS_DIR) and
 	// missionDriver (WORKSPACES).
 	if attachmentStore != nil && missionDriver != nil {
@@ -634,10 +633,12 @@ func main() {
 	}
 
 	// search_kb: nil-safe wiring, same shape as memory retrieve/extract
-	// above — mc satisfies IngestDocument/KBSearch unconditionally, so
+	// above: mc satisfies IngestDocument/KBSearch unconditionally, so
 	// this always wires (memoryd unreachable surfaces as a per-call
 	// error, not a nil-gate, since MEMORYD_URL always resolves to a
-	// default).
+	// default). Searches the whole KB (nil collectionNames); the
+	// serving agent's Knowledge only rides along as boostCollections
+	// (D-078, issue #368).
 	kbStore := kb.New(app.DB)
 	// Ingest goroutines die with the process; fail anything a previous
 	// run left mid-ingest so the UI offers reingest instead of an
@@ -657,8 +658,8 @@ func main() {
 			app.Log.Info("kb stale-ingest sweep", "documents_failed", n)
 		}
 	}()
-	svc.SetKBSearch(func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error) {
-		hits, err := mc.KBSearch(ctx, query, collectionNames, mode, k)
+	svc.SetKBSearch(func(ctx context.Context, query string, boostCollections []string, mode string, k int) ([]builtin.KBSearchHit, error) {
+		hits, err := mc.KBSearch(ctx, query, nil, boostCollections, mode, k)
 		if err != nil {
 			return nil, err
 		}
@@ -711,23 +712,18 @@ func main() {
 }
 
 // buildSecretStore builds brain's secret-store handle (same DB, same
-// master key as the gateway) — shared by connectors and mission push,
+// master key as the gateway): shared by connectors and mission push,
 // so it's built once here rather than each caller decoding the master
 // key independently. A nil return (with an error to log) means an
 // unusable master key or init failure; callers nil-gate on it.
 // kbReadFromStore builds the read_kb backing lookup: the full stored
-// markdown straight from brain's own kb store — no memoryd round trip.
-// A document outside the caller's allowed collections reads as not
-// found (never "forbidden": the distinction would leak that the id
-// exists).
-func kbReadFromStore(kbStore *kb.Store) func(ctx context.Context, documentID string, collectionNames []string) (builtin.KBDocument, error) {
-	return func(ctx context.Context, documentID string, collectionNames []string) (builtin.KBDocument, error) {
+// markdown straight from brain's own kb store: no memoryd round trip.
+// Reaches any document by id (D-078, issue #368: collections are no
+// longer a read access gate); an unknown id reads as not found.
+func kbReadFromStore(kbStore *kb.Store) func(ctx context.Context, documentID string) (builtin.KBDocument, error) {
+	return func(ctx context.Context, documentID string) (builtin.KBDocument, error) {
 		doc, err := kbStore.GetDocument(ctx, documentID)
 		if err != nil {
-			return builtin.KBDocument{}, fmt.Errorf("document %s not found", documentID)
-		}
-		col, err := kbStore.GetCollection(ctx, doc.CollectionID)
-		if err != nil || !slices.Contains(collectionNames, col.Name) {
 			return builtin.KBDocument{}, fmt.Errorf("document %s not found", documentID)
 		}
 		return builtin.KBDocument{Title: doc.Title, SourceRef: doc.SourceRef, Markdown: doc.Markdown}, nil
@@ -760,7 +756,7 @@ func buildAttachments(db *pgpool.Pool, log *slog.Logger) *attachments.Store {
 
 // buildConnectors wires the integration control plane. secrets is
 // brain's already-built secret-store handle (nil when unavailable,
-// e.g. no valid master key) — a nil store still nil-gates the
+// e.g. no valid master key): a nil store still nil-gates the
 // connector surface exactly as before, it's just built once in main()
 // instead of here. The Google half additionally needs
 // TIMOTHY_PUBLIC_URL for the OAuth redirect; without it google
@@ -794,7 +790,7 @@ func buildConnectors(db *pgpool.Pool, secrets *secretstore.Store, log *slog.Logg
 
 // buildDestinations wires the destinations control plane (store +
 // adapters + Deliverer). missionStore nil (WORKSPACES unset) disables
-// it entirely — delivery has no meaning without missions. conns/goog
+// it entirely: delivery has no meaning without missions. conns/goog
 // nil still builds the store (webhook destinations work without
 // connectors); an email destination's create/update then fails
 // validation with a clear error, same nil-gated shape as
@@ -827,7 +823,7 @@ func buildDestinations(db *pgpool.Pool, conns *connectors.Manager, goog *connect
 }
 
 // destinationMailSender adapts *connectors.Google's attachment type to
-// destinations' own narrow mailAttachment shape — same
+// destinations' own narrow mailAttachment shape: same
 // never-import-connectors reasoning as destinationConnectorLookup.
 type destinationMailSender struct {
 	goog *connectors.Google
@@ -854,7 +850,7 @@ func (d destinationMailSender) SendMailHTML(ctx context.Context, connectorID, to
 }
 
 // destinationConnectorLookup adapts *connectors.Manager to
-// destinations' own narrow Connector/connectorLookup shape — missions
+// destinations' own narrow Connector/connectorLookup shape: missions
 // has no compile-time dependency on the connectors package's own
 // Connector type, same reasoning as connsPRSource above. A zero value
 // (conns == nil) is never boxed here; buildDestinations only
@@ -872,7 +868,7 @@ func (d destinationConnectorLookup) Get(ctx context.Context, id string) (destina
 }
 
 // destinationLister adapts *destinations.Store.List to the deliver
-// tool's own DestinationInfo shape — builtin never imports
+// tool's own DestinationInfo shape: builtin never imports
 // destinations directly (import cycle: destinations -> missions ->
 // builtin), same reasoning as builtin.MissionRecord.
 type destinationLister struct {
@@ -892,13 +888,13 @@ func (d destinationLister) List(ctx context.Context) ([]builtin.DestinationInfo,
 }
 
 // missionWorkSlotMax bounds how many missions may be status='working'
-// at once — the absolute ceiling; in practice the D-056 memory
+// at once: the absolute ceiling; in practice the D-056 memory
 // admission gate (sandboxd's /capacity) binds first, since a host tight
 // on memory denies well before 4 concurrent missions.
 const missionWorkSlotMax = 4
 
 // missionAgentResolver adapts agentReg.ResolveByID to scheduler.go's
-// AgentResolver / driver.go's SetAgentResolver shape — both need the
+// AgentResolver / driver.go's SetAgentResolver shape: both need the
 // SAME resolution (route/review_route/prompt_overlay/
 // approval_allowlist/harness from an agents row), just at different
 // moments (schedule fire time vs mission provisioning time), so one
@@ -943,7 +939,7 @@ func missionConnectorReadsResolver(agentReg *agents.Store, conns *connectors.Man
 // every available (already ReadOnly-marked, non-MCP) tool whose name
 // tools.ToolMatches an entry in allow. Empty allow (agent has no Tools
 // at all) matches nothing, same as filterDefs' empty-allow-means-
-// everything convention does NOT apply here — an agent that has never
+// everything convention does NOT apply here: an agent that has never
 // opted into any tool gets no connector reads either.
 func intersectReadOnlyConnectorTools(allow []string, available []*tools.Tool) []*tools.Tool {
 	if len(allow) == 0 {
@@ -963,12 +959,12 @@ func intersectReadOnlyConnectorTools(allow []string, available []*tools.Tool) []
 
 // buildMissions wires the mission engine (Store, Driver, Notifier,
 // Scheduler, Hub). Gated on WORKSPACES: no workspace root configured
-// means missions stay entirely inert — no goroutines started, nothing
+// means missions stay entirely inert: no goroutines started, nothing
 // scheduled, the API surface unmounted (registerMissions 404s on a nil
 // store). agentReg is D-034's agent registry, resolved at scheduler
 // fire time and mission provisioning time (never schedule-create
 // time) so an agent edited after the fact still applies. The hub
-// lives inside the same gate as everything else here — no missions,
+// lives inside the same gate as everything else here: no missions,
 // no push events either.
 func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sessions *session.Store, toolWorkspaceRoot string, flags *settings.Store, sandboxMgr *sandboxclient.Client, agentReg *agents.Store, routeForRole func(context.Context, string) string, fxStore *fxrates.Store, gwc *gwclient.Client, secrets *secretstore.Store, conns *connectors.Manager, mc *memclient.Client, packs []skills.Skill, log *slog.Logger) (*missions.Store, *missions.Driver, *missions.Notifier, *missions.Workspace, *missions.Hub, *missions.Scheduler) {
 	root := os.Getenv("WORKSPACES")
@@ -998,11 +994,12 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	// worker/reviewer shell, verify_cmd) OUT of brain's own process,
 	// through sandboxd, into a per-mission Docker container.
 	// search_kb: nil-safe (mc is never nil, MEMORYD_URL always resolves
-	// to a default), same shape as chat's own SetKBSearch wiring — the
-	// mission's OWN Knowledge snapshot (never a live agent lookup)
-	// scopes collections per turn (missions.nativeRunner.kbSearchTool).
-	kbSearch := func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error) {
-		hits, err := mc.KBSearch(ctx, query, collectionNames, mode, k)
+	// to a default), same shape as chat's own SetKBSearch wiring:
+	// searches the whole KB; the mission's OWN Knowledge snapshot (never
+	// a live agent lookup) only rides along as a ranking boost per turn
+	// (missions.nativeRunner.kbSearchTool, D-078, issue #368).
+	kbSearch := func(ctx context.Context, query string, boostCollections []string, mode string, k int) ([]builtin.KBSearchHit, error) {
+		hits, err := mc.KBSearch(ctx, query, nil, boostCollections, mode, k)
 		if err != nil {
 			return nil, err
 		}
@@ -1022,7 +1019,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	nativeRunner.SetProgressReader(store)
 	nativeRunner.SetLocation(flags.Location)
 	// The delegated runner wraps native with D-051/D-052's CLI-executor
-	// dispatch — resolve a worker route's chain via the gateway, spawn a
+	// dispatch: resolve a worker route's chain via the gateway, spawn a
 	// harness entry's CLI detached in the mission's own sandbox container,
 	// poll it to a verdict. Only wired when a sandbox manager is present
 	// (missions already require one for the native shell path); nativeRunner
@@ -1031,7 +1028,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	webhookURL := os.Getenv("NOTIFY_WEBHOOK_URL")
 	notifier := missions.NewNotifier(db, webhookURL, log)
 	notifier.SetHub(hub)
-	// A second tools.Permissions instance, not the one buildAgent built —
+	// A second tools.Permissions instance, not the one buildAgent built:
 	// it's stateless besides the shared db/root (Grant/Resolve hit
 	// Postgres directly), so a fresh instance behaves identically. Used
 	// only to pre-authorize a mission's hidden session at creation.
@@ -1060,7 +1057,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	if conns != nil && secrets != nil {
 		// A repo_url mission's clone token: resolve connector_id straight
 		// to its credential_ref's secret value, same as resolveSecret does
-		// for the push endpoint — no need to build a full connector
+		// for the push endpoint: no need to build a full connector
 		// Source just to read one credential.
 		driver.SetCloneTokenResolver(func(ctx context.Context, connectorID string) (string, error) {
 			c, err := conns.Store().Get(ctx, connectorID)
@@ -1118,7 +1115,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 		// The auto-fire-on-done hook's push token: resolve connector_id
 		// straight to its credential_ref's secret value, same as the
 		// clone token resolver above and the push endpoint's own
-		// resolvePushToken — the on_complete path never has an explicit
+		// resolvePushToken: the on_complete path never has an explicit
 		// credential_ref override, only ever the mission's own connector.
 		resolvePushToken := func(ctx context.Context, connectorID string) (string, error) {
 			c, err := conns.Store().Get(ctx, connectorID)
@@ -1138,7 +1135,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	schedulerEnabled := func(ctx context.Context) bool { return flags.Enabled(ctx, settings.KeyScheduler) }
 	// routeExists backs DefaultCodingRoute's preference check for a
 	// coding template's route (see api/missions.go's own copy of this
-	// wiring for the create-request path) — false on any resolve error,
+	// wiring for the create-request path): false on any resolve error,
 	// never a hard failure.
 	routeExists := func(ctx context.Context, name string) bool {
 		_, err := gwc.ResolveRoute(ctx, name, "")
@@ -1151,7 +1148,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 }
 
 // connsPRSource adapts *connectors.Manager to missions.PRSource for the
-// driver's on_complete auto-fire hook — missions has no compile-time
+// driver's on_complete auto-fire hook: missions has no compile-time
 // dependency on the connectors package, same reasoning as
 // CloneTokenResolver's closure-based wiring above.
 type connsPRSource struct {
@@ -1175,7 +1172,7 @@ func (c connsPRSource) CreatePR(ctx context.Context, connectorID, owner, repo, t
 }
 
 // toMissionRecord adapts a missions.Mission into the builtin package's
-// own MissionRecord shape — see MissionRecord's doc comment for why
+// own MissionRecord shape: see MissionRecord's doc comment for why
 // builtin can't import missions.Mission directly. NotPushable is
 // precomputed here since missions.NotPushable also lives in the
 // missions package.
@@ -1200,7 +1197,7 @@ func toMissionRecord(m missions.Mission) builtin.MissionRecord {
 
 // missionToolStore adapts *missions.Store to the builtin package's
 // list_missions/get_mission/push_mission_branch tool interfaces
-// (missionLister, missionEventReader) — a thin translation layer since
+// (missionLister, missionEventReader): a thin translation layer since
 // builtin cannot import missions.Mission/missions.Event directly
 // (import cycle, see MissionRecord's doc comment).
 type missionToolStore struct {
@@ -1240,7 +1237,7 @@ func (a missionToolStore) MissionEvents(ctx context.Context, id string) ([]built
 }
 
 // missionCompleterAdapter adapts *missions.Completer to the builtin
-// package's missionCompleter interface — push_mission_branch's
+// package's missionCompleter interface: push_mission_branch's
 // push/PR calls go through the exact same Completer the button/
 // auto-fire paths use. It re-Gets the mission by id from the real
 // store before calling Completer, so Completer always acts on the
@@ -1268,7 +1265,7 @@ func (a missionCompleterAdapter) OpenMissionPR(ctx context.Context, id, token st
 }
 
 // missionFollowUpCreatorAdapter adapts *missions.Driver to the builtin
-// package's missionFollowUpCreator interface — followup_mission's
+// package's missionFollowUpCreator interface: followup_mission's
 // create call goes through the exact same Driver.CreateFollowUp the
 // mission-create API's own ParentMissionID branch uses.
 type missionFollowUpCreatorAdapter struct {
@@ -1280,13 +1277,13 @@ func (a missionFollowUpCreatorAdapter) CreateFollowUpMission(ctx context.Context
 }
 
 // credResolveTimeout bounds one credential_ref resolution the delegated
-// runner does before spawning a CLI executor — same 3s bound
+// runner does before spawning a CLI executor: same 3s bound
 // cmd/gateway/main.go's credentialLookup uses for the identical
 // secretstore.Resolve call.
 const credResolveTimeout = 3 * time.Second
 
 // buildDelegatedRunner wraps native with missions.NewDelegatedRunner
-// when a sandbox manager is present — missions already require one for
+// when a sandbox manager is present: missions already require one for
 // the native shell/verify_cmd path, so its absence here would mean
 // missions are disabled entirely (buildMissions already returned early
 // in that case). A nil secrets store still lets subscription-mode
@@ -1311,7 +1308,7 @@ func buildDelegatedRunner(native missions.Runner, store *missions.Store, gwc *gw
 }
 
 // memoryProxy forwards the web's memory-management routes to memoryd
-// verbatim — brain adds only the bearer gate. The search route maps
+// verbatim: brain adds only the bearer gate. The search route maps
 // onto memoryd's retrieve endpoint.
 func memoryProxy(memorydURL string, log *slog.Logger) http.Handler {
 	target, err := url.Parse(memorydURL)
@@ -1339,7 +1336,7 @@ func memoryProxy(memorydURL string, log *slog.Logger) http.Handler {
 // gateway's internal API: /v1/admin/usage/* maps onto
 // /internal/usage/*. Brain adds the bearer gate and, for the usage
 // sub-tree only, decorates money fields with a converted_amount in the
-// user's default_currency (usageDecorate) — the gateway itself has no
+// user's default_currency (usageDecorate): the gateway itself has no
 // settings access and no fx_rates reader (it's a separate, settings-
 // unaware service), so this is the one seam where both are already
 // available. Every other admin endpoint (providers, routes, secrets)
@@ -1356,7 +1353,7 @@ func adminProxy(gatewayURL string, usageDecorate func(*http.Response) error, log
 			r.Out.URL.Path = "/internal/admin/" + strings.TrimPrefix(r.In.URL.Path, "/v1/admin/")
 		},
 		ModifyResponse: func(resp *http.Response) error {
-			// resp.Request is the OUTBOUND request — Rewrite above has
+			// resp.Request is the OUTBOUND request: Rewrite above has
 			// already turned /v1/admin/... into /internal/admin/..., so
 			// the scope check must match the rewritten prefix.
 			if usageDecorate == nil || !strings.HasPrefix(resp.Request.URL.Path, "/internal/admin/usage/") {
@@ -1390,7 +1387,7 @@ func (g gatedCompactor) MaybeCompact(ctx context.Context, sessionID string) erro
 // turnRouter sends chat turns through the agent loop and everything
 // else (titles, distills, compaction summaries) straight to the
 // gateway. With the tools switch off, chat turns bypass the agent
-// loop entirely — plain pass-through completion.
+// loop entirely: plain pass-through completion.
 type turnRouter struct {
 	agent *loop.Agent
 	gw    chat.Gateway
@@ -1449,7 +1446,7 @@ func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, wor
 	broker := loop.NewPermBroker()
 	agent := loop.NewAgent(gwc, constrained, perms, outputs, tools.NewAudit(db), store, broker, defs, log)
 	// Mission-driven turns (Request.BuiltinsOnly) get this compiled-in
-	// set only — never connector tools or the chat-only mission tools
+	// set only: never connector tools or the chat-only mission tools
 	// registered later in main(), since neither exists yet at this
 	// point. This snapshot never changes at runtime, unlike the shared
 	// registry SwapTools maintains.
@@ -1459,14 +1456,14 @@ func buildAgent(gwc *gwclient.Client, store *session.Store, db *pgpool.Pool, wor
 	agent.SetOffloadThreshold("shell", 4<<10)
 	// Connector-level sensitivity's in-turn pin (a connector marked
 	// sensitive in the connectors settings UI, e.g. gmail) is wired
-	// later via agent.SetForceRouteByConnector, once conns exists —
+	// later via agent.SetForceRouteByConnector, once conns exists:
 	// buildAgent runs before that, so there is nothing to wire here.
 	return agent, broker, outputs, set, perms, nil
 }
 
 // compileToolset registers builtin + connector tools into a fresh
 // constrained registry. A connector tool whose name collides with an
-// existing tool is skipped with a log — a remote server must never
+// existing tool is skipped with a log: a remote server must never
 // shadow a builtin.
 func compileToolset(builtins, connectorTools []*tools.Tool, log *slog.Logger, toolCalls *prometheus.CounterVec) (*tools.Constrained, []provider.ToolDef, error) {
 	reg := tools.NewRegistry()
@@ -1498,7 +1495,7 @@ func compileToolset(builtins, connectorTools []*tools.Tool, log *slog.Logger, to
 // reserved set: a connector tool (MCP raw names now included, see
 // Manager.Tools) never aggregates under a name the agent already has
 // from somewhere else, so it stays namespaced instead of shadowing it.
-// A compile failure keeps the previous surface — a broken connector
+// A compile failure keeps the previous surface: a broken connector
 // schema must not take down the builtins.
 func swapAgentTools(agent *loop.Agent, builtins []*tools.Tool, conns *connectors.Manager, log *slog.Logger, toolCalls *prometheus.CounterVec) {
 	reserved := make(map[string]bool, len(builtins))
@@ -1525,7 +1522,7 @@ const initialReloadRetry = 5 * time.Second
 // poll: a DB that wasn't ready at boot, or a row edited outside the
 // admin API, converges within a minute. The first load retries on the
 // short initialReloadRetry cadence until it succeeds once, THEN falls
-// into the normal minute ticker — later reloads don't need the fast
+// into the normal minute ticker: later reloads don't need the fast
 // path since the agent already has a tool surface.
 func runConnectorReload(ctx context.Context, conns *connectors.Manager, log *slog.Logger) {
 	for {

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -1,7 +1,7 @@
 // Package chat orchestrates one conversation turn: project the
 // session's event log into context, stream through the gateway,
 // persist the turn as events (with distilled residue), and keep the
-// projection under budget. State lives in the log — a restart loses
+// projection under budget. State lives in the log: a restart loses
 // nothing (D-006).
 package chat
 
@@ -54,7 +54,7 @@ const (
 	compactBudget = 150 * time.Second
 	titleTimeout  = 15 * time.Second
 	// approvalGrantTTL matches missions/driver.go's missionGrantTTL and
-	// loop's own sessionGrantTTL (12h) — a chat session idle longer than
+	// loop's own sessionGrantTTL (12h): a chat session idle longer than
 	// that just re-seeds the grant on its next turn, same degrade as a
 	// mission outliving its grant.
 	approvalGrantTTL = 12 * time.Hour
@@ -66,7 +66,7 @@ var ErrBadRequest = errors.New("bad request")
 
 // Gateway is the slice of the gateway client chat needs. RouteForRole
 // resolves which route currently serves one of the 4 roles Timothy
-// requires to work (D-049) — chat/turnmemory/compactor call it instead
+// requires to work (D-049): chat/turnmemory/compactor call it instead
 // of hardcoding a route name.
 type Gateway interface {
 	Stream(ctx context.Context, req gwclient.StreamRequest) (<-chan stream.StreamEvent, error)
@@ -89,7 +89,7 @@ type SessionLog interface {
 // Distill extracts turn residue; loop.DistillTurn curried with the
 // gateway in main, stubbed in tests. May return nil. route is "" for
 // the normal side-call route, or the sensitive route pin when the turn
-// executed a sensitive tool — same convention as MemoryExtract's route.
+// executed a sensitive tool: same convention as MemoryExtract's route.
 type Distill func(ctx context.Context, sessionID, turnText, route string) *session.TurnMemory
 
 // Compactor keeps a session's projection under budget.
@@ -107,21 +107,21 @@ type MemoryExtract func(ctx context.Context, sessionID string, seq int64, text s
 
 // MemoryRetrieve returns the rendered long-term memory block for a
 // user message, or "" for nothing relevant. The wrapper owns timeout
-// and error handling; a failure returns "" — a turn without memories
+// and error handling; a failure returns "": a turn without memories
 // beats no turn.
 type MemoryRetrieve func(ctx context.Context, sessionID, query string) string
 
 // AttachmentStore is the slice of *attachments.Store chat needs: Get
 // validates a ref exists (400 before any event append), Open resolves
 // its bytes to base64 at request-build time. Nil disables attachments
-// — a Request naming any Attachments id gets ErrBadRequest.
+//: a Request naming any Attachments id gets ErrBadRequest.
 type AttachmentStore interface {
 	Get(ctx context.Context, id string) (attachments.Attachment, error)
 	Open(ctx context.Context, id string) (io.ReadCloser, attachments.Attachment, error)
 }
 
 // Granter is the narrow slice of *tools.Permissions chat needs to seed
-// standing grants for a serving agent's ApprovalAllowlist — the same
+// standing grants for a serving agent's ApprovalAllowlist: the same
 // shape missions/driver.go's sessionGranter uses against the same
 // session_grants table, so a grant recorded here is visible to (and
 // glob-matched by) the exact same Permissions.Resolve chain a mission
@@ -154,8 +154,8 @@ type Service struct {
 	markitdownHTTP *http.Client                         // shared client for the markitdown sidecar call
 	whisperURL     string                               // "": audio attachments attach without a transcript (WHISPER_URL unset)
 	whisperHTTP    *http.Client                         // shared client for the whisper sidecar call
-	kbSearch       KBSearch                             // nil: search_kb never offered, regardless of agent config
-	kbRead         KBRead                               // nil: read_kb never offered, regardless of agent config
+	kbSearch       KBSearch                             // nil: search_kb never offered, regardless of agent config; whole-KB by default, agent Knowledge only boosts ranking
+	kbRead         KBRead                               // nil: read_kb never offered, regardless of agent config; reaches any document, not just the agent's Knowledge collections
 	missions       MissionStore                         // nil: mission #-mention references never resolve
 	kbDocs         KBDocStore                           // nil: kb doc #-mention references never resolve
 	logger         *slog.Logger
@@ -173,7 +173,7 @@ type Service struct {
 
 	// turns is the live-turn broadcaster registry (broadcast.go): a
 	// session ID present here means that session has a turn in flight,
-	// full stop. There is no separate turn_active bool anywhere — the
+	// full stop. There is no separate turn_active bool anywhere: the
 	// GET /v1/sessions/{id} handler and the live-reattach endpoint both
 	// read this same map through TurnActive/Subscribe, so the flag and
 	// the broadcaster can never disagree about whether a turn is
@@ -188,7 +188,7 @@ type Service struct {
 
 // roleRoute resolves the route currently bound to one of the 4 roles
 // Timothy requires to work (D-049): "default" or "vision". Returns ""
-// on any failure (role unbound, gateway unreachable) — callers must
+// on any failure (role unbound, gateway unreachable): callers must
 // never hard-fail a turn over this; an empty route falls through to
 // the gateway's own no_route error same as an unconfigured route
 // always has.
@@ -216,14 +216,14 @@ func (s *Service) SetSessionHub(publish func(sessionID string)) {
 // SetPermissionHub wires the "permission" signal push: fires once a
 // permission_request or permission_resolved event is durable (see
 // notePermission), same pattern and same nil-safe default as
-// SetSessionHub above — main wires both to the same missions.Hub, just
+// SetSessionHub above: main wires both to the same missions.Hub, just
 // a different Signal.Kind, so the web's one global /v1/events stream
 // carries both without a second transport.
 func (s *Service) SetPermissionHub(publish func(sessionID string)) {
 	s.publishPermission = publish
 }
 
-// SetMemoryExtract wires the memoryd hook. Optional — nil leaves
+// SetMemoryExtract wires the memoryd hook. Optional: nil leaves
 // long-term memory off.
 func (s *Service) SetMemoryExtract(fn MemoryExtract) { s.memory = fn }
 
@@ -232,16 +232,16 @@ func (s *Service) SetMemoryRetrieve(fn MemoryRetrieve) { s.recall = fn }
 
 // SetSensitiveTools wires the sensitive-tool route pin for side-calls
 // (memory extraction): a turn that executed a matching tool sends its
-// extraction on t.Route instead of memoryd's own default. Optional —
+// extraction on t.Route instead of memoryd's own default. Optional:
 // nil leaves every turn's side-calls on today's behavior.
 func (s *Service) SetSensitiveTools(t *session.SensitiveTools) { s.sensitive = t }
 
-// SetAttachments wires the attachment store (D-045). Optional — nil
+// SetAttachments wires the attachment store (D-045). Optional: nil
 // (ATTACHMENTS_DIR unset) rejects any Request naming Attachments ids.
 func (s *Service) SetAttachments(store AttachmentStore) { s.attachments = store }
 
 // SetMarkitdown wires the markitdown sidecar's base URL for PDF
-// attachment conversion. Optional — empty (MARKITDOWN_URL unset)
+// attachment conversion. Optional: empty (MARKITDOWN_URL unset)
 // rejects any PDF attachment ref with ErrBadRequest.
 func (s *Service) SetMarkitdown(url string) {
 	s.markitdownURL = url
@@ -251,7 +251,7 @@ func (s *Service) SetMarkitdown(url string) {
 }
 
 // SetWhisper wires the whisper sidecar's base URL for audio attachment
-// transcription. Optional — empty (WHISPER_URL unset) attaches audio
+// transcription. Optional: empty (WHISPER_URL unset) attaches audio
 // with no transcript rather than rejecting it (attach-only fallback).
 func (s *Service) SetWhisper(url string) {
 	s.whisperURL = url
@@ -260,62 +260,59 @@ func (s *Service) SetWhisper(url string) {
 	}
 }
 
-// KBSearch runs one knowledge-base search scoped to collectionNames —
-// main curries memclient.Client.KBSearch in; collectionNames travels
-// on every call, never bound once, since the same func serves every
-// agent and each turn's collections are the SERVING agent's own
-// Knowledge list (D-060: enforced here in Go, never a prompt).
-type KBSearch func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error)
+// KBSearch runs one knowledge-base search over the whole KB, boosted
+// toward boostCollections: main curries memclient.Client.KBSearch in;
+// boostCollections travels on every call, never bound once, since the
+// same func serves every agent and each turn's boost set is the SERVING
+// agent's own Knowledge list (D-078: collections rank-boost, they never
+// gate access: issue #368).
+type KBSearch func(ctx context.Context, query string, boostCollections []string, mode string, k int) ([]builtin.KBSearchHit, error)
 
 // SetKBSearch wires the search_kb tool's backing search call. Optional
-// — nil means search_kb is never offered on any turn, regardless of an
+//: nil means search_kb is never offered on any turn, regardless of an
 // agent's Knowledge list (same "the dependency's absence turns the
 // feature off entirely" contract as SetMemoryRetrieve/SetAttachments).
 func (s *Service) SetKBSearch(fn KBSearch) { s.kbSearch = fn }
 
-// kbSearchTool builds this turn's search_kb ExtraTool bound to
-// collections (the serving agent's Knowledge unioned with the
-// session's own pinned list), or nil when search_kb must not be
-// offered: no backing search call wired, or collections is empty
-// (opt-in-only, same contract as Skills/Tools — this is the "exclude
-// from the turn" choice, matching load_skill's precedent of leaving a
-// tool off the offered surface entirely rather than having it answer
-// with an error).
-func (s *Service) kbSearchTool(collections []string) *tools.Tool {
-	if s.kbSearch == nil || len(collections) == 0 {
+// kbSearchTool builds this turn's search_kb ExtraTool, or nil when no
+// backing search call is wired (KB feature off entirely). boost (the
+// serving agent's Knowledge unioned with the session's own pinned list)
+// is never a gate: every agent gets whole-KB search_kb once a backend
+// exists, empty boost or not (D-078, issue #368): boost only reorders
+// results toward those collections.
+func (s *Service) kbSearchTool(boost []string) *tools.Tool {
+	if s.kbSearch == nil {
 		return nil
 	}
-	collections = slices.Clone(collections)
+	boost = slices.Clone(boost)
 	return builtin.KBSearch(func(ctx context.Context, query, mode string, k int) ([]builtin.KBSearchHit, error) {
-		return s.kbSearch(ctx, query, collections, mode, k)
+		return s.kbSearch(ctx, query, boost, mode, k)
 	})
 }
 
-// KBRead loads one knowledge-base document scoped to collectionNames —
-// same contract as KBSearch: collectionNames travels on every call and
-// is the serving agent's own Knowledge list.
-type KBRead func(ctx context.Context, documentID string, collectionNames []string) (builtin.KBDocument, error)
+// KBRead loads one knowledge-base document by id, unscoped by
+// collection (D-078: collections no longer gate read access either:
+// issue #368).
+type KBRead func(ctx context.Context, documentID string) (builtin.KBDocument, error)
 
-// SetKBRead wires the read_kb tool's backing lookup. Optional — same
+// SetKBRead wires the read_kb tool's backing lookup. Optional: same
 // nil contract as SetKBSearch.
 func (s *Service) SetKBRead(fn KBRead) { s.kbRead = fn }
 
 // kbReadTool builds this turn's read_kb ExtraTool, gated exactly like
-// kbSearchTool: no backend or empty collections means the tool is not
-// offered.
-func (s *Service) kbReadTool(collections []string) *tools.Tool {
-	if s.kbRead == nil || len(collections) == 0 {
+// kbSearchTool: no backend wired means the tool is not offered.
+func (s *Service) kbReadTool() *tools.Tool {
+	if s.kbRead == nil {
 		return nil
 	}
-	collections = slices.Clone(collections)
 	return builtin.KBRead(func(ctx context.Context, documentID string) (builtin.KBDocument, error) {
-		return s.kbRead(ctx, documentID, collections)
+		return s.kbRead(ctx, documentID)
 	})
 }
 
 // SetAutoDispatch wires auto agent dispatch (D-034 follow-up): a
 // request naming the autoAgentName sentinel resolves through candidates
-// and classify instead of the named agent. Optional — nil candidates
+// and classify instead of the named agent. Optional: nil candidates
 // or classify makes the sentinel resolve to the default agent, same as
 // an empty name.
 func (s *Service) SetAutoDispatch(candidates AgentCandidates, classify agents.Classify) {
@@ -326,17 +323,17 @@ func (s *Service) SetAutoDispatch(candidates AgentCandidates, classify agents.Cl
 // turn served by an agent with a non-empty ApprovalAllowlist gets
 // those tools granted for its session before the turn runs, extending
 // the user's Settings-authored per-agent consent to interactive chat.
-// Optional — nil (today's default) leaves every allowlisted tool
+// Optional: nil (today's default) leaves every allowlisted tool
 // asking on its first chat call, exactly like before this existed.
 //
 // Safety framing (D-010 chain, see tools/permissions.go): this only
 // ever ADDS a session_grants row that Permissions.Resolve already knew
-// how to consult — it does not change the chain itself. Destructive-
+// how to consult: it does not change the chain itself. Destructive-
 // classified shell commands still hard-force DecisionAsk before any
 // grant (session or allowlist-seeded) is even looked at, so an
 // allowlisted destructive command parks exactly as it would for a
 // mission. The allowlist is user-authored config (Settings' per-agent
-// editor), not a model choice — seeding it as grants widens nothing
+// editor), not a model choice: seeding it as grants widens nothing
 // beyond what the user already consented to for that agent.
 func (s *Service) SetApprovalGrants(g Granter) {
 	s.grants = g
@@ -346,7 +343,7 @@ func (s *Service) SetApprovalGrants(g Granter) {
 }
 
 // seedApprovalGrants grants every tool in profile's ApprovalAllowlist
-// for sessionID, once per (session, agent) — an agent switch mid-
+// for sessionID, once per (session, agent): an agent switch mid-
 // session (a new profile.ID) seeds again, since the key includes it.
 // Best-effort and fire-and-forget on error, same convention as
 // missions/driver.go's grantSessionDefaults: a failed grant just means
@@ -421,7 +418,7 @@ func (s *Service) SetTurnTimeout(d time.Duration) error {
 
 // dispatchAgent resolves the "auto" sentinel to a real agent name via
 // agents.Dispatch. classify is built here (not injected verbatim as
-// Classify) so it always drains through this service's own Gateway —
+// Classify) so it always drains through this service's own Gateway:
 // a fresh call, not a lingering handle from setup time.
 func (s *Service) dispatchAgent(ctx context.Context, message string) string {
 	if s.candidates == nil || s.classify == nil {
@@ -432,13 +429,13 @@ func (s *Service) dispatchAgent(ctx context.Context, message string) string {
 }
 
 // ClassifyOverGateway builds an agents.Classify that asks the
-// "summarize" role's route for a one-shot text reply — the same cheap
+// "summarize" role's route for a one-shot text reply: the same cheap
 // side-call shape distillation and extraction already ride, resolved
 // dynamically by role (D-049) rather than a hardcoded route name:
 // a fixed name like "local" 502s with no_route on every install that
 // never seeded a route by that exact name. "summarize" over "default"
 // because the classification prompt carries the same message content
-// distillation/extraction already send there — the old "local for
+// distillation/extraction already send there: the old "local for
 // privacy" rationale doesn't add anything a cheap cloud role doesn't
 // already get. When the role is unbound (or the gateway lookup fails),
 // this returns an error without calling Stream at all; agents.Dispatch
@@ -479,7 +476,7 @@ func ClassifyOverGateway(gw Gateway) agents.Classify {
 }
 
 // titleChatterPrefixes are stock openers a model reaches for when it
-// answers or comments on the request instead of naming it — rejected
+// answers or comments on the request instead of naming it: rejected
 // case-insensitively, but only as whole leading words: "Okta setup"
 // must not trip on "ok".
 var titleChatterPrefixes = []string{
@@ -489,7 +486,7 @@ var titleChatterPrefixes = []string{
 
 // validTitle rejects anything that isn't a short, plain name: empty,
 // over 8 words, over 60 runes, carrying a newline/backtick/code fence,
-// or opening with a chatter prefix — the shape of a model answering or
+// or opening with a chatter prefix: the shape of a model answering or
 // commenting on the request instead of naming it.
 func validTitle(s string) bool {
 	if s == "" || utf8.RuneCountInString(s) > 60 {
@@ -510,7 +507,7 @@ func validTitle(s string) bool {
 	return true
 }
 
-// isWordChar reports whether b continues a word — used to bound a
+// isWordChar reports whether b continues a word: used to bound a
 // chatter-prefix match at a word boundary.
 func isWordChar(b byte) bool {
 	return b >= 'a' && b <= 'z' || b >= '0' && b <= '9' || b == '\''
@@ -518,18 +515,18 @@ func isWordChar(b byte) bool {
 
 // TitleOverGateway mirrors autoTitle's mechanism (same system-prompt/
 // MaxTokens-headroom/rune-safe-truncation shape) as a standalone
-// one-shot call — for callers outside chat (missions naming a mission
+// one-shot call: for callers outside chat (missions naming a mission
 // from its goal) that want a short display name generated the same
 // way a session's title is, without the session/reply/sensitive-route
 // ceremony a live chat turn carries. Titles are summarize-class work
 // (D-049): routed by the "summarize" role, falling back to "default"
 // when unbound, rather than burning the default chain's big model. A
 // rejected reply (validTitle) retries once with the same params;
-// still-invalid or any gateway failure returns "" (never an error) —
+// still-invalid or any gateway failure returns "" (never an error):
 // best-effort, exactly like autoTitle's own logged-and-dropped failure
 // path; the caller decides what "no name yet" means for its own
 // fallback rendering. Every failure path logs through log (message
-// prefix "title") so a silently-unnamed mission is diagnosable — log
+// prefix "title") so a silently-unnamed mission is diagnosable: log
 // must be non-nil, same as Service's own s.logger.
 func TitleOverGateway(gw Gateway, log *slog.Logger) func(ctx context.Context, input string) string {
 	return func(ctx context.Context, input string) string {
@@ -592,7 +589,7 @@ func TitleOverGateway(gw Gateway, log *slog.Logger) func(ctx context.Context, in
 }
 
 // collectionClassifyDocRunes caps how much document text rides into the
-// classify prompt — the model only needs the gist to pick a topic, not
+// classify prompt: the model only needs the gist to pick a topic, not
 // the full document (which can run to markitdown.TruncateMarkdown's own
 // 128KB cap).
 const collectionClassifyDocRunes = 4000
@@ -608,7 +605,7 @@ type CollectionChoice struct {
 
 // unsortedCollectionName is the fallback CollectionChoice when
 // classification can't be trusted (gateway error, empty/malformed
-// reply) — a document must land somewhere, so it lands in a generic
+// reply): a document must land somewhere, so it lands in a generic
 // catch-all rather than blocking ingest on a model failure.
 const unsortedCollectionName = "Unsorted"
 
@@ -616,14 +613,14 @@ const unsortedCollectionName = "Unsorted"
 // (same route resolution, same Stream-and-drain, same never-errors
 // contract) for a different one-shot job: given a document's title/text
 // and the existing knowledge-base collections, pick the best matching
-// collection or propose a new one. Free-text protocol, not JSON — this
+// collection or propose a new one. Free-text protocol, not JSON: this
 // codebase has no precedent for parsing prose-as-JSON from a model
 // reply (every json.Unmarshal on model output elsewhere unmarshals
 // provider-structured tool-call arguments, never free text), so the
 // model is asked for exactly one line: either a bare collection ID from
 // the list, or "NEW: <name> | <description>". Any reply that doesn't
 // parse cleanly (gateway error, empty stream, malformed line) falls
-// back to unsortedCollectionName — the one guaranteed outcome, since
+// back to unsortedCollectionName: the one guaranteed outcome, since
 // auto-classify ingest has no path to ask the user instead.
 func ClassifyCollectionOverGateway(gw Gateway, log *slog.Logger) func(ctx context.Context, docTitle, docText string, collections []kb.Collection) CollectionChoice {
 	return func(ctx context.Context, docTitle, docText string, collections []kb.Collection) CollectionChoice {
@@ -735,7 +732,7 @@ func profileAllowsSkill(allow []string, name string) bool {
 
 // retrieveOutputTool and loadSkillTool are the builtin tools' exact
 // registered names (internal/brain/tools/builtin/retrieve.go,
-// internal/brain/skills/tool.go) — not imported as constants to avoid
+// internal/brain/skills/tool.go): not imported as constants to avoid
 // pulling chat into the builtin package's dependency graph for two
 // literal strings, same convention as the sensitive-tool suffixes in
 // cmd/brain/main.go.
@@ -748,7 +745,7 @@ const (
 // loop from the serving agent's config: empty means no tools (an
 // agent must opt into tools explicitly), the same flip as skills.
 // Two exemptions, independent of the agent's own list:
-//   - retrieve_output always stays available — it is how the model
+//   - retrieve_output always stays available: it is how the model
 //     reads back its own offloaded tool results (D-019); filtering it
 //     out would silently strand any result too big to inline.
 //   - load_skill follows the SKILLS allowlist, not the tools one: it
@@ -757,7 +754,7 @@ const (
 //     omitting it saves its schema's tokens on every skill-less turn).
 //
 // Both exemptions are enforced whether or not the agent authored a
-// tool list — an agent that picks tools in the UI should not silently
+// tool list: an agent that picks tools in the UI should not silently
 // lose offload retrieval or skill loading by not knowing the infra
 // names. profile.Tools itself is never mutated.
 func resolveToolAllow(profile agents.Agent) []string {
@@ -787,20 +784,20 @@ type Request struct {
 	Agent     string `json:"agent,omitempty"`
 	Route     string `json:"route,omitempty"`
 	ModelHint string `json:"model_hint,omitempty"`
-	// SkillHint names a skill pack to force-load for this turn — set
+	// SkillHint names a skill pack to force-load for this turn: set
 	// when the user picked one explicitly (a UI chip, not parsed
 	// text). Unlike load_skill, this is not a choice the model can
 	// skip: the pack's body is in the system prompt before the first
 	// token streams.
 	SkillHint string `json:"skill_hint,omitempty"`
 	// Attachments name already-uploaded attachments (internal/brain/
-	// attachments) the user attached to this message — refs only,
+	// attachments) the user attached to this message: refs only,
 	// resolved into base64 (images) or transcript/markdown text
 	// (documents) at request-build time (D-045). Name is the original
 	// filename, display-only: the store itself doesn't carry one.
 	Attachments []AttachmentRef `json:"attachments,omitempty"`
 	// Knowledge names kb collections the user pinned to this turn's
-	// session (composer # mentions) — unioned into the session's
+	// session (composer # mentions): unioned into the session's
 	// stored knowledge list before the turn runs.
 	Knowledge []string `json:"knowledge,omitempty"`
 	// References names individual missions/sessions/kb documents the
@@ -853,7 +850,7 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 	// to the vision route, then the agent's route, then the default chain
 	// (sensitive-pin below still overrides all of this).
 	route := req.Route
-	// Only images flip to the vision route — documents are converted to
+	// Only images flip to the vision route: documents are converted to
 	// plain markdown text, not something the model needs vision
 	// capability to read.
 	if route == "" && len(images) > 0 {
@@ -931,7 +928,7 @@ func (s *Service) Chat(ctx context.Context, req Request) (string, <-chan stream.
 // resolveImages fills each message's Images from its ImageRefs
 // in-place, reading each attachment's bytes and base64-encoding them.
 // The only call site (runTurn, immediately before the gateway request
-// is built) — nothing else in the turn's lifecycle ever needs bytes
+// is built): nothing else in the turn's lifecycle ever needs bytes
 // (D-045). A no-op when nothing carries refs (the common case). Once
 // resolved, ImageRefs is cleared: it never crosses the gwclient wire
 // anyway (json:"-"), but clearing avoids holding two views of the same
@@ -976,13 +973,13 @@ func (s *Service) readAttachment(ctx context.Context, id string) (string, error)
 // BEFORE the turn's exclusivity is won or anything is appended (D-042:
 // store lookups are read-only and safe before turnBegin, but a bad ref
 // must 400 before even the user_message persists). Empty refs returns
-// nil, nil, nil without touching the store — attachments stay off when
+// nil, nil, nil without touching the store: attachments stay off when
 // unconfigured, and a message with none never needs it wired.
 //
 // PDFs/text/audio are converted to markdown (or transcript) here,
 // once, at send time (not lazily per turn like images): re-converting
 // on every turn would re-call the sidecar every turn, and any output
-// drift would rewrite an earlier projected message — breaking
+// drift would rewrite an earlier projected message: breaking
 // LLMContext's prefix stability that provider prompt caches depend on.
 // A conversion failure is the sidecar's fault, not the client's, so it
 // returns a plain wrapped error rather than ErrBadRequest.
@@ -1029,7 +1026,7 @@ func (s *Service) validateAttachments(ctx context.Context, refs []AttachmentRef)
 			}
 			documents = append(documents, doc)
 		case strings.HasPrefix(att.Mime, "video/"):
-			// Never converted or sent as content — projection.go renders
+			// Never converted or sent as content: projection.go renders
 			// an empty-markdown document as a neutralized attach-only
 			// note instead.
 			documents = append(documents, session.DocumentRef{ID: att.ID, Mime: att.Mime, Name: ref.Name})
@@ -1057,7 +1054,7 @@ func (s *Service) readAttachmentBytes(ctx context.Context, id string) ([]byte, e
 // transcribeAudioAttachment sends an audio attachment's bytes through
 // the whisper sidecar and returns a DocumentRef carrying the
 // transcript. When whisper isn't configured (WHISPER_URL unset), the
-// attachment is kept but with no transcript — attach-only, never
+// attachment is kept but with no transcript: attach-only, never
 // silently dropped.
 func (s *Service) transcribeAudioAttachment(ctx context.Context, att attachments.Attachment, name string) (session.DocumentRef, error) {
 	if s.whisperURL == "" {
@@ -1078,7 +1075,7 @@ func (s *Service) transcribeAudioAttachment(ctx context.Context, att attachments
 // turn-scoped one (SetForceRoute/turnSensitive): once ANY prior turn in
 // the session has executed a sensitive tool, the email/etc. content it
 // pulled into context is still there on every LATER turn even though
-// this turn ran no sensitive tool itself — so every subsequent turn
+// this turn ran no sensitive tool itself: so every subsequent turn
 // must start on the sensitive route, not just the turn that triggered
 // it. Overrides the route picker, the agent's own route, and the
 // default alike (same "safety floor beats user choice" rule the in-turn
@@ -1086,7 +1083,7 @@ func (s *Service) transcribeAudioAttachment(ctx context.Context, att attachments
 // SetForceRoute does: a hint outranks the route at the gateway's
 // Resolve, so a surviving hint would let the model bypass the pinned
 // route's chain entirely. A no-op whenever sensitive-tool routing is
-// unconfigured (s.sensitive nil or its Route resolves empty) — current
+// unconfigured (s.sensitive nil or its Route resolves empty): current
 // behavior everywhere until an operator sets sensitive_tool_route.
 func (s *Service) pinSensitiveRoute(ctx context.Context, events []session.Event, route, modelHint string) (string, string) {
 	if s.sensitive == nil || s.sensitive.Route == nil {
@@ -1102,7 +1099,7 @@ func (s *Service) pinSensitiveRoute(ctx context.Context, events []session.Event,
 }
 
 // ErrNoRetryableTurn marks a Retry call whose session isn't in a
-// retryable state — its last user_message already has a completed
+// retryable state: its last user_message already has a completed
 // (assistant_turn) turn after it, or there's no user_message at all.
 var ErrNoRetryableTurn = errors.New("no retryable turn")
 
@@ -1111,8 +1108,8 @@ var ErrNoRetryableTurn = errors.New("no retryable turn")
 // (line above), so a failed attempt already leaves that message durable
 // with no assistant_turn after it. A dead attempt (brain restart mid-turn)
 // can also leave trailing tool_execution/pending_state/permission events
-// after that message — lastUserMessage looks past those; only a
-// completed turn blocks retry. Retry reuses the message verbatim — same
+// after that message: lastUserMessage looks past those; only a
+// completed turn blocks retry. Retry reuses the message verbatim: same
 // route/agent/model_hint the original request resolved to, since those
 // live on the persisted UserMessage, not the transient Request. A
 // skill_hint is NOT persisted (it's a rare, deliberate one-off pick),
@@ -1145,13 +1142,13 @@ func (s *Service) Retry(ctx context.Context, sessionID string) (string, <-chan s
 
 	// Same exclusivity acquisition as Chat (D-042): Retry appends no new
 	// user_message of its own, but it must still win the slot before
-	// runTurn can touch the log — a losing Retry racing a Chat (or
+	// runTurn can touch the log: a losing Retry racing a Chat (or
 	// another Retry) must not interleave events with the winner's turn.
 	bc, err := s.turnBegin(sessionID)
 	if err != nil {
 		return sessionID, nil, err
 	}
-	// Detached turn context — same reasoning as Chat's (see there).
+	// Detached turn context: same reasoning as Chat's (see there).
 	turnCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.turnTimeout)
 	bc.setCancel(cancel)
 	return s.runTurn(turnCtx, ctx, sessionID, last.Text, modelHint, "", "", route, profile, needsTitle, bc)
@@ -1160,29 +1157,29 @@ func (s *Service) Retry(ctx context.Context, sessionID string) (string, <-chan s
 // runTurn is the shared tail of Chat and Retry: compact, project
 // context, assemble the system prompt, stream, and relay. The caller
 // has already ensured exactly the right user_message sits durable at
-// the end of the log — this never appends one itself. bc is this
+// the end of the log: this never appends one itself. bc is this
 // turn's broadcaster, already registered by the caller's turnBegin
-// (D-042) — runTurn must free it (turnDone) on every path that returns
+// (D-042): runTurn must free it (turnDone) on every path that returns
 // before the relay goroutine takes ownership of that responsibility,
 // so a setup failure here can never wedge the session's slot.
 //
 // turnCtx is the detached, session-owned context (survives the client
-// disconnecting) that everything in this function — and the whole tool
-// loop underneath gw.Stream — runs on. reqCtx is the original HTTP
+// disconnecting) that everything in this function: and the whole tool
+// loop underneath gw.Stream: runs on. reqCtx is the original HTTP
 // request's context; it is only handed to relay, which uses it solely
 // to decide whether the ORIGINAL client is still there to stream to
 // (see relay's doc comment).
 func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, modelHint, skillHint, skillBody, route string, profile agents.Agent, needsTitle bool, bc *turnBroadcaster) (string, <-chan stream.StreamEvent, error) {
 	// start marks the turn's wall-clock beginning for the stats line's
 	// duration: here, not Chat/Retry's entry, so a retried turn's
-	// duration covers only the retried run — the dead attempt's gap
+	// duration covers only the retried run: the dead attempt's gap
 	// never counts (runTurn is the shared tail both call fresh).
 	start := time.Now()
 	s.seedApprovalGrants(turnCtx, sessionID, profile)
 	// Pre-send guarantee: the context actually sent to the provider
 	// stays under budget even on the turn that crosses it. The
 	// post-turn pass below keeps sessions compacted ahead of time, so
-	// this is a cheap no-op except on the crossing turn; best-effort —
+	// this is a cheap no-op except on the crossing turn; best-effort:
 	// an oversized context beats no answer.
 	if s.compactor != nil {
 		cctx, cancel := context.WithTimeout(turnCtx, compactBudget)
@@ -1212,7 +1209,7 @@ func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, 
 	// sessionSensitive reuses this same fetch: a session pinned by a
 	// PRIOR turn still carries that turn's sensitive content in the
 	// context just projected above, even when THIS turn runs no
-	// sensitive tool itself — so persistTurn's side-calls (distill,
+	// sensitive tool itself: so persistTurn's side-calls (distill,
 	// extraction) must be pinned too, same as turnSensitive.
 	sessionSensitive := s.sensitive.SessionSensitive(turnCtx, events)
 
@@ -1242,38 +1239,39 @@ func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, 
 		}
 	}
 
-	// Collections offered this turn: the serving agent's own Knowledge
+	// Boost collections for this turn: the serving agent's own Knowledge
 	// list unioned with the session's pinned list (composer # mentions).
-	// The session lookup is best-effort — a failure must not kill the
-	// turn, it just falls back to the agent's list alone. Fetched here
-	// (not just before extraTools) so the same result also backs the
-	// pinned-knowledge system prompt block below.
-	collections := slices.Clone(profile.Knowledge)
+	// search_kb always searches the whole KB (D-078, issue #368); this
+	// set only reorders results toward these collections, never filters
+	// them. The session lookup is best-effort: a failure must not kill
+	// the turn, it just falls back to the agent's list alone. Fetched
+	// here (not just before extraTools) so the same result also backs
+	// the pinned-knowledge system prompt block below.
+	boost := slices.Clone(profile.Knowledge)
 	sk, skErr := s.log.Knowledge(turnCtx, sessionID)
 	if skErr != nil {
 		s.logger.Warn("session knowledge lookup", "session_id", sessionID, "error", skErr)
 	} else {
 		for _, name := range sk {
-			if !slices.Contains(collections, name) {
-				collections = append(collections, name)
+			if !slices.Contains(boost, name) {
+				boost = append(boost, name)
 			}
 		}
 	}
 
 	// A pinned collection is an explicit user signal to search it, not
-	// just a passive tool grant — but only when search_kb will actually
-	// be offered (skErr nil, s.kbSearch wired, union non-empty): a
-	// pinned name with no backend must never promise a tool that isn't
-	// there.
-	if skErr == nil && len(sk) > 0 && s.kbSearch != nil && len(collections) > 0 {
+	// just a passive tool grant: but only when search_kb will actually
+	// be offered (skErr nil, s.kbSearch wired): a pinned name with no
+	// backend must never promise a tool that isn't there.
+	if skErr == nil && len(sk) > 0 && s.kbSearch != nil {
 		system += "\n\n# Pinned knowledge\n\nThe user pinned these knowledge collections to this session: " + strings.Join(sk, ", ") + ". This is an explicit signal: when a question could plausibly be answered by their content, call search_kb first and ground the answer in what it returns, rather than answering from general knowledge alone."
 	}
 
 	var extraTools []*tools.Tool
-	if t := s.kbSearchTool(collections); t != nil {
+	if t := s.kbSearchTool(boost); t != nil {
 		extraTools = append(extraTools, t)
 	}
-	if t := s.kbReadTool(collections); t != nil {
+	if t := s.kbReadTool(); t != nil {
 		extraTools = append(extraTools, t)
 	}
 	upstream, err := s.gw.Stream(turnCtx, gwclient.StreamRequest{
@@ -1293,7 +1291,7 @@ func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, 
 	}
 
 	// bc was registered by the caller's turnBegin before the turn's
-	// first event append (D-042) — already live the instant the turn
+	// first event append (D-042): already live the instant the turn
 	// started, not just from here on. From this point, relay's own
 	// defer-equivalent (drainAndPersist, on every exit path) owns
 	// freeing it via turnDone.
@@ -1307,18 +1305,18 @@ func (s *Service) runTurn(turnCtx, reqCtx context.Context, sessionID, userText, 
 // client disconnect or brain shutdown mid-turn must still leave a
 // durable pending_state (the kill-test contract). sessionSensitive
 // carries forward whether a PRIOR turn in this session already pinned
-// it (see runTurn) — persistTurn ORs it with this turn's own
+// it (see runTurn): persistTurn ORs it with this turn's own
 // turnSensitive flip so side-calls stay pinned on every later turn too.
 // start is runTurn's wall-clock beginning, stamped onto the terminal
 // done event's Meta (and passed to persistTurn) so live and replayed
 // stats show the same duration. bc is this turn's broadcaster
 // (registered by runTurn before this goroutine started): every event
-// this relay sees — including ones the ORIGINAL client never gets
-// because it already disconnected (drainAndPersist) — still reaches
+// this relay sees: including ones the ORIGINAL client never gets
+// because it already disconnected (drainAndPersist): still reaches
 // bc, since a GET /live subscriber may be attached independently of
 // the POST that started the turn.
 //
-// reqCtx is the ORIGINAL request's context, not the turn's — upstream
+// reqCtx is the ORIGINAL request's context, not the turn's: upstream
 // is already bound to the detached turnCtx (runTurn's gw.Stream call),
 // so it keeps producing long after reqCtx dies. reqCtx here gates only
 // whether THIS client is still around to receive forwarded events: the
@@ -1334,17 +1332,17 @@ func (s *Service) relay(reqCtx context.Context, sessionID, userText, route strin
 	sawDone := false
 	flushed := 0
 	// turnSensitive flips once any tool this turn executed matches
-	// s.sensitive — memory extraction then rides the sensitive route
+	// s.sensitive: memory extraction then rides the sensitive route
 	// pin instead of its own default (see persistTurn).
 	turnSensitive := false
 	// ranTool records whether ANY tool executed this turn (regardless of
-	// sensitivity) — persistTurn's empty-response guard (D-044) must not
+	// sensitivity): persistTurn's empty-response guard (D-044) must not
 	// flag a turn whose answer is entirely tool/reasoning traffic with
 	// no text.
 	ranTool := false
 	// mediaRefs accumulates every media ref a tool call emitted this
 	// turn (in call-result order), rendered as a trailing UIBlock at
-	// persist time — see noteToolResult below.
+	// persist time: see noteToolResult below.
 	var mediaRefs []session.MediaRef
 	// failure captures a terminal EventError/EventIncomplete's code and
 	// message (D-044): the relay used to just drop these on the floor
@@ -1404,7 +1402,7 @@ func (s *Service) relay(reqCtx context.Context, sessionID, userText, route strin
 	// full permissionTimeout, and the whole point of this event is that
 	// a session opened while that's happening shows the same prompt the
 	// live stream shows. Same detached-timeout, best-effort pattern as
-	// flushPending — a failed write here loses the replay prompt, never
+	// flushPending: a failed write here loses the replay prompt, never
 	// the turn itself.
 	notePermission := func(ev stream.StreamEvent) {
 		var kind string
@@ -1440,7 +1438,7 @@ func (s *Service) relay(reqCtx context.Context, sessionID, userText, route strin
 	}
 
 	// flushPending checkpoints the partial answer DURING the stream so
-	// even a SIGKILL mid-turn loses at most one flush interval — the
+	// even a SIGKILL mid-turn loses at most one flush interval: the
 	// projection splices the last pending in, and a completed turn
 	// supersedes every checkpoint (the kill-test contract).
 	flushPending := func() {
@@ -1461,7 +1459,7 @@ func (s *Service) relay(reqCtx context.Context, sessionID, userText, route strin
 		// to turnCtx (session-owned), not reqCtx, so once the client is
 		// gone it may still have minutes left to run. Closing out up
 		// front frees streamTurn's client-facing goroutine immediately
-		// instead of holding it for the remainder of the turn — any
+		// instead of holding it for the remainder of the turn: any
 		// further send() calls on a dead ResponseWriter just fail
 		// silently. The drain loop below then keeps consuming upstream
 		// (publishing every event to bc for /live subscribers) until it
@@ -1487,7 +1485,7 @@ func (s *Service) relay(reqCtx context.Context, sessionID, userText, route strin
 		s.persistTurn(sessionID, userText, route, profile, needsTitle, text.String(), segmentStarts, reasoning.String(), meta, usage, sawDone, flushed, turnSensitive || sessionSensitive, failure, ranTool, mediaRefs)
 		// Terminal persist is now durable: free the broadcaster (closes
 		// every live /live subscriber) and push the session signal, in
-		// that order — mirrors missions.Store's own "publish only after
+		// that order: mirrors missions.Store's own "publish only after
 		// commit" discipline, so a client that sees turn_active flip
 		// false (via the freed entry) or gets a session signal is
 		// guaranteed the transcript already reflects the finished turn.
@@ -1543,7 +1541,7 @@ func (s *Service) relay(reqCtx context.Context, sessionID, userText, route strin
 
 // stampDuration copies base (the gateway-attributed Meta, possibly
 // nil when no provider attempt succeeded) and sets DurationMs from
-// start — a copy because base may be a shared struct decoded once per
+// start: a copy because base may be a shared struct decoded once per
 // SSE event, not something relay owns to mutate in place.
 func stampDuration(base *stream.Meta, start time.Time) *stream.Meta {
 	m := stream.Meta{}
@@ -1569,10 +1567,10 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 		}
 		// No partial worth keeping: a captured terminal error/incomplete
 		// (D-044) becomes durable evidence instead of the turn silently
-		// vanishing — same detached-context, best-effort append as the
+		// vanishing: same detached-context, best-effort append as the
 		// pending-state write above. No failure AND no text at all means
 		// every upstream producer lost its terminal on the way here
-		// (deadline racing the stream cut) — synthesize one rather than
+		// (deadline racing the stream cut): synthesize one rather than
 		// append nothing: a turn that ran must never leave zero events.
 		// A flushed partial (text non-empty, already checkpointed) keeps
 		// today's behavior: the pending state is the evidence.
@@ -1593,7 +1591,7 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 	}
 
 	// A completed turn with no text, no reasoning, and no tool
-	// executions is not a success (D-044) — persist evidence instead of
+	// executions is not a success (D-044): persist evidence instead of
 	// a blank assistant_turn. Keyed on all three being empty so a
 	// tool/reasoning-only turn (a real, valid shape some providers use)
 	// stays untouched.
@@ -1658,7 +1656,7 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 	// The assistant turn must be durable the moment the stream ends: a
 	// follow-up message can arrive within seconds, and its projection
 	// must see this turn completed (not a phantom interruption from a
-	// stale checkpoint). Distillation is an LLM call — it lands later
+	// stale checkpoint). Distillation is an LLM call: it lands later
 	// as its own turn_memory event, never on this write's clock.
 	wctx, cancel := context.WithTimeout(context.Background(), persistTimeout)
 	defer cancel()
@@ -1673,9 +1671,9 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 
 	// A turn that executed a sensitive tool itself, OR one served on an
 	// already session-pinned route (a PRIOR turn's sensitive content is
-	// still in this turn's context — see runTurn's sessionSensitive),
+	// still in this turn's context: see runTurn's sessionSensitive),
 	// pins its side-calls to the same route the loop/pin already forced
-	// the turn onto — both distillation and extraction below can see raw
+	// the turn onto: both distillation and extraction below can see raw
 	// sensitive output (e.g. email), so neither may fall back to its own
 	// cheap default.
 	sensitiveRoute := ""
@@ -1702,8 +1700,8 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 	// Long-term memory extraction rides the same residue (D-007): the
 	// user's words plus the distilled turn, never the raw trace. It
 	// runs on every COMPLETED turn even when the assistant produced no
-	// text (some providers end tool turns without a message) — the
-	// user's words alone can carry facts. Detached context — the turn
+	// text (some providers end tool turns without a message): the
+	// user's words alone can carry facts. Detached context: the turn
 	// is already over.
 	if s.memory != nil && profile.Memory {
 		mtext := "user: " + userText
@@ -1734,8 +1732,8 @@ func (s *Service) persistTurn(sessionID, userText, route string, profile agents.
 // the same pin persistTurn resolved for distill/extraction above: the
 // title prompt's input includes reply (the assistant's own synthesized
 // text, truncated), which is exactly the channel a sensitive tool's
-// output can be quoted through — the same reasoning distill/extract
-// already pin on — so titling rides the identical route pin rather than
+// output can be quoted through: the same reasoning distill/extract
+// already pin on: so titling rides the identical route pin rather than
 // staying on the default role's route whenever this turn (or an
 // earlier one this session) is sensitive. An empty sensitiveRoute (the
 // common case) falls through to the default role's route exactly as
@@ -1820,7 +1818,7 @@ func collapseRepeatedTail(s string) string {
 }
 
 // hasCompletedTurn reports whether events carries at least one
-// assistant_turn — the only kind persistTurn appends on sawDone.
+// assistant_turn: the only kind persistTurn appends on sawDone.
 // Gates auto-title: a session with no completed turn yet has never had
 // a live shot at being titled (a turn that only ever failed skips
 // autoTitle entirely), so retitling keeps being attempted on every
@@ -1835,14 +1833,14 @@ func hasCompletedTurn(events []session.Event) bool {
 }
 
 // lastUserMessage returns the session's last user_message when it has
-// no completed turn after it — the signature of a turn that never
+// no completed turn after it: the signature of a turn that never
 // finished (persistTurn only appends assistant_turn on sawDone). A
 // brain restart or crash mid-turn can leave trailing tool_execution,
 // pending_state, or permission_request/resolved events after that
 // message; none of those are turn-terminal, so they must not block a
 // retry. LLMContext already treats them as inert for anything but the
 // newest pending_state (spliced in as an interrupted assistant message
-// only if still live), so replaying them costs nothing — the retried
+// only if still live), so replaying them costs nothing: the retried
 // turn's context is exactly what the dead attempt's would have been.
 func lastUserMessage(events []session.Event) (session.UserMessage, bool) {
 	var lastMsg *session.Event

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -39,7 +39,7 @@ type fakeLog struct {
 	knowledge map[string][]string
 	createdN  int
 	// knowledgeErr, when set, makes Knowledge fail instead of reading
-	// the map — for the session-knowledge-lookup-failure fallback test.
+	// the map: for the session-knowledge-lookup-failure fallback test.
 	knowledgeErr error
 }
 
@@ -179,7 +179,7 @@ func (g *fakeGW) lastRequest() gwclient.StreamRequest {
 }
 
 // lastChatRequest skips side-calls (title, distill, extract) that race
-// the assertion after drain — the async auto-title on a fresh session
+// the assertion after drain: the async auto-title on a fresh session
 // can land after the chat request and make lastRequest nondeterministic.
 func (g *fakeGW) lastChatRequest() gwclient.StreamRequest {
 	g.mu.Lock()
@@ -192,7 +192,7 @@ func (g *fakeGW) lastChatRequest() gwclient.StreamRequest {
 	return gwclient.StreamRequest{}
 }
 
-// erroringGW resolves any role but fails every Stream call — for
+// erroringGW resolves any role but fails every Stream call: for
 // pinning a caller's best-effort behavior on a gateway-unreachable
 // error, distinct from fakeGW's always-succeeds default.
 type erroringGW struct{}
@@ -233,7 +233,7 @@ func drain(t *testing.T, ch <-chan stream.StreamEvent) []stream.StreamEvent {
 	}
 }
 
-// waitFor polls until cond or timeout — persistence runs after the
+// waitFor polls until cond or timeout: persistence runs after the
 // client channel closes.
 func waitFor(t *testing.T, cond func() bool) {
 	t.Helper()
@@ -364,7 +364,7 @@ func TestChatPersistsTurnCost(t *testing.T) {
 
 // TestChatPersistsTurnCostAbsentWhenUnpriced confirms an unpriced
 // model's turn persists with no cost field at all (omitempty), never a
-// guessed 0 — the replay must be able to distinguish "unpriced" from
+// guessed 0: the replay must be able to distinguish "unpriced" from
 // "free".
 func TestChatPersistsTurnCostAbsentWhenUnpriced(t *testing.T) {
 	t.Parallel()
@@ -393,7 +393,7 @@ func TestChatPersistsTurnCostAbsentWhenUnpriced(t *testing.T) {
 }
 
 // TestChatPersistsTurnDuration confirms the persisted assistant_turn
-// carries a wall-clock DurationMs covering the turn — a stand-in
+// carries a wall-clock DurationMs covering the turn: a stand-in
 // upstream delay proves it's measuring real elapsed time, not just
 // echoing a zero default.
 func TestChatPersistsTurnDuration(t *testing.T) {
@@ -424,7 +424,7 @@ func TestChatPersistsTurnDuration(t *testing.T) {
 
 // TestChatPersistsPermissionAsks confirms the relay appends
 // permission_request and permission_resolved as their own durable
-// session events the moment they cross the stream — not batched into
+// session events the moment they cross the stream: not batched into
 // persistTurn at turn end, since a parked ask is exactly the case
 // where the turn hasn't ended yet. A replay of the session must then
 // carry the resolved pair, and UITranscript must drop it once
@@ -493,7 +493,7 @@ func TestChatPersistsPermissionAsks(t *testing.T) {
 
 // TestChatReplayCarriesUnresolvedPermissionAsk confirms a session
 // whose turn is still parked on an ask exposes it in the UI transcript
-// projection — the whole point of persisting the request at all.
+// projection: the whole point of persisting the request at all.
 func TestChatReplayCarriesUnresolvedPermissionAsk(t *testing.T) {
 	t.Parallel()
 	log := newFakeLog()
@@ -503,7 +503,7 @@ func TestChatReplayCarriesUnresolvedPermissionAsk(t *testing.T) {
 			ID: "perm-1", CallID: "call-1", Tool: "shell", Args: "{}",
 			Danger: "safe", Rationale: "runs a shell command",
 		}},
-		// No resolution, no terminal — the turn is still parked.
+		// No resolution, no terminal: the turn is still parked.
 	}}
 	s := newService(gw, log)
 
@@ -663,7 +663,7 @@ func TestChatAutoTitlesFirstExchange(t *testing.T) {
 }
 
 // A session whose first exchange fails outright (chain exhausted, a
-// dropped stream) never reaches autoTitle — persistTurn returns before
+// dropped stream) never reaches autoTitle: persistTurn returns before
 // it on !sawDone. The old firstExchange gate then locked the session
 // out of titling forever: it only ever fired once, keyed on "is this
 // message #1", which the SECOND message already fails. hasCompletedTurn
@@ -682,7 +682,7 @@ func TestChatRetriesAutoTitleUntilATurnCompletes(t *testing.T) {
 	drain(t, ch)
 	waitFor(t, func() bool { return len(log.kinds("s1")) == 3 }) // session_started, user_message, turn_failed
 	// The slot only frees once persistTurn returns and turnDone runs,
-	// which is not synchronous with drain returning (D-042) — even on
+	// which is not synchronous with drain returning (D-042): even on
 	// an errored turn, this must still happen so the session isn't
 	// permanently wedged.
 	waitFor(t, func() bool { return !s.TurnActive("s1") })
@@ -718,7 +718,7 @@ func TestChatRetriesAutoTitleUntilATurnCompletes(t *testing.T) {
 
 // TestTerminalErrorPersistsTurnFailed pins D-044: a turn that ends on
 // a terminal EventError with no partial text must not vanish silently
-// — relay used to drop the error after streaming it to the client,
+//: relay used to drop the error after streaming it to the client,
 // leaving nothing durable. persistTurn now appends a KindTurnFailed
 // event carrying the error's code and message.
 func TestTerminalErrorPersistsTurnFailed(t *testing.T) {
@@ -753,7 +753,7 @@ func TestTerminalErrorPersistsTurnFailed(t *testing.T) {
 
 // TestEmptyResponsePersistsTurnFailed pins D-044's other half: a turn
 // that reaches a clean EventDone with no text, no reasoning, and no
-// tool executions is not a success either — persistTurn must not write
+// tool executions is not a success either: persistTurn must not write
 // a blank assistant_turn, and must instead persist evidence the model
 // answered with nothing at all.
 func TestEmptyResponsePersistsTurnFailed(t *testing.T) {
@@ -788,8 +788,8 @@ func TestEmptyResponsePersistsTurnFailed(t *testing.T) {
 
 // TestBareStreamClosePersistsTurnAborted pins the last backstop in the
 // terminal-delivery chain: when the upstream channel closes with no
-// events at all — every producer's terminal lost to the turn deadline
-// racing a stream cut — persistTurn must synthesize a turn_failed
+// events at all: every producer's terminal lost to the turn deadline
+// racing a stream cut: persistTurn must synthesize a turn_failed
 // rather than append nothing (a real ~30min turn once vanished with
 // zero session_events this way).
 func TestBareStreamClosePersistsTurnAborted(t *testing.T) {
@@ -902,7 +902,7 @@ func TestKBToolsOfferedFromSessionKnowledgeAlone(t *testing.T) {
 	s.SetKBSearch(func(context.Context, string, []string, string, int) ([]builtin.KBSearchHit, error) {
 		return nil, nil
 	})
-	s.SetKBRead(func(context.Context, string, []string) (builtin.KBDocument, error) {
+	s.SetKBRead(func(context.Context, string) (builtin.KBDocument, error) {
 		return builtin.KBDocument{}, nil
 	})
 
@@ -915,6 +915,37 @@ func TestKBToolsOfferedFromSessionKnowledgeAlone(t *testing.T) {
 	names := extraToolNames(chatRequest(t, gw))
 	if !slices.Contains(names, "search_kb") || !slices.Contains(names, "read_kb") {
 		t.Fatalf("extra tools = %v, want search_kb and read_kb from session knowledge alone", names)
+	}
+}
+
+// TestKBToolsOfferedWithNoKnowledgeAtAll pins issue #368's default:
+// an agent with no Knowledge configured and no session pins still gets
+// search_kb/read_kb offered, once a backend is wired: whole-KB search
+// is available by default, not gated on any collection being named.
+func TestKBToolsOfferedWithNoKnowledgeAtAll(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGW{events: okEvents("ok")}
+	log := newFakeLog()
+	resolver := func(context.Context, string) (agents.Agent, bool) {
+		return agents.Agent{Memory: true}, true // empty Knowledge, no session pins
+	}
+	s := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
+	s.SetKBSearch(func(context.Context, string, []string, string, int) ([]builtin.KBSearchHit, error) {
+		return nil, nil
+	})
+	s.SetKBRead(func(context.Context, string) (builtin.KBDocument, error) {
+		return builtin.KBDocument{}, nil
+	})
+
+	_, ch, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "hi"})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	drain(t, ch)
+
+	names := extraToolNames(chatRequest(t, gw))
+	if !slices.Contains(names, "search_kb") || !slices.Contains(names, "read_kb") {
+		t.Fatalf("extra tools = %v, want search_kb and read_kb offered with no knowledge configured", names)
 	}
 }
 
@@ -967,7 +998,8 @@ func TestPinnedKnowledgeNoPromptWithoutBackend(t *testing.T) {
 
 // TestKBToolsUnionDedupesAgentAndSessionCollections pins the union
 // itself: the agent's own Knowledge and the session's pinned list
-// combine without duplicates, and both feed the bound search call.
+// combine without duplicates, and both feed the bound search call as a
+// boost (never a filter: issue #368).
 func TestKBToolsUnionDedupesAgentAndSessionCollections(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGW{events: okEvents("ok")}
@@ -978,22 +1010,22 @@ func TestKBToolsUnionDedupesAgentAndSessionCollections(t *testing.T) {
 	}
 	s := New(gw, log, nil, nil, staticBudget(60_000), nil, nil, nil, resolver, discard())
 
-	var gotCollections []string
-	s.SetKBSearch(func(_ context.Context, _ string, collections []string, _ string, _ int) ([]builtin.KBSearchHit, error) {
-		gotCollections = collections
+	var gotBoost []string
+	s.SetKBSearch(func(_ context.Context, _ string, boost []string, _ string, _ int) ([]builtin.KBSearchHit, error) {
+		gotBoost = boost
 		return nil, nil
 	})
 
-	collections := s.kbSearchTool([]string{"a", "b"})
-	if collections == nil {
-		t.Fatal("kbSearchTool returned nil for a non-empty union")
+	tool := s.kbSearchTool([]string{"a", "b"})
+	if tool == nil {
+		t.Fatal("kbSearchTool returned nil with a backend wired")
 	}
-	if _, err := collections.Execute(t.Context(), []byte(`{"query":"x"}`)); err != nil {
+	if _, err := tool.Execute(t.Context(), []byte(`{"query":"x"}`)); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	sort.Strings(gotCollections)
-	if !slices.Equal(gotCollections, []string{"a", "b"}) {
-		t.Fatalf("bound collections = %v, want [a b]", gotCollections)
+	sort.Strings(gotBoost)
+	if !slices.Equal(gotBoost, []string{"a", "b"}) {
+		t.Fatalf("bound boost collections = %v, want [a b]", gotBoost)
 	}
 }
 
@@ -1055,7 +1087,7 @@ func TestChatPersistsMentionedKnowledge(t *testing.T) {
 }
 
 // The runtime allowlist gates both the system-prompt skill index and
-// skill_hint, per turn — no restart, no rebuild.
+// skill_hint, per turn: no restart, no rebuild.
 func TestChatSkillAllowlistGatesIndexAndHint(t *testing.T) {
 	t.Parallel()
 	gw := &fakeGW{events: okEvents("ok")}
@@ -1093,7 +1125,7 @@ func TestChatSkillHintRefusesUnknownSkill(t *testing.T) {
 	}
 }
 
-// An agent with an empty skills allowlist gets no packs at all — the
+// An agent with an empty skills allowlist gets no packs at all: the
 // flipped semantics (empty = none, opt-in only), unlike tools' own
 // empty = none via resolveToolAllow's exemptions below.
 func TestChatEmptySkillsAllowlistDeniesEveryPack(t *testing.T) {
@@ -1108,7 +1140,7 @@ func TestChatEmptySkillsAllowlistDeniesEveryPack(t *testing.T) {
 	s := New(gw, newFakeLog(), nil, nil, staticBudget(60_000), packs, nil, nil, resolver, discard())
 
 	// skill_hint naming a pack the (empty) allowlist doesn't list must
-	// be refused, same as an unknown skill — a denied hint is never
+	// be refused, same as an unknown skill: a denied hint is never
 	// force-loaded around the allowlist.
 	if _, _, err := s.Chat(t.Context(), Request{SessionID: "s1", Message: "hi", SkillHint: "some-skill"}); err == nil {
 		t.Fatal("skill_hint accepted for an agent with an empty skills allowlist")
@@ -1125,7 +1157,7 @@ func TestChatEmptySkillsAllowlistDeniesEveryPack(t *testing.T) {
 	}
 }
 
-// A non-empty skills allowlist admits only the packs it names — the
+// A non-empty skills allowlist admits only the packs it names: the
 // unflipped half of the same rule.
 func TestChatNonEmptySkillsAllowlistAdmitsOnlyListedPacks(t *testing.T) {
 	t.Parallel()
@@ -1338,7 +1370,7 @@ func TestChatSendsCompactedContext(t *testing.T) {
 // runs inside persistTurn, BEFORE turnDone frees the slot (see
 // relay's drainAndPersist), so a follow-up landing in that window is
 // correctly rejected with ErrTurnInFlight rather than allowed to
-// interleave — turn "done" means the slot is free, not merely that the
+// interleave: turn "done" means the slot is free, not merely that the
 // client's stream closed. (Before D-042, this test allowed that
 // follow-up to proceed immediately; that was the old
 // always-install-fresh turnBroadcast semantics this design replaces.)
@@ -1610,7 +1642,7 @@ func TestCollapseRepeatedTail(t *testing.T) {
 }
 
 // The "auto" sentinel resolves through SetAutoDispatch's candidates
-// and classify BEFORE the normal agent lookup — the resolved name (not
+// and classify BEFORE the normal agent lookup: the resolved name (not
 // "auto" itself) is what reaches the resolver, the gateway request,
 // and persistence.
 func TestChatAutoDispatchesAgent(t *testing.T) {
@@ -1664,7 +1696,7 @@ func TestChatAutoDispatchesAgent(t *testing.T) {
 }
 
 // Without SetAutoDispatch wired, the "auto" sentinel falls back to the
-// default agent — dispatch is an ergonomics layer, never a hard gate
+// default agent: dispatch is an ergonomics layer, never a hard gate
 // on serving a session; an unwired server must not turn every "Auto"
 // composer choice into a hard error.
 func TestChatAutoWithoutDispatchWiredFallsBackToDefault(t *testing.T) {
@@ -1745,7 +1777,7 @@ func TestAgentProfileShapesTurn(t *testing.T) {
 }
 
 // A failed attempt (no EventDone) leaves the user_message durable with
-// a turn_failed event after it (D-044) — persistTurn only appends
+// a turn_failed event after it (D-044): persistTurn only appends
 // assistant_turn on sawDone. Retry must reuse that message, not append
 // a second one; turn_failed doesn't block retry (lastUserMessage only
 // stops at a completed assistant_turn).
@@ -1766,7 +1798,7 @@ func TestRetryReusesLastUserMessageWithoutDuplicating(t *testing.T) {
 		t.Fatalf("kinds after failed attempt = %v, want a dangling user_message plus turn_failed", kinds)
 	}
 	// The slot only frees once turnDone runs, not synchronously with
-	// drain returning (D-042) — an errored turn must still free it so
+	// drain returning (D-042): an errored turn must still free it so
 	// Retry below isn't spuriously rejected.
 	waitFor(t, func() bool { return !s.TurnActive("s1") })
 
@@ -1802,8 +1834,8 @@ func TestRetryReusesLastUserMessageWithoutDuplicating(t *testing.T) {
 	}
 }
 
-// Retry on a session whose last event isn't a dangling user_message —
-// no messages at all, or a turn that already completed — has nothing
+// Retry on a session whose last event isn't a dangling user_message:
+// no messages at all, or a turn that already completed: has nothing
 // to retry and must reject rather than silently no-op or duplicate.
 func TestRetryRejectsWhenNothingToRetry(t *testing.T) {
 	t.Parallel()
@@ -1830,12 +1862,12 @@ func TestRetryRejectsWhenNothingToRetry(t *testing.T) {
 
 // A brain restart mid-turn can leave tool_execution/permission events
 // (and no pending_state, if the crash landed before a flush) after the
-// dangling user_message — the turn never reached persistTurn at all.
+// dangling user_message: the turn never reached persistTurn at all.
 // Retry must still treat that message as retryable: none of those
 // trailing kinds are turn-terminal, and LLMContext already excludes
 // tool_execution/permission_request/permission_resolved from the
 // model-facing projection, so the retried turn sees exactly the
-// original user message with nothing appended — a clean restart.
+// original user message with nothing appended: a clean restart.
 func TestRetrySurvivesTrailingToolAndPermissionEvents(t *testing.T) {
 	t.Parallel()
 	log := newFakeLog()
@@ -1888,7 +1920,7 @@ func TestRetrySurvivesTrailingToolAndPermissionEvents(t *testing.T) {
 	}
 
 	// The context handed to the gateway must be exactly the original
-	// user message — tool_execution and permission events never enter
+	// user message: tool_execution and permission events never enter
 	// LLMContext, and there is no pending_state here to splice in as an
 	// interrupted assistant message. A clean restart, not a replay of
 	// the dead attempt's partial state.
@@ -1903,7 +1935,7 @@ func TestRetrySurvivesTrailingToolAndPermissionEvents(t *testing.T) {
 
 // A trailing pending_state (a periodic checkpoint the dead attempt
 // flushed before dying) is the one trailing kind LLMContext does splice
-// back in — as an interrupted assistant message — so the retried turn
+// back in: as an interrupted assistant message: so the retried turn
 // picks up where the checkpoint left off instead of starting blind.
 func TestRetryReplaysTrailingPendingStateAsInterrupted(t *testing.T) {
 	t.Parallel()
@@ -1983,7 +2015,7 @@ func TestAutoTitleUsesDefaultRouteNotClassifyRoute(t *testing.T) {
 // TestClassifyOverGatewayResolvesSummarizeRole for the standalone
 // TitleOverGateway constructor (missions naming reuses this instead of
 // autoTitle directly, since a mission has no session/reply at create
-// time) — titles are summarize-class work (D-049), same quote/
+// time): titles are summarize-class work (D-049), same quote/
 // whitespace trimming.
 func TestTitleOverGatewayUsesSummarizeRoleAndTrimsQuotes(t *testing.T) {
 	t.Parallel()
@@ -2008,7 +2040,7 @@ func TestTitleOverGatewayUsesSummarizeRoleAndTrimsQuotes(t *testing.T) {
 
 // TestTitleOverGatewayFallsBackToDefaultRoleWhenSummarizeUnbound
 // confirms an unbound "summarize" role falls back to "default" rather
-// than giving up — a fresh install may not have seeded a summarize
+// than giving up: a fresh install may not have seeded a summarize
 // role yet.
 func TestTitleOverGatewayFallsBackToDefaultRoleWhenSummarizeUnbound(t *testing.T) {
 	t.Parallel()
@@ -2033,7 +2065,7 @@ func TestTitleOverGatewayFallsBackToDefaultRoleWhenSummarizeUnbound(t *testing.T
 // TestTitleOverGatewayEmptyOnGatewayError confirms the best-effort
 // contract: any Stream error returns "" rather than propagating, so a
 // caller (missions' async naming) never has to distinguish failure
-// modes — same as autoTitle's own logged-and-dropped path.
+// modes: same as autoTitle's own logged-and-dropped path.
 func TestTitleOverGatewayEmptyOnGatewayError(t *testing.T) {
 	t.Parallel()
 	gw := &erroringGW{}
@@ -2167,7 +2199,7 @@ func TestValidTitle(t *testing.T) {
 }
 
 // titleScriptedGW returns one canned reply per Stream call, in
-// order — for proving TitleOverGateway's one-retry contract, which
+// order: for proving TitleOverGateway's one-retry contract, which
 // fakeGW's always-identical-events shape can't exercise.
 type titleScriptedGW struct {
 	fakeGW
@@ -2350,7 +2382,7 @@ func TestMemoryExtractUsesEmptyRouteWhenTurnDidNotRunSensitiveTool(t *testing.T)
 	}
 }
 
-// fakeGranter is an in-memory Granter that records every Grant call —
+// fakeGranter is an in-memory Granter that records every Grant call:
 // stands in for tools.Permissions in chat-level tests, which never
 // touch a real session_grants table.
 type fakeGranter struct {
@@ -2384,7 +2416,7 @@ func (g *fakeGranter) grantedTools(sessionID string) []string {
 // TestChatSeedsApprovalAllowlistAsStandingGrant proves the mechanism
 // this feature adds: a turn served by an agent with a non-empty
 // ApprovalAllowlist grants every listed tool for the session before
-// the turn runs — the same session_grants row missions/driver.go's
+// the turn runs: the same session_grants row missions/driver.go's
 // grantSessionDefaults writes, so tools.Permissions.Resolve's
 // matchGrant (D-036 suffix rule) allows the connector-namespaced call
 // without an ask on the very first turn.
@@ -2413,7 +2445,7 @@ func TestChatSeedsApprovalAllowlistAsStandingGrant(t *testing.T) {
 }
 
 // TestChatWithoutAllowlistGrantsNothing proves the seeder only ever
-// widens consent the agent's own config already lists — an agent with
+// widens consent the agent's own config already lists: an agent with
 // no ApprovalAllowlist gets no grants, so its tools keep asking exactly
 // like before this feature existed.
 func TestChatWithoutAllowlistGrantsNothing(t *testing.T) {
@@ -2523,7 +2555,7 @@ func TestChatAgentSwitchGrantsNewAllowlist(t *testing.T) {
 // TestDistillUsesSensitiveRouteWhenTurnRanSensitiveTool mirrors the
 // memory-extract pin above: a turn that executed a sensitive tool must
 // keep its distillation on the same pinned route, not the cheap
-// "summarize" default — the turn text can quote raw sensitive output.
+// "summarize" default: the turn text can quote raw sensitive output.
 func TestDistillUsesSensitiveRouteWhenTurnRanSensitiveTool(t *testing.T) {
 	t.Parallel()
 	log := newFakeLog()
@@ -2593,7 +2625,7 @@ func TestDistillUsesEmptyRouteWhenTurnDidNotRunSensitiveTool(t *testing.T) {
 }
 
 // seedSensitiveSession pre-populates a session's log with a completed
-// turn that ran a sensitive tool — standing in for "a prior turn in
+// turn that ran a sensitive tool: standing in for "a prior turn in
 // this session already executed gmail_read", the trigger for the
 // whole-session route pin under test below.
 func seedSensitiveSession(t *testing.T, log *fakeLog, sessionID string) {
@@ -2610,7 +2642,7 @@ func seedSensitiveSession(t *testing.T, log *fakeLog, sessionID string) {
 
 // TestChatPinsSessionSensitiveRouteOnNextTurn is the feature under
 // test: once a PRIOR turn in the session executed a sensitive tool, the
-// NEXT Chat() call — which itself runs no sensitive tool — must still
+// NEXT Chat() call: which itself runs no sensitive tool: must still
 // be served on the sensitive route, with the route picker ignored and
 // the model hint dropped (a hint outranks the route at the gateway,
 // same reason the in-turn SetForceRoute pin drops it).
@@ -2774,7 +2806,7 @@ func TestPersistTurnPinsSideCallsWhenSessionPreviouslySensitive(t *testing.T) {
 }
 
 // slowGW is a Gateway whose stream keeps producing on its own schedule,
-// gated ONLY by the context passed to Stream — unlike fakeGW, its sends
+// gated ONLY by the context passed to Stream: unlike fakeGW, its sends
 // aren't wrapped in a second select that could race the caller's read.
 // Used to prove that once runTurn hands gw.Stream the detached turnCtx
 // (not the request's ctx), the upstream genuinely survives a request-
@@ -2822,7 +2854,7 @@ func (g *slowGW) Stream(ctx context.Context, _ gwclient.StreamRequest) (<-chan s
 // package exists to ship: cancelling the REQUEST context (a browser
 // nav/reload) must not cancel the turn. runTurn hands gw.Stream the
 // detached turnCtx, so slowGW here is bound to that, not to the
-// request ctx passed into Chat — the disconnect must only stop
+// request ctx passed into Chat: the disconnect must only stop
 // forwarding to the client channel, never the upstream itself.
 func TestChatSurvivesClientDisconnect(t *testing.T) {
 	t.Parallel()
@@ -2842,7 +2874,7 @@ func TestChatSurvivesClientDisconnect(t *testing.T) {
 	}
 
 	// A /live subscriber attached independently of the request that
-	// started the turn — it must still see every event, including the
+	// started the turn: it must still see every event, including the
 	// ones the disconnecting client never gets.
 	replay, live, ok := s.Subscribe("s1")
 	if !ok {
@@ -2894,8 +2926,8 @@ loop:
 		t.Fatalf("broadcaster text = %q, want full upstream text", text.String())
 	}
 
-	// The turn must persist as a completed assistant_turn — never
-	// turn_failed — despite the client having vanished mid-stream. A
+	// The turn must persist as a completed assistant_turn: never
+	// turn_failed: despite the client having vanished mid-stream. A
 	// pending_state checkpoint (flushPending, on the disconnect branch
 	// itself) may also land before it; that's an existing, harmless
 	// checkpoint superseded by the real completed turn right after.
@@ -2922,7 +2954,7 @@ loop:
 // TestStopTurnCancelsMidStream: StopTurn must let a caller (a "stop"
 // button in the UI) cancel a session's in-flight turn server-side. The
 // upstream (bound to turnCtx) winds down once cancelled, and the
-// existing abnormal-end machinery in persistTurn takes over — partial
+// existing abnormal-end machinery in persistTurn takes over: partial
 // text becomes a pending_state (the same shape a real client disconnect
 // with no terminal produces).
 func TestStopTurnCancelsMidStream(t *testing.T) {
@@ -2931,7 +2963,7 @@ func TestStopTurnCancelsMidStream(t *testing.T) {
 	// slowGW (not fakeGW): the upstream must still be live-but-idle
 	// after the first chunk, so the test can call StopTurn
 	// deterministically mid-stream rather than racing the upstream's
-	// own natural close — fakeGW's producer goroutine exits (closing
+	// own natural close: fakeGW's producer goroutine exits (closing
 	// the channel) right after its last canned event, which can beat
 	// StopTurn to the punch when there is no terminal event to hold it
 	// open. The second event is delayed well past StopTurn's cancel.
@@ -3015,7 +3047,7 @@ func TestTurnTimeoutCeilingEndsAbandonedTurn(t *testing.T) {
 	waitFor(t, func() bool { return !s.TurnActive("s1") })
 	kinds := log.kinds("s1")
 	// The ceiling fires before any chunk (500ms delay vs 30ms ceiling),
-	// so there is no partial text worth keeping — the turn ends with no
+	// so there is no partial text worth keeping: the turn ends with no
 	// assistant_turn, same shape a real abandoned/stuck upstream leaves.
 	for _, k := range kinds {
 		if k == session.KindAssistantTurn {
@@ -3070,7 +3102,7 @@ func TestClassifyOverGatewayResolvesSummarizeRole(t *testing.T) {
 }
 
 // When the "summarize" role is unbound, ClassifyOverGateway returns an
-// error WITHOUT calling Stream at all — agents.Dispatch already treats
+// error WITHOUT calling Stream at all: agents.Dispatch already treats
 // any classify error as "fall back to the default agent", so this just
 // disables auto-dispatch rather than breaking the turn or firing an
 // avoidable request.
@@ -3096,7 +3128,7 @@ func TestClassifyOverGatewaySkipsStreamWhenRoleUnbound(t *testing.T) {
 
 // Dispatch (agents package) already falls back to the default agent on
 // any classify error, so an unbound summarize role surfaces here as a
-// dispatch fallback, never a broken turn — this is the same contract
+// dispatch fallback, never a broken turn: this is the same contract
 // TestChatAutoWithoutDispatchWiredFallsBackToDefault exercises for a
 // nil classify, extended to a wired-but-erroring one.
 func TestChatAutoDispatchFallsBackWhenClassifyErrors(t *testing.T) {

--- a/internal/brain/memclient/memclient.go
+++ b/internal/brain/memclient/memclient.go
@@ -30,7 +30,7 @@ func New(baseURL string) *Client {
 }
 
 // Extract posts one extraction job and returns the inserted memory
-// ids. route overrides memoryd's own side-call route when non-empty —
+// ids. route overrides memoryd's own side-call route when non-empty:
 // set when the turn/session being extracted executed a sensitive tool
 // and must not fall back to the default side-call route. source names
 // what produced the text ("chat", "mission", "compaction") so memoryd
@@ -179,13 +179,15 @@ type KBChunkHit struct {
 	SourceRef     string  `json:"source_ref"`
 }
 
-// KBSearch asks memoryd for the top-k chunks matching query, scoped to
-// collectionNames (required, non-empty — this is the ONLY place a
-// caller can widen or narrow that scope; the tool that calls this must
-// bind names at construction, never take them from model input).
-func (c *Client) KBSearch(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]KBChunkHit, error) {
+// KBSearch asks memoryd for the top-k chunks matching query.
+// collectionNames scopes the search (empty means the whole knowledge
+// base); boostCollections reorders results toward those collections
+// without excluding anything else (issue #368). The tool that calls
+// this must bind both at construction, never take them from model
+// input.
+func (c *Client) KBSearch(ctx context.Context, query string, collectionNames, boostCollections []string, mode string, k int) ([]KBChunkHit, error) {
 	body, err := json.Marshal(map[string]any{
-		"query": query, "collection_names": collectionNames, "mode": mode, "k": k,
+		"query": query, "collection_names": collectionNames, "boost_collections": boostCollections, "mode": mode, "k": k,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("memclient: marshal: %w", err)
@@ -217,7 +219,7 @@ func (c *Client) KBSearch(ctx context.Context, query string, collectionNames []s
 // prompt tail. The preamble and the closing-tag escape are the
 // memory-poisoning defense (D-011): whatever a memory's content says,
 // it cannot close the fence or pose as instructions. Framing and
-// escaping are single-sourced from the retrieval package — memoryd's
+// escaping are single-sourced from the retrieval package: memoryd's
 // token budget is enforced against exactly these strings.
 func RenderBlock(memories []Memory) string {
 	if len(memories) == 0 {

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -137,7 +137,7 @@ func (p *StorePermissionParker) OnToolCall(ctx context.Context, missionID, phase
 type parkNotifier interface {
 	OnPermissionParked(ctx context.Context, missionID, permissionID, tool, args, danger, rationale string)
 	OnPermissionCleared(ctx context.Context, missionID string)
-	// OnPermissionDenied reports a tool result that came back denied —
+	// OnPermissionDenied reports a tool result that came back denied:
 	// most often the unattended-turn automatic denial (D-039), but any
 	// denial qualifies. Best-effort like the two methods above.
 	OnPermissionDenied(ctx context.Context, missionID, tool, digest string)
@@ -311,16 +311,16 @@ func (r *nativeRunner) SetConnectorReads(resolve ConnectorReadsResolver) {
 	r.connectorReads = resolve
 }
 
-// KBSearchFunc runs one search_kb call scoped to collectionNames: main
-// curries memclient.Client.KBSearch in, same shape as chat.go's
-// KBSearch type. collectionNames travels on every call (the mission's
-// own Knowledge snapshot), never bound once, since the same func serves
-// every mission.
-type KBSearchFunc func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error)
+// KBSearchFunc runs one search_kb call over the whole KB, boosted
+// toward boostCollections: main curries memclient.Client.KBSearch in,
+// same shape as chat.go's KBSearch type. boostCollections travels on
+// every call (the mission's own Knowledge snapshot), never bound once,
+// since the same func serves every mission (D-078, issue #368).
+type KBSearchFunc func(ctx context.Context, query string, boostCollections []string, mode string, k int) ([]builtin.KBSearchHit, error)
 
-// KBReadFunc loads one kb document scoped to collectionNames: same
-// travel-on-every-call contract as KBSearchFunc.
-type KBReadFunc func(ctx context.Context, documentID string, collectionNames []string) (builtin.KBDocument, error)
+// KBReadFunc loads one kb document by id, unscoped by collection
+// (D-078: collections no longer gate read access: issue #368).
+type KBReadFunc func(ctx context.Context, documentID string) (builtin.KBDocument, error)
 
 // NewNativeRunner wraps a production *loop.Agent as a Runner. The
 // agent instance is expected to be brain's existing chat agent: a
@@ -345,22 +345,23 @@ func NewNativeRunnerWithFloor(agent *loop.Agent, parker parkNotifier, floorDeny 
 	return &nativeRunner{agent: agent, parker: parker, modelFloorDeny: floorDeny, sandbox: sandbox, kbSearch: kbSearch, kbRead: kbRead, log: log}
 }
 
-// kbSearchTool builds this turn's search_kb ExtraTool bound to m's own
-// Knowledge snapshot, or nil when search_kb must not be offered: no
-// backend wired, or the mission's creating agent named no collections
-// (empty Knowledge = no search_kb, same opt-in-only contract as
-// chat.go's kbSearchTool, which this mirrors exactly). A non-nil sink
-// records every returned document at execution time: the harness's
-// citation evidence must come from here, not from the rendered tool
-// result: digests cap at digestCeiling and offload past 8KiB, so a
-// full search_kb result never survives into the digest text.
+// kbSearchTool builds this turn's search_kb ExtraTool, boosted toward
+// m's own Knowledge snapshot, or nil when no backend is wired (KB
+// feature off entirely). m.Knowledge is never a gate: every mission
+// gets whole-KB search_kb once a backend exists, empty Knowledge or not
+// (D-078, issue #368): Knowledge only reorders results toward those
+// collections. A non-nil sink records every returned document at
+// execution time: the harness's citation evidence must come from here,
+// not from the rendered tool result: digests cap at digestCeiling and
+// offload past 8KiB, so a full search_kb result never survives into the
+// digest text.
 func (r *nativeRunner) kbSearchTool(m Mission, sink *kbRefSink) *tools.Tool {
-	if r.kbSearch == nil || len(m.Knowledge) == 0 {
+	if r.kbSearch == nil {
 		return nil
 	}
-	collections := slices.Clone(m.Knowledge)
+	boost := slices.Clone(m.Knowledge)
 	return builtin.KBSearch(func(ctx context.Context, query, mode string, k int) ([]builtin.KBSearchHit, error) {
-		hits, err := r.kbSearch(ctx, query, collections, mode, k)
+		hits, err := r.kbSearch(ctx, query, boost, mode, k)
 		if err == nil && sink != nil {
 			sink.record(hits)
 		}
@@ -369,15 +370,13 @@ func (r *nativeRunner) kbSearchTool(m Mission, sink *kbRefSink) *tools.Tool {
 }
 
 // kbReadTool builds this turn's read_kb ExtraTool, gated exactly like
-// kbSearchTool: no backend, or an empty Knowledge snapshot, means the
-// tool is not offered.
+// kbSearchTool: no backend wired means the tool is not offered.
 func (r *nativeRunner) kbReadTool(m Mission) *tools.Tool {
-	if r.kbRead == nil || len(m.Knowledge) == 0 {
+	if r.kbRead == nil {
 		return nil
 	}
-	collections := slices.Clone(m.Knowledge)
 	return builtin.KBRead(func(ctx context.Context, documentID string) (builtin.KBDocument, error) {
-		return r.kbRead(ctx, documentID, collections)
+		return r.kbRead(ctx, documentID)
 	})
 }
 
@@ -417,7 +416,7 @@ func (s *kbRefSink) all() []string {
 
 // missionTools builds the turn-scoped file tools rooted in the
 // mission's OWN directory (worktree for coding, workspace otherwise):
-// a shell that replaces the global workspace-rooted one for the turn —
+// a shell that replaces the global workspace-rooted one for the turn:
 // the root cause of a whole failure family was workers writing into
 // the shared root while verify_cmd and the reviewer looked in the
 // per-mission directory: and write_file, so artifact writes never go
@@ -580,7 +579,7 @@ func toolCallDigest(args json.RawMessage) string {
 func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTool string, phase Phase) (turnResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, turnTimeout)
 	defer cancel()
-	// D-075: the sentinel call's successful execution ends the turn —
+	// D-075: the sentinel call's successful execution ends the turn:
 	// every mission phase (worker/explore/plan/review) goes through
 	// this one call site.
 	req.EndTurnTools = []string{sentinelTool}
@@ -616,7 +615,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if ev.ToolCall != nil && ev.ToolCall.Name == "fetch_url" {
 				seenURLs = append(seenURLs, webFetchArgURL(ev.ToolCall.Input)...)
 			}
-			// Any tool call OTHER than the sentinel is mid-turn activity —
+			// Any tool call OTHER than the sentinel is mid-turn activity:
 			// the text written before it is stale narration, not the
 			// deliverable. The sentinel call itself carries no assistant
 			// text of its own, so it must not reset finalSeg.
@@ -800,7 +799,7 @@ func oversightModel(m Mission) string {
 }
 
 // reviewModel is reviewRoute's model-pin counterpart. Precedence tracks
-// reviewRoute exactly: ReviewRouteModel > PlanRouteModel > RouteModel —
+// reviewRoute exactly: ReviewRouteModel > PlanRouteModel > RouteModel:
 // otherwise a mission with only PlanRouteModel set would run review on
 // the (correctly inherited) plan_route but an unpinned model within it.
 func reviewModel(m Mission) string {
@@ -813,7 +812,7 @@ func reviewModel(m Mission) string {
 // RunWorker seeds a fresh session (packet only, no prior transcript)
 // and enforces the sentinel ladder: a present, well-formed
 // mission_status call is trusted directly; a missing or invalid one
-// triggers one recovery re-run, then falls back to bail detection —
+// triggers one recovery re-run, then falls back to bail detection:
 // either path that doesn't yield a trusted verdict becomes a forced
 // retry, never a silent accept.
 func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPacket) (WorkerVerdict, string, error) {

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -170,7 +170,7 @@ func TestRunWorkerSentinelPresent(t *testing.T) {
 // light-mission delivery: a worker session with several internal
 // tool-calling rounds within ONE loop.Agent turn (draft narration, a
 // shell call, more narration, then the sentinel) must expose only the
-// text written since the last non-sentinel tool call as FinalMessage —
+// text written since the last non-sentinel tool call as FinalMessage:
 // the deliverable, not the whole session's chatter. The full text
 // return (RunWorker's second value) stays unchanged: everything, in
 // order, for progress-note/log purposes.
@@ -426,7 +426,7 @@ func TestRunReviewRecoversWhenVerdictMissingThenPresent(t *testing.T) {
 }
 
 // TestRunReviewFallsBackToTextSentinel covers the observed qwen3:30b
-// reviewer failure: prose review, never a review_verdict tool call —
+// reviewer failure: prose review, never a review_verdict tool call:
 // the runner must recover the verdict from a text-form sentinel in the
 // recovery turn instead of erroring the round out.
 func TestRunReviewFallsBackToTextSentinel(t *testing.T) {
@@ -1021,7 +1021,7 @@ func TestRunWorkerConcurrentParksClearOnlyWhenAllResolve(t *testing.T) {
 	}
 	if len(parker.resultsDeliveredAtClear) != 1 || parker.resultsDeliveredAtClear[0] != 2 {
 		// The bug this guards: the buggy single-bool version clears
-		// after resultsDelivered==1 (right after call1, prematurely) —
+		// after resultsDelivered==1 (right after call1, prematurely):
 		// this asserts the clear only happens once BOTH results (2) have
 		// actually been delivered.
 		t.Fatalf("clear fired after %v results delivered, want exactly one clear after both (2) results", parker.resultsDeliveredAtClear)
@@ -1308,7 +1308,7 @@ func TestRunWorkerGetsMissionScopedShell(t *testing.T) {
 }
 
 // TestRunWorkerIncludesConnectorReadsWhenResolverSet confirms RunWorker
-// layers the connector reads resolver's tools into ExtraTools —
+// layers the connector reads resolver's tools into ExtraTools:
 // scheduled general missions (daily inbox digest) need gmail/calendar
 // reads despite BuiltinsOnly.
 func TestRunWorkerIncludesConnectorReadsWhenResolverSet(t *testing.T) {
@@ -1338,7 +1338,7 @@ func TestRunWorkerIncludesConnectorReadsWhenResolverSet(t *testing.T) {
 }
 
 // TestRunWorkerOmitsConnectorReadsWhenResolverUnset confirms unset
-// connectorReads (today's default) never adds connector tools —
+// connectorReads (today's default) never adds connector tools:
 // nil-safe, same as before this existed.
 func TestRunWorkerOmitsConnectorReadsWhenResolverUnset(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
@@ -1502,7 +1502,7 @@ func TestRunWorkerAttendedWithoutScheduleID(t *testing.T) {
 
 // TestRunWorkerReportsPermissionDenied confirms a denied tool result
 // (the D-039 automatic unattended denial, or any other denial) reaches
-// the mission via parkNotifier as a mission.permission_denied event —
+// the mission via parkNotifier as a mission.permission_denied event:
 // without this, an unattended turn's fast-fail denials would be
 // invisible to anything watching the mission (no park event is ever
 // emitted for them, unlike the ask-and-timeout path).
@@ -2049,21 +2049,18 @@ func TestKBSearchToolRecordsRefsInSink(t *testing.T) {
 	}
 }
 
-// kbReadTool follows kbSearchTool's opt-in-only contract exactly: no
-// backend, or an empty Knowledge snapshot, keeps the tool off the
-// offered surface; with both present it serves the bound collections.
+// kbReadTool is gated only on a backend being wired (D-078, issue
+// #368): a mission's own Knowledge no longer scopes or gates read_kb,
+// so an empty snapshot still gets the tool once a backend exists.
 func TestKBReadToolGating(t *testing.T) {
-	read := func(ctx context.Context, documentID string, collections []string) (builtin.KBDocument, error) {
-		if !slices.Equal(collections, []string{"docs"}) {
-			t.Fatalf("collections = %v, want the mission snapshot", collections)
-		}
+	read := func(ctx context.Context, documentID string) (builtin.KBDocument, error) {
 		return builtin.KBDocument{Title: "Runbook", Markdown: "content"}, nil
 	}
 	if tool := (&nativeRunner{log: slog.Default()}).kbReadTool(Mission{Knowledge: []string{"docs"}}); tool != nil {
 		t.Fatal("kbReadTool offered without a backend")
 	}
-	if tool := (&nativeRunner{log: slog.Default(), kbRead: read}).kbReadTool(Mission{}); tool != nil {
-		t.Fatal("kbReadTool offered with empty knowledge")
+	if tool := (&nativeRunner{log: slog.Default(), kbRead: read}).kbReadTool(Mission{}); tool == nil {
+		t.Fatal("kbReadTool = nil with backend wired and empty knowledge")
 	}
 	tool := (&nativeRunner{log: slog.Default(), kbRead: read}).kbReadTool(Mission{Knowledge: []string{"docs"}})
 	if tool == nil {
@@ -2115,12 +2112,11 @@ func (a *kbExecutingAgent) Start(ctx context.Context, req loop.Request) (<-chan 
 	return a.scriptedAgent.Start(ctx, req)
 }
 
-// TestRunWorkerOffersKBSearchOnlyWhenMissionHasKnowledge covers
-// kbSearchTool's opt-in-only contract: no backend wired, or a mission
-// with an empty Knowledge snapshot, must never put search_kb on the
-// turn's offered tool surface (chat.go's kbSearchTool mirrors this
-// exactly on the chat side).
-func TestRunWorkerOffersKBSearchOnlyWhenMissionHasKnowledge(t *testing.T) {
+// TestRunWorkerOffersKBSearchRegardlessOfMissionKnowledge covers
+// kbSearchTool's gate after issue #368: only a wired backend controls
+// whether search_kb is offered. A mission's own Knowledge (empty or
+// not) never withholds the tool, it only boosts ranking.
+func TestRunWorkerOffersKBSearchRegardlessOfMissionKnowledge(t *testing.T) {
 	hasKBSearch := func(req loop.Request) bool {
 		for _, tool := range req.ExtraTools {
 			if tool.Name == "search_kb" {
@@ -2142,24 +2138,24 @@ func TestRunWorkerOffersKBSearchOnlyWhenMissionHasKnowledge(t *testing.T) {
 		}
 	})
 
-	t.Run("empty mission knowledge", func(t *testing.T) {
+	t.Run("backend wired, no mission knowledge", func(t *testing.T) {
 		agent := &scriptedAgent{batches: doneBatch}
 		r := newTestRunner(agent)
-		r.kbSearch = func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error) {
+		r.kbSearch = func(ctx context.Context, query string, boostCollections []string, mode string, k int) ([]builtin.KBSearchHit, error) {
 			return nil, nil
 		}
 		if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"}); err != nil {
 			t.Fatalf("RunWorker: %v", err)
 		}
-		if hasKBSearch(agent.requests[0]) {
-			t.Fatal("search_kb offered with empty mission Knowledge")
+		if !hasKBSearch(agent.requests[0]) {
+			t.Fatal("search_kb not offered despite backend wired, whole-KB default (issue #368)")
 		}
 	})
 
 	t.Run("backend wired and knowledge set", func(t *testing.T) {
 		agent := &scriptedAgent{batches: doneBatch}
 		r := newTestRunner(agent)
-		r.kbSearch = func(ctx context.Context, query string, collectionNames []string, mode string, k int) ([]builtin.KBSearchHit, error) {
+		r.kbSearch = func(ctx context.Context, query string, boostCollections []string, mode string, k int) ([]builtin.KBSearchHit, error) {
 			return nil, nil
 		}
 		if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default", Knowledge: []string{"docs"}}, WorkPacket{Goal: "test"}); err != nil {

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -61,7 +61,7 @@ func testStore(t *testing.T) *Store {
 }
 
 // execer is the shared Exec surface between a pool connection and a
-// one-shot pgx.Conn — lets sweep run identically at setup (via the
+// one-shot pgx.Conn: lets sweep run identically at setup (via the
 // pool) and teardown (via a fresh connection, since the pool dies with
 // t.Context()).
 type execer interface {
@@ -70,12 +70,12 @@ type execer interface {
 
 // sweep clears every fixture row this package's tests create. Missions
 // spawned by a test schedule carry the schedule's mission_template
-// goal verbatim, not the marker prefix — delete them via the schedule
+// goal verbatim, not the marker prefix: delete them via the schedule
 // join FIRST, before deleting schedules (whose FK would otherwise
 // orphan them under ON DELETE CASCADE at an unpredictable order
 // relative to a concurrently running test). Schedule NAMES can't carry
 // marker verbatim (it has a trailing space; schedule names must be a
-// slug — see schedules_integration_test.go's slugMarker), so schedule
+// slug: see schedules_integration_test.go's slugMarker), so schedule
 // rows are also swept by the slug form.
 func sweep(ctx context.Context, db execer) {
 	slug := strings.TrimSpace(marker)
@@ -207,7 +207,7 @@ func TestMissionReferencedContextRoundTrips(t *testing.T) {
 
 // TestMissionDelete covers Store.Delete's three outcomes: unknown id
 // (ErrNotFound), a live (non-terminal) mission (ErrNotTerminal), and a
-// terminal mission — which must actually remove the row, and its
+// terminal mission: which must actually remove the row, and its
 // mission_events via the ON DELETE CASCADE migrations 0025/0027 rely
 // on.
 func TestMissionDelete(t *testing.T) {
@@ -258,7 +258,7 @@ func TestMissionDelete(t *testing.T) {
 // TestMissionParentLineageRoundTrips covers the follow-up columns:
 // parent_mission_id/parent_context round-trip through Create/Get, and
 // deleting the (terminal) parent SETs NULL rather than blocking or
-// cascading — the child mission stays valid with an empty
+// cascading: the child mission stays valid with an empty
 // ParentMissionID afterward.
 func TestMissionParentLineageRoundTrips(t *testing.T) {
 	s := testStore(t)
@@ -368,7 +368,7 @@ func TestMissionPromptOverlayRoundTrips(t *testing.T) {
 		t.Fatalf("PromptOverlay = %q, want it to round-trip unchanged", m.PromptOverlay)
 	}
 
-	// Absent means "no agent overlay" (the general agent, e.g.) — must
+	// Absent means "no agent overlay" (the general agent, e.g.): must
 	// stay empty, not some driver default.
 	id2, err := s.Create(ctx, Mission{Goal: marker + "no-overlay", Kind: "general", Route: "default"})
 	if err != nil {
@@ -405,8 +405,9 @@ func TestMissionKnowledgeRoundTrips(t *testing.T) {
 		t.Fatalf("Knowledge = %v, want it to round-trip unchanged", m.Knowledge)
 	}
 
-	// Absent means "search_kb never offered" — must stay empty, not some
-	// driver default.
+	// Absent means "no boost collections" (search_kb still gets
+	// offered, whole-KB, by the runner: issue #368): must stay empty,
+	// not some driver default.
 	id2, err := s.Create(ctx, Mission{Goal: marker + "no-knowledge", Kind: "general", Route: "default"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -422,7 +423,7 @@ func TestMissionKnowledgeRoundTrips(t *testing.T) {
 
 // TestMissionHarnessRoundTrips covers D-051: harness is a first-class
 // column snapshotted at create time, same shape as PromptOverlay above
-// — "" (native) is the default when a mission omits it.
+//: "" (native) is the default when a mission omits it.
 func TestMissionHarnessRoundTrips(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
@@ -455,7 +456,7 @@ func TestMissionHarnessRoundTrips(t *testing.T) {
 }
 
 // TestMissionModelPinsRoundTrip covers route_model/plan_route_model/
-// review_route_model (D-078) — same shape as TestMissionHarnessRoundTrips:
+// review_route_model (D-078): same shape as TestMissionHarnessRoundTrips:
 // set on create, read back verbatim; unset stays empty.
 func TestMissionModelPinsRoundTrip(t *testing.T) {
 	s := testStore(t)
@@ -496,7 +497,7 @@ func TestMissionModelPinsRoundTrip(t *testing.T) {
 }
 
 // TestMissionLightAndFinalOutputRoundTrip covers light (D-069, born
-// phase=execute) and SetFinalOutput — same shape as
+// phase=execute) and SetFinalOutput: same shape as
 // TestMissionHarnessRoundTrips above, plus the setter mission state
 // (not an event) is written and read back correctly.
 func TestMissionLightAndFinalOutputRoundTrip(t *testing.T) {
@@ -549,7 +550,7 @@ func TestMissionLightAndFinalOutputRoundTrip(t *testing.T) {
 }
 
 // TestMissionOnCompleteRoundTrips covers on_complete: a first-class
-// column snapshotted at create time, same shape as Harness above — ""
+// column snapshotted at create time, same shape as Harness above: ""
 // (do nothing) is the default when a mission omits it.
 func TestMissionOnCompleteRoundTrips(t *testing.T) {
 	s := testStore(t)
@@ -585,7 +586,7 @@ func TestMissionOnCompleteRoundTrips(t *testing.T) {
 
 // TestMissionGitStrategyRoundTrips covers branch_pattern/commit_style:
 // first-class columns snapshotted at create time, same shape as Harness
-// above — "" (use the settings default) is the default when a mission
+// above: "" (use the settings default) is the default when a mission
 // omits them.
 func TestMissionGitStrategyRoundTrips(t *testing.T) {
 	s := testStore(t)
@@ -813,7 +814,7 @@ func TestApplyTransitionAndEvents(t *testing.T) {
 
 // TestApplyTransitionClearsPendingPermissionOnTerminal reproduces a
 // real bug: cancelling (or otherwise terminating) a mission parked on
-// a permission left the pending_permission_* columns populated —
+// a permission left the pending_permission_* columns populated:
 // the mission was dead, but its "Allow" banner kept showing in the
 // UI since nothing ever cleared them on the terminal transition.
 func TestApplyTransitionClearsPendingPermissionOnTerminal(t *testing.T) {
@@ -828,7 +829,7 @@ func TestApplyTransitionClearsPendingPermissionOnTerminal(t *testing.T) {
 		t.Fatalf("SetPendingPermission: %v", err)
 	}
 
-	// Non-terminal transition must NOT clear it — only a terminal one.
+	// Non-terminal transition must NOT clear it: only a terminal one.
 	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8}}); err != nil {
 		t.Fatalf("ApplyTransition (non-terminal): %v", err)
 	}
@@ -858,7 +859,7 @@ func TestApplyTransitionClearsPendingPermissionOnTerminal(t *testing.T) {
 
 // TestApplyTransitionRejectsWriteOnTerminalMission reproduces a real
 // bug: a mission cancelled (terminal phase persisted) while a Drive
-// loop's turn was in flight — the turn's own ApplyTransition,
+// loop's turn was in flight: the turn's own ApplyTransition,
 // operating on a stale pre-cancel snapshot, must not be allowed to
 // overwrite the terminal row and resurrect the mission.
 func TestApplyTransitionRejectsWriteOnTerminalMission(t *testing.T) {
@@ -877,7 +878,7 @@ func TestApplyTransitionRejectsWriteOnTerminalMission(t *testing.T) {
 	}
 
 	// A stale in-flight turn's transition arrives after cancel already
-	// landed — must be rejected, not written over the terminal row.
+	// landed: must be rejected, not written over the terminal row.
 	err = s.ApplyTransition(ctx, id, Transition{
 		Next:   StepState{Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 8},
 		Events: []EventDraft{{Kind: "mission.turn", Payload: map[string]any{"phase": "execute"}}},
@@ -985,7 +986,7 @@ func TestApplyTransitionCancelThenDoubleCancel(t *testing.T) {
 }
 
 // TestAppendEventSeqMonotonic drives concurrent appends to the SAME
-// mission and asserts seq is a gap-free 1..N sequence — the FOR UPDATE
+// mission and asserts seq is a gap-free 1..N sequence: the FOR UPDATE
 // lock on the mission row must serialize these, not merely avoid a
 // crash.
 func TestAppendEventSeqMonotonic(t *testing.T) {
@@ -1077,7 +1078,7 @@ func TestSetProvisionedBranchCollision(t *testing.T) {
 
 // TestClaimWorkSlotConcurrencyCap fires more concurrent claimants than
 // the slot cap and asserts the number actually flipped to working
-// never exceeds max — the advisory lock must make the
+// never exceeds max: the advisory lock must make the
 // count-then-update atomic, not just individually safe.
 func TestClaimWorkSlotConcurrencyCap(t *testing.T) {
 	s := testStore(t)
@@ -1086,7 +1087,7 @@ func TestClaimWorkSlotConcurrencyCap(t *testing.T) {
 	const total, max = 10, 3
 	// The cap is global across the shared database: any real mission
 	// already 'working' (the suite runs against a live stack) consumes
-	// a slot, so the expected claim count is max minus that baseline —
+	// a slot, so the expected claim count is max minus that baseline:
 	// asserting a bare max flakes whenever a live mission is running.
 	db, err := s.db.Get()
 	if err != nil {
@@ -1138,7 +1139,7 @@ func TestClaimWorkSlotConcurrencyCap(t *testing.T) {
 
 	// ClaimWorkSlot takes the oldest idle mission GLOBALLY, so in a
 	// shared database an older foreign idle row may be claimed instead
-	// of this test's fixtures — the invariant under test is the global
+	// of this test's fixtures: the invariant under test is the global
 	// cap, not which rows filled the slots.
 	var working int
 	if err := db.QueryRow(ctx, `SELECT count(*) FROM missions WHERE status = 'working'`).Scan(&working); err != nil {
@@ -1335,7 +1336,7 @@ func TestBackoffPausedAndCountBackoffPauses(t *testing.T) {
 		t.Fatalf("CountBackoffPauses after 1 pause = %d, want 1", n)
 	}
 
-	// Resume, then pause for backoff again — count must accumulate.
+	// Resume, then pause for backoff again: count must accumulate.
 	if err := s.ApplyTransition(ctx, backoffID, Transition{Next: StepState{Phase: PhaseExecute, Status: StatusIdle}}); err != nil {
 		t.Fatalf("ApplyTransition resume: %v", err)
 	}

--- a/internal/brain/tools/builtin/kbread.go
+++ b/internal/brain/tools/builtin/kbread.go
@@ -16,11 +16,9 @@ type KBDocument struct {
 	Markdown  string
 }
 
-// KBReadFunc loads one document by id. main curries the store lookup
-// in with the calling agent's collection allowlist already bound —
-// a document outside the allowed collections reads as not found, and
-// collections are NEVER a model-controlled argument (D-060: enforced
-// in Go, not a prompt).
+// KBReadFunc loads one document by id from anywhere in the knowledge
+// base (D-078, issue #368: collections no longer gate read access,
+// they only boost search ranking).
 type KBReadFunc func(ctx context.Context, documentID string) (KBDocument, error)
 
 type kbReadArgs struct {
@@ -29,7 +27,7 @@ type kbReadArgs struct {
 
 // KBRead lets the model read a knowledge-base document in full after
 // search_kb surfaced an excerpt from it. read is built per-agent,
-// per-turn with the collection set already bound — this constructor
+// per-turn with the collection set already bound: this constructor
 // never sees or accepts collection names itself.
 func KBRead(read KBReadFunc) *tools.Tool {
 	return &tools.Tool{
@@ -38,8 +36,7 @@ func KBRead(read KBReadFunc) *tools.Tool {
 
 Use after search_kb when the returned passages are not enough — to see
 a passage's surrounding context, or to read the whole document a hit
-came from. Only documents in this agent's knowledge base collections
-are readable.
+came from.
 
 Arguments:
 - ref (string, required): the "kb://<document-id>" reference from a

--- a/internal/brain/tools/builtin/kbsearch.go
+++ b/internal/brain/tools/builtin/kbsearch.go
@@ -28,11 +28,11 @@ type KBSearchHit struct {
 	SourceRef     string
 }
 
-// KBSearchFunc runs one hybrid/semantic/keyword search scoped to
-// collections; main curries memclient.Client.KBSearch in with the
-// calling agent's collection allowlist already bound — collections are
-// NEVER a model-controlled argument (D-060: enforced in Go, not a
-// prompt).
+// KBSearchFunc runs one hybrid/semantic/keyword search over the whole
+// knowledge base; main curries memclient.Client.KBSearch in with the
+// calling agent's Knowledge collections already bound as a ranking
+// boost: collections are NEVER a model-controlled argument (D-078,
+// issue #368: enforced in Go, not a prompt).
 type KBSearchFunc func(ctx context.Context, query, mode string, k int) ([]KBSearchHit, error)
 
 type kbSearchArgs struct {
@@ -41,18 +41,18 @@ type kbSearchArgs struct {
 	K     *int   `json:"k"`
 }
 
-// KBSearch lets the model search one agent's allowed knowledge-base
-// collections. search is built per-agent, per-turn (see chat.go) with
-// the collection set already bound — this constructor never sees or
-// accepts collection names itself.
+// KBSearch lets the model search the whole knowledge base. search is
+// built per-agent, per-turn (see chat.go) with the agent's own
+// collections already bound as a ranking boost: this constructor never
+// sees or accepts collection names itself.
 func KBSearch(search KBSearchFunc) *tools.Tool {
 	return &tools.Tool{
 		Name: "search_kb",
-		Description: `Searches this agent's knowledge base collections and returns matching passages with their source.
+		Description: `Searches the knowledge base and returns matching passages with their source.
 
 Use when the user asks about something that might be documented in the
-agent's configured knowledge base — internal docs, reference material,
-uploaded files — rather than general knowledge or long-term memory.
+knowledge base (internal docs, reference material, uploaded files)
+rather than general knowledge or long-term memory.
 
 Arguments:
 - query (string, required): what to search for.

--- a/internal/memory/api/kb.go
+++ b/internal/memory/api/kb.go
@@ -15,11 +15,11 @@ import (
 // satisfies it. Nil leaves the KB routes unmounted.
 type KBManager interface {
 	ReplaceChunks(ctx context.Context, documentID string, chunks []store.KBChunk) error
-	KBSearch(ctx context.Context, query string, embedding store.Vector, collectionNames []string, mode store.KBSearchMode, k int) ([]store.KBSearchHit, error)
+	KBSearch(ctx context.Context, query string, embedding store.Vector, collectionNames, boostCollections []string, mode store.KBSearchMode, k int) ([]store.KBSearchHit, error)
 }
 
 // DocumentStatusSetter reports ingestion outcomes back onto brain's
-// kb_documents row — memoryd only ever reports ready/failed here; it
+// kb_documents row: memoryd only ever reports ready/failed here; it
 // does not own that table (internal/brain/kb does).
 type DocumentStatusSetter interface {
 	SetIngested(ctx context.Context, documentID string, chunkCount int) error
@@ -34,7 +34,7 @@ type ingestRequest struct {
 
 // handleIngest runs the synchronous ingestion pipeline: chunk, embed,
 // replace the document's existing chunks, report the outcome. Always
-// deletes-and-rewrites (ReplaceChunks) — a re-ingest is never additive.
+// deletes-and-rewrites (ReplaceChunks): a re-ingest is never additive.
 func (a *API) handleIngest(w http.ResponseWriter, r *http.Request) {
 	var req ingestRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -107,10 +107,11 @@ func (a *API) reportKBFailed(ctx context.Context, documentID, msg string) {
 }
 
 type kbSearchRequest struct {
-	Query           string   `json:"query"`
-	CollectionNames []string `json:"collection_names"`
-	Mode            string   `json:"mode"`
-	K               int      `json:"k"`
+	Query            string   `json:"query"`
+	CollectionNames  []string `json:"collection_names"`
+	BoostCollections []string `json:"boost_collections"`
+	Mode             string   `json:"mode"`
+	K                int      `json:"k"`
 }
 
 type kbSearchHitJSON struct {
@@ -133,11 +134,11 @@ const (
 	kbEmbedBatchSize = 16
 )
 
-// handleKBSearch runs hybrid/semantic/keyword retrieval scoped to the
-// caller-provided collection names — collection_names is required and
-// non-empty; brain resolves it from the calling agent's Knowledge
-// allowlist before this call, but memoryd enforces the non-empty
-// requirement independently rather than trusting the caller.
+// handleKBSearch runs hybrid/semantic/keyword retrieval over the
+// knowledge base. collection_names is optional: empty searches every
+// collection, non-empty scopes to it (an explicit narrowing).
+// boost_collections never narrows the result set, it only reorders it
+// (issue #368: collections are a ranking boost, not an access gate).
 func (a *API) handleKBSearch(w http.ResponseWriter, r *http.Request) {
 	var req kbSearchRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -146,10 +147,6 @@ func (a *API) handleKBSearch(w http.ResponseWriter, r *http.Request) {
 	}
 	if strings.TrimSpace(req.Query) == "" {
 		jsonError(w, http.StatusBadRequest, "bad_request", "query is required")
-		return
-	}
-	if len(req.CollectionNames) == 0 {
-		jsonError(w, http.StatusBadRequest, "bad_request", "collection_names must be non-empty")
 		return
 	}
 	mode := store.KBSearchMode(req.Mode)
@@ -184,7 +181,7 @@ func (a *API) handleKBSearch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	hits, err := a.kb.KBSearch(r.Context(), req.Query, embedding, req.CollectionNames, mode, k)
+	hits, err := a.kb.KBSearch(r.Context(), req.Query, embedding, req.CollectionNames, req.BoostCollections, mode, k)
 	if err != nil {
 		a.log.Warn("kb search failed", "error", err)
 		jsonError(w, http.StatusInternalServerError, "search_failed", err.Error())

--- a/internal/memory/api/kb_test.go
+++ b/internal/memory/api/kb_test.go
@@ -24,6 +24,7 @@ type fakeKB struct {
 	searchErr  error
 	sawQuery   string
 	sawNames   []string
+	sawBoost   []string
 	sawMode    store.KBSearchMode
 	sawK       int
 	sawEmb     store.Vector
@@ -36,8 +37,8 @@ func (f *fakeKB) ReplaceChunks(_ context.Context, documentID string, chunks []st
 	return f.replaceErr
 }
 
-func (f *fakeKB) KBSearch(_ context.Context, query string, embedding store.Vector, names []string, mode store.KBSearchMode, k int) ([]store.KBSearchHit, error) {
-	f.sawQuery, f.sawEmb, f.sawNames, f.sawMode, f.sawK = query, embedding, names, mode, k
+func (f *fakeKB) KBSearch(_ context.Context, query string, embedding store.Vector, names, boost []string, mode store.KBSearchMode, k int) ([]store.KBSearchHit, error) {
+	f.sawQuery, f.sawEmb, f.sawNames, f.sawBoost, f.sawMode, f.sawK = query, embedding, names, boost, mode, k
 	return f.searchHits, f.searchErr
 }
 
@@ -237,12 +238,34 @@ func TestKBSearchKeywordModeSkipsEmbedding(t *testing.T) {
 	}
 }
 
-func TestKBSearchRequiresCollectionNames(t *testing.T) {
+// TestKBSearchEmptyCollectionNamesSearchesWholeKB pins issue #368's
+// default: collection_names is optional, and an empty/omitted list
+// reaches the store as nil (whole-KB), not a 400.
+func TestKBSearchEmptyCollectionNamesSearchesWholeKB(t *testing.T) {
 	t.Parallel()
-	a := kbAPIFor(&fakeKB{}, nil, &fakeEmbedder{})
+	kb := &fakeKB{}
+	a := kbAPIFor(kb, nil, &fakeEmbedder{})
 	rec := postJSON(t, a.handleKBSearch, "/v1/kb-search", `{"query":"x","collection_names":[]}`)
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if len(kb.sawNames) != 0 {
+		t.Fatalf("sawNames = %v, want empty (whole-KB)", kb.sawNames)
+	}
+}
+
+// TestKBSearchPassesBoostCollectionsThrough pins that boost_collections
+// travels to the store call unchanged, separate from collection_names.
+func TestKBSearchPassesBoostCollectionsThrough(t *testing.T) {
+	t.Parallel()
+	kb := &fakeKB{}
+	a := kbAPIFor(kb, nil, &fakeEmbedder{})
+	rec := postJSON(t, a.handleKBSearch, "/v1/kb-search", `{"query":"x","boost_collections":["docs"]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if len(kb.sawBoost) != 1 || kb.sawBoost[0] != "docs" {
+		t.Fatalf("sawBoost = %v, want [docs]", kb.sawBoost)
 	}
 }
 

--- a/internal/memory/store/kb.go
+++ b/internal/memory/store/kb.go
@@ -18,7 +18,7 @@ type KBChunk struct {
 
 // KBStore persists knowledge-base chunks (D-060) and reports ingestion
 // outcomes onto brain's kb_documents row. Collection/document CRUD is
-// brain's own (internal/brain/kb) — memoryd only writes kb_chunks and
+// brain's own (internal/brain/kb): memoryd only writes kb_chunks and
 // the narrow status/chunk_count/error columns ingestion owns, sharing
 // the one Postgres instance (D-060 doesn't split the database, just
 // the code that owns each table).
@@ -61,7 +61,7 @@ func (s *KBStore) SetFailed(ctx context.Context, documentID string, errMsg strin
 }
 
 // ReplaceChunks deletes every existing chunk for documentID and inserts
-// the new set in one transaction — re-ingest is delete-and-rewrite,
+// the new set in one transaction: re-ingest is delete-and-rewrite,
 // never an in-place update (KB documents are mutable reference data,
 // but a chunk's identity is only meaningful within one ingestion pass).
 func (s *KBStore) ReplaceChunks(ctx context.Context, documentID string, chunks []KBChunk) error {
@@ -114,7 +114,7 @@ const (
 )
 
 // legLimitLit/rrfKLit are string literals (not ints) so they concatenate
-// directly into the const SQL below — legLimit bounds each leg's
+// directly into the const SQL below: legLimit bounds each leg's
 // candidate set before RRF fusion, rrfK is the standard Reciprocal Rank
 // Fusion damping constant; both mirror the memories retrieval package's
 // own values (internal/memory/retrieval/search.go, fuse.go).
@@ -123,26 +123,33 @@ const rrfKLit = "60"
 
 // minSimilarityLit is the vector leg's relevance floor (cosine
 // similarity): below it a chunk is noise, not a match. Nearest-neighbor
-// search always returns SOMETHING — without a floor an off-topic query
+// search always returns SOMETHING: without a floor an off-topic query
 // still fills k slots with whatever is least-far away, and the model
 // may cite it. Returning nothing beats confidently-irrelevant (same
 // principle as memories retrieval). The keyword leg needs no floor: a
 // tsquery either matches lexemes or returns nothing.
 const minSimilarityLit = "0.25"
 
+// boostFactorLit multiplies a chunk's score when its collection is in
+// boostCollections (D-078: an agent's configured collections are a
+// ranking boost, not an access gate: issue #368). A plain literal, not
+// a config knob: no existing settings pattern fits one retrieval-tuning
+// constant.
+const boostFactorLit = "1.5"
+
 // KBSearch runs hybrid (vector + full-text, RRF-fused), semantic-only,
-// or keyword-only retrieval over kb_chunks, scoped to collectionNames
-// (required, non-empty — collection scoping is enforced here in SQL,
-// never left to a prompt). embedding may be nil only when mode is
+// or keyword-only retrieval over kb_chunks. Empty collectionNames
+// searches the whole knowledge base; non-empty scopes to it (an
+// explicit narrowing, still enforced here in SQL, never a prompt).
+// boostCollections gets a score multiplier at ranking time regardless
+// of collectionNames: a relevance signal, never a filter: chunks
+// outside it are still returned. embedding may be nil only when mode is
 // keyword; hybrid/semantic without an embedding return no results from
 // the vector leg (callers should not call semantic/hybrid without one).
-func (s *KBStore) KBSearch(ctx context.Context, query string, embedding Vector, collectionNames []string, mode KBSearchMode, k int) ([]KBSearchHit, error) {
+func (s *KBStore) KBSearch(ctx context.Context, query string, embedding Vector, collectionNames, boostCollections []string, mode KBSearchMode, k int) ([]KBSearchHit, error) {
 	db, err := s.db.Get()
 	if err != nil {
 		return nil, fmt.Errorf("kb search: %w", err)
-	}
-	if len(collectionNames) == 0 {
-		return nil, fmt.Errorf("kb search: collection_names is required")
 	}
 	if k <= 0 {
 		k = 8
@@ -152,11 +159,11 @@ func (s *KBStore) KBSearch(ctx context.Context, query string, embedding Vector, 
 	var args []any
 	switch mode {
 	case KBSearchSemantic:
-		sql, args = semanticSQL, []any{embedding.String(), collectionNames, k}
+		sql, args = semanticSQL, []any{embedding.String(), collectionNames, k, boostCollections}
 	case KBSearchKeyword:
-		sql, args = keywordSQL, []any{query, collectionNames, k}
+		sql, args = keywordSQL, []any{query, collectionNames, k, boostCollections}
 	default:
-		sql, args = hybridSQL, []any{embedding.String(), query, collectionNames, k}
+		sql, args = hybridSQL, []any{embedding.String(), query, collectionNames, k, boostCollections}
 	}
 
 	rows, err := db.Query(ctx, sql, args...)
@@ -178,13 +185,12 @@ func (s *KBStore) KBSearch(ctx context.Context, query string, embedding Vector, 
 }
 
 const (
-	// kbProjection joins chunk -> document -> collection, scoped by
-	// collection name — the sole point collection access control is
-	// enforced (D-060: Go code, never a prompt).
+	// kbProjection joins chunk -> document -> collection; col.name backs
+	// both the optional collection filter and the boost multiplier.
 	kbProjection = `SELECT c.id, d.id, d.title, col.name, c.breadcrumb, c.content, d.source_ref`
 
 	// kbQueryCTEq1/q2 normalize the query's lexemes and OR them
-	// together — same rationale as memories retrieval's textSQL: a
+	// together: same rationale as memories retrieval's textSQL: a
 	// multi-topic question must match each chunk that answers PART of
 	// it, which websearch/plainto AND-semantics would return nothing
 	// for. Lexemes are quoted (with '' doubling) so none can break the
@@ -197,21 +203,32 @@ const (
 			string_agg('''' || replace(lexeme, '''', '''''') || '''', ' | ')) AS query
 		FROM unnest(tsvector_to_array(to_tsvector('english', $2))) AS lexeme`
 
-	semanticSQL = kbProjection + `, 1 - (c.embedding <=> $1::vector) AS score
+	// collectionFilter matches every row when names is empty/null
+	// (whole-KB search), or scopes to it when non-empty (an explicit
+	// narrowing, still enforced in SQL).
+	collectionFilterQ2 = `(array_length($2::text[], 1) IS NULL OR col.name = ANY($2))`
+	collectionFilterQ3 = `(array_length($3::text[], 1) IS NULL OR col.name = ANY($3))`
+
+	// boostMultiplier scores a boosted-collection chunk higher without
+	// excluding anything else: CASE, not a WHERE filter.
+	boostMultiplierQ4 = `(CASE WHEN col.name = ANY($4::text[]) THEN ` + boostFactorLit + ` ELSE 1 END)`
+	boostMultiplierQ5 = `(CASE WHEN col.name = ANY($5::text[]) THEN ` + boostFactorLit + ` ELSE 1 END)`
+
+	semanticSQL = kbProjection + `, (1 - (c.embedding <=> $1::vector)) * ` + boostMultiplierQ4 + ` AS score
 		FROM kb_chunks c
 		JOIN kb_documents d ON d.id = c.document_id
 		JOIN kb_collections col ON col.id = d.collection_id
-		WHERE col.name = ANY($2) AND c.embedding IS NOT NULL
+		WHERE ` + collectionFilterQ2 + ` AND c.embedding IS NOT NULL
 		  AND 1 - (c.embedding <=> $1::vector) >= ` + minSimilarityLit + `
-		ORDER BY c.embedding <=> $1::vector
+		ORDER BY score DESC
 		LIMIT $3`
 
 	keywordSQL = `WITH q AS (` + kbQueryCTEq1 + `)
-		` + kbProjection + `, ts_rank(c.tsv, q.query) AS score
+		` + kbProjection + `, ts_rank(c.tsv, q.query) * ` + boostMultiplierQ4 + ` AS score
 		FROM kb_chunks c
 		JOIN kb_documents d ON d.id = c.document_id
 		JOIN kb_collections col ON col.id = d.collection_id, q
-		WHERE col.name = ANY($2) AND c.tsv @@ q.query
+		WHERE ` + collectionFilterQ2 + ` AND c.tsv @@ q.query
 		ORDER BY score DESC
 		LIMIT $3`
 
@@ -219,14 +236,17 @@ const (
 	// Reciprocal Rank Fusion (k=60), same fusion constant as the
 	// memories retrieval package. Each leg carries its own relevance
 	// gate (similarity floor / lexeme match), so an off-topic query
-	// yields an empty result instead of the k least-far chunks.
-	// $1 embedding, $2 query, $3 collection names, $4 result count.
+	// yields an empty result instead of the k least-far chunks. The
+	// boost multiplies the fused score, applied once at the end (not
+	// per-leg) so it can't double-count a chunk found by both legs.
+	// $1 embedding, $2 query, $3 collection names, $4 result count,
+	// $5 boost collection names.
 	hybridSQL = `WITH q AS (` + kbQueryCTEq2 + `), vec AS (
 			SELECT c.id, row_number() OVER (ORDER BY c.embedding <=> $1::vector) AS rank
 			FROM kb_chunks c
 			JOIN kb_documents d ON d.id = c.document_id
 			JOIN kb_collections col ON col.id = d.collection_id
-			WHERE col.name = ANY($3) AND c.embedding IS NOT NULL
+			WHERE ` + collectionFilterQ3 + ` AND c.embedding IS NOT NULL
 			  AND 1 - (c.embedding <=> $1::vector) >= ` + minSimilarityLit + `
 			ORDER BY c.embedding <=> $1::vector
 			LIMIT ` + legLimitLit + `
@@ -235,7 +255,7 @@ const (
 			FROM kb_chunks c
 			JOIN kb_documents d ON d.id = c.document_id
 			JOIN kb_collections col ON col.id = d.collection_id, q
-			WHERE col.name = ANY($3) AND c.tsv @@ q.query
+			WHERE ` + collectionFilterQ3 + ` AND c.tsv @@ q.query
 			ORDER BY rank
 			LIMIT ` + legLimitLit + `
 		), fused AS (
@@ -243,11 +263,11 @@ const (
 			FROM (SELECT id, rank FROM vec UNION ALL SELECT id, rank FROM fts) legs
 			GROUP BY id
 		)
-		` + kbProjection + `, fused.score
+		` + kbProjection + `, fused.score * ` + boostMultiplierQ5 + ` AS score
 		FROM fused
 		JOIN kb_chunks c ON c.id = fused.id
 		JOIN kb_documents d ON d.id = c.document_id
 		JOIN kb_collections col ON col.id = d.collection_id
-		ORDER BY fused.score DESC
+		ORDER BY score DESC
 		LIMIT $4`
 )

--- a/internal/memory/store/kb_golden_integration_test.go
+++ b/internal/memory/store/kb_golden_integration_test.go
@@ -58,12 +58,12 @@ type kbGolden struct {
 }
 
 var kbGoldens = []kbGolden{
-	// vector group — no lexical overlap
+	// vector group: no lexical overlap
 	{text: "where do the logs go?", dim: 1, want: "v-loki"},
 	{text: "how long are request journeys kept?", dim: 2, want: "v-tempo"},
 	{text: "what happens to old measurements?", dim: 3, want: "v-mimir"},
 
-	// keyword group — shared words, useless embedding
+	// keyword group: shared words, useless embedding
 	{text: "grafana alloy node exporters", dim: 900, want: "t-alloy"},
 	{text: "opentelemetry collector fans out", dim: 901, want: "t-otel"},
 	{text: "dashboards provisioning JSON", dim: 902, want: "t-dash"},
@@ -151,7 +151,7 @@ func TestKBGoldenRecall(t *testing.T) {
 	st := seedKBGolden(t)
 	hitCount := 0
 	for _, q := range kbGoldens {
-		hits, err := st.KBSearch(t.Context(), q.text, kbBasis(q.dim), []string{kbGoldenCollection}, KBSearchHybrid, 5)
+		hits, err := st.KBSearch(t.Context(), q.text, kbBasis(q.dim), []string{kbGoldenCollection}, nil, KBSearchHybrid, 5)
 		if err != nil {
 			t.Fatalf("KBSearch %q: %v", q.text, err)
 		}
@@ -172,13 +172,56 @@ func TestKBGoldenRecall(t *testing.T) {
 	}
 }
 
+// TestKBGoldenEmptyCollectionsSearchesWholeKB pins issue #368's default:
+// nil/empty collectionNames must not scope the search at all: hits
+// from both seeded collections come back for a query that matches
+// content present in both.
+func TestKBGoldenEmptyCollectionsSearchesWholeKB(t *testing.T) {
+	st := seedKBGolden(t)
+	hits, err := st.KBSearch(t.Context(), "where do the logs go?", kbBasis(1), nil, nil, KBSearchHybrid, 10)
+	if err != nil {
+		t.Fatalf("KBSearch: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, h := range hits {
+		seen[h.Collection] = true
+	}
+	if !seen[kbGoldenCollection] || !seen[kbGoldenOther] {
+		t.Fatalf("whole-KB search got collections %v, want both %s and %s", seen, kbGoldenCollection, kbGoldenOther)
+	}
+}
+
+// TestKBGoldenBoostRanksHigherWithoutFiltering pins the boost contract:
+// a collection in boostCollections must never hide the other
+// collection's equally-relevant chunk, it only has to rank first.
+func TestKBGoldenBoostRanksHigherWithoutFiltering(t *testing.T) {
+	st := seedKBGolden(t)
+	hits, err := st.KBSearch(t.Context(), "where do the logs go?", kbBasis(1), nil, []string{kbGoldenOther}, KBSearchHybrid, 10)
+	if err != nil {
+		t.Fatalf("KBSearch: %v", err)
+	}
+	if len(hits) < 2 {
+		t.Fatalf("got %d hits, want at least 2 (one per collection)", len(hits))
+	}
+	seen := map[string]bool{}
+	for _, h := range hits {
+		seen[h.Collection] = true
+	}
+	if !seen[kbGoldenCollection] || !seen[kbGoldenOther] {
+		t.Fatalf("boost filtered out a collection: got %v, want both present", seen)
+	}
+	if hits[0].Collection != kbGoldenOther {
+		t.Fatalf("top hit collection = %q, want boosted collection %q ranked first", hits[0].Collection, kbGoldenOther)
+	}
+}
+
 func TestKBGoldenOffTopicReturnsNothing(t *testing.T) {
 	st := seedKBGolden(t)
 	// No lexical overlap with any chunk (mind stemming: "filings"
 	// would match "files"), embedding on an unused axis: both legs
-	// must gate it out — returning nothing beats returning the k
+	// must gate it out: returning nothing beats returning the k
 	// least-far chunks.
-	hits, err := st.KBSearch(t.Context(), "quarterly marmalade recipes for zebras", kbBasis(950), []string{kbGoldenCollection}, KBSearchHybrid, 5)
+	hits, err := st.KBSearch(t.Context(), "quarterly marmalade recipes for zebras", kbBasis(950), []string{kbGoldenCollection}, nil, KBSearchHybrid, 5)
 	if err != nil {
 		t.Fatalf("KBSearch: %v", err)
 	}
@@ -191,7 +234,7 @@ func TestKBGoldenKeywordOnlyMultiTopic(t *testing.T) {
 	st := seedKBGolden(t)
 	hits, err := st.KBSearch(t.Context(),
 		"how does alloy scrape exporters and where do dashboards provision from?",
-		nil, []string{kbGoldenCollection}, KBSearchKeyword, 5)
+		nil, []string{kbGoldenCollection}, nil, KBSearchKeyword, 5)
 	if err != nil {
 		t.Fatalf("KBSearch: %v", err)
 	}
@@ -204,14 +247,14 @@ func TestKBGoldenKeywordOnlyMultiTopic(t *testing.T) {
 func TestKBGoldenSemanticFloor(t *testing.T) {
 	st := seedKBGolden(t)
 	// On-axis query hits; orthogonal query (similarity 0) must not.
-	hits, err := st.KBSearch(t.Context(), "anything", kbBasis(1), []string{kbGoldenCollection}, KBSearchSemantic, 5)
+	hits, err := st.KBSearch(t.Context(), "anything", kbBasis(1), []string{kbGoldenCollection}, nil, KBSearchSemantic, 5)
 	if err != nil {
 		t.Fatalf("KBSearch: %v", err)
 	}
 	if got := kbHitKeys(t, hits); !got["v-loki"] || len(hits) != 1 {
 		t.Fatalf("semantic on-axis: got %d hits %v, want exactly v-loki", len(hits), got)
 	}
-	hits, err = st.KBSearch(t.Context(), "anything", kbBasis(999), []string{kbGoldenCollection}, KBSearchSemantic, 5)
+	hits, err = st.KBSearch(t.Context(), "anything", kbBasis(999), []string{kbGoldenCollection}, nil, KBSearchSemantic, 5)
 	if err != nil {
 		t.Fatalf("KBSearch: %v", err)
 	}

--- a/web/src/components/settings/AgentForm.tsx
+++ b/web/src/components/settings/AgentForm.tsx
@@ -47,7 +47,7 @@ export function useAgentForm(agent?: AdminAgent) {
   const [harness, setHarness] = useState(agent?.harness ?? '')
 
   // Edit loads its agent asynchronously, after this hook has already
-  // mounted with blank defaults — useState's initializer only runs
+  // mounted with blank defaults: useState's initializer only runs
   // once, so the fields never pick up the fetched agent without this.
   useEffect(() => {
     if (!agent) return
@@ -100,7 +100,7 @@ export function useAgentForm(agent?: AdminAgent) {
   }
 }
 
-// AgentForm renders the shared field set for both create and edit —
+// AgentForm renders the shared field set for both create and edit:
 // name is a one-time slug fixed at creation (it lives in ledger rows
 // and event payloads), so it's the only field Add shows that Edit
 // doesn't.
@@ -193,7 +193,7 @@ export function AgentForm({
       <Field label="Tools allowlist" hint="pick from the live tool surface; empty = none">
         <ToolsPicker value={fields.tools} onChange={fields.setTools} />
       </Field>
-      <Field label="Knowledge allowlist" hint="collections this agent can search with search_kb; empty = none">
+      <Field label="Knowledge allowlist" hint="search_kb always searches the whole knowledge base; these collections rank higher in results">
         <KnowledgePicker value={fields.knowledge} onChange={fields.setKnowledge} />
       </Field>
     </div>


### PR DESCRIPTION
## Why

Closes #368. Curated knowledge should be reachable in every chat and mission turn without remembering to attach collections; collections stay as organization and become a relevance boost, not an access gate (D-078).

## Changes

- `search_kb`/`read_kb` offered whenever a KB backend is wired: chat's gate drops the `len(collections) > 0` condition, missions' runner drops `len(m.Knowledge) > 0`. The nil-backend feature-off gate is untouched, as is the #229 tool allowlist (separate mechanism, verified).
- `KBStore.KBSearch` gains `boostCollections`: `collectionNames` becomes an optional hard filter (nil = whole KB; kept for future callers, both current callers pass nil), boost is a 1.5x score multiplier applied once post-fusion so dual-leg hits aren't double-boosted. Threads through memoryd's API (`boost_collections`), memclient, and brain wiring.
- `read_kb` collection access gate removed: any document resolves by id.
- AgentForm knowledge hint updated to boost wording.

## Verification

- Unit: build, vet, vet -tags integration, `go test -race ./internal/...` clean (containerized).
- `make test-integration` full suite green against the live stack, including new KB golden tests: empty collections searches whole KB; boosted collection ranks higher without filtering others.
- `make canary` PASS with brain + memoryd rebuilt from this branch.

## Notes

Both memoryd and brain must deploy together (memoryd API adds `boost_collections`); they always do via compose.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790687528&installation_model_id=431401&pr_number=404&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F404&signature=8149627fdb6a9d23d2921ed5e03d864537bc1ef7f32e8c955a70dfe1e49fb154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->