### PR TITLE
feat(kb): cap chunks per document in search results

### DIFF
--- a/internal/memory/store/kb.go
+++ b/internal/memory/store/kb.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
 )
@@ -156,6 +157,19 @@ const (
 	provenanceWeightWebLit     = "0.6"
 )
 
+// kbPerDocumentCap bounds how many chunks of one document can land in
+// top-k (D-082, issue #419): fusion is per chunk, so a long relevant
+// document can fill every slot and starve the rest of the corpus. Cap
+// drops, never reorders; freed slots go to the next-ranked chunks of
+// other documents, and a two-pass backfill still fills k when the
+// corpus is too narrow to satisfy the cap.
+const kbPerDocumentCap = 2
+
+// kbCandidateFetchMultiplier over-fetches from SQL so the Go-side cap
+// has enough lower-ranked candidates to promote after dropping
+// over-cap chunks, without a second round trip.
+const kbCandidateFetchMultiplier = 3
+
 // KBSearch runs hybrid (vector + full-text, RRF-fused), semantic-only,
 // or keyword-only retrieval over kb_chunks. Empty collectionNames
 // searches the whole knowledge base; non-empty scopes to it (an
@@ -165,6 +179,8 @@ const (
 // outside it are still returned. embedding may be nil only when mode is
 // keyword; hybrid/semantic without an embedding return no results from
 // the vector leg (callers should not call semantic/hybrid without one).
+// Results are capped at kbPerDocumentCap chunks per document (D-082),
+// backfilled to k when the corpus can't otherwise fill it.
 func (s *KBStore) KBSearch(ctx context.Context, query string, embedding Vector, collectionNames, boostCollections []string, mode KBSearchMode, k int) ([]KBSearchHit, error) {
 	db, err := s.db.Get()
 	if err != nil {
@@ -173,16 +189,17 @@ func (s *KBStore) KBSearch(ctx context.Context, query string, embedding Vector, 
 	if k <= 0 {
 		k = 8
 	}
+	fetchN := k * kbCandidateFetchMultiplier
 
 	var sql string
 	var args []any
 	switch mode {
 	case KBSearchSemantic:
-		sql, args = semanticSQL, []any{embedding.String(), collectionNames, k, boostCollections}
+		sql, args = semanticSQL, []any{embedding.String(), collectionNames, fetchN, boostCollections}
 	case KBSearchKeyword:
-		sql, args = keywordSQL, []any{query, collectionNames, k, boostCollections}
+		sql, args = keywordSQL, []any{query, collectionNames, fetchN, boostCollections}
 	default:
-		sql, args = hybridSQL, []any{embedding.String(), query, collectionNames, k, boostCollections}
+		sql, args = hybridSQL, []any{embedding.String(), query, collectionNames, fetchN, boostCollections}
 	}
 
 	rows, err := db.Query(ctx, sql, args...)
@@ -191,16 +208,56 @@ func (s *KBStore) KBSearch(ctx context.Context, query string, embedding Vector, 
 	}
 	defer rows.Close()
 
-	var out []KBSearchHit
+	var candidates []KBSearchHit
 	for rows.Next() {
 		var h KBSearchHit
 		if err := rows.Scan(&h.ChunkID, &h.DocumentID, &h.DocumentTitle, &h.Collection,
 			&h.Breadcrumb, &h.Content, &h.SourceRef, &h.Provenance, &h.Score); err != nil {
 			return nil, fmt.Errorf("kb search: %w", err)
 		}
-		out = append(out, h)
+		candidates = append(candidates, h)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return applyPerDocumentCap(candidates, k), nil
+}
+
+// applyPerDocumentCap takes candidates (already score-descending) and
+// selects up to k, never more than kbPerDocumentCap per document. First
+// pass: walk candidates in order, keep a hit if its document is still
+// under cap. Second pass: if the cap left fewer than min(k, len(candidates))
+// selected, backfill remaining slots from the leftover candidates in
+// score order regardless of document. Both passes preserve the input's
+// score-descending order within their own selections; the final result
+// is re-sorted by score so backfilled hits merge in at the right rank.
+func applyPerDocumentCap(candidates []KBSearchHit, k int) []KBSearchHit {
+	if len(candidates) == 0 {
+		return nil
+	}
+	perDoc := make(map[string]int, len(candidates))
+	selected := make([]KBSearchHit, 0, k)
+	var leftover []KBSearchHit
+	for _, h := range candidates {
+		if len(selected) < k && perDoc[h.DocumentID] < kbPerDocumentCap {
+			selected = append(selected, h)
+			perDoc[h.DocumentID]++
+		} else {
+			leftover = append(leftover, h)
+		}
+	}
+	want := k
+	if len(candidates) < want {
+		want = len(candidates)
+	}
+	for _, h := range leftover {
+		if len(selected) >= want {
+			break
+		}
+		selected = append(selected, h)
+	}
+	sort.SliceStable(selected, func(i, j int) bool { return selected[i].Score > selected[j].Score })
+	return selected
 }
 
 const (

--- a/internal/memory/store/kb_golden_integration_test.go
+++ b/internal/memory/store/kb_golden_integration_test.go
@@ -4,6 +4,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -434,6 +435,142 @@ func TestKBGoldenProvenanceComposesWithBoost(t *testing.T) {
 	gotRatio := boostedScore / plainScore
 	if diff := gotRatio - wantRatio; diff > 0.01 || diff < -0.01 {
 		t.Fatalf("boosted/plain score ratio = %.4f, want %.4f (boost * provenance weight composed by multiplication)", gotRatio, wantRatio)
+	}
+}
+
+// D-082 (issue #419): per-document chunk cap for result diversity.
+const kbDiversityCollection = "itest-kbdiversity"
+
+// seedKBDiversity builds one dominant document with 5 chunks all on the
+// query's basis dimension (so every chunk fuses to a similar high score
+// and would otherwise fill top-k alone), plus one chunk each in three
+// other documents on the same dimension: enough non-dominant chunks
+// (3) that capping the dominant document to kbPerDocumentCap (2) still
+// fills k=5 without needing to backfill into the dominant document.
+func seedKBDiversity(t *testing.T) *KBStore {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	_, _ = db.Exec(ctx, "DELETE FROM kb_collections WHERE name = $1", kbDiversityCollection)
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer ccancel()
+		conn, err := pgx.Connect(cctx, dsn)
+		if err != nil {
+			t.Errorf("cleanup connect: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close(cctx) }()
+		_, _ = conn.Exec(cctx, "DELETE FROM kb_collections WHERE name = $1", kbDiversityCollection)
+	})
+
+	st := NewKBStore(pool)
+	var collID string
+	if err := db.QueryRow(ctx,
+		"INSERT INTO kb_collections (name) VALUES ($1) RETURNING id", kbDiversityCollection).Scan(&collID); err != nil {
+		t.Fatalf("insert collection: %v", err)
+	}
+
+	// Dominant document: 5 chunks, all on-axis (similarity 1.0).
+	var dominantID string
+	if err := db.QueryRow(ctx, `INSERT INTO kb_documents (collection_id, title, status)
+		VALUES ($1, 'dominant', 'ready') RETURNING id`, collID).Scan(&dominantID); err != nil {
+		t.Fatalf("insert dominant document: %v", err)
+	}
+	dominantChunks := make([]KBChunk, 5)
+	for i := range dominantChunks {
+		dominantChunks[i] = KBChunk{Seq: i, Content: fmt.Sprintf("dominant chunk %d about widgets", i), Embedding: kbBasis(700), EmbeddingModel: "itest"}
+	}
+	if err := st.ReplaceChunks(ctx, dominantID, dominantChunks); err != nil {
+		t.Fatalf("ReplaceChunks dominant: %v", err)
+	}
+
+	// Three other documents, one chunk each, still on-axis so they rank
+	// below the dominant document's chunks purely by keyword overlap
+	// (fewer shared lexemes) but clear the semantic floor identically.
+	for _, title := range []string{"other-a", "other-b", "other-c"} {
+		var docID string
+		if err := db.QueryRow(ctx, `INSERT INTO kb_documents (collection_id, title, status)
+			VALUES ($1, $2, 'ready') RETURNING id`, collID, title).Scan(&docID); err != nil {
+			t.Fatalf("insert document %s: %v", title, err)
+		}
+		if err := st.ReplaceChunks(ctx, docID, []KBChunk{
+			{Seq: 0, Content: title + " widgets", Embedding: kbBasis(700), EmbeddingModel: "itest"},
+		}); err != nil {
+			t.Fatalf("ReplaceChunks %s: %v", title, err)
+		}
+	}
+	return st
+}
+
+// TestKBGoldenPerDocumentCapDiversifies pins AC1: a dominant document's
+// fused chunks would otherwise fill every slot; the cap limits it to
+// kbPerDocumentCap and the freed slots surface the other documents.
+func TestKBGoldenPerDocumentCapDiversifies(t *testing.T) {
+	st := seedKBDiversity(t)
+	hits, err := st.KBSearch(t.Context(), "widgets", kbBasis(700), []string{kbDiversityCollection}, nil, KBSearchHybrid, 5)
+	if err != nil {
+		t.Fatalf("KBSearch: %v", err)
+	}
+	if len(hits) != 5 {
+		t.Fatalf("got %d hits, want 5", len(hits))
+	}
+	docCounts := map[string]int{}
+	for _, h := range hits {
+		docCounts[h.DocumentTitle]++
+	}
+	if docCounts["dominant"] != kbPerDocumentCap {
+		t.Fatalf("dominant document contributed %d chunks, want %d (cap)", docCounts["dominant"], kbPerDocumentCap)
+	}
+	if docCounts["other-a"] == 0 || docCounts["other-b"] == 0 || docCounts["other-c"] == 0 {
+		t.Fatalf("expected all three other documents to surface via freed slots, got %+v", docCounts)
+	}
+	for i := 1; i < len(hits); i++ {
+		if hits[i].Score > hits[i-1].Score {
+			t.Fatalf("hits not score-descending at index %d: %+v", i, hits)
+		}
+	}
+}
+
+// TestKBGoldenPerDocumentCapBackfillsSingleDoc pins AC2: with only one
+// matching document, the cap must not starve k below the available hit
+// count; slots backfill with that document's own chunks.
+func TestKBGoldenPerDocumentCapBackfillsSingleDoc(t *testing.T) {
+	st := seedKBDiversity(t)
+	hits, err := st.KBSearch(t.Context(), "dominant chunk", kbBasis(700), []string{kbDiversityCollection}, nil, KBSearchKeyword, 5)
+	if err != nil {
+		t.Fatalf("KBSearch: %v", err)
+	}
+	// Keyword mode only matches chunks sharing the "dominant"/"chunk"
+	// lexemes, unique to the dominant document's 5 chunks: the cap must
+	// still backfill all 5 rather than stopping at kbPerDocumentCap.
+	docCounts := map[string]int{}
+	for _, h := range hits {
+		docCounts[h.DocumentTitle]++
+	}
+	if docCounts["dominant"] != 5 {
+		t.Fatalf("dominant document contributed %d chunks, want 5 (backfilled, single matching doc)", docCounts["dominant"])
+	}
+	for i := 1; i < len(hits); i++ {
+		if hits[i].Score > hits[i-1].Score {
+			t.Fatalf("hits not score-descending at index %d: %+v", i, hits)
+		}
 	}
 }
 

--- a/internal/memory/store/kb_test.go
+++ b/internal/memory/store/kb_test.go
@@ -1,0 +1,78 @@
+package store
+
+import "testing"
+
+// TestApplyPerDocumentCapDropsOverflow pins the core cap behavior: a
+// dominant document's excess chunks are dropped, never reordered, and
+// the freed slots go to the next-ranked chunks of other documents.
+func TestApplyPerDocumentCapDropsOverflow(t *testing.T) {
+	candidates := []KBSearchHit{
+		{ChunkID: "a1", DocumentID: "docA", Score: 0.9},
+		{ChunkID: "a2", DocumentID: "docA", Score: 0.8},
+		{ChunkID: "a3", DocumentID: "docA", Score: 0.7},
+		{ChunkID: "a4", DocumentID: "docA", Score: 0.6},
+		{ChunkID: "b1", DocumentID: "docB", Score: 0.5},
+		{ChunkID: "c1", DocumentID: "docC", Score: 0.4},
+	}
+	got := applyPerDocumentCap(candidates, 4)
+	if len(got) != 4 {
+		t.Fatalf("got %d hits, want 4", len(got))
+	}
+	var docACount int
+	seenDocs := map[string]bool{}
+	for _, h := range got {
+		if h.DocumentID == "docA" {
+			docACount++
+		}
+		seenDocs[h.DocumentID] = true
+	}
+	if docACount != kbPerDocumentCap {
+		t.Fatalf("docA count = %d, want %d (cap)", docACount, kbPerDocumentCap)
+	}
+	if !seenDocs["docB"] || !seenDocs["docC"] {
+		t.Fatalf("expected freed slots to include docB and docC, got %+v", got)
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i].Score > got[i-1].Score {
+			t.Fatalf("result not score-descending at index %d: %+v", i, got)
+		}
+	}
+}
+
+// TestApplyPerDocumentCapBackfillsNarrowCorpus pins the backfill
+// contract: when only one document matches, the cap must not starve
+// the result down below min(k, available) hits.
+func TestApplyPerDocumentCapBackfillsNarrowCorpus(t *testing.T) {
+	candidates := []KBSearchHit{
+		{ChunkID: "a1", DocumentID: "docA", Score: 0.9},
+		{ChunkID: "a2", DocumentID: "docA", Score: 0.8},
+		{ChunkID: "a3", DocumentID: "docA", Score: 0.7},
+		{ChunkID: "a4", DocumentID: "docA", Score: 0.6},
+	}
+	got := applyPerDocumentCap(candidates, 5)
+	if len(got) != 4 {
+		t.Fatalf("got %d hits, want 4 (all available, backfilled past the cap)", len(got))
+	}
+	for i, h := range got {
+		if h.ChunkID != candidates[i].ChunkID {
+			t.Fatalf("backfill reordered results: got %+v, want candidate order", got)
+		}
+	}
+}
+
+// TestApplyPerDocumentCapNoOverflowIsNoop pins the common case: when no
+// document exceeds the cap, selection just truncates to k in order.
+func TestApplyPerDocumentCapNoOverflowIsNoop(t *testing.T) {
+	candidates := []KBSearchHit{
+		{ChunkID: "a1", DocumentID: "docA", Score: 0.9},
+		{ChunkID: "b1", DocumentID: "docB", Score: 0.8},
+		{ChunkID: "c1", DocumentID: "docC", Score: 0.7},
+	}
+	got := applyPerDocumentCap(candidates, 2)
+	if len(got) != 2 {
+		t.Fatalf("got %d hits, want 2", len(got))
+	}
+	if got[0].ChunkID != "a1" || got[1].ChunkID != "b1" {
+		t.Fatalf("got %+v, want top 2 by score in order", got)
+	}
+}


### PR DESCRIPTION
Closes #419.

## What

- `kbPerDocumentCap = 2` (D-082): KBSearch over-fetches 3x k candidates from the unchanged SQL, then applies the cap in Go; dropped chunks backfill remaining slots when fewer than k distinct-document hits exist. Order stays score-descending throughout.
- Pure-function unit tests for cap/backfill/pass-through plus two golden integration tests (dominant doc capped with other docs surfaced; single-doc corpus backfills to full k).

## Verification

- Containerized go build / vet / vet -tags integration / go test -race: pass
- make test-integration: pass
- make canary: PASS
- Live smoke on mirrored corpus: GraphRAG query went from 5 chunks of one doc to 2+2+backfill across two docs (only two docs clear the similarity floor for that query)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790700497&installation_model_id=431401&pr_number=421&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F421&signature=67f1dbb04407b3517d94d959c4228bf24f943987f5bc4415797bbb852296a3c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->