### PR TITLE
fix(missions): parse kb_hits and seen urls from untruncated results

### DIFF
--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -782,7 +782,7 @@ func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string,
 	// load_skill's result is the pack's full rule text — useful to the
 	// model, never to the client. Every other tool's result is fair to
 	// show (truncated) in the audit trail and the UI.
-	var digest string
+	var digest, traceContent string
 	if call.Name == "load_skill" {
 		digest = "skill loaded"
 	} else {
@@ -790,6 +790,10 @@ func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string,
 		if len(digest) > digestCeiling {
 			digest = digest[:digestCeiling] + "…"
 		}
+		// traceContent is the untruncated result, for missions' own trace
+		// parsing (kb_hits, search_web URLs): Digest is capped well below
+		// where a multi-hit result's later hits live (issue #418).
+		traceContent = content
 	}
 
 	// Bookkeeping uses a detached context: a client disconnect must
@@ -820,7 +824,7 @@ func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string,
 	emit(stream.StreamEvent{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{
 		ID: call.ID, Name: call.Name, Status: status,
 		Digest: digest, DurationMs: duration.Milliseconds(), Args: call.Input,
-		Media: streamMedia,
+		Media: streamMedia, Content: traceContent,
 	}})
 
 	return provider.ToolResult{ID: call.ID, Content: content, IsError: isError}

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -674,7 +674,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 				r.parker.OnPermissionDenied(ctx, req.MissionID, ev.ToolResult.Name, ev.ToolResult.Digest)
 			}
 			if ev.ToolResult != nil && ev.ToolResult.Status == "ok" && ev.ToolResult.Name == "search_web" {
-				seenURLs = append(seenURLs, webSearchResultURLs(ev.ToolResult.Digest)...)
+				seenURLs = append(seenURLs, webSearchResultURLs(ev.ToolResult.Content)...)
 			}
 			if ev.ToolResult != nil && ev.ToolResult.Name != sentinelTool {
 				finalB.Reset()
@@ -687,7 +687,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if ev.ToolResult != nil && r.parker != nil {
 				var kbHits []KBHitTrace
 				if ev.ToolResult.Status == "ok" && ev.ToolResult.Name == "search_kb" {
-					kbHits = kbSearchHitTrace(ev.ToolResult.Digest)
+					kbHits = kbSearchHitTrace(ev.ToolResult.Content)
 				}
 				r.parker.OnToolCall(ctx, req.MissionID, string(phase), ev.ToolResult.Name,
 					toolCallDigest(ev.ToolResult.Args), ev.ToolResult.Status, ev.ToolResult.DurationMs, kbHits)
@@ -749,15 +749,17 @@ func webFetchArgURL(input json.RawMessage) []string {
 // output: websearch.go's runSearch emits one blank-line-separated
 // entry per result as "N. title\nurl\nsnippet" (D-059). Line 2 of each
 // three-line group is the URL; anything not matching that shape (the
-// "no results found" sentinel, a truncated tail) is skipped rather
-// than guessed at. Best-effort only: the digest is capped (and big
-// results offload to a stub), so URLs past the cap are lost. That is
-// deliberate lenience on top of the reliable contract: cite what you
-// fetch_url, whose args are never truncated.
+// "no results found" sentinel) is skipped rather than guessed at.
+// Parses the tool result's full untruncated content (issue #418), not
+// the capped mission.tool_call digest; a result over the loop's 8KB
+// offload threshold still collapses to a stub, so URLs past that
+// (much higher) point are lost. That is deliberate lenience on top of
+// the reliable contract: cite what you fetch_url, whose args are
+// never truncated.
 var webSearchResultHeader = regexp.MustCompile(`^\d+\.\s`)
 
-func webSearchResultURLs(digest string) []string {
-	lines := strings.Split(digest, "\n")
+func webSearchResultURLs(content string) []string {
+	lines := strings.Split(content, "\n")
 	var urls []string
 	for i := 0; i+1 < len(lines); i++ {
 		// A result's first line is "N. title": only its second line
@@ -798,20 +800,23 @@ const kbSearchNoHits = "no matching passages found"
 var kbSearchSourceLine = regexp.MustCompile(`^Source: kb://(\S+) \(score ([-\d.]+)\)$`)
 
 // kbSearchHitTrace pulls document ids, titles, and fused scores out of
-// search_kb's rendered digest (kbsearch.go's formatKBHits), the same
+// search_kb's rendered result (kbsearch.go's formatKBHits), the same
 // parse-the-rendered-output approach webSearchResultURLs uses for
-// search_web: the digest is the only structured evidence runTurn has
-// for what a tool call returned. Returns a non-nil empty slice for the
+// search_web. Parses the tool result's full untruncated content (issue
+// #418), not the capped mission.tool_call digest, so a hit past the
+// first is never lost to that cap; a result over the loop's 8KB
+// offload threshold still collapses to a stub, an existing, separate
+// limit this does not address. Returns a non-nil empty slice for the
 // explicit no-hits sentinel, so the mission.tool_call event's kb_hits
 // field renders "no hits" rather than being absent; returns nil only
-// when the digest doesn't look like a search_kb result at all (already
-// offloaded past the digest cap, or malformed), so an event field
-// omission doesn't get misread as a confirmed empty result.
-func kbSearchHitTrace(digest string) []KBHitTrace {
-	if strings.TrimSpace(digest) == kbSearchNoHits {
+// when the content doesn't look like a search_kb result at all
+// (already offloaded past the threshold, or malformed), so an event
+// field omission doesn't get misread as a confirmed empty result.
+func kbSearchHitTrace(content string) []KBHitTrace {
+	if strings.TrimSpace(content) == kbSearchNoHits {
 		return []KBHitTrace{}
 	}
-	lines := strings.Split(digest, "\n")
+	lines := strings.Split(content, "\n")
 	var hits []KBHitTrace
 	for i := 0; i+1 < len(lines) && len(hits) < kbSearchHitCap; i++ {
 		m := kbSearchSourceLine.FindStringSubmatch(strings.TrimSpace(lines[i]))

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -2007,11 +2007,13 @@ func TestMissionRunnerRequestsAreBuiltinsOnly(t *testing.T) {
 }
 
 // okToolResultEvent is toolResultEvent's ok-status counterpart with a
-// name and digest: search_web's rendered results ride the digest,
-// never a separate raw-result field (D-059).
-func okToolResultEvent(id, name, digest string) stream.StreamEvent {
+// name and result text. Content is what runner.go's trace parsing
+// (kb_hits, search_web URLs) reads (issue #418); Digest mirrors it
+// here since the loop only diverges the two when Digest is truncated,
+// which this fixed-text helper never triggers.
+func okToolResultEvent(id, name, content string) stream.StreamEvent {
 	return stream.StreamEvent{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{
-		ID: id, Name: name, Status: "ok", Digest: digest,
+		ID: id, Name: name, Status: "ok", Digest: content, Content: content,
 	}}
 }
 
@@ -2133,6 +2135,37 @@ func TestKBSearchHitTrace(t *testing.T) {
 	}
 }
 
+// TestKBSearchHitTraceSurvivesOversizedFirstHit covers issue #418: the
+// mission.tool_call digest caps at 2000 chars (toolCallDigestCap), so a
+// first hit whose own chunk content alone exceeds that would push every
+// later hit past a capped string before it's ever parsed. Since
+// kbSearchHitTrace now runs against the tool result's full untruncated
+// content (runner.go passes ev.ToolResult.Content, not .Digest), all 10
+// hits survive regardless of how large the first hit's content is.
+func TestKBSearchHitTraceSurvivesOversizedFirstHit(t *testing.T) {
+	oversized := strings.Repeat("x", toolCallDigestCap+500)
+	var b strings.Builder
+	want := make([]KBHitTrace, 0, kbSearchHitCap)
+	for i := 1; i <= kbSearchHitCap; i++ {
+		docID := fmt.Sprintf("doc-%d", i)
+		title := fmt.Sprintf("Doc %d", i)
+		content := "short content"
+		if i == 1 {
+			content = oversized
+		}
+		fmt.Fprintf(&b, "%d. %s\nSource: kb://%s (score %.4f)\n%s\n\n", i, title, docID, float64(i)/10, content)
+		want = append(want, KBHitTrace{DocumentID: docID, DocumentTitle: title, Score: float64(i) / 10})
+	}
+	full := strings.TrimSpace(b.String())
+	if len(full) <= toolCallDigestCap {
+		t.Fatalf("test fixture too small: %d chars, want > %d", len(full), toolCallDigestCap)
+	}
+	got := kbSearchHitTrace(full)
+	if !slices.Equal(got, want) {
+		t.Fatalf("kbSearchHitTrace on %d-char content = %+v, want %d hits", len(full), got, len(want))
+	}
+}
+
 // TestRunWorkerEmitsKBSearchHitsInTrace is the end-to-end wiring check
 // for issue #413: a worker turn's search_kb call reaches the
 // mission.tool_call trace with the returned document ids/titles/scores,
@@ -2161,6 +2194,49 @@ func TestRunWorkerEmitsKBSearchHitsInTrace(t *testing.T) {
 	}
 	if shellCall := parker.toolCalls[1]; shellCall.kbHits != nil {
 		t.Fatalf("shell toolCall.kbHits = %+v, want nil", shellCall.kbHits)
+	}
+}
+
+// TestRunWorkerEmitsAllKBHitsPastOversizedFirstHit covers issue #418
+// end-to-end: a search_kb result whose first hit's chunk content alone
+// exceeds the mission.tool_call digest cap (toolCallDigestCap) must
+// still land every hit (up to kbSearchHitCap) in the trace, because
+// runner.go now parses the tool result's full content rather than its
+// capped digest.
+func TestRunWorkerEmitsAllKBHitsPastOversizedFirstHit(t *testing.T) {
+	oversized := strings.Repeat("x", toolCallDigestCap+500)
+	var b strings.Builder
+	want := make([]KBHitTrace, 0, kbSearchHitCap)
+	for i := 1; i <= kbSearchHitCap; i++ {
+		docID := fmt.Sprintf("doc-%d", i)
+		title := fmt.Sprintf("Doc %d", i)
+		content := "short content"
+		if i == 1 {
+			content = oversized
+		}
+		fmt.Fprintf(&b, "%d. %s\nSource: kb://%s (score %.4f)\n%s\n\n", i, title, docID, float64(i)/10, content)
+		want = append(want, KBHitTrace{DocumentID: docID, DocumentTitle: title, Score: float64(i) / 10})
+	}
+	full := strings.TrimSpace(b.String())
+	if len(full) <= toolCallDigestCap {
+		t.Fatalf("test fixture too small: %d chars, want > %d", len(full), toolCallDigestCap)
+	}
+
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{{
+		toolEndEvent("search_kb", `{"query":"deploy"}`),
+		okToolResultEvent("call-1", "search_kb", full),
+		toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"deployed"}`),
+	}}}
+	parker := &fakeParker{}
+	r := newTestRunnerWithParker(agent, parker)
+	if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if len(parker.toolCalls) != 1 {
+		t.Fatalf("toolCalls = %+v, want 1 entry", parker.toolCalls)
+	}
+	if got := parker.toolCalls[0].kbHits; !slices.Equal(got, want) {
+		t.Fatalf("search_kb toolCall.kbHits = %+v (%d), want %d hits", got, len(got), len(want))
 	}
 }
 

--- a/internal/gateway/stream/events.go
+++ b/internal/gateway/stream/events.go
@@ -65,6 +65,12 @@ type ToolResultEvent struct {
 	// resolve which account a unified aggregate tool call (e.g.
 	// search_mail) actually routed to (session.SensitiveTools.Matches).
 	Args json.RawMessage `json:"-"`
+	// Content is the tool's full, untruncated result text, brain-internal
+	// only (json:"-": never reaches the client wire, Digest is what's
+	// shown there). Missions' trace parsing (kb_hits, search_web URLs)
+	// needs the full text: Digest is capped well below where a
+	// multi-hit result's later hits live (issue #418).
+	Content string `json:"-"`
 }
 
 // MediaRef points at one attachment-store item a tool generated during


### PR DESCRIPTION
Closes #418.

## What

- `stream.ToolResultEvent` gains a brain-internal `Content` field (`json:"-"`, never on the wire) carrying the full tool result; `load_skill` stays redacted like the digest.
- `kbSearchHitTrace` and `webSearchResultURLs` parse `Content` instead of the 4000-char-capped `Digest`; all hits (cap 10) now survive regardless of chunk sizes.
- Persisted digests and event payload sizes unchanged.
- Pre-existing residual: results over the 8KB offload threshold still stub out before any parsing; documented, out of scope.

## Verification

- Containerized go build / vet / vet -tags integration / go test -race: pass
- make test-integration: pass (clean solo run; earlier FK failures were concurrent-suite interference)
- make canary: PASS

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790700076&installation_model_id=431401&pr_number=420&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F420&signature=0920b17a7a1305ddb2205acd203fccfdda1b593b133757eeeb409ddefa247000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->