### PR TITLE
fix(missions): ask_user is permission-exempt like the sentinels

### DIFF
--- a/internal/brain/tools/permissions.go
+++ b/internal/brain/tools/permissions.go
@@ -84,6 +84,12 @@ func NewPermissions(db *pgpool.Pool, workspaceRoot string) *Permissions {
 			"review_verdict": true,
 			"submit_plan":    true,
 			"explore_notes":  true,
+			// ask_user (D-088) is the same class: its Execute only
+			// records the question and parks the mission for the
+			// operator, who IS the permission authority. Routing it
+			// through the permission chain double-parks the mission on
+			// a prompt about asking a question.
+			"ask_user": true,
 			// write_file is root-confined by construction (relative
 			// paths only, .. rejected, root fixed at registration) —
 			// there is nothing for a prompt to guard that the tool

--- a/internal/brain/tools/permissions_test.go
+++ b/internal/brain/tools/permissions_test.go
@@ -179,7 +179,7 @@ func TestResolveShortCircuits(t *testing.T) {
 
 	t.Run("mission sentinel tools exempt", func(t *testing.T) {
 		t.Parallel()
-		for _, tool := range []string{"mission_status", "review_verdict", "submit_plan", "explore_notes"} {
+		for _, tool := range []string{"mission_status", "review_verdict", "submit_plan", "explore_notes", "ask_user"} {
 			res, err := p.Resolve(ctx, "s1", tool, json.RawMessage(`{}`))
 			if err != nil {
 				t.Fatalf("Resolve(%s): %v", tool, err)


### PR DESCRIPTION
Live probe after #462 merged caught this: the first real ask_user call landed in the permission chain (mission.permission_requested for ask_user) instead of executing, double-parking the mission on a prompt about asking a question. Execute only records the question and parks for the operator, who is the permission authority; same class as the protocol sentinels. Test extended.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790784282&installation_model_id=431401&pr_number=463&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F463&signature=30e45ca0f224f723f639ed0d9cb9ef14362ce5549824475dce0bfb1e53220bf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->