### PR TITLE
refactor(missions): destinations jsonb replaces five delivery columns

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -1219,7 +1219,7 @@ func toMissionRecord(m missions.Mission) builtin.MissionRecord {
 		CreatedAt: m.CreatedAt, UpdatedAt: m.UpdatedAt,
 		UnitsPassed: passed, UnitsTotal: len(m.Spec.Units),
 		PauseReason: string(m.PauseReason), PauseMessage: m.PauseMessage,
-		OnComplete:        m.OnComplete,
+		OnComplete:        m.OnComplete(),
 		NotPushableReason: missions.NotPushable(m),
 	}
 }

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -332,8 +332,13 @@ type missionResponse struct {
 	// Light is derived from Flow == FlowLight (issue #479): the web
 	// client's own light checks (e.g. MissionDetail.tsx's runsPlanless)
 	// read this exactly as before the light column was dropped.
-	Light            bool   `json:"light"`
-	Worktree         string `json:"worktree,omitempty"`
+	Light    bool   `json:"light"`
+	Worktree string `json:"worktree,omitempty"`
+	// OnComplete is derived from the mission's github Destinations entry
+	// (issue #480 dropped the on_complete column): the web client's own
+	// auto-push/auto-PR badge (MissionDetail.tsx) reads this exactly as
+	// before.
+	OnComplete       string `json:"on_complete,omitempty"`
 	TopModel         string `json:"top_model,omitempty"`
 	TopModelProvider string `json:"top_model_provider,omitempty"`
 }
@@ -345,7 +350,7 @@ type missionResponse struct {
 func (h *missionAPI) decorateTopModels(ctx context.Context, rows []missions.Mission) []missionResponse {
 	out := make([]missionResponse, len(rows))
 	for i, m := range rows {
-		out[i] = missionResponse{Mission: m, Light: m.Flow == missions.FlowLight, Worktree: m.WorktreePath()}
+		out[i] = missionResponse{Mission: m, Light: m.Flow == missions.FlowLight, Worktree: m.WorktreePath(), OnComplete: m.OnComplete()}
 	}
 	if h.topModels == nil || len(rows) == 0 {
 		return out
@@ -444,13 +449,15 @@ type createMissionRequest struct {
 	// happens when this mission reaches done: "" (default), "push", or
 	// "push_pr". Requires RepoURL+ConnectorID (a github-connection
 	// mission) and kind=coding — a model never decides this, only the
-	// human choosing it here.
+	// human choosing it here. Normalized into a "github" Destinations
+	// entry by destinationEntries below (issue #480).
 	OnComplete string `json:"on_complete"`
 	// BranchPattern/CommitStyle override the settings-configured git
 	// strategy defaults for this mission alone; "" (the default) applies
 	// the settings default at provisioning/commit time. Validated the
 	// same way settings.Store.SetValue validates the global default —
-	// only known placeholders/styles, never model-decided.
+	// only known placeholders/styles, never model-decided. Folded into
+	// the same "github" Destinations entry as OnComplete.
 	BranchPattern string `json:"branch_pattern"`
 	CommitStyle   string `json:"commit_style"`
 	// ParentMissionID, when set, makes this a follow-up mission: the
@@ -471,15 +478,17 @@ type createMissionRequest struct {
 	// DestinationIDs names operator-created destinations (email,
 	// webhook) to deliver this mission's outcome digest to on the
 	// terminal done transition — every id is validated to exist AND be
-	// enabled at create time (see create() below); the model never
-	// supplies or addresses a destination (D-061).
+	// enabled at create time (missions.ValidateCreate); the model never
+	// supplies or addresses a destination (D-061). Normalized into bare
+	// Destinations entries by destinationEntries below (issue #480).
 	DestinationIDs []string `json:"destination_ids"`
 	// PromoteKBCollectionID (D-081, issue #370) names a kb collection to
 	// promote this mission's markdown artifacts into on the terminal
 	// done transition: "" (default) promotes nothing automatically;
 	// validated to exist at create time (missions.ValidateCreate), the
 	// model never supplies or addresses it, same invariant as
-	// DestinationIDs.
+	// DestinationIDs. Normalized into a "kb" Destinations entry by
+	// destinationEntries below.
 	PromoteKBCollectionID string `json:"promote_kb_collection_id"`
 	// Light requests a mission that skips discover/plan/prove (D-069):
 	// kind=general only, rejected outright on kind=coding (explicit or
@@ -501,6 +510,30 @@ type createMissionRequest struct {
 	// positive integer sets this mission's own park-forever/auto-deny
 	// bound. Never negative.
 	PermissionTimeoutSeconds *int `json:"permission_timeout_seconds"`
+}
+
+// destinationEntries normalizes the request's separate DestinationIDs/
+// PromoteKBCollectionID/OnComplete/BranchPattern/CommitStyle fields
+// into missions.Mission's single Destinations slice (issue #480): one
+// bare entry per destination id, one "kb" entry when
+// PromoteKBCollectionID is set, one "github" entry when OnComplete is
+// set. The wire request shape is unchanged; only the internal Mission
+// representation moved.
+func (r createMissionRequest) destinationEntries() []missions.DestinationEntry {
+	var entries []missions.DestinationEntry
+	for _, id := range r.DestinationIDs {
+		entries = append(entries, missions.DestinationEntry{DestinationID: id})
+	}
+	if r.PromoteKBCollectionID != "" {
+		entries = append(entries, missions.DestinationEntry{Destination: missions.DestinationKindKB, CollectionID: r.PromoteKBCollectionID})
+	}
+	if r.OnComplete != "" || r.BranchPattern != "" || r.CommitStyle != "" {
+		entries = append(entries, missions.DestinationEntry{
+			Destination: missions.DestinationKindGitHub, Mode: r.OnComplete,
+			BranchPattern: r.BranchPattern, CommitStyle: r.CommitStyle,
+		})
+	}
+	return entries
 }
 
 // missionAttachmentInput names one already-uploaded attachment to
@@ -689,10 +722,10 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		RouteModel: req.RouteModel, PlanRouteModel: req.PlanRouteModel, ReviewRouteModel: req.ReviewRouteModel,
 		MaxIterations: req.MaxIterations, BudgetAmount: req.BudgetAmount, BudgetCurrency: budgetCurrency,
 		AutoApproveSafe: autoApproveSafe, AutoApprovePlan: autoApprovePlan, PromptOverlay: promptOverlay, Knowledge: knowledge, Harness: req.Harness, Environment: req.Environment,
-		RepoURL: req.RepoURL, ConnectorID: req.ConnectorID, OnComplete: req.OnComplete,
-		BranchPattern: req.BranchPattern, CommitStyle: req.CommitStyle,
+		RepoURL: req.RepoURL, ConnectorID: req.ConnectorID,
 		ParentMissionID: parentMissionID, ParentContext: parentContext, ReferencedContext: referencedContext,
-		Attachments: missionAtts, DestinationIDs: req.DestinationIDs, PromoteKBCollectionID: req.PromoteKBCollectionID,
+		Attachments:  missionAtts,
+		Destinations: req.destinationEntries(),
 		Flow:                     missions.Flow(flow),
 		PermissionTimeoutSeconds: req.PermissionTimeoutSeconds,
 	}

--- a/internal/brain/destinations/deliver.go
+++ b/internal/brain/destinations/deliver.go
@@ -2,7 +2,6 @@ package destinations
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -73,31 +72,27 @@ func NewDeliverer(store destinationStore, events eventRecorder, email *EmailAdap
 }
 
 // eventDelivered/eventDeliveryFailed name the mission_events rows
-// Deliver appends — one per destination per mission, guarded below so
-// a re-drive (Signal racing Advance) never double-delivers.
+// Deliver appends, one per destination per mission, purely for the
+// Timeline/history now that delivery dedup itself reads each entry's
+// own delivered_at/error (issue #480).
 const (
 	eventDelivered      = "mission.delivered"
 	eventDeliveryFailed = "mission.delivery_failed"
 )
 
-// Deliver runs delivery for every id in destinationIDs, best-effort
-// per destination. Recipients get the mission's generated output
-// (Render's Files, from the mission's declared plan-unit artifacts)
-// plus a short completion line, never the goal/plan/review process
-// digest. Idempotent under a re-drive: a destination that already
-// recorded mission.delivered is skipped, one that recorded
-// mission.delivery_failed (or was never attempted) is retried. No-ops
-// immediately for an empty destinationIDs. Returns an error naming
-// every destination that failed this round, or nil if all succeeded
-// (or there was nothing to deliver).
-func (d *Deliverer) Deliver(ctx context.Context, m missions.Mission, destinationIDs []string) error {
-	if len(destinationIDs) == 0 {
-		return nil
-	}
-	delivered, err := d.alreadyDelivered(ctx, m.ID)
-	if err != nil {
-		d.log.Warn("destinations: load prior delivery events failed", "mission_id", m.ID, "error", err)
-		return err
+// Deliver runs delivery for every entry in entries, best-effort per
+// destination. Recipients get the mission's generated output (Render's
+// Files, from the mission's declared plan-unit artifacts) plus a short
+// completion line, never the goal/plan/review process digest.
+// Idempotent under a re-drive: an entry whose DeliveredAt is already
+// set is skipped, one with Error set (or never attempted) is retried.
+// Returns the entries with DeliveredAt/Error updated in place (the
+// caller persists them, see missions.Driver.deliverToDestinations)
+// plus an error naming every destination that failed this round, or
+// nil if all succeeded. No-ops immediately for an empty entries.
+func (d *Deliverer) Deliver(ctx context.Context, m missions.Mission, entries []missions.DestinationEntry) ([]missions.DestinationEntry, error) {
+	if len(entries) == 0 {
+		return nil, nil
 	}
 	events, err := d.events.Events(ctx, m.ID)
 	if err != nil {
@@ -116,37 +111,44 @@ func (d *Deliverer) Deliver(ctx context.Context, m missions.Mission, destination
 	}
 	payload := Render(m, webBaseURL, events, loc)
 
+	out := make([]missions.DestinationEntry, len(entries))
 	var failed []string
-	for _, id := range destinationIDs {
-		if delivered[id] {
+	for i, e := range entries {
+		if e.DeliveredAt != "" {
+			out[i] = e
 			continue
 		}
-		if err := d.deliverOne(ctx, m.ID, id, payload); err != nil {
-			failed = append(failed, id)
+		if err := d.deliverOne(ctx, m.ID, &e, payload); err != nil {
+			failed = append(failed, e.DestinationID)
 		}
+		out[i] = e
 	}
 	if len(failed) > 0 {
-		return fmt.Errorf("delivery failed for destination(s): %s", strings.Join(failed, ", "))
+		return out, fmt.Errorf("delivery failed for destination(s): %s", strings.Join(failed, ", "))
 	}
-	return nil
+	return out, nil
 }
 
-func (d *Deliverer) deliverOne(ctx context.Context, missionID, destinationID string, payload Payload) error {
+// deliverOne attempts one entry's delivery, mutating it in place with
+// the outcome (DeliveredAt on success, Error on failure) and recording
+// the same outcome as a mission_events row for the Timeline.
+func (d *Deliverer) deliverOne(ctx context.Context, missionID string, e *missions.DestinationEntry, payload Payload) error {
+	destinationID := e.DestinationID
 	dest, err := d.store.Get(ctx, destinationID)
 	if err != nil {
 		reason := "destination not found: " + err.Error()
-		d.recordOutcome(ctx, missionID, destinationID, "", false, reason)
+		d.recordOutcome(ctx, missionID, e, "", reason)
 		return errors.New(reason)
 	}
 	if !dest.Enabled {
 		reason := "destination is disabled"
-		d.recordOutcome(ctx, missionID, destinationID, dest.Name, false, reason)
+		d.recordOutcome(ctx, missionID, e, dest.Name, reason)
 		return errors.New(reason)
 	}
 	adapter := d.adapters[dest.Kind]
 	if adapter == nil {
 		reason := "no adapter for kind " + dest.Kind
-		d.recordOutcome(ctx, missionID, destinationID, dest.Name, false, reason)
+		d.recordOutcome(ctx, missionID, e, dest.Name, reason)
 		return errors.New(reason)
 	}
 
@@ -158,14 +160,14 @@ func (d *Deliverer) deliverOne(ctx context.Context, missionID, destinationID str
 			select {
 			case <-ctx.Done():
 				timer.Stop()
-				d.recordOutcome(ctx, missionID, destinationID, dest.Name, false, ctx.Err().Error())
+				d.recordOutcome(ctx, missionID, e, dest.Name, ctx.Err().Error())
 				return ctx.Err()
 			case <-timer.C:
 			}
 		}
 		lastErr = adapter.Deliver(ctx, dest.Config, dest.CredentialRef, payload)
 		if lastErr == nil {
-			d.recordOutcome(ctx, missionID, destinationID, dest.Name, true, "")
+			d.recordOutcome(ctx, missionID, e, dest.Name, "")
 			return nil
 		}
 		d.log.Warn("destinations: delivery attempt failed", "mission_id", missionID, "destination_id", destinationID, "attempt", i+1, "error", lastErr)
@@ -176,19 +178,26 @@ func (d *Deliverer) deliverOne(ctx context.Context, missionID, destinationID str
 			break
 		}
 	}
-	d.recordOutcome(ctx, missionID, destinationID, dest.Name, false, lastErr.Error())
+	d.recordOutcome(ctx, missionID, e, dest.Name, lastErr.Error())
 	return lastErr
 }
 
-func (d *Deliverer) recordOutcome(ctx context.Context, missionID, destinationID, name string, ok bool, reason string) {
+// recordOutcome sets entry's DeliveredAt (success, reason == "") or
+// Error (failure) and appends the matching mission_events row for the
+// Timeline.
+func (d *Deliverer) recordOutcome(ctx context.Context, missionID string, e *missions.DestinationEntry, name, reason string) {
 	kind := eventDelivered
-	payload := map[string]any{"destination_id": destinationID, "destination_name": name}
-	if !ok {
+	payload := map[string]any{"destination_id": e.DestinationID, "destination_name": name}
+	if reason == "" {
+		e.DeliveredAt = time.Now().UTC().Format(time.RFC3339)
+		e.Error = ""
+	} else {
 		kind = eventDeliveryFailed
+		e.Error = reason
 		payload["reason"] = reason
 	}
 	if err := d.events.AppendEvent(ctx, missionID, kind, payload); err != nil {
-		d.log.Warn("destinations: record outcome event failed", "mission_id", missionID, "destination_id", destinationID, "error", err)
+		d.log.Warn("destinations: record outcome event failed", "mission_id", missionID, "destination_id", e.DestinationID, "error", err)
 	}
 }
 
@@ -242,30 +251,4 @@ func (d *Deliverer) DeliverNow(ctx context.Context, id, subject, body string) (n
 		return "", "", err
 	}
 	return dest.Name, dest.Kind, nil
-}
-
-// alreadyDelivered scans a mission's events for prior mission.delivered
-// rows, keyed by destination_id: a destination already delivered is
-// never re-sent on a result-phase retry (D-086), but one that only
-// recorded mission.delivery_failed (or was never attempted) IS
-// retried, so a park in result actually makes progress instead of
-// replaying the same permanent failure forever.
-func (d *Deliverer) alreadyDelivered(ctx context.Context, missionID string) (map[string]bool, error) {
-	events, err := d.events.Events(ctx, missionID)
-	if err != nil {
-		return nil, err
-	}
-	out := map[string]bool{}
-	for _, ev := range events {
-		if ev.Kind != eventDelivered {
-			continue
-		}
-		var payload struct {
-			DestinationID string `json:"destination_id"`
-		}
-		if jsonErr := json.Unmarshal(ev.Payload, &payload); jsonErr == nil && payload.DestinationID != "" {
-			out[payload.DestinationID] = true
-		}
-	}
-	return out, nil
 }

--- a/internal/brain/destinations/deliver_test.go
+++ b/internal/brain/destinations/deliver_test.go
@@ -104,12 +104,20 @@ func withFastBackoff(t *testing.T) {
 	t.Cleanup(func() { deliverBackoff = orig })
 }
 
+func entries(ids ...string) []missions.DestinationEntry {
+	out := make([]missions.DestinationEntry, len(ids))
+	for i, id := range ids {
+		out[i] = missions.DestinationEntry{DestinationID: id}
+	}
+	return out
+}
+
 func TestDeliverZeroDestinationsNoop(t *testing.T) {
 	destStore := &fakeDestStore{rows: map[string]Destination{}}
 	eventStore := &fakeEventStore{}
 	d := NewDeliverer(destStore, eventStore, nil, &WebhookAdapter{}, nil, nil, nil, discardLog())
 
-	if err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, nil); err != nil {
+	if _, err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, nil); err != nil {
 		t.Fatalf("Deliver with zero destinations: %v", err)
 	}
 
@@ -127,15 +135,18 @@ func TestDeliverRetryThenSucceed(t *testing.T) {
 	eventStore := &fakeEventStore{}
 	d := &Deliverer{store: destStore, events: eventStore, adapters: map[string]Adapter{"webhook": adapter}, log: discardLog()}
 
-	if err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"d1"}); err != nil {
+	updated, err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, entries("d1"))
+	if err != nil {
 		t.Fatalf("Deliver: %v", err)
 	}
-
 	if adapter.callCount() != 3 {
 		t.Fatalf("expected 3 attempts, got %d", adapter.callCount())
 	}
 	if len(eventStore.events) != 1 || eventStore.events[0].Kind != eventDelivered {
 		t.Fatalf("expected one mission.delivered event, got %+v", eventStore.events)
+	}
+	if len(updated) != 1 || updated[0].DeliveredAt == "" {
+		t.Fatalf("expected the returned entry to carry delivered_at, got %+v", updated)
 	}
 }
 
@@ -148,7 +159,8 @@ func TestDeliverRetryExhaustedThenFail(t *testing.T) {
 	eventStore := &fakeEventStore{}
 	d := &Deliverer{store: destStore, events: eventStore, adapters: map[string]Adapter{"webhook": adapter}, log: discardLog()}
 
-	if err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"d1"}); err == nil {
+	updated, err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, entries("d1"))
+	if err == nil {
 		t.Fatal("Deliver with an always-failing adapter: want an error, got nil")
 	}
 
@@ -157,6 +169,9 @@ func TestDeliverRetryExhaustedThenFail(t *testing.T) {
 	}
 	if len(eventStore.events) != 1 || eventStore.events[0].Kind != eventDeliveryFailed {
 		t.Fatalf("expected one mission.delivery_failed event, got %+v", eventStore.events)
+	}
+	if len(updated) != 1 || updated[0].Error == "" || updated[0].DeliveredAt != "" {
+		t.Fatalf("expected the returned entry to carry error, no delivered_at, got %+v", updated)
 	}
 }
 
@@ -173,7 +188,7 @@ func TestDeliverStopsRetryingOnMaybeDelivered(t *testing.T) {
 	eventStore := &fakeEventStore{}
 	d := &Deliverer{store: destStore, events: eventStore, adapters: map[string]Adapter{"telegram": adapter}, log: discardLog()}
 
-	if err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"d1"}); err == nil {
+	if _, err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, entries("d1")); err == nil {
 		t.Fatal("Deliver with a maybe-delivered error: want an error, got nil")
 	}
 
@@ -194,10 +209,13 @@ func TestDeliverOncePerMissionGuard(t *testing.T) {
 	eventStore := &fakeEventStore{}
 	d := &Deliverer{store: destStore, events: eventStore, adapters: map[string]Adapter{"webhook": adapter}, log: discardLog()}
 
-	if err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"d1"}); err != nil {
+	first, err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, entries("d1"))
+	if err != nil {
 		t.Fatalf("Deliver: %v", err)
 	}
-	if err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"d1"}); err != nil { // re-drive
+	// Re-drive with the entries Deliver just returned (delivered_at set):
+	// the driver always feeds the previous round's entries back in.
+	if _, err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, first); err != nil {
 		t.Fatalf("Deliver (re-drive): %v", err)
 	}
 
@@ -210,10 +228,9 @@ func TestDeliverOncePerMissionGuard(t *testing.T) {
 }
 
 // TestDeliverRedriveRetriesOnlyFailedDestination covers D-086's
-// result-phase retry contract: a destination that recorded
-// mission.delivery_failed (not mission.delivered) is retried on a
-// re-drive, unlike TestDeliverOncePerMissionGuard's already-delivered
-// case above.
+// result-phase retry contract: an entry that recorded an error (not
+// delivered_at) is retried on a re-drive, unlike
+// TestDeliverOncePerMissionGuard's already-delivered case above.
 func TestDeliverRedriveRetriesOnlyFailedDestination(t *testing.T) {
 	withFastBackoff(t)
 	adapter := &fakeAdapter{failCount: -1} // always fails
@@ -223,18 +240,23 @@ func TestDeliverRedriveRetriesOnlyFailedDestination(t *testing.T) {
 	eventStore := &fakeEventStore{}
 	d := &Deliverer{store: destStore, events: eventStore, adapters: map[string]Adapter{"webhook": adapter}, log: discardLog()}
 
-	if err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"d1"}); err == nil {
+	first, err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, entries("d1"))
+	if err == nil {
 		t.Fatal("Deliver with an always-failing adapter: want an error, got nil")
 	}
 	firstAttempts := adapter.callCount()
 
 	adapter.failCount = 0 // the retry succeeds this time
-	if err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"d1"}); err != nil {
+	updated, err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, first)
+	if err != nil {
 		t.Fatalf("Deliver (retry): %v", err)
 	}
 
 	if got := adapter.callCount(); got <= firstAttempts {
 		t.Fatalf("adapter attempts after retry = %d, want more than the first round's %d (failed destination must be retried)", got, firstAttempts)
+	}
+	if len(updated) != 1 || updated[0].DeliveredAt == "" {
+		t.Fatalf("expected the retried entry to carry delivered_at, got %+v", updated)
 	}
 	var delivered, failed int
 	for _, ev := range eventStore.events {
@@ -258,7 +280,7 @@ func TestDeliverUnknownDestinationRecordsFailure(t *testing.T) {
 	eventStore := &fakeEventStore{}
 	d := &Deliverer{store: destStore, events: eventStore, adapters: map[string]Adapter{"webhook": &WebhookAdapter{}}, log: discardLog()}
 
-	if err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"missing"}); err == nil {
+	if _, err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, entries("missing")); err == nil {
 		t.Fatal("Deliver against an unknown destination: want an error, got nil")
 	}
 
@@ -274,7 +296,7 @@ func TestDeliverDisabledDestinationRecordsFailure(t *testing.T) {
 	eventStore := &fakeEventStore{}
 	d := &Deliverer{store: destStore, events: eventStore, adapters: map[string]Adapter{"webhook": &WebhookAdapter{}}, log: discardLog()}
 
-	if err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, []string{"d1"}); err == nil {
+	if _, err := d.Deliver(t.Context(), missions.Mission{ID: "m1"}, entries("d1")); err == nil {
 		t.Fatal("Deliver against a disabled destination: want an error, got nil")
 	}
 

--- a/internal/brain/missions/artifact_copy_test.go
+++ b/internal/brain/missions/artifact_copy_test.go
@@ -12,7 +12,7 @@ import (
 // them. Both now run synchronously within the result phase's step.
 func TestDriverCopiesArtifactsBeforeDestinationDelivery(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, DestinationIDs: []string{"d1"}})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, Destinations: []DestinationEntry{{DestinationID: "d1"}}})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},

--- a/internal/brain/missions/complete.go
+++ b/internal/brain/missions/complete.go
@@ -204,7 +204,8 @@ func (c *Completer) OpenPR(ctx context.Context, m Mission, token string) (url st
 // itself is untouched either way. No retry loop — one attempt, the
 // manual push/pr endpoints remain available for the operator.
 func (c *Completer) RunOnComplete(ctx context.Context, m Mission) error {
-	if m.OnComplete == "" {
+	onComplete := m.OnComplete()
+	if onComplete == "" {
 		return nil
 	}
 	if reason := NotPushable(m); reason != "" {
@@ -217,7 +218,7 @@ func (c *Completer) RunOnComplete(ctx context.Context, m Mission) error {
 	if err != nil {
 		return fmt.Errorf("on_complete: resolve token: %w", err)
 	}
-	switch m.OnComplete {
+	switch onComplete {
 	case "push":
 		_, err := c.PushBranch(ctx, m, token)
 		return err
@@ -225,6 +226,6 @@ func (c *Completer) RunOnComplete(ctx context.Context, m Mission) error {
 		_, _, err := c.OpenPR(ctx, m, token)
 		return err
 	default:
-		return fmt.Errorf("on_complete: unknown value %q", m.OnComplete)
+		return fmt.Errorf("on_complete: unknown value %q", onComplete)
 	}
 }

--- a/internal/brain/missions/complete_test.go
+++ b/internal/brain/missions/complete_test.go
@@ -158,7 +158,7 @@ func pushableMission(t *testing.T) Mission {
 func TestCompleterRunOnCompletePush(t *testing.T) {
 	t.Parallel()
 	m := pushableMission(t)
-	m.OnComplete = "push"
+	m.Destinations = []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push"}}
 	store := &fakeEventAppender{}
 	pusher := &fakeBranchPusher{host: "github.com"}
 	resolveToken := func(ctx context.Context, connectorID string) (string, error) { return "dummy-token", nil }
@@ -181,7 +181,7 @@ func TestCompleterRunOnCompletePush(t *testing.T) {
 func TestCompleterRunOnCompletePushPR(t *testing.T) {
 	t.Parallel()
 	m := pushableMission(t)
-	m.OnComplete = "push_pr"
+	m.Destinations = []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push_pr"}}
 	store := &fakeEventAppender{}
 	pusher := &fakeBranchPusher{host: "github.com"}
 	resolveToken := func(ctx context.Context, connectorID string) (string, error) { return "dummy-token", nil }
@@ -209,7 +209,7 @@ func TestCompleterRunOnCompletePushPR(t *testing.T) {
 func TestCompleterRunOnCompletePushFailureNoPR(t *testing.T) {
 	t.Parallel()
 	m := pushableMission(t)
-	m.OnComplete = "push_pr"
+	m.Destinations = []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push_pr"}}
 	store := &fakeEventAppender{}
 	pusher := &fakeBranchPusher{err: ErrPushRejected}
 	resolveToken := func(ctx context.Context, connectorID string) (string, error) { return "dummy-token", nil }
@@ -233,7 +233,7 @@ func TestCompleterRunOnCompleteEmptyIsNoop(t *testing.T) {
 	t.Parallel()
 	store := &fakeEventAppender{}
 	c := NewCompleter(nil, store, nil, nil)
-	if err := c.RunOnComplete(context.Background(), Mission{OnComplete: ""}); err != nil {
+	if err := c.RunOnComplete(context.Background(), Mission{}); err != nil {
 		t.Fatalf("RunOnComplete with empty on_complete: %v", err)
 	}
 	if len(store.kinds()) != 0 {
@@ -249,7 +249,7 @@ func TestCompleterRunOnCompletePushFailureRecordsEvent(t *testing.T) {
 	t.Parallel()
 	store := &fakeEventAppender{}
 	c := NewCompleter(nil, store, nil, nil)
-	m := Mission{Kind: "general", OnComplete: "push"} // NotPushable rejects kind != coding
+	m := Mission{Kind: "general", Destinations: []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push"}}} // NotPushable rejects kind != coding
 	err := c.RunOnComplete(context.Background(), m)
 	if err == nil {
 		t.Fatal("RunOnComplete should fail for an unpushable mission")
@@ -264,7 +264,7 @@ func TestCompleterRunOnCompletePushFailureRecordsEvent(t *testing.T) {
 func TestCompleterRunOnCompleteNoResolverFails(t *testing.T) {
 	t.Parallel()
 	m := pushableMission(t)
-	m.OnComplete = "push"
+	m.Destinations = []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push"}}
 	store := &fakeEventAppender{}
 	c := NewCompleter(nil, store, nil, nil)
 	if err := c.RunOnComplete(context.Background(), m); err == nil {

--- a/internal/brain/missions/destination_deliver_test.go
+++ b/internal/brain/missions/destination_deliver_test.go
@@ -23,15 +23,27 @@ type recordingDeliver struct {
 }
 
 func (r *recordingDeliver) fn() DestinationDeliver {
-	return func(ctx context.Context, m Mission, destinationIDs []string) error {
+	return func(ctx context.Context, m Mission, entries []DestinationEntry) ([]DestinationEntry, error) {
 		r.mu.Lock()
 		defer r.mu.Unlock()
+		ids := make([]string, len(entries))
+		for i, e := range entries {
+			ids[i] = e.DestinationID
+		}
 		r.calls = append(r.calls, struct {
 			missionID string
 			destIDs   []string
 			mission   Mission
-		}{m.ID, destinationIDs, m})
-		return r.err
+		}{m.ID, ids, m})
+		if r.err != nil {
+			return entries, r.err
+		}
+		updated := make([]DestinationEntry, len(entries))
+		for i, e := range entries {
+			e.DeliveredAt = "2026-01-01T00:00:00Z"
+			updated[i] = e
+		}
+		return updated, nil
 	}
 }
 
@@ -43,7 +55,7 @@ func (r *recordingDeliver) count() int {
 
 func TestDriverDeliversToDestinationsOnDone(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, DestinationIDs: []string{"d1", "d2"}})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, Destinations: []DestinationEntry{{DestinationID: "d1"}, {DestinationID: "d2"}}})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -69,7 +81,7 @@ func TestDriverDeliversToDestinationsOnDone(t *testing.T) {
 
 func TestDriverSkipsDeliveryOnFailed(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 1, DestinationIDs: []string{"d1"}})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 1, Destinations: []DestinationEntry{{DestinationID: "d1"}}})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "nope"}},
 	}
@@ -117,7 +129,7 @@ func TestDriverSkipsDeliveryWhenNoDestinations(t *testing.T) {
 // backfilled one rather than empty.
 func TestDriverBackfillsNameBeforeDestinationDelivery(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, DestinationIDs: []string{"d1"}})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, Destinations: []DestinationEntry{{DestinationID: "d1"}}})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -141,7 +153,7 @@ func TestDriverBackfillsNameBeforeDestinationDelivery(t *testing.T) {
 
 func TestDriverSkipsDeliveryWhenNilHook(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, DestinationIDs: []string{"d1"}})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, Destinations: []DestinationEntry{{DestinationID: "d1"}}})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -165,7 +177,7 @@ func TestDriverSkipsDeliveryWhenNilHook(t *testing.T) {
 // transition.
 func TestDriverParksInResultOnDeliveryFailure(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, DestinationIDs: []string{"d1"}})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, Destinations: []DestinationEntry{{DestinationID: "d1"}}})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -193,7 +205,7 @@ func TestDriverParksInResultOnDeliveryFailure(t *testing.T) {
 // recorded delivered is never re-sent).
 func TestDriverResultRetryOnlyRedeliversFailedDestination(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, DestinationIDs: []string{"d1", "d2"}})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, Destinations: []DestinationEntry{{DestinationID: "d1"}, {DestinationID: "d2"}}})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -236,15 +248,16 @@ func TestDriverResultRetryOnlyRedeliversFailedDestination(t *testing.T) {
 }
 
 // idempotentFakeDeliverer models destinations.Deliverer's own
-// alreadyDelivered contract closely enough to test result-step retry
-// behavior without a real Postgres-backed events store: a destination
-// once delivered is tracked as such and never re-sent; one that
-// failed stays retryable.
+// dedup contract closely enough to test result-step retry behavior
+// without a real Postgres-backed events store: an entry whose
+// DeliveredAt is already set (persisted onto the mission row by the
+// driver's own SetDestinations call between rounds, see
+// mergeDestinationEntries) is never re-sent; one with Error set (or
+// never attempted) stays retryable.
 type idempotentFakeDeliverer struct {
-	mu        sync.Mutex
-	failOnce  map[string]bool // destination id -> fail exactly the next attempt
-	delivered map[string]bool
-	attempts  map[string]int
+	mu       sync.Mutex
+	failOnce map[string]bool // destination id -> fail exactly the next attempt
+	attempts map[string]int
 }
 
 func (f *idempotentFakeDeliverer) callsFor(destID string) int {
@@ -253,31 +266,34 @@ func (f *idempotentFakeDeliverer) callsFor(destID string) int {
 	return f.attempts[destID]
 }
 
-func (f *idempotentFakeDeliverer) deliver(ctx context.Context, m Mission, destinationIDs []string) error {
+func (f *idempotentFakeDeliverer) deliver(ctx context.Context, m Mission, entries []DestinationEntry) ([]DestinationEntry, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.attempts == nil {
 		f.attempts = map[string]int{}
 	}
-	if f.delivered == nil {
-		f.delivered = map[string]bool{}
-	}
 
 	var failed []string
-	for _, id := range destinationIDs {
-		if f.delivered[id] {
-			continue // delivered on a prior attempt: never re-sent
-		}
-		f.attempts[id]++
-		if f.failOnce[id] {
-			f.failOnce[id] = false // only the next attempt fails
-			failed = append(failed, id)
+	out := make([]DestinationEntry, len(entries))
+	for i, e := range entries {
+		if e.DeliveredAt != "" {
+			out[i] = e // delivered on a prior round: never re-sent
 			continue
 		}
-		f.delivered[id] = true
+		f.attempts[e.DestinationID]++
+		if f.failOnce[e.DestinationID] {
+			f.failOnce[e.DestinationID] = false // only the next attempt fails
+			e.Error = "delivery failed for: " + e.DestinationID
+			failed = append(failed, e.DestinationID)
+			out[i] = e
+			continue
+		}
+		e.DeliveredAt = "2026-01-01T00:00:00Z"
+		e.Error = ""
+		out[i] = e
 	}
 	if len(failed) > 0 {
-		return errors.New("delivery failed for: " + failed[0])
+		return out, errors.New("delivery failed for: " + failed[0])
 	}
-	return nil
+	return out, nil
 }

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -76,6 +76,7 @@ type driverStore interface {
 	SetDiscoverNotes(ctx context.Context, id, notes string) error
 	SetNameIfEmpty(ctx context.Context, id, name string) error
 	SetArtifactRefs(ctx context.Context, id string, refs []ArtifactRef) error
+	SetDestinations(ctx context.Context, id string, entries []DestinationEntry) error
 	AppendProgress(ctx context.Context, id, note string) error
 	Spend(ctx context.Context, missionID string) (MissionSpend, error)
 	AnswerPendingInput(ctx context.Context, id, eventKind string, payload map[string]any) error
@@ -412,8 +413,8 @@ func (d *Driver) SetPRStateResolver(resolve PRStateResolver) {
 }
 
 // SetGitCommitStyle wires the live settings getter runExecute falls
-// back to when a mission's own CommitStyle is empty — a setter for the
-// same reason SetGitBranchPattern is.
+// back to when a mission's github destination entry has no CommitStyle,
+// a setter for the same reason SetGitBranchPattern is.
 func (d *Driver) SetGitCommitStyle(get func(ctx context.Context) string) {
 	d.gitCommitStyle = get
 }
@@ -459,32 +460,79 @@ func (d *Driver) SetNameMission(fn func(context.Context, string) string) {
 }
 
 // DestinationDeliver delivers a mission's generated output to its
-// attached destination_ids, returning an error naming any destination
-// that failed: destinations.Deliverer.Deliver satisfies this
-// signature. Called SYNCHRONOUSLY from the result phase's step
+// attached destination entries (Mission.Destinations, filtered to
+// email/webhook/telegram kinds by the caller), returning the entries
+// with delivered_at/error updated in place plus an error naming any
+// destination that failed: destinations.Deliverer.Deliver satisfies
+// this signature. Called SYNCHRONOUSLY from the result phase's step
 // (runResult, slice 1 of the phase redesign): a returned error parks
 // the mission in result rather than being logged and lost. Idempotent
-// per destination: a destination already recorded delivered is
-// skipped on retry, only a destination recorded delivery_failed (or
-// never attempted) is retried.
-type DestinationDeliver func(ctx context.Context, m Mission, destinationIDs []string) error
+// per destination: an entry whose DeliveredAt is already set is
+// skipped on retry, only one with Error set (or never attempted) is
+// retried.
+type DestinationDeliver func(ctx context.Context, m Mission, entries []DestinationEntry) ([]DestinationEntry, error)
 
 // SetDestinationDeliver wires the destinations delivery hook run by
 // the result phase's step (see deliverToDestinations): a setter for
 // the same reason SetMemoryExtract is. Optional, nil skips delivery
-// entirely, same as a mission with no destination_ids.
+// entirely, same as a mission with no destination entries.
 func (d *Driver) SetDestinationDeliver(fn DestinationDeliver) {
 	d.deliverDestinations = fn
 }
 
-// deliverToDestinations runs the destinations delivery hook when the
-// mission actually has destination_ids attached, returning its error
-// (if any) for the result step to fold into its overall outcome.
+// deliverableEntries filters m.Destinations down to the kinds
+// DestinationDeliver actually delivers: email/webhook/telegram, i.e.
+// every entry naming an operator-owned destinations table row. "kb"
+// and "github" entries are acted on by promoteToKB/fireOnComplete
+// instead.
+func deliverableEntries(entries []DestinationEntry) []DestinationEntry {
+	var out []DestinationEntry
+	for _, e := range entries {
+		if e.DestinationID != "" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// deliverToDestinations runs the destinations delivery hook against
+// the mission's deliverable entries (if any), writing back each
+// entry's delivered_at/error via SetDestinations and returning the
+// hook's error (if any) for the result step to fold into its overall
+// outcome.
 func (d *Driver) deliverToDestinations(ctx context.Context, m Mission) error {
-	if d.deliverDestinations == nil || len(m.DestinationIDs) == 0 {
+	targets := deliverableEntries(m.Destinations)
+	if d.deliverDestinations == nil || len(targets) == 0 {
 		return nil
 	}
-	return d.deliverDestinations(ctx, m, m.DestinationIDs)
+	updated, err := d.deliverDestinations(ctx, m, targets)
+	if len(updated) > 0 {
+		merged := mergeDestinationEntries(m.Destinations, updated)
+		if setErr := d.store.SetDestinations(ctx, m.ID, merged); setErr != nil {
+			d.log.Warn("driver: persist destination delivery state failed", "mission_id", m.ID, "error", setErr)
+		}
+	}
+	return err
+}
+
+// mergeDestinationEntries replaces each of all's entries with its
+// updated counterpart (matched by DestinationID) when one was
+// delivered; entries deliverableEntries excluded (kb/github) pass
+// through untouched.
+func mergeDestinationEntries(all, updated []DestinationEntry) []DestinationEntry {
+	byID := make(map[string]DestinationEntry, len(updated))
+	for _, e := range updated {
+		byID[e.DestinationID] = e
+	}
+	merged := make([]DestinationEntry, len(all))
+	for i, e := range all {
+		if u, ok := byID[e.DestinationID]; ok && e.DestinationID != "" {
+			merged[i] = u
+			continue
+		}
+		merged[i] = e
+	}
+	return merged
 }
 
 // PromoteKB promotes a mission's markdown artifacts into a kb
@@ -499,19 +547,20 @@ type PromoteKB func(ctx context.Context, m Mission, collectionID string) error
 // SetPromoteKB wires the kb-promotion hook run by the result phase's
 // step (see promoteToKB): a setter for the same reason
 // SetDestinationDeliver is. Optional: nil skips promotion entirely,
-// same as a mission with no promote_kb_collection_id.
+// same as a mission with no "kb" destination entry.
 func (d *Driver) SetPromoteKB(fn PromoteKB) {
 	d.promoteKB = fn
 }
 
-// promoteToKB runs the kb-promotion hook when the mission has
-// promote_kb_collection_id set, returning its error (if any) for the
-// result step to fold into its overall outcome.
+// promoteToKB runs the kb-promotion hook when the mission has a "kb"
+// destination entry, returning its error (if any) for the result step
+// to fold into its overall outcome.
 func (d *Driver) promoteToKB(ctx context.Context, m Mission) error {
-	if d.promoteKB == nil || m.PromoteKBCollectionID == "" {
+	collectionID := m.KBCollectionID()
+	if d.promoteKB == nil || collectionID == "" {
 		return nil
 	}
-	return d.promoteKB(ctx, m, m.PromoteKBCollectionID)
+	return d.promoteKB(ctx, m, collectionID)
 }
 
 // ArtifactCopy best-effort copies a terminal mission's declared
@@ -605,13 +654,14 @@ func (d *Driver) fireOnTerminal(m Mission) {
 // create time, so a failure here must be visible and retryable, not
 // silently swallowed).
 func (d *Driver) fireOnComplete(ctx context.Context, id string, m Mission) error {
-	if d.completer == nil || m.OnComplete == "" {
+	onComplete := m.OnComplete()
+	if d.completer == nil || onComplete == "" {
 		return nil
 	}
 	if err := d.completer.RunOnComplete(ctx, m); err != nil {
-		d.log.Error("driver: on_complete auto-fire failed", "mission_id", id, "on_complete", m.OnComplete, "error", err)
+		d.log.Error("driver: on_complete auto-fire failed", "mission_id", id, "on_complete", onComplete, "error", err)
 		if d.notifyPushFailed != nil {
-			d.notifyPushFailed(ctx, id, fmt.Sprintf("mission %s: automatic %s failed: %s", id, m.OnComplete, err.Error()))
+			d.notifyPushFailed(ctx, id, fmt.Sprintf("mission %s: automatic %s failed: %s", id, onComplete, err.Error()))
 		}
 		return err
 	}
@@ -653,25 +703,28 @@ func (d *Driver) runResult(ctx context.Context, m Mission) (StepInput, error) {
 	summary := map[string]any{}
 	var failures []string
 
+	targets := deliverableEntries(m.Destinations)
 	if err := d.deliverToDestinations(ctx, m); err != nil {
 		failures = append(failures, "delivery: "+err.Error())
 		summary["delivery_error"] = err.Error()
-	} else if len(m.DestinationIDs) > 0 {
-		summary["delivered"] = len(m.DestinationIDs)
+	} else if len(targets) > 0 {
+		summary["delivered"] = len(targets)
 	}
 
+	kbCollectionID := m.KBCollectionID()
 	if err := d.promoteToKB(ctx, m); err != nil {
 		failures = append(failures, "kb promotion: "+err.Error())
 		summary["promote_kb_error"] = err.Error()
-	} else if m.PromoteKBCollectionID != "" {
-		summary["promoted_kb_collection_id"] = m.PromoteKBCollectionID
+	} else if kbCollectionID != "" {
+		summary["promoted_kb_collection_id"] = kbCollectionID
 	}
 
+	onComplete := m.OnComplete()
 	if err := d.fireOnComplete(ctx, m.ID, m); err != nil {
 		failures = append(failures, "on_complete: "+err.Error())
 		summary["on_complete_error"] = err.Error()
-	} else if m.OnComplete != "" {
-		summary["on_complete"] = m.OnComplete
+	} else if onComplete != "" {
+		summary["on_complete"] = onComplete
 	}
 
 	if len(m.ArtifactRefs) > 0 {
@@ -1309,8 +1362,8 @@ func restorePassedUnits(spec *Spec, prior Spec) {
 // effectiveCommitStyle resolves the precedence mission override >
 // settings default > CommitMessage's own conventional-style default.
 func (d *Driver) effectiveCommitStyle(ctx context.Context, m Mission) string {
-	if m.CommitStyle != "" {
-		return m.CommitStyle
+	if e, ok := m.GitHubEntry(); ok && e.CommitStyle != "" {
+		return e.CommitStyle
 	}
 	if d.gitCommitStyle != nil {
 		return d.gitCommitStyle(ctx)

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -196,6 +196,15 @@ func (f *fakeStore) SetArtifactRefs(ctx context.Context, id string, refs []Artif
 	return nil
 }
 
+func (f *fakeStore) SetDestinations(ctx context.Context, id string, entries []DestinationEntry) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	m := f.missions[id]
+	m.Destinations = entries
+	f.missions[id] = m
+	return nil
+}
+
 func (f *fakeStore) AppendProgress(ctx context.Context, id, note string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -409,7 +418,7 @@ func TestDriverFiresOnCompletePushPROnDone(t *testing.T) {
 	store.put("m1", Mission{
 		ID: "m1", Kind: "coding", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true,
 		Workspace: dir, BaseCommit: base, Branch: "mission/x", RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1",
-		OnComplete: "push_pr",
+		Destinations: []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push_pr"}},
 	})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit", VerifyCmd: ""}}}},
@@ -462,7 +471,7 @@ func TestDriverOnCompleteFailureParksInResultAndNotifies(t *testing.T) {
 	store.put("m1", Mission{
 		ID: "m1", Kind: "coding", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true,
 		Workspace: dir, BaseCommit: base, Branch: "mission/x", RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1",
-		OnComplete: "push",
+		Destinations: []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push"}},
 	})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit", VerifyCmd: ""}}}},
@@ -1874,13 +1883,15 @@ func TestDriverAdvanceLazilyProvisionsBareMission(t *testing.T) {
 }
 
 // TestDriverProvisionUsesMissionBranchPatternOverSettings confirms the
-// precedence order ensureProvisioned resolves: a mission's own
-// BranchPattern wins over the settings-configured default.
+// precedence order ensureProvisioned resolves: a mission's own github
+// destination entry's BranchPattern wins over the settings-configured
+// default.
 func TestDriverProvisionUsesMissionBranchPatternOverSettings(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Goal: "Fix the login bug", Kind: "coding", BranchPattern: "custom/{slug}",
-		Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+		ID: "m1", Goal: "Fix the login bug", Kind: "coding",
+		Destinations: []DestinationEntry{{Destination: DestinationKindGitHub, BranchPattern: "custom/{slug}"}},
+		Phase:        PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
 	})
 	sessions := &fakeSessionCreator{}
 	wsRoot := t.TempDir()
@@ -2017,7 +2028,11 @@ func TestDriverEffectiveCommitStylePrecedence(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			d := &Driver{gitCommitStyle: tc.settingsStyle, log: slog.Default()}
-			got := d.effectiveCommitStyle(context.Background(), Mission{CommitStyle: tc.missionStyle})
+			var destinations []DestinationEntry
+			if tc.missionStyle != "" {
+				destinations = []DestinationEntry{{Destination: DestinationKindGitHub, CommitStyle: tc.missionStyle}}
+			}
+			got := d.effectiveCommitStyle(context.Background(), Mission{Destinations: destinations})
 			if got != tc.want {
 				t.Fatalf("effectiveCommitStyle = %q, want %q", got, tc.want)
 			}

--- a/internal/brain/missions/followup.go
+++ b/internal/brain/missions/followup.go
@@ -37,12 +37,11 @@ func (d *Driver) CreateFollowUp(ctx context.Context, parentID, goal string) (str
 		AutoApproveSafe: parent.AutoApproveSafe, AutoApprovePlan: parent.AutoApprovePlan, PromptOverlay: parent.PromptOverlay,
 		Knowledge: parent.Knowledge, Harness: parent.Harness, Environment: parent.Environment,
 		RepoURL: parent.RepoURL, ConnectorID: parent.ConnectorID,
-		BranchPattern: parent.BranchPattern, CommitStyle: parent.CommitStyle,
 		Flow: parent.Flow, ParentMissionID: parent.ID, ParentContext: parentContext,
-		// Deliberately NOT copied from parent: OnComplete (push consent is
-		// a per-mission human choice), DestinationIDs (D-061, operator
-		// addresses outputs per mission), Attachments (a follow-up's own
-		// documents, not the parent's).
+		// Deliberately NOT copied from parent: Destinations (push consent,
+		// destination_ids, and kb promotion are per-mission human choices,
+		// D-061, operator addresses outputs per mission), Attachments (a
+		// follow-up's own documents, not the parent's).
 	}
 	id, err := d.Create(ctx, child)
 	if err != nil {

--- a/internal/brain/missions/followup_test.go
+++ b/internal/brain/missions/followup_test.go
@@ -45,8 +45,8 @@ func TestCreateFollowUpUnknownParent(t *testing.T) {
 
 // TestCreateFollowUpCopiesParentSettings proves the child mission
 // inherits the parent's kind/agent/routes/repo/harness settings, carries
-// a non-empty ParentContext, and does NOT inherit OnComplete or
-// DestinationIDs.
+// a non-empty ParentContext, and does NOT inherit Destinations (push
+// consent, destination ids, kb promotion).
 func TestCreateFollowUpCopiesParentSettings(t *testing.T) {
 	store := newFakeStore()
 	store.put("parent", Mission{
@@ -56,8 +56,11 @@ func TestCreateFollowUpCopiesParentSettings(t *testing.T) {
 		RouteModel: "P/m-a", PlanRouteModel: "P/m-c", ReviewRouteModel: "P/m-b",
 		AutoApproveSafe: true, PromptOverlay: "be terse", Knowledge: []string{"kb1"},
 		Harness: "claude-cli", Environment: "node", RepoURL: "https://github.com/o/r.git",
-		ConnectorID: "conn1", BranchPattern: "custom/{slug}", CommitStyle: "conventional",
-		OnComplete: "push_pr", DestinationIDs: []string{"dest-1"},
+		ConnectorID: "conn1",
+		Destinations: []DestinationEntry{
+			{Destination: DestinationKindGitHub, Mode: "push_pr", BranchPattern: "custom/{slug}", CommitStyle: "conventional"},
+			{DestinationID: "dest-1"},
+		},
 	})
 	d := NewDriver(store, followUpBlockedRunner(), nil, nil, &fakeSessionCreator{}, &fakeGranter{}, nil, nil, slog.Default())
 
@@ -76,7 +79,7 @@ func TestCreateFollowUpCopiesParentSettings(t *testing.T) {
 		child.ReviewRoute != "route-b" || child.PlanRoute != "route-c" || child.EscalationRoute != "route-d" ||
 		child.MaxIterations != 12 || child.AutoApproveSafe != true || child.PromptOverlay != "be terse" ||
 		child.Harness != "claude-cli" || child.Environment != "node" || child.RepoURL != "https://github.com/o/r.git" ||
-		child.ConnectorID != "conn1" || child.BranchPattern != "custom/{slug}" || child.CommitStyle != "conventional" ||
+		child.ConnectorID != "conn1" ||
 		child.RouteModel != "P/m-a" || child.PlanRouteModel != "P/m-c" || child.ReviewRouteModel != "P/m-b" {
 		t.Fatalf("child did not inherit parent settings: %+v", child)
 	}
@@ -92,11 +95,8 @@ func TestCreateFollowUpCopiesParentSettings(t *testing.T) {
 	if !strings.Contains(child.ParentContext, "fix the login bug") {
 		t.Fatalf("child.ParentContext = %q, want it to mention the parent's goal", child.ParentContext)
 	}
-	if child.OnComplete != "" {
-		t.Fatalf("child.OnComplete = %q, want empty — push consent is a per-mission choice", child.OnComplete)
-	}
-	if len(child.DestinationIDs) != 0 {
-		t.Fatalf("child.DestinationIDs = %v, want empty — destinations are a per-mission choice", child.DestinationIDs)
+	if len(child.Destinations) != 0 {
+		t.Fatalf("child.Destinations = %+v, want empty, destinations are a per-mission choice", child.Destinations)
 	}
 }
 

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -53,23 +53,7 @@ type Mission struct {
 	// token itself is never stored, only resolved fresh at provisioning.
 	RepoURL     string `json:"repo_url,omitempty"`
 	ConnectorID string `json:"connector_id,omitempty"`
-	// BranchPattern/CommitStyle are this mission's own override of the
-	// settings-configured git strategy defaults (git_branch_pattern/
-	// git_commit_style), snapshotted at create time: "" means "use the
-	// settings default," resolved fresh at provisioning/commit time
-	// (driver.go), never baked in here. See branchtemplate.go for the
-	// template placeholders and style values.
-	BranchPattern string `json:"branch_pattern,omitempty"`
-	CommitStyle   string `json:"commit_style,omitempty"`
-	// OnComplete is the operator's consent-at-create choice for what
-	// happens when this mission reaches phase=done: "" (default) does
-	// nothing, "push" pushes the branch, "push_pr" pushes then opens a
-	// pull request. Only ever set at create time (api/missions.go's
-	// validation); the harness (driver.go) executes it automatically on
-	// the done transition using the SAME push/PR code path the manual
-	// push/pr endpoints use.
-	OnComplete string         `json:"on_complete,omitempty"`
-	Spec       Spec           `json:"spec"`
+	Spec        Spec   `json:"spec"`
 	Progress   []ProgressNote `json:"progress"`
 	// LastEvidence is the most recent worker mission_status call's
 	// evidence text — carried from execute into review so a
@@ -219,22 +203,19 @@ type Mission struct {
 	// bookkeeping (session_events, audit) hard-requires a real session
 	// id, which a mission otherwise has no reason to have.
 	SessionID string `json:"-"`
-	// DestinationIDs names the operator-created destinations (email,
-	// webhook) this mission's outcome digest delivers to on the
-	// terminal done transition (driver.go's deliverToDestinations) —
-	// validated against the destinations table at create time
-	// (api/missions.go), never model-decided.
-	DestinationIDs []string `json:"destination_ids,omitempty"`
-	// PromoteKBCollectionID (D-081, issue #370) is the kb collection this
-	// mission's markdown artifacts promote into on the terminal done
-	// transition (driver.go's promoteToKB): an explicit id, same
-	// operator-owned pattern as DestinationIDs, never a model choice or
-	// an auto-created default collection. "" (default) promotes nothing
-	// automatically; the operator can still promote manually via
-	// POST .../promote-kb after the mission is done.
-	PromoteKBCollectionID string    `json:"promote_kb_collection_id,omitempty"`
-	CreatedAt             time.Time `json:"created_at"`
-	UpdatedAt             time.Time `json:"updated_at"`
+	// Destinations names every sink this mission's outcome delivers to
+	// or acts on in the result phase's step (issue #480, replacing the
+	// five columns destination_ids/on_complete/branch_pattern/
+	// commit_style/promote_kb_collection_id): destination/webhook/email/
+	// telegram entries (D-061, validated against the operator-owned
+	// destinations table at create time), a "kb" entry (D-081), and a
+	// "github" entry (the operator's consent-at-create push/push_pr
+	// choice). Never model-decided. Each entry's delivered_at/error
+	// fields are the result step's own delivery-state record, written
+	// back by runResult (see SetDestinations).
+	Destinations []DestinationEntry `json:"destinations,omitempty"`
+	CreatedAt    time.Time          `json:"created_at"`
+	UpdatedAt    time.Time          `json:"updated_at"`
 	// WorkflowRunID/WorkflowStep name the workflow run and step
 	// (internal/brain/workflows) this mission was spawned as, if any —
 	// empty for an ordinary mission. Set only at create time; the
@@ -257,6 +238,103 @@ type ArtifactRef struct {
 	ID   string `json:"id"`
 	Mime string `json:"mime"`
 	Name string `json:"name,omitempty"`
+}
+
+// destinationKind names DestinationEntry.Destination's known values:
+// "email"/"webhook"/"telegram" ride an operator-created destinations
+// table row (DestinationID); "kb" and "github" are harness-native
+// sinks with no such row.
+const (
+	DestinationKindKB     = "kb"
+	DestinationKindGitHub = "github"
+)
+
+// DestinationEntry is one sink this mission's result phase delivers to
+// or acts on (issue #480): the union of what were five separate mission
+// columns (destination_ids, promote_kb_collection_id, on_complete,
+// branch_pattern, commit_style). Destination names the kind
+// ("email"/"webhook"/"telegram"/"kb"/"github"); DestinationID, when
+// set, names the operator-owned destinations table row carrying that
+// sink's auth/channel config. DeliveredAt/Error are the result step's
+// own delivery-state record (runResult, SetDestinations): DeliveredAt
+// (RFC3339) is set on success, Error on failure, mutually exclusive,
+// both empty before the first attempt. A retry skips an entry whose
+// DeliveredAt is already set and retries one whose Error is set (or
+// which was never attempted).
+type DestinationEntry struct {
+	Destination   string `json:"destination"`
+	DestinationID string `json:"destination_id,omitempty"`
+	// CollectionID names a kb_collections row for a "kb" entry (D-081):
+	// the collection this mission's markdown artifacts promote into.
+	CollectionID string `json:"collection_id,omitempty"`
+	// ConnectorID/RepoURL/Mode/BranchPattern/CommitStyle are a "github"
+	// entry's fields: the operator's consent-at-create push automation
+	// (mirrors the old on_complete/branch_pattern/commit_style columns).
+	// Mode is "push" or "push_pr". BranchPattern/CommitStyle empty means
+	// "use the settings default," resolved fresh at provisioning/commit
+	// time (driver.go), same precedence the old columns had.
+	ConnectorID   string `json:"connector_id,omitempty"`
+	RepoURL       string `json:"repo_url,omitempty"`
+	Mode          string `json:"mode,omitempty"`
+	BranchPattern string `json:"branch_pattern,omitempty"`
+	CommitStyle   string `json:"commit_style,omitempty"`
+	DeliveredAt   string `json:"delivered_at,omitempty"`
+	Error         string `json:"error,omitempty"`
+}
+
+// GitHubEntry returns this mission's "github" destination entry, if
+// any: there is at most one per mission (api/missions.go's create
+// only ever appends one from on_complete). ok is false when the
+// mission has none.
+func (m Mission) GitHubEntry() (DestinationEntry, bool) {
+	for _, e := range m.Destinations {
+		if e.Destination == DestinationKindGitHub {
+			return e, true
+		}
+	}
+	return DestinationEntry{}, false
+}
+
+// OnComplete is the effective on_complete value the pre-#480 Mission
+// column used to carry: "" when there is no github entry, else its
+// Mode ("push" or "push_pr"). Kept as a read-only derivation for the
+// handful of call sites (Completer, NotPushable, the missions builtin
+// tool) that only ever need this one field, not the full entry.
+func (m Mission) OnComplete() string {
+	e, ok := m.GitHubEntry()
+	if !ok {
+		return ""
+	}
+	return e.Mode
+}
+
+// KBCollectionID is the effective promote_kb_collection_id the
+// pre-#480 Mission column used to carry: "" when the mission has no
+// "kb" destination entry.
+func (m Mission) KBCollectionID() string {
+	for _, e := range m.Destinations {
+		if e.Destination == DestinationKindKB {
+			return e.CollectionID
+		}
+	}
+	return ""
+}
+
+// DestinationIDs returns every entry's DestinationID in order, empty
+// entries (kb/github, which have none) skipped: the shape
+// destinations.Deliverer historically took, kept for call sites that
+// only need the id list, not the full entry (e.g. the webhook payload's
+// dedup against mission_events was the pre-#480 mechanism; delivery
+// dedup itself now reads Destinations directly, see driver.go's
+// deliverToDestinations).
+func (m Mission) DestinationIDs() []string {
+	var ids []string
+	for _, e := range m.Destinations {
+		if e.DestinationID != "" {
+			ids = append(ids, e.DestinationID)
+		}
+	}
+	return ids
 }
 
 // MissionAttachment is one PDF document attached at mission create

--- a/internal/brain/missions/promote_kb_test.go
+++ b/internal/brain/missions/promote_kb_test.go
@@ -40,7 +40,7 @@ func (r *recordingPromoteKB) count() int {
 
 func TestDriverPromotesToKBOnDone(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, PromoteKBCollectionID: "c1"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, Destinations: []DestinationEntry{{Destination: DestinationKindKB, CollectionID: "c1"}}})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -62,7 +62,7 @@ func TestDriverPromotesToKBOnDone(t *testing.T) {
 
 func TestDriverSkipsPromoteKBOnFailed(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 1, PromoteKBCollectionID: "c1"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 1, Destinations: []DestinationEntry{{Destination: DestinationKindKB, CollectionID: "c1"}}})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "nope"}},
 	}
@@ -105,7 +105,7 @@ func TestDriverSkipsPromoteKBWhenNoCollection(t *testing.T) {
 
 func TestDriverSkipsPromoteKBWhenNilHook(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, PromoteKBCollectionID: "c1"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, Destinations: []DestinationEntry{{Destination: DestinationKindKB, CollectionID: "c1"}}})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
@@ -128,7 +128,7 @@ func TestDriverSkipsPromoteKBWhenNilHook(t *testing.T) {
 // the mission IN result rather than being logged and lost.
 func TestDriverParksInResultOnPromoteKBFailure(t *testing.T) {
 	store := newFakeStore()
-	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, PromoteKBCollectionID: "c1"})
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true, Destinations: []DestinationEntry{{Destination: DestinationKindKB, CollectionID: "c1"}}})
 	runner := &scriptedRunner{
 		plans:          []Spec{{Units: []PlanUnit{{Title: "only unit"}}}},
 		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},

--- a/internal/brain/missions/provision.go
+++ b/internal/brain/missions/provision.go
@@ -47,10 +47,11 @@ type provisioner struct {
 
 	// gitBranchPattern resolves the settings-configured default branch
 	// pattern (see SetGitBranchPattern) — consulted by ensureProvisioned
-	// only when the mission's own BranchPattern is empty (mission
-	// override > settings > worktree.go's DefaultBranchPattern). nil-safe:
-	// unset falls straight through to Provision's own DefaultBranchPattern
-	// fallback, same as before this setting existed.
+	// only when the mission's own github destination entry has no
+	// BranchPattern (mission override > settings > worktree.go's
+	// DefaultBranchPattern). nil-safe: unset falls straight through to
+	// Provision's own DefaultBranchPattern fallback, same as before this
+	// setting existed.
 	gitBranchPattern func(ctx context.Context) string
 
 	// resolvePRState resolves whether a github PR has been merged (see
@@ -116,7 +117,10 @@ func (p *provisioner) ensureProvisioned(ctx context.Context, m Mission) (Mission
 				}
 			}
 		}
-		branchPattern := m.BranchPattern
+		branchPattern := ""
+		if e, ok := m.GitHubEntry(); ok {
+			branchPattern = e.BranchPattern
+		}
 		if branchPattern == "" && p.gitBranchPattern != nil {
 			branchPattern = p.gitBranchPattern(ctx)
 		}

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -463,11 +463,19 @@ func (s *Scheduler) markSkipped(ctx context.Context, tx pgx.Tx, sc Schedule, now
 // creation time.
 func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedule) error {
 	t, promptOverlay, knowledge := resolveTemplateDefaults(ctx, sc.MissionTemplate, s.resolve, s.routeForRole, s.routeExists, s.codingExecutorDefault)
-	// destination_ids is NOT NULL; a nil slice binds as a NULL array
-	// parameter, same fix as store.go's Create.
+	// destinations is NOT NULL; entries built from the (fire-time
+	// re-checked) template destination ids. Destination (kind) is left
+	// empty here: the deliverer resolves the live kind by id at
+	// delivery time (destinations.Deliverer.deliverOne), so nothing
+	// downstream reads this entry's own kind field.
 	destinationIDs := s.filterDestinationIDs(ctx, t.DestinationIDs)
-	if destinationIDs == nil {
-		destinationIDs = []string{}
+	entries := make([]DestinationEntry, 0, len(destinationIDs))
+	for _, id := range destinationIDs {
+		entries = append(entries, DestinationEntry{DestinationID: id})
+	}
+	destinationsJSON, err := json.Marshal(entries)
+	if err != nil {
+		return fmt.Errorf("marshal destinations: %w", err)
 	}
 	spec, _ := json.Marshal(Spec{})
 	budgetCurrency := t.BudgetCurrency
@@ -500,10 +508,10 @@ func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedu
 	// template (D-087, issue #456): a scheduler-fired mission runs
 	// unattended, so nobody is watching to approve its plan.
 	_, err = tx.Exec(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, knowledge, auto_approve_safe, auto_approve_plan, spec, schedule_id, harness, environment, destination_ids, phase, flow)
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, knowledge, auto_approve_safe, auto_approve_plan, spec, schedule_id, harness, environment, destinations, phase, flow)
 		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)`,
 		t.Goal, name, t.Kind, t.AgentID, orDefault(t.MaxIterations, 3), t.BudgetAmount, budgetCurrency, t.Route, t.ReviewRoute, t.PlanRoute,
-		promptOverlay, knowledgeJSON, t.AutoApproveSafe, true, spec, sc.ID, t.Harness, t.Environment, destinationIDs, phase, flow)
+		promptOverlay, knowledgeJSON, t.AutoApproveSafe, true, spec, sc.ID, t.Harness, t.Environment, destinationsJSON, phase, flow)
 	return err
 }
 

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -49,9 +49,9 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 	consecutive_failures, last_gap_fingerprint, stall_count, budget_amount, budget_currency, route, review_route,
 	plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, knowledge,
 	pending_permission, auto_approve_safe, auto_approve_plan, last_evidence,
-	discover_notes, replan_used, schedule_id, session_id, harness, environment, repo_url, connector_id, on_complete,
-	branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, final_output, created_at, updated_at,
-	workflow_run_id, workflow_step, artifact_refs, promote_kb_collection_id, permission_timeout_seconds, pending_input, asks_used, flow`
+	discover_notes, replan_used, schedule_id, session_id, harness, environment, repo_url, connector_id,
+	parent_mission_id, parent_context, referenced_context, attachments, destinations, final_output, created_at, updated_at,
+	workflow_run_id, workflow_step, artifact_refs, permission_timeout_seconds, pending_input, asks_used, flow`
 
 // pendingPermissionRow is pending_permission's jsonb shape in the
 // missions table: bundles the five columns the API's flat
@@ -106,17 +106,16 @@ func scanPendingInput(m *Mission, raw []byte) {
 // web UI's mission list/detail views read.
 func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 	var (
-		m                                                             Mission
-		agentID, scheduleID, sessionID, parentMission                 *string
-		phase, status                                                 string
-		pendingPermissionRaw                                          []byte
-		spec, progress, attachmentsRaw, knowledgeRaw, artifactRefsRaw []byte
-		failureReason                                                 *string
-		workflowRunID                                                 *string
-		promoteKBCollectionID                                         *string
-		permissionTimeoutSeconds                                      *int
-		pendingInputRaw                                               []byte
-		flow                                                          string
+		m                                                                              Mission
+		agentID, scheduleID, sessionID, parentMission                                  *string
+		phase, status                                                                  string
+		pendingPermissionRaw                                                           []byte
+		spec, progress, attachmentsRaw, knowledgeRaw, artifactRefsRaw, destinationsRaw []byte
+		failureReason                                                                  *string
+		workflowRunID                                                                  *string
+		permissionTimeoutSeconds                                                       *int
+		pendingInputRaw                                                                []byte
+		flow                                                                           string
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
@@ -124,10 +123,10 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&m.PlanRoute, &m.EscalationRoute, &m.RouteModel, &m.PlanRouteModel, &m.ReviewRouteModel, &m.PromptOverlay, &knowledgeRaw,
 		&pendingPermissionRaw, &m.AutoApproveSafe, &m.AutoApprovePlan, &m.LastEvidence,
 		&m.DiscoverNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
-		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &m.ReferencedContext, &attachmentsRaw,
-		&m.DestinationIDs, &m.FinalOutput,
+		&m.RepoURL, &m.ConnectorID, &parentMission, &m.ParentContext, &m.ReferencedContext, &attachmentsRaw,
+		&destinationsRaw, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
-		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &promoteKBCollectionID, &permissionTimeoutSeconds,
+		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &permissionTimeoutSeconds,
 		&pendingInputRaw, &m.AsksUsed, &flow,
 		&failureReason); err != nil {
 		return Mission{}, err
@@ -135,6 +134,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 	m.Flow = Flow(flow)
 	_ = json.Unmarshal(knowledgeRaw, &m.Knowledge)
 	_ = json.Unmarshal(artifactRefsRaw, &m.ArtifactRefs)
+	_ = json.Unmarshal(destinationsRaw, &m.Destinations)
 	scanPendingPermission(&m, pendingPermissionRaw)
 	scanPendingInput(&m, pendingInputRaw)
 	if agentID != nil {
@@ -153,9 +153,6 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		m.WorkflowRunID = *workflowRunID
 	}
 	m.PermissionTimeoutSeconds = permissionTimeoutSeconds
-	if promoteKBCollectionID != nil {
-		m.PromoteKBCollectionID = *promoteKBCollectionID
-	}
 	if failureReason != nil {
 		m.FailureReason = *failureReason
 	}
@@ -197,16 +194,15 @@ const failureReasonJoin = `
 
 func scanMission(row pgx.Row) (Mission, error) {
 	var (
-		m                                                             Mission
-		agentID, scheduleID, sessionID, parentMission                 *string
-		phase, status                                                 string
-		pendingPermissionRaw                                          []byte
-		spec, progress, attachmentsRaw, knowledgeRaw, artifactRefsRaw []byte
-		workflowRunID                                                 *string
-		promoteKBCollectionID                                         *string
-		permissionTimeoutSeconds                                      *int
-		pendingInputRaw                                               []byte
-		flow                                                          string
+		m                                                                              Mission
+		agentID, scheduleID, sessionID, parentMission                                  *string
+		phase, status                                                                  string
+		pendingPermissionRaw                                                           []byte
+		spec, progress, attachmentsRaw, knowledgeRaw, artifactRefsRaw, destinationsRaw []byte
+		workflowRunID                                                                  *string
+		permissionTimeoutSeconds                                                       *int
+		pendingInputRaw                                                                []byte
+		flow                                                                           string
 	)
 	if err := row.Scan(&m.ID, &m.Goal, &m.Name, &m.Kind, &agentID, &phase, &status, &m.PauseReason, &m.PauseMessage,
 		&m.Workspace, &m.Branch, &m.BaseCommit, &spec, &progress, &m.Iteration, &m.MaxIterations,
@@ -214,16 +210,17 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&m.PlanRoute, &m.EscalationRoute, &m.RouteModel, &m.PlanRouteModel, &m.ReviewRouteModel, &m.PromptOverlay, &knowledgeRaw,
 		&pendingPermissionRaw, &m.AutoApproveSafe, &m.AutoApprovePlan, &m.LastEvidence,
 		&m.DiscoverNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
-		&m.RepoURL, &m.ConnectorID, &m.OnComplete, &m.BranchPattern, &m.CommitStyle, &parentMission, &m.ParentContext, &m.ReferencedContext, &attachmentsRaw,
-		&m.DestinationIDs, &m.FinalOutput,
+		&m.RepoURL, &m.ConnectorID, &parentMission, &m.ParentContext, &m.ReferencedContext, &attachmentsRaw,
+		&destinationsRaw, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
-		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &promoteKBCollectionID, &permissionTimeoutSeconds,
+		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &permissionTimeoutSeconds,
 		&pendingInputRaw, &m.AsksUsed, &flow); err != nil {
 		return Mission{}, err
 	}
 	m.Flow = Flow(flow)
 	_ = json.Unmarshal(knowledgeRaw, &m.Knowledge)
 	_ = json.Unmarshal(artifactRefsRaw, &m.ArtifactRefs)
+	_ = json.Unmarshal(destinationsRaw, &m.Destinations)
 	scanPendingPermission(&m, pendingPermissionRaw)
 	scanPendingInput(&m, pendingInputRaw)
 	if agentID != nil {
@@ -240,9 +237,6 @@ func scanMission(row pgx.Row) (Mission, error) {
 	}
 	if workflowRunID != nil {
 		m.WorkflowRunID = *workflowRunID
-	}
-	if promoteKBCollectionID != nil {
-		m.PromoteKBCollectionID = *promoteKBCollectionID
 	}
 	m.PermissionTimeoutSeconds = permissionTimeoutSeconds
 	// Fail-safe degrade: an unrecognized phase/status (e.g. a future
@@ -307,12 +301,16 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	if budgetCurrency == "" {
 		budgetCurrency = "USD"
 	}
-	// destination_ids is NOT NULL; a nil slice binds as a NULL array
-	// parameter, so a mission with no destinations gets an empty slice
-	// instead.
-	destinationIDs := m.DestinationIDs
-	if destinationIDs == nil {
-		destinationIDs = []string{}
+	// destinations is NOT NULL; a nil slice marshals to "null", which
+	// would violate that, so a mission with no destinations gets "[]"
+	// instead (same fix as attachments/knowledge above).
+	destinations := m.Destinations
+	if destinations == nil {
+		destinations = []DestinationEntry{}
+	}
+	destinationsJSON, err := json.Marshal(destinations)
+	if err != nil {
+		return "", fmt.Errorf("missions create destinations: %w", err)
 	}
 	// flow defaults to full for any caller (test fixture, a pre-#459
 	// code path) that never set it: matches the column's own DB
@@ -323,9 +321,9 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	}
 	phase := initialPhase(m.Kind, flow)
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, auto_approve_plan, harness, environment, repo_url, connector_id, on_complete, branch_pattern, commit_style, parent_mission_id, parent_context, referenced_context, attachments, destination_ids, phase, workflow_run_id, workflow_step, promote_kb_collection_id, permission_timeout_seconds, flow)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NULLIF($18, '')::uuid, $19, $20, $21, $22, $23, $24, $25, $26, $27, NULLIF($28, '')::uuid, $29, $30, $31, $32, $33, NULLIF($34, '')::uuid, $35, NULLIF($36, '')::uuid, $37, $38) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.AutoApprovePlan, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.OnComplete, m.BranchPattern, m.CommitStyle, m.ParentMissionID, m.ParentContext, m.ReferencedContext, attachmentsJSON, destinationIDs, phase, m.WorkflowRunID, m.WorkflowStep, m.PromoteKBCollectionID, m.PermissionTimeoutSeconds, flow,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, knowledge, spec, session_id, auto_approve_safe, auto_approve_plan, harness, environment, repo_url, connector_id, parent_mission_id, parent_context, referenced_context, attachments, destinations, phase, workflow_run_id, workflow_step, permission_timeout_seconds, flow)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NULLIF($18, '')::uuid, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, NULLIF($31, '')::uuid, $32, $33, $34) RETURNING id`,
+		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, knowledgeJSON, spec, m.SessionID, m.AutoApproveSafe, m.AutoApprovePlan, m.Harness, m.Environment, m.RepoURL, m.ConnectorID, m.ParentMissionID, m.ParentContext, m.ReferencedContext, attachmentsJSON, destinationsJSON, phase, m.WorkflowRunID, m.WorkflowStep, m.PermissionTimeoutSeconds, flow,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)
@@ -495,6 +493,29 @@ func (s *Store) SetArtifactRefs(ctx context.Context, id string, refs []ArtifactR
 	}
 	if _, err := db.Exec(ctx, `UPDATE missions SET artifact_refs = $2, updated_at = now() WHERE id = $1`, id, data); err != nil {
 		return fmt.Errorf("missions set artifact refs: %w", err)
+	}
+	return nil
+}
+
+// SetDestinations persists the mission's destinations entries whole,
+// written by the result phase's step (runResult) after each delivery
+// attempt records its own delivered_at/error onto its entry. Bypasses
+// the state machine, same as SetSpec/SetArtifactRefs: a delivery-state
+// update doesn't coincide with a phase/status change.
+func (s *Store) SetDestinations(ctx context.Context, id string, entries []DestinationEntry) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("missions set destinations: %w", err)
+	}
+	if entries == nil {
+		entries = []DestinationEntry{}
+	}
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return fmt.Errorf("missions set destinations: %w", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE missions SET destinations = $2, updated_at = now() WHERE id = $1`, id, data); err != nil {
+		return fmt.Errorf("missions set destinations: %w", err)
 	}
 	return nil
 }
@@ -1367,9 +1388,9 @@ func (s *Store) RecoverStaleWorking(ctx context.Context, staleAfter time.Duratio
 
 // ActiveMissionReferencesDestination reports whether any NON-terminal
 // mission (phase NOT IN ('done', 'failed')) still names destinationID
-// in its destination_ids — the guard destinations.Store.Delete calls
-// before removing a row, so a live mission's delivery target can't
-// vanish out from under it. A historical (terminal) mission's
+// in its destinations entries, the guard destinations.Store.Delete
+// calls before removing a row, so a live mission's delivery target
+// can't vanish out from under it. A historical (terminal) mission's
 // reference never blocks deletion.
 func (s *Store) ActiveMissionReferencesDestination(ctx context.Context, destinationID string) (bool, error) {
 	db, err := s.db.Get()
@@ -1379,7 +1400,8 @@ func (s *Store) ActiveMissionReferencesDestination(ctx context.Context, destinat
 	var exists bool
 	err = db.QueryRow(ctx, `SELECT EXISTS (
 		SELECT 1 FROM missions
-		WHERE phase NOT IN ('done', 'failed') AND $1 = ANY(destination_ids)
+		WHERE phase NOT IN ('done', 'failed')
+		AND EXISTS (SELECT 1 FROM jsonb_array_elements(destinations) d WHERE d->>'destination_id' = $1)
 	)`, destinationID).Scan(&exists)
 	if err != nil {
 		return false, fmt.Errorf("missions active destination reference: %w", err)

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -549,16 +549,18 @@ func TestMissionLightAndFinalOutputRoundTrip(t *testing.T) {
 	}
 }
 
-// TestMissionOnCompleteRoundTrips covers on_complete: a first-class
-// column snapshotted at create time, same shape as Harness above: ""
-// (do nothing) is the default when a mission omits it.
+// TestMissionOnCompleteRoundTrips covers on_complete: a "github"
+// destinations entry snapshotted at create time (issue #480), same
+// shape as Harness above: no github entry (do nothing) is the default
+// when a mission omits it.
 func TestMissionOnCompleteRoundTrips(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
 
 	id, err := s.Create(ctx, Mission{
 		Goal: marker + "on-complete", Kind: "coding", Route: "default",
-		RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1", OnComplete: "push_pr",
+		RepoURL: "https://github.com/octo/repo.git", ConnectorID: "conn1",
+		Destinations: []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push_pr"}},
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -567,8 +569,8 @@ func TestMissionOnCompleteRoundTrips(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if m.OnComplete != "push_pr" {
-		t.Fatalf("OnComplete = %q, want push_pr", m.OnComplete)
+	if m.OnComplete() != "push_pr" {
+		t.Fatalf("OnComplete() = %q, want push_pr", m.OnComplete())
 	}
 
 	id2, err := s.Create(ctx, Mission{Goal: marker + "no-on-complete", Kind: "general", Route: "default"})
@@ -579,22 +581,22 @@ func TestMissionOnCompleteRoundTrips(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if m2.OnComplete != "" {
-		t.Fatalf("OnComplete = %q, want empty when not set", m2.OnComplete)
+	if m2.OnComplete() != "" {
+		t.Fatalf("OnComplete() = %q, want empty when not set", m2.OnComplete())
 	}
 }
 
 // TestMissionGitStrategyRoundTrips covers branch_pattern/commit_style:
-// first-class columns snapshotted at create time, same shape as Harness
-// above: "" (use the settings default) is the default when a mission
-// omits them.
+// fields of a "github" destinations entry snapshotted at create time
+// (issue #480), same shape as Harness above: "" (use the settings
+// default) is the default when a mission omits them.
 func TestMissionGitStrategyRoundTrips(t *testing.T) {
 	s := testStore(t)
 	ctx := t.Context()
 
 	id, err := s.Create(ctx, Mission{
 		Goal: marker + "git-strategy", Kind: "coding", Route: "default",
-		BranchPattern: "{type}/{login}/{slug}", CommitStyle: "plain",
+		Destinations: []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push", BranchPattern: "{type}/{login}/{slug}", CommitStyle: "plain"}},
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -603,11 +605,15 @@ func TestMissionGitStrategyRoundTrips(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if m.BranchPattern != "{type}/{login}/{slug}" {
-		t.Fatalf("BranchPattern = %q, want {type}/{login}/{slug}", m.BranchPattern)
+	e, ok := m.GitHubEntry()
+	if !ok {
+		t.Fatal("GitHubEntry() ok = false, want true")
 	}
-	if m.CommitStyle != "plain" {
-		t.Fatalf("CommitStyle = %q, want plain", m.CommitStyle)
+	if e.BranchPattern != "{type}/{login}/{slug}" {
+		t.Fatalf("BranchPattern = %q, want {type}/{login}/{slug}", e.BranchPattern)
+	}
+	if e.CommitStyle != "plain" {
+		t.Fatalf("CommitStyle = %q, want plain", e.CommitStyle)
 	}
 
 	id2, err := s.Create(ctx, Mission{Goal: marker + "no-git-strategy", Kind: "general", Route: "default"})
@@ -618,8 +624,8 @@ func TestMissionGitStrategyRoundTrips(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if m2.BranchPattern != "" || m2.CommitStyle != "" {
-		t.Fatalf("BranchPattern/CommitStyle = %q/%q, want empty when not set", m2.BranchPattern, m2.CommitStyle)
+	if _, ok := m2.GitHubEntry(); ok {
+		t.Fatal("GitHubEntry() ok = true, want false when not set")
 	}
 }
 

--- a/internal/brain/missions/validate.go
+++ b/internal/brain/missions/validate.go
@@ -32,15 +32,15 @@ type ValidateDeps struct {
 	RouteExists func(ctx context.Context, name string) bool
 	// DestinationEnabled reports whether id names a real, enabled
 	// destinations row (destinations.Store.EnabledByID) — nil skips
-	// destination_ids validation entirely (same as api/missions.go's
+	// destination-entry validation entirely (same as api/missions.go's
 	// validateDestinationIDs with h.destinations == nil, except this
 	// degrades to "unchecked" rather than "reject every non-empty list",
 	// since a caller with no destinations wiring has nothing to check
 	// against).
 	DestinationEnabled func(ctx context.Context, id string) (bool, error)
 	// KBCollectionExists reports whether id names a real kb_collections
-	// row: nil skips promote_kb_collection_id validation entirely, same
-	// degrade-to-unchecked reasoning as DestinationEnabled.
+	// row: nil skips a "kb" destination entry's collection_id validation
+	// entirely, same degrade-to-unchecked reasoning as DestinationEnabled.
 	KBCollectionExists func(ctx context.Context, id string) (bool, error)
 }
 
@@ -84,6 +84,7 @@ func ValidateCreate(ctx context.Context, m Mission, deps ValidateDeps) error {
 	if m.Flow == FlowLight && m.Kind != KindGeneral {
 		return fmt.Errorf("%w: flow=%q is only valid for kind=general missions", ErrInvalidMission, FlowLight)
 	}
+	githubEntry, hasGitHub := m.GitHubEntry()
 	if !missionPolicyFor(m).canDelegate {
 		switch {
 		case m.Harness != "":
@@ -92,12 +93,8 @@ func ValidateCreate(ctx context.Context, m Mission, deps ValidateDeps) error {
 			return fmt.Errorf("%w: environment is only valid for kind=coding missions", ErrInvalidMission)
 		case m.RepoURL != "":
 			return fmt.Errorf("%w: repo_url is only valid for kind=coding missions", ErrInvalidMission)
-		case m.BranchPattern != "":
-			return fmt.Errorf("%w: branch_pattern is only valid for kind=coding missions", ErrInvalidMission)
-		case m.CommitStyle != "":
-			return fmt.Errorf("%w: commit_style is only valid for kind=coding missions", ErrInvalidMission)
-		case m.OnComplete != "":
-			return fmt.Errorf("%w: on_complete is only valid for kind=coding missions", ErrInvalidMission)
+		case hasGitHub:
+			return fmt.Errorf("%w: a github destination is only valid for kind=coding missions", ErrInvalidMission)
 		}
 	}
 	if m.Harness != "" {
@@ -114,22 +111,27 @@ func ValidateCreate(ctx context.Context, m Mission, deps ValidateDeps) error {
 	case m.RepoURL == "" && m.ConnectorID != "":
 		return fmt.Errorf("%w: connector_id is only valid alongside repo_url", ErrInvalidMission)
 	}
-	switch m.OnComplete {
-	case "":
-	case "push", "push_pr":
-		if m.RepoURL == "" || m.ConnectorID == "" {
-			return fmt.Errorf("%w: on_complete requires repo_url and connector_id on a kind=coding mission", ErrInvalidMission)
+	if hasGitHub {
+		switch githubEntry.Mode {
+		case "":
+			// A github entry can carry only BranchPattern/CommitStyle with
+			// no on_complete choice: the operator overriding the git
+			// strategy without opting into auto-push.
+		case "push", "push_pr":
+			if m.RepoURL == "" || m.ConnectorID == "" {
+				return fmt.Errorf("%w: on_complete requires repo_url and connector_id on a kind=coding mission", ErrInvalidMission)
+			}
+		default:
+			return fmt.Errorf(`%w: on_complete must be "", "push", or "push_pr"`, ErrInvalidMission)
 		}
-	default:
-		return fmt.Errorf(`%w: on_complete must be "", "push", or "push_pr"`, ErrInvalidMission)
-	}
-	if m.BranchPattern != "" {
-		if err := ValidateBranchPattern(m.BranchPattern); err != nil {
+		if githubEntry.BranchPattern != "" {
+			if err := ValidateBranchPattern(githubEntry.BranchPattern); err != nil {
+				return fmt.Errorf("%w: %s", ErrInvalidMission, err.Error())
+			}
+		}
+		if err := ValidateCommitStyle(githubEntry.CommitStyle); err != nil {
 			return fmt.Errorf("%w: %s", ErrInvalidMission, err.Error())
 		}
-	}
-	if err := ValidateCommitStyle(m.CommitStyle); err != nil {
-		return fmt.Errorf("%w: %s", ErrInvalidMission, err.Error())
 	}
 	if m.Route == "" {
 		return fmt.Errorf("%w: route is required", ErrInvalidMission)
@@ -142,9 +144,9 @@ func ValidateCreate(ctx context.Context, m Mission, deps ValidateDeps) error {
 	case m.ReviewRouteModel != "" && !validModelPin(m.ReviewRouteModel):
 		return fmt.Errorf(`%w: review_route_model must be "provider name/model"`, ErrInvalidMission)
 	}
-	if deps.DestinationEnabled != nil && len(m.DestinationIDs) > 0 {
+	if deps.DestinationEnabled != nil {
 		var invalid []string
-		for _, id := range m.DestinationIDs {
+		for _, id := range m.DestinationIDs() {
 			ok, err := deps.DestinationEnabled(ctx, id)
 			if err != nil {
 				return fmt.Errorf("%w: destination_ids: %s", ErrInvalidMission, err.Error())
@@ -157,13 +159,15 @@ func ValidateCreate(ctx context.Context, m Mission, deps ValidateDeps) error {
 			return fmt.Errorf("%w: unknown or disabled destination id(s): %s", ErrInvalidMission, strings.Join(invalid, ", "))
 		}
 	}
-	if deps.KBCollectionExists != nil && m.PromoteKBCollectionID != "" {
-		ok, err := deps.KBCollectionExists(ctx, m.PromoteKBCollectionID)
-		if err != nil {
-			return fmt.Errorf("%w: promote_kb_collection_id: %s", ErrInvalidMission, err.Error())
-		}
-		if !ok {
-			return fmt.Errorf("%w: unknown promote_kb_collection_id %q", ErrInvalidMission, m.PromoteKBCollectionID)
+	if deps.KBCollectionExists != nil {
+		if collectionID := m.KBCollectionID(); collectionID != "" {
+			ok, err := deps.KBCollectionExists(ctx, collectionID)
+			if err != nil {
+				return fmt.Errorf("%w: promote_kb_collection_id: %s", ErrInvalidMission, err.Error())
+			}
+			if !ok {
+				return fmt.Errorf("%w: unknown promote_kb_collection_id %q", ErrInvalidMission, collectionID)
+			}
 		}
 	}
 	return nil

--- a/internal/brain/missions/validate_test.go
+++ b/internal/brain/missions/validate_test.go
@@ -75,43 +75,54 @@ func TestValidateCreate(t *testing.T) {
 			return m
 		}, ValidateDeps{}, true},
 		{"branch_pattern on general", func(m Mission) Mission {
-			m.BranchPattern = "{type}/{slug}"
+			m.Destinations = []DestinationEntry{{Destination: DestinationKindGitHub, BranchPattern: "{type}/{slug}"}}
 			return m
 		}, ValidateDeps{}, true},
 		{"commit_style on general", func(m Mission) Mission {
-			m.CommitStyle = CommitStylePlain
+			m.Destinations = []DestinationEntry{{Destination: DestinationKindGitHub, CommitStyle: CommitStylePlain}}
 			return m
 		}, ValidateDeps{}, true},
 		{"on_complete on general", func(m Mission) Mission {
-			m.OnComplete = "push"
+			m.Destinations = []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push"}}
 			return m
 		}, ValidateDeps{}, true},
 		{"invalid branch_pattern on coding", func(m Mission) Mission {
-			m.Kind, m.BranchPattern = "coding", "{oops}/{slug}"
+			m.Kind = "coding"
+			m.Destinations = []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push", BranchPattern: "{oops}/{slug}"}}
+			m.RepoURL, m.ConnectorID = "https://github.com/o/r", "conn-1"
 			return m
 		}, ValidateDeps{}, true},
 		{"valid branch_pattern on coding", func(m Mission) Mission {
-			m.Kind, m.BranchPattern = "coding", "{type}/{slug}"
+			m.Kind = "coding"
+			m.Destinations = []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push", BranchPattern: "{type}/{slug}"}}
+			m.RepoURL, m.ConnectorID = "https://github.com/o/r", "conn-1"
 			return m
 		}, ValidateDeps{}, false},
 		{"invalid commit_style on coding", func(m Mission) Mission {
-			m.Kind, m.CommitStyle = "coding", "loud"
+			m.Kind = "coding"
+			m.Destinations = []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push", CommitStyle: "loud"}}
+			m.RepoURL, m.ConnectorID = "https://github.com/o/r", "conn-1"
 			return m
 		}, ValidateDeps{}, true},
 		{"valid commit_style on coding", func(m Mission) Mission {
-			m.Kind, m.CommitStyle = "coding", CommitStylePlain
+			m.Kind = "coding"
+			m.Destinations = []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push", CommitStyle: CommitStylePlain}}
+			m.RepoURL, m.ConnectorID = "https://github.com/o/r", "conn-1"
 			return m
 		}, ValidateDeps{}, false},
 		{"on_complete unknown value", func(m Mission) Mission {
-			m.Kind, m.OnComplete = "coding", "bogus"
+			m.Kind = "coding"
+			m.Destinations = []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "bogus"}}
 			return m
 		}, ValidateDeps{}, true},
 		{"on_complete push without repo/connector", func(m Mission) Mission {
-			m.Kind, m.OnComplete = "coding", "push"
+			m.Kind = "coding"
+			m.Destinations = []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push"}}
 			return m
 		}, ValidateDeps{}, true},
 		{"on_complete push with repo/connector", func(m Mission) Mission {
-			m.Kind, m.OnComplete = "coding", "push"
+			m.Kind = "coding"
+			m.Destinations = []DestinationEntry{{Destination: DestinationKindGitHub, Mode: "push"}}
 			m.RepoURL, m.ConnectorID = "https://github.com/o/r", "conn-1"
 			return m
 		}, ValidateDeps{}, false},
@@ -159,47 +170,47 @@ func TestValidateCreate(t *testing.T) {
 			return m
 		}, ValidateDeps{}, false},
 		{"destination_ids all enabled", func(m Mission) Mission {
-			m.DestinationIDs = []string{"d1", "d2"}
+			m.Destinations = []DestinationEntry{{DestinationID: "d1"}, {DestinationID: "d2"}}
 			return m
 		}, ValidateDeps{DestinationEnabled: func(ctx context.Context, id string) (bool, error) {
 			return true, nil
 		}}, false},
 		{"destination_ids one disabled", func(m Mission) Mission {
-			m.DestinationIDs = []string{"d1", "d2"}
+			m.Destinations = []DestinationEntry{{DestinationID: "d1"}, {DestinationID: "d2"}}
 			return m
 		}, ValidateDeps{DestinationEnabled: func(ctx context.Context, id string) (bool, error) {
 			return id == "d1", nil
 		}}, true},
 		{"destination_ids lookup error", func(m Mission) Mission {
-			m.DestinationIDs = []string{"d1"}
+			m.Destinations = []DestinationEntry{{DestinationID: "d1"}}
 			return m
 		}, ValidateDeps{DestinationEnabled: func(ctx context.Context, id string) (bool, error) {
 			return false, fmt.Errorf("db unavailable")
 		}}, true},
 		{"destination_ids unchecked when dep nil", func(m Mission) Mission {
-			m.DestinationIDs = []string{"d1"}
+			m.Destinations = []DestinationEntry{{DestinationID: "d1"}}
 			return m
 		}, ValidateDeps{}, false},
 		{"promote_kb_collection_id exists", func(m Mission) Mission {
-			m.PromoteKBCollectionID = "c1"
+			m.Destinations = []DestinationEntry{{Destination: DestinationKindKB, CollectionID: "c1"}}
 			return m
 		}, ValidateDeps{KBCollectionExists: func(ctx context.Context, id string) (bool, error) {
 			return id == "c1", nil
 		}}, false},
 		{"promote_kb_collection_id unknown", func(m Mission) Mission {
-			m.PromoteKBCollectionID = "bogus"
+			m.Destinations = []DestinationEntry{{Destination: DestinationKindKB, CollectionID: "bogus"}}
 			return m
 		}, ValidateDeps{KBCollectionExists: func(ctx context.Context, id string) (bool, error) {
 			return id == "c1", nil
 		}}, true},
 		{"promote_kb_collection_id lookup error", func(m Mission) Mission {
-			m.PromoteKBCollectionID = "c1"
+			m.Destinations = []DestinationEntry{{Destination: DestinationKindKB, CollectionID: "c1"}}
 			return m
 		}, ValidateDeps{KBCollectionExists: func(ctx context.Context, id string) (bool, error) {
 			return false, fmt.Errorf("db unavailable")
 		}}, true},
 		{"promote_kb_collection_id unchecked when dep nil", func(m Mission) Mission {
-			m.PromoteKBCollectionID = "c1"
+			m.Destinations = []DestinationEntry{{Destination: DestinationKindKB, CollectionID: "c1"}}
 			return m
 		}, ValidateDeps{}, false},
 		{"unknown flow rejected", func(m Mission) Mission {

--- a/internal/brain/workflows/engine.go
+++ b/internal/brain/workflows/engine.go
@@ -214,9 +214,20 @@ func (e *Engine) spawnStep(ctx context.Context, runID, stepName string, step Ste
 	if step.Light {
 		flow = missions.FlowLight
 	}
+	// step.OnComplete/DestinationIDs become destination entries, same
+	// "github" (kind=coding, mode=on_complete) and bare-id shape
+	// api/missions.go's create handler normalizes a request into (see
+	// missions.DestinationEntry).
+	var destinations []missions.DestinationEntry
+	for _, id := range step.DestinationIDs {
+		destinations = append(destinations, missions.DestinationEntry{DestinationID: id})
+	}
+	if step.OnComplete != "" {
+		destinations = append(destinations, missions.DestinationEntry{Destination: missions.DestinationKindGitHub, Mode: step.OnComplete})
+	}
 	return e.spawner.Create(ctx, missions.Mission{
 		Goal: goal, Kind: step.Kind, Flow: flow, Route: route, PlanRoute: step.PlanRoute, AgentID: step.AgentID,
-		OnComplete: step.OnComplete, DestinationIDs: step.DestinationIDs,
+		Destinations:    destinations,
 		ParentMissionID: parentMissionID, ParentContext: outcome,
 		WorkflowRunID: runID, WorkflowStep: stepName,
 		// Forced true (D-087, issue #456): a workflow-spawned mission

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -721,38 +721,24 @@ CREATE TABLE IF NOT EXISTS missions (
     -- connector_id's credential_ref at provisioning time only.
     repo_url              text NOT NULL DEFAULT '',
     connector_id          text NOT NULL DEFAULT '',
-    -- Consent-at-create for the mission's auto-completion action: ''
-    -- (default) does nothing in the result phase's step; 'push'
-    -- pushes the branch; 'push_pr' pushes then opens a pull request.
-    -- Chosen by the operator at create time (api/missions.go), never
-    -- decided by the model -- keeps the pushes-stay-human invariant:
-    -- the harness only ever executes a choice a human already made.
-    -- Requires repo_url+connector_id and kind='coding', same guards as
-    -- the manual push/pr endpoints.
-    on_complete           text NOT NULL DEFAULT '',
-    -- This mission's own override of the settings-configured git
-    -- strategy defaults (settings.ValueGitBranchPattern/
-    -- ValueGitCommitStyle): '' (the default) means "use the settings
-    -- default," resolved fresh at provisioning/commit time
-    -- (internal/brain/missions/driver.go), never baked in here.
-    -- branch_pattern is a validated template (internal/brain/missions/
-    -- branchtemplate.go); commit_style is 'conventional' or 'plain'.
-    branch_pattern        text NOT NULL DEFAULT '',
-    commit_style          text NOT NULL DEFAULT '',
-    -- Destination ids to deliver this mission's outcome digest to in
-    -- the result phase's step (destinations.go's Deliverer,
-    -- driver.go's runResult, D-086). Never model-decided: api/missions.go's
-    -- create validates every id against the operator-owned destinations
-    -- table before it lands here.
-    destination_ids       uuid[] NOT NULL DEFAULT '{}',
-    -- D-081 (issue #370): kb collection to promote this mission's
-    -- markdown artifacts into in the result phase's step
-    -- (kb.go's promoteToKB, driver.go's runResult, D-086). ''
-    -- (default) does nothing. Explicit id, never a default "Missions"
-    -- collection auto-create, same as destination_ids above; the
-    -- operator can also promote manually via POST .../promote-kb after
-    -- the mission is done, using the same code path.
-    promote_kb_collection_id uuid,
+    -- destinations replaces the five separate columns issue #480
+    -- dropped (destination_ids, on_complete, branch_pattern,
+    -- commit_style, promote_kb_collection_id): a jsonb array of
+    -- entries, each {"destination": <kind>, "destination_id": <uuid>?,
+    -- ...per-kind fields, "delivered_at"?, "error"?}
+    -- (missions.DestinationEntry). "email"/"webhook"/"telegram" entries
+    -- carry destination_id, naming an operator-owned destinations table
+    -- row; "kb" carries collection_id (D-081); "github" carries the
+    -- operator's consent-at-create push automation (connector_id,
+    -- repo_url, mode "push"/"push_pr", optional branch_pattern/
+    -- commit_style overriding the settings-configured git strategy
+    -- defaults). delivered_at/error are the result phase's own
+    -- delivery-state record (driver.go's runResult,
+    -- destinations.Deliverer, D-086), written back per entry. Never
+    -- model-decided: api/missions.go's create validates every
+    -- destination_id against the operator-owned destinations table
+    -- before it lands here.
+    destinations          jsonb NOT NULL DEFAULT '[]',
     -- workflow_run_id/workflow_step name the workflow run and step
     -- (internal/brain/workflows) this mission was spawned as, if any.
     -- NULL/'' for an ordinary mission. The workflow engine reads these

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -131,3 +131,52 @@ it going forward, never reads the old column again).
 ALTER TABLE missions DROP COLUMN IF EXISTS light;
 ALTER TABLE missions DROP COLUMN IF EXISTS worktree;
 ```
+
+## Schema restructure slice 2 (issue #480)
+
+Required on live DBs before/with the next deploy. destinations (the
+new jsonb column) is added additive first; the data migration below
+folds destination_ids/promote_kb_collection_id/on_complete/
+branch_pattern/commit_style into it (guarded so a re-run is a no-op:
+it only touches rows still at destinations = '[]' and only runs while
+the old columns still exist); the five old columns are then dropped.
+Run all three steps together: the data migration reads columns the
+last step removes.
+
+```sql
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS destinations jsonb NOT NULL DEFAULT '[]';
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'missions' AND column_name = 'destination_ids'
+    ) THEN
+        UPDATE missions m SET destinations = (
+            COALESCE((
+                SELECT jsonb_agg(jsonb_build_object('destination', d.kind, 'destination_id', d.id::text))
+                FROM unnest(m.destination_ids) AS did(id)
+                JOIN destinations d ON d.id = did.id
+            ), '[]'::jsonb)
+            || CASE WHEN m.promote_kb_collection_id IS NOT NULL
+                THEN jsonb_build_array(jsonb_build_object('destination', 'kb', 'collection_id', m.promote_kb_collection_id::text))
+                ELSE '[]'::jsonb END
+            || CASE WHEN m.on_complete <> '' OR m.branch_pattern <> '' OR m.commit_style <> ''
+                THEN jsonb_build_array(jsonb_strip_nulls(jsonb_build_object(
+                    'destination', 'github', 'mode', NULLIF(m.on_complete, ''),
+                    'branch_pattern', NULLIF(m.branch_pattern, ''), 'commit_style', NULLIF(m.commit_style, '')
+                )))
+                ELSE '[]'::jsonb END
+        )
+        WHERE m.destinations = '[]'::jsonb
+          AND (array_length(m.destination_ids, 1) > 0 OR m.promote_kb_collection_id IS NOT NULL
+               OR m.on_complete <> '' OR m.branch_pattern <> '' OR m.commit_style <> '');
+    END IF;
+END $$;
+
+ALTER TABLE missions DROP COLUMN IF EXISTS destination_ids;
+ALTER TABLE missions DROP COLUMN IF EXISTS on_complete;
+ALTER TABLE missions DROP COLUMN IF EXISTS branch_pattern;
+ALTER TABLE missions DROP COLUMN IF EXISTS commit_style;
+ALTER TABLE missions DROP COLUMN IF EXISTS promote_kb_collection_id;
+```

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -717,10 +717,11 @@ export interface Mission {
   // authenticated the clone; only present alongside repo_url.
   repo_url?: string
   connector_id?: string
-  // on_complete is the operator's consent-at-create choice for what the
-  // harness does automatically when this mission reaches done: '' does
-  // nothing, 'push' pushes the branch, 'push_pr' pushes then opens a
-  // pull request. Only ever set at create time, never by the model.
+  // on_complete is derived server-side from the mission's "github"
+  // destinations entry (issue #480 dropped the on_complete column):
+  // '' does nothing, 'push' pushes the branch, 'push_pr' pushes then
+  // opens a pull request. Only ever set at create time, never by the
+  // model.
   on_complete?: '' | 'push' | 'push_pr'
   // discover_notes is set once, at the end of the discover phase
   // (driver.go's runDiscover): absent/empty for a mission created
@@ -792,11 +793,6 @@ export interface Mission {
   // dispatch, "claude-cli"/"pi"/"codex-cli"/"opencode"/"cursor-cli" name
   // a registered executor.
   harness?: string
-  // branch_pattern/commit_style are this mission's own override of the
-  // settings-configured git strategy defaults; "" or absent means the
-  // settings default applied at provisioning/commit time.
-  branch_pattern?: string
-  commit_style?: string
   // top_model/top_model_provider are decorated onto the list/get
   // response from the cost ledger's top-served-model-per-mission
   // lookup (internal/brain/api/missions.go's decorateTopModels): the
@@ -813,16 +809,6 @@ export interface Mission {
   // attachments are PDF documents attached at create time: markdown is
   // never sent over the wire (see api/missions.go's sanitizeMission).
   attachments?: { id: string; mime: string; name?: string }[]
-  // destination_ids names operator-created destinations (email,
-  // webhook) this mission delivers its outcome digest to in the result
-  // phase's step (D-086). Validated against the destinations table
-  // at create time: never model-decided.
-  destination_ids?: string[]
-  // promote_kb_collection_id names a kb collection this mission's
-  // markdown artifacts promote into in the result phase's step
-  // (D-081, issue #370; D-086). Absent/'' promotes nothing automatically;
-  // the operator can still promote manually via POST .../promote-kb.
-  promote_kb_collection_id?: string
   // light marks a mission that skips discover/plan/prove (D-069):
   // kind=general only, born in phase=generate, one bare worker turn.
   // final_output is that worker's verbatim final message: the

--- a/web/src/pages/NewMission.tsx
+++ b/web/src/pages/NewMission.tsx
@@ -19,8 +19,6 @@ function missionToInitial(m: Mission): Partial<CreateMissionInput> {
     escalation_route: m.escalation_route,
     harness: m.harness,
     environment: m.environment,
-    branch_pattern: m.branch_pattern,
-    commit_style: m.commit_style,
     on_complete: m.on_complete,
   }
 }


### PR DESCRIPTION
Closes #480. Slice 2 of the missions schema restructure.

One destinations jsonb column now carries every delivery target with per-entry delivered_at/error state, replacing destination_ids, on_complete, branch_pattern, commit_style, and promote_kb_collection_id. Delivery dedup moves from scanning mission.delivered events to the entry state itself (events still appended for timeline history). Create path keeps accepting the old request fields and normalizes them into entries; schedules and workflow steps build entries at spawn; response keeps a derived on_complete for web compat. Data migration in pending-alters folds existing rows before the five drops.

Verified: go build/vet (incl. integration tag)/test -race green; web build+lint clean, 1027/1028 (known pre-existing MissionForm date flake).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790842785&installation_model_id=431401&pr_number=486&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F486&signature=0ed55f7f64d560d143e020f9bd1fa122ec85ca2c18ab45482a94334ea389f956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->