### PR TITLE
feat(chat): nudge chat sessions to consult the kb

### DIFF
--- a/internal/brain/chat/systemprompt.go
+++ b/internal/brain/chat/systemprompt.go
@@ -3,7 +3,7 @@ package chat
 import "time"
 
 // systemPromptVersion increments with any change to the prompt text.
-const systemPromptVersion = 6
+const systemPromptVersion = 7
 
 // systemPrompt is Timothy's identity. Additions APPEND after the
 // existing text and the terseness steer stays the LAST line: the
@@ -18,7 +18,9 @@ Answer from knowledge when confident; say plainly when you are unsure or lack ac
 
 Before a tool call, write at most one short line saying what you are checking — never the answer itself; the answer comes only after the tool results are in. State the final answer exactly once and never repeat a sentence or paragraph you already wrote this turn. Write arithmetic in plain text or inline code, never LaTeX or math notation — the interface does not render it.
 
-A message block starting with "[attached document <id> (<mime>)]" is followed by that document's full content, already extracted — never fetch it with fetch_url or any other tool.`
+A message block starting with "[attached document <id> (<mime>)]" is followed by that document's full content, already extracted — never fetch it with fetch_url or any other tool.
+
+The owner keeps a curated knowledge base of their own notes and reference material, reachable via search_kb. When a question is substantive and could be informed by that material, search_kb first and ground the answer in what you find rather than answering from general knowledge alone. Skip it only for small talk or questions that clearly cannot touch stored notes.`
 
 // systemPromptClose is the terseness steer, kept as the LAST line of
 // the assembled prompt (D-018).

--- a/internal/brain/chat/systemprompt_test.go
+++ b/internal/brain/chat/systemprompt_test.go
@@ -76,6 +76,21 @@ func TestAssembleSystemDateLineIncludesTimezoneSteer(t *testing.T) {
 	})
 }
 
+// TestAssembleSystemIncludesKBNudge pins that the assembled prompt
+// tells the model to consult search_kb for questions that plausibly
+// overlap curated content (issue #429), matching the mission explore
+// nudge (#405) in spirit but scoped to chat's own tool guidance.
+func TestAssembleSystemIncludesKBNudge(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.July, 28, 0, 0, 0, 0, time.UTC)
+	got := assembleSystem("", now, nil)
+
+	want := "curated knowledge base of their own notes and reference material, reachable via search_kb"
+	if !strings.Contains(got, want) {
+		t.Fatalf("KB nudge missing:\n%s\nwant substring:\n%s", got, want)
+	}
+}
+
 func TestAssembleSystemCloseStaysLast(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, time.July, 28, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
Closes #429.

Chat sessions never called search_kb on their own: the KB nudge (#405) lived only in the mission explore prompt. Adds a nudge to the chat system prompt (systemprompt.go, version 7) that names the KB as the owner's curated notes and directs search_kb first on substantive questions, sparing small talk. Kept in the cache-stable prefix (D-018).

## Verified behaviorally (stack rebuilt)
Two chat turns, twice each, stable:
- "tradeoffs of adopting a service mesh for a small kubernetes cluster?" -> search_kb FIRED both runs.
- "fun icebreaker for a team lunch?" -> search_kb did not fire both runs.

An initial softer wording ("plausibly overlaps stored content") did not trigger the model to search; naming the KB concretely and directing search-first fixed it.

## Tests
go build + vet + go test -race ./internal/brain/chat/ clean; unit test asserts the nudge is in the assembled prompt. No tool wiring or permission changes (search_kb was already offered to chat, gated only on a KB backend being configured).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790711276&installation_model_id=431401&pr_number=442&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F442&signature=848839d2a39b90b9fb88f3d2ccbab5de3d28e855aeda2d4490d561101ff89e6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->