### PR TITLE
feat(missions): phase chips and route/agent context in timeline, logs

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -933,6 +933,7 @@ func missionAgentResolver(agentReg *agents.Store) missions.AgentResolver {
 			return missions.AgentDefaults{}, false
 		}
 		return missions.AgentDefaults{
+			Name:  a.Name,
 			Route: a.Route, ReviewRoute: a.ReviewRoute, PromptOverlay: a.PromptOverlay,
 			ApprovalAllowlist: a.ApprovalAllowlist,
 			Knowledge:         a.Knowledge, Harness: a.Harness,

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -308,6 +308,21 @@ func (d *Driver) SetAgentResolver(resolve AgentResolver) {
 	d.provision.resolveAgent = resolve
 }
 
+// agentName resolves a mission's agent to its display name for the
+// mission.turn event payload (issue #473). Empty agentID or an unwired/
+// missing resolver both return "" rather than erroring: a label is a
+// nicety, never worth failing turn telemetry over.
+func (d *Driver) agentName(ctx context.Context, agentID string) string {
+	if agentID == "" || d.provision.resolveAgent == nil {
+		return ""
+	}
+	defaults, ok := d.provision.resolveAgent(ctx, agentID)
+	if !ok {
+		return ""
+	}
+	return defaults.Name
+}
+
 // SetSkillsIndex wires the resolver packet() uses to render the
 // mission agent's skill index into worker prompts — a setter for the
 // same construction-order reason SetAgentResolver is. nil (unwired)
@@ -794,7 +809,7 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 	// never got an immediate Drive at all.
 	if m.Status == StatusIdle {
 		if admit, reason := admitWork(ctx, d.capacity, d.log); !admit {
-			d.log.Info("driver: capacity denied, mission stays idle", "mission_id", id, "reason", reason)
+			d.log.Info("driver: capacity denied, mission stays idle", "mission_id", id, "phase", m.Phase, "reason", reason)
 			return false, nil
 		}
 	}
@@ -811,7 +826,7 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 			// the work-slot sweep to retry ensureProvisioned every 30s
 			// forever. Pause it as an infra failure instead, same path a
 			// phase-run error takes below.
-			d.log.Error("driver: provisioning failed", "mission_id", id, "error", provErr)
+			d.log.Error("driver: provisioning failed", "mission_id", id, "agent", d.agentName(ctx, m.AgentID), "error", provErr)
 			in := StepInput{Input: InputReviewInfraFailure, Reason: "provisioning failed: " + provErr.Error()}
 			t := Step(d.toStepState(ctx, m), in, d.cfg)
 			if err := d.store.ApplyTransition(ctx, id, t); err != nil {
@@ -835,7 +850,8 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 		err = nil
 	}
 	if err != nil {
-		d.log.Error("driver: phase run failed", "mission_id", id, "phase", m.Phase, "error", err)
+		d.log.Error("driver: phase run failed", "mission_id", id, "phase", m.Phase,
+			"route", phaseRoute(m), "agent", d.agentName(ctx, m.AgentID), "error", err)
 		switch {
 		case errors.Is(err, ErrModelFloor):
 			// A below-floor fallback model served this turn: it cannot
@@ -873,6 +889,17 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 	if m.Phase == PhaseGenerate && workerRoute(m) != m.Route {
 		payload["escalated_route"] = workerRoute(m)
 	}
+	// Route/agent context (issue #473): route is the mission's own
+	// effective route for the phase that just ran (same helpers
+	// runner.go's request builders already use), never the resolved
+	// model, since the runner doesn't surface which chain entry
+	// actually served the turn, and guessing one is worse than omitting it.
+	if route := phaseRoute(m); route != "" {
+		payload["route"] = route
+	}
+	if agent := d.agentName(ctx, m.AgentID); agent != "" {
+		payload["agent"] = agent
+	}
 	if evErr := d.store.AppendEvent(ctx, id, "mission.turn", payload); evErr != nil {
 		d.log.Warn("driver: record turn failed", "mission_id", id, "error", evErr)
 	}
@@ -895,7 +922,7 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 			// row. Cancel's own transition already tore down the sandbox;
 			// this is the belt for a turn that raced past that teardown and
 			// may have started a fresh container of its own.
-			d.log.Info("driver: mission reached terminal state mid-turn, discarding turn result", "mission_id", id)
+			d.log.Info("driver: mission reached terminal state mid-turn, discarding turn result", "mission_id", id, "phase", m.Phase)
 			delete(d.gatekeepers, id)
 			d.removeSandbox(id)
 			return false, nil

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -2523,6 +2523,50 @@ func TestDriverModelFloorPausesImmediately(t *testing.T) {
 	}
 }
 
+// TestDriverTurnEventCarriesRouteAndAgent covers issue #473: the
+// mission.turn event payload records the phase's effective route
+// (phaseRoute) and the mission agent's display name (via the wired
+// AgentResolver), never a guessed model.
+func TestDriverTurnEventCarriesRouteAndAgent(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking,
+		MaxIterations: 8, Route: "mini", AgentID: "coder-agent",
+	})
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "complete"}}}
+	d := testDriver(store, runner)
+	d.SetAgentResolver(func(ctx context.Context, agentID string) (AgentDefaults, bool) {
+		if agentID != "coder-agent" {
+			return AgentDefaults{}, false
+		}
+		return AgentDefaults{Name: "Coder"}, true
+	})
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	events, _ := store.Events(context.Background(), "m1")
+	var turn Event
+	for _, e := range events {
+		if e.Kind == "mission.turn" {
+			turn = e
+		}
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(turn.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal mission.turn payload: %v", err)
+	}
+	if payload["route"] != "mini" {
+		t.Fatalf("payload[route] = %v, want mini", payload["route"])
+	}
+	if payload["agent"] != "Coder" {
+		t.Fatalf("payload[agent] = %v, want Coder", payload["agent"])
+	}
+	if _, ok := payload["model"]; ok {
+		t.Fatalf("payload[model] = %v, want absent (never guessed)", payload["model"])
+	}
+}
+
 // TestDriverAdvanceDeniesIdleToWorkingOnCapacity covers D-056's driver-
 // path gate: an idle mission whose capacity gate denies must not run
 // its turn at all (the runner is never called) and canContinue=false so

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -947,6 +947,24 @@ func reviewRoute(m Mission) string {
 	return oversightRoute(m)
 }
 
+// phaseRoute reports the route a mission's just-run phase actually
+// used, mirroring the same helper each phase's request builder calls
+// (discover/plan -> oversightRoute, generate -> workerRoute, prove ->
+// reviewRoute). Used only for the mission.turn event's telemetry
+// (issue #473); result runs no LLM turn, so it reports "".
+func phaseRoute(m Mission) string {
+	switch m.Phase {
+	case PhaseDiscover, PhasePlan:
+		return oversightRoute(m)
+	case PhaseGenerate:
+		return workerRoute(m)
+	case PhaseProve:
+		return reviewRoute(m)
+	default:
+		return ""
+	}
+}
+
 // workerModel is workerRoute's model-pin counterpart (D-078): RouteModel
 // pins execute turns to one chain entry in workerRoute(m). Cleared
 // whenever workerRoute has swapped to EscalationRoute: RouteModel names
@@ -1064,7 +1082,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 	combined := text + "\n" + recoverText
 	if raw, ok := extractTextSentinel(combined, missionStatusToolName); ok {
 		if v, ok := r.tryParseVerdict(raw); ok {
-			r.log.Warn("mission worker expressed mission_status as text, not a tool call", "mission_id", m.ID)
+			r.log.Warn("mission worker expressed mission_status as text, not a tool call", "mission_id", m.ID, "route", workerRoute(m))
 			v.SeenURLs = append(seenURLs, kbSeen.all()...)
 			v.FinalMessage = recoverRes.finalSeg
 			return v, combined, nil
@@ -1074,9 +1092,9 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 	// Still missing: bail detection informs the log, but either way this
 	// is a forced retry: detection accuracy never gates the outcome.
 	if detectBail(combined) {
-		r.log.Warn("mission worker bailed without a sentinel call", "mission_id", m.ID)
+		r.log.Warn("mission worker bailed without a sentinel call", "mission_id", m.ID, "route", workerRoute(m))
 	} else {
-		r.log.Warn("mission worker ended without a sentinel call", "mission_id", m.ID)
+		r.log.Warn("mission worker ended without a sentinel call", "mission_id", m.ID, "route", workerRoute(m))
 	}
 	return forcedRetryVerdict("the worker did not report a status; treated as a failed attempt"), combined, nil
 }
@@ -1202,7 +1220,7 @@ func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (string, 
 
 	// Advisory phase: never a forced failure. The raw turn text is still
 	// useful context for the planner even with no structured findings.
-	r.log.Warn("mission discover ended without a discover_notes call; using raw turn text", "mission_id", m.ID)
+	r.log.Warn("mission discover ended without a discover_notes call; using raw turn text", "mission_id", m.ID, "route", oversightRoute(m))
 	return strings.TrimSpace(combined), nil
 }
 
@@ -1289,7 +1307,7 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 			// tolerates.
 			combined := text + "\n" + recoverText
 			if raw, ok := extractTextSentinel(combined, reviewVerdictToolName); ok {
-				r.log.Warn("mission reviewer expressed review_verdict as text, not a tool call", "mission_id", m.ID)
+				r.log.Warn("mission reviewer expressed review_verdict as text, not a tool call", "mission_id", m.ID, "route", reviewRoute(m))
 				text, args = combined, raw
 			} else {
 				return ReviewVerdict{}, nil, fmt.Errorf("mission runner: reviewer ended without a review_verdict call")
@@ -1459,12 +1477,12 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, discoverNotes
 		return Spec{}, err
 	}
 	if len(recoverArgs) == 0 {
-		r.log.Warn("mission planner ended without a submit_plan call", "mission_id", m.ID, "text", text, "recover_text", recoverText)
+		r.log.Warn("mission planner ended without a submit_plan call", "mission_id", m.ID, "route", oversightRoute(m), "text", text, "recover_text", recoverText)
 		return Spec{}, fmt.Errorf("mission runner: planner ended without a submit_plan call")
 	}
 	spec, err := parseSpec(string(recoverArgs))
 	if err != nil {
-		r.log.Warn("mission planner submitted an invalid plan twice", "mission_id", m.ID, "text", text, "recover_text", recoverText, "error", err)
+		r.log.Warn("mission planner submitted an invalid plan twice", "mission_id", m.ID, "route", oversightRoute(m), "text", text, "recover_text", recoverText, "error", err)
 		return Spec{}, err
 	}
 	return spec, nil

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -1228,6 +1228,30 @@ func TestReviewRoute(t *testing.T) {
 	}
 }
 
+// TestPhaseRoute pins the mission.turn event's route field (issue
+// #473) to whichever route helper the phase's own request builder
+// actually uses, and to "" for result (no LLM turn runs there).
+func TestPhaseRoute(t *testing.T) {
+	tests := []struct {
+		name string
+		m    Mission
+		want string
+	}{
+		{"discover uses oversight route", Mission{Phase: PhaseDiscover, Route: "mini", PlanRoute: "strong"}, "strong"},
+		{"plan uses oversight route", Mission{Phase: PhasePlan, Route: "mini", PlanRoute: "strong"}, "strong"},
+		{"generate uses worker route", Mission{Phase: PhaseGenerate, Route: "mini", EscalationRoute: "coding", ConsecutiveFailures: 1}, "coding"},
+		{"prove uses review route", Mission{Phase: PhaseProve, Route: "mini", ReviewRoute: "reviewer"}, "reviewer"},
+		{"result runs no LLM turn", Mission{Phase: PhaseResult, Route: "mini"}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := phaseRoute(tc.m); got != tc.want {
+				t.Fatalf("phaseRoute = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestWorkerModel pins route_model's precedence: it backs execute
 // exactly like Route, but must NOT carry over once workerRoute has
 // swapped to EscalationRoute: it names an entry in the base route's

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -106,6 +106,11 @@ type MissionTemplate struct {
 // api/missions.go's create-handler resolution so a scheduler-fired
 // mission gets the same defaults a UI-created one would.
 type AgentDefaults struct {
+	// Name is the agent's display name, used to label a mission's
+	// turns in the timeline (issue #473), resolved fresh here rather
+	// than snapshotted on the mission, same freshness reasoning as the
+	// rest of this struct.
+	Name              string
 	Route             string
 	ReviewRoute       string
 	PromptOverlay     string

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -958,6 +958,12 @@ export interface MissionSteeredPayload {
 // MissionTurnPayload is mission.turn's payload: one event per phase
 // run (driver.go's Advance), recording wall time and the StepInput that
 // resulted regardless of which phase actually ran.
+// route/agent (issue #473) are the phase's effective route and the
+// mission agent's display name, both absent on a legacy event
+// recorded before this field existed and absent when unresolvable
+// (e.g. no agent set), never a placeholder string. model is
+// deliberately not carried here: the runner doesn't surface which
+// chain entry actually served the turn, and driver.go never guesses one.
 export interface MissionTurnPayload {
   phase: string
   duration_ms: number
@@ -965,6 +971,8 @@ export interface MissionTurnPayload {
   input: string
   reason?: string
   escalated_route?: string
+  route?: string
+  agent?: string
 }
 
 // MissionRetryPayload is mission.retry's payload (statemachine.go);

--- a/web/src/components/missions/TimelineSection.test.tsx
+++ b/web/src/components/missions/TimelineSection.test.tsx
@@ -245,3 +245,50 @@ describe('TimelineSection tool call trace', () => {
     expect(screen.queryByText(/tool call/)).toBeNull()
   })
 })
+
+describe('TimelineSection phase chips', () => {
+  it('chips each row with the phase most recently started before it', () => {
+    const phaseEvents: MissionEvent[] = [
+      {
+        mission_id: 'm1',
+        seq: 1,
+        kind: 'mission.phase_started',
+        payload: { phase: 'discover' },
+        provenance: 'harness',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        mission_id: 'm1',
+        seq: 2,
+        kind: 'mission.discover_complete',
+        payload: { chars: 10 },
+        provenance: 'harness',
+        created_at: '2026-01-01T00:00:01Z',
+      },
+      {
+        mission_id: 'm1',
+        seq: 3,
+        kind: 'mission.phase_started',
+        payload: { phase: 'plan' },
+        provenance: 'harness',
+        created_at: '2026-01-01T00:00:02Z',
+      },
+      {
+        mission_id: 'm1',
+        seq: 4,
+        kind: 'mission.plan_created',
+        payload: { units: 1 },
+        provenance: 'harness',
+        created_at: '2026-01-01T00:00:03Z',
+      },
+    ]
+    render(<TimelineSection events={phaseEvents} />)
+    expect(screen.getAllByText('discover')).toHaveLength(2) // phase_started row + discover_complete row
+    expect(screen.getAllByText('plan')).toHaveLength(2) // phase_started row + plan_created row
+  })
+
+  it('renders no chip when the mission has no phase_started event at all', () => {
+    render(<TimelineSection events={events} />)
+    expect(screen.queryByText('discover')).toBeNull()
+  })
+})

--- a/web/src/components/missions/TimelineSection.tsx
+++ b/web/src/components/missions/TimelineSection.tsx
@@ -8,6 +8,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/
 import { renderEvent, toolCallStatusClass } from './eventRenderers'
 import { FullscreenDialog, FullscreenToggle, useFullscreenPanel } from './FullscreenPanel'
 import { formatDuration } from '../../lib/format'
+import { phaseColors, phaseLabel } from '../../lib/phaseColors'
 
 // How close to the bottom (px) counts as "already following the tail"
 //: auto-scroll only kicks in within this margin, so a reader who has
@@ -45,6 +46,38 @@ function turnToolCalls(events: MissionEvent[]): Map<number, MissionEvent[]> {
     }
   }
   return byTurn
+}
+
+// rowPhases maps each rendered row's seq to the phase chip it should
+// show: the phase most recently started (mission.phase_started) before
+// that row, or the first phase_started's phase for rows that precede
+// it (nothing has started yet, so the mission's opening phase is the
+// closest honest label, see mission.phase_started's payload). A
+// mission with no phase_started event at all (shouldn't happen past
+// create, but a defensive default) leaves every row unchipped.
+function rowPhases(rows: MissionEvent[]): Map<number, string> {
+  const starts = rows.filter((e) => e.kind === 'mission.phase_started')
+  if (starts.length === 0) return new Map()
+  const firstPhase = String((starts[0].payload as { phase?: string }).phase ?? '')
+  const chips = new Map<number, string>()
+  let current = firstPhase
+  for (const e of rows) {
+    if (e.kind === 'mission.phase_started') {
+      current = String((e.payload as { phase?: string }).phase ?? current)
+    }
+    chips.set(e.seq, current)
+  }
+  return chips
+}
+
+// PhaseChip renders a small color-coded phase label (issue #473): one
+// consistent color per phase (lib/phaseColors), shared with anywhere
+// else a phase gets colored.
+function PhaseChip({ phase }: { phase: string }) {
+  const label = phaseLabel(phase)
+  const color = phaseColors[label]
+  if (!color) return null
+  return <span className={`mr-1.5 rounded px-1 py-0.5 text-[10px] font-semibold whitespace-nowrap ${color}`}>{label}</span>
 }
 
 // TurnTraceToggle renders the expand/collapse control and, when
@@ -115,6 +148,7 @@ function timelineText(rows: MissionEvent[]): string {
 export function TimelineSection({ events }: { events: MissionEvent[] }) {
   const rows = events.filter(rowKind)
   const toolCallsByTurn = turnToolCalls(events)
+  const phasesBySeq = rowPhases(rows)
   const containerRef = useRef<HTMLDivElement>(null)
   const wasAtBottomRef = useRef(true)
   const { fullscreen, toggle, close } = useFullscreenPanel()
@@ -203,6 +237,7 @@ export function TimelineSection({ events }: { events: MissionEvent[] }) {
                   {new Date(e.created_at).toLocaleTimeString()}
                 </span>
                 <span className="flex-1 break-words">
+                  {phasesBySeq.has(e.seq) && <PhaseChip phase={phasesBySeq.get(e.seq)!} />}
                   {renderEvent(e, rows)}
                   {e.kind === 'mission.turn' && <TurnTraceToggle calls={toolCallsByTurn.get(e.seq) ?? []} />}
                 </span>

--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -298,6 +298,30 @@ describe('mission.turn rendering', () => {
     )
     expect(screen.getByText('Turn (execute): ok · 800ms')).toBeInTheDocument()
   })
+
+  it('renders route and agent as muted context when the payload carries them', () => {
+    render(
+      <div>
+        {renderEvent(
+          event(
+            { phase: 'generate', duration_ms: 1500, ok: true, input: 'worker_retry', route: 'coding', agent: 'Coder' },
+            'mission.turn',
+          ),
+        )}
+      </div>,
+    )
+    const row = screen.getByText(/Turn \(generate\): ok/)
+    expect(row).toHaveTextContent('Coder · coding')
+  })
+
+  it('renders exactly as before when route/agent are absent (legacy event)', () => {
+    render(
+      <div>{renderEvent(event({ phase: 'generate', duration_ms: 1500, ok: true, input: 'worker_retry' }, 'mission.turn'))}</div>,
+    )
+    const row = screen.getByText('Turn (generate): ok · 1.5s')
+    expect(row).toBeInTheDocument()
+    expect(row).not.toHaveTextContent('undefined')
+  })
 })
 
 describe('mission.discover_complete / mission.explore_complete rendering', () => {

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -58,12 +58,22 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
     return <span className={approved ? 'text-green-400' : 'text-amber-400'}>Review verdict: {String(decision ?? '?')}</span>
   },
   'mission.turn': (p) => {
-    const { phase, duration_ms, ok, reason } = p as MissionTurnPayload
+    const { phase, duration_ms, ok, reason, route, agent } = p as MissionTurnPayload
     const base = `Turn (${phase}): ${ok ? 'ok' : 'failed'} · ${formatDuration(duration_ms)}`
-    if (ok || !reason) return <span className={ok ? undefined : 'text-red-400'}>{base}</span>
+    const context = [agent, route].filter(Boolean).join(' · ')
+    const contextEl = context && <span className="ml-1 text-zinc-500">{context}</span>
+    if (ok || !reason) {
+      return (
+        <span className={ok ? undefined : 'text-red-400'}>
+          {base}
+          {contextEl}
+        </span>
+      )
+    }
     return (
       <span className="text-red-400" title={reason}>
         {base}: {truncateForDisplay(reason, 160)}
+        {contextEl}
       </span>
     )
   },

--- a/web/src/lib/phaseColors.ts
+++ b/web/src/lib/phaseColors.ts
@@ -1,0 +1,28 @@
+// phaseColors is the one shared color-per-phase map (issue #473): a
+// mission's discover/plan/generate/prove/result phase reads with the
+// same color wherever it's chipped, following MissionCard's own
+// bg-X-100/dark:bg-X-950 status-pill convention. done/failed/legacy
+// (explore/execute/review, pre-D-086 rename) fall back to phaseColors'
+// caller-side default rather than being listed here: this map only
+// covers the five phases the timeline chips.
+export const phaseColors: Record<string, string> = {
+  discover: 'bg-sky-100 text-sky-800 dark:bg-sky-950 dark:text-sky-300',
+  plan: 'bg-violet-100 text-violet-800 dark:bg-violet-950 dark:text-violet-300',
+  generate: 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300',
+  prove: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300',
+  result: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300',
+}
+
+// phaseLabel normalizes a phase string for display: the pre-D-086
+// names (explore/execute/review) a historical mission's events may
+// still carry map to their current equivalents, same mapping
+// statemachine.go's parsePhase applies on read.
+const legacyPhaseNames: Record<string, string> = {
+  explore: 'discover',
+  execute: 'generate',
+  review: 'prove',
+}
+
+export function phaseLabel(phase: string): string {
+  return legacyPhaseNames[phase] ?? phase
+}


### PR DESCRIPTION
Closes #473.

Timeline entries now carry a color-coded phase chip (shared phase color map, legacy explore/execute/review names tolerated) derived from the nearest preceding phase_started event. mission.turn payloads record the route that served the turn (same helpers each phase's request builder uses) and the agent name (resolved through the existing AgentResolver, no new Driver dependency); the web renders them as muted context on turn rows. Mission lifecycle slog lines gain phase/route/agent fields where in scope. Model is deliberately omitted from turn payloads, surfacing the served model would change all four Runner interface signatures; recorded only what is actually known, never guessed.

Verified: go build/vet/test green; web build+lint clean, 1024/1025 tests (single failure is a pre-existing date-boundary flake in MissionForm.test.tsx, reproduced on untouched main).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790813088&installation_model_id=431401&pr_number=477&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F477&signature=8517b3f43de9dfbc107c87bac698c8625de8c5ef707c579fd547f8c2382744e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->