### PR TITLE
fix(canary): count only full review rounds, drop dead repo_path field

### DIFF
--- a/scripts/canary-coding.sh
+++ b/scripts/canary-coding.sh
@@ -1,20 +1,19 @@
 #!/usr/bin/env bash
-# Coding-mission canary: seeds a tiny fixture git repo inside the brain
-# container, runs one coding mission against it end-to-end, and asserts
-# the coding-specific harness contract — worktree provisioned, LLM
-# review actually ran (coding never skips review), harness-verified
-# artifact present in the worktree, zero human permission parks. The
-# general-mission canary (canary-mission.sh) cannot catch regressions in
-# the git/worktree/review path; this one exists for exactly that.
+# Coding-mission canary: runs one coding mission end-to-end against its
+# own self-initialized worktree repo and asserts the coding-specific
+# harness contract — worktree provisioned, LLM review actually ran
+# (coding never skips review), harness-verified artifact present in the
+# worktree, zero human permission parks. The general-mission canary
+# (canary-mission.sh) cannot catch regressions in the git/worktree/
+# review path; this one exists for exactly that.
 # CANARY_TWO_UNIT=1 runs a two-file goal instead and additionally asserts
-# the plan had two units and exactly one review round ran (D-096).
+# the plan had two units and exactly one full review round ran (D-096).
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COMPOSE=(docker compose -f "${REPO_ROOT}/deploy/docker-compose.yml")
 BASE_URL="${CANARY_BASE_URL:-http://localhost:${BRAIN_PORT:-8300}}"
 TIMEOUT_SECS="${CANARY_TIMEOUT:-900}"
-FIXTURE=/workspace/canary-fixture
 
 # A different goal every run: repeating one fixed goal would let
 # prompt caches and prior runs' artifacts flatter the result. Each
@@ -61,19 +60,14 @@ fi
 
 auth=(-H "Authorization: Bearer ${TIMOTHY_API_TOKEN}" -H "Content-Type: application/json")
 
-echo "canary-coding: seeding fixture repo at ${FIXTURE} (inside brain)"
-"${COMPOSE[@]}" exec -T brain sh -c "
-  rm -rf ${FIXTURE} &&
-  git init -q -b main ${FIXTURE} &&
-  cd ${FIXTURE} &&
-  printf '# Canary Fixture\n\nTiny repo the coding-mission canary works against.\n' > README.md &&
-  git add README.md &&
-  git -c user.name=timothy -c user.email=timothy@localhost commit -q -m 'add readme'
-"
-
+# No repo_path/repo_url: repo_path is not a supported create field
+# (issue #523) and repo_url clones from a github connector, neither of
+# which fits a local fixture. A coding mission with no clone source
+# self-initializes its own repo in the worktree, so the mission's
+# worktree IS the fixture the assertions below check.
 echo "canary-coding: creating mission against ${BASE_URL}"
 create_resp="$(curl -sf "${auth[@]}" -X POST "${BASE_URL}/v1/missions" \
-  -d "{\"goal\": \"${GOAL}\", \"kind\": \"coding\", \"repo_path\": \"${FIXTURE}\"}")"
+  -d "{\"goal\": \"${GOAL}\", \"kind\": \"coding\"}")"
 id="$(echo "${create_resp}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
 echo "canary-coding: mission ${id}"
 
@@ -125,13 +119,20 @@ verified = [e for e in events if e["kind"] == "mission.unit_verified"
             and (e.get("payload") or {}).get("passed") is True]
 # The driver records one review_verdict per round; the state machine
 # appends another on rework, so count rounds by the driver's payload key.
+# A full round covers the whole plan (findings_only false or absent); a
+# findings-only round only re-checks open findings after a fix and is
+# expected once a full round opened a blocking finding (D-096, #524), so
+# it is reported but never counted toward the "one round" assertion.
 rounds = [e for e in events if e["kind"] == "mission.review_verdict"
           and "findings_only" in (e.get("payload") or {})]
+full_rounds = [e for e in rounds if not (e.get("payload") or {}).get("findings_only")]
+findings_only_rounds = [e for e in rounds if (e.get("payload") or {}).get("findings_only")]
 worker_turns = [e for e in turns if (e.get("payload") or {}).get("phase") == "generate"]
 
 print(f"canary-coding: event counts: {json.dumps(kinds, sort_keys=True)}")
 print(f"canary-coding: {len(turns)} model turns, {total_ms/1000:.0f}s total model time")
-print(f"canary-coding: {len(units)} plan unit(s), {len(worker_turns)} worker turn(s), {len(rounds)} review round(s)")
+print(f"canary-coding: {len(units)} plan unit(s), {len(worker_turns)} worker turn(s), "
+      f"{len(full_rounds)} full review round(s), {len(findings_only_rounds)} findings-only round(s)")
 
 failures = []
 if parks > 0:
@@ -147,8 +148,8 @@ if len(turns) > 10:
 if two_unit:
     if len(units) < 2:
         failures.append(f"{len(units)} plan unit(s) for a two-file goal: the two-unit case needs two units")
-    if len(rounds) != 1:
-        failures.append(f"{len(rounds)} review round(s): one round must cover the whole plan once every unit is harness-passed")
+    if len(full_rounds) != 1:
+        failures.append(f"{len(full_rounds)} full review round(s): one round must cover the whole plan once every unit is harness-passed")
 if failures:
     print("canary-coding: FAIL — " + "; ".join(failures), file=sys.stderr)
     sys.exit(1)
@@ -156,13 +157,16 @@ PY
 
 # The harness already verified declared artifacts in the worktree; this
 # re-checks from outside the mission's own machinery — an independent
-# witness that the branch and the file are really on disk.
+# witness that the branch and the file are really on disk. A coding
+# mission self-initializes its own repo in the worktree (there is no
+# separate clone source to check against), so the branch is witnessed
+# there, same as canary-executor.sh's equivalent check.
 if [[ -z "${worktree}" || -z "${branch}" ]]; then
   echo "canary-coding: FAIL — mission has no worktree/branch (worktree='${worktree}' branch='${branch}')" >&2
   exit 1
 fi
 "${COMPOSE[@]}" exec -T brain sh -c "
-  git -C ${FIXTURE} rev-parse --verify --quiet '${branch}' >/dev/null
+  git -C '${worktree}' rev-parse --verify --quiet '${branch}' >/dev/null
 " || {
   echo "canary-coding: FAIL: branch ${branch} missing in container" >&2
   exit 1

--- a/scripts/canary-coding.sh
+++ b/scripts/canary-coding.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Coding-mission canary: runs one coding mission end-to-end against its
 # own self-initialized worktree repo and asserts the coding-specific
-# harness contract — worktree provisioned, LLM review actually ran
+# harness contract: worktree provisioned, LLM review actually ran
 # (coding never skips review), harness-verified artifact present in the
 # worktree, zero human permission parks. The general-mission canary
 # (canary-mission.sh) cannot catch regressions in the git/worktree/


### PR DESCRIPTION
## Summary

- `canary-two-unit`'s gate now counts only full `mission.review_verdict` events (`findings_only` false or absent) toward the "exactly one review round" assertion. A findings-only round after a valid full round (the loop working as designed per #524) is reported in the summary but no longer fails the run. Two full rounds still fail with the same message, just now scoped to full rounds.
- `canary-coding.sh` posted a `repo_path` field the create handler has never implemented (verified against the request struct in `internal/brain/api/missions.go`: only `repo_url` + `connector_id` clone a repo, and that path is coding-only, requires a github connector, and is validated as an https clone URL — none of which fits a local fixture path). The mission always self-initialized its own repo in the worktree regardless, so the final assertion, which checked the unused fixture repo for the branch, always failed. Dropped the dead `repo_path` field and the now-pointless fixture-seeding step, and pointed the final branch/artifact check at the mission's own worktree, matching `canary-executor.sh`'s already-correct equivalent check.

## Verified API field

`internal/brain/api/missions.go` create request struct: `RepoURL string \`json:"repo_url"\`` plus `ConnectorID string \`json:"connector_id"\``. No `repo_path` field exists anywhere in the struct or handler; unknown JSON fields are silently ignored (no `DisallowUnknownFields`), matching the symptom described in #523.

## Scope note

Issue #523 also names `canary-impossible.sh` and `canary-executor.sh` as sending the same dead `repo_path` field. This PR's assigned scope is `scripts/canary-coding.sh` only; `canary-executor.sh` already checks the worktree correctly (it never relied on the fixture for its final assertion), and `canary-impossible.sh`'s assertions do not depend on the fixture repo receiving anything, so neither is failing today for this reason. Left both untouched.

## Test plan

- `bash -n scripts/canary-coding.sh` passes.
- `shellcheck` via `docker run --rm -v .../scripts:/scripts koalaman/shellcheck:stable /scripts/canary-coding.sh` passes clean.
- Embedded Python heredoc compiled with `python3 -m py_compile`.
- Not run against the live stack from this worktree (no compose stack available here). The coordinator should run `make canary-two-unit` before merge to confirm the mission reaches done with one full round plus a findings-only re-review not failing the gate, and that the final branch/artifact assertion passes against the worktree.

Closes #531
Closes #523

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791015055&installation_model_id=431401&pr_number=534&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F534&signature=6540c51e9b0b49f24acb08cf18c1cab9441e3f24c357ed19009ffa4601236969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->