### PR TITLE
fix(missions): retry gateway resolve instead of native fallback

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -293,7 +293,7 @@ func main() {
 	kbStore := kb.New(app.DB)
 	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub, missionScheduler := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, fxStore, gwc, secrets, conns, mc, packs, app.Log)
 	if missionDriver != nil {
-		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, missionNotifier,
+		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, missionNotifier, gwc,
 			flags.PermissionTimeoutSeconds, flags.AskTimeoutSeconds, broker.Resolve, app.Log)
 	}
 	destinationStore, destinationDeliverer := buildDestinations(app.DB, conns, goog, secrets, flags, missionStore, app.Log)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/SumonMSelim/timothy/internal/gateway/catalog"
 	"github.com/SumonMSelim/timothy/internal/gateway/ledger"
 	"github.com/SumonMSelim/timothy/internal/gateway/router"
+	"github.com/SumonMSelim/timothy/internal/platform/httpserver"
 	"github.com/SumonMSelim/timothy/internal/platform/service"
 	"github.com/SumonMSelim/timothy/internal/secretstore"
 	"github.com/SumonMSelim/timothy/migrations"
@@ -66,6 +67,15 @@ func main() {
 	go runCatalogSweep(ctx, cat, app.Log)
 	store := router.NewStore(app.DB, credentialLookup(secrets, app.Log), cat, app.Log)
 	go store.Run(ctx)
+	// D-101: brain's boot recovery sweep polls this before re-driving a
+	// mission left working, so a re-drive never races the routing
+	// snapshot's own load and hits a spurious config_unavailable.
+	app.AddCheck("routing", func() httpserver.Check {
+		if store.Snapshot() == nil {
+			return httpserver.Check{Status: "degraded", Detail: "routing configuration not loaded yet"}
+		}
+		return httpserver.Check{Status: "ok"}
+	})
 	unpricedUsage := app.Metrics.NewCounter("gateway_unpriced_usage_total",
 		"Billable calls recorded with no catalog price (cost = NULL).")
 	led := ledger.New(app.DB, app.Log, unpricedUsage)

--- a/internal/brain/gwclient/gwclient.go
+++ b/internal/brain/gwclient/gwclient.go
@@ -53,6 +53,14 @@ type StreamRequest struct {
 	ProviderState json.RawMessage `json:"provider_state,omitempty"`
 }
 
+// ErrGatewayUnavailable reports that the gateway itself is not yet
+// serving (unreachable, or answering 503 config_unavailable because its
+// routing snapshot hasn't loaded), distinct from a route genuinely not
+// existing (404 not_found) or a bad request (400). Callers that
+// dispatch on a route resolve (D-101, missions' delegated runner) must
+// treat this as transient infra and retry, never as "no such route".
+var ErrGatewayUnavailable = errors.New("gwclient: gateway unavailable")
+
 // windowsTTL matches the gateway's own config poll cadence: a fresher
 // read couldn't observe anything newer.
 const windowsTTL = 30 * time.Second
@@ -244,9 +252,13 @@ func (c *Client) ResolveRoute(ctx context.Context, name, harness string) (*Resol
 	}
 	resp, err := c.http.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("gwclient: gateway unreachable: %w", err)
+		return nil, fmt.Errorf("%w: %v", ErrGatewayUnavailable, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("%w: gateway http %d: %s", ErrGatewayUnavailable, resp.StatusCode, string(msg))
+	}
 	if resp.StatusCode != http.StatusOK {
 		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
 		return nil, fmt.Errorf("gwclient: gateway http %d: %s", resp.StatusCode, string(msg))
@@ -263,6 +275,44 @@ func (c *Client) ResolveRoute(ctx context.Context, name, harness string) (*Resol
 	c.resolved[cacheKey] = resolveCacheEntry{route: &out, exp: time.Now().Add(resolveTTL)}
 	c.mu.Unlock()
 	return &out, nil
+}
+
+// Ready reports whether the gateway's /health says its routing
+// snapshot has loaded (D-101): the "routing" check gateway's own
+// cmd/gateway/main.go registers alongside postgres/migrations. Used by
+// the boot recovery sweep to wait out the same window that otherwise
+// hands a re-driven mission's route resolve a spurious
+// config_unavailable. A non-ok status (including "routing" missing
+// entirely, an older gateway build) reports not ready with the
+// detail/status named so the sweep can log something useful.
+func (c *Client) Ready(ctx context.Context) (bool, string, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/health", nil)
+	if err != nil {
+		return false, "", fmt.Errorf("gwclient: request: %w", err)
+	}
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return false, "", fmt.Errorf("%w: %v", ErrGatewayUnavailable, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var health struct {
+		Status string `json:"status"`
+		Checks map[string]struct {
+			Status string `json:"status"`
+			Detail string `json:"detail"`
+		} `json:"checks"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		return false, "", fmt.Errorf("gwclient: decode health: %w", err)
+	}
+	routing, ok := health.Checks["routing"]
+	if !ok {
+		return false, "routing check not reported", nil
+	}
+	if routing.Status != "ok" {
+		return false, routing.Detail, nil
+	}
+	return true, "", nil
 }
 
 // SecretRef mirrors the gateway admin's SecretRef: a stored secret's

--- a/internal/brain/gwclient/gwclient_test.go
+++ b/internal/brain/gwclient/gwclient_test.go
@@ -2,6 +2,7 @@ package gwclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -281,5 +282,108 @@ func TestModelWindowsGatewayError(t *testing.T) {
 
 	if _, err := c.ModelWindows(t.Context()); err == nil {
 		t.Fatal("ModelWindows() = nil error for 503 gateway response")
+	}
+}
+
+// TestResolveRouteConfigUnavailableWrapsErrGatewayUnavailable proves
+// D-101 (issue #511): a 503 config_unavailable resolve response must be
+// classified as ErrGatewayUnavailable so missions' delegated runner
+// retries it instead of treating it as "no delegated route".
+func TestResolveRouteConfigUnavailableWrapsErrGatewayUnavailable(t *testing.T) {
+	t.Parallel()
+	c := gatewayStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"config_unavailable","message":"routing configuration not loaded yet"}`, http.StatusServiceUnavailable)
+	})
+
+	_, err := c.ResolveRoute(t.Context(), "coding", "claude-cli")
+	if err == nil {
+		t.Fatal("ResolveRoute() = nil error for 503 config_unavailable")
+	}
+	if !errors.Is(err, ErrGatewayUnavailable) {
+		t.Fatalf("ResolveRoute() error = %v, want it to wrap ErrGatewayUnavailable", err)
+	}
+}
+
+// TestResolveRouteUnreachableWrapsErrGatewayUnavailable proves the same
+// classification applies to a pure transport failure (gateway process
+// not listening at all), not only an HTTP 503 response.
+func TestResolveRouteUnreachableWrapsErrGatewayUnavailable(t *testing.T) {
+	t.Parallel()
+	c := New("http://127.0.0.1:1") // nothing listens here
+
+	_, err := c.ResolveRoute(t.Context(), "coding", "claude-cli")
+	if err == nil {
+		t.Fatal("ResolveRoute() = nil error for an unreachable gateway")
+	}
+	if !errors.Is(err, ErrGatewayUnavailable) {
+		t.Fatalf("ResolveRoute() error = %v, want it to wrap ErrGatewayUnavailable", err)
+	}
+}
+
+// TestResolveRouteNotFoundDoesNotWrapErrGatewayUnavailable proves a
+// genuinely definitive "no such route" answer (404) is never mistaken
+// for the gateway being unavailable: only that distinction lets
+// missions' delegated runner retry the transient case while still
+// falling back to native on this one.
+func TestResolveRouteNotFoundDoesNotWrapErrGatewayUnavailable(t *testing.T) {
+	t.Parallel()
+	c := gatewayStub(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"not_found"}`, http.StatusNotFound)
+	})
+
+	_, err := c.ResolveRoute(t.Context(), "no-such-route", "")
+	if err == nil {
+		t.Fatal("ResolveRoute() = nil error for 404 gateway response")
+	}
+	if errors.Is(err, ErrGatewayUnavailable) {
+		t.Fatalf("ResolveRoute() error = %v, want it NOT to wrap ErrGatewayUnavailable for a 404", err)
+	}
+}
+
+func TestReadyReportsRoutingCheckStatus(t *testing.T) {
+	t.Parallel()
+	c := gatewayStub(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `{"status":"degraded","checks":{"routing":{"status":"degraded","detail":"routing configuration not loaded yet"}}}`)
+	})
+
+	ready, detail, err := c.Ready(t.Context())
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if ready {
+		t.Fatal("Ready() = true, want false for a degraded routing check")
+	}
+	if detail == "" {
+		t.Fatal("Ready() detail is empty, want the routing check's detail")
+	}
+}
+
+func TestReadyReportsOKWhenRoutingLoaded(t *testing.T) {
+	t.Parallel()
+	c := gatewayStub(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `{"status":"ok","checks":{"postgres":{"status":"ok"},"routing":{"status":"ok"}}}`)
+	})
+
+	ready, _, err := c.Ready(t.Context())
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if !ready {
+		t.Fatal("Ready() = false, want true once the routing check is ok")
+	}
+}
+
+func TestReadyMissingRoutingCheckReportsNotReady(t *testing.T) {
+	t.Parallel()
+	c := gatewayStub(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `{"status":"ok","checks":{"postgres":{"status":"ok"}}}`)
+	})
+
+	ready, _, err := c.Ready(t.Context())
+	if err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+	if ready {
+		t.Fatal("Ready() = true, want false when an older gateway build reports no routing check at all")
 	}
 }

--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -29,6 +29,16 @@ import (
 // driver pauses the mission as infra instead of burning iterations.
 var ErrExecutorAuth = errors.New("executor: authentication failed")
 
+// ErrGatewayUnavailable reports that a delegated worker turn's route
+// resolve never got past the gateway itself being unavailable (D-101,
+// issue #511) after routeResolveRetries attempts: the gateway was
+// unreachable, or still answering 503 config_unavailable because its
+// routing snapshot hadn't loaded (e.g. a brain restart's boot recovery
+// sweep re-driving a mission before the gateway finished loading). This
+// is never a "no delegated route" answer: RunWorker must not fall back
+// to native on it, only the driver's infra pause.
+var ErrGatewayUnavailable = errors.New("delegated runner: gateway unavailable")
+
 // D-052: the delegated run protocol. A launch is one detached sandboxd
 // exec (setsid + nohup-style backgrounding via `&`, pid captured to a
 // file) so the CLI keeps running past the 60s ExecEnv call that started
@@ -60,6 +70,15 @@ const (
 	maxExecutorEvents = 300
 	pollInfraRetries  = 3
 	pollInfraBackoff  = 5 * time.Second
+
+	// routeResolveRetries/routeResolveBackoff bound RunWorker's retry of
+	// a route resolve that fails with ErrGatewayUnavailable (D-101): 5
+	// attempts, backoff doubling from 2s (2+4+8+16 = 30s of sleep across
+	// 4 waits before the 5th and final attempt) so the total wall clock
+	// stays close to the acceptance criterion's "5 attempts over about
+	// 30s" without a fixed-interval retry racing a slow gateway boot.
+	routeResolveRetries    = 5
+	routeResolveBackoffMin = 2 * time.Second
 )
 
 // routeResolver is the narrow seam over gwclient.Client.ResolveRoute —
@@ -145,9 +164,10 @@ type delegatedRunner struct {
 	log *slog.Logger
 
 	// Overridable in tests so scenarios don't wait real minutes.
-	pollInterval time.Duration
-	idleTimeout  time.Duration
-	runBudget    time.Duration
+	pollInterval        time.Duration
+	idleTimeout         time.Duration
+	runBudget           time.Duration
+	routeResolveBackoff time.Duration
 	// runBudgetFn, when set, is read once per launch and wins over
 	// runBudget: the settings-backed cap (issue #498).
 	runBudgetFn func(context.Context) time.Duration
@@ -167,7 +187,8 @@ func NewDelegatedRunner(native Runner, resolveRoute routeResolver, resolveCred c
 		native: native, resolveRoute: resolveRoute, resolveCred: resolveCred,
 		sandboxExec: sandboxExec, events: events, lastRun: lastRun, ledger: led, log: log,
 		pollInterval: pollInterval, idleTimeout: idleTimeout, runBudget: runBudgetDefault, runBudgetFn: runBudget,
-		cooldown: map[cooldownKey]time.Time{},
+		routeResolveBackoff: routeResolveBackoffMin,
+		cooldown:            map[cooldownKey]time.Time{},
 	}
 }
 
@@ -197,13 +218,19 @@ func (r *delegatedRunner) RunReview(ctx context.Context, m Mission, packet Revie
 // to native.RunWorker (which itself lets the gateway walk any native
 // chain). Otherwise it looks up the adapter and resolves the worker
 // route on the executor axis, walking the first usable, non-cooled
-// entry into the delegated protocol. An unknown harness, a resolve
-// failure, or no usable entry at all falls back to native.RunWorker
-// unchanged — today's behavior is always the floor — but a mission
-// that explicitly asked for a harness must not fall back silently: an
-// executor.skipped event is recorded first (see recordSkipped) so the
-// mission's own history shows the requested harness was never actually
-// used.
+// entry into the delegated protocol. An unknown harness or no usable
+// entry at all falls back to native.RunWorker unchanged: today's
+// behavior is always the floor, but a mission that explicitly asked
+// for a harness must not fall back silently: an executor.skipped event
+// is recorded first (see recordSkipped) so the mission's own history
+// shows the requested harness was never actually used. A route resolve
+// that fails because the gateway itself is unavailable (D-101, issue
+// #511) is different: that is transient infra, not "no delegated
+// route", so resolveRouteWithRetry retries it with bounded backoff and,
+// if still failing, this returns ErrGatewayUnavailable instead of
+// falling back: the driver pauses the mission as infra rather than
+// running a native worker turn behind a delegated run that may still be
+// alive in the sandbox.
 func (r *delegatedRunner) RunWorker(ctx context.Context, m Mission, packet WorkPacket) (WorkerVerdict, string, error) {
 	if m.Harness == "" {
 		return r.native.RunWorker(ctx, m, packet)
@@ -224,14 +251,19 @@ func (r *delegatedRunner) RunWorker(ctx context.Context, m Mission, packet WorkP
 		return r.native.RunWorker(ctx, m, packet)
 	}
 
-	route, err := r.resolveRoute(ctx, workerRoute(m), m.Harness)
-	if err != nil || route == nil {
-		if err != nil {
-			r.log.Warn("delegated runner: route resolve failed; falling back to native", "mission_id", m.ID, "error", err)
-			r.recordSkipped(ctx, m.ID, m.Harness, "resolve_failed", map[string]any{"error": truncate(err.Error(), 2000)})
-		} else {
-			r.recordSkipped(ctx, m.ID, m.Harness, "resolve_failed", map[string]any{"error": "resolved route was nil without an error"})
+	route, err := r.resolveRouteWithRetry(ctx, m, workerRoute(m))
+	if err != nil {
+		if errors.Is(err, gwclient.ErrGatewayUnavailable) {
+			r.log.Error("delegated runner: gateway unavailable after retries; pausing as infra", "mission_id", m.ID, "error", err)
+			r.recordSkipped(ctx, m.ID, m.Harness, "gateway_unavailable", map[string]any{"error": truncate(err.Error(), 2000)})
+			return WorkerVerdict{}, "", fmt.Errorf("%w: %v", ErrGatewayUnavailable, err)
 		}
+		r.log.Warn("delegated runner: route resolve failed; falling back to native", "mission_id", m.ID, "error", err)
+		r.recordSkipped(ctx, m.ID, m.Harness, "resolve_failed", map[string]any{"error": truncate(err.Error(), 2000)})
+		return r.native.RunWorker(ctx, m, packet)
+	}
+	if route == nil {
+		r.recordSkipped(ctx, m.ID, m.Harness, "resolve_failed", map[string]any{"error": "resolved route was nil without an error"})
 		return r.native.RunWorker(ctx, m, packet)
 	}
 
@@ -292,6 +324,43 @@ func (r *delegatedRunner) RunWorker(ctx context.Context, m Mission, packet WorkP
 		r.recordSkipped(ctx, m.ID, m.Harness, "no_usable_entry", map[string]any{"skip_reasons": boundStrings(skipReasons, 5)})
 	}
 	return r.native.RunWorker(ctx, m, packet)
+}
+
+// resolveRouteWithRetry resolves route on the harness's executor axis,
+// retrying with bounded exponential backoff (routeResolveRetries
+// attempts, starting at routeResolveBackoffMin) ONLY when the failure is
+// gwclient.ErrGatewayUnavailable, the gateway unreachable or still
+// answering 503 config_unavailable because its routing snapshot hasn't
+// loaded (D-101, issue #511). Any other resolve error (unknown route,
+// bad request) returns immediately on the first attempt: those are
+// definitive "no delegated route" answers, not transient infra, and
+// retrying them would just delay the existing native fallback. Bounded
+// and ctx-aware: a cancelled ctx or an exhausted retry budget both
+// return the last error seen.
+func (r *delegatedRunner) resolveRouteWithRetry(ctx context.Context, m Mission, route string) (*gwclient.ResolvedRoute, error) {
+	backoff := r.routeResolveBackoff
+	var lastErr error
+	for attempt := 1; attempt <= routeResolveRetries; attempt++ {
+		resolved, err := r.resolveRoute(ctx, route, m.Harness)
+		if err == nil {
+			return resolved, nil
+		}
+		lastErr = err
+		if !errors.Is(err, gwclient.ErrGatewayUnavailable) {
+			return nil, err
+		}
+		if attempt == routeResolveRetries {
+			break
+		}
+		r.log.Warn("delegated runner: gateway unavailable resolving route, retrying", "mission_id", m.ID, "attempt", attempt, "error", err)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+	}
+	return nil, lastErr
 }
 
 // pinInChain reports whether pin ("provider name/model") names any entry

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -666,6 +666,29 @@ func TestDriverErrExecutorAuthPausesImmediately(t *testing.T) {
 	}
 }
 
+// TestDriverErrGatewayUnavailablePausesImmediately proves the D-101 fix
+// (issue #511) at the driver level: a worker turn failing with
+// ErrGatewayUnavailable (the delegated runner's route resolve
+// exhausting its retry budget against a 503 config_unavailable gateway)
+// pauses the mission as infra on the very first occurrence, the same as
+// ErrExecutorAuth/ErrModelFloor: never the ordinary worker_failed
+// backoff ladder, which would keep retrying a mission whose delegated
+// run may still be alive in the sandbox.
+func TestDriverErrGatewayUnavailablePausesImmediately(t *testing.T) {
+	store := newFakeStore()
+	store.put("m1", Mission{ID: "m1", Kind: "general", Phase: PhaseGenerate, Status: StatusWorking, MaxIterations: 8})
+	runner := &scriptedRunner{workerErr: fmt.Errorf("%w: gwclient: gateway unavailable: gateway http 503: config_unavailable", ErrGatewayUnavailable)}
+	d := testDriver(store, runner)
+
+	if _, err := d.Advance(context.Background(), "m1"); err != nil {
+		t.Fatalf("Advance: %v", err)
+	}
+	m, _ := store.Get(context.Background(), "m1")
+	if m.Status != StatusPaused || m.PauseReason != PauseInfra {
+		t.Fatalf("mission after gateway-unavailable turn = %s/%s, want paused/infra immediately", m.Status, m.PauseReason)
+	}
+}
+
 // --- scenario 5: re-attach ------------------------------------------------
 
 func TestDelegatedRunWorker_ReattachResumesWithoutRespawning(t *testing.T) {
@@ -1546,6 +1569,102 @@ func TestDelegatedRunWorker_Dispatch_ResolveErrorFallsBackToNative(t *testing.T)
 	}
 	if errStr, _ := skippedPayload["error"].(string); errStr == "" {
 		t.Fatalf("executor.skipped error = %q, want a non-empty error string", errStr)
+	}
+}
+
+// countingResolver wraps resolve, counting how many times it was
+// called: TestDelegatedRunWorker_GatewayUnavailable_RetriesThenFails
+// and its sibling need to assert the retry count directly.
+func countingResolver(resolve routeResolver) (routeResolver, *int) {
+	calls := 0
+	return func(ctx context.Context, name, harness string) (*gwclient.ResolvedRoute, error) {
+		calls++
+		return resolve(ctx, name, harness)
+	}, &calls
+}
+
+// TestDelegatedRunWorker_GatewayUnavailable_RetriesThenFails proves the
+// D-101 fix (issue #511): a route resolve failing with
+// gwclient.ErrGatewayUnavailable (503 config_unavailable, or the
+// gateway unreachable) is retried with bounded backoff, never falls
+// back to native, and once the retry budget is exhausted the turn
+// fails with ErrGatewayUnavailable so the driver can pause the mission
+// as infra instead of running a native worker turn.
+func TestDelegatedRunWorker_GatewayUnavailable_RetriesThenFails(t *testing.T) {
+	native := &fakeNative{verdict: WorkerVerdict{Outcome: "done"}}
+	sandbox := newFakeSandbox()
+	events := &fakeEventSink{}
+
+	gwErr := fmt.Errorf("%w: gateway http 503: config_unavailable", gwclient.ErrGatewayUnavailable)
+	resolve, calls := countingResolver(scriptedResolver(nil, gwErr))
+	r := newTestDelegatedRunner(native, resolve, scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	r.routeResolveBackoff = time.Millisecond
+	m := testMission("m1", t.TempDir())
+
+	_, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	if err == nil {
+		t.Fatal("RunWorker: got nil error, want ErrGatewayUnavailable")
+	}
+	if !errors.Is(err, ErrGatewayUnavailable) {
+		t.Fatalf("RunWorker error = %v, want it to wrap ErrGatewayUnavailable", err)
+	}
+	if *calls != routeResolveRetries {
+		t.Fatalf("resolve call count = %d, want %d (bounded retry)", *calls, routeResolveRetries)
+	}
+	if native.callCount() != 0 {
+		t.Fatalf("native call count = %d, want 0: a gateway-unavailable resolve must never fall back to native", native.callCount())
+	}
+	if events.count("executor.skipped") != 1 {
+		t.Fatalf("executor.skipped count = %d, want 1", events.count("executor.skipped"))
+	}
+	skipped, _ := events.last("executor.skipped")
+	var skippedPayload map[string]any
+	_ = json.Unmarshal(skipped.Payload, &skippedPayload)
+	if skippedPayload["reason"] != "gateway_unavailable" {
+		t.Fatalf("executor.skipped reason = %v, want gateway_unavailable", skippedPayload["reason"])
+	}
+}
+
+// TestDelegatedRunWorker_GatewayUnavailable_RecoversWithinRetryBudget
+// proves a transient config_unavailable that clears before the retry
+// budget is exhausted resolves normally: the mission proceeds through
+// the ordinary delegated path (no native fallback, no error) rather
+// than paying for every attempt.
+func TestDelegatedRunWorker_GatewayUnavailable_RecoversWithinRetryBudget(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
+	sandbox.seedChunk = 40
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	gwErr := fmt.Errorf("%w: gateway http 503: config_unavailable", gwclient.ErrGatewayUnavailable)
+	attempt := 0
+	resolve := func(ctx context.Context, name, harness string) (*gwclient.ResolvedRoute, error) {
+		attempt++
+		if attempt < 3 {
+			return nil, gwErr
+		}
+		return route, nil
+	}
+	native := &fakeNative{}
+	r := newTestDelegatedRunner(native, resolve, scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	r.routeResolveBackoff = time.Millisecond
+	m := testMission("m1", t.TempDir())
+
+	verdict, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if verdict.Outcome != "done" {
+		t.Fatalf("Outcome = %q, want done", verdict.Outcome)
+	}
+	if attempt != 3 {
+		t.Fatalf("resolve call count = %d, want 3 (recovers on the 3rd attempt)", attempt)
+	}
+	if native.callCount() != 0 {
+		t.Fatalf("native call count = %d, want 0", native.callCount())
 	}
 }
 

--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -1010,6 +1010,15 @@ func (d *Driver) Advance(ctx context.Context, id string) (canContinue bool, err 
 			// same entry is futile, so pause immediately as infra instead
 			// of burning iterations (same reasoning as ErrModelFloor above).
 			in = StepInput{Input: InputReviewInfraFailure, Reason: err.Error()}
+		case errors.Is(err, ErrGatewayUnavailable):
+			// D-101: the delegated runner already retried its route resolve
+			// with bounded backoff before giving up: this is the gateway
+			// itself not yet serving (unreachable, or 503 config_unavailable
+			// mid-boot), never "no delegated route". Pause immediately as
+			// infra rather than burning iterations on a native worker turn
+			// that would race a delegated run possibly still alive in the
+			// sandbox.
+			in = StepInput{Input: InputReviewInfraFailure, Reason: err.Error()}
 		case m.Phase == PhaseProve:
 			in = StepInput{Input: InputReviewInfraFailure, Reason: err.Error()}
 			if route, skip, ok := d.reviewRouteSkip(ctx, m, err); ok {

--- a/internal/brain/missions/sweep.go
+++ b/internal/brain/missions/sweep.go
@@ -38,6 +38,71 @@ const (
 	recoverWorkingRetryDelay = 2 * time.Second
 )
 
+// gatewayReadyPollInterval and gatewayReadyMaxWait bound how long the
+// boot recovery pass waits for the gateway's routing snapshot to load
+// before re-driving a mission left working (D-101, issue #511): without
+// this wait, a re-drive lands mid-boot, its worker turn's route resolve
+// hits 503 config_unavailable, and (pre-D-101) fell back to native
+// while the prior process's own delegated run was still alive in the
+// sandbox. gatewayReadyMaxWait is a sane cap, not a promise the gateway
+// will be ready by then: past it, recoverWorking proceeds anyway and
+// leans on the delegated runner's own bounded retry/infra-pause path
+// (RunWorker's resolveRouteWithRetry) for whatever config_unavailable
+// window remains.
+// var, not const, so tests can shrink both instead of waiting real minutes.
+var (
+	gatewayReadyPollInterval = 2 * time.Second
+	gatewayReadyMaxWait      = 2 * time.Minute
+)
+
+// gatewayReadyChecker is the narrow seam over gwclient.Client.Ready,
+// faked in tests so the wait's polling/logging is testable without a
+// real gateway. nil is valid (no gateway wired, or a deployment that
+// predates this check): recoverWorking then skips the wait entirely,
+// same as before this existed.
+type gatewayReadyChecker interface {
+	Ready(ctx context.Context) (bool, string, error)
+}
+
+// waitForGatewayReady polls checker.Ready until it reports ready, ctx
+// ends, or gatewayReadyMaxWait elapses, logging the wait exactly once
+// (not once per poll) so a slow-booting gateway doesn't flood the log.
+// A checker error is treated as not-ready and keeps polling: a
+// transiently unreachable gateway is exactly the condition this wait
+// exists to ride out.
+func waitForGatewayReady(ctx context.Context, checker gatewayReadyChecker, log *slog.Logger) {
+	if checker == nil {
+		return
+	}
+	ready, _, err := checker.Ready(ctx)
+	if err == nil && ready {
+		return
+	}
+	logged := false
+	deadline := time.Now().Add(gatewayReadyMaxWait)
+	ticker := time.NewTicker(gatewayReadyPollInterval)
+	defer ticker.Stop()
+	for {
+		if !logged {
+			log.Info("mission recovery: waiting for gateway readiness before re-driving")
+			logged = true
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			ready, detail, err := checker.Ready(ctx)
+			if err == nil && ready {
+				return
+			}
+			if time.Now().After(deadline) {
+				log.Warn("mission recovery: gateway still not ready after max wait, proceeding anyway", "detail", detail)
+				return
+			}
+		}
+	}
+}
+
 // permissionTimeoutStore is the narrow slice of *Store the parked-
 // permission timeout sweep needs, an interface for the same reason
 // backoffStore/pausedByReasonStore are: unit-testable against a faked
@@ -168,8 +233,8 @@ func admitWork(ctx context.Context, gate capacityChecker, log *slog.Logger) (adm
 // is the live in-memory PermBroker's Resolve, best-effort. nil is valid
 // (a still-running turn just times out on its own permissionTimeout
 // instead of waking early).
-func RecoverAndSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, notify messageNotifier, globalPermissionTimeout func(context.Context) int, globalAskTimeout func(context.Context) int, resolveBroker func(id, decision string) bool, log *slog.Logger) {
-	recoverWorking(ctx, d, store, log)
+func RecoverAndSweep(ctx context.Context, d *Driver, store *Store, maxConcurrent int, sandbox sandboxSweeper, capacity capacityChecker, notify messageNotifier, gateway gatewayReadyChecker, globalPermissionTimeout func(context.Context) int, globalAskTimeout func(context.Context) int, resolveBroker func(id, decision string) bool, log *slog.Logger) {
+	recoverWorking(ctx, d, store, gateway, log)
 	runWorkSlotSweep(ctx, d, store, maxConcurrent, sandbox, capacity, notify, globalPermissionTimeout, globalAskTimeout, resolveBroker, log)
 }
 
@@ -202,8 +267,12 @@ func sweepOrphanSandboxes(ctx context.Context, store *Store, sandbox sandboxSwee
 // recoverWorking runs once at service boot: every mission Store
 // reports via RecoverWorking (status='working' at process start,
 // meaning the prior process died mid-Advance) gets re-Driven — this is
-// what makes driveTimeBound and any hard crash NOT a dead end.
-func recoverWorking(ctx context.Context, d *Driver, store *Store, log *slog.Logger) {
+// what makes driveTimeBound and any hard crash NOT a dead end. Waits
+// for gateway readiness first (D-101, issue #511): re-driving before
+// the gateway's routing snapshot has loaded is what let a delegated
+// worker turn's route resolve hit 503 config_unavailable and (pre-
+// D-101) fall back to native.
+func recoverWorking(ctx context.Context, d *Driver, store *Store, gateway gatewayReadyChecker, log *slog.Logger) {
 	var missions []Mission
 	var err error
 	for attempt := 1; attempt <= recoverWorkingRetries; attempt++ {
@@ -224,6 +293,10 @@ func recoverWorking(ctx context.Context, d *Driver, store *Store, log *slog.Logg
 		log.Error("mission recovery sweep: giving up after retries", "attempts", recoverWorkingRetries, "error", err)
 		return
 	}
+	if len(missions) == 0 {
+		return
+	}
+	waitForGatewayReady(ctx, gateway, log)
 	for _, m := range missions {
 		log.Info("mission recovery: re-driving a mission left working at boot", "mission_id", m.ID)
 		go func(id string) {

--- a/internal/brain/missions/sweep_test.go
+++ b/internal/brain/missions/sweep_test.go
@@ -526,3 +526,131 @@ func TestSweepAskTimeoutsAppliesDefaultAndDrives(t *testing.T) {
 		t.Fatalf("drove = %v, want exactly [timed-out]", driver.drove)
 	}
 }
+
+// scriptedGatewayReady returns ready/detail/err in sequence, one per
+// call, then repeats its last entry: waitForGatewayReady's own tests
+// script the gateway's boot sequence (not ready a few times, then
+// ready) without a real gwclient.Client.
+type scriptedGatewayReady struct {
+	mu    sync.Mutex
+	seq   []bool
+	calls int
+}
+
+func (s *scriptedGatewayReady) Ready(ctx context.Context) (bool, string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	i := s.calls
+	if i >= len(s.seq) {
+		i = len(s.seq) - 1
+	}
+	s.calls++
+	if s.seq[i] {
+		return true, "", nil
+	}
+	return false, "routing configuration not loaded yet", nil
+}
+
+func (s *scriptedGatewayReady) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// TestWaitForGatewayReadyNilCheckerSkipsWait covers a deployment with no
+// gateway readiness checker wired (or one that predates D-101): the
+// wait must be a no-op, same as before this existed.
+func TestWaitForGatewayReadyNilCheckerSkipsWait(t *testing.T) {
+	t.Parallel()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	done := make(chan struct{})
+	go func() {
+		waitForGatewayReady(context.Background(), nil, log)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("waitForGatewayReady(nil checker) did not return promptly")
+	}
+}
+
+// TestWaitForGatewayReadyReturnsOnceReady proves the wait polls until
+// the gateway reports ready (D-101, issue #511): the boot recovery
+// sweep must not re-drive a mission while the gateway's routing
+// snapshot is still loading.
+func TestWaitForGatewayReadyReturnsOnceReady(t *testing.T) {
+	origInterval, origMaxWait := gatewayReadyPollInterval, gatewayReadyMaxWait
+	gatewayReadyPollInterval = time.Millisecond
+	gatewayReadyMaxWait = time.Minute
+	t.Cleanup(func() { gatewayReadyPollInterval, gatewayReadyMaxWait = origInterval, origMaxWait })
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	checker := &scriptedGatewayReady{seq: []bool{false, false, true}}
+
+	done := make(chan struct{})
+	go func() {
+		waitForGatewayReady(context.Background(), checker, log)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForGatewayReady did not return once the checker reported ready")
+	}
+	if checker.callCount() < 3 {
+		t.Fatalf("Ready call count = %d, want at least 3 (polled until ready)", checker.callCount())
+	}
+}
+
+// TestWaitForGatewayReadyGivesUpAfterMaxWait proves the bounded cap: a
+// gateway that never reports ready must not hang the boot recovery
+// sweep forever: waitForGatewayReady gives up and returns once
+// gatewayReadyMaxWait elapses.
+func TestWaitForGatewayReadyGivesUpAfterMaxWait(t *testing.T) {
+	origInterval, origMaxWait := gatewayReadyPollInterval, gatewayReadyMaxWait
+	gatewayReadyPollInterval = time.Millisecond
+	gatewayReadyMaxWait = 20 * time.Millisecond
+	t.Cleanup(func() { gatewayReadyPollInterval, gatewayReadyMaxWait = origInterval, origMaxWait })
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	checker := &scriptedGatewayReady{seq: []bool{false}}
+
+	done := make(chan struct{})
+	go func() {
+		waitForGatewayReady(context.Background(), checker, log)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForGatewayReady did not give up after gatewayReadyMaxWait")
+	}
+}
+
+// TestWaitForGatewayReadyRespectsContextCancellation proves the wait is
+// context-aware: a cancelled ctx must return promptly rather than
+// blocking until gatewayReadyMaxWait.
+func TestWaitForGatewayReadyRespectsContextCancellation(t *testing.T) {
+	origInterval, origMaxWait := gatewayReadyPollInterval, gatewayReadyMaxWait
+	gatewayReadyPollInterval = time.Millisecond
+	gatewayReadyMaxWait = time.Minute
+	t.Cleanup(func() { gatewayReadyPollInterval, gatewayReadyMaxWait = origInterval, origMaxWait })
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	checker := &scriptedGatewayReady{seq: []bool{false}}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		waitForGatewayReady(ctx, checker, log)
+		close(done)
+	}()
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waitForGatewayReady did not return promptly after context cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

- D-101 (issue #511): a delegated worker turn's route resolve that fails with the gateway's 503 `config_unavailable` (or a transport error) is now retried with bounded exponential backoff (5 attempts, ~2s/4s/8s/16s waits, ~30s total, context-aware) instead of falling back to the native runner. If the gateway is still unavailable after retries, the turn fails with `ErrGatewayUnavailable` and the driver pauses the mission as infra (same treatment as `ErrModelFloor`/`ErrExecutorAuth`), naming the gateway state. Every other resolve failure (unknown route, bad request, no usable/cooled entry) still falls back to native unchanged.
- `gwclient.ResolveRoute` and the new `gwclient.Client.Ready` both classify a 503/transport failure as `gwclient.ErrGatewayUnavailable`; a 404 "route not found" is left unwrapped since that is a genuine "no delegated route" answer.
- Gateway now registers a `routing` health check (`store.Snapshot() == nil` -> degraded) alongside its existing postgres/migrations checks, so `/health` actually reflects whether the routing snapshot has loaded.
- The boot recovery sweep (`recoverWorking`) waits for gateway readiness via `gwclient.Client.Ready` before re-driving any mission left `working`, bounded at 2 minutes, logging the wait exactly once; past the cap it proceeds and leans on the delegated runner's own bounded retry/infra-pause path.
- Boot recovery re-attach to a live delegated run (pid alive, no exit_code) was already implemented via `attemptResume`/`runDelegated`; the bug was that a premature native fallback on gateway-unavailable skipped that path entirely. Fixing the fallback restores the existing re-attach behavior for this case. Issue #499 (dead-run resume by session id) is untouched.

## Test plan

- `TestResolveRouteConfigUnavailableWrapsErrGatewayUnavailable`, `TestResolveRouteUnreachableWrapsErrGatewayUnavailable`, `TestResolveRouteNotFoundDoesNotWrapErrGatewayUnavailable`, `TestReadyReportsRoutingCheckStatus`, `TestReadyReportsOKWhenRoutingLoaded`, `TestReadyMissingRoutingCheckReportsNotReady` (`internal/brain/gwclient`)
- `TestDelegatedRunWorker_GatewayUnavailable_RetriesThenFails`, `TestDelegatedRunWorker_GatewayUnavailable_RecoversWithinRetryBudget`, `TestDriverErrGatewayUnavailablePausesImmediately` (`internal/brain/missions`)
- `TestWaitForGatewayReadyNilCheckerSkipsWait`, `TestWaitForGatewayReadyReturnsOnceReady`, `TestWaitForGatewayReadyGivesUpAfterMaxWait`, `TestWaitForGatewayReadyRespectsContextCancellation` (`internal/brain/missions`)
- Existing `TestDelegatedRunWorker_ReattachResumesWithoutRespawning` (live run dir re-attach) still passes unchanged
- `go build ./...`, `go vet ./...`, `go test ./...` all green; `golangci-lint run ./...` reports 0 issues
- `make canary` was not run from this worktree (shared compose project); the coordinator runs canaries

Closes #511

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791059283&installation_model_id=431401&pr_number=550&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F550&signature=3f826e69a43954473b770c50b55ce0bec7a836368e199fb774485df0d033c6e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->