### PR TITLE
fix(web): match the harness's actual review verdict decision values

### DIFF
--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -42,6 +42,27 @@ describe('mission.finding_demoted rendering', () => {
   })
 })
 
+describe('mission.review_verdict rendering', () => {
+  it('renders an approved decision green', () => {
+    render(<div>{renderEvent(event({ decision: 'approved', findings: [], resolved: [] }, 'mission.review_verdict'))}</div>)
+    expect(screen.getByText('Review verdict: approved')).toHaveClass('text-green-400')
+  })
+
+  it('renders a rework decision amber with the open finding ids', () => {
+    render(<div>{renderEvent(event({ decision: 'rework', reason: 'missing test', round: 1, open: ['F1', 'F2'] }, 'mission.review_verdict'))}</div>)
+    expect(screen.getByText('Review verdict: rework: open F1, F2')).toHaveClass('text-amber-400')
+  })
+
+  it('marks a findings_only round as such', () => {
+    render(
+      <div>
+        {renderEvent(event({ decision: 'rework', findings: [], resolved: [], findings_only: true }, 'mission.review_verdict'))}
+      </div>,
+    )
+    expect(screen.getByText('Review verdict: rework (findings-only round)')).toHaveClass('text-amber-400')
+  })
+})
+
 describe('mission.generate_skipped rendering', () => {
   it('explains the skipped worker turn', () => {
     expect(renderEvent(event({}, 'mission.generate_skipped'))).toBe('Worker turn skipped: every unit is harness-verified')

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -80,9 +80,18 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
     )
   },
   'mission.review_verdict': (p) => {
-    const { decision } = asRecord(p)
-    const approved = decision === 'approve'
-    return <span className={approved ? 'text-green-400' : 'text-amber-400'}>Review verdict: {String(decision ?? '?')}</span>
+    const { decision, open, findings_only } = asRecord(p)
+    const approved = decision === 'approved'
+    const findingsOnly = findings_only === true ? ' (findings-only round)' : ''
+    const openIDs = Array.isArray(open) ? open : undefined
+    const openSuffix = !approved && openIDs && openIDs.length > 0 ? `: open ${openIDs.join(', ')}` : ''
+    return (
+      <span className={approved ? 'text-green-400' : 'text-amber-400'}>
+        Review verdict: {String(decision ?? '?')}
+        {findingsOnly}
+        {openSuffix}
+      </span>
+    )
   },
   'mission.turn': (p) => {
     const { phase, duration_ms, ok, reason, route, agent, provider, model } = p as MissionTurnPayload


### PR DESCRIPTION
## Summary
- The `mission.review_verdict` renderer checked `decision === 'approve'`, but the driver's `runReview` writes `"approved"` and the state machine writes `"rework"` — every verdict rendered amber, approved included.
- Render both event shapes the harness emits per rework round: the driver's raw verdict (`decision`, `findings_only`) and the state machine's applied verdict (`decision`, `open`, `round`).
- Approved renders green; rework stays amber and lists open finding ids when present; a `findings_only: true` payload is labeled as a findings-only round.
- No harness payload changes.

## Test plan
- [x] `eventRenderers.test.tsx`: added cases for approved (green), rework with open ids (amber), and findings-only rework.
- [x] `npm run build` — passes.
- [x] `npm run lint` — 0 errors (pre-existing warnings unrelated to this change).
- [x] `npx vitest run` — 1065 passed, 2 failed (both `AgentRoutePicker.test.tsx`, the known flake, unrelated to this change).

Closes #526

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791058576&installation_model_id=431401&pr_number=548&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F548&signature=3091a2963a91d627a618b0ab54a5a9af7817ec00d973277a52a033aed144748e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->