### PR TITLE
refactor(missions): drop light and worktree columns, kind path segment

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -322,9 +322,18 @@ func sanitizeMission(m missions.Mission) missions.Mission {
 // missionResponse is missions.Mission plus fields the store itself
 // has no business computing: top_model/top_model_provider come from
 // the cost ledger (a different service's data), decorated on here at
-// serve time rather than added to missions.Mission itself.
+// serve time. Light/Worktree (issue #479) are likewise computed here
+// rather than stored: dropping their columns means Mission itself no
+// longer carries them, but the web client still reads mission.light
+// and mission.worktree unchanged, so the API response derives both
+// from Flow/WorktreePath() on the way out.
 type missionResponse struct {
 	missions.Mission
+	// Light is derived from Flow == FlowLight (issue #479): the web
+	// client's own light checks (e.g. MissionDetail.tsx's runsPlanless)
+	// read this exactly as before the light column was dropped.
+	Light            bool   `json:"light"`
+	Worktree         string `json:"worktree,omitempty"`
 	TopModel         string `json:"top_model,omitempty"`
 	TopModelProvider string `json:"top_model_provider,omitempty"`
 }
@@ -336,7 +345,7 @@ type missionResponse struct {
 func (h *missionAPI) decorateTopModels(ctx context.Context, rows []missions.Mission) []missionResponse {
 	out := make([]missionResponse, len(rows))
 	for i, m := range rows {
-		out[i] = missionResponse{Mission: m}
+		out[i] = missionResponse{Mission: m, Light: m.Flow == missions.FlowLight, Worktree: m.WorktreePath()}
 	}
 	if h.topModels == nil || len(rows) == 0 {
 		return out
@@ -661,23 +670,18 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 	}
 	// flow/light normalization (D-090, issue #459): flow omitted maps to
 	// today's exact pre-#459 behavior (light=true -> "light", else
-	// "full"); flow="light" always implies light=true so every existing
-	// D-069 code path (policyFor, packet.go's WorkPacket.Light) keeps
-	// keying off the light column unchanged. Any other mismatch between
-	// an explicit flow and light (or kind=coding requesting a non-full
-	// flow) is left for missions.ValidateCreate to reject with the
-	// specific reason, not silently resolved here.
+	// "full"). Any other mismatch between an explicit flow and light (or
+	// kind=coding requesting a non-full flow) is left for
+	// missions.ValidateCreate to reject with the specific reason, not
+	// silently resolved here. issue #479 dropped the mission.light
+	// column: flow alone drives every downstream code path now.
 	flow := req.Flow
-	light := req.Light
 	if flow == "" {
-		if light {
+		if req.Light {
 			flow = string(missions.FlowLight)
 		} else {
 			flow = string(missions.FlowFull)
 		}
-	}
-	if flow == string(missions.FlowLight) {
-		light = true
 	}
 	m := missions.Mission{
 		Goal: req.Goal, Kind: req.Kind, AgentID: req.AgentID,
@@ -688,7 +692,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		RepoURL: req.RepoURL, ConnectorID: req.ConnectorID, OnComplete: req.OnComplete,
 		BranchPattern: req.BranchPattern, CommitStyle: req.CommitStyle,
 		ParentMissionID: parentMissionID, ParentContext: parentContext, ReferencedContext: referencedContext,
-		Attachments: missionAtts, DestinationIDs: req.DestinationIDs, PromoteKBCollectionID: req.PromoteKBCollectionID, Light: light,
+		Attachments: missionAtts, DestinationIDs: req.DestinationIDs, PromoteKBCollectionID: req.PromoteKBCollectionID,
 		Flow:                     missions.Flow(flow),
 		PermissionTimeoutSeconds: req.PermissionTimeoutSeconds,
 	}
@@ -715,7 +719,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusCreated, map[string]string{"id": id})
 		return
 	}
-	writeJSON(w, http.StatusCreated, sanitizeMission(created))
+	writeJSON(w, http.StatusCreated, h.decorateTopModels(r.Context(), []missions.Mission{sanitizeMission(created)})[0])
 }
 
 // resolveReferenceContext resolves a create request's picked
@@ -1320,7 +1324,7 @@ func (h *missionAPI) delete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if m.Workspace != "" && h.workspace != nil {
-		if err := h.workspace.Teardown(r.Context(), m.Workspace, m.Worktree, m.Kind); err != nil {
+		if err := h.workspace.Teardown(r.Context(), m.Workspace, m.WorktreePath(), m.Kind); err != nil {
 			h.log.Warn("mission delete: workspace cleanup failed", "mission_id", m.ID, "workspace", m.Workspace, "error", err)
 		}
 	}

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -1256,11 +1256,13 @@ func createGitHubConnectorRow(t *testing.T, mgr *connectors.Manager) string {
 }
 
 // createGitHubConnectionMission fabricates a mission row with
-// connector_id/repo_url set and SetProvisioned pointed at worktree —
-// the shape Driver.ensureProvisioned would have produced for a real
-// repo_url mission, without actually running provisioning (these tests
-// only exercise push/pr, not clone/authorship, which worktree_test.go
-// already covers).
+// connector_id/repo_url set and SetProvisioned pointed at worktree's
+// parent workspace dir, the shape Driver.ensureProvisioned would have
+// produced for a real repo_url mission, without actually running
+// provisioning (these tests only exercise push/pr, not clone/
+// authorship, which worktree_test.go already covers). worktree must be
+// workspace/wt (Mission.WorktreePath's fixed derivation, issue #479):
+// every caller passes seedBareRepoWithMissionBranch's own tmpdir+"/wt".
 func createGitHubConnectionMission(t *testing.T, store *missions.Store, connectorID, repoURL, worktree, branch string) string {
 	t.Helper()
 	id, err := store.Create(t.Context(), missions.Mission{
@@ -1269,7 +1271,7 @@ func createGitHubConnectionMission(t *testing.T, store *missions.Store, connecto
 	if err != nil {
 		t.Fatalf("create mission: %v", err)
 	}
-	if err := store.SetProvisioned(t.Context(), id, worktree+"/..", worktree, branch, "deadbeef"); err != nil {
+	if err := store.SetProvisioned(t.Context(), id, worktree+"/..", branch, "deadbeef"); err != nil {
 		t.Fatalf("SetProvisioned: %v", err)
 	}
 	return id
@@ -1594,7 +1596,7 @@ func testExportMission(t *testing.T, store *missions.Store, goal string) (id, wo
 		t.Fatalf("Create: %v", err)
 	}
 	workRoot = t.TempDir()
-	if err := store.SetProvisioned(t.Context(), id, workRoot, "", "", ""); err != nil {
+	if err := store.SetProvisioned(t.Context(), id, workRoot, "", ""); err != nil {
 		t.Fatalf("SetProvisioned: %v", err)
 	}
 	return id, workRoot

--- a/internal/brain/destinations/files_test.go
+++ b/internal/brain/destinations/files_test.go
@@ -49,11 +49,14 @@ func TestResolveArtifactFilesReadsUnderWorkspace(t *testing.T) {
 
 func TestResolveArtifactFilesUsesWorktreeOverWorkspace(t *testing.T) {
 	workspace := t.TempDir()
-	worktree := t.TempDir()
+	worktree := filepath.Join(workspace, "wt")
+	if err := os.MkdirAll(worktree, 0o750); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(worktree, "out.md"), []byte("from worktree"), 0o600); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
-	m := missions.Mission{Workspace: workspace, Worktree: worktree, Spec: missions.Spec{Units: []missions.PlanUnit{
+	m := missions.Mission{Kind: "coding", Flow: "full", Workspace: workspace, Spec: missions.Spec{Units: []missions.PlanUnit{
 		{Artifacts: []string{"out.md"}},
 	}}}
 

--- a/internal/brain/destinations/render_test.go
+++ b/internal/brain/destinations/render_test.go
@@ -126,7 +126,7 @@ func TestRender(t *testing.T) {
 
 	t.Run("light mission body is the final output, not a completion line", func(t *testing.T) {
 		light := m
-		light.Light = true
+		light.Flow = missions.FlowLight
 		light.FinalOutput = "here is the complete deliverable"
 		p := Render(light, "", nil, time.UTC)
 		if p.Body != "here is the complete deliverable" {
@@ -136,7 +136,7 @@ func TestRender(t *testing.T) {
 
 	t.Run("light mission with no final output falls back to the completion line", func(t *testing.T) {
 		light := m
-		light.Light = true
+		light.Flow = missions.FlowLight
 		p := Render(light, "", nil, time.UTC)
 		if p.Body != "Mission complete: Ship it" {
 			t.Fatalf("Body = %q, want the completion-line fallback", p.Body)

--- a/internal/brain/missions/complete.go
+++ b/internal/brain/missions/complete.go
@@ -95,7 +95,7 @@ func NotPushable(m Mission) string {
 	case m.Branch == "":
 		return "mission has no branch"
 	default:
-		if _, err := os.Stat(m.Worktree); err != nil {
+		if _, err := os.Stat(m.WorktreePath()); err != nil {
 			return "mission worktree is not available"
 		}
 	}
@@ -108,7 +108,7 @@ func NotPushable(m Mission) string {
 // driver's auto-fire hook use, so the Timeline reads identically
 // regardless of which one fired.
 func (c *Completer) PushBranch(ctx context.Context, m Mission, token string) (host string, err error) {
-	host, pushErr := c.workspace.Push(ctx, m.Worktree, m.Branch, token)
+	host, pushErr := c.workspace.Push(ctx, m.WorktreePath(), m.Branch, token)
 	if pushErr != nil {
 		reason := "push failed"
 		switch {

--- a/internal/brain/missions/complete_test.go
+++ b/internal/brain/missions/complete_test.go
@@ -2,6 +2,7 @@ package missions
 
 import (
 	"context"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -64,7 +65,7 @@ func TestNotPushableGuards(t *testing.T) {
 	if reason := NotPushable(Mission{Kind: "coding"}); reason == "" {
 		t.Fatal("coding mission with no branch should not be pushable")
 	}
-	if reason := NotPushable(Mission{Kind: "coding", Branch: "mission/x", Worktree: "/does/not/exist"}); reason == "" {
+	if reason := NotPushable(Mission{Kind: "coding", Branch: "mission/x", Workspace: "/does/not/exist"}); reason == "" {
 		t.Fatal("coding mission with a missing worktree should not be pushable")
 	}
 }
@@ -140,11 +141,15 @@ func (f *fakeBranchPusher) Push(ctx context.Context, worktree, branch, token str
 
 // pushableMission is a coding mission with the guards NotPushable
 // requires already satisfied (worktree present, branch set) — t.TempDir()
-// stands in for a real worktree since fakeBranchPusher never touches
-// the filesystem.
+// stands in for a real workspace since fakeBranchPusher never touches
+// the filesystem; WorktreePath() derives workspace/wt from it.
 func pushableMission(t *testing.T) Mission {
 	t.Helper()
-	return Mission{ID: "m1", Kind: "coding", Worktree: t.TempDir(), Branch: "mission/x", RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1"}
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir+"/wt", 0o750); err != nil {
+		t.Fatal(err)
+	}
+	return Mission{ID: "m1", Kind: "coding", Workspace: dir, Branch: "mission/x", RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1"}
 }
 
 // TestCompleterRunOnCompletePush proves on_complete="push" pushes the

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -70,7 +70,7 @@ type driverStore interface {
 	Events(ctx context.Context, id string) ([]Event, error)
 	SetSpec(ctx context.Context, id string, spec Spec) error
 	SetSession(ctx context.Context, id, sessionID string) error
-	SetProvisioned(ctx context.Context, id, workspace, worktree, branch, baseCommit string) error
+	SetProvisioned(ctx context.Context, id, workspace, branch, baseCommit string) error
 	SetLastEvidence(ctx context.Context, id, evidence string) error
 	SetFinalOutput(ctx context.Context, id, text string) error
 	SetDiscoverNotes(ctx context.Context, id, notes string) error
@@ -819,7 +819,7 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 	// turn that actually drives it, rather than leaving the worker with
 	// no shell/write_file tools (runner.go's missionTools returns nil for
 	// an empty WorkRoot).
-	if m.SessionID == "" || (m.Workspace == "" && m.Worktree == "") {
+	if m.SessionID == "" || m.Workspace == "" {
 		provisioned, provErr := d.ensureProvisioned(ctx, m)
 		if provErr != nil {
 			// Returning the error here would leave the mission idle for
@@ -1125,7 +1125,7 @@ func (d *Driver) toStepState(ctx context.Context, m Mission) StepState {
 		ConsecutiveFailures: m.ConsecutiveFailures, LastGapFingerprint: m.LastGapFingerprint,
 		StallCount: m.StallCount, Spent: spent, Budget: m.BudgetAmount,
 		MixedCurrencySpend: mixed, RateAsOf: rateAsOf,
-		LastUnit: isLastUnit(m.Spec), ReplanUsed: m.ReplanUsed, Light: m.Light,
+		LastUnit: isLastUnit(m.Spec), ReplanUsed: m.ReplanUsed,
 		AutoApprovePlan: m.AutoApprovePlan, Flow: m.Flow,
 	}
 }
@@ -1340,14 +1340,14 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 
 	switch verdict.Outcome {
 	case "done":
-		if m.Worktree != "" {
+		if wt := m.WorktreePath(); wt != "" {
 			var unitTitle string
 			if unit, _ := currentUnit(m.Spec); unit != nil {
 				unitTitle = unit.Title
 			}
 			body := "mission " + m.ID + " iteration " + fmt.Sprint(m.Iteration)
 			msg := CommitMessage(unitTitle, m.Goal, body, d.effectiveCommitStyle(ctx, m))
-			if err := d.workspace.CommitUnit(ctx, m.Worktree, msg); err != nil {
+			if err := d.workspace.CommitUnit(ctx, wt, msg); err != nil {
 				d.log.Warn("driver: commit unit failed", "mission_id", m.ID, "error", err)
 			}
 		}
@@ -1394,8 +1394,8 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 	case "blocked":
 		return StepInput{Input: InputWorkerBlocked, Message: verdict.Question}, nil
 	default: // "retry" or anything unrecognized
-		if m.Worktree != "" {
-			if err := d.workspace.Rollback(ctx, m.Worktree, m.Kind); err != nil {
+		if wt := m.WorktreePath(); wt != "" {
+			if err := d.workspace.Rollback(ctx, wt, m.Kind); err != nil {
 				d.log.Warn("driver: rollback failed", "mission_id", m.ID, "error", err)
 			}
 		}
@@ -1474,9 +1474,9 @@ func currentUnit(spec Spec) (*PlanUnit, int) {
 
 func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 	var diff string
-	if m.Worktree != "" {
+	if wt := m.WorktreePath(); wt != "" {
 		var err error
-		diff, err = BaselineDiff(ctx, m.Worktree, m.BaseCommit)
+		diff, err = BaselineDiff(ctx, wt, m.BaseCommit)
 		if err != nil {
 			return StepInput{}, err
 		}
@@ -1498,8 +1498,8 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 	d.gatekeepers[m.ID] = nextGK
 	// The reviewer's own worktree side effects (it may run tests) are
 	// rolled back unconditionally after every review round.
-	if m.Worktree != "" {
-		if err := d.workspace.Rollback(ctx, m.Worktree, m.Kind); err != nil {
+	if wt := m.WorktreePath(); wt != "" {
+		if err := d.workspace.Rollback(ctx, wt, m.Kind); err != nil {
 			d.log.Warn("driver: post-review rollback failed", "mission_id", m.ID, "error", err)
 		}
 	}
@@ -1576,8 +1576,8 @@ func (d *Driver) markUnitPassed(ctx context.Context, m Mission, unit int) error 
 // directly from mission fields — no unused indirection.
 func (d *Driver) packet(ctx context.Context, m Mission) (WorkPacket, error) {
 	gitLog := ""
-	if m.Worktree != "" {
-		gitLog, _ = gitLogSince(ctx, m.Worktree, m.BaseCommit)
+	if wt := m.WorktreePath(); wt != "" {
+		gitLog, _ = gitLogSince(ctx, wt, m.BaseCommit)
 	}
 	var loc *time.Location
 	if d.location != nil {

--- a/internal/brain/missions/driver_integration_test.go
+++ b/internal/brain/missions/driver_integration_test.go
@@ -36,7 +36,7 @@ func TestDriverEndToEndCodingMission(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
-	if err := store.SetProvisioned(ctx, id, ws, wt, branch, base); err != nil {
+	if err := store.SetProvisioned(ctx, id, ws, branch, base); err != nil {
 		t.Fatalf("SetProvisioned: %v", err)
 	}
 

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -68,11 +68,11 @@ func (f *fakeStore) Create(ctx context.Context, m Mission) (string, error) {
 	return m.ID, nil
 }
 
-func (f *fakeStore) SetProvisioned(ctx context.Context, id, workspace, worktree, branch, baseCommit string) error {
+func (f *fakeStore) SetProvisioned(ctx context.Context, id, workspace, branch, baseCommit string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	m := f.missions[id]
-	m.Workspace, m.Worktree, m.Branch, m.BaseCommit = workspace, worktree, branch, baseCommit
+	m.Workspace, m.Branch, m.BaseCommit = workspace, branch, baseCommit
 	f.missions[id] = m
 	return nil
 }
@@ -376,22 +376,27 @@ func TestDriverHappyPathToDone(t *testing.T) {
 	}
 }
 
-// codingWorktree inits a real git repo with one commit — coding
-// missions run BaselineDiff/CommitUnit against a real worktree even
-// with a scripted Runner, so on_complete tests (which need Kind=coding
-// for NotPushable to accept them) need a real git dir, not merely a
-// TempDir. Returns the dir and its HEAD commit hash for BaseCommit.
-func codingWorktree(t *testing.T) (dir, baseCommit string) {
+// codingWorktree inits a real git repo with one commit, laid out as
+// workspace/wt (WorktreePath's fixed derivation), since coding missions
+// run BaselineDiff/CommitUnit against a real worktree even with a scripted
+// Runner, so on_complete tests (which need Kind=coding for NotPushable
+// to accept them) need a real git dir, not merely a TempDir. Returns
+// the workspace root and the repo's HEAD commit hash for BaseCommit.
+func codingWorktree(t *testing.T) (workspace, baseCommit string) {
 	t.Helper()
 	requireGitForPush(t)
-	dir = t.TempDir()
+	workspace = t.TempDir()
+	dir := filepath.Join(workspace, "wt")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
 	gitRun(t, dir, "init", "-q")
 	if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte("seed"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	gitRun(t, dir, "add", "seed.txt")
 	gitRun(t, dir, "-c", "user.name=test", "-c", "user.email=test@test", "commit", "-q", "-m", "seed")
-	return dir, strings.TrimSpace(gitRun(t, dir, "rev-parse", "HEAD"))
+	return workspace, strings.TrimSpace(gitRun(t, dir, "rev-parse", "HEAD"))
 }
 
 // TestDriverFiresOnCompletePushPROnDone proves a coding mission with
@@ -403,7 +408,7 @@ func TestDriverFiresOnCompletePushPROnDone(t *testing.T) {
 	dir, base := codingWorktree(t)
 	store.put("m1", Mission{
 		ID: "m1", Kind: "coding", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true,
-		Worktree: dir, BaseCommit: base, Branch: "mission/x", RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1",
+		Workspace: dir, BaseCommit: base, Branch: "mission/x", RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1",
 		OnComplete: "push_pr",
 	})
 	runner := &scriptedRunner{
@@ -456,7 +461,7 @@ func TestDriverOnCompleteFailureParksInResultAndNotifies(t *testing.T) {
 	dir, base := codingWorktree(t)
 	store.put("m1", Mission{
 		ID: "m1", Kind: "coding", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true,
-		Worktree: dir, BaseCommit: base, Branch: "mission/x", RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1",
+		Workspace: dir, BaseCommit: base, Branch: "mission/x", RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1",
 		OnComplete: "push",
 	})
 	runner := &scriptedRunner{
@@ -902,7 +907,7 @@ func TestDriverExecuteRecordsRawTextWithoutHandoff(t *testing.T) {
 // more Advance call away from done.
 func TestDriverLightDoneSetsFinalOutputAndSkipsToResult(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Light: true, Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Flow: FlowLight, Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did the thing", FinalMessage: "here is the complete deliverable"}},
 		workerText:     "draft1 tool-retry-narration here is the complete deliverable",
@@ -945,7 +950,7 @@ func TestDriverLightDoneSetsFinalOutputAndSkipsToResult(t *testing.T) {
 // after) still records something rather than an empty FinalOutput.
 func TestDriverLightDoneFallsBackToFullTextWhenFinalMessageEmpty(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Light: true, Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Flow: FlowLight, Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did the thing"}}, // FinalMessage left empty
 		workerText:     "the only text the runner produced",
@@ -1095,9 +1100,10 @@ func TestDriverPacketOmitsDiscoverNotesForNonPlanlessFlow(t *testing.T) {
 }
 
 // TestDriverNonLightDoneStillGoesThroughReview confirms the light
-// short-circuit is gated on m.Light: an ordinary general mission with a
-// unit that has no declared artifacts still falls through to
-// InputPhaseComplete (review), unchanged from before this feature.
+// short-circuit is gated on m.RunsPlanless() (Flow == FlowLight): an
+// ordinary general mission with a unit that has no declared artifacts
+// still falls through to InputPhaseComplete (review), unchanged from
+// before this feature.
 func TestDriverNonLightDoneStillGoesThroughReview(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
@@ -1711,7 +1717,7 @@ func TestDriverCreateRejectsInvalidMissionWhenValidateDepsWired(t *testing.T) {
 	d.SetValidateDeps(ValidateDeps{})
 
 	_, err := d.Create(context.Background(), Mission{
-		Goal: "test", Kind: "coding", Route: "route-x", Light: true, // light is general-only
+		Goal: "test", Kind: "coding", Route: "route-x", Flow: FlowLight, // light is general-only
 		Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
 	})
 	if err == nil {
@@ -1734,7 +1740,7 @@ func TestDriverCreateSkipsValidationWhenDepsUnset(t *testing.T) {
 	d := testDriver(store, &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}})
 
 	if _, err := d.Create(context.Background(), Mission{
-		Goal: "test", Kind: "coding", Light: true, // would be rejected if validated
+		Goal: "test", Kind: "coding", Flow: FlowLight, // would be rejected if validated
 		Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
 	}); err != nil {
 		t.Fatalf("Create with no ValidateDeps wired: %v, want nil (validation skipped)", err)
@@ -1982,14 +1988,14 @@ func TestDriverProvisionThreadsSigningKeyFromIdentityResolver(t *testing.T) {
 		t.Fatalf("Advance: %v", err)
 	}
 	m, _ := store.Get(context.Background(), "m1")
-	if m.Worktree == "" {
+	if m.WorktreePath() == "" {
 		t.Fatal("Advance did not provision a worktree")
 	}
 	keyPath := filepath.Join(m.Workspace, signingKeyFileName)
 	if _, err := os.Stat(keyPath); err != nil {
 		t.Fatalf("signing key file missing: %v", err)
 	}
-	got, ok := gitConfigLocal(context.Background(), m.Worktree, "user.signingkey")
+	got, ok := gitConfigLocal(context.Background(), m.WorktreePath(), "user.signingkey")
 	if !ok || got != keyPath {
 		t.Fatalf("local user.signingkey = %q (ok=%v), want %q", got, ok, keyPath)
 	}
@@ -2181,21 +2187,23 @@ func TestDriverCitationCheckBlocksInvokedCitation(t *testing.T) {
 // for Kind == "coding". The scriptedRunner has a review verdict
 // scripted since coding missions always review.
 func TestDriverCitationCheckSkippedForCodingMission(t *testing.T) {
-	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "report.md"), []byte("source: [docs](https://example.com/invented)"), 0o600); err != nil {
+	root, base := codingWorktree(t)
+	if err := os.WriteFile(filepath.Join(root, "wt", "report.md"), []byte("source: [docs](https://example.com/invented)"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	store := newFakeStore()
 	store.put("m1", Mission{
 		ID: "m1", Kind: "coding", Phase: PhaseGenerate, Status: StatusWorking,
-		MaxIterations: 8, Workspace: root,
+		MaxIterations: 8, Workspace: root, BaseCommit: base,
 		Spec: Spec{Units: []PlanUnit{{Title: "write report", Artifacts: []string{"report.md"}}}},
 	})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote it"}},
 		reviewVerdicts: []ReviewVerdict{{Approved: true}},
 	}
-	d := testDriver(store, runner)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := NewDriver(store, runner, NewWorkspace("", nil, log), nil, nil, nil, fakeSandboxExec, nil, log)
+	d.retryDelayFn = func(int) time.Duration { return 0 }
 
 	driveN(t, d, "m1", 3) // generate -> prove -> result -> done
 
@@ -2395,21 +2403,23 @@ func TestDriverFirstPlanDoesNotGetReplanNotes(t *testing.T) {
 // to coding missions — a diff can be wrong in ways existence checks
 // cannot see.
 func TestDriverCodingMissionsAlwaysReview(t *testing.T) {
-	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main"), 0o600); err != nil {
+	root, base := codingWorktree(t)
+	if err := os.WriteFile(filepath.Join(root, "wt", "main.go"), []byte("package main"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	store := newFakeStore()
 	store.put("m1", Mission{
 		ID: "m1", Kind: "coding", Phase: PhaseGenerate, Status: StatusWorking,
-		MaxIterations: 8, Workspace: root,
+		MaxIterations: 8, Workspace: root, BaseCommit: base,
 		Spec: Spec{Units: []PlanUnit{{Title: "write code", Artifacts: []string{"main.go"}}}},
 	})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote it"}},
 		reviewVerdicts: []ReviewVerdict{{Approved: true}},
 	}
-	d := testDriver(store, runner)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := NewDriver(store, runner, NewWorkspace("", nil, log), nil, nil, nil, fakeSandboxExec, nil, log)
+	d.retryDelayFn = func(int) time.Duration { return 0 }
 
 	driveN(t, d, "m1", 3)
 

--- a/internal/brain/missions/followup.go
+++ b/internal/brain/missions/followup.go
@@ -38,7 +38,7 @@ func (d *Driver) CreateFollowUp(ctx context.Context, parentID, goal string) (str
 		Knowledge: parent.Knowledge, Harness: parent.Harness, Environment: parent.Environment,
 		RepoURL: parent.RepoURL, ConnectorID: parent.ConnectorID,
 		BranchPattern: parent.BranchPattern, CommitStyle: parent.CommitStyle,
-		Light: parent.Light, Flow: parent.Flow, ParentMissionID: parent.ID, ParentContext: parentContext,
+		Flow: parent.Flow, ParentMissionID: parent.ID, ParentContext: parentContext,
 		// Deliberately NOT copied from parent: OnComplete (push consent is
 		// a per-mission human choice), DestinationIDs (D-061, operator
 		// addresses outputs per mission), Attachments (a follow-up's own

--- a/internal/brain/missions/memory_test.go
+++ b/internal/brain/missions/memory_test.go
@@ -73,7 +73,7 @@ func TestOutcomeDigest(t *testing.T) {
 		{
 			name: "light mission includes final output",
 			mission: Mission{
-				Goal: "summarize the doc", Kind: "general", Light: true,
+				Goal: "summarize the doc", Kind: "general", Flow: FlowLight,
 				FinalOutput: "the doc says X, Y, and Z",
 			},
 			events:       []Event{{Kind: "mission.review_skipped", Payload: json.RawMessage(`{"reason":"light"}`)}},
@@ -110,7 +110,7 @@ func TestOutcomeDigest(t *testing.T) {
 // deliverable verbatim.
 func TestOutcomeDigestTruncatesLightFinalOutput(t *testing.T) {
 	long := strings.Repeat("é", finalOutputDigestCap+500) // multi-byte rune, proves rune- not byte-counting
-	m := Mission{Goal: "g", Kind: "general", Light: true, FinalOutput: long}
+	m := Mission{Goal: "g", Kind: "general", Flow: FlowLight, FinalOutput: long}
 	digest := OutcomeDigest(m, nil, PhaseDone, "")
 	i := strings.Index(digest, "final output:\n")
 	if i < 0 {

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -10,6 +10,7 @@ package missions
 import (
 	"encoding/json"
 	"errors"
+	"path/filepath"
 	"time"
 )
 
@@ -43,7 +44,6 @@ type Mission struct {
 	PauseReason   PauseReason `json:"pause_reason,omitempty"`
 	PauseMessage  string      `json:"pause_message,omitempty"`
 	Workspace     string      `json:"workspace,omitempty"`
-	Worktree      string      `json:"worktree,omitempty"`
 	Branch        string      `json:"branch,omitempty"`
 	BaseCommit    string      `json:"base_commit,omitempty"`
 	// RepoURL is the GitHub repo this coding mission was cloned from
@@ -125,15 +125,15 @@ type Mission struct {
 	// (internal/brain/missions/executor). Coding-only; a general mission
 	// always runs native.
 	Harness string `json:"harness,omitempty"`
-	// Light missions (D-069, general kind only) skip discover/plan/
-	// prove entirely: born in phase=generate, one bare worker turn, the
-	// final worker message is the deliverable, then result/done.
-	Light bool `json:"light"`
 	// Flow is the phase set this mission runs (D-090, issue #459),
 	// chosen once at create time, snapshotted here, never model-
-	// mutable. Light stays the source of truth for every existing
-	// D-069 code path; Flow=FlowLight always implies Light=true
-	// (api/missions.go's create normalizes this at write time).
+	// mutable. FlowLight (D-069, general kind only) skips discover/plan/
+	// prove entirely: born in phase=generate, one bare worker turn, the
+	// final worker message is the deliverable, then result/done. Flow is
+	// the single source of truth (issue #479 dropped the redundant light
+	// column); code that means "light mission" tests Flow == FlowLight.
+	// The API layer derives a "light" JSON field from this for the web
+	// client (api/missions.go's missionResponse).
 	Flow Flow `json:"flow"`
 	// FinalOutput is a light mission's verbatim final worker message,
 	// set on the done transition (driver.go's runExecute) — the
@@ -272,11 +272,24 @@ type MissionAttachment struct {
 	Markdown string `json:"markdown,omitempty"`
 }
 
+// WorktreePath derives the worktree directory (issue #479 dropped the
+// stored worktree column): worktree.go's Provision always lays a
+// needsWorktree mission's git checkout at workspace/wt, so this is
+// pure derivation, never a fresh lookup. "" when the mission's kind/
+// flow policy has no worktree, or Workspace itself is empty (not yet
+// provisioned).
+func (m Mission) WorktreePath() string {
+	if m.Workspace == "" || !missionPolicyFor(m).needsWorktree {
+		return ""
+	}
+	return filepath.Join(m.Workspace, "wt")
+}
+
 // WorkRoot is where mission workers/verify/review actually operate:
 // the worktree for coding missions, the plain workspace dir otherwise.
 func (m Mission) WorkRoot() string {
-	if m.Worktree != "" {
-		return m.Worktree
+	if wt := m.WorktreePath(); wt != "" {
+		return wt
 	}
 	return m.Workspace
 }

--- a/internal/brain/missions/policy.go
+++ b/internal/brain/missions/policy.go
@@ -57,24 +57,24 @@ type missionPolicy struct {
 	canPush         bool // on_complete push/push_pr allowed
 }
 
-// policyFor derives kind's policy, then folds in light's effect
-// (general only, D-069) and flow's effect (D-090, issue #459):
-// flow=no_prove forces alwaysReview false on a general-shaped policy,
-// since skipping the LLM reviewer is the whole point of choosing it
-// (CheckArtifacts in verifier.go still runs via trySkipReview either
-// way). flow=discover_generate does NOT need this override: it never
-// reaches trySkipReview at all, its generate turn takes the same
-// planless short-circuit as light (Mission.RunsPlanless), which never
-// consults alwaysReview. Coding stays alwaysReview true regardless of
-// flow (ValidateCreate rejects any non-full flow for kind=coding at
-// create time, so this is a second, defensive belt, not the
-// enforcement point). An unknown kind also stays alwaysReview true:
-// fail conservative, a kind this table doesn't recognize must never
-// silently skip review.
+// policyFor derives kind's policy, then folds in flow's effect
+// (D-090, issue #459): flow=light (general only, D-069) sets
+// skipsPlanning; flow=no_prove forces alwaysReview false on a
+// general-shaped policy, since skipping the LLM reviewer is the whole
+// point of choosing it (CheckArtifacts in verifier.go still runs via
+// trySkipReview either way). flow=discover_generate does NOT need this
+// override: it never reaches trySkipReview at all, its generate turn
+// takes the same planless short-circuit as flow=light
+// (Mission.RunsPlanless), which never consults alwaysReview. Coding
+// stays alwaysReview true regardless of flow (ValidateCreate rejects
+// any non-full flow for kind=coding at create time, so this is a
+// second, defensive belt, not the enforcement point). An unknown kind
+// also stays alwaysReview true: fail conservative, a kind this table
+// doesn't recognize must never silently skip review.
 //
 // D-072: the single source of behavior-by-kind; every call site that
 // used to test Kind/Light directly now derives it from here instead.
-func policyFor(kind string, light bool, flow Flow) missionPolicy {
+func policyFor(kind string, flow Flow) missionPolicy {
 	switch kind {
 	case KindCoding:
 		return missionPolicy{
@@ -94,7 +94,7 @@ func policyFor(kind string, light bool, flow Flow) missionPolicy {
 			skipsPlanning:   false,
 			canPush:         false,
 		}
-		if light {
+		if flow == FlowLight {
 			p.skipsPlanning = true
 		}
 		if flow == FlowNoProve {
@@ -115,30 +115,30 @@ func policyFor(kind string, light bool, flow Flow) missionPolicy {
 
 // missionPolicyFor is policyFor over a live Mission row.
 func missionPolicyFor(m Mission) missionPolicy {
-	return policyFor(m.Kind, m.Light, m.Flow)
+	return policyFor(m.Kind, m.Flow)
 }
 
 // RunsPlanless reports whether m's generate phase runs the D-069
 // light worker path: no plan, no artifact check, the worker's final
 // message (mission_status's final_output) is the deliverable.
 // FlowDiscoverGenerate (D-090, issue #459) shares this exact worker
-// behavior with Light, the only difference being it runs discover
-// first; unlike Light (missionPolicy.skipsPlanning), it is NOT used
-// by initialPhase: a discover_generate mission is still born in
+// behavior with FlowLight, the only difference being it runs discover
+// first; unlike FlowLight (missionPolicy.skipsPlanning), it is NOT
+// used by initialPhase: a discover_generate mission is still born in
 // PhaseDiscover, only generate itself runs planless. Exported: read
 // outside this package by destinations.renderPayload, which needs the
 // same "final_output IS the result" gate memory.go's digest uses.
 func (m Mission) RunsPlanless() bool {
-	return m.Light || m.Flow == FlowDiscoverGenerate
+	return m.Flow == FlowLight || m.Flow == FlowDiscoverGenerate
 }
 
 // initialPhase is the phase a newly created mission row starts in:
-// PhaseGenerate for a light mission (D-069, skips discover/plan),
+// PhaseGenerate for a flow=light mission (D-069, skips discover/plan),
 // PhaseDiscover otherwise. Shared by store.go's Create and
 // scheduler.go's createFromTemplate, which both used to duplicate
 // this check inline.
-func initialPhase(kind string, light bool) Phase {
-	if policyFor(kind, light, FlowFull).skipsPlanning {
+func initialPhase(kind string, flow Flow) Phase {
+	if policyFor(kind, flow).skipsPlanning {
 		return PhaseGenerate
 	}
 	return PhaseDiscover

--- a/internal/brain/missions/policy_test.go
+++ b/internal/brain/missions/policy_test.go
@@ -4,11 +4,10 @@ import "testing"
 
 func TestPolicyFor(t *testing.T) {
 	cases := []struct {
-		name  string
-		kind  string
-		light bool
-		flow  Flow
-		want  missionPolicy
+		name string
+		kind string
+		flow Flow
+		want missionPolicy
 	}{
 		{
 			name: "coding",
@@ -16,8 +15,8 @@ func TestPolicyFor(t *testing.T) {
 			want: missionPolicy{needsWorktree: true, alwaysReview: true, checksCitations: false, canDelegate: true, skipsPlanning: false, canPush: true},
 		},
 		{
-			name: "coding light is meaningless but still coding-shaped",
-			kind: KindCoding, light: true, flow: FlowFull,
+			name: "coding stays coding-shaped regardless of flow rejected elsewhere",
+			kind: KindCoding, flow: FlowFull,
 			want: missionPolicy{needsWorktree: true, alwaysReview: true, checksCitations: false, canDelegate: true, skipsPlanning: false, canPush: true},
 		},
 		{
@@ -27,7 +26,7 @@ func TestPolicyFor(t *testing.T) {
 		},
 		{
 			name: "general light",
-			kind: KindGeneral, light: true, flow: FlowLight,
+			kind: KindGeneral, flow: FlowLight,
 			want: missionPolicy{needsWorktree: false, alwaysReview: false, checksCitations: true, canDelegate: false, skipsPlanning: true, canPush: false},
 		},
 		{
@@ -36,8 +35,8 @@ func TestPolicyFor(t *testing.T) {
 			want: missionPolicy{needsWorktree: false, alwaysReview: true, checksCitations: true, canDelegate: false, skipsPlanning: false, canPush: false},
 		},
 		{
-			name: "unknown kind with light stays conservative, ignores light",
-			kind: "bogus", light: true, flow: FlowFull,
+			name: "unknown kind with light flow stays conservative, ignores flow",
+			kind: "bogus", flow: FlowLight,
 			want: missionPolicy{needsWorktree: false, alwaysReview: true, checksCitations: true, canDelegate: false, skipsPlanning: false, canPush: false},
 		},
 		{
@@ -63,18 +62,18 @@ func TestPolicyFor(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := policyFor(tc.kind, tc.light, tc.flow)
+			got := policyFor(tc.kind, tc.flow)
 			if got != tc.want {
-				t.Fatalf("policyFor(%q, %v, %q) = %+v, want %+v", tc.kind, tc.light, tc.flow, got, tc.want)
+				t.Fatalf("policyFor(%q, %q) = %+v, want %+v", tc.kind, tc.flow, got, tc.want)
 			}
 		})
 	}
 }
 
 func TestMissionPolicyFor(t *testing.T) {
-	m := Mission{Kind: KindGeneral, Light: true, Flow: FlowLight}
+	m := Mission{Kind: KindGeneral, Flow: FlowLight}
 	got := missionPolicyFor(m)
-	want := policyFor(KindGeneral, true, FlowLight)
+	want := policyFor(KindGeneral, FlowLight)
 	if got != want {
 		t.Fatalf("missionPolicyFor(%+v) = %+v, want %+v", m, got, want)
 	}
@@ -82,20 +81,20 @@ func TestMissionPolicyFor(t *testing.T) {
 
 func TestInitialPhase(t *testing.T) {
 	cases := []struct {
-		name  string
-		kind  string
-		light bool
-		want  Phase
+		name string
+		kind string
+		flow Flow
+		want Phase
 	}{
-		{name: "coding starts at discover", kind: KindCoding, want: PhaseDiscover},
-		{name: "general starts at discover", kind: KindGeneral, want: PhaseDiscover},
-		{name: "light general starts at generate", kind: KindGeneral, light: true, want: PhaseGenerate},
-		{name: "unknown kind starts at discover even if light requested", kind: "bogus", light: true, want: PhaseDiscover},
+		{name: "coding starts at discover", kind: KindCoding, flow: FlowFull, want: PhaseDiscover},
+		{name: "general starts at discover", kind: KindGeneral, flow: FlowFull, want: PhaseDiscover},
+		{name: "light general starts at generate", kind: KindGeneral, flow: FlowLight, want: PhaseGenerate},
+		{name: "unknown kind starts at discover even if light requested", kind: "bogus", flow: FlowLight, want: PhaseDiscover},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := initialPhase(tc.kind, tc.light); got != tc.want {
-				t.Fatalf("initialPhase(%q, %v) = %v, want %v", tc.kind, tc.light, got, tc.want)
+			if got := initialPhase(tc.kind, tc.flow); got != tc.want {
+				t.Fatalf("initialPhase(%q, %q) = %v, want %v", tc.kind, tc.flow, got, tc.want)
 			}
 		})
 	}

--- a/internal/brain/missions/provision.go
+++ b/internal/brain/missions/provision.go
@@ -91,7 +91,7 @@ func (p *provisioner) ensureProvisioned(ctx context.Context, m Mission) (Mission
 		m.SessionID = sessionID
 		p.grantSessionDefaults(ctx, m)
 	}
-	if p.workspace != nil && m.Workspace == "" && m.Worktree == "" {
+	if p.workspace != nil && m.Workspace == "" {
 		var token string
 		var connIdentity *GitIdentity
 		if m.RepoURL != "" {
@@ -125,10 +125,10 @@ func (p *provisioner) ensureProvisioned(ctx context.Context, m Mission) (Mission
 		if err != nil {
 			return m, fmt.Errorf("provision: %w", err)
 		}
-		if err := p.store.SetProvisioned(ctx, m.ID, workspace, worktree, branch, baseCommit); err != nil {
+		if err := p.store.SetProvisioned(ctx, m.ID, workspace, branch, baseCommit); err != nil {
 			return m, err
 		}
-		m.Workspace, m.Worktree, m.Branch, m.BaseCommit = workspace, worktree, branch, baseCommit
+		m.Workspace, m.Branch, m.BaseCommit = workspace, branch, baseCommit
 		if m.ParentMissionID != "" && missionPolicyFor(m).needsWorktree {
 			ref := baseUsed
 			if ref == "" {

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -485,24 +485,25 @@ func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedu
 	if name == "" {
 		name = sc.Name
 	}
-	phase := initialPhase(t.Kind, t.Light)
 	// flow follows light exactly at fire time (D-090, issue #459): a
 	// schedule template has no flow field of its own, only light, but
 	// a digest schedule that runs light must still produce flow='light'
 	// so all D-069 code paths (policyFor, packet.go's WorkPacket.Light)
-	// key off the same column consistently.
+	// key off the same value consistently (issue #479 dropped the
+	// redundant light column, flow is now the only column written).
 	flow := FlowFull
 	if t.Light {
 		flow = FlowLight
 	}
+	phase := initialPhase(t.Kind, flow)
 	// auto_approve_plan is forced true here, never taken from the
 	// template (D-087, issue #456): a scheduler-fired mission runs
 	// unattended, so nobody is watching to approve its plan.
 	_, err = tx.Exec(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, knowledge, auto_approve_safe, auto_approve_plan, spec, schedule_id, harness, environment, destination_ids, light, phase, flow)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)`,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, knowledge, auto_approve_safe, auto_approve_plan, spec, schedule_id, harness, environment, destination_ids, phase, flow)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)`,
 		t.Goal, name, t.Kind, t.AgentID, orDefault(t.MaxIterations, 3), t.BudgetAmount, budgetCurrency, t.Route, t.ReviewRoute, t.PlanRoute,
-		promptOverlay, knowledgeJSON, t.AutoApproveSafe, true, spec, sc.ID, t.Harness, t.Environment, destinationIDs, t.Light, phase, flow)
+		promptOverlay, knowledgeJSON, t.AutoApproveSafe, true, spec, sc.ID, t.Harness, t.Environment, destinationIDs, phase, flow)
 	return err
 }
 
@@ -567,7 +568,7 @@ func resolveTemplateDefaults(ctx context.Context, t MissionTemplate, resolve Age
 			agentHarness = defaults.Harness
 		}
 	}
-	policy := policyFor(t.Kind, t.Light, FlowFull)
+	policy := policyFor(t.Kind, FlowFull)
 	defaultRoute := ""
 	if routeForRole != nil {
 		defaultRoute = routeForRole(ctx, "default")

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -215,34 +215,31 @@ type StepState struct {
 	// stepReviewRework), a second stall pauses for a human same as
 	// before this feature existed.
 	ReplanUsed bool
-	// Light marks a mission that skips discover/plan/prove (D-069), a
-	// stall can never replan into PhasePlan for one, since it never
-	// visits that phase.
-	Light bool
 	// Flow is the phase set this mission runs (D-090, issue #459):
 	// nextPhase consults it so discover's completion routes straight to
 	// generate for FlowDiscoverGenerate, skipping plan, the same way
-	// Light skips discover/plan by being born in PhaseGenerate. Empty
-	// (a zero-value StepState, every fixture that predates this field)
-	// behaves exactly like FlowFull.
+	// FlowLight skips discover/plan by being born in PhaseGenerate
+	// (D-069), so a stall can never replan into PhasePlan for either.
+	// Empty (a zero-value StepState, every fixture that predates this
+	// field) behaves exactly like FlowFull.
 	Flow Flow
 	// AutoApprovePlan gates the plan phase's success transition
 	// (D-087, issue #456): true (the default) advances straight to
 	// generate, byte-identical to pre-#456 behavior. false parks the
 	// mission on PauseApproval instead, waiting for one of the three
-	// operator verbs. Light missions never visit PhasePlan, so this
+	// operator verbs. FlowLight missions never visit PhasePlan, so this
 	// flag has no effect on them regardless of its value; neither does
 	// FlowDiscoverGenerate, which also never visits PhasePlan.
 	AutoApprovePlan bool
 }
 
 // neverVisitsPlan reports whether s's mission can never be in
-// PhasePlan: Light (born in PhaseGenerate) and FlowDiscoverGenerate
+// PhasePlan: FlowLight (born in PhaseGenerate) and FlowDiscoverGenerate
 // (discover's completion routes straight to generate, D-090) both
 // qualify. Used wherever plan-specific state (the stall/replan brake)
 // must be skipped for a mission structurally incapable of reaching it.
 func (s StepState) neverVisitsPlan() bool {
-	return s.Light || s.Flow == FlowDiscoverGenerate
+	return s.Flow == FlowLight || s.Flow == FlowDiscoverGenerate
 }
 
 // StepInput bundles the triggering Input with whatever data it
@@ -658,11 +655,11 @@ func stepReviewRework(s StepState, in StepInput, cfg Config) Transition {
 func stepResultComplete(s StepState) Transition {
 	s.Phase = PhaseDone
 	s.Status = StatusDone
-	// verified: false for a planless mission (light, or
+	// verified: false for a planless mission (flow=light, or
 	// flow=discover_generate, D-090), both of which reach done with zero
 	// harness verification (no spec units, no CheckArtifacts/RunVerify);
 	// distinguishes that in the event log from a harness-verified done.
-	verified := !s.Light && s.Flow != FlowDiscoverGenerate
+	verified := s.Flow != FlowLight && s.Flow != FlowDiscoverGenerate
 	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.done", Payload: map[string]any{"verified": verified}}}}
 }
 

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -500,7 +500,7 @@ func TestStepReplanEmitsReasonAndUsesReplanOnlyOnce(t *testing.T) {
 // phase now sits between the last unit's approval and done.
 func TestStepLightApproveGoesResult(t *testing.T) {
 	got := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, Light: true, LastUnit: true},
+		StepState{Phase: PhaseGenerate, Status: StatusWorking, Flow: FlowLight, LastUnit: true},
 		StepInput{Input: InputReviewApprove},
 		DefaultConfig,
 	)
@@ -530,7 +530,7 @@ func TestStepDiscoverGenerateApproveGoesResult(t *testing.T) {
 // now emitted by stepResultComplete rather than stepReviewApprove.
 func TestStepResultCompleteEmitsVerifiedFlag(t *testing.T) {
 	light := Step(
-		StepState{Phase: PhaseResult, Status: StatusWorking, Light: true},
+		StepState{Phase: PhaseResult, Status: StatusWorking, Flow: FlowLight},
 		StepInput{Input: InputResultComplete},
 		DefaultConfig,
 	)
@@ -542,7 +542,7 @@ func TestStepResultCompleteEmitsVerifiedFlag(t *testing.T) {
 	}
 
 	nonLight := Step(
-		StepState{Phase: PhaseResult, Status: StatusWorking, Light: false},
+		StepState{Phase: PhaseResult, Status: StatusWorking, Flow: FlowFull},
 		StepInput{Input: InputResultComplete},
 		DefaultConfig,
 	)
@@ -615,7 +615,7 @@ func TestStepLightStallNeverReplans(t *testing.T) {
 	// mission (StallCount already at the threshold, ReplanUsed false)
 	// must instead fall through to the plain retry path for a light one.
 	got := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, Light: true, MaxIterations: 8, Iteration: 0, StallCount: 1, LastGapFingerprint: "fp"},
+		StepState{Phase: PhaseGenerate, Status: StatusWorking, Flow: FlowLight, MaxIterations: 8, Iteration: 0, StallCount: 1, LastGapFingerprint: "fp"},
 		StepInput{Input: InputWorkerRetry, GapFingerprint: "fp", Reason: "stuck"},
 		DefaultConfig,
 	)
@@ -632,7 +632,7 @@ func TestStepLightStallNeverReplans(t *testing.T) {
 	// Repeated identical-fingerprint stalls still respect the hard
 	// max_iterations ceiling, exactly like worker_failed.
 	final := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, Light: true, MaxIterations: 1, Iteration: 0, StallCount: 1, LastGapFingerprint: "fp"},
+		StepState{Phase: PhaseGenerate, Status: StatusWorking, Flow: FlowLight, MaxIterations: 1, Iteration: 0, StallCount: 1, LastGapFingerprint: "fp"},
 		StepInput{Input: InputWorkerRetry, GapFingerprint: "fp", Reason: "stuck"},
 		DefaultConfig,
 	)

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -45,12 +45,12 @@ func (s *Store) SetHub(hub *Hub) {
 }
 
 const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_reason, pause_message,
-	workspace, worktree, branch, base_commit, spec, progress, iteration, max_iterations,
+	workspace, branch, base_commit, spec, progress, iteration, max_iterations,
 	consecutive_failures, last_gap_fingerprint, stall_count, budget_amount, budget_currency, route, review_route,
 	plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, knowledge,
 	pending_permission, auto_approve_safe, auto_approve_plan, last_evidence,
 	discover_notes, replan_used, schedule_id, session_id, harness, environment, repo_url, connector_id, on_complete,
-	branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, light, final_output, created_at, updated_at,
+	branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, final_output, created_at, updated_at,
 	workflow_run_id, workflow_step, artifact_refs, promote_kb_collection_id, permission_timeout_seconds, pending_input, asks_used, flow`
 
 // pendingPermissionRow is pending_permission's jsonb shape in the
@@ -119,13 +119,13 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		flow                                                          string
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
-		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
+		&m.Workspace, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
 		&m.ConsecutiveFailures, &m.LastGapFingerprint, &m.StallCount, &m.BudgetAmount, &m.BudgetCurrency, &m.Route, &m.ReviewRoute,
 		&m.PlanRoute, &m.EscalationRoute, &m.RouteModel, &m.PlanRouteModel, &m.ReviewRouteModel, &m.PromptOverlay, &knowledgeRaw,
 		&pendingPermissionRaw, &m.AutoApproveSafe, &m.AutoApprovePlan, &m.LastEvidence,
 		&m.DiscoverNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &m.ReferencedContext, &attachmentsRaw,
-		&m.DestinationIDs, &m.Light, &m.FinalOutput,
+		&m.DestinationIDs, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
 		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &promoteKBCollectionID, &permissionTimeoutSeconds,
 		&pendingInputRaw, &m.AsksUsed, &flow,
@@ -209,13 +209,13 @@ func scanMission(row pgx.Row) (Mission, error) {
 		flow                                                          string
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
-		&m.Workspace, &m.Worktree, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
+		&m.Workspace, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
 		&m.ConsecutiveFailures, &m.LastGapFingerprint, &m.StallCount, &m.BudgetAmount, &m.BudgetCurrency, &m.Route, &m.ReviewRoute,
 		&m.PlanRoute, &m.EscalationRoute, &m.RouteModel, &m.PlanRouteModel, &m.ReviewRouteModel, &m.PromptOverlay, &knowledgeRaw,
 		&pendingPermissionRaw, &m.AutoApproveSafe, &m.AutoApprovePlan, &m.LastEvidence,
 		&m.DiscoverNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
 		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &m.ReferencedContext, &attachmentsRaw,
-		&m.DestinationIDs, &m.Light, &m.FinalOutput,
+		&m.DestinationIDs, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
 		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &promoteKBCollectionID, &permissionTimeoutSeconds,
 		&pendingInputRaw, &m.AsksUsed, &flow); err != nil {
@@ -314,7 +314,6 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	if destinationIDs == nil {
 		destinationIDs = []string{}
 	}
-	phase := initialPhase(m.Kind, m.Light)
 	// flow defaults to full for any caller (test fixture, a pre-#459
 	// code path) that never set it: matches the column's own DB
 	// default and today's pre-#459 behavior exactly.
@@ -322,10 +321,11 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	if flow == "" {
 		flow = FlowFull
 	}
+	phase := initialPhase(m.Kind, flow)
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, auto_approve_plan, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, light, phase, workflow_run_id, workflow_step, promote_kb_collection_id, permission_timeout_seconds, flow)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NULLIF($18, '')::uuid, $19, $20, $21, $22, $23, $24, $25, $26, $27, NULLIF($28, '')::uuid, $29, $30, $31, $32, $33, $34, NULLIF($35, '')::uuid, $36, NULLIF($37, '')::uuid, $38, $39) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.AutoApprovePlan, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, m.ReferencedContext, attachmentsJSON, destinationIDs, m.Light, phase, m.WorkflowRunID, m.WorkflowStep, m.PromoteKBCollectionID, m.PermissionTimeoutSeconds, flow,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, auto_approve_plan, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, phase, workflow_run_id, workflow_step, promote_kb_collection_id, permission_timeout_seconds, flow)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NULLIF($18, '')::uuid, $19, $20, $21, $22, $23, $24, $25, $26, $27, NULLIF($28, '')::uuid, $29, $30, $31, $32, $33, NULLIF($34, '')::uuid, $35, NULLIF($36, '')::uuid, $37, $38) RETURNING id`,
+		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.AutoApprovePlan, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, m.ReferencedContext, attachmentsJSON, destinationIDs, phase, m.WorkflowRunID, m.WorkflowStep, m.PromoteKBCollectionID, m.PermissionTimeoutSeconds, flow,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)
@@ -1222,11 +1222,14 @@ func (s *Store) SetSession(ctx context.Context, id, sessionID string) error {
 	return nil
 }
 
-// SetProvisioned checks-and-writes workspace/worktree/branch/base_commit
-// in one txn (SELECT ... FOR UPDATE across active missions sharing the
-// same workspace+branch), refusing with ErrBranchConflict if another
-// ACTIVE mission (phase NOT IN ('done','failed')) already holds it.
-func (s *Store) SetProvisioned(ctx context.Context, id, workspace, worktree, branch, baseCommit string) error {
+// SetProvisioned checks-and-writes workspace/branch/base_commit in one
+// txn (SELECT ... FOR UPDATE across active missions sharing the same
+// workspace+branch), refusing with ErrBranchConflict if another ACTIVE
+// mission (phase NOT IN ('done','failed')) already holds it. worktree
+// is no longer persisted (issue #479): it's a fixed derivation of
+// workspace (Mission.WorktreePath), so the caller-provided value is
+// only used by ensureProvisioned itself, never written here.
+func (s *Store) SetProvisioned(ctx context.Context, id, workspace, branch, baseCommit string) error {
 	db, err := s.db.Get()
 	if err != nil {
 		return fmt.Errorf("missions set provisioned: %w", err)
@@ -1251,8 +1254,8 @@ func (s *Store) SetProvisioned(ctx context.Context, id, workspace, worktree, bra
 		}
 	}
 	if _, err := tx.Exec(ctx, `UPDATE missions SET
-			workspace = $2, worktree = $3, branch = $4, base_commit = $5, updated_at = now()
-		WHERE id = $1`, id, workspace, worktree, branch, baseCommit); err != nil {
+			workspace = $2, branch = $3, base_commit = $4, updated_at = now()
+		WHERE id = $1`, id, workspace, branch, baseCommit); err != nil {
 		return fmt.Errorf("missions set provisioned update: %w", err)
 	}
 	if err := appendEventTx(ctx, tx, id, "mission.provisioned", map[string]any{

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -504,7 +504,7 @@ func TestMissionLightAndFinalOutputRoundTrip(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
 
-	id, err := s.Create(ctx, Mission{Goal: marker + "light", Kind: "general", Route: "default", Light: true})
+	id, err := s.Create(ctx, Mission{Goal: marker + "light", Kind: "general", Route: "default", Flow: FlowLight})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -512,8 +512,8 @@ func TestMissionLightAndFinalOutputRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if !m.Light {
-		t.Fatal("Light = false, want true")
+	if m.Flow != FlowLight {
+		t.Fatalf("Flow = %q, want %q", m.Flow, FlowLight)
 	}
 	if m.Phase != PhaseGenerate {
 		t.Fatalf("Phase = %q, want execute for a light mission at create", m.Phase)
@@ -541,8 +541,8 @@ func TestMissionLightAndFinalOutputRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if m2.Light {
-		t.Fatal("Light = true, want false when not set")
+	if m2.Flow == FlowLight {
+		t.Fatal("Flow = light, want full when not set")
 	}
 	if m2.Phase != PhaseDiscover {
 		t.Fatalf("Phase = %q, want discover for a non-light mission at create", m2.Phase)
@@ -1102,17 +1102,17 @@ func TestSetProvisionedBranchCollision(t *testing.T) {
 		t.Fatalf("Create 2: %v", err)
 	}
 
-	if err := s.SetProvisioned(ctx, id1, "/ws", "/ws/wt1", "mission/shared-branch", "abc123"); err != nil {
+	if err := s.SetProvisioned(ctx, id1, "/ws", "mission/shared-branch", "abc123"); err != nil {
 		t.Fatalf("SetProvisioned 1: %v", err)
 	}
 	// Same workspace+branch, different mission, still active: refused.
-	err = s.SetProvisioned(ctx, id2, "/ws", "/ws/wt2", "mission/shared-branch", "abc123")
+	err = s.SetProvisioned(ctx, id2, "/ws", "mission/shared-branch", "abc123")
 	if err == nil {
 		t.Fatal("SetProvisioned allowed a branch collision with an active mission")
 	}
 
 	// A different branch on the same workspace is fine.
-	if err := s.SetProvisioned(ctx, id2, "/ws", "/ws/wt2", "mission/other-branch", "abc123"); err != nil {
+	if err := s.SetProvisioned(ctx, id2, "/ws", "mission/other-branch", "abc123"); err != nil {
 		t.Fatalf("SetProvisioned distinct branch: %v", err)
 	}
 
@@ -1124,7 +1124,7 @@ func TestSetProvisionedBranchCollision(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create 3: %v", err)
 	}
-	if err := s.SetProvisioned(ctx, id3, "/ws", "/ws/wt3", "mission/shared-branch", "def456"); err != nil {
+	if err := s.SetProvisioned(ctx, id3, "/ws", "mission/shared-branch", "def456"); err != nil {
 		t.Fatalf("SetProvisioned after mission 1 terminal: %v", err)
 	}
 }

--- a/internal/brain/missions/validate.go
+++ b/internal/brain/missions/validate.go
@@ -75,20 +75,14 @@ func ValidateCreate(ctx context.Context, m Mission, deps ValidateDeps) error {
 	default:
 		return fmt.Errorf(`%w: kind must be "coding" or "general"`, ErrInvalidMission)
 	}
-	if m.Light && m.Kind != KindGeneral {
-		return fmt.Errorf("%w: light is only valid for kind=general missions", ErrInvalidMission)
-	}
 	if !ValidFlow(string(m.Flow)) {
 		return fmt.Errorf("%w: unknown flow %q", ErrInvalidMission, m.Flow)
 	}
 	if m.Kind == KindCoding && m.Flow != FlowFull {
 		return fmt.Errorf("%w: flow must be %q for kind=coding missions", ErrInvalidMission, FlowFull)
 	}
-	if m.Light && m.Flow != FlowLight {
-		return fmt.Errorf("%w: light=true requires flow=%q", ErrInvalidMission, FlowLight)
-	}
-	if m.Flow == FlowLight && !m.Light {
-		return fmt.Errorf("%w: flow=%q requires light=true", ErrInvalidMission, FlowLight)
+	if m.Flow == FlowLight && m.Kind != KindGeneral {
+		return fmt.Errorf("%w: flow=%q is only valid for kind=general missions", ErrInvalidMission, FlowLight)
 	}
 	if !missionPolicyFor(m).canDelegate {
 		switch {

--- a/internal/brain/missions/validate_test.go
+++ b/internal/brain/missions/validate_test.go
@@ -34,12 +34,12 @@ func TestValidateCreate(t *testing.T) {
 			m.Kind = ""
 			return m
 		}, ValidateDeps{}, true},
-		{"light on coding", func(m Mission) Mission {
-			m.Kind, m.Light = "coding", true
+		{"flow light on coding", func(m Mission) Mission {
+			m.Kind, m.Flow = "coding", FlowLight
 			return m
 		}, ValidateDeps{}, true},
-		{"light on general", func(m Mission) Mission {
-			m.Light, m.Flow = true, FlowLight
+		{"flow light on general", func(m Mission) Mission {
+			m.Flow = FlowLight
 			return m
 		}, ValidateDeps{}, false},
 		{"harness on general", func(m Mission) Mission {
@@ -220,18 +220,6 @@ func TestValidateCreate(t *testing.T) {
 		}, ValidateDeps{}, true},
 		{"discover_generate on coding rejected", func(m Mission) Mission {
 			m.Kind, m.Flow = "coding", FlowDiscoverGenerate
-			return m
-		}, ValidateDeps{}, true},
-		{"flow light on coding rejected", func(m Mission) Mission {
-			m.Kind, m.Flow = "coding", FlowLight
-			return m
-		}, ValidateDeps{}, true},
-		{"light true with flow full is contradictory", func(m Mission) Mission {
-			m.Light = true
-			return m
-		}, ValidateDeps{}, true},
-		{"flow light without light true is contradictory", func(m Mission) Mission {
-			m.Flow = FlowLight
 			return m
 		}, ValidateDeps{}, true},
 	}

--- a/internal/brain/missions/worktree.go
+++ b/internal/brain/missions/worktree.go
@@ -75,12 +75,12 @@ func NewWorkspace(root string, identity func(context.Context) (name, email strin
 // or the clone's default branch on fallback), so the caller can record
 // an accurate note.
 func (w *Workspace) Provision(ctx context.Context, missionID, goal, kind, repoURL, token string, connIdentity *GitIdentity, branchPattern, baseRef string) (workspace, worktree, branch, baseCommit, baseUsed string, err error) {
-	workspace = filepath.Join(w.root, missionID)
+	workspace = filepath.Join(w.root, kind, missionID)
 	if err := os.MkdirAll(workspace, 0o750); err != nil {
 		return "", "", "", "", "", fmt.Errorf("worktree: provision: mkdir %s: %w", workspace, err)
 	}
 
-	if !policyFor(kind, false, FlowFull).needsWorktree {
+	if !policyFor(kind, FlowFull).needsWorktree {
 		return workspace, "", "", "", "", nil
 	}
 
@@ -406,7 +406,7 @@ func CommitMessage(unitTitle, goal, body, style string) string {
 // Rollback discards uncommitted work: `git checkout -- .` + `git clean
 // -fd` for coding missions, no-op otherwise.
 func (w *Workspace) Rollback(ctx context.Context, worktree, kind string) error {
-	if !policyFor(kind, false, FlowFull).needsWorktree || worktree == "" {
+	if !policyFor(kind, FlowFull).needsWorktree || worktree == "" {
 		return nil
 	}
 	cctx, cancel := context.WithTimeout(ctx, rollbackTimeout)

--- a/internal/brain/missions/worktree_test.go
+++ b/internal/brain/missions/worktree_test.go
@@ -181,6 +181,73 @@ func newTestWorkspace(t *testing.T) *Workspace {
 	return NewWorkspace(root, nil, log)
 }
 
+// TestMissionWorktreePath covers Mission.WorktreePath's derivation
+// (issue #479 dropped the stored worktree column): workspace/wt for a
+// needsWorktree kind/flow with a provisioned workspace, "" otherwise.
+func TestMissionWorktreePath(t *testing.T) {
+	cases := []struct {
+		name string
+		m    Mission
+		want string
+	}{
+		{
+			name: "coding mission with workspace gets workspace/wt",
+			m:    Mission{Kind: KindCoding, Flow: FlowFull, Workspace: "/ws/coding/m1"},
+			want: "/ws/coding/m1/wt",
+		},
+		{
+			name: "general mission never gets a worktree",
+			m:    Mission{Kind: KindGeneral, Flow: FlowFull, Workspace: "/ws/general/m1"},
+			want: "",
+		},
+		{
+			name: "light general mission never gets a worktree",
+			m:    Mission{Kind: KindGeneral, Flow: FlowLight, Workspace: "/ws/general/m1"},
+			want: "",
+		},
+		{
+			name: "coding mission not yet provisioned has no workspace to derive from",
+			m:    Mission{Kind: KindCoding, Flow: FlowFull},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.m.WorktreePath(); got != tc.want {
+				t.Fatalf("WorktreePath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProvisionWorkspacePathIncludesKind confirms a new mission's
+// workspace lands at root/kind/id (issue #479), not root/id: kind
+// segments the flat workspace root so a listing separates coding from
+// general missions.
+func TestProvisionWorkspacePathIncludesKind(t *testing.T) {
+	requireGit(t)
+	w := newTestWorkspace(t)
+	ctx := context.Background()
+
+	workspace, _, _, _, _, err := w.Provision(ctx, "mission-kind-1", "Fix the login bug", "coding", "", "", nil, "", "")
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	want := filepath.Join(w.root, "coding", "mission-kind-1")
+	if workspace != want {
+		t.Fatalf("workspace = %q, want %q", workspace, want)
+	}
+
+	workspace2, _, _, _, _, err := w.Provision(ctx, "mission-kind-2", "Summarize the doc", "general", "", "", nil, "", "")
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	want2 := filepath.Join(w.root, "general", "mission-kind-2")
+	if workspace2 != want2 {
+		t.Fatalf("workspace = %q, want %q", workspace2, want2)
+	}
+}
+
 // TestProvisionCodingMissionSelfInitsRepo covers the fix's core case:
 // a coding mission always self-initializes its own git repo inside
 // its workspace — no repo needs to pre-exist in the container.

--- a/internal/brain/workflows/engine.go
+++ b/internal/brain/workflows/engine.go
@@ -215,7 +215,7 @@ func (e *Engine) spawnStep(ctx context.Context, runID, stepName string, step Ste
 		flow = missions.FlowLight
 	}
 	return e.spawner.Create(ctx, missions.Mission{
-		Goal: goal, Kind: step.Kind, Light: step.Light, Flow: flow, Route: route, PlanRoute: step.PlanRoute, AgentID: step.AgentID,
+		Goal: goal, Kind: step.Kind, Flow: flow, Route: route, PlanRoute: step.PlanRoute, AgentID: step.AgentID,
 		OnComplete: step.OnComplete, DestinationIDs: step.DestinationIDs,
 		ParentMissionID: parentMissionID, ParentContext: outcome,
 		WorkflowRunID: runID, WorkflowStep: stepName,

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -558,7 +558,6 @@ CREATE TABLE IF NOT EXISTS missions (
     pause_reason          text NOT NULL DEFAULT '',
     pause_message         text NOT NULL DEFAULT '',
     workspace             text NOT NULL DEFAULT '',
-    worktree              text NOT NULL DEFAULT '',
     branch                text NOT NULL DEFAULT '',
     base_commit           text NOT NULL DEFAULT '',
     spec                  jsonb NOT NULL DEFAULT '{}',
@@ -652,10 +651,6 @@ CREATE TABLE IF NOT EXISTS missions (
     -- settings at dispatch. "" is native; "claude-cli" (etc) names a
     -- registered delegated executor (internal/brain/missions/executor).
     harness               text NOT NULL DEFAULT '',
-    -- Light missions (D-069, general kind only) skip discover/plan/
-    -- prove: born in phase=generate, one bare worker turn, the final
-    -- worker message is the deliverable, then result/done.
-    light                 boolean NOT NULL DEFAULT false,
     -- Mission worker turns run through loop.Agent same as chat, but
     -- tool-call bookkeeping (session_events, tools audit) hard-requires
     -- a real session_id uuid FK -- a mission has no chat session of its
@@ -794,9 +789,11 @@ CREATE TABLE IF NOT EXISTS missions (
     -- 'discover_generate' skips plan (generate runs planless, same as
     -- light) and prove; 'no_prove' keeps plan but skips the LLM
     -- reviewer round (harness CheckArtifacts still runs on generate's
-    -- exit); 'light' is the existing D-069 behavior. light column stays
-    -- the source of truth for D-069 code paths; flow='light' always
-    -- implies light=true (api/missions.go's create normalizes this).
+    -- exit); 'light' is the existing D-069 behavior (general kind only:
+    -- born in phase=generate, one bare worker turn, the final worker
+    -- message is the deliverable). flow is the single source of truth
+    -- for D-069 code paths (issue #479 dropped the redundant light
+    -- column).
     flow                  text NOT NULL DEFAULT 'full'
         CHECK (flow IN ('full', 'discover_generate', 'no_prove', 'light'))
 );

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -118,3 +118,16 @@ SET approval_allowlist = (
 )
 WHERE approval_allowlist @> '["explore_notes"]';
 ```
+
+## Schema restructure slice 1 (issue #479)
+
+Required on live DBs before/with the next deploy. Data is already
+coherent before either drop: flow='light' iff light (normalized at
+create since D-090), and worktree is always workspace + "/wt" for a
+mission whose kind/flow policy needs one (Mission.WorktreePath derives
+it going forward, never reads the old column again).
+
+```sql
+ALTER TABLE missions DROP COLUMN IF EXISTS light;
+ALTER TABLE missions DROP COLUMN IF EXISTS worktree;
+```


### PR DESCRIPTION
Closes #479. Slice 1 of the missions schema restructure.

flow already encodes what light duplicated (D-090 normalized them at create), and worktree is always workspace + /wt when the kind/flow policy needs one, so both columns die. API responses keep light and worktree as derived fields, so web and canary scripts are untouched. New missions provision under <root>/<kind>/<missionID>; existing rows keep their stored workspace paths. 0001 edited in place, DROPs in pending-alters.

Verified: go build/vet (incl. -tags integration)/test -race all green; no web changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790817567&installation_model_id=431401&pr_number=485&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F485&signature=325187ef478bc2233c18a8c97d18d4eaae6780200da9ae24bc57a6d52e46b20f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->