### PR TITLE
feat(missions): gate unusable routes, edit review route while paused

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -1070,6 +1070,7 @@ func buildMissions(ctx context.Context, db *pgpool.Pool, agent *loop.Agent, sess
 	driver.SetGitCommitStyle(flags.GitCommitStyle)
 	driver.SetLocation(flags.Location)
 	driver.SetReviewWindow(missions.GatewayReviewWindow(gwc.ResolveRoute, gwc.ModelWindows))
+	driver.SetRouteResolver(gwc.ResolveRoute)
 	driver.SetReviewTokenCeiling(flags.ReviewTokenCeiling)
 	resolveAgent := missionAgentResolver(agentReg)
 	driver.SetAgentResolver(resolveAgent)

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -113,6 +113,8 @@ func (a *API) registerMissions(handle func(pattern string, h http.Handler), stor
 	handle("GET /v1/missions/{id}", a.auth(http.HandlerFunc(h.get)))
 	handle("DELETE /v1/missions/{id}", a.auth(http.HandlerFunc(h.delete)))
 	handle("GET /v1/missions/{id}/events", a.auth(http.HandlerFunc(h.events)))
+	handle("GET /v1/missions/{id}/execution-plan", a.auth(http.HandlerFunc(h.missionExecutionPlan)))
+	handle("PATCH /v1/missions/{id}/routing", a.auth(http.HandlerFunc(h.routing)))
 	handle("POST /v1/missions/{id}/resume", a.auth(http.HandlerFunc(h.resume)))
 	handle("POST /v1/missions/{id}/note", a.auth(http.HandlerFunc(h.note)))
 	handle("POST /v1/missions/{id}/cancel", a.auth(http.HandlerFunc(h.cancel)))
@@ -265,6 +267,8 @@ func failMission(w http.ResponseWriter, err error) {
 		jsonError(w, http.StatusConflict, "not_terminal", err.Error())
 	case errors.Is(err, missions.ErrNotAwaitingApproval):
 		jsonError(w, http.StatusConflict, "not_awaiting_approval", err.Error())
+	case errors.Is(err, missions.ErrNotPaused):
+		jsonError(w, http.StatusConflict, "not_paused", err.Error())
 	case errors.Is(err, missions.ErrInvalidMission):
 		jsonError(w, http.StatusBadRequest, "bad_request", err.Error())
 	default:
@@ -778,6 +782,13 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 			flow = string(missions.FlowFull)
 		}
 	}
+	// Route gate (D-100, issue #536): every phase axis this flow runs
+	// must resolve to at least one usable chain entry, else the mission
+	// would park on its first turn with the gateway's no_route error.
+	if route, reason, unusable := h.unusableCreateRoute(r.Context(), req, missions.Flow(flow)); unusable {
+		jsonError(w, http.StatusBadRequest, "route_unusable", fmt.Sprintf("route %q has no usable provider: %s", route, reason))
+		return
+	}
 	// Sources order matches packet.go's renderSources exactly (issue
 	// #481): parent-mission digest, then referenced picks, then
 	// attached PDFs, then the github clone source (order-independent,
@@ -830,6 +841,99 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		h.generateName(id, req.Goal)
 	}
 	writeJSON(w, http.StatusCreated, h.decorateTopModels(r.Context(), []missions.Mission{sanitizeMission(created)})[0])
+}
+
+// routeUnusable resolves route on the given axis (harness == "" is the
+// chat axis) and reports whether the chain has entries but none is
+// usable, with the first entry's skip reason. A resolve error, missing
+// gateway wiring, or an empty chain is never "unusable": the gate
+// blocks only on positive evidence of dead entries, same degrade
+// executorOptions applies.
+func (h *missionAPI) routeUnusable(ctx context.Context, route, harness string) (reason string, unusable bool) {
+	if route == "" || h.resolveRoute == nil {
+		return "", false
+	}
+	resolved, err := h.resolveRoute(ctx, route, harness)
+	if err != nil || resolved == nil || len(resolved.Entries) == 0 {
+		return "", false
+	}
+	reason = "no usable provider for this route"
+	for _, e := range resolved.Entries {
+		if e.Usable {
+			return "", false
+		}
+		if reason == "no usable provider for this route" && e.SkipReason != "" {
+			reason = e.SkipReason
+		}
+	}
+	return reason, true
+}
+
+// unusableCreateRoute walks the phase axes a create request's flow
+// actually runs (D-100): generate on the harness axis, discover/plan on
+// the oversight route and prove on the review route (chat axis) unless
+// the flow skips them, escalate when set. Returns the first route with
+// zero usable entries and its reason.
+func (h *missionAPI) unusableCreateRoute(ctx context.Context, req createMissionRequest, flow missions.Flow) (route, reason string, unusable bool) {
+	type axis struct{ route, harness string }
+	axes := []axis{{req.Route, req.Harness}}
+	if flow != missions.FlowLight {
+		oversight := req.PlanRoute
+		if oversight == "" {
+			oversight = req.Route
+		}
+		axes = append(axes, axis{oversight, ""})
+	}
+	if flow == missions.FlowFull || flow == "" {
+		axes = append(axes, axis{req.ReviewRoute, ""})
+	}
+	if req.EscalationRoute != "" {
+		axes = append(axes, axis{req.EscalationRoute, ""})
+	}
+	seen := map[axis]bool{}
+	for _, a := range axes {
+		if a.route == "" || seen[a] {
+			continue
+		}
+		seen[a] = true
+		if reason, bad := h.routeUnusable(ctx, a.route, a.harness); bad {
+			return a.route, reason, true
+		}
+	}
+	return "", "", false
+}
+
+// routing handles PATCH /v1/missions/{id}/routing (D-100, issue #536):
+// rewrites a paused mission's review route and optional model pin. The
+// route must resolve with at least one usable chain entry on the chat
+// axis; the driver enforces the paused-only state gate (409 not_paused
+// otherwise). Worker and plan routes are never touched here.
+func (h *missionAPI) routing(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ReviewRoute      string `json:"review_route"`
+		ReviewRouteModel string `json:"review_route_model"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.ReviewRoute == "" {
+		jsonError(w, http.StatusBadRequest, "bad_request", "body must be JSON with a non-empty review_route field")
+		return
+	}
+	if h.resolveRoute == nil {
+		jsonError(w, http.StatusNotFound, "not_found", "route validation is not enabled")
+		return
+	}
+	if _, err := h.resolveRoute(r.Context(), body.ReviewRoute, ""); err != nil {
+		jsonError(w, http.StatusBadRequest, "unknown_route", fmt.Sprintf("route %q did not resolve: %s", body.ReviewRoute, err.Error()))
+		return
+	}
+	if reason, unusable := h.routeUnusable(r.Context(), body.ReviewRoute, ""); unusable {
+		jsonError(w, http.StatusBadRequest, "route_unusable", fmt.Sprintf("route %q has no usable provider: %s", body.ReviewRoute, reason))
+		return
+	}
+	if err := h.driver.ChangeRouting(r.Context(), r.PathValue("id"), body.ReviewRoute, body.ReviewRouteModel); err != nil {
+		failMission(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // referenceSourceKind maps a composer #-mention Reference.Kind to its
@@ -1367,17 +1471,70 @@ func (h *missionAPI) executionPlan(w http.ResponseWriter, r *http.Request) {
 	routeModel := q.Get("route_model")
 	planRouteModel := q.Get("plan_route_model")
 	reviewRouteModel := q.Get("review_route_model")
-	oversightModel := routeModel
-	if planRouteModel != "" {
-		oversightModel = planRouteModel
-	}
-	reviewModel := oversightModel
-	if reviewRouteModel != "" {
-		reviewModel = reviewRouteModel
-	}
 
 	ctx := r.Context()
 	base, baseSource := h.baseRoute(ctx, kind, route, agentID)
+	harness, harnessSource := h.resolveHarness(ctx, kind, explicitHarness, agentID)
+	writeJSON(w, http.StatusOK, map[string]any{"phases": h.buildExecutionPlan(ctx, executionPlanInput{
+		route: base, routeSource: baseSource, planRoute: planRoute, reviewRoute: reviewRoute, escalationRoute: escalationRoute,
+		harness: harness, harnessSource: harnessSource,
+		routeModel: routeModel, planRouteModel: planRouteModel, reviewRouteModel: reviewRouteModel, light: light,
+	})})
+}
+
+// executionPlanInput is the resolved route/harness set buildExecutionPlan
+// renders: the create preview fills it from query params through the
+// create-time precedence chain, the per-mission view straight from the
+// row (D-100).
+type executionPlanInput struct {
+	route, routeSource                           string
+	planRoute, reviewRoute, escalationRoute      string
+	harness, harnessSource                       string
+	routeModel, planRouteModel, reviewRouteModel string
+	light                                        bool
+}
+
+// missionExecutionPlan serves GET /v1/missions/{id}/execution-plan
+// (D-100, issue #536): the same five-phase read-out as the create
+// preview, resolved from the mission row's own snapshotted routes so
+// the detail page shows unusable entries per phase as they stand now.
+func (h *missionAPI) missionExecutionPlan(w http.ResponseWriter, r *http.Request) {
+	if h.resolveRoute == nil {
+		jsonError(w, http.StatusNotFound, "not_found", "execution plan preview is not enabled")
+		return
+	}
+	m, err := h.store.Get(r.Context(), r.PathValue("id"))
+	if err != nil {
+		failMission(w, err)
+		return
+	}
+	harnessSource := "native"
+	if m.Harness != "" {
+		harnessSource = "mission"
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"phases": h.buildExecutionPlan(r.Context(), executionPlanInput{
+		route: m.Route, routeSource: "mission", planRoute: m.PlanRoute, reviewRoute: m.ReviewRoute, escalationRoute: m.EscalationRoute,
+		harness: m.Harness, harnessSource: harnessSource,
+		routeModel: m.RouteModel, planRouteModel: m.PlanRouteModel, reviewRouteModel: m.ReviewRouteModel,
+		light: m.Flow == missions.FlowLight,
+	})})
+}
+
+// buildExecutionPlan resolves every phase (discover, plan, generate,
+// prove, escalate) for one route/harness set.
+func (h *missionAPI) buildExecutionPlan(ctx context.Context, in executionPlanInput) []executionPlanPhase {
+	base, baseSource := in.route, in.routeSource
+	planRoute, reviewRoute, escalationRoute := in.planRoute, in.reviewRoute, in.escalationRoute
+	harness, harnessSource := in.harness, in.harnessSource
+	routeModel, light := in.routeModel, in.light
+	oversightModel := routeModel
+	if in.planRouteModel != "" {
+		oversightModel = in.planRouteModel
+	}
+	reviewModel := oversightModel
+	if in.reviewRouteModel != "" {
+		reviewModel = in.reviewRouteModel
+	}
 
 	// oversightRoute mirrors runner.go's own helper: plan_route when
 	// set, else the base route.
@@ -1386,7 +1543,6 @@ func (h *missionAPI) executionPlan(w http.ResponseWriter, r *http.Request) {
 		oversight, oversightSource = planRoute, "explicit"
 	}
 
-	harness, harnessSource := h.resolveHarness(ctx, kind, explicitHarness, agentID)
 	executeAxis := "native"
 	if harness != "" {
 		executeAxis = "harness"
@@ -1453,7 +1609,7 @@ func (h *missionAPI) executionPlan(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{"phases": phases})
+	return phases
 }
 
 // skipReasonIf returns lightReason when skipped is true, else

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -1966,4 +1967,79 @@ func TestMissionsPromoteKB(t *testing.T) {
 			t.Fatalf("ingest calls = %d, want 2 (one per promote)", ingest.callCount())
 		}
 	})
+}
+
+// TestMissionsRoutingPatchStateGate covers PATCH .../routing end to end
+// (D-100, issue #536): 409 not_paused while working, 204 while paused
+// with the row and a mission.route_changed event updated, and a later
+// hand-built transition leaving the new routing in place.
+func TestMissionsRoutingPatchStateGate(t *testing.T) {
+	store := testMissionStore(t)
+	ctx := context.Background()
+
+	id, err := store.Create(ctx, missions.Mission{Goal: "itest-api-mission routing", Kind: "general", Route: "worker", ReviewRoute: "old", ReviewRouteModel: "a/b"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.ApplyTransition(ctx, id, missions.Transition{
+		Next: missions.StepState{Phase: missions.PhaseProve, Status: missions.StatusWorking},
+	}); err != nil {
+		t.Fatalf("ApplyTransition: %v", err)
+	}
+
+	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, resolveRouteFixture, nil, nil, nil, nil, "", nil, nil, nil, nil)
+
+	patch := func(body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest("PATCH", "/v1/missions/"+id+"/routing", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w
+	}
+
+	if w := patch(`{"review_route":"careful"}`); w.Code != http.StatusConflict || !strings.Contains(w.Body.String(), "not_paused") {
+		t.Fatalf("PATCH while working = %d %s, want 409 not_paused", w.Code, w.Body.String())
+	}
+	got, err := store.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ReviewRoute != "old" || got.ReviewRouteModel != "a/b" {
+		t.Fatalf("routing after hand-built transition = %q/%q, want old/a/b untouched", got.ReviewRoute, got.ReviewRouteModel)
+	}
+
+	if err := store.ApplyTransition(ctx, id, missions.Transition{
+		Next: missions.StepState{Phase: missions.PhaseProve, Status: missions.StatusPaused, PauseReason: missions.PauseInfra},
+	}); err != nil {
+		t.Fatalf("ApplyTransition: %v", err)
+	}
+	if w := patch(`{"review_route":"careful","review_route_model":"ok/m"}`); w.Code != http.StatusNoContent {
+		t.Fatalf("PATCH while paused = %d %s, want 204", w.Code, w.Body.String())
+	}
+	got, err = store.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ReviewRoute != "careful" || got.ReviewRouteModel != "ok/m" || got.Route != "worker" || got.Status != missions.StatusPaused {
+		t.Fatalf("mission after PATCH = route %q review %q/%q status %q, want worker/careful/ok/m/paused", got.Route, got.ReviewRoute, got.ReviewRouteModel, got.Status)
+	}
+	events, err := store.Events(ctx, id)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	var payload map[string]string
+	for _, e := range events {
+		if e.Kind == "mission.route_changed" {
+			if err := json.Unmarshal(e.Payload, &payload); err != nil {
+				t.Fatalf("decode mission.route_changed payload: %v", err)
+			}
+		}
+	}
+	want := map[string]string{"from_route": "old", "to_route": "careful", "from_model": "a/b", "to_model": "ok/m"}
+	if !reflect.DeepEqual(payload, want) {
+		t.Fatalf("mission.route_changed payload = %v, want %v", payload, want)
+	}
 }

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -1970,3 +1970,112 @@ func TestPromoteKBReachesStore(t *testing.T) {
 		t.Fatalf("code=%d body=%s, want 400 from the degraded store", w.Code, w.Body.String())
 	}
 }
+
+// resolveRouteFixture fakes gwclient.ResolveRoute for the D-100 route
+// gate tests: "dead" has only unusable entries, "empty" has no chain,
+// "unknown" fails to resolve, everything else has one usable entry.
+func resolveRouteFixture(_ context.Context, route, harness string) (*gwclient.ResolvedRoute, error) {
+	switch route {
+	case "dead":
+		return &gwclient.ResolvedRoute{Route: route, Entries: []gwclient.ResolvedRouteEntry{
+			{ProviderName: "zai", Model: "glm-4.7", Usable: false, SkipReason: "cooling down until 12:00"},
+			{ProviderName: "openai", Model: "gpt-5", Usable: false, SkipReason: "disabled"},
+		}}, nil
+	case "empty":
+		return &gwclient.ResolvedRoute{Route: route}, nil
+	case "unknown":
+		return nil, errors.New("gwclient: gateway http 404: no such route")
+	case "harness-only-dead":
+		if harness != "" {
+			return &gwclient.ResolvedRoute{Route: route, Entries: []gwclient.ResolvedRouteEntry{{Usable: false, SkipReason: "no executor entry"}}}, nil
+		}
+	}
+	return &gwclient.ResolvedRoute{Route: route, Entries: []gwclient.ResolvedRouteEntry{{ProviderName: "ok", Model: "m", Usable: true}}}, nil
+}
+
+// TestMissionsUnusableCreateRoute table-tests the create-time route
+// gate (D-100, issue #536) across phase axes and flows.
+func TestMissionsUnusableCreateRoute(t *testing.T) {
+	t.Parallel()
+	h := &missionAPI{log: discard(), resolveRoute: resolveRouteFixture}
+	for _, tc := range []struct {
+		name       string
+		req        createMissionRequest
+		flow       missions.Flow
+		wantRoute  string
+		wantReason string
+	}{
+		{name: "all usable", req: createMissionRequest{Route: "alive", ReviewRoute: "alive"}, flow: missions.FlowFull},
+		{name: "dead worker route", req: createMissionRequest{Route: "dead", ReviewRoute: "alive"}, flow: missions.FlowFull, wantRoute: "dead", wantReason: "cooling down until 12:00"},
+		{name: "dead review route", req: createMissionRequest{Route: "alive", ReviewRoute: "dead"}, flow: missions.FlowFull, wantRoute: "dead", wantReason: "cooling down until 12:00"},
+		{name: "dead plan route", req: createMissionRequest{Route: "alive", PlanRoute: "dead", ReviewRoute: "alive"}, flow: missions.FlowFull, wantRoute: "dead", wantReason: "cooling down until 12:00"},
+		{name: "empty chain never blocks", req: createMissionRequest{Route: "alive", PlanRoute: "empty", ReviewRoute: "alive"}, flow: missions.FlowFull},
+		{name: "dead escalation route", req: createMissionRequest{Route: "alive", ReviewRoute: "alive", EscalationRoute: "dead"}, flow: missions.FlowFull, wantRoute: "dead", wantReason: "cooling down until 12:00"},
+		{name: "light skips oversight and review", req: createMissionRequest{Route: "alive", PlanRoute: "dead", ReviewRoute: "dead"}, flow: missions.FlowLight},
+		{name: "no_prove skips review only", req: createMissionRequest{Route: "alive", ReviewRoute: "dead"}, flow: missions.FlowNoProve},
+		{name: "harness axis resolves separately", req: createMissionRequest{Route: "harness-only-dead", Harness: "claude-cli", ReviewRoute: "alive"}, flow: missions.FlowFull, wantRoute: "harness-only-dead", wantReason: "no executor entry"},
+		{name: "resolve error never blocks", req: createMissionRequest{Route: "unknown", ReviewRoute: "unknown"}, flow: missions.FlowFull},
+	} {
+		route, reason, unusable := h.unusableCreateRoute(context.Background(), tc.req, tc.flow)
+		if unusable != (tc.wantRoute != "") || route != tc.wantRoute || reason != tc.wantReason {
+			t.Errorf("%s: got (%q, %q, %v), want (%q, %q, %v)", tc.name, route, reason, unusable, tc.wantRoute, tc.wantReason, tc.wantRoute != "")
+		}
+	}
+	if _, _, unusable := (&missionAPI{log: discard()}).unusableCreateRoute(context.Background(), createMissionRequest{Route: "dead"}, missions.FlowFull); unusable {
+		t.Fatal("no gateway wiring must never block create")
+	}
+}
+
+// TestMissionsCreateRejectsUnusableRoute confirms the create handler
+// answers 400 route_unusable naming the route and first skip reason.
+func TestMissionsCreateRejectsUnusableRoute(t *testing.T) {
+	t.Parallel()
+	h := &missionAPI{log: discard(), resolveRoute: resolveRouteFixture}
+	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(`{"goal":"g","kind":"general","route":"alive","review_route":"dead"}`))
+	w := httptest.NewRecorder()
+	h.create(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", w.Code, w.Body.String())
+	}
+	var body struct{ Error, Message string }
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error != "route_unusable" || !strings.Contains(body.Message, `"dead"`) || !strings.Contains(body.Message, "cooling down until 12:00") {
+		t.Fatalf("body = %+v, want route_unusable naming the route and skip reason", body)
+	}
+}
+
+// TestMissionsRoutingValidation covers PATCH .../routing's request
+// checks that need no store: body shape, gateway wiring, and the
+// route's own resolution. The paused-only state gate lives in the
+// driver (TestDriverChangeRouting) and the integration test.
+func TestMissionsRoutingValidation(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		h        *missionAPI
+		body     string
+		wantCode int
+		wantErr  string
+	}{
+		{"malformed body", &missionAPI{log: discard(), resolveRoute: resolveRouteFixture}, `{`, 400, "bad_request"},
+		{"missing review_route", &missionAPI{log: discard(), resolveRoute: resolveRouteFixture}, `{"review_route_model":"a/b"}`, 400, "bad_request"},
+		{"no gateway wiring", &missionAPI{log: discard()}, `{"review_route":"alive"}`, 404, "not_found"},
+		{"unknown route", &missionAPI{log: discard(), resolveRoute: resolveRouteFixture}, `{"review_route":"unknown"}`, 400, "unknown_route"},
+		{"unusable route", &missionAPI{log: discard(), resolveRoute: resolveRouteFixture}, `{"review_route":"dead"}`, 400, "route_unusable"},
+	} {
+		req := httptest.NewRequest("PATCH", "/v1/missions/abc/routing", strings.NewReader(tc.body))
+		req.SetPathValue("id", "abc")
+		w := httptest.NewRecorder()
+		tc.h.routing(w, req)
+		var body struct{ Error, Message string }
+		_ = json.NewDecoder(w.Body).Decode(&body)
+		if w.Code != tc.wantCode || body.Error != tc.wantErr {
+			t.Errorf("%s: got %d %q, want %d %q", tc.name, w.Code, body.Error, tc.wantCode, tc.wantErr)
+		}
+		if tc.wantErr == "route_unusable" && !strings.Contains(body.Message, "cooling down until 12:00") {
+			t.Errorf("%s: message = %q, want the first skip reason", tc.name, body.Message)
+		}
+	}
+}

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -169,6 +169,10 @@ type Driver struct {
 	// SetReviewWindow); nil or 0 means unknown, reviewByteBudget's
 	// fallback applies.
 	reviewWindow func(ctx context.Context, route, model string) int
+	// resolveRoute names the dead chain entry when a review turn fails
+	// on the gateway's no usable provider error (D-100); nil leaves the
+	// pause detail as the raw error.
+	resolveRoute routeResolver
 
 	// reviewTokenCeiling reads the per-mission review input token cap
 	// (D-097, see SetReviewTokenCeiling); nil or 0 disables the check.
@@ -435,6 +439,12 @@ func (d *Driver) SetLocation(loc func(ctx context.Context) *time.Location) {
 // setter for the same reason SetLocation is.
 func (d *Driver) SetReviewWindow(fn func(ctx context.Context, route, model string) int) {
 	d.reviewWindow = fn
+}
+
+// SetRouteResolver wires gwclient.ResolveRoute for review-route pause
+// details (D-100).
+func (d *Driver) SetRouteResolver(fn routeResolver) {
+	d.resolveRoute = fn
 }
 
 // SetReviewTokenCeiling wires the settings-backed review token ceiling
@@ -1002,6 +1012,10 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 			in = StepInput{Input: InputReviewInfraFailure, Reason: err.Error()}
 		case m.Phase == PhaseProve:
 			in = StepInput{Input: InputReviewInfraFailure, Reason: err.Error()}
+			if route, skip, ok := d.reviewRouteSkip(ctx, m, err); ok {
+				in.Route = route
+				in.Reason = fmt.Sprintf("review route %q has no usable provider: %s", route, skip)
+			}
 		case m.Phase == PhaseResult:
 			// runResult itself never returns an error (each hook's own
 			// failure is folded into the result, see runResult); this
@@ -1189,6 +1203,63 @@ func (d *Driver) Signal(ctx context.Context, id string, input Input) error {
 	return nil
 }
 
+// isNoRouteError reports whether err is the gateway's no usable
+// provider failure, as gwclient surfaces it (an HTTP 502 body carrying
+// the no_route code, or the router's own message).
+func isNoRouteError(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, `"no_route"`) || strings.Contains(msg, "no usable provider")
+}
+
+// reviewRouteSkip names the review route a failed prove turn ran on
+// and the first chain entry's skip reason (D-100), so the pause detail
+// says which entry is dead. ok is false when err is not the gateway's
+// no usable provider error or the route cannot be resolved.
+func (d *Driver) reviewRouteSkip(ctx context.Context, m Mission, err error) (route, skip string, ok bool) {
+	if d.resolveRoute == nil || !isNoRouteError(err) {
+		return "", "", false
+	}
+	route = reviewRoute(m)
+	resolved, rerr := d.resolveRoute(ctx, route, "")
+	if rerr != nil || resolved == nil {
+		return "", "", false
+	}
+	skip = "route has no chain entries"
+	for _, e := range resolved.Entries {
+		if e.Usable {
+			return "", "", false
+		}
+		if e.SkipReason != "" {
+			skip = e.SkipReason
+			break
+		}
+	}
+	return route, skip, true
+}
+
+// ChangeRouting rewrites a paused mission's review route and model pin
+// (D-100, issue #536): the API layer's routing PATCH calls this after
+// validating the route resolves. ErrNotPaused for any other status,
+// mapped to 409 by the API layer. The mission stays paused; resume is
+// a separate operator action.
+func (d *Driver) ChangeRouting(ctx context.Context, id, reviewRoute, reviewRouteModel string) error {
+	m, err := d.store.Get(ctx, id)
+	if err != nil {
+		return fmt.Errorf("driver: change routing: %w", err)
+	}
+	if m.Phase.Terminal() {
+		return ErrTerminal
+	}
+	if m.Status != StatusPaused {
+		return ErrNotPaused
+	}
+	t := Step(d.toStepState(ctx, m), StepInput{Input: InputRouteChange, ReviewRoute: reviewRoute, ReviewRouteModel: reviewRouteModel}, d.cfg)
+	if err := d.store.ApplyTransition(ctx, id, t); err != nil {
+		return fmt.Errorf("driver: change routing: apply transition: %w", err)
+	}
+	return nil
+}
+
 // DecidePlan applies one of the three plan-approval verbs (D-087,
 // issue #456) to a mission parked on PauseApproval: the API layer's
 // approve/replan/rediscover endpoints call this, never the model.
@@ -1274,6 +1345,7 @@ func (d *Driver) toStepState(ctx context.Context, m Mission) StepState {
 		AutoApprovePlan: m.AutoApprovePlan, Flow: m.Flow,
 		ReviewFindings: m.ReviewFindings, ReworkRounds: m.ReworkRounds,
 		LastReviewCommit: m.Plan.LastReviewCommit, LastReviewAt: m.Plan.LastReviewAt,
+		ReviewRoute: m.ReviewRoute, ReviewRouteModel: m.ReviewRouteModel,
 	}
 }
 

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -123,6 +123,9 @@ func (f *fakeStore) ApplyTransition(ctx context.Context, id string, t Transition
 	m.ConsecutiveFailures, m.LastGapFingerprint, m.StallCount = t.Next.ConsecutiveFailures, t.Next.LastGapFingerprint, t.Next.StallCount
 	m.ReplanUsed = t.Next.ReplanUsed
 	m.ReviewFindings, m.ReworkRounds = t.Next.ReviewFindings, t.Next.ReworkRounds
+	if t.Next.ReviewRoute != "" {
+		m.ReviewRoute, m.ReviewRouteModel = t.Next.ReviewRoute, t.Next.ReviewRouteModel
+	}
 	if len(t.Next.Units) > 0 {
 		m.Plan.Units = t.Next.Units
 	}
@@ -3928,5 +3931,84 @@ func TestGatewayReviewWindow(t *testing.T) {
 	failing := GatewayReviewWindow(resolve, func(context.Context) (map[string]int, error) { return nil, errors.New("down") })
 	if got := failing(context.Background(), "review", "big"); got != 0 {
 		t.Fatalf("window with the catalog down = %d, want 0", got)
+	}
+}
+
+// TestDriverChangeRouting covers the routing PATCH's driver half (D-100,
+// issue #536): paused missions get the new review route and a
+// mission.route_changed event, anything else is refused untouched.
+func TestDriverChangeRouting(t *testing.T) {
+	store := newFakeStore()
+	store.put("paused", Mission{ID: "paused", Phase: PhaseProve, Status: StatusPaused, PauseReason: PauseInfra, Route: "worker", ReviewRoute: "old", ReviewRouteModel: "a/b"})
+	store.put("working", Mission{ID: "working", Phase: PhaseProve, Status: StatusWorking, ReviewRoute: "old"})
+	store.put("done", Mission{ID: "done", Phase: PhaseDone, Status: StatusDone, ReviewRoute: "old"})
+	d := testDriver(store, nil)
+	ctx := context.Background()
+
+	if err := d.ChangeRouting(ctx, "paused", "careful", ""); err != nil {
+		t.Fatalf("ChangeRouting(paused): %v", err)
+	}
+	got := store.missions["paused"]
+	if got.ReviewRoute != "careful" || got.ReviewRouteModel != "" || got.Route != "worker" || got.Status != StatusPaused {
+		t.Fatalf("mission after change = %+v, want review_route=careful, cleared pin, worker route and pause untouched", got)
+	}
+	events := store.events["paused"]
+	if len(events) != 1 || events[0].Kind != "mission.route_changed" || !strings.Contains(string(events[0].Payload), `"from_route":"old"`) || !strings.Contains(string(events[0].Payload), `"to_route":"careful"`) {
+		t.Fatalf("events = %+v, want one mission.route_changed with old and new route", events)
+	}
+
+	if err := d.ChangeRouting(ctx, "working", "careful", ""); !errors.Is(err, ErrNotPaused) {
+		t.Fatalf("ChangeRouting(working) = %v, want ErrNotPaused", err)
+	}
+	if err := d.ChangeRouting(ctx, "done", "careful", ""); !errors.Is(err, ErrTerminal) {
+		t.Fatalf("ChangeRouting(done) = %v, want ErrTerminal", err)
+	}
+	if store.missions["working"].ReviewRoute != "old" || len(store.events["working"]) != 0 {
+		t.Fatalf("working mission touched: %+v / %+v", store.missions["working"], store.events["working"])
+	}
+}
+
+// TestDriverReviewRouteSkip confirms a prove turn's no usable provider
+// failure is translated into the review route's name and first skip
+// reason (D-100), and that any other error, or a usable route, leaves
+// the raw error alone.
+func TestDriverReviewRouteSkip(t *testing.T) {
+	store := newFakeStore()
+	d := testDriver(store, nil)
+	m := Mission{Route: "worker", PlanRoute: "plan", ReviewRoute: "careful"}
+	noRoute := errors.New(`gwclient: gateway http 502: {"error":"no_route","message":"no usable provider for route \"careful\""}`)
+
+	if _, _, ok := d.reviewRouteSkip(context.Background(), m, noRoute); ok {
+		t.Fatal("no resolver wired: want ok=false")
+	}
+	d.SetRouteResolver(func(_ context.Context, route, harness string) (*gwclient.ResolvedRoute, error) {
+		if harness != "" {
+			t.Fatalf("resolve harness = %q, want the chat axis", harness)
+		}
+		switch route {
+		case "careful":
+			return &gwclient.ResolvedRoute{Route: route, Entries: []gwclient.ResolvedRouteEntry{
+				{ProviderName: "zai", Model: "glm", Usable: false, SkipReason: "cooling down until 12:00"},
+				{ProviderName: "openai", Model: "gpt", Usable: false, SkipReason: "disabled"},
+			}}, nil
+		case "alive":
+			return &gwclient.ResolvedRoute{Route: route, Entries: []gwclient.ResolvedRouteEntry{{Usable: true}}}, nil
+		}
+		return nil, errors.New("unknown route")
+	})
+	route, skip, ok := d.reviewRouteSkip(context.Background(), m, noRoute)
+	if !ok || route != "careful" || skip != "cooling down until 12:00" {
+		t.Fatalf("reviewRouteSkip = %q, %q, %v; want careful, first skip reason, true", route, skip, ok)
+	}
+	if _, _, ok := d.reviewRouteSkip(context.Background(), m, errors.New("context deadline exceeded")); ok {
+		t.Fatal("unrelated error: want ok=false")
+	}
+	m.ReviewRoute = "alive"
+	if _, _, ok := d.reviewRouteSkip(context.Background(), m, noRoute); ok {
+		t.Fatal("route with a usable entry: want ok=false")
+	}
+	m.ReviewRoute = ""
+	if route, _, ok := d.reviewRouteSkip(context.Background(), m, noRoute); ok || route != "" {
+		t.Fatalf("unknown route resolve error: got %q, %v; want ok=false", route, ok)
 	}
 }

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -637,4 +637,7 @@ var (
 	// (D-087, issue #456): approve/replan/rediscover are only valid
 	// while the mission is parked on PauseApproval.
 	ErrNotAwaitingApproval = errors.New("mission is not awaiting plan approval")
+	// ErrNotPaused guards the routing PATCH (D-100, issue #536): the
+	// review route is editable only while the mission is paused.
+	ErrNotPaused = errors.New("mission is not paused")
 )

--- a/internal/brain/missions/statemachine.go
+++ b/internal/brain/missions/statemachine.go
@@ -194,6 +194,10 @@ const (
 	// Status to waiting_for_input); the difference is ask_user's answer
 	// resolves through Store.AnswerPendingInput, not a plain resume.
 	InputAskUser Input = "ask_user"
+	// InputRouteChange rewrites a paused mission's review route and
+	// model pin (D-100, issue #536): valid only while Status is paused
+	// (any pause reason, plan approval included); a no-op anywhere else.
+	InputRouteChange Input = "route_change"
 )
 
 // StepState is the state-machine-relevant slice of a Mission — Step
@@ -268,6 +272,12 @@ type StepState struct {
 	// LastReviewAt is when the last rework round closed (D-098): the
 	// findings-only packet renders only progress notes written after it.
 	LastReviewAt time.Time
+	// ReviewRoute/ReviewRouteModel mirror the mission row's review
+	// routing (D-100): carried so ApplyTransition writes them back
+	// unchanged on every transition and InputRouteChange can rewrite
+	// them. An empty ReviewRoute leaves both columns untouched.
+	ReviewRoute      string
+	ReviewRouteModel string
 }
 
 // neverVisitsPlan reports whether s's mission can never be in
@@ -319,6 +329,14 @@ type StepInput struct {
 	// by applyVerification whatever the input is, so harness evidence
 	// is never lost to the transition that follows it.
 	Verified []UnitVerification
+	// Route names the route a failed review turn ran on (D-100), set on
+	// InputReviewInfraFailure when the gateway found no usable provider;
+	// empty otherwise.
+	Route string
+	// ReviewRoute/ReviewRouteModel are the new values an
+	// InputRouteChange writes (D-100).
+	ReviewRoute      string
+	ReviewRouteModel string
 }
 
 // EventDraft is one event Step decided must be appended; the Store
@@ -431,9 +449,13 @@ func stepInput(s StepState, in StepInput, cfg Config) Transition {
 	case InputReviewRework:
 		return stepReviewRework(s, in, cfg)
 	case InputReviewInfraFailure:
+		payload := map[string]any{"reason": string(PauseInfra), "detail": in.Reason}
+		if in.Route != "" {
+			payload["route"] = in.Route
+		}
 		return Transition{
 			Next:   withPause(s, PauseInfra),
-			Events: []EventDraft{{Kind: "mission.paused", Payload: map[string]any{"reason": string(PauseInfra), "detail": in.Reason}}},
+			Events: []EventDraft{{Kind: "mission.paused", Payload: payload}},
 		}
 	case InputReviewBudget:
 		return Transition{
@@ -463,6 +485,8 @@ func stepInput(s StepState, in StepInput, cfg Config) Transition {
 		return stepPlanReplan(s, in)
 	case InputPlanRediscover:
 		return stepPlanRediscover(s)
+	case InputRouteChange:
+		return stepRouteChange(s, in)
 	default:
 		// Unrecognized input: no-op rather than a panic or a silent
 		// wrong transition — the driver logs this as a bug elsewhere.
@@ -622,6 +646,24 @@ func stepPlanRediscover(s StepState) Transition {
 	s.Iteration = 0
 	s.ConsecutiveFailures = 0
 	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.rediscover_requested", Payload: map[string]any{}}}}
+}
+
+// stepRouteChange rewrites the review route and model pin of a paused
+// mission (D-100, issue #536). The mission stays paused: the operator
+// resumes separately, and the next review round reads the new route
+// off the row. Any other status is a no-op (the API layer already
+// rejects it with 409).
+func stepRouteChange(s StepState, in StepInput) Transition {
+	if s.Phase.Terminal() || s.Status != StatusPaused || in.ReviewRoute == "" {
+		return Transition{Next: s}
+	}
+	payload := map[string]any{
+		"from_route": s.ReviewRoute, "to_route": in.ReviewRoute,
+		"from_model": s.ReviewRouteModel, "to_model": in.ReviewRouteModel,
+	}
+	s.ReviewRoute = in.ReviewRoute
+	s.ReviewRouteModel = in.ReviewRouteModel
+	return Transition{Next: s, Events: []EventDraft{{Kind: "mission.route_changed", Payload: payload}}}
 }
 
 // stepWorkerFailed counts consecutive failures toward the backoff

--- a/internal/brain/missions/statemachine_test.go
+++ b/internal/brain/missions/statemachine_test.go
@@ -1269,3 +1269,57 @@ func TestStepReworkStallsOnUntouchedFile(t *testing.T) {
 		t.Fatalf("a minor finding must never stall the mission: %+v", minor.Next)
 	}
 }
+
+// TestStepRouteChange covers the review-route rewrite (D-100, issue
+// #536): legal only while paused, records old and new values, and
+// leaves the mission paused for the operator's separate resume.
+func TestStepRouteChange(t *testing.T) {
+	paused := StepState{Phase: PhaseProve, Status: StatusPaused, PauseReason: PauseInfra, ReviewRoute: "old", ReviewRouteModel: "zai/glm-4.7"}
+	got := Step(paused, StepInput{Input: InputRouteChange, ReviewRoute: "careful", ReviewRouteModel: "openai/gpt-5"}, DefaultConfig)
+	want := paused
+	want.ReviewRoute, want.ReviewRouteModel = "careful", "openai/gpt-5"
+	if !reflect.DeepEqual(got.Next, want) {
+		t.Fatalf("Next = %+v, want %+v", got.Next, want)
+	}
+	if len(got.Events) != 1 || got.Events[0].Kind != "mission.route_changed" {
+		t.Fatalf("Events = %+v, want exactly one mission.route_changed", got.Events)
+	}
+	wantPayload := map[string]any{"from_route": "old", "to_route": "careful", "from_model": "zai/glm-4.7", "to_model": "openai/gpt-5"}
+	if !reflect.DeepEqual(got.Events[0].Payload, wantPayload) {
+		t.Fatalf("payload = %+v, want %+v", got.Events[0].Payload, wantPayload)
+	}
+
+	approval := StepState{Phase: PhasePlan, Status: StatusPaused, PauseReason: PauseApproval, ReviewRoute: "old"}
+	if got := Step(approval, StepInput{Input: InputRouteChange, ReviewRoute: "careful"}, DefaultConfig); got.Next.ReviewRoute != "careful" || got.Next.PauseReason != PauseApproval {
+		t.Fatalf("plan-approval park: Next = %+v, want route changed and still parked on approval", got.Next)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		state StepState
+		input StepInput
+	}{
+		{"working is a no-op", StepState{Phase: PhaseProve, Status: StatusWorking, ReviewRoute: "old"}, StepInput{Input: InputRouteChange, ReviewRoute: "careful"}},
+		{"terminal is a no-op", StepState{Phase: PhaseDone, Status: StatusDone, ReviewRoute: "old"}, StepInput{Input: InputRouteChange, ReviewRoute: "careful"}},
+		{"empty route is a no-op", paused, StepInput{Input: InputRouteChange}},
+	} {
+		got := Step(tc.state, tc.input, DefaultConfig)
+		if !reflect.DeepEqual(got.Next, tc.state) || len(got.Events) != 0 {
+			t.Fatalf("%s: got %+v / %+v, want unchanged state and no events", tc.name, got.Next, got.Events)
+		}
+	}
+}
+
+// TestStepReviewInfraFailureCarriesRoute confirms the pause payload
+// names the route when the input carries one (D-100) and omits the key
+// otherwise, so older readers see the same shape as before.
+func TestStepReviewInfraFailureCarriesRoute(t *testing.T) {
+	got := Step(StepState{Phase: PhaseProve, Status: StatusWorking}, StepInput{Input: InputReviewInfraFailure, Reason: "dead", Route: "careful"}, DefaultConfig)
+	if r, _ := got.Events[0].Payload["route"].(string); r != "careful" {
+		t.Fatalf("payload = %+v, want route=careful", got.Events[0].Payload)
+	}
+	got = Step(StepState{Phase: PhaseProve, Status: StatusWorking}, StepInput{Input: InputReviewInfraFailure, Reason: "dead"}, DefaultConfig)
+	if _, ok := got.Events[0].Payload["route"]; ok {
+		t.Fatalf("payload = %+v, want no route key", got.Events[0].Payload)
+	}
+}

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -1101,7 +1101,9 @@ func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) er
 	// units key is rewritten, and only when the plan has units, so a
 	// planless mission's '{}' stays untouched. last_review_commit (D-096)
 	// and last_review_at (D-098) sit next to it, written only when a
-	// rework recorded them.
+	// rework recorded them. review_route/review_route_model (D-100) are
+	// written only when the state carries a review route, so a
+	// hand-built StepState never blanks the row's routing.
 	var unitsJSON []byte
 	if len(t.Next.Units) > 0 {
 		if unitsJSON, err = json.Marshal(t.Next.Units); err != nil {
@@ -1119,12 +1121,15 @@ func (s *Store) ApplyTransition(ctx context.Context, id string, t Transition) er
 			review_findings = $12, rework_rounds = $13,
 			plan = (CASE WHEN $14::jsonb IS NULL THEN plan ELSE jsonb_set(plan, '{units}', $14::jsonb) END)
 				|| CASE WHEN $15::text = '' THEN '{}'::jsonb ELSE jsonb_build_object('last_review_commit', $15::text) END
-				|| CASE WHEN $16::text = '' THEN '{}'::jsonb ELSE jsonb_build_object('last_review_at', $16::text) END
+				|| CASE WHEN $16::text = '' THEN '{}'::jsonb ELSE jsonb_build_object('last_review_at', $16::text) END,
+			review_route = CASE WHEN $17::text = '' THEN review_route ELSE $17::text END,
+			review_route_model = CASE WHEN $17::text = '' THEN review_route_model ELSE $18::text END
 		WHERE id = $1`,
 		id, string(t.Next.Phase), string(t.Next.Status), string(t.Next.PauseReason),
 		t.Next.Iteration, t.Next.MaxIterations, t.Next.ConsecutiveFailures,
 		t.Next.LastGapFingerprint, t.Next.StallCount, clearPending, t.Next.ReplanUsed,
 		findingsJSON, t.Next.ReworkRounds, unitsJSON, t.Next.LastReviewCommit, lastReviewAt,
+		t.Next.ReviewRoute, t.Next.ReviewRouteModel,
 	); err != nil {
 		return fmt.Errorf("missions apply transition update: %w", err)
 	}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1515,6 +1515,28 @@ export async function rediscoverMission(id: string): Promise<void> {
   await request<void>(`/v1/missions/${id}/rediscover`, { method: 'POST' })
 }
 
+// getMissionDetailExecutionPlan resolves an existing mission's phases
+// from its own snapshotted routes (D-100), the detail page's read-only
+// counterpart to getMissionExecutionPlan.
+export async function getMissionDetailExecutionPlan(id: string): Promise<ExecutionPlanPhase[]> {
+  const { phases } = await request<{ phases: ExecutionPlanPhase[] }>(`/v1/missions/${id}/execution-plan`)
+  return phases ?? []
+}
+
+// patchMissionRouting rewrites a paused mission's review route and
+// optional model pin (D-100). The server answers 409 not_paused for a
+// running or finished mission and 400 route_unusable when the route
+// has no usable chain entry.
+export async function patchMissionRouting(
+  id: string,
+  input: { review_route: string; review_route_model?: string },
+): Promise<void> {
+  await request<void>(`/v1/missions/${id}/routing`, {
+    method: 'PATCH',
+    body: JSON.stringify(input),
+  })
+}
+
 // answerMissionQuestion answers a mission parked on ask_user
 // (pending_input): mcq/yes_no answers must match the question's own
 // options, open accepts any non-empty text, the server validates

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1030,6 +1030,16 @@ export interface MissionSteeredPayload {
   phase?: string
 }
 
+// MissionRouteChangedPayload is mission.route_changed's payload
+// (D-100): the review route and model pin before and after an
+// operator's routing PATCH on a paused mission.
+export interface MissionRouteChangedPayload {
+  from_route: string
+  to_route: string
+  from_model?: string
+  to_model?: string
+}
+
 // MissionTurnPayload is mission.turn's payload: one event per phase
 // run (driver.go's Advance), recording wall time and the StepInput that
 // resulted regardless of which phase actually ran.

--- a/web/src/components/missions/MissionExecutionPlan.tsx
+++ b/web/src/components/missions/MissionExecutionPlan.tsx
@@ -1,4 +1,5 @@
 import type { ExecutionPlanEntry, ExecutionPlanPhase } from '../../api/types'
+import { unusablePhases, unusableReason } from './executionPlan'
 import { executorChoices } from './MissionForm'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { matchPreset } from '../settings/presets'
@@ -71,11 +72,11 @@ function modelPinFor(phaseKey: string, props: MissionExecutionPlanProps): string
   switch (phaseKey) {
     case 'discover':
     case 'plan':
-      return props.planRouteModel
+      return props.planRouteModel ?? ''
     case 'generate':
-      return props.routeModel
+      return props.routeModel ?? ''
     case 'prove':
-      return props.reviewRouteModel
+      return props.reviewRouteModel ?? ''
     default:
       return ''
   }
@@ -88,11 +89,11 @@ function onModelPinChangeFor(
   switch (phaseKey) {
     case 'discover':
     case 'plan':
-      return props.onPlanRouteModelChange
+      return props.onPlanRouteModelChange ?? null
     case 'generate':
-      return props.onRouteModelChange
+      return props.onRouteModelChange ?? null
     case 'prove':
-      return props.onReviewRouteModelChange
+      return props.onReviewRouteModelChange ?? null
     default:
       return null
   }
@@ -100,12 +101,17 @@ function onModelPinChangeFor(
 
 interface MissionExecutionPlanProps {
   plan: ExecutionPlanPhase[] | null
-  routeModel: string
-  onRouteModelChange: (v: string) => void
-  planRouteModel: string
-  onPlanRouteModelChange: (v: string) => void
-  reviewRouteModel: string
-  onReviewRouteModelChange: (v: string) => void
+  // title heads the table; the create form's default names the
+  // consequence of the form state, the detail page passes its own.
+  title?: string
+  // Pins and their change handlers are optional: omitted, a phase's
+  // resolved model renders read only (the mission detail page).
+  routeModel?: string
+  onRouteModelChange?: (v: string) => void
+  planRouteModel?: string
+  onPlanRouteModelChange?: (v: string) => void
+  reviewRouteModel?: string
+  onReviewRouteModelChange?: (v: string) => void
 }
 
 // MissionExecutionPlan renders the five-phase read-out of what a
@@ -113,15 +119,17 @@ interface MissionExecutionPlanProps {
 // the server-resolved consequence of the route/harness selects above
 // it, plus a per-phase model pin (D-078): a select over that phase's
 // entries, defaulting to "Auto (first usable)". Renders nothing while
-// the plan hasn't loaded yet.
+// the plan hasn't loaded yet. Phases whose route has no usable entry
+// get a warning line under the table (D-100).
 export function MissionExecutionPlan(props: MissionExecutionPlanProps) {
-  const { plan } = props
+  const { plan, title = 'This mission will run' } = props
   if (!plan || plan.length === 0) return null
   const byPhase = new Map(plan.map((p) => [p.phase, p]))
+  const unusable = unusablePhases(plan)
 
   return (
     <div className="rounded-lg border border-border p-4">
-      <div className="text-sm font-semibold">This mission will run</div>
+      <div className="text-sm font-semibold">{title}</div>
       <div className="mt-2 divide-y divide-border">
         {phaseOrder.map((key) => {
           const phase = byPhase.get(key)
@@ -129,6 +137,12 @@ export function MissionExecutionPlan(props: MissionExecutionPlanProps) {
           return <PhaseRow key={key} phase={phase} phaseKey={key} props={props} />
         })}
       </div>
+      {unusable.map((phase) => (
+        <p key={phase.phase} role="alert" className="mt-2 text-xs text-destructive">
+          Route {phase.route} has no usable provider for {phaseLabels[phase.phase] ?? phase.phase}:{' '}
+          {unusableReason(phase.entries)}
+        </p>
+      ))}
       <p className="mt-2 text-xs text-muted-foreground">
         Naming and memory extraction use the summarize route.
       </p>
@@ -202,7 +216,7 @@ function PhaseRow({
 // same pattern PhaseRow already used for display-only unusable counts.
 // The Auto item names the entry it actually resolves to when one is
 // selected and usable, so "Auto" isn't a mystery next to a picked model.
-function ModelPinSelect({
+export function ModelPinSelect({
   label,
   entries,
   pin,

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -1810,3 +1810,37 @@ describe('MissionForm: execution plan', () => {
     )
   })
 })
+
+describe('MissionForm: unusable route gate', () => {
+  it('warns and blocks submit when a phase route has no usable entry', async () => {
+    const plan = fivePhases.map((p) =>
+      p.phase === 'prove'
+        ? {
+            ...p,
+            route: 'careful',
+            entries: [
+              {
+                provider_name: 'OpenAI',
+                driver: 'openaicompat',
+                kind: 'chat',
+                base_url: 'https://api.openai.com/v1',
+                model: 'gpt-5-mini',
+                usable: false,
+                skip_reason: 'cooling down until 12:00',
+                selected: false,
+              },
+            ],
+          }
+        : p,
+    )
+    vi.mocked(getMissionExecutionPlan).mockResolvedValue(plan)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(await screen.findByLabelText('Goal'), { target: { value: 'g' } })
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Route careful has no usable provider for Prove: cooling down until 12:00',
+    )
+    expect(screen.getByRole('button', { name: 'Create mission' })).toBeDisabled()
+    expect(createMission).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -51,6 +51,7 @@ import { envIcon } from '../icons/EnvIcons'
 import { type PendingAttachment } from '../Composer'
 import { MissionAttachments } from './MissionAttachments'
 import { GoalTextarea } from './MissionReferences'
+import { unusablePhases } from './executionPlan'
 import { MissionExecutionPlan } from './MissionExecutionPlan'
 
 type RepoSource = 'none' | 'github'
@@ -820,7 +821,8 @@ export function MissionForm({
         (!repeat || validCronShape(cron)) &&
         githubSourceReady &&
         githubDestinationReady &&
-        !attachments.some((a) => a.uploading)
+        !attachments.some((a) => a.uploading) &&
+        unusablePhases(executionPlan).length === 0
 
   const submitMission = async () => {
     let repoURL: string | undefined

--- a/web/src/components/missions/ReviewRoutePicker.test.tsx
+++ b/web/src/components/missions/ReviewRoutePicker.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AdminRoute, ExecutionPlanPhase, Mission } from '../../api/types'
+
+vi.mock('../../api/client', () => ({
+  listRoutes: vi.fn(),
+  getMissionExecutionPlan: vi.fn(),
+  patchMissionRouting: vi.fn(),
+}))
+
+import { getMissionExecutionPlan, listRoutes, patchMissionRouting } from '../../api/client'
+import { ReviewRoutePicker } from './ReviewRoutePicker'
+
+afterEach(cleanup)
+
+const routes: AdminRoute[] = [
+  { name: 'default', strategy: 'ordered', enabled: true, chain: [] },
+  { name: 'careful', strategy: 'ordered', enabled: true, chain: [] },
+  { name: 'disabled-route', strategy: 'ordered', enabled: false, chain: [] },
+]
+
+const paused = {
+  id: 'm1',
+  goal: 'g',
+  kind: 'general',
+  phase: 'prove',
+  status: 'paused',
+  pause_reason: 'infra',
+  route: 'default',
+  review_route: 'default',
+  flow: 'full',
+  plan: { units: [] },
+  progress: [],
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+} as unknown as Mission
+
+function provePhase(entries: ExecutionPlanPhase['entries']): ExecutionPlanPhase[] {
+  return [
+    {
+      phase: 'prove',
+      route: 'careful',
+      route_source: 'explicit',
+      axis: 'native',
+      harness: '',
+      harness_source: '',
+      skipped: false,
+      skip_reason: '',
+      entries,
+    },
+  ]
+}
+
+const entry = {
+  provider_name: 'OpenAI',
+  driver: 'openaicompat',
+  kind: 'chat',
+  base_url: 'https://api.openai.com/v1',
+  model: 'gpt-5',
+  usable: true,
+  skip_reason: '',
+  selected: true,
+}
+
+describe('ReviewRoutePicker', () => {
+  beforeEach(() => {
+    // jsdom has no scrollIntoView; Radix Select calls it on open.
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.mocked(listRoutes).mockResolvedValue(routes)
+    vi.mocked(getMissionExecutionPlan).mockResolvedValue(provePhase([entry]))
+    vi.mocked(patchMissionRouting).mockResolvedValue(undefined)
+  })
+
+  it('starts on the mission review route with Save disabled until something changes', async () => {
+    render(<ReviewRoutePicker mission={paused} onSaved={vi.fn()} />)
+    expect(await screen.findByRole('combobox', { name: 'Review route' })).toHaveTextContent('default')
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('saves the picked route through the routing endpoint', async () => {
+    const onSaved = vi.fn()
+    render(<ReviewRoutePicker mission={paused} onSaved={onSaved} />)
+    fireEvent.click(await screen.findByRole('combobox', { name: 'Review route' }))
+    fireEvent.click(await screen.findByRole('option', { name: 'careful' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled())
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() =>
+      expect(patchMissionRouting).toHaveBeenCalledWith('m1', { review_route: 'careful', review_route_model: undefined }),
+    )
+    expect(onSaved).toHaveBeenCalled()
+  })
+
+  it('disables Save and warns when the picked route has no usable entry', async () => {
+    vi.mocked(getMissionExecutionPlan).mockResolvedValue(
+      provePhase([{ ...entry, usable: false, selected: false, skip_reason: 'cooling down until 12:00' }]),
+    )
+    render(<ReviewRoutePicker mission={paused} onSaved={vi.fn()} />)
+    fireEvent.click(await screen.findByRole('combobox', { name: 'Review route' }))
+    fireEvent.click(await screen.findByRole('option', { name: 'careful' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Route careful has no usable provider: cooling down until 12:00',
+    )
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    // The unusable entry stays listed in the model pin select, disabled
+    // with its reason.
+    fireEvent.click(screen.getByLabelText('Review model'))
+    const option = await screen.findByText(/gpt-5 - cooling down until 12:00/)
+    expect(option.closest('[role="option"]')).toHaveAttribute('aria-disabled', 'true')
+  })
+})

--- a/web/src/components/missions/ReviewRoutePicker.tsx
+++ b/web/src/components/missions/ReviewRoutePicker.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { getMissionExecutionPlan, patchMissionRouting } from '../../api/client'
+import type { ExecutionPlanEntry, Mission } from '../../api/types'
+import { useRoutes } from '../AgentPicker'
+import { errText } from '../settings/util'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { unusableReason } from './executionPlan'
+import { ModelPinSelect } from './MissionExecutionPlan'
+
+interface ReviewRoutePickerProps {
+  mission: Mission
+  onSaved: () => void
+}
+
+// ReviewRoutePicker edits a paused mission's review route and model pin
+// in place (D-100, issue #536): the same route select the create form
+// renders, the prove phase's chain resolved through the execution plan
+// endpoint so unusable entries stay listed but disabled with their
+// reason, and a Save that calls PATCH .../routing. Worker and plan
+// routes are not editable here.
+export function ReviewRoutePicker({ mission, onSaved }: ReviewRoutePickerProps) {
+  const routes = useRoutes()
+  const enabledRoutes = routes?.filter((r) => r.enabled) ?? []
+  const [reviewRoute, setReviewRoute] = useState(mission.review_route)
+  const [reviewRouteModel, setReviewRouteModel] = useState(mission.review_route_model ?? '')
+  const [entries, setEntries] = useState<ExecutionPlanEntry[] | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!reviewRoute) return
+    let cancelled = false
+    getMissionExecutionPlan({
+      kind: mission.kind,
+      route: mission.route,
+      plan_route: mission.plan_route,
+      review_route: reviewRoute,
+      harness: mission.harness,
+    }).then(
+      (phases) => {
+        if (!cancelled) setEntries(phases.find((p) => p.phase === 'prove')?.entries ?? [])
+      },
+      () => {
+        if (!cancelled) setEntries([])
+      },
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [reviewRoute, mission.kind, mission.route, mission.plan_route, mission.harness])
+
+  const unusable = !!reviewRoute && entries !== null && entries.length > 0 && !entries.some((e) => e.usable)
+  const dirty = reviewRoute !== mission.review_route || reviewRouteModel !== (mission.review_route_model ?? '')
+  const selected = entries?.find((e) => (reviewRouteModel ? `${e.provider_name}/${e.model}` === reviewRouteModel : e.selected))
+
+  const save = async () => {
+    setSaving(true)
+    try {
+      await patchMissionRouting(mission.id, {
+        review_route: reviewRoute,
+        review_route_model: reviewRouteModel || undefined,
+      })
+      toast.success('Review route updated')
+      onSaved()
+    } catch (err) {
+      toast.error('Could not change the review route', { description: errText(err) })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-2 rounded-lg border border-border p-3">
+      <Label htmlFor="mission-review-route">Review route</Label>
+      <div className="flex flex-wrap items-center gap-2">
+        {routes === null ? (
+          <Input
+            id="mission-review-route"
+            className="w-48"
+            value={reviewRoute}
+            onChange={(e) => setReviewRoute(e.target.value)}
+          />
+        ) : (
+          <Select value={reviewRoute} onValueChange={setReviewRoute}>
+            <SelectTrigger id="mission-review-route" className="w-48">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {enabledRoutes.map((r) => (
+                <SelectItem key={r.name} value={r.name}>
+                  {r.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+        {reviewRoute && entries && entries.length > 0 && (
+          <ModelPinSelect
+            label="Review model"
+            entries={entries}
+            pin={reviewRouteModel}
+            onChange={setReviewRouteModel}
+            selected={selected}
+          />
+        )}
+        <Button size="sm" disabled={saving || !dirty || !reviewRoute || unusable} onClick={() => void save()}>
+          Save
+        </Button>
+      </div>
+      {unusable && entries && (
+        <p role="alert" className="text-xs text-destructive">
+          Route {reviewRoute} has no usable provider: {unusableReason(entries)}
+        </p>
+      )}
+      <p className="text-xs text-muted-foreground">
+        The next review round after resume runs on this route. Worker and plan routes stay as they are.
+      </p>
+    </div>
+  )
+}

--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -454,3 +454,21 @@ describe('unknown event kind fallback', () => {
     expect(renderEvent(event({}, 'some.future.kind'))).toBe('some.future.kind')
   })
 })
+
+describe('mission.route_changed rendering', () => {
+  it('names the old and new review route', () => {
+    render(<div>{renderEvent(event({ from_route: 'default', to_route: 'careful' }, 'mission.route_changed'))}</div>)
+    expect(screen.getByText('Review route changed: default → careful')).toHaveClass('text-amber-400')
+  })
+
+  it('appends the model pin change when it differs', () => {
+    render(
+      <div>
+        {renderEvent(
+          event({ from_route: 'default', to_route: 'careful', from_model: '', to_model: 'openai/gpt-5' }, 'mission.route_changed'),
+        )}
+      </div>,
+    )
+    expect(screen.getByText('Review route changed: default → careful · model auto → openai/gpt-5')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -10,6 +10,7 @@ import type {
   MissionPermissionDeniedPayload,
   MissionPROpenedPayload,
   MissionRetryPayload,
+  MissionRouteChangedPayload,
   MissionSteeredPayload,
   MissionToolCallPayload,
   MissionTurnPayload,
@@ -195,6 +196,16 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
     return (
       <span className="text-amber-400">
         Operator note{phase ? ` (${phase})` : ''}: {note}
+      </span>
+    )
+  },
+  'mission.route_changed': (p) => {
+    const { from_route, to_route, from_model, to_model } = p as MissionRouteChangedPayload
+    const pin = (from_model ?? '') !== (to_model ?? '') ? ` · model ${from_model || 'auto'} → ${to_model || 'auto'}` : ''
+    return (
+      <span className="text-amber-400">
+        Review route changed: {from_route || 'none'} → {to_route}
+        {pin}
       </span>
     )
   },

--- a/web/src/components/missions/executionPlan.ts
+++ b/web/src/components/missions/executionPlan.ts
@@ -1,0 +1,18 @@
+import type { ExecutionPlanEntry, ExecutionPlanPhase } from '../../api/types'
+
+// unusablePhases lists the phases that will run on a chain whose
+// entries are all unusable (D-100): the create form blocks submit on
+// it and the server rejects the same request with route_unusable. A
+// phase with no entries (resolve failure, empty chain) is left out,
+// matching the server's own gate.
+export function unusablePhases(plan: ExecutionPlanPhase[] | null): ExecutionPlanPhase[] {
+  return (plan ?? []).filter(
+    (p) => !p.skipped && !!p.route && p.entries.length > 0 && !p.entries.some((e) => e.usable),
+  )
+}
+
+// unusableReason is the first skip reason among an unusable chain's
+// entries, or the server's generic reason.
+export function unusableReason(entries: ExecutionPlanEntry[]): string {
+  return entries.find((e) => e.skip_reason)?.skip_reason ?? 'no usable provider for this route'
+}

--- a/web/src/pages/MissionDetail.test.tsx
+++ b/web/src/pages/MissionDetail.test.tsx
@@ -27,6 +27,10 @@ vi.mock('../api/client', () => ({
   pushMission: vi.fn(),
   openMissionPR: vi.fn(),
   fetchAttachmentBlob: vi.fn(),
+  getMissionDetailExecutionPlan: vi.fn().mockResolvedValue([]),
+  getMissionExecutionPlan: vi.fn().mockResolvedValue([]),
+  patchMissionRouting: vi.fn(),
+  listRoutes: vi.fn().mockResolvedValue([]),
 }))
 
 import {
@@ -34,6 +38,7 @@ import {
   cancelMission,
   deleteMission,
   getMission,
+  getMissionDetailExecutionPlan,
   getSettings,
   listMissionFiles,
   listSchedules,
@@ -963,6 +968,56 @@ describe('MissionDetail', () => {
     renderPage()
     await screen.findByText('Fix the login bug')
     expect(screen.getByRole('button', { name: 'Intervene' })).toBeDisabled()
+  })
+
+  it('offers the review route picker in the Intervene modal only while paused', async () => {
+    vi.mocked(getMission).mockResolvedValue({ ...baseMission, status: 'paused', pause_reason: 'infra', review_route: 'default' })
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    fireEvent.click(screen.getByRole('button', { name: 'Intervene' }))
+    expect(await screen.findByRole('combobox', { name: 'Review route' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('omits the review route picker from the Intervene modal while working', async () => {
+    renderPage()
+    await screen.findByText('Fix the login bug')
+    fireEvent.click(screen.getByRole('button', { name: 'Intervene' }))
+    await screen.findByPlaceholderText('Steer this mission (markdown supported)…')
+    expect(screen.queryByLabelText('Review route')).toBeNull()
+  })
+
+  it('renders the execution plan resolved from the mission row with its unusable entries', async () => {
+    vi.mocked(getMissionDetailExecutionPlan).mockResolvedValue([
+      {
+        phase: 'prove',
+        route: 'careful',
+        route_source: 'mission',
+        axis: 'native',
+        harness: '',
+        harness_source: '',
+        skipped: false,
+        skip_reason: '',
+        entries: [
+          {
+            provider_name: 'OpenAI',
+            driver: 'openaicompat',
+            kind: 'chat',
+            base_url: '',
+            model: 'gpt-5',
+            usable: false,
+            skip_reason: 'cooling down until 12:00',
+            selected: false,
+          },
+        ],
+      },
+    ])
+    renderPage()
+    await screen.findByText('Execution plan')
+    expect(screen.getByText('1 unusable - cooling down until 12:00')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Route careful has no usable provider for Prove: cooling down until 12:00',
+    )
   })
 
   it('surfaces the most recent mission.paused event detail while paused', async () => {

--- a/web/src/pages/MissionDetail.tsx
+++ b/web/src/pages/MissionDetail.tsx
@@ -18,6 +18,7 @@ import {
   cancelMission,
   deleteMission,
   getMission,
+  getMissionDetailExecutionPlan,
   listSchedules,
   missionEvents,
   missionUsage,
@@ -29,6 +30,7 @@ import {
   sendMissionNote,
 } from '../api/client'
 import type {
+  ExecutionPlanPhase,
   ExecutorProgressPayload,
   Mission,
   MissionEvent,
@@ -42,6 +44,8 @@ import { FindingsSection } from '../components/missions/FindingsSection'
 import { GoalSection } from '../components/missions/GoalSection'
 import { InputRequestBanner } from '../components/missions/InputRequestBanner'
 import { MarkdownField } from '../components/missions/MarkdownField'
+import { MissionExecutionPlan } from '../components/missions/MissionExecutionPlan'
+import { ReviewRoutePicker } from '../components/missions/ReviewRoutePicker'
 import { PermissionBanner } from '../components/missions/PermissionBanner'
 import { PlanApprovalBanner } from '../components/missions/PlanApprovalBanner'
 import { PlanSection } from '../components/missions/PlanSection'
@@ -252,6 +256,10 @@ export function MissionDetail() {
   const [mission, setMission] = useState<Mission | null>(null)
   const [events, setEvents] = useState<MissionEvent[]>([])
   const [usage, setUsage] = useState<MissionUsage | null>(null)
+  // executionPlan is the mission's own per-phase route resolution
+  // (D-100): read only here, refetched with the mission so a routing
+  // change or a provider coming back shows up.
+  const [executionPlan, setExecutionPlan] = useState<ExecutionPlanPhase[] | null>(null)
   const [schedule, setSchedule] = useState<Schedule | null>(null)
   const [busy, setBusy] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
@@ -311,6 +319,9 @@ export function MissionDetail() {
     }, () => undefined)
     missionUsage(id).then((u) => {
       if (seq === refreshSeq.current) setUsage(u)
+    }, () => undefined)
+    getMissionDetailExecutionPlan(id).then((p) => {
+      if (seq === refreshSeq.current) setExecutionPlan(p)
     }, () => undefined)
   }, [id])
 
@@ -997,6 +1008,15 @@ export function MissionDetail() {
             Currently in <span className="font-medium text-foreground">{mission.phase}</span> ·{' '}
             {mission.status.replace(/_/g, ' ')}
           </p>
+          {mission.status === 'paused' && (
+            <ReviewRoutePicker
+              mission={mission}
+              onSaved={() => {
+                setIntervening(false)
+                refresh()
+              }}
+            />
+          )}
           <MarkdownField
             placeholder="Steer this mission (markdown supported)…"
             value={noteText}
@@ -1014,6 +1034,8 @@ export function MissionDetail() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <MissionExecutionPlan plan={executionPlan} title="Execution plan" />
 
       {mission.discover_notes && (
         <section>


### PR DESCRIPTION
## Summary

Slice 8 of the prove loop redesign v2 (D-100).

- Create rejects a mission whose route chain (generate on its harness axis, discover/plan on the oversight route, prove on the review route, escalate when set) resolves with entries but none usable: `400 route_unusable` naming the route and the first skip reason. Flows that skip a phase skip that axis; a resolve error or empty chain never blocks, matching the gate's positive-evidence rule.
- The create form blocks submit and shows the same warning from the execution plan data it already loads; `unusablePhases` / `unusableReason` live in `web/src/components/missions/executionPlan.ts` and back both the form and the detail page.
- `GET /v1/missions/{id}/execution-plan` resolves an existing mission's phases from its own snapshotted routes; the detail page renders it read only through `MissionExecutionPlan` (pins and handlers are now optional props, no second renderer).
- A prove turn failing on the gateway's no usable provider error now parks with `review route "x" has no usable provider: <skip reason>` in the pause detail and a `route` key in the `mission.paused` payload, resolved through `gwclient.ResolveRoute` (new `Driver.SetRouteResolver`, wired in `cmd/brain/main.go`).
- `PATCH /v1/missions/{id}/routing` with `{review_route, review_route_model?}`: validates the route resolves with at least one usable chat-axis entry, then `Driver.ChangeRouting` applies the new `route_change` state machine input through `ApplyTransition`, appending `mission.route_changed` with `from_route`/`to_route`/`from_model`/`to_model`. Legal only while paused (any pause reason, plan approval included); `409 not_paused` otherwise. The mission stays paused; the next review round after resume reads the route off the row. Worker and plan routes untouched.
- `ApplyTransition` writes `review_route`/`review_route_model` only when the state carries a review route (`toStepState` always does), so hand-built states never blank the row's routing.
- Web: the Intervene dialog on a paused mission shows `ReviewRoutePicker` (the create form's route select plus the shared `ModelPinSelect`, unusable entries disabled with their reason, Save disabled while the picked route has no usable entry); the timeline renders `mission.route_changed`.

No schema change: `review_route` and `review_route_model` are existing columns.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test -race ./...`, `golangci-lint run ./...` (0 issues) in `golang:1.26.6` / `golangci/golangci-lint:v2.12.2`
- [x] New: `TestStepRouteChange`, `TestStepReviewInfraFailureCarriesRoute`, `TestDriverChangeRouting`, `TestDriverReviewRouteSkip`, `TestMissionsUnusableCreateRoute`, `TestMissionsCreateRejectsUnusableRoute`, `TestMissionsRoutingValidation`
- [x] Integration: `TestMissionsRoutingPatchStateGate` plus the existing `TestMissions*`/`TestStore*`/`TestDriver*` integration tests against a throwaway `pgvector/pgvector:0.8.4-pg18-trixie` container
- [x] Web (`node:24.18.0-alpine`): build, lint (0 errors), full vitest suite 1064 passed; new tests for `ReviewRoutePicker`, the `mission.route_changed` renderer, the form's unusable-route gate, and the detail page's picker/execution plan
- [ ] `make canary` and `make canary-two-unit` were not run from the worktree (shared compose project); the coordinator runs them against this commit before merge

Closes #536
Part of #510

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791021332&installation_model_id=431401&pr_number=538&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F538&signature=0aa3cbf61d21ea42ee2a4ad709d71d97c50e47bb95a1637bfb10c78ca07938d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->