### PR TITLE
fix: name mission in ask-timeout notice, success style, full-width goal

### DIFF
--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -753,9 +753,13 @@ func (s *Store) ClearPendingInput(ctx context.Context, id string) error {
 }
 
 // ParkedInput is one PendingInputs row: just enough for the timeout
-// sweep's elapsed-time decision, mirroring ParkedPermission.
+// sweep's elapsed-time decision, mirroring ParkedPermission. Name and
+// Goal let the sweep's notification name the mission (PRTitle takes a
+// Mission, so both are carried rather than a pre-computed title).
 type ParkedInput struct {
 	MissionID string
+	Name      string
+	Goal      string
 	Input     PendingInput
 }
 
@@ -766,23 +770,23 @@ func (s *Store) PendingInputs(ctx context.Context) ([]ParkedInput, error) {
 	if err != nil {
 		return nil, fmt.Errorf("missions pending inputs: %w", err)
 	}
-	rows, err := db.Query(ctx, `SELECT id, pending_input FROM missions WHERE pending_input IS NOT NULL`)
+	rows, err := db.Query(ctx, `SELECT id, name, goal, pending_input FROM missions WHERE pending_input IS NOT NULL`)
 	if err != nil {
 		return nil, fmt.Errorf("missions pending inputs: %w", err)
 	}
 	defer rows.Close()
 	out := []ParkedInput{}
 	for rows.Next() {
-		var id string
+		var id, name, goal string
 		var raw []byte
-		if err := rows.Scan(&id, &raw); err != nil {
+		if err := rows.Scan(&id, &name, &goal, &raw); err != nil {
 			return nil, fmt.Errorf("missions pending inputs: %w", err)
 		}
 		var p PendingInput
 		if err := json.Unmarshal(raw, &p); err != nil {
 			continue // corrupt row: skip rather than fail the whole sweep
 		}
-		out = append(out, ParkedInput{MissionID: id, Input: p})
+		out = append(out, ParkedInput{MissionID: id, Name: name, Goal: goal, Input: p})
 	}
 	return out, rows.Err()
 }

--- a/internal/brain/missions/sweep.go
+++ b/internal/brain/missions/sweep.go
@@ -548,8 +548,9 @@ func sweepAskTimeouts(ctx context.Context, d askTimeoutDriver, store askTimeoutS
 			continue
 		}
 		if notify != nil {
-			if err := notify.NotifyMessage(ctx, p.MissionID, "ask_timed_out",
-				"a pending question timed out and the proposed default was applied automatically"); err != nil {
+			title := PRTitle(Mission{Name: p.Name, Goal: p.Goal})
+			message := fmt.Sprintf("Mission - %s: pending question timed out; applied the proposed default (%s).", title, p.Input.ProposedDefault)
+			if err := notify.NotifyMessage(ctx, p.MissionID, "ask_timed_out", message); err != nil {
 				log.Warn("ask timeout sweep: notify failed", "mission_id", p.MissionID, "error", err)
 			}
 		}

--- a/internal/brain/missions/sweep_test.go
+++ b/internal/brain/missions/sweep_test.go
@@ -93,13 +93,16 @@ func (f *fakeSignaler) Signal(ctx context.Context, id string, input Input) error
 }
 
 // fakeMessageNotifier captures NotifyMessage calls for
-// autoResumeBackoff tests.
+// autoResumeBackoff tests. messages mirrors notified 1:1, added for
+// tests that need to assert on the notification text itself.
 type fakeMessageNotifier struct {
 	notified []string
+	messages []string
 }
 
 func (f *fakeMessageNotifier) NotifyMessage(ctx context.Context, missionID, kind, message string) error {
 	f.notified = append(f.notified, missionID)
+	f.messages = append(f.messages, message)
 	return nil
 }
 
@@ -498,8 +501,8 @@ func TestSweepAskTimeoutsAppliesDefaultAndDrives(t *testing.T) {
 	now := time.Now()
 	store := &fakeAskTimeoutStore{
 		pending: []ParkedInput{
-			{MissionID: "timed-out", Input: PendingInput{ProposedDefault: "yes", AskedAt: now.Add(-10 * time.Minute)}},
-			{MissionID: "still-waiting", Input: PendingInput{ProposedDefault: "no", AskedAt: now.Add(-1 * time.Second)}},
+			{MissionID: "timed-out", Name: "Fix login bug", Input: PendingInput{ProposedDefault: "yes", AskedAt: now.Add(-10 * time.Minute)}},
+			{MissionID: "still-waiting", Name: "Other mission", Input: PendingInput{ProposedDefault: "no", AskedAt: now.Add(-1 * time.Second)}},
 		},
 	}
 	driver := &fakeAskTimeoutDriver{}
@@ -514,6 +517,10 @@ func TestSweepAskTimeoutsAppliesDefaultAndDrives(t *testing.T) {
 	}
 	if len(notifier.notified) != 1 || notifier.notified[0] != "timed-out" {
 		t.Fatalf("notified = %v, want exactly [timed-out]", notifier.notified)
+	}
+	wantMessage := "Mission - Fix login bug: pending question timed out; applied the proposed default (yes)."
+	if len(notifier.messages) != 1 || notifier.messages[0] != wantMessage {
+		t.Fatalf("messages = %v, want exactly [%q]", notifier.messages, wantMessage)
 	}
 	if len(driver.drove) != 1 || driver.drove[0] != "timed-out" {
 		t.Fatalf("drove = %v, want exactly [timed-out]", driver.drove)

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -620,9 +620,6 @@ export function MissionDetail() {
         <div className="flex items-start justify-between gap-4">
           <div>
             <h1 className="text-xl font-semibold tracking-tight">{missionDisplayName(mission)}</h1>
-            <div className="mt-1.5">
-              <GoalSection goal={mission.goal} />
-            </div>
             <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-sm text-muted-foreground">
               <span className="capitalize">{mission.kind}</span>
               <span>{mission.phase}</span>
@@ -811,6 +808,9 @@ export function MissionDetail() {
               )}
             </div>
           </TooltipProvider>
+        </div>
+        <div className="mt-2">
+          <GoalSection goal={mission.goal} />
         </div>
         <div className="mt-3 flex flex-wrap items-center gap-1.5">
           {usage &&

--- a/web/src/pages/Missions.tsx
+++ b/web/src/pages/Missions.tsx
@@ -31,6 +31,8 @@ function harnessLabel(harness?: string): string {
 // kind) falls back to the existing amber styling.
 const notificationSeverityClasses: Record<string, string> = {
   done: 'border-green-200 bg-green-50 text-green-900 dark:border-green-900 dark:bg-green-950 dark:text-green-200',
+  ask_timed_out:
+    'border-green-200 bg-green-50 text-green-900 dark:border-green-900 dark:bg-green-950 dark:text-green-200',
   error:
     'border-red-200 bg-red-50 text-red-900 dark:border-red-900 dark:bg-red-950 dark:text-red-200',
   paused:
@@ -41,6 +43,8 @@ const notificationSeverityClasses: Record<string, string> = {
 
 const notificationDismissClasses: Record<string, string> = {
   done: 'text-green-700 hover:text-green-900 dark:text-green-400 dark:hover:text-green-200',
+  ask_timed_out:
+    'text-green-700 hover:text-green-900 dark:text-green-400 dark:hover:text-green-200',
   error: 'text-red-700 hover:text-red-900 dark:text-red-400 dark:hover:text-red-200',
   paused: 'text-amber-700 hover:text-amber-900 dark:text-amber-400 dark:hover:text-amber-200',
   waiting_for_input:


### PR DESCRIPTION
Closes #470.

The ask-timeout notification was generic amber text with no mission identity; it now names the mission and states the applied default, and renders with the green success styling (applying the proposed default is the designed benign outcome, not a warning). The mission detail goal box was clipped to the header's left flex column; it now renders full width below the header row.

Verified: go test -race ./internal/brain/missions/ ok, go vet clean, web build+lint+test 1021/1021.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790809762&installation_model_id=431401&pr_number=471&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F471&signature=c0ef53498f7ac2913d8f9584a38add5f165b285963d5e41ec0da5bc2a380d792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->