### PR TITLE
test(missions): read scheduler destinations from jsonb column

### DIFF
--- a/internal/brain/missions/scheduler_integration_test.go
+++ b/internal/brain/missions/scheduler_integration_test.go
@@ -193,9 +193,9 @@ func TestSchedulerFireFiltersDestinationIDs(t *testing.T) {
 	store := testStore(t)
 	ctx := context.Background()
 
-	// destination_ids is a uuid[] column — the ids exercised here must
-	// parse as UUIDs even though no destinations row backs them (the
-	// fake destinationEnabled below stands in for the real lookup).
+	// The ids exercised here must parse as UUIDs even though no
+	// destinations row backs them (the fake destinationEnabled below
+	// stands in for the real lookup).
 	const (
 		kept            = "11111111-1111-1111-1111-111111111111"
 		droppedDisabled = "22222222-2222-2222-2222-222222222222"
@@ -232,12 +232,16 @@ func TestSchedulerFireFiltersDestinationIDs(t *testing.T) {
 		t.Fatalf("tick: %v", err)
 	}
 
-	var got []string
-	if err := db.QueryRow(ctx, `SELECT destination_ids FROM missions WHERE schedule_id = $1`, scID).Scan(&got); err != nil {
-		t.Fatalf("query fired mission's destination_ids: %v", err)
+	var raw []byte
+	if err := db.QueryRow(ctx, `SELECT destinations FROM missions WHERE schedule_id = $1`, scID).Scan(&raw); err != nil {
+		t.Fatalf("query fired mission's destinations: %v", err)
 	}
-	if len(got) != 1 || got[0] != kept {
-		t.Fatalf("fired mission destination_ids = %v, want [%s]", got, kept)
+	var got []DestinationEntry
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal destinations: %v", err)
+	}
+	if len(got) != 1 || got[0].DestinationID != kept {
+		t.Fatalf("fired mission destinations = %+v, want one entry with destination_id %s", got, kept)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #486: the scheduler fire-filter integration test still selected the dropped destination_ids column (SQL strings are invisible to vet). Now reads the destinations jsonb entries. Verified against the live dev DB: scheduler integration tests ok.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790850143&installation_model_id=431401&pr_number=488&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F488&signature=490f4a5876a3777ede0d38fb0a1f8456f9efbfc57d84d1fb342d3af014c16a1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->