### PR TITLE
fix(web): chip timeline rows by their own phase, not first transition

### DIFF
--- a/web/src/components/missions/TimelineSection.test.tsx
+++ b/web/src/components/missions/TimelineSection.test.tsx
@@ -287,8 +287,59 @@ describe('TimelineSection phase chips', () => {
     expect(screen.getAllByText('plan')).toHaveLength(2) // phase_started row + plan_created row
   })
 
-  it('renders no chip when the mission has no phase_started event at all', () => {
-    render(<TimelineSection events={events} />)
+  it('chips rows from their own payload phase without any phase_started', () => {
+    render(<TimelineSection events={toolCallTraceEvents} />)
+    expect(screen.getAllByText('generate').length).toBeGreaterThan(0)
+  })
+
+  it('chips initial-phase rows before the first transition with their own phase', () => {
+    // A mission never emits phase_started for its initial phase, so
+    // discover rows must take their phase from their own payloads, not
+    // from the first transition (the pre-fix bug chipped them "plan").
+    const phaseEvents: MissionEvent[] = [
+      {
+        mission_id: 'm1',
+        seq: 1,
+        kind: 'mission.provisioned',
+        payload: { workspace: '/w' },
+        provenance: 'harness',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        mission_id: 'm1',
+        seq: 2,
+        kind: 'mission.turn',
+        payload: { phase: 'discover', duration_ms: 10, ok: true, input: 'phase_complete' },
+        provenance: 'harness',
+        created_at: '2026-01-01T00:00:01Z',
+      },
+      {
+        mission_id: 'm1',
+        seq: 3,
+        kind: 'mission.phase_started',
+        payload: { phase: 'plan' },
+        provenance: 'harness',
+        created_at: '2026-01-01T00:00:02Z',
+      },
+    ]
+    render(<TimelineSection events={phaseEvents} />)
+    // provisioned (backfilled) + the discover turn
+    expect(screen.getAllByText('discover')).toHaveLength(2)
+    expect(screen.getAllByText('plan')).toHaveLength(1)
+  })
+
+  it('renders no chip when no event carries a phase at all', () => {
+    const bare: MissionEvent[] = [
+      {
+        mission_id: 'm1',
+        seq: 1,
+        kind: 'mission.provisioned',
+        payload: { workspace: '/w' },
+        provenance: 'harness',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ]
+    render(<TimelineSection events={bare} />)
     expect(screen.queryByText('discover')).toBeNull()
   })
 })

--- a/web/src/components/missions/TimelineSection.tsx
+++ b/web/src/components/missions/TimelineSection.tsx
@@ -49,23 +49,30 @@ function turnToolCalls(events: MissionEvent[]): Map<number, MissionEvent[]> {
 }
 
 // rowPhases maps each rendered row's seq to the phase chip it should
-// show: the phase most recently started (mission.phase_started) before
-// that row, or the first phase_started's phase for rows that precede
-// it (nothing has started yet, so the mission's opening phase is the
-// closest honest label, see mission.phase_started's payload). A
-// mission with no phase_started event at all (shouldn't happen past
-// create, but a defensive default) leaves every row unchipped.
+// show. A mission never emits phase_started for its INITIAL phase
+// (only transitions), so anchoring on the first phase_started would
+// mislabel every earlier row with the first TRANSITION's phase. Most
+// events carry their own payload.phase (turn, tool_call, input and
+// permission events); that is authoritative for the row and advances
+// the running phase, with phase_started marking transitions for the
+// payload-less rows between them. Leading rows before any signal
+// (e.g. provisioned) backfill from the first known phase. A mission
+// with no phase signal at all leaves every row unchipped.
 function rowPhases(rows: MissionEvent[]): Map<number, string> {
-  const starts = rows.filter((e) => e.kind === 'mission.phase_started')
-  if (starts.length === 0) return new Map()
-  const firstPhase = String((starts[0].payload as { phase?: string }).phase ?? '')
   const chips = new Map<number, string>()
-  let current = firstPhase
+  let current = ''
   for (const e of rows) {
-    if (e.kind === 'mission.phase_started') {
-      current = String((e.payload as { phase?: string }).phase ?? current)
+    const own = String((e.payload as { phase?: string }).phase ?? '')
+    if (own !== '') {
+      current = own
     }
     chips.set(e.seq, current)
+  }
+  const first = rows.map((e) => chips.get(e.seq) ?? '').find((p) => p !== '')
+  if (first === undefined) return new Map()
+  for (const e of rows) {
+    if (chips.get(e.seq) === '') chips.set(e.seq, first)
+    else break
   }
   return chips
 }


### PR DESCRIPTION
Missions never emit phase_started for their initial phase, so the #473 chip derivation anchored on the first TRANSITION and mislabeled every earlier row (all plan, or all result on light missions). Rows now take the phase their own payload carries (turn/tool_call/input events), phase_started still marks transitions, and leading payload-less rows backfill from the first known phase.

Verified: timeline suite 19/19, full web 1026/1027 (single failure is the known pre-existing MissionForm date-boundary flake, fails on clean main).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790815804&installation_model_id=431401&pr_number=478&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F478&signature=8921004cdef32aa0c5888f4d90fa077790fb3eb74c7e9e25aa08cb9bf9ad3132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->