### PR TITLE
missions: show served provider and model on turn timelines

### DIFF
--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -181,7 +181,7 @@ func (r *delegatedRunner) effectiveRunBudget(ctx context.Context) time.Duration 
 	return r.runBudget
 }
 
-func (r *delegatedRunner) DiscoverSession(ctx context.Context, m Mission) (string, error) {
+func (r *delegatedRunner) DiscoverSession(ctx context.Context, m Mission) (string, string, string, error) {
 	return r.native.DiscoverSession(ctx, m)
 }
 
@@ -881,6 +881,15 @@ func (r *delegatedRunner) finish(ctx context.Context, m Mission, entry gwclient.
 			parseKind = "none"
 			verdict = forcedRetryVerdict("executor finished without a status report")
 		}
+	}
+	// issue #507: the executor did produce a result (or a text-form
+	// sentinel), so the entry that ran it is who served the turn.
+	// reportedModel (the harness's own claimed model) takes precedence
+	// over entry.Model, same precedence recordLedger already uses.
+	verdict.Provider = entry.ProviderName
+	verdict.Model = entry.Model
+	if st.reportedModel != "" {
+		verdict.Model = st.reportedModel
 	}
 
 	authFailed := st.resultEvent.Err != "" && isAuthFailure(st.resultEvent.Err)

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -403,7 +403,9 @@ func (f *fakeNative) RunReview(ctx context.Context, m Mission, packet ReviewPack
 func (f *fakeNative) PlanSession(ctx context.Context, m Mission, discoverNotes string) (Plan, error) {
 	return Plan{}, nil
 }
-func (f *fakeNative) DiscoverSession(ctx context.Context, m Mission) (string, error) { return "", nil }
+func (f *fakeNative) DiscoverSession(ctx context.Context, m Mission) (string, string, string, error) {
+	return "", "", "", nil
+}
 
 func (f *fakeNative) callCount() int {
 	f.mu.Lock()
@@ -488,6 +490,35 @@ func TestDelegatedRunWorker_HappyPath(t *testing.T) {
 	}
 	if led.entries[0].Purpose != "executor" || led.entries[0].Agent != "mission-worker" {
 		t.Fatalf("ledger entry purpose/agent = %q/%q, want executor/mission-worker", led.entries[0].Purpose, led.entries[0].Agent)
+	}
+}
+
+// TestDelegatedRunWorker_HappyPath_VerdictCarriesServedProviderAndModel
+// covers issue #507: a delegated turn's verdict reports the executor's
+// own chain entry as who served it (the same values executor.spawned
+// already carries).
+func TestDelegatedRunWorker_HappyPath_VerdictCarriesServedProviderAndModel(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
+	sandbox.seedChunk = 40
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	led := &fakeLedger{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, led)
+	m := testMission("m1", t.TempDir())
+
+	verdict, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if verdict.Provider != entry.ProviderName {
+		t.Fatalf("verdict.Provider = %q, want %q", verdict.Provider, entry.ProviderName)
+	}
+	if verdict.Model != entry.Model {
+		t.Fatalf("verdict.Model = %q, want %q", verdict.Model, entry.Model)
 	}
 }
 
@@ -1525,7 +1556,7 @@ func TestDelegatedRunner_PassesThroughNonWorkerSessions(t *testing.T) {
 	r := newTestDelegatedRunner(native, scriptedResolver(nil, nil), scriptedCred("", nil), newFakeSandbox(), nil, nil, nil)
 	m := testMission("m1", t.TempDir())
 
-	if _, err := r.DiscoverSession(context.Background(), m); err != nil {
+	if _, _, _, err := r.DiscoverSession(context.Background(), m); err != nil {
 		t.Fatalf("DiscoverSession: %v", err)
 	}
 	if _, err := r.PlanSession(context.Background(), m, ""); err != nil {

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -988,6 +988,15 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 	if agent := d.agentName(ctx, m.AgentID); agent != "" {
 		payload["agent"] = agent
 	}
+	// Provider/model (issue #507): who actually served the turn, from
+	// the runner's own verdict/plan; empty (never guessed) when the
+	// turn failed before any provider answered.
+	if in.Provider != "" {
+		payload["provider"] = in.Provider
+	}
+	if in.Model != "" {
+		payload["model"] = in.Model
+	}
 	if evErr := d.store.AppendEvent(ctx, id, "mission.turn", payload); evErr != nil {
 		d.log.Warn("driver: record turn failed", "mission_id", id, "error", evErr)
 	}
@@ -1271,7 +1280,7 @@ const discoverNotesCap = 8000
 // are stored on the mission (SetDiscoverNotes) so the next phase's own
 // (separate) Advance call reads them back via a fresh Get.
 func (d *Driver) runDiscover(ctx context.Context, m Mission) (StepInput, error) {
-	notes, err := d.runner.DiscoverSession(ctx, m)
+	notes, provider, model, err := d.runner.DiscoverSession(ctx, m)
 	if err != nil {
 		return StepInput{}, err
 	}
@@ -1283,7 +1292,7 @@ func (d *Driver) runDiscover(ctx context.Context, m Mission) (StepInput, error) 
 		d.log.Warn("driver: record discover complete failed", "mission_id", m.ID, "error", err)
 	}
 	d.recreateSandboxIfEnvironmentChanged(ctx, m)
-	return StepInput{Input: InputPhaseComplete}, nil
+	return StepInput{Input: InputPhaseComplete, Provider: provider, Model: model}, nil
 }
 
 // recreateSandboxIfEnvironmentChanged removes the mission's sandbox
@@ -1324,7 +1333,7 @@ func (d *Driver) runPlan(ctx context.Context, m Mission) (StepInput, error) {
 		if err := d.store.AppendEvent(ctx, m.ID, "mission.plan_infeasible", map[string]any{"reason": plan.InfeasibleReason}); err != nil {
 			return StepInput{}, fmt.Errorf("driver: record plan infeasible: %w", err)
 		}
-		return StepInput{Input: InputPlanInfeasible, Reason: plan.InfeasibleReason}, nil
+		return StepInput{Input: InputPlanInfeasible, Reason: plan.InfeasibleReason, Provider: plan.Provider, Model: plan.Model}, nil
 	}
 	planCreatedPayload := map[string]any{"units": len(plan.Units)}
 	if len(plan.Assumptions) > 0 {
@@ -1343,7 +1352,7 @@ func (d *Driver) runPlan(ctx context.Context, m Mission) (StepInput, error) {
 	if err := d.store.SetPlan(ctx, m.ID, plan); err != nil {
 		return StepInput{}, err
 	}
-	return StepInput{Input: InputPhaseComplete}, nil
+	return StepInput{Input: InputPhaseComplete, Provider: plan.Provider, Model: plan.Model}, nil
 }
 
 // replanNotes extends the planner's discoverNotes input with what
@@ -1499,21 +1508,22 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 			if err := d.store.AppendEvent(ctx, m.ID, "mission.review_skipped", map[string]any{"reason": reason, "verified": false}); err != nil {
 				d.log.Warn("driver: record review skip failed", "mission_id", m.ID, "error", err)
 			}
-			return StepInput{Input: InputReviewApprove}, nil
+			return StepInput{Input: InputReviewApprove, Provider: verdict.Provider, Model: verdict.Model}, nil
 		}
 		if in, ok := d.trySkipReview(ctx, m, verdict.SeenURLs); ok {
+			in.Provider, in.Model = verdict.Provider, verdict.Model
 			return in, nil
 		}
-		return StepInput{Input: InputPhaseComplete}, nil
+		return StepInput{Input: InputPhaseComplete, Provider: verdict.Provider, Model: verdict.Model}, nil
 	case "blocked":
-		return StepInput{Input: InputWorkerBlocked, Message: verdict.Question}, nil
+		return StepInput{Input: InputWorkerBlocked, Message: verdict.Question, Provider: verdict.Provider, Model: verdict.Model}, nil
 	default: // "retry" or anything unrecognized
 		if wt := m.WorktreePath(); wt != "" {
 			if err := d.workspace.Rollback(ctx, wt, m.Kind); err != nil {
 				d.log.Warn("driver: rollback failed", "mission_id", m.ID, "error", err)
 			}
 		}
-		in := StepInput{Input: InputWorkerRetry, Reason: truncate(verdict.Analysis, 500)}
+		in := StepInput{Input: InputWorkerRetry, Reason: truncate(verdict.Analysis, 500), Provider: verdict.Provider, Model: verdict.Model}
 		if verdict.Forced {
 			// Neither a tool call nor a text-form sentinel (runner.go's
 			// extractTextSentinel) could be read from this turn — a
@@ -1710,14 +1720,15 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 					d.log.Warn("driver: record verify-failure note failed", "mission_id", m.ID, "error", err)
 				}
 				fp := fmt.Sprintf("verify_failed:unit_%d", vf.unit)
-				return StepInput{Input: InputReviewRework, GapFingerprint: fp}, nil
+				return StepInput{Input: InputReviewRework, GapFingerprint: fp, Provider: verdict.Provider, Model: verdict.Model}, nil
 			}
 			return StepInput{Input: InputReviewInfraFailure}, err
 		}
 		if in, regressed := d.verify.checkRegressions(ctx, m); regressed {
+			in.Provider, in.Model = verdict.Provider, verdict.Model
 			return in, nil
 		}
-		return StepInput{Input: InputReviewApprove}, nil
+		return StepInput{Input: InputReviewApprove, Provider: verdict.Provider, Model: verdict.Model}, nil
 	}
 	fp := GapFingerprint(verdict.Findings)
 	if fp != "" && fp == m.LastGapFingerprint {
@@ -1727,7 +1738,7 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 		// with fresh eyes instead of re-asserting its previous verdict.
 		delete(d.gatekeepers, m.ID)
 	}
-	return StepInput{Input: InputReviewRework, GapFingerprint: fp, Reason: truncate(reviewReason(verdict.Findings), 500)}, nil
+	return StepInput{Input: InputReviewRework, GapFingerprint: fp, Reason: truncate(reviewReason(verdict.Findings), 500), Provider: verdict.Provider, Model: verdict.Model}, nil
 }
 
 // reviewReason flattens findings into one line for event payloads.

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -327,21 +327,21 @@ func (r *scriptedRunner) PlanSession(ctx context.Context, m Mission, discoverNot
 	return s, nil
 }
 
-func (r *scriptedRunner) DiscoverSession(ctx context.Context, m Mission) (string, error) {
+func (r *scriptedRunner) DiscoverSession(ctx context.Context, m Mission) (string, string, string, error) {
 	if r.discoverErr != nil {
-		return "", r.discoverErr
+		return "", "", "", r.discoverErr
 	}
 	if r.onDiscover != nil {
 		r.onDiscover(ctx, m)
 	}
 	if len(r.discoverNotes) == 0 {
-		return "", nil
+		return "", "", "", nil
 	}
 	notes := r.discoverNotes[r.discoverIdx]
 	if r.discoverIdx < len(r.discoverNotes)-1 {
 		r.discoverIdx++
 	}
-	return notes, nil
+	return notes, "", "", nil
 }
 
 // fakeSandboxExec runs command via /bin/sh -c directly in workdir —
@@ -1706,8 +1706,8 @@ func (r *blockingRunner) PlanSession(ctx context.Context, m Mission, discoverNot
 	return r.planSpec, nil
 }
 
-func (r *blockingRunner) DiscoverSession(ctx context.Context, m Mission) (string, error) {
-	return "", nil
+func (r *blockingRunner) DiscoverSession(ctx context.Context, m Mission) (string, string, string, error) {
+	return "", "", "", nil
 }
 
 // TestDriverDriveIsSerializedPerMission reproduces a real bug: the
@@ -2871,6 +2871,73 @@ func TestDriverTurnEventCarriesRouteAndAgent(t *testing.T) {
 	}
 	if _, ok := payload["model"]; ok {
 		t.Fatalf("payload[model] = %v, want absent (never guessed)", payload["model"])
+	}
+}
+
+// TestDriverTurnEventCarriesServedProviderAndModel covers issue #507:
+// the mission.turn event payload includes provider/model from the
+// runner's verdict when the turn actually got an answer, and omits
+// them when it didn't.
+func TestDriverTurnEventCarriesServedProviderAndModel(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8,
+	})
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{
+		{Outcome: "complete", Provider: "OpenAI Responses", Model: "gpt-5.3-codex"},
+	}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	events, _ := store.Events(context.Background(), "m1")
+	var turn Event
+	for _, e := range events {
+		if e.Kind == "mission.turn" {
+			turn = e
+		}
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(turn.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal mission.turn payload: %v", err)
+	}
+	if payload["provider"] != "OpenAI Responses" {
+		t.Fatalf("payload[provider] = %v, want OpenAI Responses", payload["provider"])
+	}
+	if payload["model"] != "gpt-5.3-codex" {
+		t.Fatalf("payload[model] = %v, want gpt-5.3-codex", payload["model"])
+	}
+}
+
+// TestDriverTurnEventOmitsProviderModelWhenNeverServed covers issue
+// #507: a turn that failed before any provider answered must never
+// guess provider/model on the mission.turn payload.
+func TestDriverTurnEventOmitsProviderModelWhenNeverServed(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	runner := &scriptedRunner{workerErr: fmt.Errorf("mission runner: provider stream error")}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	events, _ := store.Events(context.Background(), "m1")
+	var turn Event
+	for _, e := range events {
+		if e.Kind == "mission.turn" {
+			turn = e
+		}
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(turn.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal mission.turn payload: %v", err)
+	}
+	if _, ok := payload["provider"]; ok {
+		t.Fatalf("payload[provider] = %v, want absent", payload["provider"])
+	}
+	if _, ok := payload["model"]; ok {
+		t.Fatalf("payload[model] = %v, want absent", payload["model"])
 	}
 }
 

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -505,6 +505,10 @@ type Plan struct {
 	// never a gate — the operator catches a wrong guess via a steering
 	// note, not a pause.
 	Assumptions []PlanAssumption `json:"assumptions,omitempty"`
+	// Provider/Model (issue #507) are who served the plan turn; set by
+	// PlanSession after parsing, never persisted with the stored plan.
+	Provider string `json:"-"`
+	Model    string `json:"-"`
 }
 
 // PlanAssumption is one ambiguity the planner resolved on its own,

--- a/internal/brain/missions/review.go
+++ b/internal/brain/missions/review.go
@@ -189,6 +189,10 @@ type Finding struct {
 type ReviewVerdict struct {
 	Approved bool
 	Findings []Finding
+	// Provider/Model (issue #507) are who served the review turn; set by
+	// RunReview after parsing.
+	Provider string
+	Model    string
 }
 
 // parseReviewVerdict decodes a review_verdict tool call's arguments.

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -79,8 +79,8 @@ type Runner interface {
 	// explores the workspace and (via base tools) the web, ending with a
 	// discover_notes sentinel call. Discovery is advisory: a turn that
 	// never produces the sentinel degrades to the raw turn text rather
-	// than failing the phase.
-	DiscoverSession(ctx context.Context, m Mission) (string, error)
+	// than failing the phase. Also returns who served the turn (issue #507).
+	DiscoverSession(ctx context.Context, m Mission) (notes, provider, model string, err error)
 }
 
 // agentStream is the narrow slice of *loop.Agent nativeRunner actually
@@ -626,12 +626,17 @@ func (r *nativeRunner) belowFloor(model string) bool {
 // treating a missing sentinel as "no verdict," since ask_user's
 // EndTurnTools membership means the turn legitimately ends with no
 // sentinel call at all.
+// provider/model (issue #507) are the last stream meta event's values:
+// the chain entry that actually served the turn after any failover.
+// Empty when the turn failed before any provider answered.
 type turnResult struct {
 	text         string
 	sentinelArgs json.RawMessage
 	seenURLs     []string
 	finalSeg     string
 	askedUser    bool
+	provider     string
+	model        string
 }
 
 // toolCallDigestCap bounds a mission.tool_call event's args digest:
@@ -691,6 +696,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 	// not be mistaken for the still-blocked destructive one resolving.
 	parked := map[string]bool{}
 	servedModel := ""
+	servedProvider := ""
 	// sawTerminal mirrors chat's D-044 discipline: a channel that
 	// closes with no done/error/incomplete means every producer lost
 	// its terminal (deadline racing a stream cut). Without this check a
@@ -769,6 +775,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			sawTerminal = true
 			if ev.Meta != nil {
 				servedModel = ev.Meta.Model
+				servedProvider = ev.Meta.Provider
 			}
 		case stream.EventIncomplete:
 			// A cut-off stream is an infra failure, not a short clean
@@ -779,7 +786,7 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 			if len(parked) > 0 && r.parker != nil {
 				r.parker.OnPermissionCleared(ctx, req.MissionID)
 			}
-			return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser}, fmt.Errorf("mission runner: incomplete stream: %s", ev.Text)
+			return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser, provider: servedProvider, model: servedModel}, fmt.Errorf("mission runner: incomplete stream: %s", ev.Text)
 		case stream.EventError:
 			if len(parked) > 0 && r.parker != nil {
 				r.parker.OnPermissionCleared(ctx, req.MissionID)
@@ -789,21 +796,21 @@ func (r *nativeRunner) runTurn(ctx context.Context, req loop.Request, sentinelTo
 				msg = ev.Err.Message
 			}
 			if strings.Contains(msg, "context_length") {
-				return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser}, fmt.Errorf("%w: %s", ErrPromptTooLong, msg)
+				return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser, provider: servedProvider, model: servedModel}, fmt.Errorf("%w: %s", ErrPromptTooLong, msg)
 			}
-			return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser}, fmt.Errorf("mission runner: %s", msg)
+			return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser, provider: servedProvider, model: servedModel}, fmt.Errorf("mission runner: %s", msg)
 		}
 	}
 	if !sawTerminal {
 		if len(parked) > 0 && r.parker != nil {
 			r.parker.OnPermissionCleared(ctx, req.MissionID)
 		}
-		return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser}, fmt.Errorf("mission runner: stream ended without a terminal event")
+		return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser, provider: servedProvider, model: servedModel}, fmt.Errorf("mission runner: stream ended without a terminal event")
 	}
 	if servedModel != "" && r.belowFloor(servedModel) {
-		return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser}, fmt.Errorf("%w: %s", ErrModelFloor, servedModel)
+		return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser, provider: servedProvider, model: servedModel}, fmt.Errorf("%w: %s", ErrModelFloor, servedModel)
 	}
-	return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser}, nil
+	return turnResult{text: b.String(), sentinelArgs: sentinelArgs, seenURLs: seenURLs, finalSeg: finalB.String(), askedUser: askedUser, provider: servedProvider, model: servedModel}, nil
 }
 
 // webFetchArgURL extracts the url arg from a fetch_url call's raw
@@ -1068,6 +1075,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 	if v, ok := r.tryParseVerdict(res.sentinelArgs); ok {
 		v.SeenURLs = append(seenURLs, kbSeen.all()...)
 		v.FinalMessage = res.finalSeg
+		v.Provider, v.Model = res.provider, res.model
 		return v, text, nil
 	}
 
@@ -1086,6 +1094,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 	if v, ok := r.tryParseVerdict(recoverRes.sentinelArgs); ok {
 		v.SeenURLs = append(seenURLs, kbSeen.all()...)
 		v.FinalMessage = recoverRes.finalSeg
+		v.Provider, v.Model = recoverRes.provider, recoverRes.model
 		return v, text + "\n" + recoverText, nil
 	}
 
@@ -1104,6 +1113,7 @@ func (r *nativeRunner) RunWorker(ctx context.Context, m Mission, packet WorkPack
 			r.log.Warn("mission worker expressed mission_status as text, not a tool call", "mission_id", m.ID, "route", workerRoute(m))
 			v.SeenURLs = append(seenURLs, kbSeen.all()...)
 			v.FinalMessage = recoverRes.finalSeg
+			v.Provider, v.Model = recoverRes.provider, recoverRes.model
 			return v, combined, nil
 		}
 	}
@@ -1155,8 +1165,9 @@ func forcedRetryVerdict(reason string) WorkerVerdict {
 // ladder, a missing discover_notes call never fails the phase: the
 // findings are advisory input to the planner, not a gate on progress,
 // so the ladder's last resort is the raw turn text rather than a forced
-// failure.
-func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (string, error) {
+// failure. provider/model (issue #507) are who served the turn that
+// produced the returned notes; empty when the turn errored.
+func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (notes, servedProvider, servedModel string, err error) {
 	system := "You are discovering one mission before it is planned. Investigate the goal: explore the workspace with shell (read-only, do not create or modify files; the generate phase does the actual work), and use web search/fetch tools if available and relevant to the goal. If the goal is self-contained and needs no exploration, say so briefly. End your turn with exactly one discover_notes tool call whose findings field contains everything the planner needs: what exists, what's relevant, constraints, gotchas, unknowns." + r.discoverEnvironmentNudge(m) + toolDisciplineNote + r.kbDiscoverNudge(m) + r.execEnvironmentNote(ctx)
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if pc := m.ParentContext(); pc != "" {
@@ -1204,13 +1215,13 @@ func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (string, 
 	res, err := r.runTurn(ctx, req, discoverNotesToolName, PhaseDiscover)
 	text := res.text
 	if err != nil {
-		return "", err
+		return "", "", "", err
 	}
 	if res.askedUser {
-		return "", ErrAskedUser
+		return "", "", "", ErrAskedUser
 	}
 	if report, ok := tryParseFindings(res.sentinelArgs); ok {
-		return r.applyDiscoverReport(ctx, m, report), nil
+		return r.applyDiscoverReport(ctx, m, report), res.provider, res.model, nil
 	}
 
 	// One recovery re-run, same ladder shape as RunWorker/PlanSession.
@@ -1222,10 +1233,10 @@ func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (string, 
 	recoverRes, err := r.runTurn(ctx, recoverReq, discoverNotesToolName, PhaseDiscover)
 	recoverText := recoverRes.text
 	if err != nil {
-		return "", err
+		return "", "", "", err
 	}
 	if report, ok := tryParseFindings(recoverRes.sentinelArgs); ok {
-		return r.applyDiscoverReport(ctx, m, report), nil
+		return r.applyDiscoverReport(ctx, m, report), recoverRes.provider, recoverRes.model, nil
 	}
 
 	// Neither turn produced a tool call: check for a text-form sentinel
@@ -1233,14 +1244,14 @@ func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (string, 
 	combined := text + "\n" + recoverText
 	if raw, ok := extractTextSentinel(combined, discoverNotesToolName); ok {
 		if report, ok := tryParseFindings(raw); ok {
-			return r.applyDiscoverReport(ctx, m, report), nil
+			return r.applyDiscoverReport(ctx, m, report), recoverRes.provider, recoverRes.model, nil
 		}
 	}
 
 	// Advisory phase: never a forced failure. The raw turn text is still
 	// useful context for the planner even with no structured findings.
 	r.log.Warn("mission discover ended without a discover_notes call; using raw turn text", "mission_id", m.ID, "route", oversightRoute(m))
-	return strings.TrimSpace(combined), nil
+	return strings.TrimSpace(combined), recoverRes.provider, recoverRes.model, nil
 }
 
 // tryParseFindings reports whether args decodes to a non-empty findings
@@ -1331,6 +1342,7 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 	if res.askedUser {
 		return ReviewVerdict{}, nil, ErrAskedUser
 	}
+	servedProvider, servedModel := res.provider, res.model
 	if len(args) == 0 {
 		// Recovery re-run: same one-shot ladder RunWorker uses: a
 		// reviewer that ran long on analysis and didn't reach its tool
@@ -1346,6 +1358,7 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 		if err != nil {
 			return ReviewVerdict{}, nil, err
 		}
+		servedProvider, servedModel = recoverRes.provider, recoverRes.model
 		if len(recoverArgs) == 0 {
 			// Neither turn produced a review_verdict tool call: before
 			// failing the round, check for a text-form verdict: observed
@@ -1372,6 +1385,7 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 	if err != nil {
 		return ReviewVerdict{}, nil, fmt.Errorf("mission runner: parse review_verdict: %w", err)
 	}
+	verdict.Provider, verdict.Model = servedProvider, servedModel
 
 	// D-091/issue #505: the round's full packet (goal, plan, artifacts,
 	// diff) is never retained across rounds: reviewers reword findings,
@@ -1569,6 +1583,7 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, discoverNotes
 	}
 	if len(args) > 0 {
 		if plan, planErr := parsePlan(string(args)); planErr == nil {
+			plan.Provider, plan.Model = res.provider, res.model
 			return plan, nil
 		}
 	}
@@ -1603,6 +1618,7 @@ func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, discoverNotes
 		r.log.Warn("mission planner submitted an invalid plan twice", "mission_id", m.ID, "route", oversightRoute(m), "text", text, "recover_text", recoverText, "error", err)
 		return Plan{}, err
 	}
+	plan.Provider, plan.Model = recoverRes.provider, recoverRes.model
 	return plan, nil
 }
 

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -1194,6 +1194,10 @@ func doneEvent(model string) stream.StreamEvent {
 	return stream.StreamEvent{Type: stream.EventDone, Meta: &stream.Meta{Model: model}}
 }
 
+func doneEventMeta(provider, model string) stream.StreamEvent {
+	return stream.StreamEvent{Type: stream.EventDone, Meta: &stream.Meta{Provider: provider, Model: model}}
+}
+
 // TestRunWorkerModelFloor: a turn served by a deny-listed fallback
 // model must surface ErrModelFloor so the driver pauses the mission
 // immediately instead of burning iterations on a model that cannot
@@ -1222,6 +1226,41 @@ func TestRunWorkerModelFloorDisabledByDefault(t *testing.T) {
 	}
 	if v.Outcome != "done" {
 		t.Fatalf("verdict = %+v", v)
+	}
+}
+
+// TestRunTurnCarriesServedProviderAndModel covers issue #507: runTurn
+// must surface the last stream meta event's provider/model on
+// turnResult, the entry that actually served the turn after any
+// failover.
+func TestRunTurnCarriesServedProviderAndModel(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ok"}`), doneEventMeta("OpenAI Responses", "gpt-5.3-codex")},
+	}}
+	r := newTestRunner(agent)
+	res, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseGenerate)
+	if err != nil {
+		t.Fatalf("runTurn: %v", err)
+	}
+	if res.provider != "OpenAI Responses" || res.model != "gpt-5.3-codex" {
+		t.Fatalf("turnResult provider/model = %q/%q, want OpenAI Responses/gpt-5.3-codex", res.provider, res.model)
+	}
+}
+
+// TestRunTurnOmitsProviderModelWhenNeverServed covers issue #507: a
+// turn that errors before any provider answered must never guess a
+// provider/model.
+func TestRunTurnOmitsProviderModelWhenNeverServed(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{{Type: stream.EventError, Err: &stream.StreamError{Message: "boom"}}},
+	}}
+	r := newTestRunner(agent)
+	res, err := r.runTurn(context.Background(), loop.Request{MissionID: "m1"}, missionStatusToolName, PhaseGenerate)
+	if err == nil {
+		t.Fatal("runTurn: expected an error")
+	}
+	if res.provider != "" || res.model != "" {
+		t.Fatalf("turnResult provider/model = %q/%q, want both empty", res.provider, res.model)
 	}
 }
 
@@ -1506,7 +1545,7 @@ func TestDiscoverSessionIncludesConnectorReadsWhenResolverSet(t *testing.T) {
 		return []*tools.Tool{{Name: "google-calendar_calendar_list_events", ReadOnly: true}}
 	}
 	m := Mission{ID: "m1", AgentID: "a1", Route: "default"}
-	if _, err := r.DiscoverSession(context.Background(), m); err != nil {
+	if _, _, _, err := r.DiscoverSession(context.Background(), m); err != nil {
 		t.Fatalf("DiscoverSession: %v", err)
 	}
 	var names []string
@@ -1752,7 +1791,7 @@ func TestDiscoverSessionSentinelPresent(t *testing.T) {
 		{textEvent("looked around"), toolEndEvent(discoverNotesToolName, `{"findings":"no prior implementation; goal is self-contained"}`)},
 	}}
 	r := newTestRunner(agent)
-	notes, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"})
+	notes, _, _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"})
 	if err != nil {
 		t.Fatalf("DiscoverSession: %v", err)
 	}
@@ -1772,7 +1811,7 @@ func TestDiscoverSessionUsesPlanRoute(t *testing.T) {
 	}}
 	r := newTestRunner(agent)
 	m := Mission{ID: "m1", Route: "mini", PlanRoute: "strong", Goal: "test"}
-	if _, err := r.DiscoverSession(context.Background(), m); err != nil {
+	if _, _, _, err := r.DiscoverSession(context.Background(), m); err != nil {
 		t.Fatalf("DiscoverSession: %v", err)
 	}
 	if got := agent.requests[0].Route; got != "strong" {
@@ -1791,7 +1830,7 @@ func TestDiscoverSessionIncludesParentContext(t *testing.T) {
 		ID: "m1", Route: "default", Goal: "test", ParentMissionID: "parent",
 		Sources: []SourceEntry{{Source: SourceKindMission, ID: ParentLineageID, MissionID: "parent", Digest: "prior mission fixed the signup bug"}},
 	}
-	if _, err := r.DiscoverSession(context.Background(), m); err != nil {
+	if _, _, _, err := r.DiscoverSession(context.Background(), m); err != nil {
 		t.Fatalf("DiscoverSession: %v", err)
 	}
 	msgs := agent.requests[0].Messages
@@ -1816,7 +1855,7 @@ func TestDiscoverSessionIncludesReferencedContext(t *testing.T) {
 			{Source: SourceKindKB, DocID: "doc1", Name: "runbook", Digest: "kb doc: the login flow uses OAuth"},
 		},
 	}
-	if _, err := r.DiscoverSession(context.Background(), m); err != nil {
+	if _, _, _, err := r.DiscoverSession(context.Background(), m); err != nil {
 		t.Fatalf("DiscoverSession: %v", err)
 	}
 	msgs := agent.requests[0].Messages
@@ -1839,7 +1878,7 @@ func TestDiscoverSessionIncludesAttachments(t *testing.T) {
 	m := Mission{ID: "m1", Route: "default", Goal: "test", Sources: []SourceEntry{
 		{Source: SourceKindPDF, ID: "att1", Name: "spec.pdf", Markdown: "the spec says fix it this way"},
 	}}
-	if _, err := r.DiscoverSession(context.Background(), m); err != nil {
+	if _, _, _, err := r.DiscoverSession(context.Background(), m); err != nil {
 		t.Fatalf("DiscoverSession: %v", err)
 	}
 	msgs := agent.requests[0].Messages
@@ -1889,7 +1928,7 @@ func TestDiscoverSessionReportsEnvironment(t *testing.T) {
 			r := newTestRunner(agent)
 			sink := &fakeEnvironmentSink{}
 			r.SetEnvironmentSink(sink)
-			if _, err := r.DiscoverSession(context.Background(), tc.mission); err != nil {
+			if _, _, _, err := r.DiscoverSession(context.Background(), tc.mission); err != nil {
 				t.Fatalf("DiscoverSession: %v", err)
 			}
 			if strings.Join(sink.calls, ",") != strings.Join(tc.wantCalls, ",") {
@@ -1907,7 +1946,7 @@ func TestDiscoverSessionPrefixesUnsupportedStack(t *testing.T) {
 		{toolEndEvent(discoverNotesToolName, `{"findings":"Cargo.toml at the root","stack":"Rust CLI"}`)},
 	}}
 	r := newTestRunner(agent)
-	notes, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Kind: KindCoding, Route: "default", Goal: "test"})
+	notes, _, _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Kind: KindCoding, Route: "default", Goal: "test"})
 	if err != nil {
 		t.Fatalf("DiscoverSession: %v", err)
 	}
@@ -1927,7 +1966,7 @@ func TestDiscoverSessionRecoversWhenSentinelMissingThenPresent(t *testing.T) {
 		{textEvent("done discovering"), toolEndEvent(discoverNotesToolName, `{"findings":"found a reusable config loader"}`)},
 	}}
 	r := newTestRunner(agent)
-	notes, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"})
+	notes, _, _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"})
 	if err != nil {
 		t.Fatalf("DiscoverSession: %v", err)
 	}
@@ -1948,7 +1987,7 @@ func TestDiscoverSessionFallsBackToTextSentinel(t *testing.T) {
 		{textEvent(`Done. <discover_notes findings="the goal needs no exploration; it is self-contained"/>`)},
 	}}
 	r := newTestRunner(agent)
-	notes, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"})
+	notes, _, _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"})
 	if err != nil {
 		t.Fatalf("DiscoverSession: %v", err)
 	}
@@ -1967,7 +2006,7 @@ func TestDiscoverSessionFallsBackToRawText(t *testing.T) {
 		{textEvent("Confirmed, nothing else to add.")},
 	}}
 	r := newTestRunner(agent)
-	notes, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"})
+	notes, _, _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"})
 	if err != nil {
 		t.Fatalf("DiscoverSession: %v", err)
 	}
@@ -1988,7 +2027,7 @@ func TestDiscoverSessionStreamErrorPropagates(t *testing.T) {
 		{Type: stream.EventError, Err: &stream.StreamError{Message: "connection lost"}},
 	}}}
 	r := newTestRunner(agent)
-	if _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err == nil {
+	if _, _, _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err == nil {
 		t.Fatal("DiscoverSession: expected the stream error to propagate")
 	}
 }
@@ -2003,7 +2042,7 @@ func TestDiscoverSessionGetsShellButNotWriteFile(t *testing.T) {
 	}}
 	r := newTestRunner(agent)
 	m := Mission{ID: "m1", Route: "default", Goal: "test", Workspace: "/workspace/missions/m1"}
-	if _, err := r.DiscoverSession(context.Background(), m); err != nil {
+	if _, _, _, err := r.DiscoverSession(context.Background(), m); err != nil {
 		t.Fatalf("DiscoverSession: %v", err)
 	}
 	var names []string
@@ -2036,7 +2075,7 @@ func TestDiscoverSessionKBNudge(t *testing.T) {
 	t.Run("no backend wired", func(t *testing.T) {
 		agent := &scriptedAgent{batches: notesBatch}
 		r := newTestRunner(agent)
-		if _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err != nil {
+		if _, _, _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err != nil {
 			t.Fatalf("DiscoverSession: %v", err)
 		}
 		if strings.Contains(agent.requests[0].System, "search_kb") {
@@ -2050,7 +2089,7 @@ func TestDiscoverSessionKBNudge(t *testing.T) {
 		r.kbSearch = func(ctx context.Context, query string, boostCollections []string, mode string, k int) ([]builtin.KBSearchHit, error) {
 			return nil, nil
 		}
-		if _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err != nil {
+		if _, _, _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err != nil {
 			t.Fatalf("DiscoverSession: %v", err)
 		}
 		system := agent.requests[0].System
@@ -2167,7 +2206,7 @@ func TestMissionRunnerRequestsAreBuiltinsOnly(t *testing.T) {
 		{toolEndEvent(discoverNotesToolName, `{"findings":"none"}`)},
 	}}
 	r = newTestRunner(agent)
-	if _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err != nil {
+	if _, _, _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err != nil {
 		t.Fatalf("DiscoverSession: %v", err)
 	}
 	if !agent.requests[len(agent.requests)-1].BuiltinsOnly {
@@ -2751,7 +2790,7 @@ func TestDiscoverSessionWiresSteeringFromProgressReader(t *testing.T) {
 		agent := &scriptedAgent{batches: batch}
 		r := newTestRunner(agent)
 		r.SetProgressReader(&fakeProgressReader{})
-		if _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err != nil {
+		if _, _, _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err != nil {
 			t.Fatalf("DiscoverSession: %v", err)
 		}
 		if agent.requests[0].Steering == nil {
@@ -2762,7 +2801,7 @@ func TestDiscoverSessionWiresSteeringFromProgressReader(t *testing.T) {
 	t.Run("unwired", func(t *testing.T) {
 		agent := &scriptedAgent{batches: batch}
 		r := newTestRunner(agent)
-		if _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err != nil {
+		if _, _, _, err := r.DiscoverSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "test"}); err != nil {
 			t.Fatalf("DiscoverSession: %v", err)
 		}
 		if agent.requests[0].Steering != nil {

--- a/internal/brain/missions/sentinel.go
+++ b/internal/brain/missions/sentinel.go
@@ -223,6 +223,12 @@ type WorkerVerdict struct {
 	// the mission_status tool call's own JSON args; set by RunWorker
 	// after parsing. Empty for the delegated (CLI harness) path.
 	FinalMessage string `json:"-"`
+	// Provider/Model (issue #507) are who actually served this turn:
+	// the last stream meta event for a native turn, or the executor's
+	// own chain entry for a delegated turn. Empty when the turn failed
+	// before any provider answered.
+	Provider string `json:"-"`
+	Model    string `json:"-"`
 }
 
 // parseWorkerVerdict decodes a mission_status tool call's arguments.

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -253,6 +253,11 @@ type StepInput struct {
 	// transition's event payloads so a mission's failure cause is
 	// readable from its event log alone, never only from process logs.
 	Reason string
+	// Provider/Model (issue #507) are who actually served the phase's
+	// turn, read back from the runner's verdict/plan; empty when the
+	// turn failed before any provider answered.
+	Provider string
+	Model    string
 }
 
 // EventDraft is one event Step decided must be appended; the Store

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -984,9 +984,11 @@ export interface MissionSteeredPayload {
 // route/agent (issue #473) are the phase's effective route and the
 // mission agent's display name, both absent on a legacy event
 // recorded before this field existed and absent when unresolvable
-// (e.g. no agent set), never a placeholder string. model is
-// deliberately not carried here: the runner doesn't surface which
-// chain entry actually served the turn, and driver.go never guesses one.
+// (e.g. no agent set), never a placeholder string. provider/model
+// (issue #507) are who actually served the turn (the last stream meta
+// event after any failover, or the delegated executor's own chain
+// entry); both absent on a legacy event and on a turn that failed
+// before any provider answered, never guessed.
 export interface MissionTurnPayload {
   phase: string
   duration_ms: number
@@ -996,6 +998,8 @@ export interface MissionTurnPayload {
   escalated_route?: string
   route?: string
   agent?: string
+  provider?: string
+  model?: string
 }
 
 // MissionRetryPayload is mission.retry's payload (statemachine.go);

--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -322,6 +322,42 @@ describe('mission.turn rendering', () => {
     expect(row).toBeInTheDocument()
     expect(row).not.toHaveTextContent('undefined')
   })
+
+  it('shows the served model in place of route when the payload carries one, with provider/route in the title', () => {
+    render(
+      <div>
+        {renderEvent(
+          event(
+            {
+              phase: 'prove', duration_ms: 42000, ok: true, input: 'review_approve',
+              route: 'coding', agent: 'coder', provider: 'OpenAI Responses', model: 'gpt-5.3-codex',
+            },
+            'mission.turn',
+          ),
+        )}
+      </div>,
+    )
+    const row = screen.getByText(/Turn \(prove\): ok · 42\.0s/)
+    expect(row).toHaveTextContent('coder · gpt-5.3-codex')
+    expect(row).not.toHaveTextContent('coding')
+    const context = screen.getByText('coder · gpt-5.3-codex')
+    expect(context).toHaveAttribute('title', 'OpenAI Responses / coding')
+  })
+
+  it('falls back to the agent · route form when model is absent (older events)', () => {
+    render(
+      <div>
+        {renderEvent(
+          event(
+            { phase: 'generate', duration_ms: 1500, ok: true, input: 'worker_retry', route: 'coding', agent: 'Coder' },
+            'mission.turn',
+          ),
+        )}
+      </div>,
+    )
+    const context = screen.getByText('Coder · coding')
+    expect(context).not.toHaveAttribute('title')
+  })
 })
 
 describe('mission.discover_complete / mission.explore_complete rendering', () => {

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -58,10 +58,18 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
     return <span className={approved ? 'text-green-400' : 'text-amber-400'}>Review verdict: {String(decision ?? '?')}</span>
   },
   'mission.turn': (p) => {
-    const { phase, duration_ms, ok, reason, route, agent } = p as MissionTurnPayload
+    const { phase, duration_ms, ok, reason, route, agent, provider, model } = p as MissionTurnPayload
     const base = `Turn (${phase}): ${ok ? 'ok' : 'failed'} · ${formatDuration(duration_ms)}`
-    const context = [agent, route].filter(Boolean).join(' · ')
-    const contextEl = context && <span className="ml-1 text-zinc-500">{context}</span>
+    // Served model in place of route when known (provider/route stay
+    // reachable via title); falls back to the agent · route form for
+    // older events with no model recorded.
+    const context = model ? [agent, model].filter(Boolean).join(' · ') : [agent, route].filter(Boolean).join(' · ')
+    const contextTitle = model ? [provider, route].filter(Boolean).join(' / ') : undefined
+    const contextEl = context && (
+      <span className="ml-1 text-zinc-500" title={contextTitle || undefined}>
+        {context}
+      </span>
+    )
     if (ok || !reason) {
       return (
         <span className={ok ? undefined : 'text-red-400'}>


### PR DESCRIPTION
## Summary
- The runner already saw provider/model on the stream's meta event but never surfaced it; wire it through turnResult -> WorkerVerdict/ReviewVerdict/Plan -> StepInput -> the mission.turn event payload, plus the delegated executor's own chain entry for CLI-harness turns. Provider/model are omitted (never guessed) when a turn failed before any provider answered.
- Web timeline: the turn line now shows the served model in place of the route name (e.g. `Turn (prove): ok · 42s · coder · gpt-5.3-codex`), falling back to the existing `agent · route` form when model is absent (older events). Provider and route stay reachable via the element's title attribute on hover.

Closes #507

## Test plan
- [x] `make build test vet lint`
- [x] `docker run ... npm run build && npm run lint && npm test` (web)
- [x] New Go tests: runner (`TestRunTurnCarriesServedProviderAndModel`, `TestRunTurnOmitsProviderModelWhenNeverServed`), delegated runner (`TestDelegatedRunWorker_HappyPath_VerdictCarriesServedProviderAndModel`), driver (`TestDriverTurnEventCarriesServedProviderAndModel`, `TestDriverTurnEventOmitsProviderModelWhenNeverServed`)
- [x] New web test: `eventRenderers.test.tsx` covers both the new payload shape (model shown, title populated) and the legacy shape (route/agent fallback, no title)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790905798&installation_model_id=431401&pr_number=515&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F515&signature=397c09215889e12b0080947f1fd3cbaaa873afcf8a60b19975041870f704751b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->