### PR TITLE
feat(missions): promote markdown artifacts into kb on completion

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -286,6 +286,11 @@ func main() {
 		}
 		return name
 	}
+	// Built here, above buildMissions/ValidateDeps wiring, so the
+	// create-time promote_kb_collection_id check (KBCollectionExists
+	// below) can close over the same store the kb admin API and mission
+	// promotion hook use later in this function.
+	kbStore := kb.New(app.DB)
 	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub, missionScheduler := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, fxStore, gwc, secrets, conns, mc, packs, app.Log)
 	if missionDriver != nil {
 		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, missionNotifier, app.Log)
@@ -312,6 +317,15 @@ func main() {
 		}
 		if destinationStore != nil {
 			deps.DestinationEnabled = destinationStore.EnabledByID
+		}
+		deps.KBCollectionExists = func(ctx context.Context, id string) (bool, error) {
+			if _, err := kbStore.GetCollection(ctx, id); err != nil {
+				if errors.Is(err, kb.ErrNotFound) {
+					return false, nil
+				}
+				return false, err
+			}
+			return true, nil
 		}
 		missionDriver.SetValidateDeps(deps)
 	}
@@ -632,6 +646,16 @@ func main() {
 		missionDriver.SetArtifactCopy(destinations.CopyArtifacts(attachmentStore, app.Log))
 	}
 
+	// Mission kb promotion (D-081, issue #370): the terminal-done
+	// auto-fire hook for promote_kb_collection_id, sharing PromoteMission
+	// with the manual POST .../promote-kb endpoint so neither path can
+	// diverge on what "promote" means. Nil-gated on attachmentStore, same
+	// as artifact copy above (promotion reads from the attachment-store
+	// refs artifact copy just wrote).
+	if attachmentStore != nil && missionDriver != nil {
+		missionDriver.SetPromoteKB(destinations.PromoteKB(attachmentStore, kbStore, mc, app.Log))
+	}
+
 	// search_kb: nil-safe wiring, same shape as memory retrieve/extract
 	// above: mc satisfies IngestDocument/KBSearch unconditionally, so
 	// this always wires (memoryd unreachable surfaces as a per-call
@@ -639,7 +663,6 @@ func main() {
 	// default). Searches the whole KB (nil collectionNames); the
 	// serving agent's Knowledge only rides along as boostCollections
 	// (D-078, issue #368).
-	kbStore := kb.New(app.DB)
 	// Ingest goroutines die with the process; fail anything a previous
 	// run left mid-ingest so the UI offers reingest instead of an
 	// eternal spinner. On its own goroutine behind WaitHealthy: at this

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -159,7 +159,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	if destinationStore != nil {
 		destLookup = destinationStore
 	}
-	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret, routeForRole, missionClassify, codingExecutorDefault, resolveRoute, nameMission, topModels, conns, missionAttachments, markitdownURL, pdfService)
+	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret, routeForRole, missionClassify, codingExecutorDefault, resolveRoute, nameMission, topModels, conns, missionAttachments, markitdownURL, pdfService, kbStore, kbIngest)
 	a.registerSchedules(srv.Handle, missionStore, destLookup)
 	// destinationRefs/destinationScheduleRefs are *missions.Store itself
 	// (ActiveMissionReferencesDestination / ScheduleReferencingDestinationID) —

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -18,7 +18,9 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/attachments"
 	"github.com/SumonMSelim/timothy/internal/brain/chat"
 	"github.com/SumonMSelim/timothy/internal/brain/connectors"
+	"github.com/SumonMSelim/timothy/internal/brain/destinations"
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/brain/kb"
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
 	"github.com/SumonMSelim/timothy/internal/brain/missions/executor"
 	pdfgenservice "github.com/SumonMSelim/timothy/internal/brain/pdfgen"
@@ -73,7 +75,7 @@ type missionAttachmentStore interface {
 // (not *attachments.Store) so the caller's own nil-box guard (a nil
 // *attachments.Store boxed here would be a non-nil interface value)
 // happens once, at the call site — same shape as chat.Service.SetAttachments.
-func (a *API) registerMissions(handle func(pattern string, h http.Handler), store *missions.Store, driver *missions.Driver, notifier *missions.Notifier, agentReg *agents.Store, workspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, classify agents.Classify, codingExecutorDefault func(context.Context) string, resolveRoute func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), conns *connectors.Manager, attachmentStore missionAttachmentStore, markitdownURL string, pdfService *pdfgenservice.Service) {
+func (a *API) registerMissions(handle func(pattern string, h http.Handler), store *missions.Store, driver *missions.Driver, notifier *missions.Notifier, agentReg *agents.Store, workspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, classify agents.Classify, codingExecutorDefault func(context.Context) string, resolveRoute func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), conns *connectors.Manager, attachmentStore missionAttachmentStore, markitdownURL string, pdfService *pdfgenservice.Service, kbStore *kb.Store, kbIngest kbIngester) {
 	if store == nil {
 		return
 	}
@@ -101,7 +103,7 @@ func (a *API) registerMissions(handle func(pattern string, h http.Handler), stor
 			return a.Harness, true
 		}
 	}
-	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, resolveAgentRoute: resolveAgentRoute, resolveAgentHarness: resolveAgentHarness, workspace: workspace, resolveSecret: resolveSecret, routeForRole: routeForRole, classify: classify, codingExecutorDefault: codingExecutorDefault, resolveRoute: resolveRoute, nameMission: nameMission, topModels: topModels, conns: conns, perms: a.perms, dir: a.dir, log: a.log, attachments: attachmentStore, markitdownURL: markitdownURL, markitdownHTTP: &http.Client{}, pdfService: pdfService, resolveReferences: a.svc.ResolveReferences}
+	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, resolveAgentRoute: resolveAgentRoute, resolveAgentHarness: resolveAgentHarness, workspace: workspace, resolveSecret: resolveSecret, routeForRole: routeForRole, classify: classify, codingExecutorDefault: codingExecutorDefault, resolveRoute: resolveRoute, nameMission: nameMission, topModels: topModels, conns: conns, perms: a.perms, dir: a.dir, log: a.log, attachments: attachmentStore, markitdownURL: markitdownURL, markitdownHTTP: &http.Client{}, pdfService: pdfService, resolveReferences: a.svc.ResolveReferences, kbStore: kbStore, kbIngest: kbIngest}
 	handle("GET /v1/missions", a.auth(http.HandlerFunc(h.list)))
 	handle("POST /v1/missions", a.auth(http.HandlerFunc(h.create)))
 	handle("POST /v1/missions/classify", a.auth(http.HandlerFunc(h.classifyGoal)))
@@ -118,6 +120,7 @@ func (a *API) registerMissions(handle func(pattern string, h http.Handler), stor
 	handle("GET /v1/missions/{id}/files/{path...}", a.auth(http.HandlerFunc(h.download)))
 	handle("GET /v1/missions/{id}/archive", a.auth(http.HandlerFunc(h.archive)))
 	handle("POST /v1/missions/{id}/export-pdf", a.auth(http.HandlerFunc(h.exportPDF)))
+	handle("POST /v1/missions/{id}/promote-kb", a.auth(http.HandlerFunc(h.promoteKB)))
 	handle("POST /v1/missions/{id}/push", a.auth(http.HandlerFunc(h.push)))
 	handle("POST /v1/missions/{id}/pr", a.auth(http.HandlerFunc(h.pr)))
 	handle("GET /v1/notifications", a.auth(http.HandlerFunc(h.notifications)))
@@ -196,6 +199,12 @@ type missionAPI struct {
 	// pdfService renders export-pdf requests via the pdfgen sidecar; nil
 	// (PDFGEN_URL unset or attachments disabled) 503s the endpoint.
 	pdfService *pdfgenservice.Service
+	// kbStore/kbIngest back POST .../promote-kb (D-081, issue #370): nil
+	// kbStore (kb disabled) or nil kbIngest (memoryd unreachable is a
+	// runtime error, not expected here since mc always resolves) 503s
+	// the endpoint the same way pdfService's absence does export-pdf.
+	kbStore  *kb.Store
+	kbIngest kbIngester
 	// resolveReferences resolves a create request's picked #-mention
 	// references (mission/session/kb doc) into documents: chat.Service's
 	// own resolver (chat.go's ResolveReferences), reused here so a
@@ -444,6 +453,13 @@ type createMissionRequest struct {
 	// enabled at create time (see create() below); the model never
 	// supplies or addresses a destination (D-061).
 	DestinationIDs []string `json:"destination_ids"`
+	// PromoteKBCollectionID (D-081, issue #370) names a kb collection to
+	// promote this mission's markdown artifacts into on the terminal
+	// done transition: "" (default) promotes nothing automatically;
+	// validated to exist at create time (missions.ValidateCreate), the
+	// model never supplies or addresses it, same invariant as
+	// DestinationIDs.
+	PromoteKBCollectionID string `json:"promote_kb_collection_id"`
 	// Light requests a mission that skips explore/plan/review (D-069):
 	// kind=general only, rejected outright on kind=coding (explicit or
 	// classified). Always the operator's explicit choice — the classify
@@ -617,7 +633,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		RepoURL: req.RepoURL, ConnectorID: req.ConnectorID, OnComplete: req.OnComplete,
 		BranchPattern: req.BranchPattern, CommitStyle: req.CommitStyle,
 		ParentMissionID: parentMissionID, ParentContext: parentContext, ReferencedContext: referencedContext,
-		Attachments: missionAtts, DestinationIDs: req.DestinationIDs, Light: req.Light,
+		Attachments: missionAtts, DestinationIDs: req.DestinationIDs, PromoteKBCollectionID: req.PromoteKBCollectionID, Light: req.Light,
 	}
 	id, err := h.driver.Create(r.Context(), m)
 	if err != nil {
@@ -1530,6 +1546,72 @@ func (h *missionAPI) exportPDF(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"attachment_id": result.AttachmentID, "cached": result.Cached})
+}
+
+// promoteKB serves POST .../promote-kb: promotes a done mission's
+// markdown artifact refs into collection_id as kb documents with
+// provenance='mission' (D-081, issue #370): destinations.PromoteMission
+// does the actual work, the SAME code path the terminal-done auto-fire
+// hook (promote_kb_collection_id) uses, so a manual promote and an
+// auto-fired one can never diverge. Done-only: a failed mission's
+// artifacts are unverified (CheckArtifacts never ran to completion),
+// so promoting them would put unverified content into search results.
+// Idempotent: see PromoteMission's own doc comment.
+func (h *missionAPI) promoteKB(w http.ResponseWriter, r *http.Request) {
+	if h.kbStore == nil {
+		jsonError(w, http.StatusServiceUnavailable, "not_enabled", "knowledge base is not enabled")
+		return
+	}
+	m, err := h.store.Get(r.Context(), r.PathValue("id"))
+	if err != nil {
+		failMission(w, err)
+		return
+	}
+	if m.Phase != missions.PhaseDone {
+		jsonError(w, http.StatusBadRequest, "not_done", "only a mission in phase=done can be promoted")
+		return
+	}
+	var body struct {
+		CollectionID string `json:"collection_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, http.StatusBadRequest, "bad_request", "body must be JSON with a collection_id field")
+		return
+	}
+	if body.CollectionID == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "collection_id is required")
+		return
+	}
+	if _, err := h.kbStore.GetCollection(r.Context(), body.CollectionID); err != nil {
+		if errors.Is(err, kb.ErrNotFound) {
+			jsonError(w, http.StatusBadRequest, "bad_request", "unknown collection_id")
+			return
+		}
+		jsonError(w, http.StatusInternalServerError, "promote_failed", err.Error())
+		return
+	}
+	if len(m.ArtifactRefs) == 0 {
+		jsonError(w, http.StatusBadRequest, "no_artifacts", "mission has no artifacts to promote")
+		return
+	}
+	promoted, errs := destinations.PromoteMission(r.Context(), h.attachments, h.kbStore, h.kbIngest, m, body.CollectionID)
+	if promoted == 0 {
+		msg := "no markdown artifacts were promoted"
+		if len(errs) > 0 {
+			msg = errs[0].Error()
+		}
+		jsonError(w, http.StatusBadGateway, "promote_failed", msg)
+		return
+	}
+	resp := map[string]any{"promoted": promoted}
+	if len(errs) > 0 {
+		failed := make([]string, len(errs))
+		for i, e := range errs {
+			failed[i] = e.Error()
+		}
+		resp["failed"] = failed
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 var (

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -136,7 +136,7 @@ func TestMissionsResumeWithAnswerReachesWorker(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/resume", strings.NewReader(`{"answer":"the deploy target is staging"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -206,7 +206,7 @@ func TestMissionsResumeWithoutAnswerLeavesProgressUntouched(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/resume", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -250,7 +250,7 @@ func TestMissionsNoteAppendsEventAndProgressWithoutPhaseChange(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":"focus on the staging config next"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -296,7 +296,7 @@ func TestMissionsNoteUnknownMission(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/00000000-0000-0000-0000-000000000000/note", strings.NewReader(`{"text":"hello"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -320,7 +320,7 @@ func TestMissionsNoteEmptyTextRejected(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":""}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -350,7 +350,7 @@ func TestMissionsNoteTerminalMissionRejected(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":"too late"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -374,7 +374,7 @@ func TestMissionsCreateResponseCarriesDetectedEnvironment(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	body := `{"goal":"itest-api-mission write a Go CLI that parses logs","kind":"coding"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -413,7 +413,7 @@ func TestMissionsCreateCarriesPlanRoute(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	body := `{"goal":"itest-api-mission plan route round trip","kind":"general","route":"mini","plan_route":"strong"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -452,7 +452,7 @@ func TestMissionsCreateFollowUp(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	post := func(body string) (int, []byte) {
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -517,7 +517,7 @@ func TestMissionsCreateFollowUpUnknownParent(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	body := `{"goal":"itest-api-mission follow-up unknown parent","kind":"general","parent_mission_id":"00000000-0000-0000-0000-000000000000"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -572,7 +572,7 @@ func TestMissionsCreateWithPDFAttachment(t *testing.T) {
 		defer md.Close()
 
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil, nil, nil)
 
 		code, body := post(m, `{"goal":"itest-api-mission with attachment","kind":"general","attachments":[{"id":"`+att.ID+`","name":"spec.pdf"}]}`)
 		if code != http.StatusCreated {
@@ -637,7 +637,7 @@ func TestMissionsCreateWithPDFAttachment(t *testing.T) {
 		defer md.Close()
 
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil, nil, nil)
 
 		code, body := post(m, `{"goal":"itest-api-mission with huge attachment","kind":"general","attachments":[{"id":"`+att.ID+`"}]}`)
 		if code != http.StatusCreated {
@@ -666,7 +666,7 @@ func TestMissionsCreateWithPDFAttachment(t *testing.T) {
 		defer md.Close()
 
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil, nil, nil)
 
 		code, body := post(m, `{"goal":"itest-api-mission markitdown failure","kind":"general","attachments":[{"id":"`+att.ID+`"}]}`)
 		if code != http.StatusInternalServerError {
@@ -691,7 +691,7 @@ func TestMissionsCreateGeneratesNameAsync(t *testing.T) {
 	nameMission := func(ctx context.Context, goal string) string {
 		return "Parse Logs Utility"
 	}
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "", nil, nil, nil)
 
 	body := `{"goal":"itest-api-mission write a Go CLI that parses logs","kind":"general"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -739,7 +739,7 @@ func TestMissionsCreateNameFallsBackToEmptyOnGenerationFailure(t *testing.T) {
 		defer close(done)
 		return "" // simulates a gateway/timeout failure, same as TitleOverGateway
 	}
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "", nil, nil, nil)
 
 	body := `{"goal":"itest-api-mission a goal whose naming will fail","kind":"general"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -999,7 +999,7 @@ func TestMissionsPushResolvesConnectorToken(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/push", strings.NewReader(`{}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1071,7 +1071,7 @@ func TestMissionsPushConnectorTable(t *testing.T) {
 
 			a := &API{token: "tok", log: discard()}
 			m := mux(a)
-			a.registerMissions(m.Handle, store, nil, nil, nil, workspace, nil, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil)
+			a.registerMissions(m.Handle, store, nil, nil, nil, workspace, nil, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil, nil, nil)
 
 			req := httptest.NewRequest("POST", "/v1/missions/"+id+"/push", strings.NewReader(`{}`))
 			req.Header.Set("Authorization", "Bearer tok")
@@ -1105,7 +1105,7 @@ func TestMissionsPushExplicitCredentialRefOverridesConnector(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/push", strings.NewReader(`{"credential_ref":"explicit-ref"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1160,7 +1160,7 @@ func TestMissionsPRHappyPath(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/pr", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1237,7 +1237,7 @@ func TestMissionsPRAlreadyExistsReturnsExisting(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/pr", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1271,7 +1271,7 @@ func TestMissionsPRRejectsNonGitHubConnectionMission(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/pr", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1329,7 +1329,7 @@ func TestMissionsExportPDFBadPath(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/export-pdf", strings.NewReader(`{"path":"notes.txt"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1352,7 +1352,7 @@ func TestMissionsExportPDFTraversal(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/export-pdf", strings.NewReader(`{"path":"../../../etc/passwd.md"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1375,7 +1375,7 @@ func TestMissionsExportPDFNoMarkdownFiles(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/export-pdf", strings.NewReader(`{}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1399,7 +1399,7 @@ func TestMissionsExportPDFOverCap(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/export-pdf", strings.NewReader(`{"path":"big.md"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1429,7 +1429,7 @@ func TestMissionsExportPDFSingleFileHappyPath(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/export-pdf", strings.NewReader(`{"path":"report.md"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1498,7 +1498,7 @@ func TestMissionsExportPDFMergedHappyPath(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/export-pdf", strings.NewReader(`{}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1519,4 +1519,147 @@ func TestMissionsExportPDFMergedHappyPath(t *testing.T) {
 	if calls != 1 {
 		t.Fatalf("sidecar calls = %d, want 1", calls)
 	}
+}
+
+// TestMissionsPromoteKB covers POST .../promote-kb (D-081, issue #370):
+// the done-only gate, an unknown collection_id, the happy path
+// promoting one markdown artifact ref, and idempotency (re-promoting
+// replaces content rather than duplicating the kb document).
+func TestMissionsPromoteKB(t *testing.T) {
+	store := testMissionStore(t)
+	kbStore := testKBStore(t)
+	ctx := context.Background()
+
+	collectionID, err := kbStore.CreateCollection(ctx, "itest-promote-kb", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	newMission := func(t *testing.T) string {
+		t.Helper()
+		id, err := store.Create(ctx, missions.Mission{Goal: "itest-api-mission promote-kb test", Kind: "general"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		return id
+	}
+
+	fa := &fakeMissionAttachments{
+		byID: map[string]attachments.Attachment{
+			"report1": {ID: "report1", Mime: "text/plain", SizeBytes: int64(len("# Report\n\nfindings"))},
+		},
+		data: map[string][]byte{
+			"report1": []byte("# Report\n\nfindings"),
+		},
+	}
+
+	newAPI := func(t *testing.T, ingest kbIngester) *http.ServeMux {
+		t.Helper()
+		a := &API{token: "tok", log: discard()}
+		m := mux(a)
+		a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, fa, "", nil, kbStore, ingest)
+		return m
+	}
+
+	post := func(t *testing.T, m *http.ServeMux, id, body string) (int, []byte) {
+		t.Helper()
+		req := httptest.NewRequest("POST", "/v1/missions/"+id+"/promote-kb", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w.Code, w.Body.Bytes()
+	}
+
+	t.Run("not done rejects", func(t *testing.T) {
+		id := newMission(t)
+		m := newAPI(t, &fakeIngester{})
+		code, body := post(t, m, id, `{"collection_id":"`+collectionID+`"}`)
+		if code != http.StatusBadRequest || !strings.Contains(string(body), "phase=done") {
+			t.Fatalf("code=%d body=%s, want 400 not-done", code, body)
+		}
+	})
+
+	t.Run("missing collection_id rejects", func(t *testing.T) {
+		id := newMission(t)
+		if err := store.ApplyTransition(ctx, id, missions.Transition{Next: missions.StepState{Phase: missions.PhaseDone, Status: missions.StatusDone}}); err != nil {
+			t.Fatalf("ApplyTransition: %v", err)
+		}
+		m := newAPI(t, &fakeIngester{})
+		code, body := post(t, m, id, `{}`)
+		if code != http.StatusBadRequest || !strings.Contains(string(body), "collection_id is required") {
+			t.Fatalf("code=%d body=%s, want 400 collection_id-required", code, body)
+		}
+	})
+
+	t.Run("unknown collection_id rejects", func(t *testing.T) {
+		id := newMission(t)
+		if err := store.ApplyTransition(ctx, id, missions.Transition{Next: missions.StepState{Phase: missions.PhaseDone, Status: missions.StatusDone}}); err != nil {
+			t.Fatalf("ApplyTransition: %v", err)
+		}
+		if err := store.SetArtifactRefs(ctx, id, []missions.ArtifactRef{{ID: "report1", Mime: "text/plain", Name: "report.md"}}); err != nil {
+			t.Fatalf("SetArtifactRefs: %v", err)
+		}
+		m := newAPI(t, &fakeIngester{})
+		code, body := post(t, m, id, `{"collection_id":"00000000-0000-0000-0000-000000000000"}`)
+		if code != http.StatusBadRequest || !strings.Contains(string(body), "unknown collection_id") {
+			t.Fatalf("code=%d body=%s, want 400 unknown-collection", code, body)
+		}
+	})
+
+	t.Run("happy path promotes and re-promoting is idempotent", func(t *testing.T) {
+		id := newMission(t)
+		if err := store.ApplyTransition(ctx, id, missions.Transition{Next: missions.StepState{Phase: missions.PhaseDone, Status: missions.StatusDone}}); err != nil {
+			t.Fatalf("ApplyTransition: %v", err)
+		}
+		if err := store.SetArtifactRefs(ctx, id, []missions.ArtifactRef{{ID: "report1", Mime: "text/plain", Name: "report.md"}}); err != nil {
+			t.Fatalf("SetArtifactRefs: %v", err)
+		}
+		ingest := &fakeIngester{}
+		m := newAPI(t, ingest)
+
+		code, body := post(t, m, id, `{"collection_id":"`+collectionID+`"}`)
+		if code != http.StatusOK {
+			t.Fatalf("promote = %d, want 200: %s", code, body)
+		}
+		var resp struct {
+			Promoted int `json:"promoted"`
+		}
+		if err := json.Unmarshal(body, &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.Promoted != 1 {
+			t.Fatalf("promoted = %d, want 1", resp.Promoted)
+		}
+
+		docs, err := kbStore.ListDocuments(ctx, collectionID)
+		if err != nil {
+			t.Fatalf("ListDocuments: %v", err)
+		}
+		if len(docs) != 1 {
+			t.Fatalf("documents = %d, want 1", len(docs))
+		}
+		if docs[0].Provenance != "mission" {
+			t.Fatalf("provenance = %q, want mission", docs[0].Provenance)
+		}
+		if docs[0].SourceRef != "mission:"+id+":report.md" {
+			t.Fatalf("source_ref = %q", docs[0].SourceRef)
+		}
+
+		// Re-promote: still exactly one document, content replaced in
+		// place rather than a duplicate row.
+		code, body = post(t, m, id, `{"collection_id":"`+collectionID+`"}`)
+		if code != http.StatusOK {
+			t.Fatalf("re-promote = %d, want 200: %s", code, body)
+		}
+		docs, err = kbStore.ListDocuments(ctx, collectionID)
+		if err != nil {
+			t.Fatalf("ListDocuments: %v", err)
+		}
+		if len(docs) != 1 {
+			t.Fatalf("documents after re-promote = %d, want 1 (idempotent)", len(docs))
+		}
+		if ingest.callCount() != 2 {
+			t.Fatalf("ingest calls = %d, want 2 (one per promote)", ingest.callCount())
+		}
+	})
 }

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/brain/attachments"
 	"github.com/SumonMSelim/timothy/internal/brain/connectors"
 	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+	"github.com/SumonMSelim/timothy/internal/brain/kb"
 	"github.com/SumonMSelim/timothy/internal/brain/missions"
 	"github.com/SumonMSelim/timothy/internal/gateway/ledger"
 	"github.com/SumonMSelim/timothy/internal/gateway/router"
@@ -25,7 +26,7 @@ func TestMissionsEndpointsUnmountedWhenStoreNil(t *testing.T) {
 	t.Parallel()
 	a, _, _ := testAPI(t, "tok", nil)
 	m := mux(a)
-	a.registerMissions(m.Handle, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	for _, req := range []struct{ method, path string }{
 		{"GET", "/v1/missions"},
@@ -65,7 +66,7 @@ func TestMissionsListFilterValidation(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	call := func(path string) int {
 		req := httptest.NewRequest("GET", path, nil)
@@ -119,7 +120,7 @@ func TestMissionsDeleteReachesStore(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	req := httptest.NewRequest("DELETE", "/v1/missions/abc", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -139,7 +140,7 @@ func TestMissionsExportPDFNotEnabled(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/abc/export-pdf", strings.NewReader(`{}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -178,7 +179,7 @@ func TestMissionsCreateValidatesHarness(t *testing.T) {
 
 	post := func(codingExecutorDefault func(context.Context) string, body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, codingExecutorDefault, nil, nil, nil, nil, nil, "", nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, codingExecutorDefault, nil, nil, nil, nil, nil, "", nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -239,7 +240,7 @@ func TestMissionsCreateValidatesLight(t *testing.T) {
 
 	post := func(classify func(context.Context, string) (string, error), body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "", nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -282,7 +283,7 @@ func TestMissionsCreateValidatesRepoURL(t *testing.T) {
 
 	post := func(body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "", nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "", nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -308,7 +309,7 @@ func TestMissionsCreateValidatesRepoURL(t *testing.T) {
 	// No conns wired at all: repo_url is rejected outright rather than
 	// panicking on a nil manager.
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(`{"goal":"g","kind":"coding","repo_url":"https://github.com/o/r","connector_id":"1"}`))
 	req.Header.Set("Authorization", "Bearer tok")
 	w := httptest.NewRecorder()
@@ -333,7 +334,7 @@ func TestMissionsCreateValidatesOnComplete(t *testing.T) {
 
 	post := func(body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "", nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "", nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -372,7 +373,7 @@ func TestMissionsCreateValidatesGitStrategy(t *testing.T) {
 
 	post := func(body string) (int, string) {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -412,7 +413,7 @@ func TestMissionsCreateValidatesParentMission(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(`{"goal":"g","kind":"general","parent_mission_id":"00000000-0000-0000-0000-000000000000"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -491,7 +492,7 @@ func TestMissionsCreateAttachmentsValidation(t *testing.T) {
 		t.Helper()
 		a, _, _ := testAPI(t, "tok", nil)
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, atts, markitdownURL, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, atts, markitdownURL, nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -576,7 +577,7 @@ func TestMissionsCreateReferencesValidation(t *testing.T) {
 		t.Helper()
 		a, _, _ := testAPI(t, "tok", nil)
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -804,7 +805,7 @@ func TestMissionsClassifyEndpoint(t *testing.T) {
 		return "general light", nil
 	}
 	m := mux(a)
-	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	call := func(body string) (int, string) {
 		req := httptest.NewRequest("POST", "/v1/missions/classify", strings.NewReader(body))
@@ -837,7 +838,7 @@ func TestMissionsResumeMalformedBodyRejected(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/abc/resume", strings.NewReader(`{not json`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -860,7 +861,7 @@ func TestMissionsResumeEmptyBodyUnchanged(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	call := func(body io.Reader) int {
 		req := httptest.NewRequest("POST", "/v1/missions/abc/resume", body)
@@ -891,7 +892,7 @@ func TestMissionsNoteMalformedOrEmptyBodyRejected(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	call := func(body io.Reader) int {
 		req := httptest.NewRequest("POST", "/v1/missions/abc/note", body)
@@ -1039,7 +1040,7 @@ func TestMissionsCreateKindOptional(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	driver.SetValidateDeps(missions.ValidateDeps{})
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	call := func(body string) (int, string) {
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -1076,7 +1077,7 @@ func TestPRRejectsNonGitHubConnectionMission(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
 
 	// Against a degraded pool, store.Get itself fails before the
 	// connector_id/repo_url gate is ever reached — this test only
@@ -1738,5 +1739,59 @@ func TestChapterTitle(t *testing.T) {
 				t.Errorf("content = %q, want %q", remaining, tc.wantContent)
 			}
 		})
+	}
+}
+
+// TestPromoteKBNotEnabledWithoutStore covers promoteKB's own nil-gate
+// (a nil kbStore, e.g. kb disabled): the SAME shape exportPDF's own
+// pdfService nil-gate uses, checked before the mission is even loaded.
+func TestPromoteKBNotEnabledWithoutStore(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	m := mux(a)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/v1/missions/some-id/promote-kb", strings.NewReader(`{"collection_id":"c1"}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable || !strings.Contains(w.Body.String(), "knowledge base is not enabled") {
+		t.Fatalf("code=%d body=%s, want 503 not-enabled", w.Code, w.Body.String())
+	}
+}
+
+// noopIngester never calls memoryd: used where a test only needs a
+// non-nil kbIngester to get past promoteKB's nil-gate, same reasoning
+// as kb_integration_test.go's fakeIngester (unavailable here: this file
+// has no integration build tag).
+type noopIngester struct{}
+
+func (noopIngester) IngestDocument(context.Context, string, string, string) (int, error) {
+	return 0, nil
+}
+
+// TestPromoteKBReachesStore covers the enabled-kbStore path against a
+// degraded pool, proving the route exists and reaches the mission
+// lookup (400, not 404): same reasoning as TestMissionsDeleteReachesStore.
+// collection_id's own validation (reached only once a mission loads
+// successfully) is covered by the happy-path/gate tests in
+// missions_integration_test.go, which use a real store.
+func TestPromoteKBReachesStore(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	kbStore := kb.New(pool)
+	m := mux(a)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, kbStore, noopIngester{})
+
+	req := httptest.NewRequest("POST", "/v1/missions/some-id/promote-kb", strings.NewReader(`{"collection_id":"c1"}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code=%d body=%s, want 400 from the degraded store", w.Code, w.Body.String())
 	}
 }

--- a/internal/brain/destinations/promote_kb.go
+++ b/internal/brain/destinations/promote_kb.go
@@ -1,0 +1,136 @@
+package destinations
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	"github.com/SumonMSelim/timothy/internal/brain/attachments"
+	"github.com/SumonMSelim/timothy/internal/brain/kb"
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+// artifactOpener is the slice of *attachments.Store PromoteKB needs.
+type artifactOpener interface {
+	Open(ctx context.Context, id string) (io.ReadCloser, attachments.Attachment, error)
+}
+
+// kbIngester runs memoryd's ingest pipeline for one document:
+// api/kb.go's kbIngester satisfies this, kept as a local interface for
+// the same reason artifactOpener is.
+type kbIngester interface {
+	IngestDocument(ctx context.Context, documentID, title, markdown string) (int, error)
+}
+
+// kbDocStore is the slice of *kb.Store PromoteKB needs.
+type kbDocStore interface {
+	FindDocumentBySource(ctx context.Context, sourceType, sourceRef string) (kb.Document, error)
+	CreateDocument(ctx context.Context, collectionID, title, sourceType, sourceRef, provenance, markdown string, bytes int64) (string, error)
+	ReplaceDocumentContent(ctx context.Context, id, title, markdown string, bytes int64, collectionID string) error
+	SetIngesting(ctx context.Context, id string) error
+	SetFailed(ctx context.Context, id, errMsg string) error
+	GetDocument(ctx context.Context, id string) (kb.Document, error)
+}
+
+// markdownArtifactExt names the ArtifactRef extensions PromoteKB
+// promotes: the same narrow set resolveArtifactFiles renders inline
+// (textArtifactExts): a promoted document is prose, not an arbitrary
+// binary artifact.
+var markdownArtifactExt = map[string]bool{".md": true, ".txt": true}
+
+// promoteSourceRef is the kb_documents dedup key for one mission
+// artifact: mission id plus filename, so a mission with several
+// markdown artifacts promotes each as its own document, and re-running
+// promotion (auto on_complete plus a manual re-promote, or promoting
+// twice) replaces content in place instead of duplicating rows.
+func promoteSourceRef(missionID, name string) string {
+	return fmt.Sprintf("mission:%s:%s", missionID, name)
+}
+
+// PromoteMission promotes a terminal mission's markdown artifact refs
+// (m.ArtifactRefs, already copied into the attachment store by
+// copyArtifacts before the auto-fire hook runs) into collectionID as kb
+// documents with provenance='mission': D-081, issue #370. Idempotent:
+// re-promoting the same mission replaces each document's content in
+// place (FindDocumentBySource + ReplaceDocumentContent) rather than
+// duplicating rows, the same dedup shape api/kb.go's clip re-ingest
+// uses. promoted counts documents successfully promoted; errs collects
+// one error per artifact that failed (a vanished/non-markdown artifact
+// is silently skipped, not an error): the caller decides whether a
+// partial failure matters (the manual endpoint reports it, the
+// auto-fire hook just logs it).
+func PromoteMission(ctx context.Context, opener artifactOpener, store kbDocStore, ingest kbIngester, m missions.Mission, collectionID string) (promoted int, errs []error) {
+	for _, ref := range m.ArtifactRefs {
+		if !markdownArtifactExt[strings.ToLower(filepath.Ext(ref.Name))] {
+			continue
+		}
+		if err := promoteOne(ctx, opener, store, ingest, m.ID, collectionID, ref); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", ref.Name, err))
+			continue
+		}
+		promoted++
+	}
+	return promoted, errs
+}
+
+// PromoteKB adapts PromoteMission to missions.PromoteKB, the driver's
+// fire-and-forget terminal hook signature: failures are logged, never
+// returned, matching CopyArtifacts' own contract.
+func PromoteKB(opener artifactOpener, store kbDocStore, ingest kbIngester, log *slog.Logger) missions.PromoteKB {
+	return func(ctx context.Context, m missions.Mission, collectionID string) {
+		if _, errs := PromoteMission(ctx, opener, store, ingest, m, collectionID); len(errs) > 0 {
+			for _, err := range errs {
+				log.Warn("mission kb promotion skipped", "mission_id", m.ID, "error", err)
+			}
+		}
+	}
+}
+
+func promoteOne(ctx context.Context, opener artifactOpener, store kbDocStore, ingest kbIngester, missionID, collectionID string, ref missions.ArtifactRef) error {
+	r, att, err := opener.Open(ctx, ref.ID)
+	if err != nil {
+		return fmt.Errorf("open artifact: %w", err)
+	}
+	defer func() { _ = r.Close() }()
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("read artifact: %w", err)
+	}
+	markdown := strings.ToValidUTF8(strings.ReplaceAll(string(data), "\x00", ""), "�")
+	title := strings.TrimSuffix(ref.Name, filepath.Ext(ref.Name))
+	sourceRef := promoteSourceRef(missionID, ref.Name)
+
+	existing, err := store.FindDocumentBySource(ctx, "mission", sourceRef)
+	var docID string
+	if err == nil {
+		if err := store.ReplaceDocumentContent(ctx, existing.ID, title, markdown, att.SizeBytes, collectionID); err != nil {
+			return fmt.Errorf("replace document: %w", err)
+		}
+		docID = existing.ID
+	} else {
+		docID, err = store.CreateDocument(ctx, collectionID, title, "mission", sourceRef, "mission", markdown, att.SizeBytes)
+		if err != nil {
+			return fmt.Errorf("create document: %w", err)
+		}
+	}
+
+	if err := store.SetIngesting(ctx, docID); err != nil {
+		return fmt.Errorf("set ingesting: %w", err)
+	}
+	doc, err := store.GetDocument(ctx, docID)
+	if err != nil {
+		return fmt.Errorf("reload document: %w", err)
+	}
+	if ingest == nil {
+		_ = store.SetFailed(ctx, docID, "memoryd is not configured")
+		return fmt.Errorf("ingest: memoryd is not configured")
+	}
+	if _, err := ingest.IngestDocument(ctx, docID, title, doc.Markdown); err != nil {
+		_ = store.SetFailed(ctx, docID, err.Error())
+		return fmt.Errorf("ingest: %w", err)
+	}
+	return nil
+}

--- a/internal/brain/destinations/promote_kb_test.go
+++ b/internal/brain/destinations/promote_kb_test.go
@@ -1,0 +1,212 @@
+package destinations
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/attachments"
+	"github.com/SumonMSelim/timothy/internal/brain/kb"
+	"github.com/SumonMSelim/timothy/internal/brain/missions"
+)
+
+// fakeOpener stubs artifactOpener over an in-memory id -> content map.
+type fakeOpener struct {
+	data map[string][]byte
+}
+
+func (f *fakeOpener) Open(_ context.Context, id string) (io.ReadCloser, attachments.Attachment, error) {
+	data, ok := f.data[id]
+	if !ok {
+		return nil, attachments.Attachment{}, attachments.ErrNotFound
+	}
+	return io.NopCloser(bytes.NewReader(data)), attachments.Attachment{ID: id, Mime: "text/plain", SizeBytes: int64(len(data))}, nil
+}
+
+// fakeKBStore stubs kbDocStore over an in-memory document map, keyed by
+// (source_type, source_ref) for FindDocumentBySource: mirrors kb.Store's
+// own dedup contract without a real Postgres pool.
+type fakeKBStore struct {
+	docs   map[string]kb.Document
+	nextID int
+}
+
+func newFakeKBStore() *fakeKBStore {
+	return &fakeKBStore{docs: map[string]kb.Document{}}
+}
+
+func (f *fakeKBStore) FindDocumentBySource(_ context.Context, sourceType, sourceRef string) (kb.Document, error) {
+	for _, d := range f.docs {
+		if d.SourceType == sourceType && d.SourceRef == sourceRef {
+			return d, nil
+		}
+	}
+	return kb.Document{}, kb.ErrNotFound
+}
+
+func (f *fakeKBStore) CreateDocument(_ context.Context, collectionID, title, sourceType, sourceRef, provenance, markdown string, bytes int64) (string, error) {
+	f.nextID++
+	id := "doc" + string(rune('0'+f.nextID))
+	f.docs[id] = kb.Document{ID: id, CollectionID: collectionID, Title: title, SourceType: sourceType, SourceRef: sourceRef, Provenance: provenance, Markdown: markdown, Bytes: bytes, Status: "pending"}
+	return id, nil
+}
+
+func (f *fakeKBStore) ReplaceDocumentContent(_ context.Context, id, title, markdown string, bytes int64, collectionID string) error {
+	d, ok := f.docs[id]
+	if !ok {
+		return kb.ErrNotFound
+	}
+	d.Title, d.Markdown, d.Bytes = title, markdown, bytes
+	if collectionID != "" {
+		d.CollectionID = collectionID
+	}
+	d.Status = "pending"
+	f.docs[id] = d
+	return nil
+}
+
+func (f *fakeKBStore) SetIngesting(_ context.Context, id string) error {
+	d, ok := f.docs[id]
+	if !ok {
+		return kb.ErrNotFound
+	}
+	d.Status = "ingesting"
+	f.docs[id] = d
+	return nil
+}
+
+func (f *fakeKBStore) SetFailed(_ context.Context, id, errMsg string) error {
+	d, ok := f.docs[id]
+	if !ok {
+		return kb.ErrNotFound
+	}
+	d.Status, d.Error = "failed", errMsg
+	f.docs[id] = d
+	return nil
+}
+
+func (f *fakeKBStore) GetDocument(_ context.Context, id string) (kb.Document, error) {
+	d, ok := f.docs[id]
+	if !ok {
+		return kb.Document{}, kb.ErrNotFound
+	}
+	return d, nil
+}
+
+// fakeIngest stubs kbIngester, optionally erroring for a fixed doc id.
+type fakeIngest struct {
+	failFor string
+	calls   int
+}
+
+func (f *fakeIngest) IngestDocument(_ context.Context, documentID, _, _ string) (int, error) {
+	f.calls++
+	if documentID == f.failFor {
+		return 0, errors.New("ingest failed")
+	}
+	return 1, nil
+}
+
+func TestPromoteMissionHappyPath(t *testing.T) {
+	opener := &fakeOpener{data: map[string][]byte{"a1": []byte("# Report\n\nbody")}}
+	store := newFakeKBStore()
+	ingest := &fakeIngest{}
+	m := missions.Mission{ID: "m1", ArtifactRefs: []missions.ArtifactRef{{ID: "a1", Mime: "text/plain", Name: "report.md"}}}
+
+	promoted, errs := PromoteMission(t.Context(), opener, store, ingest, m, "col1")
+	if promoted != 1 || len(errs) != 0 {
+		t.Fatalf("promoted=%d errs=%v, want 1 promoted, no errors", promoted, errs)
+	}
+	if len(store.docs) != 1 {
+		t.Fatalf("documents = %d, want 1", len(store.docs))
+	}
+	for _, d := range store.docs {
+		if d.Provenance != "mission" || d.SourceType != "mission" || d.SourceRef != "mission:m1:report.md" {
+			t.Fatalf("document = %+v, want provenance=mission source_type=mission source_ref=mission:m1:report.md", d)
+		}
+		if d.Status != "ingesting" && d.Status != "ready" {
+			// SetIngesting runs before ingest; the fake never advances to
+			// ready, so ingesting is the expected terminal state here.
+			t.Fatalf("status = %q, want ingesting", d.Status)
+		}
+	}
+	if ingest.calls != 1 {
+		t.Fatalf("ingest calls = %d, want 1", ingest.calls)
+	}
+}
+
+func TestPromoteMissionIgnoresNonMarkdownArtifacts(t *testing.T) {
+	opener := &fakeOpener{data: map[string][]byte{"a1": []byte("binary")}}
+	store := newFakeKBStore()
+	m := missions.Mission{ID: "m1", ArtifactRefs: []missions.ArtifactRef{{ID: "a1", Mime: "application/pdf", Name: "chart.pdf"}}}
+
+	promoted, errs := PromoteMission(t.Context(), opener, store, &fakeIngest{}, m, "col1")
+	if promoted != 0 || len(errs) != 0 {
+		t.Fatalf("promoted=%d errs=%v, want 0 and no errors (non-markdown skipped silently)", promoted, errs)
+	}
+	if len(store.docs) != 0 {
+		t.Fatalf("documents = %d, want 0", len(store.docs))
+	}
+}
+
+func TestPromoteMissionIdempotentReplacesContent(t *testing.T) {
+	opener := &fakeOpener{data: map[string][]byte{"a1": []byte("v1")}}
+	store := newFakeKBStore()
+	m := missions.Mission{ID: "m1", ArtifactRefs: []missions.ArtifactRef{{ID: "a1", Mime: "text/plain", Name: "report.md"}}}
+
+	if _, errs := PromoteMission(t.Context(), opener, store, &fakeIngest{}, m, "col1"); len(errs) != 0 {
+		t.Fatalf("first promote errs = %v", errs)
+	}
+	if len(store.docs) != 1 {
+		t.Fatalf("documents after first promote = %d, want 1", len(store.docs))
+	}
+
+	// Re-promote with updated content: must replace in place, not add a
+	// second document.
+	opener.data["a1"] = []byte("v2")
+	if _, errs := PromoteMission(t.Context(), opener, store, &fakeIngest{}, m, "col1"); len(errs) != 0 {
+		t.Fatalf("second promote errs = %v", errs)
+	}
+	if len(store.docs) != 1 {
+		t.Fatalf("documents after re-promote = %d, want 1 (idempotent)", len(store.docs))
+	}
+	for _, d := range store.docs {
+		if d.Markdown != "v2" {
+			t.Fatalf("markdown = %q, want v2 (content replaced)", d.Markdown)
+		}
+	}
+}
+
+func TestPromoteMissionCollectsIngestErrors(t *testing.T) {
+	opener := &fakeOpener{data: map[string][]byte{"a1": []byte("body")}}
+	store := newFakeKBStore()
+	m := missions.Mission{ID: "m1", ArtifactRefs: []missions.ArtifactRef{{ID: "a1", Mime: "text/plain", Name: "report.md"}}}
+
+	// failFor targets the first created document id (doc1, per
+	// fakeKBStore.CreateDocument's counter).
+	promoted, errs := PromoteMission(t.Context(), opener, store, &fakeIngest{failFor: "doc1"}, m, "col1")
+	if promoted != 0 || len(errs) != 1 {
+		t.Fatalf("promoted=%d errs=%v, want 0 promoted, 1 error", promoted, errs)
+	}
+	for _, d := range store.docs {
+		if d.Status != "failed" {
+			t.Fatalf("status = %q, want failed", d.Status)
+		}
+	}
+}
+
+func TestPromoteKBLogsAndNeverReturnsError(t *testing.T) {
+	opener := &fakeOpener{data: map[string][]byte{}} // a1 vanished
+	store := newFakeKBStore()
+	m := missions.Mission{ID: "m1", ArtifactRefs: []missions.ArtifactRef{{ID: "a1", Mime: "text/plain", Name: "report.md"}}}
+
+	// Must not panic: PromoteKB's contract is fire-and-forget, same as
+	// CopyArtifacts.
+	PromoteKB(opener, store, &fakeIngest{}, slog.Default())(t.Context(), m, "col1")
+	if len(store.docs) != 0 {
+		t.Fatalf("documents = %d, want 0 (vanished artifact skipped)", len(store.docs))
+	}
+}

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -215,7 +215,15 @@ type Driver struct {
 	// missions.Mission, so missions can't import workflows back.
 	onTerminal OnTerminal
 
-	// validateDeps backs ValidateCreate's store-backed checks (D-071) —
+	// promoteKB wires the kb-promotion hook fired on a mission's terminal
+	// done transition (see SetPromoteKB / promoteToKB), nil-safe: unset
+	// skips promotion entirely, same as a mission with no
+	// promote_kb_collection_id. A func type for the same import-cycle
+	// reason as deliverDestinations: promotion needs the attachment store
+	// and kb store, both out of missions' reach.
+	promoteKB PromoteKB
+
+	// validateDeps backs ValidateCreate's store-backed checks (D-071):
 	// a *ValidateDeps, not a value, so "unset" is distinguishable from
 	// "set to the zero value": nil skips ValidateCreate's call entirely
 	// (existing callers/tests that predate D-071 keep working
@@ -466,6 +474,34 @@ func (d *Driver) deliverToDestinations(m Mission, terminal Phase) {
 	go d.deliverDestinations(rctx, m, m.DestinationIDs) //nolint:gosec // G118: deliberate — the mission is already terminal, delivery must outlive whatever request/ctx observed that transition
 }
 
+// PromoteKB promotes a terminal mission's markdown artifacts into a kb
+// collection with provenance='mission': kb.PromoteMission (D-081,
+// issue #370) satisfies this signature. Fire-and-forget by contract,
+// same as DestinationDeliver: it must never return an error, block, or
+// affect mission state; failures are its own concern to log.
+type PromoteKB func(ctx context.Context, m Mission, collectionID string)
+
+// SetPromoteKB wires the kb-promotion hook fired on a mission's
+// terminal done transition (see promoteToKB): a setter for the same
+// reason SetDestinationDeliver is. Optional: nil skips promotion
+// entirely, same as a mission with no promote_kb_collection_id.
+func (d *Driver) SetPromoteKB(fn PromoteKB) {
+	d.promoteKB = fn
+}
+
+// promoteToKB fires the kb-promotion hook exactly on a transition into
+// phase=done (mirrors deliverToDestinations) and only when the mission
+// has promote_kb_collection_id set. Detached from ctx like
+// deliverToDestinations: the mission is already terminal, so promotion
+// must outlive a request that may be winding down.
+func (d *Driver) promoteToKB(m Mission, terminal Phase) {
+	if d.promoteKB == nil || terminal != PhaseDone || m.PromoteKBCollectionID == "" {
+		return
+	}
+	rctx := context.Background()
+	go d.promoteKB(rctx, m, m.PromoteKBCollectionID) //nolint:gosec // G118: deliberate: the mission is already terminal, promotion must outlive whatever request/ctx observed that transition
+}
+
 // ArtifactCopy best-effort copies a terminal mission's declared
 // artifact files into the attachment store and returns the resulting
 // refs — destinations.CopyArtifacts satisfies this signature. Must
@@ -587,9 +623,9 @@ func (d *Driver) fireOnComplete(ctx context.Context, id string, m Mission) {
 //  5. artifact copy (SYNCHRONOUS, done transitions only — see
 //     copyArtifacts) — runs BEFORE the hooks below so destinations
 //     delivery's webhook payload can include the resulting refs
-//  6. memory extraction, destinations delivery, workflow onTerminal —
-//     each handed the SAME reloaded (and artifact-copy-updated)
-//     Mission, no hook reloads on its own
+//  6. memory extraction, destinations delivery, kb promotion, workflow
+//     onTerminal: each handed the SAME reloaded (and
+//     artifact-copy-updated) Mission, no hook reloads on its own
 //  7. fireOnComplete, done transitions only
 //
 // Each hook may still dispatch its own goroutine (memory/destinations/
@@ -626,6 +662,7 @@ func (d *Driver) runTerminalHooks(ctx context.Context, id string, terminal Phase
 	m = d.copyArtifacts(ctx, id, m, terminal)
 	d.extractMissionMemory(ctx, m, terminal, reason)
 	d.deliverToDestinations(m, terminal)
+	d.promoteToKB(m, terminal)
 	d.fireOnTerminal(m)
 	if terminal == PhaseDone {
 		d.fireOnComplete(ctx, id, m)

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -189,9 +189,17 @@ type Mission struct {
 	// terminal done transition (driver.go's deliverToDestinations) —
 	// validated against the destinations table at create time
 	// (api/missions.go), never model-decided.
-	DestinationIDs []string  `json:"destination_ids,omitempty"`
-	CreatedAt      time.Time `json:"created_at"`
-	UpdatedAt      time.Time `json:"updated_at"`
+	DestinationIDs []string `json:"destination_ids,omitempty"`
+	// PromoteKBCollectionID (D-081, issue #370) is the kb collection this
+	// mission's markdown artifacts promote into on the terminal done
+	// transition (driver.go's promoteToKB): an explicit id, same
+	// operator-owned pattern as DestinationIDs, never a model choice or
+	// an auto-created default collection. "" (default) promotes nothing
+	// automatically; the operator can still promote manually via
+	// POST .../promote-kb after the mission is done.
+	PromoteKBCollectionID string    `json:"promote_kb_collection_id,omitempty"`
+	CreatedAt             time.Time `json:"created_at"`
+	UpdatedAt             time.Time `json:"updated_at"`
 	// WorkflowRunID/WorkflowStep name the workflow run and step
 	// (internal/brain/workflows) this mission was spawned as, if any —
 	// empty for an ordinary mission. Set only at create time; the

--- a/internal/brain/missions/promote_kb_test.go
+++ b/internal/brain/missions/promote_kb_test.go
@@ -1,0 +1,132 @@
+package missions
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recordingPromoteKB is a PromoteKB fake that records every call it
+// receives, synchronized so tests can assert on it after the driver's
+// dispatching goroutine has had a chance to run (fired via `go` from
+// promoteToKB, same as DestinationDeliver).
+type recordingPromoteKB struct {
+	mu    sync.Mutex
+	calls []struct {
+		mission      Mission
+		collectionID string
+	}
+}
+
+func (r *recordingPromoteKB) fn() PromoteKB {
+	return func(ctx context.Context, m Mission, collectionID string) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.calls = append(r.calls, struct {
+			mission      Mission
+			collectionID string
+		}{m, collectionID})
+	}
+}
+
+func (r *recordingPromoteKB) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
+}
+
+func waitForPromoteKBCalls(t *testing.T, r *recordingPromoteKB, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if r.count() == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("promote kb calls = %d, want %d", r.count(), want)
+}
+
+func TestDriverPromotesToKBOnDone(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8, PromoteKBCollectionID: "c1"})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner)
+	rec := &recordingPromoteKB{}
+	d.SetPromoteKB(rec.fn())
+
+	driveN(t, d, "m1", 4) // explore -> plan -> execute -> review -> done
+
+	waitForPromoteKBCalls(t, rec, 1)
+	if got := rec.calls[0].collectionID; got != "c1" {
+		t.Fatalf("collection id = %q, want c1", got)
+	}
+}
+
+func TestDriverSkipsPromoteKBOnFailed(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExecute, Status: StatusWorking, MaxIterations: 1, PromoteKBCollectionID: "c1"})
+	runner := &scriptedRunner{
+		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "nope"}},
+	}
+	d := testDriver(store, runner)
+	rec := &recordingPromoteKB{}
+	d.SetPromoteKB(rec.fn())
+
+	// MaxIterations=1: the first retry immediately exhausts iterations
+	// and the state machine fails the mission (stepWorkerRetry).
+	driveN(t, d, "m1", 1)
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseFailed {
+		t.Fatalf("mission phase = %s, want failed", m.Phase)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if got := rec.count(); got != 0 {
+		t.Fatalf("promote kb calls on a failed mission = %d, want 0 (artifacts of a failed mission are unverified)", got)
+	}
+}
+
+func TestDriverSkipsPromoteKBWhenNoCollection(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner)
+	rec := &recordingPromoteKB{}
+	d.SetPromoteKB(rec.fn())
+
+	driveN(t, d, "m1", 4)
+
+	time.Sleep(20 * time.Millisecond)
+	if got := rec.count(); got != 0 {
+		t.Fatalf("promote kb calls for a mission with no promote_kb_collection_id = %d, want 0", got)
+	}
+}
+
+func TestDriverSkipsPromoteKBWhenNilHook(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseExplore, Status: StatusWorking, MaxIterations: 8, PromoteKBCollectionID: "c1"})
+	runner := &scriptedRunner{
+		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner) // no SetPromoteKB call: d.promoteKB stays nil
+
+	// This must not panic: the whole point of the nil-safe field.
+	driveN(t, d, "m1", 4)
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseDone {
+		t.Fatalf("mission phase = %s, want done", m.Phase)
+	}
+}

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -52,7 +52,7 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 	pending_permission_danger, pending_permission_rationale, auto_approve_safe, last_evidence,
 	explore_notes, replan_used, schedule_id, session_id, harness, environment, repo_url, connector_id, on_complete,
 	branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, light, final_output, created_at, updated_at,
-	workflow_run_id, workflow_step, artifact_refs`
+	workflow_run_id, workflow_step, artifact_refs, promote_kb_collection_id`
 
 // scanMissionWithFailureReason is scanMission plus one extra trailing
 // column: the mission's latest mission.failed event's payload.reason
@@ -68,6 +68,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		spec, progress, attachmentsRaw, knowledgeRaw, artifactRefsRaw []byte
 		failureReason                                                 *string
 		workflowRunID                                                 *string
+		promoteKBCollectionID                                         *string
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
@@ -79,7 +80,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &m.ReferencedContext, &attachmentsRaw,
 		&m.DestinationIDs, &m.Light, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
-		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw,
+		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &promoteKBCollectionID,
 		&failureReason); err != nil {
 		return Mission{}, err
 	}
@@ -102,6 +103,9 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 	}
 	if workflowRunID != nil {
 		m.WorkflowRunID = *workflowRunID
+	}
+	if promoteKBCollectionID != nil {
+		m.PromoteKBCollectionID = *promoteKBCollectionID
 	}
 	if failureReason != nil {
 		m.FailureReason = *failureReason
@@ -150,6 +154,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		pendingPermission                                             *string
 		spec, progress, attachmentsRaw, knowledgeRaw, artifactRefsRaw []byte
 		workflowRunID                                                 *string
+		promoteKBCollectionID                                         *string
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
@@ -161,7 +166,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &m.ReferencedContext, &attachmentsRaw,
 		&m.DestinationIDs, &m.Light, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
-		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw); err != nil {
+		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &promoteKBCollectionID); err != nil {
 		return Mission{}, err
 	}
 	_ = json.Unmarshal(knowledgeRaw, &m.Knowledge)
@@ -183,6 +188,9 @@ func scanMission(row pgx.Row) (Mission, error) {
 	}
 	if workflowRunID != nil {
 		m.WorkflowRunID = *workflowRunID
+	}
+	if promoteKBCollectionID != nil {
+		m.PromoteKBCollectionID = *promoteKBCollectionID
 	}
 	// Fail-safe degrade: an unrecognized phase/status (e.g. a future
 	// value an older binary doesn't know) loads as paused/infra rather
@@ -255,9 +263,9 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	}
 	phase := initialPhase(m.Kind, m.Light)
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, light, phase, workflow_run_id, workflow_step)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NULLIF($18, '')::uuid, $19, $20, $21, $22, $23, $24, $25, $26, NULLIF($27, '')::uuid, $28, $29, $30, $31, $32, $33, NULLIF($34, '')::uuid, $35) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, m.ReferencedContext, attachmentsJSON, destinationIDs, m.Light, phase, m.WorkflowRunID, m.WorkflowStep,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, light, phase, workflow_run_id, workflow_step, promote_kb_collection_id)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NULLIF($18, '')::uuid, $19, $20, $21, $22, $23, $24, $25, $26, NULLIF($27, '')::uuid, $28, $29, $30, $31, $32, $33, NULLIF($34, '')::uuid, $35, NULLIF($36, '')::uuid) RETURNING id`,
+		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, m.ReferencedContext, attachmentsJSON, destinationIDs, m.Light, phase, m.WorkflowRunID, m.WorkflowStep, m.PromoteKBCollectionID,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)

--- a/internal/brain/missions/validate.go
+++ b/internal/brain/missions/validate.go
@@ -38,6 +38,10 @@ type ValidateDeps struct {
 	// since a caller with no destinations wiring has nothing to check
 	// against).
 	DestinationEnabled func(ctx context.Context, id string) (bool, error)
+	// KBCollectionExists reports whether id names a real kb_collections
+	// row: nil skips promote_kb_collection_id validation entirely, same
+	// degrade-to-unchecked reasoning as DestinationEnabled.
+	KBCollectionExists func(ctx context.Context, id string) (bool, error)
 }
 
 // validModelPin reports whether pin is well-formed "provider name/model"
@@ -145,6 +149,15 @@ func ValidateCreate(ctx context.Context, m Mission, deps ValidateDeps) error {
 		}
 		if len(invalid) > 0 {
 			return fmt.Errorf("%w: unknown or disabled destination id(s): %s", ErrInvalidMission, strings.Join(invalid, ", "))
+		}
+	}
+	if deps.KBCollectionExists != nil && m.PromoteKBCollectionID != "" {
+		ok, err := deps.KBCollectionExists(ctx, m.PromoteKBCollectionID)
+		if err != nil {
+			return fmt.Errorf("%w: promote_kb_collection_id: %s", ErrInvalidMission, err.Error())
+		}
+		if !ok {
+			return fmt.Errorf("%w: unknown promote_kb_collection_id %q", ErrInvalidMission, m.PromoteKBCollectionID)
 		}
 	}
 	return nil

--- a/internal/brain/missions/validate_test.go
+++ b/internal/brain/missions/validate_test.go
@@ -180,6 +180,28 @@ func TestValidateCreate(t *testing.T) {
 			m.DestinationIDs = []string{"d1"}
 			return m
 		}, ValidateDeps{}, false},
+		{"promote_kb_collection_id exists", func(m Mission) Mission {
+			m.PromoteKBCollectionID = "c1"
+			return m
+		}, ValidateDeps{KBCollectionExists: func(ctx context.Context, id string) (bool, error) {
+			return id == "c1", nil
+		}}, false},
+		{"promote_kb_collection_id unknown", func(m Mission) Mission {
+			m.PromoteKBCollectionID = "bogus"
+			return m
+		}, ValidateDeps{KBCollectionExists: func(ctx context.Context, id string) (bool, error) {
+			return id == "c1", nil
+		}}, true},
+		{"promote_kb_collection_id lookup error", func(m Mission) Mission {
+			m.PromoteKBCollectionID = "c1"
+			return m
+		}, ValidateDeps{KBCollectionExists: func(ctx context.Context, id string) (bool, error) {
+			return false, fmt.Errorf("db unavailable")
+		}}, true},
+		{"promote_kb_collection_id unchecked when dep nil", func(m Mission) Mission {
+			m.PromoteKBCollectionID = "c1"
+			return m
+		}, ValidateDeps{}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/migrations/0010_missions.sql
+++ b/migrations/0010_missions.sql
@@ -204,6 +204,14 @@ CREATE TABLE IF NOT EXISTS missions (
     -- api/missions.go's create validates every id against the
     -- operator-owned destinations table before it lands here.
     destination_ids       uuid[] NOT NULL DEFAULT '{}',
+    -- D-081 (issue #370): kb collection to promote this mission's
+    -- markdown artifacts into on the terminal done transition
+    -- (kb.go's promoteToKB, driver.go's fireOnComplete-style hook). ''
+    -- (default) does nothing. Explicit id, never a default "Missions"
+    -- collection auto-create, same as destination_ids above; the
+    -- operator can also promote manually via POST .../promote-kb after
+    -- the mission is done, using the same code path.
+    promote_kb_collection_id uuid,
     -- workflow_run_id/workflow_step name the workflow run and step
     -- (internal/brain/workflows) this mission was spawned as, if any.
     -- NULL/'' for an ordinary mission. The workflow engine reads these

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1284,6 +1284,10 @@ export interface CreateMissionInput {
   // mission's outcome digest to on the terminal done transition; omit
   // (or empty) delivers nowhere.
   destination_ids?: string[]
+  // promote_kb_collection_id names a kb collection to promote this
+  // mission's markdown artifacts into on the terminal done transition
+  // (D-081, issue #370); omit (or "") promotes nothing automatically.
+  promote_kb_collection_id?: string
   // light requests a mission that skips explore/plan/review (D-069):
   // single worker turn, final message delivered as the result. Only
   // valid when kind === 'general'.
@@ -1583,6 +1587,20 @@ export async function exportMissionPdf(
 // saves it under the caller-supplied filename.
 export async function downloadMissionPdfExport(attachmentId: string, filename: string): Promise<void> {
   return fetchBlobDownload(`/v1/attachments/${attachmentId}`, filename)
+}
+
+// promoteMissionToKB promotes a done mission's markdown artifacts into
+// collectionId as kb documents with provenance='mission' (D-081, issue
+// #370). Done-only server-side; idempotent (re-promoting replaces
+// content rather than duplicating documents).
+export async function promoteMissionToKB(
+  id: string,
+  collectionId: string,
+): Promise<{ promoted: number; failed?: string[] }> {
+  return request<{ promoted: number; failed?: string[] }>(`/v1/missions/${id}/promote-kb`, {
+    method: 'POST',
+    body: JSON.stringify({ collection_id: collectionId }),
+  })
 }
 
 // exportMessagePDF renders one chat message's already-rendered markdown

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -645,7 +645,7 @@ export interface KbDocument {
   id: string
   collection_id: string
   title: string
-  source_type: 'file' | 'notion' | 'wiki' | 'url' | 'clip'
+  source_type: 'file' | 'notion' | 'wiki' | 'url' | 'clip' | 'mission'
   source_ref: string
   // provenance weights retrieval ranking (curated > mission > web): see
   // internal/memory/store/kb.go KBSearch.
@@ -780,6 +780,11 @@ export interface Mission {
   // terminal done transition. Validated against the destinations table
   // at create time: never model-decided.
   destination_ids?: string[]
+  // promote_kb_collection_id names a kb collection this mission's
+  // markdown artifacts promote into on the terminal done transition
+  // (D-081, issue #370). Absent/'' promotes nothing automatically; the
+  // operator can still promote manually via POST .../promote-kb.
+  promote_kb_collection_id?: string
   // light marks a mission that skips explore/plan/review (D-069):
   // kind=general only, born in phase=execute, one bare worker turn.
   // final_output is that worker's verbatim final message: the

--- a/web/src/components/knowledge/KnowledgeCollectionDetail.test.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionDetail.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { KbDocument } from '../../api/types'
 import { TooltipProvider } from '../ui/tooltip'
@@ -23,9 +24,11 @@ const baseDoc: KbDocument = {
 
 function renderBadge(doc: KbDocument) {
   return render(
-    <TooltipProvider>
-      <SourceBadge doc={doc} />
-    </TooltipProvider>,
+    <MemoryRouter>
+      <TooltipProvider>
+        <SourceBadge doc={doc} />
+      </TooltipProvider>
+    </MemoryRouter>,
   )
 }
 
@@ -52,6 +55,18 @@ describe('SourceBadge', () => {
     renderBadge(baseDoc)
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
     expect(screen.getByText('file')).toBeInTheDocument()
+  })
+
+  it('links a promoted mission document to its mission detail page', () => {
+    const doc: KbDocument = {
+      ...baseDoc,
+      source_type: 'mission',
+      source_ref: 'mission:m-123:report.md',
+    }
+    renderBadge(doc)
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/missions/m-123')
+    expect(link).not.toHaveAttribute('target')
   })
 })
 

--- a/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
@@ -39,24 +39,37 @@ import { KbUploadForm } from './KbUploadForm'
 
 const linkedSourceTypes = new Set<KbDocument['source_type']>(['url', 'clip'])
 
+// missionSourceRefRe matches a promoted mission document's source_ref
+// (D-081, issue #370): "mission:<id>" or "mission:<id>:<filename>":
+// the mission id is always the first segment.
+const missionSourceRefRe = /^mission:([^:]+)/
+
 export function SourceBadge({ doc }: { doc: KbDocument }) {
   const badge = (
     <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase text-muted-foreground">
       {doc.source_type}
     </span>
   )
-  const content = linkedSourceTypes.has(doc.source_type) ? (
-    <a
-      href={doc.source_ref}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="hover:text-foreground"
-    >
-      {badge}
-    </a>
-  ) : (
-    badge
-  )
+  const missionMatch = doc.source_type === 'mission' ? missionSourceRefRe.exec(doc.source_ref) : null
+  let content = badge
+  if (linkedSourceTypes.has(doc.source_type)) {
+    content = (
+      <a
+        href={doc.source_ref}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="hover:text-foreground"
+      >
+        {badge}
+      </a>
+    )
+  } else if (missionMatch) {
+    content = (
+      <Link to={`/missions/${missionMatch[1]}`} className="hover:text-foreground">
+        {badge}
+      </Link>
+    )
+  }
 
   return (
     <Tooltip>

--- a/web/src/components/missions/ArtifactsSection.test.tsx
+++ b/web/src/components/missions/ArtifactsSection.test.tsx
@@ -12,6 +12,8 @@ vi.mock('../../api/client', () => ({
   getSettings: vi.fn(),
   fetchMissionFileBlob: vi.fn(),
   fetchAttachmentBlob: vi.fn(),
+  listKbCollections: vi.fn(),
+  promoteMissionToKB: vi.fn(),
   missionFilePreviewCap: 1_000_000,
   MissionFileTooLargeError: class MissionFileTooLargeError extends Error {},
 }))
@@ -22,7 +24,9 @@ import {
   fetchAttachmentBlob,
   fetchMissionFileBlob,
   getSettings,
+  listKbCollections,
   listMissionFiles,
+  promoteMissionToKB,
 } from '../../api/client'
 
 afterEach(cleanup)
@@ -32,6 +36,7 @@ beforeEach(() => {
   vi.mocked(fetchMissionFileBlob).mockResolvedValue(new Blob(['hello']))
   vi.mocked(fetchAttachmentBlob).mockResolvedValue(new Blob(['hello']))
   vi.mocked(getSettings).mockResolvedValue({ settings: {}, values: {} })
+  vi.mocked(listKbCollections).mockResolvedValue([])
 })
 
 const refs: MediaRef[] = [{ id: 'att-1', mime: 'text/markdown', name: 'report.md' }]
@@ -187,5 +192,53 @@ describe('ArtifactsSection', () => {
     expect(exportMissionPdf).toHaveBeenCalledWith('m4')
     await screen.findByRole('button', { name: 'Export all workspace markdown as one merged PDF' })
     expect(downloadMissionPdfExport).toHaveBeenCalledWith('att-9', 'My Mission.pdf')
+  })
+
+  describe('promote to knowledge base', () => {
+    it('hides the action when the mission is not done', () => {
+      render(<ArtifactsSection missionId="m1" phase="execute" workspace={undefined} refs={refs} />)
+      expect(screen.queryByText('Promote to KB')).toBeNull()
+    })
+
+    it('hides the action when there are no markdown artifacts', () => {
+      render(
+        <ArtifactsSection
+          missionId="m1"
+          phase="done"
+          workspace={undefined}
+          refs={[{ id: 'a1', mime: 'application/pdf', name: 'chart.pdf' }]}
+        />,
+      )
+      expect(screen.queryByText('Promote to KB')).toBeNull()
+    })
+
+    it('opens a dialog with a collection picker and promotes on submit', async () => {
+      vi.mocked(listKbCollections).mockResolvedValue([
+        { id: 'c1', name: 'Reports', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+      ])
+      vi.mocked(promoteMissionToKB).mockResolvedValue({ promoted: 1 })
+      render(<ArtifactsSection missionId="m1" phase="done" workspace={undefined} refs={refs} />)
+
+      fireEvent.click(screen.getByText('Promote to KB'))
+      expect(await screen.findByText('Promote to knowledge base')).toBeInTheDocument()
+
+      const select = await screen.findByLabelText('Collection')
+      fireEvent.change(select, { target: { value: 'c1' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Promote' }))
+
+      await waitFor(() => expect(promoteMissionToKB).toHaveBeenCalledWith('m1', 'c1'))
+      expect(await screen.findByText(/Promoted 1 document/)).toBeInTheDocument()
+    })
+
+    it('disables Promote until a collection is picked', async () => {
+      vi.mocked(listKbCollections).mockResolvedValue([
+        { id: 'c1', name: 'Reports', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+      ])
+      render(<ArtifactsSection missionId="m1" phase="done" workspace={undefined} refs={refs} />)
+
+      fireEvent.click(screen.getByText('Promote to KB'))
+      await screen.findByText('Promote to knowledge base')
+      expect(screen.getByRole('button', { name: 'Promote' })).toBeDisabled()
+    })
   })
 })

--- a/web/src/components/missions/ArtifactsSection.tsx
+++ b/web/src/components/missions/ArtifactsSection.tsx
@@ -1,4 +1,9 @@
-import { FolderZipIcon, Loading03Icon, Pdf02Icon } from '@hugeicons-pro/core-stroke-rounded'
+import {
+  FolderZipIcon,
+  LibraryIcon,
+  Loading03Icon,
+  Pdf02Icon,
+} from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
@@ -7,11 +12,14 @@ import {
   downloadMissionPdfExport,
   exportMissionPdf,
   getSettings,
+  listKbCollections,
   listMissionFiles,
+  promoteMissionToKB,
 } from '../../api/client'
-import type { MediaRef, MissionFile } from '../../api/types'
+import type { KbCollection, MediaRef, MissionFile } from '../../api/types'
 import { errText } from '../settings/util'
 import { Button } from '../ui/button'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import { ArtifactRefChips } from './ArtifactRefsSection'
 import { buildFileTree, type FileTreeNode } from './fileTree'
@@ -20,6 +28,96 @@ import { FileViewer } from './FileViewer'
 import { FullscreenDialog, FullscreenToggle, useFullscreenPanel } from './FullscreenPanel'
 
 const markdownFileRe = /\.(md|markdown)$/i
+
+// PromoteToKBDialog offers a collection picker and promotes the
+// mission's markdown artifacts into it (D-081, issue #370). Only shown
+// when the mission is done and has at least one artifact ref (the
+// promote endpoint's own gates).
+function PromoteToKBDialog({
+  missionId,
+  open,
+  onOpenChange,
+}: {
+  missionId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const [collections, setCollections] = useState<KbCollection[] | null>(null)
+  const [collectionId, setCollectionId] = useState('')
+  const [promoting, setPromoting] = useState(false)
+  const [promoted, setPromoted] = useState<number | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    setPromoted(null)
+    listKbCollections()
+      .then(setCollections)
+      .catch((err: unknown) => toast.error('Could not load collections', { description: errText(err) }))
+  }, [open])
+
+  const promote = async () => {
+    if (!collectionId) return
+    setPromoting(true)
+    try {
+      const result = await promoteMissionToKB(missionId, collectionId)
+      setPromoted(result.promoted)
+      if (result.promoted > 0) {
+        toast.success(`Promoted ${result.promoted} document${result.promoted === 1 ? '' : 's'} to the knowledge base`)
+      } else {
+        toast.error('Nothing was promoted', { description: result.failed?.[0] })
+      }
+    } catch (err) {
+      toast.error('Could not promote to knowledge base', { description: errText(err) })
+    } finally {
+      setPromoting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Promote to knowledge base</DialogTitle>
+        </DialogHeader>
+        {promoted !== null ? (
+          <p className="text-sm text-muted-foreground">
+            Promoted {promoted} document{promoted === 1 ? '' : 's'}. Searchable via search_kb once
+            ingestion finishes.
+          </p>
+        ) : (
+          <div className="space-y-1.5">
+            <label htmlFor="promote-kb-collection" className="text-sm font-medium">
+              Collection
+            </label>
+            <select
+              id="promote-kb-collection"
+              value={collectionId}
+              onChange={(e) => setCollectionId(e.target.value)}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            >
+              <option value="">Select a collection…</option>
+              {(collections ?? []).map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {promoted !== null ? 'Close' : 'Cancel'}
+          </Button>
+          {promoted === null && (
+            <Button disabled={!collectionId || promoting} onClick={() => void promote()}>
+              {promoting ? 'Promoting…' : 'Promote'}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
 
 export function ArtifactsSection({
   missionId,
@@ -40,7 +138,9 @@ export function ArtifactsSection({
   const [selected, setSelected] = useState<MissionFile | undefined>(undefined)
   const [pdfExportEnabled, setPdfExportEnabled] = useState(false)
   const [exportingPdf, setExportingPdf] = useState(false)
+  const [promoteOpen, setPromoteOpen] = useState(false)
   const { fullscreen, toggle, close } = useFullscreenPanel()
+  const canPromote = phase === 'done' && refs.some((r) => markdownFileRe.test(r.name ?? ''))
 
   useEffect(() => {
     getSettings()
@@ -93,8 +193,17 @@ export function ArtifactsSection({
   if (!hasWorkspace) {
     return (
       <section>
-        <h2 className="mb-2 text-sm font-semibold tracking-tight">Artifacts</h2>
+        <div className="mb-2 flex items-center justify-between">
+          <h2 className="text-sm font-semibold tracking-tight">Artifacts</h2>
+          {canPromote && (
+            <Button variant="outline" size="sm" onClick={() => setPromoteOpen(true)}>
+              <HugeiconsIcon icon={LibraryIcon} />
+              Promote to KB
+            </Button>
+          )}
+        </div>
         <ArtifactRefChips refs={refs} />
+        <PromoteToKBDialog missionId={missionId} open={promoteOpen} onOpenChange={setPromoteOpen} />
       </section>
     )
   }
@@ -112,6 +221,21 @@ export function ArtifactsSection({
           {files.length} file{files.length === 1 ? '' : 's'}
         </span>
         <div className="flex items-center gap-1">
+          {canPromote && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Promote workspace markdown artifacts to the knowledge base"
+                  onClick={() => setPromoteOpen(true)}
+                >
+                  <HugeiconsIcon icon={LibraryIcon} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Promote to knowledge base</TooltipContent>
+            </Tooltip>
+          )}
           {pdfExportEnabled && hasMarkdown && (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -185,6 +309,7 @@ export function ArtifactsSection({
           panel
         )}
       </section>
+      <PromoteToKBDialog missionId={missionId} open={promoteOpen} onOpenChange={setPromoteOpen} />
     </TooltipProvider>
   )
 }

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -20,6 +20,7 @@ vi.mock('../../api/client', () => ({
   testConnector: vi.fn().mockResolvedValue({ ok: true }),
   uploadAttachment: vi.fn(),
   listDestinations: vi.fn().mockResolvedValue([]),
+  listKbCollections: vi.fn().mockResolvedValue([]),
   listMissions: vi.fn().mockResolvedValue([]),
   listSessions: vi.fn().mockResolvedValue([]),
   searchKbDocuments: vi.fn().mockResolvedValue([]),

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -14,6 +14,7 @@ import {
   listConnectorRepos,
   listConnectors,
   listDestinations,
+  listKbCollections,
   patchSchedule,
   testConnector,
 } from '../../api/client'
@@ -25,6 +26,7 @@ import type {
   ExecutionPlanPhase,
   GitHubIdentity,
   GitHubRepo,
+  KbCollection,
   Reference,
   Schedule,
 } from '../../api/types'
@@ -336,6 +338,19 @@ export function MissionForm({
       .catch(() => {
         // Non-fatal: the section just stays hidden if this fails, same
         // degrade as any other optional list fetch in this form.
+      })
+  }, [])
+  // Promote-to-KB collection picker (D-081, issue #370): one-off create
+  // only, same visibility/fetch-failure reasoning as destinations above.
+  const [kbCollections, setKbCollections] = useState<KbCollection[] | null>(null)
+  const [promoteKBCollectionID, setPromoteKBCollectionID] = useState(
+    initial?.promote_kb_collection_id ?? '',
+  )
+  useEffect(() => {
+    listKbCollections()
+      .then(setKbCollections)
+      .catch(() => {
+        // Non-fatal: the section just stays hidden if this fails.
       })
   }, [])
   const [showAdvanced, setShowAdvanced] = useState(false)
@@ -689,6 +704,7 @@ export function MissionForm({
       attachments:
         attachments.length > 0 ? attachments.map((a) => ({ id: a.id, name: a.name ?? '' })) : undefined,
       destination_ids: destinationIDs.length > 0 ? destinationIDs : undefined,
+      promote_kb_collection_id: promoteKBCollectionID || undefined,
       light: kind === 'general' ? light : undefined,
       references:
         references.length > 0 ? references.map((r) => ({ kind: r.kind, id: r.id })) : undefined,
@@ -1327,6 +1343,25 @@ export function MissionForm({
                 </label>
               ))}
             </div>
+          </div>
+        )}
+
+        {mode === 'create' && !repeat && kbCollections && kbCollections.length > 0 && (
+          <div className="space-y-1.5">
+            <Label htmlFor="mission-promote-kb">Promote to knowledge base on done</Label>
+            <select
+              id="mission-promote-kb"
+              value={promoteKBCollectionID}
+              onChange={(e) => setPromoteKBCollectionID(e.target.value)}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+            >
+              <option value="">Don't promote automatically</option>
+              {kbCollections.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
           </div>
         )}
 


### PR DESCRIPTION
Closes #370.

## What

- `promote_kb_collection_id` on mission create: on the terminal done transition the harness promotes the mission's markdown artifacts (`.md`/`.txt`) into that kb collection with provenance `mission`, source `mission:<id>:<filename>` (D-081).
- `POST /v1/missions/{id}/promote-kb` for manual promotion after the fact; same code path, gated to `phase=done` (failed-mission artifacts are unverified).
- Reads artifact copies from the attachment store (survive workspace teardown), not the workspace.
- Idempotent: re-promotion replaces document content in place via the source key, no duplicate rows.
- Web: collection picker on mission create, promote action in the artifacts section, mission source badge links back from the kb document list.
- `migrations/0010_missions.sql` edited in place per pre-release convention; deployed DBs need `ALTER TABLE missions ADD COLUMN IF NOT EXISTS promote_kb_collection_id uuid` pre-flight.

## Verification

- Containerized `go build` / `vet` / `vet -tags integration` / `go test -race ./...`: pass
- Web build + lint + tests: pass (known AgentRoutePicker flake only; passes isolated)
- `make test-integration`: pass
- `make canary`: PASS

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790691924&installation_model_id=431401&pr_number=411&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F411&signature=411a5a6478558cb5a149117ea8cfc14f29581d48455280749af6c0b7f5fe0dcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->