### PR TITLE
feat(kb): retrieval eval harness with fixed fixture and query set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GO_RUN := docker run --rm -v $(CURDIR):/src -w /src \
 	-e GOFLAGS=-buildvcs=false $(GO_IMAGE)
 
 .PHONY: build test test-integration test-live vet lint tidy skills-validate up down logs \
-	brain gateway memoryd web markitdown pdfgen sandboxd dev canary canary-coding canary-research canary-executor canary-impossible sandbox-image
+	brain gateway memoryd web markitdown pdfgen sandboxd dev canary canary-coding canary-research canary-executor canary-impossible kb-eval sandbox-image
 
 build:
 	$(GO_RUN) go build ./...
@@ -132,6 +132,15 @@ canary-executor:
 # `make sandbox-image` run first.
 canary-impossible:
 	./scripts/canary-impossible.sh
+
+# Retrieval regression gate (issue #412): ingests a curated fixture set
+# into a dedicated collection, runs a fixed query set through the real
+# hybrid retrieval path, scores recall@5 and MRR, then deletes the
+# collection. Independent of make canary: the mission harness gate and
+# the retrieval gate must be able to fail on their own. Needs the stack
+# up. Override the pass threshold with KB_EVAL_MIN_RECALL (default 0.8).
+kb-eval:
+	./scripts/kb-eval/kb-eval.sh
 
 # Builds the per-mission sandbox images: the base (python3/node/git/
 # bash — deploy/sandbox-base.Dockerfile) plus one variant per

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Frontend development with hot reload:
 make dev   # Vite dev server on :3301, proxies /v1 to brain
 ```
 
-`make test-integration` and `make canary` need the compose stack up (`make up` first).
+`make test-integration`, `make canary`, and `make kb-eval` (retrieval eval harness, `scripts/kb-eval/`) need the compose stack up (`make up` first).
 
 Design decisions are documented as `D-0XX` markers in code comments next to the code they explain.
 

--- a/scripts/kb-eval/eval.yaml
+++ b/scripts/kb-eval/eval.yaml
@@ -1,0 +1,30 @@
+# Retrieval eval query set (issue #412). Flat, line-oriented format
+# parsed by a small python3 block in kb-eval.sh: no YAML dependency.
+#
+# Each query is a block starting with "query:" and ending at the next
+# "query:" or end of file. Fields:
+#   query: <text>              the search string
+#   expect: <document title>   one line per expected document (repeatable)
+#   negative: true             marks a query that must return zero hits
+#
+# Document titles must match the fixture filenames' derived titles
+# (filename without extension, as kb upload assigns).
+
+query: service mesh pay off small kubernetes cluster migration risks
+expect: mesh-migration-risks
+expect: mesh-when-it-pays-off
+
+query: how should I chunk documents for retrieval augmented generation
+expect: rag-chunking-strategy
+
+query: caching strategies to speed up a slow CI pipeline
+expect: cicd-pipeline-caching
+
+query: how do I choose which database columns to index
+expect: database-index-selection
+
+query: watercolor painting technique wet on wet blending
+negative: true
+
+query: fermenting kimchi at home with napa cabbage
+negative: true

--- a/scripts/kb-eval/fixtures/cicd-pipeline-caching.md
+++ b/scripts/kb-eval/fixtures/cicd-pipeline-caching.md
@@ -1,0 +1,41 @@
+# Caching Strategies for CI/CD Pipelines
+
+Slow CI pipelines cost teams far more time than the minutes shown on
+any single build. A pipeline that takes fifteen minutes when it could
+take three discourages small commits and makes reviewers wait on
+checks before merging.
+
+## Dependency caching
+
+Caching package manager directories, such as a language's module
+cache or a container layer cache, is usually the highest leverage
+change available. A cache keyed on the lock file's hash invalidates
+correctly when dependencies change and stays valid otherwise, which
+covers the common case where most commits do not touch dependencies
+at all.
+
+## Build artifact caching
+
+Compiled artifacts and generated code can be cached between runs when
+the inputs are unchanged, but this requires a reliable way to detect
+that inputs are actually unchanged. A cache keyed too loosely, on a
+branch name rather than a content hash, produces stale artifacts that
+pass locally and fail in production, which is worse than no cache at
+all.
+
+## Parallelization
+
+Splitting a test suite across multiple runners cuts wall clock time
+roughly in proportion to the number of runners, provided the split is
+balanced by historical run time rather than by naive alphabetical
+grouping. An unbalanced split leaves one runner as the long pole while
+others sit idle, which erases most of the expected benefit.
+
+## Cache invalidation discipline
+
+The classic problem with caching, knowing when to invalidate, applies
+directly to CI. A cache that never expires accumulates stale layers
+that silently change build behavior over time. Pipelines should
+rebuild caches from scratch on a schedule, weekly is a common choice,
+even if no invalidation trigger fired, to catch drift before it causes
+a hard to diagnose failure.

--- a/scripts/kb-eval/fixtures/database-index-selection.md
+++ b/scripts/kb-eval/fixtures/database-index-selection.md
@@ -1,0 +1,40 @@
+# Choosing Database Indexes for Read Heavy Workloads
+
+Adding an index is not free: every index speeds up the reads it
+matches while slowing down every write to that table, and consumes
+disk space that grows with the table. Choosing which columns to index
+is a trade off, not a default to apply everywhere.
+
+## Matching indexes to query patterns
+
+An index only helps a query if it matches the columns used in the
+query's filter or sort, in an order the planner can use. A composite
+index on columns A and B helps a query filtering on A alone, or on A
+and B together, but does not help a query filtering on B alone unless
+a separate index exists for that access pattern.
+
+## Over indexing
+
+Tables with many indexes suffer on every insert and update, since each
+index has to be maintained alongside the base table. A common failure
+mode is adding a new index for every slow query reported in
+production without ever removing indexes that later queries made
+redundant, until the table's write path is dominated by index
+maintenance rather than the actual write.
+
+## Partial and covering indexes
+
+A partial index, one that only covers rows matching a condition such
+as an active flag, can be far smaller and faster than a full index
+when the query only ever touches that subset of rows. A covering
+index, one that includes every column a query needs so the planner
+never has to touch the base table, trades index size for avoiding a
+second lookup, which matters most for queries run at high frequency.
+
+## Measuring before and after
+
+Any indexing decision should be checked against the query planner's
+actual execution plan before and after, since the planner sometimes
+declines to use a new index for reasons that are not obvious from the
+schema alone, such as the table being small enough that a sequential
+scan is already cheaper.

--- a/scripts/kb-eval/fixtures/mesh-migration-risks.md
+++ b/scripts/kb-eval/fixtures/mesh-migration-risks.md
@@ -1,0 +1,49 @@
+# Zero Downtime Istio Migration Risks
+
+Migrating an existing cluster onto Istio without downtime carries a
+specific set of risks that teams underestimate. The sidecar injection
+step alone can break workloads that assume a single container per
+pod, since liveness and readiness probes on the original container
+may fail while the sidecar is still starting.
+
+## Sidecar rollout order
+
+Rolling out sidecars namespace by namespace, rather than cluster wide,
+limits the blast radius of a bad injection. Start with a low traffic
+namespace, watch error rates for a full business cycle, then proceed.
+Skipping this staged rollout is the single most common cause of a
+failed migration.
+
+## mTLS mode transitions
+
+Istio's permissive mode allows plaintext and mTLS traffic
+simultaneously during migration, which is safer than jumping straight
+to strict mode. Flipping to strict mode before every workload in a
+namespace has a sidecar causes silent connection failures that are
+hard to diagnose because the error looks like a generic timeout
+rather than a TLS handshake rejection.
+
+## Resource overhead
+
+Each sidecar proxy consumes CPU and memory that the original capacity
+planning did not account for. Small clusters running near their node
+limits can see pod scheduling failures once sidecars are injected
+cluster wide. Budget roughly 100 to 250 megabytes of memory and a
+tenth of a CPU core per sidecar as a starting estimate, then adjust
+from real usage.
+
+## Rollback plan
+
+Every migration wave needs a tested rollback: removing the sidecar
+injection label from a namespace and restarting its pods. Teams that
+skip rehearsing this step often discover during an actual incident
+that rollback takes far longer than expected because of unexpected
+interactions with existing network policies.
+
+## Observability gaps
+
+Istio's own telemetry can mask upstream failures if dashboards are
+not updated to distinguish sidecar level metrics from application
+level metrics. Confirm before migrating that on call engineers can
+tell the difference between a proxy failure and an application
+failure from the existing dashboards.

--- a/scripts/kb-eval/fixtures/mesh-when-it-pays-off.md
+++ b/scripts/kb-eval/fixtures/mesh-when-it-pays-off.md
@@ -1,0 +1,55 @@
+# When a Service Mesh Pays Off on a Small Kubernetes Cluster
+
+A service mesh is not free. The operational cost of running one,
+including sidecar overhead, control plane maintenance, and the
+learning curve for the team, has to be weighed against what it buys.
+For a small Kubernetes cluster, the answer is often no, at least not
+yet.
+
+## Signals that favor adopting a mesh
+
+A cluster with more than a handful of services calling each other
+over the network benefits most, particularly once teams start asking
+for consistent retries, timeouts, and circuit breaking without
+rewriting that logic in every service. Mutual TLS between services
+without touching application code is another strong reason: a mesh
+gives you encryption in transit and identity based authorization as
+infrastructure rather than a library each team has to adopt
+correctly.
+
+Multi team clusters where different groups own different services
+also benefit, since the mesh gives platform teams a single place to
+enforce traffic policy instead of chasing every team's ad hoc client
+library configuration.
+
+## Signals that argue against it
+
+A cluster running fewer than ten services, especially if most calls
+are simple request and response between two or three components, is
+unlikely to see enough benefit to offset the added complexity. Small
+teams without dedicated platform engineers often underestimate the
+ongoing maintenance a mesh control plane requires: version upgrades,
+certificate rotation issues, and debugging a new network layer during
+incidents.
+
+If the actual pain point is service discovery or basic load balancing,
+Kubernetes already solves that natively, and a mesh adds overhead
+without addressing a real gap.
+
+## A practical migration path
+
+Start by introducing a mesh in a single namespace with clear traffic
+patterns and low risk, running in permissive mode so plaintext
+traffic keeps working during the transition. Measure the resource
+overhead and the on call team's comfort level before expanding
+cluster wide. Teams that try to adopt a mesh everywhere at once, on a
+cluster that was already resource constrained, are the ones most
+likely to regret the decision within the first quarter.
+
+## Bottom line
+
+For a small cluster with a handful of services and no cross team
+ownership problem, a service mesh rarely pays off soon enough to
+justify the cost. For a growing cluster with multiple teams and a
+real need for consistent security and traffic policy, it usually
+does.

--- a/scripts/kb-eval/fixtures/operator-profile.md
+++ b/scripts/kb-eval/fixtures/operator-profile.md
@@ -1,0 +1,47 @@
+# Operator Profile
+
+Experienced infrastructure operator with a broad background across
+cloud platforms and container tooling. Comfortable working with
+Kubernetes clusters, Istio service mesh configuration, Docker, and
+Terraform. Has touched GraphRAG pipelines, vector databases, and
+various LLM orchestration frameworks on internal projects.
+
+## Summary
+
+Ten years of experience spanning platform engineering, developer
+tooling, and site reliability. Has deployed workloads on Kubernetes,
+configured Istio for traffic management, and set up CI/CD pipelines
+using Jenkins and GitHub Actions. Familiar with Prometheus, Grafana,
+and the broader observability stack. Has also worked with GraphRAG
+and retrieval augmented generation concepts in a support capacity.
+
+## Skills
+
+Kubernetes, Istio, Docker, Terraform, Ansible, Jenkins, GitHub
+Actions, Prometheus, Grafana, AWS, GCP, Azure, Python, Go, GraphRAG,
+vector databases, PostgreSQL, Redis, Kafka, gRPC, service mesh,
+microservices, observability, CI/CD.
+
+## Experience
+
+Platform engineer at a mid-size logistics company, responsible for
+maintaining a fleet of Kubernetes clusters across three regions.
+Introduced Istio for mutual TLS and traffic shaping between internal
+services. Built dashboards in Grafana for on-call visibility and
+wrote runbooks for common incidents.
+
+Prior to that, worked as a DevOps consultant helping smaller teams set
+up their first CI/CD pipelines and containerize legacy applications.
+Advised on when to introduce Kubernetes and when a simpler deployment
+target would serve the team better.
+
+## Education
+
+Bachelor's degree in computer science. Certified Kubernetes
+Administrator. Completed coursework on distributed systems and
+networking fundamentals.
+
+## Interests
+
+Open source infrastructure tooling, homelab experimentation, and
+mentoring junior engineers on platform reliability practices.

--- a/scripts/kb-eval/fixtures/rag-chunking-strategy.md
+++ b/scripts/kb-eval/fixtures/rag-chunking-strategy.md
@@ -1,0 +1,44 @@
+# Chunking Strategy for Retrieval Augmented Generation
+
+The way a document is split into chunks before embedding has more
+impact on retrieval quality than most teams expect. Chunk boundaries
+that cut a definition in half, or separate a claim from its
+supporting example, hurt recall even when the embedding model itself
+is strong.
+
+## Fixed size versus structural chunking
+
+Fixed size chunking, splitting every document into equal token
+windows, is simple to implement but ignores document structure. A
+heading and its first paragraph can end up in different chunks,
+which weakens the semantic signal for a query that matches the
+heading's topic. Structural chunking, splitting along headings and
+paragraph boundaries, keeps a section's context together at the cost
+of variable chunk sizes.
+
+## Overlap and breadcrumbs
+
+Adding a small overlap between adjacent chunks, or prepending a
+breadcrumb of the enclosing headings to each chunk's text, recovers
+context that a hard boundary would otherwise lose. A breadcrumb costs
+almost nothing at embedding time and meaningfully improves recall for
+queries that depend on knowing which section a chunk came from.
+
+## Chunk size trade offs
+
+Very small chunks, a sentence or two, tend to produce embeddings too
+narrow to match a broader query, and flood a search result with near
+duplicate hits from the same document. Very large chunks dilute the
+embedding with unrelated content and reduce precision. A few hundred
+words per chunk is a reasonable default for prose documents, with
+adjustments for tables and code blocks which behave differently under
+either scheme.
+
+## Testing chunking changes
+
+Any change to a chunking strategy should be evaluated against a fixed
+set of representative queries with known expected documents, since
+chunking interacts with the embedding model, the fusion method, and
+the similarity floor in ways that are hard to predict from theory
+alone. A regression in recall after a chunking change is easy to miss
+without this kind of harness.

--- a/scripts/kb-eval/kb-eval.sh
+++ b/scripts/kb-eval/kb-eval.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Retrieval eval harness (issue #412): ingests a curated fixture set
+# into a dedicated collection, runs a fixed query set through the real
+# hybrid retrieval path, scores recall@5 and MRR, then deletes the
+# collection. Self-contained: never depends on, or touches, whatever
+# the operator already has in their live knowledge base.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FIXTURE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE=(docker compose -f "${REPO_ROOT}/deploy/docker-compose.yml")
+BASE_URL="${KB_EVAL_BASE_URL:-http://localhost:${BRAIN_PORT:-8300}}"
+MIN_RECALL="${KB_EVAL_MIN_RECALL:-0.8}"
+TIMEOUT_SECS="${KB_EVAL_TIMEOUT:-120}"
+
+# A unique run tag every invocation: same reasoning as canary's varying
+# goal set, a fixed collection name would let leftovers or provider
+# caches flatter the result across runs.
+RUN_TAG="kb-eval-$(date +%s)"
+
+# The API token stays in the shell environment only: sourced here,
+# never printed.
+if [[ -z "${TIMOTHY_API_TOKEN:-}" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${REPO_ROOT}/deploy/.env"
+  set +a
+fi
+if [[ -z "${TIMOTHY_API_TOKEN:-}" ]]; then
+  echo "kb-eval: TIMOTHY_API_TOKEN not set and deploy/.env did not provide it" >&2
+  exit 2
+fi
+
+auth=(-H "Authorization: Bearer ${TIMOTHY_API_TOKEN}" -H "Content-Type: application/json")
+
+collection_id=""
+results_file="$(mktemp)"
+cleanup() {
+  rm -f "${results_file}"
+  if [[ -n "${collection_id}" ]]; then
+    if curl -sf -X DELETE "${auth[@]}" "${BASE_URL}/v1/admin/kb/collections/${collection_id}" >/dev/null; then
+      echo "kb-eval: cleaned up collection ${RUN_TAG} (${collection_id})"
+    else
+      echo "kb-eval: WARNING: cleanup of collection ${RUN_TAG} (${collection_id}) failed (non-fatal)" >&2
+    fi
+  fi
+}
+trap cleanup EXIT
+
+echo "kb-eval: creating collection ${RUN_TAG} against ${BASE_URL}"
+create_resp="$(curl -sf "${auth[@]}" -X POST "${BASE_URL}/v1/admin/kb/collections" \
+  -d "{\"name\": \"${RUN_TAG}\", \"description\": \"kb-eval harness run, safe to delete\"}")"
+collection_id="$(echo "${create_resp}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+echo "kb-eval: collection ${collection_id}"
+
+# Upload every fixture document, tracking its document id so we can
+# poll ingestion status by name.
+declare -A doc_ids
+for f in "${FIXTURE_DIR}"/fixtures/*.md; do
+  title="$(basename "${f}" .md)"
+  resp="$(curl -sf -H "Authorization: Bearer ${TIMOTHY_API_TOKEN}" \
+    -X POST "${BASE_URL}/v1/admin/kb/collections/${collection_id}/documents" \
+    -F "file=@${f};filename=${title}.md;type=text/markdown")"
+  doc_id="$(echo "${resp}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+  doc_ids["${title}"]="${doc_id}"
+  echo "kb-eval: uploaded ${title} (${doc_id})"
+done
+
+# Poll until every document is ready, failing fast by name on a
+# failed or timed-out ingestion.
+echo "kb-eval: waiting for ingestion"
+start=$(date +%s)
+while :; do
+  now=$(date +%s)
+  if (( now - start > TIMEOUT_SECS )); then
+    echo "kb-eval: FAIL: ingestion timed out after ${TIMEOUT_SECS}s" >&2
+    exit 1
+  fi
+  docs_resp="$(curl -sf "${auth[@]}" "${BASE_URL}/v1/admin/kb/collections/${collection_id}/documents")"
+  all_ready=true
+  for title in "${!doc_ids[@]}"; do
+    doc_id="${doc_ids[${title}]}"
+    status="$(DOCS_JSON="${docs_resp}" DOC_ID="${doc_id}" python3 -c '
+import json, os
+docs = json.loads(os.environ["DOCS_JSON"])["documents"]
+for d in docs:
+    if d["id"] == os.environ["DOC_ID"]:
+        print(d["status"])
+        break
+else:
+    print("missing")
+')"
+    if [[ "${status}" == "failed" ]]; then
+      err="$(DOCS_JSON="${docs_resp}" DOC_ID="${doc_id}" python3 -c '
+import json, os
+docs = json.loads(os.environ["DOCS_JSON"])["documents"]
+for d in docs:
+    if d["id"] == os.environ["DOC_ID"]:
+        print(d.get("error") or "")
+        break
+')"
+      echo "kb-eval: FAIL: document ${title} failed ingestion: ${err}" >&2
+      exit 1
+    fi
+    if [[ "${status}" != "ready" ]]; then
+      all_ready=false
+    fi
+  done
+  if [[ "${all_ready}" == "true" ]]; then
+    break
+  fi
+  sleep 2
+done
+echo "kb-eval: all fixtures ready (t+$(( $(date +%s) - start ))s)"
+
+# Run every query in eval.yaml through the real retrieval stack, via
+# memoryd's kb-search directly (memoryd embeds the query itself),
+# scoped to this run's collection with docker exec into the brain
+# container (memoryd is not published on the host network).
+echo "kb-eval: running queries"
+query_idx=0
+while IFS=$'\t' read -r qtext negative expects; do
+  query_idx=$((query_idx + 1))
+  payload="$(QTEXT="${qtext}" COLLECTION="${RUN_TAG}" python3 -c '
+import json, os
+print(json.dumps({"query": os.environ["QTEXT"], "mode": "hybrid", "k": 5, "collection_names": [os.environ["COLLECTION"]]}))
+')"
+  hits_json="$("${COMPOSE[@]}" exec -T brain wget -qO- \
+    --header="Content-Type: application/json" \
+    --post-data="${payload}" \
+    http://memoryd:8082/v1/kb-search </dev/null)"
+  # One JSON object per line (JSONL): the hits response can carry
+  # embedded newlines in chunk content, which would otherwise split a
+  # single result across multiple lines of a naive TSV file.
+  QTEXT="${qtext}" EXPECTS="${expects}" NEGATIVE="${negative}" HITS_JSON="${hits_json}" python3 -c '
+import json, os
+print(json.dumps({
+    "query": os.environ["QTEXT"],
+    "expects": os.environ["EXPECTS"],
+    "negative": os.environ["NEGATIVE"],
+    "hits": json.loads(os.environ["HITS_JSON"]),
+}))
+' >> "${results_file}"
+done < <(EVAL_YAML="$(cat "${FIXTURE_DIR}/eval.yaml")" python3 -c '
+import os
+
+lines = os.environ["EVAL_YAML"].splitlines()
+query = None
+expects = []
+negative = False
+
+def flush():
+    if query is not None:
+        joined = "|".join(expects) if expects else "-"
+        flag = 1 if negative else 0
+        print(f"{query}\t{flag}\t{joined}")
+
+for line in lines:
+    line = line.strip()
+    if not line or line.startswith("#"):
+        continue
+    if line.startswith("query:"):
+        flush()
+        query = line[len("query:"):].strip()
+        expects = []
+        negative = False
+    elif line.startswith("expect:"):
+        expects.append(line[len("expect:"):].strip())
+    elif line.startswith("negative:"):
+        negative = line[len("negative:"):].strip().lower() == "true"
+flush()
+')
+
+# Score recall@5 and MRR per query, matching expected docs by title
+# (document_title in the kb-search response), then gate on aggregate
+# recall@5. A negative query is scored as a miss if it returns any hit
+# at all.
+KB_EVAL_MIN_RECALL="${MIN_RECALL}" RESULTS_FILE="${results_file}" python3 <<'PY'
+import json, os, sys
+
+min_recall = float(os.environ["KB_EVAL_MIN_RECALL"])
+results_path = os.environ["RESULTS_FILE"]
+
+rows = []
+recalls = []
+reciprocal_ranks = []
+failures = []
+
+with open(results_path, encoding="utf-8") as fh:
+    for line in fh:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        record = json.loads(line)
+        qtext = record["query"]
+        expects_raw = record["expects"]
+        expects = [e for e in expects_raw.split("|") if e] if expects_raw != "-" else []
+        negative = record["negative"] == "1"
+        hits = record["hits"].get("results", [])
+        titles = [h["document_title"] for h in hits]
+
+        if negative:
+            hit = len(titles) == 0
+            recall = 1.0 if hit else 0.0
+            rr = 0.0
+            note = "OK (no hits)" if hit else f"MISS (got hits: {titles})"
+        else:
+            found = [t for t in expects if t in titles]
+            recall = len(found) / len(expects) if expects else 1.0
+            rr = 0.0
+            for rank, t in enumerate(titles, start=1):
+                if t in expects:
+                    rr = 1.0 / rank
+                    break
+            note = f"found {found} of {expects}" if found else f"MISS (expected {expects}, got {titles})"
+
+        recalls.append(recall)
+        reciprocal_ranks.append(rr)
+        rows.append((qtext, recall, rr, note))
+        if recall < 1.0:
+            failures.append((qtext, note))
+
+agg_recall = sum(recalls) / len(recalls) if recalls else 0.0
+agg_mrr = sum(reciprocal_ranks) / len(reciprocal_ranks) if reciprocal_ranks else 0.0
+
+print(f"kb-eval: {len(rows)} queries scored")
+for qtext, recall, rr, note in rows:
+    print(f"kb-eval:   [{recall:.2f} recall, {rr:.2f} rr] \"{qtext}\": {note}")
+print(f"kb-eval: aggregate recall@5 = {agg_recall:.3f} (threshold {min_recall:.3f})")
+print(f"kb-eval: aggregate MRR = {agg_mrr:.3f}")
+
+if agg_recall < min_recall:
+    print("kb-eval: FAIL: aggregate recall@5 below threshold", file=sys.stderr)
+    print("kb-eval: per-query breakdown of failures:", file=sys.stderr)
+    for qtext, note in failures:
+        print(f"kb-eval:   \"{qtext}\": {note}", file=sys.stderr)
+    sys.exit(1)
+
+print("kb-eval: PASS")
+PY


### PR DESCRIPTION
Closes #412.

## What

- `scripts/kb-eval/kb-eval.sh`: creates a uniquely tagged collection, uploads six fixture docs, polls until ingested, runs a fixed query set through the real hybrid retrieval path (`memoryd:8082/v1/kb-search` scoped to the run's collection), scores recall@5 and MRR, deletes the collection in an EXIT trap.
- `scripts/kb-eval/eval.yaml`: six queries, four positive and two negative, including the bystander regression case (mesh query must return both mesh docs and never the operator profile doc).
- `make kb-eval` target, independent of `make canary`. Threshold via `KB_EVAL_MIN_RECALL` (default 0.8).

## Verified live

- `make kb-eval`: aggregate recall@5 = 1.000, MRR = 0.667, PASS, collection cleaned up.
- `KB_EVAL_MIN_RECALL=1.01`: non-zero exit with per-query breakdown, cleanup still ran.
- No `kb-eval-*` collections survive any run; the 12 pre-existing collections untouched.

## Notes

Negative queries chosen with zero lexeme overlap against the fixture corpus: the keyword leg uses OR-semantics tsquery with no similarity floor, so any shared common word produces a hit. That is production behavior, not a harness bug; the eval avoids being flaky on it.

Weighted RRF tuning is now unblocked (measure with this gate).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790702005&installation_model_id=431401&pr_number=422&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F422&signature=2836c1f17512e6104c5fc55fedabcd01f9f4d8aeb8b6e77e4234fe904904eb76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->