### PR TITLE
fix(missions): per-unit review files and re-review closes wrong findings

### DIFF
--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -1273,7 +1273,7 @@ func (d *Driver) toStepState(ctx context.Context, m Mission) StepState {
 		Units: m.Plan.Units, ReplanUsed: m.ReplanUsed,
 		AutoApprovePlan: m.AutoApprovePlan, Flow: m.Flow,
 		ReviewFindings: m.ReviewFindings, ReworkRounds: m.ReworkRounds,
-		LastReviewCommit: m.Plan.LastReviewCommit,
+		LastReviewCommit: m.Plan.LastReviewCommit, LastReviewAt: m.Plan.LastReviewAt,
 	}
 }
 
@@ -1769,9 +1769,10 @@ func (d *Driver) reviewWithShrink(ctx context.Context, m Mission, packet ReviewP
 
 // fullReviewPacket builds the packet for a round over the whole change
 // set (D-095): the reviewed units' criteria in place of the goal
-// (legacy plans without criteria keep the goal), the whole-change stat
-// and the diff restricted to the units' scope. The returned files are
-// every path the change touches, for the evidence gate.
+// (legacy plans without criteria keep the goal), the whole-change stat,
+// the diff restricted to the units' scope and, per unit, the changed
+// files inside its own scope (D-098). The returned files are every path
+// the change touches, for the evidence gate.
 func (d *Driver) fullReviewPacket(ctx context.Context, m Mission, units []PlanUnit) (ReviewPacket, []string, error) {
 	var changedFiles []string
 	packet := ReviewPacket{
@@ -1793,6 +1794,10 @@ func (d *Driver) fullReviewPacket(ctx context.Context, m Mission, units []PlanUn
 		if changedFiles, err = ChangedFiles(ctx, wt, m.BaseCommit); err != nil {
 			return ReviewPacket{}, nil, err
 		}
+		packet.UnitFiles = make([][]string, len(units))
+		for i, u := range units {
+			packet.UnitFiles[i] = insideScope(changedFiles, u.Scope)
+		}
 	}
 	if artifacts := reviewArtifacts(units, packet.Diff != ""); len(artifacts) > 0 {
 		packet.Artifacts = ReadArtifacts(m.WorkRoot(), artifacts)
@@ -1804,9 +1809,10 @@ func (d *Driver) fullReviewPacket(ctx context.Context, m Mission, units []PlanUn
 // findings, the diff since the last review commit restricted to the
 // finding files and the affected units' scope, the finding files'
 // contents, the affected units' harness state (criteria dropped, the
-// findings are the question), and the files changed outside every
-// unit's scope. The returned files are the delta's paths plus the
-// finding files, for the evidence gate.
+// findings are the question), the files changed outside every unit's
+// scope, and the progress notes written since the last round (D-098:
+// the rework turns' own account). The returned files are the delta's
+// paths plus the finding files, for the evidence gate.
 func (d *Driver) findingsReviewPacket(ctx context.Context, m Mission, open []Finding) (ReviewPacket, []string, error) {
 	files := findingFiles(open)
 	var affected []PlanUnit
@@ -1820,7 +1826,10 @@ func (d *Driver) findingsReviewPacket(ctx context.Context, m Mission, open []Fin
 		u.Criteria = nil
 		affected = append(affected, u)
 	}
-	packet := ReviewPacket{FindingsOnly: true, Units: affected, OpenFindings: open}
+	packet := ReviewPacket{
+		FindingsOnly: true, Units: affected, OpenFindings: open,
+		Progress: progressSince(m.Progress, m.Plan.LastReviewAt),
+	}
 	wt := m.WorktreePath()
 	paths := append(append([]string{}, files...), reviewScope(affected)...)
 	var err error
@@ -1913,7 +1922,9 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 	}
 	// The reviewer's own worktree side effects (it may run tests) are
 	// rolled back unconditionally after every review round. The HEAD
-	// left behind anchors the next round's findings-only diff (D-096).
+	// left behind anchors the next round's findings-only diff (D-096);
+	// the round's time anchors that packet's progress notes (D-098).
+	reviewAt := time.Now().UTC()
 	reviewCommit := ""
 	if wt := m.WorktreePath(); wt != "" {
 		if err := d.workspace.Rollback(ctx, wt, m.Kind); err != nil {
@@ -1959,7 +1970,7 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 			}
 			return StepInput{
 				Input: InputReviewRework, Findings: findings, Unit: failing[0].Unit, Reason: reviewReason(findings),
-				Verified: verified, ReviewCommit: reviewCommit, Provider: verdict.Provider, Model: verdict.Model,
+				Verified: verified, ReviewCommit: reviewCommit, ReviewAt: reviewAt, Provider: verdict.Provider, Model: verdict.Model,
 			}, nil
 		}
 		return StepInput{Input: InputReviewApprove, Verified: verified, Provider: verdict.Provider, Model: verdict.Model}, nil
@@ -1967,7 +1978,7 @@ func (d *Driver) runReview(ctx context.Context, m Mission) (StepInput, error) {
 	return StepInput{
 		Input: InputReviewRework, Findings: verdict.Findings, Resolved: verdict.Resolved, Unit: unitIdx,
 		Reason:       truncate(reviewReason(verdict.Findings), 500),
-		ReviewCommit: reviewCommit, Provider: verdict.Provider, Model: verdict.Model,
+		ReviewCommit: reviewCommit, ReviewAt: reviewAt, Provider: verdict.Provider, Model: verdict.Model,
 	}, nil
 }
 

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -128,6 +129,9 @@ func (f *fakeStore) ApplyTransition(ctx context.Context, id string, t Transition
 	if t.Next.LastReviewCommit != "" {
 		m.Plan.LastReviewCommit = t.Next.LastReviewCommit
 	}
+	if !t.Next.LastReviewAt.IsZero() {
+		m.Plan.LastReviewAt = t.Next.LastReviewAt
+	}
 	f.missions[id] = m
 	for _, ev := range t.Events {
 		f.seq[id]++
@@ -235,7 +239,7 @@ func (f *fakeStore) AppendProgress(ctx context.Context, id, note string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	m := f.missions[id]
-	m.Progress = append(m.Progress, ProgressNote{Note: note})
+	m.Progress = append(m.Progress, ProgressNote{At: time.Now().UTC(), Note: note})
 	f.missions[id] = m
 	f.seq[id]++
 	f.events[id] = append(f.events[id], Event{MissionID: id, Seq: f.seq[id], Kind: "mission.progress"})
@@ -3579,9 +3583,10 @@ func countEvents(store *fakeStore, id, kind string) int {
 // finding's file and strays into a file outside every unit's scope; the
 // second round's packet is findings-only (the open finding, the delta
 // diff, the named file's contents, the scope-creep list, the affected
-// unit's harness state, and no goal, plan, stat, listing, artifacts,
-// progress or worker report) at a fraction of the first round's bytes;
-// the reviewer resolving F1 with no new finding counts as approval.
+// unit's harness state, the rework turn's progress note alone (D-098),
+// and no goal, plan, stat, listing, artifacts or worker report) at a
+// fraction of the first round's bytes; the reviewer resolving F1 with
+// no new finding counts as approval.
 func TestDriverFindingsOnlyReReview(t *testing.T) {
 	root, base := codingWorktree(t)
 	wt := filepath.Join(root, "wt")
@@ -3601,7 +3606,7 @@ func TestDriverFindingsOnlyReReview(t *testing.T) {
 		}}},
 	})
 	runner := &scriptedRunner{
-		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "validated"}},
+		workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "validated", Handoff: "F1 does not match the repository: main.go already validates"}},
 		reviewVerdicts: []ReviewVerdict{
 			{Findings: []Finding{{Title: "missing validation", File: "src/main.go", Detail: "no input check", Evidence: "+func main() {}"}}},
 			{Resolved: []string{"F1"}},
@@ -3616,12 +3621,15 @@ func TestDriverFindingsOnlyReReview(t *testing.T) {
 	}
 	m, _ := store.Get(context.Background(), "m1")
 	head := strings.TrimSpace(gitRun(t, wt, "rev-parse", "HEAD"))
-	if m.Phase != PhaseGenerate || m.Plan.LastReviewCommit != head {
-		t.Fatalf("after round 1: phase %q last_review_commit %q, want generate with HEAD %s", m.Phase, m.Plan.LastReviewCommit, head)
+	if m.Phase != PhaseGenerate || m.Plan.LastReviewCommit != head || m.Plan.LastReviewAt.IsZero() {
+		t.Fatalf("after round 1: phase %q last_review_commit %q last_review_at %v, want generate with HEAD %s and a round time", m.Phase, m.Plan.LastReviewCommit, m.Plan.LastReviewAt, head)
 	}
 	full := runner.reviewCalls[0]
 	if full.FindingsOnly || full.Diff == "" || full.DiffStat == "" {
 		t.Fatalf("round 1 packet = %+v, want the full packet", full)
+	}
+	if len(full.UnitFiles) != 1 || !reflect.DeepEqual(full.UnitFiles[0], []string{"src/main.go", "src/other.go"}) {
+		t.Fatalf("round 1 unit files = %v, want the changed files inside the unit's scope", full.UnitFiles)
 	}
 
 	// The rework turn: the worker fixes main.go and also edits docs/.
@@ -3643,8 +3651,12 @@ func TestDriverFindingsOnlyReReview(t *testing.T) {
 	}
 	delta := runner.reviewCalls[1]
 	if !delta.FindingsOnly || delta.Goal != "" || len(delta.Plan.Units) != 0 || delta.DiffStat != "" ||
-		delta.Listing != "" || delta.Evidence != "" || len(delta.Progress) != 0 || len(delta.Artifacts) != 0 {
+		delta.Listing != "" || delta.Evidence != "" || len(delta.Artifacts) != 0 || len(delta.UnitFiles) != 0 {
 		t.Fatalf("round 2 packet carries full-round material: %+v", delta)
+	}
+	// D-098: only the rework turn's note, not the pre-review operator note.
+	if len(delta.Progress) != 1 || !strings.Contains(delta.Progress[0].Note, "F1 does not match the repository") {
+		t.Fatalf("round 2 progress = %+v, want the rework turn's note alone", delta.Progress)
 	}
 	if len(delta.OpenFindings) != 1 || delta.OpenFindings[0].ID != "F1" {
 		t.Fatalf("round 2 open findings = %+v, want F1", delta.OpenFindings)
@@ -3722,8 +3734,8 @@ func TestDriverTwoUnitPlanReviewsOnce(t *testing.T) {
 	store.put("m1", Mission{
 		ID: "m1", Kind: "coding", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8, Workspace: root, BaseCommit: base,
 		Plan: Plan{Units: []PlanUnit{
-			{Title: "write a", Artifacts: []string{"a.md"}, Criteria: []string{"a.md exists", "a.md has content"}},
-			{Title: "write b", Artifacts: []string{"b.md"}, Criteria: []string{"b.md exists", "b.md has content"}},
+			{Title: "write a", Artifacts: []string{"a.md"}, Scope: []string{"a.md"}, Criteria: []string{"a.md exists", "no other root files modified"}},
+			{Title: "write b", Artifacts: []string{"b.md"}, Scope: []string{"b.md"}, Criteria: []string{"b.md exists", "no other root files modified"}},
 		}},
 	})
 	runner := &scriptedRunner{
@@ -3761,6 +3773,11 @@ func TestDriverTwoUnitPlanReviewsOnce(t *testing.T) {
 	}
 	if len(runner.reviewCalls) != 1 || len(runner.reviewCalls[0].Units) != 2 {
 		t.Fatalf("review calls = %d (units %d), want one round over both units", len(runner.reviewCalls), len(runner.reviewCalls[0].Units))
+	}
+	// D-098: each unit's block names only the changed files inside its
+	// own scope (defaulted to the root artifact itself at plan parse).
+	if got := runner.reviewCalls[0].UnitFiles; !reflect.DeepEqual(got, [][]string{{"a.md"}, {"b.md"}}) {
+		t.Fatalf("unit files = %v, want [[a.md] [b.md]]", got)
 	}
 	if n := countEvents(store, "m1", "mission.review_verdict"); n != 1 {
 		t.Fatalf("review_verdict events = %d, want exactly 1", n)

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -518,6 +518,10 @@ type Plan struct {
 	// D-096), which means the next round gets the full packet. Written
 	// only through Store.ApplyTransition.
 	LastReviewCommit string `json:"last_review_commit,omitempty"`
+	// LastReviewAt (D-098, issue #529) is when that round closed: the
+	// findings-only packet renders only progress notes written after
+	// it, the rework turns' notes. Zero on plans written before D-098.
+	LastReviewAt time.Time `json:"last_review_at,omitzero"`
 	// Provider/Model (issue #507) are who served the plan turn; set by
 	// PlanSession after parsing, never persisted with the stored plan.
 	Provider string `json:"-"`

--- a/internal/brain/missions/review.go
+++ b/internal/brain/missions/review.go
@@ -127,6 +127,14 @@ type ReviewPacket struct {
 	// diff restricted to the reviewed units' scope paths.
 	DiffStat string
 	Diff     string
+	// UnitFiles (D-098, issue #529) lists, per entry of Units, the
+	// changed files inside that unit's scope: the files the reviewer
+	// judges an exclusivity criterion ("no other files modified")
+	// against, since DiffStat spans every unit. The harness records no
+	// per-unit commit, so scope is the attribution. nil without a
+	// worktree; an empty entry means the change touched nothing in
+	// the unit's scope.
+	UnitFiles [][]string
 	// Artifacts maps workspace-relative path -> file contents, read by
 	// the harness (ReadArtifacts), capped at reviewArtifactFileCap each
 	// and reviewArtifactsCap total.
@@ -139,7 +147,9 @@ type ReviewPacket struct {
 	// Progress is the mission's progress log, rendered so an operator
 	// steering note posted mid-mission reaches the reviewer too: a
 	// rework-triggering note ("skip the CSS polish") must not be invisible
-	// to the round deciding whether the unit passes.
+	// to the round deciding whether the unit passes. A findings-only
+	// round carries only the notes written since the last review round
+	// (D-098): the worker's own account of the rework turns.
 	Progress []ProgressNote
 	// OpenFindings are the prior rounds' still-open findings (D-092):
 	// the reviewer marks the ids it considers closed in resolved. This
@@ -148,8 +158,9 @@ type ReviewPacket struct {
 	// FindingsOnly marks a re-review round (D-096, issue #524): the
 	// packet carries the open findings, Diff since the last review commit
 	// (restricted to the finding files and the affected units' scope),
-	// Files, ScopeCreep and the affected units' harness state, and none
-	// of Goal, Plan, DiffStat, Listing, Evidence or Progress.
+	// Files, ScopeCreep, the affected units' harness state and the
+	// Progress notes since that commit, and none of Goal, Plan,
+	// DiffStat, Listing or Evidence.
 	FindingsOnly bool
 	// Files maps each open finding's file to its contents, capped at
 	// reviewArtifactFileCap each; findings-only rounds.
@@ -183,17 +194,47 @@ func outsideScope(files, scope []string) []string {
 	}
 	var out []string
 	for _, file := range files {
-		got := normalizeFindingPath(file)
-		inScope := false
-		for _, s := range scope {
-			want := normalizeFindingPath(s)
-			if want == "" || got == want || strings.HasPrefix(got, want+"/") {
-				inScope = true
-				break
-			}
-		}
-		if !inScope {
+		if !inScope(file, scope) {
 			out = append(out, file)
+		}
+	}
+	return out
+}
+
+// insideScope returns the files under any of the scope paths, in
+// order; every file when scope is empty (the whole tree). Never nil.
+func insideScope(files, scope []string) []string {
+	out := []string{}
+	for _, file := range files {
+		if len(scope) == 0 || inScope(file, scope) {
+			out = append(out, file)
+		}
+	}
+	return out
+}
+
+// inScope reports whether file equals a scope entry or sits beneath it.
+func inScope(file string, scope []string) bool {
+	got := normalizeFindingPath(file)
+	for _, s := range scope {
+		want := normalizeFindingPath(s)
+		if want == "" || got == want || strings.HasPrefix(got, want+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// progressSince returns the notes written after since, in order; every
+// note when since is zero (a plan written before D-098).
+func progressSince(notes []ProgressNote, since time.Time) []ProgressNote {
+	if since.IsZero() {
+		return notes
+	}
+	var out []ProgressNote
+	for _, n := range notes {
+		if n.At.After(since) {
+			out = append(out, n)
 		}
 	}
 	return out

--- a/internal/brain/missions/review_test.go
+++ b/internal/brain/missions/review_test.go
@@ -8,7 +8,51 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
+
+// TestInsideScope covers the D-098 per-unit attribution: files equal
+// to or beneath a scope entry, every file for an empty scope, and a
+// non-nil empty result when nothing matches.
+func TestInsideScope(t *testing.T) {
+	files := []string{"CHANGELOG.md", "CONTRIBUTING.md", "src/main.go", "src/sub/x.go", "srcfoo/y.go"}
+	cases := []struct {
+		name  string
+		scope []string
+		want  []string
+	}{
+		{"root file", []string{"CHANGELOG.md"}, []string{"CHANGELOG.md"}},
+		{"directory", []string{"src"}, []string{"src/main.go", "src/sub/x.go"}},
+		{"dot-slash prefix", []string{"./src/"}, []string{"src/main.go", "src/sub/x.go"}},
+		{"empty scope is the whole tree", nil, files},
+		{"nothing matches", []string{"docs"}, []string{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := insideScope(files, tc.scope); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("insideScope = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProgressSince pins the findings-only progress filter: only notes
+// written after the anchor, every note for a zero anchor (plans written
+// before D-098).
+func TestProgressSince(t *testing.T) {
+	anchor := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
+	notes := []ProgressNote{
+		{At: anchor.Add(-time.Minute), Note: "before"},
+		{At: anchor, Note: "at"},
+		{At: anchor.Add(time.Minute), Note: "after"},
+	}
+	if got := progressSince(notes, anchor); len(got) != 1 || got[0].Note != "after" {
+		t.Fatalf("progressSince = %+v, want the note after the anchor only", got)
+	}
+	if got := progressSince(notes, time.Time{}); len(got) != 3 {
+		t.Fatalf("progressSince with a zero anchor = %+v, want every note", got)
+	}
+}
 
 func TestParseReviewVerdict(t *testing.T) {
 	v, err := parseReviewVerdict([]byte(`{"decision":"rework","findings":[{"title":"x","file":"y.go","detail":"z"}]}`))

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -1316,7 +1316,7 @@ func (r *nativeRunner) applyDiscoverReport(ctx context.Context, m Mission, repor
 // session (D-092): findings carry across rounds as mission state, so
 // no reviewer transcript is retained to anchor the next verdict.
 func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPacket) (ReviewVerdict, error) {
-	system := "You are reviewing units of a mission's work. Each unit's acceptance criteria, the harness's own check results, the diff and the actual artifact contents (read from disk by the harness, not reported by the worker) are all below; judge against THEM. Look for real reasons to reject before approving: a criterion the work does not satisfy, unsupported claims, missing substance. Do NOT reject for material you were not given (the harness supplies everything there is) and do not re-run checks the harness already reports as passed. Every blocking finding must name a file that appears in the diff or the artifacts and quote the line that shows the gap in evidence; a blocking finding without both is demoted to minor. Prior rounds' open findings are listed with ids: name each one the work has now closed in resolved, and report only NEW gaps as findings. End your turn with exactly one review_verdict tool call."
+	system := "You are reviewing units of a mission's work. Each unit's acceptance criteria, the harness's own check results, the diff and the actual artifact contents (read from disk by the harness, not reported by the worker) are all below; judge against THEM. Look for real reasons to reject before approving: a criterion the work does not satisfy, unsupported claims, missing substance. Do NOT reject for material you were not given (the harness supplies everything there is) and do not re-run checks the harness already reports as passed. Every blocking finding must name a file that appears in the diff or the artifacts and quote the line that shows the gap in evidence; a blocking finding without both is demoted to minor. The changed-files stat spans every unit of the plan: judge a criterion about files a unit must not touch (\"no other files modified\") against the files listed for that unit alone, never against another unit's files. Prior rounds' open findings are listed with ids: name each one the work has now closed in resolved, and report only NEW gaps as findings. End your turn with exactly one review_verdict tool call."
 	messages := []provider.Message{{Role: "user", Content: renderReviewContent(packet)}}
 
 	extra := append([]*tools.Tool{ReviewVerdictTool()}, r.missionTools(m)...)
@@ -1407,24 +1407,44 @@ func renderReviewContent(p ReviewPacket) string {
 	var b strings.Builder
 	if p.FindingsOnly {
 		// D-096: the whole change was reviewed in an earlier round; this
-		// round judges only whether the open findings are closed.
-		b.WriteString("Re-review of open findings only. An earlier round reviewed the whole change and the units below pass the harness checks; judge only whether each open finding is closed by the changes since that round, and name every closed id in resolved. Report a NEW finding only with evidence quoted from the diff or files below.\n")
+		// round judges only whether the open findings are closed. D-098:
+		// closed means the current file contents do not show the gap,
+		// whether or not the delta diff changed them, so a finding that
+		// described a state the files were never in can be resolved.
+		b.WriteString("Re-review of open findings only. An earlier round reviewed the whole change and the units below pass the harness checks; judge only whether each open finding still describes a real gap in the CURRENT contents of the files below. Mark a finding resolved when the current state does not show the described gap, whether or not the diff since the last review changed it (the finding may have been wrong when opened); name every closed id in resolved. Report a NEW finding only with evidence quoted from the diff or files below.\n")
 	}
 	if p.Goal != "" {
 		fmt.Fprintf(&b, "Mission goal: %s\n", NeutralizeSlot(p.Goal))
 	}
+	unitFiles := len(p.UnitFiles) == len(p.Units)
 	if len(p.Units) > 0 {
 		if p.FindingsOnly {
 			b.WriteString("\nAffected units (harness state):\n")
 		} else {
 			b.WriteString("Units under review (judge each against its acceptance criteria):\n")
+			if len(p.Units) > 1 {
+				// D-098: the stat below spans every unit; a criterion of
+				// the form "no other files modified" is judged against the
+				// unit's own files, listed in its block.
+				b.WriteString("The change set below spans all of these units. Judge a criterion about files a unit must not touch (\"no other files modified\") against the files listed for that unit alone; a file another unit changed is never a gap for this one.\n")
+			}
 		}
-		for _, u := range p.Units {
+		for i, u := range p.Units {
 			fmt.Fprintf(&b, "\n### %s [%s]\n", NeutralizeSlot(u.Title), unitStatus(u))
 			if len(u.Criteria) > 0 {
 				b.WriteString("Acceptance criteria:\n")
 				for _, c := range u.Criteria {
 					fmt.Fprintf(&b, "- %s\n", NeutralizeSlot(c))
+				}
+			}
+			if unitFiles {
+				switch {
+				case len(p.UnitFiles[i]) == 0:
+					b.WriteString("Files this unit changed: none\n")
+				case len(u.Scope) == 0:
+					fmt.Fprintf(&b, "Files this unit changed (no scope declared, so every changed file): %s\n", NeutralizeSlot(strings.Join(p.UnitFiles[i], ", ")))
+				default:
+					fmt.Fprintf(&b, "Files this unit changed (changed files inside its scope): %s\n", NeutralizeSlot(strings.Join(p.UnitFiles[i], ", ")))
 				}
 			}
 			if u.VerifyCheck != "" {
@@ -1498,7 +1518,11 @@ func renderReviewContent(p ReviewPacket) string {
 		}
 	}
 	if p.DiffStat != "" {
-		b.WriteString("\nChanged files (whole change):\n")
+		if len(p.Units) > 1 {
+			b.WriteString("\nChanged files (whole change, spanning every unit above; each unit's own files are listed in its block):\n")
+		} else {
+			b.WriteString("\nChanged files (whole change):\n")
+		}
 		b.WriteString(p.DiffStat)
 		b.WriteString("\n")
 	}
@@ -1516,7 +1540,11 @@ func renderReviewContent(p ReviewPacket) string {
 		if len(notes) > progressRenderCap {
 			notes = notes[len(notes)-progressRenderCap:]
 		}
-		b.WriteString("\nRecent progress (includes any operator steering notes):\n")
+		if p.FindingsOnly {
+			b.WriteString("\nWorker notes since the last review round (its own account of the rework; verify against the files above):\n")
+		} else {
+			b.WriteString("\nRecent progress (includes any operator steering notes):\n")
+		}
 		for _, n := range notes {
 			fmt.Fprintf(&b, "- %s\n", NeutralizeSlot(n.Note))
 		}

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -363,8 +363,8 @@ func TestRunReviewPacketListsOpenFindings(t *testing.T) {
 // TestRenderReviewContentFindingsOnly pins the D-096 re-review packet
 // shape: the open findings with detail and evidence, the finding files,
 // the scope-creep list, the delta diff and the affected units' harness
-// state render; goal, plan, whole-change stat, listing, progress and the
-// worker's report never do.
+// state render; goal, plan, whole-change stat, listing and the worker's
+// report never do.
 func TestRenderReviewContentFindingsOnly(t *testing.T) {
 	content := renderReviewContent(ReviewPacket{
 		FindingsOnly: true,
@@ -376,7 +376,7 @@ func TestRenderReviewContentFindingsOnly(t *testing.T) {
 		// Fields a findings-only packet never carries; set here to prove
 		// the renderer does not leak them.
 		Goal: "the goal", Plan: Plan{Units: []PlanUnit{{Title: "write code"}}}, DiffStat: "1 file changed",
-		Listing: "src/main.go (13 bytes)", Evidence: "worker says done", Progress: []ProgressNote{{Note: "steer"}},
+		Listing: "src/main.go (13 bytes)", Evidence: "worker says done",
 	})
 	for _, want := range []string{
 		"Re-review of open findings only.",
@@ -397,6 +397,82 @@ func TestRenderReviewContentFindingsOnly(t *testing.T) {
 	}
 	if strings.Contains(content, "acceptance criteria") {
 		t.Fatalf("findings-only content must not ask for criteria judgement:\n%s", content)
+	}
+}
+
+// TestRenderReviewContentFindingsOnlyEmptyDelta pins D-098 (issue #529):
+// a re-review whose delta diff is empty still carries the finding
+// files' current contents, the affected units' harness state and the
+// worker's rework note, and its instruction tells the reviewer to
+// resolve a finding the current state does not show, whether or not the
+// delta changed it.
+func TestRenderReviewContentFindingsOnlyEmptyDelta(t *testing.T) {
+	content := renderReviewContent(ReviewPacket{
+		FindingsOnly: true,
+		Units:        []PlanUnit{{Title: "add changelog", HarnessPassed: true, VerifyCheck: "verify_cmd"}},
+		OpenFindings: []Finding{{ID: "F1", Unit: 0, Title: "other root files modified", File: "CHANGELOG.md", Evidence: " CONTRIBUTING.md | 3 +++", Severity: SeverityBlocking, Status: FindingOpen}},
+		Files:        map[string]string{"CHANGELOG.md": "# Changelog\n"},
+		Progress:     []ProgressNote{{Note: "F1 does not match the repository: this unit's commit touched CHANGELOG.md only"}},
+	})
+	for _, want := range []string{
+		"Mark a finding resolved when the current state does not show the described gap, whether or not the diff since the last review changed it",
+		"### add changelog [harness-verified]",
+		"Harness verify_cmd check: passed",
+		"Files named by the findings (read from disk by the harness):\n\n--- CHANGELOG.md ---\n# Changelog",
+		"Worker notes since the last review round (its own account of the rework; verify against the files above):\n- F1 does not match the repository",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("empty-delta content missing %q:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, "Diff since the last review") {
+		t.Fatalf("empty delta must render no diff section:\n%s", content)
+	}
+}
+
+// TestRenderReviewContentMultiUnitFiles pins D-098's attribution in a
+// full round over several units: each unit block lists the changed
+// files inside its own scope, the whole-change stat is labelled as
+// spanning every unit, and the instruction says exclusivity criteria
+// are judged against the unit's own files. A single-unit round renders
+// the files line but neither the label nor the instruction.
+func TestRenderReviewContentMultiUnitFiles(t *testing.T) {
+	units := []PlanUnit{
+		{Title: "add changelog", Scope: []string{"CHANGELOG.md"}, Criteria: []string{"no other root files modified"}, HarnessPassed: true},
+		{Title: "add contributing", Scope: []string{"CONTRIBUTING.md"}, Criteria: []string{"no other root files modified"}, HarnessPassed: true},
+		{Title: "legacy unit", HarnessPassed: true},
+		{Title: "untouched unit", Scope: []string{"docs"}, HarnessPassed: true},
+	}
+	stat := " CHANGELOG.md | 3 +++\n CONTRIBUTING.md | 2 ++\n 2 files changed"
+	got := renderReviewContent(ReviewPacket{
+		Units:     units,
+		UnitFiles: [][]string{{"CHANGELOG.md"}, {"CONTRIBUTING.md"}, {"CHANGELOG.md", "CONTRIBUTING.md"}, {}},
+		DiffStat:  stat,
+	})
+	for _, want := range []string{
+		"The change set below spans all of these units. Judge a criterion about files a unit must not touch (\"no other files modified\") against the files listed for that unit alone",
+		"### add changelog [harness-verified]\nAcceptance criteria:\n- no other root files modified\nFiles this unit changed (changed files inside its scope): CHANGELOG.md\n",
+		"### add contributing [harness-verified]\nAcceptance criteria:\n- no other root files modified\nFiles this unit changed (changed files inside its scope): CONTRIBUTING.md\n",
+		"### legacy unit [harness-verified]\nFiles this unit changed (no scope declared, so every changed file): CHANGELOG.md, CONTRIBUTING.md\n",
+		"### untouched unit [harness-verified]\nFiles this unit changed: none\n",
+		"Changed files (whole change, spanning every unit above; each unit's own files are listed in its block):\n" + stat,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("multi-unit content missing %q:\n%s", want, got)
+		}
+	}
+
+	single := renderReviewContent(ReviewPacket{Units: units[:1], UnitFiles: [][]string{{"CHANGELOG.md"}}, DiffStat: stat})
+	if !strings.Contains(single, "Files this unit changed (changed files inside its scope): CHANGELOG.md") || !strings.Contains(single, "Changed files (whole change):\n") {
+		t.Fatalf("single-unit content missing the files line or plain stat heading:\n%s", single)
+	}
+	if strings.Contains(single, "spans all of these units") || strings.Contains(single, "spanning every unit") {
+		t.Fatalf("single-unit content carries the multi-unit instruction:\n%s", single)
+	}
+
+	// No worktree: no UnitFiles, no files line.
+	if none := renderReviewContent(ReviewPacket{Units: units[:2]}); strings.Contains(none, "Files this unit changed") {
+		t.Fatalf("packet without unit files renders a files line:\n%s", none)
 	}
 }
 

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 	"unicode"
 )
 
@@ -264,6 +265,9 @@ type StepState struct {
 	// LastReviewCommit is the worktree HEAD recorded by the last rework
 	// (D-096): the anchor for the next round's findings-only diff.
 	LastReviewCommit string
+	// LastReviewAt is when the last rework round closed (D-098): the
+	// findings-only packet renders only progress notes written after it.
+	LastReviewAt time.Time
 }
 
 // neverVisitsPlan reports whether s's mission can never be in
@@ -296,6 +300,9 @@ type StepInput struct {
 	// produced this input (D-096), set on InputReviewRework; empty when
 	// there is no worktree, leaving LastReviewCommit as it was.
 	ReviewCommit string
+	// ReviewAt is when the review round that produced this input closed
+	// (D-098), set on InputReviewRework; zero leaves LastReviewAt as it was.
+	ReviewAt time.Time
 	// TouchedFiles is every workspace-relative path the worker turn
 	// that just ended changed (git diff --name-only against the
 	// pre-turn HEAD), set on InputPhaseComplete from generate. nil means
@@ -851,12 +858,17 @@ func reviewSkippedOrProvePassTransition(s StepState) Transition {
 //     a failure: the work must survive for the operator.
 //
 // The round's worktree HEAD becomes LastReviewCommit (D-096): the next
-// round reviews only the open findings against the diff since it.
+// round reviews only the open findings against the diff since it; the
+// round's time becomes LastReviewAt (D-098) so that packet carries only
+// the rework turns' progress notes.
 func stepReviewRework(s StepState, in StepInput, cfg Config) Transition {
 	s.ReworkRounds++
 	s.ReviewFindings = mergeFindings(s.ReviewFindings, in.Findings, in.Resolved, in.Unit, s.ReworkRounds)
 	if in.ReviewCommit != "" {
 		s.LastReviewCommit = in.ReviewCommit
+	}
+	if !in.ReviewAt.IsZero() {
+		s.LastReviewAt = in.ReviewAt
 	}
 	open := OpenFindings(s.ReviewFindings)
 	s.Phase = PhaseGenerate

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestStep(t *testing.T) {
@@ -1126,25 +1127,28 @@ func TestStepPhaseCompleteRoutesOnPendingUnits(t *testing.T) {
 }
 
 // TestStepReworkRecordsReviewCommit pins D-096's anchor: a rework
-// records the round's worktree HEAD as LastReviewCommit, an input
-// without one leaves the previous anchor alone, and approval keeps it
-// (harmless: findings-only needs an open finding too).
+// records the round's worktree HEAD as LastReviewCommit and its time as
+// LastReviewAt (D-098), an input without them leaves the previous
+// anchors alone, and approval keeps them (harmless: findings-only needs
+// an open finding too).
 func TestStepReworkRecordsReviewCommit(t *testing.T) {
+	t1 := time.Date(2026, 9, 2, 10, 0, 0, 0, time.UTC)
+	t2 := t1.Add(time.Hour)
 	first := Step(
 		StepState{Phase: PhaseProve, Status: StatusWorking, MaxIterations: 8},
-		StepInput{Input: InputReviewRework, ReviewCommit: "abc123", Findings: []Finding{{Title: "gap", File: "x.go"}}},
+		StepInput{Input: InputReviewRework, ReviewCommit: "abc123", ReviewAt: t1, Findings: []Finding{{Title: "gap", File: "x.go"}}},
 		DefaultConfig,
 	)
-	if first.Next.LastReviewCommit != "abc123" {
-		t.Fatalf("LastReviewCommit = %q, want abc123", first.Next.LastReviewCommit)
+	if first.Next.LastReviewCommit != "abc123" || !first.Next.LastReviewAt.Equal(t1) {
+		t.Fatalf("LastReviewCommit = %q LastReviewAt = %v, want abc123 at %v", first.Next.LastReviewCommit, first.Next.LastReviewAt, t1)
 	}
 	second := Step(withStatus(first.Next, StatusWorking), StepInput{Input: InputReviewRework}, DefaultConfig)
-	if second.Next.LastReviewCommit != "abc123" {
-		t.Fatalf("LastReviewCommit = %q after a rework without a commit, want abc123 kept", second.Next.LastReviewCommit)
+	if second.Next.LastReviewCommit != "abc123" || !second.Next.LastReviewAt.Equal(t1) {
+		t.Fatalf("anchors = %q %v after a rework without them, want abc123 at %v kept", second.Next.LastReviewCommit, second.Next.LastReviewAt, t1)
 	}
-	third := Step(withStatus(second.Next, StatusWorking), StepInput{Input: InputReviewRework, ReviewCommit: "def456"}, DefaultConfig)
-	if third.Next.LastReviewCommit != "def456" {
-		t.Fatalf("LastReviewCommit = %q, want def456", third.Next.LastReviewCommit)
+	third := Step(withStatus(second.Next, StatusWorking), StepInput{Input: InputReviewRework, ReviewCommit: "def456", ReviewAt: t2}, DefaultConfig)
+	if third.Next.LastReviewCommit != "def456" || !third.Next.LastReviewAt.Equal(t2) {
+		t.Fatalf("anchors = %q %v, want def456 at %v", third.Next.LastReviewCommit, third.Next.LastReviewAt, t2)
 	}
 }
 

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -1100,12 +1100,17 @@ func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) er
 	// Per-unit verify state (D-094) lives inside the plan jsonb; only the
 	// units key is rewritten, and only when the plan has units, so a
 	// planless mission's '{}' stays untouched. last_review_commit (D-096)
-	// sits next to it, written only when a rework recorded one.
+	// and last_review_at (D-098) sit next to it, written only when a
+	// rework recorded them.
 	var unitsJSON []byte
 	if len(t.Next.Units) > 0 {
 		if unitsJSON, err = json.Marshal(t.Next.Units); err != nil {
 			return fmt.Errorf("missions apply transition marshal units: %w", err)
 		}
+	}
+	lastReviewAt := ""
+	if !t.Next.LastReviewAt.IsZero() {
+		lastReviewAt = t.Next.LastReviewAt.UTC().Format(time.RFC3339Nano)
 	}
 	if _, err := tx.Exec(ctx, `UPDATE missions SET
 			phase = $2, status = $3, pause_reason = $4, pause_message = '', iteration = $5, max_iterations = $6,
@@ -1114,11 +1119,12 @@ func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) er
 			review_findings = $12, rework_rounds = $13,
 			plan = (CASE WHEN $14::jsonb IS NULL THEN plan ELSE jsonb_set(plan, '{units}', $14::jsonb) END)
 				|| CASE WHEN $15::text = '' THEN '{}'::jsonb ELSE jsonb_build_object('last_review_commit', $15::text) END
+				|| CASE WHEN $16::text = '' THEN '{}'::jsonb ELSE jsonb_build_object('last_review_at', $16::text) END
 		WHERE id = $1`,
 		id, string(t.Next.Phase), string(t.Next.Status), string(t.Next.PauseReason),
 		t.Next.Iteration, t.Next.MaxIterations, t.Next.ConsecutiveFailures,
 		t.Next.LastGapFingerprint, t.Next.StallCount, clearPending, t.Next.ReplanUsed,
-		findingsJSON, t.Next.ReworkRounds, unitsJSON, t.Next.LastReviewCommit,
+		findingsJSON, t.Next.ReworkRounds, unitsJSON, t.Next.LastReviewCommit, lastReviewAt,
 	); err != nil {
 		return fmt.Errorf("missions apply transition update: %w", err)
 	}

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -848,8 +848,9 @@ func TestApplyTransitionPersistsLastReviewCommit(t *testing.T) {
 		t.Fatalf("SetPlan: %v", err)
 	}
 	units := []PlanUnit{{Title: "write a.md", Artifacts: []string{"a.md"}, HarnessPassed: true}}
+	reviewAt := time.Date(2026, 9, 2, 10, 30, 0, 0, time.UTC)
 	if err := s.ApplyTransition(ctx, id, Transition{
-		Next: StepState{Phase: PhaseGenerate, Status: StatusIdle, MaxIterations: 3, Units: units, LastReviewCommit: "abc123", ReworkRounds: 1},
+		Next: StepState{Phase: PhaseGenerate, Status: StatusIdle, MaxIterations: 3, Units: units, LastReviewCommit: "abc123", LastReviewAt: reviewAt, ReworkRounds: 1},
 	}); err != nil {
 		t.Fatalf("ApplyTransition with review commit: %v", err)
 	}
@@ -859,6 +860,9 @@ func TestApplyTransitionPersistsLastReviewCommit(t *testing.T) {
 	}
 	if m.Plan.LastReviewCommit != "abc123" || len(m.Plan.Units) != 1 || !m.Plan.Units[0].HarnessPassed || len(m.Plan.Assumptions) != 1 {
 		t.Fatalf("plan after transition = %+v, want last_review_commit abc123 with units and assumptions intact", m.Plan)
+	}
+	if !m.Plan.LastReviewAt.Equal(reviewAt) {
+		t.Fatalf("last_review_at = %v, want %v", m.Plan.LastReviewAt, reviewAt)
 	}
 
 	if err := s.ApplyTransition(ctx, id, Transition{
@@ -870,8 +874,8 @@ func TestApplyTransitionPersistsLastReviewCommit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if m.Plan.LastReviewCommit != "abc123" || m.Phase != PhaseProve {
-		t.Fatalf("plan after second transition = %+v phase %q, want last_review_commit kept", m.Plan, m.Phase)
+	if m.Plan.LastReviewCommit != "abc123" || !m.Plan.LastReviewAt.Equal(reviewAt) || m.Phase != PhaseProve {
+		t.Fatalf("plan after second transition = %+v phase %q, want last_review_commit and last_review_at kept", m.Plan, m.Phase)
 	}
 }
 


### PR DESCRIPTION
## Summary

Observed on `make canary-two-unit` (mission `536555c2`): the single full review round sent one whole-change stat with nothing saying it spanned both units, the reviewer opened a "no other root files modified" finding per unit citing the other unit's file, the worker rightly changed nothing, and the findings-only rounds (empty delta, instruction to resolve only what the delta closed) returned `resolved: []` until the mission parked with `no_progress`.

Design marker D-098.

**Full round over several units**

- `ReviewPacket.UnitFiles` (driver `fullReviewPacket`): per reviewed unit, the changed files inside that unit's scope. The harness records no per-unit commit sha on `PlanUnit` (the worker commit carries only the unit title in its subject), so scope intersected with `git diff --name-only` is the attribution; `defaultScope` already narrows a root artifact to the file itself, which is exactly the two-unit case. A unit without a scope (legacy plan) lists every changed file, labelled as such.
- Each unit block renders `Files this unit changed (changed files inside its scope): ...`; the whole-change stat is kept and, with more than one unit, labelled as spanning every unit.
- The reviewer system prompt and the multi-unit packet header say a criterion of the form "no other files modified" is judged against the unit's own files, never another unit's.

**Findings-only re-review with an empty delta**

- The instruction now tells the reviewer to mark a finding resolved when the current contents of the finding files do not show the described gap, whether or not the diff since the last review changed them. `Files` (8 KB cap each) and the affected units' harness state were already carried and stay.
- The packet carries the worker's progress notes written since the last review round (previously dropped in findings-only rounds), rendered as "Worker notes since the last review round". To bound that to the rework turns, the plan jsonb gains `last_review_at` next to `last_review_commit` (`Plan.LastReviewAt`, `StepState.LastReviewAt`, `StepInput.ReviewAt`), written only through `ApplyTransition` on rework. Plans written before this field render every note in a findings-only round.

Out of scope, unchanged: the evidence gate rule (#520), the byte budget (#527), the `--allow-empty` unit commit.

## Test plan

New or extended tests:

- `TestRenderReviewContentMultiUnitFiles` (runner_test): per-unit files line for scoped, legacy and untouched units, the spanning label on the stat, the exclusivity instruction only with more than one unit, no files line without a worktree.
- `TestRenderReviewContentFindingsOnlyEmptyDelta` (runner_test): empty delta still renders the finding file contents, the unit's harness state, the worker note, and the "resolve when the current state does not show the gap" instruction.
- `TestInsideScope`, `TestProgressSince` (review_test).
- `TestStepReworkRecordsReviewCommit` (statemachine_test) now also pins `LastReviewAt`.
- `TestDriverFindingsOnlyReReview` (driver_test) asserts `UnitFiles` on the full round, `LastReviewAt` recorded, and that round 2 carries only the rework turn's handoff note, not the pre-review operator note.
- `TestDriverTwoUnitPlanReviewsOnce` (driver_test) asserts `UnitFiles == [[a.md] [b.md]]` for two root-file units with exclusivity criteria.
- `TestApplyTransitionPersistsLastReviewCommit` (store_integration_test) also round-trips `last_review_at`.

Ran from the worktree, all through `golang:1.26.6` in Docker: `go build ./...`, `go vet ./...`, `go vet -tags integration ./internal/brain/missions/`, `go test -race -count=1 ./...`, `golangci-lint run` (v2.12.2, 0 issues), and `go test -race -count=1 -tags integration -p 1 -run TestApplyTransition ./internal/brain/missions/` against a throwaway `pgvector/pgvector:0.8.4-pg18-trixie` container.

`make canary` and `make canary-two-unit` were NOT run from this worktree (shared compose project name); the coordinator runs them against this PR's commit before merge.

Closes #529
Part of #510

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790976770&installation_model_id=431401&pr_number=530&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F530&signature=32069dc539c384c022ff20cd3787095c2c48d92bf0e45b6936f88131ecea8605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->