### PR TITLE
fix(agents): seed generate_pdf and share_file, truthful load_skill digest

### DIFF
--- a/internal/brain/loop/agent.go
+++ b/internal/brain/loop/agent.go
@@ -848,11 +848,12 @@ func (a *Agent) executeOne(ctx context.Context, exec Executor, sessionID string,
 	}
 
 	duration := time.Since(start)
-	// load_skill's result is the pack's full rule text — useful to the
-	// model, never to the client. Every other tool's result is fair to
-	// show (truncated) in the audit trail and the UI.
+	// load_skill's result is the pack's full rule text, useful to the
+	// model, never to the client. Every other tool's result, and a
+	// failed load_skill (unknown skill name), is fair to show
+	// (truncated) in the audit trail and the UI.
 	var digest, traceContent string
-	if call.Name == "load_skill" {
+	if call.Name == "load_skill" && !isError {
 		digest = "skill loaded"
 	} else {
 		digest = content

--- a/internal/brain/loop/agent_test.go
+++ b/internal/brain/loop/agent_test.go
@@ -3,6 +3,7 @@ package loop
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -2538,5 +2539,45 @@ func TestAgentRequestMaxToolCallsRefusesPastCap(t *testing.T) {
 				t.Fatal("refused call's result must be an error so the model keeps full effort")
 			}
 		})
+	}
+}
+
+// TestAgentLoadSkillErrorDigestIsTruthful: a failed load_skill (unknown
+// skill name) must not be shown to the client as "skill loaded"; the
+// digest carries the error the model saw.
+func TestAgentLoadSkillErrorDigestIsTruthful(t *testing.T) {
+	t.Parallel()
+	loadSkill := &tools.Tool{
+		Name:        "load_skill",
+		Description: "stands in for the real load_skill tool",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}},"required":["name"],"additionalProperties":false}`),
+		Execute: func(_ context.Context, _ json.RawMessage) (string, error) {
+			return "", errors.New(`unknown skill "pdf", available: coding, research-brief`)
+		},
+	}
+	gw := &scriptedGateway{scripts: [][]stream.StreamEvent{
+		toolCallStep([2]string{"load_skill", `{"name":"pdf"}`}),
+		finalStep("done"),
+	}}
+	a, _, _, _ := testAgent(t, gw, loadSkill)
+
+	ch, err := a.Start(t.Context(), Request{SessionID: "s1", Route: "coding", Messages: []provider.Message{{Role: "user", Content: "load the pdf skill"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var saw bool
+	for _, ev := range collect(t, ch) {
+		if ev.Type == stream.EventToolResult && ev.ToolResult != nil {
+			saw = true
+			if ev.ToolResult.Status == "ok" {
+				t.Fatalf("status = ok, want error")
+			}
+			if ev.ToolResult.Digest == "skill loaded" || !strings.Contains(ev.ToolResult.Digest, `unknown skill "pdf"`) {
+				t.Fatalf("digest = %q, want the load_skill error", ev.ToolResult.Digest)
+			}
+		}
+	}
+	if !saw {
+		t.Fatal("no tool_result event")
 	}
 }

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -464,7 +464,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS agents_one_default
 INSERT INTO agents (name, description, prompt_overlay, route, skills, tools, is_default)
 SELECT 'general', 'Everyday questions and tasks on a strong all-round chain.', '', 'default',
     '["research-brief", "deep-research", "coding", "email-research"]',
-    '["get_current_time", "convert_time", "calculate", "convert_currency", "search_web", "fetch_url", "remember", "list_missions", "get_mission", "push_mission_branch", "followup_mission", "search_mail", "read_mail", "read_mail_attachment", "send_mail", "list_calendar_events", "create_calendar_event"]',
+    '["get_current_time", "convert_time", "calculate", "convert_currency", "search_web", "fetch_url", "remember", "list_missions", "get_mission", "push_mission_branch", "followup_mission", "search_mail", "read_mail", "read_mail_attachment", "send_mail", "list_calendar_events", "create_calendar_event", "share_file", "generate_pdf"]',
     NOT EXISTS (SELECT 1 FROM agents WHERE is_default)
 WHERE NOT EXISTS (SELECT 1 FROM agents WHERE name = 'general');
 

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -13,3 +13,15 @@ run before deploy.
 ALTER TABLE missions ADD COLUMN IF NOT EXISTS review_findings jsonb NOT NULL DEFAULT '[]';
 ALTER TABLE missions ADD COLUMN IF NOT EXISTS rework_rounds integer NOT NULL DEFAULT 0;
 ```
+
+## generate_pdf and share_file on the general agent (issue #546)
+
+Live rows seeded before this change never received the two builtins
+(agent tool lists are opt-in, #229). Idempotent, safe to run any time.
+
+```sql
+UPDATE agents SET tools = tools || '["share_file"]'::jsonb
+  WHERE name IN ('general', 'researcher') AND NOT tools ? 'share_file';
+UPDATE agents SET tools = tools || '["generate_pdf"]'::jsonb
+  WHERE name IN ('general', 'researcher') AND NOT tools ? 'generate_pdf';
+```


### PR DESCRIPTION
## Summary
- Seed `share_file` and `generate_pdf` into the `general` agent's tool list; agent tool lists are opt-in (#229), so #398 registering the builtin was not enough for existing or new agents to see it. Observed on a homelab chat session that asked for a PDF twice and got Google Docs instructions.
- Idempotent UPDATE for live rows (general, researcher) added to `scripts/pending-alters.md`.
- `load_skill` digest is "skill loaded" only when the call succeeded; a failed load (unknown skill name) now shows the error in the transcript instead.

## Test plan
- [x] `go build ./...`, `go vet ./internal/brain/...`, `go test -race ./internal/brain/loop/`, golangci-lint 0 issues (Docker)
- [x] New `TestAgentLoadSkillErrorDigestIsTruthful`; existing `TestAgentRedactsLoadSkillDigest` still passes
- No harness change, canary not needed

Closes #546

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791057834&installation_model_id=431401&pr_number=547&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F547&signature=5288af64b55848bf207da10c03207849afb03d06c33d3e557258e6a8352a7d84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->