### PR TITLE
fix(settings): connector/provider naming polish + secret-ref registry

### DIFF
--- a/internal/brain/api/admin.go
+++ b/internal/brain/api/admin.go
@@ -194,14 +194,12 @@ type secretsAPI struct {
 }
 
 // connectorRefs maps every stored secret ref name to the connector
-// names referencing it: each row's credential_ref, plus — for a github
-// connector with commit signing enabled — the derived
-// connectors.SigningKeyRefSuffix ref its private signing key lives
-// under, so the signing key never looks orphaned in the panel or
-// becomes deletable while the connector still signs with it. A google
-// connector's config.client_secret_ref counts the same way: it is
-// resolved on every OAuth token refresh, so deleting it would break
-// the connector at the next refresh.
+// names referencing it, via each row's connectors.Connector.SecretRefs
+// — the kind-specific list of every secret it resolves (base
+// credential, OAuth client secret, derived signing key, ...), so a
+// secret backing an active connector never looks orphaned or becomes
+// deletable out from under it. A kind missing from that registry is a
+// connectors-package bug, guarded by its own test, not this caller's.
 func connectorRefs(ctx context.Context, store connectorLister) (map[string][]referenceInfo, error) {
 	if store == nil {
 		return map[string][]referenceInfo{}, nil
@@ -212,28 +210,11 @@ func connectorRefs(ctx context.Context, store connectorLister) (map[string][]ref
 	}
 	out := map[string][]referenceInfo{}
 	for _, c := range rows {
-		if c.CredentialRef == "" {
-			continue
-		}
-		// A google connector's credential_ref is the machine-written
-		// OAuth token bundle, never a valid manual pick.
-		credRole := "credential"
-		if c.Kind == "google" {
-			credRole = "oauth_tokens" //nolint:gosec // G101: role label, not a credential value.
-		}
-		out[c.CredentialRef] = append(out[c.CredentialRef], referenceInfo{Kind: "connector", Name: c.Name, Role: credRole})
-		if c.Kind == "github" {
-			var cfg connectors.GitHubConfig
-			if json.Unmarshal(c.Config, &cfg) == nil && (cfg.SignCommits || cfg.SigningPublicKey != "") {
-				ref := connectors.SigningKeyRefSuffix(c.CredentialRef)
-				out[ref] = append(out[ref], referenceInfo{Kind: "connector", Name: c.Name, Role: "signing_key"})
+		for _, ref := range c.SecretRefs() {
+			if ref.RefName == "" {
+				continue
 			}
-		}
-		if c.Kind == "google" {
-			var cfg connectors.GoogleConfig
-			if json.Unmarshal(c.Config, &cfg) == nil && cfg.ClientSecretRef != "" {
-				out[cfg.ClientSecretRef] = append(out[cfg.ClientSecretRef], referenceInfo{Kind: "connector", Name: c.Name, Role: "client_secret"})
-			}
+			out[ref.RefName] = append(out[ref.RefName], referenceInfo{Kind: "connector", Name: c.Name, Role: ref.Role})
 		}
 	}
 	return out, nil

--- a/internal/brain/api/secrets_test.go
+++ b/internal/brain/api/secrets_test.go
@@ -210,6 +210,74 @@ func TestDeleteSecretRefusesGoogleClientSecretRef(t *testing.T) {
 	}
 }
 
+func TestListSecretsCountsMicrosoftClientSecretRef(t *testing.T) {
+	t.Parallel()
+	a := &API{token: "tok", log: discard()}
+	gw := &fakeGatewaySecrets{refs: []gwclient.SecretRef{
+		{RefName: "OUTLOOK_MICROSOFT_OAUTH"},
+		{RefName: "OUTLOOK_MICROSOFT_CLIENT_SECRET"},
+	}}
+	conns := &fakeConnectorLister{rows: []connectors.Connector{
+		//nolint:gosec // G101: fixture ref names, not credential values.
+		{Name: "outlook", Kind: "microsoft", CredentialRef: "OUTLOOK_MICROSOFT_OAUTH",
+			Config: json.RawMessage(`{"client_id":"x","client_secret_ref":"OUTLOOK_MICROSOFT_CLIENT_SECRET"}`)},
+	}}
+	m := http.NewServeMux()
+	a.registerSecrets(m.Handle, gw, conns, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/secrets", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var body struct {
+		Secrets []secretRefEntry `json:"secrets"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byName := map[string]secretRefEntry{}
+	for _, s := range body.Secrets {
+		byName[s.RefName] = s
+	}
+	got := byName["OUTLOOK_MICROSOFT_CLIENT_SECRET"].ReferencedBy
+	if len(got) != 1 || got[0] != (referenceInfo{Kind: "connector", Name: "outlook", Role: "client_secret"}) {
+		t.Fatalf("OUTLOOK_MICROSOFT_CLIENT_SECRET referenced_by = %+v, want the microsoft connector with role client_secret (client secret is resolved on every token refresh, must never look orphaned)", got)
+	}
+	oauth := byName["OUTLOOK_MICROSOFT_OAUTH"].ReferencedBy
+	if len(oauth) != 1 || oauth[0] != (referenceInfo{Kind: "connector", Name: "outlook", Role: "oauth_tokens"}) {
+		t.Fatalf("OUTLOOK_MICROSOFT_OAUTH referenced_by = %+v, want the microsoft connector with role oauth_tokens (machine-managed token bundle, never a manual pick)", oauth)
+	}
+}
+
+func TestDeleteSecretRefusesMicrosoftClientSecretRef(t *testing.T) {
+	t.Parallel()
+	a := &API{token: "tok", log: discard()}
+	gw := &fakeGatewaySecrets{}
+	conns := &fakeConnectorLister{rows: []connectors.Connector{
+		//nolint:gosec // G101: fixture ref names, not credential values.
+		{Name: "outlook", Kind: "microsoft", CredentialRef: "OUTLOOK_MICROSOFT_OAUTH",
+			Config: json.RawMessage(`{"client_secret_ref":"OUTLOOK_MICROSOFT_CLIENT_SECRET"}`)},
+	}}
+	m := http.NewServeMux()
+	a.registerSecrets(m.Handle, gw, conns, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/admin/secrets/OUTLOOK_MICROSOFT_CLIENT_SECRET", nil)
+	req.Header.Set("Authorization", "Bearer tok")
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", w.Code)
+	}
+	if gw.deletedRef != "" {
+		t.Fatalf("gateway DeleteSecret called with %q, want never called", gw.deletedRef)
+	}
+}
+
 func TestDeleteSecretRefusesWhenConnectorReferencesIt(t *testing.T) {
 	t.Parallel()
 	a := &API{token: "tok", log: discard()}

--- a/internal/brain/connectors/secretrefs.go
+++ b/internal/brain/connectors/secretrefs.go
@@ -1,0 +1,71 @@
+package connectors
+
+import "encoding/json"
+
+// SecretRefRole is one secret-store ref a connector row resolves, with
+// the role it plays — surfaced by admin/secrets so the ref never looks
+// orphaned (or deletable) while a connector still depends on it.
+type SecretRefRole struct {
+	RefName string
+	Role    string
+}
+
+// baseCredentialRole reports the role a kind's own CredentialRef plays
+// — "oauth_tokens" for a machine-written token bundle (never a valid
+// manual pick), "credential" for anything else (a PAT, a bearer token).
+// Registered here, next to the kinds whitelist, so a new kind that
+// skips this map fails the same way an unregistered builder does —
+// silently dormant, not silently wrong (see the consistency test).
+var baseCredentialRole = map[string]string{
+	"google":    "oauth_tokens", //nolint:gosec // G101: role label, not a credential value.
+	"microsoft": "oauth_tokens", //nolint:gosec // G101: role label, not a credential value.
+	"github":    "credential",
+	"mcp":       "credential",
+	"imap":      "credential",
+	"caldav":    "credential",
+}
+
+// extraSecretRefs maps a kind to the secret refs it resolves beyond its
+// own base CredentialRef — an OAuth client secret, a derived signing
+// key. A kind with none is simply absent from this map.
+var extraSecretRefs = map[string]func(c Connector) []SecretRefRole{
+	"google": func(c Connector) []SecretRefRole {
+		var cfg GoogleConfig
+		if json.Unmarshal(c.Config, &cfg) == nil && cfg.ClientSecretRef != "" {
+			return []SecretRefRole{{RefName: cfg.ClientSecretRef, Role: "client_secret"}}
+		}
+		return nil
+	},
+	"microsoft": func(c Connector) []SecretRefRole {
+		var cfg MicrosoftConfig
+		if json.Unmarshal(c.Config, &cfg) == nil && cfg.ClientSecretRef != "" {
+			return []SecretRefRole{{RefName: cfg.ClientSecretRef, Role: "client_secret"}}
+		}
+		return nil
+	},
+	"github": func(c Connector) []SecretRefRole {
+		var cfg GitHubConfig
+		if json.Unmarshal(c.Config, &cfg) == nil && (cfg.SignCommits || cfg.SigningPublicKey != "") {
+			return []SecretRefRole{{RefName: SigningKeyRefSuffix(c.CredentialRef), Role: "signing_key"}}
+		}
+		return nil
+	},
+}
+
+// SecretRefs reports every secret-store ref this connector resolves,
+// with its role: the base CredentialRef (role from baseCredentialRole,
+// default "credential" for a kind missing from that map — impossible
+// for a kind that passed the kinds whitelist, see the consistency
+// test), plus any kind-specific extras from extraSecretRefs. Empty
+// CredentialRef is included; the caller drops it.
+func (c Connector) SecretRefs() []SecretRefRole {
+	role, ok := baseCredentialRole[c.Kind]
+	if !ok {
+		role = "credential"
+	}
+	refs := []SecretRefRole{{RefName: c.CredentialRef, Role: role}}
+	if fn, ok := extraSecretRefs[c.Kind]; ok {
+		refs = append(refs, fn(c)...)
+	}
+	return refs
+}

--- a/internal/brain/connectors/secretrefs_test.go
+++ b/internal/brain/connectors/secretrefs_test.go
@@ -1,0 +1,62 @@
+package connectors
+
+import "testing"
+
+// TestBaseCredentialRoleRegisteredForEveryKind guards the exact gap
+// that let "microsoft" ship mislabeled: every whitelisted kind must
+// declare its base CredentialRef's role explicitly, so a new kind added
+// to `kinds` without one fails a test instead of silently defaulting.
+func TestBaseCredentialRoleRegisteredForEveryKind(t *testing.T) {
+	for kind := range kinds {
+		if _, ok := baseCredentialRole[kind]; !ok {
+			t.Errorf("kind %q has no baseCredentialRole entry", kind)
+		}
+	}
+}
+
+func TestConnectorSecretRefsGoogleClientSecret(t *testing.T) {
+	//nolint:gosec // G101: fixture ref names, not credential values.
+	c := Connector{
+		Kind: "google", CredentialRef: "GMAIL_GOOGLE_OAUTH",
+		Config: []byte(`{"client_id":"x","client_secret_ref":"GMAIL_GOOGLE_CLIENT_SECRET"}`),
+	}
+	got := c.SecretRefs()
+	want := []SecretRefRole{
+		{RefName: "GMAIL_GOOGLE_OAUTH", Role: "oauth_tokens"},
+		{RefName: "GMAIL_GOOGLE_CLIENT_SECRET", Role: "client_secret"},
+	}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("SecretRefs() = %+v, want %+v", got, want)
+	}
+}
+
+func TestConnectorSecretRefsMicrosoftClientSecret(t *testing.T) {
+	//nolint:gosec // G101: fixture ref names, not credential values.
+	c := Connector{
+		Kind: "microsoft", CredentialRef: "OUTLOOK_MICROSOFT_OAUTH",
+		Config: []byte(`{"client_id":"x","client_secret_ref":"OUTLOOK_MICROSOFT_CLIENT_SECRET"}`),
+	}
+	got := c.SecretRefs()
+	want := []SecretRefRole{
+		{RefName: "OUTLOOK_MICROSOFT_OAUTH", Role: "oauth_tokens"},
+		{RefName: "OUTLOOK_MICROSOFT_CLIENT_SECRET", Role: "client_secret"},
+	}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("SecretRefs() = %+v, want %+v", got, want)
+	}
+}
+
+func TestConnectorSecretRefsGitHubSigningKey(t *testing.T) {
+	c := Connector{
+		Kind: "github", CredentialRef: "MYCONN_PAT",
+		Config: []byte(`{"sign_commits":true}`),
+	}
+	got := c.SecretRefs()
+	want := []SecretRefRole{
+		{RefName: "MYCONN_PAT", Role: "credential"},
+		{RefName: SigningKeyRefSuffix("MYCONN_PAT"), Role: "signing_key"},
+	}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("SecretRefs() = %+v, want %+v", got, want)
+	}
+}

--- a/internal/gateway/admin/admin.go
+++ b/internal/gateway/admin/admin.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/SumonMSelim/timothy/internal/gateway/catalog"
 	"github.com/SumonMSelim/timothy/internal/gateway/ledger"
@@ -754,6 +755,7 @@ func (a *Admin) bootstrapRoutes(ctx context.Context, p router.ProviderRow, candi
 // Patch applies a partial update. Only fields present in the request
 // change; before/after land in the audit row.
 type ProviderPatch struct {
+	Name                 *string            `json:"name"`
 	BaseURL              *string            `json:"base_url"`
 	DefaultModel         *string            `json:"default_model"`
 	CredentialRef        *string            `json:"credential_ref"`
@@ -763,7 +765,16 @@ type ProviderPatch struct {
 	Options              *map[string]string `json:"options"`
 }
 
+// isUniqueViolation reports whether err is a Postgres unique_violation (23505).
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
 func (a *Admin) Patch(ctx context.Context, id string, patch ProviderPatch) error {
+	if patch.Name != nil && *patch.Name == "" {
+		return fmt.Errorf("name is required")
+	}
 	if patch.CredentialRef != nil && !credentialRefPattern.MatchString(*patch.CredentialRef) {
 		return fmt.Errorf("credential_ref must be a name or path, never a secret value")
 	}
@@ -800,6 +811,9 @@ func (a *Admin) Patch(ctx context.Context, id string, patch ProviderPatch) error
 		return err
 	}
 	after := before
+	if patch.Name != nil {
+		after.Name = *patch.Name
+	}
 	if patch.BaseURL != nil {
 		after.BaseURL = *patch.BaseURL
 	}
@@ -822,12 +836,15 @@ func (a *Admin) Patch(ctx context.Context, id string, patch ProviderPatch) error
 		after.Options = *patch.Options
 	}
 
-	tag, err := tx.Exec(ctx, `UPDATE providers SET base_url = $2, default_model = $3,
-			credential_ref = $4, headers = $5, enabled = $6, exclude_from_bootstrap = $7, options = $8, updated_at = now()
+	tag, err := tx.Exec(ctx, `UPDATE providers SET name = $2, base_url = $3, default_model = $4,
+			credential_ref = $5, headers = $6, enabled = $7, exclude_from_bootstrap = $8, options = $9, updated_at = now()
 		WHERE id = $1`,
-		id, after.BaseURL, after.DefaultModel,
+		id, after.Name, after.BaseURL, after.DefaultModel,
 		after.CredentialRef, jsonOr(after.Headers, "{}"), after.Enabled, after.ExcludeFromBootstrap, jsonOr(after.Options, "{}"))
 	if err != nil {
+		if isUniqueViolation(err) {
+			return fmt.Errorf("provider name %q already in use", after.Name)
+		}
 		return fmt.Errorf("admin patch: %w", err)
 	}
 	if tag.RowsAffected() == 0 {

--- a/internal/gateway/admin/admin_integration_test.go
+++ b/internal/gateway/admin/admin_integration_test.go
@@ -207,6 +207,42 @@ func TestProviderCRUDAuditsAndReloads(t *testing.T) {
 		t.Fatalf("patched provider = %+v, want enabled", got)
 	}
 
+	renamed := name + "-renamed"
+	if err := adm.Patch(ctx, id, ProviderPatch{Name: &renamed}); err != nil {
+		t.Fatalf("Patch rename: %v", err)
+	}
+	list, err = adm.List(ctx)
+	if err != nil {
+		t.Fatalf("List after rename: %v", err)
+	}
+	got = nil
+	for i := range list {
+		if list[i].ID == id {
+			got = &list[i]
+		}
+	}
+	if got == nil || got.Name != renamed {
+		t.Fatalf("patched provider = %+v, want name %q", got, renamed)
+	}
+	name = renamed
+
+	// A rename colliding with another provider's name is refused.
+	otherID, err := adm.Create(ctx, Provider{
+		Name: adminMarker + "crud-other", Kind: "api", Driver: "openaicompat",
+		BaseURL: "https://example.invalid/v1", DefaultModel: "m1",
+		CredentialRef: "SOME_ENV_NAME",
+	})
+	if err != nil {
+		t.Fatalf("Create other: %v", err)
+	}
+	otherName := adminMarker + "crud-other"
+	if err := adm.Patch(ctx, id, ProviderPatch{Name: &otherName}); err == nil {
+		t.Fatalf("Patch rename to duplicate name = nil, want error")
+	}
+	if err := adm.Delete(ctx, otherID); err != nil {
+		t.Fatalf("Delete other: %v", err)
+	}
+
 	// Route pointing at it blocks deletion while enabled.
 	if err := adm.PatchRoute(ctx, seedRoute(t, pool, adminMarker+"cat", id), RoutePatch{}); err != nil {
 		t.Fatalf("PatchRoute noop: %v", err)

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -1561,6 +1561,12 @@ describe('MissionForm: edit mode', () => {
   })
 
   it('picks a new expiry date from the calendar and submits it', async () => {
+    // The calendar defaults its open month to the real current date, not
+    // the fixture's expires_at — fake only Date so "August 15th, 2026"
+    // stays clickable regardless of when the suite actually runs, while
+    // findByRole/waitFor's polling keeps using real timers.
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-08-01T00:00:00Z'))
     vi.mocked(patchSchedule).mockResolvedValue(schedule)
     renderForm(<MissionForm mode="edit" schedule={schedule} onDone={vi.fn()} onCancel={vi.fn()} />)
 

--- a/web/src/components/settings/ConnectorEdit.tsx
+++ b/web/src/components/settings/ConnectorEdit.tsx
@@ -23,7 +23,7 @@ import {
 import { Input } from '../ui/input'
 import { slugify } from './AgentForm'
 import { ConnectorLogo } from './ConnectorLogo'
-import { connectorPresets, unknownPreset } from './connectorPresets'
+import { presetFor } from './connectorPresets'
 import { Field, Toggle } from './shared'
 import { connectedAs, errText, isTimothyAuthError } from './util'
 
@@ -170,7 +170,7 @@ export function ConnectorEdit() {
   if (connector === null) return <Navigate to="/settings/connectors" replace />
   if (connector === undefined) return null
 
-  const preset = connectorPresets.find((p) => p.kind === connector.kind) ?? unknownPreset
+  const preset = presetFor(connector)
   const isOAuth = connector.kind === 'google' || connector.kind === 'microsoft'
 
   return (
@@ -212,7 +212,7 @@ export function ConnectorEdit() {
               </button>
             </div>
           )}
-          <p className="text-sm text-muted-foreground uppercase">{connector.kind}</p>
+          <p className="text-sm text-muted-foreground uppercase">{preset.name}</p>
         </div>
         <Button variant="destructive" onClick={() => setConfirmDelete(true)}>
           <HugeiconsIcon icon={Delete02Icon} />

--- a/web/src/components/settings/ConnectorsList.tsx
+++ b/web/src/components/settings/ConnectorsList.tsx
@@ -5,7 +5,7 @@ import { listConnectors, patchConnector, testConnector } from '../../api/client'
 import type { AdminConnector, GitHubIdentity } from '../../api/types'
 import { Button } from '../ui/button'
 import { ConnectorLogo } from './ConnectorLogo'
-import { connectorPresets, unknownPreset } from './connectorPresets'
+import { connectorPresets, presetFor } from './connectorPresets'
 import { Toggle } from './shared'
 import { connectedAs, errText, isTimothyAuthError } from './util'
 
@@ -112,7 +112,7 @@ function ConnectorCard({
   onChanged: () => void
   onManage: () => void
 }) {
-  const preset = connectorPresets.find((p) => matchesPreset(connector, p)) ?? unknownPreset
+  const preset = presetFor(connector)
   const [testing, setTesting] = useState(false)
   const [test, setTest] = useState<{ ok: boolean; error?: string; identity?: GitHubIdentity } | null>(
     null,
@@ -153,7 +153,7 @@ function ConnectorCard({
               </span>
             )}
           </div>
-          <div className="text-xs text-muted-foreground uppercase">{connector.kind}</div>
+          <div className="text-xs text-muted-foreground uppercase">{preset.name}</div>
         </div>
         <Toggle on={connector.enabled} onChange={toggle} label={`${connector.name} enabled`} />
       </div>
@@ -192,16 +192,3 @@ function ConnectorCard({
   )
 }
 
-function matchesPreset(
-  c: AdminConnector,
-  p: { kind: 'mcp' | 'google' | 'github' | 'microsoft' | 'imap' | 'caldav'; scopes?: string[]; endpoint?: string },
-) {
-  if (p.kind !== c.kind) return false
-  if (c.kind === 'google' || c.kind === 'microsoft') {
-    const scopes = JSON.stringify(c.config.scopes ?? '')
-    return p.scopes?.every((s) => scopes.includes(s)) ?? false
-  }
-  if (c.kind === 'github' || c.kind === 'imap' || c.kind === 'caldav') return true
-  const endpoint = String(c.config.endpoint ?? '')
-  return !!p.endpoint && endpoint.startsWith(p.endpoint)
-}

--- a/web/src/components/settings/ProviderEdit.test.tsx
+++ b/web/src/components/settings/ProviderEdit.test.tsx
@@ -156,7 +156,7 @@ describe('ProviderEdit default model section', () => {
     vi.mocked(listProviders).mockResolvedValue([cliProvider])
     renderPage('p3')
 
-    await screen.findByText('Claude Code')
+    await screen.findByDisplayValue('Claude Code')
     expect(screen.getAllByPlaceholderText('sonnet')).toHaveLength(1)
     expect(screen.queryByPlaceholderText('model id')).not.toBeInTheDocument()
   })
@@ -220,7 +220,7 @@ describe('ProviderEdit cli (subscription) provider', () => {
     vi.mocked(listProviders).mockResolvedValue([cliProvider])
     renderPage('p3')
 
-    await screen.findByText('Claude Code')
+    await screen.findByDisplayValue('Claude Code')
     expect(screen.getByPlaceholderText('sonnet')).toHaveValue('sonnet')
     expect(screen.queryByPlaceholderText('model id')).not.toBeInTheDocument()
   })
@@ -244,7 +244,7 @@ describe('ProviderEdit cli (subscription) provider', () => {
     vi.mocked(listProviders).mockResolvedValue([cliProvider])
     renderPage('p3')
 
-    await screen.findByText('Claude Code')
+    await screen.findByDisplayValue('Claude Code')
     expect(screen.queryByRole('button', { name: 'Test connection' })).not.toBeInTheDocument()
   })
 })
@@ -286,7 +286,7 @@ describe('ProviderEdit reasoning section', () => {
     vi.mocked(listProviders).mockResolvedValue([bedrockProvider])
     renderPage('p1')
 
-    await screen.findByText('AWS Bedrock')
+    await screen.findByDisplayValue('AWS Bedrock')
     expect(screen.queryByRole('switch', { name: 'Disable reasoning' })).toBeNull()
   })
 
@@ -422,7 +422,7 @@ describe('ProviderEdit catalog provider section', () => {
     vi.mocked(listProviders).mockResolvedValue([cliProvider])
     renderPage('p3')
 
-    await screen.findByText('Claude Code')
+    await screen.findByDisplayValue('Claude Code')
     expect(screen.queryByPlaceholderText('e.g. xai, zai')).not.toBeInTheDocument()
   })
 })
@@ -432,7 +432,7 @@ describe('ProviderEdit region section', () => {
     vi.mocked(listProviders).mockResolvedValue([openaicompatProvider])
     renderPage('p2')
 
-    await screen.findByText('Ollama')
+    await screen.findByDisplayValue('Ollama')
     expect(screen.queryByText('Region')).toBeNull()
   })
 

--- a/web/src/components/settings/ProviderEdit.tsx
+++ b/web/src/components/settings/ProviderEdit.tsx
@@ -42,6 +42,7 @@ export function ProviderEdit() {
 
   const [provider, setProvider] = useState<AdminProvider | null | undefined>(undefined)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const [name, setName] = useState('')
 
   const refresh = useCallback(() => {
     listProviders()
@@ -49,6 +50,22 @@ export function ProviderEdit() {
       .catch((err: unknown) => toast.error('Could not load provider', { description: errText(err) }))
   }, [id])
   useEffect(refresh, [refresh])
+  useEffect(() => {
+    if (provider) setName(provider.name)
+  }, [provider])
+
+  const saveName = () => {
+    if (!provider) return
+    const trimmed = name.trim()
+    if (!trimmed || trimmed === provider.name) {
+      setName(provider.name)
+      return
+    }
+    patchProvider(provider.id, { name: trimmed }).then(refresh, (err: unknown) => {
+      setName(provider.name)
+      toast.error('Could not rename provider', { description: errText(err) })
+    })
+  }
 
   const remove = async () => {
     if (!provider) return
@@ -78,7 +95,16 @@ export function ProviderEdit() {
       <div className="flex items-center gap-4 border-b border-border pb-6">
         <ProviderLogo preset={matchPreset(provider)} className="size-12" />
         <div className="min-w-0 flex-1">
-          <h1 className="truncate text-xl font-semibold tracking-tight">{provider.name}</h1>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onBlur={saveName}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') e.currentTarget.blur()
+            }}
+            className="h-9 max-w-sm truncate border-transparent bg-transparent px-0 text-xl font-semibold tracking-tight shadow-none hover:border-border focus-visible:border-border focus-visible:bg-background focus-visible:px-3"
+            aria-label="Provider name"
+          />
           <p className="text-sm text-muted-foreground">driver: {provider.driver}</p>
         </div>
         <Button variant="destructive" onClick={() => setConfirmDelete(true)}>

--- a/web/src/components/settings/connectorPresets.ts
+++ b/web/src/components/settings/connectorPresets.ts
@@ -121,3 +121,26 @@ export const unknownPreset: ConnectorPreset = {
   description: '',
   brandColor: '#4B5563',
 }
+
+// matchesPreset distinguishes presets sharing a kind (e.g. Gmail vs
+// Google Calendar, both kind=google) by their OAuth scopes; kinds with
+// only one preset match on kind alone.
+function matchesPreset(
+  c: { kind: string; config: Record<string, unknown> },
+  p: ConnectorPreset,
+): boolean {
+  if (p.kind !== c.kind) return false
+  if (c.kind === 'google' || c.kind === 'microsoft') {
+    const scopes = JSON.stringify(c.config.scopes ?? '')
+    return p.scopes?.every((s) => scopes.includes(s)) ?? false
+  }
+  if (c.kind === 'github' || c.kind === 'imap' || c.kind === 'caldav') return true
+  const endpoint = String(c.config.endpoint ?? '')
+  return !!p.endpoint && endpoint.startsWith(p.endpoint)
+}
+
+// presetFor resolves a connector to its friendly preset (name, logo,
+// description) by kind + scopes, falling back to unknownPreset.
+export function presetFor(c: { kind: string; config: Record<string, unknown> }): ConnectorPreset {
+  return connectorPresets.find((p) => matchesPreset(c, p)) ?? unknownPreset
+}

--- a/web/src/pages/Settings.test.tsx
+++ b/web/src/pages/Settings.test.tsx
@@ -388,6 +388,6 @@ describe('Provider manage page', () => {
   it('navigates to the manage page from the card', async () => {
     renderPage('/settings/providers')
     fireEvent.click(await screen.findByRole('button', { name: 'Manage' }))
-    expect(await screen.findByRole('heading', { name: 'OpenAI' })).toBeTruthy()
+    expect(await screen.findByDisplayValue('OpenAI')).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- Providers can now be renamed (header field, duplicate-name refused with 409).
- Connector list/manage pages show the friendly type (Gmail, Outlook, Google Docs, ...) instead of the raw kind, and match presets by scopes not just kind.
- `OUTLOOK_MICROSOFT_CLIENT_SECRET` (and any future connector's client-secret-style ref) can no longer show as orphaned: connectorRefs now goes through `connectors.Connector.SecretRefs()`, backed by a kind-keyed registry that fails a test if a new kind skips it.

## Test plan
- [x] `make build test vet lint`
- [x] web `npm run build && npm run lint && npm test`
- [x] gateway integration test: rename + duplicate-name-refusal (`TestProviderCRUDAuditsAndReloads`)
- [x] manual: renamed a provider via UI, confirmed connector badges show friendly names on both pages

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790892052&installation_model_id=431401&pr_number=493&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F493&signature=746dbff80bb1711e4bcbcf16df1f86132ea46b13254e39845b63d34402ed83ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->