### PR TITLE
fix(security): redact provider headers and connector config in admin audit

### DIFF
--- a/internal/brain/connectors/audit_test.go
+++ b/internal/brain/connectors/audit_test.go
@@ -1,0 +1,90 @@
+package connectors
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestRedactAuditValueConnector covers issue #444: free-form connector
+// Config (imap/caldav) can carry sensitive values that the dedicated
+// secret path never sees, and admin_audit has no secret handling of
+// its own.
+func TestRedactAuditValueConnector(t *testing.T) {
+	t.Parallel()
+	secret := "hunter2-app-password"
+	c := Connector{
+		ID:     "1",
+		Name:   "personal-imap",
+		Kind:   "imap",
+		Config: json.RawMessage(`{"host":"imap.example.com","port":993,"username":"me@example.com","password":"` + secret + `","tls":true}`),
+	}
+
+	redacted, ok := redactAuditValue(c).(Connector)
+	if !ok {
+		t.Fatalf("redactAuditValue changed type: %T", redactAuditValue(c))
+	}
+
+	b, err := json.Marshal(redacted)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), secret) || strings.Contains(string(b), "me@example.com") || strings.Contains(string(b), "imap.example.com") {
+		t.Fatalf("audit payload leaked a config value: %s", b)
+	}
+	for _, key := range []string{"host", "port", "username", "password", "tls"} {
+		if !strings.Contains(string(b), key) {
+			t.Fatalf("audit payload dropped config key %q: %s", key, b)
+		}
+	}
+	// non-string values are kept as-is, only string leaves are redacted
+	if !strings.Contains(string(b), "993") {
+		t.Fatalf("audit payload should keep the numeric port: %s", b)
+	}
+	if !strings.Contains(string(b), "true") {
+		t.Fatalf("audit payload should keep the boolean tls flag: %s", b)
+	}
+
+	// the stored connector's Config must not have been mutated
+	if !strings.Contains(string(c.Config), secret) {
+		t.Fatalf("redactAuditValue mutated the live Connector.Config: %s", c.Config)
+	}
+}
+
+func TestRedactAuditValueConnectorNestedConfig(t *testing.T) {
+	t.Parallel()
+	c := Connector{
+		Config: json.RawMessage(`{"auth":{"token":"abc123"},"scopes":["mail.read","mail.send"]}`),
+	}
+
+	redacted, ok := redactAuditValue(c).(Connector)
+	if !ok {
+		t.Fatalf("redactAuditValue changed type: %T", redactAuditValue(c))
+	}
+	b, _ := json.Marshal(redacted)
+	if strings.Contains(string(b), "abc123") || strings.Contains(string(b), "mail.read") {
+		t.Fatalf("audit payload leaked nested string values: %s", b)
+	}
+	if !strings.Contains(string(b), `"token"`) {
+		t.Fatalf("audit payload dropped nested key: %s", b)
+	}
+}
+
+func TestRedactAuditValueConnectorEmptyConfig(t *testing.T) {
+	t.Parallel()
+	c := Connector{ID: "1", Name: "n", Kind: "imap"}
+	redacted, ok := redactAuditValue(c).(Connector)
+	if !ok {
+		t.Fatalf("redactAuditValue changed type: %T", redactAuditValue(c))
+	}
+	if len(redacted.Config) != 0 {
+		t.Fatalf("Config = %s, want empty", redacted.Config)
+	}
+}
+
+func TestRedactAuditValuePassesThroughOtherTypes(t *testing.T) {
+	t.Parallel()
+	if got := redactAuditValue(nil); got != nil {
+		t.Fatalf("redactAuditValue(nil) = %v, want nil", got)
+	}
+}

--- a/internal/brain/connectors/connectors.go
+++ b/internal/brain/connectors/connectors.go
@@ -283,10 +283,61 @@ func (s *Store) audit(ctx context.Context, action, entityID string, before, afte
 		s.log.Warn("connector audit skipped", "action", action, "error", err)
 		return
 	}
-	b, _ := json.Marshal(before)
-	aft, _ := json.Marshal(after)
+	b, _ := json.Marshal(redactAuditValue(before))
+	aft, _ := json.Marshal(redactAuditValue(after))
 	if _, err := db.Exec(ctx, `INSERT INTO admin_audit (action, entity, entity_id, before, after)
 		VALUES ($1, 'connector', $2, $3, $4)`, action, entityID, b, aft); err != nil {
 		s.log.Warn("connector audit failed", "action", action, "error", err)
+	}
+}
+
+// redactAuditValue blanks Connector.Config's string values before a
+// payload is written to admin_audit: imap/caldav configs carry
+// host/username/password-shaped fields, and admin_audit is a plain
+// table with no dedicated secret handling. Keys and non-string
+// structure (numbers, bools, nesting) survive so the audit still shows
+// what changed shape-wise; only string leaves are redacted, since a
+// key-based allowlist would miss whatever field name the next
+// connector kind picks. Never mutates the stored connector's Config.
+func redactAuditValue(v any) any {
+	c, ok := v.(Connector)
+	if !ok {
+		return v
+	}
+	if len(c.Config) == 0 {
+		return c
+	}
+	var parsed any
+	if err := json.Unmarshal(c.Config, &parsed); err != nil {
+		return c
+	}
+	redacted, err := json.Marshal(redactStrings(parsed))
+	if err != nil {
+		return c
+	}
+	c.Config = redacted
+	return c
+}
+
+// redactStrings walks a decoded JSON value, replacing every string leaf
+// with "[redacted]" and recursing into objects/arrays unchanged.
+func redactStrings(v any) any {
+	switch val := v.(type) {
+	case string:
+		return "[redacted]"
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, vv := range val {
+			out[k] = redactStrings(vv)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, vv := range val {
+			out[i] = redactStrings(vv)
+		}
+		return out
+	default:
+		return val
 	}
 }

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -1620,12 +1620,33 @@ func (a *Admin) audit(ctx context.Context, action, entity, entityID string, befo
 		a.log.Warn("admin audit skipped", "action", action, "entity", entity, "error", err)
 		return
 	}
-	b, _ := json.Marshal(before)
-	aft, _ := json.Marshal(after)
+	b, _ := json.Marshal(redactAuditValue(before))
+	aft, _ := json.Marshal(redactAuditValue(after))
 	if _, err := db.Exec(ctx, `INSERT INTO admin_audit (action, entity, entity_id, before, after)
 		VALUES ($1, $2, $3, $4, $5)`, action, entity, entityID, b, aft); err != nil {
 		a.log.Warn("admin audit failed", "action", action, "entity", entity, "error", err)
 	}
+}
+
+// redactAuditValue blanks Provider.Headers values before a payload is
+// written to admin_audit: header-authenticated providers put
+// Authorization/x-api-key values there, and admin_audit is a plain
+// table with no dedicated secret handling. Copies the map so the live
+// struct (and whatever the caller does with it afterward) is untouched.
+func redactAuditValue(v any) any {
+	p, ok := v.(Provider)
+	if !ok {
+		return v
+	}
+	if len(p.Headers) == 0 {
+		return p
+	}
+	redacted := make(map[string]string, len(p.Headers))
+	for k := range p.Headers {
+		redacted[k] = "[redacted]"
+	}
+	p.Headers = redacted
+	return p
 }
 
 // reload swaps the serving snapshot; a failure keeps the last good one

--- a/internal/gateway/admin/admin_audit_test.go
+++ b/internal/gateway/admin/admin_audit_test.go
@@ -1,0 +1,62 @@
+package admin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestRedactAuditValueProvider covers issue #444: header-authenticated
+// providers put secrets (Authorization, x-api-key) in Headers, and
+// admin_audit has no dedicated secret handling of its own.
+func TestRedactAuditValueProvider(t *testing.T) {
+	t.Parallel()
+	secret := "Bearer sk-super-secret-value" //nolint:gosec // fake fixture value, not a credential
+	p := Provider{
+		Name:    "p",
+		Kind:    "api",
+		Driver:  "openaicompat",
+		Headers: map[string]string{"Authorization": secret, "x-api-key": "another-secret"},
+	}
+
+	redacted := redactAuditValue(p)
+
+	b, err := json.Marshal(redacted)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), secret) || strings.Contains(string(b), "another-secret") {
+		t.Fatalf("audit payload leaked a header secret: %s", b)
+	}
+	if !strings.Contains(string(b), "Authorization") || !strings.Contains(string(b), "x-api-key") {
+		t.Fatalf("audit payload dropped header keys: %s", b)
+	}
+
+	// the live struct passed in must not have been mutated
+	if p.Headers["Authorization"] != secret {
+		t.Fatalf("redactAuditValue mutated the live Provider.Headers: %v", p.Headers)
+	}
+}
+
+func TestRedactAuditValueProviderNoHeaders(t *testing.T) {
+	t.Parallel()
+	p := Provider{Name: "p", Kind: "api", Driver: "openaicompat"}
+	redacted, ok := redactAuditValue(p).(Provider)
+	if !ok {
+		t.Fatalf("redactAuditValue changed type: %T", redacted)
+	}
+	if len(redacted.Headers) != 0 {
+		t.Fatalf("Headers = %v, want empty", redacted.Headers)
+	}
+}
+
+func TestRedactAuditValuePassesThroughOtherTypes(t *testing.T) {
+	t.Parallel()
+	v := map[string]any{"configured": true}
+	if got := redactAuditValue(v); got == nil {
+		t.Fatalf("redactAuditValue(%v) = nil", v)
+	}
+	if got := redactAuditValue(nil); got != nil {
+		t.Fatalf("redactAuditValue(nil) = %v, want nil", got)
+	}
+}

--- a/scripts/scrub-admin-audit.sql
+++ b/scripts/scrub-admin-audit.sql
@@ -1,0 +1,41 @@
+-- One-time scrub for issue #444: admin_audit rows written before the
+-- go-forward redaction (internal/gateway/admin/admin.go,
+-- internal/brain/connectors/connectors.go) stored provider Headers and
+-- connector Config verbatim, including secret values.
+--
+-- Idempotent: every update is guarded by a "not already scrubbed"
+-- check, safe to re-run.
+--
+-- Coarser than the go-forward redaction on purpose: the Go code
+-- redacts individual string leaves and keeps keys/structure so a
+-- fresh audit still shows what changed shape-wise; here we replace
+-- the whole headers/config sub-object with a single marker. Faithful
+-- SQL replication of the recursive per-string-leaf rule (arbitrary
+-- config nesting) isn't worth the complexity for a one-time pass over
+-- an append-only table nothing reads.
+
+-- provider rows: blank the whole headers object, before and after.
+UPDATE admin_audit
+SET before = jsonb_set(before, '{headers}', '{"redacted": true}'::jsonb)
+WHERE entity = 'provider'
+  AND before ? 'headers'
+  AND before->'headers' <> '{"redacted": true}'::jsonb;
+
+UPDATE admin_audit
+SET after = jsonb_set(after, '{headers}', '{"redacted": true}'::jsonb)
+WHERE entity = 'provider'
+  AND after ? 'headers'
+  AND after->'headers' <> '{"redacted": true}'::jsonb;
+
+-- connector rows: blank the whole config object, before and after.
+UPDATE admin_audit
+SET before = jsonb_set(before, '{config}', '{"redacted": true}'::jsonb)
+WHERE entity = 'connector'
+  AND before ? 'config'
+  AND before->'config' <> '{"redacted": true}'::jsonb;
+
+UPDATE admin_audit
+SET after = jsonb_set(after, '{config}', '{"redacted": true}'::jsonb)
+WHERE entity = 'connector'
+  AND after ? 'config'
+  AND after->'config' <> '{"redacted": true}'::jsonb;


### PR DESCRIPTION
Closes #444.

## What

- Gateway audit helper redacts provider header values (keys kept) on create/update/delete audit rows; deep-copies, never mutates the live struct.
- Connectors audit helper recursively redacts every string leaf in the connector config copy written to admin_audit; numbers, booleans, keys, and nesting survive so the audit still shows what changed shape-wise. Stored config untouched.
- `scripts/scrub-admin-audit.sql`: idempotent one-time scrub replacing existing rows' headers/config sub-objects with `{"redacted": true}` (coarser than the go-forward redaction, noted in the script).
- Tests assert no fixture secret survives into the marshalled audit payload and the live entities are not redacted.

## Why

admin_audit is append-only and read by no code; provider headers are exactly where header-authenticated API keys live, so every provider edit persisted credentials into a table with zero utility. The dedicated secret paths were already careful; this closes the two free-form gaps.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790753529&installation_model_id=431401&pr_number=449&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F449&signature=3893d93269ad4970ecc7ce687d069509a4c2dcc218ada3d31481004b456f50ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->