### PR TITLE
feat(missions): review byte budget and per-mission review token ceiling

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -1069,6 +1069,8 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	driver.SetGitBranchPattern(flags.GitBranchPattern)
 	driver.SetGitCommitStyle(flags.GitCommitStyle)
 	driver.SetLocation(flags.Location)
+	driver.SetReviewWindow(missions.GatewayReviewWindow(gwc.ResolveRoute, gwc.ModelWindows))
+	driver.SetReviewTokenCeiling(flags.ReviewTokenCeiling)
 	resolveAgent := missionAgentResolver(agentReg)
 	driver.SetAgentResolver(resolveAgent)
 	driver.SetNameMission(chat.TitleOverGateway(gwc, log))

--- a/internal/brain/api/usage.go
+++ b/internal/brain/api/usage.go
@@ -143,6 +143,26 @@ func decorateObject(obj map[string]any, target string, rates map[string]fxrates.
 	}
 }
 
+// WithReviewTokenCeiling adds review_token_ceiling next to a mission
+// usage object's review_input_tokens (D-097): the gateway aggregates
+// the tokens, the ceiling is a brain setting, so the join happens
+// here. Any other response passes through untouched.
+func WithReviewTokenCeiling(body []byte, ceiling int64) []byte {
+	var obj map[string]any
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return body
+	}
+	if _, ok := obj["review_input_tokens"]; !ok {
+		return body
+	}
+	obj["review_token_ceiling"] = ceiling
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
 // moneyField finds the row's monetary amount under whichever key this
 // response shape uses ("cost" for aggregator rows, "amount" for a
 // BudgetLimit) — both never coexist on the same object, so checking
@@ -193,6 +213,7 @@ func (d *UsageDecorator) Decorate(resp *http.Response) error {
 		rates = nil // degrade to "nothing converts," never guess
 	}
 	decorated := DecorateUsageResponse(body, target, rates)
+	decorated = WithReviewTokenCeiling(decorated, d.flags.ReviewTokenCeiling(ctx))
 
 	resp.Body = io.NopCloser(bytes.NewReader(decorated))
 	resp.ContentLength = int64(len(decorated))

--- a/internal/brain/api/usage_test.go
+++ b/internal/brain/api/usage_test.go
@@ -237,3 +237,23 @@ func TestDecorateUsageResponseMissionUsageUnconvertibleCurrencyOmitted(t *testin
 		t.Fatalf("decoded = %+v, want no converted_cost_by_currency when nothing converts", decoded)
 	}
 }
+
+// TestWithReviewTokenCeiling pins D-097: a mission usage body gains
+// review_token_ceiling next to its review_input_tokens; every other
+// body passes through byte for byte.
+func TestWithReviewTokenCeiling(t *testing.T) {
+	t.Parallel()
+	out := WithReviewTokenCeiling([]byte(`{"mission_id":"m1","review_input_tokens":42}`), 1_500_000)
+	var decoded map[string]any
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded["review_token_ceiling"] != float64(1_500_000) || decoded["review_input_tokens"] != float64(42) {
+		t.Fatalf("decoded = %+v, want review_token_ceiling 1500000 beside review_input_tokens 42", decoded)
+	}
+	for _, body := range []string{`{"summaries":[{"currency":"USD","cost":1}]}`, `not json`, `[1,2]`} {
+		if got := WithReviewTokenCeiling([]byte(body), 5); string(got) != body {
+			t.Fatalf("WithReviewTokenCeiling(%q) = %q, want unchanged", body, got)
+		}
+	}
+}

--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -341,7 +341,16 @@ type Request struct {
 	// the model sees it. The audit trail and offload store keep the
 	// full result; only the transcript is capped.
 	ToolResultCap int
+
+	// MaxToolCalls, when > 0, caps how many tool calls this turn executes
+	// (D-097): every call past the cap gets toolCallCapMessage as an
+	// error result instead of running. EndTurnTools never count.
+	MaxToolCalls int
 }
+
+// toolCallCapMessage is the result a call past Request.MaxToolCalls
+// receives.
+const toolCallCapMessage = "tool call limit for this turn reached: conclude now with what you already have"
 
 // Start launches the loop and returns its event stream. The channel
 // follows the stream package's terminal contract: exactly one done,
@@ -444,6 +453,7 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 	var providerState json.RawMessage
 	effort := ""
 	toolCallCount := 0
+	executedCalls := 0
 	coerced := false
 	var repeats tools.RepeatGuard
 	stuck := false
@@ -670,7 +680,33 @@ func (a *Agent) run(ctx context.Context, req Request, out chan<- stream.StreamEv
 				}
 			}
 		}
-		results := a.executeAll(ctx, exec, req.SessionID, calls, toolNames, req.Unattended, emit)
+		// D-097: calls past MaxToolCalls are refused without running;
+		// an end-turn (sentinel) call always runs.
+		var run []provider.ToolCall
+		refused := make([]bool, len(calls))
+		for i, c := range calls {
+			if req.MaxToolCalls > 0 && !endTurnTools[c.Name] {
+				if executedCalls >= req.MaxToolCalls {
+					refused[i] = true
+					emit(stream.StreamEvent{Type: stream.EventToolResult, ToolResult: &stream.ToolResultEvent{
+						ID: c.ID, Name: c.Name, Status: "error", Digest: toolCallCapMessage, Args: c.Input,
+					}})
+					continue
+				}
+				executedCalls++
+			}
+			run = append(run, c)
+		}
+		executed := a.executeAll(ctx, exec, req.SessionID, run, toolNames, req.Unattended, emit)
+		results := make([]provider.ToolResult, 0, len(calls))
+		for i, c := range calls {
+			if refused[i] {
+				results = append(results, provider.ToolResult{ID: c.ID, Content: toolCallCapMessage, IsError: true})
+				continue
+			}
+			results = append(results, executed[0])
+			executed = executed[1:]
+		}
 
 		msgs = append(msgs, provider.Message{
 			Role: "assistant", Content: text.String(), ToolCalls: calls,

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -2478,3 +2478,65 @@ func TestAgentEndTurnToolsErrorContinues(t *testing.T) {
 		t.Fatalf("done events = %d, want exactly 1", len(got))
 	}
 }
+
+// TestAgentRequestMaxToolCallsRefusesPastCap pins D-097: with
+// MaxToolCalls 2, the third tool call of a turn is not executed and
+// comes back as an error result carrying toolCallCapMessage, while an
+// end-turn (sentinel) call past the cap still runs and ends the turn.
+// 0 leaves the count unbounded.
+func TestAgentRequestMaxToolCallsRefusesPastCap(t *testing.T) {
+	t.Parallel()
+	sentinel := &tools.Tool{
+		Name:        "review_verdict",
+		Description: "records the verdict",
+		InputSchema: json.RawMessage(`{"type":"object","additionalProperties":false}`),
+		Execute:     func(context.Context, json.RawMessage) (string, error) { return "recorded", nil },
+	}
+	cases := []struct {
+		name          string
+		maxCalls      int
+		wantExecuted  int
+		wantThirdText string
+	}{
+		{"cap of 2 refuses the third", 2, 3, toolCallCapMessage}, // 2 echo + sentinel
+		{"zero runs every call", 0, 4, "echo: call 3"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+				toolCallStep([2]string{"echo", `{"text":"call 1"}`}),
+				toolCallStep([2]string{"echo", `{"text":"call 2"}`}),
+				toolCallStep([2]string{"echo", `{"text":"call 3"}`}),
+				toolCallStep([2]string{"review_verdict", `{}`}),
+			}}
+			a, _, events, _ := testAgent(t, gw, sentinel)
+			ch, err := a.Start(t.Context(), Request{
+				SessionID: "s1", Route: "coding",
+				Messages:     []provider.Message{{Role: "user", Content: "go"}},
+				EndTurnTools: []string{"review_verdict"},
+				MaxToolCalls: tc.maxCalls,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			evs := collect(t, ch)
+			if len(ofType(evs, stream.EventDone)) != 1 {
+				t.Fatal("no clean terminal event")
+			}
+			if len(gw.requests) != 4 {
+				t.Fatalf("gateway calls = %d, want 4", len(gw.requests))
+			}
+			if len(events.kinds) != tc.wantExecuted {
+				t.Fatalf("tool executions persisted = %d, want %d", len(events.kinds), tc.wantExecuted)
+			}
+			msgs := gw.requests[3].Messages
+			third := msgs[len(msgs)-1].ToolResult
+			if third == nil || third.Content != tc.wantThirdText {
+				t.Fatalf("third call's result = %+v, want content %q", third, tc.wantThirdText)
+			}
+			if tc.maxCalls > 0 && !third.IsError {
+				t.Fatal("refused call's result must be an error so the model keeps full effort")
+			}
+		})
+	}
+}

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -80,6 +80,7 @@ type driverStore interface {
 	SetDestinations(ctx context.Context, id string, entries []DestinationEntry) error
 	AppendProgress(ctx context.Context, id, note string) error
 	Spend(ctx context.Context, missionID string) (MissionSpend, error)
+	ReviewInputTokens(ctx context.Context, missionID string) (int64, error)
 	AnswerPendingInput(ctx context.Context, id, eventKind string, payload map[string]any) error
 }
 
@@ -162,6 +163,16 @@ type Driver struct {
 	// > CommitStyleConventional). nil-safe: unset falls straight through
 	// to CommitMessage's own conventional-style default.
 	gitCommitStyle func(ctx context.Context) string
+
+	// reviewWindow resolves the context window (tokens) of the model a
+	// review route would serve, for the packet byte budget (D-097, see
+	// SetReviewWindow); nil or 0 means unknown, reviewByteBudget's
+	// fallback applies.
+	reviewWindow func(ctx context.Context, route, model string) int
+
+	// reviewTokenCeiling reads the per-mission review input token cap
+	// (D-097, see SetReviewTokenCeiling); nil or 0 disables the check.
+	reviewTokenCeiling func(ctx context.Context) int64
 
 	// location resolves the operator's configured timezone for the
 	// worker packet's exec-environment note and progress-note timestamps
@@ -418,6 +429,53 @@ func (d *Driver) SetGitCommitStyle(get func(ctx context.Context) string) {
 // SetGitCommitStyle is.
 func (d *Driver) SetLocation(loc func(ctx context.Context) *time.Location) {
 	d.location = loc
+}
+
+// SetReviewWindow wires the review model window lookup (D-097), a
+// setter for the same reason SetLocation is.
+func (d *Driver) SetReviewWindow(fn func(ctx context.Context, route, model string) int) {
+	d.reviewWindow = fn
+}
+
+// SetReviewTokenCeiling wires the settings-backed review token ceiling
+// (D-097).
+func (d *Driver) SetReviewTokenCeiling(fn func(ctx context.Context) int64) {
+	d.reviewTokenCeiling = fn
+}
+
+// GatewayReviewWindow builds a Driver.reviewWindow over the gateway
+// client: the model hint's own id when the catalog knows it, else the
+// route's first usable chain entry. 0 when neither has a window.
+func GatewayReviewWindow(resolve routeResolver, windows func(ctx context.Context) (map[string]int, error)) func(ctx context.Context, route, model string) int {
+	return func(ctx context.Context, route, model string) int {
+		ws, err := windows(ctx)
+		if err != nil {
+			return 0
+		}
+		// A D-078 pin is "provider name/model"; the catalog keys by model id.
+		if i := strings.LastIndex(model, "/"); i >= 0 {
+			model = model[i+1:]
+		}
+		if w := ws[model]; w > 0 {
+			return w
+		}
+		resolved, err := resolve(ctx, route, "")
+		if err != nil {
+			return 0
+		}
+		for _, e := range resolved.Entries {
+			if e.Usable {
+				return ws[e.Model]
+			}
+		}
+		return 0
+	}
+}
+
+// reviewTokensExceeded reports whether used review input tokens have
+// reached ceiling; a ceiling of 0 disables the check.
+func reviewTokensExceeded(used, ceiling int64) bool {
+	return ceiling > 0 && used >= ceiling
 }
 
 // SetCompleter wires the Completer the driver's auto-fire-on-done hook
@@ -1781,6 +1839,19 @@ func (d *Driver) findingsReviewPacket(ctx context.Context, m Mission, open []Fin
 }
 
 func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
+	// D-097: the review token ceiling is checked from the ledger before
+	// any model call; at or above it the mission parks on budget.
+	if d.reviewTokenCeiling != nil {
+		if ceiling := d.reviewTokenCeiling(ctx); ceiling > 0 {
+			used, err := d.store.ReviewInputTokens(ctx, m.ID)
+			if err != nil {
+				return StepInput{}, err
+			}
+			if reviewTokensExceeded(used, ceiling) {
+				return StepInput{Input: InputReviewBudget, Reason: fmt.Sprintf("review input tokens %d reached the ceiling %d", used, ceiling)}, nil
+			}
+		}
+	}
 	idx, units := reviewUnits(m.Plan)
 	unitIdx := -1
 	if len(idx) > 0 {
@@ -1801,6 +1872,21 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 	}
 	if err != nil {
 		return StepInput{}, err
+	}
+	// D-097: size the packet to the resolved model's window before the
+	// first send; reviewWithShrink's context_length retry stays behind it.
+	window := 0
+	if d.reviewWindow != nil {
+		window = d.reviewWindow(ctx, reviewRoute(m), reviewModel(m))
+	}
+	var shrink reviewShrink
+	if packet, shrink = fitReviewPacket(packet, reviewByteBudget(window)); shrink.cut() {
+		if evErr := d.store.AppendEvent(ctx, m.ID, "mission.review_prompt_shrunk", map[string]any{
+			"action": "byte_budget", "window": window, "budget": shrink.Budget, "rendered": shrink.Rendered,
+			"diff_cut": shrink.DiffCut, "artifacts_cut": shrink.ArtifactsCut,
+		}); evErr != nil {
+			d.log.Warn("driver: record review prompt shrunk failed", "mission_id", m.ID, "error", evErr)
+		}
 	}
 	verdict, err := d.reviewWithShrink(ctx, m, packet)
 	if err != nil {

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/SumonMSelim/timothy/internal/brain/fxrates"
+	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
 )
 
 // fakeStore is an in-memory driverStore for scripting Driver scenarios
@@ -30,6 +31,8 @@ type fakeStore struct {
 	// zero spend in every currency, matching a mission with no ledger
 	// rows yet.
 	spend map[string]MissionSpend
+	// reviewTokens scripts ReviewInputTokens' return per mission id.
+	reviewTokens map[string]int64
 	// applyTransitionErr, when set, makes ApplyTransition return this
 	// error instead of writing — scripts the real Store's terminal-row
 	// guard (ErrTerminal) without a Postgres pool.
@@ -37,12 +40,18 @@ type fakeStore struct {
 }
 
 func newFakeStore() *fakeStore {
-	return &fakeStore{missions: map[string]Mission{}, events: map[string][]Event{}, seq: map[string]int64{}, spend: map[string]MissionSpend{}}
+	return &fakeStore{missions: map[string]Mission{}, events: map[string][]Event{}, seq: map[string]int64{}, spend: map[string]MissionSpend{}, reviewTokens: map[string]int64{}}
 }
 
 // Spend returns the scripted MissionSpend for id, or a zero-value
 // (empty ByCurrency) if the test never set one — mirrors a real
 // mission with no cost_ledger rows.
+func (f *fakeStore) ReviewInputTokens(ctx context.Context, missionID string) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reviewTokens[missionID], nil
+}
+
 func (f *fakeStore) Spend(ctx context.Context, missionID string) (MissionSpend, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -3755,5 +3764,106 @@ func TestDriverTwoUnitPlanReviewsOnce(t *testing.T) {
 	}
 	if n := countEvents(store, "m1", "mission.review_verdict"); n != 1 {
 		t.Fatalf("review_verdict events = %d, want exactly 1", n)
+	}
+}
+
+// TestDriverReviewTokenCeiling pins D-097: before a review round the
+// driver sums the mission's reviewer-turn input tokens from the ledger
+// and parks on budget with detail review_tokens at or above the
+// ceiling, without calling the reviewer; below it, or with the ceiling
+// disabled (0) or unwired, the round runs.
+func TestDriverReviewTokenCeiling(t *testing.T) {
+	tests := []struct {
+		name     string
+		used     int64
+		ceiling  int64
+		wired    bool
+		wantPark bool
+	}{
+		{"below the ceiling reviews", 1_499_999, 1_500_000, true, false},
+		{"at the ceiling parks", 1_500_000, 1_500_000, true, true},
+		{"above the ceiling parks", 2_000_000, 1_500_000, true, true},
+		{"zero disables the ceiling", 5_000_000, 0, true, false},
+		{"unwired ceiling reviews", 5_000_000, 0, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newFakeStore()
+			store.put("m1", Mission{
+				ID: "m1", Kind: "general", Phase: PhaseProve, Status: StatusWorking, MaxIterations: 8,
+				Plan: Plan{Units: []PlanUnit{{Title: "only unit"}}},
+			})
+			store.reviewTokens["m1"] = tc.used
+			runner := &scriptedRunner{reviewVerdicts: []ReviewVerdict{{Approved: true}}}
+			d := testDriver(store, runner)
+			if tc.wired {
+				d.SetReviewTokenCeiling(func(context.Context) int64 { return tc.ceiling })
+			}
+			if _, err := d.Advance(context.Background(), "m1"); err != nil {
+				t.Fatalf("Advance: %v", err)
+			}
+			m, _ := store.Get(context.Background(), "m1")
+			if tc.wantPark {
+				if len(runner.reviewCalls) != 0 {
+					t.Fatalf("RunReview called %d times, want none past the ceiling", len(runner.reviewCalls))
+				}
+				if m.Status != StatusPaused || m.PauseReason != PauseBudget {
+					t.Fatalf("mission = status %q pause_reason %q, want paused/budget", m.Status, m.PauseReason)
+				}
+				if got := pausedDetail(t, store, "m1"); got != "review_tokens" {
+					t.Fatalf("paused detail = %q, want review_tokens", got)
+				}
+				return
+			}
+			if len(runner.reviewCalls) != 1 {
+				t.Fatalf("RunReview called %d times, want 1", len(runner.reviewCalls))
+			}
+			if m.Status == StatusPaused {
+				t.Fatalf("mission paused (%s) below the ceiling", m.PauseReason)
+			}
+		})
+	}
+}
+
+// TestGatewayReviewWindow pins the D-097 window lookup: a pinned
+// "provider/model" hint resolves by its model id, an unpinned route by
+// its first usable chain entry, and a catalog miss or gateway error is
+// 0 (unknown), never a guess.
+func TestGatewayReviewWindow(t *testing.T) {
+	windows := func(context.Context) (map[string]int, error) {
+		return map[string]int{"big": 1_000_000, "mid": 200_000}, nil
+	}
+	resolve := func(_ context.Context, route, _ string) (*gwclient.ResolvedRoute, error) {
+		switch route {
+		case "review":
+			return &gwclient.ResolvedRoute{Entries: []gwclient.ResolvedRouteEntry{
+				{Model: "dead", Usable: false}, {Model: "mid", Usable: true}, {Model: "big", Usable: true},
+			}}, nil
+		case "unknown-model":
+			return &gwclient.ResolvedRoute{Entries: []gwclient.ResolvedRouteEntry{{Model: "nope", Usable: true}}}, nil
+		}
+		return nil, errors.New("no such route")
+	}
+	fn := GatewayReviewWindow(resolve, windows)
+	tests := []struct {
+		name, route, model string
+		want               int
+	}{
+		{"pinned model wins", "review", "Anthropic/big", 1_000_000},
+		{"bare model hint", "review", "mid", 200_000},
+		{"first usable chain entry", "review", "", 200_000},
+		{"catalog miss is unknown", "unknown-model", "", 0},
+		{"resolve error is unknown", "missing", "", 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fn(context.Background(), tc.route, tc.model); got != tc.want {
+				t.Fatalf("window(%q, %q) = %d, want %d", tc.route, tc.model, got, tc.want)
+			}
+		})
+	}
+	failing := GatewayReviewWindow(resolve, func(context.Context) (map[string]int, error) { return nil, errors.New("down") })
+	if got := failing(context.Background(), "review", "big"); got != 0 {
+		t.Fatalf("window with the catalog down = %d, want 0", got)
 	}
 }

--- a/internal/brain/missions/review.go
+++ b/internal/brain/missions/review.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,7 +30,85 @@ const (
 	reviewArtifactFileCap = 8 << 10
 	// reviewListingCap bounds the workspace file listing.
 	reviewListingCap = 2 << 10
+
+	// Review packet byte budget (D-097, issue #527): the resolved
+	// model's catalog window (reviewFallbackWindow when unknown) times
+	// reviewBytesPerToken, minus reviewByteMargin for the system
+	// prompt, tool definitions and the reviewer's own tool loop.
+	reviewFallbackWindow = 128_000
+	reviewBytesPerToken  = 3.5
+	reviewByteMargin     = 128 << 10
+	// reviewDiffFloor is the smallest diff fitReviewPacket cuts to
+	// before it starts on the artifacts.
+	reviewDiffFloor = baselineDiffCap / 4
 )
+
+// reviewByteBudget derives the packet byte budget from a model's
+// context window in tokens; window <= 0 means unknown.
+func reviewByteBudget(window int) int {
+	if window <= 0 {
+		window = reviewFallbackWindow
+	}
+	return int(float64(window)*reviewBytesPerToken) - reviewByteMargin
+}
+
+// reviewShrink records what fitReviewPacket did.
+type reviewShrink struct {
+	Budget       int
+	Rendered     int
+	DiffCut      int
+	ArtifactsCut int
+}
+
+// cut reports whether anything was removed.
+func (r reviewShrink) cut() bool { return r.DiffCut > 0 || r.ArtifactsCut > 0 }
+
+// fitReviewPacket shrinks p's rendered form to budget bytes: the diff
+// first (file boundary cut, never below reviewDiffFloor), then the
+// artifact and finding-file contents, then the diff again down to
+// nothing. Criteria, findings and every other section stay untouched.
+// The rendered size is re-measured after every cut so the truncation
+// markers themselves are accounted for.
+func fitReviewPacket(p ReviewPacket, budget int) (ReviewPacket, reviewShrink) {
+	r := reviewShrink{Budget: budget, Rendered: len(renderReviewContent(p))}
+	if r.Rendered <= budget {
+		return p, r
+	}
+	excess := func() int { return len(renderReviewContent(p)) - budget }
+	cutDiff := func(floor int) {
+		for over := excess(); over > 0 && len(p.Diff) > floor; over = excess() {
+			before := len(p.Diff)
+			p.Diff = truncateDiff(p.Diff, max(before-over, floor))
+			if len(p.Diff) >= before {
+				return
+			}
+			r.DiffCut += before - len(p.Diff)
+		}
+	}
+	cutFiles := func(files *map[string]string) {
+		if excess() <= 0 || len(*files) == 0 {
+			return
+		}
+		out := maps.Clone(*files)
+		*files = out
+		for _, path := range slices.Sorted(maps.Keys(out)) {
+			over := excess()
+			if over <= 0 {
+				return
+			}
+			content := out[path]
+			marker := fmt.Sprintf("\n[truncated: file is %d bytes, review byte budget reached]", len(content))
+			keep := lastNewlineBefore([]byte(content), max(len(content)-over-len(marker), 0))
+			out[path] = content[:keep] + marker
+			r.ArtifactsCut += len(content) - keep
+		}
+	}
+	cutDiff(min(len(p.Diff), reviewDiffFloor))
+	cutFiles(&p.Artifacts)
+	cutFiles(&p.Files)
+	cutDiff(0)
+	return p, r
+}
 
 // ReviewPacket is everything a reviewer turn judges: the units under
 // review with their acceptance criteria and harness evidence (D-095),

--- a/internal/brain/missions/review_test.go
+++ b/internal/brain/missions/review_test.go
@@ -383,3 +383,116 @@ func TestParseReviewVerdictEvidence(t *testing.T) {
 		t.Fatalf("Evidence = %q", v.Findings[0].Evidence)
 	}
 }
+
+// TestReviewByteBudget pins D-097's derivation: window x 3.5 bytes per
+// token minus the fixed margin, with 128k tokens standing in for an
+// unknown window.
+func TestReviewByteBudget(t *testing.T) {
+	tests := []struct {
+		name   string
+		window int
+		want   int
+	}{
+		{"known 200k window", 200_000, 700_000 - reviewByteMargin},
+		{"unknown window falls back to 128k", 0, 448_000 - reviewByteMargin},
+		{"negative window is unknown too", -1, 448_000 - reviewByteMargin},
+		{"small window keeps the same margin", 32_000, 112_000 - reviewByteMargin},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := reviewByteBudget(tc.window); got != tc.want {
+				t.Fatalf("reviewByteBudget(%d) = %d, want %d", tc.window, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFitReviewPacketShrinkOrder pins D-097's shrink order: the diff
+// gives first (down to the floor), then the artifacts, then the diff
+// again; criteria and findings are never touched; a packet within
+// budget is returned as is.
+func TestFitReviewPacketShrinkOrder(t *testing.T) {
+	criteria := []string{"the report names every retry header", "the summary is under 200 words"}
+	findings := []Finding{{ID: "F1", Title: "missing retry-after", File: "report.md", Status: FindingOpen, Detail: strings.Repeat("d", 300)}}
+	// Two 40 KB files: 80 KB total, above the 64 KB floor, so the first
+	// pass can drop the second file and no more.
+	fileA := "diff --git a/a b/a\n" + strings.Repeat("+aaaa\n", 40<<10/6)
+	fileB := "diff --git a/b b/b\n" + strings.Repeat("+bbbb\n", 40<<10/6)
+	diff := fileA + fileB
+	artifacts := map[string]string{"report.md": strings.Repeat("report line\n", 200), "notes.md": strings.Repeat("note line\n", 100)}
+	base := ReviewPacket{
+		Units:        []PlanUnit{{Title: "u1", Criteria: criteria, Artifacts: []string{"report.md"}}},
+		Diff:         diff,
+		Artifacts:    artifacts,
+		OpenFindings: findings,
+	}
+	full := len(renderReviewContent(base))
+
+	t.Run("within budget is untouched", func(t *testing.T) {
+		got, r := fitReviewPacket(base, full)
+		if r.cut() || got.Diff != diff || len(got.Artifacts["report.md"]) != len(artifacts["report.md"]) {
+			t.Fatalf("packet within budget was altered: %+v", r)
+		}
+	})
+	t.Run("diff shrinks first, artifacts untouched", func(t *testing.T) {
+		budget := full - 1000
+		got, r := fitReviewPacket(base, budget)
+		if r.DiffCut == 0 || r.ArtifactsCut != 0 {
+			t.Fatalf("shrink = %+v, want only the diff cut", r)
+		}
+		if got.Artifacts["report.md"] != artifacts["report.md"] {
+			t.Fatal("artifacts were cut while the diff still had room")
+		}
+		if !strings.Contains(got.Diff, "[diff truncated: 1 files omitted]") || strings.Contains(got.Diff, "+bbbb") {
+			t.Fatalf("diff was not cut on the file boundary:\n%s", got.Diff[len(got.Diff)-120:])
+		}
+		if rendered := len(renderReviewContent(got)); rendered > budget {
+			t.Fatalf("rendered %d bytes, want <= %d", rendered, budget)
+		}
+	})
+	t.Run("artifacts shrink once the diff is at the floor", func(t *testing.T) {
+		// More than the diff can give at the floor: the second file goes,
+		// the first stays whole, and the rest comes out of the artifacts.
+		budget := full - len(fileB) - 1000
+		got, r := fitReviewPacket(base, budget)
+		if r.DiffCut == 0 || r.ArtifactsCut == 0 {
+			t.Fatalf("shrink = %+v, want both diff and artifacts cut", r)
+		}
+		if !strings.HasPrefix(got.Diff, fileA) {
+			t.Fatal("first diff file was cut before the artifacts gave")
+		}
+		if !strings.Contains(got.Artifacts["notes.md"], "review byte budget reached") {
+			t.Fatalf("cut artifact lacks its marker:\n%s", got.Artifacts["notes.md"])
+		}
+		if base.Artifacts["notes.md"] != artifacts["notes.md"] {
+			t.Fatal("caller's artifact map was mutated")
+		}
+		if rendered := len(renderReviewContent(got)); rendered > budget {
+			t.Fatalf("rendered %d bytes, want <= %d", rendered, budget)
+		}
+	})
+	t.Run("diff goes below the floor only after the artifacts are gone", func(t *testing.T) {
+		got, r := fitReviewPacket(base, 3000)
+		if r.DiffCut == 0 || r.ArtifactsCut == 0 {
+			t.Fatalf("shrink = %+v, want both cut", r)
+		}
+		if len(got.Diff) >= len(fileA) {
+			t.Fatalf("diff = %d bytes, want cut below the first file's %d", len(got.Diff), len(fileA))
+		}
+	})
+	t.Run("criteria and findings are never dropped", func(t *testing.T) {
+		got, _ := fitReviewPacket(base, 10)
+		if !reflect.DeepEqual(got.Units[0].Criteria, criteria) || !reflect.DeepEqual(got.OpenFindings, findings) {
+			t.Fatalf("criteria/findings changed: %+v / %+v", got.Units[0].Criteria, got.OpenFindings)
+		}
+		rendered := renderReviewContent(got)
+		for _, c := range criteria {
+			if !strings.Contains(rendered, c) {
+				t.Fatalf("criterion %q missing from the shrunk packet", c)
+			}
+		}
+		if !strings.Contains(rendered, "F1") {
+			t.Fatal("finding F1 missing from the shrunk packet")
+		}
+	})
+}

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -46,12 +46,19 @@ var ErrPromptTooLong = errors.New("mission turn rejected: prompt exceeds the mod
 // mistaking the missing sentinel for a forced failure.
 var ErrAskedUser = errors.New("mission turn parked on ask_user")
 
-// Reviewer tool-loop caps (D-093): step ceiling and per-result bytes
-// for RunReview's loop.Request. Go constants, never prompt text.
+// Reviewer tool-loop caps (D-093, D-097): step ceiling, per-result
+// bytes and executed tool calls for RunReview's loop.Request. Go
+// constants, never prompt text.
 const (
 	reviewMaxSteps      = 4
 	reviewToolResultCap = 4096
+	reviewMaxToolCalls  = 2
 )
+
+// reviewerAgent tags every reviewer turn's ledger row (loop.Request
+// Agent), which is how Store.ReviewInputTokens tells review turns from
+// worker turns (D-097).
+const reviewerAgent = "mission-reviewer"
 
 // Runner executes ONE session (worker turn, reviewer turn, or planner
 // turn) and owns NO state-transition logic: it reports what happened,
@@ -1320,7 +1327,7 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 		SessionID:    m.SessionID,
 		Route:        reviewRoute(m),
 		ModelHint:    reviewModel(m),
-		Agent:        "mission-reviewer",
+		Agent:        reviewerAgent,
 		MissionID:    m.ID,
 		System:       system,
 		Messages:     messages,
@@ -1335,6 +1342,7 @@ func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPa
 		// agent defaults.
 		MaxSteps:      reviewMaxSteps,
 		ToolResultCap: reviewToolResultCap,
+		MaxToolCalls:  reviewMaxToolCalls,
 	}
 	res, err := r.runTurn(ctx, req, reviewVerdictToolName, PhaseProve)
 	text, args := res.text, res.sentinelArgs

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -158,8 +158,12 @@ const (
 	InputReviewApprove      Input = "review_approve"
 	InputReviewRework       Input = "review_rework"
 	InputReviewInfraFailure Input = "review_infra_failure"
-	InputResume             Input = "resume"
-	InputCancel             Input = "cancel"
+	// InputReviewBudget parks a mission whose review turns' input tokens
+	// reached the operator's review token ceiling (D-097, issue #527),
+	// before the round's model call.
+	InputReviewBudget Input = "review_budget"
+	InputResume       Input = "resume"
+	InputCancel       Input = "cancel"
 	// InputPlanInfeasible fires when the planner reports the goal cannot
 	// be achieved as stated (D-077); valid only in PhasePlan, fails the
 	// mission instead of letting a rewritten goal reach generate.
@@ -423,6 +427,13 @@ func stepInput(s StepState, in StepInput, cfg Config) Transition {
 		return Transition{
 			Next:   withPause(s, PauseInfra),
 			Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseInfra), "detail": in.Reason}}},
+		}
+	case InputReviewBudget:
+		return Transition{
+			Next: withPause(s, PauseBudget),
+			Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{
+				"reason": string(PauseBudget), "detail": "review_tokens", "message": in.Reason,
+			}}},
 		}
 	case InputResultComplete:
 		return stepResultComplete(s)

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -273,6 +273,13 @@ func TestStep(t *testing.T) {
 			want:  StepState{Phase: PhaseProve, Status: StatusPaused, PauseReason: PauseInfra},
 		},
 		{
+			name:  "review_budget pauses with budget reason (D-097)",
+			state: StepState{Phase: PhaseProve, Status: StatusWorking, Iteration: 2},
+			input: StepInput{Input: InputReviewBudget, Reason: "review input tokens 1500100 reached the ceiling 1500000"},
+			cfg:   DefaultConfig,
+			want:  StepState{Phase: PhaseProve, Status: StatusPaused, PauseReason: PauseBudget, Iteration: 2},
+		},
+		{
 			name:  "resume from paused clears the pause reason and goes idle",
 			state: StepState{Phase: PhaseGenerate, Status: StatusPaused, PauseReason: PauseBackoff, Iteration: 3, ConsecutiveFailures: 2},
 			input: StepInput{Input: InputResume},

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -1483,6 +1483,22 @@ func (s *Store) Spend(ctx context.Context, missionID string) (MissionSpend, erro
 	return out, rows.Err()
 }
 
+// ReviewInputTokens sums the input tokens of a mission's reviewer turns
+// (ledger rows tagged agent=mission-reviewer by runner.go's RunReview),
+// the figure the review token ceiling is checked against (D-097).
+func (s *Store) ReviewInputTokens(ctx context.Context, missionID string) (int64, error) {
+	db, err := s.db.Get()
+	if err != nil {
+		return 0, fmt.Errorf("missions review input tokens: %w", err)
+	}
+	var total int64
+	if err := db.QueryRow(ctx, `SELECT COALESCE(SUM(input_tokens), 0) FROM cost_ledger
+		WHERE mission_id = $1 AND agent = $2`, missionID, reviewerAgent).Scan(&total); err != nil {
+		return 0, fmt.Errorf("missions review input tokens: %w", err)
+	}
+	return total, nil
+}
+
 // BackoffPausedMission is PausedByReason's row: just enough to drive
 // the auto-resume ladders (sweep.go's autoResumeBackoff and
 // autoResumeInfra) without the cost of a full Mission scan.

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -1647,6 +1647,53 @@ func TestSpendExcludesUnbilledRows(t *testing.T) {
 	}
 }
 
+// TestReviewInputTokensSumsReviewerRowsOnly pins D-097's ledger read:
+// only rows tagged agent=mission-reviewer count, worker rows and other
+// missions' rows do not, and a mission with no reviewer rows sums to 0.
+func TestReviewInputTokensSumsReviewerRowsOnly(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+	id, err := s.Create(ctx, Mission{Goal: marker + "review-tokens", Kind: "general", Route: "default"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	other, err := s.Create(ctx, Mission{Goal: marker + "review-tokens-other", Kind: "general", Route: "default"})
+	if err != nil {
+		t.Fatalf("Create other: %v", err)
+	}
+	db, err := s.db.Get()
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	for _, row := range []struct {
+		mission string
+		agent   string
+		tokens  int
+	}{{id, reviewerAgent, 30_000}, {id, reviewerAgent, 12_000}, {id, "mission-worker", 500_000}, {other, reviewerAgent, 7_000}} {
+		if _, err := db.Exec(ctx, `INSERT INTO cost_ledger
+			(provider, model, route, agent, latency_ms, status, input_tokens, mission_id)
+			VALUES ('itest-provider', 'itest-model', 'itest', $1, 1, 'ok', $2, $3)`,
+			row.agent, row.tokens, row.mission); err != nil {
+			t.Fatalf("insert ledger row: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = db.Exec(context.Background(), `DELETE FROM cost_ledger WHERE mission_id IN ($1, $2)`, id, other)
+	})
+
+	got, err := s.ReviewInputTokens(ctx, id)
+	if err != nil {
+		t.Fatalf("ReviewInputTokens: %v", err)
+	}
+	if got != 42_000 {
+		t.Fatalf("ReviewInputTokens = %d, want 42000 (reviewer rows of this mission only)", got)
+	}
+	none, err := s.ReviewInputTokens(ctx, marker+"never-reviewed")
+	if err != nil || none != 0 {
+		t.Fatalf("ReviewInputTokens(no rows) = %d, %v, want 0, nil", none, err)
+	}
+}
+
 // TestPendingPermissionsAndResolveTimeout covers issue #445's store
 // layer: PendingPermissions lists a mission's parked request with its
 // parked_at and per-mission override intact, and

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -101,7 +101,16 @@ const (
 	// stop a broken run, so this stays large enough that a healthy
 	// multi-hour coding mission never hits it.
 	ValueExecutorRunBudgetMinutes = "executor_run_budget_minutes"
+	// ValueReviewTokenCeiling caps the input tokens one mission may spend
+	// on review turns (missions/driver.go, D-097, issue #527), summed
+	// from the cost ledger before every review round; "" (the default)
+	// defers to DefaultReviewTokenCeiling, "0" disables the ceiling.
+	ValueReviewTokenCeiling = "mission_review_token_ceiling"
 )
+
+// DefaultReviewTokenCeiling is the per-mission review input token cap
+// when ValueReviewTokenCeiling is unset.
+const DefaultReviewTokenCeiling int64 = 1_500_000
 
 // DefaultExecutorRunBudget is the wall-clock cap a delegated executor
 // run gets when ValueExecutorRunBudgetMinutes is unset.
@@ -115,7 +124,7 @@ var knownValueKeys = map[string]bool{
 	ValueGitBranchPattern: true, ValueGitCommitStyle: true,
 	ValueWebBaseURL: true, ValueTimezone: true,
 	ValuePermissionTimeoutSeconds: true, ValueAskTimeoutSeconds: true,
-	ValueExecutorRunBudgetMinutes: true,
+	ValueExecutorRunBudgetMinutes: true, ValueReviewTokenCeiling: true,
 }
 
 // allowedCurrencies is the flat, fixed list of ISO 4217 codes the
@@ -229,6 +238,18 @@ func (s *Store) ExecutorRunBudget(ctx context.Context) time.Duration {
 		}
 	}
 	return DefaultExecutorRunBudget
+}
+
+// ReviewTokenCeiling parses the per-mission review input token cap:
+// unset or unparsable falls back to DefaultReviewTokenCeiling, 0
+// disables the ceiling.
+func (s *Store) ReviewTokenCeiling(ctx context.Context) int64 {
+	if v := s.Value(ctx, ValueReviewTokenCeiling); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return DefaultReviewTokenCeiling
 }
 
 // DefaultCurrency returns the configured default currency, falling
@@ -377,7 +398,7 @@ func (s *Store) SetValue(ctx context.Context, key, value string) error {
 			return fmt.Errorf("%s must be a positive integer or empty", key)
 		}
 	}
-	if (key == ValuePermissionTimeoutSeconds || key == ValueAskTimeoutSeconds) && value != "" {
+	if (key == ValuePermissionTimeoutSeconds || key == ValueAskTimeoutSeconds || key == ValueReviewTokenCeiling) && value != "" {
 		if n, err := strconv.Atoi(value); err != nil || n < 0 {
 			return fmt.Errorf("%s must be a non-negative integer or empty", key)
 		}

--- a/internal/brain/settings/settings_integration_test.go
+++ b/internal/brain/settings/settings_integration_test.go
@@ -163,6 +163,33 @@ func TestRuntimeValueSettings(t *testing.T) {
 		t.Fatalf("clear run budget: %v", err)
 	}
 
+	// D-097: review token ceiling defaults to 1.5M, accepts 0 (disabled),
+	// rejects negatives and non-numbers.
+	if got := s.ReviewTokenCeiling(ctx); got != DefaultReviewTokenCeiling {
+		t.Fatalf("ReviewTokenCeiling default = %d, want %d", got, DefaultReviewTokenCeiling)
+	}
+	if err := s.SetValue(ctx, ValueReviewTokenCeiling, "-1"); err == nil {
+		t.Fatal("negative review token ceiling accepted")
+	}
+	if err := s.SetValue(ctx, ValueReviewTokenCeiling, "lots"); err == nil {
+		t.Fatal("non-numeric review token ceiling accepted")
+	}
+	if err := s.SetValue(ctx, ValueReviewTokenCeiling, "0"); err != nil {
+		t.Fatalf("SetValue review token ceiling 0: %v", err)
+	}
+	if got := s.ReviewTokenCeiling(ctx); got != 0 {
+		t.Fatalf("ReviewTokenCeiling = %d, want 0 (disabled)", got)
+	}
+	if err := s.SetValue(ctx, ValueReviewTokenCeiling, "250000"); err != nil {
+		t.Fatalf("SetValue review token ceiling: %v", err)
+	}
+	if got := s.ReviewTokenCeiling(ctx); got != 250_000 {
+		t.Fatalf("ReviewTokenCeiling = %d, want 250000", got)
+	}
+	if err := s.SetValue(ctx, ValueReviewTokenCeiling, ""); err != nil {
+		t.Fatalf("clear review token ceiling: %v", err)
+	}
+
 	if err := s.SetValue(ctx, ValueTokenBudget, "120000"); err != nil {
 		t.Fatalf("SetValue budget: %v", err)
 	}

--- a/internal/gateway/ledger/aggregate.go
+++ b/internal/gateway/ledger/aggregate.go
@@ -289,10 +289,14 @@ type MissionUsage struct {
 	// CacheReadTokens is the input read from the provider's prompt
 	// cache (D-093): shown next to input_tokens so the caching
 	// breakpoints' effect is visible per mission.
-	CacheReadTokens  int64       `json:"cache_read_tokens"`
-	Requests         int64       `json:"requests"`
-	UnpricedRequests int64       `json:"unpriced_requests"`
-	Models           []ModelUsed `json:"models"`
+	CacheReadTokens int64 `json:"cache_read_tokens"`
+	// ReviewInputTokens is the input of the mission's reviewer turns
+	// (rows tagged agent=reviewerAgent), shown against the review token
+	// ceiling (D-097).
+	ReviewInputTokens int64       `json:"review_input_tokens"`
+	Requests          int64       `json:"requests"`
+	UnpricedRequests  int64       `json:"unpriced_requests"`
+	Models            []ModelUsed `json:"models"`
 }
 
 // ModelUsed is one provider/model/harness-ness triple actually invoked
@@ -311,6 +315,10 @@ type ModelUsed struct {
 	LastUsed time.Time `json:"last_used"`
 }
 
+// reviewerAgent is the agent tag brain's mission reviewer turns carry
+// (internal/brain/missions/runner.go).
+const reviewerAgent = "mission-reviewer"
+
 func (a *Aggregator) Mission(ctx context.Context, missionID string) (MissionUsage, error) {
 	db, err := a.db.Get()
 	if err != nil {
@@ -325,10 +333,11 @@ func (a *Aggregator) Mission(ctx context.Context, missionID string) (MissionUsag
 	}
 	err = db.QueryRow(ctx, `SELECT
 			COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0), COALESCE(SUM(cache_read_tokens), 0),
+			COALESCE(SUM(input_tokens) FILTER (WHERE agent = $2), 0),
 			COUNT(*), COUNT(*) FILTER (WHERE cost IS NULL)
 		FROM cost_ledger
-		WHERE mission_id = $1 AND `+notTest, missionID).
-		Scan(&m.InputTokens, &m.OutputTokens, &m.CacheReadTokens, &m.Requests, &m.UnpricedRequests)
+		WHERE mission_id = $1 AND `+notTest, missionID, reviewerAgent).
+		Scan(&m.InputTokens, &m.OutputTokens, &m.CacheReadTokens, &m.ReviewInputTokens, &m.Requests, &m.UnpricedRequests)
 	if err != nil {
 		return MissionUsage{}, fmt.Errorf("usage mission: %w", err)
 	}

--- a/internal/gateway/ledger/aggregate_integration_test.go
+++ b/internal/gateway/ledger/aggregate_integration_test.go
@@ -423,9 +423,10 @@ func TestAggregateMissionUsage(t *testing.T) {
 		{Provider: aggMarker + "a", Model: "m1", Route: "coding", MissionID: mission,
 			Usage:     &stream.Usage{InputTokens: 200, OutputTokens: 100, CacheReadTokens: 10},
 			LatencyMS: 100, Status: "ok", Cost: usd(0.20)},
-		// A fallback to a second model — the whole point of Models: a
-		// route is a chain, not one model, so both must show up.
-		{Provider: aggMarker + "a", Model: "m-local", Route: "coding", MissionID: mission,
+		// A fallback to a second model, the whole point of Models: a
+		// route is a chain, not one model, so both must show up. Tagged
+		// as the reviewer's turn so ReviewInputTokens has one row (D-097).
+		{Provider: aggMarker + "a", Model: "m-local", Route: "coding", Agent: reviewerAgent, MissionID: mission,
 			Usage:     &stream.Usage{InputTokens: 40, OutputTokens: 20},
 			LatencyMS: 100, Status: "ok"},
 		// Same provider/model as the harness's delegated CLI executor
@@ -458,6 +459,9 @@ func TestAggregateMissionUsage(t *testing.T) {
 	}
 	if got.CacheReadTokens != 40 {
 		t.Fatalf("CacheReadTokens = %d, want 40 (D-093: cached reads summed per mission)", got.CacheReadTokens)
+	}
+	if got.ReviewInputTokens != 40 {
+		t.Fatalf("ReviewInputTokens = %d, want 40 (D-097: only the reviewer-tagged row)", got.ReviewInputTokens)
 	}
 	// The executor-purpose row's $0.05 is the harness's; the rest is
 	// brain's.

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -391,6 +391,11 @@ export interface MissionUsage {
   // cache_read_tokens is input served from the provider's prompt cache
   // (D-093), shown next to input_tokens on the cost card.
   cache_read_tokens?: number
+  // review_input_tokens is the input spent on reviewer turns, shown
+  // against review_token_ceiling (the mission_review_token_ceiling
+  // setting, 0 = no ceiling) on the cost card (D-097).
+  review_input_tokens?: number
+  review_token_ceiling?: number
   requests: number
   unpriced_requests: number
   models: ModelUsed[]

--- a/web/src/components/settings/FeaturesTab.test.tsx
+++ b/web/src/components/settings/FeaturesTab.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FeaturesTab } from './FeaturesTab'
+
+vi.mock('../../api/client', () => ({
+  getSettings: vi.fn(),
+  listRoutes: vi.fn(),
+  patchSettings: vi.fn(),
+  patchSettingValues: vi.fn(),
+}))
+
+import { getSettings, listRoutes, patchSettingValues } from '../../api/client'
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(listRoutes).mockResolvedValue([])
+  vi.mocked(patchSettingValues).mockResolvedValue(undefined)
+})
+
+describe('FeaturesTab review token ceiling', () => {
+  it('shows the stored ceiling beside the run budget and saves an edit', async () => {
+    vi.mocked(getSettings).mockResolvedValue({
+      settings: {},
+      values: { executor_run_budget_minutes: '90', mission_review_token_ceiling: '250000' },
+    })
+    render(<FeaturesTab />)
+    const input = (await screen.findByLabelText('Review token ceiling')) as HTMLInputElement
+    expect(input.value).toBe('250000')
+    expect(screen.getByLabelText('Harness run budget minutes')).toBeTruthy()
+
+    fireEvent.change(input, { target: { value: '0' } })
+    fireEvent.click(within(input.closest('div.rounded-xl') as HTMLElement).getByText('Save'))
+    await waitFor(() => expect(patchSettingValues).toHaveBeenCalledWith({ mission_review_token_ceiling: '0' }))
+  })
+
+  it('shows the default as a placeholder when unset', async () => {
+    vi.mocked(getSettings).mockResolvedValue({ settings: {}, values: {} })
+    render(<FeaturesTab />)
+    const input = (await screen.findByLabelText('Review token ceiling')) as HTMLInputElement
+    expect(input.value).toBe('')
+    expect(input.placeholder).toBe('1500000')
+  })
+})

--- a/web/src/components/settings/FeaturesTab.tsx
+++ b/web/src/components/settings/FeaturesTab.tsx
@@ -102,6 +102,7 @@ export function FeaturesTab() {
       {values && <DefaultCurrencyCard values={values} onError={setError} onSaved={refresh} />}
       {values && <DefaultCodingExecutorCard values={values} onError={setError} onSaved={refresh} />}
       {values && <ExecutorRunBudgetCard values={values} onError={setError} onSaved={refresh} />}
+      {values && <ReviewTokenCeilingCard values={values} onError={setError} onSaved={refresh} />}
       {values && <GitBranchPatternCard values={values} onError={setError} onSaved={refresh} />}
       {values && <GitCommitStyleCard values={values} onError={setError} onSaved={refresh} />}
       <NotificationSoundCard />
@@ -307,6 +308,62 @@ function ExecutorRunBudgetCard({
       <p className="mt-2 text-xs text-muted-foreground">
         Wall-clock cap for one delegated coding run. Empty uses the default (8 hours). A run that
         stops producing output is killed by the 10-minute idle timeout regardless.
+      </p>
+    </div>
+  )
+}
+
+// REVIEW_TOKEN_CEILING_DEFAULT mirrors settings.DefaultReviewTokenCeiling
+// for the placeholder; the server applies the real default.
+const REVIEW_TOKEN_CEILING_DEFAULT = 1_500_000
+
+// ReviewTokenCeilingCard sets the input tokens one mission may spend on
+// review turns before it parks on budget (D-097). 0 disables the ceiling.
+function ReviewTokenCeilingCard({
+  values,
+  onError,
+  onSaved,
+}: {
+  values: Record<string, string>
+  onError: (msg: string) => void
+  onSaved: () => void
+}) {
+  const [tokens, setTokens] = useState(values.mission_review_token_ceiling ?? '')
+  const [saved, setSaved] = useState(false)
+
+  const save = () => {
+    setSaved(false)
+    patchSettingValues({ mission_review_token_ceiling: tokens.trim() })
+      .then(() => {
+        setSaved(true)
+        onSaved()
+      })
+      .catch((err: unknown) => onError(errText(err)))
+  }
+
+  return (
+    <div className="rounded-xl border border-border p-4">
+      <div className="text-sm font-medium">Review token ceiling</div>
+      <div className="mt-3 flex flex-wrap items-end gap-3">
+        <div className="grid gap-1 text-xs text-muted-foreground">
+          <span>Input tokens per mission</span>
+          <Input
+            type="number"
+            min={0}
+            value={tokens}
+            onChange={(e) => setTokens(e.target.value)}
+            placeholder={String(REVIEW_TOKEN_CEILING_DEFAULT)}
+            className="h-10 w-40"
+            aria-label="Review token ceiling"
+          />
+        </div>
+        <Button onClick={save}>Save</Button>
+        {saved && <span className="text-xs text-muted-foreground">Saved.</span>}
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Input tokens a mission may spend on review turns, summed from the cost ledger before every
+        review round; at the ceiling the mission pauses on budget. Empty uses the default (1.5M),
+        0 disables the ceiling.
       </p>
     </div>
   )

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -192,6 +192,38 @@ describe('MissionDetail spend', () => {
     expect(await screen.findByText('120.0k→8.0k tok · 90.0k cached')).toBeTruthy()
   })
 
+  it('shows review input tokens against the ceiling', async () => {
+    vi.mocked(missionUsage).mockResolvedValue({
+      mission_id: 'm1',
+      cost_by_currency: { USD: 0.5 },
+      input_tokens: 120_000,
+      output_tokens: 8_000,
+      review_input_tokens: 40_000,
+      review_token_ceiling: 1_500_000,
+      requests: 7,
+      unpriced_requests: 0,
+      models: [],
+    })
+    renderPage()
+    expect(await screen.findByText('review 40.0k / 1.5M tok')).toBeTruthy()
+  })
+
+  it('shows review input tokens alone when the ceiling is disabled', async () => {
+    vi.mocked(missionUsage).mockResolvedValue({
+      mission_id: 'm1',
+      cost_by_currency: { USD: 0.5 },
+      input_tokens: 120_000,
+      output_tokens: 8_000,
+      review_input_tokens: 40_000,
+      review_token_ceiling: 0,
+      requests: 7,
+      unpriced_requests: 0,
+      models: [],
+    })
+    renderPage()
+    expect(await screen.findByText('review 40.0k tok')).toBeTruthy()
+  })
+
   it('uses the converted figure for budget percent when spend is in another currency', async () => {
     vi.mocked(getMission).mockResolvedValue({ ...baseMission, budget_amount: 2, budget_currency: 'BDT' })
     vi.mocked(missionUsage).mockResolvedValue({

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -900,6 +900,19 @@ export function MissionDetail() {
               {usage.cache_read_tokens ? ` · ${compact(usage.cache_read_tokens)} cached` : ''}
             </Badge>
           )}
+          {usage && usage.review_input_tokens ? (
+            <Badge
+              variant="secondary"
+              title={
+                usage.review_token_ceiling
+                  ? 'Input tokens spent on review turns against the per-mission review token ceiling'
+                  : 'Input tokens spent on review turns (no ceiling set)'
+              }
+            >
+              review {compact(usage.review_input_tokens)}
+              {usage.review_token_ceiling ? ` / ${compact(usage.review_token_ceiling)}` : ''} tok
+            </Badge>
+          ) : null}
           <Badge variant="secondary" title="Time spent actively processing">
             proc {formatDuration(processingMs)}
           </Badge>


### PR DESCRIPTION
## Summary

Slice 6 of the prove loop redesign v2 (#510), marker D-097.

**Review packet byte budget from the model window**
- `reviewByteBudget(window)`: catalog `max_input_tokens` of the model the review route resolves to (fallback 128k when unknown) x 3.5 bytes per token minus a fixed 128 KB margin for the system prompt, tool definitions and the reviewer's tool loop.
- `fitReviewPacket` shrinks the rendered packet to the budget before the first send: the diff first (file boundary cut with the existing markers, never below the 64 KB floor), then artifact and finding-file contents, then the diff again. Criteria, findings and every other section are never touched. A `mission.review_prompt_shrunk` event (`action: byte_budget`) records the window, budget, rendered size and what was cut.
- The existing `reviewWithShrink` context_length path stays as the second line and still parks with `review_prompt_too_large`.
- Brain learns the window through the gateway: `GatewayReviewWindow` composes the existing `gwclient.ModelWindows` (`GET /v1/providers`) and `ResolveRoute`; a D-078 `provider/model` pin resolves by its model id, otherwise the route's first usable chain entry. No per-model limits in brain code, no new gateway endpoint needed.

**Reviewer tool calls**
- `loop.Request.MaxToolCalls` (D-097): past the cap a call is not executed and returns a short error result telling the model to conclude; end-turn (sentinel) calls never count. `RunReview` sets it to 2; the #513 step ceiling 4 and 4 KB result cap stay.

**Per-mission review token ceiling**
- New setting `mission_review_token_ceiling` (default 1500000, 0 disables, negative rejected). Before every review round the driver sums the mission's reviewer-turn input tokens from `cost_ledger` and parks with `PauseBudget` and detail `review_tokens` (new `InputReviewBudget`) instead of calling the model.
- No schema change: reviewer turns already write `agent = 'mission-reviewer'` on their ledger rows through the existing turn metadata path (`loop.Request.Agent` -> `ledger.Entry.Agent`), so `Store.ReviewInputTokens` filters on that. `scripts/pending-alters.md` is unchanged.
- The gateway's mission usage aggregate gains `review_input_tokens`; brain's usage decorator adds `review_token_ceiling` from the setting. The settings page shows the ceiling card next to the harness run budget; the mission cost card shows `review X / Y tok` (or `review X tok` when disabled).

## Test plan

- [x] `make build test vet lint` equivalents in Docker: build clean, `go test -race ./...` green, `go vet ./...` clean, `golangci-lint run` 0 issues
- [x] `go vet -tags integration ./...` clean
- [x] `go test -race -count=1 -tags integration -p 1 ./internal/...` against a throwaway `pgvector/pgvector:0.8.4-pg18-trixie` container: all green, including the new `TestReviewInputTokensSumsReviewerRowsOnly`, the extended `TestAggregateMissionUsage` and the settings parse cases
- [x] Web `npm run build`, `npm run lint` (0 errors, pre-existing warnings), `npm test`: 1054 passed; the one failure is the known order-dependent `AgentRoutePicker` flake on main
- [x] New table tests: `TestReviewByteBudget` (known window, unknown fallback, margin), `TestFitReviewPacketShrinkOrder` (diff first, artifacts next, diff below the floor last, criteria and findings untouched, caller map not mutated), `TestAgentRequestMaxToolCallsRefusesPastCap` (cap of 2 vs unbounded, sentinel still runs), `TestDriverReviewTokenCeiling` (below, at, above, disabled, unwired), `TestGatewayReviewWindow`, `TestStep` `review_budget` case, `TestWithReviewTokenCeiling`, MissionDetail cost card cases, new `FeaturesTab.test.tsx`
- [ ] `make canary` was NOT run: this branch was built in an isolated worktree without the compose stack. Please run it before merge.

Closes #527
Part of #510

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790972834&installation_model_id=431401&pr_number=528&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F528&signature=940cfdf0bbf53d1ce587bbde6527cbff38480823a8395adb52b077a95ea974d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->