### PR TITLE
feat(kb): auto-retry transiently failed document ingests

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -681,6 +681,9 @@ func main() {
 			app.Log.Info("kb stale-ingest sweep", "documents_failed", n)
 		}
 	}()
+	// kb retry sweep (issue #414): re-ingests documents that failed on a
+	// transient embedding/provider error, on their own backoff schedule.
+	go api.RunKBRetrySweep(ctx, kbStore, mc, app.Log)
 	svc.SetKBSearch(func(ctx context.Context, query string, boostCollections []string, mode string, k int) ([]builtin.KBSearchHit, error) {
 		hits, err := mc.KBSearch(ctx, query, nil, boostCollections, mode, k)
 		if err != nil {

--- a/internal/brain/api/kb.go
+++ b/internal/brain/api/kb.go
@@ -42,6 +42,31 @@ var kbAllowedExt = map[string]bool{
 	".pdf": true, ".md": true, ".txt": true, ".docx": true, ".html": true,
 }
 
+// kbRetryMaxAttempts bounds how many automatic retries a transiently
+// failed document gets before it's left failed for a human (issue
+// #414): indexed by retry_count at failure time (1st, 2nd, 3rd retry).
+// kbRetryBackoff ladders the wait before each: short enough to recover
+// from a brief provider blip within the hour, capped so a persistent
+// outage doesn't hammer the gateway.
+const kbRetryMaxAttempts = 3
+
+var kbRetryBackoff = [...]time.Duration{2 * time.Minute, 10 * time.Minute, 30 * time.Minute}
+
+// kbRetryDelay returns the backoff before the next attempt, indexed by
+// retry_count after this failure (1-based: 1st scheduled retry uses
+// the first rung). Retry counts past the ladder's length reuse its
+// last (longest) rung.
+func kbRetryDelay(retryCount int) time.Duration {
+	idx := retryCount - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(kbRetryBackoff) {
+		idx = len(kbRetryBackoff) - 1
+	}
+	return kbRetryBackoff[idx]
+}
+
 // kbIngester runs memoryd's ingest pipeline for one document; nil
 // disables background ingestion (memoryd unreachable is a runtime
 // error, not a nil-gate, but MEMORYD_URL is always configured: this
@@ -727,7 +752,12 @@ func titleFromURL(u *url.URL) string {
 
 // startIngest fires the status->ingesting->memoryd->terminal sequence
 // in the background: upload/reingest both return as soon as the
-// document row exists, not once ingestion finishes.
+// document row exists, not once ingestion finishes. A failure
+// classified retryable (kb.IsRetryable) schedules an automatic retry
+// via ScheduleRetry as long as the document's retry_count is under
+// kbRetryMaxAttempts; a permanent error, or a retryable one past the
+// budget, falls back to SetFailed and stays failed until a human (or
+// this same path, called again manually) reingests it.
 func (h *kbAPI) startIngest(docID, title string) {
 	go func() {
 		ctx := context.Background()
@@ -745,6 +775,13 @@ func (h *kbAPI) startIngest(docID, title string) {
 		}
 		if _, err := h.ingest.IngestDocument(ctx, docID, title, doc.Markdown); err != nil {
 			h.log.Warn("kb ingest failed", "document_id", docID, "error", err)
+			if kb.IsRetryable(err.Error()) && doc.RetryCount < kbRetryMaxAttempts {
+				next := time.Now().Add(kbRetryDelay(doc.RetryCount + 1))
+				if serr := h.store.ScheduleRetry(ctx, docID, err.Error(), next); serr != nil {
+					h.log.Warn("kb ingest retry schedule failed", "document_id", docID, "error", serr)
+				}
+				return
+			}
 			_ = h.store.SetFailed(ctx, docID, err.Error())
 		}
 	}()
@@ -774,4 +811,50 @@ func (h *kbAPI) reingestDocument(w http.ResponseWriter, r *http.Request) {
 	}
 	h.startIngest(docID, doc.Title)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// kbRetrySweepInterval is how often RunKBRetrySweep checks for failed
+// documents whose backoff has elapsed (issue #414).
+const kbRetrySweepInterval = time.Minute
+
+// RunKBRetrySweep periodically re-ingests failed documents scheduled
+// for automatic retry (kb.Store.DueForRetry), reusing the same
+// startIngest path as the manual POST .../reingest endpoint so the two
+// never diverge on what "retry" means. Runs until ctx is done; store
+// nil (KB unmounted) or ingest nil (memoryd not configured) makes this
+// a no-op loop.
+func RunKBRetrySweep(ctx context.Context, store *kb.Store, ingest kbIngester, log *slog.Logger) {
+	if store == nil || ingest == nil {
+		return
+	}
+	ticker := time.NewTicker(kbRetrySweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			sweepKBRetries(ctx, store, ingest, log)
+		}
+	}
+}
+
+// sweepKBRetries runs one retry-sweep tick: re-ingests every document
+// DueForRetry reports. Logs nothing when there is nothing due, to keep
+// the steady-state quiet (issue #414 acceptance criteria).
+func sweepKBRetries(ctx context.Context, store *kb.Store, ingest kbIngester, log *slog.Logger) {
+	docs, err := store.DueForRetry(ctx)
+	if err != nil {
+		log.Error("kb retry sweep: list failed", "error", err)
+		return
+	}
+	if len(docs) == 0 {
+		return
+	}
+	h := &kbAPI{store: store, ingest: ingest, log: log}
+	for _, doc := range docs {
+		log.Info("kb retry sweep: re-ingesting a transiently failed document",
+			"document_id", doc.ID, "retry_count", doc.RetryCount)
+		h.startIngest(doc.ID, doc.Title)
+	}
 }

--- a/internal/brain/api/kb_integration_test.go
+++ b/internal/brain/api/kb_integration_test.go
@@ -1314,3 +1314,199 @@ func TestKBDocumentReingestFailureSetsFailedStatus(t *testing.T) {
 		t.Fatalf("document = %+v, want failed with the ingester's error", final)
 	}
 }
+
+// waitForDocument polls store.GetDocument until check reports true or
+// the deadline elapses: startIngest runs its own goroutine (kb.go), so
+// tests observe its effect asynchronously.
+func waitForDocument(t *testing.T, store *kb.Store, docID string, check func(kb.Document) bool) kb.Document {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	var last kb.Document
+	for time.Now().Before(deadline) {
+		doc, err := store.GetDocument(context.Background(), docID)
+		if err != nil {
+			t.Fatalf("GetDocument: %v", err)
+		}
+		last = doc
+		if check(doc) {
+			return doc
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return last
+}
+
+// TestKBDocumentReingestRetryableErrorSchedulesRetry pins issue #414:
+// a reingest failing on a retryable error (chain_exhausted here)
+// schedules an automatic retry instead of leaving the document
+// permanently failed, bumping retry_count and setting next_retry_at.
+func TestKBDocumentReingestRetryableErrorSchedulesRetry(t *testing.T) {
+	store := testKBStore(t)
+	ingester := &fakeIngester{err: errors.New("every provider failed: chain_exhausted")}
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
+
+	collID, err := store.CreateCollection(context.Background(), "itest-retry-schedule", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	docID, err := store.CreateDocument(context.Background(), collID, "Doc", "file", "doc.md", "curated", "content", 7)
+	if err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/v1/admin/kb/documents/"+docID+"/reingest", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("reingest status = %d body %s", w.Code, w.Body)
+	}
+
+	final := waitForDocument(t, store, docID, func(d kb.Document) bool { return d.RetryCount > 0 })
+	if final.Status != "failed" {
+		t.Fatalf("status = %q, want failed", final.Status)
+	}
+	if final.RetryCount != 1 {
+		t.Fatalf("retry_count = %d, want 1", final.RetryCount)
+	}
+	if final.NextRetryAt == nil || !final.NextRetryAt.After(time.Now()) {
+		t.Fatalf("next_retry_at = %v, want set in the future", final.NextRetryAt)
+	}
+	if !strings.Contains(final.Error, "chain_exhausted") {
+		t.Fatalf("error = %q, want the ingester's error preserved", final.Error)
+	}
+}
+
+// TestKBDocumentReingestPermanentErrorNeverSchedulesRetry pins issue
+// #414's other half: an error with no retryable marker (an unsupported
+// format here) leaves the document failed with next_retry_at unset, so
+// the retry sweep never picks it back up.
+func TestKBDocumentReingestPermanentErrorNeverSchedulesRetry(t *testing.T) {
+	store := testKBStore(t)
+	ingester := &fakeIngester{err: errors.New("document produced no chunks")}
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
+
+	collID, err := store.CreateCollection(context.Background(), "itest-retry-permanent", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	docID, err := store.CreateDocument(context.Background(), collID, "Doc", "file", "doc.md", "curated", "content", 7)
+	if err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/v1/admin/kb/documents/"+docID+"/reingest", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("reingest status = %d body %s", w.Code, w.Body)
+	}
+
+	final := waitForDocument(t, store, docID, func(d kb.Document) bool { return d.Status == "failed" })
+	if final.RetryCount != 0 {
+		t.Fatalf("retry_count = %d, want 0 (permanent error never schedules)", final.RetryCount)
+	}
+	if final.NextRetryAt != nil {
+		t.Fatalf("next_retry_at = %v, want unset for a permanent error", final.NextRetryAt)
+	}
+}
+
+// TestRunKBRetrySweepRetriesUntilBudgetExhausted pins the sweep's
+// bounded-attempts contract (issue #414): a document stuck on a
+// retryable error gets picked up and retried by RunKBRetrySweep across
+// several ticks, and once retry_count reaches kbRetryMaxAttempts the
+// next failure leaves it permanently failed (no next_retry_at), still
+// manually reingestable.
+func TestRunKBRetrySweepRetriesUntilBudgetExhausted(t *testing.T) {
+	store := testKBStore(t)
+	ingester := &fakeIngester{err: errors.New("gwclient: gateway http 503: service unavailable")}
+
+	collID, err := store.CreateCollection(context.Background(), "itest-retry-sweep", "")
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	docID, err := store.CreateDocument(context.Background(), collID, "Doc", "file", "doc.md", "curated", "content", 7)
+	if err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+
+	// Force every retry due immediately: this test exercises the sweep's
+	// selection/exhaustion logic, not the real backoff wait.
+	forceDue := func() {
+		conn, err := pgx.Connect(context.Background(), os.Getenv("DATABASE_URL"))
+		if err != nil {
+			t.Fatalf("connect: %v", err)
+		}
+		defer func() { _ = conn.Close(context.Background()) }()
+		if _, err := conn.Exec(context.Background(),
+			`UPDATE kb_documents SET next_retry_at = now() - interval '1 second' WHERE id = $1 AND next_retry_at IS NOT NULL`,
+			docID); err != nil {
+			t.Fatalf("force due: %v", err)
+		}
+	}
+
+	// First failure via reingest seeds retry_count=1 with a future
+	// next_retry_at; the sweep must not pick it up until it's due.
+	h := &kbAPI{store: store, ingest: ingester, log: discard()}
+	h.startIngest(docID, "Doc")
+	waitForDocument(t, store, docID, func(d kb.Document) bool { return d.RetryCount == 1 })
+
+	ctx := context.Background()
+
+	// Drive the sweep through every remaining attempt: kbRetryMaxAttempts
+	// total scheduled retries, then one more failure exhausts the budget.
+	for want := 2; want <= kbRetryMaxAttempts; want++ {
+		forceDue()
+		sweepKBRetries(ctx, store, ingester, discard())
+		waitForDocument(t, store, docID, func(d kb.Document) bool { return d.RetryCount >= want })
+	}
+	forceDue()
+	sweepKBRetries(ctx, store, ingester, discard())
+	final := waitForDocument(t, store, docID, func(d kb.Document) bool { return d.NextRetryAt == nil })
+
+	if final.Status != "failed" {
+		t.Fatalf("status = %q, want failed", final.Status)
+	}
+	if final.RetryCount != kbRetryMaxAttempts {
+		t.Fatalf("retry_count = %d, want %d (exhausted, no further bump)", final.RetryCount, kbRetryMaxAttempts)
+	}
+	if final.NextRetryAt != nil {
+		t.Fatalf("next_retry_at = %v, want unset once the retry budget is exhausted", final.NextRetryAt)
+	}
+	if !strings.Contains(final.Error, "503") {
+		t.Fatalf("error = %q, want the ingester's last error preserved", final.Error)
+	}
+
+	// Exhausted but still manually reingestable (AC): reingest must not
+	// be blocked by the spent automatic-retry budget.
+	req := httptest.NewRequest("POST", "/v1/admin/kb/documents/"+docID+"/reingest", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("manual reingest after exhaustion status = %d body %s", w.Code, w.Body)
+	}
+}
+
+// TestSweepKBRetriesNoopIsQuiet pins the "no failed documents, no log
+// noise" acceptance criterion: an empty DueForRetry result must not
+// log anything.
+func TestSweepKBRetriesNoopIsQuiet(t *testing.T) {
+	store := testKBStore(t)
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, nil))
+
+	sweepKBRetries(context.Background(), store, &fakeIngester{}, log)
+
+	if buf.Len() != 0 {
+		t.Fatalf("sweep logged with no failed documents: %s", buf.String())
+	}
+}

--- a/internal/brain/api/kb_test.go
+++ b/internal/brain/api/kb_test.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+// TestKBRetryDelay pins the retry backoff ladder (issue #414): each
+// scheduled retry uses the rung matching its retry_count, clamped to
+// the ladder's last rung past kbRetryMaxAttempts.
+func TestKBRetryDelay(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		retryCount int
+		want       time.Duration
+	}{
+		{0, 2 * time.Minute},
+		{1, 2 * time.Minute},
+		{2, 10 * time.Minute},
+		{3, 30 * time.Minute},
+		{4, 30 * time.Minute},
+		{100, 30 * time.Minute},
+	}
+	for _, tc := range cases {
+		if got := kbRetryDelay(tc.retryCount); got != tc.want {
+			t.Fatalf("kbRetryDelay(%d) = %v, want %v", tc.retryCount, got, tc.want)
+		}
+	}
+}

--- a/internal/brain/kb/kb.go
+++ b/internal/brain/kb/kb.go
@@ -53,6 +53,10 @@ type Document struct {
 	Error      string `json:"error"`
 	Bytes      int64  `json:"bytes"`
 	ChunkCount int    `json:"chunk_count"`
+	// RetryCount/NextRetryAt back the auto-retry sweep (issue #414): a
+	// failed document with NextRetryAt set is due for another attempt.
+	RetryCount  int        `json:"retry_count"`
+	NextRetryAt *time.Time `json:"next_retry_at"`
 
 	IngestedAt *time.Time `json:"ingested_at"`
 	CreatedAt  time.Time  `json:"created_at"`
@@ -173,12 +177,12 @@ func (s *Store) DeleteCollection(ctx context.Context, id string) error {
 	return nil
 }
 
-const documentColumns = `id, collection_id, title, source_type, source_ref, provenance, status, error, bytes, chunk_count, ingested_at, created_at, markdown`
+const documentColumns = `id, collection_id, title, source_type, source_ref, provenance, status, error, bytes, chunk_count, retry_count, next_retry_at, ingested_at, created_at, markdown`
 
 func scanDocument(row pgx.Row) (Document, error) {
 	var d Document
 	err := row.Scan(&d.ID, &d.CollectionID, &d.Title, &d.SourceType, &d.SourceRef, &d.Provenance,
-		&d.Status, &d.Error, &d.Bytes, &d.ChunkCount, &d.IngestedAt, &d.CreatedAt, &d.Markdown)
+		&d.Status, &d.Error, &d.Bytes, &d.ChunkCount, &d.RetryCount, &d.NextRetryAt, &d.IngestedAt, &d.CreatedAt, &d.Markdown)
 	return d, err
 }
 
@@ -311,7 +315,7 @@ func (s *Store) SetIngesting(ctx context.Context, id string) error {
 	if err != nil {
 		return fmt.Errorf("kb document %s ingesting: %w", id, err)
 	}
-	if _, err := db.Exec(ctx, `UPDATE kb_documents SET status = 'ingesting', updated_at = now() WHERE id = $1`, id); err != nil {
+	if _, err := db.Exec(ctx, `UPDATE kb_documents SET status = 'ingesting', next_retry_at = NULL, updated_at = now() WHERE id = $1`, id); err != nil {
 		return fmt.Errorf("kb document %s ingesting: %w", id, err)
 	}
 	return nil
@@ -323,16 +327,60 @@ const kbErrorCap = 500
 
 // SetFailed marks a document failed: used when brain itself (not
 // memoryd) hits an error before the ingest call ever reaches memoryd,
-// e.g. memoryd unreachable.
+// e.g. memoryd unreachable. Clears any pending retry schedule: a
+// permanent error (or the retry sweep giving up) must not leave
+// next_retry_at set, or the sweep would keep picking the row back up.
 func (s *Store) SetFailed(ctx context.Context, id, errMsg string) error {
 	db, err := s.db.Get()
 	if err != nil {
 		return fmt.Errorf("kb document %s failed: %w", id, err)
 	}
-	if _, err := db.Exec(ctx, `UPDATE kb_documents SET status = 'failed', error = $2, updated_at = now() WHERE id = $1`, id, truncate(errMsg, kbErrorCap)); err != nil {
+	if _, err := db.Exec(ctx, `UPDATE kb_documents SET status = 'failed', error = $2, next_retry_at = NULL, updated_at = now() WHERE id = $1`, id, truncate(errMsg, kbErrorCap)); err != nil {
 		return fmt.Errorf("kb document %s failed: %w", id, err)
 	}
 	return nil
+}
+
+// ScheduleRetry records a failed ingest attempt classified as
+// retryable: bumps retry_count and sets next_retry_at so the retry
+// sweep picks the document back up once the backoff elapses (issue
+// #414). The document stays status='failed' and manually reingestable
+// in the meantime, same as any other failure.
+func (s *Store) ScheduleRetry(ctx context.Context, id, errMsg string, nextRetryAt time.Time) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("kb document %s schedule retry: %w", id, err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE kb_documents
+		SET status = 'failed', error = $2, retry_count = retry_count + 1, next_retry_at = $3, updated_at = now()
+		WHERE id = $1`, id, truncate(errMsg, kbErrorCap), nextRetryAt); err != nil {
+		return fmt.Errorf("kb document %s schedule retry: %w", id, err)
+	}
+	return nil
+}
+
+// DueForRetry returns failed documents whose scheduled retry time has
+// arrived: the retry sweep's candidate set (issue #414).
+func (s *Store) DueForRetry(ctx context.Context) ([]Document, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("kb documents due for retry: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT `+documentColumns+` FROM kb_documents
+		WHERE status = 'failed' AND next_retry_at IS NOT NULL AND next_retry_at <= now()`)
+	if err != nil {
+		return nil, fmt.Errorf("kb documents due for retry: %w", err)
+	}
+	defer rows.Close()
+	out := []Document{}
+	for rows.Next() {
+		d, err := scanDocument(rows)
+		if err != nil {
+			return nil, fmt.Errorf("kb documents due for retry: %w", err)
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
 }
 
 func truncate(s string, n int) string {
@@ -373,6 +421,7 @@ func (s *Store) ReplaceDocumentContent(ctx context.Context, id, title, markdown 
 	}
 	tag, err := db.Exec(ctx, `UPDATE kb_documents
 		SET title = $2, markdown = $3, bytes = $4, status = 'pending', error = '',
+			retry_count = 0, next_retry_at = NULL,
 			collection_id = COALESCE(NULLIF($5, '')::uuid, collection_id), updated_at = now()
 		WHERE id = $1`, id, title, markdown, bytes, collectionID)
 	if err != nil {

--- a/internal/brain/kb/retry.go
+++ b/internal/brain/kb/retry.go
@@ -1,0 +1,42 @@
+package kb
+
+import "strings"
+
+// retryableMarkers are substrings of a stored failure error that mark
+// it a transient embedding/provider failure (issue #414): gateway
+// chain exhaustion, provider 5xx/429, timeouts, and connection errors
+// all surface through gwclient/memclient error wrapping and reach
+// SetFailed with one of these in the message. Anything else (content
+// too large, unsupported format, empty document) is treated as
+// permanent: the allowlist is deliberately conservative so an unknown
+// error string never retries forever instead of surfacing to the
+// operator.
+var retryableMarkers = []string{
+	"chain_exhausted",
+	"memoryd unreachable",
+	"gateway unreachable",
+	"http 429",
+	"http 500",
+	"http 502",
+	"http 503",
+	"http 504",
+	"timeout",
+	"deadline exceeded",
+	"connection refused",
+	"connection reset",
+	"eof",
+	"ingestion interrupted by a restart",
+}
+
+// IsRetryable reports whether a document's stored error looks like a
+// transient embedding/provider failure worth an automatic retry, as
+// opposed to a permanent content or format error.
+func IsRetryable(errMsg string) bool {
+	lower := strings.ToLower(errMsg)
+	for _, marker := range retryableMarkers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/brain/kb/retry_test.go
+++ b/internal/brain/kb/retry_test.go
@@ -1,0 +1,36 @@
+package kb
+
+import "testing"
+
+func TestIsRetryable(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  string
+		want bool
+	}{
+		{"chain exhausted", "every provider failed: chain_exhausted", true},
+		{"gateway 502", "gwclient: gateway http 502: bad gateway", true},
+		{"gateway 503", "gwclient: gateway http 503: service unavailable", true},
+		{"gateway 429", "gwclient: gateway http 429: rate limited", true},
+		{"memoryd unreachable", "memclient: memoryd unreachable: dial tcp: connection refused", true},
+		{"gateway unreachable", "gwclient: gateway unreachable: dial tcp: i/o timeout", true},
+		{"timeout", "embedding failed: context deadline exceeded", true},
+		{"connection reset", "memclient: memoryd http 500: read: connection reset by peer", true},
+		{"stale restart", "ingestion interrupted by a restart — re-ingest to retry", true},
+		{"unexpected EOF", "embedding failed: unexpected EOF", true},
+		{"unsupported format", "unsupported content type \"application/zip\" at example.com: only html, pdf, markdown, and plain text", false},
+		{"empty document", "document produced no chunks", false},
+		{"no markdown", "document has no stored markdown to reingest", false},
+		{"unknown error", "something went sideways", false},
+		{"empty string", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsRetryable(tc.err); got != tc.want {
+				t.Fatalf("IsRetryable(%q) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/memory/store/kb.go
+++ b/internal/memory/store/kb.go
@@ -37,7 +37,8 @@ func (s *KBStore) SetIngested(ctx context.Context, documentID string, chunkCount
 		return fmt.Errorf("kb set ingested: %w", err)
 	}
 	_, err = db.Exec(ctx, `UPDATE kb_documents
-		SET status = 'ready', chunk_count = $2, error = '', ingested_at = now(), updated_at = now()
+		SET status = 'ready', chunk_count = $2, error = '', retry_count = 0, next_retry_at = NULL,
+			ingested_at = now(), updated_at = now()
 		WHERE id = $1`, documentID, chunkCount)
 	if err != nil {
 		return fmt.Errorf("kb set ingested: %w", err)

--- a/migrations/0012_knowledge.sql
+++ b/migrations/0012_knowledge.sql
@@ -44,6 +44,12 @@ CREATE TABLE IF NOT EXISTS kb_documents (
     error         text NOT NULL DEFAULT '',
     bytes         bigint NOT NULL DEFAULT 0,
     chunk_count   int NOT NULL DEFAULT 0,
+    -- retry_count/next_retry_at back the auto-retry sweep (issue #414):
+    -- a failed document classified as a transient error gets re-ingested
+    -- with bounded attempts and backoff; a permanent error leaves both
+    -- untouched and the document stays only manually reingestable.
+    retry_count   int NOT NULL DEFAULT 0,
+    next_retry_at timestamptz,
     ingested_at   timestamptz,
     created_at    timestamptz NOT NULL DEFAULT now(),
     updated_at    timestamptz NOT NULL DEFAULT now()


### PR DESCRIPTION
Closes #414.

## What

- Failed ingests are classified (`kb.IsRetryable`, conservative allowlist: chain_exhausted, 5xx, timeouts, connection errors, restart interruption); retryable failures schedule bounded automatic retries instead of landing at failed.
- Budget: 3 attempts, backoff ladder 2m / 10m / 30m. A 1-minute sweep (`RunKBRetrySweep`) drives due retries through the exact same `startIngest` path the manual reingest endpoint uses.
- Exhausted or permanent failures: `SetFailed` as before, doc keeps its last error and stays manually reingestable. Empty sweep ticks are silent.
- `migrations/0012_knowledge.sql` edited in place (pre-release convention). Deployed DBs pre-flight: `ALTER TABLE kb_documents ADD COLUMN retry_count int NOT NULL DEFAULT 0, ADD COLUMN next_retry_at timestamptz;`

## Verification

- Containerized go build / vet / vet -tags integration / go test -race: pass
- make test-integration: pass (4 new retry integration tests)
- make canary: PASS

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790697119&installation_model_id=431401&pr_number=416&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F416&signature=11a3f6e4fefa5aa89a5451e383bfbca7269750850ebe8f1198c6a9049a43bb18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->