### PR TITLE
feat(missions): nudge explore phase to search the kb first

### DIFF
--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -380,6 +380,25 @@ func (r *nativeRunner) kbReadTool(m Mission) *tools.Tool {
 	})
 }
 
+// kbExploreNudge tells the explorer a curated knowledge base is
+// available and to search it before concluding no research is needed
+// (issue #367): explore turns were finishing in seconds with zero
+// search_kb calls, silently skipping directly relevant curated
+// articles. Empty when no KB backend is wired, so the tool-absent case
+// never mentions a tool the model doesn't have. When the mission has
+// its own Knowledge collections, they are named as operator-attached
+// and prioritized (they already boost search_kb ranking, D-078).
+func (r *nativeRunner) kbExploreNudge(m Mission) string {
+	if r.kbSearch == nil {
+		return ""
+	}
+	nudge := " A curated knowledge base is available via search_kb: search it for anything relevant to the goal before concluding no research is needed."
+	if len(m.Knowledge) > 0 {
+		nudge += " The operator attached these collections, prioritized in results: " + strings.Join(m.Knowledge, ", ") + "."
+	}
+	return nudge
+}
+
 // connectorReadTools resolves m's read-only connector tools (nil
 // resolver or no agent id means none): appended to worker/explore
 // ExtraTools so a scheduled mission (daily inbox digest, calendar
@@ -942,7 +961,7 @@ func forcedRetryVerdict(reason string) WorkerVerdict {
 // so the ladder's last resort is the raw turn text rather than a forced
 // failure.
 func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, error) {
-	system := "You are exploring one mission before it is planned. Investigate the goal: explore the workspace with shell (read-only — do not create or modify files; the execute phase does the actual work), and use web search/fetch tools if available and relevant to the goal. If the goal is self-contained and needs no exploration, say so briefly. End your turn with exactly one explore_notes tool call whose findings field contains everything the planner needs: what exists, what's relevant, constraints, gotchas, unknowns." + toolDisciplineNote + r.execEnvironmentNote(ctx)
+	system := "You are exploring one mission before it is planned. Investigate the goal: explore the workspace with shell (read-only — do not create or modify files; the execute phase does the actual work), and use web search/fetch tools if available and relevant to the goal. If the goal is self-contained and needs no exploration, say so briefly. End your turn with exactly one explore_notes tool call whose findings field contains everything the planner needs: what exists, what's relevant, constraints, gotchas, unknowns." + toolDisciplineNote + r.kbExploreNudge(m) + r.execEnvironmentNote(ctx)
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if m.ParentContext != "" {
 		user += "\n\nPrevious mission outcome:\n" + NeutralizeSlot(m.ParentContext)

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -1786,6 +1786,65 @@ func TestExploreSessionGetsShellButNotWriteFile(t *testing.T) {
 	}
 }
 
+// TestExploreSessionKBNudge pins issue #367: the explorer's system
+// prompt nudges it to search_kb before declaring a goal self-contained,
+// exactly when search_kb is offered (kbSearch wired); attached
+// Knowledge collections are named as operator-prioritized; no backend
+// means no mention of a tool the model doesn't have.
+func TestExploreSessionKBNudge(t *testing.T) {
+	notesBatch := [][]stream.StreamEvent{
+		{toolEndEvent(exploreNotesToolName, `{"findings":"nothing notable"}`)},
+	}
+
+	t.Run("no backend wired", func(t *testing.T) {
+		agent := &scriptedAgent{batches: notesBatch}
+		r := newTestRunner(agent)
+		if _, err := r.ExploreSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err != nil {
+			t.Fatalf("ExploreSession: %v", err)
+		}
+		if strings.Contains(agent.requests[0].System, "search_kb") {
+			t.Fatalf("explore system prompt mentions search_kb with no backend wired: %s", agent.requests[0].System)
+		}
+	})
+
+	t.Run("backend wired, no mission knowledge", func(t *testing.T) {
+		agent := &scriptedAgent{batches: notesBatch}
+		r := newTestRunner(agent)
+		r.kbSearch = func(ctx context.Context, query string, boostCollections []string, mode string, k int) ([]builtin.KBSearchHit, error) {
+			return nil, nil
+		}
+		if _, err := r.ExploreSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err != nil {
+			t.Fatalf("ExploreSession: %v", err)
+		}
+		system := agent.requests[0].System
+		if !strings.Contains(system, "search_kb") {
+			t.Fatalf("explore system prompt missing search_kb nudge with backend wired: %s", system)
+		}
+		if strings.Contains(system, "operator attached") {
+			t.Fatalf("explore system prompt names attached collections with none set: %s", system)
+		}
+	})
+
+	t.Run("backend wired and knowledge set", func(t *testing.T) {
+		agent := &scriptedAgent{batches: notesBatch}
+		r := newTestRunner(agent)
+		r.kbSearch = func(ctx context.Context, query string, boostCollections []string, mode string, k int) ([]builtin.KBSearchHit, error) {
+			return nil, nil
+		}
+		m := Mission{ID: "m1", Route: "default", Goal: "test", Knowledge: []string{"System Design"}}
+		if _, err := r.ExploreSession(context.Background(), m); err != nil {
+			t.Fatalf("ExploreSession: %v", err)
+		}
+		system := agent.requests[0].System
+		if !strings.Contains(system, "search_kb") {
+			t.Fatalf("explore system prompt missing search_kb nudge: %s", system)
+		}
+		if !strings.Contains(system, "operator attached") || !strings.Contains(system, "System Design") {
+			t.Fatalf("explore system prompt doesn't name attached collection: %s", system)
+		}
+	})
+}
+
 func TestRunTurnBareCloseIsError(t *testing.T) {
 	agent := &scriptedAgent{rawClose: true, batches: [][]stream.StreamEvent{{
 		textEvent("partial work"),


### PR DESCRIPTION
## Why

Closes #367. Explore turns skipped curated knowledge and declared goals self-contained (mission aca04d5d: zero kb searches despite a directly relevant attached article).

## Changes

- `kbExploreNudge(m)` in `internal/brain/missions/runner.go`, gated on `r.kbSearch != nil` (mirrors the D-078 tool-offering gate): appends to the explore system prompt an instruction to search the kb via search_kb before concluding no research is needed; names operator-attached collections when the mission has Knowledge. Returns empty when no backend is wired, so the prompt never mentions an absent tool. Prompt-only, no Go-side enforcement.

## Verification

- `go build`, `go vet`, `go test -race ./internal/brain/missions/` clean (containerized).
- `TestExploreSessionKBNudge`: nudge present when wired, absent when not, collections named when set.
- `make canary` PASS with brain rebuilt from this branch (7 turns incl. a replan and 2 retries, all within budget).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790688142&installation_model_id=431401&pr_number=405&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F405&signature=167238ff3bfbe246a55dd7463c7642da0e8563499c258ea57592e6d3e60bf344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->