### PR TITLE
feat(missions): batch harness verification after every worker turn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,16 @@ First run: `cp deploy/env.example deploy/.env` and set
   must exist, non-empty, inside the workspace) runs BEFORE any
   model-authored `verify_cmd`. `passes` flags flip only on harness
   evidence, never on model claims.
+- Batch verification (D-094, issue #518): after every generate turn
+  `verifier.verifyAll` checks every unit (unverified ones fully,
+  already-passed ones as the regression subset) and the driver hands
+  the outcomes to `Step` via `StepInput.Verified`; `applyVerification`
+  records `harness_passed`, a 4 KB `verify_excerpt` and `regressed` on
+  the plan units, persisted only by `ApplyTransition`. A failing or
+  regressed unit costs a worker turn (`worker_retry`), never a review;
+  `stepReviewApprove` flips `passes` on harness-passed units only; a
+  generate phase with every unit harness-passed and no open finding
+  skips the worker turn (`mission.generate_skipped`).
 - Workers get per-mission `shell` + `write_file` tools via turn-scoped
   `ExtraTools` that shadow base tools by name. Workers must create files
   with `write_file` only; shell redirects/heredocs classify destructive

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -140,9 +140,9 @@ type Driver struct {
 	budget budgetProjector
 
 	// verify holds the harness-evidence slice split out into its own
-	// type (D-074): verifyCurrentUnit, markUnitPassed, checkRegressions,
-	// regressed — the only code allowed to flip a PlanUnit's Passes
-	// flag.
+	// type (D-074): verifyAll's batch pass (D-094), whose outcomes are
+	// the only evidence that ever flips a PlanUnit's HarnessPassed and,
+	// through stepReviewApprove, Passes.
 	verify verifier
 
 	// capacity backs the D-056 admission gate (see SetCapacityGate /
@@ -992,10 +992,10 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 		d.log.Warn("driver: record turn failed", "mission_id", id, "error", evErr)
 	}
 
-	// runPhase may have written plan changes of its own (e.g. review's
-	// verifyCurrentUnit -> markUnitPassed flipping a unit to passed) —
-	// re-fetch so the completion check below sees that write rather
-	// than the pre-round snapshot loaded at the top of this call.
+	// runPhase may have written mission state of its own (runPlan's
+	// SetPlan, progress notes, evidence): re-fetch so Step sees those
+	// writes rather than the pre-round snapshot loaded at the top of
+	// this call.
 	m, err = d.store.Get(ctx, id)
 	if err != nil {
 		return false, fmt.Errorf("driver advance: reload after phase: %w", err)
@@ -1212,24 +1212,10 @@ func (d *Driver) toStepState(ctx context.Context, m Mission) StepState {
 		ConsecutiveFailures: m.ConsecutiveFailures, LastGapFingerprint: m.LastGapFingerprint,
 		StallCount: m.StallCount, Spent: spent, Budget: m.BudgetAmount,
 		MixedCurrencySpend: mixed, RateAsOf: rateAsOf,
-		LastUnit: isLastUnit(m.Plan), ReplanUsed: m.ReplanUsed,
+		Units: m.Plan.Units, ReplanUsed: m.ReplanUsed,
 		AutoApprovePlan: m.AutoApprovePlan, Flow: m.Flow,
 		ReviewFindings: m.ReviewFindings, ReworkRounds: m.ReworkRounds,
 	}
-}
-
-// isLastUnit reports whether every unit in the plan has passed — the
-// mission is only done once nothing remains unverified, not merely
-// when the first still-unverified unit happens to sit at the last
-// index (that check alone is one unit short: it's true the moment the
-// second-to-last unit passes, before the actual last unit ever runs).
-func isLastUnit(plan Plan) bool {
-	for _, u := range plan.Units {
-		if !u.Passes {
-			return false
-		}
-	}
-	return true
 }
 
 // runPhase runs the phase-appropriate session and returns the StepInput
@@ -1415,7 +1401,7 @@ func restorePassedUnits(plan *Plan, prior Plan) {
 	}
 	for i := range plan.Units {
 		if passed[plan.Units[i].Title+"\x00"+plan.Units[i].VerifyCmd] {
-			plan.Units[i].Passes = true
+			plan.Units[i].Passes, plan.Units[i].HarnessPassed = true, true
 		}
 	}
 }
@@ -1433,6 +1419,16 @@ func (d *Driver) effectiveCommitStyle(ctx context.Context, m Mission) string {
 }
 
 func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
+	// D-094: every unit already harness-passed and no finding open means
+	// there is nothing for a worker to do; go straight to prove.
+	if !m.RunsPlanless() && len(m.Plan.Units) > 0 && firstUnverified(m.Plan) == -1 && len(OpenFindings(m.ReviewFindings)) == 0 {
+		if err := d.store.AppendEvent(ctx, m.ID, "mission.generate_skipped", map[string]any{
+			"reason": "every unit is harness-verified and no review finding is open",
+		}); err != nil {
+			d.log.Warn("driver: record generate skip failed", "mission_id", m.ID, "error", err)
+		}
+		return d.routeVerified(ctx, m, nil), nil
+	}
 	packet, err := d.packet(ctx, m)
 	if err != nil {
 		return StepInput{}, err
@@ -1477,7 +1473,7 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 		if m.RunsPlanless() {
 			// D-069/D-090: a planless mission (light, or
 			// flow=discover_generate) has no plan/artifacts for
-			// trySkipReview to check (it would bail into review for want
+			// routeVerified to check (it would bail into review for want
 			// of them); the worker's final message IS the deliverable,
 			// so approve directly instead. FinalMessage is the text
 			// written since the worker's last non-sentinel tool call, not
@@ -1507,11 +1503,20 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 			}
 			return StepInput{Input: InputReviewApprove, Provider: verdict.Provider, Model: verdict.Model}, nil
 		}
-		if in, ok := d.trySkipReview(ctx, m, verdict.SeenURLs); ok {
-			in.Provider, in.Model = verdict.Provider, verdict.Model
+		// D-094: the harness checks every unit now, not the reviewer
+		// later. The worker's unit failing, or an earlier unit regressing,
+		// buys another worker turn with the excerpt in its packet.
+		verified, err := d.verify.verifyAll(ctx, m, verdict.SeenURLs, true)
+		if err != nil {
+			return StepInput{}, err
+		}
+		if failing := failedUnits(verified); len(failing) > 0 {
+			in := StepInput{Input: InputWorkerRetry, Verified: verified, Provider: verdict.Provider, Model: verdict.Model}
+			in.Reason, in.GapFingerprint = harnessFailureReason(m.Plan, failing)
 			return in, nil
 		}
-		in := StepInput{Input: InputPhaseComplete, Provider: verdict.Provider, Model: verdict.Model}
+		in := d.routeVerified(ctx, m, verified)
+		in.Provider, in.Model = verdict.Provider, verdict.Model
 		if preTurnHead != "" {
 			in.TouchedFiles = touchedFiles(ctx, m.WorktreePath(), preTurnHead)
 		}
@@ -1539,62 +1544,85 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 	}
 }
 
-// trySkipReview short-circuits the review round for a non-coding
-// mission's unit when the harness's own deterministic evidence
-// (declared artifacts present and non-empty, verify_cmd passing)
-// already establishes the unit holds up — an LLM review round on top
-// of passing harness checks adds tokens, latency, and (with the
-// reviewer being the least reliable link) failure modes, not safety.
-// Coding missions always review: a diff can be wrong in ways
-// existence checks can't see. Units with no declared artifacts always
-// review too: there is no harness evidence to stand on. flow=no_prove
-// (D-090, issue #459) forces alwaysReview false the same way general
-// kind already does (policyFor), so this function is its only skip
-// mechanism: a no_prove unit with no artifacts still falls through to
-// a real review round, same as flow=full. flow=discover_generate never
-// reaches this function at all: it takes the light-style planless
-// path in runExecute instead, with no plan units to check.
-func (d *Driver) trySkipReview(ctx context.Context, m Mission, seenURLs []string) (StepInput, bool) {
-	if missionPolicyFor(m).alwaysReview {
-		return StepInput{}, false
+// routeVerified picks the input after a batch pass with no failures
+// (D-094): review_approve when the harness evidence alone settles the
+// units awaiting approval, phase_complete (into prove) otherwise. The
+// skip needs a policy that does not always review (coding missions
+// do: a diff can be wrong in ways existence checks can't see), no open
+// finding (a reviewer must close those), and declared artifacts on every
+// unit awaiting approval (none means no harness evidence to stand on).
+// flow=no_prove (D-090, issue #459) forces alwaysReview false the same
+// way general kind does (policyFor), so this is its only skip mechanism.
+func (d *Driver) routeVerified(ctx context.Context, m Mission, verified []UnitVerification) StepInput {
+	in := StepInput{Input: InputPhaseComplete, Verified: verified}
+	if missionPolicyFor(m).alwaysReview || len(OpenFindings(m.ReviewFindings)) > 0 {
+		return in
 	}
-	unit, idx := currentUnit(m.Plan)
-	if unit == nil || len(unit.Artifacts) == 0 {
-		return StepInput{}, false
-	}
-	if err := d.verify.verifyCurrentUnit(ctx, m, seenURLs); err != nil {
-		var vf *verifyFailure
-		if errors.As(err, &vf) {
-			note := fmt.Sprintf("Verification failed for unit %d before review: %s", vf.unit+1, vf.excerpt)
-			if perr := d.recordProgress(ctx, m.ID, note); perr != nil {
-				d.log.Warn("driver: record verify-failure note failed", "mission_id", m.ID, "error", perr)
-			}
-			fp := fmt.Sprintf("verify_failed:unit_%d", vf.unit)
-			return StepInput{Input: InputWorkerRetry, Reason: truncate(note, 500), GapFingerprint: fp}, true
+	units, _ := applyVerification(StepState{Units: m.Plan.Units}, verified)
+	pending := unitsUnderReview(units.Units)
+	for _, i := range pending {
+		if len(units.Units[i].Artifacts) == 0 {
+			return in
 		}
-		d.log.Warn("driver: pre-review verify errored; falling back to review", "mission_id", m.ID, "error", err)
-		return StepInput{}, false
-	}
-	if in, regressed := d.verify.checkRegressions(ctx, m); regressed {
-		return in, true
 	}
 	if err := d.store.AppendEvent(ctx, m.ID, "mission.review_skipped", map[string]any{
-		"unit": idx, "reason": "artifacts and verify_cmd passed harness checks",
+		"units": pending, "reason": "artifacts and verify_cmd passed harness checks",
 	}); err != nil {
 		d.log.Warn("driver: record review skip failed", "mission_id", m.ID, "error", err)
 	}
-	return StepInput{Input: InputReviewApprove}, true
+	in.Input = InputReviewApprove
+	return in
 }
 
-// currentUnit returns the plan's first unverified unit and its index,
-// or nil when every unit already passed.
-func currentUnit(plan Plan) (*PlanUnit, int) {
-	for i := range plan.Units {
-		if !plan.Units[i].Passes {
-			return &plan.Units[i], i
+// harnessFailureReason renders a batch pass's failures into the retry
+// event's reason and the stall fingerprint: a regression of an earlier
+// unit and the current unit failing are different stalls.
+func harnessFailureReason(plan Plan, failing []UnitVerification) (reason, fingerprint string) {
+	parts := make([]string, 0, len(failing))
+	for _, f := range failing {
+		label := fmt.Sprintf("unit %d", f.Unit+1)
+		if f.Unit < len(plan.Units) && plan.Units[f.Unit].verified() {
+			label = fmt.Sprintf("regression in unit %d %q", f.Unit+1, plan.Units[f.Unit].Title)
+			if fingerprint == "" {
+				fingerprint = fmt.Sprintf("regression:unit_%d", f.Unit)
+			}
+		} else if fingerprint == "" {
+			fingerprint = fmt.Sprintf("verify_failed:unit_%d", f.Unit)
 		}
+		parts = append(parts, fmt.Sprintf("%s failed the harness %s check", label, f.Check))
+	}
+	return truncate(strings.Join(parts, "; "), 500), fingerprint
+}
+
+// currentUnit returns the plan's first unit without harness evidence
+// (the one the next worker turn works on) and its index, or nil when
+// every unit is harness-passed.
+func currentUnit(plan Plan) (*PlanUnit, int) {
+	if i := firstUnverified(plan); i >= 0 {
+		return &plan.Units[i], i
 	}
 	return nil, -1
+}
+
+// reviewUnits returns the indices, titles and declared artifact paths
+// of the units a prove round judges: the harness-passed, not yet
+// approved ones (unitsUnderReview), falling back to the first unit
+// still pending for rows written before HarnessPassed existed.
+func reviewUnits(plan Plan) (idx []int, titles, artifacts []string) {
+	idx = unitsUnderReview(plan.Units)
+	if len(idx) == 0 {
+		for i, u := range plan.Units {
+			if !u.Passes {
+				idx = []int{i}
+				break
+			}
+		}
+	}
+	for _, i := range idx {
+		titles = append(titles, plan.Units[i].Title)
+		artifacts = append(artifacts, plan.Units[i].Artifacts...)
+	}
+	return idx, titles, artifacts
 }
 
 // reviewWithShrink runs RunReview, recovering from a prompt rejected
@@ -1620,8 +1648,8 @@ func (d *Driver) reviewWithShrink(ctx context.Context, m Mission, packet ReviewP
 		}
 		trimmed.Diff = trimmedDiff
 	}
-	if unit, _ := currentUnit(m.Plan); unit != nil {
-		trimmed.Artifacts = ReadArtifactsCapped(m.WorkRoot(), unit.Artifacts, artifactsCap)
+	if _, _, artifacts := reviewUnits(m.Plan); len(artifacts) > 0 {
+		trimmed.Artifacts = ReadArtifactsCapped(m.WorkRoot(), artifacts, artifactsCap)
 	}
 	if evErr := d.store.AppendEvent(ctx, m.ID, "mission.review_prompt_shrunk", map[string]any{
 		"action": "trimmed_packet", "diff_cap": diffCap, "artifacts_cap": artifactsCap,
@@ -1653,10 +1681,14 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 		Listing: ListWorkspace(workRoot), Progress: m.Progress,
 		OpenFindings: OpenFindings(m.ReviewFindings),
 	}
-	unit, unitIdx := currentUnit(m.Plan)
-	if unit != nil {
-		packet.UnitTitle = unit.Title
-		packet.Artifacts = ReadArtifacts(workRoot, unit.Artifacts)
+	idx, titles, artifacts := reviewUnits(m.Plan)
+	unitIdx := -1
+	if len(idx) > 0 {
+		unitIdx = idx[0]
+	}
+	packet.UnitTitle = strings.Join(titles, "; ")
+	if len(artifacts) > 0 {
+		packet.Artifacts = ReadArtifacts(workRoot, artifacts)
 	}
 	verdict, err := d.reviewWithShrink(ctx, m, packet)
 	if err != nil {
@@ -1684,39 +1716,33 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 	}
 
 	if verdict.Approved {
-		var vf *verifyFailure
-		if err := d.verify.verifyCurrentUnit(ctx, m, nil); err != nil {
-			if errors.As(err, &vf) {
-				// The reviewer approved, but the harness's own verify_cmd
-				// disagrees — real evidence the approval didn't hold up
-				// (e.g. a claimed file was never actually written), not an
-				// infra fault. Route through the SAME rework path a
-				// reviewer's own rejection takes, as a harness-authored
-				// finding (D-092): back to generate with the failure in the
-				// worker's packet, counted against the rework ceiling, and
-				// deduplicated by title so the same failing verify never
-				// opens a second finding.
-				note := fmt.Sprintf("Verification failed for unit %d: the harness ran verify_cmd and it did NOT pass. Output:\n%s", vf.unit+1, vf.excerpt)
-				if err := d.recordProgress(ctx, m.ID, note); err != nil {
-					d.log.Warn("driver: record verify-failure note failed", "mission_id", m.ID, "error", err)
-				}
-				finding := Finding{
-					Title:    fmt.Sprintf("verify_cmd failed for unit %d", vf.unit+1),
-					Detail:   truncate(vf.excerpt, 500),
-					Severity: SeverityBlocking,
-				}
-				return StepInput{
-					Input: InputReviewRework, Findings: []Finding{finding}, Unit: vf.unit, Reason: finding.Title,
-					Provider: verdict.Provider, Model: verdict.Model,
-				}, nil
-			}
+		// The approval only lands on harness evidence: the batch pass
+		// runs again (no citations: the worker turn's seenURLs are gone)
+		// and a unit failing it, reviewed or regressed, routes through the
+		// SAME rework path a reviewer's own rejection takes, as a
+		// harness-authored blocking finding (D-092): back to generate with
+		// the failure in the worker's packet, counted against the rework
+		// ceiling, and deduplicated by title so the same failing verify
+		// never opens a second finding.
+		verified, err := d.verify.verifyAll(ctx, m, nil, false)
+		if err != nil {
 			return StepInput{Input: InputReviewInfraFailure}, err
 		}
-		if in, regressed := d.verify.checkRegressions(ctx, m); regressed {
-			in.Provider, in.Model = verdict.Provider, verdict.Model
-			return in, nil
+		if failing := failedUnits(verified); len(failing) > 0 {
+			findings := make([]Finding, 0, len(failing))
+			for _, f := range failing {
+				findings = append(findings, Finding{
+					Title:    fmt.Sprintf("harness %s check failed for unit %d", f.Check, f.Unit+1),
+					Detail:   truncate(f.Excerpt, 500),
+					Severity: SeverityBlocking,
+				})
+			}
+			return StepInput{
+				Input: InputReviewRework, Findings: findings, Unit: failing[0].Unit, Reason: reviewReason(findings),
+				Verified: verified, Provider: verdict.Provider, Model: verdict.Model,
+			}, nil
 		}
-		return StepInput{Input: InputReviewApprove, Provider: verdict.Provider, Model: verdict.Model}, nil
+		return StepInput{Input: InputReviewApprove, Verified: verified, Provider: verdict.Provider, Model: verdict.Model}, nil
 	}
 	return StepInput{
 		Input: InputReviewRework, Findings: verdict.Findings, Resolved: verdict.Resolved, Unit: unitIdx,
@@ -1732,13 +1758,6 @@ func reviewReason(findings []Finding) string {
 		titles = append(titles, f.Title)
 	}
 	return strings.Join(titles, "; ")
-}
-
-// markUnitPassed delegates to verifier.markUnitPassed (verifier.go,
-// D-074) — kept as a Driver method since units_test.go's alias-safety
-// guard calls it directly as d.markUnitPassed.
-func (d *Driver) markUnitPassed(ctx context.Context, m Mission, unit int) error {
-	return d.verify.markUnitPassed(ctx, m, unit)
 }
 
 // packet builds the WorkPacket for the current phase/iteration

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -113,6 +113,9 @@ func (f *fakeStore) ApplyTransition(ctx context.Context, id string, t Transition
 	m.ConsecutiveFailures, m.LastGapFingerprint, m.StallCount = t.Next.ConsecutiveFailures, t.Next.LastGapFingerprint, t.Next.StallCount
 	m.ReplanUsed = t.Next.ReplanUsed
 	m.ReviewFindings, m.ReworkRounds = t.Next.ReviewFindings, t.Next.ReworkRounds
+	if len(t.Next.Units) > 0 {
+		m.Plan.Units = t.Next.Units
+	}
 	f.missions[id] = m
 	for _, ev := range t.Events {
 		f.seq[id]++
@@ -1032,7 +1035,7 @@ func TestDriverExecuteRecordsRawTextWithoutHandoff(t *testing.T) {
 }
 
 // TestDriverLightDoneSetsFinalOutputAndSkipsToResult confirms a light
-// mission's done branch (D-069) short-circuits trySkipReview: it sets
+// mission's done branch (D-069) short-circuits routeVerified: it sets
 // FinalOutput to the worker's FinalMessage (the text since its last
 // non-sentinel tool call, NOT the whole multi-turn transcript — see
 // TestRunWorkerFinalMessageExcludesPriorToolRoundNarration for the
@@ -1263,7 +1266,7 @@ func TestDriverNonLightDoneStillGoesThroughReview(t *testing.T) {
 
 // TestDriverNoProveStillReviewsWithoutArtifacts confirms flow=no_prove
 // does NOT approve a unit directly when it has no declared artifacts:
-// trySkipReview's skip mechanism requires real harness evidence
+// routeVerified's skip mechanism requires real harness evidence
 // (artifacts + verify_cmd), same as an ordinary flow=full general
 // mission (TestDriverNonLightDoneStillGoesThroughReview). no_prove
 // keeps discover/plan and a real plan's units; it is not a planless
@@ -1865,7 +1868,7 @@ func TestDriverDriveIsSerializedPerMission(t *testing.T) {
 // be treated as an infra fault (which just parks the mission for a
 // human to blindly resume forever); it must route through rework,
 // back to execute, so the worker gets another attempt with the actual
-// failure recorded as a progress note.
+// failure recorded on the unit (D-094) and as a blocking finding.
 func TestDriverReviewApprovalContradictedByVerifyRoutesToRework(t *testing.T) {
 	store := newFakeStore()
 	store.put("m1", Mission{
@@ -1887,11 +1890,11 @@ func TestDriverReviewApprovalContradictedByVerifyRoutesToRework(t *testing.T) {
 	if m.Iteration != 1 {
 		t.Fatalf("iteration = %d, want 1 (rework costs an iteration like any other rework)", m.Iteration)
 	}
-	if len(m.Progress) == 0 {
-		t.Fatal("expected a progress note explaining the verify failure to the next worker turn")
+	if open := OpenFindings(m.ReviewFindings); len(open) != 1 || !strings.Contains(open[0].Title, "verify_cmd check failed for unit 1") {
+		t.Fatalf("open findings = %+v, want one harness-authored verify_cmd finding", open)
 	}
-	if !strings.Contains(m.Progress[len(m.Progress)-1].Note, "Verification failed") {
-		t.Fatalf("progress note = %q, want it to explain the verify failure", m.Progress[len(m.Progress)-1].Note)
+	if u := m.Plan.Units[0]; u.HarnessPassed || u.VerifyCheck != "verify_cmd" {
+		t.Fatalf("unit = %+v, want the failed verify_cmd check recorded on it for the next worker packet", u)
 	}
 }
 
@@ -2575,8 +2578,8 @@ func TestDriverCitationCheckBlocksInvokedCitation(t *testing.T) {
 	if m.Phase != PhaseGenerate || m.Plan.Units[0].Passes {
 		t.Fatalf("mission = phase %s passes %v, want back in generate with the unit NOT passed", m.Phase, m.Plan.Units[0].Passes)
 	}
-	if len(m.Progress) == 0 || !strings.Contains(m.Progress[len(m.Progress)-1].Note, "citation check failed") {
-		t.Fatalf("progress = %+v, want a note explaining the citation failure", m.Progress)
+	if u := m.Plan.Units[0]; u.VerifyCheck != "citations" || !strings.Contains(u.VerifyExcerpt, "citation check failed") {
+		t.Fatalf("unit = %+v, want the citation failure recorded on it for the next worker packet", u)
 	}
 }
 
@@ -2612,22 +2615,18 @@ func TestDriverCitationCheckSkippedForCodingMission(t *testing.T) {
 	}
 }
 
-// TestDriverRegressionFlipsUnitAndRetriesInsteadOfAdvancing reproduces
-// the fix: a unit that already passed can silently break while a LATER
-// unit's work is happening. Unit 0's artifact ("a.md") passed
-// previously; before the driver verifies unit 1, a.md gets deleted (as
-// if the worker's unit-1 changes broke it). The regression check must
-// catch this at the point unit 1's own verify succeeds, flip unit 0's
-// Passes back to false, emit mission.regression, and route back to
-// execute (worker_retry) instead of letting the mission advance to
-// review for unit 1.
+// TestDriverRegressionFlipsUnitAndRetriesInsteadOfAdvancing covers the
+// pass-then-regress case end to end (D-094): unit 0 passes its own
+// turn; during unit 1's turn its artifact ("a.md") gets deleted. The
+// batch pass after unit 1's turn must catch this, flip unit 0 back to
+// pending (Passes and HarnessPassed both false, Regressed set, the
+// excerpt attached), append mission.unit_regressed, route back to
+// generate (worker_retry) instead of approving unit 1, and name the
+// regression in the next worker packet's current-unit block.
 func TestDriverRegressionFlipsUnitAndRetriesInsteadOfAdvancing(t *testing.T) {
 	root := t.TempDir()
 	aPath := filepath.Join(root, "a.md")
 	if err := os.WriteFile(aPath, []byte("unit 0 content"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "b.md"), []byte("unit 1 content"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	store := newFakeStore()
@@ -2635,43 +2634,206 @@ func TestDriverRegressionFlipsUnitAndRetriesInsteadOfAdvancing(t *testing.T) {
 		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking,
 		MaxIterations: 8, Workspace: root,
 		Plan: Plan{Units: []PlanUnit{
-			{Title: "unit0", Artifacts: []string{"a.md"}, Passes: true},
+			{Title: "unit0", Artifacts: []string{"a.md"}},
 			{Title: "unit1", Artifacts: []string{"b.md"}},
 		}},
 	})
-	// Simulate unit 1's work having broken unit 0's artifact by the time
-	// the harness re-checks it: delete a.md right before the driver runs.
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{
+		{Outcome: "done", Evidence: "wrote a.md"},
+		{Outcome: "done", Evidence: "wrote b.md"},
+	}}
+	d := testDriver(store, runner)
+
+	// Turn 1: unit 0 passes on harness evidence and the mission moves on
+	// to unit 1 without a review (general kind, artifacts declared).
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if u := m.Plan.Units[0]; !u.Passes || !u.HarnessPassed {
+		t.Fatalf("unit 0 after its turn = %+v, want passed on harness evidence", u)
+	}
+
+	// Turn 2: unit 1's work breaks unit 0's artifact.
+	if err := os.WriteFile(filepath.Join(root, "b.md"), []byte("unit 1 content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.Remove(aPath); err != nil {
 		t.Fatal(err)
 	}
-	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote b.md"}}}
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+
+	m, _ = store.Get(context.Background(), "m1")
+	if m.Phase != PhaseGenerate {
+		t.Fatalf("mission phase = %q, want generate (regression routes back to work, not forward)", m.Phase)
+	}
+	u := m.Plan.Units[0]
+	if u.Passes || u.HarnessPassed || !u.Regressed || u.VerifyCheck != "artifacts" || !strings.Contains(u.VerifyExcerpt, "a.md: not found") {
+		t.Fatalf("unit 0 = %+v, want flipped back to pending as a regression with the failing output attached", u)
+	}
+	if !m.Plan.Units[1].HarnessPassed {
+		t.Fatal("unit 1 passed its own checks and must keep that harness evidence")
+	}
+	found := false
+	for _, ev := range store.events["m1"] {
+		if ev.Kind == "mission.unit_regressed" {
+			found = true
+			if !strings.Contains(string(ev.Payload), `"unit":0`) || !strings.Contains(string(ev.Payload), `"check":"artifacts"`) {
+				t.Fatalf("mission.unit_regressed payload = %s, want unit=0 check=artifacts", ev.Payload)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected a mission.unit_regressed event")
+	}
+	if m.Iteration == 0 {
+		t.Fatal("a regression must cost an iteration via worker_retry, same as any other rework")
+	}
+	packet, err := d.packet(context.Background(), m)
+	if err != nil {
+		t.Fatalf("packet: %v", err)
+	}
+	_, user := packet.Render()
+	if !strings.Contains(user, "Current unit: unit0\nREGRESSED:") || !strings.Contains(user, "[regressed] unit0") || !strings.Contains(user, "[harness-verified] unit1") {
+		t.Fatalf("worker packet = %q, want unit0 named as the regressed current unit and unit1 harness-verified", user)
+	}
+}
+
+// TestDriverBatchVerifyPassesLaterUnitInSameTurn confirms D-094's batch
+// pass verifies every unit, not just the one the worker was assigned:
+// a worker that finishes two units in one turn gets both harness-passed
+// and the mission moves straight on, costing no turn for the second.
+func TestDriverBatchVerifyPassesLaterUnitInSameTurn(t *testing.T) {
+	root := t.TempDir()
+	for _, f := range []string{"a.md", "b.md"} {
+		if err := os.WriteFile(filepath.Join(root, f), []byte("content"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking,
+		MaxIterations: 8, Workspace: root,
+		Plan: Plan{Units: []PlanUnit{
+			{Title: "unit0", Artifacts: []string{"a.md"}, VerifyCmd: "grep -q content a.md"},
+			{Title: "unit1", Artifacts: []string{"b.md"}, VerifyCmd: "grep -q content b.md"},
+		}},
+	})
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote both"}}}
+	d := testDriver(store, runner)
+
+	driveN(t, d, "m1", 3) // generate -> result -> done
+
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseDone {
+		t.Fatalf("mission phase = %q, want done: both units were harness-verified in one pass", m.Phase)
+	}
+	for i, u := range m.Plan.Units {
+		if !u.Passes || !u.HarnessPassed {
+			t.Fatalf("unit %d = %+v, want passed on harness evidence", i, u)
+		}
+	}
+	if len(runner.workerPackets) != 1 {
+		t.Fatalf("RunWorker ran %d times, want exactly 1 turn for two units", len(runner.workerPackets))
+	}
+}
+
+// TestDriverCodingVerifyFailureRetriesBeforeReview confirms a coding
+// mission's worker claim is harness-checked at the end of its turn
+// (D-094): a failing verify_cmd buys another worker turn with the
+// excerpt on the unit, and no review round runs on failing work.
+func TestDriverCodingVerifyFailureRetriesBeforeReview(t *testing.T) {
+	root, base := codingWorktree(t)
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "coding", Phase: PhaseGenerate, Status: StatusWorking,
+		MaxIterations: 8, Workspace: root, BaseCommit: base,
+		Plan: Plan{Units: []PlanUnit{{Title: "add feature", VerifyCmd: "echo tests failed; exit 1"}}},
+	})
+	runner := &scriptedRunner{
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "did it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := NewDriver(store, runner, NewWorkspace("", nil, log), nil, nil, nil, fakeSandboxExec, nil, log)
+	d.retryDelayFn = func(int) time.Duration { return 0 }
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseGenerate || m.Iteration != 1 {
+		t.Fatalf("mission = phase %s iteration %d, want another generate turn (worker_retry)", m.Phase, m.Iteration)
+	}
+	if len(runner.reviewCalls) != 0 {
+		t.Fatal("a review round ran on work the harness had already failed")
+	}
+	if u := m.Plan.Units[0]; u.HarnessPassed || u.VerifyCheck != "verify_cmd" || !strings.Contains(u.VerifyExcerpt, "tests failed") {
+		t.Fatalf("unit = %+v, want the verify_cmd failure and output recorded", u)
+	}
+	if m.LastGapFingerprint != "verify_failed:unit_0" {
+		t.Fatalf("fingerprint = %q, want verify_failed:unit_0 for the stall brake", m.LastGapFingerprint)
+	}
+}
+
+// TestDriverSkipsGenerateWhenAllUnitsHarnessPassed confirms the D-094
+// short-circuit: a mission entering generate with every unit
+// harness-verified and no finding open never runs a worker turn; it
+// records mission.generate_skipped and moves to prove.
+func TestDriverSkipsGenerateWhenAllUnitsHarnessPassed(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "coding", Phase: PhaseGenerate, Status: StatusIdle, MaxIterations: 8,
+		Plan: Plan{Units: []PlanUnit{{Title: "unit0", HarnessPassed: true}}},
+	})
+	runner := &scriptedRunner{workerErr: errors.New("RunWorker must not be called")}
 	d := testDriver(store, runner)
 
 	if _, err := d.Advance(context.Background(), "m1"); err != nil {
 		t.Fatalf("Advance: %v", err)
 	}
-
 	m, _ := store.Get(context.Background(), "m1")
-	if m.Phase != PhaseGenerate {
-		t.Fatalf("mission phase = %q, want execute (regression routes back to work, not forward)", m.Phase)
-	}
-	if m.Plan.Units[0].Passes {
-		t.Fatal("unit 0's Passes was not flipped back to false after its artifact regressed")
+	if m.Phase != PhaseProve {
+		t.Fatalf("mission phase = %q, want prove without a worker turn", m.Phase)
 	}
 	found := false
 	for _, ev := range store.events["m1"] {
-		if ev.Kind == "mission.regression" {
-			found = true
-			if !strings.Contains(string(ev.Payload), `"unit":"unit0"`) || !strings.Contains(string(ev.Payload), `"check":"artifacts"`) {
-				t.Fatalf("mission.regression payload = %s, want unit=unit0 check=artifacts", ev.Payload)
-			}
-		}
+		found = found || ev.Kind == "mission.generate_skipped"
 	}
 	if !found {
-		t.Fatal("expected a mission.regression event")
+		t.Fatal("expected a mission.generate_skipped event")
 	}
-	if m.Iteration == 0 {
-		t.Fatal("a regression must cost an iteration via worker_retry, same as any other rework")
+}
+
+// TestDriverOpenFindingsStillRunGenerate confirms the skip does not
+// fire while a review finding is open: harness-passed units with an
+// unresolved finding still need a rework turn.
+func TestDriverOpenFindingsStillRunGenerate(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.md"), []byte("content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusIdle, MaxIterations: 8, Workspace: root,
+		Plan:           Plan{Units: []PlanUnit{{Title: "unit0", Artifacts: []string{"a.md"}, HarnessPassed: true}}},
+		ReviewFindings: []Finding{{ID: "F1", Title: "wrong tone", File: "a.md", Severity: SeverityBlocking, Status: FindingOpen, RoundOpened: 1}},
+		ReworkRounds:   1,
+	})
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "fixed"}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if len(runner.workerPackets) != 1 {
+		t.Fatal("the rework turn must run while a finding is open")
+	}
+	if m.Phase != PhaseProve {
+		t.Fatalf("mission phase = %q, want prove (the reviewer must close the finding, no skip)", m.Phase)
 	}
 }
 
@@ -2691,7 +2853,7 @@ func TestDriverNoRegressionAdvancesNormally(t *testing.T) {
 		ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking,
 		MaxIterations: 8, Workspace: root,
 		Plan: Plan{Units: []PlanUnit{
-			{Title: "unit0", Artifacts: []string{"a.md"}, Passes: true},
+			{Title: "unit0", Artifacts: []string{"a.md"}, Passes: true, HarnessPassed: true},
 			{Title: "unit1", Artifacts: []string{"b.md"}},
 		}},
 	})
@@ -2709,7 +2871,7 @@ func TestDriverNoRegressionAdvancesNormally(t *testing.T) {
 		t.Fatal("unit 0 must remain passed when its artifact still holds up")
 	}
 	for _, ev := range store.events["m1"] {
-		if ev.Kind == "mission.regression" {
+		if ev.Kind == "mission.unit_regressed" {
 			t.Fatal("no regression event expected when nothing regressed")
 		}
 	}

--- a/internal/brain/missions/memory.go
+++ b/internal/brain/missions/memory.go
@@ -187,7 +187,7 @@ func lastReviewVerdict(events []Event) (decision, findings string, ok bool) {
 
 // reviewSkipped reports whether any mission.review_skipped event fired
 // — the non-coding fast path that bypasses LLM review entirely on
-// harness evidence (driver.go's trySkipReview).
+// harness evidence (driver.go's routeVerified).
 func reviewSkipped(events []Event) bool {
 	for _, ev := range events {
 		if ev.Kind == "mission.review_skipped" {

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -535,8 +535,28 @@ type PlanUnit struct {
 	// verify_cmd — a tautological verify_cmd (echo 'done') can no
 	// longer fake completion when the declared artifact is missing.
 	Artifacts []string `json:"artifacts,omitempty"`
-	Passes    bool     `json:"passes"`
+	// Passes marks the unit complete: harness-passed and, for missions
+	// that review, approved by the reviewer. Never true without
+	// HarnessPassed (legacy rows written before D-094 excepted).
+	Passes bool `json:"passes"`
+	// HarnessPassed (D-094, issue #518) is the batch verifier's own
+	// verdict: artifacts present and verify_cmd exit 0 after the last
+	// worker turn. Cleared when a later turn regresses the unit.
+	HarnessPassed bool `json:"harness_passed"`
+	// VerifyCheck names the check that decided the last verification
+	// (artifacts, citations, verify_cmd, timeout); VerifyExcerpt is its
+	// trailing output, capped at verifyExcerptCap, rendered into the
+	// worker packet while the unit is failing.
+	VerifyCheck   string `json:"verify_check,omitempty"`
+	VerifyExcerpt string `json:"verify_excerpt,omitempty"`
+	// Regressed marks a unit that had passed and failed a later
+	// regression run; cleared once it passes again.
+	Regressed bool `json:"regressed,omitempty"`
 }
+
+// verified reports whether the harness has passed this unit: Passes
+// implies it for rows written before HarnessPassed existed.
+func (u PlanUnit) verified() bool { return u.HarnessPassed || u.Passes }
 
 // PendingInput is ask_user's park detail (D-088, issue #457): the
 // structured question a phase turn is waiting on the operator to

--- a/internal/brain/missions/packet.go
+++ b/internal/brain/missions/packet.go
@@ -154,14 +154,11 @@ func (p WorkPacket) render(preamble string) (system, user string) {
 	if len(p.Plan.Units) > 0 {
 		if unit, _ := currentUnit(p.Plan); unit != nil {
 			fmt.Fprintf(&b, "Current unit: %s\n", NeutralizeSlot(unit.Title))
+			b.WriteString(renderUnitFailure(*unit))
 		}
 		b.WriteString("Plan:\n")
 		for _, u := range p.Plan.Units {
-			status := "pending"
-			if u.Passes {
-				status = "verified"
-			}
-			fmt.Fprintf(&b, "- [%s] %s\n", status, NeutralizeSlot(u.Title))
+			fmt.Fprintf(&b, "- [%s] %s\n", unitStatus(u), NeutralizeSlot(u.Title))
 			// The EXACT artifact paths the harness will check — a worker
 			// that invents its own filename (http-429 vs http429) fails
 			// verification without ever seeing why.
@@ -215,6 +212,43 @@ func (p WorkPacket) render(preamble string) (system, user string) {
 	b.WriteString(renderAttachments(p.Attachments))
 
 	return system, b.String()
+}
+
+// unitStatus is the plan marker a worker or reviewer prompt shows for a
+// unit (D-094): verified (complete), harness-verified (awaiting
+// approval), regressed (passed once, failing now), or pending.
+func unitStatus(u PlanUnit) string {
+	switch {
+	case u.Passes:
+		return "verified"
+	case u.HarnessPassed:
+		return "harness-verified"
+	case u.Regressed:
+		return "regressed"
+	default:
+		return "pending"
+	}
+}
+
+// renderUnitFailure is the current-unit block's harness evidence
+// (D-094): the last failing check and its output excerpt, named as a
+// regression when the unit had passed before. Empty for a unit the
+// harness has not failed yet. The excerpt is command output, so it
+// passes NeutralizeSlot.
+func renderUnitFailure(u PlanUnit) string {
+	if u.verified() || u.VerifyCheck == "" {
+		return ""
+	}
+	var b strings.Builder
+	if u.Regressed {
+		fmt.Fprintf(&b, "REGRESSED: this unit passed before and now fails its %s check. Fix it before anything else.\n", u.VerifyCheck)
+	} else {
+		fmt.Fprintf(&b, "Last harness %s check failed for this unit.\n", u.VerifyCheck)
+	}
+	if u.VerifyExcerpt != "" {
+		fmt.Fprintf(&b, "Harness output:\n%s\n", NeutralizeSlot(strings.TrimRight(u.VerifyExcerpt, "\n")))
+	}
+	return b.String()
 }
 
 // renderOpenFindings is the rework turn's work order (D-092): the open

--- a/internal/brain/missions/packet_test.go
+++ b/internal/brain/missions/packet_test.go
@@ -37,6 +37,45 @@ func TestWorkPacketRender(t *testing.T) {
 	}
 }
 
+// TestWorkPacketRenderUnitFailure is the golden test for the D-094
+// current-unit block: the first unit without harness evidence is the
+// current one, its last failing check and excerpt render under it, and
+// plan markers distinguish verified, harness-verified, regressed and
+// pending units. A unit the harness never failed renders no block.
+func TestWorkPacketRenderUnitFailure(t *testing.T) {
+	p := WorkPacket{
+		Goal: "Write the report",
+		Plan: Plan{Units: []PlanUnit{
+			{Title: "Outline", Passes: true, HarnessPassed: true},
+			{Title: "Body", HarnessPassed: false, Regressed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "grep: body.md: No such file\n"},
+			{Title: "Appendix", HarnessPassed: true},
+			{Title: "Index"},
+		}},
+	}
+	_, user := p.Render()
+	want := "Current unit: Body\nREGRESSED: this unit passed before and now fails its verify_cmd check. Fix it before anything else.\nHarness output:\ngrep: body.md: No such file\nPlan:\n"
+	if !strings.Contains(user, want) {
+		t.Fatalf("Render current-unit block = %q, want it to contain %q", user, want)
+	}
+	for _, marker := range []string{"[verified] Outline", "[regressed] Body", "[harness-verified] Appendix", "[pending] Index"} {
+		if !strings.Contains(user, marker) {
+			t.Fatalf("Render = %q, want plan marker %q", user, marker)
+		}
+	}
+
+	p.Plan.Units[1] = PlanUnit{Title: "Body", VerifyCheck: "artifacts", VerifyExcerpt: "body.md: not found"}
+	_, user = p.Render()
+	if !strings.Contains(user, "Current unit: Body\nLast harness artifacts check failed for this unit.\nHarness output:\nbody.md: not found\n") {
+		t.Fatalf("Render = %q, want a plain failure block for a unit that never passed", user)
+	}
+
+	p.Plan.Units[1] = PlanUnit{Title: "Body"}
+	_, user = p.Render()
+	if !strings.Contains(user, "Current unit: Body\nPlan:\n") {
+		t.Fatalf("Render = %q, want no failure block for a unit the harness never checked", user)
+	}
+}
+
 // TestWorkPacketRenderOpenFindings is the golden test for the D-092
 // rework work order: the current-unit line above the plan, then the
 // findings block (exact wording, before "Progress so far"), identical

--- a/internal/brain/missions/policy.go
+++ b/internal/brain/missions/policy.go
@@ -62,8 +62,8 @@ type missionPolicy struct {
 // skipsPlanning; flow=no_prove forces alwaysReview false on a
 // general-shaped policy, since skipping the LLM reviewer is the whole
 // point of choosing it (CheckArtifacts in verifier.go still runs via
-// trySkipReview either way). flow=discover_generate does NOT need this
-// override: it never reaches trySkipReview at all, its generate turn
+// routeVerified either way). flow=discover_generate does NOT need this
+// override: it never reaches routeVerified at all, its generate turn
 // takes the same planless short-circuit as flow=light
 // (Mission.RunsPlanless), which never consults alwaysReview. Coding
 // stays alwaysReview true regardless of flow (ValidateCreate rejects

--- a/internal/brain/missions/policy_test.go
+++ b/internal/brain/missions/policy_test.go
@@ -50,7 +50,7 @@ func TestPolicyFor(t *testing.T) {
 			want: missionPolicy{needsWorktree: false, alwaysReview: false, checksCitations: true, canDelegate: false, skipsPlanning: false, canPush: false},
 		},
 		{
-			// discover_generate never reaches trySkipReview (its generate
+			// discover_generate never reaches routeVerified (its generate
 			// turn takes the planless short-circuit instead), so policyFor
 			// does not special-case it: this is the plain general policy,
 			// same as flow=full; alwaysReview is false here only because

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -1402,11 +1402,7 @@ func renderReviewContent(p ReviewPacket) string {
 	if len(p.Plan.Units) > 0 {
 		b.WriteString("\nPlan:\n")
 		for _, u := range p.Plan.Units {
-			status := "pending"
-			if u.Passes {
-				status = "verified"
-			}
-			fmt.Fprintf(&b, "- [%s] %s\n", status, NeutralizeSlot(u.Title))
+			fmt.Fprintf(&b, "- [%s] %s\n", unitStatus(u), NeutralizeSlot(u.Title))
 		}
 	}
 	if open := OpenFindings(p.OpenFindings); len(open) > 0 {
@@ -1683,10 +1679,12 @@ func parsePlan(raw string) (Plan, error) {
 			}
 		}
 	}
-	// Passes is harness-only evidence (RunVerify); a plan is never born
-	// pre-verified regardless of what the planner's JSON claims.
+	// Passes and the D-094 verify state are harness-only evidence; a plan
+	// is never born pre-verified regardless of what the planner's JSON
+	// claims.
 	for i := range plan.Units {
-		plan.Units[i].Passes = false
+		u := &plan.Units[i]
+		u.Passes, u.HarnessPassed, u.Regressed, u.VerifyCheck, u.VerifyExcerpt = false, false, false, "", ""
 	}
 	return plan, nil
 }

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -28,7 +28,7 @@ const (
 // phaseOrder is the fixed pipeline stepPhaseComplete walks for
 // FlowFull/FlowNoProve: prove is its last entry since a mission never
 // reaches result via InputPhaseComplete, only via
-// stepReviewApprove/trySkipReview once the plan's last unit is
+// stepReviewApprove/routeVerified once the plan's last unit is
 // verified (reviewSkippedOrProvePassTransition).
 var phaseOrder = []Phase{PhaseDiscover, PhasePlan, PhaseGenerate, PhaseProve}
 
@@ -219,10 +219,13 @@ type StepState struct {
 	Budget             *float64
 	MixedCurrencySpend bool
 	RateAsOf           string
-	// LastUnit reports whether the unit under review is the plan's
-	// last unit: PhaseProve's approve transition needs this to decide
-	// between advancing to generate (more units left) or result.
-	LastUnit bool
+	// Units is the plan's unit list (D-094): applyVerification records
+	// each batch verify outcome on it and stepReviewApprove flips
+	// Passes on the harness-passed ones, deciding between generate
+	// (units left) and result (all passed). Always copied before a
+	// write: it shares its backing array with the Mission row. An empty
+	// plan counts as all passed (planless flows).
+	Units []PlanUnit
 	// ReplanUsed reports whether this mission already spent its one
 	// automatic replan-on-stall attempt (stepWorkerRetry/
 	// stepReviewRework), a second stall pauses for a human same as
@@ -293,6 +296,11 @@ type StepInput struct {
 	// turn failed before any provider answered.
 	Provider string
 	Model    string
+	// Verified is the batch verify pass that preceded this input
+	// (D-094): verifier.verifyAll's outcome per unit, folded into Units
+	// by applyVerification whatever the input is, so harness evidence
+	// is never lost to the transition that follows it.
+	Verified []UnitVerification
 }
 
 // EventDraft is one event Step decided must be appended; the Store
@@ -332,6 +340,11 @@ var DefaultConfig = Config{BackoffFailures: 3, StallRounds: 2}
 //     input-specific handling — an over-budget or unconvertible-spend
 //     mission pauses regardless of what input arrived.
 //  3. input-specific switch on (Phase, Status, Input).
+//
+// Batch verify evidence carried by the input (StepInput.Verified, D-094)
+// is folded into Units right after the cancel check, ahead of the
+// budget brake and the input switch: a mission pausing on budget still
+// keeps the harness outcome its last turn produced.
 func Step(s StepState, in StepInput, cfg Config) Transition {
 	if in.Input == InputCancel {
 		if s.Phase.Terminal() {
@@ -344,7 +357,15 @@ func Step(s StepState, in StepInput, cfg Config) Transition {
 			Events: []EventDraft{{Kind: "mission.failed", Payload: map[string]any{"reason": "cancelled"}}},
 		}
 	}
+	s, verifyEvents := applyVerification(s, in.Verified)
+	t := stepInput(s, in, cfg)
+	t.Events = append(verifyEvents, t.Events...)
+	return t
+}
 
+// stepInput is Step's budget brake and input switch, after cancel and
+// verification have been handled.
+func stepInput(s StepState, in StepInput, cfg Config) Transition {
 	if s.Budget != nil && !s.Phase.Terminal() {
 		if s.MixedCurrencySpend {
 			return Transition{
@@ -649,10 +670,11 @@ func replanTransition(s StepState, in StepInput) Transition {
 	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.replan", Payload: map[string]any{"reason": in.Reason}}}}
 }
 
-// stepReviewApprove clears the stall counter (progress was made) and
-// either moves to the next unit (more generate work) or advances to
-// the result phase, depending on whether the reviewed unit was the
-// plan's last.
+// stepReviewApprove clears the stall counter (progress was made),
+// flips Passes on every harness-passed unit (D-094: approval, whether a
+// reviewer's or the review-skip fast path's, only ever lands on harness
+// evidence), and either moves on to generate (units left) or advances
+// to the result phase (all passed).
 func stepReviewApprove(s StepState) Transition {
 	s.StallCount = 0
 	s.LastGapFingerprint = ""
@@ -660,7 +682,8 @@ func stepReviewApprove(s StepState) Transition {
 	// open is resolved by it and the rework counter starts over.
 	s.ReviewFindings = resolveAll(s.ReviewFindings)
 	s.ReworkRounds = 0
-	if s.LastUnit {
+	s.Units = passHarnessVerified(s.Units)
+	if allPassed(s.Units) {
 		return reviewSkippedOrProvePassTransition(s)
 	}
 	s.Phase = PhaseGenerate
@@ -668,6 +691,95 @@ func stepReviewApprove(s StepState) Transition {
 	s.Iteration = 0
 	s.ConsecutiveFailures = 0
 	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.unit_verified", Payload: map[string]any{"passed": true, "check": "review"}}}}
+}
+
+// applyVerification folds a batch verify pass into the plan (D-094):
+// a passing unit becomes harness-passed (Passes stays for
+// stepReviewApprove); a failing one keeps the excerpt for the worker
+// packet, and if it had passed before it flips back to pending as a
+// regression with a mission.unit_regressed event. Copies Units before
+// writing: the slice shares its backing array with the Mission row.
+func applyVerification(s StepState, verified []UnitVerification) (StepState, []EventDraft) {
+	if len(verified) == 0 {
+		return s, nil
+	}
+	units := make([]PlanUnit, len(s.Units))
+	copy(units, s.Units)
+	var events []EventDraft
+	for _, v := range verified {
+		if v.Unit < 0 || v.Unit >= len(units) {
+			continue
+		}
+		u := &units[v.Unit]
+		u.VerifyCheck = v.Check
+		u.VerifyExcerpt = truncate(v.Excerpt, verifyExcerptCap)
+		if v.Passed {
+			u.HarnessPassed, u.Regressed = true, false
+			continue
+		}
+		if u.verified() {
+			u.Regressed = true
+			events = append(events, EventDraft{Kind: "mission.unit_regressed", Payload: map[string]any{
+				"unit": v.Unit, "title": u.Title, "check": v.Check, "excerpt": truncate(v.Excerpt, 500),
+			}})
+		}
+		u.HarnessPassed, u.Passes = false, false
+	}
+	s.Units = units
+	return s, events
+}
+
+// passHarnessVerified returns units with Passes set wherever the
+// harness has passed the unit; units without harness evidence are left
+// alone. Returns the input unchanged when nothing flips.
+func passHarnessVerified(units []PlanUnit) []PlanUnit {
+	if len(unitsUnderReview(units)) == 0 {
+		return units
+	}
+	out := make([]PlanUnit, len(units))
+	copy(out, units)
+	for i := range out {
+		if out[i].HarnessPassed {
+			out[i].Passes = true
+		}
+	}
+	return out
+}
+
+// allPassed reports whether every unit is complete: the mission is only
+// done once nothing remains, not when the first still-unverified unit
+// happens to sit at the last index. An empty plan is trivially passed.
+func allPassed(units []PlanUnit) bool {
+	for _, u := range units {
+		if !u.Passes {
+			return false
+		}
+	}
+	return true
+}
+
+// firstUnverified returns the index of the first unit without harness
+// evidence, the one the next worker turn works on, or -1 when every
+// unit is harness-passed.
+func firstUnverified(plan Plan) int {
+	for i, u := range plan.Units {
+		if !u.verified() {
+			return i
+		}
+	}
+	return -1
+}
+
+// unitsUnderReview lists the indices of units the harness has passed
+// but no approval has flipped yet: what a prove round judges.
+func unitsUnderReview(units []PlanUnit) []int {
+	var out []int
+	for i, u := range units {
+		if u.HarnessPassed && !u.Passes {
+			out = append(out, i)
+		}
+	}
+	return out
 }
 
 // reviewSkippedOrProvePassTransition advances a mission whose last

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -60,10 +60,10 @@ func TestStep(t *testing.T) {
 		},
 		{
 			name:  "spend under budget does not pause",
-			state: StepState{Phase: PhaseProve, Status: StatusWorking, Spent: 5, Budget: budget(10), LastUnit: true},
+			state: StepState{Phase: PhaseProve, Status: StatusWorking, Spent: 5, Budget: budget(10)},
 			input: StepInput{Input: InputReviewApprove},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseResult, Status: StatusIdle, Spent: 5, Budget: budget(10), LastUnit: true},
+			want:  StepState{Phase: PhaseResult, Status: StatusIdle, Spent: 5, Budget: budget(10)},
 		},
 		{
 			name:  "nil budget never pauses on spend",
@@ -212,17 +212,17 @@ func TestStep(t *testing.T) {
 		},
 		{
 			name:  "review_approve on a non-last unit returns to generate",
-			state: StepState{Phase: PhaseProve, Status: StatusWorking, LastUnit: false, StallCount: 1, LastGapFingerprint: "x"},
+			state: StepState{Phase: PhaseProve, Status: StatusWorking, StallCount: 1, LastGapFingerprint: "x", Units: []PlanUnit{{}}},
 			input: StepInput{Input: InputReviewApprove},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseGenerate, Status: StatusIdle, LastUnit: false},
+			want:  StepState{Phase: PhaseGenerate, Status: StatusIdle, Units: []PlanUnit{{}}},
 		},
 		{
 			name:  "review_approve on the last unit advances to result, not done",
-			state: StepState{Phase: PhaseProve, Status: StatusWorking, LastUnit: true, StallCount: 1, LastGapFingerprint: "x"},
+			state: StepState{Phase: PhaseProve, Status: StatusWorking, StallCount: 1, LastGapFingerprint: "x"},
 			input: StepInput{Input: InputReviewApprove},
 			cfg:   DefaultConfig,
-			want:  StepState{Phase: PhaseResult, Status: StatusIdle, LastUnit: true},
+			want:  StepState{Phase: PhaseResult, Status: StatusIdle},
 		},
 		{
 			name:  "review_rework with no findings returns to generate and counts the round",
@@ -396,7 +396,7 @@ func TestStep(t *testing.T) {
 // treats as false).
 func TestStepReviewApproveEmitsPassedTrue(t *testing.T) {
 	got := Step(
-		StepState{Phase: PhaseProve, Status: StatusWorking, LastUnit: false},
+		StepState{Phase: PhaseProve, Status: StatusWorking, Units: []PlanUnit{{}}},
 		StepInput{Input: InputReviewApprove},
 		DefaultConfig,
 	)
@@ -481,13 +481,13 @@ func TestStepReplanEmitsReasonAndUsesReplanOnlyOnce(t *testing.T) {
 }
 
 // TestStepLightApproveGoesResult confirms a light mission (born in
-// PhaseGenerate, empty spec so LastUnit is always true) advances to
+// PhaseGenerate, empty plan so every unit counts as passed) advances to
 // the result phase on review_approve exactly like a coding/general
 // mission's last unit: not straight to done, since D-086's result
 // phase now sits between the last unit's approval and done.
 func TestStepLightApproveGoesResult(t *testing.T) {
 	got := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, Flow: FlowLight, LastUnit: true},
+		StepState{Phase: PhaseGenerate, Status: StatusWorking, Flow: FlowLight},
 		StepInput{Input: InputReviewApprove},
 		DefaultConfig,
 	)
@@ -498,11 +498,11 @@ func TestStepLightApproveGoesResult(t *testing.T) {
 
 // TestStepDiscoverGenerateApproveGoesResult confirms a discover_generate
 // mission (generate turn takes the same planless short-circuit as
-// light, empty spec so LastUnit is always true) advances to the
+// light, empty plan so every unit counts as passed) advances to the
 // result phase on review_approve exactly like light, D-090.
 func TestStepDiscoverGenerateApproveGoesResult(t *testing.T) {
 	got := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, Flow: FlowDiscoverGenerate, LastUnit: true},
+		StepState{Phase: PhaseGenerate, Status: StatusWorking, Flow: FlowDiscoverGenerate},
 		StepInput{Input: InputReviewApprove},
 		DefaultConfig,
 	)
@@ -575,15 +575,127 @@ func TestStepResultFailedParksInResult(t *testing.T) {
 	}
 }
 
+// TestStepAppliesVerification pins D-094's plan bookkeeping: a batch
+// pass carried by any input lands on Units before the input itself is
+// handled, Passes only ever flips on approval over harness evidence, and
+// a passed unit failing again flips back to pending with a
+// mission.unit_regressed event.
+func TestStepAppliesVerification(t *testing.T) {
+	long := strings.Repeat("x", verifyExcerptCap+100)
+	cases := []struct {
+		name       string
+		state      StepState
+		input      StepInput
+		wantUnits  []PlanUnit
+		wantPhase  Phase
+		wantEvents []string
+	}{
+		{
+			name:  "worker_retry records the failing excerpt without flipping anything",
+			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Units: []PlanUnit{{Title: "a"}}},
+			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "verify_failed:unit_0", Verified: []UnitVerification{{Unit: 0, Check: "verify_cmd", Excerpt: long}}},
+			wantUnits: []PlanUnit{{Title: "a", VerifyCheck: "verify_cmd", VerifyExcerpt: long[:verifyExcerptCap] + "…"}},
+			wantPhase: PhaseGenerate, wantEvents: []string{"mission.retry"},
+		},
+		{
+			name:  "phase_complete marks a passing unit harness-passed, Passes waits for approval",
+			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, Units: []PlanUnit{{Title: "a"}, {Title: "b"}}},
+			input: StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 0, Passed: true, Check: "verify_cmd", Excerpt: "ok"}}},
+			wantUnits: []PlanUnit{{Title: "a", HarnessPassed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "ok"}, {Title: "b"}},
+			wantPhase: PhaseProve, wantEvents: []string{"mission.phase_started"},
+		},
+		{
+			name: "review_approve flips every harness-passed unit and advances to result when all passed",
+			state: StepState{Phase: PhaseProve, Status: StatusWorking, Units: []PlanUnit{
+				{Title: "a", Passes: true, HarnessPassed: true}, {Title: "b", HarnessPassed: true},
+			}},
+			input:     StepInput{Input: InputReviewApprove, Verified: []UnitVerification{{Unit: 0, Passed: true, Check: "artifacts"}, {Unit: 1, Passed: true, Check: "artifacts"}}},
+			wantUnits: []PlanUnit{{Title: "a", Passes: true, HarnessPassed: true, VerifyCheck: "artifacts"}, {Title: "b", Passes: true, HarnessPassed: true, VerifyCheck: "artifacts"}},
+			wantPhase: PhaseResult, wantEvents: []string{"mission.phase_started"},
+		},
+		{
+			name:      "review_approve never flips a unit without harness evidence",
+			state:     StepState{Phase: PhaseProve, Status: StatusWorking, Units: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b"}}},
+			input:     StepInput{Input: InputReviewApprove},
+			wantUnits: []PlanUnit{{Title: "a", Passes: true, HarnessPassed: true}, {Title: "b"}},
+			wantPhase: PhaseGenerate, wantEvents: []string{"mission.unit_verified"},
+		},
+		{
+			name: "a passed unit failing again regresses to pending with the excerpt and an event",
+			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Units: []PlanUnit{
+				{Title: "a", Passes: true, HarnessPassed: true}, {Title: "b"},
+			}},
+			input: StepInput{Input: InputWorkerRetry, GapFingerprint: "regression:unit_0", Verified: []UnitVerification{
+				{Unit: 0, Check: "artifacts", Excerpt: "a.md: not found"}, {Unit: 1, Passed: true, Check: "verify_cmd"},
+			}},
+			wantUnits: []PlanUnit{
+				{Title: "a", Regressed: true, VerifyCheck: "artifacts", VerifyExcerpt: "a.md: not found"},
+				{Title: "b", HarnessPassed: true, VerifyCheck: "verify_cmd"},
+			},
+			wantPhase: PhaseGenerate, wantEvents: []string{"mission.unit_regressed", "mission.retry"},
+		},
+		{
+			name:      "a regressed unit passing again clears the regression marker",
+			state:     StepState{Phase: PhaseGenerate, Status: StatusWorking, Units: []PlanUnit{{Title: "a", Regressed: true, VerifyCheck: "artifacts", VerifyExcerpt: "gone"}}},
+			input:     StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 0, Passed: true, Check: "verify_cmd", Excerpt: "ok"}}},
+			wantUnits: []PlanUnit{{Title: "a", HarnessPassed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "ok"}},
+			wantPhase: PhaseProve, wantEvents: []string{"mission.phase_started"},
+		},
+		{
+			name:      "an out-of-range unit index is ignored",
+			state:     StepState{Phase: PhaseGenerate, Status: StatusWorking, Units: []PlanUnit{{Title: "a"}}},
+			input:     StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 4, Passed: true}}},
+			wantUnits: []PlanUnit{{Title: "a"}},
+			wantPhase: PhaseProve, wantEvents: []string{"mission.phase_started"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Step(tc.state, tc.input, DefaultConfig)
+			if got.Next.Phase != tc.wantPhase {
+				t.Fatalf("phase = %q, want %q", got.Next.Phase, tc.wantPhase)
+			}
+			if !reflect.DeepEqual(got.Next.Units, tc.wantUnits) {
+				t.Fatalf("units = %+v, want %+v", got.Next.Units, tc.wantUnits)
+			}
+			kinds := make([]string, 0, len(got.Events))
+			for _, ev := range got.Events {
+				kinds = append(kinds, ev.Kind)
+			}
+			if !reflect.DeepEqual(kinds, tc.wantEvents) {
+				t.Fatalf("events = %v, want %v", kinds, tc.wantEvents)
+			}
+		})
+	}
+}
+
+// TestStepRegressionEventPayload pins what mission.unit_regressed
+// carries: the unit index and title, the failing check, and a bounded
+// excerpt, so the timeline names what broke without the full output.
+func TestStepRegressionEventPayload(t *testing.T) {
+	got := Step(
+		StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Units: []PlanUnit{{Title: "write a.md", Passes: true, HarnessPassed: true}}},
+		StepInput{Input: InputWorkerRetry, Verified: []UnitVerification{{Unit: 0, Check: "verify_cmd", Excerpt: strings.Repeat("y", 600)}}},
+		DefaultConfig,
+	)
+	if len(got.Events) == 0 || got.Events[0].Kind != "mission.unit_regressed" {
+		t.Fatalf("events = %+v, want mission.unit_regressed first", got.Events)
+	}
+	p := got.Events[0].Payload
+	if p["unit"] != 0 || p["title"] != "write a.md" || p["check"] != "verify_cmd" || len(p["excerpt"].(string)) > 510 {
+		t.Fatalf("payload = %+v, want unit 0, the title, the check and a bounded excerpt", p)
+	}
+}
+
 // TestStepReviewSkippedGoesResult confirms the non-coding review-skip
-// fast path (trySkipReview firing InputReviewApprove directly, driver.go)
+// fast path (routeVerified firing InputReviewApprove directly, driver.go)
 // lands in result the same way an approved prove round does: the
 // state machine can't distinguish the two, by design, so this is
 // really the same case as review_approve on the last unit; kept
 // separate as documentation of that fast path's contract.
 func TestStepReviewSkippedGoesResult(t *testing.T) {
 	got := Step(
-		StepState{Phase: PhaseGenerate, Status: StatusWorking, LastUnit: true},
+		StepState{Phase: PhaseGenerate, Status: StatusWorking},
 		StepInput{Input: InputReviewApprove},
 		DefaultConfig,
 	)

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -457,10 +457,11 @@ func (s *Store) List(ctx context.Context, filter ListFilter) ([]Mission, error) 
 	return out, rows.Err()
 }
 
-// SetPlan persists the mission's plan -- written by the plan phase
-// (initial plan) and by unit verification (flipping a unit's Passes),
-// independent of ApplyTransition since a plan update doesn't always
-// coincide with a phase/status change.
+// SetPlan persists the mission's plan, written by the plan phase
+// (initial plan and replans) independent of ApplyTransition since a
+// plan landing doesn't coincide with a phase/status change. Per-unit
+// verify state (Passes, HarnessPassed, excerpts) is written only by
+// ApplyTransition (D-094).
 func (s *Store) SetPlan(ctx context.Context, id string, plan Plan) error {
 	db, err := s.db.Get()
 	if err != nil {
@@ -1096,16 +1097,26 @@ func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) er
 	if err != nil {
 		return fmt.Errorf("missions apply transition marshal findings: %w", err)
 	}
+	// Per-unit verify state (D-094) lives inside the plan jsonb; only the
+	// units key is rewritten, and only when the plan has units, so a
+	// planless mission's '{}' stays untouched.
+	var unitsJSON []byte
+	if len(t.Next.Units) > 0 {
+		if unitsJSON, err = json.Marshal(t.Next.Units); err != nil {
+			return fmt.Errorf("missions apply transition marshal units: %w", err)
+		}
+	}
 	if _, err := tx.Exec(ctx, `UPDATE missions SET
 			phase = $2, status = $3, pause_reason = $4, pause_message = '', iteration = $5, max_iterations = $6,
 			consecutive_failures = $7, last_gap_fingerprint = $8, stall_count = $9, replan_used = $11, updated_at = now(),
 			pending_permission = CASE WHEN $10 THEN NULL ELSE pending_permission END,
-			review_findings = $12, rework_rounds = $13
+			review_findings = $12, rework_rounds = $13,
+			plan = CASE WHEN $14::jsonb IS NULL THEN plan ELSE jsonb_set(plan, '{units}', $14::jsonb) END
 		WHERE id = $1`,
 		id, string(t.Next.Phase), string(t.Next.Status), string(t.Next.PauseReason),
 		t.Next.Iteration, t.Next.MaxIterations, t.Next.ConsecutiveFailures,
 		t.Next.LastGapFingerprint, t.Next.StallCount, clearPending, t.Next.ReplanUsed,
-		findingsJSON, t.Next.ReworkRounds,
+		findingsJSON, t.Next.ReworkRounds, unitsJSON,
 	); err != nil {
 		return fmt.Errorf("missions apply transition update: %w", err)
 	}

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -828,6 +828,98 @@ func TestReviewFindingsRoundTrip(t *testing.T) {
 	}
 }
 
+// TestApplyTransitionPersistsUnitVerifyState confirms D-094's per-unit
+// verify state is real DB state written through ApplyTransition: a unit
+// passes, then regresses, and each step's Units land in the plan jsonb
+// (the plan's other keys untouched) with the events appended in order.
+// A transition with no units leaves a planless mission's plan alone.
+func TestApplyTransitionPersistsUnitVerifyState(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{Goal: marker + "verify state", Kind: "general"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := s.ApplyTransition(ctx, id, Transition{Next: StepState{Phase: PhasePlan, Status: StatusIdle, MaxIterations: 8}}); err != nil {
+		t.Fatalf("ApplyTransition planless: %v", err)
+	}
+	planless, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(planless.Plan.Units) != 0 {
+		t.Fatalf("planless plan = %+v, want no units written", planless.Plan)
+	}
+
+	plan := Plan{
+		Units:       []PlanUnit{{Title: "write a.md", Artifacts: []string{"a.md"}, VerifyCmd: "test -s a.md"}, {Title: "write b.md"}},
+		Assumptions: []PlanAssumption{{Assumption: "format", Default: "markdown"}},
+	}
+	if err := s.SetPlan(ctx, id, plan); err != nil {
+		t.Fatalf("SetPlan: %v", err)
+	}
+
+	// Turn 1: unit 0 passes on harness evidence.
+	passed := Step(
+		StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Units: plan.Units},
+		StepInput{Input: InputReviewApprove, Verified: []UnitVerification{{Unit: 0, Passed: true, Check: "verify_cmd", Excerpt: "ok"}}},
+		DefaultConfig,
+	)
+	if err := s.ApplyTransition(ctx, id, passed); err != nil {
+		t.Fatalf("ApplyTransition pass: %v", err)
+	}
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if u := m.Plan.Units[0]; !u.Passes || !u.HarnessPassed || u.VerifyCheck != "verify_cmd" || u.VerifyExcerpt != "ok" {
+		t.Fatalf("unit 0 after pass = %+v, want passed on harness evidence with the excerpt", u)
+	}
+	if len(m.Plan.Assumptions) != 1 || m.Plan.Units[1].Title != "write b.md" {
+		t.Fatalf("plan after pass = %+v, want assumptions and the other unit untouched", m.Plan)
+	}
+
+	// Turn 2: unit 0 regresses while unit 1 passes.
+	regressed := Step(
+		StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Units: m.Plan.Units},
+		StepInput{Input: InputWorkerRetry, GapFingerprint: "regression:unit_0", Verified: []UnitVerification{
+			{Unit: 0, Check: "artifacts", Excerpt: "a.md: not found"}, {Unit: 1, Passed: true, Check: "artifacts"},
+		}},
+		DefaultConfig,
+	)
+	if err := s.ApplyTransition(ctx, id, regressed); err != nil {
+		t.Fatalf("ApplyTransition regression: %v", err)
+	}
+	m, err = s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if u := m.Plan.Units[0]; u.Passes || u.HarnessPassed || !u.Regressed || u.VerifyCheck != "artifacts" || u.VerifyExcerpt != "a.md: not found" {
+		t.Fatalf("unit 0 after regression = %+v, want pending, regressed, with the failing output", u)
+	}
+	if u := m.Plan.Units[1]; !u.HarnessPassed || u.Passes {
+		t.Fatalf("unit 1 after regression = %+v, want harness-passed awaiting approval", u)
+	}
+	events, err := s.Events(ctx, id)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	var kinds []string
+	for _, ev := range events {
+		kinds = append(kinds, ev.Kind)
+	}
+	want := []string{"mission.unit_verified", "mission.unit_regressed", "mission.retry"}
+	if len(kinds) != len(want) {
+		t.Fatalf("event kinds = %v, want %v", kinds, want)
+	}
+	for i := range want {
+		if kinds[i] != want[i] {
+			t.Fatalf("event kinds = %v, want %v", kinds, want)
+		}
+	}
+}
+
 // TestPlanApprovalParkRoundTrip confirms D-087 (issue #456) is real DB
 // state, not in-memory only: a mission created with auto_approve_plan
 // false, parked on PauseApproval via ApplyTransition, survives a fresh

--- a/internal/brain/missions/units_test.go
+++ b/internal/brain/missions/units_test.go
@@ -1,12 +1,10 @@
 package missions
 
 import (
-	"context"
-	"log/slog"
 	"testing"
 )
 
-func TestIsLastUnit(t *testing.T) {
+func TestAllPassed(t *testing.T) {
 	cases := []struct {
 		name  string
 		units []PlanUnit
@@ -24,43 +22,41 @@ func TestIsLastUnit(t *testing.T) {
 			false,
 		},
 		{"only last unit unverified with one unit total", []PlanUnit{{Passes: false}}, false},
+		{"harness-passed but not approved is not passed", []PlanUnit{{HarnessPassed: true}}, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := isLastUnit(Plan{Units: c.units})
+			got := allPassed(c.units)
 			if got != c.want {
-				t.Fatalf("isLastUnit(%+v) = %v, want %v", c.units, got, c.want)
+				t.Fatalf("allPassed(%+v) = %v, want %v", c.units, got, c.want)
 			}
 		})
 	}
 }
 
-// TestMarkUnitPassedDoesNotAliasCaller guards the actual production
-// bug: markUnitPassed must not mutate the caller's Plan.Units backing
-// array. If it did, a caller that inspects m.Plan after calling it
-// (e.g. Advance's toStepState(m)) would observe a unit as passed one
-// full round before the harness ever verified it.
-func TestMarkUnitPassedDoesNotAliasCaller(t *testing.T) {
-	store := newFakeStore()
-	d := NewDriver(store, nil, nil, nil, nil, nil, nil, nil, slog.Default())
-
-	units := []PlanUnit{{Title: "a", Passes: true}, {Title: "b", Passes: false}, {Title: "c", Passes: false}}
+// TestStepDoesNotAliasCallerUnits guards the aliasing bug D-094 inherits
+// from the old markUnitPassed: Step receives Units sharing its backing
+// array with the caller's Mission row, so applyVerification and
+// stepReviewApprove must copy before writing. If they wrote through, a
+// caller inspecting m.Plan after Step (Advance's own m) would observe a
+// unit as passed before ApplyTransition ever persisted it.
+func TestStepDoesNotAliasCallerUnits(t *testing.T) {
+	units := []PlanUnit{{Title: "a", Passes: true, HarnessPassed: true}, {Title: "b", HarnessPassed: true}, {Title: "c"}}
 	m := Mission{ID: "m1", Plan: Plan{Units: units}}
-	store.put(m.ID, m)
 
-	if err := d.markUnitPassed(context.Background(), m, 1); err != nil {
-		t.Fatalf("markUnitPassed: %v", err)
-	}
+	got := Step(
+		StepState{Phase: PhaseProve, Status: StatusWorking, Units: m.Plan.Units},
+		StepInput{Input: InputReviewApprove, Verified: []UnitVerification{{Unit: 2, Passed: false, Check: "artifacts", Excerpt: "missing"}}},
+		DefaultConfig,
+	)
 
-	if m.Plan.Units[1].Passes {
-		t.Fatal("markUnitPassed mutated the caller's Mission value through a shared slice backing array")
+	if m.Plan.Units[1].Passes || m.Plan.Units[2].VerifyExcerpt != "" {
+		t.Fatalf("Step mutated the caller's Mission value through a shared slice backing array: %+v", m.Plan.Units)
 	}
-
-	persisted := store.missions[m.ID]
-	if !persisted.Plan.Units[1].Passes {
-		t.Fatal("markUnitPassed did not persist the update to the store")
+	if !got.Next.Units[1].Passes {
+		t.Fatal("approve did not flip the harness-passed unit in the returned state")
 	}
-	if persisted.Plan.Units[2].Passes {
-		t.Fatal("markUnitPassed must not affect unrelated units")
+	if got.Next.Units[2].Passes || got.Next.Units[2].VerifyExcerpt != "missing" {
+		t.Fatalf("unit c = %+v, want unverified with the excerpt recorded", got.Next.Units[2])
 	}
 }

--- a/internal/brain/missions/verifier.go
+++ b/internal/brain/missions/verifier.go
@@ -1,11 +1,10 @@
 package missions
 
-// D-074: verifier holds the harness-evidence slice split out of Driver
-// (verifyCurrentUnit, markUnitPassed, checkRegressions, regressed) — a
-// pure extraction, no behavior change. This makes the harness-evidence
-// invariant (only verifier flips a unit's Passes flag, never model
-// output) type-visible: Driver's own runExecute/runReview/trySkipReview
-// call into it, but never write Passes any other way.
+// D-074: verifier holds the harness-evidence slice split out of Driver.
+// D-094 (issue #518) reshapes it into one batch pass: verifyAll checks
+// every unit after a worker turn (and again on a review approval) and
+// returns the outcomes; Step folds them into the plan and ApplyTransition
+// persists them. The verifier itself never writes the plan.
 
 import (
 	"context"
@@ -17,187 +16,93 @@ import (
 )
 
 // verifier runs the harness's own deterministic checks (declared
-// artifacts, verify_cmd) for a mission's plan units and is the only
-// thing allowed to flip a PlanUnit's Passes flag.
+// artifacts, citations, verify_cmd) for a mission's plan units.
 type verifier struct {
 	store       driverStore
 	sandboxExec sandboxExec
 	log         *slog.Logger
 }
 
-// verifyFailure is a unit's verify_cmd genuinely running and reporting
-// failure — real evidence the reviewer's approval didn't hold up, not
-// an infrastructure fault. Kept distinct from a plain error (RunVerify
-// itself erroring: timeout, exec failure) so the caller can route each
-// to a different StepInput instead of conflating both as infra.
-type verifyFailure struct {
-	unit    int
-	excerpt string
-}
-
-func (e *verifyFailure) Error() string {
-	return fmt.Sprintf("driver: unit %d verify_cmd failed", e.unit)
-}
-
-// verifyCurrentUnit runs the harness's own checks for the plan's
-// current (first unverified) unit and marks it passed — only this
-// harness-run evidence may flip a unit's Passes flag, never model
-// output. Declared artifacts are checked first (exists, non-empty),
-// then (general missions only, D-059) that every URL cited in those
-// artifacts was actually seen by the worker via fetch_url/search_web
-// this turn — a tautological verify_cmd cannot pass a unit whose
-// artifact was never written, or whose citations were invented.
-// seenURLs is only ever populated by the caller right after the
-// worker turn that produced it (runExecute); it is empty on the later
-// runReview call, which is fine — for a general mission trySkipReview
-// already ran this exact check with the real evidence, and runReview
-// only reaches this path for coding missions (out of scope) or the
-// rare infra-failure fallback.
-func (v *verifier) verifyCurrentUnit(ctx context.Context, m Mission, seenURLs []string) error {
+// verifyAll runs the harness checks for every plan unit and returns one
+// UnitVerification per unit checked:
+//   - a unit not yet harness-passed gets CheckArtifacts, then (citations
+//     true, general missions only, D-059) CheckCitations against seenURLs,
+//     then verify_cmd. A unit after the current one whose artifacts are
+//     missing is skipped: not started yet, nothing to record.
+//   - an already harness-passed unit gets CheckArtifacts plus verify_cmd
+//     as the regression subset.
+//
+// A hung verify_cmd counts as failed (RunVerifyWithBackend's TimedOut);
+// any other exec error aborts the pass as an infrastructure failure.
+func (v *verifier) verifyAll(ctx context.Context, m Mission, seenURLs []string, citations bool) ([]UnitVerification, error) {
+	workRoot := m.WorkRoot()
+	current := firstUnverified(m.Plan)
+	checkCitations := citations && missionPolicyFor(m).checksCitations
+	var out []UnitVerification
 	for i, u := range m.Plan.Units {
-		if u.Passes {
-			continue
-		}
-		workRoot := m.WorkRoot()
+		res := UnitVerification{Unit: i}
 		if problems := CheckArtifacts(workRoot, u.Artifacts); len(problems) > 0 {
-			excerpt := "declared artifacts failed the harness check:\n" + strings.Join(problems, "\n")
-			// Show what DOES exist: the dominant failure here is a
-			// worker writing a real file under a slightly different
-			// name and never spotting the mismatch from "not found"
-			// alone.
-			if listing := ListWorkspace(workRoot); listing != "" {
-				excerpt += "\nfiles currently in the workspace:\n" + listing
-			} else {
-				excerpt += "\nthe workspace is currently empty"
+			if !u.verified() && i != current {
+				continue
 			}
-			if err := v.store.AppendEvent(ctx, m.ID, "mission.unit_verified", map[string]any{
-				"unit": i, "passed": false, "check": "artifacts", "problems": problems,
-			}); err != nil {
-				v.log.Warn("driver: record verify failed", "mission_id", m.ID, "error", err)
-			}
-			return &verifyFailure{unit: i, excerpt: excerpt}
-		}
-		if missionPolicyFor(m).checksCitations {
+			res.Check, res.Excerpt = "artifacts", artifactsExcerpt(workRoot, problems)
+		} else if checkCitations && !u.verified() {
 			if problems := CheckCitations(workRoot, u.Artifacts, seenURLs); len(problems) > 0 {
-				excerpt := "citation check failed:\n" + strings.Join(problems, "\n")
-				if err := v.store.AppendEvent(ctx, m.ID, "mission.unit_verified", map[string]any{
-					"unit": i, "passed": false, "check": "citations", "problems": problems,
-				}); err != nil {
-					v.log.Warn("driver: record verify failed", "mission_id", m.ID, "error", err)
-				}
-				return &verifyFailure{unit: i, excerpt: excerpt}
+				res.Check, res.Excerpt = "citations", "citation check failed:\n"+strings.Join(problems, "\n")
 			}
 		}
-		if u.VerifyCmd == "" {
-			return v.markUnitPassed(ctx, m, i)
+		payload := map[string]any{"unit": i, "regression": u.verified()}
+		if res.Check == "" {
+			if u.VerifyCmd == "" {
+				res.Passed, res.Check = true, "artifacts"
+			} else {
+				r, err := v.runVerify(ctx, m.ID, m.Environment, workRoot, u.VerifyCmd)
+				if err != nil {
+					return nil, fmt.Errorf("driver: verify unit %d: %w", i, err)
+				}
+				res.Passed, res.Check, res.Excerpt = r.Passed, "verify_cmd", r.Excerpt
+				if r.TimedOut {
+					res.Check = "timeout"
+				}
+				payload["exit_code"], payload["output_sha256"] = r.ExitCode, r.OutputSHA256
+			}
 		}
-		res, err := v.runVerify(ctx, m.ID, m.Environment, workRoot, u.VerifyCmd)
-		if err != nil {
-			return fmt.Errorf("driver: verify unit %d: %w", i, err)
+		payload["passed"], payload["check"] = res.Passed, res.Check
+		if !res.Passed {
+			payload["excerpt"] = truncate(res.Excerpt, 500)
 		}
-		if err := v.store.AppendEvent(ctx, m.ID, "mission.unit_verified", map[string]any{
-			"unit": i, "passed": res.Passed, "check": "verify_cmd", "exit_code": res.ExitCode, "output_sha256": res.OutputSHA256,
-		}); err != nil {
+		if err := v.store.AppendEvent(ctx, m.ID, "mission.unit_verified", payload); err != nil {
 			v.log.Warn("driver: record verify failed", "mission_id", m.ID, "error", err)
 		}
-		if !res.Passed {
-			return &verifyFailure{unit: i, excerpt: res.Excerpt}
-		}
-		return v.markUnitPassed(ctx, m, i)
+		out = append(out, res)
 	}
-	return nil
+	return out, nil
 }
 
-// markUnitPassed persists unit as passed. It copies Units before
-// mutating -- m.Plan.Units is a slice header, so writing through it
-// in place would silently mutate the caller's own Mission value too
-// (same backing array), corrupting whatever that caller does with it
-// afterward in the same round (e.g. Advance's toStepState call).
-func (v *verifier) markUnitPassed(ctx context.Context, m Mission, unit int) error {
-	units := make([]PlanUnit, len(m.Plan.Units))
-	copy(units, m.Plan.Units)
-	units[unit].Passes = true
-	return v.store.SetPlan(ctx, m.ID, Plan{Units: units})
+// artifactsExcerpt explains a CheckArtifacts failure and shows what
+// DOES exist: the dominant failure is a worker writing a real file
+// under a slightly different name and never spotting the mismatch from
+// "not found" alone.
+func artifactsExcerpt(workRoot string, problems []string) string {
+	excerpt := "declared artifacts failed the harness check:\n" + strings.Join(problems, "\n")
+	if listing := ListWorkspace(workRoot); listing != "" {
+		return excerpt + "\nfiles currently in the workspace:\n" + listing
+	}
+	return excerpt + "\nthe workspace is currently empty"
 }
 
-// checkRegressions re-verifies every unit that had ALREADY passed
-// (excluding whichever unit the caller just verified) after a unit's
-// own verify_cmd/CheckArtifacts just succeeded — a later unit's work
-// can silently break an earlier unit's artifacts, and passes today
-// only ever moves forward, never re-checked. Cheap and deterministic
-// (harness-side shell, same as verifyCurrentUnit), capped at the
-// plan's own unit count. Re-fetches the mission first: verifyCurrentUnit's
-// SetPlan write is not reflected in the caller's in-memory m.
-func (v *verifier) checkRegressions(ctx context.Context, m Mission) (StepInput, bool) {
-	fresh, err := v.store.Get(ctx, m.ID)
-	if err != nil {
-		v.log.Warn("driver: regression check reload failed", "mission_id", m.ID, "error", err)
-		return StepInput{}, false
-	}
-	// Deliberately omits verifyCurrentUnit's CheckCitations step: that
-	// check validates URLs against seenURLs, which only ever holds the
-	// citations from the turn that just produced the current unit's
-	// output (runExecute's live evidence). A regression recheck has no
-	// such turn — it's re-verifying units OTHER than the one just
-	// worked — so seenURLs would be empty here and CheckCitations would
-	// false-fail every already-passed unit on every regression pass.
-	workRoot := fresh.WorkRoot()
-	for i, u := range fresh.Plan.Units {
-		if !u.Passes {
-			continue
-		}
-		if problems := CheckArtifacts(workRoot, u.Artifacts); len(problems) > 0 {
-			return v.regressed(ctx, fresh, i, "artifacts", strings.Join(problems, "\n"))
-		}
-		if u.VerifyCmd == "" {
-			continue
-		}
-		res, err := v.runVerify(ctx, fresh.ID, fresh.Environment, workRoot, u.VerifyCmd)
-		if err != nil {
-			v.log.Warn("driver: regression re-verify errored", "mission_id", fresh.ID, "unit", i, "error", err)
-			continue
-		}
-		if !res.Passed {
-			return v.regressed(ctx, fresh, i, "verify_cmd", res.Excerpt)
+// failedUnits filters a batch pass down to the units that did not pass.
+func failedUnits(verified []UnitVerification) []UnitVerification {
+	var out []UnitVerification
+	for _, v := range verified {
+		if !v.Passed {
+			out = append(out, v)
 		}
 	}
-	return StepInput{}, false
+	return out
 }
 
-// regressed flips a previously-passed unit back to unverified, records
-// mission.regression, and returns the same StepInput shape a failed
-// current-unit verify produces — the existing worker-retry/stall
-// machinery drives the fix with zero statemachine changes.
-func (v *verifier) regressed(ctx context.Context, m Mission, unit int, check, excerpt string) (StepInput, bool) {
-	units := make([]PlanUnit, len(m.Plan.Units))
-	copy(units, m.Plan.Units)
-	title := units[unit].Title
-	units[unit].Passes = false
-	if err := v.store.SetPlan(ctx, m.ID, Plan{Units: units}); err != nil {
-		v.log.Warn("driver: record regression plan write failed", "mission_id", m.ID, "error", err)
-	}
-	if err := v.store.AppendEvent(ctx, m.ID, "mission.regression", map[string]any{"unit": title, "check": check}); err != nil {
-		v.log.Warn("driver: record regression event failed", "mission_id", m.ID, "error", err)
-	}
-	note := fmt.Sprintf("Regression: unit %q, previously verified, now fails its %s check:\n%s", title, check, excerpt)
-	if err := v.recordProgress(ctx, m.ID, note); err != nil {
-		v.log.Warn("driver: record regression progress note failed", "mission_id", m.ID, "error", err)
-	}
-	fp := "regression:" + title
-	return StepInput{Input: InputWorkerRetry, Reason: truncate(note, 500), GapFingerprint: fp}, true
-}
-
-// recordProgress mirrors Driver.recordProgress — duplicated rather than
-// shared since it's a two-line wrapper around store.AppendProgress and
-// verifier must not depend back on Driver.
-func (v *verifier) recordProgress(ctx context.Context, id, text string) error {
-	if text == "" {
-		return nil
-	}
-	return v.store.AppendProgress(ctx, id, NeutralizeSlot(truncate(text, 2000)))
-}
-
-// runVerify executes verify_cmd via the mission's sandbox container —
+// runVerify executes verify_cmd via the mission's sandbox container,
 // the verify-side counterpart of nativeRunner routing shell/write_file
 // through the same backend. environment (D-05x) only matters on the
 // mission's first exec, since a container's image is fixed once

--- a/internal/brain/missions/verifier_test.go
+++ b/internal/brain/missions/verifier_test.go
@@ -3,148 +3,187 @@ package missions
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func newFakeVerifier() *verifier {
 	return &verifier{store: newFakeStore(), sandboxExec: fakeSandboxExec, log: slog.Default()}
 }
 
-// TestVerifierVerifyCurrentUnitNoVerifyCmdPasses covers the simplest
-// case directly (previously only reachable through the whole Driver):
-// a unit with no declared artifacts and no verify_cmd passes outright
-// and marks itself passed in the store.
-func TestVerifierVerifyCurrentUnitNoVerifyCmdPasses(t *testing.T) {
+// TestVerifyAllNoVerifyCmdPasses covers the simplest case: a unit with
+// no declared artifacts and no verify_cmd passes outright.
+func TestVerifyAllNoVerifyCmdPasses(t *testing.T) {
 	v := newFakeVerifier()
-	store := v.store.(*fakeStore)
 	m := Mission{ID: "m1", Plan: Plan{Units: []PlanUnit{{Title: "only unit"}}}}
-	store.put(m.ID, m)
 
-	if err := v.verifyCurrentUnit(context.Background(), m, nil); err != nil {
-		t.Fatalf("verifyCurrentUnit: %v", err)
+	got, err := v.verifyAll(context.Background(), m, nil, true)
+	if err != nil {
+		t.Fatalf("verifyAll: %v", err)
 	}
-	if !store.missions[m.ID].Plan.Units[0].Passes {
-		t.Fatal("verifyCurrentUnit did not mark the unit passed in the store")
+	if len(got) != 1 || !got[0].Passed || got[0].Unit != 0 {
+		t.Fatalf("verifyAll = %+v, want unit 0 passed", got)
 	}
 }
 
-// TestVerifierVerifyCurrentUnitMissingArtifactFails confirms a unit
-// declaring an artifact that was never written fails as a
-// *verifyFailure (never a plain error) and never gets marked passed —
-// this is the harness-evidence gate the whole verifier type exists to
-// make type-visible.
-func TestVerifierVerifyCurrentUnitMissingArtifactFails(t *testing.T) {
+// TestVerifyAllMissingArtifactFailsCurrentSkipsLater confirms the
+// current unit's missing artifact is a recorded failure while a later,
+// not yet started unit with a missing artifact is skipped: nothing to
+// record about work nobody attempted.
+func TestVerifyAllMissingArtifactFailsCurrentSkipsLater(t *testing.T) {
 	v := newFakeVerifier()
-	store := v.store.(*fakeStore)
 	workRoot := t.TempDir()
 	m := Mission{
 		ID: "m1", Workspace: workRoot,
-		Plan: Plan{Units: []PlanUnit{{Title: "writes a file", Artifacts: []string{"out.txt"}}}},
+		Plan: Plan{Units: []PlanUnit{
+			{Title: "writes a file", Artifacts: []string{"out.txt"}},
+			{Title: "later", Artifacts: []string{"later.txt"}},
+		}},
 	}
-	store.put(m.ID, m)
 
-	err := v.verifyCurrentUnit(context.Background(), m, nil)
-	var vf *verifyFailure
-	if !errors.As(err, &vf) {
-		t.Fatalf("verifyCurrentUnit error = %v, want a *verifyFailure", err)
+	got, err := v.verifyAll(context.Background(), m, nil, true)
+	if err != nil {
+		t.Fatalf("verifyAll: %v", err)
 	}
-	if vf.unit != 0 {
-		t.Fatalf("verifyFailure.unit = %d, want 0", vf.unit)
+	if len(got) != 1 || got[0].Unit != 0 || got[0].Passed || got[0].Check != "artifacts" {
+		t.Fatalf("verifyAll = %+v, want only unit 0, failed on artifacts", got)
 	}
-	if store.missions[m.ID].Plan.Units[0].Passes {
-		t.Fatal("verifyCurrentUnit must not mark a unit passed when its artifact is missing")
+	if !strings.Contains(got[0].Excerpt, "out.txt: not found") {
+		t.Fatalf("excerpt = %q, want the missing path named", got[0].Excerpt)
 	}
 }
 
-// TestVerifierVerifyCurrentUnitVerifyCmdGatesPass confirms verify_cmd's
-// exit code — not any model claim — is what flips Passes: a failing
-// command fails the unit, a passing one (after the artifact exists)
-// marks it passed.
-func TestVerifierVerifyCurrentUnitVerifyCmdGatesPass(t *testing.T) {
+// TestVerifyAllVerifyCmdGatesPass confirms verify_cmd's exit code, not
+// any model claim, is what passes a unit, and that a later unit whose
+// artifacts already exist is verified in the same pass.
+func TestVerifyAllVerifyCmdGatesPass(t *testing.T) {
 	v := newFakeVerifier()
-	store := v.store.(*fakeStore)
 	workRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(workRoot, "out.txt"), []byte("data"), 0o600); err != nil {
+	for _, f := range []string{"out.txt", "later.txt"} {
+		if err := os.WriteFile(filepath.Join(workRoot, f), []byte("data"), 0o600); err != nil {
+			t.Fatalf("seed artifact: %v", err)
+		}
+	}
+	m := Mission{
+		ID: "m1", Workspace: workRoot,
+		Plan: Plan{Units: []PlanUnit{
+			{Title: "writes and checks", Artifacts: []string{"out.txt"}, VerifyCmd: "echo boom; exit 1"},
+			{Title: "later", Artifacts: []string{"later.txt"}, VerifyCmd: "exit 0"},
+		}},
+	}
+
+	got, err := v.verifyAll(context.Background(), m, nil, true)
+	if err != nil {
+		t.Fatalf("verifyAll: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("verifyAll = %+v, want both units checked", got)
+	}
+	if got[0].Passed || got[0].Check != "verify_cmd" || !strings.Contains(got[0].Excerpt, "boom") {
+		t.Fatalf("unit 0 = %+v, want a verify_cmd failure carrying the output", got[0])
+	}
+	if !got[1].Passed {
+		t.Fatalf("unit 1 = %+v, want passed (its artifact exists and verify_cmd exits 0)", got[1])
+	}
+}
+
+// TestVerifyAllRegressionSubsetRerunsPassedUnits confirms an already
+// harness-passed unit is re-checked (artifacts and verify_cmd) and
+// reported failed when its artifact vanished, without a citations
+// check that would false-fail it for want of this turn's seenURLs.
+func TestVerifyAllRegressionSubsetRerunsPassedUnits(t *testing.T) {
+	v := newFakeVerifier()
+	workRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workRoot, "b.md"), []byte("see https://example.com/x"), 0o600); err != nil {
 		t.Fatalf("seed artifact: %v", err)
 	}
 	m := Mission{
-		ID: "m1", Workspace: workRoot,
-		Plan: Plan{Units: []PlanUnit{{Title: "writes and checks", Artifacts: []string{"out.txt"}, VerifyCmd: "exit 1"}}},
-	}
-	store.put(m.ID, m)
-
-	err := v.verifyCurrentUnit(context.Background(), m, nil)
-	var vf *verifyFailure
-	if !errors.As(err, &vf) {
-		t.Fatalf("verifyCurrentUnit error = %v, want a *verifyFailure for a failing verify_cmd", err)
-	}
-	if store.missions[m.ID].Plan.Units[0].Passes {
-		t.Fatal("verifyCurrentUnit must not mark a unit passed when verify_cmd fails")
+		ID: "m1", Kind: "general", Workspace: workRoot,
+		Plan: Plan{Units: []PlanUnit{
+			{Title: "gone", Artifacts: []string{"a.md"}, HarnessPassed: true, Passes: true},
+			{Title: "intact", Artifacts: []string{"b.md"}, VerifyCmd: "exit 0", HarnessPassed: true, Passes: true},
+		}},
 	}
 
-	// Same unit, verify_cmd now passes: the unit flips to passed.
-	m2 := store.missions[m.ID]
-	m2.Plan.Units[0].VerifyCmd = "exit 0"
-	store.put(m.ID, m2)
-	if err := v.verifyCurrentUnit(context.Background(), m2, nil); err != nil {
-		t.Fatalf("verifyCurrentUnit: %v", err)
+	got, err := v.verifyAll(context.Background(), m, nil, true)
+	if err != nil {
+		t.Fatalf("verifyAll: %v", err)
 	}
-	if !store.missions[m.ID].Plan.Units[0].Passes {
-		t.Fatal("verifyCurrentUnit did not mark the unit passed once verify_cmd exited 0")
+	if len(got) != 2 || got[0].Passed || got[0].Check != "artifacts" || !got[1].Passed {
+		t.Fatalf("verifyAll = %+v, want unit 0 regressed on artifacts and unit 1 still passing", got)
+	}
+	events, _ := v.store.Events(context.Background(), m.ID)
+	if len(events) != 2 || !strings.Contains(string(events[0].Payload), `"regression":true`) {
+		t.Fatalf("events = %+v, want two mission.unit_verified events flagged as regression runs", events)
 	}
 }
 
-// TestVerifierCheckRegressionsDetectsBrokenArtifact confirms a
-// previously-passed unit whose declared artifact later disappears is
-// caught and flipped back to unverified via regressed — passes must
-// never move only forward, silently, once a later unit breaks earlier
-// evidence.
-func TestVerifierCheckRegressionsDetectsBrokenArtifact(t *testing.T) {
+// TestVerifyAllCitationsOnlyForUnverifiedUnits confirms the citation
+// check (general missions) runs for the current unit against this
+// turn's seenURLs and fails an invented citation.
+func TestVerifyAllCitationsOnlyForUnverifiedUnits(t *testing.T) {
 	v := newFakeVerifier()
-	store := v.store.(*fakeStore)
 	workRoot := t.TempDir()
-	m := Mission{
-		ID: "m1", Workspace: workRoot,
-		Plan: Plan{Units: []PlanUnit{{Title: "earlier unit", Artifacts: []string{"out.txt"}, Passes: true}}},
-	}
-	store.put(m.ID, m)
-	// out.txt was never (re)written in workRoot: CheckArtifacts must
-	// report it missing, simulating a later unit having deleted it.
-
-	in, regressed := v.checkRegressions(context.Background(), m)
-	if !regressed {
-		t.Fatal("checkRegressions = false, want true for a unit whose artifact vanished")
-	}
-	if in.Input != InputWorkerRetry {
-		t.Fatalf("checkRegressions StepInput.Input = %q, want %q", in.Input, InputWorkerRetry)
-	}
-	if store.missions[m.ID].Plan.Units[0].Passes {
-		t.Fatal("checkRegressions must flip the regressed unit's Passes back to false")
-	}
-}
-
-// TestVerifierCheckRegressionsNoRegressionLeavesPassesAlone confirms a
-// still-intact previously-passed unit is left untouched.
-func TestVerifierCheckRegressionsNoRegressionLeavesPassesAlone(t *testing.T) {
-	v := newFakeVerifier()
-	store := v.store.(*fakeStore)
-	workRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(workRoot, "out.txt"), []byte("data"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(workRoot, "r.md"), []byte("[x](https://example.com/invented)"), 0o600); err != nil {
 		t.Fatalf("seed artifact: %v", err)
 	}
 	m := Mission{
-		ID: "m1", Workspace: workRoot,
-		Plan: Plan{Units: []PlanUnit{{Title: "earlier unit", Artifacts: []string{"out.txt"}, Passes: true}}},
+		ID: "m1", Kind: "general", Workspace: workRoot,
+		Plan: Plan{Units: []PlanUnit{{Title: "report", Artifacts: []string{"r.md"}}}},
 	}
-	store.put(m.ID, m)
 
-	if _, regressed := v.checkRegressions(context.Background(), m); regressed {
-		t.Fatal("checkRegressions = true, want false when the artifact is still intact")
+	got, err := v.verifyAll(context.Background(), m, []string{"https://example.com/other"}, true)
+	if err != nil {
+		t.Fatalf("verifyAll: %v", err)
 	}
-	if !store.missions[m.ID].Plan.Units[0].Passes {
-		t.Fatal("checkRegressions must not touch a unit that did not regress")
+	if len(got) != 1 || got[0].Passed || got[0].Check != "citations" {
+		t.Fatalf("verifyAll = %+v, want a citations failure", got)
+	}
+	// The review-approval pass has no seenURLs and must not re-run it.
+	got, err = v.verifyAll(context.Background(), m, nil, false)
+	if err != nil {
+		t.Fatalf("verifyAll: %v", err)
+	}
+	if len(got) != 1 || !got[0].Passed {
+		t.Fatalf("verifyAll without citations = %+v, want passed", got)
+	}
+}
+
+// TestRunVerifyTimedHungCommandCountsAsFailed confirms a verify_cmd that
+// outlives its timeout is reported as a failed result naming the
+// timeout, never as an infrastructure error (the driver would otherwise
+// route it to worker_failed and retry the same hang).
+func TestRunVerifyTimedHungCommandCountsAsFailed(t *testing.T) {
+	hang := func(ctx context.Context, workdir, command string, timeout time.Duration, out io.Writer) (int, error) {
+		_, _ = io.WriteString(out, "still running")
+		<-ctx.Done()
+		return 0, ctx.Err()
+	}
+	res, err := runVerifyTimed(context.Background(), hang, t.TempDir(), "sleep 60", 20*time.Millisecond)
+	if err != nil {
+		t.Fatalf("runVerifyTimed: %v, want a failed result instead of an error", err)
+	}
+	if res.Passed || !res.TimedOut || !strings.Contains(res.Excerpt, "timed out after") || !strings.Contains(res.Excerpt, "still running") {
+		t.Fatalf("result = %+v, want failed, TimedOut, excerpt with output and the timeout", res)
+	}
+}
+
+// TestRunVerifyTimedCallerCancelIsAnError confirms the caller's own
+// cancellation (a mission cancel mid-verify) stays an error: it is not
+// evidence about the unit.
+func TestRunVerifyTimedCallerCancelIsAnError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	hang := func(ctx context.Context, workdir, command string, timeout time.Duration, out io.Writer) (int, error) {
+		<-ctx.Done()
+		return 0, ctx.Err()
+	}
+	if _, err := runVerifyTimed(ctx, hang, t.TempDir(), "true", time.Minute); !errors.Is(err, context.Canceled) {
+		t.Fatalf("runVerifyTimed = %v, want context.Canceled", err)
 	}
 }

--- a/internal/brain/missions/verify.go
+++ b/internal/brain/missions/verify.go
@@ -29,8 +29,9 @@ type verifyBackend func(ctx context.Context, workdir, command string, timeout ti
 const verifyTimeout = 10 * time.Minute
 
 // verifyExcerptCap is the trailing slice of output kept alongside the
-// full digest — enough to see what failed without storing megabytes.
-const verifyExcerptCap = 2 << 10
+// full digest and stored per unit in the plan (D-094): enough to see
+// what failed without storing megabytes.
+const verifyExcerptCap = 4 << 10
 
 // VerifyResult is a plan unit's verification evidence. Only
 // RunVerifyWithBackend produces this — never model output — and only
@@ -40,6 +41,19 @@ type VerifyResult struct {
 	OutputSHA256 string
 	Excerpt      string
 	Passed       bool
+	// TimedOut marks a verify_cmd that hit verifyTimeout: a failure
+	// with the timeout named in Excerpt, never an infrastructure error.
+	TimedOut bool
+}
+
+// UnitVerification is one plan unit's outcome from a batch verify pass
+// (D-094): the driver collects these after a worker turn or a review
+// approval and Step folds them into the plan through ApplyTransition.
+type UnitVerification struct {
+	Unit    int
+	Passed  bool
+	Check   string // artifacts, citations, verify_cmd, timeout
+	Excerpt string
 }
 
 // RunVerifyWithBackend executes a plan unit's verify_cmd via backend
@@ -50,13 +64,31 @@ type VerifyResult struct {
 // full output, and a trailing excerpt — "done is auditable from
 // events alone."
 func RunVerifyWithBackend(ctx context.Context, backend verifyBackend, workRoot, verifyCmd string) (VerifyResult, error) {
-	cctx, cancel := context.WithTimeout(ctx, verifyTimeout)
+	return runVerifyTimed(ctx, backend, workRoot, verifyCmd, verifyTimeout)
+}
+
+// runVerifyTimed is RunVerifyWithBackend with the timeout as a
+// parameter so tests can exercise the hung-command path.
+func runVerifyTimed(ctx context.Context, backend verifyBackend, workRoot, verifyCmd string, timeout time.Duration) (VerifyResult, error) {
+	cctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	hash := sha256.New()
 	tail := &tailBuffer{max: verifyExcerptCap}
-	exitCode, err := backend(cctx, workRoot, verifyCmd, verifyTimeout, io.MultiWriter(hash, tail))
+	exitCode, err := backend(cctx, workRoot, verifyCmd, timeout, io.MultiWriter(hash, tail))
 	if err != nil {
+		// Our own deadline firing (not the caller's cancel), or sandboxd's
+		// server-side timeout for the same duration, is a hung verify_cmd:
+		// real evidence the unit did not pass, not infra.
+		sandboxTimeout := strings.Contains(err.Error(), "timed out")
+		if ctx.Err() == nil && (cctx.Err() != nil || sandboxTimeout) {
+			return VerifyResult{
+				ExitCode:     exitCode,
+				OutputSHA256: hex.EncodeToString(hash.Sum(nil)),
+				Excerpt:      tail.String() + fmt.Sprintf("\nverify_cmd timed out after %s", timeout),
+				TimedOut:     true,
+			}, nil
+		}
 		return VerifyResult{}, err
 	}
 	return VerifyResult{

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -665,12 +665,20 @@ export interface KbDocument {
 }
 
 // PlanUnit is one item of a mission's plan. passes is flipped only by
-// the harness (RunVerify), never claimed by the model.
+// the harness (RunVerify), never claimed by the model. harness_passed
+// (D-094) is the batch verifier's own verdict after the last worker
+// turn, ahead of any review approval; regressed marks a unit that had
+// passed and fails now, with the failing check and output excerpt in
+// verify_check/verify_excerpt.
 export interface PlanUnit {
   title: string
   verify_cmd: string
   artifacts?: string[]
   passes: boolean
+  harness_passed?: boolean
+  verify_check?: string
+  verify_excerpt?: string
+  regressed?: boolean
 }
 
 // PlanAssumption is one ambiguity the planner resolved silently, and

--- a/web/src/components/missions/PlanSection.test.tsx
+++ b/web/src/components/missions/PlanSection.test.tsx
@@ -13,6 +13,23 @@ describe('PlanSection', () => {
     expect(screen.getByText('No plan yet.')).toBeInTheDocument()
   })
 
+  it('badges units by harness state: verified, harness-verified, regressed, pending', () => {
+    render(
+      <PlanSection
+        units={[
+          { title: 'done', verify_cmd: '', passes: true, harness_passed: true },
+          { title: 'awaiting review', verify_cmd: '', passes: false, harness_passed: true },
+          { title: 'broke', verify_cmd: '', passes: false, regressed: true, verify_check: 'artifacts', verify_excerpt: 'a.md: not found' },
+          { title: 'todo', verify_cmd: '', passes: false },
+        ]}
+      />,
+    )
+    expect(screen.getByText('verified')).toBeInTheDocument()
+    expect(screen.getByText('harness-verified')).toBeInTheDocument()
+    expect(screen.getByText('regressed')).toHaveAttribute('title', 'a.md: not found')
+    expect(screen.getByText('pending')).toBeInTheDocument()
+  })
+
   it('does not render an Assumptions header when assumptions is absent', () => {
     render(<PlanSection units={units} />)
     expect(screen.queryByText('Assumptions')).toBeNull()

--- a/web/src/components/missions/PlanSection.tsx
+++ b/web/src/components/missions/PlanSection.tsx
@@ -1,5 +1,21 @@
 import type { PlanAssumption, PlanUnit } from '../../api/types'
 
+// unitBadge mirrors the harness's plan markers (missions.unitStatus,
+// D-094): verified (complete), harness-verified (awaiting review),
+// regressed (passed once, failing now), pending.
+export function unitBadge(u: PlanUnit): { label: string; className: string } {
+  if (u.passes) {
+    return { label: 'verified', className: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300' }
+  }
+  if (u.harness_passed) {
+    return { label: 'harness-verified', className: 'bg-green-50 text-green-700 dark:bg-green-950/60 dark:text-green-400' }
+  }
+  if (u.regressed) {
+    return { label: 'regressed', className: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300' }
+  }
+  return { label: 'pending', className: 'bg-muted text-muted-foreground' }
+}
+
 export function PlanSection({ units, assumptions }: { units: PlanUnit[]; assumptions?: PlanAssumption[] }) {
   if (units.length === 0) {
     return <p className="text-sm text-muted-foreground">No plan yet.</p>
@@ -7,20 +23,20 @@ export function PlanSection({ units, assumptions }: { units: PlanUnit[]; assumpt
   return (
     <div className="space-y-3">
       <ul className="space-y-1.5">
-        {units.map((u, i) => (
-          <li key={i} className="flex items-center gap-2 text-sm">
-            <span
-              className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium ${
-                u.passes
-                  ? 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300'
-                  : 'bg-muted text-muted-foreground'
-              }`}
-            >
-              {u.passes ? 'verified' : 'pending'}
-            </span>
-            <span>{u.title}</span>
-          </li>
-        ))}
+        {units.map((u, i) => {
+          const badge = unitBadge(u)
+          return (
+            <li key={i} className="flex items-center gap-2 text-sm">
+              <span
+                className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium ${badge.className}`}
+                title={!u.passes && !u.harness_passed && u.verify_excerpt ? u.verify_excerpt : undefined}
+              >
+                {badge.label}
+              </span>
+              <span>{u.title}</span>
+            </li>
+          )
+        })}
       </ul>
       {assumptions && assumptions.length > 0 && (
         <div>

--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -28,6 +28,19 @@ describe('mission.unit_verified rendering', () => {
   })
 })
 
+describe('mission.unit_regressed rendering', () => {
+  it('names the unit 1-indexed with its title and failing check', () => {
+    render(<div>{renderEvent(event({ unit: 0, title: 'write report', check: 'artifacts' }, 'mission.unit_regressed'))}</div>)
+    expect(screen.getByText('Unit 1 (write report) regressed: artifacts check failed')).toHaveClass('text-red-400')
+  })
+})
+
+describe('mission.generate_skipped rendering', () => {
+  it('explains the skipped worker turn', () => {
+    expect(renderEvent(event({}, 'mission.generate_skipped'))).toBe('Worker turn skipped: every unit is harness-verified')
+  })
+})
+
 describe('mission.plan_created rendering', () => {
   it('shows unit count alone when the plan has no assumptions', () => {
     expect(renderEvent(event({ units: 2 }, 'mission.plan_created'))).toBe('Plan created with 2 unit(s)')

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -52,6 +52,18 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
       </span>
     )
   },
+  'mission.unit_regressed': (p) => {
+    const { unit, title, check } = asRecord(p)
+    const label = typeof unit === 'number' ? `Unit ${unit + 1}` : 'Unit'
+    const name = title ? ` (${String(title)})` : ''
+    return (
+      <span className="text-red-400">
+        {label}
+        {name} regressed: {String(check ?? 'harness')} check failed
+      </span>
+    )
+  },
+  'mission.generate_skipped': () => 'Worker turn skipped: every unit is harness-verified',
   'mission.review_verdict': (p) => {
     const { decision } = asRecord(p)
     const approved = decision === 'approve'


### PR DESCRIPTION
## Summary

Slice 2 of the prove loop redesign v2 (D-094). After every generate turn the driver runs one batch harness pass over the plan and the state machine records the outcome on the plan units.

- `verifier.verifyAll` replaces `verifyCurrentUnit`/`checkRegressions`/`markUnitPassed`: every unit without harness evidence gets `CheckArtifacts`, the citation check (general missions, this turn's `seenURLs`) and its `verify_cmd`; every unit that already passed reruns `CheckArtifacts` plus `verify_cmd` as the regression subset. Units after the current one whose artifacts do not exist yet are skipped (not started). The verifier no longer writes the plan.
- Outcomes travel in `StepInput.Verified`; `applyVerification` in `Step` records `harness_passed`, `verify_check`, a 4 KB `verify_excerpt` and `regressed` per unit, and a previously passed unit that fails flips back to pending with a `mission.unit_regressed` event. `ApplyTransition` is the only writer of this state (`jsonb_set(plan, '{units}', ...)`, other plan keys untouched); `mission_events` stays append-only.
- `passes` flips only in `stepReviewApprove`, and only on units with `harness_passed` (reviewer approval and the review-skip fast path both land on harness evidence). `StepState.LastUnit` is replaced by `Units`; all-passed is computed after the flip.
- Routing after a worker turn: a failing current unit or a regression is `worker_retry` with the excerpt on the unit (fingerprints `verify_failed:unit_N` / `regression:unit_N`), never a review round. Coding missions now get their claim harness-checked before any review. When nothing fails, `routeVerified` skips review on harness evidence (non-always-review policy, artifacts declared, no open finding) or advances to prove.
- A generate phase entered with every unit harness-passed and no open finding skips the worker turn (`mission.generate_skipped`) and advances to prove.
- The prove round judges the harness-passed, not yet approved units (`reviewUnits`); an approval reruns the batch pass, and a failing unit routes through the existing harness-authored blocking finding path.
- Worker packet: the current unit is the first unit without harness evidence; its block renders the last failing check and excerpt, named as a regression when applicable. Plan markers read `verified`, `harness-verified`, `regressed`, `pending` (worker and reviewer prompts share `unitStatus`).
- A hung `verify_cmd` (own deadline or sandboxd's server-side timeout) is a failed check with a timeout excerpt, not an infrastructure error.
- Web: `PlanUnit` type gains the new fields, `PlanSection` badges the four states (excerpt as tooltip on a failing unit), timeline renders `mission.unit_regressed` and `mission.generate_skipped`.

No schema change: the new fields live inside the existing `plan` jsonb, and rows written before this change keep working (`Passes` implies harness evidence through `PlanUnit.verified()`), so `scripts/pending-alters.md` is unchanged.

Deviation from the issue text: progress notes are no longer written for harness failures; the excerpt on the unit and the `mission.unit_verified` event payload carry that information instead, so 4 KB excerpts do not pile up in the progress log rendered into every packet.

Closes #518
Part of #510

## Test plan

- `make build test vet lint`: pass.
- `make test-integration` (local stack): pass, including the new `TestApplyTransitionPersistsUnitVerifyState` (a unit passes, then regresses, through `ApplyTransition`).
- `go vet -tags integration ./...`: pass.
- Web `npm run build && npm run lint && npm test`: pass (1045 tests, lint 0 errors).
- `make canary` against the local stack rebuilt from this branch: PASS (4 model turns, 66s).
- New/updated tests: `TestStepAppliesVerification`, `TestStepRegressionEventPayload`, `TestStepDoesNotAliasCallerUnits`, `TestAllPassed`, `verifier_test.go` rewritten for `verifyAll` (current vs not-started units, regression subset, citations, hung command, caller cancel), `TestWorkPacketRenderUnitFailure`, driver tests for batch bonus unit, coding verify failure before review, generate skip, open findings still rework, and the pass-then-regress flow asserting the packet names the regressed unit; web tests for the badges and the new renderers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790943348&installation_model_id=431401&pr_number=519&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F519&signature=116196f3da8eb6c769daeee9ee58cb56e4b1be42e48a241c851b985354ad7e68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->