### PR TITLE
feat(missions): ask_user tool with waiting-input park (D-088)

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -294,7 +294,7 @@ func main() {
 	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub, missionScheduler := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, fxStore, gwc, secrets, conns, mc, packs, app.Log)
 	if missionDriver != nil {
 		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, missionNotifier,
-			flags.PermissionTimeoutSeconds, broker.Resolve, app.Log)
+			flags.PermissionTimeoutSeconds, flags.AskTimeoutSeconds, broker.Resolve, app.Log)
 	}
 	destinationStore, destinationDeliverer := buildDestinations(app.DB, conns, goog, secrets, flags, missionStore, app.Log)
 	if missionDriver != nil && destinationDeliverer != nil {
@@ -1045,6 +1045,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	}
 	nativeRunner.SetProgressReader(store)
 	nativeRunner.SetLocation(flags.Location)
+	nativeRunner.SetAskParker(store)
 	// The delegated runner wraps native with D-051/D-052's CLI-executor
 	// dispatch: resolve a worker route's chain via the gateway, spawn a
 	// harness entry's CLI detached in the mission's own sandbox container,

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -119,6 +119,7 @@ func (a *API) registerMissions(handle func(pattern string, h http.Handler), stor
 	handle("POST /v1/missions/{id}/approve-plan", a.auth(http.HandlerFunc(h.approvePlan)))
 	handle("POST /v1/missions/{id}/replan", a.auth(http.HandlerFunc(h.replan)))
 	handle("POST /v1/missions/{id}/rediscover", a.auth(http.HandlerFunc(h.rediscover)))
+	handle("POST /v1/missions/{id}/answer", a.auth(http.HandlerFunc(h.answer)))
 	handle("GET /v1/missions/{id}/files", a.auth(http.HandlerFunc(h.files)))
 	handle("GET /v1/missions/{id}/files/{path...}", a.auth(http.HandlerFunc(h.download)))
 	handle("GET /v1/missions/{id}/archive", a.auth(http.HandlerFunc(h.archive)))
@@ -1489,6 +1490,57 @@ func (h *missionAPI) replan(w http.ResponseWriter, r *http.Request) {
 // feedback text taken (unlike replan).
 func (h *missionAPI) rediscover(w http.ResponseWriter, r *http.Request) {
 	if err := h.driver.DecidePlan(r.Context(), r.PathValue("id"), missions.InputPlanRediscover, ""); err != nil {
+		failMission(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// answer handles POST /v1/missions/{id}/answer: the operator's reply to
+// a mission's parked ask_user question (D-088, issue #457). Valid only
+// while the mission is actually parked on one, 409 otherwise, same
+// convention as approve-plan's DecidePlan error mapping. mcq answers
+// must be one of the question's own options; yes_no answers must be
+// "yes" or "no"; open accepts any non-empty text.
+func (h *missionAPI) answer(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Answer string `json:"answer"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Answer == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "body must be JSON with a non-empty answer field")
+		return
+	}
+	id := r.PathValue("id")
+	m, err := h.store.Get(r.Context(), id)
+	if err != nil {
+		failMission(w, err)
+		return
+	}
+	if m.PendingInput == nil {
+		jsonError(w, http.StatusConflict, "not_awaiting_answer", "this mission is not awaiting an answer")
+		return
+	}
+	switch m.PendingInput.Kind {
+	case "mcq":
+		valid := false
+		for _, opt := range m.PendingInput.Options {
+			if opt == body.Answer {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			jsonError(w, http.StatusBadRequest, "bad_request", "answer must be one of the question's options")
+			return
+		}
+	case "yes_no":
+		if body.Answer != "yes" && body.Answer != "no" {
+			jsonError(w, http.StatusBadRequest, "bad_request", `answer must be "yes" or "no"`)
+			return
+		}
+	}
+	answer := truncateAnswer(body.Answer, resumeAnswerCap)
+	if err := h.driver.AnswerAskUser(r.Context(), id, answer); err != nil {
 		failMission(w, err)
 		return
 	}

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -503,6 +503,106 @@ func TestMissionsApprovePlanAdvancesToGenerate(t *testing.T) {
 	}
 }
 
+// TestMissionsAnswerRejectedWhenNotParked confirms POST .../answer 409s
+// on a mission with no pending_input (D-088, issue #457), same 409
+// convention as approve-plan/replan/rediscover on a non-parked mission.
+func TestMissionsAnswerRejectedWhenNotParked(t *testing.T) {
+	store := testMissionStore(t)
+	ctx := context.Background()
+	id, err := store.Create(ctx, missions.Mission{Goal: "itest-api-mission answer not parked", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/answer", strings.NewReader(`{"answer":"yes"}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("answer on a non-parked mission = %d, want 409: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestMissionsAnswerValidatesMCQOption confirms an mcq answer outside
+// the question's own options 400s before ever reaching the driver.
+func TestMissionsAnswerValidatesMCQOption(t *testing.T) {
+	store := testMissionStore(t)
+	ctx := context.Background()
+	id, err := store.Create(ctx, missions.Mission{Goal: "itest-api-mission answer mcq validation", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.SetPendingInput(ctx, id, missions.PendingInput{
+		Question: "which runtime?", Kind: "mcq", Options: []string{"node", "python"}, ProposedDefault: "node", Phase: missions.PhaseGenerate,
+	}); err != nil {
+		t.Fatalf("SetPendingInput: %v", err)
+	}
+
+	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/answer", strings.NewReader(`{"answer":"rust"}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("answer with an out-of-set mcq option = %d, want 400: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestMissionsAnswerResumesMission confirms the full round trip: a
+// mission parked on pending_input, a valid answer clears it and
+// resumes the mission back to idle/working.
+func TestMissionsAnswerResumesMission(t *testing.T) {
+	store := testMissionStore(t)
+	ctx := context.Background()
+	id, err := store.Create(ctx, missions.Mission{Goal: "itest-api-mission answer happy path", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.ApplyTransition(ctx, id, missions.Transition{
+		Next: missions.StepState{Phase: missions.PhaseGenerate, Status: missions.StatusWaitingForInput},
+	}); err != nil {
+		t.Fatalf("ApplyTransition: %v", err)
+	}
+	if err := store.SetPendingInput(ctx, id, missions.PendingInput{
+		Question: "continue?", Kind: "yes_no", ProposedDefault: "yes", Phase: missions.PhaseGenerate,
+	}); err != nil {
+		t.Fatalf("SetPendingInput: %v", err)
+	}
+
+	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
+
+	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/answer", strings.NewReader(`{"answer":"yes"}`))
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("answer = %d, want 204: %s", w.Code, w.Body.String())
+	}
+
+	got, err := store.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.PendingInput != nil {
+		t.Fatalf("mission after answer still has PendingInput = %+v", got.PendingInput)
+	}
+	if got.Status != missions.StatusIdle && got.Status != missions.StatusWorking {
+		t.Fatalf("mission after answer status = %s, want idle-or-working (Drive may have already claimed it)", got.Status)
+	}
+}
+
 // TestMissionsCreateResponseCarriesDetectedEnvironment confirms the
 // POST /v1/missions response reflects the row create() actually
 // persisted — the create() handler resolves an omitted coding

--- a/internal/brain/missions/asktool.go
+++ b/internal/brain/missions/asktool.go
@@ -1,0 +1,140 @@
+package missions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/SumonMSelim/timothy/internal/brain/tools"
+)
+
+// askUserToolName is the operator-question tool a phase turn may call
+// at most askBudget times per mission (D-088, issue #457).
+const askUserToolName = "ask_user"
+
+// askBudget caps how many ask_user calls one mission may spend,
+// enforced by the harness (Execute below), never the prompt: a
+// mission asking for every ambiguity would defeat #446's "assume and
+// declare" default. Scheduler/workflow missions get budget 0 instead
+// (see askBudgetFor): nobody is watching to answer.
+const askBudget = 2
+
+// askUserKinds enumerates ask_user's valid kind values.
+var askUserKinds = map[string]bool{"mcq": true, "yes_no": true, "open": true}
+
+// askUserArgs is ask_user's tool-call payload.
+type askUserArgs struct {
+	Question        string   `json:"question"`
+	Kind            string   `json:"kind"`
+	Options         []string `json:"options,omitempty"`
+	ProposedDefault string   `json:"proposed_default"`
+}
+
+// askBudgetFor is the ask_user budget for one mission: 0 for a
+// scheduler-fired or workflow-spawned mission (same signal
+// nativeRunner already uses for Unattended: nobody is watching to
+// answer a parked question), askBudget otherwise.
+func askBudgetFor(m Mission) int {
+	if m.ScheduleID != "" || m.WorkflowRunID != "" {
+		return 0
+	}
+	return askBudget
+}
+
+// validateAskUser checks args against kind-specific rules, returning a
+// message suitable for a plain tool-call error (never a park) when
+// invalid.
+func validateAskUser(a askUserArgs) error {
+	if a.Question == "" {
+		return fmt.Errorf("question is required")
+	}
+	if !askUserKinds[a.Kind] {
+		return fmt.Errorf(`kind must be "mcq", "yes_no", or "open"`)
+	}
+	if a.ProposedDefault == "" {
+		return fmt.Errorf("proposed_default is required")
+	}
+	switch a.Kind {
+	case "mcq":
+		if len(a.Options) < 2 || len(a.Options) > 6 {
+			return fmt.Errorf("mcq requires 2-6 options")
+		}
+		found := false
+		for _, opt := range a.Options {
+			if opt == a.ProposedDefault {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("proposed_default must be one of options")
+		}
+	case "yes_no":
+		if a.ProposedDefault != "yes" && a.ProposedDefault != "no" {
+			return fmt.Errorf(`proposed_default must be "yes" or "no" for yes_no`)
+		}
+		if len(a.Options) > 0 {
+			return fmt.Errorf("options must be empty for yes_no")
+		}
+	case "open":
+		if len(a.Options) > 0 {
+			return fmt.Errorf("options must be empty for open")
+		}
+	}
+	return nil
+}
+
+// askUserPark records a park, notifies the inbox, and reports whether
+// the park was recorded: the caller (Execute) ends the turn only when
+// it was. Backed by *Store in production (parkAskUser below), faked in
+// tests: kept separate from parkNotifier (runner.go) since ask_user's
+// park is a different jsonb column with its own budget check, not the
+// permission broker's.
+type askUserParker interface {
+	ParkAskUser(ctx context.Context, missionID string, input PendingInput) error
+}
+
+// AskUserTool defines the operator-question sentinel a phase turn may
+// call: registered per-turn via loop.Request.ExtraTools AND
+// loop.Request.EndTurnTools (D-075's end-turn pattern): successful
+// execution parks the mission and ends the turn immediately, the same
+// mechanism mission_status/review_verdict/submit_plan/explore_notes
+// already use. missionID/phase/asksUsed are the turn's own values,
+// closed over at construction (one tool built per turn, same as
+// kbSearchTool); parker records the durable park.
+func AskUserTool(missionID string, phase Phase, asksUsed int, budget int, parker askUserParker) *tools.Tool {
+	return &tools.Tool{
+		Name: askUserToolName,
+		Description: fmt.Sprintf("Ask the operator one structured question when a genuinely blocking ambiguity needs a human decision, not for anything you can reasonably assume and declare instead. Ends your turn; the mission parks until answered or the timeout applies your proposed_default. Budget: %d per mission (%d used so far).", budget, asksUsed),
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"question": {"type": "string", "description": "The exact question to ask."},
+				"kind": {"type": "string", "enum": ["mcq", "yes_no", "open"], "description": "mcq: pick one of options. yes_no: yes or no. open: free text."},
+				"options": {"type": "array", "items": {"type": "string"}, "description": "Required for mcq: 2-6 choices."},
+				"proposed_default": {"type": "string", "description": "Required: what you'd choose if nobody answers in time. For mcq, must be one of options. For yes_no, \"yes\" or \"no\"."}
+			},
+			"required": ["question", "kind", "proposed_default"]
+		}`),
+		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
+			if asksUsed >= budget {
+				return "", fmt.Errorf("ask_user budget exhausted (%d/%d used): proceed on your own best judgment instead", asksUsed, budget)
+			}
+			var a askUserArgs
+			if err := json.Unmarshal(args, &a); err != nil {
+				return "", fmt.Errorf("invalid ask_user arguments: %w", err)
+			}
+			if err := validateAskUser(a); err != nil {
+				return "", err
+			}
+			input := PendingInput{
+				Question: a.Question, Kind: a.Kind, Options: a.Options,
+				ProposedDefault: a.ProposedDefault, Phase: phase,
+			}
+			if err := parker.ParkAskUser(ctx, missionID, input); err != nil {
+				return "", fmt.Errorf("recording the question failed: %w", err)
+			}
+			return "question recorded, mission parked awaiting the operator's answer", nil
+		},
+	}
+}

--- a/internal/brain/missions/asktool_test.go
+++ b/internal/brain/missions/asktool_test.go
@@ -1,0 +1,141 @@
+package missions
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// fakeAskUserParker scripts ParkAskUser for asktool tests, capturing
+// every recorded park without a real Postgres pool.
+type fakeAskUserParker struct {
+	err    error
+	parked []PendingInput
+}
+
+func (f *fakeAskUserParker) ParkAskUser(ctx context.Context, missionID string, input PendingInput) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.parked = append(f.parked, input)
+	return nil
+}
+
+// TestAskUserToolExecute table-tests every kind's valid path (parks and
+// records) plus the invalid-argument and over-budget paths (plain tool
+// error, never a park) for D-088, issue #457.
+func TestAskUserToolExecute(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		asksUsed    int
+		budget      int
+		args        string
+		wantErr     bool
+		wantParked  bool
+		wantDefault string
+	}{
+		{
+			name: "mcq valid parks", asksUsed: 0, budget: 2,
+			args:       `{"question":"which runtime?","kind":"mcq","options":["node","python"],"proposed_default":"node"}`,
+			wantParked: true, wantDefault: "node",
+		},
+		{
+			name: "yes_no valid parks", asksUsed: 0, budget: 2,
+			args:       `{"question":"continue?","kind":"yes_no","proposed_default":"yes"}`,
+			wantParked: true, wantDefault: "yes",
+		},
+		{
+			name: "open valid parks", asksUsed: 0, budget: 2,
+			args:       `{"question":"what should the title be?","kind":"open","proposed_default":"Untitled"}`,
+			wantParked: true, wantDefault: "Untitled",
+		},
+		{
+			name: "mcq default not in options errors without parking", asksUsed: 0, budget: 2,
+			args:    `{"question":"which runtime?","kind":"mcq","options":["node","python"],"proposed_default":"rust"}`,
+			wantErr: true,
+		},
+		{
+			name: "mcq too few options errors without parking", asksUsed: 0, budget: 2,
+			args:    `{"question":"which runtime?","kind":"mcq","options":["node"],"proposed_default":"node"}`,
+			wantErr: true,
+		},
+		{
+			name: "yes_no invalid default errors without parking", asksUsed: 0, budget: 2,
+			args:    `{"question":"continue?","kind":"yes_no","proposed_default":"maybe"}`,
+			wantErr: true,
+		},
+		{
+			name: "missing question errors without parking", asksUsed: 0, budget: 2,
+			args:    `{"kind":"open","proposed_default":"x"}`,
+			wantErr: true,
+		},
+		{
+			name: "unknown kind errors without parking", asksUsed: 0, budget: 2,
+			args:    `{"question":"x?","kind":"multi_select","proposed_default":"x"}`,
+			wantErr: true,
+		},
+		{
+			name: "missing proposed_default errors without parking", asksUsed: 0, budget: 2,
+			args:    `{"question":"x?","kind":"open"}`,
+			wantErr: true,
+		},
+		{
+			name: "over budget errors without parking", asksUsed: 2, budget: 2,
+			args:    `{"question":"one more?","kind":"open","proposed_default":"no"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			parker := &fakeAskUserParker{}
+			tool := AskUserTool("m1", PhaseGenerate, tc.asksUsed, tc.budget, parker)
+			_, err := tool.Execute(context.Background(), json.RawMessage(tc.args))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Execute() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			gotParked := len(parker.parked) == 1
+			if gotParked != tc.wantParked {
+				t.Fatalf("parked = %v, want %v", gotParked, tc.wantParked)
+			}
+			if tc.wantParked {
+				if parker.parked[0].ProposedDefault != tc.wantDefault {
+					t.Fatalf("ProposedDefault = %q, want %q", parker.parked[0].ProposedDefault, tc.wantDefault)
+				}
+				if parker.parked[0].Phase != PhaseGenerate {
+					t.Fatalf("Phase = %q, want generate", parker.parked[0].Phase)
+				}
+			}
+		})
+	}
+}
+
+// TestAskUserToolExecuteParkerErrorNoPanic confirms a park failure
+// (store write error) surfaces as a plain tool error, never a panic.
+func TestAskUserToolExecuteParkerErrorNoPanic(t *testing.T) {
+	t.Parallel()
+	parker := &fakeAskUserParker{err: context.DeadlineExceeded}
+	tool := AskUserTool("m1", PhasePlan, 0, 2, parker)
+	_, err := tool.Execute(context.Background(), json.RawMessage(`{"question":"x?","kind":"open","proposed_default":"y"}`))
+	if err == nil {
+		t.Fatal("Execute() error = nil, want an error when the parker fails")
+	}
+}
+
+// TestAskBudgetFor confirms scheduler/workflow missions get zero budget
+// (nobody is watching to answer), everyone else gets askBudget.
+func TestAskBudgetFor(t *testing.T) {
+	t.Parallel()
+	if got := askBudgetFor(Mission{}); got != askBudget {
+		t.Fatalf("askBudgetFor(plain mission) = %d, want %d", got, askBudget)
+	}
+	if got := askBudgetFor(Mission{ScheduleID: "sched1"}); got != 0 {
+		t.Fatalf("askBudgetFor(scheduled) = %d, want 0", got)
+	}
+	if got := askBudgetFor(Mission{WorkflowRunID: "wf1"}); got != 0 {
+		t.Fatalf("askBudgetFor(workflow) = %d, want 0", got)
+	}
+}

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -78,6 +78,7 @@ type driverStore interface {
 	SetArtifactRefs(ctx context.Context, id string, refs []ArtifactRef) error
 	AppendProgress(ctx context.Context, id, note string) error
 	Spend(ctx context.Context, missionID string) (MissionSpend, error)
+	AnswerPendingInput(ctx context.Context, id, eventKind string, payload map[string]any) error
 }
 
 // fxRateSource is the narrow slice of *fxrates.Store Driver needs for
@@ -825,6 +826,14 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 	turnStart := time.Now()
 	in, err := d.runPhase(ctx, m)
 	turnMs := time.Since(turnStart).Milliseconds()
+	if err != nil && errors.Is(err, ErrAskedUser) {
+		// The turn already parked (nativeRunner.askUserTool's Execute
+		// recorded pending_input and incremented asks_used before ending
+		// the turn): this is not a failure, just the phase's own runner
+		// method reporting "no verdict, ask_user handled it instead."
+		in = StepInput{Input: InputAskUser}
+		err = nil
+	}
 	if err != nil {
 		d.log.Error("driver: phase run failed", "mission_id", id, "phase", m.Phase, "error", err)
 		switch {
@@ -1044,6 +1053,40 @@ func (d *Driver) DecidePlan(ctx context.Context, id string, input Input, feedbac
 	return nil
 }
 
+// AnswerAskUser resolves a mission's parked ask_user question (D-088):
+// the API layer's answer endpoint calls this, never the model.
+// Records the Q+A as a progress note (the same durable channel a
+// worker/review/plan turn already reads back: WorkPacket.Progress,
+// ReviewPacket.Progress, replanNotes' recentProgressNotes), so the
+// NEXT turn of the SAME phase (Store.AnswerPendingInput resumes to
+// idle without touching Phase) carries the question and answer
+// verbatim. Returns ErrNotAwaitingApproval if the mission isn't
+// currently parked on a question, reused rather than a new sentinel
+// since both mean the same thing to a caller: "there's nothing here to
+// answer."
+func (d *Driver) AnswerAskUser(ctx context.Context, id, answer string) error {
+	m, err := d.store.Get(ctx, id)
+	if err != nil {
+		return fmt.Errorf("driver: answer ask user: %w", err)
+	}
+	if m.PendingInput == nil {
+		return ErrNotAwaitingApproval
+	}
+	note := fmt.Sprintf("Operator answered your question %q: %s", m.PendingInput.Question, NeutralizeSlot(answer))
+	if err := d.store.AppendProgress(ctx, id, note); err != nil {
+		d.log.Warn("driver: record ask_user answer progress failed", "mission_id", id, "error", err)
+	}
+	if err := d.store.AnswerPendingInput(ctx, id, "mission.input_answered", map[string]any{"answer": answer}); err != nil {
+		return fmt.Errorf("driver: answer ask user: %w", err)
+	}
+	go func() { //nolint:gosec // G118: deliberate, the mission must outlive the HTTP request that answered it, driveTimeBound is Drive's own cap
+		if err := d.Drive(context.Background(), id); err != nil {
+			d.log.Error("driver: post-answer drive failed", "mission_id", id, "error", err)
+		}
+	}()
+	return nil
+}
+
 // toStepState projects a Mission onto the state machine's input shape,
 // pulling actual ledger spend for the budget brake via budgetProjector
 // (budget.go, D-074).
@@ -1174,7 +1217,16 @@ func (d *Driver) runPlan(ctx context.Context, m Mission) (StepInput, error) {
 // "a plan already exists" check instead.
 func replanNotes(m Mission) string {
 	if len(m.Spec.Units) == 0 {
-		return m.ExploreNotes
+		notes := m.ExploreNotes
+		// D-088: an ask_user answer during a first-time plan turn (no
+		// plan landed yet, so the "being replanned" branch below never
+		// runs) still needs to reach the very next plan turn's prompt,
+		// same recentProgressNotes channel, just not gated on a plan
+		// existing yet.
+		if progress := recentProgressNotes(m.Progress, 3); progress != "" {
+			notes += "\n\nRecent progress (includes any operator answers to prior questions):\n" + progress
+		}
+		return notes
 	}
 	var b strings.Builder
 	b.WriteString(m.ExploreNotes)

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -207,6 +207,20 @@ func (f *fakeStore) AppendProgress(ctx context.Context, id, note string) error {
 	return nil
 }
 
+// AnswerPendingInput mirrors the real Store.AnswerPendingInput: clears
+// PendingInput, resumes to idle, and appends eventKind.
+func (f *fakeStore) AnswerPendingInput(ctx context.Context, id, eventKind string, payload map[string]any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	m := f.missions[id]
+	m.PendingInput = nil
+	m.Status = StatusIdle
+	f.missions[id] = m
+	f.seq[id]++
+	f.events[id] = append(f.events[id], Event{MissionID: id, Seq: f.seq[id], Kind: eventKind})
+	return nil
+}
+
 // scriptedRunner replays fixed responses for RunWorker/RunReview/
 // PlanSession, one entry consumed per call — lets a test script an
 // exact sequence of outcomes across several Advance calls. workerErr,

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -162,6 +162,15 @@ type Mission struct {
 	// stored value <= 0 the same as "disabled," matching the global
 	// setting's own 0-means-off convention.
 	PermissionTimeoutSeconds *int `json:"permission_timeout_seconds,omitempty"`
+	// PendingInput is ask_user's park (D-088, issue #457): non-nil while
+	// a phase turn is waiting on the operator's answer, cleared once
+	// answered or timed out. A second park kind alongside
+	// PendingPermission, the two never overlap since a turn only ever
+	// parks on one or the other at a time.
+	PendingInput *PendingInput `json:"pending_input,omitempty"`
+	// AsksUsed counts ask_user calls this mission has spent (D-088);
+	// enforced against askBudget in asktool.go.
+	AsksUsed int `json:"asks_used"`
 	// AutoApproveSafe, when true (the default for new missions), grants
 	// the hidden session standing approval for any shell call the
 	// danger classifier rates safe — a mission runs for hours
@@ -302,6 +311,20 @@ type PlanUnit struct {
 	// longer fake completion when the declared artifact is missing.
 	Artifacts []string `json:"artifacts,omitempty"`
 	Passes    bool     `json:"passes"`
+}
+
+// PendingInput is ask_user's park detail (D-088, issue #457): the
+// structured question a phase turn is waiting on the operator to
+// answer. Kind is "mcq", "yes_no", or "open"; Options is populated
+// only for "mcq". ProposedDefault is required on every ask: the
+// timeout sweep applies it verbatim if nobody answers in time.
+type PendingInput struct {
+	Question        string    `json:"question"`
+	Kind            string    `json:"kind"`
+	Options         []string  `json:"options,omitempty"`
+	ProposedDefault string    `json:"proposed_default"`
+	AskedAt         time.Time `json:"asked_at"`
+	Phase           Phase     `json:"phase"`
 }
 
 // ProgressNote is one append-only entry in the mission's progress log

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -30,6 +30,14 @@ import (
 // succeed.
 var ErrModelFloor = errors.New("mission turn served by a below-floor model")
 
+// ErrAskedUser reports that a turn ended via a successful ask_user
+// call (D-088) rather than the phase's own sentinel: every phase
+// entry point (RunWorker/ExploreSession/PlanSession/RunReview) returns
+// this instead of running its normal recovery/parse ladder, so the
+// driver's runPhase can map it straight to InputAskUser without
+// mistaking the missing sentinel for a forced failure.
+var ErrAskedUser = errors.New("mission turn parked on ask_user")
+
 // GatekeeperState is whatever a reviewer session needs to resume
 // in-memory for a delta recheck on rework, instead of cold-reanalyzing
 // from scratch. Acceptable to lose on restart: a cold reviewer just
@@ -207,6 +215,36 @@ type nativeRunner struct {
 	// location resolves the operator's configured timezone for the
 	// explore/plan prompts' date line; nil means UTC.
 	location func(ctx context.Context) *time.Location
+
+	// askParker backs ask_user's park (D-088): nil means ask_user is
+	// never offered on any mission turn, same nil-safe contract as
+	// kbSearch/kbRead: a store wiring bug degrades to "no ask_user"
+	// rather than a panic.
+	askParker askUserParker
+}
+
+// SetAskParker wires the store ask_user parks against: a setter (not
+// a NewNativeRunner parameter) so cmd/brain/main.go can pass the same
+// *Store it builds the runner alongside, same pattern as
+// SetProgressReader/SetConnectorReads.
+func (r *nativeRunner) SetAskParker(p askUserParker) {
+	r.askParker = p
+}
+
+// askUserTool builds this turn's ask_user ExtraTool, or nil when no
+// parker is wired or the mission's budget is already exhausted (0 for
+// scheduler/workflow missions per askBudgetFor, or spent for anyone
+// else): an exhausted/disabled ask_user is simply not offered, rather
+// than offered and always erroring.
+func (r *nativeRunner) askUserTool(m Mission, phase Phase) *tools.Tool {
+	if r.askParker == nil {
+		return nil
+	}
+	budget := askBudgetFor(m)
+	if m.AsksUsed >= budget {
+		return nil
+	}
+	return AskUserTool(m.ID, phase, m.AsksUsed, budget, r.askParker)
 }
 
 // ProgressReader re-reads one mission's progress notes mid-run, the
@@ -565,11 +603,18 @@ func (r *nativeRunner) belowFloor(model string) bool {
 // sentinel tool call's raw arguments (if any), URLs the turn's
 // search_web/fetch_url calls saw, and the final assistant segment
 // (see finalSeg's doc below, formerly a bare 5th return value).
+// askedUser (D-088) reports whether the turn ended via a successful
+// ask_user call rather than the phase's own sentinel: the caller
+// (RunWorker/ExploreSession/PlanSession/RunReview) checks this BEFORE
+// treating a missing sentinel as "no verdict," since ask_user's
+// EndTurnTools membership means the turn legitimately ends with no
+// sentinel call at all.
 type turnResult struct {
 	text         string
 	sentinelArgs json.RawMessage
 	seenURLs     []string
 	finalSeg     string
+	askedUser    bool
 }
 
 // toolCallDigestCap bounds a mission.tool_call event's args digest:
@@ -609,8 +654,12 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 	defer cancel()
 	// D-075: the sentinel call's successful execution ends the turn:
 	// every mission phase (worker/explore/plan/review) goes through
-	// this one call site.
-	req.EndTurnTools = []string{sentinelTool}
+	// this one call site. ask_user (D-088) ends the turn the same way
+	// when offered: naming it here even when the turn's ExtraTools
+	// don't include it (askParker unwired, budget exhausted) is
+	// harmless: loop.Agent's endTurnTools is a plain lookup, never
+	// validated against what's actually offered.
+	req.EndTurnTools = []string{sentinelTool, askUserToolName}
 	events, err := r.agent.Start(ctx, req)
 	if err != nil {
 		return turnResult{}, err
@@ -618,6 +667,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 	var b, finalB strings.Builder
 	var sentinelArgs json.RawMessage
 	var seenURLs []string
+	askedUser := false
 	// parked tracks in-flight parks by CallID, not a single flag: a
 	// turn can issue concurrent tool calls (executeAll runs up to
 	// maxParallelTools at once), so a sibling call finishing first must
@@ -676,6 +726,12 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if ev.ToolResult != nil && ev.ToolResult.Status == "ok" && ev.ToolResult.Name == "search_web" {
 				seenURLs = append(seenURLs, webSearchResultURLs(ev.ToolResult.Content)...)
 			}
+			// D-088: a successful ask_user call ends the turn with no
+			// sentinel call at all: the caller must not read that as a
+			// missing verdict and force a recovery re-run.
+			if ev.ToolResult != nil && ev.ToolResult.Status == "ok" && ev.ToolResult.Name == askUserToolName {
+				askedUser = true
+			}
 			if ev.ToolResult != nil && ev.ToolResult.Name != sentinelTool {
 				finalB.Reset()
 			}
@@ -706,7 +762,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if len(parked) > 0 && r.parker != nil {
 				r.parker.OnPermissionCleared(ctx, req.MissionID)
 			}
-			return turnResult{b.String(), sentinelArgs, seenURLs, finalB.String()}, fmt.Errorf("mission runner: incomplete stream: %s", ev.Text)
+			return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser}, fmt.Errorf("mission runner: incomplete stream: %s", ev.Text)
 		case stream.EventError:
 			if len(parked) > 0 && r.parker != nil {
 				r.parker.OnPermissionCleared(ctx, req.MissionID)
@@ -715,19 +771,19 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if ev.Err != nil {
 				msg = ev.Err.Message
 			}
-			return turnResult{b.String(), sentinelArgs, seenURLs, finalB.String()}, fmt.Errorf("mission runner: %s", msg)
+			return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser}, fmt.Errorf("mission runner: %s", msg)
 		}
 	}
 	if !sawTerminal {
 		if len(parked) > 0 && r.parker != nil {
 			r.parker.OnPermissionCleared(ctx, req.MissionID)
 		}
-		return turnResult{b.String(), sentinelArgs, seenURLs, finalB.String()}, fmt.Errorf("mission runner: stream ended without a terminal event")
+		return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser}, fmt.Errorf("mission runner: stream ended without a terminal event")
 	}
 	if servedModel != "" && r.belowFloor(servedModel) {
-		return turnResult{b.String(), sentinelArgs, seenURLs, finalB.String()}, fmt.Errorf("%w: %s", ErrModelFloor, servedModel)
+		return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser}, fmt.Errorf("%w: %s", ErrModelFloor, servedModel)
 	}
-	return turnResult{b.String(), sentinelArgs, seenURLs, finalB.String()}, nil
+	return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser}, nil
 }
 
 // webFetchArgURL extracts the url arg from a fetch_url call's raw
@@ -941,6 +997,9 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		extra = append(extra, t)
 	}
 	extra = append(extra, r.connectorReadTools(ctx, m)...)
+	if t := r.askUserTool(m, PhaseGenerate); t != nil {
+		extra = append(extra, t)
+	}
 	req := loop.Request{
 		SessionID:    m.SessionID,
 		Route:        workerRoute(m),
@@ -964,6 +1023,9 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 	text, seenURLs := res.text, res.seenURLs
 	if err != nil {
 		return WorkerVerdict{}, text, err
+	}
+	if res.askedUser {
+		return WorkerVerdict{}, text, ErrAskedUser
 	}
 	if v, ok := r.tryParseVerdict(res.sentinelArgs); ok {
 		v.SeenURLs = append(seenURLs, kbSeen.all()...)
@@ -1065,6 +1127,9 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 	if m.ReferencedContext != "" {
 		user += "\n\nReferenced context:\n" + NeutralizeSlot(m.ReferencedContext)
 	}
+	if notes := recentProgressNotes(m.Progress, progressRenderCap); notes != "" {
+		user += "\n\nProgress so far (includes any operator answers to prior questions):\n" + notes
+	}
 	user += renderAttachments(m.Attachments)
 
 	extra := []*tools.Tool{ExploreNotesTool()}
@@ -1078,6 +1143,9 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 		extra = append(extra, t)
 	}
 	extra = append(extra, r.connectorReadTools(ctx, m)...)
+	if t := r.askUserTool(m, PhaseDiscover); t != nil {
+		extra = append(extra, t)
+	}
 	req := loop.Request{
 		SessionID:    m.SessionID,
 		Route:        oversightRoute(m),
@@ -1095,6 +1163,9 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 	text := res.text
 	if err != nil {
 		return "", err
+	}
+	if res.askedUser {
+		return "", ErrAskedUser
 	}
 	if notes, ok := tryParseFindings(res.sentinelArgs); ok {
 		return notes, nil
@@ -1160,6 +1231,9 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 	messages = append(messages, provider.Message{Role: "user", Content: content})
 
 	extra := append([]*tools.Tool{ReviewVerdictTool()}, r.missionTools(m)...)
+	if t := r.askUserTool(m, PhaseProve); t != nil {
+		extra = append(extra, t)
+	}
 	req := loop.Request{
 		SessionID:    m.SessionID,
 		Route:        reviewRoute(m),
@@ -1176,6 +1250,9 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 	text, args := res.text, res.sentinelArgs
 	if err != nil {
 		return ReviewVerdict{}, nil, err
+	}
+	if res.askedUser {
+		return ReviewVerdict{}, nil, ErrAskedUser
 	}
 	if len(args) == 0 {
 		// Recovery re-run: same one-shot ladder RunWorker uses: a
@@ -1309,6 +1386,9 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 	if t := r.kbReadTool(m); t != nil {
 		extra = append(extra, t)
 	}
+	if t := r.askUserTool(m, PhasePlan); t != nil {
+		extra = append(extra, t)
+	}
 	req := loop.Request{
 		SessionID: m.SessionID,
 		Route:     oversightRoute(m),
@@ -1338,6 +1418,9 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 	text, args := res.text, res.sentinelArgs
 	if err != nil {
 		return Spec{}, err
+	}
+	if res.askedUser {
+		return Spec{}, ErrAskedUser
 	}
 	if len(args) > 0 {
 		if spec, specErr := parseSpec(string(args)); specErr == nil {

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -161,9 +161,11 @@ func TestRunWorkerSentinelPresent(t *testing.T) {
 	}
 	// D-075: the worker turn must tell loop.Agent its sentinel ends the
 	// turn, so a clean mission_status call never triggers a pointless
-	// continuation call.
-	if len(agent.requests) != 1 || len(agent.requests[0].EndTurnTools) != 1 || agent.requests[0].EndTurnTools[0] != missionStatusToolName {
-		t.Fatalf("EndTurnTools = %+v, want [%q]", agent.requests[0].EndTurnTools, missionStatusToolName)
+	// continuation call. ask_user (D-088) always rides along in
+	// EndTurnTools too, whether or not the turn actually offers it.
+	wantEndTurnTools := []string{missionStatusToolName, askUserToolName}
+	if len(agent.requests) != 1 || !slices.Equal(agent.requests[0].EndTurnTools, wantEndTurnTools) {
+		t.Fatalf("EndTurnTools = %+v, want %+v", agent.requests[0].EndTurnTools, wantEndTurnTools)
 	}
 }
 

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -153,6 +153,13 @@ const (
 	InputPlanApprove    Input = "plan_approve"
 	InputPlanReplan     Input = "plan_replan"
 	InputPlanRediscover Input = "plan_rediscover"
+	// InputAskUser fires when a phase turn's ask_user tool call parks the
+	// mission (D-088, issue #457): the store has already recorded
+	// pending_input and incremented asks_used by the time this input
+	// reaches Step (mirrors InputWorkerBlocked's shape, both just move
+	// Status to waiting_for_input); the difference is ask_user's answer
+	// resolves through Store.AnswerPendingInput, not a plain resume.
+	InputAskUser Input = "ask_user"
 )
 
 // StepState is the state-machine-relevant slice of a Mission — Step
@@ -299,6 +306,12 @@ func Step(s StepState, in StepInput, cfg Config) Transition {
 			Next:   withStatus(s, StatusWaitingForInput),
 			Events: []EventDraft{{Kind: "mission.blocked", Payload: map[string]any{"question": in.Message}}},
 		}
+	case InputAskUser:
+		// The store already appended mission.input_requested (SetPendingInput)
+		// before this input reaches Step: no separate event here, same as
+		// pending_permission's own park (Store writes it, Step only moves
+		// Status).
+		return Transition{Next: withStatus(s, StatusWaitingForInput)}
 	case InputWorkerFailed:
 		return stepWorkerFailed(s, in, cfg)
 	case InputReviewApprove:

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -745,3 +745,36 @@ func TestStepPlanRediscoverEmitsEvent(t *testing.T) {
 		t.Fatalf("Events = %+v, want exactly one mission.rediscover_requested event", got.Events)
 	}
 }
+
+// TestStepAskUserParksWithoutEvent confirms InputAskUser moves Status
+// to waiting_for_input and leaves Phase untouched (D-088, issue #457):
+// no event here since Store.SetPendingInput already appended
+// mission.input_requested before this input reaches Step, same
+// division of labor as pending_permission's own park.
+func TestStepAskUserParksWithoutEvent(t *testing.T) {
+	got := Step(
+		StepState{Phase: PhaseGenerate, Status: StatusWorking},
+		StepInput{Input: InputAskUser},
+		DefaultConfig,
+	)
+	if got.Next.Status != StatusWaitingForInput {
+		t.Fatalf("Status = %s, want waiting_for_input", got.Next.Status)
+	}
+	if got.Next.Phase != PhaseGenerate {
+		t.Fatalf("Phase = %s, want generate (unchanged)", got.Next.Phase)
+	}
+	if len(got.Events) != 0 {
+		t.Fatalf("Events = %+v, want none: the store already recorded mission.input_requested", got.Events)
+	}
+}
+
+// TestStepAskUserParksInEveryLLMPhase confirms the park applies
+// uniformly regardless of which of the four LLM phases asked.
+func TestStepAskUserParksInEveryLLMPhase(t *testing.T) {
+	for _, phase := range []Phase{PhaseDiscover, PhasePlan, PhaseGenerate, PhaseProve} {
+		got := Step(StepState{Phase: phase, Status: StatusWorking}, StepInput{Input: InputAskUser}, DefaultConfig)
+		if got.Next.Status != StatusWaitingForInput || got.Next.Phase != phase {
+			t.Fatalf("phase %s: Next = %+v, want same phase with status waiting_for_input", phase, got.Next)
+		}
+	}
+}

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -51,7 +51,7 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 	pending_permission, auto_approve_safe, auto_approve_plan, last_evidence,
 	explore_notes, replan_used, schedule_id, session_id, harness, environment, repo_url, connector_id, on_complete,
 	branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, light, final_output, created_at, updated_at,
-	workflow_run_id, workflow_step, artifact_refs, promote_kb_collection_id, permission_timeout_seconds`
+	workflow_run_id, workflow_step, artifact_refs, promote_kb_collection_id, permission_timeout_seconds, pending_input, asks_used`
 
 // pendingPermissionRow is pending_permission's jsonb shape in the
 // missions table: bundles the five columns the API's flat
@@ -86,6 +86,19 @@ func scanPendingPermission(m *Mission, raw []byte) {
 	m.PendingPermissionParkedAt = p.ParkedAt
 }
 
+// scanPendingInput unmarshals the pending_input jsonb column (nil when
+// there's no pending question) into Mission.PendingInput.
+func scanPendingInput(m *Mission, raw []byte) {
+	if raw == nil {
+		return
+	}
+	var p PendingInput
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return
+	}
+	m.PendingInput = &p
+}
+
 // scanMissionWithFailureReason is scanMission plus one extra trailing
 // column: the mission's latest mission.failed event's payload.reason
 // (via a lateral join, added by the caller's query), empty for a
@@ -102,6 +115,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		workflowRunID                                                 *string
 		promoteKBCollectionID                                         *string
 		permissionTimeoutSeconds                                      *int
+		pendingInputRaw                                               []byte
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
@@ -113,12 +127,14 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&m.DestinationIDs, &m.Light, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
 		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &promoteKBCollectionID, &permissionTimeoutSeconds,
+		&pendingInputRaw, &m.AsksUsed,
 		&failureReason); err != nil {
 		return Mission{}, err
 	}
 	_ = json.Unmarshal(knowledgeRaw, &m.Knowledge)
 	_ = json.Unmarshal(artifactRefsRaw, &m.ArtifactRefs)
 	scanPendingPermission(&m, pendingPermissionRaw)
+	scanPendingInput(&m, pendingInputRaw)
 	if agentID != nil {
 		m.AgentID = *agentID
 	}
@@ -187,6 +203,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		workflowRunID                                                 *string
 		promoteKBCollectionID                                         *string
 		permissionTimeoutSeconds                                      *int
+		pendingInputRaw                                               []byte
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
@@ -197,12 +214,14 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &m.ReferencedContext, &attachmentsRaw,
 		&m.DestinationIDs, &m.Light, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
-		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &promoteKBCollectionID, &permissionTimeoutSeconds); err != nil {
+		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &promoteKBCollectionID, &permissionTimeoutSeconds,
+		&pendingInputRaw, &m.AsksUsed); err != nil {
 		return Mission{}, err
 	}
 	_ = json.Unmarshal(knowledgeRaw, &m.Knowledge)
 	_ = json.Unmarshal(artifactRefsRaw, &m.ArtifactRefs)
 	scanPendingPermission(&m, pendingPermissionRaw)
+	scanPendingInput(&m, pendingInputRaw)
 	if agentID != nil {
 		m.AgentID = *agentID
 	}
@@ -650,6 +669,141 @@ func (s *Store) ResolvePendingPermissionTimeout(ctx context.Context, id, tool st
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("missions resolve pending permission timeout commit: %w", err)
+	}
+	if s.hub != nil {
+		s.hub.Publish(Signal{Kind: "mission", ID: id})
+	}
+	return nil
+}
+
+// SetPendingInput records ask_user's park (D-088): a second park kind
+// alongside pending_permission, mirroring SetPendingPermission's shape
+// and reasoning exactly: bypasses ApplyTransition since parking
+// happens mid-turn, appends mission.input_requested in the same
+// transaction so the Timeline shows the question immediately. AskedAt
+// is stamped here, server-side, same as SetPendingPermission's ParkedAt.
+func (s *Store) SetPendingInput(ctx context.Context, id string, input PendingInput) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("missions set pending input: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("missions set pending input begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+	input.AskedAt = time.Now().UTC()
+	data, err := json.Marshal(input)
+	if err != nil {
+		return fmt.Errorf("missions set pending input: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `UPDATE missions SET
+			pending_input = $2, asks_used = asks_used + 1, updated_at = now()
+		WHERE id = $1`, id, data); err != nil {
+		return fmt.Errorf("missions set pending input: %w", err)
+	}
+	payload := map[string]any{
+		"question": input.Question, "kind": input.Kind, "options": input.Options,
+		"proposed_default": input.ProposedDefault, "phase": string(input.Phase),
+	}
+	if err := appendEventTx(ctx, tx, id, "mission.input_requested", payload, "live"); err != nil {
+		return fmt.Errorf("missions set pending input: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("missions set pending input commit: %w", err)
+	}
+	if s.hub != nil {
+		s.hub.Publish(Signal{Kind: "mission", ID: id})
+	}
+	return nil
+}
+
+// ParkAskUser satisfies askUserParker (asktool.go): the tool's own
+// Execute callback into the store, kept as a thin alias so the
+// runner-facing interface name documents ask_user's specific purpose
+// rather than exposing SetPendingInput's more general store-level name.
+func (s *Store) ParkAskUser(ctx context.Context, missionID string, input PendingInput) error {
+	return s.SetPendingInput(ctx, missionID, input)
+}
+
+// ClearPendingInput drops a mission's parked question once it's
+// answered or timed out.
+func (s *Store) ClearPendingInput(ctx context.Context, id string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("missions clear pending input: %w", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE missions SET
+			pending_input = NULL, updated_at = now()
+		WHERE id = $1`, id); err != nil {
+		return fmt.Errorf("missions clear pending input: %w", err)
+	}
+	return nil
+}
+
+// ParkedInput is one PendingInputs row: just enough for the timeout
+// sweep's elapsed-time decision, mirroring ParkedPermission.
+type ParkedInput struct {
+	MissionID string
+	Input     PendingInput
+}
+
+// PendingInputs returns every mission currently parked on pending_input,
+// the ask-timeout sweep's input.
+func (s *Store) PendingInputs(ctx context.Context) ([]ParkedInput, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return nil, fmt.Errorf("missions pending inputs: %w", err)
+	}
+	rows, err := db.Query(ctx, `SELECT id, pending_input FROM missions WHERE pending_input IS NOT NULL`)
+	if err != nil {
+		return nil, fmt.Errorf("missions pending inputs: %w", err)
+	}
+	defer rows.Close()
+	out := []ParkedInput{}
+	for rows.Next() {
+		var id string
+		var raw []byte
+		if err := rows.Scan(&id, &raw); err != nil {
+			return nil, fmt.Errorf("missions pending inputs: %w", err)
+		}
+		var p PendingInput
+		if err := json.Unmarshal(raw, &p); err != nil {
+			continue // corrupt row: skip rather than fail the whole sweep
+		}
+		out = append(out, ParkedInput{MissionID: id, Input: p})
+	}
+	return out, rows.Err()
+}
+
+// AnswerPendingInput resolves a mission's parked question with answer
+// (an operator's own text, or the proposed_default on timeout): clears
+// pending_input, appends the given event kind (mission.input_answered
+// or mission.input_timed_out) and payload, and resumes the mission from
+// waiting_for_input back to idle so the next Drive re-enters the same
+// phase the question was asked in: the answer rides into that turn's
+// prompt via the progress log (recordProgress), not through this
+// method, which only owns the park/resume transition.
+func (s *Store) AnswerPendingInput(ctx context.Context, id, eventKind string, payload map[string]any) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("missions answer pending input: %w", err)
+	}
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("missions answer pending input begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+	if _, err := tx.Exec(ctx, `UPDATE missions SET
+			pending_input = NULL, status = 'idle', updated_at = now()
+		WHERE id = $1`, id); err != nil {
+		return fmt.Errorf("missions answer pending input: %w", err)
+	}
+	if err := appendEventTx(ctx, tx, id, eventKind, payload, "live"); err != nil {
+		return fmt.Errorf("missions answer pending input: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("missions answer pending input commit: %w", err)
 	}
 	if s.hub != nil {
 		s.hub.Publish(Signal{Kind: "mission", ID: id})

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -1533,6 +1533,105 @@ func TestPendingPermissionsAndResolveTimeout(t *testing.T) {
 	}
 }
 
+// TestAskUserParkAnswerRoundTripCarriesQAIntoNextTurn covers D-088's
+// full path against a real store: ask_user's park (SetPendingInput),
+// the operator's answer (AnswerAskUser via AppendProgress +
+// AnswerPendingInput), and the durable channel that carries the Q+A
+// into the NEXT turn of the same phase: WorkPacket.Render reads
+// m.Progress verbatim, so no separate wiring is needed once the answer
+// lands as a progress note.
+func TestAskUserParkAnswerRoundTripCarriesQAIntoNextTurn(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{Goal: marker + "ask-user-round-trip", Kind: "general", Route: "default"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseGenerate, Status: StatusWorking}}); err != nil {
+		t.Fatalf("ApplyTransition working: %v", err)
+	}
+
+	input := PendingInput{
+		Question: "which runtime should this target?", Kind: "mcq",
+		Options: []string{"node", "python"}, ProposedDefault: "node", Phase: PhaseGenerate,
+	}
+	if err := s.SetPendingInput(ctx, id, input); err != nil {
+		t.Fatalf("SetPendingInput: %v", err)
+	}
+	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseGenerate, Status: StatusWaitingForInput}}); err != nil {
+		t.Fatalf("ApplyTransition waiting_for_input: %v", err)
+	}
+
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get after park: %v", err)
+	}
+	if m.PendingInput == nil || m.PendingInput.Question != input.Question {
+		t.Fatalf("PendingInput after park = %+v, want %+v", m.PendingInput, input)
+	}
+	if m.AsksUsed != 1 {
+		t.Fatalf("AsksUsed after park = %d, want 1", m.AsksUsed)
+	}
+
+	// The API's answer handler validates the mcq option, appends the Q+A
+	// progress note, then calls Store.AnswerPendingInput: mirrored here
+	// directly against the store (Driver.AnswerAskUser wraps the same two
+	// calls).
+	if err := s.AppendProgress(ctx, id, `Operator answered your question "which runtime should this target?": python`); err != nil {
+		t.Fatalf("AppendProgress: %v", err)
+	}
+	if err := s.AnswerPendingInput(ctx, id, "mission.input_answered", map[string]any{"answer": "python"}); err != nil {
+		t.Fatalf("AnswerPendingInput: %v", err)
+	}
+
+	m, err = s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get after answer: %v", err)
+	}
+	if m.PendingInput != nil {
+		t.Fatalf("PendingInput after answer = %+v, want nil", m.PendingInput)
+	}
+	if m.Status != StatusIdle {
+		t.Fatalf("Status after answer = %s, want idle", m.Status)
+	}
+
+	// The next worker turn's packet renders m.Progress verbatim
+	// (WorkPacket.Render, packet.go): this is the "next-turn-prompt
+	// carries Q+A round trip" the design promises, without any packet
+	// changes: the Q+A rides the same durable channel a steering note
+	// already uses.
+	packet := WorkPacket{Progress: m.Progress}
+	_, user := packet.Render()
+	if !strings.Contains(user, input.Question) || !strings.Contains(user, "python") {
+		t.Fatalf("next worker packet does not carry the Q+A verbatim: %s", user)
+	}
+
+	events, err := s.Events(ctx, id)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	var sawRequested, sawAnswered bool
+	for _, e := range events {
+		switch e.Kind {
+		case "mission.input_requested":
+			sawRequested = true
+		case "mission.input_answered":
+			sawAnswered = true
+			var payload struct{ Answer string }
+			if err := json.Unmarshal(e.Payload, &payload); err != nil {
+				t.Fatalf("unmarshal input_answered payload: %v", err)
+			}
+			if payload.Answer != "python" {
+				t.Fatalf("input_answered payload = %+v, want answer=python", payload)
+			}
+		}
+	}
+	if !sawRequested || !sawAnswered {
+		t.Fatalf("events = %+v, want both mission.input_requested and mission.input_answered", events)
+	}
+}
+
 // fakePermissionTimeoutDriverIT captures Drive calls from
 // sweepPermissionTimeouts against a real store, synchronized so the
 // test can wait for the sweep's background goroutine before asserting.

--- a/internal/brain/missions/store_test.go
+++ b/internal/brain/missions/store_test.go
@@ -2,6 +2,44 @@ package missions
 
 import "testing"
 
+// TestScanPendingInput mirrors TestScanPendingPermission for
+// pending_input's own jsonb boundary (D-088, issue #457).
+func TestScanPendingInput(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  []byte
+		want *PendingInput
+	}{
+		{name: "nil leaves PendingInput nil", raw: nil, want: nil},
+		{
+			name: "populated unmarshals",
+			raw:  []byte(`{"question":"which runtime?","kind":"mcq","options":["node","python"],"proposed_default":"node","phase":"generate"}`),
+			want: &PendingInput{Question: "which runtime?", Kind: "mcq", Options: []string{"node", "python"}, ProposedDefault: "node", Phase: PhaseGenerate},
+		},
+		{name: "invalid json leaves PendingInput nil", raw: []byte(`not json`), want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m Mission
+			scanPendingInput(&m, tt.raw)
+			if tt.want == nil {
+				if m.PendingInput != nil {
+					t.Fatalf("PendingInput = %+v, want nil", m.PendingInput)
+				}
+				return
+			}
+			if m.PendingInput == nil {
+				t.Fatalf("PendingInput = nil, want %+v", tt.want)
+			}
+			if m.PendingInput.Question != tt.want.Question || m.PendingInput.Kind != tt.want.Kind ||
+				m.PendingInput.ProposedDefault != tt.want.ProposedDefault || m.PendingInput.Phase != tt.want.Phase ||
+				len(m.PendingInput.Options) != len(tt.want.Options) {
+				t.Fatalf("PendingInput = %+v, want %+v", m.PendingInput, tt.want)
+			}
+		})
+	}
+}
+
 // TestScanPendingPermission covers the jsonb-to-flat-fields boundary
 // (issue #423's pending_permission bundle) without a database: nil
 // means no pending request, a populated row unmarshals into Mission's

--- a/internal/brain/missions/sweep.go
+++ b/internal/brain/missions/sweep.go
@@ -44,6 +44,13 @@ type permissionTimeoutStore interface {
 	ResolvePendingPermissionTimeout(ctx context.Context, id, tool string) error
 }
 
+// askTimeoutStore is the narrow slice of *Store the ask_user timeout
+// sweep needs (D-088), mirroring permissionTimeoutStore.
+type askTimeoutStore interface {
+	PendingInputs(ctx context.Context) ([]ParkedInput, error)
+	AnswerPendingInput(ctx context.Context, id, eventKind string, payload map[string]any) error
+}
+
 // sandboxSweeper is the narrow slice of the sandbox backend the
 // periodic orphan pass needs — kept as an interface (not an import of
 // sandboxd or sandboxclient) for the same reason as Driver's
@@ -158,9 +165,9 @@ func admitWork(ctx context.Context, gate capacityChecker, log *slog.Logger) (adm
 // is the live in-memory PermBroker's Resolve, best-effort. nil is valid
 // (a still-running turn just times out on its own permissionTimeout
 // instead of waking early).
-func RecoverAndSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, notify messageNotifier, globalPermissionTimeout func(context.Context) int, resolveBroker func(id, decision string) bool, log *slog.Logger) {
+func RecoverAndSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, notify messageNotifier, globalPermissionTimeout func(context.Context) int, globalAskTimeout func(context.Context) int, resolveBroker func(id, decision string) bool, log *slog.Logger) {
 	recoverWorking(ctx, d, store, log)
-	runWorkSlotSweep(ctx, d, store, maxConcurrent, sandbox, capacity, notify, globalPermissionTimeout, resolveBroker, log)
+	runWorkSlotSweep(ctx, d, store, maxConcurrent, sandbox, capacity, notify, globalPermissionTimeout, globalAskTimeout, resolveBroker, log)
 }
 
 // sweepOrphanSandboxes runs on every runWorkSlotSweep tick (previously
@@ -231,7 +238,7 @@ func recoverWorking(ctx context.Context, d *Driver, store *Store, log *slog.Logg
 // auto-denies any pending_permission parked past its effective timeout,
 // all on the same tick. Runs until ctx is done; this call blocks, so
 // RecoverAndSweep's caller runs it in its own goroutine.
-func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, notify messageNotifier, globalPermissionTimeout func(context.Context) int, resolveBroker func(id, decision string) bool, log *slog.Logger) {
+func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, notify messageNotifier, globalPermissionTimeout func(context.Context) int, globalAskTimeout func(context.Context) int, resolveBroker func(id, decision string) bool, log *slog.Logger) {
 	ticker := time.NewTicker(workSlotSweepInterval)
 	defer ticker.Stop()
 	for {
@@ -244,6 +251,7 @@ func runWorkSlotSweep(ctx context.Context, d *Driver, store *Store, maxConcurren
 			autoResumeBackoff(ctx, d, store, notify, log)
 			autoResumeInfra(ctx, d, store, notify, log)
 			sweepPermissionTimeouts(ctx, d, store, globalPermissionTimeout, resolveBroker, notify, log)
+			sweepAskTimeouts(ctx, d, store, globalAskTimeout, notify, log)
 			// D-056: skip the claim entirely this tick if the host can't
 			// afford another working mission — the mission stays idle,
 			// and this same sweep retries it in workSlotSweepInterval; that
@@ -480,6 +488,74 @@ func sweepPermissionTimeouts(ctx context.Context, d permissionTimeoutDriver, sto
 		go func(id string) {
 			if err := d.Drive(ctx, id); err != nil {
 				log.Error("permission timeout sweep: drive failed", "mission_id", id, "error", err)
+			}
+		}(p.MissionID)
+	}
+}
+
+// shouldTimeoutAsk is shouldTimeoutPermission's ask_user counterpart
+// (D-088): identical elapsed-time decision, no per-mission override:
+// ask_user has no mission-level column analogous to
+// permission_timeout_seconds, only the global setting.
+func shouldTimeoutAsk(now, askedAt time.Time, globalSeconds int) bool {
+	if globalSeconds <= 0 {
+		return false
+	}
+	return now.Sub(askedAt) >= time.Duration(globalSeconds)*time.Second
+}
+
+// askTimeoutDriver is the narrow slice of *Driver sweepAskTimeouts
+// needs to rescue a mission whose worker goroutine died while parked:
+// same Drive-not-Signal reasoning as permissionTimeoutDriver: pending_input
+// never advances Status away from waiting_for_input on its own, so
+// re-Drive is always safe (Driver.claimDriving's no-op guard).
+type askTimeoutDriver interface {
+	Drive(ctx context.Context, id string) error
+}
+
+// sweepAskTimeouts auto-answers any mission whose pending_input has sat
+// unanswered past settings.ValueAskTimeoutSeconds (D-088, issue #457):
+// a deployment that never sets it (or sets it to 0) sees this do
+// nothing, the same park-forever default ValuePermissionTimeoutSeconds
+// has. Applies the question's own proposed_default, exactly as an
+// operator's own answer would (Store.AnswerPendingInput), so the next
+// turn of the same phase sees the default as the answer, distinguished
+// in the event log by mission.input_timed_out instead of
+// mission.input_answered.
+func sweepAskTimeouts(ctx context.Context, d askTimeoutDriver, store askTimeoutStore, globalAskTimeout func(context.Context) int, notify messageNotifier, log *slog.Logger) {
+	if globalAskTimeout == nil {
+		return
+	}
+	pending, err := store.PendingInputs(ctx)
+	if err != nil {
+		log.Error("ask timeout sweep: list failed", "error", err)
+		return
+	}
+	if len(pending) == 0 {
+		return
+	}
+	globalSeconds := globalAskTimeout(ctx)
+	now := time.Now().UTC()
+	for _, p := range pending {
+		if !shouldTimeoutAsk(now, p.Input.AskedAt, globalSeconds) {
+			continue
+		}
+		log.Warn("ask timeout sweep: auto-answering a parked question with its proposed default", "mission_id", p.MissionID)
+		if err := store.AnswerPendingInput(ctx, p.MissionID, "mission.input_timed_out", map[string]any{
+			"applied_default": p.Input.ProposedDefault,
+		}); err != nil {
+			log.Error("ask timeout sweep: resolve failed", "mission_id", p.MissionID, "error", err)
+			continue
+		}
+		if notify != nil {
+			if err := notify.NotifyMessage(ctx, p.MissionID, "ask_timed_out",
+				"a pending question timed out and the proposed default was applied automatically"); err != nil {
+				log.Warn("ask timeout sweep: notify failed", "mission_id", p.MissionID, "error", err)
+			}
+		}
+		go func(id string) {
+			if err := d.Drive(ctx, id); err != nil {
+				log.Error("ask timeout sweep: drive failed", "mission_id", id, "error", err)
 			}
 		}(p.MissionID)
 	}

--- a/internal/brain/missions/sweep_test.go
+++ b/internal/brain/missions/sweep_test.go
@@ -407,3 +407,115 @@ func TestSweepPermissionTimeoutsNilResolveBrokerSafe(t *testing.T) {
 		t.Fatalf("resolved = %v, want exactly one", store.resolved)
 	}
 }
+
+// TestShouldTimeoutAsk mirrors TestShouldTimeoutPermission's table for
+// ask_user's own timeout decision (D-088, issue #457): no per-mission
+// override exists (unlike permission's), just the global setting.
+func TestShouldTimeoutAsk(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	cases := []struct {
+		name        string
+		askedAgo    time.Duration
+		global      int
+		wantTimeout bool
+	}{
+		{"global disabled (0): never times out", 999 * time.Hour, 0, false},
+		{"global negative: never times out", 999 * time.Hour, -1, false},
+		{"just before due", 59 * time.Second, 60, false},
+		{"just after due", 61 * time.Second, 60, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := shouldTimeoutAsk(now, now.Add(-tc.askedAgo), tc.global)
+			if got != tc.wantTimeout {
+				t.Errorf("shouldTimeoutAsk() = %v, want %v", got, tc.wantTimeout)
+			}
+		})
+	}
+}
+
+// fakeAskTimeoutStore scripts PendingInputs/AnswerPendingInput for
+// sweepAskTimeouts tests, mirroring fakePermissionTimeoutStore.
+type fakeAskTimeoutStore struct {
+	pending  []ParkedInput
+	resolved []string
+}
+
+func (f *fakeAskTimeoutStore) PendingInputs(ctx context.Context) ([]ParkedInput, error) {
+	return f.pending, nil
+}
+
+func (f *fakeAskTimeoutStore) AnswerPendingInput(ctx context.Context, id, eventKind string, payload map[string]any) error {
+	f.resolved = append(f.resolved, id+"|"+eventKind)
+	return nil
+}
+
+// fakeAskTimeoutDriver captures Drive calls, mirroring
+// fakePermissionTimeoutDriver.
+type fakeAskTimeoutDriver struct {
+	mu    sync.Mutex
+	wg    sync.WaitGroup
+	drove []string
+}
+
+func (f *fakeAskTimeoutDriver) Drive(ctx context.Context, id string) error {
+	defer f.wg.Done()
+	f.mu.Lock()
+	f.drove = append(f.drove, id)
+	f.mu.Unlock()
+	return nil
+}
+
+// TestSweepAskTimeoutsDisabledByDefault mirrors
+// TestSweepPermissionTimeoutsDisabledByDefault: a global setting of 0
+// leaves every parked question untouched.
+func TestSweepAskTimeoutsDisabledByDefault(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := &fakeAskTimeoutStore{
+		pending: []ParkedInput{{MissionID: "m1", Input: PendingInput{AskedAt: time.Now().Add(-999 * time.Hour)}}},
+	}
+	driver := &fakeAskTimeoutDriver{}
+	notifier := &fakeMessageNotifier{}
+	sweepAskTimeouts(context.Background(), driver, store, func(context.Context) int { return 0 }, notifier, log)
+
+	if len(store.resolved) != 0 {
+		t.Fatalf("resolved = %v, want none (sweep disabled)", store.resolved)
+	}
+	if len(notifier.notified) != 0 {
+		t.Fatalf("notified = %v, want none (sweep disabled)", notifier.notified)
+	}
+}
+
+// TestSweepAskTimeoutsAppliesDefaultAndDrives covers the enabled path:
+// a mission parked past the effective timeout has its proposed_default
+// applied via mission.input_timed_out, is notified, and re-Driven; one
+// still within its window is left alone.
+func TestSweepAskTimeoutsAppliesDefaultAndDrives(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	now := time.Now()
+	store := &fakeAskTimeoutStore{
+		pending: []ParkedInput{
+			{MissionID: "timed-out", Input: PendingInput{ProposedDefault: "yes", AskedAt: now.Add(-10 * time.Minute)}},
+			{MissionID: "still-waiting", Input: PendingInput{ProposedDefault: "no", AskedAt: now.Add(-1 * time.Second)}},
+		},
+	}
+	driver := &fakeAskTimeoutDriver{}
+	driver.wg.Add(1) // exactly one mission (timed-out) crosses the 60s global timeout
+	notifier := &fakeMessageNotifier{}
+
+	sweepAskTimeouts(context.Background(), driver, store, func(context.Context) int { return 60 }, notifier, log)
+	driver.wg.Wait()
+
+	if len(store.resolved) != 1 || store.resolved[0] != "timed-out|mission.input_timed_out" {
+		t.Fatalf("resolved = %v, want exactly [timed-out|mission.input_timed_out]", store.resolved)
+	}
+	if len(notifier.notified) != 1 || notifier.notified[0] != "timed-out" {
+		t.Fatalf("notified = %v, want exactly [timed-out]", notifier.notified)
+	}
+	if len(driver.drove) != 1 || driver.drove[0] != "timed-out" {
+		t.Fatalf("drove = %v, want exactly [timed-out]", driver.drove)
+	}
+}

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -87,6 +87,13 @@ const (
 	// behavior. A mission's own permission_timeout_seconds column
 	// overrides this per mission.
 	ValuePermissionTimeoutSeconds = "permission_timeout_seconds"
+	// ValueAskTimeoutSeconds bounds how long a mission may sit parked on
+	// pending_input (ask_user, D-088, issue #457) before the periodic
+	// sweep (missions/sweep.go) applies the question's proposed_default
+	// and resumes; "" or "0" (the default) disables the sweep, so an
+	// ask_user park waits forever unless the operator opts in, same
+	// 0-means-off convention as ValuePermissionTimeoutSeconds.
+	ValueAskTimeoutSeconds = "ask_timeout_seconds"
 )
 
 var knownValueKeys = map[string]bool{
@@ -96,7 +103,7 @@ var knownValueKeys = map[string]bool{
 	ValueCodingExecutor:   true,
 	ValueGitBranchPattern: true, ValueGitCommitStyle: true,
 	ValueWebBaseURL: true, ValueTimezone: true,
-	ValuePermissionTimeoutSeconds: true,
+	ValuePermissionTimeoutSeconds: true, ValueAskTimeoutSeconds: true,
 }
 
 // allowedCurrencies is the flat, fixed list of ISO 4217 codes the
@@ -182,6 +189,18 @@ func (s *Store) TokenBudget(ctx context.Context, def int) int {
 // behavior.
 func (s *Store) PermissionTimeoutSeconds(ctx context.Context) int {
 	if v := s.Value(ctx, ValuePermissionTimeoutSeconds); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return 0
+}
+
+// AskTimeoutSeconds parses the global ask_user timeout (D-088), falling
+// back to 0 (disabled) when unset or unparsable, same shape as
+// PermissionTimeoutSeconds.
+func (s *Store) AskTimeoutSeconds(ctx context.Context) int {
+	if v := s.Value(ctx, ValueAskTimeoutSeconds); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
 			return n
 		}
@@ -335,7 +354,7 @@ func (s *Store) SetValue(ctx context.Context, key, value string) error {
 			return fmt.Errorf("%s must be a positive integer or empty", key)
 		}
 	}
-	if key == ValuePermissionTimeoutSeconds && value != "" {
+	if (key == ValuePermissionTimeoutSeconds || key == ValueAskTimeoutSeconds) && value != "" {
 		if n, err := strconv.Atoi(value); err != nil || n < 0 {
 			return fmt.Errorf("%s must be a non-negative integer or empty", key)
 		}

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -777,7 +777,17 @@ CREATE TABLE IF NOT EXISTS missions (
     -- permission_timeout_seconds setting; the setting itself defaults to
     -- 0 (disabled, park forever) so this is opt-in and changes nothing
     -- for an existing deployment that never sets it.
-    permission_timeout_seconds integer
+    permission_timeout_seconds integer,
+    -- PendingInput is ask_user's park (D-088, issue #457), a second park
+    -- kind alongside pending_permission: NULL means no pending question,
+    -- otherwise {question, kind, options, proposed_default, asked_at,
+    -- phase}. Mirrors pending_permission's shape/lifecycle exactly
+    -- (store.go's SetPendingInput/ClearPendingInput).
+    pending_input         jsonb,
+    -- AsksUsed counts ask_user calls this mission has spent, enforced
+    -- against askBudget (missions/asktool.go); a third call over
+    -- budget is a plain tool error back to the model, no park.
+    asks_used              integer NOT NULL DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS missions_status_idx ON missions (status);

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -59,3 +59,13 @@ run before deploy.
 ```sql
 ALTER TABLE missions ADD COLUMN IF NOT EXISTS auto_approve_plan boolean NOT NULL DEFAULT true;
 ```
+
+## ask_user tool and waiting-input park (issue #457, slice 3 of the phase redesign)
+
+Required on live DBs before/with the next deploy. Additive, safe to
+run before deploy.
+
+```sql
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS pending_input jsonb;
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS asks_used integer NOT NULL DEFAULT 0;
+```

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1466,6 +1466,17 @@ export async function rediscoverMission(id: string): Promise<void> {
   await request<void>(`/v1/missions/${id}/rediscover`, { method: 'POST' })
 }
 
+// answerMissionQuestion answers a mission parked on ask_user
+// (pending_input): mcq/yes_no answers must match the question's own
+// options, open accepts any non-empty text, the server validates
+// again either way.
+export async function answerMissionQuestion(id: string, answer: string): Promise<void> {
+  await request<void>(`/v1/missions/${id}/answer`, {
+    method: 'POST',
+    body: JSON.stringify({ answer }),
+  })
+}
+
 // pushMission pushes the mission's branch to its worktree's origin
 // remote. credentialRef is optional: omitted (undefined) resolves a
 // github-connection mission's connector PAT server-side; passing one

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -762,6 +762,19 @@ export interface Mission {
   // know an unanswered request auto-denies after a timeout.
   pending_permission_parked_at?: string
   permission_timeout_seconds?: number
+  // pending_input is ask_user's park (D-088, issue #457): a second park
+  // kind alongside pending_permission, present only while a phase turn
+  // is waiting on the operator's answer (status: "waiting_for_input").
+  pending_input?: {
+    question: string
+    kind: 'mcq' | 'yes_no' | 'open'
+    options?: string[]
+    proposed_default: string
+    asked_at: string
+    phase: string
+  }
+  // asks_used counts ask_user calls this mission has spent so far.
+  asks_used: number
   last_evidence?: string
   auto_approve_safe: boolean
   // auto_approve_plan: true (default) advances straight from plan to

--- a/web/src/components/missions/InputRequestBanner.test.tsx
+++ b/web/src/components/missions/InputRequestBanner.test.tsx
@@ -1,0 +1,107 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { InputRequestBanner } from './InputRequestBanner'
+
+afterEach(cleanup)
+
+describe('InputRequestBanner', () => {
+  it('renders mcq options with the proposed default marked, and answers on click', () => {
+    const onAnswer = vi.fn()
+    render(
+      <InputRequestBanner
+        question="which runtime should this target?"
+        kind="mcq"
+        options={['node', 'python']}
+        proposedDefault="node"
+        onAnswer={onAnswer}
+      />,
+    )
+    expect(screen.getByText(/which runtime should this target/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /node.*proposed/ })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /^python$/ }))
+    expect(onAnswer).toHaveBeenCalledWith('python')
+  })
+
+  it('renders yes/no buttons with the proposed default marked', () => {
+    const onAnswer = vi.fn()
+    render(
+      <InputRequestBanner
+        question="continue?"
+        kind="yes_no"
+        proposedDefault="yes"
+        onAnswer={onAnswer}
+      />,
+    )
+    expect(screen.getByRole('button', { name: /Yes.*proposed/ })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /^No$/ }))
+    expect(onAnswer).toHaveBeenCalledWith('no')
+  })
+
+  it('renders an open textarea and submits typed text', () => {
+    const onAnswer = vi.fn()
+    render(
+      <InputRequestBanner
+        question="what should the title be?"
+        kind="open"
+        proposedDefault="Untitled"
+        onAnswer={onAnswer}
+      />,
+    )
+    const textarea = screen.getByPlaceholderText('Untitled')
+    fireEvent.change(textarea, { target: { value: 'My Report' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(onAnswer).toHaveBeenCalledWith('My Report')
+  })
+
+  it('falls back to the proposed default when open text is left empty', () => {
+    const onAnswer = vi.fn()
+    render(
+      <InputRequestBanner
+        question="what should the title be?"
+        kind="open"
+        proposedDefault="Untitled"
+        onAnswer={onAnswer}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(onAnswer).toHaveBeenCalledWith('Untitled')
+  })
+
+  it('shows a status line and hides the inputs once answered', () => {
+    render(
+      <InputRequestBanner
+        question="continue?"
+        kind="yes_no"
+        proposedDefault="yes"
+        answered="yes"
+        onAnswer={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/Answered: yes/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^Yes/ })).not.toBeInTheDocument()
+  })
+
+  it('renders a timeout line only when both timeoutSeconds and askedAt are given', () => {
+    const { rerender } = render(
+      <InputRequestBanner
+        question="continue?"
+        kind="yes_no"
+        proposedDefault="yes"
+        onAnswer={vi.fn()}
+      />,
+    )
+    expect(screen.queryByText(/Auto-answers/)).not.toBeInTheDocument()
+
+    rerender(
+      <InputRequestBanner
+        question="continue?"
+        kind="yes_no"
+        proposedDefault="yes"
+        onAnswer={vi.fn()}
+        timeoutSeconds={300}
+        askedAt="2026-08-30T00:00:00Z"
+      />,
+    )
+    expect(screen.getByText(/Auto-answers/)).toBeInTheDocument()
+  })
+})

--- a/web/src/components/missions/InputRequestBanner.tsx
+++ b/web/src/components/missions/InputRequestBanner.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import { Button } from '../ui/button'
+import { Textarea } from '../ui/textarea'
+
+// InputRequestBanner renders only when a mission has a live
+// pending_input (ask_user's park, D-088). Same architecture as
+// PermissionBanner/PlanApprovalBanner: callbacks as props for isolated
+// testing, and once answered the inputs are replaced by a status line
+// so a second submit can't fire before the mission row's own refetch
+// catches up.
+export function InputRequestBanner({
+  question,
+  kind,
+  options,
+  proposedDefault,
+  answered,
+  onAnswer,
+  timeoutSeconds,
+  askedAt,
+}: {
+  question: string
+  kind: 'mcq' | 'yes_no' | 'open'
+  options?: string[]
+  proposedDefault: string
+  answered?: string
+  onAnswer: (answer: string) => void
+  // timeoutSeconds is the operator-configured global ask_timeout_seconds
+  // (D-088): an ask_user park auto-answers with proposedDefault after
+  // this many seconds. undefined/0 means no timeout: the mission waits
+  // forever, same convention as PermissionBanner's timeoutSeconds.
+  timeoutSeconds?: number
+  // askedAt is when this question was recorded (PendingInput.AskedAt),
+  // needed alongside timeoutSeconds to render a countdown; only
+  // rendered when both are resolvable client-side (mirrors #445's
+  // PermissionBanner choice not to compute a live remaining-time value,
+  // just a static line).
+  askedAt?: string
+}) {
+  const [openAnswer, setOpenAnswer] = useState('')
+
+  return (
+    <div className="space-y-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900 dark:bg-amber-950">
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-amber-900 dark:text-amber-200">{question}</p>
+        {typeof timeoutSeconds === 'number' && timeoutSeconds > 0 && askedAt && (
+          <p className="text-xs text-amber-700 dark:text-amber-400">
+            Auto-answers with the proposed default if unanswered for {timeoutSeconds}s
+          </p>
+        )}
+      </div>
+
+      {answered !== undefined ? (
+        <p className="text-sm text-amber-800 dark:text-amber-300">Answered: {answered}</p>
+      ) : kind === 'mcq' ? (
+        <div className="flex flex-wrap gap-2">
+          {(options ?? []).map((opt) => (
+            <Button
+              key={opt}
+              variant={opt === proposedDefault ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => onAnswer(opt)}
+            >
+              {opt}
+              {opt === proposedDefault && ' (proposed)'}
+            </Button>
+          ))}
+        </div>
+      ) : kind === 'yes_no' ? (
+        <div className="flex gap-2">
+          <Button
+            variant={proposedDefault === 'yes' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => onAnswer('yes')}
+          >
+            Yes{proposedDefault === 'yes' && ' (proposed)'}
+          </Button>
+          <Button
+            variant={proposedDefault === 'no' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => onAnswer('no')}
+          >
+            No{proposedDefault === 'no' && ' (proposed)'}
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <Textarea
+            placeholder={proposedDefault || 'Your answer…'}
+            value={openAnswer}
+            onChange={(e) => setOpenAnswer(e.target.value)}
+          />
+          <Button size="sm" onClick={() => onAnswer(openAnswer.trim() || proposedDefault)}>
+            Send
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/missions/MissionCard.test.tsx
+++ b/web/src/components/missions/MissionCard.test.tsx
@@ -22,6 +22,7 @@ const baseMission: Mission = {
   review_route: 'default',
   auto_approve_safe: true,
   auto_approve_plan: true,
+  asks_used: 0,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 }

--- a/web/src/components/missions/MissionCard.tsx
+++ b/web/src/components/missions/MissionCard.tsx
@@ -86,6 +86,11 @@ export function MissionCard({ mission }: { mission: Mission }) {
             needs approval
           </span>
         )}
+        {mission.pending_input && (
+          <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-semibold text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+            needs answer
+          </span>
+        )}
         <span className="inline-flex items-center gap-1">
           <HarnessIcon harness={mission.harness} />
           {harnessLabel(mission.harness)}

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -108,6 +108,29 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
     const { tool, decision } = asRecord(p)
     return `Permission ${String(decision ?? '?')}: ${String(tool ?? 'a tool call')}`
   },
+  'mission.input_requested': (p) => {
+    const { question, kind, proposed_default } = asRecord(p)
+    return (
+      <span>
+        Question asked ({String(kind ?? '?')}): {String(question ?? '?')}
+        {proposed_default ? (
+          <span className="text-zinc-500"> (proposed: {String(proposed_default)})</span>
+        ) : null}
+      </span>
+    )
+  },
+  'mission.input_answered': (p) => {
+    const { answer } = asRecord(p)
+    return `Answered: ${String(answer ?? '?')}`
+  },
+  'mission.input_timed_out': (p) => {
+    const { applied_default } = asRecord(p)
+    return (
+      <span className="text-amber-400">
+        Question timed out, applied default: {String(applied_default ?? '?')}
+      </span>
+    )
+  },
   'mission.permission_denied': (p) => {
     const { tool, detail } = p as MissionPermissionDeniedPayload
     return (

--- a/web/src/pages/AutomationDetail.test.tsx
+++ b/web/src/pages/AutomationDetail.test.tsx
@@ -54,6 +54,7 @@ const firedMission: Mission = {
   review_route: 'default',
   auto_approve_safe: true,
   auto_approve_plan: true,
+  asks_used: 0,
   schedule_id: 's1',
   created_at: '2026-07-27T08:00:00Z',
   updated_at: '2026-07-27T08:01:00Z',

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -79,6 +79,7 @@ const baseMission: Mission = {
   review_route: 'default',
   auto_approve_safe: true,
   auto_approve_plan: true,
+  asks_used: 0,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 }

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -12,6 +12,7 @@ import { Link, useNavigate, useParams } from 'react-router'
 import { toast } from 'sonner'
 import {
   answerMissionPermission,
+  answerMissionQuestion,
   approveMissionPlan,
   cancelMission,
   deleteMission,
@@ -28,6 +29,7 @@ import {
 } from '../api/client'
 import type { Mission, MissionEvent, MissionPROpenedPayload, MissionUsage, Schedule } from '../api/types'
 import { ArtifactsSection } from '../components/missions/ArtifactsSection'
+import { InputRequestBanner } from '../components/missions/InputRequestBanner'
 import { PermissionBanner } from '../components/missions/PermissionBanner'
 import { PlanApprovalBanner } from '../components/missions/PlanApprovalBanner'
 import { PlanSection } from '../components/missions/PlanSection'
@@ -258,6 +260,14 @@ export function MissionDetail() {
   const [answeredPlanDecision, setAnsweredPlanDecision] = useState<'approve' | 'replan' | 'rediscover' | null>(
     null,
   )
+  // answeredQuestion mirrors answeredPermission's own pattern: the
+  // answer POST resolves right away, but pending_input only clears once
+  // the harness resumes the mission and the next fetch catches up.
+  // Keyed by the question text (not a bare boolean) so a NEW question
+  // arriving later renders as a fresh actionable card.
+  const [answeredQuestion, setAnsweredQuestion] = useState<{ question: string; answer: string } | null>(
+    null,
+  )
 
   const refreshSeq = useRef(0)
 
@@ -279,6 +289,8 @@ export function MissionDetail() {
   const wasPendingRef = useRef(false)
   const pendingPlanApproval = mission?.phase === 'plan' && mission?.pause_reason === 'approval'
   const wasPlanParkedRef = useRef(false)
+  const pendingInput = mission?.pending_input
+  const wasQuestionPendingRef = useRef(false)
 
   useEffect(() => {
     refresh()
@@ -324,6 +336,13 @@ export function MissionDetail() {
     wasPlanParkedRef.current = pendingPlanApproval
     if (!pendingPlanApproval) setAnsweredPlanDecision(null)
   }, [pendingPlanApproval])
+
+  // Same chime-once-on-transition treatment for a new ask_user question
+  // arriving, tracked with its own ref.
+  useEffect(() => {
+    if (pendingInput && !wasQuestionPendingRef.current) playAlertSound()
+    wasQuestionPendingRef.current = !!pendingInput
+  }, [pendingInput])
 
   if (!id) return null
   if (!mission) {
@@ -501,6 +520,18 @@ export function MissionDetail() {
     }
   }
 
+  const answerQuestion = async (answer: string) => {
+    const question = pendingInput?.question
+    try {
+      await answerMissionQuestion(id, answer)
+      if (question) setAnsweredQuestion({ question, answer })
+    } catch (err) {
+      toast.error('Could not send answer', { description: errText(err) })
+    } finally {
+      refresh()
+    }
+  }
+
   // Cross-tab/refresh fallback: this tab may not have the optimistic
   // answeredPermission state (a fresh load, or the decision happened
   // in another tab) but the events list already fetched can still show
@@ -555,6 +586,22 @@ export function MissionDetail() {
           onApprove={() => void approvePlan()}
           onReplan={(feedback) => void requestReplan(feedback)}
           onRediscover={() => void rediscover()}
+        />
+      )}
+
+      {pendingInput && (
+        <InputRequestBanner
+          question={pendingInput.question}
+          kind={pendingInput.kind}
+          options={pendingInput.options}
+          proposedDefault={pendingInput.proposed_default}
+          answered={
+            answeredQuestion && answeredQuestion.question === pendingInput.question
+              ? answeredQuestion.answer
+              : undefined
+          }
+          onAnswer={(answer) => void answerQuestion(answer)}
+          askedAt={pendingInput.asked_at}
         />
       )}
 

--- a/web/src/pages/Missions.test.tsx
+++ b/web/src/pages/Missions.test.tsx
@@ -45,6 +45,7 @@ const mission: Mission = {
   review_route: 'default',
   auto_approve_safe: true,
   auto_approve_plan: true,
+  asks_used: 0,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 }


### PR DESCRIPTION
Closes #457. Slice 3 of the phase redesign.

## What

- `ask_user` end-turn tool on all four LLM phase turns: one structured question (mcq with 2-6 options / yes_no / open), required proposed_default, validated hard before any park.
- Durable park in `missions.pending_input` jsonb (mirrors pending_permission's lifecycle), budget 2 per mission enforced in Go; scheduler/workflow missions get budget 0 via the existing Unattended signal.
- `POST /v1/missions/{id}/answer` validates per kind, resumes the same phase; Q+A reaches the next prompt via the existing progress-note channel (discover and plan prompts now render recent progress notes too, closing a gap where they ignored them).
- Answer timeout sweep (setting `ask_timeout_seconds`, default 0 = wait forever) applies the proposed default, mirroring #445's permission-timeout machinery.
- Web: InputRequestBanner renders option buttons (default pre-selected), yes/no buttons, or a markdown textarea; needs-answer badge; timeline renderers for input_requested/answered/timed_out.

## Why

A genuinely blocking ambiguity gets an operator answer instead of a guess, without missions stalling forever and without making asking free enough to replace thinking (#446's assume-and-declare stays the default path).

## Verified

Unit gates + lint clean, web 1013/1013, full solo integration suite green after local ALTERs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790783752&installation_model_id=431401&pr_number=462&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F462&signature=008f8e06e65192f9a9b40c5a0a88a74dbc2c3ae15c0c78b7d7bbbf9a6caf340e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->