### PR TITLE
feat(missions): one full review round, findings-only re-review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,20 @@ First run: `cp deploy/env.example deploy/.env` and set
   `mission.finding_demoted` event; a round left with only minor findings
   and no unresolved prior blocking one counts as approval. Light
   missions never plan, so none of this applies to them.
+- One review round, findings-only re-review (D-096, issue #524): a
+  generate turn that leaves units without harness evidence and no
+  finding open stays in generate (`mission.generate_continued`); prove
+  runs one full round once every unit is harness-passed (or a finding
+  is open). A rework records the worktree HEAD in the plan jsonb as
+  `last_review_commit` (written only by `ApplyTransition`); every later
+  round with open findings is findings-only
+  (`Driver.findingsReviewPacket`): the open findings, the diff since
+  that commit scoped to the finding files and the affected units'
+  scope, the finding files (8 KB each), the affected units' harness
+  state, and a "Changed outside unit scope" list the harness opens no
+  finding for. The reviewer answers with `resolved` ids plus gated new
+  findings; all blocking ones resolved counts as approval. Missions
+  without `last_review_commit` get the full packet.
 - Workers get per-mission `shell` + `write_file` tools via turn-scoped
   `ExtraTools` that shadow base tools by name. Workers must create files
   with `write_file` only; shell redirects/heredocs classify destructive

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GO_RUN := docker run --rm -v $(CURDIR):/src -w /src \
 	-e GOFLAGS=-buildvcs=false $(GO_IMAGE)
 
 .PHONY: build test test-integration test-live vet lint tidy skills-validate up down logs \
-	brain gateway memoryd web markitdown pdfgen sandboxd dev canary canary-coding canary-research canary-executor canary-impossible kb-eval sandbox-image
+	brain gateway memoryd web markitdown pdfgen sandboxd dev canary canary-coding canary-two-unit canary-research canary-executor canary-impossible kb-eval sandbox-image
 
 build:
 	$(GO_RUN) go build ./...
@@ -105,6 +105,12 @@ canary:
 # without it.
 canary-coding:
 	./scripts/canary-coding.sh
+
+# Same coding gate with a two-file goal planned as two units (D-096,
+# issue #524): asserts exactly one review round ran once both units were
+# harness-passed and both artifacts landed in the worktree.
+canary-two-unit:
+	CANARY_TWO_UNIT=1 ./scripts/canary-coding.sh
 
 # Same gate for research work: the goal requires current web
 # information and a cited markdown report, so it exercises

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -1215,6 +1215,7 @@ func (d *Driver) toStepState(ctx context.Context, m Mission) StepState {
 		Units: m.Plan.Units, ReplanUsed: m.ReplanUsed,
 		AutoApprovePlan: m.AutoApprovePlan, Flow: m.Flow,
 		ReviewFindings: m.ReviewFindings, ReworkRounds: m.ReworkRounds,
+		LastReviewCommit: m.Plan.LastReviewCommit,
 	}
 }
 
@@ -1678,13 +1679,19 @@ func (d *Driver) reviewWithShrink(ctx context.Context, m Mission, packet ReviewP
 	diffCap, artifactsCap := baselineDiffCap/4, reviewArtifactsCap/2
 	trimmed := packet
 	if wt := m.WorktreePath(); wt != "" {
-		trimmedDiff, diffErr := baselineDiffCapped(ctx, wt, m.BaseCommit, reviewScope(packet.Units), diffCap)
+		// D-096: a findings-only packet diffs from the last review commit
+		// over the finding files and the affected units' scope.
+		base, scope := m.BaseCommit, reviewScope(packet.Units)
+		if packet.FindingsOnly {
+			base, scope = m.Plan.LastReviewCommit, append(findingFiles(packet.OpenFindings), scope...)
+		}
+		trimmedDiff, diffErr := baselineDiffCapped(ctx, wt, base, scope, diffCap)
 		if diffErr != nil {
 			return ReviewVerdict{}, diffErr
 		}
 		trimmed.Diff = trimmedDiff
 	}
-	if artifacts := reviewArtifacts(packet.Units, packet.Diff != ""); len(artifacts) > 0 {
+	if artifacts := reviewArtifacts(packet.Units, packet.Diff != ""); !packet.FindingsOnly && len(artifacts) > 0 {
 		trimmed.Artifacts = ReadArtifactsCapped(m.WorkRoot(), artifacts, artifactsCap)
 	}
 	if evErr := d.store.AppendEvent(ctx, m.ID, "mission.review_prompt_shrunk", map[string]any{
@@ -1702,16 +1709,12 @@ func (d *Driver) reviewWithShrink(ctx context.Context, m Mission, packet ReviewP
 	return verdict, nil
 }
 
-func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
-	idx, units := reviewUnits(m.Plan)
-	unitIdx := -1
-	if len(idx) > 0 {
-		unitIdx = idx[0]
-	}
-	// D-095: the packet carries the reviewed units' criteria in place of
-	// the goal (legacy plans without criteria keep the goal), the
-	// whole-change stat and the diff restricted to the units' scope.
-	// changedFiles feeds the evidence gate below.
+// fullReviewPacket builds the packet for a round over the whole change
+// set (D-095): the reviewed units' criteria in place of the goal
+// (legacy plans without criteria keep the goal), the whole-change stat
+// and the diff restricted to the units' scope. The returned files are
+// every path the change touches, for the evidence gate.
+func (d *Driver) fullReviewPacket(ctx context.Context, m Mission, units []PlanUnit) (ReviewPacket, []string, error) {
 	var changedFiles []string
 	packet := ReviewPacket{
 		Plan: m.Plan, Units: units, Evidence: m.LastEvidence,
@@ -1724,17 +1727,80 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 	if wt := m.WorktreePath(); wt != "" {
 		var err error
 		if packet.Diff, err = BaselineDiff(ctx, wt, m.BaseCommit, reviewScope(units)); err != nil {
-			return StepInput{}, err
+			return ReviewPacket{}, nil, err
 		}
 		if packet.DiffStat, err = DiffStat(ctx, wt, m.BaseCommit); err != nil {
-			return StepInput{}, err
+			return ReviewPacket{}, nil, err
 		}
 		if changedFiles, err = ChangedFiles(ctx, wt, m.BaseCommit); err != nil {
-			return StepInput{}, err
+			return ReviewPacket{}, nil, err
 		}
 	}
 	if artifacts := reviewArtifacts(units, packet.Diff != ""); len(artifacts) > 0 {
 		packet.Artifacts = ReadArtifacts(m.WorkRoot(), artifacts)
+	}
+	return packet, changedFiles, nil
+}
+
+// findingsReviewPacket builds the re-review packet (D-096): the open
+// findings, the diff since the last review commit restricted to the
+// finding files and the affected units' scope, the finding files'
+// contents, the affected units' harness state (criteria dropped, the
+// findings are the question), and the files changed outside every
+// unit's scope. The returned files are the delta's paths plus the
+// finding files, for the evidence gate.
+func (d *Driver) findingsReviewPacket(ctx context.Context, m Mission, open []Finding) (ReviewPacket, []string, error) {
+	files := findingFiles(open)
+	var affected []PlanUnit
+	seen := map[int]bool{}
+	for _, f := range open {
+		if f.Unit < 0 || f.Unit >= len(m.Plan.Units) || seen[f.Unit] {
+			continue
+		}
+		seen[f.Unit] = true
+		u := m.Plan.Units[f.Unit]
+		u.Criteria = nil
+		affected = append(affected, u)
+	}
+	packet := ReviewPacket{FindingsOnly: true, Units: affected, OpenFindings: open}
+	wt := m.WorktreePath()
+	paths := append(append([]string{}, files...), reviewScope(affected)...)
+	var err error
+	if packet.Diff, err = BaselineDiff(ctx, wt, m.Plan.LastReviewCommit, paths); err != nil {
+		return ReviewPacket{}, nil, err
+	}
+	changed, err := ChangedFiles(ctx, wt, m.Plan.LastReviewCommit)
+	if err != nil {
+		return ReviewPacket{}, nil, err
+	}
+	packet.ScopeCreep = outsideScope(changed, reviewScope(m.Plan.Units))
+	if len(files) > 0 {
+		packet.Files = ReadArtifactsCapped(m.WorkRoot(), files, len(files)*reviewArtifactFileCap)
+	}
+	return packet, append(changed, files...), nil
+}
+
+func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
+	idx, units := reviewUnits(m.Plan)
+	unitIdx := -1
+	if len(idx) > 0 {
+		unitIdx = idx[0]
+	}
+	// D-096: a round after one that left findings open reviews only
+	// those findings against the diff since it; missions without a
+	// recorded review commit (or no worktree) get the full packet.
+	var (
+		packet       ReviewPacket
+		changedFiles []string
+		err          error
+	)
+	if open := OpenFindings(m.ReviewFindings); len(open) > 0 && m.Plan.LastReviewCommit != "" && m.WorktreePath() != "" {
+		packet, changedFiles, err = d.findingsReviewPacket(ctx, m, open)
+	} else {
+		packet, changedFiles, err = d.fullReviewPacket(ctx, m, units)
+	}
+	if err != nil {
+		return StepInput{}, err
 	}
 	verdict, err := d.reviewWithShrink(ctx, m, packet)
 	if err != nil {
@@ -1743,8 +1809,9 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 	// D-095 evidence gate: a blocking finding must name a changed or
 	// declared file and quote evidence, or it is demoted to minor here,
 	// deterministically. A rework whose findings all end up minor, with
-	// no prior blocking finding left unresolved, counts as approval.
-	if !verdict.Approved && len(verdict.Findings) > 0 {
+	// no prior blocking finding left unresolved (D-096: a re-review that
+	// resolves every open blocking finding), counts as approval.
+	if !verdict.Approved {
 		gated, demoted := gateFindings(verdict.Findings, append(changedFiles, planArtifacts(m.Plan)...))
 		for _, dm := range demoted {
 			if err := d.store.AppendEvent(ctx, m.ID, "mission.finding_demoted", map[string]any{
@@ -1759,11 +1826,14 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 		}
 	}
 	// The reviewer's own worktree side effects (it may run tests) are
-	// rolled back unconditionally after every review round.
+	// rolled back unconditionally after every review round. The HEAD
+	// left behind anchors the next round's findings-only diff (D-096).
+	reviewCommit := ""
 	if wt := m.WorktreePath(); wt != "" {
 		if err := d.workspace.Rollback(ctx, wt, m.Kind); err != nil {
 			d.log.Warn("driver: post-review rollback failed", "mission_id", m.ID, "error", err)
 		}
+		reviewCommit = worktreeHead(ctx, wt)
 	}
 
 	// Every verdict is recorded, approvals included — a review that
@@ -1774,7 +1844,7 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 		decision = "approved"
 	}
 	if err := d.store.AppendEvent(ctx, m.ID, "mission.review_verdict", map[string]any{
-		"decision": decision, "findings": verdict.Findings, "resolved": verdict.Resolved,
+		"decision": decision, "findings": verdict.Findings, "resolved": verdict.Resolved, "findings_only": packet.FindingsOnly,
 	}); err != nil {
 		d.log.Warn("driver: record review verdict failed", "mission_id", m.ID, "error", err)
 	}
@@ -1803,15 +1873,15 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 			}
 			return StepInput{
 				Input: InputReviewRework, Findings: findings, Unit: failing[0].Unit, Reason: reviewReason(findings),
-				Verified: verified, Provider: verdict.Provider, Model: verdict.Model,
+				Verified: verified, ReviewCommit: reviewCommit, Provider: verdict.Provider, Model: verdict.Model,
 			}, nil
 		}
 		return StepInput{Input: InputReviewApprove, Verified: verified, Provider: verdict.Provider, Model: verdict.Model}, nil
 	}
 	return StepInput{
 		Input: InputReviewRework, Findings: verdict.Findings, Resolved: verdict.Resolved, Unit: unitIdx,
-		Reason:   truncate(reviewReason(verdict.Findings), 500),
-		Provider: verdict.Provider, Model: verdict.Model,
+		Reason:       truncate(reviewReason(verdict.Findings), 500),
+		ReviewCommit: reviewCommit, Provider: verdict.Provider, Model: verdict.Model,
 	}, nil
 }
 

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -116,6 +116,9 @@ func (f *fakeStore) ApplyTransition(ctx context.Context, id string, t Transition
 	if len(t.Next.Units) > 0 {
 		m.Plan.Units = t.Next.Units
 	}
+	if t.Next.LastReviewCommit != "" {
+		m.Plan.LastReviewCommit = t.Next.LastReviewCommit
+	}
 	f.missions[id] = m
 	for _, ev := range t.Events {
 		f.seq[id]++
@@ -3535,5 +3538,222 @@ func TestDriverReviewPacketScopedDiffAndGate(t *testing.T) {
 		if ev.Kind == "mission.finding_demoted" {
 			t.Fatalf("finding naming a changed file with evidence was demoted: %s", ev.Payload)
 		}
+	}
+}
+
+// writeWorktreeFile writes a workspace-relative file into wt, creating
+// parent directories.
+func writeWorktreeFile(t *testing.T, wt, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filepath.Join(wt, path)), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt, path), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// countEvents returns how many events of kind the fake store holds.
+func countEvents(store *fakeStore, id, kind string) int {
+	n := 0
+	for _, ev := range store.events[id] {
+		if ev.Kind == kind {
+			n++
+		}
+	}
+	return n
+}
+
+// TestDriverFindingsOnlyReReview drives D-096 end to end on a real
+// worktree: the first round (full packet) leaves F1 open and records
+// the worktree HEAD as last_review_commit; the rework turn changes the
+// finding's file and strays into a file outside every unit's scope; the
+// second round's packet is findings-only (the open finding, the delta
+// diff, the named file's contents, the scope-creep list, the affected
+// unit's harness state, and no goal, plan, stat, listing, artifacts,
+// progress or worker report) at a fraction of the first round's bytes;
+// the reviewer resolving F1 with no new finding counts as approval.
+func TestDriverFindingsOnlyReReview(t *testing.T) {
+	root, base := codingWorktree(t)
+	wt := filepath.Join(root, "wt")
+	filler := strings.Repeat("// filler line that pads the first round's diff\n", 60)
+	writeWorktreeFile(t, wt, "src/main.go", "package main\n\nfunc main() {}\n"+filler)
+	writeWorktreeFile(t, wt, "src/other.go", "package main\n"+strings.Repeat(filler, 4))
+	gitRun(t, wt, "add", "-A")
+	gitRun(t, wt, "-c", "user.name=test", "-c", "user.email=test@test", "commit", "-q", "-m", "unit work")
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "coding", Phase: PhaseProve, Status: StatusWorking, MaxIterations: 8, Workspace: root, BaseCommit: base,
+		Goal: "add input validation to main", LastEvidence: "wrote main.go",
+		Progress: []ProgressNote{{Note: "operator: keep it small"}},
+		Plan: Plan{Units: []PlanUnit{{
+			Title: "write code", Artifacts: []string{"src/main.go"}, Scope: []string{"src"},
+			Criteria: []string{"main.go validates input", "main.go compiles"}, HarnessPassed: true,
+		}}},
+	})
+	runner := &scriptedRunner{
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "validated"}},
+		reviewVerdicts: []ReviewVerdict{
+			{Findings: []Finding{{Title: "missing validation", File: "src/main.go", Detail: "no input check", Evidence: "+func main() {}"}}},
+			{Resolved: []string{"F1"}},
+		},
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := NewDriver(store, runner, NewWorkspace("", nil, log), nil, nil, nil, fakeSandboxExec, nil, log)
+
+	// Round 1: the full packet; F1 opens and HEAD is recorded.
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("review round 1: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	head := strings.TrimSpace(gitRun(t, wt, "rev-parse", "HEAD"))
+	if m.Phase != PhaseGenerate || m.Plan.LastReviewCommit != head {
+		t.Fatalf("after round 1: phase %q last_review_commit %q, want generate with HEAD %s", m.Phase, m.Plan.LastReviewCommit, head)
+	}
+	full := runner.reviewCalls[0]
+	if full.FindingsOnly || full.Diff == "" || full.DiffStat == "" {
+		t.Fatalf("round 1 packet = %+v, want the full packet", full)
+	}
+
+	// The rework turn: the worker fixes main.go and also edits docs/.
+	writeWorktreeFile(t, wt, "src/main.go", "package main\n\nfunc main() { validate() }\n"+filler)
+	writeWorktreeFile(t, wt, "docs/notes.md", "# notes\n")
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("rework turn: %v", err)
+	}
+	if m, _ = store.Get(context.Background(), "m1"); m.Phase != PhaseProve {
+		t.Fatalf("after the rework turn: phase %q, want prove", m.Phase)
+	}
+
+	// Round 2: findings-only.
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("review round 2: %v", err)
+	}
+	if len(runner.reviewCalls) != 2 {
+		t.Fatalf("RunReview ran %d times, want 2", len(runner.reviewCalls))
+	}
+	delta := runner.reviewCalls[1]
+	if !delta.FindingsOnly || delta.Goal != "" || len(delta.Plan.Units) != 0 || delta.DiffStat != "" ||
+		delta.Listing != "" || delta.Evidence != "" || len(delta.Progress) != 0 || len(delta.Artifacts) != 0 {
+		t.Fatalf("round 2 packet carries full-round material: %+v", delta)
+	}
+	if len(delta.OpenFindings) != 1 || delta.OpenFindings[0].ID != "F1" {
+		t.Fatalf("round 2 open findings = %+v, want F1", delta.OpenFindings)
+	}
+	if !strings.Contains(delta.Diff, "+func main() { validate() }") || strings.Contains(delta.Diff, "+// filler") || strings.Contains(delta.Diff, "docs/notes.md") {
+		t.Fatalf("round 2 diff is not the delta scoped to the finding file and unit scope:\n%s", delta.Diff)
+	}
+	if body, ok := delta.Files["src/main.go"]; !ok || !strings.Contains(body, "validate()") {
+		t.Fatalf("round 2 files = %v, want the finding's file contents", delta.Files)
+	}
+	if len(delta.ScopeCreep) != 1 || delta.ScopeCreep[0] != "docs/notes.md" {
+		t.Fatalf("round 2 scope creep = %v, want [docs/notes.md]", delta.ScopeCreep)
+	}
+	if len(delta.Units) != 1 || len(delta.Units[0].Criteria) != 0 || !delta.Units[0].HarnessPassed {
+		t.Fatalf("round 2 units = %+v, want the affected unit's harness state without criteria", delta.Units)
+	}
+	fullBytes, deltaBytes := len(renderReviewContent(full)), len(renderReviewContent(delta))
+	if deltaBytes*3 > fullBytes {
+		t.Fatalf("findings-only request is %d bytes against %d for the full round, want under a third", deltaBytes, fullBytes)
+	}
+
+	// Resolving F1 with nothing new counts as approval on harness evidence.
+	m, _ = store.Get(context.Background(), "m1")
+	if m.Phase != PhaseResult || !m.Plan.Units[0].Passes || len(OpenFindings(m.ReviewFindings)) != 0 {
+		t.Fatalf("after round 2: phase %q unit %+v findings %+v, want result with F1 resolved", m.Phase, m.Plan.Units[0], m.ReviewFindings)
+	}
+	// The driver's own verdict events (the state machine appends another
+	// on rework, without findings_only): round 1 full rework, round 2
+	// findings-only approval.
+	var driverVerdicts []string
+	for _, ev := range store.events["m1"] {
+		if ev.Kind == "mission.review_verdict" && strings.Contains(string(ev.Payload), "findings_only") {
+			driverVerdicts = append(driverVerdicts, string(ev.Payload))
+		}
+	}
+	if len(driverVerdicts) != 2 || !strings.Contains(driverVerdicts[0], `"findings_only":false`) ||
+		!strings.Contains(driverVerdicts[1], `"findings_only":true`) || !strings.Contains(driverVerdicts[1], `"decision":"approved"`) {
+		t.Fatalf("driver verdict events = %v, want a full rework then a findings-only approval", driverVerdicts)
+	}
+}
+
+// TestDriverOpenFindingsWithoutReviewCommitUseFullPacket pins the D-096
+// compatibility rule: a mission created before last_review_commit
+// existed re-reviews its open findings with the full packet.
+func TestDriverOpenFindingsWithoutReviewCommitUseFullPacket(t *testing.T) {
+	root, base := codingWorktree(t)
+	writeWorktreeFile(t, filepath.Join(root, "wt"), "x.go", "package x\n")
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "coding", Phase: PhaseProve, Status: StatusWorking, MaxIterations: 8, Workspace: root, BaseCommit: base, Goal: "legacy",
+		Plan:           Plan{Units: []PlanUnit{{Title: "u1", Artifacts: []string{"x.go"}, HarnessPassed: true}}},
+		ReviewFindings: []Finding{{ID: "F1", Title: "gap", File: "x.go", Severity: SeverityBlocking, Status: FindingOpen, RoundOpened: 1}},
+	})
+	runner := &scriptedRunner{reviewVerdicts: []ReviewVerdict{{Approved: true}}}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := NewDriver(store, runner, NewWorkspace("", nil, log), nil, nil, nil, fakeSandboxExec, nil, log)
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	packet := runner.reviewCalls[0]
+	if packet.FindingsOnly || packet.Goal != "legacy" || len(packet.Plan.Units) != 1 || len(packet.OpenFindings) != 1 {
+		t.Fatalf("packet = %+v, want the full packet with the open finding", packet)
+	}
+}
+
+// TestDriverTwoUnitPlanReviewsOnce pins the D-096 routing through the
+// driver: a coding mission whose worker finishes one unit per turn stays
+// in generate after the first (mission.generate_continued, no review),
+// enters prove once both are harness-passed, and runs exactly one review
+// round covering both units before the mission advances to result.
+func TestDriverTwoUnitPlanReviewsOnce(t *testing.T) {
+	root, base := codingWorktree(t)
+	wt := filepath.Join(root, "wt")
+	store := newFakeStore()
+	store.put("m1", Mission{
+		ID: "m1", Kind: "coding", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Workspace: root, BaseCommit: base,
+		Plan: Plan{Units: []PlanUnit{
+			{Title: "write a", Artifacts: []string{"a.md"}, Criteria: []string{"a.md exists", "a.md has content"}},
+			{Title: "write b", Artifacts: []string{"b.md"}, Criteria: []string{"b.md exists", "b.md has content"}},
+		}},
+	})
+	runner := &scriptedRunner{
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote it"}},
+		reviewVerdicts: []ReviewVerdict{{Approved: true}},
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d := NewDriver(store, runner, NewWorkspace("", nil, log), nil, nil, nil, fakeSandboxExec, nil, log)
+
+	writeWorktreeFile(t, wt, "a.md", "a\n")
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("worker turn 1: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Phase != PhaseGenerate || !m.Plan.Units[0].HarnessPassed || m.Plan.Units[0].Passes || m.Plan.Units[1].HarnessPassed {
+		t.Fatalf("after turn 1: phase %q units %+v, want generate with only unit 0 harness-passed", m.Phase, m.Plan.Units)
+	}
+	if len(runner.reviewCalls) != 0 || countEvents(store, "m1", "mission.generate_continued") != 1 {
+		t.Fatalf("after turn 1: %d reviews, %d generate_continued events, want 0 and 1", len(runner.reviewCalls), countEvents(store, "m1", "mission.generate_continued"))
+	}
+
+	writeWorktreeFile(t, wt, "b.md", "b\n")
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("worker turn 2: %v", err)
+	}
+	if m, _ = store.Get(context.Background(), "m1"); m.Phase != PhaseProve {
+		t.Fatalf("after turn 2: phase %q, want prove", m.Phase)
+	}
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("review round: %v", err)
+	}
+	m, _ = store.Get(context.Background(), "m1")
+	if m.Phase != PhaseResult || !m.Plan.Units[0].Passes || !m.Plan.Units[1].Passes {
+		t.Fatalf("after review: phase %q units %+v, want result with both units passed", m.Phase, m.Plan.Units)
+	}
+	if len(runner.reviewCalls) != 1 || len(runner.reviewCalls[0].Units) != 2 {
+		t.Fatalf("review calls = %d (units %d), want one round over both units", len(runner.reviewCalls), len(runner.reviewCalls[0].Units))
+	}
+	if n := countEvents(store, "m1", "mission.review_verdict"); n != 1 {
+		t.Fatalf("review_verdict events = %d, want exactly 1", n)
 	}
 }

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -511,6 +511,13 @@ type Plan struct {
 	// never a gate — the operator catches a wrong guess via a steering
 	// note, not a pause.
 	Assumptions []PlanAssumption `json:"assumptions,omitempty"`
+	// LastReviewCommit (D-096, issue #524) is the worktree HEAD when the
+	// last review round closed with findings still open: the next round
+	// reviews only the open findings against the diff since it. Empty
+	// until a round leaves findings open (and on plans written before
+	// D-096), which means the next round gets the full packet. Written
+	// only through Store.ApplyTransition.
+	LastReviewCommit string `json:"last_review_commit,omitempty"`
 	// Provider/Model (issue #507) are who served the plan turn; set by
 	// PlanSession after parsing, never persisted with the stored plan.
 	Provider string `json:"-"`

--- a/internal/brain/missions/review.go
+++ b/internal/brain/missions/review.go
@@ -66,6 +66,58 @@ type ReviewPacket struct {
 	// the reviewer marks the ids it considers closed in resolved. This
 	// replaces the old in-process reviewer session carry-over.
 	OpenFindings []Finding
+	// FindingsOnly marks a re-review round (D-096, issue #524): the
+	// packet carries the open findings, Diff since the last review commit
+	// (restricted to the finding files and the affected units' scope),
+	// Files, ScopeCreep and the affected units' harness state, and none
+	// of Goal, Plan, DiffStat, Listing, Evidence or Progress.
+	FindingsOnly bool
+	// Files maps each open finding's file to its contents, capped at
+	// reviewArtifactFileCap each; findings-only rounds.
+	Files map[string]string
+	// ScopeCreep lists files changed since the last review outside every
+	// unit's scope, for the reviewer to judge; the harness opens no
+	// finding for them.
+	ScopeCreep []string
+}
+
+// findingFiles lists the distinct files the findings name, in order.
+func findingFiles(findings []Finding) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, f := range findings {
+		file := strings.TrimSpace(f.File)
+		if key := normalizeFindingPath(file); key != "" && !seen[key] {
+			seen[key] = true
+			out = append(out, file)
+		}
+	}
+	return out
+}
+
+// outsideScope returns the files under none of the scope paths (a file
+// equal to a scope entry or beneath it is in scope). An empty scope
+// means the whole tree, so nothing is outside it.
+func outsideScope(files, scope []string) []string {
+	if len(scope) == 0 {
+		return nil
+	}
+	var out []string
+	for _, file := range files {
+		got := normalizeFindingPath(file)
+		inScope := false
+		for _, s := range scope {
+			want := normalizeFindingPath(s)
+			if want == "" || got == want || strings.HasPrefix(got, want+"/") {
+				inScope = true
+				break
+			}
+		}
+		if !inScope {
+			out = append(out, file)
+		}
+	}
+	return out
 }
 
 // ReadArtifacts reads each declared artifact from workRoot, capped at

--- a/internal/brain/missions/review_test.go
+++ b/internal/brain/missions/review_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -345,6 +346,34 @@ func TestReadArtifactsPerFileCap(t *testing.T) {
 
 // TestParseReviewVerdictEvidence pins that a finding's evidence line
 // survives parsing.
+// TestFindingFiles pins the D-096 helper: distinct finding files in
+// first-seen order, normalized for duplicates, blanks skipped.
+func TestFindingFiles(t *testing.T) {
+	got := findingFiles([]Finding{
+		{File: "src/x.go"}, {File: ""}, {File: "./src/x.go"}, {File: "docs/a.md"}, {File: "  "},
+	})
+	if !reflect.DeepEqual(got, []string{"src/x.go", "docs/a.md"}) {
+		t.Fatalf("findingFiles = %v, want [src/x.go docs/a.md]", got)
+	}
+}
+
+// TestOutsideScope pins the scope-creep rule (D-096): a file equal to or
+// beneath a scope entry is in scope; an empty scope (legacy plan) puts
+// nothing outside; a directory prefix must match on a path boundary.
+func TestOutsideScope(t *testing.T) {
+	files := []string{"src/main.go", "src/util/x.go", "srcs/y.go", "docs/notes.md", "README.md"}
+	got := outsideScope(files, []string{"src", "README.md"})
+	if !reflect.DeepEqual(got, []string{"srcs/y.go", "docs/notes.md"}) {
+		t.Fatalf("outsideScope = %v, want [srcs/y.go docs/notes.md]", got)
+	}
+	if got := outsideScope(files, nil); got != nil {
+		t.Fatalf("empty scope must put nothing outside, got %v", got)
+	}
+	if got := outsideScope(files, []string{"./src/", "docs", "README.md", "srcs"}); got != nil {
+		t.Fatalf("every file in scope, got %v", got)
+	}
+}
+
 func TestParseReviewVerdictEvidence(t *testing.T) {
 	v, err := parseReviewVerdict([]byte(`{"decision":"rework","findings":[{"title":"x","file":"a.go","evidence":"+return nil"}]}`))
 	if err != nil {

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -1397,11 +1397,20 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 // model-produced text passes through NeutralizeSlot.
 func renderReviewContent(p ReviewPacket) string {
 	var b strings.Builder
+	if p.FindingsOnly {
+		// D-096: the whole change was reviewed in an earlier round; this
+		// round judges only whether the open findings are closed.
+		b.WriteString("Re-review of open findings only. An earlier round reviewed the whole change and the units below pass the harness checks; judge only whether each open finding is closed by the changes since that round, and name every closed id in resolved. Report a NEW finding only with evidence quoted from the diff or files below.\n")
+	}
 	if p.Goal != "" {
 		fmt.Fprintf(&b, "Mission goal: %s\n", NeutralizeSlot(p.Goal))
 	}
 	if len(p.Units) > 0 {
-		b.WriteString("Units under review (judge each against its acceptance criteria):\n")
+		if p.FindingsOnly {
+			b.WriteString("\nAffected units (harness state):\n")
+		} else {
+			b.WriteString("Units under review (judge each against its acceptance criteria):\n")
+		}
 		for _, u := range p.Units {
 			fmt.Fprintf(&b, "\n### %s [%s]\n", NeutralizeSlot(u.Title), unitStatus(u))
 			if len(u.Criteria) > 0 {
@@ -1435,11 +1444,34 @@ func renderReviewContent(p ReviewPacket) string {
 			if severity == "" {
 				severity = SeverityBlocking
 			}
-			fmt.Fprintf(&b, "- %s [%s]", f.ID, severity)
+			fmt.Fprintf(&b, "- %s [%s] (unit %d)", f.ID, severity, f.Unit+1)
 			if f.File != "" {
 				fmt.Fprintf(&b, " %s:", NeutralizeSlot(f.File))
 			}
 			fmt.Fprintf(&b, " %s\n", NeutralizeSlot(f.Title))
+			if f.Detail != "" {
+				fmt.Fprintf(&b, "  detail: %s\n", NeutralizeSlot(f.Detail))
+			}
+			if f.Evidence != "" {
+				fmt.Fprintf(&b, "  evidence: %s\n", NeutralizeSlot(f.Evidence))
+			}
+		}
+	}
+	if len(p.Files) > 0 {
+		paths := make([]string, 0, len(p.Files))
+		for path := range p.Files {
+			paths = append(paths, path)
+		}
+		sort.Strings(paths)
+		b.WriteString("\nFiles named by the findings (read from disk by the harness):\n")
+		for _, path := range paths {
+			fmt.Fprintf(&b, "\n--- %s ---\n%s\n", path, NeutralizeSlot(p.Files[path]))
+		}
+	}
+	if len(p.ScopeCreep) > 0 {
+		b.WriteString("\nChanged outside unit scope (judge whether these changes belong; the harness opened no finding for them):\n")
+		for _, path := range p.ScopeCreep {
+			fmt.Fprintf(&b, "- %s\n", NeutralizeSlot(path))
 		}
 	}
 	if p.Listing != "" {
@@ -1463,7 +1495,11 @@ func renderReviewContent(p ReviewPacket) string {
 		b.WriteString("\n")
 	}
 	if p.Diff != "" {
-		b.WriteString("\nDiff to review (restricted to the reviewed units' scope):\n")
+		if p.FindingsOnly {
+			b.WriteString("\nDiff since the last review (restricted to the finding files and the affected units' scope):\n")
+		} else {
+			b.WriteString("\nDiff to review (restricted to the reviewed units' scope):\n")
+		}
 		b.WriteString(p.Diff)
 		b.WriteString("\n")
 	}

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -345,8 +345,8 @@ func TestRunReviewPacketListsOpenFindings(t *testing.T) {
 	content := agent.requests[0].Messages[0].Content
 	for _, want := range []string{
 		"Open findings from prior rounds (mark resolved ids in your verdict):",
-		"- F1 [blocking] x.go: missing validation",
-		"- F2 [minor] typo in banner",
+		"- F1 [blocking] (unit 1) x.go: missing validation",
+		"- F2 [minor] (unit 1) typo in banner",
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("reviewer message missing %q:\n%s", want, content)
@@ -357,6 +357,61 @@ func TestRunReviewPacketListsOpenFindings(t *testing.T) {
 	}
 	if strings.Contains(renderReviewContent(ReviewPacket{Goal: "goal"}), "Open findings") {
 		t.Fatal("empty ledger must render no findings section")
+	}
+}
+
+// TestRenderReviewContentFindingsOnly pins the D-096 re-review packet
+// shape: the open findings with detail and evidence, the finding files,
+// the scope-creep list, the delta diff and the affected units' harness
+// state render; goal, plan, whole-change stat, listing, progress and the
+// worker's report never do.
+func TestRenderReviewContentFindingsOnly(t *testing.T) {
+	content := renderReviewContent(ReviewPacket{
+		FindingsOnly: true,
+		Units:        []PlanUnit{{Title: "write code", HarnessPassed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "ok\n"}},
+		OpenFindings: []Finding{{ID: "F1", Unit: 0, Title: "missing validation", File: "src/main.go", Detail: "no input check", Evidence: "+func main()", Severity: SeverityBlocking, Status: FindingOpen}},
+		Files:        map[string]string{"src/main.go": "package main\n"},
+		ScopeCreep:   []string{"docs/notes.md"},
+		Diff:         "diff --git a/src/main.go b/src/main.go\n+validated\n",
+		// Fields a findings-only packet never carries; set here to prove
+		// the renderer does not leak them.
+		Goal: "the goal", Plan: Plan{Units: []PlanUnit{{Title: "write code"}}}, DiffStat: "1 file changed",
+		Listing: "src/main.go (13 bytes)", Evidence: "worker says done", Progress: []ProgressNote{{Note: "steer"}},
+	})
+	for _, want := range []string{
+		"Re-review of open findings only.",
+		"Affected units (harness state):",
+		"### write code [harness-verified]",
+		"Harness verify_cmd check: passed",
+		"- F1 [blocking] (unit 1) src/main.go: missing validation",
+		"  detail: no input check",
+		"  evidence: +func main()",
+		"Files named by the findings (read from disk by the harness):",
+		"--- src/main.go ---\npackage main",
+		"Changed outside unit scope (judge whether these changes belong; the harness opened no finding for them):\n- docs/notes.md",
+		"Diff since the last review (restricted to the finding files and the affected units' scope):",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("findings-only content missing %q:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, "acceptance criteria") {
+		t.Fatalf("findings-only content must not ask for criteria judgement:\n%s", content)
+	}
+}
+
+// TestRenderReviewContentFullOmitsFindingsOnlySections confirms the
+// full round renders no re-review header and no scope-creep or files
+// section when the packet carries none.
+func TestRenderReviewContentFullOmitsFindingsOnlySections(t *testing.T) {
+	content := renderReviewContent(ReviewPacket{Goal: "goal", Diff: "diff --git a/x b/x\n"})
+	for _, banned := range []string{"Re-review", "Changed outside unit scope", "Files named by the findings", "Diff since the last review"} {
+		if strings.Contains(content, banned) {
+			t.Fatalf("full-round content carries %q:\n%s", banned, content)
+		}
+	}
+	if !strings.Contains(content, "Diff to review (restricted to the reviewed units' scope):") {
+		t.Fatalf("full-round diff heading missing:\n%s", content)
 	}
 }
 

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -257,6 +257,9 @@ type StepState struct {
 	// stepPhaseComplete (which resets Iteration and so made
 	// max_iterations dead for rework before D-092).
 	ReworkRounds int
+	// LastReviewCommit is the worktree HEAD recorded by the last rework
+	// (D-096): the anchor for the next round's findings-only diff.
+	LastReviewCommit string
 }
 
 // neverVisitsPlan reports whether s's mission can never be in
@@ -285,6 +288,10 @@ type StepInput struct {
 	Findings []Finding
 	Resolved []string
 	Unit     int
+	// ReviewCommit is the worktree HEAD after the review round that
+	// produced this input (D-096), set on InputReviewRework; empty when
+	// there is no worktree, leaving LastReviewCommit as it was.
+	ReviewCommit string
 	// TouchedFiles is every workspace-relative path the worker turn
 	// that just ended changed (git diff --name-only against the
 	// pre-turn HEAD), set on InputPhaseComplete from generate. nil means
@@ -501,6 +508,12 @@ func stepResume(s StepState) Transition {
 // stall input stepReviewRework reads), and the blocking ones are named
 // in mission.rework_untouched. ReworkRounds is deliberately NOT reset
 // here: the review cycle is still running.
+//
+// A generate completion with units still lacking harness evidence and
+// no finding open stays in generate for the next unit (D-096, issue
+// #524): prove runs one round over the whole change set once every unit
+// is harness-passed, instead of one round per unit. Open findings send
+// the turn to prove regardless: a rework must be re-reviewed.
 func stepPhaseComplete(s StepState, in StepInput) Transition {
 	if s.Phase == PhasePlan && !s.AutoApprovePlan {
 		return Transition{
@@ -520,6 +533,17 @@ func stepPhaseComplete(s StepState, in StepInput) Transition {
 			events = append(events, EventDraft{Kind: "mission.rework_untouched", Payload: map[string]any{
 				"findings": findingIDs(untouched), "detail": findingsSummary(untouched),
 			}})
+		}
+	}
+	if s.Phase == PhaseGenerate && len(OpenFindings(s.ReviewFindings)) == 0 {
+		if pending := unverifiedUnits(s.Units); len(pending) > 0 {
+			s.Status = StatusIdle
+			s.Iteration = 0
+			s.ConsecutiveFailures = 0
+			events = append(events, EventDraft{Kind: "mission.generate_continued", Payload: map[string]any{
+				"next_unit": pending[0], "pending_units": len(pending),
+			}})
+			return Transition{Next: s, Events: events}
 		}
 	}
 	s.Phase = next
@@ -762,12 +786,21 @@ func allPassed(units []PlanUnit) bool {
 // evidence, the one the next worker turn works on, or -1 when every
 // unit is harness-passed.
 func firstUnverified(plan Plan) int {
-	for i, u := range plan.Units {
-		if !u.verified() {
-			return i
-		}
+	if pending := unverifiedUnits(plan.Units); len(pending) > 0 {
+		return pending[0]
 	}
 	return -1
+}
+
+// unverifiedUnits lists the indices of units without harness evidence.
+func unverifiedUnits(units []PlanUnit) []int {
+	var out []int
+	for i, u := range units {
+		if !u.verified() {
+			out = append(out, i)
+		}
+	}
+	return out
 }
 
 // unitsUnderReview lists the indices of units the harness has passed
@@ -805,9 +838,15 @@ func reviewSkippedOrProvePassTransition(s StepState) Transition {
 //  2. exhaustion: ReworkRounds reaching MaxIterations parks
 //     review_exhausted with the open ids in the detail. A park, never
 //     a failure: the work must survive for the operator.
+//
+// The round's worktree HEAD becomes LastReviewCommit (D-096): the next
+// round reviews only the open findings against the diff since it.
 func stepReviewRework(s StepState, in StepInput, cfg Config) Transition {
 	s.ReworkRounds++
 	s.ReviewFindings = mergeFindings(s.ReviewFindings, in.Findings, in.Resolved, in.Unit, s.ReworkRounds)
+	if in.ReviewCommit != "" {
+		s.LastReviewCommit = in.ReviewCommit
+	}
 	open := OpenFindings(s.ReviewFindings)
 	s.Phase = PhaseGenerate
 	s.Status = StatusIdle

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -598,10 +598,17 @@ func TestStepAppliesVerification(t *testing.T) {
 			wantPhase: PhaseGenerate, wantEvents: []string{"mission.retry"},
 		},
 		{
-			name:  "phase_complete marks a passing unit harness-passed, Passes waits for approval",
+			name:  "phase_complete marks a passing unit harness-passed and stays in generate while a unit is pending (D-096)",
 			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, Units: []PlanUnit{{Title: "a"}, {Title: "b"}}},
 			input: StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 0, Passed: true, Check: "verify_cmd", Excerpt: "ok"}}},
 			wantUnits: []PlanUnit{{Title: "a", HarnessPassed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "ok"}, {Title: "b"}},
+			wantPhase: PhaseGenerate, wantEvents: []string{"mission.generate_continued"},
+		},
+		{
+			name:  "phase_complete enters prove once every unit is harness-passed, Passes waits for approval",
+			state: StepState{Phase: PhaseGenerate, Status: StatusWorking, Units: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b"}}},
+			input: StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 1, Passed: true, Check: "verify_cmd", Excerpt: "ok"}}},
+			wantUnits: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b", HarnessPassed: true, VerifyCheck: "verify_cmd", VerifyExcerpt: "ok"}},
 			wantPhase: PhaseProve, wantEvents: []string{"mission.phase_started"},
 		},
 		{
@@ -646,7 +653,7 @@ func TestStepAppliesVerification(t *testing.T) {
 			state:     StepState{Phase: PhaseGenerate, Status: StatusWorking, Units: []PlanUnit{{Title: "a"}}},
 			input:     StepInput{Input: InputPhaseComplete, Verified: []UnitVerification{{Unit: 4, Passed: true}}},
 			wantUnits: []PlanUnit{{Title: "a"}},
-			wantPhase: PhaseProve, wantEvents: []string{"mission.phase_started"},
+			wantPhase: PhaseGenerate, wantEvents: []string{"mission.generate_continued"},
 		},
 	}
 	for _, tc := range cases {
@@ -1066,6 +1073,71 @@ func TestStepPhaseCompleteKeepsReworkRounds(t *testing.T) {
 	final := Step(got.Next, StepInput{Input: InputReviewRework}, DefaultConfig)
 	if final.Next.PauseReason != PauseReviewExhausted {
 		t.Fatalf("third rework after a phase_complete = %+v, want review_exhausted park", final.Next)
+	}
+}
+
+// TestStepPhaseCompleteRoutesOnPendingUnits pins the D-096 routing: a
+// generate completion stays in generate (counters reset, next unit
+// named) while any unit lacks harness evidence and nothing is open,
+// enters prove once every unit is harness-passed, and enters prove
+// regardless when a finding is open (a rework must be re-reviewed).
+// Legacy Passes-only rows count as verified.
+func TestStepPhaseCompleteRoutesOnPendingUnits(t *testing.T) {
+	pending := Step(
+		StepState{Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Iteration: 2, ConsecutiveFailures: 1, Units: []PlanUnit{
+			{Title: "a", HarnessPassed: true}, {Title: "b"}, {Title: "c"},
+		}},
+		StepInput{Input: InputPhaseComplete}, DefaultConfig,
+	)
+	if pending.Next.Phase != PhaseGenerate || pending.Next.Status != StatusIdle || pending.Next.Iteration != 0 || pending.Next.ConsecutiveFailures != 0 {
+		t.Fatalf("Next = %+v, want generate/idle with counters reset", pending.Next)
+	}
+	ev := eventOfKind(pending.Events, "mission.generate_continued")
+	if ev == nil || ev.Payload["next_unit"] != 1 || ev.Payload["pending_units"] != 2 {
+		t.Fatalf("events = %+v, want generate_continued naming unit 1 with 2 pending", pending.Events)
+	}
+	if eventOfKind(pending.Events, "mission.phase_started") != nil {
+		t.Fatal("staying in generate must not emit phase_started")
+	}
+
+	allPassed := Step(
+		StepState{Phase: PhaseGenerate, Status: StatusWorking, Units: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b", Passes: true}}},
+		StepInput{Input: InputPhaseComplete}, DefaultConfig,
+	)
+	if allPassed.Next.Phase != PhaseProve || eventOfKind(allPassed.Events, "mission.phase_started") == nil {
+		t.Fatalf("Next = %+v events %+v, want prove", allPassed.Next, allPassed.Events)
+	}
+
+	openFinding := Step(
+		StepState{Phase: PhaseGenerate, Status: StatusWorking, Units: []PlanUnit{{Title: "a", HarnessPassed: true}, {Title: "b"}},
+			ReviewFindings: []Finding{{ID: "F1", Title: "gap", Status: FindingOpen}}},
+		StepInput{Input: InputPhaseComplete}, DefaultConfig,
+	)
+	if openFinding.Next.Phase != PhaseProve {
+		t.Fatalf("Next = %+v, want prove: an open finding needs re-review even with a unit pending", openFinding.Next)
+	}
+}
+
+// TestStepReworkRecordsReviewCommit pins D-096's anchor: a rework
+// records the round's worktree HEAD as LastReviewCommit, an input
+// without one leaves the previous anchor alone, and approval keeps it
+// (harmless: findings-only needs an open finding too).
+func TestStepReworkRecordsReviewCommit(t *testing.T) {
+	first := Step(
+		StepState{Phase: PhaseProve, Status: StatusWorking, MaxIterations: 8},
+		StepInput{Input: InputReviewRework, ReviewCommit: "abc123", Findings: []Finding{{Title: "gap", File: "x.go"}}},
+		DefaultConfig,
+	)
+	if first.Next.LastReviewCommit != "abc123" {
+		t.Fatalf("LastReviewCommit = %q, want abc123", first.Next.LastReviewCommit)
+	}
+	second := Step(withStatus(first.Next, StatusWorking), StepInput{Input: InputReviewRework}, DefaultConfig)
+	if second.Next.LastReviewCommit != "abc123" {
+		t.Fatalf("LastReviewCommit = %q after a rework without a commit, want abc123 kept", second.Next.LastReviewCommit)
+	}
+	third := Step(withStatus(second.Next, StatusWorking), StepInput{Input: InputReviewRework, ReviewCommit: "def456"}, DefaultConfig)
+	if third.Next.LastReviewCommit != "def456" {
+		t.Fatalf("LastReviewCommit = %q, want def456", third.Next.LastReviewCommit)
 	}
 }
 

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -1099,7 +1099,8 @@ func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) er
 	}
 	// Per-unit verify state (D-094) lives inside the plan jsonb; only the
 	// units key is rewritten, and only when the plan has units, so a
-	// planless mission's '{}' stays untouched.
+	// planless mission's '{}' stays untouched. last_review_commit (D-096)
+	// sits next to it, written only when a rework recorded one.
 	var unitsJSON []byte
 	if len(t.Next.Units) > 0 {
 		if unitsJSON, err = json.Marshal(t.Next.Units); err != nil {
@@ -1111,12 +1112,13 @@ func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) er
 			consecutive_failures = $7, last_gap_fingerprint = $8, stall_count = $9, replan_used = $11, updated_at = now(),
 			pending_permission = CASE WHEN $10 THEN NULL ELSE pending_permission END,
 			review_findings = $12, rework_rounds = $13,
-			plan = CASE WHEN $14::jsonb IS NULL THEN plan ELSE jsonb_set(plan, '{units}', $14::jsonb) END
+			plan = (CASE WHEN $14::jsonb IS NULL THEN plan ELSE jsonb_set(plan, '{units}', $14::jsonb) END)
+				|| CASE WHEN $15::text = '' THEN '{}'::jsonb ELSE jsonb_build_object('last_review_commit', $15::text) END
 		WHERE id = $1`,
 		id, string(t.Next.Phase), string(t.Next.Status), string(t.Next.PauseReason),
 		t.Next.Iteration, t.Next.MaxIterations, t.Next.ConsecutiveFailures,
 		t.Next.LastGapFingerprint, t.Next.StallCount, clearPending, t.Next.ReplanUsed,
-		findingsJSON, t.Next.ReworkRounds, unitsJSON,
+		findingsJSON, t.Next.ReworkRounds, unitsJSON, t.Next.LastReviewCommit,
 	); err != nil {
 		return fmt.Errorf("missions apply transition update: %w", err)
 	}

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -828,6 +828,53 @@ func TestReviewFindingsRoundTrip(t *testing.T) {
 	}
 }
 
+// TestApplyTransitionPersistsLastReviewCommit confirms D-096's anchor is
+// real DB state inside the plan jsonb: a transition carrying it lands it
+// next to the units without touching the plan's other keys, and a later
+// transition without one leaves it in place.
+func TestApplyTransitionPersistsLastReviewCommit(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{Goal: marker + "review commit", Kind: "coding"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	plan := Plan{
+		Units:       []PlanUnit{{Title: "write a.md", Artifacts: []string{"a.md"}}},
+		Assumptions: []PlanAssumption{{Assumption: "format", Default: "markdown"}},
+	}
+	if err := s.SetPlan(ctx, id, plan); err != nil {
+		t.Fatalf("SetPlan: %v", err)
+	}
+	units := []PlanUnit{{Title: "write a.md", Artifacts: []string{"a.md"}, HarnessPassed: true}}
+	if err := s.ApplyTransition(ctx, id, Transition{
+		Next: StepState{Phase: PhaseGenerate, Status: StatusIdle, MaxIterations: 3, Units: units, LastReviewCommit: "abc123", ReworkRounds: 1},
+	}); err != nil {
+		t.Fatalf("ApplyTransition with review commit: %v", err)
+	}
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.Plan.LastReviewCommit != "abc123" || len(m.Plan.Units) != 1 || !m.Plan.Units[0].HarnessPassed || len(m.Plan.Assumptions) != 1 {
+		t.Fatalf("plan after transition = %+v, want last_review_commit abc123 with units and assumptions intact", m.Plan)
+	}
+
+	if err := s.ApplyTransition(ctx, id, Transition{
+		Next: StepState{Phase: PhaseProve, Status: StatusIdle, MaxIterations: 3, Units: units, ReworkRounds: 1},
+	}); err != nil {
+		t.Fatalf("ApplyTransition without review commit: %v", err)
+	}
+	m, err = s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.Plan.LastReviewCommit != "abc123" || m.Phase != PhaseProve {
+		t.Fatalf("plan after second transition = %+v phase %q, want last_review_commit kept", m.Plan, m.Phase)
+	}
+}
+
 // TestApplyTransitionPersistsUnitVerifyState confirms D-094's per-unit
 // verify state is real DB state written through ApplyTransition: a unit
 // passes, then regresses, and each step's Units land in the plan jsonb

--- a/scripts/canary-coding.sh
+++ b/scripts/canary-coding.sh
@@ -6,6 +6,8 @@
 # artifact present in the worktree, zero human permission parks. The
 # general-mission canary (canary-mission.sh) cannot catch regressions in
 # the git/worktree/review path; this one exists for exactly that.
+# CANARY_TWO_UNIT=1 runs a two-file goal instead and additionally asserts
+# the plan had two units and exactly one review round ran (D-096).
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -26,8 +28,22 @@ CASES=(
   ".editorconfig|Add an .editorconfig file at the repository root with root=true and basic UTF-8/LF settings."
   "docs/FAQ.md|Add a docs/FAQ.md file with two short frequently-asked questions and answers about this repo."
 )
-CASE="${CASES[$((RANDOM % ${#CASES[@]}))]}"
-ARTIFACT="${CASE%%|*}"
+# Two-unit cases (D-096, issue #524): the goal names two files as two
+# separate plan units, so the run asserts the harness ran exactly one
+# review round once both units were harness-passed. Selected with
+# CANARY_TWO_UNIT=1 (make canary-two-unit); artifacts are space separated.
+TWO_UNIT_CASES=(
+  "CHANGELOG.md CONTRIBUTING.md|Add two files at the repository root, planned as two separate units: CHANGELOG.md with a version heading and one bullet point describing the initial release, and CONTRIBUTING.md with a short section on how to propose a change."
+  "SECURITY.md docs/USAGE.md|Add two files, planned as two separate units: SECURITY.md at the repository root describing how to report a vulnerability, and docs/USAGE.md with a short Usage section explaining what this fixture repo is for."
+  "docs/FAQ.md .editorconfig|Add two files, planned as two separate units: docs/FAQ.md with two short frequently-asked questions and answers about this repo, and an .editorconfig at the repository root with root=true and basic UTF-8/LF settings."
+)
+TWO_UNIT="${CANARY_TWO_UNIT:-0}"
+if [[ "${TWO_UNIT}" == "1" ]]; then
+  CASE="${TWO_UNIT_CASES[$((RANDOM % ${#TWO_UNIT_CASES[@]}))]}"
+else
+  CASE="${CASES[$((RANDOM % ${#CASES[@]}))]}"
+fi
+ARTIFACTS="${CASE%%|*}"
 GOAL="${CASE#*|}"
 
 # The API token stays in the shell environment only — sourced here,
@@ -93,9 +109,11 @@ worktree="$(echo "${m}" | python3 -c 'import json,sys; print(json.load(sys.stdin
 branch="$(echo "${m}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("branch") or "")')"
 
 events="$(curl -sf "${auth[@]}" "${BASE_URL}/v1/missions/${id}/events")"
-CANARY_EVENTS="${events}" python3 <<'PY'
+CANARY_EVENTS="${events}" CANARY_MISSION="${m}" CANARY_TWO_UNIT="${TWO_UNIT}" python3 <<'PY'
 import json, os, sys
 events = json.loads(os.environ["CANARY_EVENTS"])["events"]
+units = (json.loads(os.environ["CANARY_MISSION"]).get("plan") or {}).get("units") or []
+two_unit = os.environ["CANARY_TWO_UNIT"] == "1"
 kinds = {}
 for e in events:
     kinds[e["kind"]] = kinds.get(e["kind"], 0) + 1
@@ -105,9 +123,15 @@ turns = [e for e in events if e["kind"] == "mission.turn"]
 total_ms = sum((e.get("payload") or {}).get("duration_ms", 0) for e in turns)
 verified = [e for e in events if e["kind"] == "mission.unit_verified"
             and (e.get("payload") or {}).get("passed") is True]
+# The driver records one review_verdict per round; the state machine
+# appends another on rework, so count rounds by the driver's payload key.
+rounds = [e for e in events if e["kind"] == "mission.review_verdict"
+          and "findings_only" in (e.get("payload") or {})]
+worker_turns = [e for e in turns if (e.get("payload") or {}).get("phase") == "generate"]
 
 print(f"canary-coding: event counts: {json.dumps(kinds, sort_keys=True)}")
 print(f"canary-coding: {len(turns)} model turns, {total_ms/1000:.0f}s total model time")
+print(f"canary-coding: {len(units)} plan unit(s), {len(worker_turns)} worker turn(s), {len(rounds)} review round(s)")
 
 failures = []
 if parks > 0:
@@ -120,6 +144,11 @@ if kinds.get("mission.review_verdict", 0) == 0:
     failures.append("no review verdict — the coding review path never ran")
 if len(turns) > 10:
     failures.append(f"{len(turns)} turns for a trivial change — loop is not right-sized")
+if two_unit:
+    if len(units) < 2:
+        failures.append(f"{len(units)} plan unit(s) for a two-file goal: the two-unit case needs two units")
+    if len(rounds) != 1:
+        failures.append(f"{len(rounds)} review round(s): one round must cover the whole plan once every unit is harness-passed")
 if failures:
     print("canary-coding: FAIL — " + "; ".join(failures), file=sys.stderr)
     sys.exit(1)
@@ -133,12 +162,17 @@ if [[ -z "${worktree}" || -z "${branch}" ]]; then
   exit 1
 fi
 "${COMPOSE[@]}" exec -T brain sh -c "
-  git -C ${FIXTURE} rev-parse --verify --quiet '${branch}' >/dev/null &&
-  test -s '${worktree}/${ARTIFACT}'
+  git -C ${FIXTURE} rev-parse --verify --quiet '${branch}' >/dev/null
 " || {
-  echo "canary-coding: FAIL — branch ${branch} or ${worktree}/${ARTIFACT} missing in container" >&2
+  echo "canary-coding: FAIL: branch ${branch} missing in container" >&2
   exit 1
 }
+for artifact in ${ARTIFACTS}; do
+  "${COMPOSE[@]}" exec -T brain sh -c "test -s '${worktree}/${artifact}'" || {
+    echo "canary-coding: FAIL: ${worktree}/${artifact} missing in container" >&2
+    exit 1
+  }
+done
 
 echo "canary-coding: PASS"
 

--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -48,6 +48,20 @@ describe('mission.generate_skipped rendering', () => {
   })
 })
 
+describe('mission.generate_continued rendering', () => {
+  it('names the next unit 1-indexed with the pending count', () => {
+    expect(renderEvent(event({ next_unit: 1, pending_units: 2 }, 'mission.generate_continued'))).toBe(
+      'Next worker turn on unit 2 (2 pending): review runs once every unit is harness-verified',
+    )
+  })
+
+  it('falls back to a generic label when the payload has no index', () => {
+    expect(renderEvent(event({}, 'mission.generate_continued'))).toBe(
+      'Next worker turn on the next unit: review runs once every unit is harness-verified',
+    )
+  })
+})
+
 describe('mission.plan_created rendering', () => {
   it('shows unit count alone when the plan has no assumptions', () => {
     expect(renderEvent(event({ units: 2 }, 'mission.plan_created'))).toBe('Plan created with 2 unit(s)')

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -64,6 +64,12 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
     )
   },
   'mission.generate_skipped': () => 'Worker turn skipped: every unit is harness-verified',
+  'mission.generate_continued': (p) => {
+    const { next_unit, pending_units } = asRecord(p)
+    const unit = typeof next_unit === 'number' ? `unit ${next_unit + 1}` : 'the next unit'
+    const pending = typeof pending_units === 'number' ? ` (${pending_units} pending)` : ''
+    return `Next worker turn on ${unit}${pending}: review runs once every unit is harness-verified`
+  },
   'mission.finding_demoted': (p) => {
     const { title, reason } = asRecord(p)
     return (


### PR DESCRIPTION
## Summary

Slice 5 of the prove loop redesign v2 (D-096). A mission with N units now costs one full review round plus small findings-only rounds, instead of N full reviews that re-litigate approved work.

- **One full review round.** `stepPhaseComplete` from generate stays in generate (`mission.generate_continued`, counters reset, next unit named) while any unit still lacks harness evidence and no finding is open; it enters prove once every unit is harness-passed. An open finding still routes to prove regardless, since a rework must be re-reviewed. `stepReviewApprove` already flips every harness-passed unit together.
- **`last_review_commit`.** A rework records the worktree HEAD (taken after the post-review rollback) in the plan jsonb as `last_review_commit`, carried through `StepInput.ReviewCommit` and written only by `ApplyTransition` (`jsonb_build_object` merged next to `units`; never cleared). No column, no ALTER.
- **Findings-only re-review.** When findings are open and a review commit exists, `Driver.findingsReviewPacket` builds a packet with only: the open findings (id, unit, file, severity, title, detail, evidence), the diff since `last_review_commit` scoped to the finding files plus the affected units' scope (same `truncateDiff` rule as #520), the finding files' contents (8 KB each via `ReadArtifactsCapped`), and the affected units' harness status and verify excerpt (criteria dropped). No goal, plan, whole-change diff, stat, listing, progress or worker report. `renderReviewContent` renders it under a re-review header; `reviewWithShrink` shrinks it against the right base.
- **Verdict.** The evidence gate now runs on every non-approve verdict (including one with zero new findings), so `resolved: [ids]` closing every open blocking finding counts as approval. New findings still pass the #520 gate against the delta's files, the finding files and the declared artifacts. Nothing approved is reopened. `mission.review_verdict` (driver-authored) carries `findings_only`.
- **Scope creep.** Files changed since the last review outside every unit's scope render in a "Changed outside unit scope" section for the reviewer to judge; the harness opens no finding for them. Legacy plans without scope list nothing.
- **Compatibility.** Missions without `last_review_commit` (or without a worktree) use the full packet.
- Web: renderer for `mission.generate_continued`. Makefile: `make canary-two-unit`. CLAUDE.md: D-096 bullet.

### Interpretation notes

- "The remaining units cannot progress without review (worker retries exhausted)": in the current state machine a unit whose worker retries are exhausted fails the mission (`max_iterations`), so the only "cannot progress" case that reaches routing is an open finding, which routes to prove. Everything else still has a worker turn to spend and stays in generate.
- The worker preamble still says "You are executing one unit of a plan"; whether the worker finishes two units in one turn is up to the model. The two-unit canary asserts what the harness owns: two plan units, exactly one review round, both artifacts on disk, regardless of how many worker turns it took.
- The state machine appends its own `mission.review_verdict` on rework (pre-existing); the driver's event is the one carrying `findings_only`, so "exactly one round" in the canary and the driver test counts driver-authored events.

## Test plan

- [x] `make build vet lint` (0 issues) and `make test` (all packages).
- [x] `go vet -tags integration ./...`.
- [x] Integration suite `go test -race -count=1 -tags integration -p 1 ./internal/...` against a throwaway `pgvector/pgvector:0.8.4-pg18-trixie` container (the worktree has no `deploy/.env`, so `make test-integration` could not be used verbatim); all packages pass, including the new `TestApplyTransitionPersistsLastReviewCommit`.
- [x] Web `npm run build`, `npm run lint` (0 errors), `npm test`: `eventRenderers.test.tsx` passes; the only failures are the two pre-existing `AgentRoutePicker.test.tsx` cases that also fail on `main` in the full suite and pass in isolation (order-dependent, unrelated).
- [ ] `make canary` / `make canary-two-unit` against a brain rebuilt from this branch: **not run**. The isolated worktree has no `deploy/.env`, and the local stack belongs to the main checkout, so `make brain` could not be pointed at this branch without copying the env file (blocked by the secrets rule). Please run `make brain && make canary && make canary-two-unit` before merging. Note #523: the coding canaries post an ignored `repo_path`, so a failure at the final fixture-repo assertion would be that pre-existing issue, not this change.

New tests:
- `statemachine_test.go`: `TestStepPhaseCompleteRoutesOnPendingUnits`, `TestStepReworkRecordsReviewCommit`; `TestStepAppliesVerification` cases updated for the new routing.
- `review_test.go`: `TestFindingFiles`, `TestOutsideScope`.
- `runner_test.go`: `TestRenderReviewContentFindingsOnly`, `TestRenderReviewContentFullOmitsFindingsOnlySections`.
- `driver_test.go`: `TestDriverFindingsOnlyReReview` (real worktree; asserts `last_review_commit` = HEAD, the findings-only packet shape, scope creep, and that the rendered findings-only request is under a third of the full round's bytes on the same fixture), `TestDriverOpenFindingsWithoutReviewCommitUseFullPacket`, `TestDriverTwoUnitPlanReviewsOnce`.
- `store_integration_test.go`: `TestApplyTransitionPersistsLastReviewCommit`.
- `eventRenderers.test.tsx`: `mission.generate_continued`.

Closes #524
Part of #510

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790967884&installation_model_id=431401&pr_number=525&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F525&signature=67004d33200eae51fef1e81ce334eb9e20c5b2ec578673b657556ab2a9b4b35f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->