### PR TITLE
feat(missions): name the mission before cutting its branch

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -815,7 +815,6 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		failMission(w, err)
 		return
 	}
-	h.generateName(id, req.Goal)
 	// Re-read rather than echo req/m back: Driver.Create's own
 	// provisioning (ensureProvisioned) can mutate the row before this
 	// handler ever sees it again — environment auto-detection in
@@ -830,8 +829,12 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 	created, err := h.store.Get(r.Context(), id)
 	if err != nil {
 		h.log.Warn("mission: re-read after create failed", "mission_id", id, "error", err)
+		h.generateName(id, req.Goal)
 		writeJSON(w, http.StatusCreated, map[string]string{"id": id})
 		return
+	}
+	if created.Name == "" {
+		h.generateName(id, req.Goal)
 	}
 	writeJSON(w, http.StatusCreated, h.decorateTopModels(r.Context(), []missions.Mission{sanitizeMission(created)})[0])
 }
@@ -973,7 +976,10 @@ func (h *missionAPI) resolveAttachments(w http.ResponseWriter, ctx context.Conte
 
 // generateName fires the mission's one-shot naming call in the
 // background — never blocks or fails create, mirrors chat.autoTitle's
-// fire-and-forget shape exactly. Detached from the request context
+// fire-and-forget shape exactly. Since issue #494 the driver names a
+// mission synchronously before cutting its branch, so this only runs
+// when create returned a still-unnamed row (driver naming unwired or
+// failed). Detached from the request context
 // (context.Background()) so a client disconnect right after create
 // doesn't cancel it; nameMission carries its own short timeout
 // (chat.TitleOverGateway). SetNameIfEmpty's own guard is what makes

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -451,12 +451,15 @@ func (d *Driver) SetMemoryExtract(fn MemoryExtract) {
 	d.memory = fn
 }
 
-// SetNameMission installs the display-name generator used to backfill
-// missions that reached a terminal phase without a name (the create-time
-// fire-and-forget call failed). A setter for the same reason
-// SetMemoryExtract is. Optional — nil leaves unnamed missions unnamed.
+// SetNameMission installs the display-name generator: ensureProvisioned
+// names a mission before its branch is cut so the slug comes from the
+// title, not the goal (issue #494), and runResult backfills any mission
+// that still reached a terminal phase unnamed. A setter for the same
+// reason SetMemoryExtract is. Optional — nil leaves unnamed missions
+// unnamed and branches slugged from the goal, same as before.
 func (d *Driver) SetNameMission(fn func(context.Context, string) string) {
 	d.nameMission = fn
+	d.provision.nameMission = fn
 }
 
 // DestinationDeliver delivers a mission's generated output to its

--- a/internal/brain/missions/driver_integration_test.go
+++ b/internal/brain/missions/driver_integration_test.go
@@ -32,7 +32,7 @@ func TestDriverEndToEndCodingMission(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	ws, wt, branch, base, _, err := workspace.Provision(ctx, id, marker+"e2e coding", "coding", "", "", nil, "", "")
+	ws, wt, branch, base, _, err := workspace.Provision(ctx, id, marker+"e2e coding", "", "coding", "", "", nil, "", "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -1959,6 +1959,63 @@ func TestDriverProvisionFallsBackToDefaultBranchPattern(t *testing.T) {
 	}
 }
 
+// TestDriverProvisionNamesMissionBeforeBranch confirms ensureProvisioned
+// generates and stores the display name first and slugs the branch
+// from it, not the goal (issue #494); {type} still derives from the goal.
+func TestDriverProvisionNamesMissionBeforeBranch(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Goal: "Absolutely. Below is a handoff-ready fix for the login bug", Kind: "coding",
+		Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+	})
+	sessions := &fakeSessionCreator{}
+	workspace := NewWorkspace(t.TempDir(), nil, slog.Default())
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
+	d := NewDriver(store, runner, workspace, nil, sessions, &fakeGranter{}, nil, nil, slog.Default())
+	calls := 0
+	d.SetNameMission(func(context.Context, string) string { calls++; return "Login Bug Fix" })
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Name != "Login Bug Fix" {
+		t.Fatalf("Name = %q, want the generated title stored before provisioning", m.Name)
+	}
+	if got, want := m.Branch, "fix/login-bug-fix"; got != want {
+		t.Fatalf("Branch = %q, want %q (slug from title, type from goal)", got, want)
+	}
+	if calls != 1 {
+		t.Fatalf("nameMission called %d times, want exactly once", calls)
+	}
+}
+
+// TestDriverProvisionFallsBackToGoalSlugWhenNamingFails confirms an empty
+// title leaves the branch slugged from the goal, as before #494.
+func TestDriverProvisionFallsBackToGoalSlugWhenNamingFails(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Goal: "Fix the login bug", Kind: "coding",
+		Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+	})
+	sessions := &fakeSessionCreator{}
+	workspace := NewWorkspace(t.TempDir(), nil, slog.Default())
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
+	d := NewDriver(store, runner, workspace, nil, sessions, &fakeGranter{}, nil, nil, slog.Default())
+	d.SetNameMission(func(context.Context, string) string { return "" })
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Name != "" {
+		t.Fatalf("Name = %q, want empty when generation returns nothing", m.Name)
+	}
+	if got, want := m.Branch, "fix/fix-the-login-bug"; got != want {
+		t.Fatalf("Branch = %q, want %q (goal slug fallback)", got, want)
+	}
+}
+
 // TestDriverProvisionThreadsSigningKeyFromIdentityResolver proves a
 // CloneIdentityResolver returning a non-empty SigningKey reaches the
 // clone's LOCAL git config (user.signingkey/gpg.format/commit.gpgsign)

--- a/internal/brain/missions/provision.go
+++ b/internal/brain/missions/provision.go
@@ -62,6 +62,13 @@ type provisioner struct {
 	// resolve error) falls straight through to the parent-branch base,
 	// same as before this existed.
 	resolvePRState PRStateResolver
+
+	// nameMission generates the display name (Driver.SetNameMission).
+	// ensureProvisioned calls it before cutting the branch so the slug
+	// is the title's, not the goal's (issue #494). nil-safe: unset
+	// leaves the mission unnamed here and the branch slugged from the
+	// goal; runResult's backfill still names it later.
+	nameMission func(context.Context, string) string
 }
 
 // ensureProvisioned gives a mission everything Create used to set up
@@ -80,6 +87,29 @@ type provisioner struct {
 // provisioning halves below — same shape as Create always had, plus
 // the new ApprovalAllowlist grants (via resolveAgent) once a session
 // exists, whichever half of ensureProvisioned actually created it.
+// nameBeforeBranch generates and stores the mission's display name when
+// it has none yet, so Provision can slug the branch from it (issue
+// #494). Synchronous on purpose: the branch is cut once and never
+// renamed, so this is the only moment the title can still shape it.
+// nameMission carries its own short timeout; an empty result just
+// leaves the goal as the slug source, same as before.
+func (p *provisioner) nameBeforeBranch(ctx context.Context, m Mission) Mission {
+	if m.Name != "" || p.nameMission == nil {
+		return m
+	}
+	name := p.nameMission(ctx, m.Goal)
+	if name == "" {
+		p.log.Warn("driver: name generation returned empty before provisioning; branch slug falls back to the goal", "mission_id", m.ID)
+		return m
+	}
+	if err := p.store.SetNameIfEmpty(ctx, m.ID, name); err != nil {
+		p.log.Warn("driver: set name before provisioning failed", "mission_id", m.ID, "error", err)
+		return m
+	}
+	m.Name = name
+	return m
+}
+
 func (p *provisioner) ensureProvisioned(ctx context.Context, m Mission) (Mission, error) {
 	if m.SessionID == "" && p.sessions != nil {
 		sessionID, err := p.sessions.Create(ctx, "")
@@ -127,7 +157,8 @@ func (p *provisioner) ensureProvisioned(ctx context.Context, m Mission) (Mission
 			branchPattern = p.gitBranchPattern(ctx)
 		}
 		baseRef := p.followUpBaseRef(ctx, m)
-		workspace, worktree, branch, baseCommit, baseUsed, err := p.workspace.Provision(ctx, m.ID, m.Goal, m.Kind, repoURL, token, connIdentity, branchPattern, baseRef)
+		m = p.nameBeforeBranch(ctx, m)
+		workspace, worktree, branch, baseCommit, baseUsed, err := p.workspace.Provision(ctx, m.ID, m.Goal, m.Name, m.Kind, repoURL, token, connIdentity, branchPattern, baseRef)
 		if err != nil {
 			return m, fmt.Errorf("provision: %w", err)
 		}

--- a/internal/brain/missions/worktree.go
+++ b/internal/brain/missions/worktree.go
@@ -73,8 +73,11 @@ func NewWorkspace(root string, identity func(context.Context) (name, email strin
 // default branch on any error (see cloneRepo) — baseUsed reports which
 // ref the new branch actually landed on ("" for a self-init'd mission,
 // or the clone's default branch on fallback), so the caller can record
-// an accurate note.
-func (w *Workspace) Provision(ctx context.Context, missionID, goal, kind, repoURL, token string, connIdentity *GitIdentity, branchPattern, baseRef string) (workspace, worktree, branch, baseCommit, baseUsed string, err error) {
+// an accurate note. name is the mission's display name when already
+// generated: the branch {slug} comes from it (issue #494), falling back
+// to the goal when empty; {type} always derives from the goal, whose
+// wording ("fix", "docs") carries the intent a six-word title drops.
+func (w *Workspace) Provision(ctx context.Context, missionID, goal, name, kind, repoURL, token string, connIdentity *GitIdentity, branchPattern, baseRef string) (workspace, worktree, branch, baseCommit, baseUsed string, err error) {
 	workspace = filepath.Join(w.root, kind, missionID)
 	if err := os.MkdirAll(workspace, 0o750); err != nil {
 		return "", "", "", "", "", fmt.Errorf("worktree: provision: mkdir %s: %w", workspace, err)
@@ -91,7 +94,11 @@ func (w *Workspace) Provision(ctx context.Context, missionID, goal, kind, repoUR
 	if connIdentity != nil {
 		login = connIdentity.Login
 	}
-	branch = ExpandBranchPattern(branchPattern, CommitType(goal), Slug(goal, missionID), login, branchDate())
+	slugSource := name
+	if slugSource == "" {
+		slugSource = goal
+	}
+	branch = ExpandBranchPattern(branchPattern, CommitType(goal), Slug(slugSource, missionID), login, branchDate())
 	worktree = filepath.Join(workspace, "wt")
 
 	if repoURL != "" {

--- a/internal/brain/missions/worktree_integration_test.go
+++ b/internal/brain/missions/worktree_integration_test.go
@@ -19,7 +19,7 @@ func TestProvisionNonCodingMission(t *testing.T) {
 	w := newTestWorkspace(t)
 	ctx := context.Background()
 
-	workspace, worktree, branch, baseCommit, _, err := w.Provision(ctx, "mission-2", "Do something", "general", "", "", nil, "", "")
+	workspace, worktree, branch, baseCommit, _, err := w.Provision(ctx, "mission-2", "Do something", "", "general", "", "", nil, "", "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}

--- a/internal/brain/missions/worktree_test.go
+++ b/internal/brain/missions/worktree_test.go
@@ -229,7 +229,7 @@ func TestProvisionWorkspacePathIncludesKind(t *testing.T) {
 	w := newTestWorkspace(t)
 	ctx := context.Background()
 
-	workspace, _, _, _, _, err := w.Provision(ctx, "mission-kind-1", "Fix the login bug", "coding", "", "", nil, "", "")
+	workspace, _, _, _, _, err := w.Provision(ctx, "mission-kind-1", "Fix the login bug", "", "coding", "", "", nil, "", "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestProvisionWorkspacePathIncludesKind(t *testing.T) {
 		t.Fatalf("workspace = %q, want %q", workspace, want)
 	}
 
-	workspace2, _, _, _, _, err := w.Provision(ctx, "mission-kind-2", "Summarize the doc", "general", "", "", nil, "", "")
+	workspace2, _, _, _, _, err := w.Provision(ctx, "mission-kind-2", "Summarize the doc", "", "general", "", "", nil, "", "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -256,7 +256,7 @@ func TestProvisionCodingMissionSelfInitsRepo(t *testing.T) {
 	w := newTestWorkspace(t)
 	ctx := context.Background()
 
-	workspace, worktree, branch, baseCommit, _, err := w.Provision(ctx, "mission-self", "Fix the login bug", "coding", "", "", nil, "", "")
+	workspace, worktree, branch, baseCommit, _, err := w.Provision(ctx, "mission-self", "Fix the login bug", "", "coding", "", "", nil, "", "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -310,7 +310,7 @@ func TestProvisionSelfInitRollbackAndCommitUnit(t *testing.T) {
 	w := newTestWorkspace(t)
 	ctx := context.Background()
 
-	_, worktree, _, _, _, err := w.Provision(ctx, "mission-self-2", "Add a feature", "coding", "", "", nil, "", "")
+	_, worktree, _, _, _, err := w.Provision(ctx, "mission-self-2", "Add a feature", "", "coding", "", "", nil, "", "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -368,7 +368,7 @@ func TestProvisionClonesRepo(t *testing.T) {
 	gitRun(t, seed, "remote", "add", "origin", bare)
 	gitRun(t, seed, "push", "-q", "origin", "main")
 
-	workspace, worktree, branch, baseCommit, _, err := w.Provision(ctx, "mission-clone", "Fix the login bug", "coding", bare, "dummy-token", nil, "", "")
+	workspace, worktree, branch, baseCommit, _, err := w.Provision(ctx, "mission-clone", "Fix the login bug", "", "coding", bare, "dummy-token", nil, "", "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -433,7 +433,7 @@ func TestProvisionClonesRepoWithBaseRef(t *testing.T) {
 		t.Fatal("test setup: parent branch commit must differ from main")
 	}
 
-	_, worktree, branch, baseCommit, baseUsed, err := w.Provision(ctx, "mission-followup", "Continue the work", "coding", bare, "dummy-token", nil, "", "feat/parent-work")
+	_, worktree, branch, baseCommit, baseUsed, err := w.Provision(ctx, "mission-followup", "Continue the work", "", "coding", bare, "dummy-token", nil, "", "feat/parent-work")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -482,7 +482,7 @@ func TestProvisionClonesRepoWithUnreachableBaseRefFallsBack(t *testing.T) {
 	gitRun(t, seed, "push", "-q", "origin", "main")
 	mainCommit := strings.TrimSpace(gitRun(t, seed, "rev-parse", "main"))
 
-	_, worktree, branch, baseCommit, baseUsed, err := w.Provision(ctx, "mission-followup-missing", "Continue the work", "coding", bare, "dummy-token", nil, "", "does-not-exist")
+	_, worktree, branch, baseCommit, baseUsed, err := w.Provision(ctx, "mission-followup-missing", "Continue the work", "", "coding", bare, "dummy-token", nil, "", "does-not-exist")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -528,7 +528,7 @@ func TestProvisionClonesRepoWithConnIdentity(t *testing.T) {
 	gitRun(t, seed, "push", "-q", "origin", "main")
 
 	identity := &GitIdentity{Name: "conn-bot", Email: "conn-bot@example.com"}
-	_, worktree, _, _, _, err := w.Provision(ctx, "mission-conn-identity", "Fix the login bug", "coding", bare, "dummy-token", identity, "", "")
+	_, worktree, _, _, _, err := w.Provision(ctx, "mission-conn-identity", "Fix the login bug", "", "coding", bare, "dummy-token", identity, "", "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -591,7 +591,7 @@ func TestProvisionClonesRepoWithSigningKey(t *testing.T) {
 
 	privatePEM, publicLine := testSigningKeypair(t)
 	identity := &GitIdentity{Name: "conn-bot", Email: "conn-bot@example.com", SigningKey: privatePEM}
-	workspace, worktree, _, _, _, err := w.Provision(ctx, "mission-signing", "Fix the login bug", "coding", bare, "dummy-token", identity, "", "")
+	workspace, worktree, _, _, _, err := w.Provision(ctx, "mission-signing", "Fix the login bug", "", "coding", bare, "dummy-token", identity, "", "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}
@@ -674,7 +674,7 @@ func TestTeardownRemovesSelfInitRepo(t *testing.T) {
 	w := newTestWorkspace(t)
 	ctx := context.Background()
 
-	workspace, worktree, _, _, _, err := w.Provision(ctx, "mission-self-3", "Teardown test", "coding", "", "", nil, "", "")
+	workspace, worktree, _, _, _, err := w.Provision(ctx, "mission-self-3", "Teardown test", "", "coding", "", "", nil, "", "")
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
 	}


### PR DESCRIPTION
## Summary
- `provisioner.nameBeforeBranch` calls the wired `nameMission` (`chat.TitleOverGateway`, 15s cap) and stores the name via `SetNameIfEmpty` before `Workspace.Provision`.
- `Provision` gains a `name` argument: `{slug}` from the title when present, goal otherwise; `{type}` stays goal-derived.
- API create handler only fires its async naming fallback when the re-read row is still unnamed.

Closes #494

## Test plan
- [x] `TestDriverProvisionNamesMissionBeforeBranch` (title -> `fix/login-bug-fix`, name stored, generator called once)
- [x] `TestDriverProvisionFallsBackToGoalSlugWhenNamingFails`
- [x] existing Provision/worktree/api create-name tests updated and green (unit + integration against the local stack)
- [x] `make build vet lint`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790897785&installation_model_id=431401&pr_number=503&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F503&signature=f55a1ca42b7b9ab4e8675b866433467da4a67f416f8a6cc0266539e8ec9a4b6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->