### PR TITLE
feat(web): pre-fill mission kind and light from goal context

### DIFF
--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -563,6 +563,91 @@ describe('MissionForm: follow-up', () => {
   })
 })
 
+describe('MissionForm: kind and light pre-fill (#447)', () => {
+  it('pre-selects coding when a repo/connector is seeded and kind is untouched', async () => {
+    vi.mocked(listConnectorRepos).mockResolvedValue([])
+    renderForm(
+      <MissionForm
+        mode="create"
+        initial={{
+          repo_url: 'https://github.com/octocat/hello-world.git',
+          connector_id: 'c1',
+        }}
+        onDone={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Continue the work' } })
+    expect(await screen.findByText('Coding · branches from repo')).toBeInTheDocument()
+  })
+
+  it('a manual general choice is never overridden by the repo signal', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm-manual' } as Mission)
+    vi.mocked(listConnectorRepos).mockResolvedValue([])
+    renderForm(
+      <MissionForm
+        mode="create"
+        initial={{
+          kind: 'coding',
+          repo_url: 'https://github.com/octocat/hello-world.git',
+          connector_id: 'c1',
+        }}
+        onDone={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Continue the work' } })
+    expect(screen.getByText('Coding · branches from repo')).toBeInTheDocument()
+
+    // Operator explicitly picks general despite the repo signal.
+    fireEvent.click(screen.getByText('Coding · branches from repo'))
+    expect(screen.getByText('General · scratch workspace')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ kind: 'general' })),
+    )
+  })
+
+  it('pre-fills light on for a summarize-shaped goal on a general mission', async () => {
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), {
+      target: { value: 'summarize my inbox from this week' },
+    })
+
+    expect(await screen.findByLabelText(/Light mission/)).toBeChecked()
+  })
+
+  it('a manually toggled-off light stays off after the goal changes again', async () => {
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), {
+      target: { value: 'summarize my inbox from this week' },
+    })
+    const toggle = await screen.findByLabelText(/Light mission/)
+    expect(toggle).toBeChecked()
+
+    fireEvent.click(toggle) // operator turns it off
+    expect(toggle).not.toBeChecked()
+
+    fireEvent.change(screen.getByLabelText('Goal'), {
+      target: { value: 'summarize my inbox from this week, and also the calendar' },
+    })
+    expect(toggle).not.toBeChecked()
+  })
+
+  it('leaves kind and light at their current defaults when no signal is present', async () => {
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Look into something' } })
+    expect(await screen.findByText('General · scratch workspace')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Light mission/)).not.toBeChecked()
+  })
+})
+
 describe('MissionForm: kind chip', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -755,10 +840,10 @@ describe('MissionForm: light mission toggle', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'summarize this' } })
-    // Explicitly check it, then immediately uncheck it: the operator's
-    // deliberate final choice is false, which must survive the classify
-    // preview resolving to light: true.
-    fireEvent.click(screen.getByLabelText(/Light mission/))
+    // The goal's own summarize-shaped text pre-fills the toggle on
+    // (issue #447) before the classify debounce even fires; the
+    // operator then explicitly unchecks it, and that deliberate final
+    // choice must survive the classify preview resolving to light: true.
     fireEvent.click(screen.getByLabelText(/Light mission/))
     expect(screen.getByLabelText(/Light mission/)).not.toBeChecked()
 

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -238,6 +238,20 @@ const commitStyleChoices: { value: string; label: string }[] = [
   { value: 'plain', label: 'Plain' },
 ]
 
+// lightSignalPattern matches goal text shaped like a lightweight
+// digest/summary ask (issue #447): conservative on purpose, since a
+// false positive wrongly forces light on while a false negative just
+// leaves the manual toggle to the operator.
+const lightSignalPattern = /\b(summarize|summary|digest|brief overview)\b/i
+
+// looksLikeLightGoal flags a short goal that reads like a summary/
+// digest ask, the pre-fill signal for the light-mission toggle.
+function looksLikeLightGoal(goal: string): boolean {
+  const trimmed = goal.trim()
+  if (trimmed === '' || trimmed.split(/\s+/).length > 20) return false
+  return lightSignalPattern.test(trimmed)
+}
+
 // expiresAt is stored as the wire-compatible 'YYYY-MM-DDTHH:mm' string the
 // API already expects; these split it into a Date (for the calendar) and a
 // 'HH:mm' string (for the time input) and back.
@@ -396,6 +410,23 @@ export function MissionForm({
   const [newRepo, setNewRepo] = useState(false)
   const [newRepoName, setNewRepoName] = useState('')
   const [newRepoPrivate, setNewRepoPrivate] = useState(true)
+
+  // A repo/connector is considered "attached" once it resolves to a
+  // clone URL: mirrors githubSourceReady's own readiness check below.
+  const repoAttached =
+    repoSource === 'github' && !!connectorID && (newRepo ? newRepoName.trim() !== '' : !!selectedRepo)
+
+  // Kind pre-fill signal 1 (issue #447): a repo/connector attached
+  // implies a coding mission. Purely client-side, re-evaluated whenever
+  // the repo attachment changes, and never fires once the operator has
+  // made an explicit kind choice (kindLocked). Also locks kind so the
+  // goal-classify debounce below can't clobber this signal afterward.
+  useEffect(() => {
+    if (repoAttached && !kindLocked) {
+      setKind('coding')
+      setKindLocked(true)
+    }
+  }, [repoAttached, kindLocked])
 
   // Consent-at-create for the mission's auto-completion action:
   // resets whenever the GitHub source is unpicked, since on_complete is
@@ -608,6 +639,15 @@ export function MissionForm({
       setClassifying(false)
     }
   }, [goal, kindLocked, lightTouched])
+
+  // Light pre-fill signal 2 (issue #447): a short goal shaped like a
+  // summary/digest ask, on a general mission, pre-toggles light on.
+  // Re-evaluated on every goal edit but never fires once the operator
+  // has touched the toggle directly (lightTouched).
+  useEffect(() => {
+    if (kind !== 'general' || lightTouched) return
+    if (looksLikeLightGoal(goal)) setLight(true)
+  }, [goal, kind, lightTouched])
 
   const onGoalChange = (v: string) => {
     setGoal(v)


### PR DESCRIPTION
Closes #447.

## What

- MissionForm pre-selects kind=coding once a repo/connector is attached, locking kind against the goal-classify debounce so the pre-fill survives.
- MissionForm pre-toggles light on for a short (<=20 word) general-kind goal matching /\b(summarize|summary|digest|brief overview)\b/i.
- Both signals defer permanently to the existing kindLocked/lightTouched flags the moment the operator makes an explicit choice; they never re-fire after that.
- Web-only, no backend/API changes.

## Why

Environment, harness, and routes already infer from context; kind and light were the last always-manual picks on mission create. Conservative heuristic on purpose: a missed pre-fill costs one click, a wrong one costs a misconfigured mission.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790755571&installation_model_id=431401&pr_number=451&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F451&signature=c0d524117c3150d38d0026b33df337cd42d86825df7906720ed5592d0ce02d36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->