### PR TITLE
feat(missions): plan approval gate (auto_approve_plan, D-087)

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -116,6 +116,9 @@ func (a *API) registerMissions(handle func(pattern string, h http.Handler), stor
 	handle("POST /v1/missions/{id}/note", a.auth(http.HandlerFunc(h.note)))
 	handle("POST /v1/missions/{id}/cancel", a.auth(http.HandlerFunc(h.cancel)))
 	handle("POST /v1/missions/{id}/permission", a.auth(http.HandlerFunc(h.permission)))
+	handle("POST /v1/missions/{id}/approve-plan", a.auth(http.HandlerFunc(h.approvePlan)))
+	handle("POST /v1/missions/{id}/replan", a.auth(http.HandlerFunc(h.replan)))
+	handle("POST /v1/missions/{id}/rediscover", a.auth(http.HandlerFunc(h.rediscover)))
 	handle("GET /v1/missions/{id}/files", a.auth(http.HandlerFunc(h.files)))
 	handle("GET /v1/missions/{id}/files/{path...}", a.auth(http.HandlerFunc(h.download)))
 	handle("GET /v1/missions/{id}/archive", a.auth(http.HandlerFunc(h.archive)))
@@ -253,6 +256,8 @@ func failMission(w http.ResponseWriter, err error) {
 		jsonError(w, http.StatusConflict, "already_finished", err.Error())
 	case errors.Is(err, missions.ErrNotTerminal):
 		jsonError(w, http.StatusConflict, "not_terminal", err.Error())
+	case errors.Is(err, missions.ErrNotAwaitingApproval):
+		jsonError(w, http.StatusConflict, "not_awaiting_approval", err.Error())
 	case errors.Is(err, missions.ErrInvalidMission):
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 	default:
@@ -410,6 +415,12 @@ type createMissionRequest struct {
 	// unattended, so auto-approving DangerSafe shell calls is the
 	// sensible default; destructive commands always ask regardless.
 	AutoApproveSafe *bool `json:"auto_approve_safe"`
+	// AutoApprovePlan defaults true (pointer, same "omitted vs explicit
+	// false" reasoning as AutoApproveSafe above): false parks the
+	// mission for operator approve/replan/rediscover once the plan
+	// phase lands (D-087, issue #456). Ignored (forced true) for
+	// scheduler-fired and workflow-spawned missions.
+	AutoApprovePlan *bool `json:"auto_approve_plan"`
 	// RepoURL is a GitHub repo's https clone URL: when set, the mission
 	// clones it instead of self-initializing an empty repo. Mutually
 	// exclusive with a future repo_path option and coding-only, same as
@@ -626,6 +637,10 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 	if req.AutoApproveSafe != nil {
 		autoApproveSafe = *req.AutoApproveSafe
 	}
+	autoApprovePlan := true
+	if req.AutoApprovePlan != nil {
+		autoApprovePlan = *req.AutoApprovePlan
+	}
 	if req.PermissionTimeoutSeconds != nil && *req.PermissionTimeoutSeconds < 0 {
 		jsonError(w, http.StatusBadRequest, "bad_request", "permission_timeout_seconds must not be negative")
 		return
@@ -639,7 +654,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		Route: req.Route, ReviewRoute: req.ReviewRoute, PlanRoute: req.PlanRoute, EscalationRoute: req.EscalationRoute,
 		RouteModel: req.RouteModel, PlanRouteModel: req.PlanRouteModel, ReviewRouteModel: req.ReviewRouteModel,
 		MaxIterations: req.MaxIterations, BudgetAmount: req.BudgetAmount, BudgetCurrency: budgetCurrency,
-		AutoApproveSafe: autoApproveSafe, PromptOverlay: promptOverlay, Knowledge: knowledge, Harness: req.Harness, Environment: req.Environment,
+		AutoApproveSafe: autoApproveSafe, AutoApprovePlan: autoApprovePlan, PromptOverlay: promptOverlay, Knowledge: knowledge, Harness: req.Harness, Environment: req.Environment,
 		RepoURL: req.RepoURL, ConnectorID: req.ConnectorID, OnComplete: req.OnComplete,
 		BranchPattern: req.BranchPattern, CommitStyle: req.CommitStyle,
 		ParentMissionID: parentMissionID, ParentContext: parentContext, ReferencedContext: referencedContext,
@@ -1422,6 +1437,60 @@ func (h *missionAPI) permission(w http.ResponseWriter, r *http.Request) {
 	if err := h.store.AppendEvent(r.Context(), m.ID, "mission.permission_answered",
 		map[string]any{"tool": m.PendingPermissionTool, "decision": body.Decision}); err != nil {
 		h.log.Warn("mission: record permission_answered event failed", "mission_id", m.ID, "error", err)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// approvePlan handles POST /v1/missions/{id}/approve-plan: the operator
+// accepts the plan as landed, advancing straight to generate (D-087,
+// issue #456). Plain HTTP handler only, never a tool: the model
+// cannot call this.
+func (h *missionAPI) approvePlan(w http.ResponseWriter, r *http.Request) {
+	if err := h.driver.DecidePlan(r.Context(), r.PathValue("id"), missions.InputPlanApprove, ""); err != nil {
+		failMission(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// replan handles POST /v1/missions/{id}/replan: re-runs the plan phase
+// with optional operator feedback folded into the next planning
+// prompt. Feedback is recorded as a progress note (same channel the
+// note endpoint's steering notes use, and the same precedent for
+// storing the operator's own text verbatim in an event payload) BEFORE
+// DecidePlan runs, so runPlan's replanNotes picks it up on the very
+// next planning turn. Does not consume the mission's automatic
+// stall-replan budget (ReplanUsed): an operator-requested replan is a
+// free, unlimited iteration.
+func (h *missionAPI) replan(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Feedback string `json:"feedback"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+		jsonError(w, http.StatusBadRequest, "bad_request", "body must be JSON with an optional feedback field")
+		return
+	}
+	id := r.PathValue("id")
+	feedback := missions.NeutralizeSlot(truncateAnswer(body.Feedback, resumeAnswerCap))
+	if feedback != "" {
+		if err := h.store.AppendProgress(r.Context(), id, "Operator replan feedback: "+feedback); err != nil {
+			h.log.Warn("mission: record replan feedback progress note failed", "mission_id", id, "error", err)
+		}
+	}
+	if err := h.driver.DecidePlan(r.Context(), id, missions.InputPlanReplan, feedback); err != nil {
+		failMission(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// rediscover handles POST /v1/missions/{id}/rediscover: sends the
+// mission back to the discover phase for a fresh exploration pass, no
+// feedback text taken (unlike replan).
+func (h *missionAPI) rediscover(w http.ResponseWriter, r *http.Request) {
+	if err := h.driver.DecidePlan(r.Context(), r.PathValue("id"), missions.InputPlanRediscover, ""); err != nil {
+		failMission(w, err)
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -361,6 +361,148 @@ func TestMissionsNoteTerminalMissionRejected(t *testing.T) {
 	}
 }
 
+// TestMissionsCreateDefaultsAutoApprovePlanTrue confirms an omitted
+// auto_approve_plan defaults true (D-087, issue #456), the same
+// "pointer field, omitted vs explicit false" shape as auto_approve_safe.
+func TestMissionsCreateDefaultsAutoApprovePlanTrue(t *testing.T) {
+	store := testMissionStore(t)
+	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
+
+	body := `{"goal":"itest-api-mission default auto_approve_plan","kind":"general"}`
+	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create = %d, want 201: %s", w.Code, w.Body.String())
+	}
+	var created missions.Mission
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if !created.AutoApprovePlan {
+		t.Fatal("create response AutoApprovePlan = false, want true by default")
+	}
+	got, err := store.Get(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.AutoApprovePlan {
+		t.Fatal("stored AutoApprovePlan = false, want true by default")
+	}
+}
+
+// TestMissionsCreateHonorsExplicitAutoApprovePlanFalse confirms an
+// explicit false request field is honored (not silently overridden by
+// the true default).
+func TestMissionsCreateHonorsExplicitAutoApprovePlanFalse(t *testing.T) {
+	store := testMissionStore(t)
+	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
+
+	body := `{"goal":"itest-api-mission explicit auto_approve_plan false","kind":"general","auto_approve_plan":false}`
+	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create = %d, want 201: %s", w.Code, w.Body.String())
+	}
+	got, err := store.Get(context.Background(), gjsonID(t, w.Body.Bytes()))
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AutoApprovePlan {
+		t.Fatal("stored AutoApprovePlan = true, want false when the request explicitly set it")
+	}
+}
+
+// gjsonID decodes just the id field of a create response, avoiding a
+// second full missions.Mission decode in tests that only need it.
+func gjsonID(t *testing.T, body []byte) string {
+	t.Helper()
+	var v struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(body, &v); err != nil {
+		t.Fatalf("decode id: %v", err)
+	}
+	return v.ID
+}
+
+// TestMissionsApprovePlanRejectedWhenNotParked confirms 409 for all
+// three plan-approval verbs when the mission isn't currently parked on
+// PauseApproval: here, a fresh mission still in phase=discover.
+func TestMissionsApprovePlanRejectedWhenNotParked(t *testing.T) {
+	store := testMissionStore(t)
+	ctx := context.Background()
+	id, err := store.Create(ctx, missions.Mission{Goal: "itest-api-mission approve-plan not parked", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
+
+	for _, verb := range []string{"approve-plan", "replan", "rediscover"} {
+		req := httptest.NewRequest("POST", "/v1/missions/"+id+"/"+verb, nil)
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		if w.Code != http.StatusConflict {
+			t.Fatalf("%s on a non-parked mission = %d, want 409: %s", verb, w.Code, w.Body.String())
+		}
+	}
+}
+
+// TestMissionsApprovePlanAdvancesToGenerate confirms the full round
+// trip: a mission parked on PauseApproval, approve-plan advances it to
+// generate.
+func TestMissionsApprovePlanAdvancesToGenerate(t *testing.T) {
+	store := testMissionStore(t)
+	ctx := context.Background()
+	id, err := store.Create(ctx, missions.Mission{
+		Goal: "itest-api-mission approve-plan happy path", Kind: "general",
+		Spec: missions.Spec{Units: []missions.PlanUnit{{Title: "only unit"}}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.ApplyTransition(ctx, id, missions.Transition{
+		Next: missions.StepState{Phase: missions.PhasePlan, Status: missions.StatusPaused, PauseReason: missions.PauseApproval},
+	}); err != nil {
+		t.Fatalf("ApplyTransition: %v", err)
+	}
+
+	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/approve-plan", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("approve-plan = %d, want 204: %s", w.Code, w.Body.String())
+	}
+
+	got, err := store.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Phase != missions.PhaseGenerate || got.Status != missions.StatusIdle && got.Status != missions.StatusWorking {
+		t.Fatalf("mission after approve-plan = %s/%s, want generate/idle-or-working (Drive may have already claimed it)", got.Phase, got.Status)
+	}
+}
+
 // TestMissionsCreateResponseCarriesDetectedEnvironment confirms the
 // POST /v1/missions response reflects the row create() actually
 // persisted — the create() handler resolves an omitted coding

--- a/internal/brain/missions/artifact_copy_test.go
+++ b/internal/brain/missions/artifact_copy_test.go
@@ -12,7 +12,7 @@ import (
 // them. Both now run synchronously within the result phase's step.
 func TestDriverCopiesArtifactsBeforeDestinationDelivery(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, DestinationIDs: []string{"d1"}})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, DestinationIDs: []string{"d1"}})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -74,7 +74,7 @@ func TestDriverSkipsArtifactCopyOnFailed(t *testing.T) {
 // never panics and leaves ArtifactRefs empty.
 func TestDriverSkipsArtifactCopyWhenNilHook(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},

--- a/internal/brain/missions/destination_deliver_test.go
+++ b/internal/brain/missions/destination_deliver_test.go
@@ -43,7 +43,7 @@ func (r *recordingDeliver) count() int {
 
 func TestDriverDeliversToDestinationsOnDone(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, DestinationIDs: []string{"d1", "d2"}})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, DestinationIDs: []string{"d1", "d2"}})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -93,7 +93,7 @@ func TestDriverSkipsDeliveryOnFailed(t *testing.T) {
 
 func TestDriverSkipsDeliveryWhenNoDestinations(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -117,7 +117,7 @@ func TestDriverSkipsDeliveryWhenNoDestinations(t *testing.T) {
 // backfilled one rather than empty.
 func TestDriverBackfillsNameBeforeDestinationDelivery(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, DestinationIDs: []string{"d1"}})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, DestinationIDs: []string{"d1"}})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -141,7 +141,7 @@ func TestDriverBackfillsNameBeforeDestinationDelivery(t *testing.T) {
 
 func TestDriverSkipsDeliveryWhenNilHook(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, DestinationIDs: []string{"d1"}})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, DestinationIDs: []string{"d1"}})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -165,7 +165,7 @@ func TestDriverSkipsDeliveryWhenNilHook(t *testing.T) {
 // transition.
 func TestDriverParksInResultOnDeliveryFailure(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, DestinationIDs: []string{"d1"}})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, DestinationIDs: []string{"d1"}})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -193,7 +193,7 @@ func TestDriverParksInResultOnDeliveryFailure(t *testing.T) {
 // recorded delivered is never re-sent).
 func TestDriverResultRetryOnlyRedeliversFailedDestination(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, DestinationIDs: []string{"d1", "d2"}})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, DestinationIDs: []string{"d1", "d2"}})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -1008,6 +1008,42 @@ func (d *Driver) Signal(ctx context.Context, id string, input Input) error {
 	return nil
 }
 
+// DecidePlan applies one of the three plan-approval verbs (D-087,
+// issue #456) to a mission parked on PauseApproval: the API layer's
+// approve/replan/rediscover endpoints call this, never the model.
+// feedback is only meaningful on InputPlanReplan (folded into the next
+// planning prompt by runPlan via replanNotes); ignored otherwise.
+// Returns ErrNotAwaitingApproval for any other state, mapped to 409 by
+// the API layer.
+func (d *Driver) DecidePlan(ctx context.Context, id string, input Input, feedback string) error {
+	if input != InputPlanApprove && input != InputPlanReplan && input != InputPlanRediscover {
+		return fmt.Errorf("driver: decide plan: %q is not a plan-approval input", input)
+	}
+	m, err := d.store.Get(ctx, id)
+	if err != nil {
+		return fmt.Errorf("driver: decide plan: %w", err)
+	}
+	if m.Phase != PhasePlan || m.PauseReason != PauseApproval {
+		return ErrNotAwaitingApproval
+	}
+	before := m.Status
+	t := Step(d.toStepState(ctx, m), StepInput{Input: input, Reason: feedback}, d.cfg)
+	if err := d.store.ApplyTransition(ctx, id, t); err != nil {
+		return fmt.Errorf("driver: decide plan: apply transition: %w", err)
+	}
+	if d.notify != nil {
+		if err := d.notify.OnTransition(ctx, m, before, t.Next.Status, failedReason(t.Events)); err != nil {
+			d.log.Warn("driver: notify failed", "mission_id", id, "error", err)
+		}
+	}
+	go func() { //nolint:gosec // G118: deliberate, the mission must outlive the HTTP request that decided it, driveTimeBound is Drive's own cap
+		if err := d.Drive(context.Background(), id); err != nil {
+			d.log.Error("driver: post-plan-decision drive failed", "mission_id", id, "error", err)
+		}
+	}()
+	return nil
+}
+
 // toStepState projects a Mission onto the state machine's input shape,
 // pulling actual ledger spend for the budget brake via budgetProjector
 // (budget.go, D-074).
@@ -1020,6 +1056,7 @@ func (d *Driver) toStepState(ctx context.Context, m Mission) StepState {
 		StallCount: m.StallCount, Spent: spent, Budget: m.BudgetAmount,
 		MixedCurrencySpend: mixed, RateAsOf: rateAsOf,
 		LastUnit: isLastUnit(m.Spec), ReplanUsed: m.ReplanUsed, Light: m.Light,
+		AutoApprovePlan: m.AutoApprovePlan,
 	}
 }
 
@@ -1126,13 +1163,22 @@ func (d *Driver) runPlan(ctx context.Context, m Mission) (StepInput, error) {
 // through unchanged. Folded into the existing exploreNotes string
 // argument (rather than a new Runner parameter) so PlanSession's
 // interface never has to change for this feature.
+//
+// Gated on len(m.Spec.Units) > 0 rather than m.ReplanUsed alone: an
+// operator-requested replan (D-087, issue #456) re-enters PhasePlan
+// without setting ReplanUsed (that flag is reserved for the automatic
+// stall-replan budget, never spent by a free operator iteration (see
+// stepPlanReplan), so the prior plan and any operator feedback
+// (appended as a progress note by the API's replan handler, same
+// channel as a steering note) must reach the prompt through this same
+// "a plan already exists" check instead.
 func replanNotes(m Mission) string {
-	if !m.ReplanUsed || len(m.Spec.Units) == 0 {
+	if len(m.Spec.Units) == 0 {
 		return m.ExploreNotes
 	}
 	var b strings.Builder
 	b.WriteString(m.ExploreNotes)
-	b.WriteString("\n\nThe previous plan stalled and is being replanned. Current plan:\n")
+	b.WriteString("\n\nThe previous plan is being replanned. Current plan:\n")
 	for _, u := range m.Spec.Units {
 		status := "pending"
 		if u.Passes {

--- a/internal/brain/missions/driver_integration_test.go
+++ b/internal/brain/missions/driver_integration_test.go
@@ -28,7 +28,7 @@ func TestDriverEndToEndCodingMission(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	workspace := NewWorkspace(wsRoot, nil, log)
 
-	id, err := store.Create(ctx, Mission{Goal: marker + "e2e coding", Kind: "coding", Route: "default", ReviewRoute: "default"})
+	id, err := store.Create(ctx, Mission{Goal: marker + "e2e coding", Kind: "coding", Route: "default", ReviewRoute: "default", AutoApprovePlan: true})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -337,7 +337,7 @@ func driveN(t *testing.T, d *Driver, id string, n int) {
 
 func TestDriverHappyPathToDone(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit", VerifyCmd: ""}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -382,7 +382,7 @@ func TestDriverFiresOnCompletePushPROnDone(t *testing.T) {
 	store := newFakeStore()
 	dir, base := codingWorktree(t)
 	store.put("m1", Mission{
-		ID: "m1", Kind: "coding", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8,
+		ID: "m1", Kind: "coding", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true,
 		Worktree: dir, BaseCommit: base, Branch: "mission/x", RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1",
 		OnComplete: "push_pr",
 	})
@@ -435,7 +435,7 @@ func TestDriverOnCompleteFailureParksInResultAndNotifies(t *testing.T) {
 	store := newFakeStore()
 	dir, base := codingWorktree(t)
 	store.put("m1", Mission{
-		ID: "m1", Kind: "coding", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8,
+		ID: "m1", Kind: "coding", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true,
 		Worktree: dir, BaseCommit: base, Branch: "mission/x", RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1",
 		OnComplete: "push",
 	})
@@ -480,7 +480,7 @@ func TestDriverOnCompleteFailureParksInResultAndNotifies(t *testing.T) {
 // mission.discover_complete, and advances to plan.
 func TestDriverExploreStoresNotesAndAdvances(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true})
 	runner := &scriptedRunner{
 		exploreNotes: []string{"no prior implementation exists; goal is self-contained"},
 		plans:        []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
@@ -514,7 +514,7 @@ func TestDriverExploreStoresNotesAndAdvances(t *testing.T) {
 // prompt, so unbounded notes would blow out that turn's context.
 func TestDriverExploreTruncatesLongNotes(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true})
 	long := strings.Repeat("x", exploreNotesCap+500)
 	runner := &scriptedRunner{
 		exploreNotes: []string{long},
@@ -538,7 +538,7 @@ func TestDriverExploreTruncatesLongNotes(t *testing.T) {
 // explore has no phase-specific error input of its own.
 func TestDriverExploreErrorRoutesToWorkerFailed(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true})
 	runner := &scriptedRunner{exploreErr: fmt.Errorf("gateway unreachable")}
 	d := testDriver(store, runner)
 
@@ -560,7 +560,7 @@ func TestDriverExploreErrorRoutesToWorkerFailed(t *testing.T) {
 // stale in-memory value from the explore turn.
 func TestDriverPlanReceivesStoredExploreNotes(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true})
 	runner := &scriptedRunner{
 		exploreNotes: []string{"found a reusable config loader in internal/platform/config"},
 		plans:        []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
@@ -653,6 +653,129 @@ func TestDriverPlanCreatedEventOmitsEmptyAssumptions(t *testing.T) {
 	}
 	if _, ok := payload["assumptions"]; ok {
 		t.Fatalf("plan_created payload = %+v, want no assumptions key for an unambiguous plan", payload)
+	}
+}
+
+// TestDriverPlanApprovalGateParks confirms D-087 (issue #456): a plan
+// phase turn on a mission with AutoApprovePlan=false parks on
+// PauseApproval with the plan already stored, instead of advancing to
+// generate; no worker turn runs (scriptedRunner has no workerVerdicts
+// scripted, so a stray runExecute call would fail the test via an
+// unscripted-call panic/error).
+func TestDriverPlanApprovalGateParks(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhasePlan, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: false})
+	runner := &scriptedRunner{plans: []Spec{{Units: []PlanUnit{{Title: "only unit"}}}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	got := store.missions["m1"]
+	if got.Phase != PhasePlan || got.Status != StatusPaused || got.PauseReason != PauseApproval {
+		t.Fatalf("mission after plan with auto_approve_plan=false = %s/%s/%s, want plan/paused/approval", got.Phase, got.Status, got.PauseReason)
+	}
+	if len(got.Spec.Units) != 1 {
+		t.Fatalf("Spec.Units = %+v, want the plan stored even though the mission parked", got.Spec.Units)
+	}
+}
+
+// TestDriverDecidePlanApprove confirms DecidePlan's approve verb
+// unparks a PauseApproval mission straight to generate. Scripts a
+// workerVerdicts entry (blocked) so the background Drive goroutine
+// DecidePlan kicks off, which continues into the now-unparked
+// generate phase, settles cleanly instead of panicking on an
+// unscripted RunWorker call once it runs past this assertion.
+func TestDriverDecidePlanApprove(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval,
+		MaxIterations: 8, Spec: Spec{Units: []PlanUnit{{Title: "only unit"}}},
+	})
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
+	d := testDriver(store, runner)
+
+	if err := d.DecidePlan(context.Background(), "m1", InputPlanApprove, ""); err != nil {
+		t.Fatalf("DecidePlan: %v", err)
+	}
+	// DecidePlan's own ApplyTransition write happens synchronously before
+	// it spawns the post-decision Drive goroutine, but reading it back
+	// via Get (mutex-guarded) rather than a raw map index avoids racing
+	// that goroutine's own concurrent Get/writes.
+	got, err := store.Get(context.Background(), "m1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Phase != PhaseGenerate || got.Status != StatusIdle || got.PauseReason != "" {
+		t.Fatalf("mission after approve = %s/%s/%s, want generate/idle/<none>", got.Phase, got.Status, got.PauseReason)
+	}
+}
+
+// TestDriverDecidePlanReplanRejectedWhenNotParked confirms the driver's
+// own belt-and-suspenders guard: DecidePlan returns
+// ErrNotAwaitingApproval for a mission not currently parked on
+// PauseApproval, regardless of phase.
+func TestDriverDecidePlanReplanRejectedWhenNotParked(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	d := testDriver(store, &scriptedRunner{})
+
+	err := d.DecidePlan(context.Background(), "m1", InputPlanReplan, "feedback")
+	if !errors.Is(err, ErrNotAwaitingApproval) {
+		t.Fatalf("DecidePlan error = %v, want ErrNotAwaitingApproval", err)
+	}
+	got := store.missions["m1"]
+	if got.Phase != PhaseGenerate || got.Status != StatusWorking {
+		t.Fatalf("mission after rejected decide = %s/%s, want untouched generate/working", got.Phase, got.Status)
+	}
+}
+
+// TestDriverReplanFeedsFollowingPlanTurn confirms the operator's
+// replan feedback (recorded as a progress note by the API layer, same
+// channel as h.note's steering notes) reaches the NEXT plan turn's
+// prompt via replanNotes, without spending ReplanUsed. Drives the
+// unpark step directly via Step+ApplyTransition (the API/DecidePlan's
+// own transition), then a synchronous Advance for the plan turn itself.
+// This avoids DecidePlan's background Drive re-kick racing this test's
+// own reads of the unsynchronized scriptedRunner test double.
+func TestDriverReplanFeedsFollowingPlanTurn(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval,
+		MaxIterations: 8, ExploreNotes: "original findings",
+		Spec: Spec{Units: []PlanUnit{{Title: "unit0"}}},
+	})
+	runner := &scriptedRunner{plans: []Spec{{Units: []PlanUnit{{Title: "unit0 revised"}}}}}
+	d := testDriver(store, runner)
+
+	// AppendProgress mirrors what the API's replan handler does before
+	// the state transition, same channel as h.note's steering notes.
+	if err := store.AppendProgress(context.Background(), "m1", "Operator replan feedback: use Go 1.23"); err != nil {
+		t.Fatalf("AppendProgress: %v", err)
+	}
+	t1 := Step(StepState{Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval, MaxIterations: 8},
+		StepInput{Input: InputPlanReplan, Reason: "use Go 1.23"}, DefaultConfig)
+	if err := store.ApplyTransition(context.Background(), "m1", t1); err != nil {
+		t.Fatalf("ApplyTransition: %v", err)
+	}
+	if t1.Next.ReplanUsed {
+		t.Fatal("replan transition set ReplanUsed, operator iterations must stay free")
+	}
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if len(runner.planExploreNotes) != 1 {
+		t.Fatalf("PlanSession call count = %d, want 1", len(runner.planExploreNotes))
+	}
+	if got := runner.planExploreNotes[0]; !strings.Contains(got, "use Go 1.23") {
+		t.Fatalf("replan prompt = %q, want it to contain the operator feedback", got)
+	}
+	// The replanned plan (AutoApprovePlan still false on this fixture)
+	// parks on approval again once runPlan completes.
+	got := store.missions["m1"]
+	if got.Phase != PhasePlan || got.Status != StatusPaused || got.PauseReason != PauseApproval || got.ReplanUsed {
+		t.Fatalf("mission after replanned plan lands = %s/%s/%s/ReplanUsed=%v, want plan/paused/approval/false", got.Phase, got.Status, got.PauseReason, got.ReplanUsed)
 	}
 }
 
@@ -2034,7 +2157,7 @@ func TestDriverReplanPromptCarriesStallContext(t *testing.T) {
 		t.Fatalf("PlanSession call count = %d, want 1", len(runner.planExploreNotes))
 	}
 	got := runner.planExploreNotes[0]
-	for _, want := range []string{"original findings", "previous plan stalled", "tried approach A, failed", "unit0"} {
+	for _, want := range []string{"original findings", "previous plan is being replanned", "tried approach A, failed", "unit0"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("replan prompt = %q, want it to contain %q", got, want)
 		}
@@ -2281,7 +2404,7 @@ func TestDriverAdvanceNilCapacityGateRunsTurn(t *testing.T) {
 // must keep advancing even when the gate denies.
 func TestDriverAdvanceCapacityGateIgnoredWhenAlreadyWorking(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true})
 	runner := &scriptedRunner{exploreNotes: []string{"explored"}}
 	d := testDriver(store, runner)
 	d.SetCapacityGate(fakeCapacityChecker{admit: false, reason: "denied"})

--- a/internal/brain/missions/followup.go
+++ b/internal/brain/missions/followup.go
@@ -34,7 +34,7 @@ func (d *Driver) CreateFollowUp(ctx context.Context, parentID, goal string) (str
 		RouteModel: parent.RouteModel, PlanRouteModel: parent.PlanRouteModel,
 		ReviewRouteModel: parent.ReviewRouteModel,
 		BudgetAmount:     parent.BudgetAmount, BudgetCurrency: parent.BudgetCurrency,
-		AutoApproveSafe: parent.AutoApproveSafe, PromptOverlay: parent.PromptOverlay,
+		AutoApproveSafe: parent.AutoApproveSafe, AutoApprovePlan: parent.AutoApprovePlan, PromptOverlay: parent.PromptOverlay,
 		Knowledge: parent.Knowledge, Harness: parent.Harness, Environment: parent.Environment,
 		RepoURL: parent.RepoURL, ConnectorID: parent.ConnectorID,
 		BranchPattern: parent.BranchPattern, CommitStyle: parent.CommitStyle,

--- a/internal/brain/missions/memory_test.go
+++ b/internal/brain/missions/memory_test.go
@@ -167,7 +167,7 @@ func waitForCalls(t *testing.T, r *recordingExtract, want int) {
 
 func TestDriverExtractsMemoryOnDone(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, SessionID: "sess-1"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, SessionID: "sess-1"})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -210,7 +210,7 @@ func TestDriverExtractsMemoryOnFailed(t *testing.T) {
 
 func TestDriverDoesNotExtractOnNonTerminalTransitions(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, SessionID: "sess-1"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, SessionID: "sess-1"})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -261,7 +261,7 @@ func TestDriverExtractsMemoryOnceOnRedrive(t *testing.T) {
 // committed before extraction was even dispatched.
 func TestDriverMemoryExtractionErrorDoesNotBlockTransition(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, SessionID: "sess-1"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, SessionID: "sess-1"})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -288,7 +288,7 @@ func TestDriverMemoryExtractionErrorDoesNotBlockTransition(t *testing.T) {
 
 func TestDriverSkipsExtractionWhenNilClient(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, SessionID: "sess-1"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, SessionID: "sess-1"})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -170,7 +170,16 @@ type Mission struct {
 	// (but harmless) shell invocation. Destructive-classified commands
 	// still always ask: tools.Permissions.Resolve forces that
 	// regardless of any grant, so this cannot weaken that guarantee.
-	AutoApproveSafe bool   `json:"auto_approve_safe"`
+	AutoApproveSafe bool `json:"auto_approve_safe"`
+	// AutoApprovePlan, when true (the default), advances straight from
+	// plan to generate the moment a plan lands, exactly as every
+	// mission has always worked. false parks the mission on
+	// PauseApproval instead (D-087, issue #456), waiting for an
+	// operator to approve/replan/rediscover. Snapshotted at create
+	// time, same as AutoApproveSafe; scheduler.go and the workflow
+	// engine both force this true regardless of template/step input:
+	// an unattended mission has nobody to approve its plan.
+	AutoApprovePlan bool   `json:"auto_approve_plan"`
 	ScheduleID      string `json:"schedule_id,omitempty"`
 	// ParentMissionID names the terminal mission this one follows up on
 	// (api/missions.go's create) — empty for an ordinary mission.
@@ -336,4 +345,8 @@ var (
 	// deleted, so a live mission's row/events/workspace can never vanish
 	// out from under a running Driver.Advance.
 	ErrNotTerminal = errors.New("mission is not terminal")
+	// ErrNotAwaitingApproval guards the three plan-approval verbs
+	// (D-087, issue #456): approve/replan/rediscover are only valid
+	// while the mission is parked on PauseApproval.
+	ErrNotAwaitingApproval = errors.New("mission is not awaiting plan approval")
 )

--- a/internal/brain/missions/onterminal_test.go
+++ b/internal/brain/missions/onterminal_test.go
@@ -44,7 +44,7 @@ func waitForOnTerminalCalls(t *testing.T, r *recordingOnTerminal, want int) {
 
 func TestDriverFiresOnTerminalForWorkflowMission(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, WorkflowRunID: "run-1", WorkflowStep: "step-a"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, WorkflowRunID: "run-1", WorkflowStep: "step-a"})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -64,7 +64,7 @@ func TestDriverFiresOnTerminalForWorkflowMission(t *testing.T) {
 
 func TestDriverSkipsOnTerminalWithoutWorkflowRunID(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -84,7 +84,7 @@ func TestDriverSkipsOnTerminalWithoutWorkflowRunID(t *testing.T) {
 
 func TestDriverSkipsOnTerminalWhenNilHook(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, WorkflowRunID: "run-1"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, WorkflowRunID: "run-1"})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},

--- a/internal/brain/missions/promote_kb_test.go
+++ b/internal/brain/missions/promote_kb_test.go
@@ -40,7 +40,7 @@ func (r *recordingPromoteKB) count() int {
 
 func TestDriverPromotesToKBOnDone(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, PromoteKBCollectionID: "c1"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, PromoteKBCollectionID: "c1"})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -86,7 +86,7 @@ func TestDriverSkipsPromoteKBOnFailed(t *testing.T) {
 
 func TestDriverSkipsPromoteKBWhenNoCollection(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -105,7 +105,7 @@ func TestDriverSkipsPromoteKBWhenNoCollection(t *testing.T) {
 
 func TestDriverSkipsPromoteKBWhenNilHook(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, PromoteKBCollectionID: "c1"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, PromoteKBCollectionID: "c1"})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -128,7 +128,7 @@ func TestDriverSkipsPromoteKBWhenNilHook(t *testing.T) {
 // the mission IN result rather than being logged and lost.
 func TestDriverParksInResultOnPromoteKBFailure(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, PromoteKBCollectionID: "c1"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, PromoteKBCollectionID: "c1"})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -481,11 +481,14 @@ func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedu
 		name = sc.Name
 	}
 	phase := initialPhase(t.Kind, t.Light)
+	// auto_approve_plan is forced true here, never taken from the
+	// template (D-087, issue #456): a scheduler-fired mission runs
+	// unattended, so nobody is watching to approve its plan.
 	_, err = tx.Exec(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, knowledge, auto_approve_safe, spec, schedule_id, harness, environment, destination_ids, light, phase)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)`,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, knowledge, auto_approve_safe, auto_approve_plan, spec, schedule_id, harness, environment, destination_ids, light, phase)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)`,
 		t.Goal, name, t.Kind, t.AgentID, orDefault(t.MaxIterations, 3), t.BudgetAmount, budgetCurrency, t.Route, t.ReviewRoute, t.PlanRoute,
-		promptOverlay, knowledgeJSON, t.AutoApproveSafe, spec, sc.ID, t.Harness, t.Environment, destinationIDs, t.Light, phase)
+		promptOverlay, knowledgeJSON, t.AutoApproveSafe, true, spec, sc.ID, t.Harness, t.Environment, destinationIDs, t.Light, phase)
 	return err
 }
 

--- a/internal/brain/missions/scheduler_integration_test.go
+++ b/internal/brain/missions/scheduler_integration_test.go
@@ -102,6 +102,36 @@ func TestSchedulerFireUsesScheduleNameDirectly(t *testing.T) {
 	}
 }
 
+// TestSchedulerFireForcesAutoApprovePlanTrue confirms D-087 (issue
+// #456): a scheduler-fired mission always gets auto_approve_plan=true.
+// MissionTemplate has no field for it at all, so this is really
+// confirming createFromTemplate's own INSERT hardcodes true rather
+// than silently leaving the column at its Go zero-value false.
+func TestSchedulerFireForcesAutoApprovePlanTrue(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	id := createTestSchedule(t, store, marker+"force-approve-plan", "* * * * *")
+	db, _ := store.db.Get()
+	past := time.Now().Add(-2 * time.Minute)
+	if _, err := db.Exec(ctx, "UPDATE schedules SET created_at = $2 WHERE id = $1", id, past); err != nil {
+		t.Fatalf("backdate schedule: %v", err)
+	}
+
+	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, nil, store.log)
+	if err := sched.tick(ctx, time.Now()); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	var autoApprovePlan bool
+	if err := db.QueryRow(ctx, `SELECT auto_approve_plan FROM missions WHERE schedule_id = $1`, id).Scan(&autoApprovePlan); err != nil {
+		t.Fatalf("query fired mission's auto_approve_plan: %v", err)
+	}
+	if !autoApprovePlan {
+		t.Fatal("fired mission auto_approve_plan = false, want true (unattended missions have nobody to approve a plan)")
+	}
+}
+
 // TestSchedulerFireUsesTemplateNameOverSlug guards the fix for a real
 // UI gap: schedule names are strict lowercase slugs (shared validation
 // with connectors/destinations/agents), so a scheduled mission's

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -106,6 +106,16 @@ const (
 	// for spend, not just price). A convertible other-currency amount
 	// is folded into Spent instead and never reaches this pause.
 	PauseMixedCurrency PauseReason = "mixed_currency"
+	// PauseApproval parks a mission whose plan just landed with
+	// auto_approve_plan=false (D-087, issue #456), waiting on one of
+	// the three operator verbs (approve/replan/rediscover). Distinct
+	// from PauseInfra/PauseBackoff/PauseNoProgress/PauseBudget: those
+	// all describe something going wrong that a sweep may self-heal or
+	// escalate; this describes an operator decision point with no safe
+	// default, so no sweep (autoResumeInfra, sweepPermissionTimeouts,
+	// or any future one) ever inspects this reason. It waits forever
+	// until a human acts.
+	PauseApproval PauseReason = "approval"
 )
 
 // Input is one event the driver feeds into Step.
@@ -132,6 +142,17 @@ const (
 	// work product isn't lost.
 	InputResultComplete Input = "result_complete"
 	InputResultFailed   Input = "result_failed"
+	// InputPlanApprove/InputPlanReplan/InputPlanRediscover are the three
+	// operator verbs that resolve a PauseApproval park (D-087): approve
+	// advances straight to generate on the plan as landed; replan
+	// re-enters PhasePlan with optional feedback folded into the next
+	// planning prompt; rediscover re-enters PhaseDiscover. Valid only
+	// when the mission is paused for PauseApproval; a no-op transition
+	// otherwise, same "unrecognized/out-of-state input" convention as
+	// InputPlanInfeasible's own phase check.
+	InputPlanApprove    Input = "plan_approve"
+	InputPlanReplan     Input = "plan_replan"
+	InputPlanRediscover Input = "plan_rediscover"
 )
 
 // StepState is the state-machine-relevant slice of a Mission — Step
@@ -175,6 +196,13 @@ type StepState struct {
 	// stall can never replan into PhasePlan for one, since it never
 	// visits that phase.
 	Light bool
+	// AutoApprovePlan gates the plan phase's success transition
+	// (D-087, issue #456): true (the default) advances straight to
+	// generate, byte-identical to pre-#456 behavior. false parks the
+	// mission on PauseApproval instead, waiting for one of the three
+	// operator verbs. Light missions never visit PhasePlan, so this
+	// flag has no effect on them regardless of its value.
+	AutoApprovePlan bool
 }
 
 // StepInput bundles the triggering Input with whatever data it
@@ -297,6 +325,12 @@ func Step(s StepState, in StepInput, cfg Config) Transition {
 			Next:   withPhaseFailed(s),
 			Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "goal_infeasible", "detail": in.Reason}}},
 		}
+	case InputPlanApprove:
+		return stepPlanApprove(s)
+	case InputPlanReplan:
+		return stepPlanReplan(s, in)
+	case InputPlanRediscover:
+		return stepPlanRediscover(s)
 	default:
 		// Unrecognized input: no-op rather than a panic or a silent
 		// wrong transition — the driver logs this as a bug elsewhere.
@@ -340,7 +374,19 @@ func stepResume(s StepState) Transition {
 // requests review, it doesn't itself complete the phase: the driver
 // routes DONE into a review round, whose outcome arrives as
 // InputReviewApprove/InputReviewRework, not InputPhaseComplete).
+//
+// The plan phase's own completion forks on AutoApprovePlan (D-087,
+// issue #456): true is the byte-identical default, straight through to
+// nextPhase like every other phase. false parks the mission instead:
+// the plan already landed (runPlan's own SetSpec ran before this
+// input arrives), so the park shows the real plan, not a stale one.
 func stepPhaseComplete(s StepState) Transition {
+	if s.Phase == PhasePlan && !s.AutoApprovePlan {
+		return Transition{
+			Next:   withPause(s, PauseApproval),
+			Events: []EventDraft{{Kind: "mission.plan_awaiting_approval", Payload: map[string]any{}}},
+		}
+	}
 	next, ok := nextPhase(s.Phase)
 	if !ok {
 		return Transition{Next: s}
@@ -350,6 +396,58 @@ func stepPhaseComplete(s StepState) Transition {
 	s.Iteration = 0
 	s.ConsecutiveFailures = 0
 	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.phase_started", Payload: map[string]any{"phase": string(next)}}}}
+}
+
+// stepPlanApprove is the approve verb (D-087): valid only while parked
+// on PauseApproval, advances straight to generate on the plan as it
+// landed: the same nextPhase(PhasePlan) step stepPhaseComplete would
+// have taken had AutoApprovePlan been true. Any other state is a no-op
+// (the API layer rejects the request with 409 before Step ever sees
+// it; this is the state machine's own belt).
+func stepPlanApprove(s StepState) Transition {
+	if s.Phase != PhasePlan || s.PauseReason != PauseApproval {
+		return Transition{Next: s}
+	}
+	s.Status = StatusIdle
+	s.PauseReason = ""
+	s.Phase = PhaseGenerate
+	s.Iteration = 0
+	s.ConsecutiveFailures = 0
+	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.plan_approved", Payload: map[string]any{}}}}
+}
+
+// stepPlanReplan is the replan verb (D-087): re-enters PhasePlan for
+// another planning turn with the operator's feedback (in.Reason)
+// folded into the next prompt by the driver (mirrors replanNotes'
+// existing stall-replan folding). Deliberately does NOT set
+// ReplanUsed: only an AUTOMATIC stall replan spends that budget
+// (stepWorkerRetry/stepReviewRework); an operator-requested replan is
+// a free, unlimited iteration, per #456's "unlimited iterations" scope.
+func stepPlanReplan(s StepState, in StepInput) Transition {
+	if s.Phase != PhasePlan || s.PauseReason != PauseApproval {
+		return Transition{Next: s}
+	}
+	s.Status = StatusIdle
+	s.PauseReason = ""
+	s.Iteration = 0
+	s.ConsecutiveFailures = 0
+	payload := map[string]any{"feedback": in.Reason != ""}
+	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.plan_replan_requested", Payload: payload}}}
+}
+
+// stepPlanRediscover is the rediscover verb (D-087): back to
+// PhaseDiscover for a fresh exploration pass, same free-iteration
+// reasoning as stepPlanReplan (no ReplanUsed, no iteration spend).
+func stepPlanRediscover(s StepState) Transition {
+	if s.Phase != PhasePlan || s.PauseReason != PauseApproval {
+		return Transition{Next: s}
+	}
+	s.Status = StatusIdle
+	s.PauseReason = ""
+	s.Phase = PhaseDiscover
+	s.Iteration = 0
+	s.ConsecutiveFailures = 0
+	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.rediscover_requested", Payload: map[string]any{}}}}
 }
 
 // stepWorkerFailed counts consecutive failures toward the backoff

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -93,11 +93,18 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhasePlan, Status: StatusIdle},
 		},
 		{
-			name:  "phase_complete advances plan to generate",
+			name:  "phase_complete advances plan to generate when auto_approve_plan is true",
+			state: StepState{Phase: PhasePlan, Status: StatusWorking, AutoApprovePlan: true},
+			input: StepInput{Input: InputPhaseComplete},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseGenerate, Status: StatusIdle, AutoApprovePlan: true},
+		},
+		{
+			name:  "phase_complete parks on approval when auto_approve_plan is false",
 			state: StepState{Phase: PhasePlan, Status: StatusWorking},
 			input: StepInput{Input: InputPhaseComplete},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusIdle},
+			want:  StepState{Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval},
 		},
 		{
 			name:  "phase_complete advances generate to prove",
@@ -327,6 +334,50 @@ func TestStep(t *testing.T) {
 			name:  "result_failed parks the mission in result with an infra pause",
 			state: StepState{Phase: PhaseResult, Status: StatusWorking},
 			input: StepInput{Input: InputResultFailed, Reason: "delivery: destination unreachable"},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseResult, Status: StatusPaused, PauseReason: PauseInfra},
+		},
+		{
+			name:  "plan_approve from an approval park advances to generate",
+			state: StepState{Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval},
+			input: StepInput{Input: InputPlanApprove},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseGenerate, Status: StatusIdle},
+		},
+		{
+			// Operator iterations are free: replan must NOT set ReplanUsed
+			// (that budget is reserved for the automatic stall-replan path).
+			name:  "plan_replan from an approval park re-enters plan without spending ReplanUsed",
+			state: StepState{Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval},
+			input: StepInput{Input: InputPlanReplan, Reason: "use Go 1.23 not 1.21"},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhasePlan, Status: StatusIdle},
+		},
+		{
+			name:  "plan_rediscover from an approval park re-enters discover",
+			state: StepState{Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval},
+			input: StepInput{Input: InputPlanRediscover},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseDiscover, Status: StatusIdle},
+		},
+		{
+			name:  "plan_approve outside an approval park is a no-op",
+			state: StepState{Phase: PhaseGenerate, Status: StatusWorking},
+			input: StepInput{Input: InputPlanApprove},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseGenerate, Status: StatusWorking},
+		},
+		{
+			name:  "plan_replan outside an approval park is a no-op",
+			state: StepState{Phase: PhasePlan, Status: StatusWorking},
+			input: StepInput{Input: InputPlanReplan, Reason: "feedback"},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhasePlan, Status: StatusWorking},
+		},
+		{
+			name:  "plan_rediscover outside an approval park is a no-op",
+			state: StepState{Phase: PhaseResult, Status: StatusPaused, PauseReason: PauseInfra},
+			input: StepInput{Input: InputPlanRediscover},
 			cfg:   DefaultConfig,
 			want:  StepState{Phase: PhaseResult, Status: StatusPaused, PauseReason: PauseInfra},
 		},
@@ -620,5 +671,77 @@ func TestPhaseTerminal(t *testing.T) {
 		if p.Terminal() {
 			t.Fatalf("%q.Terminal() = true, want false", p)
 		}
+	}
+}
+
+// TestStepPlanAwaitingApprovalEmitsEvent confirms the park itself
+// (D-087, issue #456) fires mission.plan_awaiting_approval. The
+// notification inbox entry (Notifier.OnTransition) rides the generic
+// idle/working -> paused transition this produces, no separate wiring
+// needed.
+func TestStepPlanAwaitingApprovalEmitsEvent(t *testing.T) {
+	got := Step(
+		StepState{Phase: PhasePlan, Status: StatusWorking},
+		StepInput{Input: InputPhaseComplete},
+		DefaultConfig,
+	)
+	if len(got.Events) != 1 || got.Events[0].Kind != "mission.plan_awaiting_approval" {
+		t.Fatalf("Events = %+v, want exactly one mission.plan_awaiting_approval event", got.Events)
+	}
+}
+
+// TestStepPlanApproveEmitsEvent confirms the approve verb's event.
+func TestStepPlanApproveEmitsEvent(t *testing.T) {
+	got := Step(
+		StepState{Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval},
+		StepInput{Input: InputPlanApprove},
+		DefaultConfig,
+	)
+	if len(got.Events) != 1 || got.Events[0].Kind != "mission.plan_approved" {
+		t.Fatalf("Events = %+v, want exactly one mission.plan_approved event", got.Events)
+	}
+}
+
+// TestStepPlanReplanEventCarriesFeedbackPresence confirms the replan
+// verb's event payload records only WHETHER feedback text was given
+// (matching mission.blocked/mission.answered's own precedent for
+// operator-authored text: full text does get stored, but the event's
+// own "feedback" key is a presence bool the API layer decides, this
+// tests both the with- and without-feedback shapes).
+func TestStepPlanReplanEventCarriesFeedbackPresence(t *testing.T) {
+	withFeedback := Step(
+		StepState{Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval},
+		StepInput{Input: InputPlanReplan, Reason: "use Go 1.23"},
+		DefaultConfig,
+	)
+	if len(withFeedback.Events) != 1 || withFeedback.Events[0].Kind != "mission.plan_replan_requested" {
+		t.Fatalf("Events = %+v, want exactly one mission.plan_replan_requested event", withFeedback.Events)
+	}
+	if got, _ := withFeedback.Events[0].Payload["feedback"].(bool); !got {
+		t.Fatalf("payload[feedback] = %v, want true when Reason is set", withFeedback.Events[0].Payload)
+	}
+	if withFeedback.Next.ReplanUsed {
+		t.Fatal("operator replan must not set ReplanUsed, that budget is only spent by an automatic stall replan")
+	}
+
+	noFeedback := Step(
+		StepState{Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval},
+		StepInput{Input: InputPlanReplan},
+		DefaultConfig,
+	)
+	if got, _ := noFeedback.Events[0].Payload["feedback"].(bool); got {
+		t.Fatalf("payload[feedback] = %v, want false when Reason is empty", noFeedback.Events[0].Payload)
+	}
+}
+
+// TestStepPlanRediscoverEmitsEvent confirms the rediscover verb's event.
+func TestStepPlanRediscoverEmitsEvent(t *testing.T) {
+	got := Step(
+		StepState{Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval},
+		StepInput{Input: InputPlanRediscover},
+		DefaultConfig,
+	)
+	if len(got.Events) != 1 || got.Events[0].Kind != "mission.rediscover_requested" {
+		t.Fatalf("Events = %+v, want exactly one mission.rediscover_requested event", got.Events)
 	}
 }

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -48,7 +48,7 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 	workspace, worktree, branch, base_commit, spec, progress, iteration, max_iterations,
 	consecutive_failures, last_gap_fingerprint, stall_count, budget_amount, budget_currency, route, review_route,
 	plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, knowledge,
-	pending_permission, auto_approve_safe, last_evidence,
+	pending_permission, auto_approve_safe, auto_approve_plan, last_evidence,
 	explore_notes, replan_used, schedule_id, session_id, harness, environment, repo_url, connector_id, on_complete,
 	branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, light, final_output, created_at, updated_at,
 	workflow_run_id, workflow_step, artifact_refs, promote_kb_collection_id, permission_timeout_seconds`
@@ -107,7 +107,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
 		&m.ConsecutiveFailures, &m.LastGapFingerprint, &m.StallCount, &m.BudgetAmount, &m.BudgetCurrency, &m.Route, &m.ReviewRoute,
 		&m.PlanRoute, &m.EscalationRoute, &m.RouteModel, &m.PlanRouteModel, &m.ReviewRouteModel, &m.PromptOverlay, &knowledgeRaw,
-		&pendingPermissionRaw, &m.AutoApproveSafe, &m.LastEvidence,
+		&pendingPermissionRaw, &m.AutoApproveSafe, &m.AutoApprovePlan, &m.LastEvidence,
 		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &m.ReferencedContext, &attachmentsRaw,
 		&m.DestinationIDs, &m.Light, &m.FinalOutput,
@@ -192,7 +192,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
 		&m.ConsecutiveFailures, &m.LastGapFingerprint, &m.StallCount, &m.BudgetAmount, &m.BudgetCurrency, &m.Route, &m.ReviewRoute,
 		&m.PlanRoute, &m.EscalationRoute, &m.RouteModel, &m.PlanRouteModel, &m.ReviewRouteModel, &m.PromptOverlay, &knowledgeRaw,
-		&pendingPermissionRaw, &m.AutoApproveSafe, &m.LastEvidence,
+		&pendingPermissionRaw, &m.AutoApproveSafe, &m.AutoApprovePlan, &m.LastEvidence,
 		&m.ExploreNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &m.ReferencedContext, &attachmentsRaw,
 		&m.DestinationIDs, &m.Light, &m.FinalOutput,
@@ -293,9 +293,9 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	}
 	phase := initialPhase(m.Kind, m.Light)
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, light, phase, workflow_run_id, workflow_step, promote_kb_collection_id, permission_timeout_seconds)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NULLIF($18, '')::uuid, $19, $20, $21, $22, $23, $24, $25, $26, NULLIF($27, '')::uuid, $28, $29, $30, $31, $32, $33, NULLIF($34, '')::uuid, $35, NULLIF($36, '')::uuid, $37) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, m.ReferencedContext, attachmentsJSON, destinationIDs, m.Light, phase, m.WorkflowRunID, m.WorkflowStep, m.PromoteKBCollectionID, m.PermissionTimeoutSeconds,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, auto_approve_plan, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, light, phase, workflow_run_id, workflow_step, promote_kb_collection_id, permission_timeout_seconds)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NULLIF($18, '')::uuid, $19, $20, $21, $22, $23, $24, $25, $26, $27, NULLIF($28, '')::uuid, $29, $30, $31, $32, $33, $34, NULLIF($35, '')::uuid, $36, NULLIF($37, '')::uuid, $38) RETURNING id`,
+		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.AutoApprovePlan, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, m.ReferencedContext, attachmentsJSON, destinationIDs, m.Light, phase, m.WorkflowRunID, m.WorkflowStep, m.PromoteKBCollectionID, m.PermissionTimeoutSeconds,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -812,6 +812,59 @@ func TestApplyTransitionAndEvents(t *testing.T) {
 	}
 }
 
+// TestPlanApprovalParkRoundTrip confirms D-087 (issue #456) is real DB
+// state, not in-memory only: a mission created with auto_approve_plan
+// false, parked on PauseApproval via ApplyTransition, survives a fresh
+// Get exactly as parked (same as a process restart would see), then
+// the approve verb's own transition unparks it to generate.
+func TestPlanApprovalParkRoundTrip(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{Goal: marker + "plan approval park", Kind: "general", AutoApprovePlan: false})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	created, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get after create: %v", err)
+	}
+	if created.AutoApprovePlan {
+		t.Fatal("AutoApprovePlan = true after create, want false (explicit request honored)")
+	}
+
+	if err := s.ApplyTransition(ctx, id, Transition{
+		Next:   StepState{Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval, MaxIterations: 8},
+		Events: []EventDraft{{Kind: "mission.plan_awaiting_approval", Payload: map[string]any{}}},
+	}); err != nil {
+		t.Fatalf("ApplyTransition (park): %v", err)
+	}
+
+	// A fresh Get is exactly what a restarted process sees: the park
+	// is real DB state, not driver-in-memory.
+	parked, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get after park: %v", err)
+	}
+	if parked.Phase != PhasePlan || parked.Status != StatusPaused || parked.PauseReason != PauseApproval {
+		t.Fatalf("mission after park = %s/%s/%s, want plan/paused/approval", parked.Phase, parked.Status, parked.PauseReason)
+	}
+
+	if err := s.ApplyTransition(ctx, id, Transition{
+		Next:   StepState{Phase: PhaseGenerate, Status: StatusIdle, MaxIterations: 8},
+		Events: []EventDraft{{Kind: "mission.plan_approved", Payload: map[string]any{}}},
+	}); err != nil {
+		t.Fatalf("ApplyTransition (approve): %v", err)
+	}
+	approved, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get after approve: %v", err)
+	}
+	if approved.Phase != PhaseGenerate || approved.Status != StatusIdle || approved.PauseReason != "" {
+		t.Fatalf("mission after approve = %s/%s/%s, want generate/idle/<none>", approved.Phase, approved.Status, approved.PauseReason)
+	}
+}
+
 // TestApplyTransitionClearsPendingPermissionOnTerminal reproduces a
 // real bug: cancelling (or otherwise terminating) a mission parked on
 // a permission left the pending_permission_* columns populated:

--- a/internal/brain/workflows/engine.go
+++ b/internal/brain/workflows/engine.go
@@ -212,6 +212,9 @@ func (e *Engine) spawnStep(ctx context.Context, runID, stepName string, step Ste
 		OnComplete: step.OnComplete, DestinationIDs: step.DestinationIDs,
 		ParentMissionID: parentMissionID, ParentContext: outcome,
 		WorkflowRunID: runID, WorkflowStep: stepName,
+		// Forced true (D-087, issue #456): a workflow-spawned mission
+		// runs unattended, so nobody is watching to approve its plan.
+		AutoApprovePlan: true,
 	})
 }
 

--- a/internal/brain/workflows/engine_test.go
+++ b/internal/brain/workflows/engine_test.go
@@ -193,6 +193,25 @@ func TestStartRunSpawnsEntryStep(t *testing.T) {
 	}
 }
 
+// TestStartRunForcesAutoApprovePlanTrue confirms D-087 (issue #456): a
+// workflow-spawned mission always gets AutoApprovePlan=true. Step has
+// no field for it at all, so this really confirms spawnStep's own
+// missions.Mission{} literal sets it explicitly rather than leaving it
+// at the Go zero-value false.
+func TestStartRunForcesAutoApprovePlanTrue(t *testing.T) {
+	store := newFakeEngineStore()
+	store.putWorkflow("wf1", coderQADefinition(), true)
+	spawner := &fakeSpawner{}
+	e := testEngine(store, spawner)
+
+	if _, err := e.StartRun(context.Background(), "wf1", map[string]string{"K": "v"}); err != nil {
+		t.Fatalf("StartRun() = %v", err)
+	}
+	if m := spawner.last(); !m.AutoApprovePlan {
+		t.Fatalf("spawned mission AutoApprovePlan = false, want true (unattended missions have nobody to approve a plan)")
+	}
+}
+
 func TestStartRunRefusesDisabledWorkflow(t *testing.T) {
 	store := newFakeEngineStore()
 	store.putWorkflow("wf1", coderQADefinition(), false)

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -672,6 +672,14 @@ CREATE TABLE IF NOT EXISTS missions (
     -- classified commands still always ask, unaffected by this column
     -- or any grant.
     auto_approve_safe     boolean NOT NULL DEFAULT true,
+    -- D-087 (issue #456): true (default) advances plan -> generate the
+    -- moment a plan lands, byte-identical to every mission before this
+    -- column existed. false parks the mission on pause_reason='approval'
+    -- instead, waiting for an operator approve/replan/rediscover verb --
+    -- never auto-resumed by any sweep, an approval decision has no safe
+    -- default. Forced true at creation for scheduler-fired and
+    -- workflow-spawned missions regardless of template/step input.
+    auto_approve_plan     boolean NOT NULL DEFAULT true,
     -- The reviewer judges the baseline git diff, but a general
     -- mission never touches tracked files -- its diff is
     -- always empty, so the reviewer previously had zero evidence to

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -50,3 +50,12 @@ UPDATE missions SET phase = CASE phase
 END
 WHERE phase IN ('explore', 'execute', 'review');
 ```
+
+## Plan approval gate (issue #456, slice 2 of the phase redesign)
+
+Required on live DBs before/with the next deploy. Additive, safe to
+run before deploy.
+
+```sql
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS auto_approve_plan boolean NOT NULL DEFAULT true;
+```

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1244,6 +1244,10 @@ export interface CreateMissionInput {
   budget_amount?: number
   budget_currency?: string
   auto_approve_safe?: boolean
+  // auto_approve_plan: omit (or true) advances straight from plan to
+  // generate; false parks the mission awaiting operator approval once
+  // the plan phase produces a plan.
+  auto_approve_plan?: boolean
   // harness names the delegated coding-CLI executor a coding mission
   // runs under: omit (or "") to apply the settings default,
   // "native" to force the built-in agent loop. Only valid when
@@ -1438,6 +1442,28 @@ export async function answerMissionPermission(
     method: 'POST',
     body: JSON.stringify({ decision }),
   })
+}
+
+// approveMissionPlan approves a mission parked on plan approval
+// (pause_reason: "approval"): the mission moves to phase=generate.
+export async function approveMissionPlan(id: string): Promise<void> {
+  await request<void>(`/v1/missions/${id}/approve-plan`, { method: 'POST' })
+}
+
+// replanMission re-runs the plan phase, folding feedback into the next
+// planning prompt: the mission re-parks on plan approval once the new
+// plan lands.
+export async function replanMission(id: string, feedback?: string): Promise<void> {
+  await request<void>(`/v1/missions/${id}/replan`, {
+    method: 'POST',
+    body: JSON.stringify(feedback ? { feedback } : {}),
+  })
+}
+
+// rediscoverMission sends a mission parked on plan approval back to
+// the discover phase.
+export async function rediscoverMission(id: string): Promise<void> {
+  await request<void>(`/v1/missions/${id}/rediscover`, { method: 'POST' })
 }
 
 // pushMission pushes the mission's branch to its worktree's origin

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -705,7 +705,7 @@ export interface Mission {
   // mission's latest mission.failed event's payload.reason:
   // "cancelled" or "max_iterations": set only when phase is 'failed'.
   failure_reason?: string
-  pause_reason?: 'backoff' | 'no_progress' | 'infra' | 'budget' | 'mixed_currency' | ''
+  pause_reason?: 'backoff' | 'no_progress' | 'infra' | 'budget' | 'mixed_currency' | 'approval' | ''
   pause_message?: string
   workspace?: string
   worktree?: string
@@ -764,6 +764,11 @@ export interface Mission {
   permission_timeout_seconds?: number
   last_evidence?: string
   auto_approve_safe: boolean
+  // auto_approve_plan: true (default) advances straight from plan to
+  // generate; false parks the mission (status: "paused", pause_reason:
+  // "approval") once the plan phase produces a plan, until an operator
+  // approves, replans, or sends it back to discover.
+  auto_approve_plan: boolean
   // environment is the sandbox image key (D-05x) this coding mission's
   // container runs: "" means base, resolved server-side at create
   // time (explicit request > repo markers > goal keyword > base).

--- a/web/src/components/missions/MissionCard.test.tsx
+++ b/web/src/components/missions/MissionCard.test.tsx
@@ -21,6 +21,7 @@ const baseMission: Mission = {
   route: 'default',
   review_route: 'default',
   auto_approve_safe: true,
+  auto_approve_plan: true,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 }
@@ -113,6 +114,18 @@ describe('MissionCard created timestamp', () => {
     renderCard({ ...baseMission, created_at: '2026-01-01T00:00:00Z' })
     const el = screen.getByText('3h ago')
     expect(el).toHaveAttribute('title', new Date('2026-01-01T00:00:00Z').toLocaleString())
+  })
+})
+
+describe('MissionCard needs-approval badge', () => {
+  it('shows the badge when parked on plan approval', () => {
+    renderCard({ ...baseMission, phase: 'plan', pause_reason: 'approval' })
+    expect(screen.getByText('needs approval')).toBeInTheDocument()
+  })
+
+  it('omits the badge for a mission not parked on plan approval', () => {
+    renderCard({ ...baseMission, phase: 'plan' })
+    expect(screen.queryByText('needs approval')).not.toBeInTheDocument()
   })
 })
 

--- a/web/src/components/missions/MissionCard.tsx
+++ b/web/src/components/missions/MissionCard.tsx
@@ -81,6 +81,11 @@ export function MissionCard({ mission }: { mission: Mission }) {
             recurring
           </span>
         )}
+        {mission.phase === 'plan' && mission.pause_reason === 'approval' && (
+          <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-semibold text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+            needs approval
+          </span>
+        )}
         <span className="inline-flex items-center gap-1">
           <HarnessIcon harness={mission.harness} />
           {harnessLabel(mission.harness)}

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -195,6 +195,31 @@ describe('MissionForm: create mode, one-off mission', () => {
     )
   })
 
+  it('sends auto_approve_plan: true by default', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm2' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Research something new' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ auto_approve_plan: true })),
+    )
+  })
+
+  it('sends auto_approve_plan: false when the toggle is unchecked', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm2' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Research something new' } })
+    fireEvent.click(screen.getByLabelText(/Auto-approve the plan/))
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ auto_approve_plan: false })),
+    )
+  })
+
   it('disables submit until a goal is entered', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -378,6 +378,7 @@ export function MissionForm({
   const [budget, setBudget] = useState('')
   const [budgetCurrency, setBudgetCurrency] = useState('USD')
   const [autoApproveSafe, setAutoApproveSafe] = useState(true)
+  const [autoApprovePlan, setAutoApprovePlan] = useState(true)
   const [harness, setHarness] = useState(initial?.harness ?? '')
   const [environment, setEnvironment] = useState(initial?.environment ?? '')
   const [branchPattern, setBranchPattern] = useState(initial?.branch_pattern ?? '')
@@ -733,6 +734,7 @@ export function MissionForm({
       budget_amount: budget ? Number(budget) : undefined,
       budget_currency: budget ? budgetCurrency : undefined,
       auto_approve_safe: autoApproveSafe,
+      auto_approve_plan: autoApprovePlan,
       harness: kind === 'coding' ? harness || undefined : undefined,
       environment: kind === 'coding' ? environment || undefined : undefined,
       branch_pattern: kind === 'coding' ? branchPattern.trim() || undefined : undefined,
@@ -1361,6 +1363,25 @@ export function MissionForm({
             </span>
           </span>
         </label>
+
+        {mode === 'create' && !repeat && (
+          <label htmlFor="mission-auto-approve-plan" className="flex items-start gap-2 text-sm">
+            <input
+              id="mission-auto-approve-plan"
+              type="checkbox"
+              checked={autoApprovePlan}
+              onChange={(e) => setAutoApprovePlan(e.target.checked)}
+              className="mt-0.5"
+            />
+            <span>
+              Auto-approve the plan
+              <span className="block text-xs text-muted-foreground">
+                Advances straight from plan to work. Turn off to review and approve the plan
+                yourself before work starts.
+              </span>
+            </span>
+          </label>
+        )}
 
         {destinations && destinations.length > 0 && (
           <div className="space-y-1.5">

--- a/web/src/components/missions/PlanApprovalBanner.test.tsx
+++ b/web/src/components/missions/PlanApprovalBanner.test.tsx
@@ -1,0 +1,81 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PlanUnit } from '../../api/types'
+import { PlanApprovalBanner } from './PlanApprovalBanner'
+
+afterEach(cleanup)
+
+const units: PlanUnit[] = [{ title: 'Add validation', verify_cmd: 'go test ./...', passes: false }]
+
+describe('PlanApprovalBanner', () => {
+  it('renders the plan units and assumptions', () => {
+    render(
+      <PlanApprovalBanner
+        units={units}
+        assumptions={[{ assumption: 'no language version was specified', default: 'Python 3.12' }]}
+        onApprove={vi.fn()}
+        onReplan={vi.fn()}
+        onRediscover={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('Add validation')).toBeInTheDocument()
+    expect(screen.getByText(/no language version was specified/)).toBeInTheDocument()
+  })
+
+  it('calls onApprove when Approve is clicked', () => {
+    const onApprove = vi.fn()
+    render(
+      <PlanApprovalBanner units={units} onApprove={onApprove} onReplan={vi.fn()} onRediscover={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }))
+    expect(onApprove).toHaveBeenCalled()
+  })
+
+  it('calls onRediscover when Rediscover is clicked', () => {
+    const onRediscover = vi.fn()
+    render(
+      <PlanApprovalBanner units={units} onApprove={vi.fn()} onReplan={vi.fn()} onRediscover={onRediscover} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Rediscover' }))
+    expect(onRediscover).toHaveBeenCalled()
+  })
+
+  it('reveals a textarea when Request replan is clicked, and submits its text', () => {
+    const onReplan = vi.fn()
+    render(
+      <PlanApprovalBanner units={units} onApprove={vi.fn()} onReplan={onReplan} onRediscover={vi.fn()} />,
+    )
+    expect(screen.queryByPlaceholderText(/Optional feedback/)).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Request replan' }))
+    const textarea = screen.getByPlaceholderText(/Optional feedback/)
+    fireEvent.change(textarea, { target: { value: 'try a different approach' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    expect(onReplan).toHaveBeenCalledWith('try a different approach')
+  })
+
+  it('submits empty feedback when Send is clicked with no text typed', () => {
+    const onReplan = vi.fn()
+    render(
+      <PlanApprovalBanner units={units} onApprove={vi.fn()} onReplan={onReplan} onRediscover={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Request replan' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(onReplan).toHaveBeenCalledWith('')
+  })
+
+  it('shows a status line and hides the buttons once answered', () => {
+    render(
+      <PlanApprovalBanner
+        units={units}
+        answeredDecision="approve"
+        onApprove={vi.fn()}
+        onReplan={vi.fn()}
+        onRediscover={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/Approved/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/missions/PlanApprovalBanner.tsx
+++ b/web/src/components/missions/PlanApprovalBanner.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+import type { PlanAssumption, PlanUnit } from '../../api/types'
+import { Button } from '../ui/button'
+import { Textarea } from '../ui/textarea'
+import { PlanSection } from './PlanSection'
+
+// answeredCopy mirrors PermissionBanner's own status-line pattern: the
+// mission row's phase/pause_reason only clears once the harness has
+// actually acted on the decision, so the card must not look
+// unanswered for that span.
+const answeredCopy: Record<'approve' | 'replan' | 'rediscover', string> = {
+  approve: 'Approved, moving to generate…',
+  replan: 'Replan requested…',
+  rediscover: 'Sending back to discover…',
+}
+
+// PlanApprovalBanner renders only when a mission is parked on
+// phase=plan with pause_reason=approval (auto_approve_plan: false).
+// Same architecture as PermissionBanner: callbacks as props for
+// isolated testing, and once answered the buttons are replaced by a
+// status line so a second click can't fire before the mission row's
+// own refetch catches up.
+export function PlanApprovalBanner({
+  units,
+  assumptions,
+  answeredDecision,
+  onApprove,
+  onReplan,
+  onRediscover,
+}: {
+  units: PlanUnit[]
+  assumptions?: PlanAssumption[]
+  answeredDecision?: 'approve' | 'replan' | 'rediscover'
+  onApprove: () => void
+  onReplan: (feedback: string) => void
+  onRediscover: () => void
+}) {
+  const [showFeedback, setShowFeedback] = useState(false)
+  const [feedback, setFeedback] = useState('')
+
+  const submitReplan = () => {
+    onReplan(feedback.trim())
+  }
+
+  return (
+    <div className="space-y-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900 dark:bg-amber-950">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-sm font-medium text-amber-900 dark:text-amber-200">
+          Plan ready for review
+        </p>
+        {answeredDecision !== undefined ? (
+          <p className="shrink-0 text-sm text-amber-800 dark:text-amber-300">
+            {answeredCopy[answeredDecision]}
+          </p>
+        ) : (
+          <div className="flex shrink-0 gap-2">
+            <Button variant="ghost" size="sm" onClick={onRediscover}>
+              Rediscover
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowFeedback((v) => !v)}
+            >
+              Request replan
+            </Button>
+            <Button size="sm" onClick={onApprove}>
+              Approve
+            </Button>
+          </div>
+        )}
+      </div>
+      <PlanSection units={units} assumptions={assumptions} />
+      {answeredDecision === undefined && showFeedback && (
+        <div className="space-y-2">
+          <Textarea
+            placeholder="Optional feedback for the replan…"
+            value={feedback}
+            onChange={(e) => setFeedback(e.target.value)}
+          />
+          <Button size="sm" onClick={submitReplan}>
+            Send
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/AutomationDetail.test.tsx
+++ b/web/src/pages/AutomationDetail.test.tsx
@@ -53,6 +53,7 @@ const firedMission: Mission = {
   route: 'default',
   review_route: 'default',
   auto_approve_safe: true,
+  auto_approve_plan: true,
   schedule_id: 's1',
   created_at: '2026-07-27T08:00:00Z',
   updated_at: '2026-07-27T08:01:00Z',

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -78,6 +78,7 @@ const baseMission: Mission = {
   route: 'default',
   review_route: 'default',
   auto_approve_safe: true,
+  auto_approve_plan: true,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 }

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -12,6 +12,7 @@ import { Link, useNavigate, useParams } from 'react-router'
 import { toast } from 'sonner'
 import {
   answerMissionPermission,
+  approveMissionPlan,
   cancelMission,
   deleteMission,
   getMission,
@@ -20,12 +21,15 @@ import {
   missionUsage,
   openMissionPR,
   pushMission,
+  rediscoverMission,
+  replanMission,
   resumeMission,
   sendMissionNote,
 } from '../api/client'
 import type { Mission, MissionEvent, MissionPROpenedPayload, MissionUsage, Schedule } from '../api/types'
 import { ArtifactsSection } from '../components/missions/ArtifactsSection'
 import { PermissionBanner } from '../components/missions/PermissionBanner'
+import { PlanApprovalBanner } from '../components/missions/PlanApprovalBanner'
 import { PlanSection } from '../components/missions/PlanSection'
 import { ExploreSection } from '../components/missions/ExploreSection'
 import { GoalSection } from '../components/missions/GoalSection'
@@ -245,6 +249,15 @@ export function MissionDetail() {
     id: string
     decision: 'once' | 'session' | 'deny'
   } | null>(null)
+  // answeredPlanDecision mirrors answeredPermission's own pattern: the
+  // decision POST resolves right away, but the mission's phase/
+  // pause_reason only clear once the harness has acted on it, so the
+  // card must stop being actionable before that refetch lands. Reset
+  // to null whenever the mission leaves the parked-on-approval state
+  // (a fresh park re-renders actionable).
+  const [answeredPlanDecision, setAnsweredPlanDecision] = useState<'approve' | 'replan' | 'rediscover' | null>(
+    null,
+  )
 
   const refreshSeq = useRef(0)
 
@@ -264,6 +277,8 @@ export function MissionDetail() {
 
   const pendingPermission = mission?.pending_permission
   const wasPendingRef = useRef(false)
+  const pendingPlanApproval = mission?.phase === 'plan' && mission?.pause_reason === 'approval'
+  const wasPlanParkedRef = useRef(false)
 
   useEffect(() => {
     refresh()
@@ -300,6 +315,15 @@ export function MissionDetail() {
     if (pendingPermission && !wasPendingRef.current) playAlertSound()
     wasPendingRef.current = !!pendingPermission
   }, [pendingPermission])
+
+  // Same chime-once-on-transition treatment for entering the
+  // parked-on-plan-approval state, tracked with its own ref so it
+  // doesn't conflate with the permission chime above.
+  useEffect(() => {
+    if (pendingPlanApproval && !wasPlanParkedRef.current) playAlertSound()
+    wasPlanParkedRef.current = pendingPlanApproval
+    if (!pendingPlanApproval) setAnsweredPlanDecision(null)
+  }, [pendingPlanApproval])
 
   if (!id) return null
   if (!mission) {
@@ -444,6 +468,39 @@ export function MissionDetail() {
     }
   }
 
+  const approvePlan = async () => {
+    try {
+      await approveMissionPlan(id)
+      setAnsweredPlanDecision('approve')
+    } catch (err) {
+      toast.error('Could not approve plan', { description: errText(err) })
+    } finally {
+      refresh()
+    }
+  }
+
+  const requestReplan = async (feedback: string) => {
+    try {
+      await replanMission(id, feedback || undefined)
+      setAnsweredPlanDecision('replan')
+    } catch (err) {
+      toast.error('Could not request a replan', { description: errText(err) })
+    } finally {
+      refresh()
+    }
+  }
+
+  const rediscover = async () => {
+    try {
+      await rediscoverMission(id)
+      setAnsweredPlanDecision('rediscover')
+    } catch (err) {
+      toast.error('Could not send mission back to discover', { description: errText(err) })
+    } finally {
+      refresh()
+    }
+  }
+
   // Cross-tab/refresh fallback: this tab may not have the optimistic
   // answeredPermission state (a fresh load, or the decision happened
   // in another tab) but the events list already fetched can still show
@@ -487,6 +544,17 @@ export function MissionDetail() {
           answeredDecision={answeredDecision}
           onDecide={(d) => void decidePermission(d)}
           timeoutSeconds={mission.permission_timeout_seconds}
+        />
+      )}
+
+      {pendingPlanApproval && (
+        <PlanApprovalBanner
+          units={mission.spec?.units ?? []}
+          assumptions={mission.spec?.assumptions}
+          answeredDecision={answeredPlanDecision ?? undefined}
+          onApprove={() => void approvePlan()}
+          onReplan={(feedback) => void requestReplan(feedback)}
+          onRediscover={() => void rediscover()}
         />
       )}
 

--- a/web/src/pages/Missions.test.tsx
+++ b/web/src/pages/Missions.test.tsx
@@ -44,6 +44,7 @@ const mission: Mission = {
   route: 'default',
   review_route: 'default',
   auto_approve_safe: true,
+  auto_approve_plan: true,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 }


### PR DESCRIPTION
Closes #456. Slice 2 of the phase redesign.

## What

- `auto_approve_plan` (default true, today's behavior byte-identical) snapshotted at create. false parks the mission after submit_plan on a new `PauseApproval` pause reason.
- Three operator-only HTTP verbs: approve (-> generate), replan (optional feedback folded into the next plan prompt via the existing replanNotes channel), rediscover (-> discover). 409 outside the parked state; never tool-callable.
- Operator iterations are free: replan/rediscover never spend `replan_used` (reserved for the automatic stall-replan valve).
- Scheduler-fired and workflow-spawned missions force auto-approve in Go at their create sites; follow-ups inherit the parent's flag.
- Web: awaiting-approval card (plan units + #446 assumptions + Approve / Request replan with feedback / Rediscover), mission-list badge, create-form toggle.

## Why the park mechanism

PauseApproval rides StatusPaused like PauseInfra/PauseBudget: crash-durable, notification-on-park, and structurally excluded from every auto-resume sweep (each sweep filters by its own reason string). No timeout: an approval has no safe default.

## Verified

Unit gates + lint clean, web 1007/1007. Full solo integration suite green after one fixture fix (the e2e coding fixture predates the flag; zero-value parked it on the gate). Canaries run post-merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790774430&installation_model_id=431401&pr_number=461&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F461&signature=89c7b5c22222f117979cf0c98bfd0d20433d1a448321bb2627f93506c3b7e58c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->