### PR TITLE
feat(missions): skip planning when the goal already carries a plan

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -565,6 +565,12 @@ type createMissionRequest struct {
 	// Flow=light below when Flow is omitted, and must never contradict
 	// an explicit Flow.
 	Light bool `json:"light"`
+	// HasPlan (D-102, issue #496) marks a goal that already carries the
+	// operator's own plan: the plan turn runs in transcribe mode instead
+	// of designing units from scratch. "" (omitted) is false, the
+	// unchanged default. The classify preview only suggests a value
+	// (classifyGoal), the operator's checkbox is what actually sets it.
+	HasPlan bool `json:"has_plan"`
 	// Flow selects the phase set this mission runs (D-090, issue #459):
 	// "" (omitted, the default) maps to "light" when Light=true, else
 	// "full", today's exact pre-#459 behavior. Rejected outright on
@@ -808,6 +814,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		RouteModel: req.RouteModel, PlanRouteModel: req.PlanRouteModel, ReviewRouteModel: req.ReviewRouteModel,
 		MaxIterations: req.MaxIterations, BudgetAmount: req.BudgetAmount, BudgetCurrency: budgetCurrency,
 		AutoApproveTools: autoApproveTools, AutoApprovePlan: autoApprovePlan, PromptOverlay: promptOverlay, Harness: req.Harness, Environment: req.Environment,
+		HasPlan:                  req.HasPlan,
 		ParentMissionID:          parentMissionID,
 		Sources:                  sources,
 		Destinations:             req.destinationEntries(),
@@ -1145,6 +1152,23 @@ func classifyLight(ctx context.Context, classify agents.Classify, goal string) b
 	return strings.Contains(reply, "yes") && !strings.Contains(reply, "no")
 }
 
+// hasPlanPattern matches a goal shaped like an explicit numbered or
+// step-labeled plan (D-102, issue #496): "1. ...", "1) ...", "Step 1"
+// on its own line, anchored to line starts so a stray "1." mid-sentence
+// never matches. A syntactic heuristic, not an LLM call: cheap enough
+// for classifyGoal's every-keystroke preview, and the operator's own
+// checkbox is the real gate on create().
+var hasPlanPattern = regexp.MustCompile(`(?im)^\s*(?:[0-9]+[.)]|step\s+[0-9]+\b)`)
+
+// classifyHasPlan reports whether goal reads like it already contains
+// an explicit plan: two or more distinct numbered/step lines. One
+// stray "1." isn't enough signal (a goal can legitimately mention a
+// single numbered item without being a plan), so this counts matches
+// rather than just checking for one.
+func classifyHasPlan(goal string) bool {
+	return len(hasPlanPattern.FindAllString(goal, -1)) >= 2
+}
+
 // classifyKindAndLight answers both classifyKind and classifyLight's
 // questions in one model call — used only by the preview endpoint
 // (classifyGoal), which needs both on every debounced keystroke and
@@ -1210,7 +1234,8 @@ func (h *missionAPI) classifyGoal(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	kind, light := classifyKindAndLight(r.Context(), h.classify, req.Goal)
-	writeJSON(w, http.StatusOK, map[string]any{"kind": kind, "light": light})
+	hasPlan := classifyHasPlan(req.Goal)
+	writeJSON(w, http.StatusOK, map[string]any{"kind": kind, "light": light, "has_plan": hasPlan})
 }
 
 // detectDestination serves POST /v1/missions/detect-destination

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -905,10 +905,54 @@ func TestClassifyKindAndLight(t *testing.T) {
 	}
 }
 
+// TestClassifyHasPlan covers classifyHasPlan's shape heuristic (D-102,
+// issue #496): a goal shaped like an explicit numbered/step plan (two
+// or more distinct numbered/step lines) infers true; a plain goal, or
+// one with only a single stray numbered mention, infers false.
+func TestClassifyHasPlan(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		goal string
+		want bool
+	}{
+		{"plain goal", "write a report on Q3 sales", false},
+		{
+			"numbered plan with periods",
+			"Do the following:\n1. Create main.go\n2. Add a test\n3. Run go build",
+			true,
+		},
+		{
+			"numbered plan with parens",
+			"Steps:\n1) set up the repo\n2) write the handler\n3) wire it up",
+			true,
+		},
+		{
+			"step-labeled plan",
+			"Step 1: clone the repo\nStep 2: install dependencies\nStep 3: run the tests",
+			true,
+		},
+		{
+			"single stray numbered mention is not a plan",
+			"Ship v1.0 of the library, see also RFC 2.0 for background",
+			false,
+		},
+		{"empty goal", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := classifyHasPlan(tc.goal); got != tc.want {
+				t.Fatalf("classifyHasPlan(%q) = %v, want %v", tc.goal, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestMissionsClassifyEndpoint covers POST /v1/missions/classify: the
-// happy path returning the classifier's verdict (kind and light), and
-// the empty-goal 400 — this endpoint has no store/driver dependency, so
-// it can be tested end to end without Postgres.
+// happy path returning the classifier's verdict (kind, light, and
+// has_plan), and the empty-goal 400 — this endpoint has no store/driver
+// dependency, so it can be tested end to end without Postgres.
 func TestMissionsClassifyEndpoint(t *testing.T) {
 	t.Parallel()
 	a, _, _ := testAPI(t, "tok", nil)
@@ -928,8 +972,14 @@ func TestMissionsClassifyEndpoint(t *testing.T) {
 
 	if code, body := call(`{"goal":"write a report on Q3 sales"}`); code != http.StatusOK {
 		t.Fatalf("classify with a goal = %d %s, want 200", code, body)
-	} else if !strings.Contains(body, `"kind":"general"`) || !strings.Contains(body, `"light":true`) {
-		t.Fatalf("classify body = %s, want kind general and light true", body)
+	} else if !strings.Contains(body, `"kind":"general"`) || !strings.Contains(body, `"light":true`) || !strings.Contains(body, `"has_plan":false`) {
+		t.Fatalf("classify body = %s, want kind general, light true, has_plan false", body)
+	}
+
+	if code, body := call(`{"goal":"Do the following:\n1. write main.go\n2. add a test\n3. run go build"}`); code != http.StatusOK {
+		t.Fatalf("classify with a plan-shaped goal = %d %s, want 200", code, body)
+	} else if !strings.Contains(body, `"has_plan":true`) {
+		t.Fatalf("classify body = %s, want has_plan true", body)
 	}
 
 	if code, _ := call(`{"goal":""}`); code != http.StatusBadRequest {
@@ -1239,6 +1289,67 @@ func TestMissionsCreateKindOptional(t *testing.T) {
 	}
 	if code, body := call(`{"goal":"do something","kind":"bogus"}`); code != http.StatusBadRequest || !strings.Contains(body, "kind must be") {
 		t.Fatalf("create with an invalid kind = %d %s, want 400 from kind validation", code, body)
+	}
+}
+
+// TestMissionsCreateHasPlan covers has_plan's create-request parsing
+// (D-102, issue #496): true and omitted (defaults to false) both pass
+// straight through to the degraded driver/store (no ValidateCreate
+// rejection -- has_plan has no shape rules of its own), mirroring
+// TestMissionsCreateKindOptional's pattern of asserting on the response
+// body rather than the status code alone.
+func TestMissionsCreateHasPlan(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	driver.SetValidateDeps(missions.ValidateDeps{})
+	m := mux(a)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+
+	call := func(body string) (int, string) {
+		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w.Code, w.Body.String()
+	}
+
+	if code, body := call(`{"goal":"do something","kind":"general","has_plan":true}`); code != http.StatusBadRequest || strings.Contains(body, "has_plan") {
+		t.Fatalf("create with has_plan=true = %d %s, want 400 from the degraded driver, not has_plan validation", code, body)
+	}
+	if code, body := call(`{"goal":"do something","kind":"general"}`); code != http.StatusBadRequest || strings.Contains(body, "has_plan") {
+		t.Fatalf("create with has_plan omitted = %d %s, want 400 from the degraded driver, not has_plan validation", code, body)
+	}
+}
+
+// TestCreateMissionRequestDecodesHasPlan pins the wire shape directly:
+// has_plan decodes to true only when explicitly set, omitted/false
+// both decode to false (Go's bool zero value), matching Light's own
+// json:"light" (no omitempty on read) tag shape.
+func TestCreateMissionRequestDecodesHasPlan(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"explicit true", `{"goal":"g","has_plan":true}`, true},
+		{"explicit false", `{"goal":"g","has_plan":false}`, false},
+		{"omitted defaults false", `{"goal":"g"}`, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var req createMissionRequest
+			if err := json.Unmarshal([]byte(tc.body), &req); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if req.HasPlan != tc.want {
+				t.Fatalf("HasPlan = %v, want %v", req.HasPlan, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -176,6 +176,13 @@ type Mission struct {
 	// engine both force this true regardless of template/step input:
 	// an unattended mission has nobody to approve its plan.
 	AutoApprovePlan bool   `json:"auto_approve_plan"`
+	// HasPlan (D-102, issue #496) marks a mission whose goal already
+	// carries the operator's own plan: the plan turn runs in transcribe
+	// mode (PlanSession), converting the goal's plan into units instead
+	// of designing one from scratch. Snapshotted at create time, never
+	// model-mutable; light missions never plan, so this has no effect
+	// there.
+	HasPlan         bool   `json:"has_plan,omitempty"`
 	ScheduleID      string `json:"schedule_id,omitempty"`
 	// ParentMissionID names the terminal mission this one follows up on
 	// (api/missions.go's create) — empty for an ordinary mission.

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -1560,6 +1560,31 @@ func renderReviewContent(p ReviewPacket) string {
 	return b.String()
 }
 
+// planUnitShapeRules is the unit-shape contract every plan must
+// satisfy regardless of how it was derived (designed from scratch or
+// transcribed from an operator-supplied plan, D-102): artifacts,
+// criteria, scope, verify_cmd's POSIX-shell/no-substitution/content-
+// check rules, workspace-relative paths, the infeasible escape hatch
+// (D-077), and assumptions. Kept as one shared string so
+// generate/prove's unit parsing (parsePlan) never has to distinguish
+// which mode produced a plan.
+const planUnitShapeRules = " Every unit must list at least one artifact, the workspace-relative file(s) the unit must produce (for a report-style goal, the report file itself is the artifact); the harness itself checks each exists and is non-empty, so name the real deliverables. Every unit must also list 2 to 6 acceptance criteria: short single lines taken from the goal stating what the unit's output must satisfy (constraints, required content, format), because the reviewer judges the unit against these criteria rather than the goal text; name the artifact file in a criterion when judging it requires reading its contents. Optionally list scope: the workspace-relative files or directories the unit may touch (defaults to the artifact directories). verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory; it must be a real POSIX shell command (using binaries like grep, test, wc, NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Never use command substitution ($(...) or backticks) in verify_cmd; write the direct command instead; for a line-count check use awk, e.g. `awk 'END{exit NR<10}' report.md`, NEVER `test $(wc -l ...)`. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. If the goal cannot be achieved as stated (it forbids the only possible action, contradicts what actually exists in the workspace, or is self-contradictory), do not invent a workaround plan: call submit_plan with infeasible=true and a reason instead of units. If the goal left something ambiguous and you resolved it silently, list it in assumptions with the default you chose (e.g. \"no language version was specified\" -> \"Python 3.12\", \"output format unspecified\" -> \"single markdown file\"); leave assumptions empty when nothing was ambiguous. End your turn with exactly one submit_plan tool call."
+
+// planSystemPrompt builds PlanSession's system prompt: the design-mode
+// opening (break the goal into units from scratch) or, when hasPlan is
+// true (D-102, issue #496), transcribe mode -- the goal already
+// contains the operator's own plan, so the model converts it into
+// units faithfully instead of redesigning it. Either way the unit
+// shape (planUnitShapeRules) is identical, so generate/prove need no
+// changes: the same D-077 infeasible and D-095 criteria checks apply
+// to a transcribed plan as to a designed one.
+func planSystemPrompt(hasPlan bool) string {
+	if hasPlan {
+		return "You are transcribing a mission plan. The goal below already contains the operator's own plan: convert it into an ordered list of verifiable units faithfully, preserving its steps and order. Do not redesign the plan, do not add scope or steps the operator didn't ask for, and do not merge or split steps the operator kept separate, except where the shape rules below force a natural split (e.g. one step whose own deliverable would truncate a single worker turn)." + planUnitShapeRules
+	}
+	return "You are planning one mission. Break the goal into the SMALLEST ordered list of verifiable units that achieves it: one unit is correct for a simple goal; never pad the plan. A worker turn is one continuous model generation: if a single unit's own deliverable would demand a very long uninterrupted output (many chapters, dozens of sections, a large multi-file dataset, or similar), a long stream is more likely to truncate mid-generation, so split that unit along its own natural boundaries (one unit per chapter/section/file) instead of one unit for the whole deliverable; this applies regardless of the goal's subject matter." + planUnitShapeRules
+}
+
 // PlanSession runs the planning turn that produces a Plan from the
 // mission's goal and discover-phase findings. The plan is forced
 // through the submit_plan tool call (mirroring RunWorker/RunReview's
@@ -1568,7 +1593,7 @@ func renderReviewContent(p ReviewPacket) string {
 // stuck mission (5 straight "invalid plan JSON" failures, identical
 // each retry since nothing told the model what went wrong).
 func (r *nativeRunner) PlanSession(ctx context.Context, m Mission, discoverNotes string) (Plan, error) {
-	system := "You are planning one mission. Break the goal into the SMALLEST ordered list of verifiable units that achieves it: one unit is correct for a simple goal; never pad the plan. A worker turn is one continuous model generation: if a single unit's own deliverable would demand a very long uninterrupted output (many chapters, dozens of sections, a large multi-file dataset, or similar), a long stream is more likely to truncate mid-generation, so split that unit along its own natural boundaries (one unit per chapter/section/file) instead of one unit for the whole deliverable; this applies regardless of the goal's subject matter. Every unit must list at least one artifact, the workspace-relative file(s) the unit must produce (for a report-style goal, the report file itself is the artifact); the harness itself checks each exists and is non-empty, so name the real deliverables. Every unit must also list 2 to 6 acceptance criteria: short single lines taken from the goal stating what the unit's output must satisfy (constraints, required content, format), because the reviewer judges the unit against these criteria rather than the goal text; name the artifact file in a criterion when judging it requires reading its contents. Optionally list scope: the workspace-relative files or directories the unit may touch (defaults to the artifact directories). verify_cmd is executed literally as `/bin/sh -c \"<verify_cmd>\"` in the mission's own workspace directory; it must be a real POSIX shell command (using binaries like grep, test, wc, NOT a tool name from your own tool list, which does not exist as a shell command) and must check the CONTENT of the artifacts (e.g. grep -qi 'retry-after' summary.md), never a bare echo, which proves nothing. Never use command substitution ($(...) or backticks) in verify_cmd; write the direct command instead; for a line-count check use awk, e.g. `awk 'END{exit NR<10}' report.md`, NEVER `test $(wc -l ...)`. Use paths relative to the workspace; never /tmp or any absolute path outside it, since the worker's shell is confined to the workspace. If the goal cannot be achieved as stated (it forbids the only possible action, contradicts what actually exists in the workspace, or is self-contradictory), do not invent a workaround plan: call submit_plan with infeasible=true and a reason instead of units. If the goal left something ambiguous and you resolved it silently, list it in assumptions with the default you chose (e.g. \"no language version was specified\" -> \"Python 3.12\", \"output format unspecified\" -> \"single markdown file\"); leave assumptions empty when nothing was ambiguous. End your turn with exactly one submit_plan tool call." + r.execEnvironmentNote(ctx)
+	system := planSystemPrompt(m.HasPlan) + r.execEnvironmentNote(ctx)
 	user := "Goal: " + NeutralizeSlot(m.Goal)
 	if discoverNotes != "" {
 		user += "\n\nDiscovery findings:\n" + NeutralizeSlot(discoverNotes)

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -784,6 +784,60 @@ func TestPlanSessionPromptsLengthAwareSplitting(t *testing.T) {
 	}
 }
 
+// TestPlanSessionTranscribeMode pins D-102 (issue #496): a mission
+// with HasPlan=true gets the transcribe-mode system prompt (told the
+// goal already carries the plan, must not redesign or add scope)
+// instead of the design-from-scratch opening, while the shared
+// unit-shape rules (artifacts/criteria/verify_cmd/infeasible) still
+// apply either way so generate/prove need no changes.
+func TestPlanSessionTranscribeMode(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
+	}}
+	r := newTestRunner(agent)
+	m := Mission{ID: "m1", Route: "default", Goal: "1. do a\n2. do b", HasPlan: true}
+	if _, err := r.PlanSession(context.Background(), m, ""); err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	system := agent.requests[0].System
+	if !strings.Contains(system, "You are transcribing a mission plan") {
+		t.Fatalf("planner system prompt missing transcribe-mode opening: %s", system)
+	}
+	if !strings.Contains(system, "Do not redesign the plan") {
+		t.Fatalf("planner system prompt missing the no-redesign instruction: %s", system)
+	}
+	if strings.Contains(system, "Break the goal into the SMALLEST ordered list") {
+		t.Fatalf("planner system prompt still carries the design-from-scratch opening: %s", system)
+	}
+	// The unit-shape contract must be unchanged: same artifacts/
+	// criteria/verify_cmd/infeasible rules regardless of mode.
+	if !strings.Contains(system, "Every unit must list at least one artifact") ||
+		!strings.Contains(system, "2 to 6 acceptance criteria") ||
+		!strings.Contains(system, "infeasible=true") {
+		t.Fatalf("planner system prompt missing unit-shape rules in transcribe mode: %s", system)
+	}
+}
+
+// TestPlanSessionDesignModeByDefault confirms HasPlan=false (the
+// default, omitted) keeps the pre-D-102 design-from-scratch opening.
+func TestPlanSessionDesignModeByDefault(t *testing.T) {
+	agent := &scriptedAgent{batches: [][]stream.StreamEvent{
+		{toolEndEvent(planToolName, `{"units":[{"title":"Add validation","artifacts":["out.md"],"criteria":["c1","c2"],"verify_cmd":"go test ./...","passes":true}]}`)},
+	}}
+	r := newTestRunner(agent)
+	m := Mission{ID: "m1", Route: "default", Goal: "fix bug"}
+	if _, err := r.PlanSession(context.Background(), m, ""); err != nil {
+		t.Fatalf("PlanSession: %v", err)
+	}
+	system := agent.requests[0].System
+	if !strings.Contains(system, "Break the goal into the SMALLEST ordered list") {
+		t.Fatalf("planner system prompt missing design-from-scratch opening: %s", system)
+	}
+	if strings.Contains(system, "You are transcribing a mission plan") {
+		t.Fatalf("planner system prompt unexpectedly in transcribe mode: %s", system)
+	}
+}
+
 // TestPlanSessionForcesPlanTool pins D-063: when submit_plan is the
 // planning turn's sole tool, the request forces it.
 func TestPlanSessionForcesPlanTool(t *testing.T) {

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -52,7 +52,7 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 	discover_notes, replan_used, schedule_id, session_id, harness, environment,
 	parent_mission_id, sources, destinations, final_output, created_at, updated_at,
 	workflow_run_id, workflow_step, artifact_refs, permission_timeout_seconds, pending_input, asks_used, flow,
-	review_findings, rework_rounds`
+	review_findings, rework_rounds, has_plan`
 
 // pendingPermissionRow is pending_permission's jsonb shape in the
 // missions table: bundles the five columns the API's flat
@@ -138,7 +138,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&parentMission, &sourcesRaw, &destinationsRaw, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
 		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &permissionTimeoutSeconds,
-		&pendingInputRaw, &m.AsksUsed, &flow, &reviewFindingsRaw, &m.ReworkRounds,
+		&pendingInputRaw, &m.AsksUsed, &flow, &reviewFindingsRaw, &m.ReworkRounds, &m.HasPlan,
 		&failureReason); err != nil {
 		return Mission{}, err
 	}
@@ -225,7 +225,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&parentMission, &sourcesRaw, &destinationsRaw, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
 		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &permissionTimeoutSeconds,
-		&pendingInputRaw, &m.AsksUsed, &flow, &reviewFindingsRaw, &m.ReworkRounds); err != nil {
+		&pendingInputRaw, &m.AsksUsed, &flow, &reviewFindingsRaw, &m.ReworkRounds, &m.HasPlan); err != nil {
 		return Mission{}, err
 	}
 	m.Flow = Flow(flow)
@@ -322,9 +322,9 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	}
 	phase := initialPhase(m.Kind, flow)
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, plan, session_id, auto_approve_tools, auto_approve_plan, harness, environment, parent_mission_id, sources, destinations, phase, workflow_run_id, workflow_step, permission_timeout_seconds, flow)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, NULLIF($17, '')::uuid, $18, $19, $20, $21, NULLIF($22, '')::uuid, $23, $24, $25, NULLIF($26, '')::uuid, $27, $28, $29) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, plan, m.SessionID, m.AutoApproveTools, m.AutoApprovePlan, m.Harness, m.Environment, m.ParentMissionID, sourcesJSON, destinationsJSON, phase, m.WorkflowRunID, m.WorkflowStep, m.PermissionTimeoutSeconds, flow,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, plan, session_id, auto_approve_tools, auto_approve_plan, harness, environment, parent_mission_id, sources, destinations, phase, workflow_run_id, workflow_step, permission_timeout_seconds, flow, has_plan)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, NULLIF($17, '')::uuid, $18, $19, $20, $21, NULLIF($22, '')::uuid, $23, $24, $25, NULLIF($26, '')::uuid, $27, $28, $29, $30) RETURNING id`,
+		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, plan, m.SessionID, m.AutoApproveTools, m.AutoApprovePlan, m.Harness, m.Environment, m.ParentMissionID, sourcesJSON, destinationsJSON, phase, m.WorkflowRunID, m.WorkflowStep, m.PermissionTimeoutSeconds, flow, m.HasPlan,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -802,7 +802,12 @@ CREATE TABLE IF NOT EXISTS missions (
     -- for D-069 code paths (issue #479 dropped the redundant light
     -- column).
     flow                  text NOT NULL DEFAULT 'full'
-        CHECK (flow IN ('full', 'discover_generate', 'no_prove', 'light'))
+        CHECK (flow IN ('full', 'discover_generate', 'no_prove', 'light')),
+    -- has_plan (D-102, issue #496): the goal already carries the
+    -- operator's own plan, so the plan turn transcribes it into units
+    -- instead of designing one from scratch. false (default) is
+    -- today's behavior unchanged.
+    has_plan              boolean NOT NULL DEFAULT false
 );
 
 CREATE INDEX IF NOT EXISTS missions_status_idx ON missions (status);

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -13,3 +13,12 @@ run before deploy.
 ALTER TABLE missions ADD COLUMN IF NOT EXISTS review_findings jsonb NOT NULL DEFAULT '[]';
 ALTER TABLE missions ADD COLUMN IF NOT EXISTS rework_rounds integer NOT NULL DEFAULT 0;
 ```
+
+## Transcribe-mode plan flag (D-102, issue #496)
+
+Required on live DBs before/with the next deploy. Additive, safe to
+run before deploy.
+
+```sql
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS has_plan boolean NOT NULL DEFAULT false;
+```

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1321,6 +1321,12 @@ export interface CreateMissionInput {
   // same worker behavior as light. Only "full" is valid when
   // kind === 'coding'.
   flow?: 'full' | 'discover_generate' | 'no_prove' | 'light'
+  // has_plan (D-102, issue #496) marks a goal that already carries the
+  // operator's own plan: the plan turn transcribes it into units
+  // instead of designing one from scratch. Omit (or false) for the
+  // pre-#496 default. The classify preview only ever suggests a value;
+  // this is the operator's own checkbox choice.
+  has_plan?: boolean
   // references name composer #-mention picks (missions/chats/kb docs)
   // to resolve at create time into ReferencedContext.
   references?: { kind: ReferenceKind; id: string }[]
@@ -1409,19 +1415,24 @@ export async function createMission(input: CreateMissionInput): Promise<Mission>
   })
 }
 
-// classifyMission previews the kind create() would infer for goal, and
+// classifyMission previews the kind create() would infer for goal,
 // (for a general goal) whether it looks like a single-pass light
-// mission: the same classifyKind/classifyLight logic the server falls
-// back to/suggests, exposed standalone for the create form's live chip
-// and light toggle default. light is only ever a suggestion; create()
-// still requires the operator's explicit flag.
+// mission, and whether the goal already reads like it contains an
+// explicit plan (D-102, issue #496): the same classifyKind/
+// classifyLight/classifyHasPlan logic the server falls back to/
+// suggests, exposed standalone for the create form's live chip and
+// toggle defaults. light and has_plan are only ever suggestions;
+// create() still requires the operator's explicit flag.
 export async function classifyMission(
   goal: string,
-): Promise<{ kind: 'coding' | 'general'; light: boolean }> {
-  return request<{ kind: 'coding' | 'general'; light: boolean }>('/v1/missions/classify', {
-    method: 'POST',
-    body: JSON.stringify({ goal }),
-  })
+): Promise<{ kind: 'coding' | 'general'; light: boolean; has_plan: boolean }> {
+  return request<{ kind: 'coding' | 'general'; light: boolean; has_plan: boolean }>(
+    '/v1/missions/classify',
+    {
+      method: 'POST',
+      body: JSON.stringify({ goal }),
+    },
+  )
 }
 
 // GitHubDestinationDetection is detectMissionDestination's result: a

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -877,6 +877,10 @@ export interface Mission {
   // deliverable, same worker behavior as light); "light" is the
   // existing D-069 behavior, always paired with light: true.
   flow?: 'full' | 'discover_generate' | 'no_prove' | 'light'
+  // has_plan (D-102, issue #496) marks a mission whose goal already
+  // carried the operator's own plan: the plan turn ran in transcribe
+  // mode instead of designing units from scratch.
+  has_plan?: boolean
   final_output?: string
   // artifact_refs are this mission's declared artifact files, best-
   // effort copied into the attachment store in the result phase's step

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -142,7 +142,7 @@ beforeEach(() => {
   vi.mocked(listAgents).mockResolvedValue([])
   vi.mocked(listRoutes).mockResolvedValue(routes)
   vi.mocked(getSettings).mockResolvedValue({ settings: {}, values: {} })
-  vi.mocked(classifyMission).mockResolvedValue({ kind: 'general', light: false })
+  vi.mocked(classifyMission).mockResolvedValue({ kind: 'general', light: false, has_plan: false })
   vi.mocked(getMissionExecutorOptions).mockResolvedValue([])
   vi.mocked(getMissionExecutionPlan).mockResolvedValue([])
   vi.mocked(listConnectors).mockResolvedValue([])
@@ -685,7 +685,7 @@ describe('MissionForm: kind chip', () => {
   })
 
   it('shows a detecting state then the classified kind after the debounce', async () => {
-    vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding', light: false })
+    vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding', light: false, has_plan: false })
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Fix a bug in the repo' } })
@@ -713,7 +713,7 @@ describe('MissionForm: kind chip', () => {
   })
 
   it('submits the mission with the classified kind', async () => {
-    vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding', light: false })
+    vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding', light: false, has_plan: false })
     vi.mocked(createMission).mockResolvedValue({ id: 'm3' } as Mission)
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
@@ -852,7 +852,7 @@ describe('MissionForm: light mission toggle', () => {
 
   it('defaults the toggle from the classify preview when untouched', async () => {
     vi.useFakeTimers()
-    vi.mocked(classifyMission).mockResolvedValue({ kind: 'general', light: true })
+    vi.mocked(classifyMission).mockResolvedValue({ kind: 'general', light: true, has_plan: false })
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'summarize this' } })
@@ -864,7 +864,7 @@ describe('MissionForm: light mission toggle', () => {
 
   it('an operator-touched toggle is never overridden by a later classify preview', async () => {
     vi.useFakeTimers()
-    vi.mocked(classifyMission).mockResolvedValue({ kind: 'general', light: true })
+    vi.mocked(classifyMission).mockResolvedValue({ kind: 'general', light: true, has_plan: false })
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'summarize this' } })
@@ -904,6 +904,88 @@ describe('MissionForm: light mission toggle', () => {
 
     await waitFor(() =>
       expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ light: undefined })),
+    )
+  })
+})
+
+describe('MissionForm: has-plan checkbox', () => {
+  it('shows the checkbox for a general mission', async () => {
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    expect(await screen.findByText('General · scratch workspace')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Goal already contains the plan/)).toBeInTheDocument()
+  })
+
+  it('shows the checkbox for a coding mission too, unlike the light toggle', async () => {
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(await screen.findByText('General · scratch workspace'))
+    expect(await screen.findByText('Coding · branches from repo')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Goal already contains the plan/)).toBeInTheDocument()
+  })
+
+  it('defaults the checkbox from the classify preview when untouched', async () => {
+    vi.useFakeTimers()
+    vi.mocked(classifyMission).mockResolvedValue({ kind: 'general', light: false, has_plan: true })
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), {
+      target: { value: 'Do the following:\n1. do a\n2. do b' },
+    })
+    await vi.advanceTimersByTimeAsync(600)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(screen.getByLabelText(/Goal already contains the plan/)).toBeChecked()
+  })
+
+  it('an operator-touched checkbox is never overridden by a later classify preview', async () => {
+    vi.useFakeTimers()
+    vi.mocked(classifyMission).mockResolvedValue({ kind: 'general', light: false, has_plan: true })
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(screen.getByLabelText(/Goal already contains the plan/))
+    expect(screen.getByLabelText(/Goal already contains the plan/)).toBeChecked()
+
+    await vi.advanceTimersByTimeAsync(600)
+    await vi.advanceTimersByTimeAsync(0)
+
+    // classify resolved has_plan: true, matching the operator's own
+    // choice here, so this only proves the touched flag stops any
+    // further overrides -- the meaningful case is checked next.
+    expect(screen.getByLabelText(/Goal already contains the plan/)).toBeChecked()
+
+    fireEvent.click(screen.getByLabelText(/Goal already contains the plan/))
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g2' } })
+    await vi.advanceTimersByTimeAsync(600)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(screen.getByLabelText(/Goal already contains the plan/)).not.toBeChecked()
+  })
+
+  it('submits has_plan=true when checked, and omits it when left unchecked', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm10' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(await screen.findByLabelText(/Goal already contains the plan/))
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ has_plan: true })),
+    )
+  })
+
+  it('omits has_plan from the create payload when left unchecked', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm11' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ has_plan: undefined })),
     )
   })
 })
@@ -1327,7 +1409,7 @@ describe('MissionForm: create mode, repeat on schedule', () => {
 
   it('forces kind to general and locks it when repeat turns on with coding selected', async () => {
     vi.useFakeTimers()
-    vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding', light: false })
+    vi.mocked(classifyMission).mockResolvedValue({ kind: 'coding', light: false, has_plan: false })
     vi.mocked(createSchedule).mockResolvedValue({ id: 'sc1' })
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -362,6 +362,12 @@ export function MissionForm({
   // unless the operator has touched the toggle directly (lightTouched).
   const [light, setLight] = useState(initial?.light ?? false)
   const [lightTouched, setLightTouched] = useState(!!initial?.light)
+  // hasPlan (D-102, issue #496): the goal already carries the
+  // operator's own plan, so the plan turn transcribes it instead of
+  // designing one from scratch. Same "defaults from classify preview
+  // unless touched" pattern as light above.
+  const [hasPlan, setHasPlan] = useState(initial?.has_plan ?? false)
+  const [hasPlanTouched, setHasPlanTouched] = useState(!!initial?.has_plan)
   // flow (D-090, issue #459): defaults from kind/light (light=true ->
   // "light", else "full") unless the operator has picked a flow
   // directly (flowTouched), same "permanently defer once touched"
@@ -720,6 +726,9 @@ export function MissionForm({
           // operator's own choice (lightTouched): and only makes sense
           // once the goal actually classified as general.
           if (!lightTouched) setLight(r.kind === 'general' && r.light)
+          // has_plan likewise only ever defaults its own toggle, never
+          // overriding an explicit operator choice (hasPlanTouched).
+          if (!hasPlanTouched) setHasPlan(r.has_plan)
         })
         .catch(() => {
           // Best-effort preview: a failed classify leaves whatever kind
@@ -731,7 +740,7 @@ export function MissionForm({
       clearTimeout(t)
       setClassifying(false)
     }
-  }, [goal, kindLocked, lightTouched])
+  }, [goal, kindLocked, lightTouched, hasPlanTouched])
 
   // Light pre-fill signal 2 (issue #447): a short goal shaped like a
   // summary/digest ask, on a general mission, pre-toggles light on.
@@ -868,6 +877,7 @@ export function MissionForm({
       promote_kb_collection_id: promoteKBCollectionID || undefined,
       light: kind === 'general' ? light : undefined,
       flow: kind === 'general' ? flow : undefined,
+      has_plan: hasPlan || undefined,
       references:
         references.length > 0 ? references.map((r) => ({ kind: r.kind, id: r.id })) : undefined,
     })
@@ -1030,6 +1040,27 @@ export function MissionForm({
               <span className="block text-xs text-muted-foreground">
                 Skips discover/plan/prove for a single-pass task; the worker's final message
                 is delivered as the result.
+              </span>
+            </span>
+          </label>
+        )}
+        {mode === 'create' && !repeat && (kind !== 'general' || !light) && (
+          <label htmlFor="mission-has-plan" className="flex items-start gap-2 text-sm">
+            <input
+              id="mission-has-plan"
+              type="checkbox"
+              checked={hasPlan}
+              onChange={(e) => {
+                setHasPlan(e.target.checked)
+                setHasPlanTouched(true)
+              }}
+              className="mt-0.5"
+            />
+            <span>
+              Goal already contains the plan
+              <span className="block text-xs text-muted-foreground">
+                Skips designing a plan; the planner converts the goal's own steps into units
+                instead.
               </span>
             </span>
           </label>


### PR DESCRIPTION
## Summary

D-102 (issue #496): a mission whose goal already carries a full plan no longer has the planner redesign it from scratch.

- `has_plan` on the create request (`internal/brain/api/missions.go`) is snapshotted onto the new `missions.Mission.HasPlan` field and column, threaded through create/scan (`internal/brain/missions/store.go`).
- `PlanSession` (`internal/brain/missions/runner.go`) branches its system prompt: transcribe mode tells the model the goal already contains the plan and to convert it into units faithfully, without redesigning or adding scope; the shared `planUnitShapeRules` (artifacts/criteria/verify_cmd/infeasible/assumptions) are unchanged, so generate/prove need no changes and D-077 infeasible / D-095 `plan_invalid` retries still apply.
- `classifyGoal` (`classifyHasPlan`, a syntactic numbered/step-line heuristic, no extra LLM call) now also returns `has_plan` to prefill the web form.
- Web: `MissionForm.tsx` adds a "Goal already contains the plan" checkbox (visible for both coding and general missions, hidden only when a general mission has light checked, since light skips planning entirely), defaulting from the classify preview unless the operator touches it directly; `types.ts`/`client.ts` carry the new field.
- Light missions are unaffected: discover always runs, `has_plan` only affects the plan phase.
- Schema: additive `has_plan boolean NOT NULL DEFAULT false` column added to `migrations/0001_init.sql` in place (pre-release, per project convention) plus an `ALTER TABLE` appended to `scripts/pending-alters.md` for live DBs.

## Test plan

- [x] `go build ./...`, `go vet ./...` (plain and `-tags integration`), `golangci-lint run ./...` (0 issues) — all via Docker (`golang:1.26.6`, `golangci/golangci-lint:v2.12.2`)
- [x] `go test ./...` — full repo green
- [x] New Go tests: `TestClassifyHasPlan` (table test, plan-shaped vs plain goals), `TestCreateMissionRequestDecodesHasPlan`, `TestMissionsCreateHasPlan`, updated `TestMissionsClassifyEndpoint`, `TestPlanSessionTranscribeMode`, `TestPlanSessionDesignModeByDefault`
- [x] Web: `npm run build`, `npm run lint` (0 errors, pre-existing warning count unchanged), `npm test -- MissionForm` (99 tests, 6 new) — via Docker `node:24.18.0-alpine` with the main checkout's `node_modules` mounted read-only
- [ ] Canaries were **not** run from this worktree (shared compose project); the coordinator runs `make canary`

Closes #496

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791059281&installation_model_id=431401&pr_number=549&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F549&signature=e5c4fabe99dbae4e87379bed941b1cad14583fba51f559ddf99b0cd8b747a32e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->