### PR TITLE
feat(missions): unit criteria and scoped review with an evidence gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,20 @@ First run: `cp deploy/env.example deploy/.env` and set
   `stepReviewApprove` flips `passes` on harness-passed units only; a
   generate phase with every unit harness-passed and no open finding
   skips the worker turn (`mission.generate_skipped`).
+- Unit criteria and scoped review (D-095, issue #520): every plan unit
+  carries `criteria` (2 to 6 lines, `parsePlan` rejects the plan with
+  `plan_invalid` otherwise, one planner retry) and `scope` (paths,
+  default the artifact directories). The reviewer packet carries the
+  reviewed units' title, criteria, harness status and verify excerpt in
+  place of the goal (legacy plans without criteria still get the goal),
+  `git diff --stat` for the whole change and the diff restricted to the
+  units' scope, cut on a file boundary at the byte budget, plus
+  artifacts a criterion names (8 KB each). Evidence gate in
+  `Driver.runReview`: a blocking finding must name a changed or declared
+  file and quote `evidence`, else it is demoted to minor with a
+  `mission.finding_demoted` event; a round left with only minor findings
+  and no unresolved prior blocking one counts as approval. Light
+  missions never plan, so none of this applies to them.
 - Workers get per-mission `shell` + `write_file` tools via turn-scoped
   `ExtraTools` that shadow base tools by name. Workers must create files
   with `write_file` only; shell redirects/heredocs classify destructive

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -1604,11 +1604,11 @@ func currentUnit(plan Plan) (*PlanUnit, int) {
 	return nil, -1
 }
 
-// reviewUnits returns the indices, titles and declared artifact paths
-// of the units a prove round judges: the harness-passed, not yet
-// approved ones (unitsUnderReview), falling back to the first unit
-// still pending for rows written before HarnessPassed existed.
-func reviewUnits(plan Plan) (idx []int, titles, artifacts []string) {
+// reviewUnits returns the indices and units a prove round judges: the
+// harness-passed, not yet approved ones (unitsUnderReview), falling
+// back to the first unit still pending for rows written before
+// HarnessPassed existed.
+func reviewUnits(plan Plan) (idx []int, units []PlanUnit) {
 	idx = unitsUnderReview(plan.Units)
 	if len(idx) == 0 {
 		for i, u := range plan.Units {
@@ -1619,10 +1619,46 @@ func reviewUnits(plan Plan) (idx []int, titles, artifacts []string) {
 		}
 	}
 	for _, i := range idx {
-		titles = append(titles, plan.Units[i].Title)
-		artifacts = append(artifacts, plan.Units[i].Artifacts...)
+		units = append(units, plan.Units[i])
 	}
-	return idx, titles, artifacts
+	return idx, units
+}
+
+// reviewScope is the union of the units' scope paths (D-095), in
+// first-seen order; empty, meaning the whole tree, when no unit
+// declares one (legacy plans).
+func reviewScope(units []PlanUnit) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, u := range units {
+		for _, p := range u.Scope {
+			if !seen[p] {
+				seen[p] = true
+				out = append(out, p)
+			}
+		}
+	}
+	return out
+}
+
+// hasCriteria reports whether any unit carries acceptance criteria; a
+// plan without them predates D-095 and reviews against the goal.
+func hasCriteria(units []PlanUnit) bool {
+	for _, u := range units {
+		if len(u.Criteria) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// planArtifacts lists every artifact the plan declares.
+func planArtifacts(plan Plan) []string {
+	var out []string
+	for _, u := range plan.Units {
+		out = append(out, u.Artifacts...)
+	}
+	return out
 }
 
 // reviewWithShrink runs RunReview, recovering from a prompt rejected
@@ -1642,13 +1678,13 @@ func (d *Driver) reviewWithShrink(ctx context.Context, m Mission, packet ReviewP
 	diffCap, artifactsCap := baselineDiffCap/4, reviewArtifactsCap/2
 	trimmed := packet
 	if wt := m.WorktreePath(); wt != "" {
-		trimmedDiff, diffErr := baselineDiffCapped(ctx, wt, m.BaseCommit, diffCap)
+		trimmedDiff, diffErr := baselineDiffCapped(ctx, wt, m.BaseCommit, reviewScope(packet.Units), diffCap)
 		if diffErr != nil {
 			return ReviewVerdict{}, diffErr
 		}
 		trimmed.Diff = trimmedDiff
 	}
-	if _, _, artifacts := reviewUnits(m.Plan); len(artifacts) > 0 {
+	if artifacts := reviewArtifacts(packet.Units, packet.Diff != ""); len(artifacts) > 0 {
 		trimmed.Artifacts = ReadArtifactsCapped(m.WorkRoot(), artifacts, artifactsCap)
 	}
 	if evErr := d.store.AppendEvent(ctx, m.ID, "mission.review_prompt_shrunk", map[string]any{
@@ -1667,32 +1703,60 @@ func (d *Driver) reviewWithShrink(ctx context.Context, m Mission, packet ReviewP
 }
 
 func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
-	var diff string
-	if wt := m.WorktreePath(); wt != "" {
-		var err error
-		diff, err = BaselineDiff(ctx, wt, m.BaseCommit)
-		if err != nil {
-			return StepInput{}, err
-		}
-	}
-	workRoot := m.WorkRoot()
-	packet := ReviewPacket{
-		Goal: m.Goal, Plan: m.Plan, Diff: diff, Evidence: m.LastEvidence,
-		Listing: ListWorkspace(workRoot), Progress: m.Progress,
-		OpenFindings: OpenFindings(m.ReviewFindings),
-	}
-	idx, titles, artifacts := reviewUnits(m.Plan)
+	idx, units := reviewUnits(m.Plan)
 	unitIdx := -1
 	if len(idx) > 0 {
 		unitIdx = idx[0]
 	}
-	packet.UnitTitle = strings.Join(titles, "; ")
-	if len(artifacts) > 0 {
-		packet.Artifacts = ReadArtifacts(workRoot, artifacts)
+	// D-095: the packet carries the reviewed units' criteria in place of
+	// the goal (legacy plans without criteria keep the goal), the
+	// whole-change stat and the diff restricted to the units' scope.
+	// changedFiles feeds the evidence gate below.
+	var changedFiles []string
+	packet := ReviewPacket{
+		Plan: m.Plan, Units: units, Evidence: m.LastEvidence,
+		Listing: ListWorkspace(m.WorkRoot()), Progress: m.Progress,
+		OpenFindings: OpenFindings(m.ReviewFindings),
+	}
+	if !hasCriteria(units) {
+		packet.Goal = m.Goal
+	}
+	if wt := m.WorktreePath(); wt != "" {
+		var err error
+		if packet.Diff, err = BaselineDiff(ctx, wt, m.BaseCommit, reviewScope(units)); err != nil {
+			return StepInput{}, err
+		}
+		if packet.DiffStat, err = DiffStat(ctx, wt, m.BaseCommit); err != nil {
+			return StepInput{}, err
+		}
+		if changedFiles, err = ChangedFiles(ctx, wt, m.BaseCommit); err != nil {
+			return StepInput{}, err
+		}
+	}
+	if artifacts := reviewArtifacts(units, packet.Diff != ""); len(artifacts) > 0 {
+		packet.Artifacts = ReadArtifacts(m.WorkRoot(), artifacts)
 	}
 	verdict, err := d.reviewWithShrink(ctx, m, packet)
 	if err != nil {
 		return StepInput{}, err
+	}
+	// D-095 evidence gate: a blocking finding must name a changed or
+	// declared file and quote evidence, or it is demoted to minor here,
+	// deterministically. A rework whose findings all end up minor, with
+	// no prior blocking finding left unresolved, counts as approval.
+	if !verdict.Approved && len(verdict.Findings) > 0 {
+		gated, demoted := gateFindings(verdict.Findings, append(changedFiles, planArtifacts(m.Plan)...))
+		for _, dm := range demoted {
+			if err := d.store.AppendEvent(ctx, m.ID, "mission.finding_demoted", map[string]any{
+				"title": dm.Finding.Title, "file": dm.Finding.File, "reason": dm.Reason,
+			}); err != nil {
+				d.log.Warn("driver: record finding demoted failed", "mission_id", m.ID, "error", err)
+			}
+		}
+		verdict.Findings = gated
+		if !blockingRemain(gated, packet.OpenFindings, verdict.Resolved) {
+			verdict.Approved = true
+		}
 	}
 	// The reviewer's own worktree side effects (it may run tests) are
 	// rolled back unconditionally after every review round.

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -1361,17 +1361,24 @@ func TestDriverWorkerRetryDoesNotCountTowardBackoff(t *testing.T) {
 // made max_iterations dead for rework), and the round that reaches
 // max_iterations parks review_exhausted naming F1 instead of failing.
 func TestDriverReworkOpensFindingsAndParksWhenExhausted(t *testing.T) {
+	// x.go is a declared artifact present on disk: the D-095 evidence
+	// gate keeps a blocking finding only when it names such a file and
+	// quotes evidence.
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "x.go"), []byte("package x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	store := newFakeStore()
 	store.put("m1", Mission{
-		ID: "m1", Kind: "general", Phase: PhaseProve, Status: StatusWorking, MaxIterations: 3,
-		Plan: Plan{Units: []PlanUnit{{Title: "u1"}}},
+		ID: "m1", Kind: "general", Phase: PhaseProve, Status: StatusWorking, MaxIterations: 3, Workspace: root,
+		Plan: Plan{Units: []PlanUnit{{Title: "u1", Artifacts: []string{"x.go"}}}},
 	})
 	runner := &scriptedRunner{
 		workerVerdicts: []WorkerVerdict{{Outcome: "done"}},
 		reviewVerdicts: []ReviewVerdict{
-			{Findings: []Finding{{Title: "missing validation", File: "x.go", Detail: "no input check"}}},
-			{Findings: []Finding{{Title: "Validation missing.", File: "./x.go"}}},
-			{Findings: []Finding{{Title: "MISSING validation", File: "x.go"}}},
+			{Findings: []Finding{{Title: "missing validation", File: "x.go", Detail: "no input check", Evidence: "package x"}}},
+			{Findings: []Finding{{Title: "Validation missing.", File: "./x.go", Evidence: "package x"}}},
+			{Findings: []Finding{{Title: "MISSING validation", File: "x.go", Evidence: "package x"}}},
 		},
 	}
 	d := testDriver(store, runner)
@@ -3395,6 +3402,138 @@ func TestRetryDelay(t *testing.T) {
 	for _, tc := range cases {
 		if got := retryDelay(tc.consecutiveFailures); got != tc.want {
 			t.Fatalf("retryDelay(%d) = %v, want %v", tc.consecutiveFailures, got, tc.want)
+		}
+	}
+}
+
+// TestDriverEvidenceGateDemotesAndApproves pins the D-095 gate through
+// Advance: a rework whose only blocking finding names a file outside
+// the change and quotes nothing is demoted with a
+// mission.finding_demoted event, the round counts as approval, and the
+// packet carried the unit's criteria in place of the goal.
+func TestDriverEvidenceGateDemotesAndApproves(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "out.md"), []byte("429 Too Many Requests\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseProve, Status: StatusWorking, MaxIterations: 3, Workspace: root, Goal: "explain 429",
+		Plan: Plan{Units: []PlanUnit{{
+			Title: "u1", Artifacts: []string{"out.md"}, Criteria: []string{"out.md explains 429", "cites the RFC"}, HarnessPassed: true,
+		}}},
+	})
+	runner := &scriptedRunner{reviewVerdicts: []ReviewVerdict{{Findings: []Finding{
+		{Title: "wrong status text", File: "nope.md", Detail: "should say Too Many Requests"},
+		{Title: "style nit", Severity: SeverityMinor},
+	}}}}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseResult || !m.Plan.Units[0].Passes {
+		t.Fatalf("mission phase %q passes %v, want result with the unit passed", m.Phase, m.Plan.Units[0].Passes)
+	}
+	if len(OpenFindings(m.ReviewFindings)) != 0 {
+		t.Fatalf("findings = %+v, want none open after the gated approval", m.ReviewFindings)
+	}
+	var demoted, approved bool
+	for _, ev := range store.events["m1"] {
+		switch ev.Kind {
+		case "mission.finding_demoted":
+			demoted = true
+			if !strings.Contains(string(ev.Payload), `"nope.md"`) || !strings.Contains(string(ev.Payload), "not in the diff") {
+				t.Fatalf("finding_demoted payload = %s, want the file and reason", ev.Payload)
+			}
+		case "mission.review_verdict":
+			if strings.Contains(string(ev.Payload), `"decision":"approved"`) {
+				approved = true
+			}
+		}
+	}
+	if !demoted || !approved {
+		t.Fatalf("demoted=%v approved=%v, want both events", demoted, approved)
+	}
+	packet := runner.reviewCalls[0]
+	if packet.Goal != "" || len(packet.Units) != 1 || len(packet.Units[0].Criteria) != 2 {
+		t.Fatalf("review packet = %+v, want criteria and no goal", packet)
+	}
+	if _, ok := packet.Artifacts["out.md"]; !ok {
+		t.Fatalf("review packet artifacts = %v, want out.md (no diff, so every artifact)", packet.Artifacts)
+	}
+}
+
+// TestDriverLegacyPlanReviewsAgainstGoal pins the D-095 fallback: a
+// plan whose units carry no criteria still hands the reviewer the goal.
+func TestDriverLegacyPlanReviewsAgainstGoal(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "general", Phase: PhaseProve, Status: StatusWorking, MaxIterations: 3, Goal: "the legacy goal",
+		Plan: Plan{Units: []PlanUnit{{Title: "u1", HarnessPassed: true}}},
+	})
+	runner := &scriptedRunner{reviewVerdicts: []ReviewVerdict{{Approved: true}}}
+	d := testDriver(store, runner)
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	if got := runner.reviewCalls[0].Goal; got != "the legacy goal" {
+		t.Fatalf("review packet goal = %q, want the goal for a plan without criteria", got)
+	}
+}
+
+// TestDriverReviewPacketScopedDiffAndGate pins D-095 with a real
+// worktree: the packet's diff is restricted to the reviewed unit's
+// scope while the stat covers every changed file, and a blocking
+// finding naming a changed file outside the scope, with evidence,
+// survives the gate and sends the mission back to generate.
+func TestDriverReviewPacketScopedDiffAndGate(t *testing.T) {
+	root, base := codingWorktree(t)
+	wt := filepath.Join(root, "wt")
+	for path, content := range map[string]string{"src/main.go": "package main\n", "docs/notes.md": "# notes\n"} {
+		if err := os.MkdirAll(filepath.Dir(filepath.Join(wt, path)), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(wt, path), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	gitRun(t, wt, "add", "-A")
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "coding", Phase: PhaseProve, Status: StatusWorking, MaxIterations: 8, Workspace: root, BaseCommit: base,
+		Plan: Plan{Units: []PlanUnit{{
+			Title: "write code", Artifacts: []string{"src/main.go"}, Scope: []string{"src"},
+			Criteria: []string{"main.go compiles", "no docs edits"}, HarnessPassed: true,
+		}}},
+	})
+	runner := &scriptedRunner{reviewVerdicts: []ReviewVerdict{{Findings: []Finding{
+		{Title: "docs changed", File: "docs/notes.md", Evidence: "+# notes"},
+	}}}}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := NewDriver(store, runner, NewWorkspace("", nil, log), nil, nil, nil, fakeSandboxExec, nil, log)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	packet := runner.reviewCalls[0]
+	if !strings.Contains(packet.Diff, "src/main.go") || strings.Contains(packet.Diff, "docs/notes.md") {
+		t.Fatalf("packet diff not restricted to scope:\n%s", packet.Diff)
+	}
+	if !strings.Contains(packet.DiffStat, "docs/notes.md") || !strings.Contains(packet.DiffStat, "src/main.go") {
+		t.Fatalf("packet stat missing changed files:\n%s", packet.DiffStat)
+	}
+	if _, ok := packet.Artifacts["src/main.go"]; !ok {
+		t.Fatalf("criteria name main.go, so its contents must be attached: %v", packet.Artifacts)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseGenerate || len(OpenFindings(m.ReviewFindings)) != 1 || !m.ReviewFindings[0].Blocking() {
+		t.Fatalf("mission phase %q findings %+v, want generate with the blocking finding kept", m.Phase, m.ReviewFindings)
+	}
+	for _, ev := range store.events["m1"] {
+		if ev.Kind == "mission.finding_demoted" {
+			t.Fatalf("finding naming a changed file with evidence was demoted: %s", ev.Payload)
 		}
 	}
 }

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -535,6 +535,15 @@ type PlanUnit struct {
 	// verify_cmd — a tautological verify_cmd (echo 'done') can no
 	// longer fake completion when the declared artifact is missing.
 	Artifacts []string `json:"artifacts,omitempty"`
+	// Criteria (D-095, issue #520) are the unit's acceptance criteria,
+	// 2 to 6 short lines the planner extracts from the goal: the
+	// reviewer judges the unit against them instead of the full goal.
+	// Empty on plans written before D-095 (review falls back to the goal).
+	Criteria []string `json:"criteria,omitempty"`
+	// Scope lists the paths (files or directory prefixes) the unit may
+	// touch; the reviewer's diff is restricted to the reviewed units'
+	// scope. Defaults to the artifact directories at plan parse.
+	Scope []string `json:"scope,omitempty"`
 	// Passes marks the unit complete: harness-passed and, for missions
 	// that review, approved by the reviewer. Never true without
 	// HarnessPassed (legacy rows written before D-094 excepted).

--- a/internal/brain/missions/review.go
+++ b/internal/brain/missions/review.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -23,23 +24,33 @@ const (
 	// sees — enough for real research/config artifacts, small enough
 	// to never balloon the review turn.
 	reviewArtifactsCap = 32 << 10
+	// reviewArtifactFileCap bounds one artifact's bytes in the packet
+	// (D-095): enough to judge a file's shape, never a whole document.
+	reviewArtifactFileCap = 8 << 10
 	// reviewListingCap bounds the workspace file listing.
 	reviewListingCap = 2 << 10
 )
 
-// ReviewPacket is everything a reviewer turn judges: the mission's
-// goal and plan (an earlier failure mode was reviewers rejecting with
-// "missing original mission goal"), the ACTUAL artifact contents read
-// by the harness from the workspace (never the worker's description
-// of them), the baseline diff when a worktree exists, and the
-// worker's evidence text last.
+// ReviewPacket is everything a reviewer turn judges: the units under
+// review with their acceptance criteria and harness evidence (D-095),
+// the plan, the ACTUAL artifact contents read by the harness from the
+// workspace (never the worker's description of them), the change's
+// diff stat and the diff restricted to the units' scope when a
+// worktree exists, and the worker's evidence text last.
 type ReviewPacket struct {
-	Goal      string
-	UnitTitle string
-	Plan      Plan
-	Diff      string
+	// Goal is set only for legacy plans whose units carry no criteria
+	// (rows written before D-095); the criteria replace it otherwise.
+	Goal string
+	// Units are the plan units this round judges.
+	Units []PlanUnit
+	Plan  Plan
+	// DiffStat is `git diff --stat` for the whole change; Diff is the
+	// diff restricted to the reviewed units' scope paths.
+	DiffStat string
+	Diff     string
 	// Artifacts maps workspace-relative path -> file contents, read by
-	// the harness (ReadArtifacts), capped at reviewArtifactsCap total.
+	// the harness (ReadArtifacts), capped at reviewArtifactFileCap each
+	// and reviewArtifactsCap total.
 	Artifacts map[string]string
 	// Listing is a flat file listing of the workspace (name + size) so
 	// the reviewer can see what exists even when a unit declares no
@@ -104,10 +115,53 @@ func ReadArtifactsCapped(workRoot string, artifacts []string, limit int) map[str
 			remaining = 0
 			continue
 		}
+		if len(b) > reviewArtifactFileCap {
+			out[rel] = string(b[:reviewArtifactFileCap]) + fmt.Sprintf("\n[truncated: file is %d bytes, per-file cap is %d]", len(b), reviewArtifactFileCap)
+			remaining -= reviewArtifactFileCap
+			continue
+		}
 		out[rel] = string(b)
 		remaining -= len(b)
 	}
 	return out
+}
+
+// reviewArtifacts picks which of the reviewed units' artifacts the
+// packet carries (D-095): every artifact when the unit has no criteria
+// (legacy plan) or the mission has no diff (the artifacts are the only
+// evidence), otherwise only those a criterion names by path or file
+// name. Deduplicated, in unit order.
+func reviewArtifacts(units []PlanUnit, hasDiff bool) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(a string) {
+		if a = strings.TrimSpace(a); a != "" && !seen[a] {
+			seen[a] = true
+			out = append(out, a)
+		}
+	}
+	for _, u := range units {
+		for _, a := range u.Artifacts {
+			if len(u.Criteria) == 0 || !hasDiff || criteriaMention(u.Criteria, a) {
+				add(a)
+			}
+		}
+	}
+	return out
+}
+
+// criteriaMention reports whether any criterion names the artifact by
+// its workspace-relative path or bare file name, case-insensitively.
+func criteriaMention(criteria []string, artifact string) bool {
+	rel := strings.ToLower(strings.TrimSpace(artifact))
+	base := strings.ToLower(filepath.Base(rel))
+	for _, c := range criteria {
+		c = strings.ToLower(c)
+		if strings.Contains(c, rel) || strings.Contains(c, base) {
+			return true
+		}
+	}
+	return false
 }
 
 // ListWorkspace returns a flat "path (size)" listing of regular files
@@ -166,7 +220,8 @@ func ReviewVerdictTool() *tools.Tool {
 							"title": {"type": "string", "description": "One-line summary of the gap."},
 							"file": {"type": "string", "description": "The file the gap is in, if applicable."},
 							"detail": {"type": "string", "description": "Why this is a gap and what would fix it."},
-							"severity": {"type": "string", "enum": ["blocking", "minor"], "description": "blocking (default) prevents approval; minor is advisory."}
+							"severity": {"type": "string", "enum": ["blocking", "minor"], "description": "blocking (default) prevents approval; minor is advisory. A blocking finding must name a file present in the diff or the artifacts and quote evidence, or the harness demotes it to minor."},
+							"evidence": {"type": "string", "description": "A line quoted verbatim from the diff, an artifact, or the harness output that shows the gap. Required for blocking."}
 						},
 						"required": ["title"]
 					}
@@ -210,6 +265,9 @@ type Finding struct {
 	Detail string `json:"detail"`
 	// Severity is blocking (default when absent) or minor.
 	Severity string `json:"severity,omitempty"`
+	// Evidence is the reviewer's quoted diff, artifact or output line
+	// (D-095); a blocking finding without it is demoted to minor.
+	Evidence string `json:"evidence,omitempty"`
 	// Status is open, resolved, or accepted (operator won't-fix).
 	Status      string `json:"status,omitempty"`
 	RoundOpened int    `json:"round_opened,omitempty"`
@@ -286,40 +344,170 @@ var baselineDiffExcludes = []string{
 const baselineDiffExcludeTrailer = "\n[diff excludes lockfiles, dist/, build/, node_modules/, vendor/, target/, minified and source-map files]"
 
 // BaselineDiff runs `git diff <baseCommit>` in the mission's own
-// worktree — the reviewer judges the actual diff, never the worker's
-// account of it — capped at baselineDiffCap with a truncation marker
-// that never splits mid-line.
-func BaselineDiff(ctx context.Context, worktree, baseCommit string) (string, error) {
-	return baselineDiffCapped(ctx, worktree, baseCommit, baselineDiffCap)
+// worktree (the reviewer judges the actual diff, never the worker's
+// account of it), restricted to the scope paths (whole tree when
+// empty, D-095) and capped at baselineDiffCap, cut on a file boundary.
+func BaselineDiff(ctx context.Context, worktree, baseCommit string, scope []string) (string, error) {
+	return baselineDiffCapped(ctx, worktree, baseCommit, scope, baselineDiffCap)
 }
 
 // baselineDiffCapped is BaselineDiff with the byte cap as a parameter,
 // so a reviewer round that overflowed the model's context can retry
 // with a smaller one (see driver.go's reviewWithShrink).
-func baselineDiffCapped(ctx context.Context, worktree, baseCommit string, limit int) (string, error) {
+func baselineDiffCapped(ctx context.Context, worktree, baseCommit string, scope []string, limit int) (string, error) {
+	out, err := gitDiff(ctx, worktree, baseCommit, nil, scope)
+	if err != nil || len(out) == 0 {
+		return "", err
+	}
+	return truncateDiff(string(out), limit) + baselineDiffExcludeTrailer, nil
+}
+
+// diffStatCap bounds the whole-change stat block in the review packet.
+const diffStatCap = 4 << 10
+
+// DiffStat runs `git diff --stat <baseCommit>` over the whole change
+// (D-095): the reviewer sees every touched file even when the scoped
+// diff omits it.
+func DiffStat(ctx context.Context, worktree, baseCommit string) (string, error) {
+	out, err := gitDiff(ctx, worktree, baseCommit, []string{"--stat=120"}, nil)
+	if err != nil || len(out) <= diffStatCap {
+		return string(out), err
+	}
+	cut := lastNewlineBefore(out, diffStatCap)
+	return string(out[:cut]) + "\n[stat truncated]", nil
+}
+
+// ChangedFiles lists every path the change touches (`git diff
+// --name-only`), the evidence gate's notion of "a file in the diff".
+func ChangedFiles(ctx context.Context, worktree, baseCommit string) ([]string, error) {
+	out, err := gitDiff(ctx, worktree, baseCommit, []string{"--name-only"}, nil)
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			files = append(files, line)
+		}
+	}
+	return files, nil
+}
+
+// gitDiff runs `git diff <flags> <baseCommit> -- <paths> <excludes>`
+// in worktree; paths defaults to the whole tree.
+func gitDiff(ctx context.Context, worktree, baseCommit string, flags, paths []string) ([]byte, error) {
 	if baseCommit == "" || baseCommit == unavailableCommit {
-		return "", fmt.Errorf("review: no base commit recorded for this worktree")
+		return nil, fmt.Errorf("review: no base commit recorded for this worktree")
 	}
 	cctx, cancel := context.WithTimeout(ctx, baselineDiffTimeout)
 	defer cancel()
-	args := []string{"diff", baseCommit, "--", "."}
+	args := append([]string{"diff"}, flags...)
+	args = append(args, baseCommit, "--")
+	if len(paths) == 0 {
+		paths = []string{"."}
+	}
+	args = append(args, paths...)
 	for _, pattern := range baselineDiffExcludes {
 		args = append(args, ":(exclude,glob)"+pattern)
 	}
-	cmd := exec.CommandContext(cctx, "git", args...) //nolint:gosec // baseCommit is a git commit hash captured by our own Provision, not user input
+	cmd := exec.CommandContext(cctx, "git", args...) //nolint:gosec // baseCommit is a git commit hash captured by our own Provision; paths are plan scope entries, passed after -- so git reads them as pathspecs only
 	cmd.Dir = worktree
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("review: git diff: %w", err)
+		return nil, fmt.Errorf("review: git diff: %w", err)
 	}
-	if len(out) == 0 {
-		return "", nil
+	return out, nil
+}
+
+// truncateDiff cuts a diff over limit on a file boundary (D-095),
+// appending "[diff truncated: N files omitted]". When even the first
+// file overflows the budget its head is kept, cut on a line, so a
+// single large change never renders as an empty diff.
+func truncateDiff(diff string, limit int) string {
+	if len(diff) <= limit {
+		return diff
 	}
-	if len(out) <= limit {
-		return string(out) + baselineDiffExcludeTrailer, nil
+	files := strings.Split(diff, "\ndiff --git ")
+	for i := 1; i < len(files); i++ {
+		files[i] = "\ndiff --git " + files[i]
 	}
-	cut := lastNewlineBefore(out, limit)
-	return string(out[:cut]) + fmt.Sprintf("\n[truncated at %d bytes: diff is %d bytes]", cut, len(out)) + baselineDiffExcludeTrailer, nil
+	var b strings.Builder
+	kept := 0
+	for _, f := range files {
+		if b.Len()+len(f) > limit {
+			if kept == 0 {
+				cut := lastNewlineBefore([]byte(f), limit)
+				b.WriteString(f[:cut])
+				fmt.Fprintf(&b, "\n[truncated at %d bytes: file diff is %d bytes]", cut, len(f))
+				kept++
+			}
+			break
+		}
+		b.WriteString(f)
+		kept++
+	}
+	fmt.Fprintf(&b, "\n[diff truncated: %d files omitted]", len(files)-kept)
+	return b.String()
+}
+
+// findingDemotion is one blocking finding the evidence gate demoted,
+// with why.
+type findingDemotion struct {
+	Finding Finding
+	Reason  string
+}
+
+// gateFindings is the D-095 evidence gate: a blocking finding must name
+// a file among known (the changed files plus the declared artifacts)
+// and quote non-empty evidence, or it becomes minor. Deterministic,
+// no model pass. Returns a gated copy and the demotions.
+func gateFindings(findings []Finding, known []string) ([]Finding, []findingDemotion) {
+	set := make(map[string]bool, len(known))
+	for _, k := range known {
+		if n := normalizeFindingPath(k); n != "" {
+			set[n] = true
+		}
+	}
+	out := make([]Finding, len(findings))
+	copy(out, findings)
+	var demoted []findingDemotion
+	for i := range out {
+		f := &out[i]
+		if !f.Blocking() {
+			continue
+		}
+		var reason string
+		switch {
+		case strings.TrimSpace(f.File) == "":
+			reason = "names no file"
+		case !set[normalizeFindingPath(f.File)]:
+			reason = fmt.Sprintf("file %q is not in the diff or the declared artifacts", f.File)
+		case strings.TrimSpace(f.Evidence) == "":
+			reason = "quotes no evidence"
+		default:
+			continue
+		}
+		f.Severity = SeverityMinor
+		demoted = append(demoted, findingDemotion{Finding: *f, Reason: reason})
+	}
+	return out, demoted
+}
+
+// blockingRemain reports whether approval is still off the table after
+// the gate: a blocking finding in this round, or a prior open blocking
+// finding the reviewer did not resolve.
+func blockingRemain(gated, open []Finding, resolved []string) bool {
+	for _, f := range gated {
+		if f.Blocking() {
+			return true
+		}
+	}
+	for _, f := range open {
+		if f.Blocking() && !slices.Contains(resolved, f.ID) {
+			return true
+		}
+	}
+	return false
 }
 
 // lastNewlineBefore returns the index of the last '\n' at or before

--- a/internal/brain/missions/review_test.go
+++ b/internal/brain/missions/review_test.go
@@ -127,7 +127,7 @@ func TestBaselineDiffExcludesLockfilesAndBuildOutput(t *testing.T) {
 		"package-lock.json": `{"lockfileVersion": 2}` + "\n",
 		"dist/x.js":         "console.log('built');\n",
 	})
-	diff, err := BaselineDiff(context.Background(), worktree, base)
+	diff, err := BaselineDiff(context.Background(), worktree, base, nil)
 	if err != nil {
 		t.Fatalf("BaselineDiff: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestBaselineDiffCappedParameter(t *testing.T) {
 	worktree, base := gitRepo(t, map[string]string{
 		"big.txt": strings.Repeat("line of content here\n", 1000),
 	})
-	diff, err := baselineDiffCapped(context.Background(), worktree, base, 200)
+	diff, err := baselineDiffCapped(context.Background(), worktree, base, nil, 200)
 	if err != nil {
 		t.Fatalf("baselineDiffCapped: %v", err)
 	}
@@ -175,5 +175,182 @@ func TestLastNewlineBefore(t *testing.T) {
 	noNewline := []byte("nonewlinehere")
 	if got := lastNewlineBefore(noNewline, 5); got != 5 {
 		t.Fatalf("lastNewlineBefore with no newline = %d, want fallback to limit 5", got)
+	}
+}
+
+// TestBaselineDiffRestrictedToScope pins D-095 against a real git
+// binary: the reviewer's diff covers only the scope paths, while the
+// stat and the changed-file list cover the whole change.
+func TestBaselineDiffRestrictedToScope(t *testing.T) {
+	worktree, base := gitRepo(t, map[string]string{
+		"src/a.ts":  "export const a = 1;\n",
+		"docs/b.md": "# b\n",
+		"report.md": "# report\n",
+		"README.md": "readme\n",
+	})
+	ctx := context.Background()
+	diff, err := BaselineDiff(ctx, worktree, base, []string{"src", "report.md"})
+	if err != nil {
+		t.Fatalf("BaselineDiff: %v", err)
+	}
+	for _, want := range []string{"src/a.ts", "report.md"} {
+		if !strings.Contains(diff, want) {
+			t.Fatalf("scoped diff missing %s:\n%s", want, diff)
+		}
+	}
+	for _, unwanted := range []string{"docs/b.md", "README.md"} {
+		if strings.Contains(diff, unwanted) {
+			t.Fatalf("scoped diff includes out-of-scope %s:\n%s", unwanted, diff)
+		}
+	}
+	stat, err := DiffStat(ctx, worktree, base)
+	if err != nil {
+		t.Fatalf("DiffStat: %v", err)
+	}
+	for _, want := range []string{"src/a.ts", "docs/b.md", "README.md", "4 files changed"} {
+		if !strings.Contains(stat, want) {
+			t.Fatalf("stat missing %q:\n%s", want, stat)
+		}
+	}
+	files, err := ChangedFiles(ctx, worktree, base)
+	if err != nil {
+		t.Fatalf("ChangedFiles: %v", err)
+	}
+	if len(files) != 4 {
+		t.Fatalf("ChangedFiles = %v, want 4 paths", files)
+	}
+}
+
+// TestTruncateDiffCutsOnFileBoundary pins the D-095 truncation rule:
+// whole files are dropped from the end with a count marker; a first
+// file larger than the budget keeps its head, cut on a line.
+func TestTruncateDiffCutsOnFileBoundary(t *testing.T) {
+	a := "diff --git a/a b/a\n" + strings.Repeat("+aaaa\n", 20)
+	b := "diff --git a/b b/b\n" + strings.Repeat("+bbbb\n", 20)
+	c := "diff --git a/c b/c\n+c\n"
+	full := a + b + c
+
+	if got := truncateDiff(full, len(full)); got != full {
+		t.Fatalf("diff within budget was altered:\n%s", got)
+	}
+	got := truncateDiff(full, len(a)+len(b)-2)
+	if !strings.Contains(got, "a/a") || strings.Contains(got, "a/b") || strings.Contains(got, "a/c") {
+		t.Fatalf("truncated diff should keep only the first file:\n%s", got)
+	}
+	if !strings.HasSuffix(got, "[diff truncated: 2 files omitted]") {
+		t.Fatalf("truncated diff missing the omitted-files marker:\n%s", got)
+	}
+	got = truncateDiff(full, 40)
+	if !strings.Contains(got, "diff --git a/a b/a\n+aaaa\n") || !strings.Contains(got, "[truncated at ") || !strings.HasSuffix(got, "[diff truncated: 2 files omitted]") {
+		t.Fatalf("oversized first file should keep its head with both markers:\n%s", got)
+	}
+	if strings.Contains(got, "+bbbb") {
+		t.Fatalf("oversized first file cut must not leak the next file:\n%s", got)
+	}
+}
+
+// TestGateFindings is the D-095 evidence gate table: a blocking finding
+// survives only with a known file and non-empty evidence.
+func TestGateFindings(t *testing.T) {
+	known := []string{"./src/a.ts", "report.md"}
+	tests := []struct {
+		name       string
+		finding    Finding
+		wantMinor  bool
+		wantReason string
+	}{
+		{"known file with evidence stays blocking", Finding{Title: "x", File: "src/a.ts", Evidence: "+const a = 1"}, false, ""},
+		{"no file", Finding{Title: "x", Evidence: "+const a = 1"}, true, "names no file"},
+		{"file outside the change", Finding{Title: "x", File: "src/zzz.ts", Evidence: "+z"}, true, "not in the diff"},
+		{"no evidence", Finding{Title: "x", File: "report.md"}, true, "quotes no evidence"},
+		{"blank evidence", Finding{Title: "x", File: "report.md", Evidence: "  "}, true, "quotes no evidence"},
+		{"minor untouched", Finding{Title: "x", Severity: SeverityMinor}, true, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gated, demoted := gateFindings([]Finding{tc.finding}, known)
+			if got := !gated[0].Blocking(); got != tc.wantMinor {
+				t.Fatalf("minor = %v, want %v", got, tc.wantMinor)
+			}
+			if tc.wantReason == "" {
+				if len(demoted) != 0 {
+					t.Fatalf("demoted = %+v, want none", demoted)
+				}
+				return
+			}
+			if len(demoted) != 1 || !strings.Contains(demoted[0].Reason, tc.wantReason) {
+				t.Fatalf("demoted = %+v, want one with reason containing %q", demoted, tc.wantReason)
+			}
+		})
+	}
+	in := []Finding{{Title: "x"}}
+	gateFindings(in, nil)
+	if in[0].Severity == SeverityMinor {
+		t.Fatal("gateFindings mutated its input")
+	}
+}
+
+// TestBlockingRemain pins the approve-after-gate rule: only-minor new
+// findings approve unless a prior open blocking finding was left
+// unresolved.
+func TestBlockingRemain(t *testing.T) {
+	minor := []Finding{{Title: "nit", Severity: SeverityMinor}}
+	open := []Finding{{ID: "F1", Severity: SeverityBlocking, Status: FindingOpen}}
+	if blockingRemain(minor, nil, nil) {
+		t.Fatal("minor-only findings with no prior open ones must not block")
+	}
+	if !blockingRemain(minor, open, nil) {
+		t.Fatal("an unresolved prior blocking finding must block")
+	}
+	if blockingRemain(minor, open, []string{"F1"}) {
+		t.Fatal("a resolved prior blocking finding must not block")
+	}
+	if !blockingRemain([]Finding{{Title: "real", File: "a", Evidence: "b"}}, nil, nil) {
+		t.Fatal("a blocking finding must block")
+	}
+}
+
+// TestReviewArtifacts pins which artifacts the D-095 packet carries:
+// all of them for legacy units or diff-less missions, otherwise only
+// those a criterion names.
+func TestReviewArtifacts(t *testing.T) {
+	units := []PlanUnit{
+		{Artifacts: []string{"docs/summary.md", "src/a.ts"}, Criteria: []string{"Summary.md lists every endpoint", "tests pass"}},
+		{Artifacts: []string{"src/b.ts"}, Criteria: []string{"b exports the client"}},
+	}
+	if got := reviewArtifacts(units, true); len(got) != 1 || got[0] != "docs/summary.md" {
+		t.Fatalf("reviewArtifacts(with diff) = %v, want only the criteria-named summary", got)
+	}
+	if got := reviewArtifacts(units, false); len(got) != 3 {
+		t.Fatalf("reviewArtifacts(no diff) = %v, want every artifact", got)
+	}
+	legacy := []PlanUnit{{Artifacts: []string{"out.md", "out.md"}}}
+	if got := reviewArtifacts(legacy, true); len(got) != 1 || got[0] != "out.md" {
+		t.Fatalf("reviewArtifacts(legacy) = %v, want the deduplicated artifact", got)
+	}
+}
+
+// TestReadArtifactsPerFileCap pins the 8 KB per-file cap (D-095) on
+// top of the total cap.
+func TestReadArtifactsPerFileCap(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "big.md"), []byte(strings.Repeat("x", reviewArtifactFileCap+100)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := ReadArtifacts(root, []string{"big.md"})["big.md"]
+	if !strings.Contains(got, "per-file cap") || len(got) > reviewArtifactFileCap+200 {
+		t.Fatalf("big artifact not capped per file (len %d)", len(got))
+	}
+}
+
+// TestParseReviewVerdictEvidence pins that a finding's evidence line
+// survives parsing.
+func TestParseReviewVerdictEvidence(t *testing.T) {
+	v, err := parseReviewVerdict([]byte(`{"decision":"rework","findings":[{"title":"x","file":"a.go","evidence":"+return nil"}]}`))
+	if err != nil {
+		t.Fatalf("parseReviewVerdict: %v", err)
+	}
+	if v.Findings[0].Evidence != "+return nil" {
+		t.Fatalf("Evidence = %q", v.Findings[0].Evidence)
 	}
 }

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"log/slog"
 	"os/exec"
+	"path"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"sort"
@@ -1307,7 +1309,7 @@ func (r *nativeRunner) applyDiscoverReport(ctx context.Context, m Mission, repor
 // session (D-092): findings carry across rounds as mission state, so
 // no reviewer transcript is retained to anchor the next verdict.
 func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPacket) (ReviewVerdict, error) {
-	system := "You are reviewing one unit of a mission's work. The mission goal, the plan, and the actual artifact contents (read from disk by the harness, not reported by the worker) are all below; judge against THEM. Look for real reasons to reject before approving: the artifact not satisfying the goal, unsupported claims, missing substance. Reject when the work violates an explicit constraint stated in the goal, even if it faithfully follows the plan: the goal outranks the plan. Do NOT reject for material you were not given (the harness supplies everything there is). Prior rounds' open findings are listed with ids: name each one the work has now closed in resolved, and report only NEW gaps as findings. End your turn with exactly one review_verdict tool call."
+	system := "You are reviewing units of a mission's work. Each unit's acceptance criteria, the harness's own check results, the diff and the actual artifact contents (read from disk by the harness, not reported by the worker) are all below; judge against THEM. Look for real reasons to reject before approving: a criterion the work does not satisfy, unsupported claims, missing substance. Do NOT reject for material you were not given (the harness supplies everything there is) and do not re-run checks the harness already reports as passed. Every blocking finding must name a file that appears in the diff or the artifacts and quote the line that shows the gap in evidence; a blocking finding without both is demoted to minor. Prior rounds' open findings are listed with ids: name each one the work has now closed in resolved, and report only NEW gaps as findings. End your turn with exactly one review_verdict tool call."
 	messages := []provider.Message{{Role: "user", Content: renderReviewContent(packet)}}
 
 	extra := append([]*tools.Tool{ReviewVerdictTool()}, r.missionTools(m)...)
@@ -1395,9 +1397,30 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 // model-produced text passes through NeutralizeSlot.
 func renderReviewContent(p ReviewPacket) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "Mission goal: %s\n", NeutralizeSlot(p.Goal))
-	if p.UnitTitle != "" {
-		fmt.Fprintf(&b, "Unit under review: %s\n", NeutralizeSlot(p.UnitTitle))
+	if p.Goal != "" {
+		fmt.Fprintf(&b, "Mission goal: %s\n", NeutralizeSlot(p.Goal))
+	}
+	if len(p.Units) > 0 {
+		b.WriteString("Units under review (judge each against its acceptance criteria):\n")
+		for _, u := range p.Units {
+			fmt.Fprintf(&b, "\n### %s [%s]\n", NeutralizeSlot(u.Title), unitStatus(u))
+			if len(u.Criteria) > 0 {
+				b.WriteString("Acceptance criteria:\n")
+				for _, c := range u.Criteria {
+					fmt.Fprintf(&b, "- %s\n", NeutralizeSlot(c))
+				}
+			}
+			if u.VerifyCheck != "" {
+				result := "failed"
+				if u.verified() {
+					result = "passed"
+				}
+				fmt.Fprintf(&b, "Harness %s check: %s\n", u.VerifyCheck, result)
+			}
+			if u.VerifyExcerpt != "" {
+				fmt.Fprintf(&b, "Verify output:\n%s\n", NeutralizeSlot(strings.TrimRight(u.VerifyExcerpt, "\n")))
+			}
+		}
 	}
 	if len(p.Plan.Units) > 0 {
 		b.WriteString("\nPlan:\n")
@@ -1434,8 +1457,13 @@ func renderReviewContent(p ReviewPacket) string {
 			fmt.Fprintf(&b, "\n--- %s ---\n%s\n", path, NeutralizeSlot(p.Artifacts[path]))
 		}
 	}
+	if p.DiffStat != "" {
+		b.WriteString("\nChanged files (whole change):\n")
+		b.WriteString(p.DiffStat)
+		b.WriteString("\n")
+	}
 	if p.Diff != "" {
-		b.WriteString("\nDiff to review:\n")
+		b.WriteString("\nDiff to review (restricted to the reviewed units' scope):\n")
 		b.WriteString(p.Diff)
 		b.WriteString("\n")
 	}
@@ -1465,7 +1493,7 @@ func renderReviewContent(p ReviewPacket) string {
 // stuck mission (5 straight "invalid plan JSON" failures, identical
 // each retry since nothing told the model what went wrong).
 func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, discoverNotes string) (Plan, error) {
-	system := "You are planning one mission. Break the goal into the SMALLEST ordered list of verifiable units that achieves it — one unit is correct for a simple goal; never pad the plan. A worker turn is one continuous model generation: if a single unit's own deliverable would demand a very long uninterrupted output (many chapters, dozens of sections, a large multi-file dataset, or similar), a long stream is more likely to truncate mid-generation, so split that unit along its own natural boundaries (one unit per chapter/section/file) instead of one unit for the whole deliverable — this applies regardless of the goal's subject matter. Every unit must list at least one artifact — the workspace-relative file(s) the unit must produce (for a report-style goal, the report file itself is the artifact); the harness itself checks each exists and is non-empty, so name the real deliverables. verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory — it must be a real POSIX shell command (using binaries like grep, test, wc — NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Never use command substitution ($(...) or backticks) in verify_cmd — write the direct command instead; for a line-count check use awk, e.g. `awk 'END{exit NR<10}' report.md`, NEVER `test $(wc -l ...)`. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. If the goal cannot be achieved as stated (it forbids the only possible action, contradicts what actually exists in the workspace, or is self-contradictory), do not invent a workaround plan: call submit_plan with infeasible=true and a reason instead of units. If the goal left something ambiguous and you resolved it silently, list it in assumptions with the default you chose (e.g. \"no language version was specified\" -> \"Python 3.12\", \"output format unspecified\" -> \"single markdown file\"); leave assumptions empty when nothing was ambiguous. End your turn with exactly one submit_plan tool call." + r.execEnvironmentNote(ctx)
+	system := "You are planning one mission. Break the goal into the SMALLEST ordered list of verifiable units that achieves it: one unit is correct for a simple goal; never pad the plan. A worker turn is one continuous model generation: if a single unit's own deliverable would demand a very long uninterrupted output (many chapters, dozens of sections, a large multi-file dataset, or similar), a long stream is more likely to truncate mid-generation, so split that unit along its own natural boundaries (one unit per chapter/section/file) instead of one unit for the whole deliverable; this applies regardless of the goal's subject matter. Every unit must list at least one artifact, the workspace-relative file(s) the unit must produce (for a report-style goal, the report file itself is the artifact); the harness itself checks each exists and is non-empty, so name the real deliverables. Every unit must also list 2 to 6 acceptance criteria: short single lines taken from the goal stating what the unit's output must satisfy (constraints, required content, format), because the reviewer judges the unit against these criteria rather than the goal text; name the artifact file in a criterion when judging it requires reading its contents. Optionally list scope: the workspace-relative files or directories the unit may touch (defaults to the artifact directories). verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory; it must be a real POSIX shell command (using binaries like grep, test, wc, NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Never use command substitution ($(...) or backticks) in verify_cmd; write the direct command instead; for a line-count check use awk, e.g. `awk 'END{exit NR<10}' report.md`, NEVER `test $(wc -l ...)`. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. If the goal cannot be achieved as stated (it forbids the only possible action, contradicts what actually exists in the workspace, or is self-contradictory), do not invent a workaround plan: call submit_plan with infeasible=true and a reason instead of units. If the goal left something ambiguous and you resolved it silently, list it in assumptions with the default you chose (e.g. \"no language version was specified\" -> \"Python 3.12\", \"output format unspecified\" -> \"single markdown file\"); leave assumptions empty when nothing was ambiguous. End your turn with exactly one submit_plan tool call." + r.execEnvironmentNote(ctx)
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if discoverNotes != "" {
 		user += "\n\nDiscovery findings:\n" + NeutralizeSlot(discoverNotes)
@@ -1646,6 +1674,20 @@ func parsePlan(raw string) (Plan, error) {
 			return Plan{}, fmt.Errorf("mission runner: unit %q must list at least one workspace-relative artifact file the harness can check (for a report-style goal, the report file itself is the artifact)", u.Title)
 		}
 	}
+	// D-095: every unit carries 2 to 6 acceptance criteria; the reviewer
+	// judges against them, never the full goal. Scope defaults to the
+	// artifact directories when the planner left it out.
+	for i := range plan.Units {
+		u := &plan.Units[i]
+		u.Criteria = trimNonEmpty(u.Criteria)
+		if len(u.Criteria) < minUnitCriteria || len(u.Criteria) > maxUnitCriteria {
+			return Plan{}, fmt.Errorf("mission runner: plan_invalid: unit %q must list %d to %d acceptance criteria (one short line each, taken from the goal), got %d", u.Title, minUnitCriteria, maxUnitCriteria, len(u.Criteria))
+		}
+		u.Scope = trimNonEmpty(u.Scope)
+		if len(u.Scope) == 0 {
+			u.Scope = defaultScope(u.Artifacts)
+		}
+	}
 	// D-068: reject verify_cmds that succeed regardless of outcome.
 	// Deny-set on the first shell word only, deliberately not a shell
 	// parser; a no-op buried after && is out of scope.
@@ -1687,4 +1729,47 @@ func parsePlan(raw string) (Plan, error) {
 		u.Passes, u.HarnessPassed, u.Regressed, u.VerifyCheck, u.VerifyExcerpt = false, false, false, "", ""
 	}
 	return plan, nil
+}
+
+// Unit criteria bounds (D-095): few enough to quote back whole, many
+// enough to pin the goal's constraints.
+const (
+	minUnitCriteria = 2
+	maxUnitCriteria = 6
+)
+
+// trimNonEmpty trims each entry and drops the blank ones; nil when
+// nothing survives.
+func trimNonEmpty(in []string) []string {
+	var out []string
+	for _, s := range in {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// defaultScope derives a unit's scope from its artifacts: the parent
+// directory of each nested artifact, the file itself for one at the
+// workspace root (the root directory would scope the whole tree).
+// Deduplicated, in first-seen order.
+func defaultScope(artifacts []string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, a := range artifacts {
+		a = path.Clean(filepath.ToSlash(strings.TrimSpace(a)))
+		if a == "" || a == "." {
+			continue
+		}
+		p := a
+		if dir := path.Dir(a); dir != "." {
+			p = dir
+		}
+		if !seen[p] {
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -429,7 +429,7 @@ func TestRunReviewPacketRendersArtifactsGoalAndEvidence(t *testing.T) {
 	r := newTestRunner(agent)
 	packet := ReviewPacket{
 		Goal:      "Summarize HTTP 429",
-		UnitTitle: "write summary",
+		Units:     []PlanUnit{{Title: "write summary"}},
 		Artifacts: map[string]string{"summary.md": "429 means Too Many Requests, per RFC 6585."},
 		Evidence:  "Summary written to summary.md, sourced from RFC 6585.",
 	}
@@ -536,7 +536,7 @@ func TestRunReviewFallsBackToTokenJSONTextSentinel(t *testing.T) {
 
 func TestPlanSessionParsesSpec(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
@@ -570,17 +570,17 @@ func TestPlanSessionParsesAssumptions(t *testing.T) {
 	}{
 		{
 			name: "omitted",
-			json: `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./..."}]}`,
+			json: `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./..."}]}`,
 			want: nil,
 		},
 		{
 			name: "empty",
-			json: `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./..."}],"assumptions":[]}`,
+			json: `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./..."}],"assumptions":[]}`,
 			want: nil,
 		},
 		{
 			name: "populated",
-			json: `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./..."}],"assumptions":[{"assumption":"no language version was specified","default":"Python 3.12"}]}`,
+			json: `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./..."}],"assumptions":[{"assumption":"no language version was specified","default":"Python 3.12"}]}`,
 			want: []PlanAssumption{{Assumption: "no language version was specified", Default: "Python 3.12"}},
 		},
 	}
@@ -611,7 +611,7 @@ func TestPlanSessionParsesAssumptions(t *testing.T) {
 // into one unit and truncated on a long model stream, twice).
 func TestPlanSessionPromptsLengthAwareSplitting(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	if _, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, ""); err != nil {
@@ -627,7 +627,7 @@ func TestPlanSessionPromptsLengthAwareSplitting(t *testing.T) {
 // planning turn's sole tool, the request forces it.
 func TestPlanSessionForcesPlanTool(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	if _, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, ""); err != nil {
@@ -643,7 +643,7 @@ func TestPlanSessionForcesPlanTool(t *testing.T) {
 // turn, so forcing submit_plan would make consulting them impossible.
 func TestPlanSessionNoForceToolWithKB(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	r.kbSearch = func(ctx context.Context, query string, collections []string, mode string, k int) ([]builtin.KBSearchHit, error) {
@@ -662,7 +662,7 @@ func TestPlanSessionNoForceToolWithKB(t *testing.T) {
 // PlanRoute when set, instead of Route.
 func TestPlanSessionUsesPlanRoute(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	m := Mission{ID: "m1", Route: "mini", PlanRoute: "strong", Goal: "fix bug"}
@@ -678,7 +678,7 @@ func TestPlanSessionUsesPlanRoute(t *testing.T) {
 // prior outcome digest reaches the planner's user prompt.
 func TestPlanSessionIncludesParentContext(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	m := Mission{
@@ -700,7 +700,7 @@ func TestPlanSessionIncludesParentContext(t *testing.T) {
 // additive to (not instead of) ParentContext.
 func TestPlanSessionIncludesReferencedContext(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	m := Mission{
@@ -727,7 +727,7 @@ func TestPlanSessionIncludesReferencedContext(t *testing.T) {
 // attachment's markdown reaches the planner's user prompt.
 func TestPlanSessionIncludesAttachments(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
 	}}
 	r := newTestRunner(agent)
 	m := Mission{ID: "m1", Route: "default", Goal: "fix bug", Sources: []SourceEntry{
@@ -800,8 +800,8 @@ func TestPlanSessionRejectsInfeasibleWithoutReason(t *testing.T) {
 // submission, with feedback the planner can act on immediately.
 func TestPlanSessionRejectsCommandSubstitution(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
-		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	_, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
@@ -836,8 +836,8 @@ func TestPlanSessionRejectsBackticks(t *testing.T) {
 // what was wrong and a corrected plan on the next turn is accepted.
 func TestPlanSessionRecoversFromCommandSubstitutionFeedback(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
-		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"verify_cmd":"grep -qi ok out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"test \"$(cat out.md)\" = ok"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Check output","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -qi ok out.md"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
@@ -861,8 +861,8 @@ func TestPlanSessionRecoversFromCommandSubstitutionFeedback(t *testing.T) {
 func TestPlanSessionAcceptsLegitimateVerifyCmd(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{toolEndEvent(planToolName, `{"units":[`+
-			`{"title":"Check content","artifacts":["out.md"],"verify_cmd":"grep -qi 'foo' out.md"},`+
-			`{"title":"Check line count","artifacts":["x"],"verify_cmd":"test -f x && wc -l < x"}`+
+			`{"title":"Check content","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -qi 'foo' out.md"},`+
+			`{"title":"Check line count","artifacts":["x"],"criteria":["c1","c2"],"verify_cmd":"test -f x && wc -l < x"}`+
 			`]}`)},
 	}}
 	r := newTestRunner(agent)
@@ -889,7 +889,7 @@ func TestPlanSessionAcceptsLegitimateVerifyCmd(t *testing.T) {
 func TestPlanSessionRejectsUnitWithNoArtifacts(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{toolEndEvent(planToolName, `{"units":[{"title":"Integrate Gmail API","verify_cmd":"grep -qi ok out.md"}]}`)},
-		{toolEndEvent(planToolName, `{"units":[{"title":"Integrate Gmail API","artifacts":["out.md"],"verify_cmd":"grep -qi ok out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Integrate Gmail API","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -qi ok out.md"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
@@ -929,7 +929,7 @@ func TestPlanSessionRejectsNoOpVerifyCmd(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			plan := fmt.Sprintf(`{"units":[{"title":"Ship it","artifacts":["out.md"],"verify_cmd":%q}]}`, tc.cmd)
+			plan := fmt.Sprintf(`{"units":[{"title":"Ship it","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":%q}]}`, tc.cmd)
 			agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 				{toolEndEvent(planToolName, plan)},
 				{toolEndEvent(planToolName, plan)},
@@ -953,8 +953,8 @@ func TestPlanSessionRejectsNoOpVerifyCmd(t *testing.T) {
 func TestPlanSessionAcceptsVerifyCmdContainingEchoWord(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{toolEndEvent(planToolName, `{"units":[`+
-			`{"title":"Check literal word","artifacts":["file.md"],"verify_cmd":"grep -q echo file.md"},`+
-			`{"title":"Check then echo","artifacts":["report.md"],"verify_cmd":"test -s report.md && grep -q x report.md"}`+
+			`{"title":"Check literal word","artifacts":["file.md"],"criteria":["c1","c2"],"verify_cmd":"grep -q echo file.md"},`+
+			`{"title":"Check then echo","artifacts":["report.md"],"criteria":["c1","c2"],"verify_cmd":"test -s report.md && grep -q x report.md"}`+
 			`]}`)},
 	}}
 	r := newTestRunner(agent)
@@ -983,8 +983,8 @@ func TestPlanSessionRejectsUnterminatedQuote(t *testing.T) {
 	}
 	bad := `grep -q "unterminated report.md`
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, fmt.Sprintf(`{"units":[{"title":"Ship it","artifacts":["report.md"],"verify_cmd":%q}]}`, bad))},
-		{toolEndEvent(planToolName, fmt.Sprintf(`{"units":[{"title":"Ship it","artifacts":["report.md"],"verify_cmd":%q}]}`, bad))},
+		{toolEndEvent(planToolName, fmt.Sprintf(`{"units":[{"title":"Ship it","artifacts":["report.md"],"criteria":["c1","c2"],"verify_cmd":%q}]}`, bad))},
+		{toolEndEvent(planToolName, fmt.Sprintf(`{"units":[{"title":"Ship it","artifacts":["report.md"],"criteria":["c1","c2"],"verify_cmd":%q}]}`, bad))},
 	}}
 	r := newTestRunner(agent)
 	_, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
@@ -1003,7 +1003,7 @@ func TestPlanSessionAcceptsValidQuoting(t *testing.T) {
 		t.Skip("no /bin/sh on this machine")
 	}
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Ship it","artifacts":["report.md"],"verify_cmd":"grep -qi 'retry-after' report.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Ship it","artifacts":["report.md"],"criteria":["c1","c2"],"verify_cmd":"grep -qi 'retry-after' report.md"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default"}, "")
@@ -1040,7 +1040,7 @@ func TestPlanSessionRejectsMalformedJSON(t *testing.T) {
 func TestPlanSessionRecoversWithFeedback(t *testing.T) {
 	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
 		{textEvent("here's my plan in prose, no tool call")},
-		{toolEndEvent(planToolName, `{"units":[{"title":"Fix it","artifacts":["out.md"],"verify_cmd":"grep -qi ok out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Fix it","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -qi ok out.md"}]}`)},
 	}}
 	r := newTestRunner(agent)
 	spec, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, "")
@@ -2232,7 +2232,7 @@ func TestMissionRunnerRequestsAreBuiltinsOnly(t *testing.T) {
 	}
 
 	agent = &scriptedAgent{batches: [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"do it","artifacts":["out.md"],"verify_cmd":"grep -qi ok out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"do it","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"grep -qi ok out.md"}]}`)},
 	}}
 	r = newTestRunner(agent)
 	if _, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "fix bug"}, ""); err != nil {
@@ -2822,7 +2822,7 @@ func TestDiscoverSessionWiresSteeringFromProgressReader(t *testing.T) {
 // (D-089, issue #458).
 func TestPlanSessionWiresSteeringFromProgressReader(t *testing.T) {
 	batch := [][]stream.StreamEvent{
-		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"verify_cmd":"go test ./...","passes":true}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
 	}
 
 	t.Run("wired", func(t *testing.T) {
@@ -2879,4 +2879,112 @@ func TestRunReviewWiresSteeringFromProgressReader(t *testing.T) {
 			t.Fatal("Steering wired despite no ProgressReader")
 		}
 	})
+}
+
+// TestParsePlanCriteriaAndScope is the D-095 plan validation table:
+// 2 to 6 criteria per unit or plan_invalid naming the unit; blank
+// entries trimmed; scope defaults to the artifact directories (the
+// file itself at the workspace root) unless the planner sets it.
+func TestParsePlanCriteriaAndScope(t *testing.T) {
+	unit := func(extra string) string {
+		return `{"units":[{"title":"Write it","artifacts":["src/a.go","report.md","src/b.go"],"verify_cmd":"grep -q x report.md"` + extra + `}]}`
+	}
+	tests := []struct {
+		name      string
+		json      string
+		wantErr   string
+		wantCrit  []string
+		wantScope []string
+	}{
+		{"missing criteria", unit(``), "plan_invalid: unit \"Write it\"", nil, nil},
+		{"one criterion", unit(`,"criteria":["only one"]`), "plan_invalid", nil, nil},
+		{"seven criteria", unit(`,"criteria":["1","2","3","4","5","6","7"]`), "plan_invalid", nil, nil},
+		{"blank entries do not count", unit(`,"criteria":["real"," ",""]`), "plan_invalid", nil, nil},
+		{"two criteria, default scope", unit(`,"criteria":[" a ","b"]`), "", []string{"a", "b"}, []string{"src", "report.md"}},
+		{"explicit scope kept", unit(`,"criteria":["a","b"],"scope":["src/","docs"]`), "", []string{"a", "b"}, []string{"src/", "docs"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			plan, err := parsePlan(tc.json)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("parsePlan err = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parsePlan: %v", err)
+			}
+			u := plan.Units[0]
+			if strings.Join(u.Criteria, "|") != strings.Join(tc.wantCrit, "|") {
+				t.Fatalf("Criteria = %v, want %v", u.Criteria, tc.wantCrit)
+			}
+			if strings.Join(u.Scope, "|") != strings.Join(tc.wantScope, "|") {
+				t.Fatalf("Scope = %v, want %v", u.Scope, tc.wantScope)
+			}
+		})
+	}
+}
+
+// TestPlanSessionRetriesWithCriteriaError pins the D-095 retry: a plan
+// without criteria buys one recovery turn whose message names the
+// plan_invalid error, and a corrected plan on that turn is accepted.
+func TestPlanSessionRetriesWithCriteriaError(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, `{"units":[{"title":"Write it","artifacts":["out.md"],"verify_cmd":"grep -q x out.md"}]}`)},
+		{toolEndEvent(planToolName, `{"units":[{"title":"Write it","artifacts":["out.md"],"criteria":["a","b"],"verify_cmd":"grep -q x out.md"}]}`)},
+	}}
+	r := newTestRunner(agent)
+	plan, err := r.PlanSession(context.Background(), Mission{ID: "m1", Route: "default", Goal: "g"}, "")
+	if err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	if agent.call != 2 || len(plan.Units[0].Criteria) != 2 {
+		t.Fatalf("calls = %d, plan = %+v; want one recovery turn and the corrected plan", agent.call, plan)
+	}
+	msgs := agent.requests[1].Messages
+	last := msgs[len(msgs)-1].Content
+	if !strings.Contains(last, "plan_invalid: unit \"Write it\"") {
+		t.Fatalf("recovery message = %q, want the plan_invalid error naming the unit", last)
+	}
+}
+
+// TestRenderReviewContentCriteriaReplaceGoal pins the D-095 reviewer
+// packet: units render with criteria, harness status and verify
+// excerpt, the whole-change stat precedes the scoped diff, and the goal
+// is absent unless the packet sets it (legacy plans).
+func TestRenderReviewContentCriteriaReplaceGoal(t *testing.T) {
+	p := ReviewPacket{
+		Units: []PlanUnit{{
+			Title: "Write summary", Criteria: []string{"summary.md names RFC 6585", "under 200 words"},
+			HarnessPassed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "grep ok\n",
+		}},
+		DiffStat: " summary.md | 3 +++\n 1 file changed",
+		Diff:     "diff --git a/summary.md b/summary.md\n+429",
+	}
+	got := renderReviewContent(p)
+	for _, want := range []string{
+		"Units under review (judge each against its acceptance criteria):",
+		"### Write summary [harness-verified]",
+		"- summary.md names RFC 6585",
+		"- under 200 words",
+		"Harness verify_cmd check: passed",
+		"Verify output:\ngrep ok\n",
+		"Changed files (whole change):\n summary.md | 3 +++",
+		"Diff to review (restricted to the reviewed units' scope):\ndiff --git",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("review content missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "Mission goal") {
+		t.Fatalf("review content carries the goal despite criteria:\n%s", got)
+	}
+	if statIdx, diffIdx := strings.Index(got, "Changed files"), strings.Index(got, "Diff to review"); statIdx > diffIdx {
+		t.Fatal("diff stat must precede the scoped diff")
+	}
+	legacy := renderReviewContent(ReviewPacket{Goal: "the goal", Units: []PlanUnit{{Title: "u"}}})
+	if !strings.Contains(legacy, "Mission goal: the goal") {
+		t.Fatalf("legacy packet must render the goal:\n%s", legacy)
+	}
 }

--- a/internal/brain/missions/sentinel.go
+++ b/internal/brain/missions/sentinel.go
@@ -95,9 +95,19 @@ func PlanTool() *tools.Tool {
 							"verify_cmd": {
 								"type": "string",
 								"description": "A real POSIX shell command, run as /bin/sh -c \"<verify_cmd>\" in the mission's workspace, that checks the CONTENT of the artifacts."
+							},
+							"criteria": {
+								"type": "array",
+								"items": {"type": "string"},
+								"description": "Required: 2 to 6 short acceptance criteria for this unit, each one line, extracted from the goal. The reviewer judges the unit against these lines, so quote the goal's own constraints."
+							},
+							"scope": {
+								"type": "array",
+								"items": {"type": "string"},
+								"description": "Workspace-relative files or directory prefixes this unit may touch. Optional: defaults to the directories of its artifacts."
 							}
 						},
-						"required": ["title", "artifacts", "verify_cmd"]
+						"required": ["title", "artifacts", "verify_cmd", "criteria"]
 					}
 				},
 				"infeasible": {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -674,6 +674,11 @@ export interface PlanUnit {
   title: string
   verify_cmd: string
   artifacts?: string[]
+  // criteria (D-095) are the unit's acceptance criteria, 2 to 6 short
+  // lines the reviewer judges against; scope lists the paths the unit
+  // may touch. Both absent on plans written before D-095.
+  criteria?: string[]
+  scope?: string[]
   passes: boolean
   harness_passed?: boolean
   verify_check?: string
@@ -703,6 +708,9 @@ export interface ReviewFinding {
   file: string
   detail: string
   severity?: 'blocking' | 'minor'
+  // evidence (D-095) is the reviewer's quoted diff or output line; a
+  // blocking finding without it is demoted to minor by the harness.
+  evidence?: string
   status?: 'open' | 'resolved' | 'accepted'
   round_opened?: number
   untouched_rounds?: number

--- a/web/src/components/missions/FindingsSection.test.tsx
+++ b/web/src/components/missions/FindingsSection.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { FindingsSection } from './FindingsSection'
+
+afterEach(cleanup)
+
+describe('FindingsSection', () => {
+  it('renders nothing for an empty ledger', () => {
+    const { container } = render(<FindingsSection findings={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('lists id, severity, file, title and the evidence line', () => {
+    render(
+      <FindingsSection
+        findings={[
+          {
+            id: 'F1',
+            unit: 0,
+            title: 'missing validation',
+            file: 'x.go',
+            detail: 'no input check',
+            severity: 'blocking',
+            evidence: '+func handle(r *http.Request) {',
+            status: 'open',
+          },
+          { id: 'F2', unit: 0, title: 'style nit', file: '', detail: '', severity: 'minor', status: 'resolved' },
+        ]}
+      />,
+    )
+    expect(screen.getByText('F1')).toBeInTheDocument()
+    expect(screen.getByText('blocking')).toBeInTheDocument()
+    expect(screen.getByText('x.go')).toBeInTheDocument()
+    expect(screen.getByText('missing validation')).toBeInTheDocument()
+    expect(screen.getByText('+func handle(r *http.Request) {')).toBeInTheDocument()
+    expect(screen.getByText('style nit').closest('li')).toHaveClass('line-through')
+  })
+})

--- a/web/src/components/missions/FindingsSection.tsx
+++ b/web/src/components/missions/FindingsSection.tsx
@@ -1,0 +1,42 @@
+import type { ReviewFinding } from '../../api/types'
+
+// severityClass mirrors the harness severities (missions.Finding,
+// D-092): blocking prevents approval, minor is advisory.
+function severityClass(f: ReviewFinding): string {
+  return f.severity === 'minor'
+    ? 'bg-muted text-muted-foreground'
+    : 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300'
+}
+
+// FindingsSection lists the mission's review findings ledger: id,
+// severity, file, title, and the reviewer's quoted evidence line
+// (D-095). Resolved and accepted findings render struck through.
+export function FindingsSection({ findings }: { findings: ReviewFinding[] }) {
+  if (findings.length === 0) {
+    return null
+  }
+  return (
+    <ul className="space-y-1.5 text-sm">
+      {findings.map((f) => {
+        const closed = f.status !== undefined && f.status !== 'open'
+        return (
+          <li key={f.id} className={closed ? 'text-muted-foreground line-through' : undefined}>
+            <div className="flex items-center gap-2">
+              <span className="shrink-0 font-mono text-xs">{f.id}</span>
+              <span className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium ${severityClass(f)}`}>
+                {f.severity ?? 'blocking'}
+              </span>
+              {f.file && <span className="shrink-0 font-mono text-xs">{f.file}</span>}
+              <span>{f.title}</span>
+            </div>
+            {f.evidence && (
+              <pre className="ml-4 mt-0.5 overflow-x-auto whitespace-pre-wrap font-mono text-xs text-muted-foreground">
+                {f.evidence}
+              </pre>
+            )}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/web/src/components/missions/PlanSection.test.tsx
+++ b/web/src/components/missions/PlanSection.test.tsx
@@ -30,6 +30,20 @@ describe('PlanSection', () => {
     expect(screen.getByText('pending')).toBeInTheDocument()
   })
 
+  it('lists acceptance criteria under a unit and none for a legacy unit', () => {
+    render(
+      <PlanSection
+        units={[
+          { title: 'with criteria', verify_cmd: '', passes: false, criteria: ['report.md names RFC 6585', 'under 200 words'] },
+          { title: 'legacy', verify_cmd: '', passes: false },
+        ]}
+      />,
+    )
+    expect(screen.getByText('report.md names RFC 6585')).toBeInTheDocument()
+    expect(screen.getByText('under 200 words')).toBeInTheDocument()
+    expect(screen.getByText('legacy').closest('li')?.querySelector('ul')).toBeNull()
+  })
+
   it('does not render an Assumptions header when assumptions is absent', () => {
     render(<PlanSection units={units} />)
     expect(screen.queryByText('Assumptions')).toBeNull()

--- a/web/src/components/missions/PlanSection.tsx
+++ b/web/src/components/missions/PlanSection.tsx
@@ -26,14 +26,23 @@ export function PlanSection({ units, assumptions }: { units: PlanUnit[]; assumpt
         {units.map((u, i) => {
           const badge = unitBadge(u)
           return (
-            <li key={i} className="flex items-center gap-2 text-sm">
-              <span
-                className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium ${badge.className}`}
-                title={!u.passes && !u.harness_passed && u.verify_excerpt ? u.verify_excerpt : undefined}
-              >
-                {badge.label}
-              </span>
-              <span>{u.title}</span>
+            <li key={i} className="text-sm">
+              <div className="flex items-center gap-2">
+                <span
+                  className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium ${badge.className}`}
+                  title={!u.passes && !u.harness_passed && u.verify_excerpt ? u.verify_excerpt : undefined}
+                >
+                  {badge.label}
+                </span>
+                <span>{u.title}</span>
+              </div>
+              {u.criteria && u.criteria.length > 0 && (
+                <ul className="ml-4 mt-0.5 list-disc space-y-0.5 pl-4 text-xs text-muted-foreground">
+                  {u.criteria.map((c, j) => (
+                    <li key={j}>{c}</li>
+                  ))}
+                </ul>
+              )}
             </li>
           )
         })}

--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -35,6 +35,13 @@ describe('mission.unit_regressed rendering', () => {
   })
 })
 
+describe('mission.finding_demoted rendering', () => {
+  it('names the finding and the gate reason', () => {
+    render(<div>{renderEvent(event({ title: 'wrong status', file: 'nope.md', reason: 'quotes no evidence' }, 'mission.finding_demoted'))}</div>)
+    expect(screen.getByText('Finding demoted to minor: wrong status (quotes no evidence)')).toHaveClass('text-amber-400')
+  })
+})
+
 describe('mission.generate_skipped rendering', () => {
   it('explains the skipped worker turn', () => {
     expect(renderEvent(event({}, 'mission.generate_skipped'))).toBe('Worker turn skipped: every unit is harness-verified')

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -64,6 +64,14 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
     )
   },
   'mission.generate_skipped': () => 'Worker turn skipped: every unit is harness-verified',
+  'mission.finding_demoted': (p) => {
+    const { title, reason } = asRecord(p)
+    return (
+      <span className="text-amber-400">
+        Finding demoted to minor: {String(title ?? '?')} ({String(reason ?? 'no evidence')})
+      </span>
+    )
+  },
   'mission.review_verdict': (p) => {
     const { decision } = asRecord(p)
     const approved = decision === 'approve'

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -38,6 +38,7 @@ import type {
 } from '../api/types'
 import { ArtifactsSection } from '../components/missions/ArtifactsSection'
 import { DiscoverSection } from '../components/missions/DiscoverSection'
+import { FindingsSection } from '../components/missions/FindingsSection'
 import { GoalSection } from '../components/missions/GoalSection'
 import { InputRequestBanner } from '../components/missions/InputRequestBanner'
 import { MarkdownField } from '../components/missions/MarkdownField'
@@ -1012,6 +1013,13 @@ export function MissionDetail() {
         <section>
           <h2 className="mb-2 text-sm font-semibold tracking-tight">Plan</h2>
           <PlanSection units={mission.plan?.units ?? []} assumptions={mission.plan?.assumptions} />
+        </section>
+      )}
+
+      {(mission.review_findings?.length ?? 0) > 0 && (
+        <section>
+          <h2 className="mb-2 text-sm font-semibold tracking-tight">Review findings</h2>
+          <FindingsSection findings={mission.review_findings ?? []} />
         </section>
       )}
 


### PR DESCRIPTION
## Summary

Slice 4 of the prove loop redesign (D-095). Closes #520. Part of #510.

**Plan units carry criteria and scope**
- `PlanUnit` gains `criteria` (2 to 6 lines) and `scope` (paths). `parsePlan` rejects a plan whose unit lacks criteria with `plan_invalid: unit "<title>" ...`; `PlanSession`'s existing recovery turn carries that error to the planner, and the second failure surfaces as the phase's `worker_failed` reason. `submit_plan` requires `criteria`; the planner prompt explains both fields.
- `scope` defaults to the artifact directories, except that an artifact at the workspace root scopes to the file itself (its directory would be the whole tree, which defeats the restriction).
- Light missions never plan, so nothing changes for them.

**Reviewer packet built from criteria and the scoped diff**
- `ReviewPacket.Units` replaces `UnitTitle`: title, criteria, harness status and verify excerpt per reviewed unit. `Goal` is set only when no reviewed unit has criteria (legacy plans).
- `BaselineDiff` takes the scope paths; `truncateDiff` cuts on a file boundary at the existing 256 KB budget (64 KB on the shrink retry) with `[diff truncated: N files omitted]`; a single file larger than the budget keeps its head, cut on a line, so the diff is never empty. New `DiffStat` (whole change, 4 KB cap) and `ChangedFiles` (evidence gate input).
- Artifacts attach only when a criterion names the file (path or base name), or for legacy units and diff-less missions where the artifacts are the only evidence; 8 KB per file on top of the 32 KB total.
- Worker packet unchanged.

**Evidence gate**
- `gateFindings` demotes a blocking finding to minor when it names no file, names a file outside the changed files and declared artifacts, or quotes no `evidence`; each demotion appends `mission.finding_demoted` (title, file, reason). No second model pass.
- A rework left with only minor findings, and no prior open blocking finding the reviewer failed to resolve, counts as approval. A rework with zero findings keeps its previous behaviour.

**Schema and web**
- No schema change: `criteria`/`scope` live in the `plan` jsonb, `evidence` in `review_findings`.
- Web: criteria listed under each unit in `PlanSection`; new `FindingsSection` (id, severity, file, title, evidence line) on the mission page; `mission.finding_demoted` timeline renderer.

## Test plan

- [x] `make build test vet lint` (0 lint issues)
- [x] `make test-integration` against the local stack
- [x] `go vet -tags integration ./...`
- [x] web `npm run build && npm run lint && npm test` (1049 tests)
- [x] `make canary` against the local stack rebuilt from this branch (`make brain`): PASS on the third draw. The first two draws both picked the "301 vs 308 redirects" goal and parked `no_progress` in generate on the D-094 citations check (the worker's example URLs, `example.com` and `example.org`, are flagged as uncited); those runs never reached prove, so the failure is independent of this slice, but the citation check treating RFC 2606 placeholder domains as citations looks worth its own issue.
- [x] `make canary-coding` (exercises the real review path): the mission itself ran discover, plan (criteria + scope landed in the `plan` jsonb), generate, a rework round with two findings carrying `file` + `evidence`, a second generate turn resolving F1/F2, approval and done. The script's final assertion fails for a pre-existing reason: it posts `repo_path`, which the API does not accept (`internal/brain/api/missions.go` calls it a future option), so the mission was provisioned with an empty repo and the branch never lands in the fixture. Unrelated to this slice; the script needs updating to the `sources` shape.

New tests: `TestParsePlanCriteriaAndScope`, `TestPlanSessionRetriesWithCriteriaError`, `TestRenderReviewContentCriteriaReplaceGoal`, `TestBaselineDiffRestrictedToScope`, `TestTruncateDiffCutsOnFileBoundary`, `TestGateFindings`, `TestBlockingRemain`, `TestReviewArtifacts`, `TestReadArtifactsPerFileCap`, `TestParseReviewVerdictEvidence`, `TestDriverEvidenceGateDemotesAndApproves`, `TestDriverLegacyPlanReviewsAgainstGoal`, `TestDriverReviewPacketScopedDiffAndGate`; web `FindingsSection.test.tsx`, PlanSection criteria case, finding_demoted renderer case.

## Deviations from the issue

- Root-level artifacts default their scope to the file, not the directory (see above).
- Minor findings that survive a gated approval are recorded in the `mission.review_verdict` event payload but not merged into the `review_findings` ledger (the approve transition resolves the cycle).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790947471&installation_model_id=431401&pr_number=521&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F521&signature=308565fdb915fe99251acc82405e376b5f6a5262a919d4ddab9fc230036e87b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->