### PR TITLE
fix(missions): keep review prompts inside the model context window

### DIFF
--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -1586,6 +1586,68 @@ func currentUnit(plan Plan) (*PlanUnit, int) {
 	return nil, -1
 }
 
+// reviewWithShrink runs RunReview, recovering from a prompt rejected
+// for exceeding the model's context window (ErrPromptTooLong) instead
+// of treating it like any other infra failure: first a cold retry with
+// the gatekeeper session dropped, then (if still too long) one retry
+// with the packet itself shrunk. Exactly one retry at each stage,
+// never a loop.
+func (d *Driver) reviewWithShrink(ctx context.Context, m Mission, packet ReviewPacket) (ReviewVerdict, error) {
+	gk := d.gatekeepers[m.ID]
+	verdict, nextGK, err := d.runner.RunReview(ctx, m, packet, gk)
+	if err == nil {
+		d.gatekeepers[m.ID] = nextGK
+		return verdict, nil
+	}
+	if !errors.Is(err, ErrPromptTooLong) {
+		return ReviewVerdict{}, err
+	}
+
+	if gk != nil {
+		delete(d.gatekeepers, m.ID)
+		if evErr := d.store.AppendEvent(ctx, m.ID, "mission.review_prompt_shrunk", map[string]any{
+			"action": "dropped_reviewer_session",
+		}); evErr != nil {
+			d.log.Warn("driver: record review prompt shrunk failed", "mission_id", m.ID, "error", evErr)
+		}
+		verdict, nextGK, err = d.runner.RunReview(ctx, m, packet, nil)
+		if err == nil {
+			d.gatekeepers[m.ID] = nextGK
+			return verdict, nil
+		}
+		if !errors.Is(err, ErrPromptTooLong) {
+			return ReviewVerdict{}, err
+		}
+	}
+
+	diffCap, artifactsCap := baselineDiffCap/4, reviewArtifactsCap/2
+	trimmed := packet
+	if wt := m.WorktreePath(); wt != "" {
+		trimmedDiff, diffErr := baselineDiffCapped(ctx, wt, m.BaseCommit, diffCap)
+		if diffErr != nil {
+			return ReviewVerdict{}, diffErr
+		}
+		trimmed.Diff = trimmedDiff
+	}
+	if unit, _ := currentUnit(m.Plan); unit != nil {
+		trimmed.Artifacts = ReadArtifactsCapped(m.WorkRoot(), unit.Artifacts, artifactsCap)
+	}
+	if evErr := d.store.AppendEvent(ctx, m.ID, "mission.review_prompt_shrunk", map[string]any{
+		"action": "trimmed_packet", "diff_cap": diffCap, "artifacts_cap": artifactsCap,
+	}); evErr != nil {
+		d.log.Warn("driver: record review prompt shrunk failed", "mission_id", m.ID, "error", evErr)
+	}
+	verdict, nextGK, err = d.runner.RunReview(ctx, m, trimmed, nil)
+	if err != nil {
+		if errors.Is(err, ErrPromptTooLong) {
+			return ReviewVerdict{}, fmt.Errorf("review_prompt_too_large: %w", err)
+		}
+		return ReviewVerdict{}, err
+	}
+	d.gatekeepers[m.ID] = nextGK
+	return verdict, nil
+}
+
 func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 	var diff string
 	if wt := m.WorktreePath(); wt != "" {
@@ -1604,12 +1666,10 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 		packet.UnitTitle = unit.Title
 		packet.Artifacts = ReadArtifacts(workRoot, unit.Artifacts)
 	}
-	gk := d.gatekeepers[m.ID]
-	verdict, nextGK, err := d.runner.RunReview(ctx, m, packet, gk)
+	verdict, err := d.reviewWithShrink(ctx, m, packet)
 	if err != nil {
 		return StepInput{}, err
 	}
-	d.gatekeepers[m.ID] = nextGK
 	// The reviewer's own worktree side effects (it may run tests) are
 	// rolled back unconditionally after every review round.
 	if wt := m.WorktreePath(); wt != "" {

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/SumonMSelim/timothy/internal/brain/fxrates"
+	"github.com/SumonMSelim/timothy/internal/gateway/provider"
 )
 
 // fakeStore is an in-memory driverStore for scripting Driver scenarios
@@ -115,7 +116,8 @@ func (f *fakeStore) ApplyTransition(ctx context.Context, id string, t Transition
 	f.missions[id] = m
 	for _, ev := range t.Events {
 		f.seq[id]++
-		f.events[id] = append(f.events[id], Event{MissionID: id, Seq: f.seq[id], Kind: ev.Kind})
+		raw, _ := json.Marshal(ev.Payload)
+		f.events[id] = append(f.events[id], Event{MissionID: id, Seq: f.seq[id], Kind: ev.Kind, Payload: raw})
 	}
 	return nil
 }
@@ -262,8 +264,16 @@ type scriptedRunner struct {
 	workerPackets  []WorkPacket
 	reviewVerdicts []ReviewVerdict
 	reviewIdx      int
-	plans          []Plan
-	planIdx        int
+	// reviewErrs scripts RunReview's error return, one entry consumed per
+	// call (nil entries are a plain success): shorter than reviewCalls,
+	// once exhausted every further call succeeds. Lets a test script an
+	// ErrPromptTooLong on the first N calls and a normal verdict after.
+	reviewErrs []error
+	// reviewCalls counts every RunReview invocation and records the
+	// gatekeeper state each one was called with, in call order.
+	reviewCalls []*GatekeeperState
+	plans       []Plan
+	planIdx     int
 	// planDiscoverNotes records the discoverNotes argument PlanSession
 	// was called with, one entry per call — lets a test assert the plan
 	// phase actually received what the discover phase stored.
@@ -296,6 +306,11 @@ func (r *scriptedRunner) RunWorker(ctx context.Context, m Mission, packet WorkPa
 }
 
 func (r *scriptedRunner) RunReview(ctx context.Context, m Mission, packet ReviewPacket, gk *GatekeeperState) (ReviewVerdict, *GatekeeperState, error) {
+	call := len(r.reviewCalls)
+	r.reviewCalls = append(r.reviewCalls, gk)
+	if call < len(r.reviewErrs) && r.reviewErrs[call] != nil {
+		return ReviewVerdict{}, nil, r.reviewErrs[call]
+	}
 	v := r.reviewVerdicts[r.reviewIdx]
 	if r.reviewIdx < len(r.reviewVerdicts)-1 {
 		r.reviewIdx++
@@ -1559,6 +1574,104 @@ func TestDriverGatekeeperCleanupOnTerminal(t *testing.T) {
 	}
 	if _, stillPresent := d.gatekeepers["m1"]; stillPresent {
 		t.Fatal("gatekeeper state was not cleaned up once the mission reached a terminal phase")
+	}
+}
+
+// TestDriverReviewPromptTooLongDropsGatekeeperAndRetries pins issue
+// #505's cold-retry path: a review round that fails with
+// ErrPromptTooLong while a gatekeeper session exists gets it dropped,
+// records mission.review_prompt_shrunk, and RunReview is retried once
+// with a nil gatekeeper.
+func TestDriverReviewPromptTooLongDropsGatekeeperAndRetries(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseProve, Status: StatusWorking, MaxIterations: 8,
+		Plan: Plan{Units: []PlanUnit{{Title: "only unit"}}},
+	})
+	runner := &scriptedRunner{
+		reviewErrs:     []error{ErrPromptTooLong},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	d := testDriver(store, runner)
+	d.gatekeepers["m1"] = &GatekeeperState{Messages: []provider.Message{{Role: "user", Content: "prior round"}}}
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if len(runner.reviewCalls) != 2 {
+		t.Fatalf("RunReview called %d times, want 2 (failed cold, then retried)", len(runner.reviewCalls))
+	}
+	if runner.reviewCalls[0] == nil {
+		t.Fatal("first RunReview call should have carried the existing gatekeeper state")
+	}
+	if runner.reviewCalls[1] != nil {
+		t.Fatal("retry after dropping the gatekeeper should pass nil state")
+	}
+	var found bool
+	for _, ev := range store.events["m1"] {
+		if ev.Kind == "mission.review_prompt_shrunk" {
+			found = true
+			var payload struct {
+				Action string `json:"action"`
+			}
+			if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+				t.Fatalf("unmarshal event payload: %v", err)
+			}
+			if payload.Action != "dropped_reviewer_session" {
+				t.Fatalf("payload.Action = %q, want dropped_reviewer_session", payload.Action)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected a mission.review_prompt_shrunk event")
+	}
+}
+
+// TestDriverReviewPromptTooLongAlwaysFailsReturnsRecognisableError
+// pins the exhaustion path: a reviewer that ALWAYS rejects with
+// ErrPromptTooLong (cold retry included) gets exactly one more retry
+// with a trimmed packet, and the final error names
+// review_prompt_too_large so the infra-pause reason is diagnosable.
+func TestDriverReviewPromptTooLongAlwaysFailsReturnsRecognisableError(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseProve, Status: StatusWorking, MaxIterations: 8,
+		Plan: Plan{Units: []PlanUnit{{Title: "only unit"}}},
+	})
+	runner := &scriptedRunner{
+		reviewErrs:     []error{ErrPromptTooLong, ErrPromptTooLong, ErrPromptTooLong},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}}, // never reached
+	}
+	d := testDriver(store, runner)
+	d.gatekeepers["m1"] = &GatekeeperState{Messages: []provider.Message{{Role: "user", Content: "prior round"}}}
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if len(runner.reviewCalls) != 3 {
+		t.Fatalf("RunReview called %d times, want exactly 3 (cold, dropped-session retry, trimmed-packet retry)", len(runner.reviewCalls))
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Status != StatusPaused || m.PauseReason != PauseInfra {
+		t.Fatalf("mission = status %q pause_reason %q, want paused/infra", m.Status, m.PauseReason)
+	}
+	var sawDetail bool
+	for _, ev := range store.events["m1"] {
+		if ev.Kind != "mission.paused" {
+			continue
+		}
+		var payload struct {
+			Detail string `json:"detail"`
+		}
+		if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+			t.Fatalf("unmarshal mission.paused payload: %v", err)
+		}
+		if strings.Contains(payload.Detail, "review_prompt_too_large") {
+			sawDetail = true
+		}
+	}
+	if !sawDetail {
+		t.Fatal("expected a mission.paused event whose detail mentions review_prompt_too_large")
 	}
 }
 

--- a/internal/brain/missions/review.go
+++ b/internal/brain/missions/review.go
@@ -62,11 +62,18 @@ type ReviewPacket struct {
 // unreadable files map to an error note rather than being dropped —
 // the reviewer must see the gap, not silently less material.
 func ReadArtifacts(workRoot string, artifacts []string) map[string]string {
+	return ReadArtifactsCapped(workRoot, artifacts, reviewArtifactsCap)
+}
+
+// ReadArtifactsCapped is ReadArtifacts with the total byte cap as a
+// parameter, so a reviewer round that overflowed the model's context
+// can retry with a smaller one (see driver.go's reviewWithShrink).
+func ReadArtifactsCapped(workRoot string, artifacts []string, limit int) map[string]string {
 	if len(artifacts) == 0 {
 		return nil
 	}
 	out := make(map[string]string, len(artifacts))
-	remaining := reviewArtifactsCap
+	remaining := limit
 	for _, a := range artifacts {
 		rel := strings.TrimSpace(a)
 		if rel == "" {
@@ -214,27 +221,58 @@ func GapFingerprint(findings []Finding) string {
 	return hex.EncodeToString(h[:])
 }
 
+// baselineDiffExcludes are pathspecs excluded from the reviewer's
+// baseline diff: lockfiles and build output carry no reviewable
+// content and were the single biggest contributor to oversized review
+// prompts.
+var baselineDiffExcludes = []string{
+	"**/package-lock.json", "**/yarn.lock", "**/pnpm-lock.yaml",
+	"**/Cargo.lock", "**/poetry.lock", "**/composer.lock", "**/Gemfile.lock",
+	"**/dist/**", "**/build/**", "**/node_modules/**", "**/vendor/**", "**/target/**",
+	"**/*.min.js", "**/*.min.css", "**/*.map",
+}
+
+// baselineDiffExcludeTrailer marks a diff as having lockfiles/build
+// output excluded, appended unconditionally to any non-empty diff,
+// since detecting whether an exclusion actually matched anything isn't
+// cheap enough to bother with.
+const baselineDiffExcludeTrailer = "\n[diff excludes lockfiles, dist/, build/, node_modules/, vendor/, target/, minified and source-map files]"
+
 // BaselineDiff runs `git diff <baseCommit>` in the mission's own
 // worktree — the reviewer judges the actual diff, never the worker's
 // account of it — capped at baselineDiffCap with a truncation marker
 // that never splits mid-line.
 func BaselineDiff(ctx context.Context, worktree, baseCommit string) (string, error) {
+	return baselineDiffCapped(ctx, worktree, baseCommit, baselineDiffCap)
+}
+
+// baselineDiffCapped is BaselineDiff with the byte cap as a parameter,
+// so a reviewer round that overflowed the model's context can retry
+// with a smaller one (see driver.go's reviewWithShrink).
+func baselineDiffCapped(ctx context.Context, worktree, baseCommit string, limit int) (string, error) {
 	if baseCommit == "" || baseCommit == unavailableCommit {
 		return "", fmt.Errorf("review: no base commit recorded for this worktree")
 	}
 	cctx, cancel := context.WithTimeout(ctx, baselineDiffTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(cctx, "git", "diff", baseCommit) //nolint:gosec // baseCommit is a git commit hash captured by our own Provision, not user input
+	args := []string{"diff", baseCommit, "--", "."}
+	for _, pattern := range baselineDiffExcludes {
+		args = append(args, ":(exclude,glob)"+pattern)
+	}
+	cmd := exec.CommandContext(cctx, "git", args...) //nolint:gosec // baseCommit is a git commit hash captured by our own Provision, not user input
 	cmd.Dir = worktree
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("review: git diff: %w", err)
 	}
-	if len(out) <= baselineDiffCap {
-		return string(out), nil
+	if len(out) == 0 {
+		return "", nil
 	}
-	cut := lastNewlineBefore(out, baselineDiffCap)
-	return string(out[:cut]) + fmt.Sprintf("\n[truncated at %d bytes: diff is %d bytes]", cut, len(out)), nil
+	if len(out) <= limit {
+		return string(out) + baselineDiffExcludeTrailer, nil
+	}
+	cut := lastNewlineBefore(out, limit)
+	return string(out[:cut]) + fmt.Sprintf("\n[truncated at %d bytes: diff is %d bytes]", cut, len(out)) + baselineDiffExcludeTrailer, nil
 }
 
 // lastNewlineBefore returns the index of the last '\n' at or before

--- a/internal/brain/missions/review_test.go
+++ b/internal/brain/missions/review_test.go
@@ -1,7 +1,9 @@
 package missions
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -89,6 +91,124 @@ func TestReadArtifactsSymlinkEscape(t *testing.T) {
 	}
 	if !strings.Contains(got, "not readable") {
 		t.Fatalf("ReadArtifacts(symlink escape) = %q, want a [not readable: ...] marker", got)
+	}
+}
+
+// gitRepo creates a temp git repo, commits the given files, returns
+// its base commit hash and worktree path; the fixture
+// TestBaselineDiffExcludesLockfilesAndBuildOutput and
+// TestBaselineDiffCappedParameter both build on.
+func gitRepo(t *testing.T, files map[string]string) (worktree, baseCommit string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...) //nolint:gosec // args are fixed test-fixture git subcommands, not user input
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	run("commit", "--allow-empty", "-q", "-m", "base")
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output() //nolint:gosec // fixed test-fixture git subcommand, not user input
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := strings.TrimSpace(string(out))
+
+	for path, content := range files {
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	run("add", "-A")
+	run("commit", "-q", "-m", "changes")
+	return dir, base
+}
+
+// TestBaselineDiffExcludesLockfilesAndBuildOutput pins the pathspec
+// syntax against a real git binary: a lockfile and a build-output file
+// change alongside a real source file, and only the source file's diff
+// survives.
+func TestBaselineDiffExcludesLockfilesAndBuildOutput(t *testing.T) {
+	worktree, base := gitRepo(t, map[string]string{
+		"src/a.ts":          "export const a = 1;\n",
+		"package-lock.json": `{"lockfileVersion": 2}` + "\n",
+		"dist/x.js":         "console.log('built');\n",
+	})
+	diff, err := BaselineDiff(context.Background(), worktree, base)
+	if err != nil {
+		t.Fatalf("BaselineDiff: %v", err)
+	}
+	if !strings.Contains(diff, "src/a.ts") {
+		t.Fatalf("diff missing src/a.ts:\n%s", diff)
+	}
+	if strings.Contains(diff, "package-lock.json") {
+		t.Fatalf("diff included excluded package-lock.json:\n%s", diff)
+	}
+	if strings.Contains(diff, "dist/x.js") {
+		t.Fatalf("diff included excluded dist/x.js:\n%s", diff)
+	}
+	if !strings.Contains(diff, baselineDiffExcludeTrailer) {
+		t.Fatalf("diff missing exclusion trailer:\n%s", diff)
+	}
+}
+
+// TestBaselineDiffCappedParameter confirms baselineDiffCapped honors a
+// smaller cap than the package default, truncating accordingly.
+func TestBaselineDiffCappedParameter(t *testing.T) {
+	worktree, base := gitRepo(t, map[string]string{
+		"big.txt": strings.Repeat("line of content here\n", 1000),
+	})
+	diff, err := baselineDiffCapped(context.Background(), worktree, base, 200)
+	if err != nil {
+		t.Fatalf("baselineDiffCapped: %v", err)
+	}
+	if !strings.Contains(diff, "truncated at") {
+		t.Fatalf("diff not truncated with a small cap:\n%s", diff)
+	}
+	if len(diff) > 200+200 { // truncation marker + trailer add bounded overhead
+		t.Fatalf("diff length %d far exceeds the 200-byte cap", len(diff))
+	}
+}
+
+// TestReviewRoundSummary confirms the compact round summary carries
+// finding titles/files/details and the verdict, never diff/artifact text.
+func TestReviewRoundSummary(t *testing.T) {
+	packet := ReviewPacket{
+		UnitTitle: "Write the report",
+		Diff:      "+this line must never appear in the summary",
+		Artifacts: map[string]string{"report.md": "artifact body must never appear either"},
+	}
+	verdict := ReviewVerdict{
+		Approved: false,
+		Findings: []Finding{
+			{Title: "missing citation", File: "report.md", Detail: "claim on line 4 has no source"},
+		},
+	}
+	summary := reviewRoundSummary(packet, verdict)
+	if !strings.Contains(summary, "Write the report") {
+		t.Fatalf("summary missing unit title: %q", summary)
+	}
+	if !strings.Contains(summary, "rework") {
+		t.Fatalf("summary missing verdict: %q", summary)
+	}
+	if !strings.Contains(summary, "missing citation") || !strings.Contains(summary, "report.md") || !strings.Contains(summary, "claim on line 4 has no source") {
+		t.Fatalf("summary missing finding detail: %q", summary)
+	}
+	if strings.Contains(summary, "must never appear") {
+		t.Fatalf("summary leaked diff/artifact content: %q", summary)
 	}
 }
 

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -30,6 +30,12 @@ import (
 // succeed.
 var ErrModelFloor = errors.New("mission turn served by a below-floor model")
 
+// ErrPromptTooLong reports that a mission turn's prompt was rejected
+// for exceeding the model's context window: the driver drops or
+// shrinks the reviewer session and retries rather than treating it as
+// an ordinary infra failure.
+var ErrPromptTooLong = errors.New("mission turn rejected: prompt exceeds the model context window")
+
 // ErrAskedUser reports that a turn ended via a successful ask_user
 // call (D-088) rather than the phase's own sentinel: every phase
 // entry point (RunWorker/DiscoverSession/PlanSession/RunReview) returns
@@ -782,6 +788,9 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if ev.Err != nil {
 				msg = ev.Err.Message
 			}
+			if strings.Contains(msg, "context_length") {
+				return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser}, fmt.Errorf("%w: %s", ErrPromptTooLong, msg)
+			}
 			return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser}, fmt.Errorf("mission runner: %s", msg)
 		}
 	}
@@ -1364,8 +1373,74 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 		return ReviewVerdict{}, nil, fmt.Errorf("mission runner: parse review_verdict: %w", err)
 	}
 
-	nextState := &GatekeeperState{Messages: append(messages, provider.Message{Role: "assistant", Content: NeutralizeSlot(text)})}
+	// D-091/issue #505: the round's full packet (goal, plan, artifacts,
+	// diff) is never retained across rounds: reviewers reword findings,
+	// so a run of reworks would otherwise compound copies of it into one
+	// prompt until every provider rejects it. Only a compact summary of
+	// this round plus the assistant's verdict is kept.
+	round := append(append([]provider.Message{}, gatekeeperMessages(gatekeeper)...),
+		provider.Message{Role: "user", Content: reviewRoundSummary(packet, verdict)},
+		provider.Message{Role: "assistant", Content: NeutralizeSlot(text)},
+	)
+	nextState := &GatekeeperState{Messages: capGatekeeperRounds(round)}
 	return verdict, nextState, nil
+}
+
+// gatekeeperMessages returns gatekeeper's prior messages, or nil when
+// gatekeeper is nil (first round).
+func gatekeeperMessages(gatekeeper *GatekeeperState) []provider.Message {
+	if gatekeeper == nil {
+		return nil
+	}
+	return gatekeeper.Messages
+}
+
+// gatekeeperRoundsCap bounds how many prior review rounds' messages
+// (user summary + assistant verdict pairs) are retained across rework
+// rounds.
+const gatekeeperRoundsCap = 4
+
+// capGatekeeperRounds drops the oldest round (a user/assistant pair)
+// once messages holds more than gatekeeperRoundsCap rounds.
+func capGatekeeperRounds(messages []provider.Message) []provider.Message {
+	maxLen := gatekeeperRoundsCap * 2
+	if len(messages) <= maxLen {
+		return messages
+	}
+	return messages[len(messages)-maxLen:]
+}
+
+// reviewRoundSummary renders a compact record of one finished review
+// round for the resumed reviewer session: the full packet is never
+// retained (see RunReview), so this summary, plus the packet's next
+// round (which IS authoritative), is all the reviewer carries forward.
+func reviewRoundSummary(packet ReviewPacket, verdict ReviewVerdict) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Prior review round for unit %s. The full goal, plan, artifacts and diff were shown in that round and are omitted here; the current round's packet below is authoritative. Verdict: ", NeutralizeSlot(packet.UnitTitle))
+	if verdict.Approved {
+		b.WriteString("approve")
+	} else {
+		b.WriteString("rework")
+	}
+	b.WriteString(". Findings:")
+	if len(verdict.Findings) == 0 {
+		b.WriteString(" none")
+		return b.String()
+	}
+	for _, f := range verdict.Findings {
+		b.WriteString("\n- ")
+		b.WriteString(NeutralizeSlot(f.Title))
+		if f.File != "" {
+			b.WriteString(" (")
+			b.WriteString(NeutralizeSlot(f.File))
+			b.WriteString(")")
+		}
+		if f.Detail != "" {
+			b.WriteString(": ")
+			b.WriteString(NeutralizeSlot(f.Detail))
+		}
+	}
+	return b.String()
 }
 
 // renderReviewContent lays the packet out for the reviewer: goal and

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -323,6 +323,64 @@ func TestRunReviewParsesVerdictAndCarriesGatekeeperState(t *testing.T) {
 	}
 }
 
+// TestRunReviewNextStateOmitsFullPacket pins issue #505: the persisted
+// gatekeeper state must never carry the round's diff/artifact text
+// (reworded across rounds, it's what compounded into a multi-megabyte
+// prompt), only a compact summary naming the finding.
+func TestRunReviewNextStateOmitsFullPacket(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(reviewVerdictToolName, `{"decision":"rework","findings":[{"title":"missing citation","file":"report.md","detail":"claim on line 4 has no source"}]}`)},
+	}}
+	r := newTestRunner(agent)
+	packet := ReviewPacket{
+		Goal:      "goal text",
+		UnitTitle: "Write the report",
+		Diff:      "+this diff line must never survive into persisted state",
+		Artifacts: map[string]string{"report.md": "this artifact body must never survive into persisted state"},
+	}
+	_, state, err := r.RunReview(context.Background(), Mission{ID: "m1", ReviewRoute: "default"}, packet, nil)
+	if err != nil {
+		t.Fatalf("RunReview: %v", err)
+	}
+	if state == nil || len(state.Messages) != 2 {
+		t.Fatalf("state.Messages = %+v, want exactly 2 (summary + verdict)", state)
+	}
+	userMsg := state.Messages[0].Content
+	if strings.Contains(userMsg, "must never survive") {
+		t.Fatalf("persisted state leaked the full packet's diff/artifact content: %q", userMsg)
+	}
+	if !strings.Contains(userMsg, "missing citation") || !strings.Contains(userMsg, "Write the report") {
+		t.Fatalf("persisted state missing finding/unit summary: %q", userMsg)
+	}
+}
+
+// TestRunReviewCapsGatekeeperRounds pins the 4-round retention cap
+// (gatekeeperRoundsCap): a 6th consecutive rework round must still
+// leave only 4 rounds' worth of messages (8), oldest dropped first.
+func TestRunReviewCapsGatekeeperRounds(t *testing.T) {
+	r := newTestRunner(nil) // agent replaced per-round below
+	var gk *GatekeeperState
+	for i := 0; i < 6; i++ {
+		agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+			{toolEndEvent(reviewVerdictToolName, fmt.Sprintf(`{"decision":"rework","findings":[{"title":"gap round %d"}]}`, i))},
+		}}
+		r.agent = agent
+		_, next, err := r.RunReview(context.Background(), Mission{ID: "m1", ReviewRoute: "default"}, ReviewPacket{UnitTitle: "unit"}, gk)
+		if err != nil {
+			t.Fatalf("round %d: RunReview: %v", i, err)
+		}
+		gk = next
+	}
+	if len(gk.Messages) != gatekeeperRoundsCap*2 {
+		t.Fatalf("Messages length = %d, want %d (cap of %d rounds)", len(gk.Messages), gatekeeperRoundsCap*2, gatekeeperRoundsCap)
+	}
+	// The oldest retained round must be round 2 (0-indexed), not round 0:
+	// six rounds capped to the last four means rounds 2-5 survive.
+	if !strings.Contains(gk.Messages[0].Content, "gap round 2") {
+		t.Fatalf("oldest retained round = %q, want round 2's summary", gk.Messages[0].Content)
+	}
+}
+
 // TestRunReviewRoutePrecedence pins review's route precedence at the
 // request level: ReviewRoute > PlanRoute > Route.
 func TestRunReviewRoutePrecedence(t *testing.T) {

--- a/internal/gateway/provider/httpx.go
+++ b/internal/gateway/provider/httpx.go
@@ -118,6 +118,8 @@ func errEvent(err error) stream.StreamEvent {
 	switch {
 	case errors.Is(err, context.DeadlineExceeded):
 		code = "timeout"
+	case perm != nil && isContextLengthMessage(perm.Error()):
+		code = "context_length"
 	case perm != nil && perm.status != 0:
 		code = fmt.Sprintf("http_%d", perm.status)
 	}
@@ -126,6 +128,34 @@ func errEvent(err error) stream.StreamEvent {
 		Message:   err.Error(),
 		Retryable: retryable,
 	}}
+}
+
+// contextLengthSignatures are provider error phrasings that mean "the
+// request itself is too big for this model's context window", a
+// prompt-shape failure, not a transient one, so it gets its own code
+// distinct from the generic http_<status>.
+var contextLengthSignatures = []string{
+	"exceeds max length",
+	"exceeds the context window",
+	"context length",
+	"context_length_exceeded",
+	"maximum context length",
+	"too many tokens",
+	"prompt is too long",
+	"input is too long",
+	"request too large",
+}
+
+// isContextLengthMessage reports whether s matches any known
+// context-length rejection phrasing, case-insensitively.
+func isContextLengthMessage(s string) bool {
+	lower := strings.ToLower(s)
+	for _, sig := range contextLengthSignatures {
+		if strings.Contains(lower, sig) {
+			return true
+		}
+	}
+	return false
 }
 
 // emit sends an event unless ctx is done; it reports whether the send

--- a/internal/gateway/provider/httpx_test.go
+++ b/internal/gateway/provider/httpx_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -63,5 +64,52 @@ func TestRetryableStatus(t *testing.T) {
 		if got := retryableStatus(code); got != want {
 			t.Fatalf("retryableStatus(%d) = %v, want %v", code, got, want)
 		}
+	}
+}
+
+func TestIsContextLengthMessage(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		msg  string
+		want bool
+	}{
+		{"Prompt exceeds max length of 128000 tokens", true},
+		{"Your input exceeds the context window of this model", true},
+		{"This model's maximum context length is 8192 tokens", true},
+		{"error code: context_length_exceeded", true},
+		{"too many tokens in the request", true},
+		{"prompt is too long for this model", true},
+		{"input is too long", true},
+		{"request too large for this model", true},
+		{"CONTEXT LENGTH exceeded", true},
+		{"invalid api key", false},
+		{"rate limit exceeded", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isContextLengthMessage(c.msg); got != c.want {
+			t.Errorf("isContextLengthMessage(%q) = %v, want %v", c.msg, got, c.want)
+		}
+	}
+}
+
+func TestErrEventContextLengthCode(t *testing.T) {
+	t.Parallel()
+	err := &permanentError{status: 400, err: fmt.Errorf("http 400: Your input exceeds the context window of this model")}
+	ev := errEvent(err)
+	if ev.Err.Code != "context_length" {
+		t.Fatalf("code = %q, want context_length", ev.Err.Code)
+	}
+	if ev.Err.Retryable {
+		t.Fatal("context_length error must not be retryable")
+	}
+}
+
+func TestErrEventHTTPStatusCode(t *testing.T) {
+	t.Parallel()
+	err := &permanentError{status: 401, err: fmt.Errorf("http 401: invalid api key")}
+	ev := errEvent(err)
+	if ev.Err.Code != "http_401" {
+		t.Fatalf("code = %q, want http_401", ev.Err.Code)
 	}
 }

--- a/internal/gateway/provider/openairesponses.go
+++ b/internal/gateway/provider/openairesponses.go
@@ -520,8 +520,12 @@ func (o *OpenAIResponses) relay(ctx context.Context, body io.Reader, ch chan<- s
 				if p.Error != nil && p.Error.Message != "" {
 					msg = p.Error.Message
 				}
+				code, retryable := "provider_error", true
+				if isContextLengthMessage(msg) {
+					code, retryable = "context_length", false
+				}
 				emit(ctx, ch, stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
-					Code: "provider_error", Message: msg, Retryable: true,
+					Code: code, Message: msg, Retryable: retryable,
 				}})
 				return false
 			}
@@ -565,8 +569,12 @@ func (o *OpenAIResponses) relay(ctx context.Context, body io.Reader, ch chan<- s
 			} else if p.Response != nil {
 				msg = fmt.Sprintf("response status %s", p.Response.Status)
 			}
+			code, retryable := "provider_error", true
+			if isContextLengthMessage(msg) {
+				code, retryable = "context_length", false
+			}
 			emit(ctx, ch, stream.StreamEvent{Type: stream.EventError, Err: &stream.StreamError{
-				Code: "provider_error", Message: msg, Retryable: true,
+				Code: code, Message: msg, Retryable: retryable,
 			}})
 			return false
 		case "response.incomplete":


### PR DESCRIPTION
## Why

Prove-phase review turns on a large coding mission failed on every provider with "Prompt exceeds max length" / "Your input exceeds the context window of this model". The reviewer session (`GatekeeperState`) retained each round's full packet, so six reworded rework rounds compounded into a ~2.3 MB prompt. Details on #505.

## What

- `RunReview` persists only a per-round summary (unit, verdict, findings) plus the assistant verdict; at most four rounds kept.
- `BaselineDiff` excludes lockfiles, `dist/`, `build/`, `node_modules/`, `vendor/`, `target/`, minified and source-map files; byte cap is now a parameter.
- Gateway emits `context_length` for context-window rejections (HTTP providers and OpenAI Responses) instead of `http_400`/`provider_error`; failover behaviour unchanged.
- Driver maps `context_length` to `ErrPromptTooLong` and retries the review once with the reviewer session dropped, then once with a trimmed packet, recording `mission.review_prompt_shrunk`; a third rejection parks with `review_prompt_too_large` in the pause detail.

## Tests

Runner (compact state, round cap), review (real git repo exclusion test, cap parameter, summary), driver (drop-and-retry, always-fails path), gateway (`isContextLengthMessage`, `errEvent` codes). `make build test vet lint` green.

Closes #505

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790900677&installation_model_id=431401&pr_number=508&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F508&signature=f9ff48c5acc459bdfe1ec28357ab5832bc8145e59c2f010bbefd61781e689b88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->