### PR TITLE
feat(missions): show live worktree changes during a delegated run

### DIFF
--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -619,6 +619,9 @@ type pollState struct {
 	textBuf       strings.Builder
 	eventCount    int
 	infraRetries  int
+	// worktree is the latest non-nil WT: summary seen across polls
+	// (issue #500); nil until the first successful git status.
+	worktree *WorktreeSummary
 }
 
 // pollToVerdict polls rdir until the run terminates (exit_code present
@@ -644,7 +647,7 @@ func (r *delegatedRunner) pollToVerdict(ctx context.Context, m Mission, workRoot
 		case <-ticker.C:
 		}
 
-		chunk, exitCode, hasExit, alive, err := r.pollOnce(ctx, m.ID, m.Environment, workRoot, rdir, runID, st.offset)
+		chunk, exitCode, hasExit, alive, worktree, err := r.pollOnce(ctx, m.ID, m.Environment, workRoot, rdir, runID, st.offset)
 		if err != nil {
 			st.infraRetries++
 			if st.infraRetries >= pollInfraRetries {
@@ -654,6 +657,9 @@ func (r *delegatedRunner) pollToVerdict(ctx context.Context, m Mission, workRoot
 			continue
 		}
 		st.infraRetries = 0
+		if worktree != nil {
+			st.worktree = worktree
+		}
 
 		if len(chunk) > 0 {
 			st.offset += int64(len(chunk))
@@ -695,38 +701,74 @@ const pollBoundaryPrefix = "---TIMOTHY-RUN-"
 // it emits between tail content and status lines. The boundary rides as
 // a printf ARGUMENT ('%s\n' format), never as the format itself: dash's
 // printf builtin rejects a format string with a leading dash as an
-// illegal option.
-func buildPollCmd(rdir, runID string, offset int64) (cmd, boundary string) {
+// illegal option. workdir is the exec's cwd (the mission worktree for
+// coding missions, see Mission.WorkRoot); the WT: line runs `git
+// status --porcelain` against it directly, since the rest of the
+// command `cd`s into rdir (a sibling run-log dir, not the worktree).
+// Everything past the ALIVE check is best-effort (issue #500): a
+// missing/non-git workdir emits no WT: line rather than failing the
+// poll.
+// wtStatusLines bounds how many git status entries the WT: summary
+// inspects per poll.
+const wtStatusLines = 200
+
+func buildPollCmd(workdir, rdir, runID string, offset int64) (cmd, boundary string) {
 	boundary = pollBoundaryPrefix + runID + "---"
+	// wtCmd checks git status's own exit code first: a git failure (not
+	// a repo, git missing) prints nothing, distinct from a clean
+	// worktree's legitimate zero lines (still WT:0 0 0). Each status
+	// line's path is columns 4+; ?? marks untracked, everything else
+	// modified; newest is the max mtime seen, 0 when no path stats. The
+	// loop reads at most wtStatusLines entries so a huge untracked tree
+	// cannot turn one poll into thousands of stat calls.
+	wtCmd := `out=$(git status --porcelain 2>/dev/null) && printf '%s\n' "$out" | head -n ` + strconv.Itoa(wtStatusLines) + ` | { ` +
+		`u=0; m=0; newest=0; ` +
+		`while IFS= read -r line; do ` +
+		`[ -z "$line" ] && continue; ` +
+		`case "$line" in '??'*) u=$((u+1));; *) m=$((m+1));; esac; ` +
+		`path=$(printf '%s' "$line" | cut -c4-); ` +
+		`mt=$(stat -c %Y -- "$path" 2>/dev/null) && [ "$mt" -gt "$newest" ] && newest=$mt; ` +
+		`done; ` +
+		`printf 'WT:%d %d %d\n' "$u" "$m" "$newest"; ` +
+		`}`
 	cmd = fmt.Sprintf(
-		`cd %s && tail -c +%d run.ndjson | head -c %d; printf '%%s\n' %s; [ -f exit_code ] && printf 'EXITCODE:%%s\n' "$(cat exit_code)"; kill -0 "$(cat pid)" 2>/dev/null && printf 'ALIVE\n'`,
-		shQuote(rdir), offset+1, tailChunkCap, shQuote(boundary),
+		`cd %s && tail -c +%d run.ndjson | head -c %d; printf '%%s\n' %s; [ -f exit_code ] && printf 'EXITCODE:%%s\n' "$(cat exit_code)"; kill -0 "$(cat pid)" 2>/dev/null && printf 'ALIVE\n'; (cd %s && %s) 2>/dev/null || true`,
+		shQuote(rdir), offset+1, tailChunkCap, shQuote(boundary), shQuote(workdir), wtCmd,
 	)
 	return cmd, boundary
 }
 
+// WorktreeSummary is the cheap per-poll worktree signal (issue #500):
+// counts only, never file contents or paths, so a working delegated
+// mission with no commits yet doesn't look stuck.
+type WorktreeSummary struct {
+	Untracked   int   `json:"untracked"`
+	Modified    int   `json:"modified"`
+	NewestMtime int64 `json:"newest_mtime"`
+}
+
 // pollOnce runs one poll exec: tails run.ndjson from offset (capped at
-// tailChunkCap), then a boundary marker, then EXITCODE:/ALIVE status —
-// all in ONE exec so the exit_code/pid reads are consistent with the
-// tail snapshot they describe.
-func (r *delegatedRunner) pollOnce(ctx context.Context, missionID, environment, workRoot, rdir, runID string, offset int64) (chunk []byte, exitCode int, hasExit bool, alive bool, err error) {
-	cmd, boundary := buildPollCmd(rdir, runID, offset)
+// tailChunkCap), then a boundary marker, then EXITCODE:/ALIVE status,
+// then the WT: worktree summary, all in ONE exec so every field
+// reflects the same snapshot.
+func (r *delegatedRunner) pollOnce(ctx context.Context, missionID, environment, workRoot, rdir, runID string, offset int64) (chunk []byte, exitCode int, hasExit bool, alive bool, worktree *WorktreeSummary, err error) {
+	cmd, boundary := buildPollCmd(workRoot, rdir, runID, offset)
 	var out bytes.Buffer
 	_, execErr := r.sandboxExec(ctx, missionID, environment, workRoot, cmd, nil, pollTimeout, &out)
 	if execErr != nil {
-		return nil, 0, false, false, execErr
+		return nil, 0, false, false, nil, execErr
 	}
 	return parsePollOutput(out.Bytes(), boundary)
 }
 
 // parsePollOutput splits pollOnce's raw output at the boundary marker:
 // everything before it is tail content, everything after is the
-// EXITCODE:/ALIVE status lines (each optional).
-func parsePollOutput(raw []byte, boundary string) (chunk []byte, exitCode int, hasExit bool, alive bool, err error) {
+// EXITCODE:/ALIVE/WT: status lines (each optional).
+func parsePollOutput(raw []byte, boundary string) (chunk []byte, exitCode int, hasExit bool, alive bool, worktree *WorktreeSummary, err error) {
 	marker := []byte(boundary + "\n")
 	idx := bytes.Index(raw, marker)
 	if idx == -1 {
-		return nil, 0, false, false, fmt.Errorf("delegated runner: poll boundary marker not found in output")
+		return nil, 0, false, false, nil, fmt.Errorf("delegated runner: poll boundary marker not found in output")
 	}
 	chunk = raw[:idx]
 	status := raw[idx+len(marker):]
@@ -737,9 +779,29 @@ func parsePollOutput(raw []byte, boundary string) (chunk []byte, exitCode int, h
 			exitCode, _ = strconv.Atoi(strings.TrimPrefix(line, "EXITCODE:"))
 		case line == "ALIVE":
 			alive = true
+		case strings.HasPrefix(line, "WT:"):
+			if ws, ok := parseWorktreeLine(strings.TrimPrefix(line, "WT:")); ok {
+				worktree = ws
+			}
 		}
 	}
-	return chunk, exitCode, hasExit, alive, nil
+	return chunk, exitCode, hasExit, alive, worktree, nil
+}
+
+// parseWorktreeLine parses "<untracked> <modified> <newest_mtime>";
+// nil on any malformed field.
+func parseWorktreeLine(fields string) (*WorktreeSummary, bool) {
+	parts := strings.Fields(fields)
+	if len(parts) != 3 {
+		return nil, false
+	}
+	untracked, err1 := strconv.Atoi(parts[0])
+	modified, err2 := strconv.Atoi(parts[1])
+	newest, err3 := strconv.ParseInt(parts[2], 10, 64)
+	if err1 != nil || err2 != nil || err3 != nil {
+		return nil, false
+	}
+	return &WorktreeSummary{Untracked: untracked, Modified: modified, NewestMtime: newest}, true
 }
 
 // feedLines advances st.carry/offset bookkeeping and hands each
@@ -948,9 +1010,13 @@ func (r *delegatedRunner) recordProgressThrottled(ctx context.Context, missionID
 		return
 	}
 	st.lastProgress = time.Now()
-	r.recordEvent(ctx, missionID, st, "executor.progress", map[string]any{
+	payload := map[string]any{
 		"run_id": runID, "byte_offset": st.offset, "turns": st.turns, "tool_calls": st.toolCalls,
-	})
+	}
+	if st.worktree != nil {
+		payload["worktree"] = st.worktree
+	}
+	r.recordEvent(ctx, missionID, st, "executor.progress", payload)
 }
 
 // recordResult writes the terminal executor.result event. status is

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -1551,6 +1551,53 @@ func shRoundTrip(quoted string) (string, error) {
 
 // --- quote escaper ----------------------------------------------------------
 
+// TestParsePollOutputWorktreeLine covers the WT: line's three states:
+// present and well-formed, absent entirely, and malformed, issue #500
+// requires nil (not an error) on the latter two.
+func TestParsePollOutputWorktreeLine(t *testing.T) {
+	const boundary = "---TIMOTHY-RUN-abc---"
+	tests := []struct {
+		name string
+		raw  string
+		want *WorktreeSummary
+	}{
+		{
+			name: "present",
+			raw:  boundary + "\nEXITCODE:0\nWT:3 1 1735689600\n",
+			want: &WorktreeSummary{Untracked: 3, Modified: 1, NewestMtime: 1735689600},
+		},
+		{
+			name: "absent",
+			raw:  boundary + "\nEXITCODE:0\nALIVE\n",
+			want: nil,
+		},
+		{
+			name: "malformed_too_few_fields",
+			raw:  boundary + "\nWT:3 1\n",
+			want: nil,
+		},
+		{
+			name: "malformed_non_numeric",
+			raw:  boundary + "\nWT:x y z\n",
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, _, worktree, err := parsePollOutput([]byte(tc.raw), boundary)
+			if err != nil {
+				t.Fatalf("parsePollOutput: %v", err)
+			}
+			if (worktree == nil) != (tc.want == nil) {
+				t.Fatalf("worktree = %+v, want %+v", worktree, tc.want)
+			}
+			if tc.want != nil && *worktree != *tc.want {
+				t.Fatalf("worktree = %+v, want %+v", worktree, tc.want)
+			}
+		})
+	}
+}
+
 // TestBuildPollCmdRealShell runs the composed poll command through a real
 // /bin/sh against an on-disk run dir — the fake sandbox re-implements the
 // poll semantics, so only a real shell catches syntax the fake forgives
@@ -1568,7 +1615,8 @@ func TestBuildPollCmdRealShell(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(rdir, "pid"), []byte("999999\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	cmd, boundary := buildPollCmd(rdir, "cafe0123beef", 0)
+	workdir := t.TempDir() // not a git repo: WT: line must be absent, not fatal
+	cmd, boundary := buildPollCmd(workdir, rdir, "cafe0123beef", 0)
 	out, err := exec.Command("/bin/sh", "-c", cmd).CombinedOutput() //nolint:gosec // G204: executing the composed command is the point of the test.
 	if err != nil {
 		// The trailing `kill -0` legitimately exits nonzero for a dead
@@ -1577,7 +1625,7 @@ func TestBuildPollCmdRealShell(t *testing.T) {
 			t.Fatalf("poll command failed: %v", err)
 		}
 	}
-	chunk, exitCode, hasExit, alive, perr := parsePollOutput(out, boundary)
+	chunk, exitCode, hasExit, alive, worktree, perr := parsePollOutput(out, boundary)
 	if perr != nil {
 		t.Fatalf("parsePollOutput: %v (raw %q)", perr, out)
 	}
@@ -1589,6 +1637,76 @@ func TestBuildPollCmdRealShell(t *testing.T) {
 	}
 	if alive {
 		t.Fatal("pid 999999 should not be alive")
+	}
+	if worktree != nil {
+		t.Fatalf("worktree = %+v, want nil (workdir is not a git repo)", worktree)
+	}
+}
+
+// TestBuildPollCmdRealShellWorktreeSummary runs the composed poll
+// command against a real git repo (issue #500): one committed file,
+// one modified, two untracked. Asserts WT:2 1 <epoch> with epoch > 0.
+func TestBuildPollCmdRealShellWorktreeSummary(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable on this host; runs in the containerized suite")
+	}
+	workdir := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...) //nolint:gosec // G204: test-only, args are fixed literals from this test.
+		cmd.Dir = workdir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+	runGit("init")
+	if err := os.WriteFile(filepath.Join(workdir, "committed.txt"), []byte("v1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "committed.txt")
+	runGit("commit", "-m", "initial")
+	if err := os.WriteFile(filepath.Join(workdir, "committed.txt"), []byte("v2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "untracked1.txt"), []byte("a\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "untracked2.txt"), []byte("b\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rdir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rdir, "run.ndjson"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rdir, "exit_code"), []byte("0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rdir, "pid"), []byte("999999\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, boundary := buildPollCmd(workdir, rdir, "beef0123cafe", 0)
+	out, err := exec.Command("/bin/sh", "-c", cmd).CombinedOutput() //nolint:gosec // G204: executing the composed command is the point of the test.
+	if err != nil && len(out) == 0 {
+		t.Fatalf("poll command failed: %v", err)
+	}
+	_, _, _, _, worktree, perr := parsePollOutput(out, boundary)
+	if perr != nil {
+		t.Fatalf("parsePollOutput: %v (raw %q)", perr, out)
+	}
+	if worktree == nil {
+		t.Fatalf("worktree = nil, want a summary (raw %q)", out)
+	}
+	if worktree.Untracked != 2 || worktree.Modified != 1 {
+		t.Fatalf("worktree = %+v, want {Untracked:2 Modified:1}", worktree)
+	}
+	if worktree.NewestMtime <= 0 {
+		t.Fatalf("worktree.NewestMtime = %d, want > 0", worktree.NewestMtime)
 	}
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -928,6 +928,11 @@ export interface ExecutorProgressPayload {
   byte_offset: number
   turns: number
   tool_calls: number
+  worktree?: {
+    untracked: number
+    modified: number
+    newest_mtime: number
+  }
 }
 
 export interface ExecutorResultPayload {

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -407,6 +407,71 @@ describe('MissionDetail retries/turns/processing/elapsed', () => {
   })
 })
 
+describe('MissionDetail executor worktree summary (issue #500)', () => {
+  it('shows untracked/modified counts and a relative changed time from executor.progress', async () => {
+    vi.mocked(missionEvents).mockResolvedValue([
+      ...events,
+      {
+        mission_id: 'm1',
+        seq: 5,
+        kind: 'executor.progress',
+        payload: {
+          run_id: 'r1',
+          byte_offset: 100,
+          turns: 3,
+          tool_calls: 1,
+          worktree: { untracked: 3, modified: 1, newest_mtime: Math.floor((Date.now() - 2 * 60_000) / 1000) },
+        },
+        provenance: 'live',
+        created_at: '2026-01-01T00:04:00Z',
+      },
+    ])
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    expect(await screen.findByText(/3 new · 1 modified · changed 2m ago/)).toBeTruthy()
+  })
+
+  it('renders turns/tool calls without a worktree segment for the legacy payload shape', async () => {
+    vi.mocked(missionEvents).mockResolvedValue([
+      ...events,
+      {
+        mission_id: 'm1',
+        seq: 5,
+        kind: 'executor.progress',
+        payload: { run_id: 'r1', byte_offset: 100, turns: 3, tool_calls: 1 },
+        provenance: 'live',
+        created_at: '2026-01-01T00:04:00Z',
+      },
+    ])
+    renderPage()
+    expect(await screen.findByText(/3 turns, 1 tool call/)).toBeTruthy()
+    expect(screen.queryByText(/new ·/)).toBeNull()
+  })
+
+  it('omits the "changed ... ago" segment when newest_mtime is 0', async () => {
+    vi.mocked(missionEvents).mockResolvedValue([
+      ...events,
+      {
+        mission_id: 'm1',
+        seq: 5,
+        kind: 'executor.progress',
+        payload: {
+          run_id: 'r1',
+          byte_offset: 100,
+          turns: 3,
+          tool_calls: 1,
+          worktree: { untracked: 0, modified: 0, newest_mtime: 0 },
+        },
+        provenance: 'live',
+        created_at: '2026-01-01T00:04:00Z',
+      },
+    ])
+    renderPage()
+    expect(await screen.findByText(/0 new · 0 modified/)).toBeTruthy()
+    expect(screen.queryByText(/changed/)).toBeNull()
+  })
+})
+
 describe('MissionDetail harness pill', () => {
   it('shows just the model text (the icon alone identifies the harness), with the harness name in the accessible name/tooltip', async () => {
     vi.mocked(missionEvents).mockResolvedValue([

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -28,7 +28,14 @@ import {
   resumeMission,
   sendMissionNote,
 } from '../api/client'
-import type { Mission, MissionEvent, MissionPROpenedPayload, MissionUsage, Schedule } from '../api/types'
+import type {
+  ExecutorProgressPayload,
+  Mission,
+  MissionEvent,
+  MissionPROpenedPayload,
+  MissionUsage,
+  Schedule,
+} from '../api/types'
 import { ArtifactsSection } from '../components/missions/ArtifactsSection'
 import { DiscoverSection } from '../components/missions/DiscoverSection'
 import { GoalSection } from '../components/missions/GoalSection'
@@ -159,11 +166,10 @@ function latestPROpened(events: MissionEvent[]): MissionPROpenedPayload | null {
 // events fire on every byte the delegated CLI executor writes, far too
 // often to render as individual Timeline rows (TimelineSection drops
 // them), so only the latest one is surfaced here.
-function latestExecutorProgress(events: MissionEvent[]): { turns: number; tool_calls: number } | null {
+function latestExecutorProgress(events: MissionEvent[]): ExecutorProgressPayload | null {
   for (let i = events.length - 1; i >= 0; i--) {
     if (events[i].kind === 'executor.progress') {
-      const { turns, tool_calls } = events[i].payload as { turns: number; tool_calls: number }
-      return { turns, tool_calls }
+      return events[i].payload as ExecutorProgressPayload
     }
   }
   return null
@@ -631,6 +637,14 @@ export function MissionDetail() {
                 <span>
                   harness: {executorActivity.turns} turn{executorActivity.turns === 1 ? '' : 's'},{' '}
                   {executorActivity.tool_calls} tool call{executorActivity.tool_calls === 1 ? '' : 's'}
+                  {executorActivity.worktree && (
+                    <>
+                      {' · '}
+                      {executorActivity.worktree.untracked} new · {executorActivity.worktree.modified} modified
+                      {executorActivity.worktree.newest_mtime > 0 &&
+                        ` · changed ${relativeTime(new Date(executorActivity.worktree.newest_mtime * 1000).toISOString())}`}
+                    </>
+                  )}
                 </span>
               )}
               {!terminalPhases.has(mission.phase) && mission.iteration > 0 && (


### PR DESCRIPTION
## Why

Mission b94dc32d had a full project on disk after a 62-minute delegated turn, yet the UI showed no artifact changes until the executor finished, because artifacts come only from commits and declared `artifact_refs`. Operators read that as stuck. Details on #500.

## What

- `buildPollCmd` appends one best-effort subshell to the existing poll exec: `git status --porcelain` in the worktree, folded into a `WT:<untracked> <modified> <newest_mtime>` line (first 200 entries, per-path `stat`). Missing git or worktree emits nothing; the poll never fails on it.
- `parsePollOutput` returns a `WorktreeSummary`; `pollState` keeps the latest; `recordProgressThrottled` adds `worktree` to the `executor.progress` payload.
- Web: `ExecutorProgressPayload.worktree`; the live executor pill on the mission page appends `N new · M modified · changed 2m ago` (last clause omitted when mtime is 0). Legacy events without the field render as before.

## Tests

Real `/bin/sh` round-trip on a temp git repo (2 untracked, 1 modified), `parsePollOutput` table (present/absent/malformed), MissionDetail tests for new and legacy payloads. `make build test vet lint` and the web build/lint/test are green (one pre-existing `AgentRoutePicker` flake, passes in isolation).

Closes #500

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790901469&installation_model_id=431401&pr_number=509&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F509&signature=b2aa5d531f3dad2c483fba095e428118d3936bf43bde4afbda48946f0a9d3f7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->