### PR TITLE
feat(kb): weighted rrf fusion to discount the keyword leg

### DIFF
--- a/internal/memory/store/kb.go
+++ b/internal/memory/store/kb.go
@@ -124,6 +124,23 @@ const (
 const legLimitLit = "30"
 const rrfKLit = "60"
 
+// vecLegWeightLit/ftsLegWeightLit (D-083, issue #424) scale each leg's
+// RRF contribution before the legs sum into a fused score (KB hybrid
+// search fuses exactly these two legs, vector and keyword; there is
+// no third entity leg here, that only exists in the separate memories
+// retrieval package). The keyword (fts) leg is OR-semantics ts_rank
+// with no similarity floor (issue #425 covers the tsquery itself), so
+// generic word overlap wins it high ranks on off-topic documents;
+// discounting its contribution relative to the vector leg lets
+// on-topic documents outrank bystanders whose overlap is lexical
+// only. Equal weights (1.0/1.0) reproduce prior behavior. Tuned
+// against make kb-eval (recall@5 stays 1.0). Fusion weights only
+// re-rank across legs: a bystander chunk that also wins the raw
+// vector leg outright cannot be reversed by any leg weight, so the
+// per-document cap (D-082) remains the guard for that case.
+const vecLegWeightLit = "1.0"
+const ftsLegWeightLit = "0.1"
+
 // minSimilarityLit is the vector leg's relevance floor (cosine
 // similarity): below it a chunk is noise, not a match. Nearest-neighbor
 // search always returns SOMETHING: without a floor an off-topic query
@@ -318,11 +335,13 @@ const (
 
 	// hybridSQL fuses a vector top-30 and an FTS top-30 leg via
 	// Reciprocal Rank Fusion (k=60), same fusion constant as the
-	// memories retrieval package. Each leg carries its own relevance
-	// gate (similarity floor / lexeme match), so an off-topic query
-	// yields an empty result instead of the k least-far chunks. The
-	// boost multiplies the fused score, applied once at the end (not
-	// per-leg) so it can't double-count a chunk found by both legs.
+	// memories retrieval package, with each leg's contribution scaled
+	// by vecLegWeightLit/ftsLegWeightLit before summing (D-083). Each
+	// leg carries its own relevance gate (similarity floor / lexeme
+	// match), so an off-topic query yields an empty result instead of
+	// the k least-far chunks. The boost multiplies the fused score,
+	// applied once at the end (not per-leg) so it can't double-count a
+	// chunk found by both legs.
 	// $1 embedding, $2 query, $3 collection names, $4 result count,
 	// $5 boost collection names.
 	hybridSQL = `WITH q AS (` + kbQueryCTEq2 + `), vec AS (
@@ -343,8 +362,12 @@ const (
 			ORDER BY rank
 			LIMIT ` + legLimitLit + `
 		), fused AS (
-			SELECT id, sum(1.0 / (` + rrfKLit + ` + rank)) AS score
-			FROM (SELECT id, rank FROM vec UNION ALL SELECT id, rank FROM fts) legs
+			SELECT id, sum(weight / (` + rrfKLit + ` + rank)) AS score
+			FROM (
+				SELECT id, rank, ` + vecLegWeightLit + `::float8 AS weight FROM vec
+				UNION ALL
+				SELECT id, rank, ` + ftsLegWeightLit + `::float8 AS weight FROM fts
+			) legs
 			GROUP BY id
 		)
 		` + kbProjection + `, fused.score * ` + boostMultiplierQ5 + ` * ` + provenanceMultiplier + ` AS score

--- a/internal/memory/store/kb_golden_integration_test.go
+++ b/internal/memory/store/kb_golden_integration_test.go
@@ -574,6 +574,105 @@ func TestKBGoldenPerDocumentCapBackfillsSingleDoc(t *testing.T) {
 	}
 }
 
+// D-083 (issue #424): weighted RRF fusion.
+const kbFusionWeightCollection = "itest-kbfusionweight"
+
+// seedKBFusionWeight builds a bystander document that wins the
+// keyword leg outright (every query lexeme repeated, off-axis
+// embedding so the vector leg never returns it) and an on-topic
+// document that wins the vector leg (on-axis embedding) with only
+// partial lexeme overlap, so it ranks behind the bystander on the
+// keyword leg alone. Equal-weight RRF fusion lets the keyword leg's
+// win carry the bystander above the on-topic document; discounting
+// the keyword leg's contribution should let the on-topic document
+// win the fused ranking instead.
+func seedKBFusionWeight(t *testing.T) *KBStore {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	_, _ = db.Exec(ctx, "DELETE FROM kb_collections WHERE name = $1", kbFusionWeightCollection)
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer ccancel()
+		conn, err := pgx.Connect(cctx, dsn)
+		if err != nil {
+			t.Errorf("cleanup connect: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close(cctx) }()
+		_, _ = conn.Exec(cctx, "DELETE FROM kb_collections WHERE name = $1", kbFusionWeightCollection)
+	})
+
+	st := NewKBStore(pool)
+	var collID string
+	if err := db.QueryRow(ctx,
+		"INSERT INTO kb_collections (name) VALUES ($1) RETURNING id", kbFusionWeightCollection).Scan(&collID); err != nil {
+		t.Fatalf("insert collection: %v", err)
+	}
+
+	insert := func(title, content string, emb Vector) {
+		var docID string
+		if err := db.QueryRow(ctx, `INSERT INTO kb_documents (collection_id, title, status)
+			VALUES ($1, $2, 'ready') RETURNING id`, collID, title).Scan(&docID); err != nil {
+			t.Fatalf("insert document %s: %v", title, err)
+		}
+		if err := st.ReplaceChunks(ctx, docID, []KBChunk{
+			{Seq: 0, Content: content, Embedding: emb, EmbeddingModel: "itest"},
+		}); err != nil {
+			t.Fatalf("ReplaceChunks %s: %v", title, err)
+		}
+	}
+
+	// Bystander: every query lexeme repeated for a high ts_rank, off
+	// axis (dim 800) so it clears no similarity floor on the vector leg.
+	insert("bystander", "alpha alpha beta beta gamma gamma delta delta topic topic topic topic",
+		kbBasis(800))
+	// On-topic: on the query's axis (dim 810) so the vector leg ranks
+	// it first, with only one query lexeme ("topic") for a much lower
+	// ts_rank than the bystander.
+	insert("on-topic", "the topic under discussion here is quite relevant to what was asked",
+		kbBasis(810))
+
+	return st
+}
+
+// TestKBGoldenFusionWeightFavorsVectorLeg pins D-083: with the tuned
+// keyword-leg discount, the on-topic document (vector leg winner)
+// outranks the bystander (keyword leg winner only) in the fused
+// hybrid result, even though the bystander would win under equal
+// (1.0/1.0) leg weights.
+func TestKBGoldenFusionWeightFavorsVectorLeg(t *testing.T) {
+	st := seedKBFusionWeight(t)
+	hits, err := st.KBSearch(t.Context(), "alpha beta gamma delta topic", kbBasis(810),
+		[]string{kbFusionWeightCollection}, nil, KBSearchHybrid, 5)
+	if err != nil {
+		t.Fatalf("KBSearch: %v", err)
+	}
+	if len(hits) < 2 {
+		t.Fatalf("got %d hits, want at least 2: %+v", len(hits), hits)
+	}
+	if hits[0].DocumentTitle != "on-topic" {
+		t.Fatalf("top hit = %q, want the on-topic (vector leg) document ranked first ahead of the keyword-only bystander: %+v",
+			hits[0].DocumentTitle, hits)
+	}
+}
+
 func TestKBGoldenSemanticFloor(t *testing.T) {
 	st := seedKBGolden(t)
 	// On-axis query hits; orthogonal query (similarity 0) must not.


### PR DESCRIPTION
Closes #424.

Named per-leg RRF weights (D-083): vector 1.0, keyword 0.1. The keyword leg (OR-semantics ts_rank, no similarity floor) over-contributes on generic word overlap; discounting it 10x lets the vector leg dominate fusion.

## Verified
- make kb-eval: recall@5 = 1.0, no regression.
- New golden integration test proves the discount flips a synthetic vector-winner above a keyword-only winner.
- go vet + go test -race ./internal/memory/... clean; make test-integration green (solo).

## Scope note
The motivating real-corpus case (profile doc vs mesh docs) is only partially resolved: that chunk wins BOTH raw legs (0.8% cosine margin), and RRF is monotonic in the weights, so no reweighting can demote it. That residual is a content-overlap problem for cross-encoder reranking (#426) or data curation, not fusion tuning; the per-doc cap (#419, D-082) remains its guard. Full analysis on #424.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790706584&installation_model_id=431401&pr_number=440&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F440&signature=60d2f841d710bdd105c30361c349ea92c88ed057d459ce997d3c60cc51200c66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->