### PR TITLE
feat(missions): steering reaches every phase, Intervene button in UI

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -1364,9 +1364,11 @@ func (h *missionAPI) cancel(w http.ResponseWriter, r *http.Request) {
 
 // note handles POST /v1/missions/{id}/note: operator guidance injected
 // into a running mission via the existing progress-note pipeline — no
-// state transition, no driver signal. The next worker turn's packet
-// renders it like any other progress note (Render, packet.go), so
-// steering takes effect on its own without waking the mission early.
+// state transition, no driver signal. Accepted on any non-terminal
+// phase (D-089, issue #458): the mission.steered event carries the
+// phase it landed in, and every phase's packet renders the note like
+// any other progress note (Render, packet.go), so steering takes
+// effect on its own without waking the mission early.
 func (h *missionAPI) note(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Text string `json:"text"`
@@ -1386,7 +1388,7 @@ func (h *missionAPI) note(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	note := missions.NeutralizeSlot(truncateAnswer(body.Text, resumeAnswerCap))
-	if err := h.store.AppendEvent(r.Context(), id, "mission.steered", map[string]any{"note": note}); err != nil {
+	if err := h.store.AppendEvent(r.Context(), id, "mission.steered", map[string]any{"note": note, "phase": string(m.Phase)}); err != nil {
 		h.log.Warn("mission: record mission.steered event failed", "mission_id", id, "error", err)
 	}
 	if err := h.store.AppendProgress(r.Context(), id, "Operator note: "+note); err != nil {

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -289,6 +289,56 @@ func TestMissionsNoteAppendsEventAndProgressWithoutPhaseChange(t *testing.T) {
 	}
 }
 
+// TestMissionsNoteAcceptedOnEveryNonTerminalPhase confirms the note
+// endpoint (D-089, issue #458) is not generate-only: discover, plan,
+// prove, and generate all accept a note, and the mission.steered event
+// records which phase it landed in.
+func TestMissionsNoteAcceptedOnEveryNonTerminalPhase(t *testing.T) {
+	store := testMissionStore(t)
+	ctx := context.Background()
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
+
+	for _, phase := range []missions.Phase{missions.PhaseDiscover, missions.PhasePlan, missions.PhaseGenerate, missions.PhaseProve} {
+		phase := phase
+		t.Run(string(phase), func(t *testing.T) {
+			id, err := store.Create(ctx, missions.Mission{Goal: "itest-api-mission note phase test", Kind: "general"})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			if err := store.ApplyTransition(ctx, id, missions.Transition{
+				Next: missions.StepState{Phase: phase, Status: missions.StatusIdle},
+			}); err != nil {
+				t.Fatalf("ApplyTransition: %v", err)
+			}
+
+			req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":"steering note"}`))
+			req.Header.Set("Authorization", "Bearer tok")
+			w := httptest.NewRecorder()
+			m.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("note during %s = %d, want 200: %s", phase, w.Code, w.Body.String())
+			}
+
+			events, err := store.Events(ctx, id)
+			if err != nil {
+				t.Fatalf("Events: %v", err)
+			}
+			var sawPhase bool
+			for _, e := range events {
+				if e.Kind == "mission.steered" && strings.Contains(string(e.Payload), `"phase":"`+string(phase)+`"`) {
+					sawPhase = true
+				}
+			}
+			if !sawPhase {
+				t.Fatalf("mission.steered events = %+v, want one carrying phase=%s", events, phase)
+			}
+		})
+	}
+}
+
 // TestMissionsNoteUnknownMission confirms an unknown mission id 404s
 // before any store write is attempted.
 func TestMissionsNoteUnknownMission(t *testing.T) {

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -328,7 +328,16 @@ func TestMissionsNoteAcceptedOnEveryNonTerminalPhase(t *testing.T) {
 			}
 			var sawPhase bool
 			for _, e := range events {
-				if e.Kind == "mission.steered" && strings.Contains(string(e.Payload), `"phase":"`+string(phase)+`"`) {
+				if e.Kind != "mission.steered" {
+					continue
+				}
+				var payload struct {
+					Phase string `json:"phase"`
+				}
+				if err := json.Unmarshal(e.Payload, &payload); err != nil {
+					t.Fatalf("unmarshal mission.steered payload %s: %v", e.Payload, err)
+				}
+				if payload.Phase == string(phase) {
 					sawPhase = true
 				}
 			}

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -275,8 +275,9 @@ func (r *nativeRunner) SetLocation(loc func(ctx context.Context) *time.Location)
 // steeringFor only ever redelivers notes carrying it.
 const operatorNotePrefix = "Operator note: "
 
-// D-076: steeringFor builds a worker turn's loop.Request.Steering
-// closure: the watermark starts at the count of operator notes already
+// D-076/D-089: steeringFor builds a phase turn's loop.Request.Steering
+// closure (worker, discover, plan, and prove turns): the watermark
+// starts at the count of operator notes already
 // present in the packet the worker was seeded with, so those never
 // redeliver; each poll re-reads the mission's live progress log, takes
 // operator notes past the watermark, and advances it by however many it
@@ -1014,8 +1015,8 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 		// with feedback instead of parking (D-039). UI-created missions
 		// (ScheduleID empty) keep the park-and-answer flow.
 		Unattended: m.ScheduleID != "",
-		// Only the worker turn gets mid-run steering (D-076): explore/
-		// plan/review turns are unaffected.
+		// D-076/D-089: worker turns get mid-run steering, same mechanism
+		// now shared by discover/plan/prove turns (issue #458).
 		Steering: r.steeringFor(m.ID, packet.Progress),
 	}
 
@@ -1157,6 +1158,10 @@ func (r *nativeRunner) ExploreSession(ctx context.Context, m Mission) (string, e
 		ExtraTools:   extra,
 		BuiltinsOnly: true,
 		Unattended:   m.ScheduleID != "",
+		// D-089: discover turns get the same mid-turn steering as worker
+		// turns (issue #458): a note posted while explore is in flight
+		// reaches this turn instead of only the next phase's prompt.
+		Steering: r.steeringFor(m.ID, m.Progress),
 	}
 
 	res, err := r.runTurn(ctx, req, exploreNotesToolName, PhaseDiscover)
@@ -1245,6 +1250,8 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 		ExtraTools:   extra,
 		BuiltinsOnly: true,
 		Unattended:   m.ScheduleID != "",
+		// D-089: same mid-turn steering as discover/plan/worker (issue #458).
+		Steering: r.steeringFor(m.ID, m.Progress),
 	}
 	res, err := r.runTurn(ctx, req, reviewVerdictToolName, PhaseProve)
 	text, args := res.text, res.sentinelArgs
@@ -1407,6 +1414,8 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, exploreNotes 
 		ExtraTools:   extra,
 		BuiltinsOnly: true,
 		Unattended:   m.ScheduleID != "",
+		// D-089: same mid-turn steering as discover/worker (issue #458).
+		Steering: r.steeringFor(m.ID, m.Progress),
 	}
 	// Force submit_plan only when it is the turn's sole tool (D-063):
 	// a KB-attached mission also offers search_kb/read_kb here, and a

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -2610,3 +2610,100 @@ func TestRunWorkerWiresSteeringFromProgressReader(t *testing.T) {
 		}
 	})
 }
+
+// TestExploreSessionWiresSteeringFromProgressReader mirrors
+// TestRunWorkerWiresSteeringFromProgressReader for the discover phase
+// (D-089, issue #458): a ProgressReader must produce a non-nil Steering
+// func on the explore turn's loop.Request, same seam RunWorker uses.
+func TestExploreSessionWiresSteeringFromProgressReader(t *testing.T) {
+	batch := [][]stream.StreamEvent{
+		{toolEndEvent(exploreNotesToolName, `{"findings":"no prior implementation"}`)},
+	}
+
+	t.Run("wired", func(t *testing.T) {
+		agent := &scriptedAgent{batches: batch}
+		r := newTestRunner(agent)
+		r.SetProgressReader(&fakeProgressReader{})
+		if _, err := r.ExploreSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err != nil {
+			t.Fatalf("ExploreSession: %v", err)
+		}
+		if agent.requests[0].Steering == nil {
+			t.Fatal("Steering not wired on the explore request despite a ProgressReader")
+		}
+	})
+
+	t.Run("unwired", func(t *testing.T) {
+		agent := &scriptedAgent{batches: batch}
+		r := newTestRunner(agent)
+		if _, err := r.ExploreSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err != nil {
+			t.Fatalf("ExploreSession: %v", err)
+		}
+		if agent.requests[0].Steering != nil {
+			t.Fatal("Steering wired despite no ProgressReader")
+		}
+	})
+}
+
+// TestPlanSessionWiresSteeringFromProgressReader mirrors
+// TestRunWorkerWiresSteeringFromProgressReader for the plan phase
+// (D-089, issue #458).
+func TestPlanSessionWiresSteeringFromProgressReader(t *testing.T) {
+	batch := [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
+	}
+
+	t.Run("wired", func(t *testing.T) {
+		agent := &scriptedAgent{batches: batch}
+		r := newTestRunner(agent)
+		r.SetProgressReader(&fakeProgressReader{})
+		if _, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, ""); err != nil {
+			t.Fatalf("PlanSession: %v", err)
+		}
+		if agent.requests[0].Steering == nil {
+			t.Fatal("Steering not wired on the plan request despite a ProgressReader")
+		}
+	})
+
+	t.Run("unwired", func(t *testing.T) {
+		agent := &scriptedAgent{batches: batch}
+		r := newTestRunner(agent)
+		if _, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, ""); err != nil {
+			t.Fatalf("PlanSession: %v", err)
+		}
+		if agent.requests[0].Steering != nil {
+			t.Fatal("Steering wired despite no ProgressReader")
+		}
+	})
+}
+
+// TestRunReviewWiresSteeringFromProgressReader mirrors
+// TestRunWorkerWiresSteeringFromProgressReader for the prove phase
+// (D-089, issue #458).
+func TestRunReviewWiresSteeringFromProgressReader(t *testing.T) {
+	batch := [][]stream.StreamEvent{
+		{toolEndEvent(reviewVerdictToolName, `{"decision":"approve"}`)},
+	}
+
+	t.Run("wired", func(t *testing.T) {
+		agent := &scriptedAgent{batches: batch}
+		r := newTestRunner(agent)
+		r.SetProgressReader(&fakeProgressReader{})
+		if _, _, err := r.RunReview(context.Background(), Mission{ID: "m1", ReviewRoute: "default"}, ReviewPacket{Goal: "goal"}, nil); err != nil {
+			t.Fatalf("RunReview: %v", err)
+		}
+		if agent.requests[0].Steering == nil {
+			t.Fatal("Steering not wired on the review request despite a ProgressReader")
+		}
+	})
+
+	t.Run("unwired", func(t *testing.T) {
+		agent := &scriptedAgent{batches: batch}
+		r := newTestRunner(agent)
+		if _, _, err := r.RunReview(context.Background(), Mission{ID: "m1", ReviewRoute: "default"}, ReviewPacket{Goal: "goal"}, nil); err != nil {
+			t.Fatalf("RunReview: %v", err)
+		}
+		if agent.requests[0].Steering != nil {
+			t.Fatal("Steering wired despite no ProgressReader")
+		}
+	})
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -937,9 +937,12 @@ export interface ExecutorSkippedPayload {
 }
 
 // MissionSteeredPayload is mission.steered's payload: operator
-// guidance injected into a running mission via POST .../note.
+// guidance injected into a running mission via POST .../note. phase is
+// the mission's phase when the note landed (issue #458); absent on
+// events recorded before that field existed.
 export interface MissionSteeredPayload {
   note: string
+  phase?: string
 }
 
 // MissionTurnPayload is mission.turn's payload: one event per phase

--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -181,6 +181,13 @@ describe('mission.steered rendering', () => {
     expect(row).toBeInTheDocument()
     expect(row).toHaveClass('text-amber-400')
   })
+
+  it('includes the phase when the payload carries one', () => {
+    render(
+      <div>{renderEvent(event({ note: 'hurry up', phase: 'discover' }, 'mission.steered'))}</div>,
+    )
+    expect(screen.getByText(/Operator note \(discover\): hurry up/)).toBeInTheDocument()
+  })
 })
 
 describe('executor lifecycle event rendering', () => {

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -147,8 +147,12 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
   },
   'mission.resumed': () => 'Resumed',
   'mission.steered': (p) => {
-    const { note } = p as MissionSteeredPayload
-    return <span className="text-amber-400">Operator note: {note}</span>
+    const { note, phase } = p as MissionSteeredPayload
+    return (
+      <span className="text-amber-400">
+        Operator note{phase ? ` (${phase})` : ''}: {note}
+      </span>
+    )
   },
   'mission.recovery': () => 'Recovered after a restart',
   'mission.violation': () => <span className="text-red-400">Policy violation detected</span>,

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -769,21 +769,31 @@ describe('MissionDetail', () => {
     await waitFor(() => expect(resumeMission).toHaveBeenCalledWith('m1'))
   })
 
-  it('sends a note for a working mission and clears the input on success', async () => {
+  it('sends a note for a working mission via the Intervene modal and closes on success', async () => {
     renderPage()
     await screen.findByText('Fix the login bug')
-    const input = screen.getByPlaceholderText('Send a note to steer this mission…')
+    fireEvent.click(screen.getByRole('button', { name: 'Intervene' }))
+    const input = screen.getByPlaceholderText('Steer this mission (markdown supported)…')
     fireEvent.change(input, { target: { value: 'focus on staging next' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Send note' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
     await waitFor(() => expect(sendMissionNote).toHaveBeenCalledWith('m1', 'focus on staging next'))
-    await waitFor(() => expect(input).toHaveValue(''))
+    await waitFor(() =>
+      expect(screen.queryByPlaceholderText('Steer this mission (markdown supported)…')).toBeNull(),
+    )
   })
 
-  it('hides the note affordance once the mission is terminal', async () => {
+  it('shows the mission phase and status in the Intervene modal', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    fireEvent.click(screen.getByRole('button', { name: 'Intervene' }))
+    await screen.findByText((_, el) => el?.textContent === 'Currently in generate · working')
+  })
+
+  it('disables the Intervene button once the mission is terminal', async () => {
     vi.mocked(getMission).mockResolvedValue({ ...baseMission, phase: 'done', status: 'idle' })
     renderPage()
     await screen.findByText('Fix the login bug')
-    expect(screen.queryByPlaceholderText('Send a note to steer this mission…')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Intervene' })).toBeDisabled()
   })
 
   it('surfaces the most recent mission.paused event detail while paused', async () => {

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -4,6 +4,7 @@ import {
   Delete02Icon,
   GitBranchIcon,
   GitPullRequestCreateIcon,
+  Message01Icon,
   Pdf02Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
@@ -38,7 +39,6 @@ import { GoalSection } from '../components/missions/GoalSection'
 import { ResultSection } from '../components/missions/ResultSection'
 import { TimelineSection } from '../components/missions/TimelineSection'
 import { Button } from '../components/ui/button'
-import { Input } from '../components/ui/input'
 import {
   Dialog,
   DialogContent,
@@ -46,6 +46,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../components/ui/dialog'
+import { Textarea } from '../components/ui/textarea'
 import { ModelBadge } from '../components/ModelBadge'
 import { ClaudeCodeIcon } from '../components/icons/ClaudeCodeIcon'
 import { CursorIcon } from '../components/icons/CursorIcon'
@@ -227,6 +228,7 @@ export function MissionDetail() {
   const [schedule, setSchedule] = useState<Schedule | null>(null)
   const [busy, setBusy] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const [intervening, setIntervening] = useState(false)
   const [noteText, setNoteText] = useState('')
   const [sendingNote, setSendingNote] = useState(false)
   const [pushing, setPushing] = useState(false)
@@ -415,6 +417,7 @@ export function MissionDetail() {
     try {
       await sendMissionNote(id, text)
       setNoteText('')
+      setIntervening(false)
       toast.success('Note sent')
     } catch (err) {
       toast.error('Could not send note', { description: errText(err) })
@@ -701,24 +704,6 @@ export function MissionDetail() {
             {pauseDetail && (
               <p className="mt-2 text-sm text-amber-700 dark:text-amber-400">{pauseDetail}</p>
             )}
-            {!terminalPhases.has(mission.phase) && (
-              <div className="mt-3 flex max-w-md gap-2">
-                <Input
-                  placeholder="Send a note to steer this mission…"
-                  value={noteText}
-                  onChange={(e) => setNoteText(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && void sendNote()}
-                  disabled={sendingNote}
-                />
-                <Button
-                  variant="outline"
-                  disabled={sendingNote || !noteText.trim()}
-                  onClick={() => void sendNote()}
-                >
-                  Send note
-                </Button>
-              </div>
-            )}
           </div>
           <TooltipProvider>
             <div className="flex shrink-0 gap-2">
@@ -756,6 +741,25 @@ export function MissionDetail() {
                   )}
                 </>
               )}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <Button
+                      variant="outline"
+                      disabled={terminalPhases.has(mission.phase)}
+                      onClick={() => setIntervening(true)}
+                    >
+                      <HugeiconsIcon icon={Message01Icon} />
+                      Intervene
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {terminalPhases.has(mission.phase)
+                    ? 'This mission has finished; there is nothing left to steer'
+                    : 'Send a note to steer this mission, whatever phase it is in'}
+                </TooltipContent>
+              </Tooltip>
               {canResume && (
                 <Button variant="outline" disabled={busy} onClick={() => void resume()}>
                   Resume
@@ -925,6 +929,33 @@ export function MissionDetail() {
             </Button>
             <Button variant="destructive" disabled={busy} onClick={() => void remove()}>
               Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={intervening} onOpenChange={setIntervening}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Intervene</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Currently in <span className="font-medium text-foreground">{mission.phase}</span> ·{' '}
+            {mission.status.replace(/_/g, ' ')}
+          </p>
+          <Textarea
+            placeholder="Steer this mission (markdown supported)…"
+            value={noteText}
+            onChange={(e) => setNoteText(e.target.value)}
+            disabled={sendingNote}
+            rows={5}
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIntervening(false)}>
+              Cancel
+            </Button>
+            <Button disabled={sendingNote || !noteText.trim()} onClick={() => void sendNote()}>
+              Send
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
Closes #458.

Steering (D-076 mechanism) now reaches discover, plan, and prove turns, not just the worker turn: all four phase entry points in the native runner wire loop.Request.Steering through the existing steeringFor closure. This closes the gap found during #446: a note posted while the initial plan turn is in flight now reaches that turn live.

The note endpoint was already phase-agnostic (terminal-only rejection), so no gate change; the mission.steered event now records the phase the note landed in (D-089) and the timeline shows it.

Web: the always-visible steer text box on mission detail is removed and replaced by an Intervene button (header actions) opening a modal with the current phase/status and a markdown textarea; disabled on terminal missions.

Tests: wired/unwired steering pairs for explore/plan/review mirroring the worker test; integration table over all four phases asserting note acceptance plus phase-tagged event (payload compared via unmarshal, since jsonb round-trips reformat the text); web tests updated for the modal and phase-suffixed renderer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790787218&installation_model_id=431401&pr_number=464&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F464&signature=f06c58fccd4107f636b4d1c5d09d1e239971412f723e4821835e1e85e5694662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->