### PR TITLE
fix(web): drop flow pill, lift composer autocomplete above header

### DIFF
--- a/web/src/components/Composer.tsx
+++ b/web/src/components/Composer.tsx
@@ -583,7 +583,7 @@ export function Composer({
       className="relative rounded-2xl border border-zinc-950/10 bg-white shadow-sm transition focus-within:border-blue-500/50 focus-within:ring-4 focus-within:ring-blue-500/10 dark:border-white/10 dark:bg-zinc-800/60 dark:focus-within:border-blue-400/40"
     >
       {popupOpen && (
-        <div className="absolute bottom-full left-2 z-10 mb-1 max-h-72 w-64 overflow-y-auto rounded-lg border border-zinc-950/10 bg-white py-1 shadow-lg dark:border-white/10 dark:bg-zinc-800">
+        <div className="absolute bottom-full left-2 z-50 mb-1 max-h-72 w-64 overflow-y-auto rounded-lg border border-zinc-950/10 bg-white py-1 shadow-lg dark:border-white/10 dark:bg-zinc-800">
           {combinedOptions.map((opt, i) => (
             <div key={i}>
               {opt.header && (

--- a/web/src/components/missions/MissionReferences.tsx
+++ b/web/src/components/missions/MissionReferences.tsx
@@ -107,7 +107,7 @@ export function GoalTextarea({
     <div className="space-y-2">
       <div className="relative">
         {open && (
-          <div className="absolute bottom-full left-0 z-10 mb-1 max-h-72 w-72 overflow-y-auto rounded-lg border border-border bg-popover py-1 shadow-lg">
+          <div className="absolute bottom-full left-0 z-50 mb-1 max-h-72 w-72 overflow-y-auto rounded-lg border border-border bg-popover py-1 shadow-lg">
             {groups.map((group) => (
               <div key={group.kind}>
                 <div className="px-3 pt-1.5 pb-0.5 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase">

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -849,11 +849,6 @@ export function MissionDetail() {
                 </Badge>
               )
             })()}
-          {mission.flow && mission.flow !== 'full' && (
-            <Badge variant="secondary" title="Phase set this mission runs, chosen at create time">
-              flow · {mission.flow.replace(/_/g, ' ')}
-            </Badge>
-          )}
           {mission.on_complete === 'push' && (
             <Badge variant="secondary" title="This mission pushes its branch automatically when it finishes">
               auto-push


### PR DESCRIPTION
Closes #474.

The flow pill on mission detail duplicated information without earning its place; removed. The # autocomplete popups (chat Composer and mission goal MissionReferences) sat at z-10 while every other overlay in the app uses z-50, so long lists slid under the page header; both now use the z-50 convention.

Verified: web build + lint clean, 1021/1021 tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790811155&installation_model_id=431401&pr_number=475&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F475&signature=e801fed54213164e67c23a584178373e0f885d098d31e0fb06d779eef20bfa25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->