### PR TITLE
feat(kb): per-collection retrieval weight (D-085)

### DIFF
--- a/internal/brain/api/kb.go
+++ b/internal/brain/api/kb.go
@@ -147,7 +147,7 @@ func (h *kbAPI) resolveCollection(ctx context.Context, title, markdownText strin
 	if name == "" {
 		name = "Unsorted"
 	}
-	id, err := h.store.CreateCollection(ctx, name, choice.NewDesc)
+	id, err := h.store.CreateCollection(ctx, name, choice.NewDesc, 0)
 	if err != nil {
 		return "", fmt.Errorf("create collection %q: %w", name, err)
 	}
@@ -183,10 +183,19 @@ func (h *kbAPI) listCollections(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"collections": rows})
 }
 
+// validKBRetrievalWeight is the valid range for a collection's
+// retrieval_weight (D-085, issue #443), matching the DB CHECK
+// constraint: > 0 keeps a collection always retrievable when it's the
+// only relevant content, <= 2 bounds how far it can dominate.
+func validKBRetrievalWeight(w float64) bool {
+	return w > 0 && w <= 2
+}
+
 func (h *kbAPI) createCollection(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
+		Name            string   `json:"name"`
+		Description     string   `json:"description"`
+		RetrievalWeight *float64 `json:"retrieval_weight"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
@@ -196,7 +205,15 @@ func (h *kbAPI) createCollection(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "bad_request", "name is required")
 		return
 	}
-	id, err := h.store.CreateCollection(r.Context(), req.Name, req.Description)
+	var retrievalWeight float64
+	if req.RetrievalWeight != nil {
+		if !validKBRetrievalWeight(*req.RetrievalWeight) {
+			jsonError(w, http.StatusBadRequest, "bad_request", "retrieval_weight must be > 0 and <= 2")
+			return
+		}
+		retrievalWeight = *req.RetrievalWeight
+	}
+	id, err := h.store.CreateCollection(r.Context(), req.Name, req.Description, retrievalWeight)
 	if err != nil {
 		failKB(w, err)
 		return
@@ -218,14 +235,15 @@ func (h *kbAPI) getCollection(w http.ResponseWriter, r *http.Request) {
 // same shape the settings handlers use).
 func (h *kbAPI) updateCollection(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Name        *string `json:"name"`
-		Description *string `json:"description"`
+		Name            *string  `json:"name"`
+		Description     *string  `json:"description"`
+		RetrievalWeight *float64 `json:"retrieval_weight"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
-	if req.Name == nil && req.Description == nil {
+	if req.Name == nil && req.Description == nil && req.RetrievalWeight == nil {
 		jsonError(w, http.StatusBadRequest, "bad_request", "nothing to update")
 		return
 	}
@@ -233,7 +251,11 @@ func (h *kbAPI) updateCollection(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "bad_request", "name must not be empty")
 		return
 	}
-	if err := h.store.UpdateCollection(r.Context(), r.PathValue("id"), req.Name, req.Description); err != nil {
+	if req.RetrievalWeight != nil && !validKBRetrievalWeight(*req.RetrievalWeight) {
+		jsonError(w, http.StatusBadRequest, "bad_request", "retrieval_weight must be > 0 and <= 2")
+		return
+	}
+	if err := h.store.UpdateCollection(r.Context(), r.PathValue("id"), req.Name, req.Description, req.RetrievalWeight); err != nil {
 		failKB(w, err)
 		return
 	}

--- a/internal/brain/api/kb_integration_test.go
+++ b/internal/brain/api/kb_integration_test.go
@@ -146,6 +146,24 @@ func TestKBCollectionsCRUD(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Default retrieval_weight (D-085, issue #443) is neutral (1.0).
+	def, err := store.GetCollection(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetCollection after create: %v", err)
+	}
+	if def.RetrievalWeight != 1.0 {
+		t.Fatalf("default RetrievalWeight = %v, want 1.0", def.RetrievalWeight)
+	}
+
+	// An out-of-bounds retrieval_weight is rejected at create time too.
+	badCreate := httptest.NewRequest("POST", "/v1/admin/kb/collections", strings.NewReader(`{"name":"itest-badweight","retrieval_weight":0}`))
+	badCreate.Header.Set("Authorization", "Bearer tok")
+	w = httptest.NewRecorder()
+	m.ServeHTTP(w, badCreate)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("create with bad weight status = %d, want 400", w.Code)
+	}
+
 	list := httptest.NewRequest("GET", "/v1/admin/kb/collections", nil)
 	list.Header.Set("Authorization", "Bearer tok")
 	w = httptest.NewRecorder()
@@ -170,7 +188,7 @@ func TestKBCollectionsCRUD(t *testing.T) {
 	if renamed.Name != "itest-docs-renamed" || renamed.Description != "test collection" {
 		t.Fatalf("after rename: name=%q description=%q", renamed.Name, renamed.Description)
 	}
-	for _, body := range []string{`{}`, `{"name":"  "}`} {
+	for _, body := range []string{`{}`, `{"name":"  "}`, `{"retrieval_weight":0}`, `{"retrieval_weight":2.5}`} {
 		bad := httptest.NewRequest("PATCH", "/v1/admin/kb/collections/"+created.ID, strings.NewReader(body))
 		bad.Header.Set("Authorization", "Bearer tok")
 		w = httptest.NewRecorder()
@@ -178,6 +196,22 @@ func TestKBCollectionsCRUD(t *testing.T) {
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("patch %s status = %d, want 400", body, w.Code)
 		}
+	}
+
+	// A valid retrieval_weight (D-085, issue #443) persists.
+	weightPatch := httptest.NewRequest("PATCH", "/v1/admin/kb/collections/"+created.ID, strings.NewReader(`{"retrieval_weight":0.3}`))
+	weightPatch.Header.Set("Authorization", "Bearer tok")
+	w = httptest.NewRecorder()
+	m.ServeHTTP(w, weightPatch)
+	if w.Code != http.StatusOK {
+		t.Fatalf("weight patch status = %d body %s", w.Code, w.Body)
+	}
+	weighted, err := store.GetCollection(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetCollection after weight patch: %v", err)
+	}
+	if weighted.RetrievalWeight != 0.3 {
+		t.Fatalf("RetrievalWeight = %v, want 0.3", weighted.RetrievalWeight)
 	}
 
 	// A failed document counts toward failed_count but not the base
@@ -217,7 +251,7 @@ func TestKBDocumentUploadSkipsMarkitdownForMarkdown(t *testing.T) {
 	m := mux(a)
 	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
 
-	collID, err := store.CreateCollection(context.Background(), "itest-upload", "")
+	collID, err := store.CreateCollection(context.Background(), "itest-upload", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -288,11 +322,11 @@ func TestKBSearchDocumentsCrossCollectionTitleMatch(t *testing.T) {
 	m := mux(a)
 	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
 
-	collA, err := store.CreateCollection(context.Background(), "itest-search-a", "")
+	collA, err := store.CreateCollection(context.Background(), "itest-search-a", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
-	collB, err := store.CreateCollection(context.Background(), "itest-search-b", "")
+	collB, err := store.CreateCollection(context.Background(), "itest-search-b", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -344,7 +378,7 @@ func TestKBDocumentUploadStripsNULAndInvalidUTF8(t *testing.T) {
 	m := mux(a)
 	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
 
-	collID, err := store.CreateCollection(context.Background(), "itest-nul", "")
+	collID, err := store.CreateCollection(context.Background(), "itest-nul", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -382,7 +416,7 @@ func TestKBDocumentUploadRejectsUnsupportedType(t *testing.T) {
 	m := mux(a)
 	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
 
-	collID, err := store.CreateCollection(context.Background(), "itest-upload-bad", "")
+	collID, err := store.CreateCollection(context.Background(), "itest-upload-bad", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -418,7 +452,7 @@ func TestKBDocumentFromURLIngestsFetchedMarkdown(t *testing.T) {
 	m := mux(a)
 	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
 
-	collID, err := store.CreateCollection(context.Background(), "itest-url", "")
+	collID, err := store.CreateCollection(context.Background(), "itest-url", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -494,7 +528,7 @@ func TestKBDocumentFromURLScopedReAddRefreshesInPlace(t *testing.T) {
 	m := mux(a)
 	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
 
-	collID, err := store.CreateCollection(context.Background(), "itest-url-readd", "")
+	collID, err := store.CreateCollection(context.Background(), "itest-url-readd", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -655,7 +689,7 @@ func TestKBDocumentFromURLDifferentURLStillCreates(t *testing.T) {
 	m := mux(a)
 	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
 
-	collID, err := store.CreateCollection(context.Background(), "itest-url-distinct", "")
+	collID, err := store.CreateCollection(context.Background(), "itest-url-distinct", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -753,7 +787,7 @@ func TestKBDocumentFromURLAutoUsesExistingCollection(t *testing.T) {
 	kbFetchTransport = http.DefaultTransport
 	defer func() { kbFetchTransport = saved }()
 
-	existingID, err := store.CreateCollection(context.Background(), "itest-existing", "")
+	existingID, err := store.CreateCollection(context.Background(), "itest-existing", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -789,7 +823,7 @@ func TestKBSweepStaleFailsStuckDocuments(t *testing.T) {
 	store := testKBStore(t)
 	ctx := context.Background()
 
-	collID, err := store.CreateCollection(ctx, "itest-sweep", "")
+	collID, err := store.CreateCollection(ctx, "itest-sweep", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -979,7 +1013,7 @@ func TestKBClipNewDocumentWithCollectionSkipsClassifier(t *testing.T) {
 	m := mux(a)
 	a.registerKB(m.Handle, store, &fakeIngester{}, "", classify, nil)
 
-	collID, err := store.CreateCollection(context.Background(), "itest-clip-target", "")
+	collID, err := store.CreateCollection(context.Background(), "itest-clip-target", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -1097,11 +1131,11 @@ func TestKBClipReClipMovesCollection(t *testing.T) {
 	m := mux(a)
 	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
 
-	origID, err := store.CreateCollection(context.Background(), "itest-clip-orig", "")
+	origID, err := store.CreateCollection(context.Background(), "itest-clip-orig", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
-	newID, err := store.CreateCollection(context.Background(), "itest-clip-new", "")
+	newID, err := store.CreateCollection(context.Background(), "itest-clip-new", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -1227,7 +1261,7 @@ func TestKBDocumentFromURLRejectsBadURL(t *testing.T) {
 	m := mux(a)
 	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
 
-	collID, err := store.CreateCollection(context.Background(), "itest-url-bad", "")
+	collID, err := store.CreateCollection(context.Background(), "itest-url-bad", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -1256,7 +1290,7 @@ func TestKBDocumentFromURLBlocksLocalAddresses(t *testing.T) {
 	}))
 	defer page.Close()
 
-	collID, err := store.CreateCollection(context.Background(), "itest-url-ssrf", "")
+	collID, err := store.CreateCollection(context.Background(), "itest-url-ssrf", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -1278,7 +1312,7 @@ func TestKBDocumentReingestFailureSetsFailedStatus(t *testing.T) {
 	m := mux(a)
 	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
 
-	collID, err := store.CreateCollection(context.Background(), "itest-reingest", "")
+	collID, err := store.CreateCollection(context.Background(), "itest-reingest", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -1347,7 +1381,7 @@ func TestKBDocumentReingestRetryableErrorSchedulesRetry(t *testing.T) {
 	m := mux(a)
 	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
 
-	collID, err := store.CreateCollection(context.Background(), "itest-retry-schedule", "")
+	collID, err := store.CreateCollection(context.Background(), "itest-retry-schedule", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -1390,7 +1424,7 @@ func TestKBDocumentReingestPermanentErrorNeverSchedulesRetry(t *testing.T) {
 	m := mux(a)
 	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
 
-	collID, err := store.CreateCollection(context.Background(), "itest-retry-permanent", "")
+	collID, err := store.CreateCollection(context.Background(), "itest-retry-permanent", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
@@ -1426,7 +1460,7 @@ func TestRunKBRetrySweepRetriesUntilBudgetExhausted(t *testing.T) {
 	store := testKBStore(t)
 	ingester := &fakeIngester{err: errors.New("gwclient: gateway http 503: service unavailable")}
 
-	collID, err := store.CreateCollection(context.Background(), "itest-retry-sweep", "")
+	collID, err := store.CreateCollection(context.Background(), "itest-retry-sweep", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}

--- a/internal/brain/api/kb_test.go
+++ b/internal/brain/api/kb_test.go
@@ -27,3 +27,25 @@ func TestKBRetryDelay(t *testing.T) {
 		}
 	}
 }
+
+// TestValidKBRetrievalWeight pins the bounds (D-085, issue #443):
+// > 0 and <= 2, matching the kb_collections CHECK constraint.
+func TestValidKBRetrievalWeight(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		weight float64
+		want   bool
+	}{
+		{0, false},
+		{-0.1, false},
+		{0.1, true},
+		{1.0, true},
+		{2.0, true},
+		{2.1, false},
+	}
+	for _, tc := range cases {
+		if got := validKBRetrievalWeight(tc.weight); got != tc.want {
+			t.Fatalf("validKBRetrievalWeight(%v) = %v, want %v", tc.weight, got, tc.want)
+		}
+	}
+}

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -1530,7 +1530,7 @@ func TestMissionsPromoteKB(t *testing.T) {
 	kbStore := testKBStore(t)
 	ctx := context.Background()
 
-	collectionID, err := kbStore.CreateCollection(ctx, "itest-promote-kb", "")
+	collectionID, err := kbStore.CreateCollection(ctx, "itest-promote-kb", "", 0)
 	if err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}

--- a/internal/brain/kb/kb.go
+++ b/internal/brain/kb/kb.go
@@ -31,8 +31,11 @@ type Collection struct {
 	DocCount    int       `json:"doc_count"`
 	ChunkCount  int       `json:"chunk_count"`
 	FailedCount int       `json:"failed_count"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	// RetrievalWeight scales this collection's score at retrieval time
+	// (D-085, issue #443): 1.0 is neutral, bounded to (0, 2].
+	RetrievalWeight float64   `json:"retrieval_weight"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }
 
 // Document is one ingested file within a collection. Markdown is
@@ -76,14 +79,14 @@ func New(db *pgpool.Pool) *Store {
 	return &Store{db: db}
 }
 
-const collectionColumns = `c.id, c.name, c.description, c.created_at, c.updated_at,
+const collectionColumns = `c.id, c.name, c.description, c.retrieval_weight, c.created_at, c.updated_at,
 	(SELECT count(*) FROM kb_documents d WHERE d.collection_id = c.id),
 	(SELECT coalesce(sum(d.chunk_count), 0) FROM kb_documents d WHERE d.collection_id = c.id),
 	(SELECT count(*) FROM kb_documents d WHERE d.collection_id = c.id AND d.status = 'failed')`
 
 func scanCollection(row pgx.Row) (Collection, error) {
 	var c Collection
-	err := row.Scan(&c.ID, &c.Name, &c.Description, &c.CreatedAt, &c.UpdatedAt, &c.DocCount, &c.ChunkCount, &c.FailedCount)
+	err := row.Scan(&c.ID, &c.Name, &c.Description, &c.RetrievalWeight, &c.CreatedAt, &c.UpdatedAt, &c.DocCount, &c.ChunkCount, &c.FailedCount)
 	return c, err
 }
 
@@ -125,15 +128,22 @@ func (s *Store) GetCollection(ctx context.Context, id string) (Collection, error
 	return c, nil
 }
 
-// CreateCollection inserts a new collection.
-func (s *Store) CreateCollection(ctx context.Context, name, description string) (string, error) {
+// CreateCollection inserts a new collection. retrievalWeight of 0 uses
+// the column default (1.0, neutral); callers validate bounds before
+// calling (D-085, issue #443).
+func (s *Store) CreateCollection(ctx context.Context, name, description string, retrievalWeight float64) (string, error) {
 	db, err := s.db.Get()
 	if err != nil {
 		return "", fmt.Errorf("kb collections create: %w", err)
 	}
 	var id string
-	err = db.QueryRow(ctx, `INSERT INTO kb_collections (name, description) VALUES ($1, $2) RETURNING id`,
-		name, description).Scan(&id)
+	if retrievalWeight == 0 {
+		err = db.QueryRow(ctx, `INSERT INTO kb_collections (name, description) VALUES ($1, $2) RETURNING id`,
+			name, description).Scan(&id)
+	} else {
+		err = db.QueryRow(ctx, `INSERT INTO kb_collections (name, description, retrieval_weight) VALUES ($1, $2, $3) RETURNING id`,
+			name, description, retrievalWeight).Scan(&id)
+	}
 	if err != nil {
 		return "", fmt.Errorf("kb collections create: %w", err)
 	}
@@ -141,16 +151,18 @@ func (s *Store) CreateCollection(ctx context.Context, name, description string) 
 }
 
 // UpdateCollection renames a collection and/or replaces its
-// description. nil leaves a field unchanged, so a bare rename never
-// clobbers the description the classifier matches against.
-func (s *Store) UpdateCollection(ctx context.Context, id string, name, description *string) error {
+// description and/or retrieval weight. nil leaves a field unchanged,
+// so a bare rename never clobbers the description the classifier
+// matches against, or the retrieval weight (D-085, issue #443).
+func (s *Store) UpdateCollection(ctx context.Context, id string, name, description *string, retrievalWeight *float64) error {
 	db, err := s.db.Get()
 	if err != nil {
 		return fmt.Errorf("kb collections update: %w", err)
 	}
 	tag, err := db.Exec(ctx, `UPDATE kb_collections
-		SET name = COALESCE($2, name), description = COALESCE($3, description), updated_at = now()
-		WHERE id = $1`, id, name, description)
+		SET name = COALESCE($2, name), description = COALESCE($3, description),
+			retrieval_weight = COALESCE($4, retrieval_weight), updated_at = now()
+		WHERE id = $1`, id, name, description, retrievalWeight)
 	if err != nil {
 		return fmt.Errorf("kb collections update: %w", err)
 	}

--- a/internal/memory/store/kb.go
+++ b/internal/memory/store/kb.go
@@ -344,7 +344,13 @@ const (
 		WHEN 'web' THEN ` + provenanceWeightWebLit + `
 		ELSE ` + provenanceWeightCuratedLit + ` END)`
 
-	semanticSQL = kbProjection + `, (1 - (c.embedding <=> $1::vector)) * ` + boostMultiplierQ4 + ` * ` + provenanceMultiplier + ` AS score
+	// retrievalWeightMultiplier (D-085, issue #443) scales a chunk's
+	// score by its collection's kb_collections.retrieval_weight, joining
+	// the same post-fusion multiplication chain as boostMultiplier and
+	// provenanceMultiplier: a per-collection ranking dial, not a filter.
+	retrievalWeightMultiplier = `col.retrieval_weight`
+
+	semanticSQL = kbProjection + `, (1 - (c.embedding <=> $1::vector)) * ` + boostMultiplierQ4 + ` * ` + provenanceMultiplier + ` * ` + retrievalWeightMultiplier + ` AS score
 		FROM kb_chunks c
 		JOIN kb_documents d ON d.id = c.document_id
 		JOIN kb_collections col ON col.id = d.collection_id
@@ -354,7 +360,7 @@ const (
 		LIMIT $3`
 
 	keywordSQL = `WITH q AS (` + kbQueryCTEq1 + `)
-		` + kbProjection + `, ts_rank(c.tsv, q.query) * ` + boostMultiplierQ4 + ` * ` + provenanceMultiplier + ` AS score
+		` + kbProjection + `, ts_rank(c.tsv, q.query) * ` + boostMultiplierQ4 + ` * ` + provenanceMultiplier + ` * ` + retrievalWeightMultiplier + ` AS score
 		FROM kb_chunks c
 		JOIN kb_documents d ON d.id = c.document_id
 		JOIN kb_collections col ON col.id = d.collection_id, q
@@ -399,7 +405,7 @@ const (
 			) legs
 			GROUP BY id
 		)
-		` + kbProjection + `, fused.score * ` + boostMultiplierQ5 + ` * ` + provenanceMultiplier + ` AS score
+		` + kbProjection + `, fused.score * ` + boostMultiplierQ5 + ` * ` + provenanceMultiplier + ` * ` + retrievalWeightMultiplier + ` AS score
 		FROM fused
 		JOIN kb_chunks c ON c.id = fused.id
 		JOIN kb_documents d ON d.id = c.document_id

--- a/internal/memory/store/kb_golden_integration_test.go
+++ b/internal/memory/store/kb_golden_integration_test.go
@@ -782,6 +782,139 @@ func TestKBGoldenKeywordGateAllowsTwoLexemeOverlap(t *testing.T) {
 	}
 }
 
+// D-085 (issue #443): per-collection retrieval weight.
+const (
+	kbRetrievalWeightBystanderCollection = "itest-kbretrieval-bystander"
+	kbRetrievalWeightOnTopicCollection   = "itest-kbretrieval-ontopic"
+)
+
+// seedKBRetrievalWeight builds a bystander document in a low-weight
+// (0.3) collection that wins raw vector similarity outright (on-axis
+// embedding, exact query text), and an on-topic document in a
+// normal-weight collection that shares the query's topic vocabulary
+// but sits off the query's exact axis, so it only wins on the fused
+// (leg-weighted) ranking once the collection weight is applied. This
+// mirrors D-083's bystander pattern but at the collection level: leg
+// weights alone can't fix this case because the bystander wins the raw
+// vector leg outright (kb.go's D-083 comment).
+func seedKBRetrievalWeight(t *testing.T) *KBStore {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set; skipping integration test")
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pool := pgpool.New(t.Context(), dsn, log)
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+	if err := pool.WaitHealthy(ctx); err != nil {
+		t.Fatalf("WaitHealthy: %v", err)
+	}
+	db, err := pool.Get()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := migrate.Run(ctx, db, migrations.FS, log); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	_, _ = db.Exec(ctx, "DELETE FROM kb_collections WHERE name LIKE 'itest-kbretrieval-%'")
+	t.Cleanup(func() {
+		cctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer ccancel()
+		conn, err := pgx.Connect(cctx, dsn)
+		if err != nil {
+			t.Errorf("cleanup connect: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close(cctx) }()
+		_, _ = conn.Exec(cctx, "DELETE FROM kb_collections WHERE name LIKE 'itest-kbretrieval-%'")
+	})
+
+	st := NewKBStore(pool)
+
+	var bystanderCollID string
+	if err := db.QueryRow(ctx,
+		"INSERT INTO kb_collections (name, retrieval_weight) VALUES ($1, 0.3) RETURNING id",
+		kbRetrievalWeightBystanderCollection).Scan(&bystanderCollID); err != nil {
+		t.Fatalf("insert bystander collection: %v", err)
+	}
+	var onTopicCollID string
+	if err := db.QueryRow(ctx,
+		"INSERT INTO kb_collections (name) VALUES ($1) RETURNING id",
+		kbRetrievalWeightOnTopicCollection).Scan(&onTopicCollID); err != nil {
+		t.Fatalf("insert on-topic collection: %v", err)
+	}
+
+	insert := func(collID, title, content string, emb Vector) {
+		var docID string
+		if err := db.QueryRow(ctx, `INSERT INTO kb_documents (collection_id, title, status)
+			VALUES ($1, $2, 'ready') RETURNING id`, collID, title).Scan(&docID); err != nil {
+			t.Fatalf("insert document %s: %v", title, err)
+		}
+		if err := st.ReplaceChunks(ctx, docID, []KBChunk{
+			{Seq: 0, Content: content, Embedding: emb, EmbeddingModel: "itest"},
+		}); err != nil {
+			t.Fatalf("ReplaceChunks %s: %v", title, err)
+		}
+	}
+
+	// Bystander: on the query's exact axis, wins raw vector similarity
+	// outright, and shares every query lexeme for a high keyword rank too.
+	insert(bystanderCollID, "bystander", "kubernetes cluster migration notes for the operator's own background",
+		kbBasis(950))
+	// On-topic: shares the topic vocabulary but sits off-axis (lower
+	// cosine similarity), so it only outranks the bystander once the
+	// bystander's collection weight discounts its otherwise-winning score.
+	onTopicVec := make(Vector, 1024)
+	onTopicVec[950] = 0.9
+	onTopicVec[951] = 0.44
+	insert(onTopicCollID, "on-topic", "kubernetes cluster migration runbook for production workloads",
+		onTopicVec)
+
+	return st
+}
+
+// TestKBGoldenRetrievalWeightDownranksBystander pins D-085's main
+// contract: a bystander that wins raw retrieval on both legs (D-083's
+// stated limit) still loses the fused ranking once its collection's
+// low retrieval_weight is applied.
+func TestKBGoldenRetrievalWeightDownranksBystander(t *testing.T) {
+	st := seedKBRetrievalWeight(t)
+	hits, err := st.KBSearch(t.Context(), "kubernetes cluster migration", kbBasis(950),
+		[]string{kbRetrievalWeightBystanderCollection, kbRetrievalWeightOnTopicCollection}, nil, KBSearchHybrid, 5)
+	if err != nil {
+		t.Fatalf("KBSearch: %v", err)
+	}
+	if len(hits) < 2 {
+		t.Fatalf("got %d hits, want at least 2: %+v", len(hits), hits)
+	}
+	if hits[0].DocumentTitle != "on-topic" {
+		t.Fatalf("top hit = %q, want the on-topic document ranked first ahead of the low-weight bystander: %+v",
+			hits[0].DocumentTitle, hits)
+	}
+}
+
+// TestKBGoldenRetrievalWeightStillReachableAlone pins D-085's other
+// half: a low collection weight must never hide a document that is the
+// only relevant content for a query (the "must NOT hard-hide" AC).
+func TestKBGoldenRetrievalWeightStillReachableAlone(t *testing.T) {
+	st := seedKBRetrievalWeight(t)
+	hits, err := st.KBSearch(t.Context(), "kubernetes cluster migration", kbBasis(950),
+		[]string{kbRetrievalWeightBystanderCollection}, nil, KBSearchHybrid, 5)
+	if err != nil {
+		t.Fatalf("KBSearch: %v", err)
+	}
+	found := false
+	for _, h := range hits {
+		if h.DocumentTitle == "bystander" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("low-weight collection's only relevant document was not retrieved when it's the only candidate: %+v", hits)
+	}
+}
+
 func TestKBGoldenSemanticFloor(t *testing.T) {
 	st := seedKBGolden(t)
 	// On-axis query hits; orthogonal query (similarity 0) must not.

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -833,6 +833,11 @@ CREATE TABLE IF NOT EXISTS kb_collections (
     id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     name        text UNIQUE NOT NULL,
     description text NOT NULL DEFAULT '',
+    -- retrieval_weight (D-085, issue #443) down-weights or up-weights a
+    -- whole collection at retrieval time: a low weight keeps
+    -- identity/profile collections out of general topical contests
+    -- while still retrievable when they are the only relevant content.
+    retrieval_weight real NOT NULL DEFAULT 1.0 CHECK (retrieval_weight > 0 AND retrieval_weight <= 2),
     created_at  timestamptz NOT NULL DEFAULT now(),
     updated_at  timestamptz NOT NULL DEFAULT now()
 );

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -837,7 +837,7 @@ CREATE TABLE IF NOT EXISTS kb_collections (
     -- whole collection at retrieval time: a low weight keeps
     -- identity/profile collections out of general topical contests
     -- while still retrievable when they are the only relevant content.
-    retrieval_weight real NOT NULL DEFAULT 1.0 CHECK (retrieval_weight > 0 AND retrieval_weight <= 2),
+    retrieval_weight double precision NOT NULL DEFAULT 1.0 CHECK (retrieval_weight > 0 AND retrieval_weight <= 2),
     created_at  timestamptz NOT NULL DEFAULT now(),
     updated_at  timestamptz NOT NULL DEFAULT now()
 );

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -10,7 +10,7 @@ Required on live DBs before/with the next deploy. Additive, safe to
 run before deploy.
 
 ```sql
-ALTER TABLE kb_collections ADD COLUMN IF NOT EXISTS retrieval_weight real NOT NULL DEFAULT 1.0;
+ALTER TABLE kb_collections ADD COLUMN IF NOT EXISTS retrieval_weight double precision NOT NULL DEFAULT 1.0;
 
 DO $$
 BEGIN

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -1,0 +1,24 @@
+# Pending live-DB alters
+
+Additive schema changes not yet applied to any live database. Safe to
+run before deploy; each entry stays here until confirmed applied on
+every live instance, then it's removed.
+
+## D-085 per-collection retrieval weight (issue #443)
+
+Required on live DBs before/with the next deploy. Additive, safe to
+run before deploy.
+
+```sql
+ALTER TABLE kb_collections ADD COLUMN IF NOT EXISTS retrieval_weight real NOT NULL DEFAULT 1.0;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'kb_collections_retrieval_weight_check'
+    ) THEN
+        ALTER TABLE kb_collections ADD CONSTRAINT kb_collections_retrieval_weight_check
+            CHECK (retrieval_weight > 0 AND retrieval_weight <= 2);
+    END IF;
+END $$;
+```

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -946,7 +946,7 @@ export async function createKbCollection(c: { name: string; description: string 
 
 export async function updateKbCollection(
   id: string,
-  patch: { name?: string; description?: string },
+  patch: { name?: string; description?: string; retrieval_weight?: number },
 ): Promise<KbCollection> {
   return request<KbCollection>(`/v1/admin/kb/collections/${id}`, {
     method: 'PATCH',

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -634,6 +634,9 @@ export interface KbCollection {
   // failed_count is how many documents in this collection are in the
   // 'failed' ingestion state.
   failed_count: number
+  // retrieval_weight scales this collection's score at retrieval time
+  // (D-085): 1.0 is neutral, bounded to (0, 2].
+  retrieval_weight: number
   created_at: string
   updated_at: string
 }

--- a/web/src/components/Composer.test.tsx
+++ b/web/src/components/Composer.test.tsx
@@ -552,8 +552,8 @@ describe('Composer knowledge mentions', () => {
   it('shows a filtered popup, selects on Enter, strips the token, and stops intercepting Enter', async () => {
     const client = await import('../api/client')
     vi.mocked(client.listKbCollections).mockResolvedValue([
-      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
-      { id: '2', name: 'billing', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, retrieval_weight: 1.0, created_at: '', updated_at: '' },
+      { id: '2', name: 'billing', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, retrieval_weight: 1.0, created_at: '', updated_at: '' },
     ])
     const onSend = vi.fn()
     render(<StatefulComposer onSend={onSend} />)
@@ -578,7 +578,7 @@ describe('Composer knowledge mentions', () => {
   it('closes the popup on Escape and lets Enter send', async () => {
     const client = await import('../api/client')
     vi.mocked(client.listKbCollections).mockResolvedValue([
-      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, retrieval_weight: 1.0, created_at: '', updated_at: '' },
     ])
     const onSend = vi.fn()
     render(<StatefulComposer onSend={onSend} />)
@@ -613,7 +613,7 @@ describe('Composer knowledge mentions', () => {
     vi.mocked(client.listKbCollections)
       .mockRejectedValueOnce(new Error('network error'))
       .mockResolvedValueOnce([
-        { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+        { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, retrieval_weight: 1.0, created_at: '', updated_at: '' },
       ])
     const onSend = vi.fn()
     render(<StatefulComposer onSend={onSend} />)
@@ -632,8 +632,8 @@ describe('Composer knowledge mentions', () => {
   it('cycles the highlighted option with ArrowDown/ArrowUp, wrapping at both ends', async () => {
     const client = await import('../api/client')
     vi.mocked(client.listKbCollections).mockResolvedValue([
-      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
-      { id: '2', name: 'billing', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, retrieval_weight: 1.0, created_at: '', updated_at: '' },
+      { id: '2', name: 'billing', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, retrieval_weight: 1.0, created_at: '', updated_at: '' },
     ])
     const onSend = vi.fn()
     render(<StatefulComposer onSend={onSend} />)
@@ -662,8 +662,8 @@ describe('Composer knowledge mentions', () => {
   it('selects the clicked popup option, adding a chip and stripping the token', async () => {
     const client = await import('../api/client')
     vi.mocked(client.listKbCollections).mockResolvedValue([
-      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
-      { id: '2', name: 'billing', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, retrieval_weight: 1.0, created_at: '', updated_at: '' },
+      { id: '2', name: 'billing', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, retrieval_weight: 1.0, created_at: '', updated_at: '' },
     ])
     const onSend = vi.fn()
     render(<StatefulComposer onSend={onSend} />)
@@ -682,7 +682,7 @@ describe('Composer knowledge mentions', () => {
   it('selects the highlighted option on Tab, same as Enter', async () => {
     const client = await import('../api/client')
     vi.mocked(client.listKbCollections).mockResolvedValue([
-      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, retrieval_weight: 1.0, created_at: '', updated_at: '' },
     ])
     const onSend = vi.fn()
     render(<StatefulComposer onSend={onSend} />)
@@ -716,8 +716,8 @@ describe('Composer agent-bound knowledge chips', () => {
   it('excludes agent-bound names from the mention popup', async () => {
     const client = await import('../api/client')
     vi.mocked(client.listKbCollections).mockResolvedValue([
-      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
-      { id: '2', name: 'runbooks', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, retrieval_weight: 1.0, created_at: '', updated_at: '' },
+      { id: '2', name: 'runbooks', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, retrieval_weight: 1.0, created_at: '', updated_at: '' },
     ])
     function StatefulWithAgentKnowledge() {
       const [draft, setDraft] = useState('')

--- a/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
@@ -149,6 +149,7 @@ export function KnowledgeCollectionDetail() {
   const [editing, setEditing] = useState(false)
   const [editName, setEditName] = useState('')
   const [editDesc, setEditDesc] = useState('')
+  const [editWeight, setEditWeight] = useState('1.0')
   const [confirmDeleteDoc, setConfirmDeleteDoc] = useState<KbDocument | null>(null)
 
   const refresh = useCallback(() => {
@@ -180,7 +181,11 @@ export function KnowledgeCollectionDetail() {
   const saveEdit = async () => {
     if (!id || editName.trim() === '') return
     try {
-      const updated = await updateKbCollection(id, { name: editName.trim(), description: editDesc })
+      const updated = await updateKbCollection(id, {
+        name: editName.trim(),
+        description: editDesc,
+        retrieval_weight: Number(editWeight),
+      })
       setCollection(updated)
       setEditing(false)
       toast.success('Collection updated')
@@ -247,6 +252,7 @@ export function KnowledgeCollectionDetail() {
             onClick={() => {
               setEditName(collection.name)
               setEditDesc(collection.description ?? '')
+              setEditWeight(String(collection.retrieval_weight ?? 1.0))
               setEditing(true)
             }}
           >
@@ -351,12 +357,32 @@ export function KnowledgeCollectionDetail() {
               placeholder="Description"
               aria-label="Collection description"
             />
+            <div>
+              <Input
+                type="number"
+                min={0.1}
+                max={2.0}
+                step={0.1}
+                value={editWeight}
+                onChange={(e) => setEditWeight(e.target.value)}
+                aria-label="Retrieval weight"
+              />
+              <p className="mt-1.5 text-xs text-muted-foreground">
+                Lower keeps this collection out of general searches; 1.0 is normal.
+              </p>
+            </div>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setEditing(false)}>
               Cancel
             </Button>
-            <Button disabled={editName.trim() === ''} onClick={() => void saveEdit()}>
+            <Button
+              disabled={
+                editName.trim() === '' ||
+                !(Number(editWeight) > 0 && Number(editWeight) <= 2)
+              }
+              onClick={() => void saveEdit()}
+            >
               Save
             </Button>
           </DialogFooter>

--- a/web/src/components/missions/ArtifactsSection.test.tsx
+++ b/web/src/components/missions/ArtifactsSection.test.tsx
@@ -214,7 +214,7 @@ describe('ArtifactsSection', () => {
 
     it('opens a dialog with a collection picker and promotes on submit', async () => {
       vi.mocked(listKbCollections).mockResolvedValue([
-        { id: 'c1', name: 'Reports', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+        { id: 'c1', name: 'Reports', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, retrieval_weight: 1.0, created_at: '', updated_at: '' },
       ])
       vi.mocked(promoteMissionToKB).mockResolvedValue({ promoted: 1 })
       render(<ArtifactsSection missionId="m1" phase="done" workspace={undefined} refs={refs} />)
@@ -232,7 +232,7 @@ describe('ArtifactsSection', () => {
 
     it('disables Promote until a collection is picked', async () => {
       vi.mocked(listKbCollections).mockResolvedValue([
-        { id: 'c1', name: 'Reports', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+        { id: 'c1', name: 'Reports', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, retrieval_weight: 1.0, created_at: '', updated_at: '' },
       ])
       render(<ArtifactsSection missionId="m1" phase="done" workspace={undefined} refs={refs} />)
 

--- a/web/src/components/settings/KnowledgePicker.test.tsx
+++ b/web/src/components/settings/KnowledgePicker.test.tsx
@@ -17,6 +17,7 @@ const collections: KbCollection[] = [
     doc_count: 1,
     chunk_count: 5,
     failed_count: 0,
+    retrieval_weight: 1.0,
     created_at: '2026-08-01T00:00:00Z',
     updated_at: '2026-08-01T00:00:00Z',
   },

--- a/web/src/pages/Home.test.tsx
+++ b/web/src/pages/Home.test.tsx
@@ -143,7 +143,7 @@ describe('Home', () => {
 
   it('carries picked #mention chips into the chat intent on send', async () => {
     vi.mocked(listKbCollections).mockResolvedValue([
-      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, created_at: '', updated_at: '' },
+      { id: '1', name: 'observability', description: '', doc_count: 0, chunk_count: 0, failed_count: 0, retrieval_weight: 1.0, created_at: '', updated_at: '' },
     ])
     renderHome()
     const input = screen.getByLabelText('Message') as HTMLTextAreaElement

--- a/web/src/pages/Knowledge.test.tsx
+++ b/web/src/pages/Knowledge.test.tsx
@@ -41,6 +41,7 @@ const productDocs: KbCollection = {
   doc_count: 2,
   chunk_count: 40,
   failed_count: 0,
+  retrieval_weight: 1.0,
   created_at: '2026-08-01T00:00:00Z',
   updated_at: '2026-08-10T00:00:00Z',
 }
@@ -107,6 +108,7 @@ describe('Knowledge page', () => {
       expect(updateKbCollection).toHaveBeenCalledWith('c1', {
         name: 'Scalability',
         description: 'Product documentation for support agents.',
+        retrieval_weight: 1,
       }),
     )
     expect(await screen.findByText('Scalability')).toBeInTheDocument()


### PR DESCRIPTION
Closes #443.

## What

- `kb_collections.retrieval_weight` (double precision, default 1.0, CHECK (0, 2]): a per-collection ranking dial multiplied into the post-fusion score chain alongside the boost and provenance multipliers, in all three retrieval paths (semantic, keyword, hybrid).
- Admin API exposes it on collection responses, create, and PATCH with bounds validation.
- Collection edit dialog gets a numeric "Retrieval weight" field (0.1-2.0) with helper text.
- Golden integration tests: a raw-similarity-winning bystander in a 0.3-weight collection ranks below the on-topic doc, and a low-weight collection's doc is still returned when it is the only relevant content.
- `scripts/pending-alters.md` documents the additive live-DB ALTER (applied to local dev already).

## Why

The operator profile doc bystander-ranks above on-topic technical docs on general queries by winning both raw retrieval legs, which no leg weight can reverse (D-083 analysis). A post-fusion collection multiplier CAN demote it, without hard-hiding the doc: on background questions it is the only relevant content and still wins. Replaces the deferred cross-encoder (#426) for this pattern.

## Notes

- Weight was switched from real to double precision after integration caught the float32 round-trip (0.3 -> 0.30000001).
- kb-eval harness cannot express multi-collection fixtures; the golden integration tests carry the regression instead.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790754160&installation_model_id=431401&pr_number=450&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F450&signature=6aaaf417565e60ea2f92f7eb5daacd749b3aef3207aeb5361d9c0d6f8044a5f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->