### PR TITLE
feat(kb): require two matched lexemes on the keyword leg

### DIFF
--- a/internal/memory/store/kb.go
+++ b/internal/memory/store/kb.go
@@ -146,9 +146,28 @@ const ftsLegWeightLit = "0.1"
 // search always returns SOMETHING: without a floor an off-topic query
 // still fills k slots with whatever is least-far away, and the model
 // may cite it. Returning nothing beats confidently-irrelevant (same
-// principle as memories retrieval). The keyword leg needs no floor: a
-// tsquery either matches lexemes or returns nothing.
+// principle as memories retrieval).
 const minSimilarityLit = "0.25"
+
+// minMatchedLexemesLit is the keyword leg's relevance floor (D-084,
+// issue #425): a chunk must share at least this many distinct query
+// lexemes, not just one. OR-semantics tsquery (kbQueryCTE) matches a
+// chunk on any single shared lexeme, so a single common word (e.g.
+// "way") produced a hit regardless of topic; a query that only
+// produces one lexeme can never clear this floor at all, which is the
+// exact failure mode the issue reports. A multi-topic question still
+// matches a chunk answering only part of it (kbQueryCTE's own
+// rationale) as long as that part shares 2+ words with the chunk,
+// which a real topical passage does. Document-frequency weighting
+// (excluding corpus-common words like "every"/"best" from the count)
+// was tried and reverted: it depends on corpus size in a way that
+// breaks small/topically-narrow collections, where every word in a
+// short document is "common" relative to that document's own small
+// chunk count. A plain count floor doesn't fully rule out two generic
+// words coincidentally landing in one bystander chunk of a large,
+// broad corpus, but it does what the issue's AC asks and what
+// make kb-eval measures.
+const minMatchedLexemesLit = "2"
 
 // boostFactorLit multiplies a chunk's score when its collection is in
 // boostCollections (D-078: an agent's configured collections are a
@@ -282,19 +301,29 @@ const (
 	// both the optional collection filter and the boost multiplier.
 	kbProjection = `SELECT c.id, d.id, d.title, col.name, c.breadcrumb, c.content, d.source_ref, d.provenance`
 
-	// kbQueryCTEq1/q2 normalize the query's lexemes and OR them
-	// together: same rationale as memories retrieval's textSQL: a
+	// kbQueryCTEq1/q2 normalize the query's lexemes, OR them together
+	// for the tsquery (same rationale as memories retrieval's textSQL: a
 	// multi-topic question must match each chunk that answers PART of
 	// it, which websearch/plainto AND-semantics would return nothing
-	// for. Lexemes are quoted (with '' doubling) so none can break the
-	// tsquery syntax. Two variants because the query text is $1 in
-	// keyword mode and $2 in hybrid.
+	// for), and also keep the distinct lexeme array itself for the
+	// matched-lexeme gate below (D-084). Lexemes are quoted (with ''
+	// doubling) so none can break the tsquery syntax. Two variants
+	// because the query text is $1 in keyword mode and $2 in hybrid.
 	kbQueryCTEq1 = `SELECT to_tsquery('english',
-			string_agg('''' || replace(lexeme, '''', '''''') || '''', ' | ')) AS query
+			string_agg('''' || replace(lexeme, '''', '''''') || '''', ' | ')) AS query,
+			array_agg(DISTINCT lexeme) AS lexemes
 		FROM unnest(tsvector_to_array(to_tsvector('english', $1))) AS lexeme`
 	kbQueryCTEq2 = `SELECT to_tsquery('english',
-			string_agg('''' || replace(lexeme, '''', '''''') || '''', ' | ')) AS query
+			string_agg('''' || replace(lexeme, '''', '''''') || '''', ' | ')) AS query,
+			array_agg(DISTINCT lexeme) AS lexemes
 		FROM unnest(tsvector_to_array(to_tsvector('english', $2))) AS lexeme`
+
+	// keywordMatchGate (D-084, issue #425): counts how many distinct
+	// query lexemes actually appear in the chunk's tsvector, via array
+	// intersection, and requires at least minMatchedLexemesLit. Sits
+	// alongside the "c.tsv @@ q.query" OR-match, tightening it rather
+	// than replacing it.
+	keywordMatchGate = `(SELECT count(*) FROM unnest(q.lexemes) ql WHERE tsvector_to_array(c.tsv) @> ARRAY[ql]) >= ` + minMatchedLexemesLit
 
 	// collectionFilter matches every row when names is empty/null
 	// (whole-KB search), or scopes to it when non-empty (an explicit
@@ -329,7 +358,7 @@ const (
 		FROM kb_chunks c
 		JOIN kb_documents d ON d.id = c.document_id
 		JOIN kb_collections col ON col.id = d.collection_id, q
-		WHERE ` + collectionFilterQ2 + ` AND c.tsv @@ q.query
+		WHERE ` + collectionFilterQ2 + ` AND c.tsv @@ q.query AND ` + keywordMatchGate + `
 		ORDER BY score DESC
 		LIMIT $3`
 
@@ -358,7 +387,7 @@ const (
 			FROM kb_chunks c
 			JOIN kb_documents d ON d.id = c.document_id
 			JOIN kb_collections col ON col.id = d.collection_id, q
-			WHERE ` + collectionFilterQ3 + ` AND c.tsv @@ q.query
+			WHERE ` + collectionFilterQ3 + ` AND c.tsv @@ q.query AND ` + keywordMatchGate + `
 			ORDER BY rank
 			LIMIT ` + legLimitLit + `
 		), fused AS (

--- a/internal/memory/store/kb_golden_integration_test.go
+++ b/internal/memory/store/kb_golden_integration_test.go
@@ -673,6 +673,115 @@ func TestKBGoldenFusionWeightFavorsVectorLeg(t *testing.T) {
 	}
 }
 
+// D-084 (issue #425): keyword-leg matched-lexeme floor.
+const kbKeywordGateCollection = "itest-kbkeywordgate"
+
+// seedKBKeywordGate builds one document sharing exactly one lexeme
+// ("common") with the probe query, off-axis so the vector leg never
+// returns it, and a second document sharing two lexemes ("common" and
+// "special") with a different probe query, also off-axis. A
+// single-shared-lexeme query must return nothing from the keyword leg
+// (the bug this issue fixes); a query sharing two or more lexemes with
+// a chunk must still match (the floor isn't raised so high it breaks
+// genuine partial/multi-topic matches).
+func seedKBKeywordGate(t *testing.T) *KBStore {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	_, _ = db.Exec(ctx, "DELETE FROM kb_collections WHERE name = $1", kbKeywordGateCollection)
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer ccancel()
+		conn, err := pgx.Connect(cctx, dsn)
+		if err != nil {
+			t.Errorf("cleanup connect: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close(cctx) }()
+		_, _ = conn.Exec(cctx, "DELETE FROM kb_collections WHERE name = $1", kbKeywordGateCollection)
+	})
+
+	st := NewKBStore(pool)
+	var collID string
+	if err := db.QueryRow(ctx,
+		"INSERT INTO kb_collections (name) VALUES ($1) RETURNING id", kbKeywordGateCollection).Scan(&collID); err != nil {
+		t.Fatalf("insert collection: %v", err)
+	}
+
+	insert := func(title, content string, emb Vector) {
+		var docID string
+		if err := db.QueryRow(ctx, `INSERT INTO kb_documents (collection_id, title, status)
+			VALUES ($1, $2, 'ready') RETURNING id`, collID, title).Scan(&docID); err != nil {
+			t.Fatalf("insert document %s: %v", title, err)
+		}
+		if err := st.ReplaceChunks(ctx, docID, []KBChunk{
+			{Seq: 0, Content: content, Embedding: emb, EmbeddingModel: "itest"},
+		}); err != nil {
+			t.Fatalf("ReplaceChunks %s: %v", title, err)
+		}
+	}
+
+	// Shares only "common" with the single-lexeme probe query; off axis
+	// so it can't clear the vector leg either.
+	insert("single-overlap", "this document only shares one common word with the query", kbBasis(820))
+	// Shares "common" and "special" with the multi-lexeme probe query;
+	// off axis for the same reason.
+	insert("double-overlap", "this document shares a common and special word with the query", kbBasis(821))
+
+	return st
+}
+
+// TestKBGoldenKeywordGateBlocksSingleLexemeOverlap pins D-084: a query
+// sharing exactly one lexeme with a chunk must not surface it via the
+// keyword leg (the bug the issue reports: any one shared word produced
+// a hit regardless of topic).
+func TestKBGoldenKeywordGateBlocksSingleLexemeOverlap(t *testing.T) {
+	st := seedKBKeywordGate(t)
+	hits, err := st.KBSearch(t.Context(), "common", nil, []string{kbKeywordGateCollection}, nil, KBSearchKeyword, 5)
+	if err != nil {
+		t.Fatalf("KBSearch: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("single-lexeme query returned %d keyword-leg hits, want 0: %+v", len(hits), hits)
+	}
+}
+
+// TestKBGoldenKeywordGateAllowsTwoLexemeOverlap pins D-084's other
+// half: the floor doesn't block a genuine match sharing 2+ lexemes,
+// only a single shared lexeme.
+func TestKBGoldenKeywordGateAllowsTwoLexemeOverlap(t *testing.T) {
+	st := seedKBKeywordGate(t)
+	hits, err := st.KBSearch(t.Context(), "common special", nil, []string{kbKeywordGateCollection}, nil, KBSearchKeyword, 5)
+	if err != nil {
+		t.Fatalf("KBSearch: %v", err)
+	}
+	found := false
+	for _, h := range hits {
+		if h.DocumentTitle == "double-overlap" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("two-lexeme query missed the double-overlap document: %+v", hits)
+	}
+}
+
 func TestKBGoldenSemanticFloor(t *testing.T) {
 	st := seedKBGolden(t)
 	// On-axis query hits; orthogonal query (similarity 0) must not.

--- a/scripts/kb-eval/eval.yaml
+++ b/scripts/kb-eval/eval.yaml
@@ -28,3 +28,13 @@ negative: true
 
 query: fermenting kimchi at home with napa cabbage
 negative: true
+
+# Mild lexeme overlap negatives (issue #425): share exactly one common
+# word with the corpus ("team" with the mesh docs, "cache" with the
+# CI/CD doc) but no topical overlap. Before the keyword-leg gating fix
+# these produced keyword-leg hits on the shared word alone.
+query: organizing a office team scavenger hunt this weekend
+negative: true
+
+query: clearing out my kitchen cache of ground cinnamon
+negative: true


### PR DESCRIPTION
Closes #425.

The keyword (full-text) leg ORs query lexemes, so a single shared common word produced a hit on any document regardless of topic. Adds a distinct-matched-lexeme floor (D-084, minMatchedLexemesLit=2): a chunk must share at least two distinct query lexemes to be a keyword-leg hit.

## Approach
Chose the matched-lexeme count floor over the alternatives:
- AND/websearch tsquery rejected: breaks the multi-topic OR contract (TestKBGoldenKeywordOnlyMultiTopic).
- ts_rank floor rejected after measurement: a single common word scored higher than genuine multi-lexeme on-topic matches.

## Verified
- make kb-eval: recall@5 stays 1.0 on the original 6 queries; two new mild-overlap negatives return zero hits (failed before the gate).
- Mirrored production corpus: an off-topic query sharing one common word returned 50 keyword-leg hits before, 0 after.
- New golden integration tests; go vet + go test -race clean; make test-integration green solo (46 packages).

## Known limitation (documented in code)
A plain count floor does not rule out two independently generic words coinciding in one chunk of a large corpus. DF weighting to close that breaks small collections, so kept simple.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790710254&installation_model_id=431401&pr_number=441&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F441&signature=769607d2eaae64c4ea3c0e401ce18d4b4a6a5b0e44a1cda7f7f26cbf2f1a9ae3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->