### PR TITLE
fix(kb): surface ingest failure reason in ui, bound stored error

### DIFF
--- a/internal/brain/kb/kb.go
+++ b/internal/brain/kb/kb.go
@@ -317,6 +317,10 @@ func (s *Store) SetIngesting(ctx context.Context, id string) error {
 	return nil
 }
 
+// kbErrorCap bounds the stored failure reason: memclient/gwclient
+// errors can carry a whole gateway response body (issue #408).
+const kbErrorCap = 500
+
 // SetFailed marks a document failed: used when brain itself (not
 // memoryd) hits an error before the ingest call ever reaches memoryd,
 // e.g. memoryd unreachable.
@@ -325,10 +329,17 @@ func (s *Store) SetFailed(ctx context.Context, id, errMsg string) error {
 	if err != nil {
 		return fmt.Errorf("kb document %s failed: %w", id, err)
 	}
-	if _, err := db.Exec(ctx, `UPDATE kb_documents SET status = 'failed', error = $2, updated_at = now() WHERE id = $1`, id, errMsg); err != nil {
+	if _, err := db.Exec(ctx, `UPDATE kb_documents SET status = 'failed', error = $2, updated_at = now() WHERE id = $1`, id, truncate(errMsg, kbErrorCap)); err != nil {
 		return fmt.Errorf("kb document %s failed: %w", id, err)
 	}
 	return nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
 }
 
 // FindDocumentBySource looks up a document by its dedup key

--- a/internal/brain/kb/kb_test.go
+++ b/internal/brain/kb/kb_test.go
@@ -1,0 +1,29 @@
+package kb
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTruncate pins SetFailed's error cap (issue #408): chain_exhausted
+// errors can carry every attempt's underlying provider message, which
+// must stay bounded before it lands in kb_documents.error.
+func TestTruncate(t *testing.T) {
+	t.Parallel()
+	short := "embedding failed: provider_error"
+	if got := truncate(short, kbErrorCap); got != short {
+		t.Fatalf("truncate(short) = %q, want unchanged", got)
+	}
+
+	long := strings.Repeat("ValidationException: 400 Bad Request: Too many input tokens. ", 20)
+	got := truncate(long, kbErrorCap)
+	if len(got) <= kbErrorCap {
+		t.Fatalf("truncated length = %d, want > cap (includes the … marker)", len(got))
+	}
+	if len(got) > kbErrorCap+len("…") {
+		t.Fatalf("truncated length = %d, want <= cap+marker", len(got))
+	}
+	if got[:kbErrorCap] != long[:kbErrorCap] {
+		t.Fatal("truncate must keep the original prefix")
+	}
+}

--- a/internal/memory/api/kb.go
+++ b/internal/memory/api/kb.go
@@ -97,13 +97,25 @@ func (a *API) handleIngest(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]any{"chunk_count": len(chunks)})
 }
 
+// kbErrorCap bounds the stored failure reason: gateway chain-exhaustion
+// errors carry every attempt's underlying provider message, which can
+// run long (issue #408).
+const kbErrorCap = 500
+
 func (a *API) reportKBFailed(ctx context.Context, documentID, msg string) {
 	if a.kbDocs == nil {
 		return
 	}
-	if err := a.kbDocs.SetFailed(ctx, documentID, msg); err != nil {
+	if err := a.kbDocs.SetFailed(ctx, documentID, truncate(msg, kbErrorCap)); err != nil {
 		a.log.Warn("kb ingest failure report failed", "document_id", documentID, "error", err)
 	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
 }
 
 type kbSearchRequest struct {

--- a/internal/memory/api/kb_test.go
+++ b/internal/memory/api/kb_test.go
@@ -174,6 +174,30 @@ func TestIngestEmbeddingFailureReportsFailedStatus(t *testing.T) {
 	if docs.failedID != "doc-2" {
 		t.Fatalf("failure not reported: %+v", docs)
 	}
+	if !strings.Contains(docs.failedMsg, "gateway down") {
+		t.Fatalf("failedMsg = %q, want the underlying provider error", docs.failedMsg)
+	}
+}
+
+// TestIngestEmbeddingFailureTruncatesStoredError pins issue #408: a
+// chain_exhausted error carrying every attempt's provider message must
+// stay bounded to kbErrorCap before it reaches kb_documents.error.
+func TestIngestEmbeddingFailureTruncatesStoredError(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("ValidationException: 400 Bad Request: Too many input tokens. ", 20)
+	docs := &fakeDocStatus{}
+	a := kbAPIFor(&fakeKB{}, docs, &fakeEmbedder{err: errors.New(long)})
+	rec := postJSON(t, a.handleIngest, "/v1/ingest-document", `{"document_id":"doc-2b","markdown":"content"}`)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	if len(docs.failedMsg) > kbErrorCap+len("…") {
+		t.Fatalf("stored error length = %d, want <= cap %d", len(docs.failedMsg), kbErrorCap)
+	}
+	if !strings.HasPrefix(docs.failedMsg, "embedding failed: "+long[:20]) {
+		t.Fatalf("stored error lost the underlying message prefix: %q", docs.failedMsg)
+	}
 }
 
 func TestIngestStoreFailureReportsFailedStatus(t *testing.T) {

--- a/web/src/components/knowledge/KnowledgeCollectionDetail.test.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionDetail.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { KbDocument } from '../../api/types'
 import { TooltipProvider } from '../ui/tooltip'
-import { ProvenanceBadge, SourceBadge } from './KnowledgeCollectionDetail'
+import { DocumentErrorLine, ProvenanceBadge, SourceBadge } from './KnowledgeCollectionDetail'
 
 afterEach(cleanup)
 
@@ -61,5 +61,30 @@ describe('ProvenanceBadge', () => {
   it('shows the provenance tier label', () => {
     render(<ProvenanceBadge doc={{ ...baseDoc, provenance: 'mission' }} />)
     expect(screen.getByText('Mission')).toBeInTheDocument()
+  })
+})
+
+describe('DocumentErrorLine', () => {
+  afterEach(cleanup)
+
+  it('renders the failure reason for a failed document with an error', () => {
+    const doc: KbDocument = { ...baseDoc, status: 'failed', error: 'chain_exhausted: too many input tokens' }
+    render(<DocumentErrorLine doc={doc} />)
+    const line = screen.getByText('chain_exhausted: too many input tokens')
+    expect(line).toBeInTheDocument()
+    expect(line).toHaveAttribute('title', doc.error)
+    expect(line).toHaveClass('text-red-400')
+  })
+
+  it('renders nothing for a ready document', () => {
+    const doc: KbDocument = { ...baseDoc, status: 'ready', error: '' }
+    const { container } = render(<DocumentErrorLine doc={doc} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing for a failed document with no error text', () => {
+    const doc: KbDocument = { ...baseDoc, status: 'failed', error: '' }
+    const { container } = render(<DocumentErrorLine doc={doc} />)
+    expect(container).toBeEmptyDOMElement()
   })
 })

--- a/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
@@ -111,6 +111,18 @@ function StatusBadge({ doc }: { doc: KbDocument }) {
   )
 }
 
+// DocumentErrorLine surfaces the ingest failure reason (issue #408): a
+// one-line, title-tooltipped clamp under the title cell, matching the
+// mission failure text-red-400 + title pattern (eventRenderers.tsx).
+export function DocumentErrorLine({ doc }: { doc: KbDocument }) {
+  if (doc.status !== 'failed' || !doc.error) return null
+  return (
+    <p className="mt-0.5 truncate text-xs text-red-400" title={doc.error}>
+      {doc.error}
+    </p>
+  )
+}
+
 // pending/ingesting documents are polled every 3s until every
 // document in the collection reaches a terminal state.
 const pollMs = 3000
@@ -261,9 +273,12 @@ export function KnowledgeCollectionDetail() {
               <tbody>
                 {documents.map((doc) => (
                   <tr key={doc.id} className="border-b border-border last:border-0">
-                    <td className="flex items-center gap-2 px-3 py-2">
-                      <HugeiconsIcon icon={File02Icon} className="size-4 shrink-0 text-muted-foreground" />
-                      <span className="truncate">{doc.title}</span>
+                    <td className="px-3 py-2">
+                      <div className="flex items-center gap-2">
+                        <HugeiconsIcon icon={File02Icon} className="size-4 shrink-0 text-muted-foreground" />
+                        <span className="truncate">{doc.title}</span>
+                      </div>
+                      <DocumentErrorLine doc={doc} />
                     </td>
                     <td className="px-3 py-2">
                       <div className="flex items-center gap-1.5">


### PR DESCRIPTION
## Why

Closes #408. Companion to #409: when ingest fails, the reason must be visible where the operator looks, not buried in the API response.

## Changes

- `KnowledgeCollectionDetail.tsx`: `DocumentErrorLine` renders a truncated, red, hover-for-full error line under the title for `status=failed` docs (mission-failure display precedent). Ready/ingesting rows unchanged.
- Propagation audit: the gateway already joins each attempt's underlying provider error into the `chain_exhausted` body (`handleEmbed`), and it survives every hop into `kb_documents.error`; no content fix needed. Added the missing bound: 500-char truncation at both write points (`reportKBFailed` in memoryd, `Store.SetFailed` in brain).
- No redaction change: the text was already exposed at the same trust level at every hop; this only bounds length.

## Verification

- Go: build, vet, vet -tags integration, `go test -race ./internal/...` clean; truncation unit tests + underlying-message survival assertion.
- Web: build + lint clean; 971/973 (two known AgentRoutePicker flakes); new component tests 7/7.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790690574&installation_model_id=431401&pr_number=410&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F410&signature=dc9b11355677fc40f9c979310325de1509f1770669a3fdc3617d4ed37ceae502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->