### PR TITLE
fix(destinations): avoid rune overflow in test fixture id generator

### DIFF
--- a/internal/brain/destinations/promote_kb_test.go
+++ b/internal/brain/destinations/promote_kb_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"strconv"
 	"testing"
 
 	"github.com/SumonMSelim/timothy/internal/brain/attachments"
@@ -49,7 +50,7 @@ func (f *fakeKBStore) FindDocumentBySource(_ context.Context, sourceType, source
 
 func (f *fakeKBStore) CreateDocument(_ context.Context, collectionID, title, sourceType, sourceRef, provenance, markdown string, bytes int64) (string, error) {
 	f.nextID++
-	id := "doc" + string(rune('0'+f.nextID))
+	id := "doc" + strconv.Itoa(f.nextID)
 	f.docs[id] = kb.Document{ID: id, CollectionID: collectionID, Title: title, SourceType: sourceType, SourceRef: sourceRef, Provenance: provenance, Markdown: markdown, Bytes: bytes, Status: "pending"}
 	return id, nil
 }


### PR DESCRIPTION
The gosec finding flagged by every agent this session (pre-existing since #411, not release-blocking but easy to clear before tagging).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790760168&installation_model_id=431401&pr_number=454&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F454&signature=dde934d9a8b425e50fb4964826d4d3e8505f768943d3788da9f71ee49beae1c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->