### PR TITLE
fix(web): overlay mission copy buttons instead of own header row

### DIFF
--- a/web/src/components/missions/ExploreSection.tsx
+++ b/web/src/components/missions/ExploreSection.tsx
@@ -21,8 +21,8 @@ export function ExploreSection({ notes }: { notes: string }) {
           Show exploration
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="mt-2 rounded-lg border border-border bg-muted/30">
-            <div className="flex items-center justify-end px-3 pt-2">
+          <div className="relative mt-2 rounded-lg border border-border bg-muted/30">
+            <div className="absolute right-2 top-2">
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span className="inline-flex">
@@ -32,7 +32,7 @@ export function ExploreSection({ notes }: { notes: string }) {
                 <TooltipContent>Copy</TooltipContent>
               </Tooltip>
             </div>
-            <div className="prose prose-sm max-h-64 max-w-none overflow-y-auto p-3 pt-1 dark:prose-invert">
+            <div className="prose prose-sm max-h-64 max-w-none overflow-y-auto p-3 pr-10 dark:prose-invert">
               <ReactMarkdown
                 remarkPlugins={remarkPlugins}
                 rehypePlugins={rehypePlugins}

--- a/web/src/components/missions/GoalSection.tsx
+++ b/web/src/components/missions/GoalSection.tsx
@@ -9,8 +9,8 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/
 // markdown — same shape as ExploreSection, since the header only shows
 // the mission's name (or a truncated goal fallback) and the full text
 // moves here. Plain-text goals render unchanged: markdown of a plain
-// paragraph is a no-op. The copy button sits inside the content block,
-// same placement as ExploreSection/ResultSection's.
+// paragraph is a no-op. The copy button overlays the content block's
+// top-right corner, same placement as ExploreSection/ResultSection's.
 export function GoalSection({ goal }: { goal: string }) {
   return (
     <TooltipProvider>
@@ -19,8 +19,8 @@ export function GoalSection({ goal }: { goal: string }) {
           Show goal
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="mt-2 rounded-lg border border-border bg-muted/30">
-            <div className="flex items-center justify-end px-3 pt-2">
+          <div className="relative mt-2 rounded-lg border border-border bg-muted/30">
+            <div className="absolute right-2 top-2">
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span className="inline-flex">
@@ -30,7 +30,7 @@ export function GoalSection({ goal }: { goal: string }) {
                 <TooltipContent>Copy</TooltipContent>
               </Tooltip>
             </div>
-            <div className="prose prose-sm max-h-64 max-w-none overflow-y-auto p-3 pt-1 dark:prose-invert">
+            <div className="prose prose-sm max-h-64 max-w-none overflow-y-auto p-3 pr-10 dark:prose-invert">
               <ReactMarkdown
                 remarkPlugins={remarkPlugins}
                 rehypePlugins={rehypePlugins}

--- a/web/src/components/missions/ResultSection.tsx
+++ b/web/src/components/missions/ResultSection.tsx
@@ -9,8 +9,8 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/
 export function ResultSection({ evidence }: { evidence: string }) {
   return (
     <TooltipProvider>
-      <div className="rounded-lg border border-border bg-muted/30">
-        <div className="flex items-center justify-end px-3 pt-2">
+      <div className="relative rounded-lg border border-border bg-muted/30">
+        <div className="absolute right-2 top-2">
           <Tooltip>
             <TooltipTrigger asChild>
               <span className="inline-flex">
@@ -20,7 +20,7 @@ export function ResultSection({ evidence }: { evidence: string }) {
             <TooltipContent>Copy</TooltipContent>
           </Tooltip>
         </div>
-        <div className="prose prose-sm max-w-none p-3 pt-1 dark:prose-invert">
+        <div className="prose prose-sm max-w-none p-3 pr-10 dark:prose-invert">
           <ReactMarkdown
             remarkPlugins={remarkPlugins}
             rehypePlugins={rehypePlugins}


### PR DESCRIPTION
Copy buttons in the mission goal, result, and exploration containers took a full row above the content. Now absolutely positioned over the top-right corner (`relative` container, `absolute right-2 top-2` button, `pr-10` on content so text clears it).

## Verification

- Web build + lint: pass
- GoalSection/ResultSection/ExploreSection tests: 12/12 pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790698114&installation_model_id=431401&pr_number=417&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F417&signature=5786f6d2eae88667de7e9db07bcc209059af37166c706fa9dc8150feb951b5e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->