### PR TITLE
fix(missions): stale sweep ignores in-flight delegated runs

### DIFF
--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -1350,13 +1350,23 @@ func (s *Store) RecoverWorking(ctx context.Context) ([]Mission, error) {
 // process restart, so RecoverWorking's boot-only pass never sees it) —
 // same re-Drive path, just periodic and staleness-gated so it never
 // interferes with a mission genuinely mid-turn.
+//
+// A delegated executor run is one Advance that can outlast staleAfter
+// many times over and never touches the mission row while the CLI
+// runs; its liveness signal is the executor.progress event the poll
+// loop appends (issue #497). A mission with one newer than staleAfter
+// is mid-turn, not stale, whatever updated_at says.
 func (s *Store) RecoverStaleWorking(ctx context.Context, staleAfter time.Duration) ([]Mission, error) {
 	db, err := s.db.Get()
 	if err != nil {
 		return nil, fmt.Errorf("missions recover stale working: %w", err)
 	}
-	rows, err := db.Query(ctx, `SELECT `+missionColumns+` FROM missions
-		WHERE status = 'working' AND updated_at < now() - $1::interval`, staleAfter)
+	rows, err := db.Query(ctx, `SELECT `+missionColumns+` FROM missions m
+		WHERE m.status = 'working' AND m.updated_at < now() - $1::interval
+		  AND NOT EXISTS (
+		    SELECT 1 FROM mission_events e
+		    WHERE e.mission_id = m.id AND e.kind = 'executor.progress'
+		      AND e.created_at >= now() - $1::interval)`, staleAfter)
 	if err != nil {
 		return nil, fmt.Errorf("missions recover stale working: %w", err)
 	}

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -1296,6 +1296,23 @@ func TestRecoverStaleWorking(t *testing.T) {
 		t.Fatalf("backdate updated_at: %v", err)
 	}
 
+	// A delegated run: updated_at is old (the CLI has run for an hour)
+	// but the poll loop appended executor.progress a moment ago (#497).
+	delegatedID := workingBackdated(t, s, marker+"stale-delegated-live")
+	if err := s.AppendEvent(ctx, delegatedID, "executor.progress", map[string]any{"turns": 80}); err != nil {
+		t.Fatalf("AppendEvent live progress: %v", err)
+	}
+
+	// A delegated run whose last progress is itself older than the
+	// staleness bound: the CLI stopped without exiting, genuinely stale.
+	delegatedStaleID := workingBackdated(t, s, marker+"stale-delegated-dead")
+	if err := s.AppendEvent(ctx, delegatedStaleID, "executor.progress", map[string]any{"turns": 3}); err != nil {
+		t.Fatalf("AppendEvent old progress: %v", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE mission_events SET created_at = now() - interval '1 hour' WHERE mission_id = $1`, delegatedStaleID); err != nil {
+		t.Fatalf("backdate progress event: %v", err)
+	}
+
 	stale, err := s.RecoverStaleWorking(ctx, 15*time.Minute)
 	if err != nil {
 		t.Fatalf("RecoverStaleWorking: %v", err)
@@ -1310,6 +1327,34 @@ func TestRecoverStaleWorking(t *testing.T) {
 	if byID[freshID] {
 		t.Fatal("RecoverStaleWorking incorrectly returned a fresh working mission")
 	}
+	if byID[delegatedID] {
+		t.Fatal("RecoverStaleWorking returned a delegated run with recent executor.progress")
+	}
+	if !byID[delegatedStaleID] {
+		t.Fatal("RecoverStaleWorking did not return a delegated run whose progress went stale")
+	}
+}
+
+// workingBackdated creates a working mission whose updated_at is an hour
+// old, the shape of a long delegated run's row.
+func workingBackdated(t *testing.T, s *Store, goal string) string {
+	t.Helper()
+	ctx := t.Context()
+	id, err := s.Create(ctx, Mission{Goal: goal, Kind: "coding"})
+	if err != nil {
+		t.Fatalf("Create %s: %v", goal, err)
+	}
+	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhaseGenerate, Status: StatusWorking}}); err != nil {
+		t.Fatalf("ApplyTransition %s: %v", goal, err)
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("db.Get: %v", err)
+	}
+	if _, err := db.Exec(ctx, `UPDATE missions SET updated_at = now() - interval '1 hour' WHERE id = $1`, id); err != nil {
+		t.Fatalf("backdate %s: %v", goal, err)
+	}
+	return id
 }
 
 func TestBackoffPausedAndCountBackoffPauses(t *testing.T) {

--- a/internal/brain/missions/sweep.go
+++ b/internal/brain/missions/sweep.go
@@ -22,7 +22,10 @@ const workSlotSweepInterval = 30 * time.Second
 // still genuinely mid-turn (only claimDriving's no-op saves it from a
 // second concurrent Drive loop). Derived from turnTimeout plus margin
 // rather than a bare constant so that invariant can't silently drift out
-// of sync if turnTimeout ever changes.
+// of sync if turnTimeout ever changes. A delegated executor turn is not
+// bounded by turnTimeout at all (its cap is the CLI run budget), so for
+// those RecoverStaleWorking treats a recent executor.progress event as
+// the liveness signal instead of updated_at (issue #497).
 var staleWorkingAfter = turnTimeout + 5*time.Minute
 
 // recoverWorkingRetries and recoverWorkingRetryDelay bound the boot


### PR DESCRIPTION
## Summary
- `RecoverStaleWorking` excludes working missions that appended an `executor.progress` event within `staleWorkingAfter`; a delegated CLI run never updates the mission row, so `updated_at` alone misfired every 30s for the whole run (seen on mission b94dc32d).
- Genuinely dead delegated runs (last progress older than the bound) are still reported.

Closes #497

## Test plan
- [x] `TestRecoverStaleWorking` extended with live and dead delegated cases (integration, run against the local stack)
- [x] `make build vet lint`, missions unit tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790896826&installation_model_id=431401&pr_number=501&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F501&signature=655cb100b2f28f2136b51005c5e03a95c29bbb59f94ee923003e787ee7dff8a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->