### PR TITLE
fix(web): guard null event payloads in timeline phase derivation

### DIFF
--- a/web/src/components/missions/TimelineSection.test.tsx
+++ b/web/src/components/missions/TimelineSection.test.tsx
@@ -328,6 +328,29 @@ describe('TimelineSection phase chips', () => {
     expect(screen.getAllByText('plan')).toHaveLength(1)
   })
 
+  it('survives events with a null payload (mission.resumed)', () => {
+    const withNull: MissionEvent[] = [
+      {
+        mission_id: 'm1',
+        seq: 1,
+        kind: 'mission.turn',
+        payload: { phase: 'generate', duration_ms: 10, ok: true, input: 'worker_done' },
+        provenance: 'harness',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        mission_id: 'm1',
+        seq: 2,
+        kind: 'mission.resumed',
+        payload: null as unknown as Record<string, unknown>,
+        provenance: 'harness',
+        created_at: '2026-01-01T00:00:01Z',
+      },
+    ]
+    render(<TimelineSection events={withNull} />)
+    expect(screen.getAllByText('generate').length).toBeGreaterThan(0)
+  })
+
   it('renders no chip when no event carries a phase at all', () => {
     const bare: MissionEvent[] = [
       {

--- a/web/src/components/missions/TimelineSection.tsx
+++ b/web/src/components/missions/TimelineSection.tsx
@@ -62,7 +62,8 @@ function rowPhases(rows: MissionEvent[]): Map<number, string> {
   const chips = new Map<number, string>()
   let current = ''
   for (const e of rows) {
-    const own = String((e.payload as { phase?: string }).phase ?? '')
+    // payload can be null (e.g. mission.resumed), never assume an object
+    const own = String(((e.payload ?? {}) as { phase?: string }).phase ?? '')
     if (own !== '') {
       current = own
     }


### PR DESCRIPTION
mission.resumed events carry a null payload; the phase-chip derivation from #478 read payload.phase on every event and crashed mission detail for any resumed mission. Null-guarded, regression test added (20/20 timeline tests).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790816209&installation_model_id=431401&pr_number=484&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F484&signature=89d98ef8165f849f530ce246b14dcdb4b2c72f55f6eae083ae2b18fc0b4c8595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->