### PR TITLE
feat(missions): auto-deny parked permission after timeout

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -293,7 +293,8 @@ func main() {
 	kbStore := kb.New(app.DB)
 	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub, missionScheduler := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, fxStore, gwc, secrets, conns, mc, packs, app.Log)
 	if missionDriver != nil {
-		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, missionNotifier, app.Log)
+		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, missionNotifier,
+			flags.PermissionTimeoutSeconds, broker.Resolve, app.Log)
 	}
 	destinationStore, destinationDeliverer := buildDestinations(app.DB, conns, goog, secrets, flags, missionStore, app.Log)
 	if missionDriver != nil && destinationDeliverer != nil {

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -465,6 +465,12 @@ type createMissionRequest struct {
 	// classified). Always the operator's explicit choice — the classify
 	// preview only suggests a value, never sets it.
 	Light bool `json:"light"`
+	// PermissionTimeoutSeconds overrides the global
+	// settings.ValuePermissionTimeoutSeconds for this mission alone
+	// (issue #445): nil (omitted) inherits the global setting; 0 or a
+	// positive integer sets this mission's own park-forever/auto-deny
+	// bound. Never negative.
+	PermissionTimeoutSeconds *int `json:"permission_timeout_seconds"`
 }
 
 // missionAttachmentInput names one already-uploaded attachment to
@@ -620,6 +626,10 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 	if req.AutoApproveSafe != nil {
 		autoApproveSafe = *req.AutoApproveSafe
 	}
+	if req.PermissionTimeoutSeconds != nil && *req.PermissionTimeoutSeconds < 0 {
+		jsonError(w, http.StatusBadRequest, "bad_request", "permission_timeout_seconds must not be negative")
+		return
+	}
 	budgetCurrency := req.BudgetCurrency
 	if budgetCurrency == "" {
 		budgetCurrency = "USD"
@@ -634,6 +644,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		BranchPattern: req.BranchPattern, CommitStyle: req.CommitStyle,
 		ParentMissionID: parentMissionID, ParentContext: parentContext, ReferencedContext: referencedContext,
 		Attachments: missionAtts, DestinationIDs: req.DestinationIDs, PromoteKBCollectionID: req.PromoteKBCollectionID, Light: req.Light,
+		PermissionTimeoutSeconds: req.PermissionTimeoutSeconds,
 	}
 	id, err := h.driver.Create(r.Context(), m)
 	if err != nil {

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -151,6 +151,16 @@ type Mission struct {
 	PendingPermissionArgs      string `json:"pending_permission_args,omitempty"`
 	PendingPermissionDanger    string `json:"pending_permission_danger,omitempty"`
 	PendingPermissionRationale string `json:"pending_permission_rationale,omitempty"`
+	// PendingPermissionParkedAt is when this park started (issue #445),
+	// the periodic timeout sweep's elapsed-time input, also exposed so
+	// the UI can show how long a request has been waiting.
+	PendingPermissionParkedAt time.Time `json:"pending_permission_parked_at,omitempty"`
+	// PermissionTimeoutSeconds overrides the global
+	// settings.ValuePermissionTimeoutSeconds for this mission alone; nil
+	// inherits the global setting. Never negative: the sweep treats a
+	// stored value <= 0 the same as "disabled," matching the global
+	// setting's own 0-means-off convention.
+	PermissionTimeoutSeconds *int `json:"permission_timeout_seconds,omitempty"`
 	// AutoApproveSafe, when true (the default for new missions), grants
 	// the hidden session standing approval for any shell call the
 	// danger classifier rates safe — a mission runs for hours

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -51,19 +51,21 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 	pending_permission, auto_approve_safe, last_evidence,
 	explore_notes, replan_used, schedule_id, session_id, harness, environment, repo_url, connector_id, on_complete,
 	branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, light, final_output, created_at, updated_at,
-	workflow_run_id, workflow_step, artifact_refs, promote_kb_collection_id`
+	workflow_run_id, workflow_step, artifact_refs, promote_kb_collection_id, permission_timeout_seconds`
 
 // pendingPermissionRow is pending_permission's jsonb shape in the
 // missions table: bundles the five columns the API's flat
 // PendingPermission/PendingPermissionTool/... fields used to be, so
 // the wire shape stays unchanged while the DB representation is one
-// column instead of five.
+// column instead of five. ParkedAt (issue #445) is when the park
+// started, the timeout sweep's elapsed-time input.
 type pendingPermissionRow struct {
-	ID        string `json:"id"`
-	Tool      string `json:"tool"`
-	Args      string `json:"args"`
-	Danger    string `json:"danger"`
-	Rationale string `json:"rationale"`
+	ID        string    `json:"id"`
+	Tool      string    `json:"tool"`
+	Args      string    `json:"args"`
+	Danger    string    `json:"danger"`
+	Rationale string    `json:"rationale"`
+	ParkedAt  time.Time `json:"parked_at"`
 }
 
 // scanPendingPermission unmarshals the pending_permission jsonb column
@@ -81,6 +83,7 @@ func scanPendingPermission(m *Mission, raw []byte) {
 	m.PendingPermissionArgs = p.Args
 	m.PendingPermissionDanger = p.Danger
 	m.PendingPermissionRationale = p.Rationale
+	m.PendingPermissionParkedAt = p.ParkedAt
 }
 
 // scanMissionWithFailureReason is scanMission plus one extra trailing
@@ -98,6 +101,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		failureReason                                                 *string
 		workflowRunID                                                 *string
 		promoteKBCollectionID                                         *string
+		permissionTimeoutSeconds                                      *int
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
@@ -108,7 +112,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &m.ReferencedContext, &attachmentsRaw,
 		&m.DestinationIDs, &m.Light, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
-		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &promoteKBCollectionID,
+		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &promoteKBCollectionID, &permissionTimeoutSeconds,
 		&failureReason); err != nil {
 		return Mission{}, err
 	}
@@ -130,6 +134,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 	if workflowRunID != nil {
 		m.WorkflowRunID = *workflowRunID
 	}
+	m.PermissionTimeoutSeconds = permissionTimeoutSeconds
 	if promoteKBCollectionID != nil {
 		m.PromoteKBCollectionID = *promoteKBCollectionID
 	}
@@ -181,6 +186,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		spec, progress, attachmentsRaw, knowledgeRaw, artifactRefsRaw []byte
 		workflowRunID                                                 *string
 		promoteKBCollectionID                                         *string
+		permissionTimeoutSeconds                                      *int
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
@@ -191,7 +197,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &m.ReferencedContext, &attachmentsRaw,
 		&m.DestinationIDs, &m.Light, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
-		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &promoteKBCollectionID); err != nil {
+		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &promoteKBCollectionID, &permissionTimeoutSeconds); err != nil {
 		return Mission{}, err
 	}
 	_ = json.Unmarshal(knowledgeRaw, &m.Knowledge)
@@ -215,6 +221,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 	if promoteKBCollectionID != nil {
 		m.PromoteKBCollectionID = *promoteKBCollectionID
 	}
+	m.PermissionTimeoutSeconds = permissionTimeoutSeconds
 	// Fail-safe degrade: an unrecognized phase/status (e.g. a future
 	// value an older binary doesn't know) loads as paused/infra rather
 	// than making the row unreadable.
@@ -286,9 +293,9 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	}
 	phase := initialPhase(m.Kind, m.Light)
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, light, phase, workflow_run_id, workflow_step, promote_kb_collection_id)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NULLIF($18, '')::uuid, $19, $20, $21, $22, $23, $24, $25, $26, NULLIF($27, '')::uuid, $28, $29, $30, $31, $32, $33, NULLIF($34, '')::uuid, $35, NULLIF($36, '')::uuid) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, m.ReferencedContext, attachmentsJSON, destinationIDs, m.Light, phase, m.WorkflowRunID, m.WorkflowStep, m.PromoteKBCollectionID,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, light, phase, workflow_run_id, workflow_step, promote_kb_collection_id, permission_timeout_seconds)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NULLIF($18, '')::uuid, $19, $20, $21, $22, $23, $24, $25, $26, NULLIF($27, '')::uuid, $28, $29, $30, $31, $32, $33, NULLIF($34, '')::uuid, $35, NULLIF($36, '')::uuid, $37) RETURNING id`,
+		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, m.ReferencedContext, attachmentsJSON, destinationIDs, m.Light, phase, m.WorkflowRunID, m.WorkflowStep, m.PromoteKBCollectionID, m.PermissionTimeoutSeconds,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)
@@ -535,7 +542,7 @@ func (s *Store) SetPendingPermission(ctx context.Context, id, permissionID, tool
 		return fmt.Errorf("missions set pending permission begin: %w", err)
 	}
 	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
-	data, err := json.Marshal(pendingPermissionRow{ID: permissionID, Tool: tool, Args: args, Danger: danger, Rationale: rationale})
+	data, err := json.Marshal(pendingPermissionRow{ID: permissionID, Tool: tool, Args: args, Danger: danger, Rationale: rationale, ParkedAt: time.Now().UTC()})
 	if err != nil {
 		return fmt.Errorf("missions set pending permission: %w", err)
 	}
@@ -563,6 +570,89 @@ func (s *Store) ClearPendingPermission(ctx context.Context, id string) error {
 			pending_permission = NULL, updated_at = now()
 		WHERE id = $1`, id); err != nil {
 		return fmt.Errorf("missions clear pending permission: %w", err)
+	}
+	return nil
+}
+
+// ParkedPermission is one PendingPermissions row: just enough for the
+// timeout sweep's elapsed-time decision, without the cost of a full
+// Mission scan.
+type ParkedPermission struct {
+	MissionID string
+	// PermissionID is the broker-issued id (pendingPermissionRow.ID),
+	// distinct from MissionID, needed to resolve a still-live worker
+	// turn's in-memory PermBroker wait (loop.PermBroker.Resolve takes
+	// this id, not the mission id).
+	PermissionID    string
+	Tool            string
+	ParkedAt        time.Time
+	TimeoutOverride *int // this mission's own permission_timeout_seconds, nil = inherit the global setting
+}
+
+// PendingPermissions returns every mission currently parked on
+// pending_permission, the timeout sweep's input.
+func (s *Store) PendingPermissions(ctx context.Context) ([]ParkedPermission, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("missions pending permissions: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT id, pending_permission, permission_timeout_seconds
+		FROM missions WHERE pending_permission IS NOT NULL`)
+	if err != nil {
+		return nil, fmt.Errorf("missions pending permissions: %w", err)
+	}
+	defer rows.Close()
+	out := []ParkedPermission{}
+	for rows.Next() {
+		var (
+			id      string
+			raw     []byte
+			timeout *int
+		)
+		if err := rows.Scan(&id, &raw, &timeout); err != nil {
+			return nil, fmt.Errorf("missions pending permissions: %w", err)
+		}
+		var p pendingPermissionRow
+		if err := json.Unmarshal(raw, &p); err != nil {
+			continue // corrupt row: skip rather than fail the whole sweep
+		}
+		out = append(out, ParkedPermission{MissionID: id, PermissionID: p.ID, Tool: p.Tool, ParkedAt: p.ParkedAt, TimeoutOverride: timeout})
+	}
+	return out, rows.Err()
+}
+
+// ResolvePendingPermissionTimeout auto-denies a mission's parked
+// permission request after it sat unanswered past the effective
+// timeout (issue #445): clears pending_permission and appends the SAME
+// mission.permission_answered event kind an operator's manual deny
+// produces, with reason=timed_out distinguishing it from a human
+// decision. Never approves: there is no other decision value this
+// method can write.
+func (s *Store) ResolvePendingPermissionTimeout(ctx context.Context, id, tool string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("missions resolve pending permission timeout: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("missions resolve pending permission timeout begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+	if _, err := tx.Exec(ctx, `UPDATE missions SET
+			pending_permission = NULL, updated_at = now()
+		WHERE id = $1`, id); err != nil {
+		return fmt.Errorf("missions resolve pending permission timeout: %w", err)
+	}
+	if err := appendEventTx(ctx, tx, id, "mission.permission_answered", map[string]any{
+		"tool": tool, "decision": "deny", "reason": "timed_out",
+	}, "live"); err != nil {
+		return fmt.Errorf("missions resolve pending permission timeout: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("missions resolve pending permission timeout commit: %w", err)
+	}
+	if s.hub != nil {
+		s.hub.Publish(Signal{Kind: "mission", ID: id})
 	}
 	return nil
 }

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -423,7 +423,7 @@ func TestMissionKnowledgeRoundTrips(t *testing.T) {
 
 // TestMissionHarnessRoundTrips covers D-051: harness is a first-class
 // column snapshotted at create time, same shape as PromptOverlay above
-//: "" (native) is the default when a mission omits it.
+// : "" (native) is the default when a mission omits it.
 func TestMissionHarnessRoundTrips(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
@@ -1391,5 +1391,171 @@ func TestSpendExcludesUnbilledRows(t *testing.T) {
 	}
 	if got := spend.ByCurrency["USD"]; got != 0.05 {
 		t.Fatalf("Spend USD = %v, want 0.05 (unbilled row must be excluded from the brake)", got)
+	}
+}
+
+// TestPendingPermissionsAndResolveTimeout covers issue #445's store
+// layer: PendingPermissions lists a mission's parked request with its
+// parked_at and per-mission override intact, and
+// ResolvePendingPermissionTimeout clears the park and appends the SAME
+// mission.permission_answered event kind an operator's manual deny
+// produces, with reason=timed_out distinguishing the two.
+func TestPendingPermissionsAndResolveTimeout(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	timeout := 30
+	id, err := s.Create(ctx, Mission{Goal: marker + "permission-timeout-store", Kind: "general", Route: "default", PermissionTimeoutSeconds: &timeout})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseExecute, Status: StatusWorking}}); err != nil {
+		t.Fatalf("ApplyTransition working: %v", err)
+	}
+	if err := s.SetPendingPermission(ctx, id, "perm-timeout-1", "shell", `{"command":"rm -rf x"}`, "destructive", "deletes files"); err != nil {
+		t.Fatalf("SetPendingPermission: %v", err)
+	}
+
+	pending, err := s.PendingPermissions(ctx)
+	if err != nil {
+		t.Fatalf("PendingPermissions: %v", err)
+	}
+	var found *ParkedPermission
+	for i := range pending {
+		if pending[i].MissionID == id {
+			found = &pending[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("PendingPermissions did not return the parked mission")
+	}
+	if found.PermissionID != "perm-timeout-1" || found.Tool != "shell" {
+		t.Fatalf("ParkedPermission = %+v, want id/tool from SetPendingPermission", found)
+	}
+	if found.TimeoutOverride == nil || *found.TimeoutOverride != timeout {
+		t.Fatalf("TimeoutOverride = %v, want %d", found.TimeoutOverride, timeout)
+	}
+	if found.ParkedAt.IsZero() {
+		t.Fatal("ParkedAt was not recorded")
+	}
+
+	if err := s.ResolvePendingPermissionTimeout(ctx, id, "shell"); err != nil {
+		t.Fatalf("ResolvePendingPermissionTimeout: %v", err)
+	}
+
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.PendingPermission != "" {
+		t.Fatalf("Get after timeout resolve = %+v, want pending_permission cleared", m)
+	}
+
+	events, err := s.Events(ctx, id)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	last := events[len(events)-1]
+	if last.Kind != "mission.permission_answered" {
+		t.Fatalf("last event kind = %q, want mission.permission_answered", last.Kind)
+	}
+	var payload struct {
+		Tool, Decision, Reason string
+	}
+	if err := json.Unmarshal(last.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal event payload: %v", err)
+	}
+	if payload.Decision != "deny" || payload.Reason != "timed_out" {
+		t.Fatalf("event payload = %+v, want decision=deny reason=timed_out", payload)
+	}
+
+	pending, err = s.PendingPermissions(ctx)
+	if err != nil {
+		t.Fatalf("PendingPermissions after resolve: %v", err)
+	}
+	for _, p := range pending {
+		if p.MissionID == id {
+			t.Fatal("resolved mission still reported as pending")
+		}
+	}
+}
+
+// fakePermissionTimeoutDriverIT captures Drive calls from
+// sweepPermissionTimeouts against a real store, synchronized so the
+// test can wait for the sweep's background goroutine before asserting.
+type fakePermissionTimeoutDriverIT struct {
+	wg    sync.WaitGroup
+	mu    sync.Mutex
+	drove []string
+}
+
+func (f *fakePermissionTimeoutDriverIT) Drive(ctx context.Context, id string) error {
+	defer f.wg.Done()
+	f.mu.Lock()
+	f.drove = append(f.drove, id)
+	f.mu.Unlock()
+	return nil
+}
+
+// TestSweepPermissionTimeoutsAutoDeniesAndResumes is the end-to-end
+// path for issue #445 against a real store: a mission parked on
+// permission with a very short (1s) effective timeout gets auto-denied
+// once the sweep runs past that interval, the mission_event carries
+// reason=timed_out, and the mission is handed back to Drive to resume.
+func TestSweepPermissionTimeoutsAutoDeniesAndResumes(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	timeout := 1
+	id, err := s.Create(ctx, Mission{Goal: marker + "permission-timeout-sweep", Kind: "general", Route: "default", PermissionTimeoutSeconds: &timeout})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseExecute, Status: StatusWorking}}); err != nil {
+		t.Fatalf("ApplyTransition working: %v", err)
+	}
+	if err := s.SetPendingPermission(ctx, id, "perm-sweep-1", "shell", `{"command":"rm -rf x"}`, "destructive", "deletes files"); err != nil {
+		t.Fatalf("SetPendingPermission: %v", err)
+	}
+
+	time.Sleep(1200 * time.Millisecond) // past the 1s effective timeout
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	driver := &fakePermissionTimeoutDriverIT{}
+	driver.wg.Add(1)
+	sweepPermissionTimeouts(ctx, driver, s, func(context.Context) int { return 0 }, nil, nil, log)
+	driver.wg.Wait()
+
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.PendingPermission != "" {
+		t.Fatalf("Get after sweep = %+v, want pending_permission auto-denied", m)
+	}
+
+	events, err := s.Events(ctx, id)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	last := events[len(events)-1]
+	if last.Kind != "mission.permission_answered" {
+		t.Fatalf("last event kind = %q, want mission.permission_answered", last.Kind)
+	}
+	var payload struct {
+		Decision, Reason string
+	}
+	if err := json.Unmarshal(last.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal event payload: %v", err)
+	}
+	if payload.Decision != "deny" || payload.Reason != "timed_out" {
+		t.Fatalf("event payload = %+v, want decision=deny reason=timed_out", payload)
+	}
+
+	driver.mu.Lock()
+	drove := driver.drove
+	driver.mu.Unlock()
+	if len(drove) != 1 || drove[0] != id {
+		t.Fatalf("Drive calls = %v, want exactly [%s] (mission resumed)", drove, id)
 	}
 }

--- a/internal/brain/missions/sweep.go
+++ b/internal/brain/missions/sweep.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
+
+	"github.com/SumonMSelim/timothy/internal/brain/loop"
 )
 
 // workSlotSweepInterval is how often the idle-over-cap sweep retries
@@ -32,6 +34,15 @@ const (
 	recoverWorkingRetries    = 5
 	recoverWorkingRetryDelay = 2 * time.Second
 )
+
+// permissionTimeoutStore is the narrow slice of *Store the parked-
+// permission timeout sweep needs, an interface for the same reason
+// backoffStore/pausedByReasonStore are: unit-testable against a faked
+// store.
+type permissionTimeoutStore interface {
+	PendingPermissions(ctx context.Context) ([]ParkedPermission, error)
+	ResolvePendingPermissionTimeout(ctx context.Context, id, tool string) error
+}
 
 // sandboxSweeper is the narrow slice of the sandbox backend the
 // periodic orphan pass needs — kept as an interface (not an import of
@@ -138,13 +149,18 @@ func admitWork(ctx context.Context, gate capacityChecker, log *slog.Logger) (adm
 
 // RecoverAndSweep runs the boot-time recovery pass once (re-Drives any
 // mission left status='working' from a prior process's crash), then
-// runs the periodic work-slot sweep until ctx is done — which now also
-// sweeps orphaned sandbox containers on the same tick (see
-// runWorkSlotSweep). This is the one entry point cmd/brain/main.go
-// needs — it owns the Driver, which carries its own Store reference.
-func RecoverAndSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, notify messageNotifier, log *slog.Logger) {
+// runs the periodic work-slot sweep until ctx is done, which now also
+// sweeps orphaned sandbox containers and timed-out parked permissions on
+// the same tick (see runWorkSlotSweep). This is the one entry point
+// cmd/brain/main.go needs: it owns the Driver, which carries its own
+// Store reference. globalPermissionTimeout reads the current
+// settings.ValuePermissionTimeoutSeconds value (issue #445); resolveBroker
+// is the live in-memory PermBroker's Resolve, best-effort. nil is valid
+// (a still-running turn just times out on its own permissionTimeout
+// instead of waking early).
+func RecoverAndSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, notify messageNotifier, globalPermissionTimeout func(context.Context) int, resolveBroker func(id, decision string) bool, log *slog.Logger) {
 	recoverWorking(ctx, d, store, log)
-	runWorkSlotSweep(ctx, d, store, maxConcurrent, sandbox, capacity, notify, log)
+	runWorkSlotSweep(ctx, d, store, maxConcurrent, sandbox, capacity, notify, globalPermissionTimeout, resolveBroker, log)
 }
 
 // sweepOrphanSandboxes runs on every runWorkSlotSweep tick (previously
@@ -210,11 +226,12 @@ func recoverWorking(ctx context.Context, d *Driver, store *Store, log *slog.Logg
 
 // runWorkSlotSweep retries missions parked idle over the work-slot cap
 // every workSlotSweepInterval via ClaimWorkSlot, kicking off a Drive
-// for whichever gets claimed, sweeps orphaned sandbox containers, and
-// re-Drives any 'working' mission stale past staleWorkingAfter — all on
-// the same tick. Runs until ctx is done — this call blocks, so
+// for whichever gets claimed, sweeps orphaned sandbox containers,
+// re-Drives any 'working' mission stale past staleWorkingAfter, and
+// auto-denies any pending_permission parked past its effective timeout,
+// all on the same tick. Runs until ctx is done; this call blocks, so
 // RecoverAndSweep's caller runs it in its own goroutine.
-func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, notify messageNotifier, log *slog.Logger) {
+func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, notify messageNotifier, globalPermissionTimeout func(context.Context) int, resolveBroker func(id, decision string) bool, log *slog.Logger) {
 	ticker := time.NewTicker(workSlotSweepInterval)
 	defer ticker.Stop()
 	for {
@@ -226,6 +243,7 @@ func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurren
 			reDriveStaleWorking(ctx, d, store, log)
 			autoResumeBackoff(ctx, d, store, notify, log)
 			autoResumeInfra(ctx, d, store, notify, log)
+			sweepPermissionTimeouts(ctx, d, store, globalPermissionTimeout, resolveBroker, notify, log)
 			// D-056: skip the claim entirely this tick if the host can't
 			// afford another working mission — the mission stays idle,
 			// and this same sweep retries it in workSlotSweepInterval; that
@@ -377,5 +395,92 @@ func autoResumeInfra(ctx context.Context, d signaler, store pausedByReasonStore,
 		if err := d.Signal(ctx, m.ID, InputResume); err != nil {
 			log.Error("auto-resume infra sweep: signal failed", "mission_id", m.ID, "error", err)
 		}
+	}
+}
+
+// shouldTimeoutPermission is the pure elapsed-time decision the
+// permission-timeout sweep applies to one parked mission (issue #445):
+// missionOverride, when non-nil, takes precedence over globalSeconds
+// (per-mission opt-out/opt-in); either one <= 0 means "disabled" for
+// that mission, matching the settings default of 0 == park forever.
+// Never returns true for anything but "deny is due"; there is no
+// "approve" outcome this function can produce.
+func shouldTimeoutPermission(now, parkedAt time.Time, missionOverride *int, globalSeconds int) bool {
+	timeout := globalSeconds
+	if missionOverride != nil {
+		timeout = *missionOverride
+	}
+	if timeout <= 0 {
+		return false
+	}
+	return now.Sub(parkedAt) >= time.Duration(timeout)*time.Second
+}
+
+// permissionTimeoutDriver is the narrow slice of *Driver
+// sweepPermissionTimeouts needs to rescue a mission whose worker
+// goroutine died while parked: Drive, not Signal, since pending_permission
+// never advances Status (it stays 'working' the whole time a mission is
+// parked, same as any other mid-turn state), so forcing a resume
+// transition here would race a genuinely still-running turn's own
+// eventual ApplyTransition. Drive is always safe to call again:
+// Driver.claimDriving makes a second concurrent call for the same id a
+// no-op, exactly the guarantee reDriveStaleWorking already relies on.
+type permissionTimeoutDriver interface {
+	Drive(ctx context.Context, id string) error
+}
+
+// sweepPermissionTimeouts auto-denies any mission whose pending_permission
+// has sat unanswered past its effective timeout (issue #445): a
+// deployment that never sets settings.ValuePermissionTimeoutSeconds (or
+// sets it to 0) sees this do nothing, preserving the original park-
+// forever behavior exactly. Resolution goes through
+// Store.ResolvePendingPermissionTimeout, the same store-level deny the
+// API's operator-deny handler ends in, so a restarted process (whose
+// in-memory PermBroker lost every pending id) still gets a durable
+// answer. resolveBroker is a best-effort nudge to also wake a STILL-LIVE
+// worker turn blocked in loop.Agent's askUser immediately rather than
+// waiting out its own longer in-process permissionTimeout; a false/nil
+// result just means the turn was already gone (crash, restart) or
+// already resolved. Either way, Drive picks the mission back up: if a
+// live turn is still running it's claimDriving's own no-op, otherwise
+// this is exactly recoverWorking/reDriveStaleWorking's own rescue path
+// for a 'working' mission whose Drive loop stopped advancing.
+func sweepPermissionTimeouts(ctx context.Context, d permissionTimeoutDriver, store permissionTimeoutStore, globalPermissionTimeout func(context.Context) int, resolveBroker func(id, decision string) bool, notify messageNotifier, log *slog.Logger) {
+	if globalPermissionTimeout == nil {
+		return
+	}
+	pending, err := store.PendingPermissions(ctx)
+	if err != nil {
+		log.Error("permission timeout sweep: list failed", "error", err)
+		return
+	}
+	if len(pending) == 0 {
+		return
+	}
+	globalSeconds := globalPermissionTimeout(ctx)
+	now := time.Now().UTC()
+	for _, p := range pending {
+		if !shouldTimeoutPermission(now, p.ParkedAt, p.TimeoutOverride, globalSeconds) {
+			continue
+		}
+		log.Warn("permission timeout sweep: auto-denying a parked permission request", "mission_id", p.MissionID, "tool", p.Tool)
+		if err := store.ResolvePendingPermissionTimeout(ctx, p.MissionID, p.Tool); err != nil {
+			log.Error("permission timeout sweep: resolve failed", "mission_id", p.MissionID, "error", err)
+			continue
+		}
+		if resolveBroker != nil {
+			resolveBroker(p.PermissionID, loop.DecideDeny) // best-effort: wakes a still-live worker turn immediately
+		}
+		if notify != nil {
+			if err := notify.NotifyMessage(ctx, p.MissionID, "permission_timed_out",
+				"a pending permission request timed out and was denied automatically"); err != nil {
+				log.Warn("permission timeout sweep: notify failed", "mission_id", p.MissionID, "error", err)
+			}
+		}
+		go func(id string) {
+			if err := d.Drive(ctx, id); err != nil {
+				log.Error("permission timeout sweep: drive failed", "mission_id", id, "error", err)
+			}
+		}(p.MissionID)
 	}
 }

--- a/internal/brain/missions/sweep_test.go
+++ b/internal/brain/missions/sweep_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 )
@@ -256,5 +257,153 @@ func TestAutoResumeInfraNilNotifierSafe(t *testing.T) {
 	autoResumeInfra(context.Background(), signaler, store, nil, log)
 	if len(signaler.signaled) != 0 {
 		t.Fatal("exhausted mission must never be resumed")
+	}
+}
+
+// TestShouldTimeoutPermission covers issue #445's timeout-detection
+// decision: a mission override always wins over the global setting, and
+// <= 0 (either source) means disabled, the settings default that
+// preserves park-forever behavior for a deployment that never opts in.
+func TestShouldTimeoutPermission(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	intp := func(n int) *int { return &n }
+
+	cases := []struct {
+		name        string
+		parkedAgo   time.Duration
+		override    *int
+		global      int
+		wantTimeout bool
+	}{
+		{"global disabled (0), no override: never times out", 999 * time.Hour, nil, 0, false},
+		{"global set, just before due", 59 * time.Second, nil, 60, false},
+		{"global set, just after due", 61 * time.Second, nil, 60, true},
+		{"override disables even with global set", 999 * time.Hour, intp(0), 300, false},
+		{"override shorter than global, fires sooner", 31 * time.Second, intp(30), 300, true},
+		{"override longer than global, waits longer", 31 * time.Second, intp(300), 30, false},
+		{"negative override treated as disabled", 999 * time.Hour, intp(-1), 300, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := shouldTimeoutPermission(now, now.Add(-tc.parkedAgo), tc.override, tc.global)
+			if got != tc.wantTimeout {
+				t.Errorf("shouldTimeoutPermission() = %v, want %v", got, tc.wantTimeout)
+			}
+		})
+	}
+}
+
+// fakePermissionTimeoutStore scripts PendingPermissions/
+// ResolvePendingPermissionTimeout for sweepPermissionTimeouts tests
+// without a real Postgres pool.
+type fakePermissionTimeoutStore struct {
+	pending  []ParkedPermission
+	resolved []string
+}
+
+func (f *fakePermissionTimeoutStore) PendingPermissions(ctx context.Context) ([]ParkedPermission, error) {
+	return f.pending, nil
+}
+
+func (f *fakePermissionTimeoutStore) ResolvePendingPermissionTimeout(ctx context.Context, id, tool string) error {
+	f.resolved = append(f.resolved, id)
+	return nil
+}
+
+// fakePermissionTimeoutDriver captures Drive calls, safe for concurrent
+// use since sweepPermissionTimeouts fires Drive in a goroutine per
+// mission (mirroring reDriveStaleWorking's own fire-and-forget shape).
+type fakePermissionTimeoutDriver struct {
+	mu    sync.Mutex
+	wg    sync.WaitGroup
+	drove []string
+}
+
+func (f *fakePermissionTimeoutDriver) Drive(ctx context.Context, id string) error {
+	defer f.wg.Done()
+	f.mu.Lock()
+	f.drove = append(f.drove, id)
+	f.mu.Unlock()
+	return nil
+}
+
+// TestSweepPermissionTimeoutsDisabledByDefault confirms a global setting
+// of 0 (settings.Store.PermissionTimeoutSeconds' own default for an
+// absent/unset row) leaves every parked mission untouched, no matter how
+// long it has been parked: existing missions with pending_permission
+// stay parked forever, matching current behavior exactly.
+func TestSweepPermissionTimeoutsDisabledByDefault(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := &fakePermissionTimeoutStore{
+		pending: []ParkedPermission{{MissionID: "m1", PermissionID: "p1", Tool: "shell", ParkedAt: time.Now().Add(-999 * time.Hour)}},
+	}
+	driver := &fakePermissionTimeoutDriver{}
+	notifier := &fakeMessageNotifier{}
+	sweepPermissionTimeouts(context.Background(), driver, store, func(context.Context) int { return 0 }, nil, notifier, log)
+
+	if len(store.resolved) != 0 {
+		t.Fatalf("resolved = %v, want none (sweep disabled)", store.resolved)
+	}
+	if len(notifier.notified) != 0 {
+		t.Fatalf("notified = %v, want none (sweep disabled)", notifier.notified)
+	}
+}
+
+// TestSweepPermissionTimeoutsResolvesAndDrives covers the enabled path:
+// a mission parked past the effective timeout is resolved (denied),
+// notified, and re-Driven; one still within its window is left alone.
+func TestSweepPermissionTimeoutsResolvesAndDrives(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	now := time.Now()
+	store := &fakePermissionTimeoutStore{
+		pending: []ParkedPermission{
+			{MissionID: "timed-out", PermissionID: "p1", Tool: "shell", ParkedAt: now.Add(-10 * time.Minute)},
+			{MissionID: "still-waiting", PermissionID: "p2", Tool: "shell", ParkedAt: now.Add(-1 * time.Second)},
+		},
+	}
+	driver := &fakePermissionTimeoutDriver{}
+	driver.wg.Add(1) // exactly one mission (timed-out) crosses the 60s global timeout
+	notifier := &fakeMessageNotifier{}
+	var resolvedBrokerIDs []string
+	resolveBroker := func(id, decision string) bool {
+		resolvedBrokerIDs = append(resolvedBrokerIDs, id+"|"+decision)
+		return true
+	}
+
+	sweepPermissionTimeouts(context.Background(), driver, store, func(context.Context) int { return 60 }, resolveBroker, notifier, log)
+	driver.wg.Wait()
+
+	if len(store.resolved) != 1 || store.resolved[0] != "timed-out" {
+		t.Fatalf("resolved = %v, want exactly [timed-out]", store.resolved)
+	}
+	if len(notifier.notified) != 1 || notifier.notified[0] != "timed-out" {
+		t.Fatalf("notified = %v, want exactly [timed-out]", notifier.notified)
+	}
+	if len(driver.drove) != 1 || driver.drove[0] != "timed-out" {
+		t.Fatalf("drove = %v, want exactly [timed-out]", driver.drove)
+	}
+	if len(resolvedBrokerIDs) != 1 || resolvedBrokerIDs[0] != "p1|deny" {
+		t.Fatalf("resolveBroker calls = %v, want exactly [p1|deny]", resolvedBrokerIDs)
+	}
+}
+
+// TestSweepPermissionTimeoutsNilResolveBrokerSafe confirms a nil
+// resolveBroker (a still-live worker turn just times out on its own
+// in-process permissionTimeout instead) never panics.
+func TestSweepPermissionTimeoutsNilResolveBrokerSafe(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := &fakePermissionTimeoutStore{
+		pending: []ParkedPermission{{MissionID: "m1", PermissionID: "p1", Tool: "shell", ParkedAt: time.Now().Add(-999 * time.Hour)}},
+	}
+	driver := &fakePermissionTimeoutDriver{}
+	driver.wg.Add(1)
+	sweepPermissionTimeouts(context.Background(), driver, store, func(context.Context) int { return 60 }, nil, nil, log)
+	driver.wg.Wait()
+
+	if len(store.resolved) != 1 {
+		t.Fatalf("resolved = %v, want exactly one", store.resolved)
 	}
 }

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -80,6 +80,13 @@ const (
 	// "Europe/Amsterdam"), used to render delivery timestamps
 	// (destinations/render.go); "" defers to time.UTC.
 	ValueTimezone = "timezone"
+	// ValuePermissionTimeoutSeconds bounds how long a mission may sit
+	// parked on pending_permission before the periodic sweep
+	// (missions/sweep.go) auto-denies it (issue #445); "" or "0" (the
+	// default) disables the sweep entirely, preserving park-forever
+	// behavior. A mission's own permission_timeout_seconds column
+	// overrides this per mission.
+	ValuePermissionTimeoutSeconds = "permission_timeout_seconds"
 )
 
 var knownValueKeys = map[string]bool{
@@ -89,6 +96,7 @@ var knownValueKeys = map[string]bool{
 	ValueCodingExecutor:   true,
 	ValueGitBranchPattern: true, ValueGitCommitStyle: true,
 	ValueWebBaseURL: true, ValueTimezone: true,
+	ValuePermissionTimeoutSeconds: true,
 }
 
 // allowedCurrencies is the flat, fixed list of ISO 4217 codes the
@@ -166,6 +174,19 @@ func (s *Store) TokenBudget(ctx context.Context, def int) int {
 		}
 	}
 	return def
+}
+
+// PermissionTimeoutSeconds parses the global parked-permission timeout,
+// falling back to 0 (disabled) when unset or unparsable. 0 means the
+// sweep never auto-denies, preserving the original park-forever
+// behavior.
+func (s *Store) PermissionTimeoutSeconds(ctx context.Context) int {
+	if v := s.Value(ctx, ValuePermissionTimeoutSeconds); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return 0
 }
 
 // DefaultCurrency returns the configured default currency, falling
@@ -312,6 +333,11 @@ func (s *Store) SetValue(ctx context.Context, key, value string) error {
 	if key == ValueTokenBudget && value != "" {
 		if n, err := strconv.Atoi(value); err != nil || n <= 0 {
 			return fmt.Errorf("%s must be a positive integer or empty", key)
+		}
+	}
+	if key == ValuePermissionTimeoutSeconds && value != "" {
+		if n, err := strconv.Atoi(value); err != nil || n < 0 {
+			return fmt.Errorf("%s must be a non-negative integer or empty", key)
 		}
 	}
 	if key == ValueDefaultCurrency && value != "" {

--- a/internal/brain/settings/settings_integration_test.go
+++ b/internal/brain/settings/settings_integration_test.go
@@ -300,3 +300,44 @@ func TestTimezoneSetting(t *testing.T) {
 		t.Fatalf("Location after clear = %v, want time.UTC", got)
 	}
 }
+
+// TestPermissionTimeoutSecondsSetting covers issue #445's global setting:
+// absent/unset (or explicitly 0) means disabled, matching the original
+// park-forever behavior of a deployment that never opts in; a positive
+// value round-trips, and a negative or non-numeric value is rejected.
+func TestPermissionTimeoutSecondsSetting(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	if got := s.PermissionTimeoutSeconds(ctx); got != 0 {
+		t.Fatalf("PermissionTimeoutSeconds default = %d, want 0 (disabled)", got)
+	}
+
+	if err := s.SetValue(ctx, ValuePermissionTimeoutSeconds, "-5"); err == nil {
+		t.Fatal("negative timeout accepted")
+	}
+	if err := s.SetValue(ctx, ValuePermissionTimeoutSeconds, "not-a-number"); err == nil {
+		t.Fatal("non-numeric timeout accepted")
+	}
+
+	if err := s.SetValue(ctx, ValuePermissionTimeoutSeconds, "600"); err != nil {
+		t.Fatalf("SetValue 600: %v", err)
+	}
+	if got := s.PermissionTimeoutSeconds(ctx); got != 600 {
+		t.Fatalf("PermissionTimeoutSeconds after set = %d, want 600 (cache must invalidate on write)", got)
+	}
+
+	if err := s.SetValue(ctx, ValuePermissionTimeoutSeconds, "0"); err != nil {
+		t.Fatalf("SetValue 0: %v", err)
+	}
+	if got := s.PermissionTimeoutSeconds(ctx); got != 0 {
+		t.Fatalf("PermissionTimeoutSeconds after explicit 0 = %d, want 0 (disabled)", got)
+	}
+
+	if err := s.SetValue(ctx, ValuePermissionTimeoutSeconds, ""); err != nil {
+		t.Fatalf("SetValue clear: %v", err)
+	}
+	if got := s.PermissionTimeoutSeconds(ctx); got != 0 {
+		t.Fatalf("PermissionTimeoutSeconds after clear = %d, want 0", got)
+	}
+}

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -761,7 +761,14 @@ CREATE TABLE IF NOT EXISTS missions (
     -- mirroring attachments' own shape. Never bytes (D-045). Lets a
     -- mission's result artifacts survive workspace deletion, unlike the
     -- live-workspace files ArtifactsSection browses.
-    artifact_refs          jsonb NOT NULL DEFAULT '[]'
+    artifact_refs          jsonb NOT NULL DEFAULT '[]',
+    -- Per-mission override for how long an unanswered pending_permission
+    -- may stay parked before the periodic sweep (missions/sweep.go)
+    -- auto-denies it (issue #445). NULL inherits the global
+    -- permission_timeout_seconds setting; the setting itself defaults to
+    -- 0 (disabled, park forever) so this is opt-in and changes nothing
+    -- for an existing deployment that never sets it.
+    permission_timeout_seconds integer
 );
 
 CREATE INDEX IF NOT EXISTS missions_status_idx ON missions (status);

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -22,3 +22,12 @@ BEGIN
     END IF;
 END $$;
 ```
+
+## Parked permission timeout (issue #445)
+
+Required on live DBs before/with the next deploy. Additive, safe to
+run before deploy.
+
+```sql
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS permission_timeout_seconds integer;
+```

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -745,6 +745,12 @@ export interface Mission {
   pending_permission_args?: string
   pending_permission_danger?: string
   pending_permission_rationale?: string
+  // pending_permission_parked_at is when the current park started; used
+  // with permission_timeout_seconds (this mission's own override, if
+  // set, otherwise the operator-configured global setting applies) to
+  // know an unanswered request auto-denies after a timeout.
+  pending_permission_parked_at?: string
+  permission_timeout_seconds?: number
   last_evidence?: string
   auto_approve_safe: boolean
   // environment is the sandbox image key (D-05x) this coding mission's

--- a/web/src/components/missions/PermissionBanner.tsx
+++ b/web/src/components/missions/PermissionBanner.tsx
@@ -35,6 +35,7 @@ export function PermissionBanner({
   rationale,
   answeredDecision,
   onDecide,
+  timeoutSeconds,
 }: {
   tool?: string
   args?: string
@@ -42,6 +43,12 @@ export function PermissionBanner({
   rationale?: string
   answeredDecision?: 'once' | 'session' | 'deny' | 'unknown'
   onDecide: (decision: 'once' | 'session' | 'deny') => void
+  // timeoutSeconds is this mission's own permission_timeout_seconds
+  // override, when set: an unattended mission auto-denies an
+  // unanswered request after this many seconds. undefined means no
+  // per-mission override (the global setting may still apply; that
+  // value isn't exposed to the UI).
+  timeoutSeconds?: number
 }) {
   return (
     <div className="space-y-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900 dark:bg-amber-950">
@@ -52,6 +59,11 @@ export function PermissionBanner({
             {danger === 'destructive' && <Badge variant="destructive">destructive</Badge>}
           </p>
           {rationale && <p className="text-sm text-amber-800 dark:text-amber-300">{rationale}</p>}
+          {typeof timeoutSeconds === 'number' && timeoutSeconds > 0 && (
+            <p className="text-xs text-amber-700 dark:text-amber-400">
+              Auto-denies if unanswered for {timeoutSeconds}s
+            </p>
+          )}
         </div>
         {answeredDecision !== undefined ? (
           <p className="shrink-0 text-sm text-amber-800 dark:text-amber-300">

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -486,6 +486,7 @@ export function MissionDetail() {
           rationale={mission.pending_permission_rationale}
           answeredDecision={answeredDecision}
           onDecide={(d) => void decidePermission(d)}
+          timeoutSeconds={mission.permission_timeout_seconds}
         />
       )}
 


### PR DESCRIPTION
Closes #445.

## What

- `permission_timeout_seconds` global setting (default 0, disabled: park forever, current behavior preserved) plus a nullable per-mission override column, set at create.
- A mission parked on `pending_permission` past its effective timeout auto-resolves to DENIED with reason `timed_out`, via the same store-level path the operator-deny API handler uses (durable even if the in-memory PermBroker lost the pending id across a restart).
- Structurally deny-only: `ResolvePendingPermissionTimeout` writes a hardcoded `decision: deny`; there is no code path that can auto-approve.
- Wired into the existing 30s work-slot sweep ticker, same interval class as the stale-working and backoff sweeps.
- Timeout resolution appends a `mission.permission_answered` event and fires a notification.
- Minimal web surface: the parked-permission banner shows the override when a mission has one set; no new API surface invented.

## Why

An unattended mission (scheduled, overnight) parked on a destructive-tool permission prompt hangs forever with no expiry. The safe direction on timeout is deny, never approve: the worker gets the denial and replans around it, the approve path stays human-only.

## Verified

Rebased cleanly onto current main (after #451). Unit gates clean. Applied the additive `permission_timeout_seconds` ALTER to the local dev DB and ran the full solo integration suite (never concurrent, shared Postgres): all pass, including the new timeout-sweep integration tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790756654&installation_model_id=431401&pr_number=452&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F452&signature=3ac6f58c7bfff41218d07d74286ed2144860e2ec68b12f96397ac84fb1bd1cbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->