### PR TITLE
feat(missions): settings-backed run budget for delegated executors

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -1053,7 +1053,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	// poll it to a verdict. Only wired when a sandbox manager is present
 	// (missions already require one for the native shell path); nativeRunner
 	// alone is otherwise the floor, same as before this feature existed.
-	runner := buildDelegatedRunner(nativeRunner, store, gwc, secrets, sandboxMgr, db, log)
+	runner := buildDelegatedRunner(nativeRunner, store, gwc, secrets, sandboxMgr, db, flags, log)
 	webhookURL := os.Getenv("NOTIFY_WEBHOOK_URL")
 	notifier := missions.NewNotifier(db, webhookURL, log)
 	notifier.SetHub(hub)
@@ -1346,7 +1346,7 @@ const credResolveTimeout = 3 * time.Second
 // resolves through it); api_key-mode executors simply have no
 // resolver, so resolveCredential's ErrExecutorAuth path is what a
 // mission sees instead of a working key.
-func buildDelegatedRunner(native missions.Runner, store *missions.Store, gwc *gwclient.Client, secrets *secretstore.Store, sandboxMgr *sandboxclient.Client, db *pgpool.Pool, log *slog.Logger) missions.Runner {
+func buildDelegatedRunner(native missions.Runner, store *missions.Store, gwc *gwclient.Client, secrets *secretstore.Store, sandboxMgr *sandboxclient.Client, db *pgpool.Pool, flags *settings.Store, log *slog.Logger) missions.Runner {
 	if sandboxMgr == nil {
 		return native
 	}
@@ -1359,7 +1359,7 @@ func buildDelegatedRunner(native missions.Runner, store *missions.Store, gwc *gw
 		}
 	}
 	led := ledger.New(db, log, nil)
-	return missions.NewDelegatedRunner(native, gwc.ResolveRoute, resolveCred, sandboxMgr.ExecEnv, store, store.LastRunState, led, log)
+	return missions.NewDelegatedRunner(native, gwc.ResolveRoute, resolveCred, sandboxMgr.ExecEnv, store, store.LastRunState, led, flags.ExecutorRunBudget, log)
 }
 
 // memoryProxy forwards the web's memory-management routes to memoryd

--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -41,8 +41,16 @@ var ErrExecutorAuth = errors.New("executor: authentication failed")
 // resume polling the same directory after re-reading the manifest event
 // (see attemptResume).
 const (
-	runBudgetDefault  = 90 * time.Minute // spec.RunBudget: overall CLI wall-clock cap
+	// runBudgetDefault is the CLI wall-clock cap when no settings-backed
+	// budget is wired (tests); production reads
+	// settings.ValueExecutorRunBudgetMinutes per launch (issue #498) and
+	// settings.DefaultExecutorRunBudget carries the same 8h default. A
+	// runaway backstop only: idleTimeout is the watchdog that catches a
+	// hung CLI, so this must stay large enough never to kill a healthy
+	// multi-hour run.
+	runBudgetDefault  = 8 * time.Hour
 	launchTimeout     = 60 * time.Second
+	runBudgetExitCode = 124 // coreutils `timeout` exit status when it stopped the command
 	pollInterval      = 10 * time.Second
 	pollTimeout       = 60 * time.Second
 	idleTimeout       = 10 * time.Minute
@@ -140,6 +148,9 @@ type delegatedRunner struct {
 	pollInterval time.Duration
 	idleTimeout  time.Duration
 	runBudget    time.Duration
+	// runBudgetFn, when set, is read once per launch and wins over
+	// runBudget: the settings-backed cap (issue #498).
+	runBudgetFn func(context.Context) time.Duration
 
 	mu       sync.Mutex
 	cooldown map[cooldownKey]time.Time
@@ -149,14 +160,25 @@ type delegatedRunner struct {
 // path. sandboxExec must be non-nil (cmd/brain/main.go only constructs
 // this when a sandbox manager is present — missions already require
 // one); events/lastRun/led may be nil in tests that don't assert on
-// them, but production wiring always supplies all four.
-func NewDelegatedRunner(native Runner, resolveRoute routeResolver, resolveCred credResolver, sandboxExec sandboxExecEnv, events eventSink, lastRun lastRunStateFunc, led usageRecorder, log *slog.Logger) Runner {
+// them, but production wiring always supplies all four. runBudget
+// resolves the per-launch wall-clock cap; nil means runBudgetDefault.
+func NewDelegatedRunner(native Runner, resolveRoute routeResolver, resolveCred credResolver, sandboxExec sandboxExecEnv, events eventSink, lastRun lastRunStateFunc, led usageRecorder, runBudget func(context.Context) time.Duration, log *slog.Logger) Runner {
 	return &delegatedRunner{
 		native: native, resolveRoute: resolveRoute, resolveCred: resolveCred,
 		sandboxExec: sandboxExec, events: events, lastRun: lastRun, ledger: led, log: log,
-		pollInterval: pollInterval, idleTimeout: idleTimeout, runBudget: runBudgetDefault,
+		pollInterval: pollInterval, idleTimeout: idleTimeout, runBudget: runBudgetDefault, runBudgetFn: runBudget,
 		cooldown: map[cooldownKey]time.Time{},
 	}
+}
+
+// effectiveRunBudget is the wall-clock cap for a launch happening now.
+func (r *delegatedRunner) effectiveRunBudget(ctx context.Context) time.Duration {
+	if r.runBudgetFn != nil {
+		if d := r.runBudgetFn(ctx); d > 0 {
+			return d
+		}
+	}
+	return r.runBudget
 }
 
 func (r *delegatedRunner) DiscoverSession(ctx context.Context, m Mission) (string, error) {
@@ -431,13 +453,14 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 	system, user := packet.RenderForDelegated()
 	system += delegatedSystemAppend
 
+	runBudget := r.effectiveRunBudget(ctx)
 	spec := executor.InvocationSpec{
 		MissionID: m.ID, Workdir: workRoot,
 		PromptPath:   filepath.Join(rdir, "prompt.md"),
 		SystemAppend: system,
 		Model:        entry.Model, AuthMode: authMode, APIKey: apiKey, BaseURL: entry.BaseURL,
 		AllowTools: delegatedAllowTools, DenyTools: delegatedDenyTools,
-		ResultSchema: resultSchemaJSON, RunBudget: r.runBudget, Wire: entry.Wire,
+		ResultSchema: resultSchemaJSON, RunBudget: runBudget, Wire: entry.Wire,
 	}
 	inv, err := adapter.BuildInvocation(spec)
 	if err != nil {
@@ -462,7 +485,7 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 
 	r.recordSpawned(ctx, m.ID, m.Harness, entry, runID, rdir, authMode)
 
-	if err := r.launch(ctx, m.ID, m.Environment, workRoot, rdir, inv); err != nil {
+	if err := r.launch(ctx, m.ID, m.Environment, workRoot, rdir, inv, runBudget); err != nil {
 		r.coolDown(m.Harness, entry)
 		r.recordDied(ctx, m.ID, "spawn_failed", nil, err.Error())
 		return WorkerVerdict{}, "", fmt.Errorf("delegated runner: launch: %w", err)
@@ -510,8 +533,8 @@ func (r *delegatedRunner) attemptResume(ctx context.Context, m Mission, workRoot
 // enforces spec.RunBudget itself, independent of anything brain does
 // afterward — a crashed brain still lets the container kill a runaway
 // CLI.
-func (r *delegatedRunner) launch(ctx context.Context, missionID, environment, workdir, rdir string, inv executor.Invocation) error {
-	launchCmd, err := buildLaunchCmd(workdir, rdir, inv, r.runBudget)
+func (r *delegatedRunner) launch(ctx context.Context, missionID, environment, workdir, rdir string, inv executor.Invocation, runBudget time.Duration) error {
+	launchCmd, err := buildLaunchCmd(workdir, rdir, inv, runBudget)
 	if err != nil {
 		return err
 	}
@@ -836,6 +859,17 @@ func (r *delegatedRunner) finishNoResult(ctx context.Context, m Mission, entry g
 	reason := fmt.Sprintf("executor exited (code %d) without a result event", exitCode)
 	if exitCode == -1 {
 		reason = "executor process was lost (no exit code, no result event)"
+	}
+
+	// 124 is `timeout`'s own exit status when it had to stop the CLI:
+	// the wall-clock run budget fired (issue #498). Recorded under its
+	// own reason so the UI and canary can tell it from a crash.
+	if exitCode == runBudgetExitCode {
+		reason = "executor exceeded the run budget and was killed"
+		r.recordDied(ctx, m.ID, "run_budget", &exitCode, stderrTail)
+		r.recordLedger(ctx, m, entry, authMode, nil, start, false, "", st.reportedModel)
+		r.coolDown(m.Harness, entry)
+		return forcedRetryVerdict(reason), st.textBuf.String(), nil
 	}
 
 	if exitCode != 0 && isAuthFailure(stderrTail) {

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -114,16 +114,24 @@ type fakeSandbox struct {
 	seedExitCode int
 	seedIdle     bool
 
-	launches  int
-	launchErr error
-	pollErrN  int // fail this many poll calls with an infra error before succeeding
-	pollErrs  int
+	launches   int
+	launchErr  error
+	lastLaunch string
+	pollErrN   int // fail this many poll calls with an infra error before succeeding
+	pollErrs   int
 
 	stderrText string
 }
 
 func newFakeSandbox() *fakeSandbox {
 	return &fakeSandbox{runs: map[string]*fakeRun{}}
+}
+
+// lastLaunchCmd is the full shell command of the most recent launch.
+func (s *fakeSandbox) lastLaunchCmd() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastLaunch
 }
 
 func (s *fakeSandbox) Exec(ctx context.Context, missionID, environment, workdir, command string, env map[string]string, timeout time.Duration, out io.Writer) (int, error) {
@@ -199,6 +207,7 @@ func (s *fakeSandbox) launch(command string, env map[string]string) (int, error)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.launches++
+	s.lastLaunch = command
 	if s.launchErr != nil {
 		return 1, s.launchErr
 	}
@@ -405,7 +414,7 @@ func (f *fakeNative) callCount() int {
 // newTestDelegatedRunner builds a delegatedRunner with short test
 // timings so scenarios never wait real production minutes.
 func newTestDelegatedRunner(native Runner, resolve routeResolver, cred credResolver, sandbox *fakeSandbox, events eventSink, lastRun lastRunStateFunc, led usageRecorder) *delegatedRunner {
-	r := NewDelegatedRunner(native, resolve, cred, sandbox.Exec, events, lastRun, led, slog.Default()).(*delegatedRunner)
+	r := NewDelegatedRunner(native, resolve, cred, sandbox.Exec, events, lastRun, led, nil, slog.Default()).(*delegatedRunner)
 	r.pollInterval = 2 * time.Millisecond
 	r.idleTimeout = 30 * time.Millisecond
 	return r
@@ -505,6 +514,46 @@ func TestDelegatedRunWorker_MissingResult_ForcedRetry(t *testing.T) {
 	}
 	if events.count("executor.died") != 1 {
 		t.Fatalf("executor.died count = %d, want 1", events.count("executor.died"))
+	}
+}
+
+// --- scenario 2b: wall-clock run budget hit (issue #498) -----------------
+
+func TestDelegatedRunWorker_RunBudgetExit_RecordedAsRunBudget(t *testing.T) {
+	fixture := loadDelegatedFixture(t, "schema.ndjson")
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = fixture[:len(fixture)-1]
+	sandbox.seedExitCode = runBudgetExitCode
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	budgetReads := 0
+	r.runBudgetFn = func(context.Context) time.Duration { budgetReads++; return 3 * time.Hour }
+	m := testMission("m1", t.TempDir())
+
+	verdict, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if verdict.Outcome != "retry" || !verdict.Forced {
+		t.Fatalf("verdict = %+v, want forced retry", verdict)
+	}
+	if budgetReads != 1 {
+		t.Fatalf("run budget read %d times, want once per launch", budgetReads)
+	}
+	if !strings.Contains(sandbox.lastLaunchCmd(), "timeout -k 30 10800 ") {
+		t.Fatalf("launch cmd does not carry the settings-backed budget: %s", sandbox.lastLaunchCmd())
+	}
+	died, ok := events.last("executor.died")
+	if !ok {
+		t.Fatal("no executor.died event")
+	}
+	var payload map[string]any
+	_ = json.Unmarshal(died.Payload, &payload)
+	if payload["reason"] != "run_budget" {
+		t.Fatalf("executor.died reason = %v, want run_budget", payload["reason"])
 	}
 }
 
@@ -638,7 +687,7 @@ func TestDelegatedRunWorker_ReattachResumesWithoutRespawning(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	r.recordSpawned(context.Background(), m.ID, m.Harness, entry, runID, rdir, authMode)
-	if err := r.launch(context.Background(), m.ID, m.Environment, m.WorkRoot(), rdir, inv); err != nil {
+	if err := r.launch(context.Background(), m.ID, m.Environment, m.WorkRoot(), rdir, inv, time.Minute); err != nil {
 		t.Fatalf("launch: %v", err)
 	}
 	// One poll tick's worth of progress, then the "process" (this test's

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -94,7 +94,18 @@ const (
 	// ask_user park waits forever unless the operator opts in, same
 	// 0-means-off convention as ValuePermissionTimeoutSeconds.
 	ValueAskTimeoutSeconds = "ask_timeout_seconds"
+	// ValueExecutorRunBudgetMinutes caps one delegated executor run's
+	// wall clock (missions/delegated.go, issue #498); "" (the default)
+	// defers to DefaultExecutorRunBudget. A runaway backstop only: the
+	// idle timeout, cost budget and max_iterations are what actually
+	// stop a broken run, so this stays large enough that a healthy
+	// multi-hour coding mission never hits it.
+	ValueExecutorRunBudgetMinutes = "executor_run_budget_minutes"
 )
+
+// DefaultExecutorRunBudget is the wall-clock cap a delegated executor
+// run gets when ValueExecutorRunBudgetMinutes is unset.
+const DefaultExecutorRunBudget = 8 * time.Hour
 
 var knownValueKeys = map[string]bool{
 	ValueTokenBudget: true, ValueSkillsAllowlist: true,
@@ -104,6 +115,7 @@ var knownValueKeys = map[string]bool{
 	ValueGitBranchPattern: true, ValueGitCommitStyle: true,
 	ValueWebBaseURL: true, ValueTimezone: true,
 	ValuePermissionTimeoutSeconds: true, ValueAskTimeoutSeconds: true,
+	ValueExecutorRunBudgetMinutes: true,
 }
 
 // allowedCurrencies is the flat, fixed list of ISO 4217 codes the
@@ -206,6 +218,17 @@ func (s *Store) AskTimeoutSeconds(ctx context.Context) int {
 		}
 	}
 	return 0
+}
+
+// ExecutorRunBudget parses the delegated executor wall-clock cap,
+// falling back to DefaultExecutorRunBudget when unset or unparsable.
+func (s *Store) ExecutorRunBudget(ctx context.Context) time.Duration {
+	if v := s.Value(ctx, ValueExecutorRunBudgetMinutes); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Minute
+		}
+	}
+	return DefaultExecutorRunBudget
 }
 
 // DefaultCurrency returns the configured default currency, falling
@@ -349,7 +372,7 @@ func (s *Store) SetValue(ctx context.Context, key, value string) error {
 		return fmt.Errorf("unknown setting %q", key)
 	}
 	value = strings.TrimSpace(value)
-	if key == ValueTokenBudget && value != "" {
+	if (key == ValueTokenBudget || key == ValueExecutorRunBudgetMinutes) && value != "" {
 		if n, err := strconv.Atoi(value); err != nil || n <= 0 {
 			return fmt.Errorf("%s must be a positive integer or empty", key)
 		}

--- a/internal/brain/settings/settings_integration_test.go
+++ b/internal/brain/settings/settings_integration_test.go
@@ -147,6 +147,21 @@ func TestRuntimeValueSettings(t *testing.T) {
 	if err := s.SetValue(ctx, "nope", "x"); err == nil {
 		t.Fatal("unknown value key accepted")
 	}
+	if err := s.SetValue(ctx, ValueExecutorRunBudgetMinutes, "0"); err == nil {
+		t.Fatal("zero run budget accepted")
+	}
+	if got := s.ExecutorRunBudget(ctx); got != DefaultExecutorRunBudget {
+		t.Fatalf("ExecutorRunBudget default = %v, want %v", got, DefaultExecutorRunBudget)
+	}
+	if err := s.SetValue(ctx, ValueExecutorRunBudgetMinutes, "90"); err != nil {
+		t.Fatalf("SetValue run budget: %v", err)
+	}
+	if got := s.ExecutorRunBudget(ctx); got != 90*time.Minute {
+		t.Fatalf("ExecutorRunBudget = %v, want 90m", got)
+	}
+	if err := s.SetValue(ctx, ValueExecutorRunBudgetMinutes, ""); err != nil {
+		t.Fatalf("clear run budget: %v", err)
+	}
 
 	if err := s.SetValue(ctx, ValueTokenBudget, "120000"); err != nil {
 		t.Fatalf("SetValue budget: %v", err)

--- a/web/src/components/settings/FeaturesTab.tsx
+++ b/web/src/components/settings/FeaturesTab.tsx
@@ -101,6 +101,7 @@ export function FeaturesTab() {
       {values && <TimezoneCard values={values} onError={setError} onSaved={refresh} />}
       {values && <DefaultCurrencyCard values={values} onError={setError} onSaved={refresh} />}
       {values && <DefaultCodingExecutorCard values={values} onError={setError} onSaved={refresh} />}
+      {values && <ExecutorRunBudgetCard values={values} onError={setError} onSaved={refresh} />}
       {values && <GitBranchPatternCard values={values} onError={setError} onSaved={refresh} />}
       {values && <GitCommitStyleCard values={values} onError={setError} onSaved={refresh} />}
       <NotificationSoundCard />
@@ -249,6 +250,63 @@ function DefaultCodingExecutorCard({
       </div>
       <p className="mt-2 text-xs text-muted-foreground">
         New coding missions delegate to this harness unless overridden at creation time.
+      </p>
+    </div>
+  )
+}
+
+// EXECUTOR_RUN_BUDGET_DEFAULT_MIN mirrors settings.DefaultExecutorRunBudget
+// (8h) for the placeholder; the server applies the real default.
+const EXECUTOR_RUN_BUDGET_DEFAULT_MIN = 480
+
+// ExecutorRunBudgetCard sets the wall-clock cap for one delegated
+// harness run (issue #498). A runaway backstop, not a watchdog: the
+// idle timeout and cost budget stop a broken run, so this only needs
+// to be larger than any healthy run.
+function ExecutorRunBudgetCard({
+  values,
+  onError,
+  onSaved,
+}: {
+  values: Record<string, string>
+  onError: (msg: string) => void
+  onSaved: () => void
+}) {
+  const [minutes, setMinutes] = useState(values.executor_run_budget_minutes ?? '')
+  const [saved, setSaved] = useState(false)
+
+  const save = () => {
+    setSaved(false)
+    patchSettingValues({ executor_run_budget_minutes: minutes.trim() })
+      .then(() => {
+        setSaved(true)
+        onSaved()
+      })
+      .catch((err: unknown) => onError(errText(err)))
+  }
+
+  return (
+    <div className="rounded-xl border border-border p-4">
+      <div className="text-sm font-medium">Harness run budget</div>
+      <div className="mt-3 flex flex-wrap items-end gap-3">
+        <div className="grid gap-1 text-xs text-muted-foreground">
+          <span>Minutes per run</span>
+          <Input
+            type="number"
+            min={1}
+            value={minutes}
+            onChange={(e) => setMinutes(e.target.value)}
+            placeholder={String(EXECUTOR_RUN_BUDGET_DEFAULT_MIN)}
+            className="h-10 w-40"
+            aria-label="Harness run budget minutes"
+          />
+        </div>
+        <Button onClick={save}>Save</Button>
+        {saved && <span className="text-xs text-muted-foreground">Saved.</span>}
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Wall-clock cap for one delegated coding run. Empty uses the default (8 hours). A run that
+        stops producing output is killed by the 10-minute idle timeout regardless.
       </p>
     </div>
   )


### PR DESCRIPTION
## Summary
- New setting `executor_run_budget_minutes` (default 8h, `settings.DefaultExecutorRunBudget`) read once per delegated launch; the runner's fixed 90m `runBudgetDefault` is now only the unwired fallback.
- `timeout` exit 124 is recorded as `executor.died` reason `run_budget` instead of `transport_death`.
- Features settings page gets a "Harness run budget" card next to the default harness.
- Global setting instead of a per-agent column (noted on the issue): no ALTER, and `coding_executor` already lives there.

Closes #498

## Test plan
- [x] `TestDelegatedRunWorker_RunBudgetExit_RecordedAsRunBudget`: budget read once per launch, lands in the `timeout` argv, exit 124 -> `run_budget`
- [x] settings integration test: validation (0 rejected), default, set, clear
- [x] `make build vet lint`, missions/settings/brain tests, web build + lint

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790897223&installation_model_id=431401&pr_number=502&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F502&signature=156704fcc9c554140b97770bde248d24fec55975c062643095fa0589fc9cd47c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->