### PR TITLE
feat(missions): kb_search hit ids and scores in tool call traces

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -690,7 +690,7 @@ func main() {
 		for i, h := range hits {
 			out[i] = builtin.KBSearchHit{
 				DocumentID: h.DocumentID, DocumentTitle: h.DocumentTitle, Breadcrumb: h.Breadcrumb,
-				Content: h.Content, SourceRef: h.SourceRef,
+				Content: h.Content, SourceRef: h.SourceRef, Score: h.Score,
 			}
 		}
 		return out, nil
@@ -1030,7 +1030,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 		for i, h := range hits {
 			out[i] = builtin.KBSearchHit{
 				DocumentID: h.DocumentID, DocumentTitle: h.DocumentTitle, Breadcrumb: h.Breadcrumb,
-				Content: h.Content, SourceRef: h.SourceRef,
+				Content: h.Content, SourceRef: h.SourceRef, Score: h.Score,
 			}
 		}
 		return out, nil

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -119,11 +120,18 @@ func (p *StorePermissionParker) OnPermissionDenied(ctx context.Context, missionI
 // turn as a mission.tool_call event (issue #369): the UI's per-turn
 // trace reads these back grouped by phase, alongside the mission.turn
 // event the same runTurn call eventually produces. Best-effort like
-// the other parkNotifier methods.
-func (p *StorePermissionParker) OnToolCall(ctx context.Context, missionID, phase, tool, digest, status string, durationMs int64) {
-	if err := p.Store.AppendEvent(ctx, missionID, "mission.tool_call", map[string]any{
+// the other parkNotifier methods. kbHits carries search_kb's returned
+// document ids/titles/scores (issue #413), nil for every other tool;
+// an empty non-nil slice (search_kb returned no hits) still renders
+// explicitly, since the event payload only omits the field when nil.
+func (p *StorePermissionParker) OnToolCall(ctx context.Context, missionID, phase, tool, digest, status string, durationMs int64, kbHits []KBHitTrace) {
+	payload := map[string]any{
 		"phase": phase, "tool": tool, "args_digest": digest, "status": status, "duration_ms": durationMs,
-	}); err != nil {
+	}
+	if kbHits != nil {
+		payload["kb_hits"] = kbHits
+	}
+	if err := p.Store.AppendEvent(ctx, missionID, "mission.tool_call", payload); err != nil {
 		p.Log.Error("mission: record tool call failed", "mission_id", missionID, "error", err)
 	}
 }
@@ -144,8 +152,9 @@ type parkNotifier interface {
 	// OnToolCall reports every tool call a worker/explore/plan/review
 	// turn made, in call order: the trace the mission detail UI shows
 	// per turn (issue #369). Best-effort, same stance as the methods
-	// above.
-	OnToolCall(ctx context.Context, missionID, phase, tool, digest, status string, durationMs int64)
+	// above. kbHits is search_kb's returned hit trace (issue #413), nil
+	// for every other tool.
+	OnToolCall(ctx context.Context, missionID, phase, tool, digest, status string, durationMs int64, kbHits []KBHitTrace)
 }
 
 // sandboxExec is the narrow slice of *sandboxclient.Client nativeRunner
@@ -676,8 +685,12 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			// records a denial separately with its own digest; this event
 			// records every call's outcome regardless of status.
 			if ev.ToolResult != nil && r.parker != nil {
+				var kbHits []KBHitTrace
+				if ev.ToolResult.Status == "ok" && ev.ToolResult.Name == "search_kb" {
+					kbHits = kbSearchHitTrace(ev.ToolResult.Digest)
+				}
 				r.parker.OnToolCall(ctx, req.MissionID, string(phase), ev.ToolResult.Name,
-					toolCallDigest(ev.ToolResult.Args), ev.ToolResult.Status, ev.ToolResult.DurationMs)
+					toolCallDigest(ev.ToolResult.Args), ev.ToolResult.Status, ev.ToolResult.DurationMs, kbHits)
 			}
 		case stream.EventDone:
 			sawTerminal = true
@@ -758,6 +771,84 @@ func webSearchResultURLs(digest string) []string {
 		}
 	}
 	return urls
+}
+
+// KBHitTrace is one search_kb hit as recorded on a mission.tool_call
+// event (issue #413): document id, title, and fused score only, never
+// chunk content, matching kbSearchHits' out-of-scope note.
+type KBHitTrace struct {
+	DocumentID    string  `json:"document_id"`
+	DocumentTitle string  `json:"document_title,omitempty"`
+	Score         float64 `json:"score"`
+}
+
+// kbSearchHitCap bounds how many hits kbSearchHitTrace records on one
+// mission.tool_call event: search_kb already caps k at 10 (kbSearchMaxK),
+// so this is a defensive ceiling, not an expected truncation.
+const kbSearchHitCap = 10
+
+// kbSearchNoHits marks kbsearch.go's formatKBHits empty-result sentinel,
+// checked verbatim rather than by regexp: it's a fixed literal, not a
+// pattern.
+const kbSearchNoHits = "no matching passages found"
+
+// kbSearchSourceLine matches formatKBHits' "Source: kb://ID (score
+// X.XXXX)" line: the only line in a search_kb result that carries a
+// document id and its fused score together.
+var kbSearchSourceLine = regexp.MustCompile(`^Source: kb://(\S+) \(score ([-\d.]+)\)$`)
+
+// kbSearchHitTrace pulls document ids, titles, and fused scores out of
+// search_kb's rendered digest (kbsearch.go's formatKBHits), the same
+// parse-the-rendered-output approach webSearchResultURLs uses for
+// search_web: the digest is the only structured evidence runTurn has
+// for what a tool call returned. Returns a non-nil empty slice for the
+// explicit no-hits sentinel, so the mission.tool_call event's kb_hits
+// field renders "no hits" rather than being absent; returns nil only
+// when the digest doesn't look like a search_kb result at all (already
+// offloaded past the digest cap, or malformed), so an event field
+// omission doesn't get misread as a confirmed empty result.
+func kbSearchHitTrace(digest string) []KBHitTrace {
+	if strings.TrimSpace(digest) == kbSearchNoHits {
+		return []KBHitTrace{}
+	}
+	lines := strings.Split(digest, "\n")
+	var hits []KBHitTrace
+	for i := 0; i+1 < len(lines) && len(hits) < kbSearchHitCap; i++ {
+		m := kbSearchSourceLine.FindStringSubmatch(strings.TrimSpace(lines[i]))
+		if m == nil {
+			continue
+		}
+		score, err := strconv.ParseFloat(m[2], 64)
+		if err != nil {
+			continue
+		}
+		title := ""
+		if i > 0 {
+			title = kbSearchTitleFromHeader(lines[i-1])
+		}
+		hits = append(hits, KBHitTrace{DocumentID: m[1], DocumentTitle: title, Score: score})
+	}
+	if hits == nil {
+		return nil
+	}
+	return hits
+}
+
+// kbSearchTitleFromHeader strips formatKBHits' "N. " numbering and any
+// breadcrumb (" - text") or source_ref (" (text)") suffix from a hit's
+// header line, leaving just the document title.
+func kbSearchTitleFromHeader(line string) string {
+	line = strings.TrimSpace(line)
+	if m := webSearchResultHeader.FindString(line); m != "" {
+		line = line[len(m):]
+	}
+	if i := strings.Index(line, " — "); i >= 0 {
+		line = line[:i]
+	}
+	if i := strings.Index(line, " ("); i >= 0 {
+		line = line[:i]
+	}
+	return strings.TrimSpace(line)
 }
 
 // workerRoute picks the route a worker turn runs on. With an

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -97,6 +97,7 @@ type fakeParker struct {
 type toolCallRecord struct {
 	missionID, phase, tool, digest, status string
 	durationMs                             int64
+	kbHits                                 []KBHitTrace
 }
 
 func (f *fakeParker) OnPermissionParked(_ context.Context, missionID, _, tool, _, danger, _ string) {
@@ -111,8 +112,8 @@ func (f *fakeParker) OnPermissionDenied(_ context.Context, missionID, tool, dige
 	f.denied = append(f.denied, missionID+":"+tool+":"+digest)
 }
 
-func (f *fakeParker) OnToolCall(_ context.Context, missionID, phase, tool, digest, status string, durationMs int64) {
-	f.toolCalls = append(f.toolCalls, toolCallRecord{missionID, phase, tool, digest, status, durationMs})
+func (f *fakeParker) OnToolCall(_ context.Context, missionID, phase, tool, digest, status string, durationMs int64, kbHits []KBHitTrace) {
+	f.toolCalls = append(f.toolCalls, toolCallRecord{missionID, phase, tool, digest, status, durationMs, kbHits})
 }
 
 func permissionRequestEvent(id, callID, tool, danger string) stream.StreamEvent {
@@ -1540,18 +1541,27 @@ func TestRunWorkerEmitsToolCallTraceInOrder(t *testing.T) {
 		t.Fatalf("RunWorker: %v", err)
 	}
 	want := []toolCallRecord{
-		{"m1", "execute", "search_kb", `{"query":"first"}`, "ok", 12},
-		{"m1", "execute", "shell", `{"command":"rm -rf /"}`, "denied", 3},
-		{"m1", "execute", "write_file", `{"path":"x"}`, "error", 40},
+		{"m1", "execute", "search_kb", `{"query":"first"}`, "ok", 12, nil},
+		{"m1", "execute", "shell", `{"command":"rm -rf /"}`, "denied", 3, nil},
+		{"m1", "execute", "write_file", `{"path":"x"}`, "error", 40, nil},
 	}
 	if len(parker.toolCalls) != len(want) {
 		t.Fatalf("toolCalls = %+v, want %d entries", parker.toolCalls, len(want))
 	}
 	for i, got := range parker.toolCalls {
-		if got != want[i] {
+		if !toolCallRecordsEqual(got, want[i]) {
 			t.Fatalf("toolCalls[%d] = %+v, want %+v", i, got, want[i])
 		}
 	}
+}
+
+// toolCallRecordsEqual compares two toolCallRecord values: kbHits is a
+// slice (not comparable with ==), so this stands in for a plain struct
+// equality check.
+func toolCallRecordsEqual(a, b toolCallRecord) bool {
+	return a.missionID == b.missionID && a.phase == b.phase && a.tool == b.tool &&
+		a.digest == b.digest && a.status == b.status && a.durationMs == b.durationMs &&
+		slices.Equal(a.kbHits, b.kbHits)
 }
 
 // TestToolCallDigestCapsLargeArgs is the digest-capping table test
@@ -1575,6 +1585,20 @@ func TestToolCallDigestCapsLargeArgs(t *testing.T) {
 				t.Fatalf("toolCallDigest(%d bytes) len=%d, want len=%d", len(tt.args), len(got), len(tt.want))
 			}
 		})
+	}
+}
+
+// TestKBSearchHitTraceCapsHitCount covers issue #413's bounding
+// requirement: kbSearchHitTrace never records more than kbSearchHitCap
+// hits, even given a malformed or unexpectedly long digest.
+func TestKBSearchHitTraceCapsHitCount(t *testing.T) {
+	var b strings.Builder
+	for i := 1; i <= kbSearchHitCap+5; i++ {
+		fmt.Fprintf(&b, "%d. Doc %d\nSource: kb://doc-%d (score 0.5)\ncontent\n\n", i, i, i)
+	}
+	got := kbSearchHitTrace(b.String())
+	if len(got) != kbSearchHitCap {
+		t.Fatalf("len(kbSearchHitTrace(...)) = %d, want %d", len(got), kbSearchHitCap)
 	}
 }
 
@@ -2046,6 +2070,120 @@ func TestWebSearchResultURLs(t *testing.T) {
 				t.Fatalf("webSearchResultURLs(%q) = %v, want %v", tc.digest, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestKBSearchHitTrace covers issue #413: search_kb's rendered digest
+// (kbsearch.go's formatKBHits) parses back into document ids, titles,
+// and fused scores for the mission.tool_call trace.
+func TestKBSearchHitTrace(t *testing.T) {
+	cases := []struct {
+		name   string
+		digest string
+		want   []KBHitTrace
+	}{
+		{
+			name:   "no matching passages found sentinel yields an explicit empty result",
+			digest: "no matching passages found",
+			want:   []KBHitTrace{},
+		},
+		{
+			name: "single hit",
+			digest: "1. Runbook — Runbook > Deploy (runbook.md)\n" +
+				"Source: kb://doc-abc-123 (score 0.8123)\n" +
+				"Run make deploy.",
+			want: []KBHitTrace{{DocumentID: "doc-abc-123", DocumentTitle: "Runbook", Score: 0.8123}},
+		},
+		{
+			name: "multiple hits, one with no breadcrumb or source ref",
+			digest: "1. Runbook — Runbook > Deploy (runbook.md)\n" +
+				"Source: kb://doc-1 (score 0.9)\n" +
+				"Run make deploy.\n\n" +
+				"2. FAQ\n" +
+				"Source: kb://doc-2 (score 0.4)\n" +
+				"Ask ops.",
+			want: []KBHitTrace{
+				{DocumentID: "doc-1", DocumentTitle: "Runbook", Score: 0.9},
+				{DocumentID: "doc-2", DocumentTitle: "FAQ", Score: 0.4},
+			},
+		},
+		{
+			name:   "hit with no document id has no source line to match",
+			digest: "1. FAQ\nAsk ops.",
+			want:   nil,
+		},
+		{
+			name:   "malformed digest yields nothing",
+			digest: "not a search_kb result at all",
+			want:   nil,
+		},
+		{
+			name:   "empty digest yields nothing",
+			digest: "",
+			want:   nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := kbSearchHitTrace(tc.digest)
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("kbSearchHitTrace(%q) = %+v, want %+v", tc.digest, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRunWorkerEmitsKBSearchHitsInTrace is the end-to-end wiring check
+// for issue #413: a worker turn's search_kb call reaches the
+// mission.tool_call trace with the returned document ids/titles/scores,
+// while an unrelated tool call's kbHits stays nil.
+func TestRunWorkerEmitsKBSearchHitsInTrace(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{{
+		toolEndEvent("search_kb", `{"query":"deploy"}`),
+		okToolResultEvent("call-1", "search_kb",
+			"1. Runbook — Runbook > Deploy (runbook.md)\nSource: kb://doc-abc-123 (score 0.8123)\nRun make deploy."),
+		toolEndEvent("shell", `{"command":"ls"}`),
+		finishedToolResultEvent("call-2", "shell", "ok", `{"command":"ls"}`, 5),
+		toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"deployed"}`),
+	}}}
+	parker := &fakeParker{}
+	r := newTestRunnerWithParker(agent, parker)
+	if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if len(parker.toolCalls) != 2 {
+		t.Fatalf("toolCalls = %+v, want 2 entries", parker.toolCalls)
+	}
+	kbCall := parker.toolCalls[0]
+	want := []KBHitTrace{{DocumentID: "doc-abc-123", DocumentTitle: "Runbook", Score: 0.8123}}
+	if kbCall.tool != "search_kb" || !slices.Equal(kbCall.kbHits, want) {
+		t.Fatalf("search_kb toolCall = %+v, want kbHits %+v", kbCall, want)
+	}
+	if shellCall := parker.toolCalls[1]; shellCall.kbHits != nil {
+		t.Fatalf("shell toolCall.kbHits = %+v, want nil", shellCall.kbHits)
+	}
+}
+
+// TestRunWorkerEmitsEmptyKBSearchHitsExplicitly covers issue #413's
+// empty-result acceptance criterion: a search_kb call with no hits
+// still records a non-nil empty kbHits slice, distinguishing "searched,
+// found nothing" from "not a search_kb call".
+func TestRunWorkerEmitsEmptyKBSearchHitsExplicitly(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{{
+		toolEndEvent("search_kb", `{"query":"nothing"}`),
+		okToolResultEvent("call-1", "search_kb", "no matching passages found"),
+		toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"searched, found nothing"}`),
+	}}}
+	parker := &fakeParker{}
+	r := newTestRunnerWithParker(agent, parker)
+	if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if len(parker.toolCalls) != 1 {
+		t.Fatalf("toolCalls = %+v, want 1 entry", parker.toolCalls)
+	}
+	if kbHits := parker.toolCalls[0].kbHits; kbHits == nil || len(kbHits) != 0 {
+		t.Fatalf("kbHits = %+v, want a non-nil empty slice", kbHits)
 	}
 }
 

--- a/internal/brain/tools/builtin/kbsearch.go
+++ b/internal/brain/tools/builtin/kbsearch.go
@@ -26,6 +26,7 @@ type KBSearchHit struct {
 	Breadcrumb    string
 	Content       string
 	SourceRef     string
+	Score         float64
 }
 
 // KBSearchFunc runs one hybrid/semantic/keyword search over the whole
@@ -134,9 +135,7 @@ func formatKBHits(hits []KBSearchHit) string {
 		}
 		b.WriteString("\n")
 		if h.DocumentID != "" {
-			b.WriteString("Source: kb://")
-			b.WriteString(h.DocumentID)
-			b.WriteString("\n")
+			fmt.Fprintf(&b, "Source: kb://%s (score %.4f)\n", h.DocumentID, h.Score)
 		}
 		b.WriteString(h.Content)
 		b.WriteString("\n\n")

--- a/internal/brain/tools/builtin/kbsearch_test.go
+++ b/internal/brain/tools/builtin/kbsearch_test.go
@@ -24,7 +24,7 @@ func (f *fakeKBSearch) search(_ context.Context, query, mode string, k int) ([]K
 func TestKBSearchFormatsHits(t *testing.T) {
 	t.Parallel()
 	fk := &fakeKBSearch{hits: []KBSearchHit{
-		{DocumentID: "doc-abc-123", DocumentTitle: "Runbook", Breadcrumb: "Runbook > Deploy", Content: "Run make deploy.", SourceRef: "runbook.md"},
+		{DocumentID: "doc-abc-123", DocumentTitle: "Runbook", Breadcrumb: "Runbook > Deploy", Content: "Run make deploy.", SourceRef: "runbook.md", Score: 0.8123},
 		{DocumentTitle: "FAQ", Content: "Ask ops."},
 	}}
 	tool := KBSearch(fk.search)
@@ -33,7 +33,7 @@ func TestKBSearchFormatsHits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	for _, want := range []string{"1. Runbook", "Runbook > Deploy", "runbook.md", "Source: kb://doc-abc-123", "Run make deploy.", "2. FAQ", "Ask ops."} {
+	for _, want := range []string{"1. Runbook", "Runbook > Deploy", "runbook.md", "Source: kb://doc-abc-123 (score 0.8123)", "Run make deploy.", "2. FAQ", "Ask ops."} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("output missing %q:\n%s", want, out)
 		}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -929,13 +929,25 @@ export interface MissionRetryPayload {
 // worker/explore/plan/review turn, in call order. phase matches the
 // mission.turn event for the same turn (explore/plan/execute/review),
 // so the detail page can group a turn's trace. args_digest is capped
-// server-side, never a full args blob.
+// server-side, never a full args blob. kb_hits is set only for a
+// search_kb call (issue #413): an empty array means the search ran and
+// found nothing, undefined means this call wasn't search_kb at all.
 export interface MissionToolCallPayload {
   phase: string
   tool: string
   args_digest?: string
   status: string
   duration_ms: number
+  kb_hits?: MissionKBHit[]
+}
+
+// MissionKBHit is one search_kb hit on a mission.tool_call event
+// (runner.go's KBHitTrace, issue #413): document id/title and fused
+// score only, never chunk content.
+export interface MissionKBHit {
+  document_id: string
+  document_title?: string
+  score: number
 }
 
 // MissionPermissionDeniedPayload is mission.permission_denied's payload

--- a/web/src/components/missions/TimelineSection.test.tsx
+++ b/web/src/components/missions/TimelineSection.test.tsx
@@ -161,6 +161,75 @@ describe('TimelineSection tool call trace', () => {
     expect(screen.queryByText('search_kb')).toBeNull()
   })
 
+  it('shows the hit list with title and score when a search_kb call is expanded', () => {
+    const withHits: MissionEvent[] = [
+      {
+        mission_id: 'm1',
+        seq: 1,
+        kind: 'mission.tool_call',
+        payload: {
+          phase: 'execute',
+          tool: 'search_kb',
+          args_digest: '{"query":"deploy"}',
+          status: 'ok',
+          duration_ms: 12,
+          kb_hits: [{ document_id: 'doc-1', document_title: 'Runbook', score: 0.8123 }],
+        },
+        provenance: 'harness',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        mission_id: 'm1',
+        seq: 2,
+        kind: 'mission.turn',
+        payload: { phase: 'execute', duration_ms: 500, ok: true, input: 'worker_done' },
+        provenance: 'harness',
+        created_at: '2026-01-01T00:00:01Z',
+      },
+    ]
+    render(<TimelineSection events={withHits} />)
+    fireEvent.click(screen.getByText('1 tool call'))
+    expect(screen.getByText('Runbook · score 0.8123')).toBeTruthy()
+  })
+
+  it('shows an explicit "no hits" line for a search_kb call with an empty result', () => {
+    const noHits: MissionEvent[] = [
+      {
+        mission_id: 'm1',
+        seq: 1,
+        kind: 'mission.tool_call',
+        payload: {
+          phase: 'execute',
+          tool: 'search_kb',
+          args_digest: '{"query":"nothing"}',
+          status: 'ok',
+          duration_ms: 5,
+          kb_hits: [],
+        },
+        provenance: 'harness',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        mission_id: 'm1',
+        seq: 2,
+        kind: 'mission.turn',
+        payload: { phase: 'execute', duration_ms: 200, ok: true, input: 'worker_done' },
+        provenance: 'harness',
+        created_at: '2026-01-01T00:00:01Z',
+      },
+    ]
+    render(<TimelineSection events={noHits} />)
+    fireEvent.click(screen.getByText('1 tool call'))
+    expect(screen.getByText('no hits')).toBeTruthy()
+  })
+
+  it('shows no hit list for a non-search_kb tool call', () => {
+    render(<TimelineSection events={toolCallTraceEvents} />)
+    fireEvent.click(screen.getByText('3 tool calls'))
+    expect(screen.queryByText('no hits')).toBeNull()
+    expect(screen.queryByText(/score/)).toBeNull()
+  })
+
   it('shows no toggle for a turn with no tool calls', () => {
     const noCalls: MissionEvent[] = [
       {

--- a/web/src/components/missions/TimelineSection.tsx
+++ b/web/src/components/missions/TimelineSection.tsx
@@ -1,7 +1,7 @@
 import { ArrowDown01Icon, ArrowRight01Icon, ArrowUp01Icon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useEffect, useRef, useState } from 'react'
-import type { MissionEvent, MissionToolCallPayload } from '../../api/types'
+import type { MissionEvent, MissionKBHit, MissionToolCallPayload } from '../../api/types'
 import { CopyButton } from '../Message'
 import { Button } from '../ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
@@ -65,7 +65,7 @@ function TurnTraceToggle({ calls }: { calls: MissionEvent[] }) {
       {open && (
         <ol className="mt-1 space-y-0.5 border-l border-zinc-800 pl-3">
           {calls.map((c) => {
-            const { tool, status, duration_ms, args_digest } = c.payload as MissionToolCallPayload
+            const { tool, status, duration_ms, args_digest, kb_hits } = c.payload as MissionToolCallPayload
             return (
               <li key={c.seq} className="text-zinc-400">
                 <span className={toolCallStatusClass(status)}>{tool}</span> · {status} ·{' '}
@@ -75,12 +75,32 @@ function TurnTraceToggle({ calls }: { calls: MissionEvent[] }) {
                     {args_digest}
                   </code>
                 )}
+                {kb_hits && <KBHitList hits={kb_hits} />}
               </li>
             )
           })}
         </ol>
       )}
     </div>
+  )
+}
+
+// KBHitList renders a search_kb call's returned hits (issue #413):
+// document title/id and fused score, or an explicit "no hits" line for
+// an empty result: a bare-blank block there would be indistinguishable
+// from a search that simply hasn't finished rendering.
+function KBHitList({ hits }: { hits: MissionKBHit[] }) {
+  if (hits.length === 0) {
+    return <div className="ml-1 mt-0.5 rounded bg-muted/20 px-1 py-0.5 text-[11px] text-zinc-500">no hits</div>
+  }
+  return (
+    <ol className="ml-1 mt-0.5 space-y-0.5 rounded bg-muted/20 px-1 py-0.5 text-[11px] text-zinc-500">
+      {hits.map((h) => (
+        <li key={h.document_id} className="truncate">
+          {h.document_title || h.document_id} · score {h.score.toFixed(4)}
+        </li>
+      ))}
+    </ol>
   )
 }
 


### PR DESCRIPTION
Closes #413.

## What

- `mission.tool_call` events for `search_kb` now carry `kb_hits`: `[{document_id, document_title, score}]`, capped at 10, parsed from the tool result digest (same mechanism as search_web URL extraction). Empty results recorded as an explicit `[]`, absent for every other tool.
- `formatKBHits` appends the fused score to each hit's `Source:` line; score threaded through `KBSearchHit` from `memclient.KBChunkHit` (was dropped before).
- Mission timeline UI renders the hit list (title, score) in the expanded trace row; explicit "no hits" for empty.

## Verification

- Containerized go build / vet / vet -tags integration / go test -race: pass
- make test-integration: pass
- Web build + lint + tests: pass (known AgentRoutePicker flake only)
- make canary: PASS

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790696635&installation_model_id=431401&pr_number=415&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F415&signature=ce90715c79be1e18a0473d70b197198d825cc58630834dc0daa8c52ebe363729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->