### PR TITLE
feat(gateway): cache the tool-loop prefix and cap the reviewer loop

### DIFF
--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -328,6 +328,19 @@ type Request struct {
 	// a no-op. nil for every caller but mission worker turns: the loop
 	// itself knows nothing about missions.
 	Steering func(ctx context.Context) []string
+
+	// MaxSteps, when > 0, replaces the agent's default step ceiling
+	// (tools.DefaultMaxSteps) for this turn (D-093): a reviewer that
+	// already holds the harness's verify output needs a spot check, not
+	// sixteen iterations of re-sent packet.
+	MaxSteps int
+
+	// ToolResultCap, when > 0, bounds the bytes of every tool result
+	// that enters this turn's conversation (D-093): a longer result is
+	// cut on a line boundary with a "[truncated: N bytes]" marker before
+	// the model sees it. The audit trail and offload store keep the
+	// full result; only the transcript is capped.
+	ToolResultCap int
 }
 
 // Start launches the loop and returns its event stream. The channel
@@ -442,6 +455,10 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 	// forced route's chain and bypass it entirely.
 	route := req.Route
 	hint := req.ModelHint
+	maxSteps := a.maxSteps
+	if req.MaxSteps > 0 {
+		maxSteps = req.MaxSteps
+	}
 
 	for step := 1; ; step++ {
 		if step > 1 && req.Steering != nil {
@@ -449,7 +466,7 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 				msgs = append(msgs, provider.Message{Role: "user", Content: note})
 			}
 		}
-		directive := tools.CeilingFor(step, a.maxSteps)
+		directive := tools.CeilingFor(step, maxSteps)
 		// A model retrying the same call over and over (e.g. hoping a
 		// search tool will "book" something on a later attempt) forces
 		// synthesis early rather than burning steps up to the ceiling.
@@ -659,6 +676,7 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 			Role: "assistant", Content: text.String(), ToolCalls: calls,
 		})
 		for i := range results {
+			results[i].Content = capToolResult(results[i].Content, req.ToolResultCap)
 			msgs = append(msgs, provider.Message{Role: "tool", ToolResult: &results[i]})
 		}
 
@@ -685,6 +703,21 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 
 		effort = EffortFor(results)
 	}
+}
+
+// capToolResult truncates content to at most limit bytes on a line
+// boundary (falling back to a hard cut when no newline exists that
+// early) and appends a marker naming the full size (D-093). limit <= 0
+// or content within the limit returns content unchanged.
+func capToolResult(content string, limit int) string {
+	if limit <= 0 || len(content) <= limit {
+		return content
+	}
+	cut := limit
+	if i := strings.LastIndexByte(content[:limit+1], '\n'); i > 0 {
+		cut = i
+	}
+	return fmt.Sprintf("%s\n[truncated: %d bytes]", content[:cut], len(content))
 }
 
 // retryStep emits a stream.EventRetry for the upcoming attempt and

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -471,6 +471,123 @@ func TestAgentStepCeilingForcesSynthesis(t *testing.T) {
 	}
 }
 
+// TestAgentRequestMaxStepsReplacesDefaultCeiling pins D-093: a
+// Request.MaxSteps of 4 caps the loop at four gateway calls (warning
+// on the third, schemas dropped on the fourth) for a model that keeps
+// calling tools with fresh arguments; 0 keeps the agent default.
+func TestAgentRequestMaxStepsReplacesDefaultCeiling(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		maxSteps int
+		wantReqs int
+	}{
+		{"request cap of 4", 4, 4},
+		{"zero keeps the default", 0, tools.DefaultMaxSteps},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var scripts [][]stream.StreamEvent
+			for i := range tools.DefaultMaxSteps + 5 {
+				scripts = append(scripts, toolCallStep([2]string{"echo", fmt.Sprintf(`{"text":"call %d"}`, i)}))
+			}
+			gw := &scriptedGateway{scripts: scripts}
+			a, _, _, _ := testAgent(t, gw)
+			ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding", MaxSteps: tc.maxSteps})
+			if err != nil {
+				t.Fatal(err)
+			}
+			evs := collect(t, ch)
+			if len(ofType(evs, stream.EventDone)) != 1 {
+				t.Fatal("no clean terminal event")
+			}
+			if len(gw.requests) != tc.wantReqs {
+				t.Fatalf("gateway calls = %d, want %d", len(gw.requests), tc.wantReqs)
+			}
+			if last := gw.requests[len(gw.requests)-1]; len(last.Tools) != 0 {
+				t.Fatalf("final step still offered %d tools", len(last.Tools))
+			}
+		})
+	}
+}
+
+// TestAgentRequestToolResultCapTruncatesTranscript pins D-093: a tool
+// result longer than Request.ToolResultCap enters the conversation cut
+// on a line boundary with a marker naming the full size; the model's
+// next request carries the capped text, never the 10 KB original. The
+// audit digest keeps the full result. 0 leaves results untouched.
+func TestAgentRequestToolResultCapTruncatesTranscript(t *testing.T) {
+	t.Parallel()
+	var big strings.Builder
+	for i := 0; big.Len() < 10<<10; i++ {
+		fmt.Fprintf(&big, "line %04d of the tool output\n", i)
+	}
+	bigTool := &tools.Tool{
+		Name: "big", Description: "returns 10 KB",
+		InputSchema: json.RawMessage(`{"type":"object","additionalProperties":false}`),
+		Execute:     func(context.Context, json.RawMessage) (string, error) { return big.String(), nil },
+	}
+	cases := []struct {
+		name string
+		cap  int
+	}{
+		{"capped at 4096", 4096},
+		{"uncapped", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+				toolCallStep([2]string{"big", `{}`}),
+				finalStep("done"),
+			}}
+			// Offload threshold raised so the cap, not the offload, is what
+			// bounds the transcript here.
+			a, _, _, _ := testAgent(t, gw, bigTool)
+			a.offloadAt = 1 << 20
+			ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding", ToolResultCap: tc.cap})
+			if err != nil {
+				t.Fatal(err)
+			}
+			collect(t, ch)
+			if len(gw.requests) != 2 {
+				t.Fatalf("gateway calls = %d, want 2", len(gw.requests))
+			}
+			msgs := gw.requests[1].Messages
+			result := msgs[len(msgs)-1].ToolResult
+			if result == nil {
+				t.Fatalf("last message is not a tool result: %+v", msgs[len(msgs)-1])
+			}
+			if tc.cap == 0 {
+				if result.Content != big.String() {
+					t.Fatal("uncapped result was altered")
+				}
+				return
+			}
+			marker := fmt.Sprintf("\n[truncated: %d bytes]", big.Len())
+			if !strings.HasSuffix(result.Content, marker) {
+				t.Fatalf("capped result lacks the marker %q:\n...%s", marker, result.Content[len(result.Content)-80:])
+			}
+			body := strings.TrimSuffix(result.Content, marker)
+			if len(body) > tc.cap || !strings.HasSuffix(body, "of the tool output") {
+				t.Fatalf("capped body is %d bytes (cap %d) or not cut on a line boundary: %q", len(body), tc.cap, body[len(body)-40:])
+			}
+		})
+	}
+}
+
+func TestCapToolResult(t *testing.T) {
+	t.Parallel()
+	if got := capToolResult("short", 10); got != "short" {
+		t.Fatalf("within cap = %q, want unchanged", got)
+	}
+	if got := capToolResult("abcdefghij", 4); got != "abcd\n[truncated: 10 bytes]" {
+		t.Fatalf("no newline before the cap = %q, want a hard cut with marker", got)
+	}
+	if got := capToolResult("ab\ncd\nef", 5); got != "ab\ncd\n[truncated: 8 bytes]" {
+		t.Fatalf("line-boundary cut = %q", got)
+	}
+}
+
 // TestAgentForcesSynthesisOnRepeatedIdenticalCalls reproduces a live
 // loop: a model retrying the exact same tool call (e.g. search_web
 // hoping a later attempt "books" something it structurally cannot)
@@ -1646,7 +1763,9 @@ func (p *countingAskPerms) Resolve(_ context.Context, _, tool string, _ json.Raw
 	p.resolveCalls++
 	return tools.Resolution{Decision: tools.DecisionAsk, Subject: tool, Rationale: "no standing grant"}, nil
 }
-func (p *countingAskPerms) Grant(context.Context, string, string, string, time.Duration) error { return nil }
+func (p *countingAskPerms) Grant(context.Context, string, string, string, time.Duration) error {
+	return nil
+}
 
 // TestAgentUnknownToolRejectedBeforePermissionChain is D-039's first
 // failure mode: a hallucinated tool name must never reach the
@@ -2359,4 +2478,3 @@ func TestAgentEndTurnToolsErrorContinues(t *testing.T) {
 		t.Fatalf("done events = %d, want exactly 1", len(got))
 	}
 }
-

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -44,6 +44,13 @@ var ErrPromptTooLong = errors.New("mission turn rejected: prompt exceeds the mod
 // mistaking the missing sentinel for a forced failure.
 var ErrAskedUser = errors.New("mission turn parked on ask_user")
 
+// Reviewer tool-loop caps (D-093): step ceiling and per-result bytes
+// for RunReview's loop.Request. Go constants, never prompt text.
+const (
+	reviewMaxSteps      = 4
+	reviewToolResultCap = 4096
+)
+
 // Runner executes ONE session (worker turn, reviewer turn, or planner
 // turn) and owns NO state-transition logic: it reports what happened,
 // Driver decides what it means. A future delegated CLI executor would
@@ -1309,6 +1316,12 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 		Unattended:   m.ScheduleID != "",
 		// D-089: same mid-turn steering as discover/plan/worker (issue #458).
 		Steering: r.steeringFor(m.ID, m.Progress),
+		// D-093: the reviewer judges evidence the harness already
+		// produced; its tools are for a spot check, so the loop is
+		// short and every result small. Discover/plan/worker keep the
+		// agent defaults.
+		MaxSteps:      reviewMaxSteps,
+		ToolResultCap: reviewToolResultCap,
 	}
 	res, err := r.runTurn(ctx, req, reviewVerdictToolName, PhaseProve)
 	text, args := res.text, res.sentinelArgs

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -360,6 +360,34 @@ func TestRunReviewPacketListsOpenFindings(t *testing.T) {
 	}
 }
 
+// TestRunReviewRequestCarriesLoopCaps pins D-093: the reviewer's
+// loop.Request caps its tool loop at reviewMaxSteps and every result at
+// reviewToolResultCap, while a worker turn leaves both at zero (agent
+// defaults).
+func TestRunReviewRequestCarriesLoopCaps(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(reviewVerdictToolName, `{"decision":"approve"}`)},
+	}}
+	r := newTestRunner(agent)
+	if _, err := r.RunReview(context.Background(), Mission{ID: "m1", ReviewRoute: "default"}, ReviewPacket{Goal: "goal"}); err != nil {
+		t.Fatalf("RunReview: %v", err)
+	}
+	if req := agent.requests[0]; req.MaxSteps != 4 || req.ToolResultCap != 4096 {
+		t.Fatalf("reviewer request MaxSteps=%d ToolResultCap=%d, want 4 and 4096", req.MaxSteps, req.ToolResultCap)
+	}
+
+	worker := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(missionStatusToolName, `{"outcome":"done","evidence":"ok"}`)},
+	}}
+	r = newTestRunner(worker)
+	if _, _, err := r.RunWorker(context.Background(), Mission{ID: "m1", Route: "default"}, WorkPacket{Goal: "goal"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if req := worker.requests[0]; req.MaxSteps != 0 || req.ToolResultCap != 0 {
+		t.Fatalf("worker request MaxSteps=%d ToolResultCap=%d, want agent defaults (0, 0)", req.MaxSteps, req.ToolResultCap)
+	}
+}
+
 // TestRunReviewRoutePrecedence pins review's route precedence at the
 // request level: ReviewRoute > PlanRoute > Route.
 func TestRunReviewRoutePrecedence(t *testing.T) {

--- a/internal/gateway/ledger/aggregate.go
+++ b/internal/gateway/ledger/aggregate.go
@@ -286,9 +286,13 @@ type MissionUsage struct {
 	UnbilledCostByCurrency  map[string]float64 `json:"unbilled_cost_by_currency"`
 	InputTokens             int64              `json:"input_tokens"`
 	OutputTokens            int64              `json:"output_tokens"`
-	Requests                int64              `json:"requests"`
-	UnpricedRequests        int64              `json:"unpriced_requests"`
-	Models                  []ModelUsed        `json:"models"`
+	// CacheReadTokens is the input read from the provider's prompt
+	// cache (D-093): shown next to input_tokens so the caching
+	// breakpoints' effect is visible per mission.
+	CacheReadTokens  int64       `json:"cache_read_tokens"`
+	Requests         int64       `json:"requests"`
+	UnpricedRequests int64       `json:"unpriced_requests"`
+	Models           []ModelUsed `json:"models"`
 }
 
 // ModelUsed is one provider/model/harness-ness triple actually invoked
@@ -320,11 +324,11 @@ func (a *Aggregator) Mission(ctx context.Context, missionID string) (MissionUsag
 		UnbilledCostByCurrency:  map[string]float64{},
 	}
 	err = db.QueryRow(ctx, `SELECT
-			COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0),
+			COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cache_read_tokens), 0),
 			COUNT(*), COUNT(*) FILTER (WHERE cost IS NULL)
 		FROM cost_ledger
 		WHERE mission_id = $1 AND `+notTest, missionID).
-		Scan(&m.InputTokens, &m.OutputTokens, &m.Requests, &m.UnpricedRequests)
+		Scan(&m.InputTokens, &m.OutputTokens, &m.CacheReadTokens, &m.Requests, &m.UnpricedRequests)
 	if err != nil {
 		return MissionUsage{}, fmt.Errorf("usage mission: %w", err)
 	}

--- a/internal/gateway/ledger/aggregate_integration_test.go
+++ b/internal/gateway/ledger/aggregate_integration_test.go
@@ -418,10 +418,10 @@ func TestAggregateMissionUsage(t *testing.T) {
 
 	rows := []Entry{
 		{Provider: aggMarker + "a", Model: "m1", Route: "coding", MissionID: mission,
-			Usage:     &stream.Usage{InputTokens: 100, OutputTokens: 50},
+			Usage:     &stream.Usage{InputTokens: 100, OutputTokens: 50, CacheReadTokens: 30},
 			LatencyMS: 100, Status: "ok", Cost: usd(0.10)},
 		{Provider: aggMarker + "a", Model: "m1", Route: "coding", MissionID: mission,
-			Usage:     &stream.Usage{InputTokens: 200, OutputTokens: 100},
+			Usage:     &stream.Usage{InputTokens: 200, OutputTokens: 100, CacheReadTokens: 10},
 			LatencyMS: 100, Status: "ok", Cost: usd(0.20)},
 		// A fallback to a second model — the whole point of Models: a
 		// route is a chain, not one model, so both must show up.
@@ -455,6 +455,9 @@ func TestAggregateMissionUsage(t *testing.T) {
 		got.OutputTokens != 175 || got.Requests != 4 || got.UnpricedRequests != 1 {
 		t.Fatalf("Mission = %+v, want mission_id=%s cost=0.35 in=350 out=175 requests=4 unpriced=1",
 			got, mission)
+	}
+	if got.CacheReadTokens != 40 {
+		t.Fatalf("CacheReadTokens = %d, want 40 (D-093: cached reads summed per mission)", got.CacheReadTokens)
 	}
 	// The executor-purpose row's $0.05 is the harness's; the rest is
 	// brain's.

--- a/internal/gateway/provider/anthropic.go
+++ b/internal/gateway/provider/anthropic.go
@@ -96,6 +96,35 @@ type anthropicContentBlock struct {
 	Content   string                `json:"content,omitempty"`
 	IsError   bool                  `json:"is_error,omitempty"`
 	Source    *anthropicImageSource `json:"source,omitempty"`
+	// CacheControl marks the conversation breakpoint (D-093): set on the
+	// last block of the last message only.
+	CacheControl json.RawMessage `json:"cache_control,omitempty"`
+}
+
+// anthropicCacheEphemeral is the one cache_control value the driver
+// ever sends.
+var anthropicCacheEphemeral = json.RawMessage(`{"type":"ephemeral"}`)
+
+// markLastBlockCached puts the conversation breakpoint on the last
+// content block of the last message (D-093): the system block is the
+// first breakpoint, this is the second, so every tool-loop iteration
+// reads the previous iteration's whole prefix from cache instead of
+// re-sending it. A plain-string message is lifted to one text block
+// to carry the marker. Anthropic allows four breakpoints; the driver
+// uses two.
+func markLastBlockCached(msgs []anthropicMessage) {
+	if len(msgs) == 0 {
+		return
+	}
+	last := &msgs[len(msgs)-1]
+	switch c := last.Content.(type) {
+	case string:
+		last.Content = []anthropicContentBlock{{Type: "text", Text: c, CacheControl: anthropicCacheEphemeral}}
+	case []anthropicContentBlock:
+		if len(c) > 0 {
+			c[len(c)-1].CacheControl = anthropicCacheEphemeral
+		}
+	}
 }
 
 // anthropicImageSource is a base64 image block's source (D-045).
@@ -144,9 +173,6 @@ func anthropicMessages(msgs []Message) []anthropicMessage {
 			}
 			out = append(out, anthropicMessage{Role: "assistant", Content: blocks})
 		case len(m.Images) > 0:
-			// Text-only messages keep the plain-string shape (unchanged);
-			// only a message actually carrying images pays for the block
-			// array (D-045).
 			blocks := make([]anthropicContentBlock, 0, len(m.Images)+1)
 			if m.Content != "" {
 				blocks = append(blocks, anthropicContentBlock{Type: "text", Text: m.Content})
@@ -160,6 +186,14 @@ func anthropicMessages(msgs []Message) []anthropicMessage {
 				})
 			}
 			out = append(out, anthropicMessage{Role: m.Role, Content: blocks})
+		case m.Content != "":
+			// Text messages always take the block shape (D-093): the
+			// cache breakpoint sits on the last block of the last message,
+			// and the same message must serialise byte-identically on the
+			// next step when it is no longer last, or the cached prefix
+			// misses. An empty message keeps the string form: an empty
+			// text block is a wire error.
+			out = append(out, anthropicMessage{Role: m.Role, Content: []anthropicContentBlock{{Type: "text", Text: m.Content}}})
 		default:
 			out = append(out, anthropicMessage{Role: m.Role, Content: m.Content})
 		}
@@ -239,15 +273,17 @@ func (a *Anthropic) buildRequest(req CompletionRequest) anthropicRequest {
 		Stream:    true,
 		Messages:  anthropicMessages(req.Messages),
 	}
+	markLastBlockCached(out.Messages)
 	// req.Effort: no thinking control is wired for this driver yet, so
 	// the hint is ignored per D-020.
 	if req.System != "" {
 		// cache_control on the system block enables prompt caching for
-		// the stable prefix (D-018).
+		// the stable prefix (D-018); the conversation breakpoint above
+		// (D-093) extends that to the growing tool-loop transcript.
 		out.System = []anthropicTextBlock{{
 			Type:         "text",
 			Text:         req.System,
-			CacheControl: json.RawMessage(`{"type":"ephemeral"}`),
+			CacheControl: anthropicCacheEphemeral,
 		}}
 	}
 	for _, t := range req.Tools {

--- a/internal/gateway/provider/anthropic_test.go
+++ b/internal/gateway/provider/anthropic_test.go
@@ -2,9 +2,11 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -67,6 +69,94 @@ func TestAnthropicHappyPath(t *testing.T) {
 	}
 	if lastType(t, events) != stream.EventDone {
 		t.Fatalf("last event = %v, want done", lastType(t, events))
+	}
+}
+
+// TestAnthropicRequestCarriesTwoCacheBreakpoints pins D-093: the
+// serialised request marks exactly two blocks with cache_control, the
+// system block and the last content block of the last message, for
+// both a plain-string last message and a tool_result block list.
+func TestAnthropicRequestCarriesTwoCacheBreakpoints(t *testing.T) {
+	t.Parallel()
+	a := NewAnthropic(AnthropicConfig{Name: "a"})
+	cases := []struct {
+		name string
+		msgs []Message
+		want string // JSON fragment the marked last block must contain
+	}{
+		{"plain user message", []Message{{Role: "user", Content: "hi"}}, `{"type":"text","text":"hi","cache_control":{"type":"ephemeral"}}`},
+		{"tool result", []Message{
+			{Role: "user", Content: "hi"},
+			{Role: "assistant", ToolCalls: []ToolCall{{ID: "c1", Name: "echo", Input: json.RawMessage(`{}`)}}},
+			{Role: "tool", ToolResult: &ToolResult{ID: "c1", Content: "out"}},
+		}, `{"type":"tool_result","tool_use_id":"c1","content":"out","cache_control":{"type":"ephemeral"}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(a.buildRequest(CompletionRequest{Model: "m", System: "sys", Messages: tc.msgs}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := strings.Count(string(body), `"cache_control"`); got != 2 {
+				t.Fatalf("cache_control markers = %d, want 2 (system + last block):\n%s", got, body)
+			}
+			if !strings.Contains(string(body), tc.want) {
+				t.Fatalf("last block not marked:\nwant %s\nin   %s", tc.want, body)
+			}
+			// Only the LAST message carries the marker: the first user
+			// message in the tool-result case is an unmarked text block.
+			if len(tc.msgs) > 1 && !strings.Contains(string(body), `{"role":"user","content":[{"type":"text","text":"hi"}]}`) {
+				t.Fatalf("earlier message was marked or reshaped:\n%s", body)
+			}
+		})
+	}
+	// No system, no messages: nothing to mark, nothing to crash on.
+	if _, err := json.Marshal(a.buildRequest(CompletionRequest{Model: "m"})); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestAnthropicRequestPrefixStableAcrossSteps pins the property the
+// breakpoints rely on: step N+1 of a tool loop re-sends step N's system,
+// tools and messages byte-for-byte (the breakpoint moving to the new
+// last block is the only difference), so the provider serves the whole
+// earlier prefix from cache.
+func TestAnthropicRequestPrefixStableAcrossSteps(t *testing.T) {
+	t.Parallel()
+	a := NewAnthropic(AnthropicConfig{Name: "a"})
+	tools := []ToolDef{{Name: "echo", Description: "echoes", InputSchema: json.RawMessage(`{"type":"object"}`)}}
+	stepN := []Message{{Role: "user", Content: "packet"}}
+	stepN1 := append(append([]Message{}, stepN...),
+		Message{Role: "assistant", Content: "calling", ToolCalls: []ToolCall{{ID: "c1", Name: "echo", Input: json.RawMessage(`{"text":"x"}`)}}},
+		Message{Role: "tool", ToolResult: &ToolResult{ID: "c1", Content: "echo: x"}},
+	)
+	reqN := a.buildRequest(CompletionRequest{Model: "m", System: "sys", Tools: tools, Messages: stepN})
+	reqN1 := a.buildRequest(CompletionRequest{Model: "m", System: "sys", Tools: tools, Messages: stepN1})
+
+	marshal := func(v any) string {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+	if marshal(reqN.System) != marshal(reqN1.System) || marshal(reqN.Tools) != marshal(reqN1.Tools) {
+		t.Fatal("system or tool definitions differ between steps; the cached prefix would miss")
+	}
+	strip := func(s string) string { return strings.ReplaceAll(s, `,"cache_control":{"type":"ephemeral"}`, "") }
+	for i := range reqN.Messages {
+		got, want := strip(marshal(reqN1.Messages[i])), strip(marshal(reqN.Messages[i]))
+		if got != want {
+			t.Fatalf("message %d differs between steps:\nstep N   %s\nstep N+1 %s", i, want, got)
+		}
+	}
+	// Step N's marked last block must be plain again in step N+1 (a
+	// stale marker there would be a third breakpoint).
+	if strings.Contains(marshal(reqN1.Messages[0]), "cache_control") {
+		t.Fatalf("step N+1 still marks step N's last block:\n%s", marshal(reqN1.Messages[0]))
+	}
+	if !strings.Contains(marshal(reqN1.Messages[len(reqN1.Messages)-1]), "cache_control") {
+		t.Fatal("step N+1's last block carries no breakpoint")
 	}
 }
 

--- a/internal/gateway/provider/images_test.go
+++ b/internal/gateway/provider/images_test.go
@@ -128,19 +128,20 @@ func TestAnthropicMessagesImageBlock(t *testing.T) {
 	}
 }
 
-// TestAnthropicMessagesTextOnlyUnchangedWireShape pins the existing
-// wire shape for a plain user/assistant message: content stays a bare
-// string, not a block array, when there is nothing but text.
-func TestAnthropicMessagesTextOnlyUnchangedWireShape(t *testing.T) {
+// TestAnthropicMessagesTextOnlyIsOneTextBlock pins the wire shape for
+// a plain user/assistant message since D-093: one unmarked text block,
+// never a bare string, so the message serialises identically whether or
+// not it is the step's last (marked) message.
+func TestAnthropicMessagesTextOnlyIsOneTextBlock(t *testing.T) {
 	t.Parallel()
 	msgs := anthropicMessages([]Message{{Role: "user", Content: "hello"}})
 
 	if len(msgs) != 1 {
 		t.Fatalf("messages = %+v, want 1", msgs)
 	}
-	content, ok := msgs[0].Content.(string)
-	if !ok || content != "hello" {
-		t.Fatalf("Content = %+v, want the bare string %q", msgs[0].Content, "hello")
+	blocks, ok := msgs[0].Content.([]anthropicContentBlock)
+	if !ok || len(blocks) != 1 || blocks[0].Type != "text" || blocks[0].Text != "hello" || blocks[0].CacheControl != nil {
+		t.Fatalf("Content = %+v, want one unmarked text block %q", msgs[0].Content, "hello")
 	}
 }
 

--- a/internal/gateway/provider/toolwire_test.go
+++ b/internal/gateway/provider/toolwire_test.go
@@ -25,7 +25,7 @@ func TestAnthropicMessagesToolRoundTrip(t *testing.T) {
 	if len(msgs) != 3 {
 		t.Fatalf("got %d messages, want 3 (user, assistant, merged tool results)", len(msgs))
 	}
-	if msgs[0].Role != "user" || msgs[0].Content != "what time is it in Nairobi?" {
+	if first, ok := msgs[0].Content.([]anthropicContentBlock); msgs[0].Role != "user" || !ok || len(first) != 1 || first[0].Text != "what time is it in Nairobi?" {
 		t.Fatalf("plain message mangled: %+v", msgs[0])
 	}
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -388,6 +388,9 @@ export interface MissionUsage {
   rate_as_of?: string
   input_tokens: number
   output_tokens: number
+  // cache_read_tokens is input served from the provider's prompt cache
+  // (D-093), shown next to input_tokens on the cost card.
+  cache_read_tokens?: number
   requests: number
   unpriced_requests: number
   models: ModelUsed[]

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -177,6 +177,21 @@ describe('MissionDetail spend', () => {
     )
   })
 
+  it('shows cached input reads alongside the token counts when present', async () => {
+    vi.mocked(missionUsage).mockResolvedValue({
+      mission_id: 'm1',
+      cost_by_currency: { USD: 0.5 },
+      input_tokens: 120_000,
+      output_tokens: 8_000,
+      cache_read_tokens: 90_000,
+      requests: 7,
+      unpriced_requests: 0,
+      models: [],
+    })
+    renderPage()
+    expect(await screen.findByText('120.0k→8.0k tok · 90.0k cached')).toBeTruthy()
+  })
+
   it('uses the converted figure for budget percent when spend is in another currency', async () => {
     vi.mocked(getMission).mockResolvedValue({ ...baseMission, budget_amount: 2, budget_currency: 'BDT' })
     vi.mocked(missionUsage).mockResolvedValue({

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -894,8 +894,9 @@ export function MissionDetail() {
             </Badge>
           )}
           {usage && usage.requests > 0 && (
-            <Badge variant="secondary">
+            <Badge variant="secondary" title="input→output tokens; cached = input read from the provider's prompt cache">
               {compact(usage.input_tokens)}→{compact(usage.output_tokens)} tok
+              {usage.cache_read_tokens ? ` · ${compact(usage.cache_read_tokens)} cached` : ''}
             </Badge>
           )}
           <Badge variant="secondary" title="Time spent actively processing">


### PR DESCRIPTION
## Why

One review round today costs about 800k input tokens (mission b94dc32d): the reviewer makes several tool calls, each re-sending a ~100k-token packet, and the Anthropic driver marks only the system block for caching, so none of that transcript is served from cache. The reviewer also runs under the default 16-step ceiling with unbounded tool results, although it already holds the harness's verify output.

## What

D-093. Independent of the other #510 slices.

**Prompt caching (Anthropic driver)**
- A second `cache_control: {"type":"ephemeral"}` breakpoint on the last content block of the last message, in addition to the system block. Two breakpoints total (Anthropic allows four).
- Text messages are now always rendered as a single text content block instead of a bare string, so the same message serialises byte-identically on the next step when it is no longer the last (marked) message. Without this the moving marker would change the prefix bytes. Empty-content messages keep the string form (an empty text block is a wire error). Two existing tests that pinned the bare-string shape (`TestAnthropicMessagesTextOnlyUnchangedWireShape`, `TestAnthropicMessagesToolRoundTrip`) are updated accordingly.
- Bedrock Converse: left as is. The Nova cache point stays; Anthropic-on-Bedrock cache points are model-gated on that API and I could not verify them here, so they are not added.

**Loop caps**
- `loop.Request.MaxSteps` (0 = `tools.DefaultMaxSteps`) replaces the agent's step ceiling for that turn.
- `loop.Request.ToolResultCap` (0 = no cap) truncates every tool result entering the transcript on a line boundary with a `[truncated: N bytes]` marker (N = the full result size). The audit digest and the offload store keep the full result.
- `RunReview` sets `MaxSteps: 4`, `ToolResultCap: 4096` (`reviewMaxSteps`, `reviewToolResultCap` in runner.go). Discover, plan and worker turns are unchanged.

**Cost visibility**
- `ledger.MissionUsage` gains `cache_read_tokens` (one extra `SUM` in the existing mission query); the mission cost card shows `... tok · Nk cached` when non-zero.

## Tests

- provider: `TestAnthropicRequestCarriesTwoCacheBreakpoints` (plain message and tool_result last block, exactly two markers), `TestAnthropicRequestPrefixStableAcrossSteps` (system, tools and every step-N message byte-identical in step N+1 once the marker is stripped; the marker is only on the new last block), `TestAnthropicMessagesTextOnlyIsOneTextBlock`.
- loop: `TestAgentRequestMaxStepsReplacesDefaultCeiling` (4 gateway calls, schemas dropped on the last; 0 keeps 16), `TestAgentRequestToolResultCapTruncatesTranscript` (10 KB fake tool, capped at 4096 on a line boundary with the marker; 0 leaves it untouched), `TestCapToolResult`.
- missions: `TestRunReviewRequestCarriesLoopCaps` (reviewer 4/4096, worker 0/0).
- ledger (integration): `TestAggregateMissionUsage` asserts `CacheReadTokens`.
- web: `shows cached input reads alongside the token counts when present`.

`make build test vet lint` clean; `make test-integration` clean; web build, lint (0 errors), 1039 tests pass.

Part of #510
Closes #513

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790932073&installation_model_id=431401&pr_number=516&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F516&signature=200f634d43059dc9d469fe025f6b813d8dbadfc735cdf762bb77c5a9a463ffe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->