### PR TITLE
feat(missions): detect environment from the real workspace

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -1045,6 +1045,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 		nativeRunner.SetConnectorReads(missionConnectorReadsResolver(agentReg, conns))
 	}
 	nativeRunner.SetProgressReader(store)
+	nativeRunner.SetEnvironmentSink(store)
 	nativeRunner.SetLocation(flags.Location)
 	nativeRunner.SetAskParker(store)
 	// The delegated runner wraps native with D-051/D-052's CLI-executor

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -643,16 +643,9 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		agentHarness, _ = h.resolveAgentHarness(r.Context(), req.AgentID)
 	}
 	req.Harness, _ = missions.ResolveHarness(r.Context(), req.Kind, req.Harness, agentHarness, h.codingExecutorDefault)
-	if req.Kind == missions.KindCoding && req.Environment == "" {
-		// Auto-detect (D-05x), resolved server-side at create time so
-		// the environment is fixed before the sandbox container is ever
-		// created: no worktree exists yet (it's provisioned after this
-		// handler returns), so only the goal-keyword heuristic can fire
-		// here — repo-marker detection has nothing to check against a
-		// mission that hasn't been provisioned. Never wins over an
-		// explicit request; "" stays "" (base) when nothing matches.
-		req.Environment, _ = missions.DetectEnvironment("", req.Goal)
-	}
+	// Environment stays "" unless the request names one: detection runs
+	// against the real workspace (repo markers after the clone, then
+	// the discover turn's report, issue #495), never against goal text.
 	// connector_id existence + kind check is a store lookup ValidateCreate
 	// can't perform (it takes no connectors dependency); repo_url's other
 	// shape rules (coding-only, requires connector_id) are ValidateCreate's.

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -662,14 +662,13 @@ func TestMissionsAnswerResumesMission(t *testing.T) {
 	}
 }
 
-// TestMissionsCreateResponseCarriesDetectedEnvironment confirms the
-// POST /v1/missions response reflects the row create() actually
-// persisted — the create() handler resolves an omitted coding
-// mission's environment (D-05x, goal-keyword heuristic) BEFORE
-// building the Mission it hands to Driver.Create, but the original bug
-// was returning only {"id": id}: the detected value was stored (a
-// later GET showed it) yet never reached the create response itself.
-func TestMissionsCreateResponseCarriesDetectedEnvironment(t *testing.T) {
+// TestMissionsCreateLeavesEnvironmentForDetection covers issue #495: a
+// coding mission created without an explicit environment stays "" in
+// both the create response and the row, even when the goal text
+// mentions a language — detection happens against the real workspace
+// (repo markers after the clone, then the discover turn), never from
+// goal keywords, which misread "go ahead" as the Go toolchain.
+func TestMissionsCreateLeavesEnvironmentForDetection(t *testing.T) {
 	store := testMissionStore(t)
 
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
@@ -677,7 +676,7 @@ func TestMissionsCreateResponseCarriesDetectedEnvironment(t *testing.T) {
 	m := mux(a)
 	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
 
-	body := `{"goal":"itest-api-mission write a Go CLI that parses logs","kind":"coding"}`
+	body := `{"goal":"itest-api-mission go ahead and write a CLI that parses logs","kind":"coding"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer tok")
 	w := httptest.NewRecorder()
@@ -690,23 +689,23 @@ func TestMissionsCreateResponseCarriesDetectedEnvironment(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
 		t.Fatalf("decode create response: %v", err)
 	}
-	if created.Environment != "go" {
-		t.Fatalf("create response environment = %q, want %q", created.Environment, "go")
+	if created.Environment != "" {
+		t.Fatalf("create response environment = %q, want empty (no goal-keyword detection)", created.Environment)
 	}
 
 	got, err := store.Get(context.Background(), created.ID)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if got.Environment != created.Environment {
-		t.Fatalf("stored environment = %q, create response = %q, want equal", got.Environment, created.Environment)
+	if got.Environment != "" {
+		t.Fatalf("stored environment = %q, want empty until the workspace decides it", got.Environment)
 	}
 }
 
 // TestMissionsCreateCarriesPlanRoute confirms a create request's
 // plan_route reaches the created mission row (both the create
 // response and a subsequent store read) — mirrors
-// TestMissionsCreateResponseCarriesDetectedEnvironment's round-trip
+// TestMissionsCreateLeavesEnvironmentForDetection's round-trip
 // shape for the new field.
 func TestMissionsCreateCarriesPlanRoute(t *testing.T) {
 	store := testMissionStore(t)

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -74,6 +74,7 @@ type driverStore interface {
 	SetLastEvidence(ctx context.Context, id, evidence string) error
 	SetFinalOutput(ctx context.Context, id, text string) error
 	SetDiscoverNotes(ctx context.Context, id, notes string) error
+	SetEnvironment(ctx context.Context, id, environment, marker string) error
 	SetNameIfEmpty(ctx context.Context, id, name string) error
 	SetArtifactRefs(ctx context.Context, id string, refs []ArtifactRef) error
 	SetDestinations(ctx context.Context, id string, entries []DestinationEntry) error
@@ -1278,7 +1279,33 @@ func (d *Driver) runDiscover(ctx context.Context, m Mission) (StepInput, error) 
 	if err := d.store.AppendEvent(ctx, m.ID, "mission.discover_complete", map[string]any{"chars": len(notes)}); err != nil {
 		d.log.Warn("driver: record discover complete failed", "mission_id", m.ID, "error", err)
 	}
+	d.recreateSandboxIfEnvironmentChanged(ctx, m)
 	return StepInput{Input: InputPhaseComplete}, nil
+}
+
+// recreateSandboxIfEnvironmentChanged removes the mission's sandbox
+// container when the discover turn just set an environment (issue
+// #495): the container's image is fixed at create, and discover's own
+// shell calls already created it on base, so without this the mission
+// would keep running on base whatever Environment now says. Discover
+// holds no CLI session, so nothing in the container is lost; the next
+// exec recreates it on the right image. Best-effort: a removal failure
+// leaves the mission on base, which is what it had before.
+func (d *Driver) recreateSandboxIfEnvironmentChanged(ctx context.Context, before Mission) {
+	if d.sandboxRemove == nil {
+		return
+	}
+	after, err := d.store.Get(ctx, before.ID)
+	if err != nil || after.Environment == before.Environment {
+		return
+	}
+	if err := d.sandboxRemove.Remove(ctx, before.ID); err != nil {
+		d.log.Warn("driver: sandbox recreate after environment change failed; mission stays on base", "mission_id", before.ID, "environment", after.Environment, "error", err)
+		return
+	}
+	if err := d.store.AppendEvent(ctx, before.ID, "mission.sandbox_recreated", map[string]any{"environment": after.Environment}); err != nil {
+		d.log.Warn("driver: record sandbox recreate failed", "mission_id", before.ID, "error", err)
+	}
 }
 
 func (d *Driver) runPlan(ctx context.Context, m Mission) (StepInput, error) {

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -173,6 +173,15 @@ func (f *fakeStore) SetDiscoverNotes(ctx context.Context, id, notes string) erro
 	return nil
 }
 
+func (f *fakeStore) SetEnvironment(ctx context.Context, id, environment, marker string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	m := f.missions[id]
+	m.Environment = environment
+	f.missions[id] = m
+	return nil
+}
+
 // SetNameIfEmpty mirrors the real Store's empty-name guard — a second
 // call for a mission that already has a name is a no-op, not an
 // overwrite.
@@ -264,6 +273,10 @@ type scriptedRunner struct {
 	discoverNotes []string
 	discoverIdx   int
 	discoverErr   error
+	// onDiscover runs inside DiscoverSession before the scripted notes
+	// return: lets a test stand in for the native runner's side effects
+	// (its environment sink write, issue #495).
+	onDiscover func(ctx context.Context, m Mission)
 }
 
 func (r *scriptedRunner) RunWorker(ctx context.Context, m Mission, packet WorkPacket) (WorkerVerdict, string, error) {
@@ -302,6 +315,9 @@ func (r *scriptedRunner) PlanSession(ctx context.Context, m Mission, discoverNot
 func (r *scriptedRunner) DiscoverSession(ctx context.Context, m Mission) (string, error) {
 	if r.discoverErr != nil {
 		return "", r.discoverErr
+	}
+	if r.onDiscover != nil {
+		r.onDiscover(ctx, m)
 	}
 	if len(r.discoverNotes) == 0 {
 		return "", nil
@@ -542,6 +558,100 @@ func TestDriverDiscoverStoresNotesAndAdvances(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("events = %+v, want a mission.discover_complete event", events)
+	}
+}
+
+// TestDriverDiscoverRecreatesSandboxOnEnvironmentChange covers issue
+// #495: when the discover turn set an environment on a mission that had
+// none, the driver removes the sandbox container (created on base by
+// discover's own shell calls) so the next exec recreates it on the new
+// image, and records mission.sandbox_recreated.
+func TestDriverDiscoverRecreatesSandboxOnEnvironmentChange(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: KindCoding, Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true,
+		SessionID: "s1", Workspace: "/already/provisioned"})
+	remover := &fakeSandboxRemover{}
+	runner := &scriptedRunner{
+		discoverNotes: []string{"fresh vite project"},
+		onDiscover: func(ctx context.Context, m Mission) {
+			_ = store.SetEnvironment(ctx, m.ID, "node", "discover")
+		},
+		plans: []Plan{{Units: []PlanUnit{{Title: "only unit"}}}},
+	}
+	d := NewDriver(store, runner, nil, nil, &fakeSessionCreator{}, &fakeGranter{}, nil, remover, slog.Default())
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if got := remover.calls(); len(got) != 1 || got[0] != "m1" {
+		t.Fatalf("sandbox Remove calls = %v, want exactly [m1]", got)
+	}
+	found := false
+	for _, ev := range store.events["m1"] {
+		if ev.Kind == "mission.sandbox_recreated" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("events = %+v, want a mission.sandbox_recreated event", store.events["m1"])
+	}
+}
+
+// TestDriverDiscoverLeavesSandboxWhenEnvironmentUnchanged is the
+// counterpart: no environment change, no container churn.
+func TestDriverDiscoverLeavesSandboxWhenEnvironmentUnchanged(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: KindCoding, Phase: PhaseDiscover, Status: StatusWorking, MaxIterations: 8, AutoApprovePlan: true,
+		SessionID: "s1", Workspace: "/already/provisioned"})
+	remover := &fakeSandboxRemover{}
+	runner := &scriptedRunner{
+		discoverNotes: []string{"nothing to report"},
+		plans:         []Plan{{Units: []PlanUnit{{Title: "only unit"}}}},
+	}
+	d := NewDriver(store, runner, nil, nil, &fakeSessionCreator{}, &fakeGranter{}, nil, remover, slog.Default())
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if got := remover.calls(); len(got) != 0 {
+		t.Fatalf("sandbox Remove calls = %v, want none", got)
+	}
+}
+
+// TestDriverProvisionDetectsEnvironmentFromRepoMarkers covers the
+// reported bug behind issue #495: a cloned repo's marker file decides
+// the environment right after the clone, before any sandbox exec.
+func TestDriverProvisionDetectsEnvironmentFromRepoMarkers(t *testing.T) {
+	requireGitForPush(t)
+	bare := t.TempDir()
+	gitRun(t, bare, "init", "-q", "--bare", "-b", "main")
+	seed := t.TempDir()
+	gitRun(t, seed, "init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(seed, "package.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, seed, "add", "package.json")
+	gitRun(t, seed, "-c", "user.name=test", "-c", "user.email=test@test", "commit", "-q", "-m", "seed")
+	gitRun(t, seed, "remote", "add", "origin", bare)
+	gitRun(t, seed, "push", "-q", "origin", "main")
+
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Goal: "go ahead and fix the login page", Kind: "coding",
+		Sources: []SourceEntry{{Source: SourceKindGitHub, RepoURL: bare, ConnectorID: "conn1"}},
+		Phase:   PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+	})
+	workspace := NewWorkspace(t.TempDir(), nil, slog.Default())
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "blocked", Question: "n/a"}}}
+	d := NewDriver(store, runner, workspace, nil, &fakeSessionCreator{}, &fakeGranter{}, nil, nil, slog.Default())
+	d.SetCloneTokenResolver(func(context.Context, string) (string, error) { return "dummy-token", nil })
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Environment != "node" {
+		t.Fatalf("Environment = %q, want node from package.json (goal text mentioning \"go\" must not matter)", m.Environment)
 	}
 }
 

--- a/internal/brain/missions/environment.go
+++ b/internal/brain/missions/environment.go
@@ -3,7 +3,6 @@ package missions
 import (
 	"os"
 	"path/filepath"
-	"regexp"
 )
 
 // Environments is the D-05x allowlist of sandbox environment keys a
@@ -11,7 +10,7 @@ import (
 // key->image map (internal/sandboxd/manager.go); kept here too so the
 // API layer can validate a create/schedule request without brain
 // importing sandboxd. "base" forces the base image explicitly
-// (distinct from "", which means "auto-detect" — see ValidEnvironment).
+// (distinct from "", which means "detect", see ValidEnvironment).
 var Environments = map[string]bool{
 	"base":   true,
 	"go":     true,
@@ -21,11 +20,11 @@ var Environments = map[string]bool{
 	"php":    true,
 }
 
-// ValidEnvironment reports whether v is "" (auto-detect) or a
-// registered environment key. "" and "base" are NOT the same: "" means
-// resolve the fallback chain (markers, then goal keyword) at create
-// time, while "base" is the operator explicitly opting out of
-// detection entirely.
+// ValidEnvironment reports whether v is "" (detect) or a registered
+// environment key. "" and "base" are NOT the same: "" means detect from
+// the real workspace once it exists (repo markers right after the
+// clone, else the discover turn's own report, issue #495), while
+// "base" is the operator explicitly opting out of detection entirely.
 func ValidEnvironment(v string) bool {
 	return v == "" || Environments[v]
 }
@@ -49,11 +48,10 @@ var environmentMarkers = []struct {
 
 // detectEnvironmentFromMarkers scans worktree's top level for a known
 // marker file, returning the implied environment and the marker that
-// matched. Returns "", "" (base) when worktree is empty/unreadable or
-// no marker matches — including a freshly self-initialized mission
-// repo, which has no marker files at provisioning time (worktree.go's
-// initSelfRepo): that's exactly the case goalEnvironmentKeyword below
-// exists to still make a reasonable guess for.
+// matched. Returns "", "" when worktree is empty/unreadable or no
+// marker matches — a freshly self-initialized mission repo has no
+// marker files, which is what the discover turn's own environment
+// report (runner.go's DiscoverSession) covers.
 func detectEnvironmentFromMarkers(worktree string) (env, marker string) {
 	if worktree == "" {
 		return "", ""
@@ -62,55 +60,6 @@ func detectEnvironmentFromMarkers(worktree string) (env, marker string) {
 		if fi, err := os.Stat(filepath.Join(worktree, m.file)); err == nil && !fi.IsDir() {
 			return m.env, m.file
 		}
-	}
-	return "", ""
-}
-
-// goalEnvironmentKeyword is the last resort in the detection chain
-// (explicit request -> repo markers -> this -> base): a fresh coding
-// mission's self-initialized repo has no marker files yet, so the
-// goal text itself is the only remaining signal. Plain word-boundary
-// regex, never an LLM call — cheap, deterministic, and resolved at
-// mission creation time so the environment is fixed before the
-// sandbox container is ever created. First matching rule wins; order
-// matters only for "golang" vs "go" (checked as a distinct alternative
-// so "go" doesn't need to worry about matching inside "golang" itself,
-// though \b already prevents that).
-var goalEnvironmentRules = []struct {
-	pattern *regexp.Regexp
-	env     string
-}{
-	{regexp.MustCompile(`(?i)\b(golang|go)\b`), "go"},
-	{regexp.MustCompile(`(?i)\b(python|pip|django|flask|pytest)\b`), "python"},
-	{regexp.MustCompile(`(?i)\b(node|npm|typescript|javascript|react|vite)\b`), "node"},
-	{regexp.MustCompile(`(?i)\b(java|maven|gradle|spring)\b`), "java"},
-	{regexp.MustCompile(`(?i)\b(php|composer|laravel)\b`), "php"},
-}
-
-// goalEnvironmentKeyword returns the environment implied by the first
-// matching keyword rule against goal, or "" if none matches.
-func goalEnvironmentKeyword(goal string) string {
-	for _, r := range goalEnvironmentRules {
-		if r.pattern.MatchString(goal) {
-			return r.env
-		}
-	}
-	return ""
-}
-
-// DetectEnvironment layers the full fallback chain below the explicit
-// request (checked by callers before ever reaching here): repo
-// markers, then the goal-keyword heuristic, then base. marker names
-// which signal fired ("go.mod", or "goal:go" for the keyword path) —
-// "" means base, nothing matched. worktree == "" (no repo yet, e.g.
-// at mission-create time before provisioning) skips straight to the
-// goal-keyword heuristic.
-func DetectEnvironment(worktree, goal string) (env, marker string) {
-	if env, marker := detectEnvironmentFromMarkers(worktree); env != "" {
-		return env, marker
-	}
-	if env := goalEnvironmentKeyword(goal); env != "" {
-		return env, "goal:" + env
 	}
 	return "", ""
 }

--- a/internal/brain/missions/environment_test.go
+++ b/internal/brain/missions/environment_test.go
@@ -6,33 +6,6 @@ import (
 	"testing"
 )
 
-func TestGoalEnvironmentKeyword(t *testing.T) {
-	cases := []struct {
-		name string
-		goal string
-		want string
-	}{
-		{"go cli", "write a Go CLI that parses logs", "go"},
-		{"golang phrasing", "refactor this golang service", "go"},
-		{"python algorithm", "implement a sorting algorithm in python", "python"},
-		{"word go inside other words does not match", "design an algorithm for the routing logic", ""},
-		{"ambiguous goal falls to base", "write some documentation about the project", ""},
-		{"node keyword", "build a react dashboard with vite", "node"},
-		{"java keyword", "set up a spring boot service with maven", "java"},
-		{"php keyword", "add a laravel controller via composer", "php"},
-		{"empty goal", "", ""},
-		{"case insensitive", "PYTHON script for data cleaning", "python"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			if got := goalEnvironmentKeyword(tc.goal); got != tc.want {
-				t.Errorf("goalEnvironmentKeyword(%q) = %q, want %q", tc.goal, got, tc.want)
-			}
-		})
-	}
-}
-
 func TestDetectEnvironmentFromMarkers(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -76,38 +49,6 @@ func TestDetectEnvironmentFromMarkers(t *testing.T) {
 		env, marker := detectEnvironmentFromMarkers("")
 		if env != "" || marker != "" {
 			t.Errorf("detectEnvironmentFromMarkers(\"\") = (%q, %q), want (\"\", \"\")", env, marker)
-		}
-	})
-}
-
-func TestDetectEnvironmentChain(t *testing.T) {
-	t.Run("marker wins over goal keyword", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(""), 0o600); err != nil {
-			t.Fatalf("write marker: %v", err)
-		}
-		env, marker := DetectEnvironment(dir, "build a python script")
-		if env != "go" || marker != "go.mod" {
-			t.Errorf("detectEnvironment = (%q, %q), want (\"go\", \"go.mod\")", env, marker)
-		}
-	})
-
-	t.Run("no marker falls back to goal keyword", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		env, marker := DetectEnvironment(dir, "write a Go CLI")
-		if env != "go" || marker != "goal:go" {
-			t.Errorf("detectEnvironment = (%q, %q), want (\"go\", \"goal:go\")", env, marker)
-		}
-	})
-
-	t.Run("nothing matches falls back to base", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		env, marker := DetectEnvironment(dir, "write some documentation")
-		if env != "" || marker != "" {
-			t.Errorf("detectEnvironment = (%q, %q), want (\"\", \"\")", env, marker)
 		}
 	})
 }

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -117,9 +117,9 @@ type Mission struct {
 	// Environment selects the per-language sandbox image (D-05x) a
 	// coding mission's container runs: "" is the base image. Unlike
 	// Harness, there is no settings default — precedence is explicit
-	// request -> auto-detect from repo markers at provisioning ->
-	// base. Sticky once set (Store.SetEnvironment), never re-detected.
-	// General missions never set this.
+	// request -> repo markers right after the clone -> the discover
+	// turn's own report -> base (issue #495). Sticky once set
+	// (Store.SetEnvironment). General missions never set this.
 	Environment       string `json:"environment,omitempty"`
 	PendingPermission string `json:"pending_permission,omitempty"`
 	// PendingPermissionTool/Args/Danger/Rationale describe the parked

--- a/internal/brain/missions/provision.go
+++ b/internal/brain/missions/provision.go
@@ -135,6 +135,20 @@ func (p *provisioner) ensureProvisioned(ctx context.Context, m Mission) (Mission
 			return m, err
 		}
 		m.Workspace, m.Branch, m.BaseCommit = workspace, branch, baseCommit
+		// Repo markers are the authoritative environment signal and are
+		// only readable now that the clone exists; this runs before any
+		// sandbox exec, so the container is created on the right image
+		// (its image is fixed at create, issue #495). A repo with no
+		// marker leaves "" for the discover turn to fill in.
+		if m.Environment == "" {
+			if env, marker := detectEnvironmentFromMarkers(worktree); env != "" {
+				if err := p.store.SetEnvironment(ctx, m.ID, env, marker); err != nil {
+					p.log.Warn("driver: set environment from markers failed", "mission_id", m.ID, "error", err)
+				} else {
+					m.Environment = env
+				}
+			}
+		}
 		if m.ParentMissionID != "" && missionPolicyFor(m).needsWorktree {
 			ref := baseUsed
 			if ref == "" {

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -220,6 +220,23 @@ type nativeRunner struct {
 	// kbSearch/kbRead: a store wiring bug degrades to "no ask_user"
 	// rather than a panic.
 	askParker askUserParker
+
+	// environmentSink persists the discover turn's environment report
+	// (issue #495): nil means the report is ignored, same nil-safe
+	// contract as askParker.
+	environmentSink environmentSetter
+}
+
+// environmentSetter is the narrow slice of *Store DiscoverSession
+// writes the discover turn's environment report through.
+type environmentSetter interface {
+	SetEnvironment(ctx context.Context, id, environment, marker string) error
+}
+
+// SetEnvironmentSink wires the store the discover turn's environment
+// report is written to, same setter pattern as SetAskParker.
+func (r *nativeRunner) SetEnvironmentSink(s environmentSetter) {
+	r.environmentSink = s
 }
 
 // SetAskParker wires the store ask_user parks against: a setter (not
@@ -1131,7 +1148,7 @@ func forcedRetryVerdict(reason string) WorkerVerdict {
 // so the ladder's last resort is the raw turn text rather than a forced
 // failure.
 func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (string, error) {
-	system := "You are discovering one mission before it is planned. Investigate the goal: explore the workspace with shell (read-only, do not create or modify files; the generate phase does the actual work), and use web search/fetch tools if available and relevant to the goal. If the goal is self-contained and needs no exploration, say so briefly. End your turn with exactly one discover_notes tool call whose findings field contains everything the planner needs: what exists, what's relevant, constraints, gotchas, unknowns." + toolDisciplineNote + r.kbDiscoverNudge(m) + r.execEnvironmentNote(ctx)
+	system := "You are discovering one mission before it is planned. Investigate the goal: explore the workspace with shell (read-only, do not create or modify files; the generate phase does the actual work), and use web search/fetch tools if available and relevant to the goal. If the goal is self-contained and needs no exploration, say so briefly. End your turn with exactly one discover_notes tool call whose findings field contains everything the planner needs: what exists, what's relevant, constraints, gotchas, unknowns." + r.discoverEnvironmentNudge(m) + toolDisciplineNote + r.kbDiscoverNudge(m) + r.execEnvironmentNote(ctx)
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if pc := m.ParentContext(); pc != "" {
 		user += "\n\nPrevious mission outcome:\n" + NeutralizeSlot(pc)
@@ -1183,8 +1200,8 @@ func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (string, 
 	if res.askedUser {
 		return "", ErrAskedUser
 	}
-	if notes, ok := tryParseFindings(res.sentinelArgs); ok {
-		return notes, nil
+	if report, ok := tryParseFindings(res.sentinelArgs); ok {
+		return r.applyDiscoverReport(ctx, m, report), nil
 	}
 
 	// One recovery re-run, same ladder shape as RunWorker/PlanSession.
@@ -1198,16 +1215,16 @@ func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (string, 
 	if err != nil {
 		return "", err
 	}
-	if notes, ok := tryParseFindings(recoverRes.sentinelArgs); ok {
-		return notes, nil
+	if report, ok := tryParseFindings(recoverRes.sentinelArgs); ok {
+		return r.applyDiscoverReport(ctx, m, report), nil
 	}
 
 	// Neither turn produced a tool call: check for a text-form sentinel
 	// before giving up on structured output entirely.
 	combined := text + "\n" + recoverText
 	if raw, ok := extractTextSentinel(combined, discoverNotesToolName); ok {
-		if notes, ok := tryParseFindings(raw); ok {
-			return notes, nil
+		if report, ok := tryParseFindings(raw); ok {
+			return r.applyDiscoverReport(ctx, m, report), nil
 		}
 	}
 
@@ -1219,15 +1236,48 @@ func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (string, 
 
 // tryParseFindings reports whether args decodes to a non-empty findings
 // string.
-func tryParseFindings(args json.RawMessage) (string, bool) {
+func tryParseFindings(args json.RawMessage) (discoverReport, bool) {
 	if len(args) == 0 {
-		return "", false
+		return discoverReport{}, false
 	}
-	findings, err := parseDiscoverFindings(args)
-	if err != nil || findings == "" {
-		return "", false
+	report, err := parseDiscoverFindings(args)
+	if err != nil || report.Findings == "" {
+		return discoverReport{}, false
 	}
-	return findings, true
+	return report, true
+}
+
+// discoverEnvironmentNudge asks the discover turn to report the
+// project's toolchain only while the mission has none yet (issue
+// #495): a repo whose markers already decided it, or an operator's
+// explicit pick, is not up for debate.
+func (r *nativeRunner) discoverEnvironmentNudge(m Mission) string {
+	if m.Kind != KindCoding || m.Environment != "" {
+		return ""
+	}
+	return " Also fill the environment field with the sandbox toolchain this project needs (from what is in the workspace, or what the goal asks to build); when the language is none of the listed values, leave environment empty and name it in the stack field."
+}
+
+// applyDiscoverReport persists the report's environment when the
+// mission has none yet and the value is a registered image key other
+// than base (issue #495); the driver recreates the sandbox container
+// afterwards. A stack the sandbox has no image for is prefixed onto
+// the findings so the planner budgets a bootstrap unit instead of
+// finding out at generate time.
+func (r *nativeRunner) applyDiscoverReport(ctx context.Context, m Mission, report discoverReport) string {
+	if m.Kind == KindCoding && m.Environment == "" && r.environmentSink != nil {
+		env := strings.ToLower(strings.TrimSpace(report.Environment))
+		if env != "" && env != "base" && Environments[env] {
+			if err := r.environmentSink.SetEnvironment(ctx, m.ID, env, "discover"); err != nil {
+				r.log.Warn("mission discover: set environment failed", "mission_id", m.ID, "environment", env, "error", err)
+			}
+		}
+	}
+	stack := strings.TrimSpace(report.Stack)
+	if stack == "" {
+		return report.Findings
+	}
+	return fmt.Sprintf("Stack: %s. The sandbox has no preinstalled toolchain for it; the plan must include a unit that installs what the work needs before building or testing.\n\n%s", NeutralizeSlot(stack), report.Findings)
 }
 
 // RunReview judges the packet: the mission's goal and plan, the

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -1792,6 +1792,75 @@ func TestDiscoverSessionIncludesAttachments(t *testing.T) {
 }
 
 // TestDiscoverSessionRecoversWhenSentinelMissingThenPresent mirrors
+// fakeEnvironmentSink records SetEnvironment calls.
+type fakeEnvironmentSink struct {
+	calls []string
+}
+
+func (f *fakeEnvironmentSink) SetEnvironment(ctx context.Context, id, environment, marker string) error {
+	f.calls = append(f.calls, id+":"+environment+":"+marker)
+	return nil
+}
+
+// TestDiscoverSessionReportsEnvironment covers issue #495: a coding
+// mission with no environment yet gets the discover turn's registered
+// value written through the sink; base and unknown keys never do.
+func TestDiscoverSessionReportsEnvironment(t *testing.T) {
+	cases := []struct {
+		name      string
+		mission   Mission
+		args      string
+		wantCalls []string
+	}{
+		{"registered key on an undecided coding mission", Mission{ID: "m1", Kind: KindCoding, Route: "default", Goal: "build a vite app"},
+			`{"findings":"fresh repo","environment":"node"}`, []string{"m1:node:discover"}},
+		{"base is not a detection", Mission{ID: "m1", Kind: KindCoding, Route: "default", Goal: "docs"},
+			`{"findings":"docs only","environment":"base"}`, nil},
+		{"unknown key ignored", Mission{ID: "m1", Kind: KindCoding, Route: "default", Goal: "rust cli"},
+			`{"findings":"cargo project","environment":"rust"}`, nil},
+		{"already decided by markers", Mission{ID: "m1", Kind: KindCoding, Environment: "go", Route: "default", Goal: "x"},
+			`{"findings":"go module","environment":"node"}`, nil},
+		{"general missions never set one", Mission{ID: "m1", Kind: "general", Route: "default", Goal: "x"},
+			`{"findings":"n/a","environment":"node"}`, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+				{toolEndEvent(discoverNotesToolName, tc.args)},
+			}}
+			r := newTestRunner(agent)
+			sink := &fakeEnvironmentSink{}
+			r.SetEnvironmentSink(sink)
+			if _, err := r.DiscoverSession(context.Background(), tc.mission); err != nil {
+				t.Fatalf("DiscoverSession: %v", err)
+			}
+			if strings.Join(sink.calls, ",") != strings.Join(tc.wantCalls, ",") {
+				t.Fatalf("SetEnvironment calls = %v, want %v", sink.calls, tc.wantCalls)
+			}
+		})
+	}
+}
+
+// TestDiscoverSessionPrefixesUnsupportedStack confirms a stack the
+// sandbox has no image for lands at the top of the findings with the
+// bootstrap instruction the planner needs (issue #495).
+func TestDiscoverSessionPrefixesUnsupportedStack(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(discoverNotesToolName, `{"findings":"Cargo.toml at the root","stack":"Rust CLI"}`)},
+	}}
+	r := newTestRunner(agent)
+	notes, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Kind: KindCoding, Route: "default", Goal: "test"})
+	if err != nil {
+		t.Fatalf("DiscoverSession: %v", err)
+	}
+	if !strings.HasPrefix(notes, "Stack: Rust CLI. The sandbox has no preinstalled toolchain") {
+		t.Fatalf("notes = %q, want the stack note first", notes)
+	}
+	if !strings.HasSuffix(notes, "Cargo.toml at the root") {
+		t.Fatalf("notes = %q, want the findings kept after the stack note", notes)
+	}
+}
+
 // RunWorker's recovery ladder: a missing sentinel on the first turn
 // gets one recovery re-run before the sentinel is trusted.
 func TestDiscoverSessionRecoversWhenSentinelMissingThenPresent(t *testing.T) {

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -588,11 +588,7 @@ func resolveTemplateDefaults(ctx context.Context, t MissionTemplate, resolve Age
 		t.Harness, _ = ResolveHarness(ctx, t.Kind, t.Harness, agentHarness, codingExecutorDefault)
 	}
 	// Environment (D-05x): no settings default (unlike Harness above) —
-	// an omitted template auto-detects from the goal at fire time. No
-	// worktree exists yet, so only the goal-keyword heuristic can fire;
-	// repo-marker detection has nothing to check.
-	if policy.needsWorktree && t.Environment == "" {
-		t.Environment, _ = DetectEnvironment("", t.Goal)
-	}
+	// an omitted template stays "" and is detected against the real
+	// workspace once it exists (issue #495), never from goal text.
 	return t, promptOverlay
 }

--- a/internal/brain/missions/sentinel.go
+++ b/internal/brain/missions/sentinel.go
@@ -148,6 +148,15 @@ func DiscoverNotesTool() *tools.Tool {
 				"findings": {
 					"type": "string",
 					"description": "Everything the planner needs: what exists, what's relevant, constraints, unknowns."
+				},
+				"environment": {
+					"type": "string",
+					"enum": ["go", "node", "python", "java", "php", "base"],
+					"description": "The sandbox toolchain this project needs, judged from what is in the workspace or, for a new project, what the goal asks to build. Omit when unsure."
+				},
+				"stack": {
+					"type": "string",
+					"description": "The project's language/stack in a few words (e.g. \"Rust CLI\", \"Ruby on Rails\") when it is not one of the environment values, so the plan can bootstrap the toolchain."
 				}
 			},
 			"required": ["findings"]
@@ -158,15 +167,22 @@ func DiscoverNotesTool() *tools.Tool {
 	}
 }
 
+// discoverReport is the parsed discover_notes call. Environment and
+// Stack are optional (issue #495): Environment names a sandbox image
+// key, Stack a language the sandbox has no image for.
+type discoverReport struct {
+	Findings    string `json:"findings"`
+	Environment string `json:"environment"`
+	Stack       string `json:"stack"`
+}
+
 // parseDiscoverFindings decodes a discover_notes tool call's arguments.
-func parseDiscoverFindings(args json.RawMessage) (string, error) {
-	var v struct {
-		Findings string `json:"findings"`
-	}
+func parseDiscoverFindings(args json.RawMessage) (discoverReport, error) {
+	var v discoverReport
 	if err := json.Unmarshal(args, &v); err != nil {
-		return "", err
+		return discoverReport{}, err
 	}
-	return v.Findings, nil
+	return v, nil
 }
 
 // WorkerVerdict is the parsed mission_status call.
@@ -226,7 +242,7 @@ func parseWorkerVerdict(args json.RawMessage) (WorkerVerdict, error) {
 var sentinelAttrs = map[string][]string{
 	missionStatusToolName: {"outcome", "evidence", "analysis", "question", "handoff", "final_output"},
 	reviewVerdictToolName: {"decision"},
-	discoverNotesToolName: {"findings"},
+	discoverNotesToolName: {"findings", "environment", "stack"},
 }
 
 // sentinelDiscriminator names the field whose value is validated

--- a/internal/brain/missions/sentinel_test.go
+++ b/internal/brain/missions/sentinel_test.go
@@ -120,12 +120,12 @@ func TestParseWorkerVerdictDecodesHandoff(t *testing.T) {
 }
 
 func TestParseDiscoverFindings(t *testing.T) {
-	findings, err := parseDiscoverFindings([]byte(`{"findings":"no prior implementation exists; goal is self-contained"}`))
+	report, err := parseDiscoverFindings([]byte(`{"findings":"no prior implementation exists; goal is self-contained"}`))
 	if err != nil {
 		t.Fatalf("parseDiscoverFindings: %v", err)
 	}
-	if findings != "no prior implementation exists; goal is self-contained" {
-		t.Fatalf("parseDiscoverFindings = %q", findings)
+	if report.Findings != "no prior implementation exists; goal is self-contained" {
+		t.Fatalf("parseDiscoverFindings = %q", report.Findings)
 	}
 }
 
@@ -134,22 +134,35 @@ func TestParseDiscoverFindings(t *testing.T) {
 // parseWorkerVerdict) — a model that emits "Findings" instead of
 // "findings" still decodes.
 func TestParseDiscoverFindingsCaseInsensitiveKey(t *testing.T) {
-	findings, err := parseDiscoverFindings([]byte(`{"Findings":"found an existing config loader to reuse"}`))
+	report, err := parseDiscoverFindings([]byte(`{"Findings":"found an existing config loader to reuse"}`))
 	if err != nil {
 		t.Fatalf("parseDiscoverFindings: %v", err)
 	}
-	if findings != "found an existing config loader to reuse" {
-		t.Fatalf("parseDiscoverFindings = %q", findings)
+	if report.Findings != "found an existing config loader to reuse" {
+		t.Fatalf("parseDiscoverFindings = %q", report.Findings)
+	}
+	if report.Environment != "" || report.Stack != "" {
+		t.Fatalf("parseDiscoverFindings environment/stack = %q/%q, want empty when omitted", report.Environment, report.Stack)
+	}
+}
+
+func TestParseDiscoverFindingsEnvironmentAndStack(t *testing.T) {
+	report, err := parseDiscoverFindings([]byte(`{"findings":"vite app","environment":"node","stack":"Rust CLI"}`))
+	if err != nil {
+		t.Fatalf("parseDiscoverFindings: %v", err)
+	}
+	if report.Environment != "node" || report.Stack != "Rust CLI" {
+		t.Fatalf("parseDiscoverFindings environment/stack = %q/%q, want node/Rust CLI", report.Environment, report.Stack)
 	}
 }
 
 func TestParseDiscoverFindingsEmpty(t *testing.T) {
-	findings, err := parseDiscoverFindings([]byte(`{"findings":""}`))
+	report, err := parseDiscoverFindings([]byte(`{"findings":""}`))
 	if err != nil {
 		t.Fatalf("parseDiscoverFindings: %v", err)
 	}
-	if findings != "" {
-		t.Fatalf("parseDiscoverFindings = %q, want empty", findings)
+	if report.Findings != "" {
+		t.Fatalf("parseDiscoverFindings = %q, want empty", report.Findings)
 	}
 }
 
@@ -202,12 +215,12 @@ func TestExtractTextSentinelDiscoverNotes(t *testing.T) {
 			if !ok {
 				return
 			}
-			findings, err := parseDiscoverFindings(raw)
+			report, err := parseDiscoverFindings(raw)
 			if err != nil {
 				t.Fatalf("parseDiscoverFindings: %v", err)
 			}
-			if findings != tc.wantVal {
-				t.Fatalf("findings = %q, want %q", findings, tc.wantVal)
+			if report.Findings != tc.wantVal {
+				t.Fatalf("findings = %q, want %q", report.Findings, tc.wantVal)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- `ensureProvisioned` runs marker detection on the cloned worktree and stores the environment before the first sandbox exec (the container image is fixed at create).
- `discover_notes` gains optional `environment` (allowlist enum) and `stack`; the native runner writes a registered environment through a store sink when the mission has none, and prefixes an unsupported stack onto the findings with a bootstrap instruction for the planner.
- `runDiscover` removes the sandbox container when discover changed the environment so the next exec recreates it on the right image (`mission.sandbox_recreated`).
- Create-time goal-keyword detection removed from the API and scheduler; `Environment` stays `""` until the workspace decides.
- Sandbox install feasibility recorded on the issue: bridge egress, uid 65534, so rootless installs only.

Closes #495

## Test plan
- [x] driver: repo with `package.json` and a goal saying "go ahead" -> `node`; env change after discover -> one `Remove` + event; unchanged -> none
- [x] runner: environment sink cases (registered / base / unknown / already set / general); stack prefix
- [x] sentinel parse tests for the new fields; api create leaves environment empty
- [x] `make build vet lint`; missions/api unit + integration (local stack)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790898820&installation_model_id=431401&pr_number=504&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F504&signature=572ceb9f87366ce9acaedb457fffd2f836c233246aed9d51dc7cd6b94578270a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->