### PR TITLE
feat(missions): no empty commits, result notes, truthful plan markers

### DIFF
--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -869,7 +869,7 @@ func (r *delegatedRunner) finish(ctx context.Context, m Mission, entry gwclient.
 	case ok:
 		verdict = WorkerVerdict{
 			Outcome:  strings.ToLower(res.Status),
-			Evidence: res.Note, Analysis: res.Note, Question: res.Note,
+			Evidence: res.Note, Analysis: res.Note, Question: res.Note, Note: res.Note,
 		}
 	default:
 		if raw, sok := extractTextSentinel(st.textBuf.String(), missionStatusToolName); sok {

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -1502,14 +1502,7 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 	if err != nil {
 		return StepInput{}, err
 	}
-	// A handoff note is the worker's deliberate summary for the next
-	// session; prefer it over the raw turn text, which is often just
-	// tool chatter with no orientation value once the turn ends.
-	progressNote := text
-	if verdict.Handoff != "" {
-		progressNote = verdict.Handoff
-	}
-	if err := d.recordProgress(ctx, m.ID, progressNote); err != nil {
+	if err := d.recordProgress(ctx, m.ID, progressNote(verdict, text)); err != nil {
 		d.log.Warn("driver: record progress failed", "mission_id", m.ID, "error", err)
 	}
 
@@ -1522,7 +1515,10 @@ func (d *Driver) runExecute(ctx context.Context, m Mission) (StepInput, error) {
 			}
 			body := "mission " + m.ID + " iteration " + fmt.Sprint(m.Iteration)
 			msg := CommitMessage(unitTitle, m.Goal, body, d.effectiveCommitStyle(ctx, m))
-			if err := d.workspace.CommitUnit(ctx, wt, msg); err != nil {
+			switch err := d.workspace.CommitUnit(ctx, wt, msg); {
+			case errors.Is(err, errNothingToCommit):
+				d.log.Debug("driver: commit unit skipped, no changes", "mission_id", m.ID)
+			case err != nil:
 				d.log.Warn("driver: commit unit failed", "mission_id", m.ID, "error", err)
 			}
 		}
@@ -2020,6 +2016,22 @@ func (d *Driver) packet(ctx context.Context, m Mission) (WorkPacket, error) {
 		p.SkillsIndex = d.skillsIndex(ctx, m.AgentID)
 	}
 	return p, nil
+}
+
+// progressNoteCap bounds a raw-turn-text progress note (D-099).
+const progressNoteCap = 2000
+
+// progressNote picks the note a worker turn leaves for the next
+// session (D-099, issue #533): the handoff, else a delegated result's
+// note, else the raw turn text capped at progressNoteCap.
+func progressNote(verdict WorkerVerdict, text string) string {
+	switch {
+	case verdict.Handoff != "":
+		return verdict.Handoff
+	case verdict.Note != "":
+		return verdict.Note
+	}
+	return truncate(text, progressNoteCap)
 }
 
 func (d *Driver) recordProgress(ctx context.Context, id, text string) error {

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -1050,6 +1050,52 @@ func TestDriverExecuteRecordsRawTextWithoutHandoff(t *testing.T) {
 	}
 }
 
+// TestDriverExecuteRecordsDelegatedNote confirms a delegated turn's
+// schema result note (WorkerVerdict.Note, D-099) is the progress note
+// when no handoff was given, not the accumulated stream text.
+func TestDriverExecuteRecordsDelegatedNote(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	runner := &scriptedRunner{
+		workerVerdicts: []WorkerVerdict{{Outcome: "retry", Analysis: "tests red", Note: "tests red"}},
+		workerText:     "I'll create the file.Verification passed.",
+	}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if len(m.Progress) != 1 || m.Progress[0].Note != "tests red" {
+		t.Fatalf("Progress = %+v, want the delegated result note alone", m.Progress)
+	}
+}
+
+// TestProgressNoteSelection pins the D-099 order: handoff, then the
+// delegated result note, then the raw turn text capped at
+// progressNoteCap with a truncation marker.
+func TestProgressNoteSelection(t *testing.T) {
+	long := strings.Repeat("x", progressNoteCap+10)
+	cases := []struct {
+		name    string
+		verdict WorkerVerdict
+		text    string
+		want    string
+	}{
+		{"handoff over note and text", WorkerVerdict{Handoff: "next: finish auth", Note: "done"}, "raw", "next: finish auth"},
+		{"delegated note over text", WorkerVerdict{Note: "done"}, "raw", "done"},
+		{"raw text when nothing else", WorkerVerdict{}, "raw", "raw"},
+		{"raw text capped", WorkerVerdict{}, long, strings.Repeat("x", progressNoteCap) + "…"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := progressNote(tc.verdict, tc.text); got != tc.want {
+				t.Fatalf("progressNote = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestDriverLightDoneSetsFinalOutputAndSkipsToResult confirms a light
 // mission's done branch (D-069) short-circuits routeVerified: it sets
 // FinalOutput to the worker's FinalMessage (the text since its last
@@ -2719,7 +2765,7 @@ func TestDriverRegressionFlipsUnitAndRetriesInsteadOfAdvancing(t *testing.T) {
 		t.Fatalf("packet: %v", err)
 	}
 	_, user := packet.Render()
-	if !strings.Contains(user, "Current unit: unit0\nREGRESSED:") || !strings.Contains(user, "[regressed] unit0") || !strings.Contains(user, "[harness-verified] unit1") {
+	if !strings.Contains(user, "Current unit: unit0\nREGRESSED:") || !strings.Contains(user, "[pending] unit0 (regressed: passed before, now fails its artifacts check)") || !strings.Contains(user, "[harness-verified] unit1") {
 		t.Fatalf("worker packet = %q, want unit0 named as the regressed current unit and unit1 harness-verified", user)
 	}
 }

--- a/internal/brain/missions/packet.go
+++ b/internal/brain/missions/packet.go
@@ -158,7 +158,7 @@ func (p WorkPacket) render(preamble string) (system, user string) {
 		}
 		b.WriteString("Plan:\n")
 		for _, u := range p.Plan.Units {
-			fmt.Fprintf(&b, "- [%s] %s\n", unitStatus(u), NeutralizeSlot(u.Title))
+			b.WriteString(renderPlanLine(u))
 			// The EXACT artifact paths the harness will check — a worker
 			// that invents its own filename (http-429 vs http429) fails
 			// verification without ever seeing why.
@@ -215,19 +215,29 @@ func (p WorkPacket) render(preamble string) (system, user string) {
 }
 
 // unitStatus is the plan marker a worker or reviewer prompt shows for a
-// unit (D-094): verified (complete), harness-verified (awaiting
-// approval), regressed (passed once, failing now), or pending.
+// unit (D-099, issue #533): reviewed (a review approved it),
+// harness-verified (harness evidence, awaiting approval), or pending.
+// A regressed unit is pending; renderPlanLine adds the regressed note.
 func unitStatus(u PlanUnit) string {
 	switch {
 	case u.Passes:
-		return "verified"
+		return "reviewed"
 	case u.HarnessPassed:
 		return "harness-verified"
-	case u.Regressed:
-		return "regressed"
 	default:
 		return "pending"
 	}
+}
+
+// renderPlanLine is the plan list entry both the worker and reviewer
+// packets show for a unit: the marker, the title, and for a regressed
+// unit the note that it passed before.
+func renderPlanLine(u PlanUnit) string {
+	line := fmt.Sprintf("- [%s] %s", unitStatus(u), NeutralizeSlot(u.Title))
+	if u.Regressed && !u.verified() {
+		line += fmt.Sprintf(" (regressed: passed before, now fails its %s check)", u.VerifyCheck)
+	}
+	return line + "\n"
 }
 
 // renderUnitFailure is the current-unit block's harness evidence

--- a/internal/brain/missions/packet_test.go
+++ b/internal/brain/missions/packet_test.go
@@ -26,7 +26,7 @@ func TestWorkPacketRender(t *testing.T) {
 	if !strings.Contains(user, "Fix the login bug") {
 		t.Fatal("Render did not include the goal")
 	}
-	if !strings.Contains(user, "[verified] Add validation") || !strings.Contains(user, "[pending] Add test") {
+	if !strings.Contains(user, "[reviewed] Add validation") || !strings.Contains(user, "[pending] Add test") {
 		t.Fatalf("Render did not include plan units with correct status: %q", user)
 	}
 	if !strings.Contains(user, "found the root cause") {
@@ -40,8 +40,9 @@ func TestWorkPacketRender(t *testing.T) {
 // TestWorkPacketRenderUnitFailure is the golden test for the D-094
 // current-unit block: the first unit without harness evidence is the
 // current one, its last failing check and excerpt render under it, and
-// plan markers distinguish verified, harness-verified, regressed and
-// pending units. A unit the harness never failed renders no block.
+// plan markers distinguish reviewed, harness-verified and pending units
+// (D-099), a regressed unit rendering pending plus the regressed note.
+// A unit the harness never failed renders no block.
 func TestWorkPacketRenderUnitFailure(t *testing.T) {
 	p := WorkPacket{
 		Goal: "Write the report",
@@ -57,10 +58,13 @@ func TestWorkPacketRenderUnitFailure(t *testing.T) {
 	if !strings.Contains(user, want) {
 		t.Fatalf("Render current-unit block = %q, want it to contain %q", user, want)
 	}
-	for _, marker := range []string{"[verified] Outline", "[regressed] Body", "[harness-verified] Appendix", "[pending] Index"} {
+	for _, marker := range []string{"[reviewed] Outline", "[pending] Body (regressed: passed before, now fails its verify_cmd check)", "[harness-verified] Appendix", "[pending] Index"} {
 		if !strings.Contains(user, marker) {
 			t.Fatalf("Render = %q, want plan marker %q", user, marker)
 		}
+	}
+	if strings.Contains(user, "[verified]") || strings.Contains(user, "[regressed]") {
+		t.Fatalf("Render = %q, want no bare verified or regressed marker", user)
 	}
 
 	p.Plan.Units[1] = PlanUnit{Title: "Body", VerifyCheck: "artifacts", VerifyExcerpt: "body.md: not found"}
@@ -100,7 +104,7 @@ func TestWorkPacketRenderOpenFindings(t *testing.T) {
 	}
 	want := "Current unit: Code block menu\n" +
 		"Plan:\n" +
-		"- [verified] Toolbar\n" +
+		"- [reviewed] Toolbar\n" +
 		"- [pending] Code block menu\n" +
 		"\n" +
 		"Current work: close open review findings (round 2 of 3)\n" +

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -1431,6 +1431,9 @@ func renderReviewContent(p ReviewPacket) string {
 		}
 		for i, u := range p.Units {
 			fmt.Fprintf(&b, "\n### %s [%s]\n", NeutralizeSlot(u.Title), unitStatus(u))
+			if u.Regressed && !u.verified() {
+				b.WriteString("Regressed: this unit passed before and fails now.\n")
+			}
 			if len(u.Criteria) > 0 {
 				b.WriteString("Acceptance criteria:\n")
 				for _, c := range u.Criteria {
@@ -1462,7 +1465,7 @@ func renderReviewContent(p ReviewPacket) string {
 	if len(p.Plan.Units) > 0 {
 		b.WriteString("\nPlan:\n")
 		for _, u := range p.Plan.Units {
-			fmt.Fprintf(&b, "- [%s] %s\n", unitStatus(u), NeutralizeSlot(u.Title))
+			b.WriteString(renderPlanLine(u))
 		}
 	}
 	if open := OpenFindings(p.OpenFindings); len(open) > 0 {

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -360,6 +360,36 @@ func TestRunReviewPacketListsOpenFindings(t *testing.T) {
 	}
 }
 
+// TestRenderReviewContentPlanMarkers pins the D-099 markers in the
+// reviewer packet: reviewed, harness-verified, pending; a regressed unit
+// is pending with the regressed note; no bare verified marker.
+func TestRenderReviewContentPlanMarkers(t *testing.T) {
+	units := []PlanUnit{
+		{Title: "approved", Passes: true, HarnessPassed: true},
+		{Title: "awaiting", HarnessPassed: true},
+		{Title: "broke", Regressed: true, VerifyCheck: "artifacts", VerifyExcerpt: "a.md: not found"},
+		{Title: "todo"},
+	}
+	content := renderReviewContent(ReviewPacket{Units: units, Plan: Plan{Units: units}})
+	for _, want := range []string{
+		"### approved [reviewed]",
+		"### awaiting [harness-verified]",
+		"### broke [pending]\nRegressed: this unit passed before and fails now.\n",
+		"### todo [pending]",
+		"- [reviewed] approved\n",
+		"- [harness-verified] awaiting\n",
+		"- [pending] broke (regressed: passed before, now fails its artifacts check)\n",
+		"- [pending] todo\n",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("review content missing %q:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, "[verified]") || strings.Contains(content, "[regressed]") {
+		t.Fatalf("review content has a bare verified or regressed marker:\n%s", content)
+	}
+}
+
 // TestRenderReviewContentFindingsOnly pins the D-096 re-review packet
 // shape: the open findings with detail and evidence, the finding files,
 // the scope-creep list, the delta diff and the affected units' harness

--- a/internal/brain/missions/sentinel.go
+++ b/internal/brain/missions/sentinel.go
@@ -202,6 +202,9 @@ type WorkerVerdict struct {
 	Analysis string
 	Question string
 	Handoff  string
+	// Note is a delegated executor's result note (D-099, issue #533):
+	// the progress note when no handoff was given.
+	Note string
 	// FinalOutput is the mission_status call's own final_output argument
 	// — the deliverable a light-mission worker carries in the sentinel
 	// itself (D-069). Reasoning models routinely produce tool calls with

--- a/internal/brain/missions/worktree.go
+++ b/internal/brain/missions/worktree.go
@@ -2,6 +2,7 @@ package missions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -427,7 +428,13 @@ func (w *Workspace) Rollback(ctx context.Context, worktree, kind string) error {
 	return nil
 }
 
-// CommitUnit commits the worktree's current changes. A github-
+// errNothingToCommit is CommitUnit's answer when the worktree has no
+// changes after staging (D-099, issue #533): no commit is created, so a
+// mission branch never carries empty commits.
+var errNothingToCommit = errors.New("worktree: nothing to commit")
+
+// CommitUnit commits the worktree's current changes, or returns
+// errNothingToCommit when there are none. A github-
 // connection mission's clone carries a LOCAL user.name/user.email (set
 // once at Provision time, see cloneRepo/setLocalIdentity) — that takes
 // priority so commits are authored as the connection; otherwise falls
@@ -438,6 +445,13 @@ func (w *Workspace) CommitUnit(ctx context.Context, worktree, message string) er
 	defer cancel()
 	if out, err := runGit(cctx, worktree, "add", "-A"); err != nil {
 		return fmt.Errorf("worktree: commit add: %w: %s", err, out)
+	}
+	status, err := runGit(cctx, worktree, "status", "--porcelain")
+	if err != nil {
+		return fmt.Errorf("worktree: commit status: %w: %s", err, status)
+	}
+	if strings.TrimSpace(status) == "" {
+		return errNothingToCommit
 	}
 	name, email := commitName, commitEmail
 	if w.identity != nil {
@@ -460,7 +474,7 @@ func (w *Workspace) CommitUnit(ctx context.Context, worktree, message string) er
 	}
 	cmd := exec.CommandContext(cctx, "git", //nolint:gosec // name/email may be operator-supplied but travel as -c key=value args, never shell-interpolated; message is driver-built from mission id/iteration, not user input
 		"-c", "user.name="+name, "-c", "user.email="+email,
-		"commit", "-m", message, "--allow-empty")
+		"commit", "-m", message)
 	cmd.Dir = worktree
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("worktree: commit: %w: %s", err, string(out))

--- a/internal/brain/missions/worktree_test.go
+++ b/internal/brain/missions/worktree_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/pem"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -342,6 +343,57 @@ func TestProvisionSelfInitRollbackAndCommitUnit(t *testing.T) {
 	}
 	if len(out) == 0 {
 		t.Fatal("git log is empty after CommitUnit")
+	}
+}
+
+// TestCommitUnitSkipsWhenNothingChanged proves CommitUnit (D-099) makes
+// no commit on a clean worktree and reports errNothingToCommit, so HEAD
+// stays put and gitLogSince the base still counts only turns that
+// changed files; a later real change commits as before.
+func TestCommitUnitSkipsWhenNothingChanged(t *testing.T) {
+	requireGit(t)
+	w := newTestWorkspace(t)
+	ctx := context.Background()
+
+	_, worktree, _, _, _, err := w.Provision(ctx, "mission-noop", "Add a feature", "", "coding", "", "", nil, "", "")
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	head := func() string {
+		out, err := runGit(ctx, worktree, "rev-parse", "HEAD")
+		if err != nil {
+			t.Fatalf("rev-parse HEAD: %v: %s", err, out)
+		}
+		return strings.TrimSpace(out)
+	}
+	base := head()
+
+	if err := w.CommitUnit(ctx, worktree, "noop turn"); !errors.Is(err, errNothingToCommit) {
+		t.Fatalf("CommitUnit on a clean worktree = %v, want errNothingToCommit", err)
+	}
+	if head() != base {
+		t.Fatal("CommitUnit on a clean worktree moved HEAD")
+	}
+
+	if err := os.WriteFile(filepath.Join(worktree, "unit1.txt"), []byte("unit 1 output"), 0o600); err != nil {
+		t.Fatalf("write unit file: %v", err)
+	}
+	if err := w.CommitUnit(ctx, worktree, "unit 1"); err != nil {
+		t.Fatalf("CommitUnit with changes: %v", err)
+	}
+	if head() == base {
+		t.Fatal("CommitUnit with changes did not move HEAD")
+	}
+	if err := w.CommitUnit(ctx, worktree, "noop turn"); !errors.Is(err, errNothingToCommit) {
+		t.Fatalf("second clean CommitUnit = %v, want errNothingToCommit", err)
+	}
+
+	log, err := gitLogSince(ctx, worktree, base)
+	if err != nil {
+		t.Fatalf("gitLogSince: %v", err)
+	}
+	if lines := strings.Split(strings.TrimSpace(log), "\n"); len(lines) != 1 || !strings.Contains(lines[0], "unit 1") {
+		t.Fatalf("git log since base = %q, want exactly the one commit that changed files", log)
 	}
 }
 

--- a/web/src/components/missions/PlanSection.test.tsx
+++ b/web/src/components/missions/PlanSection.test.tsx
@@ -13,7 +13,7 @@ describe('PlanSection', () => {
     expect(screen.getByText('No plan yet.')).toBeInTheDocument()
   })
 
-  it('badges units by harness state: verified, harness-verified, regressed, pending', () => {
+  it('badges units by harness state: reviewed, harness-verified, pending; regressed is pending with a note', () => {
     render(
       <PlanSection
         units={[
@@ -24,10 +24,14 @@ describe('PlanSection', () => {
         ]}
       />,
     )
-    expect(screen.getByText('verified')).toBeInTheDocument()
+    expect(screen.getByText('reviewed')).toBeInTheDocument()
     expect(screen.getByText('harness-verified')).toBeInTheDocument()
-    expect(screen.getByText('regressed')).toHaveAttribute('title', 'a.md: not found')
-    expect(screen.getByText('pending')).toBeInTheDocument()
+    const pending = screen.getAllByText('pending')
+    expect(pending).toHaveLength(2)
+    expect(pending[0]).toHaveAttribute('title', 'a.md: not found')
+    expect(screen.getByText('regressed: passed before, now fails')).toBeInTheDocument()
+    expect(screen.queryByText('verified')).toBeNull()
+    expect(screen.queryByText('regressed')).toBeNull()
   })
 
   it('lists acceptance criteria under a unit and none for a legacy unit', () => {

--- a/web/src/components/missions/PlanSection.tsx
+++ b/web/src/components/missions/PlanSection.tsx
@@ -1,17 +1,15 @@
 import type { PlanAssumption, PlanUnit } from '../../api/types'
 
 // unitBadge mirrors the harness's plan markers (missions.unitStatus,
-// D-094): verified (complete), harness-verified (awaiting review),
-// regressed (passed once, failing now), pending.
+// D-099): reviewed (a review approved it), harness-verified (harness
+// evidence, awaiting review), pending. A regressed unit is pending and
+// gets a separate regressed note.
 export function unitBadge(u: PlanUnit): { label: string; className: string } {
   if (u.passes) {
-    return { label: 'verified', className: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300' }
+    return { label: 'reviewed', className: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300' }
   }
   if (u.harness_passed) {
     return { label: 'harness-verified', className: 'bg-green-50 text-green-700 dark:bg-green-950/60 dark:text-green-400' }
-  }
-  if (u.regressed) {
-    return { label: 'regressed', className: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300' }
   }
   return { label: 'pending', className: 'bg-muted text-muted-foreground' }
 }
@@ -35,6 +33,9 @@ export function PlanSection({ units, assumptions }: { units: PlanUnit[]; assumpt
                   {badge.label}
                 </span>
                 <span>{u.title}</span>
+                {u.regressed && !u.passes && !u.harness_passed && (
+                  <span className="text-xs text-red-700 dark:text-red-400">regressed: passed before, now fails</span>
+                )}
               </div>
               {u.criteria && u.criteria.length > 0 && (
                 <ul className="ml-4 mt-0.5 list-disc space-y-0.5 pl-4 text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

Slice 7 of #510 (design section 5.7), marker D-099.

- **No empty commits.** `CommitUnit` drops `--allow-empty`; after `git add -A` it checks `git status --porcelain` and returns `errNothingToCommit` on a clean tree. The driver logs that at debug level. `last_review_commit`, the rework delta diff (`gitDiff`/`gitLogSince`) and the result-phase push read HEAD and the base commit, so a turn without a commit changes nothing for them.
- **Structured progress note.** `WorkerVerdict` gains `Note`, set from the delegated schema result in `delegated.go`. One helper (`progressNote`) picks handoff, then note, then the raw turn text capped at 2 KB with a truncation marker. Worker and findings-only reviewer packets keep rendering the stored notes unchanged.
- **Truthful plan markers.** `unitStatus` returns `reviewed` (passes), `harness-verified` (harness_passed, not yet approved) or `pending`. A regressed unit renders `pending` plus a regressed note (`renderPlanLine`, shared by the worker and reviewer plan lists; the reviewer unit block adds a `Regressed:` line). The bare `verified` marker is gone. The web `PlanSection` shows the same three states with a separate regressed note.

## Test plan

- `TestCommitUnitSkipsWhenNothingChanged` (real git repo): clean tree returns `errNothingToCommit` and leaves HEAD alone, a change still commits, `gitLogSince` the base counts only the turn that changed files.
- `TestProgressNoteSelection` (table): handoff / delegated note / raw text / capped raw text. `TestDriverExecuteRecordsDelegatedNote`: a delegated turn's note lands in progress, not the stream text.
- `TestRenderReviewContentPlanMarkers` and updated `TestWorkPacketRenderUnitFailure`: the three markers plus the regressed note in both packet renders, and no `[verified]`/`[regressed]` marker anywhere.
- `PlanSection.test.tsx`: reviewed / harness-verified / two pending, regressed note, no `verified` or `regressed` badge.
- Ran in Docker: `go build ./...`, `go vet ./...`, `go test -race ./...`, `golangci-lint run ./...` (0 issues), `npm run build`, `npm run lint`, `npm test` (76 files, 1055 tests).
- Canaries were not run from the worktree (shared compose project); the coordinator runs `make canary` and `make canary-two-unit` against this commit before merge.

Closes #533
Part of #510

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791015754&installation_model_id=431401&pr_number=535&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F535&signature=2236fa4d12746f79e93fd82da81c646324eaeda5d205e8187ed5f736a836079e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->