### PR TITLE
feat(web): markdown-aware ask_user, intervene, and replan inputs

### DIFF
--- a/web/src/components/missions/InputRequestBanner.test.tsx
+++ b/web/src/components/missions/InputRequestBanner.test.tsx
@@ -5,6 +5,19 @@ import { InputRequestBanner } from './InputRequestBanner'
 afterEach(cleanup)
 
 describe('InputRequestBanner', () => {
+  it('renders the question as markdown', () => {
+    render(
+      <InputRequestBanner
+        question="which **runtime** should this target?"
+        kind="mcq"
+        options={['node', 'python']}
+        proposedDefault="node"
+        onAnswer={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('runtime').tagName).toBe('STRONG')
+  })
+
   it('renders mcq options with the proposed default marked, and answers on click', () => {
     const onAnswer = vi.fn()
     render(
@@ -17,7 +30,7 @@ describe('InputRequestBanner', () => {
       />,
     )
     expect(screen.getByText(/which runtime should this target/)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /node.*proposed/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /node.*default/ })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /^python$/ }))
     expect(onAnswer).toHaveBeenCalledWith('python')
   })
@@ -32,12 +45,12 @@ describe('InputRequestBanner', () => {
         onAnswer={onAnswer}
       />,
     )
-    expect(screen.getByRole('button', { name: /Yes.*proposed/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Yes.*default/ })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /^No$/ }))
     expect(onAnswer).toHaveBeenCalledWith('no')
   })
 
-  it('renders an open textarea and submits typed text', () => {
+  it('renders an open MarkdownField and submits the drafted text unchanged', () => {
     const onAnswer = vi.fn()
     render(
       <InputRequestBanner
@@ -47,10 +60,10 @@ describe('InputRequestBanner', () => {
         onAnswer={onAnswer}
       />,
     )
-    const textarea = screen.getByPlaceholderText('Untitled')
-    fireEvent.change(textarea, { target: { value: 'My Report' } })
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'My **Report**' } })
     fireEvent.click(screen.getByRole('button', { name: 'Send' }))
-    expect(onAnswer).toHaveBeenCalledWith('My Report')
+    expect(onAnswer).toHaveBeenCalledWith('My **Report**')
   })
 
   it('falls back to the proposed default when open text is left empty', () => {
@@ -81,7 +94,7 @@ describe('InputRequestBanner', () => {
     expect(screen.queryByRole('button', { name: /^Yes/ })).not.toBeInTheDocument()
   })
 
-  it('renders a timeout line only when both timeoutSeconds and askedAt are given', () => {
+  it('always names the proposed default, adding the timeout only when both are given', () => {
     const { rerender } = render(
       <InputRequestBanner
         question="continue?"
@@ -90,7 +103,8 @@ describe('InputRequestBanner', () => {
         onAnswer={vi.fn()}
       />,
     )
-    expect(screen.queryByText(/Auto-answers/)).not.toBeInTheDocument()
+    expect(screen.getByText(/Auto-answers with the proposed default \(Yes\)/)).toBeInTheDocument()
+    expect(screen.queryByText(/if unanswered for/)).not.toBeInTheDocument()
 
     rerender(
       <InputRequestBanner
@@ -102,6 +116,6 @@ describe('InputRequestBanner', () => {
         askedAt="2026-08-30T00:00:00Z"
       />,
     )
-    expect(screen.getByText(/Auto-answers/)).toBeInTheDocument()
+    expect(screen.getByText(/if unanswered for 300s/)).toBeInTheDocument()
   })
 })

--- a/web/src/components/missions/InputRequestBanner.tsx
+++ b/web/src/components/missions/InputRequestBanner.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import { CodeBlock } from '../CodeBlock'
+import { rehypePlugins, remarkPlugins } from '../../lib/markdown'
 import { Button } from '../ui/button'
-import { Textarea } from '../ui/textarea'
+import { MarkdownField } from './MarkdownField'
 
 // InputRequestBanner renders only when a mission has a live
 // pending_input (ask_user's park, D-088). Same architecture as
@@ -41,10 +44,17 @@ export function InputRequestBanner({
   return (
     <div className="space-y-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900 dark:bg-amber-950">
       <div className="space-y-1">
-        <p className="text-sm font-medium text-amber-900 dark:text-amber-200">{question}</p>
-        {typeof timeoutSeconds === 'number' && timeoutSeconds > 0 && askedAt && (
+        <div className="prose prose-sm max-w-none text-amber-900 dark:prose-invert dark:text-amber-200">
+          <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins} components={{ pre: CodeBlock }}>
+            {question}
+          </ReactMarkdown>
+        </div>
+        {answered === undefined && (
           <p className="text-xs text-amber-700 dark:text-amber-400">
-            Auto-answers with the proposed default if unanswered for {timeoutSeconds}s
+            Auto-answers with the proposed default
+            {typeof timeoutSeconds === 'number' && timeoutSeconds > 0 && askedAt
+              ? ` (${kind === 'yes_no' ? (proposedDefault === 'yes' ? 'Yes' : 'No') : proposedDefault}) if unanswered for ${timeoutSeconds}s`
+              : ` (${kind === 'yes_no' ? (proposedDefault === 'yes' ? 'Yes' : 'No') : proposedDefault}) if unanswered`}
           </p>
         )}
       </div>
@@ -61,7 +71,11 @@ export function InputRequestBanner({
               onClick={() => onAnswer(opt)}
             >
               {opt}
-              {opt === proposedDefault && ' (proposed)'}
+              {opt === proposedDefault && (
+                <span className="ml-1 rounded-full bg-black/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wide dark:bg-white/15">
+                  default
+                </span>
+              )}
             </Button>
           ))}
         </div>
@@ -72,22 +86,32 @@ export function InputRequestBanner({
             size="sm"
             onClick={() => onAnswer('yes')}
           >
-            Yes{proposedDefault === 'yes' && ' (proposed)'}
+            Yes
+            {proposedDefault === 'yes' && (
+              <span className="ml-1 rounded-full bg-black/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wide dark:bg-white/15">
+                default
+              </span>
+            )}
           </Button>
           <Button
             variant={proposedDefault === 'no' ? 'default' : 'outline'}
             size="sm"
             onClick={() => onAnswer('no')}
           >
-            No{proposedDefault === 'no' && ' (proposed)'}
+            No
+            {proposedDefault === 'no' && (
+              <span className="ml-1 rounded-full bg-black/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wide dark:bg-white/15">
+                default
+              </span>
+            )}
           </Button>
         </div>
       ) : (
         <div className="space-y-2">
-          <Textarea
-            placeholder={proposedDefault || 'Your answer…'}
+          <MarkdownField
             value={openAnswer}
-            onChange={(e) => setOpenAnswer(e.target.value)}
+            onChange={setOpenAnswer}
+            placeholder={proposedDefault || 'Your answer, markdown supported…'}
           />
           <Button size="sm" onClick={() => onAnswer(openAnswer.trim() || proposedDefault)}>
             Send

--- a/web/src/components/missions/MarkdownField.test.tsx
+++ b/web/src/components/missions/MarkdownField.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MarkdownField } from './MarkdownField'
+
+afterEach(cleanup)
+
+describe('MarkdownField', () => {
+  it('renders a textarea in Write mode', () => {
+    render(<MarkdownField value="hello" onChange={vi.fn()} />)
+    expect(screen.getByRole('textbox')).toHaveValue('hello')
+  })
+
+  it('renders markdown in Preview mode', () => {
+    render(<MarkdownField value={'**bold** text and:\n\n- one\n- two'} onChange={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }))
+
+    expect(screen.getByText('bold').tagName).toBe('STRONG')
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
+  })
+
+  it('shows an empty state in Preview when the draft is blank', () => {
+    render(<MarkdownField value="" onChange={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }))
+
+    expect(screen.getByText('Nothing to preview')).toBeInTheDocument()
+  })
+
+  it('keeps the draft after toggling back to Write', () => {
+    const onChange = vi.fn()
+    const { rerender } = render(<MarkdownField value="draft text" onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }))
+    expect(screen.getByText('draft text')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Write' }))
+    rerender(<MarkdownField value="draft text" onChange={onChange} />)
+    expect(screen.getByRole('textbox')).toHaveValue('draft text')
+  })
+
+  it('disables the textarea when disabled is set', () => {
+    render(<MarkdownField value="" onChange={vi.fn()} disabled />)
+    expect(screen.getByRole('textbox')).toBeDisabled()
+  })
+})

--- a/web/src/components/missions/MarkdownField.tsx
+++ b/web/src/components/missions/MarkdownField.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import { CodeBlock } from '../CodeBlock'
+import { rehypePlugins, remarkPlugins } from '../../lib/markdown'
+import { Button } from '../ui/button'
+import { Textarea } from '../ui/textarea'
+
+// MarkdownField is a controlled textarea with a Write/Preview toggle,
+// reusing GoalSection's markdown stack for Preview. Shared by
+// InputRequestBanner's open kind, the Intervene modal, and
+// PlanApprovalBanner's replan feedback, so all three text inputs a
+// mission operator can markdown-format render the same way the goal
+// itself does.
+export function MarkdownField({
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  rows,
+}: {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  disabled?: boolean
+  rows?: number
+}) {
+  const [tab, setTab] = useState<'write' | 'preview'>('write')
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex gap-1">
+        <Button
+          type="button"
+          variant={tab === 'write' ? 'secondary' : 'ghost'}
+          size="xs"
+          onClick={() => setTab('write')}
+        >
+          Write
+        </Button>
+        <Button
+          type="button"
+          variant={tab === 'preview' ? 'secondary' : 'ghost'}
+          size="xs"
+          onClick={() => setTab('preview')}
+        >
+          Preview
+        </Button>
+      </div>
+      {tab === 'write' ? (
+        <Textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          disabled={disabled}
+          rows={rows}
+        />
+      ) : value.trim() ? (
+        <div className="prose prose-sm min-h-16 max-w-none rounded-lg border border-input px-2.5 py-2 dark:prose-invert">
+          <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins} components={{ pre: CodeBlock }}>
+            {value}
+          </ReactMarkdown>
+        </div>
+      ) : (
+        <div className="flex min-h-16 items-center rounded-lg border border-input px-2.5 py-2 text-sm text-muted-foreground">
+          Nothing to preview
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/missions/PlanApprovalBanner.test.tsx
+++ b/web/src/components/missions/PlanApprovalBanner.test.tsx
@@ -49,10 +49,10 @@ describe('PlanApprovalBanner', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Request replan' }))
     const textarea = screen.getByPlaceholderText(/Optional feedback/)
-    fireEvent.change(textarea, { target: { value: 'try a different approach' } })
+    fireEvent.change(textarea, { target: { value: 'try a different **approach**' } })
     fireEvent.click(screen.getByRole('button', { name: 'Send' }))
 
-    expect(onReplan).toHaveBeenCalledWith('try a different approach')
+    expect(onReplan).toHaveBeenCalledWith('try a different **approach**')
   })
 
   it('submits empty feedback when Send is clicked with no text typed', () => {

--- a/web/src/components/missions/PlanApprovalBanner.tsx
+++ b/web/src/components/missions/PlanApprovalBanner.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import type { PlanAssumption, PlanUnit } from '../../api/types'
 import { Button } from '../ui/button'
-import { Textarea } from '../ui/textarea'
+import { MarkdownField } from './MarkdownField'
 import { PlanSection } from './PlanSection'
 
 // answeredCopy mirrors PermissionBanner's own status-line pattern: the
@@ -73,10 +73,10 @@ export function PlanApprovalBanner({
       <PlanSection units={units} assumptions={assumptions} />
       {answeredDecision === undefined && showFeedback && (
         <div className="space-y-2">
-          <Textarea
-            placeholder="Optional feedback for the replan…"
+          <MarkdownField
             value={feedback}
-            onChange={(e) => setFeedback(e.target.value)}
+            onChange={setFeedback}
+            placeholder="Optional feedback for the replan, markdown supported…"
           />
           <Button size="sm" onClick={submitReplan}>
             Send

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -31,6 +31,7 @@ import {
 import type { Mission, MissionEvent, MissionPROpenedPayload, MissionUsage, Schedule } from '../api/types'
 import { ArtifactsSection } from '../components/missions/ArtifactsSection'
 import { InputRequestBanner } from '../components/missions/InputRequestBanner'
+import { MarkdownField } from '../components/missions/MarkdownField'
 import { PermissionBanner } from '../components/missions/PermissionBanner'
 import { PlanApprovalBanner } from '../components/missions/PlanApprovalBanner'
 import { PlanSection } from '../components/missions/PlanSection'
@@ -46,7 +47,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../components/ui/dialog'
-import { Textarea } from '../components/ui/textarea'
 import { ModelBadge } from '../components/ModelBadge'
 import { ClaudeCodeIcon } from '../components/icons/ClaudeCodeIcon'
 import { CursorIcon } from '../components/icons/CursorIcon'
@@ -956,10 +956,10 @@ export function MissionDetail() {
             Currently in <span className="font-medium text-foreground">{mission.phase}</span> ·{' '}
             {mission.status.replace(/_/g, ' ')}
           </p>
-          <Textarea
+          <MarkdownField
             placeholder="Steer this mission (markdown supported)…"
             value={noteText}
-            onChange={(e) => setNoteText(e.target.value)}
+            onChange={setNoteText}
             disabled={sendingNote}
             rows={5}
           />


### PR DESCRIPTION
Closes #468.

Question text in the ask_user banner now renders through the house markdown stack (GoalSection pattern) for all three kinds, and the three operator text inputs (open answer, Intervene note, replan feedback) share a new MarkdownField component: a controlled textarea with a Write/Preview toggle whose preview uses the same ReactMarkdown stack and prose styling as the goal box. mcq/yes_no options mark the proposed default with a small badge instead of inline text, and the banner always states what happens if nothing is answered, appending the timeout only when one is actually set.

Web-only change; no new dependencies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790800860&installation_model_id=431401&pr_number=469&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F469&signature=0496ed29e9734c63c30df8d28a48c7426707f72a9c077c191eed944289378683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->