### PR TITLE
fix(missions): skip RFC 2606 placeholder domains in citation check

### DIFF
--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -2627,7 +2627,7 @@ func TestDriverArtifactCheckBlocksTautologicalDone(t *testing.T) {
 // uses, never letting the invented citation stand.
 func TestDriverCitationCheckBlocksInvokedCitation(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "report.md"), []byte("source: [docs](https://example.com/invented)"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "report.md"), []byte("source: [docs](https://docs.acme.dev/invented)"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	store := newFakeStore()
@@ -2636,7 +2636,7 @@ func TestDriverCitationCheckBlocksInvokedCitation(t *testing.T) {
 		MaxIterations: 8, Workspace: root,
 		Plan: Plan{Units: []PlanUnit{{Title: "write report", Artifacts: []string{"report.md"}}}},
 	})
-	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote it", SeenURLs: []string{"https://example.com/other"}}}}
+	runner := &scriptedRunner{workerVerdicts: []WorkerVerdict{{Outcome: "done", Evidence: "wrote it", SeenURLs: []string{"https://docs.acme.dev/other"}}}}
 	d := testDriver(store, runner)
 
 	if _, err := d.Advance(context.Background(), "m1"); err != nil {

--- a/internal/brain/missions/verifier_test.go
+++ b/internal/brain/missions/verifier_test.go
@@ -129,7 +129,7 @@ func TestVerifyAllRegressionSubsetRerunsPassedUnits(t *testing.T) {
 func TestVerifyAllCitationsOnlyForUnverifiedUnits(t *testing.T) {
 	v := newFakeVerifier()
 	workRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(workRoot, "r.md"), []byte("[x](https://example.com/invented)"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(workRoot, "r.md"), []byte("[x](https://docs.acme.dev/invented)"), 0o600); err != nil {
 		t.Fatalf("seed artifact: %v", err)
 	}
 	m := Mission{
@@ -137,7 +137,7 @@ func TestVerifyAllCitationsOnlyForUnverifiedUnits(t *testing.T) {
 		Plan: Plan{Units: []PlanUnit{{Title: "report", Artifacts: []string{"r.md"}}}},
 	}
 
-	got, err := v.verifyAll(context.Background(), m, []string{"https://example.com/other"}, true)
+	got, err := v.verifyAll(context.Background(), m, []string{"https://docs.acme.dev/other"}, true)
 	if err != nil {
 		t.Fatalf("verifyAll: %v", err)
 	}

--- a/internal/brain/missions/verify.go
+++ b/internal/brain/missions/verify.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -169,9 +170,72 @@ func CheckArtifacts(workRoot string, artifacts []string) []string {
 // URL/ref again from inside the parens (D-059).
 var citedURLPattern = regexp.MustCompile(`\[[^\]]*\]\(((?:https?|kb)://[^\s)]+)\)|((?:https?|kb)://[^\s)\]]+)`)
 
+// trailingURLPunct is punctuation and quote characters a URL scan
+// picks up from surrounding prose (a sentence-ending period, a closing
+// quote around a bare URL) that are never part of the URL itself.
+const trailingURLPunct = "'\",.;:)`"
+
+// placeholderDomains are RFC 2606 reserved second-level domains: exact
+// match or any subdomain is a documentation example, never a real
+// citation.
+var placeholderDomains = []string{"example.com", "example.net", "example.org"}
+
+// placeholderTLDs are RFC 2606 / RFC 6761 reserved TLDs used only in
+// documentation and examples.
+var placeholderTLDs = []string{".example", ".test", ".invalid", ".localhost"}
+
+// placeholderIPRanges are the RFC 5737 documentation IPv4 blocks.
+var placeholderIPRanges = []*net.IPNet{
+	mustCIDR("192.0.2.0/24"),
+	mustCIDR("198.51.100.0/24"),
+	mustCIDR("203.0.113.0/24"),
+}
+
+func mustCIDR(s string) *net.IPNet {
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+// isPlaceholderHost reports whether host is an RFC 2606 / RFC 6761
+// reserved documentation name or an RFC 5737 documentation IP literal
+// (issue #522): these appear in explainer goals (CORS, redirects, HTTP
+// examples) as illustrations, not as things a worker could fetch.
+func isPlaceholderHost(host string) bool {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	if host == "" {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	for _, d := range placeholderDomains {
+		if host == d || strings.HasSuffix(host, "."+d) {
+			return true
+		}
+	}
+	for _, tld := range placeholderTLDs {
+		if strings.HasSuffix(host, tld) {
+			return true
+		}
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		for _, r := range placeholderIPRanges {
+			if r.Contains(ip) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ExtractCitedURLs pulls every http(s) URL and kb:// reference cited in
 // text — markdown link targets and bare refs alike — in first-seen
-// order, deduplicated.
+// order, deduplicated. Trailing punctuation and quote characters
+// picked up from surrounding prose are stripped, and a candidate whose
+// host has no dot (e.g. a truncated "https://app") is dropped.
 func ExtractCitedURLs(text string) []string {
 	matches := citedURLPattern.FindAllStringSubmatch(text, -1)
 	seen := make(map[string]bool, len(matches))
@@ -191,6 +255,11 @@ func ExtractCitedURLs(text string) []string {
 			u = "kb://" + strings.TrimRightFunc(rest, func(r rune) bool {
 				return r != '-' && (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F')
 			})
+		} else {
+			u = strings.TrimRight(u, trailingURLPunct)
+			if !hasDottedHost(u) {
+				continue
+			}
 		}
 		if seen[u] {
 			continue
@@ -199,6 +268,24 @@ func ExtractCitedURLs(text string) []string {
 		urls = append(urls, u)
 	}
 	return urls
+}
+
+// hasDottedHost reports whether rawURL parses to a host containing a
+// dot, or is an IP literal. A bare scheme+label with no dot
+// ("https://app") is a truncated fragment, not a fetchable URL.
+func hasDottedHost(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	if host == "" {
+		return false
+	}
+	if net.ParseIP(host) != nil {
+		return true
+	}
+	return strings.Contains(host, ".")
 }
 
 // NormalizeURL canonicalizes a URL for citation comparison: lowercase
@@ -256,6 +343,9 @@ func CheckCitations(workRoot string, artifacts, seenURLs []string) []string {
 		var unknown []string
 		seenUnknown := map[string]bool{}
 		for _, cited := range ExtractCitedURLs(string(content)) {
+			if u, err := url.Parse(cited); err == nil && isPlaceholderHost(u.Hostname()) {
+				continue // RFC 2606/6761/5737 placeholder, not a real citation
+			}
 			norm := NormalizeURL(cited)
 			if allowed[norm] || seenUnknown[norm] {
 				continue

--- a/internal/brain/missions/verify_test.go
+++ b/internal/brain/missions/verify_test.go
@@ -160,12 +160,51 @@ func TestExtractCitedURLs(t *testing.T) {
 		{"markdown kb link", "see [the doc](kb://doc-123) for more", []string{"kb://doc-123"}},
 		{"mixed kb ref and url", "kb://doc-123 and also https://example.com/x", []string{"kb://doc-123", "https://example.com/x"}},
 		{"bare kb ref sheds trailing punctuation", "cites kb://a1b2c3d4-0000-0000-0000-000000000001; and kb://a1b2c3d4-0000-0000-0000-000000000002.", []string{"kb://a1b2c3d4-0000-0000-0000-000000000001", "kb://a1b2c3d4-0000-0000-0000-000000000002"}},
+		{"trailing quote stripped", "see https://app.example.org'", []string{"https://app.example.org"}},
+		{"trailing port and period stripped", "see https://example.com:443.", []string{"https://example.com:443"}},
+		{"trailing comma and quote stripped", "see https://api.example.org/resource',,", []string{"https://api.example.org/resource"}},
+		{"trailing backtick stripped", "see `https://example.com/docs`", []string{"https://example.com/docs"}},
+		{"no-dot host ignored", "a truncated https://app fragment", nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := ExtractCitedURLs(tc.text)
 			if !equalStrings(got, tc.want) {
 				t.Fatalf("ExtractCitedURLs(%q) = %v, want %v", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsPlaceholderHost(t *testing.T) {
+	cases := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{"example.com exact", "example.com", true},
+		{"example.net exact", "example.net", true},
+		{"example.org exact", "example.org", true},
+		{"example.com subdomain", "app.example.com", true},
+		{"example.org subdomain", "api.example.org", true},
+		{"reserved tld example", "service.example", true},
+		{"reserved tld test", "service.test", true},
+		{"reserved tld invalid", "box.invalid", true},
+		{"reserved tld localhost", "web.localhost", true},
+		{"bare localhost", "localhost", true},
+		{"documentation ip 192.0.2", "192.0.2.10", true},
+		{"documentation ip 198.51.100", "198.51.100.20", true},
+		{"documentation ip 203.0.113", "203.0.113.30", true},
+		{"case insensitive", "APP.EXAMPLE.COM", true},
+		{"real domain", "docs.acme.dev", false},
+		{"lookalike domain not a subdomain", "notexample.com", false},
+		{"lookalike suffix not reserved tld", "myservice.testing", false},
+		{"real ip outside documentation ranges", "8.8.8.8", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPlaceholderHost(tc.host); got != tc.want {
+				t.Fatalf("isPlaceholderHost(%q) = %v, want %v", tc.host, got, tc.want)
 			}
 		})
 	}
@@ -208,26 +247,26 @@ func TestCheckCitations(t *testing.T) {
 	}{
 		{
 			name:      "cited url was fetched",
-			content:   "source: [docs](https://example.com/docs)",
-			seenURLs:  []string{"https://example.com/docs"},
+			content:   "source: [docs](https://docs.acme.dev/docs)",
+			seenURLs:  []string{"https://docs.acme.dev/docs"},
 			wantProbs: 0,
 		},
 		{
 			name:      "invented citation fails",
-			content:   "source: [docs](https://example.com/invented)",
-			seenURLs:  []string{"https://example.com/other"},
+			content:   "source: [docs](https://docs.acme.dev/invented)",
+			seenURLs:  []string{"https://docs.acme.dev/other"},
 			wantProbs: 1,
 		},
 		{
 			name:      "bare url matched against search result",
-			content:   "see https://example.com/api for details",
-			seenURLs:  []string{"https://example.com/api"},
+			content:   "see https://docs.acme.dev/api for details",
+			seenURLs:  []string{"https://docs.acme.dev/api"},
 			wantProbs: 0,
 		},
 		{
 			name:      "trailing slash and fragment normalize equal",
-			content:   "[ref](https://example.com/docs/#intro)",
-			seenURLs:  []string{"https://example.com/docs"},
+			content:   "[ref](https://docs.acme.dev/docs/#intro)",
+			seenURLs:  []string{"https://docs.acme.dev/docs"},
 			wantProbs: 0,
 		},
 		{
@@ -238,7 +277,7 @@ func TestCheckCitations(t *testing.T) {
 		},
 		{
 			name:      "no web calls at all but links present fails",
-			content:   "[ref](https://example.com/docs)",
+			content:   "[ref](https://docs.acme.dev/docs)",
 			seenURLs:  nil,
 			wantProbs: 1,
 		},
@@ -256,9 +295,39 @@ func TestCheckCitations(t *testing.T) {
 		},
 		{
 			name:      "kb ref and url both seen passes",
-			content:   "Source: kb://doc-123\nsee also [docs](https://example.com/docs)",
-			seenURLs:  []string{"kb://doc-123", "https://example.com/docs"},
+			content:   "Source: kb://doc-123\nsee also [docs](https://docs.acme.dev/docs)",
+			seenURLs:  []string{"kb://doc-123", "https://docs.acme.dev/docs"},
 			wantProbs: 0,
+		},
+		{
+			name:      "placeholder domain skipped without being fetched",
+			content:   "example: [redirect target](https://example.com/target)",
+			seenURLs:  nil,
+			wantProbs: 0,
+		},
+		{
+			name:      "placeholder subdomain skipped",
+			content:   "example: https://app.example.org/callback",
+			seenURLs:  nil,
+			wantProbs: 0,
+		},
+		{
+			name:      "placeholder reserved tld skipped",
+			content:   "example: https://service.test/health and https://box.invalid/ping and https://web.localhost/",
+			seenURLs:  nil,
+			wantProbs: 0,
+		},
+		{
+			name:      "placeholder documentation ip skipped",
+			content:   "example: https://192.0.2.10/ and https://198.51.100.20/ and https://203.0.113.30/",
+			seenURLs:  nil,
+			wantProbs: 0,
+		},
+		{
+			name:      "mixed placeholder and real url only flags the real one",
+			content:   "see https://example.com/sample and also https://docs.acme.dev/real",
+			seenURLs:  nil,
+			wantProbs: 1,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
- The harness citation check (`internal/brain/missions/verify.go`) flagged every RFC 2606/6761 placeholder domain (example.com/net/org and subdomains, .example/.test/.invalid/.localhost, localhost) and RFC 5737 documentation IP literal as an uncited reference, parking explainer missions (redirects, CORS, HTTP examples) as `no_progress` even though the worker never claimed to have fetched them.
- `CheckCitations` now skips URLs whose host matches the placeholder allowlist (a Go table, not a prompt) before comparing against this turn's fetched/searched URLs; a real, unfetched URL still fails as before.
- `ExtractCitedURLs` now strips trailing quote/punctuation characters (`'",.;:)` and backtick) picked up from surrounding prose, and drops a candidate whose host has no dot (a truncated fragment like `https://app`).

## Test plan
- New table tests in `verify_test.go`: `TestIsPlaceholderHost` (each placeholder class), new `TestCheckCitations` cases (each placeholder class skipped, mixed real+placeholder document only flags the real URL), new `TestExtractCitedURLs` cases (each trailing-punctuation form, no-dot host ignored).
- Updated existing citation-failure tests (`driver_test.go`, `verifier_test.go`, `verify_test.go`) to use a real, non-placeholder domain so they keep testing genuine unfetched-citation failures.
- `go build ./...`, `go vet ./...`, `go test -race ./...`, `golangci-lint run ./internal/brain/missions/...` all pass.

Closes #522

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791021324&installation_model_id=431401&pr_number=537&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F537&signature=ccb6b58d88ebfe994e7b667c09044258699fc997799b79acf08ee2376535565b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->