### PR TITLE
feat(missions): resume the CLI session on retry after a mid-run death

### DIFF
--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -605,7 +605,7 @@ func (r *delegatedRunner) attemptResume(ctx context.Context, m Mission, workRoot
 }
 
 // resumeReason* name why a retry started fresh instead of resuming the
-// prior CLI session (D-103, issue #499) — recorded on executor.spawned
+// prior CLI session (D-103, issue #499): recorded on executor.spawned
 // only when resumed is false, so a mission's own history shows which
 // gate stopped it.
 const (
@@ -628,7 +628,7 @@ type resumeDecision struct {
 // CLI session instead of starting fresh (D-103, issue #499). Called
 // only after attemptResume has already ruled out a still-pollable live
 // run (handled=false there means the prior run, if any, already reached
-// a terminal event or never existed) — so a non-nil, Finished state
+// a terminal event or never existed), so a non-nil, Finished state
 // here means the prior run genuinely ended (executor.died, most often)
 // and this is a retry. Gates, in order: a prior run must exist for this
 // harness; it must have recorded a session id; the adapter must
@@ -680,7 +680,7 @@ func (r *delegatedRunner) launch(ctx context.Context, missionID, environment, wo
 // issue #499): not under /workspace (the shared workspace volume, which
 // survives a container being recreated from scratch) and not under
 // executorStateMountPath's .claude subtree (its own separate persistent
-// volume) — $HOME itself, outside that subtree, lives on the container's
+// volume): $HOME itself, outside that subtree, lives on the container's
 // own writable layer, so the marker exists only for as long as THIS
 // container instance does. Gone after a real recreate (removed + created
 // fresh), present after a mere stop/restart in place (sandboxd's
@@ -716,11 +716,11 @@ func buildLaunchCmd(workdir, rdir string, inv executor.Invocation, runBudget tim
 }
 
 // probeContainerMarker reports whether $HOME/containerMarkerFile still
-// exists in missionID's sandbox container — true means the same
+// exists in missionID's sandbox container: true means the same
 // container instance that wrote it at the died run's launch is still
 // around (D-103, issue #499's "same sandbox container is still alive"
 // test); false means it was recreated from scratch (or the probe itself
-// failed, treated the same as recreated — never guess a resume is safe).
+// failed, treated the same as recreated: never guess a resume is safe).
 func (r *delegatedRunner) probeContainerMarker(ctx context.Context, missionID, environment, workRoot string) bool {
 	var out bytes.Buffer
 	cmd := fmt.Sprintf("[ -f \"$HOME/%s\" ]", containerMarkerFile)
@@ -779,7 +779,7 @@ type pollState struct {
 	// (issue #500); nil until the first successful git status.
 	worktree *WorktreeSummary
 	// sessionID/sessionRecorded track the harness's own CLI session id
-	// (D-103, issue #499), from the run's KindSystem event —
+	// (D-103, issue #499), from the run's KindSystem event.
 	// sessionRecorded guards recordSessionSeen against writing the
 	// executor.session event more than once per run.
 	sessionID       string
@@ -1181,7 +1181,7 @@ func (r *delegatedRunner) recordSpawned(ctx context.Context, missionID, harness 
 	}
 }
 
-// recordSessionSeen writes executor.session once for a run — the first
+// recordSessionSeen writes executor.session once for a run: the first
 // time its stream reports a CLI session/thread id (D-103, issue #499).
 // Guarded by st.sessionRecorded so a run's later KindSystem-shaped noise
 // (there is none today, but the guard costs nothing) never double-writes.

--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -121,6 +121,11 @@ type runState struct {
 	// polling it, only (if genuinely still needed) treat it as already
 	// decided.
 	Finished bool
+	// SessionID is the harness's own CLI session id (issue #499),
+	// recorded by the executor.session event once the run's first
+	// KindSystem line reported one. Empty when the run died before any
+	// system line arrived, or the harness never reports one.
+	SessionID string
 }
 
 // lastRunState is the narrow seam over Store.LastRunState.
@@ -522,6 +527,8 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 	system, user := packet.RenderForDelegated()
 	system += delegatedSystemAppend
 
+	decision := r.planSessionResume(ctx, m, workRoot, adapter)
+
 	runBudget := r.effectiveRunBudget(ctx)
 	spec := executor.InvocationSpec{
 		MissionID: m.ID, Workdir: workRoot,
@@ -530,6 +537,7 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 		Model:        entry.Model, AuthMode: authMode, APIKey: apiKey, BaseURL: entry.BaseURL,
 		AllowTools: delegatedAllowTools, DenyTools: delegatedDenyTools,
 		ResultSchema: resultSchemaJSON, RunBudget: runBudget, Wire: entry.Wire,
+		ResumeSessionID: decision.sessionID,
 	}
 	inv, err := adapter.BuildInvocation(spec)
 	if err != nil {
@@ -552,7 +560,7 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 		return WorkerVerdict{}, "", fmt.Errorf("delegated runner: write invocation files: %w", err)
 	}
 
-	r.recordSpawned(ctx, m.ID, m.Harness, entry, runID, rdir, authMode)
+	r.recordSpawned(ctx, m.ID, m.Harness, entry, runID, rdir, authMode, decision)
 
 	if err := r.launch(ctx, m.ID, m.Environment, workRoot, rdir, inv, runBudget); err != nil {
 		r.coolDown(m.Harness, entry)
@@ -596,6 +604,56 @@ func (r *delegatedRunner) attemptResume(ctx context.Context, m Mission, workRoot
 	return true, v, t, rerr
 }
 
+// resumeReason* name why a retry started fresh instead of resuming the
+// prior CLI session (D-103, issue #499) — recorded on executor.spawned
+// only when resumed is false, so a mission's own history shows which
+// gate stopped it.
+const (
+	resumeReasonNoPriorRun         = "no_prior_run"
+	resumeReasonNoSessionID        = "no_session_id"
+	resumeReasonAdapterUnsupported = "adapter_unsupported"
+	resumeReasonContainerRecreated = "container_recreated"
+)
+
+// resumeDecision is what planSessionResume works out before a fresh
+// spawn: whether to relaunch through the adapter's resume path with a
+// stored session id, and if not, why.
+type resumeDecision struct {
+	resume    bool
+	sessionID string
+	reason    string // set only when resume is false
+}
+
+// planSessionResume decides whether this launch should resume the prior
+// CLI session instead of starting fresh (D-103, issue #499). Called
+// only after attemptResume has already ruled out a still-pollable live
+// run (handled=false there means the prior run, if any, already reached
+// a terminal event or never existed) — so a non-nil, Finished state
+// here means the prior run genuinely ended (executor.died, most often)
+// and this is a retry. Gates, in order: a prior run must exist for this
+// harness; it must have recorded a session id; the adapter must
+// support resume; and the SAME sandbox container (never recreated
+// since that run's launch) must still be alive.
+func (r *delegatedRunner) planSessionResume(ctx context.Context, m Mission, workRoot string, adapter executor.Adapter) resumeDecision {
+	if r.lastRun == nil {
+		return resumeDecision{reason: resumeReasonNoPriorRun}
+	}
+	state, err := r.lastRun(ctx, m.ID)
+	if err != nil || state == nil || state.Harness != m.Harness {
+		return resumeDecision{reason: resumeReasonNoPriorRun}
+	}
+	if state.SessionID == "" {
+		return resumeDecision{reason: resumeReasonNoSessionID}
+	}
+	if !adapter.Capabilities().SupportsResume {
+		return resumeDecision{reason: resumeReasonAdapterUnsupported}
+	}
+	if !r.probeContainerMarker(ctx, m.ID, m.Environment, workRoot) {
+		return resumeDecision{reason: resumeReasonContainerRecreated}
+	}
+	return resumeDecision{resume: true, sessionID: state.SessionID}
+}
+
 // launch starts the CLI detached: setsid backgrounds it so it survives
 // the ExecEnv call returning, pid captured to a file, stdout/stderr
 // redirected into the run directory. The `timeout` wrapper (D-052)
@@ -618,6 +676,20 @@ func (r *delegatedRunner) launch(ctx context.Context, missionID, environment, wo
 	return nil
 }
 
+// containerMarkerFile names a marker written directly under $HOME (D-103,
+// issue #499): not under /workspace (the shared workspace volume, which
+// survives a container being recreated from scratch) and not under
+// executorStateMountPath's .claude subtree (its own separate persistent
+// volume) — $HOME itself, outside that subtree, lives on the container's
+// own writable layer, so the marker exists only for as long as THIS
+// container instance does. Gone after a real recreate (removed + created
+// fresh), present after a mere stop/restart in place (sandboxd's
+// ensureContainer reuses the container by name unless it was actually
+// removed). Read via $HOME rather than a hardcoded container path so the
+// same command also runs against a real /bin/sh in the composed-command
+// round-trip test, where $HOME is the test host's own home directory.
+const containerMarkerFile = ".timothy-container-marker"
+
 // buildLaunchCmd composes the full detached-launch command. The inner
 // script is quoted as ONE unit via shQuote — composing it with literal
 // quotes would let the argv elements' own single quotes toggle the
@@ -634,11 +706,26 @@ func buildLaunchCmd(workdir, rdir string, inv executor.Invocation, runBudget tim
 	)
 	// Braces bound the `&` to the setsid job alone — a bare `cd && mkdir
 	// && setsid ... & echo $!` backgrounds the whole chain and races the
-	// pid write against the mkdir it depends on.
+	// pid write against the mkdir it depends on. The marker write runs
+	// synchronously before backgrounding, so it's in place before this
+	// exec even returns.
 	return fmt.Sprintf(
-		"cd %s && mkdir -p %s && { setsid sh -c %s > /dev/null 2>&1 & echo $! > %s/pid; }",
-		shQuote(workdir), shQuote(rdir), shQuote(inner), shQuote(rdir),
+		"cd %s && mkdir -p %s && echo ok > \"$HOME/%s\" && { setsid sh -c %s > /dev/null 2>&1 & echo $! > %s/pid; }",
+		shQuote(workdir), shQuote(rdir), containerMarkerFile, shQuote(inner), shQuote(rdir),
 	), nil
+}
+
+// probeContainerMarker reports whether $HOME/containerMarkerFile still
+// exists in missionID's sandbox container — true means the same
+// container instance that wrote it at the died run's launch is still
+// around (D-103, issue #499's "same sandbox container is still alive"
+// test); false means it was recreated from scratch (or the probe itself
+// failed, treated the same as recreated — never guess a resume is safe).
+func (r *delegatedRunner) probeContainerMarker(ctx context.Context, missionID, environment, workRoot string) bool {
+	var out bytes.Buffer
+	cmd := fmt.Sprintf("[ -f \"$HOME/%s\" ]", containerMarkerFile)
+	code, err := r.sandboxExec(ctx, missionID, environment, workRoot, cmd, nil, launchTimeout, &out)
+	return err == nil && code == 0
 }
 
 // renderArgv substitutes the adapter's "@PROMPT@" placeholder with
@@ -691,6 +778,12 @@ type pollState struct {
 	// worktree is the latest non-nil WT: summary seen across polls
 	// (issue #500); nil until the first successful git status.
 	worktree *WorktreeSummary
+	// sessionID/sessionRecorded track the harness's own CLI session id
+	// (D-103, issue #499), from the run's KindSystem event —
+	// sessionRecorded guards recordSessionSeen against writing the
+	// executor.session event more than once per run.
+	sessionID       string
+	sessionRecorded bool
 }
 
 // pollToVerdict polls rdir until the run terminates (exit_code present
@@ -733,7 +826,7 @@ func (r *delegatedRunner) pollToVerdict(ctx context.Context, m Mission, workRoot
 		if len(chunk) > 0 {
 			st.offset += int64(len(chunk))
 			st.lastByteMove = time.Now()
-			r.feedLines(parser, chunk, st, m.ID)
+			r.feedLines(ctx, parser, chunk, st, m.ID, runID)
 			r.recordProgressThrottled(ctx, m.ID, runID, st)
 		}
 
@@ -878,7 +971,7 @@ func parseWorktreeLine(fields string) (*WorktreeSummary, bool) {
 // Incomplete trailing bytes (no terminating newline yet) are held in
 // st.carry until the next chunk completes them — mid-line chunk splits
 // must never be fed to the parser as a partial line.
-func (r *delegatedRunner) feedLines(parser executor.StreamParser, chunk []byte, st *pollState, missionID string) {
+func (r *delegatedRunner) feedLines(ctx context.Context, parser executor.StreamParser, chunk []byte, st *pollState, missionID, runID string) {
 	data := append(st.carry, chunk...)
 	st.carry = nil
 	for {
@@ -897,6 +990,10 @@ func (r *delegatedRunner) feedLines(parser executor.StreamParser, chunk []byte, 
 		case executor.KindSystem:
 			if ev.Model != "" {
 				st.reportedModel = ev.Model
+			}
+			if ev.SessionID != "" && st.sessionID == "" {
+				st.sessionID = ev.SessionID
+				r.recordSessionSeen(ctx, missionID, runID, st)
 			}
 		case executor.KindText:
 			st.textBuf.WriteString(ev.Text)
@@ -1065,16 +1162,37 @@ func isAuthFailure(text string) bool {
 // carries the prompt substitution placeholder only ("@PROMPT@"), never
 // the rendered prompt text, and env values are never recorded, only
 // names.
-func (r *delegatedRunner) recordSpawned(ctx context.Context, missionID, harness string, entry gwclient.ResolvedRouteEntry, runID, rdir string, authMode executor.AuthMode) {
+func (r *delegatedRunner) recordSpawned(ctx context.Context, missionID, harness string, entry gwclient.ResolvedRouteEntry, runID, rdir string, authMode executor.AuthMode, decision resumeDecision) {
 	if r.events == nil {
 		return
 	}
-	if err := r.events.AppendEvent(ctx, missionID, "executor.spawned", map[string]any{
+	payload := map[string]any{
 		"harness": harness, "provider": entry.ProviderName, "model": entry.Model,
 		"auth_mode": string(authMode), "run_id": runID, "run_dir": rdir,
-	}); err != nil {
+		"resumed": decision.resume,
+	}
+	if decision.resume {
+		payload["session_id"] = decision.sessionID
+	} else {
+		payload["resume_reason"] = decision.reason
+	}
+	if err := r.events.AppendEvent(ctx, missionID, "executor.spawned", payload); err != nil {
 		r.log.Warn("delegated runner: record spawned failed", "mission_id", missionID, "error", err)
 	}
+}
+
+// recordSessionSeen writes executor.session once for a run — the first
+// time its stream reports a CLI session/thread id (D-103, issue #499).
+// Guarded by st.sessionRecorded so a run's later KindSystem-shaped noise
+// (there is none today, but the guard costs nothing) never double-writes.
+func (r *delegatedRunner) recordSessionSeen(ctx context.Context, missionID, runID string, st *pollState) {
+	if r.events == nil || st.sessionRecorded {
+		return
+	}
+	st.sessionRecorded = true
+	r.recordEventForce(ctx, missionID, "executor.session", map[string]any{
+		"run_id": runID, "session_id": st.sessionID,
+	})
 }
 
 // recordProgressThrottled writes executor.progress at most once per

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -121,10 +121,15 @@ type fakeSandbox struct {
 	pollErrs   int
 
 	stderrText string
+
+	// containerAlive gates probeContainerMarker's command (D-103, issue
+	// #499) — true (the default) simulates the same container instance
+	// still around; false simulates a recreated one, marker gone.
+	containerAlive bool
 }
 
 func newFakeSandbox() *fakeSandbox {
-	return &fakeSandbox{runs: map[string]*fakeRun{}}
+	return &fakeSandbox{runs: map[string]*fakeRun{}, containerAlive: true}
 }
 
 // lastLaunchCmd is the full shell command of the most recent launch.
@@ -153,6 +158,18 @@ func (s *fakeSandbox) Exec(ctx context.Context, missionID, environment, workdir,
 	case strings.Contains(command, "tail -c 2048 stderr.log"):
 		_, _ = out.Write([]byte(s.stderrText))
 		return 0, nil
+	case strings.Contains(command, containerMarkerFile):
+		// probeContainerMarker's `[ -f "$HOME/<marker>" ]` — never
+		// matched by the launch case above since its own marker write
+		// also contains this literal, but launch's "setsid sh -c" case
+		// is checked first.
+		s.mu.Lock()
+		alive := s.containerAlive
+		s.mu.Unlock()
+		if alive {
+			return 0, nil
+		}
+		return 1, nil
 	case strings.Contains(command, "[ -f exit_code ]"):
 		return s.probe(command)
 	default:
@@ -740,7 +757,7 @@ func TestDelegatedRunWorker_ReattachResumesWithoutRespawning(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(rdir, "prompt.md"), []byte("prompt"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	r.recordSpawned(context.Background(), m.ID, m.Harness, entry, runID, rdir, authMode)
+	r.recordSpawned(context.Background(), m.ID, m.Harness, entry, runID, rdir, authMode, resumeDecision{reason: resumeReasonNoPriorRun})
 	if err := r.launch(context.Background(), m.ID, m.Environment, m.WorkRoot(), rdir, inv, time.Minute); err != nil {
 		t.Fatalf("launch: %v", err)
 	}
@@ -790,6 +807,198 @@ func TestDelegatedRunWorker_ReattachResumesWithoutRespawning(t *testing.T) {
 	}
 	if events.count("executor.spawned") != 1 {
 		t.Fatalf("executor.spawned count = %d, want 1 (no second spawn)", events.count("executor.spawned"))
+	}
+}
+
+// --- scenario 5b: session resume (D-103, issue #499) ----------------------
+
+// diedRunLastRun builds a lastRunStateFunc reporting one finished
+// (died) prior run for harness/sessionID — the resumeDecision gate's
+// input shape after an executor.died event, distinct from scenario 5's
+// still-alive reattach case.
+func diedRunLastRun(harness, runID, rdir, sessionID string) lastRunStateFunc {
+	return func(ctx context.Context, missionID string) (*runState, error) {
+		return &runState{Harness: harness, RunID: runID, RunDir: rdir, Finished: true, SessionID: sessionID}, nil
+	}
+}
+
+// spawnedPayload decodes the last executor.spawned event's payload.
+func spawnedPayload(t *testing.T, events *fakeEventSink) map[string]any {
+	t.Helper()
+	spawned, ok := events.last("executor.spawned")
+	if !ok {
+		t.Fatal("no executor.spawned event recorded")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(spawned.Payload, &payload); err != nil {
+		t.Fatalf("decode executor.spawned payload: %v", err)
+	}
+	return payload
+}
+
+// TestDelegatedRunWorker_SessionResume_AliveContainerResumes covers the
+// acceptance criterion: a retry after executor.died with a stored
+// session id, an adapter that supports resume, and the same sandbox
+// container still alive relaunches through the adapter's resume path —
+// executor.spawned records resumed:true and the session id, and
+// BuildInvocation's argv carries the adapter's resume flag.
+func TestDelegatedRunWorker_SessionResume_AliveContainerResumes(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.containerAlive = true
+	sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+	lastRun := diedRunLastRun("claude-cli", "prior-run-id", "/does/not/matter", "sess-prior-123")
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, lastRun, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+
+	verdict, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if verdict.Outcome != "done" {
+		t.Fatalf("verdict.Outcome = %q, want done", verdict.Outcome)
+	}
+	if sandbox.launches != 1 {
+		t.Fatalf("launches = %d, want 1", sandbox.launches)
+	}
+	if !strings.Contains(sandbox.lastLaunchCmd(), "--resume") || !strings.Contains(sandbox.lastLaunchCmd(), "sess-prior-123") {
+		t.Fatalf("launch command missing --resume sess-prior-123: %s", sandbox.lastLaunchCmd())
+	}
+
+	payload := spawnedPayload(t, events)
+	if payload["resumed"] != true {
+		t.Fatalf("executor.spawned resumed = %v, want true", payload["resumed"])
+	}
+	if payload["session_id"] != "sess-prior-123" {
+		t.Fatalf("executor.spawned session_id = %v, want sess-prior-123", payload["session_id"])
+	}
+	if _, ok := payload["resume_reason"]; ok {
+		t.Fatalf("executor.spawned must not carry resume_reason when resumed, got %v", payload["resume_reason"])
+	}
+}
+
+// TestDelegatedRunWorker_SessionResume_RecreatedContainerStartsFresh
+// covers the acceptance criterion: the container marker is gone (a
+// fresh container was created after the died run), so the retry starts
+// fresh even though a session id and a resume-capable adapter are both
+// present — executor.spawned records resumed:false, resume_reason
+// container_recreated, and no --resume flag reaches the launch command.
+func TestDelegatedRunWorker_SessionResume_RecreatedContainerStartsFresh(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.containerAlive = false
+	sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+	lastRun := diedRunLastRun("claude-cli", "prior-run-id", "/does/not/matter", "sess-prior-123")
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, lastRun, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+
+	if _, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if strings.Contains(sandbox.lastLaunchCmd(), "--resume") {
+		t.Fatalf("launch command must not carry --resume after a container recreate: %s", sandbox.lastLaunchCmd())
+	}
+
+	payload := spawnedPayload(t, events)
+	if payload["resumed"] != false {
+		t.Fatalf("executor.spawned resumed = %v, want false", payload["resumed"])
+	}
+	if payload["resume_reason"] != resumeReasonContainerRecreated {
+		t.Fatalf("executor.spawned resume_reason = %v, want %q", payload["resume_reason"], resumeReasonContainerRecreated)
+	}
+	if _, ok := payload["session_id"]; ok {
+		t.Fatalf("executor.spawned must not carry session_id when not resumed, got %v", payload["session_id"])
+	}
+}
+
+// TestDelegatedRunWorker_SessionResume_UnsupportedAdapterStartsFresh
+// covers the acceptance criterion: codex-cli has no verified resume flag
+// in this slice, so even a died run with a stored session id and an
+// alive container starts fresh — executor.spawned records resumed:false,
+// resume_reason adapter_unsupported.
+func TestDelegatedRunWorker_SessionResume_UnsupportedAdapterStartsFresh(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.containerAlive = true
+	sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson") // claude fixture stands in; only the spawn decision is under test
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	entry := gwclient.ResolvedRouteEntry{
+		ProviderID: "prov-1", ProviderName: "opencode-provider", Driver: "openai",
+		Model: "gpt-oss:20b", CredentialRef: "cred-1", Usable: true, Wire: "openai",
+	}
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+	lastRun := diedRunLastRun("opencode", "prior-run-id", "/does/not/matter", "ses_prior123")
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("dummy-key", nil), sandbox, events, lastRun, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+	m.Harness = "opencode"
+
+	if _, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if strings.Contains(sandbox.lastLaunchCmd(), "ses_prior123") {
+		t.Fatalf("launch command must not reference the prior session id, opencode has no resume flag: %s", sandbox.lastLaunchCmd())
+	}
+
+	payload := spawnedPayload(t, events)
+	if payload["resumed"] != false {
+		t.Fatalf("executor.spawned resumed = %v, want false", payload["resumed"])
+	}
+	if payload["resume_reason"] != resumeReasonAdapterUnsupported {
+		t.Fatalf("executor.spawned resume_reason = %v, want %q", payload["resume_reason"], resumeReasonAdapterUnsupported)
+	}
+}
+
+// TestDelegatedRunWorker_SessionRecordedOnceWhenFirstSeen covers the
+// first acceptance criterion (D-103, issue #499): a fresh run's own
+// session id (parsed off claude-cli's system/init line) is recorded via
+// one executor.session event as soon as it's seen, and executor.spawned
+// itself reports resumed:false, resume_reason no_prior_run — there was
+// nothing to resume on the very first run.
+func TestDelegatedRunWorker_SessionRecordedOnceWhenFirstSeen(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	m := testMission("m1", t.TempDir())
+
+	verdict, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if verdict.Outcome != "done" {
+		t.Fatalf("verdict.Outcome = %q, want done", verdict.Outcome)
+	}
+	if events.count("executor.session") != 1 {
+		t.Fatalf("executor.session count = %d, want 1", events.count("executor.session"))
+	}
+	session, _ := events.last("executor.session")
+	var sessionPayload map[string]any
+	if err := json.Unmarshal(session.Payload, &sessionPayload); err != nil {
+		t.Fatalf("decode executor.session payload: %v", err)
+	}
+	if sessionPayload["session_id"] != "SESSION_ID" {
+		t.Fatalf("executor.session session_id = %v, want SESSION_ID", sessionPayload["session_id"])
+	}
+
+	payload := spawnedPayload(t, events)
+	if payload["resumed"] != false {
+		t.Fatalf("executor.spawned resumed = %v, want false (no prior run)", payload["resumed"])
+	}
+	if payload["resume_reason"] != resumeReasonNoPriorRun {
+		t.Fatalf("executor.spawned resume_reason = %v, want %q", payload["resume_reason"], resumeReasonNoPriorRun)
 	}
 }
 
@@ -1918,6 +2127,62 @@ func TestBuildLaunchCmdRealShell(t *testing.T) {
 	b, err := os.ReadFile(exitPath) //nolint:gosec // G304: path under t.TempDir.
 	if err != nil || strings.TrimSpace(string(b)) != "0" {
 		t.Fatalf("exit_code = %q, err %v; want 0", b, err)
+	}
+}
+
+// TestBuildLaunchCmdRealShell_ContainerMarker proves the D-103 (issue
+// #499) container marker round-trips through a real /bin/sh: buildLaunchCmd
+// writes $HOME/containerMarkerFile before backgrounding the CLI, and the
+// same probe command probeContainerMarker issues must then find it.
+// HOME here is the test host's own home directory - in production it's
+// the sandbox container's $HOME (/home/sandbox), never a hardcoded path,
+// so this same command shape works in both.
+func TestBuildLaunchCmdRealShell_ContainerMarker(t *testing.T) {
+	if _, err := exec.LookPath("setsid"); err != nil {
+		t.Skip("setsid unavailable on this host; runs in the containerized suite")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no $HOME on this host")
+	}
+	markerPath := filepath.Join(home, containerMarkerFile)
+	_ = os.Remove(markerPath) // clean slate; best effort
+	t.Cleanup(func() { _ = os.Remove(markerPath) })
+
+	work := t.TempDir()
+	rdir := filepath.Join(work, "runs", "test01")
+	promptPath := filepath.Join(work, "prompt.md")
+	if err := os.WriteFile(promptPath, []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cli := filepath.Join(work, "fakecli")
+	//nolint:gosec // G306: an executable stand-in script needs the exec bit.
+	if err := os.WriteFile(cli, []byte("#!/bin/sh\necho done\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	inv := executor.Invocation{Argv: []string{cli, "@PROMPT@"}, PromptFile: promptPath}
+
+	cmd, err := buildLaunchCmd(work, rdir, inv, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("/bin/sh", "-c", cmd).CombinedOutput(); err != nil { //nolint:gosec // G204: executing the composed command is the point of the test.
+		t.Fatalf("launch command failed: %v: %s", err, out)
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("marker file %s not written: %v", markerPath, err)
+	}
+
+	probeCmd := fmt.Sprintf("[ -f \"$HOME/%s\" ]", containerMarkerFile)
+	if out, err := exec.Command("/bin/sh", "-c", probeCmd).CombinedOutput(); err != nil { //nolint:gosec // G204: same command shape probeContainerMarker issues.
+		t.Fatalf("probe command failed after a real launch: %v: %s", err, out)
+	}
+
+	if err := os.Remove(markerPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("/bin/sh", "-c", probeCmd).Run(); err == nil { //nolint:gosec // G204: same command shape probeContainerMarker issues.
+		t.Fatal("probe command succeeded after the marker was removed, want failure")
 	}
 }
 

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -123,7 +123,7 @@ type fakeSandbox struct {
 	stderrText string
 
 	// containerAlive gates probeContainerMarker's command (D-103, issue
-	// #499) — true (the default) simulates the same container instance
+	// #499): true (the default) simulates the same container instance
 	// still around; false simulates a recreated one, marker gone.
 	containerAlive bool
 }
@@ -159,7 +159,7 @@ func (s *fakeSandbox) Exec(ctx context.Context, missionID, environment, workdir,
 		_, _ = out.Write([]byte(s.stderrText))
 		return 0, nil
 	case strings.Contains(command, containerMarkerFile):
-		// probeContainerMarker's `[ -f "$HOME/<marker>" ]` — never
+		// probeContainerMarker's `[ -f "$HOME/<marker>" ]`, never
 		// matched by the launch case above since its own marker write
 		// also contains this literal, but launch's "setsid sh -c" case
 		// is checked first.
@@ -813,7 +813,7 @@ func TestDelegatedRunWorker_ReattachResumesWithoutRespawning(t *testing.T) {
 // --- scenario 5b: session resume (D-103, issue #499) ----------------------
 
 // diedRunLastRun builds a lastRunStateFunc reporting one finished
-// (died) prior run for harness/sessionID — the resumeDecision gate's
+// (died) prior run for harness/sessionID: the resumeDecision gate's
 // input shape after an executor.died event, distinct from scenario 5's
 // still-alive reattach case.
 func diedRunLastRun(harness, runID, rdir, sessionID string) lastRunStateFunc {
@@ -839,7 +839,7 @@ func spawnedPayload(t *testing.T, events *fakeEventSink) map[string]any {
 // TestDelegatedRunWorker_SessionResume_AliveContainerResumes covers the
 // acceptance criterion: a retry after executor.died with a stored
 // session id, an adapter that supports resume, and the same sandbox
-// container still alive relaunches through the adapter's resume path —
+// container still alive relaunches through the adapter's resume path,
 // executor.spawned records resumed:true and the session id, and
 // BuildInvocation's argv carries the adapter's resume flag.
 func TestDelegatedRunWorker_SessionResume_AliveContainerResumes(t *testing.T) {
@@ -885,7 +885,7 @@ func TestDelegatedRunWorker_SessionResume_AliveContainerResumes(t *testing.T) {
 // covers the acceptance criterion: the container marker is gone (a
 // fresh container was created after the died run), so the retry starts
 // fresh even though a session id and a resume-capable adapter are both
-// present — executor.spawned records resumed:false, resume_reason
+// present: executor.spawned records resumed:false, resume_reason
 // container_recreated, and no --resume flag reaches the launch command.
 func TestDelegatedRunWorker_SessionResume_RecreatedContainerStartsFresh(t *testing.T) {
 	sandbox := newFakeSandbox()
@@ -922,7 +922,7 @@ func TestDelegatedRunWorker_SessionResume_RecreatedContainerStartsFresh(t *testi
 // TestDelegatedRunWorker_SessionResume_UnsupportedAdapterStartsFresh
 // covers the acceptance criterion: codex-cli has no verified resume flag
 // in this slice, so even a died run with a stored session id and an
-// alive container starts fresh — executor.spawned records resumed:false,
+// alive container starts fresh: executor.spawned records resumed:false,
 // resume_reason adapter_unsupported.
 func TestDelegatedRunWorker_SessionResume_UnsupportedAdapterStartsFresh(t *testing.T) {
 	sandbox := newFakeSandbox()
@@ -961,7 +961,7 @@ func TestDelegatedRunWorker_SessionResume_UnsupportedAdapterStartsFresh(t *testi
 // first acceptance criterion (D-103, issue #499): a fresh run's own
 // session id (parsed off claude-cli's system/init line) is recorded via
 // one executor.session event as soon as it's seen, and executor.spawned
-// itself reports resumed:false, resume_reason no_prior_run — there was
+// itself reports resumed:false, resume_reason no_prior_run: there was
 // nothing to resume on the very first run.
 func TestDelegatedRunWorker_SessionRecordedOnceWhenFirstSeen(t *testing.T) {
 	sandbox := newFakeSandbox()

--- a/internal/brain/missions/executor/claude.go
+++ b/internal/brain/missions/executor/claude.go
@@ -31,6 +31,9 @@ func (claudeAdapter) Capabilities() Capabilities {
 		StateDirs:             []string{".claude"},
 		OAuthTokenEnv:         "CLAUDE_CODE_OAUTH_TOKEN",
 		OAuthTokenPrefix:      "sk-ant-oat",
+		// claude-cli's `--resume <session-id>` is documented (`claude
+		// --help`) and combines with `-p` for a headless resumed turn.
+		SupportsResume: true,
 	}
 }
 
@@ -92,6 +95,9 @@ func (claudeAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 	if spec.SystemAppend != "" {
 		argv = append(argv, "--append-system-prompt", spec.SystemAppend)
 	}
+	if spec.ResumeSessionID != "" {
+		argv = append(argv, "--resume", spec.ResumeSessionID)
+	}
 
 	// nodeMaxOldSpaceMB (D-056) bounds the CLI's node heap: unbounded,
 	// node sizes its heap from cgroup limits, and a long run's transcript
@@ -145,8 +151,9 @@ type claudeLineEnvelope struct {
 }
 
 type claudeSystemLine struct {
-	Subtype string `json:"subtype"`
-	Model   string `json:"model"`
+	Subtype   string `json:"subtype"`
+	Model     string `json:"model"`
+	SessionID string `json:"session_id"`
 }
 
 type claudeContentBlock struct {
@@ -213,7 +220,7 @@ func (p *claudeParser) ParseLine(line []byte) (Event, bool) {
 			return Event{}, false
 		}
 		p.stats.Events++
-		return Event{Kind: KindSystem, Text: sys.Model, Model: sys.Model}, true
+		return Event{Kind: KindSystem, Text: sys.Model, Model: sys.Model, SessionID: sys.SessionID}, true
 
 	case "assistant":
 		var a claudeAssistantLine

--- a/internal/brain/missions/executor/claude_test.go
+++ b/internal/brain/missions/executor/claude_test.go
@@ -435,7 +435,7 @@ func containsFlag(argv []string, flag string) bool {
 }
 
 // containsFlagValue reports whether argv has flag immediately followed
-// by value — shared by every adapter's resume-flag test.
+// by value: shared by every adapter's resume-flag test.
 func containsFlagValue(argv []string, flag, value string) bool {
 	for i, a := range argv {
 		if a == flag && i+1 < len(argv) && argv[i+1] == value {

--- a/internal/brain/missions/executor/claude_test.go
+++ b/internal/brain/missions/executor/claude_test.go
@@ -380,6 +380,27 @@ func TestClaudeAdapter_BuildInvocation(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "resume session id appends --resume flag (D-103, issue #499)",
+			spec: InvocationSpec{
+				Model: "sonnet", PromptPath: "/tmp/p.txt", AuthMode: AuthSubscription,
+				ResumeSessionID: "sess-abc-123",
+			},
+			check: func(t *testing.T, inv Invocation) {
+				if !containsFlagValue(inv.Argv, "--resume", "sess-abc-123") {
+					t.Errorf("argv %v missing --resume sess-abc-123", inv.Argv)
+				}
+			},
+		},
+		{
+			name: "empty resume session id omits --resume flag",
+			spec: InvocationSpec{Model: "sonnet", PromptPath: "/tmp/p.txt", AuthMode: AuthSubscription},
+			check: func(t *testing.T, inv Invocation) {
+				if containsFlag(inv.Argv, "--resume") {
+					t.Error("--resume must not appear without a ResumeSessionID")
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -407,6 +428,17 @@ func TestClaudeAdapter_BuildInvocation(t *testing.T) {
 func containsFlag(argv []string, flag string) bool {
 	for _, a := range argv {
 		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// containsFlagValue reports whether argv has flag immediately followed
+// by value — shared by every adapter's resume-flag test.
+func containsFlagValue(argv []string, flag, value string) bool {
+	for i, a := range argv {
+		if a == flag && i+1 < len(argv) && argv[i+1] == value {
 			return true
 		}
 	}

--- a/internal/brain/missions/executor/codex.go
+++ b/internal/brain/missions/executor/codex.go
@@ -35,6 +35,10 @@ func (codexAdapter) Capabilities() Capabilities {
 		// not an env var - codex has no base-url env override.
 		BaseURLEnv: "",
 		StateDirs:  nil,
+		// `codex exec resume <SESSION_ID>` is documented (`codex exec
+		// resume --help`); BuildInvocation switches to that subcommand
+		// form when ResumeSessionID is set.
+		SupportsResume: true,
 	}
 }
 
@@ -77,12 +81,26 @@ func (codexAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 		"codex-home/config.toml": codexConfigTOML(baseURL),
 	}
 
-	argv := []string{
-		"codex", "exec", "--json",
-		"-C", spec.Workdir,
-		"--dangerously-bypass-approvals-and-sandbox",
-		"--skip-git-repo-check",
-		"-m", spec.Model,
+	// `codex exec resume <SESSION_ID>` is a distinct subcommand form
+	// (confirmed via `codex exec resume --help`): no `-C` flag - the
+	// resumed session keeps the working root recorded at its original
+	// spawn - but the same --json/--output-schema/-m/bypass flags apply.
+	var argv []string
+	if spec.ResumeSessionID != "" {
+		argv = []string{
+			"codex", "exec", "resume", spec.ResumeSessionID, "--json",
+			"--dangerously-bypass-approvals-and-sandbox",
+			"--skip-git-repo-check",
+			"-m", spec.Model,
+		}
+	} else {
+		argv = []string{
+			"codex", "exec", "--json",
+			"-C", spec.Workdir,
+			"--dangerously-bypass-approvals-and-sandbox",
+			"--skip-git-repo-check",
+			"-m", spec.Model,
+		}
 	}
 	if spec.ResultSchema != nil {
 		schemaPath := filepath.Join(codexHome, "schema.json")
@@ -242,7 +260,7 @@ func (p *codexParser) ParseLine(line []byte) (Event, bool) {
 			return Event{}, false
 		}
 		p.stats.Events++
-		return Event{Kind: KindSystem, Text: t.ThreadID}, true
+		return Event{Kind: KindSystem, Text: t.ThreadID, SessionID: t.ThreadID}, true
 
 	case "item.started":
 		var it codexItemLine

--- a/internal/brain/missions/executor/codex_test.go
+++ b/internal/brain/missions/executor/codex_test.go
@@ -440,6 +440,37 @@ func TestCodexAdapter_BuildInvocation(t *testing.T) {
 			},
 		},
 		{
+			name: "resume session id switches to the resume subcommand (D-103, issue #499)",
+			spec: InvocationSpec{
+				Model: "gpt-5.3-codex", PromptPath: "/tmp/run/prompt.md", Workdir: "/tmp/run/ws",
+				AuthMode: AuthAPIKey, APIKey: "sk-test", Wire: "openai",
+				ResumeSessionID: "thread-abc-123",
+			},
+			check: func(t *testing.T, inv Invocation) {
+				if inv.Argv[0] != "codex" || inv.Argv[1] != "exec" || inv.Argv[2] != "resume" || inv.Argv[3] != "thread-abc-123" {
+					t.Fatalf("argv = %v, want [codex exec resume thread-abc-123 ...]", inv.Argv)
+				}
+				if containsFlag(inv.Argv, "-C") {
+					t.Error("codex exec resume has no -C flag, must not appear in argv")
+				}
+			},
+		},
+		{
+			name: "empty resume session id keeps the plain exec subcommand",
+			spec: InvocationSpec{
+				Model: "gpt-5.3-codex", PromptPath: "/tmp/run/prompt.md", Workdir: "/tmp/run/ws",
+				AuthMode: AuthAPIKey, APIKey: "sk-test", Wire: "openai",
+			},
+			check: func(t *testing.T, inv Invocation) {
+				if containsFlag(inv.Argv, "resume") {
+					t.Error("resume subcommand must not appear without a ResumeSessionID")
+				}
+				if !containsFlagValue(inv.Argv, "-C", "/tmp/run/ws") {
+					t.Error("plain exec must still pass -C <workdir>")
+				}
+			},
+		},
+		{
 			name: "hostile base url is toml-escaped, not broken out of the string",
 			spec: InvocationSpec{
 				Model: "gpt-5.3-codex", PromptPath: "/tmp/run/prompt.md",

--- a/internal/brain/missions/executor/cursor.go
+++ b/internal/brain/missions/executor/cursor.go
@@ -41,6 +41,9 @@ func (cursorAdapter) Capabilities() Capabilities {
 		// known distinguishing value prefix to classify on - it resolves
 		// as AuthAPIKey regardless (resolveCredential, delegated.go),
 		// which BuildInvocation already requires.
+		// cursor-agent's `--resume [chatId]` is documented (`cursor-agent
+		// --help`) and combines with `-p`.
+		SupportsResume: true,
 	}
 }
 
@@ -116,6 +119,9 @@ func (cursorAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 	if spec.SystemAppend != "" {
 		argv = append(argv, spec.SystemAppend)
 	}
+	if spec.ResumeSessionID != "" {
+		argv = append(argv, "--resume", spec.ResumeSessionID)
+	}
 	argv = append(argv, "@PROMPT@", cursorVerdictInstruction)
 
 	env := map[string]string{
@@ -176,7 +182,8 @@ type cursorLineEnvelope struct {
 }
 
 type cursorSystemLine struct {
-	Model string `json:"model"`
+	Model     string `json:"model"`
+	SessionID string `json:"session_id"`
 }
 
 type cursorAssistantBlock struct {
@@ -257,7 +264,7 @@ func (p *cursorParser) ParseLine(line []byte) (Event, bool) {
 			return Event{}, false
 		}
 		p.stats.Events++
-		return Event{Kind: KindSystem, Text: sys.Model, Model: sys.Model}, true
+		return Event{Kind: KindSystem, Text: sys.Model, Model: sys.Model, SessionID: sys.SessionID}, true
 
 	case "assistant":
 		var a cursorAssistantLine

--- a/internal/brain/missions/executor/cursor_test.go
+++ b/internal/brain/missions/executor/cursor_test.go
@@ -342,6 +342,31 @@ func TestCursorAdapter_BuildInvocation(t *testing.T) {
 			},
 		},
 		{
+			name: "resume session id appends --resume flag before @PROMPT@ (D-103, issue #499)",
+			spec: InvocationSpec{ //nolint:gosec // G101: fixture value, not a real credential.
+				Model: "claude-sonnet-5-high", PromptPath: "/tmp/run/prompt.md",
+				AuthMode: AuthAPIKey, APIKey: "sk-cursor-test",
+				ResumeSessionID: "chat-abc-123",
+			},
+			check: func(t *testing.T, inv Invocation) {
+				if !containsFlagValue(inv.Argv, "--resume", "chat-abc-123") {
+					t.Errorf("argv %v missing --resume chat-abc-123", inv.Argv)
+				}
+			},
+		},
+		{
+			name: "empty resume session id omits --resume flag",
+			spec: InvocationSpec{ //nolint:gosec // G101: fixture value, not a real credential.
+				Model: "claude-sonnet-5-high", PromptPath: "/tmp/run/prompt.md",
+				AuthMode: AuthAPIKey, APIKey: "sk-cursor-test",
+			},
+			check: func(t *testing.T, inv Invocation) {
+				if containsFlag(inv.Argv, "--resume") {
+					t.Error("--resume must not appear without a ResumeSessionID")
+				}
+			},
+		},
+		{
 			name:    "subscription auth rejected",
 			spec:    InvocationSpec{Model: "m", PromptPath: "/tmp/run/prompt.md", AuthMode: AuthSubscription},
 			wantErr: true,

--- a/internal/brain/missions/executor/executor.go
+++ b/internal/brain/missions/executor/executor.go
@@ -35,6 +35,11 @@ type Capabilities struct {
 	// Empty OAuthTokenEnv means the adapter doesn't support this mode.
 	OAuthTokenEnv    string
 	OAuthTokenPrefix string
+	// SupportsResume declares whether BuildInvocation honors
+	// InvocationSpec.ResumeSessionID with a real CLI resume flag (D-103,
+	// issue #499). False means the runner must never set
+	// ResumeSessionID for this adapter — it always starts fresh.
+	SupportsResume bool
 }
 
 // InvocationSpec is what the runner supplies to build one CLI invocation.
@@ -57,6 +62,11 @@ type InvocationSpec struct {
 	// gwclient.ResolvedRouteEntry.Wire. Only a dual-wire harness (pi)
 	// needs this; a single-wire harness ignores it.
 	Wire string
+	// ResumeSessionID, when non-empty, asks BuildInvocation to resume
+	// that CLI session instead of starting fresh (D-103, issue #499).
+	// The runner only ever sets this when Capabilities().SupportsResume
+	// is true for the adapter in play.
+	ResumeSessionID string
 }
 
 // Invocation is the argv + env an adapter wants spawned. PromptFile, when
@@ -114,7 +124,13 @@ type Event struct {
 	// carries a different identifier per harness (thread id, session id,
 	// cwd), so the model needs its own field rather than an overload.
 	Model string
-	Tool  *ToolActivity
+	// SessionID is the harness's own CLI session/thread id, set only on
+	// KindSystem by adapters whose init line names one (D-103, issue
+	// #499: claude-cli, codex-cli, opencode, cursor-cli). Empty for an
+	// adapter that reports no such id, or one whose Capabilities().
+	// SupportsResume is false.
+	SessionID string
+	Tool      *ToolActivity
 	// Usage and Result are set only on KindResult; Usage may also be set
 	// standalone on KindUsage for harnesses that report it out of band.
 	Usage *Usage

--- a/internal/brain/missions/executor/executor.go
+++ b/internal/brain/missions/executor/executor.go
@@ -38,7 +38,7 @@ type Capabilities struct {
 	// SupportsResume declares whether BuildInvocation honors
 	// InvocationSpec.ResumeSessionID with a real CLI resume flag (D-103,
 	// issue #499). False means the runner must never set
-	// ResumeSessionID for this adapter — it always starts fresh.
+	// ResumeSessionID for this adapter: it always starts fresh.
 	SupportsResume bool
 }
 

--- a/internal/brain/missions/executor/opencode.go
+++ b/internal/brain/missions/executor/opencode.go
@@ -38,6 +38,10 @@ func (opencodeAdapter) Capabilities() Capabilities {
 		// not an env var - opencode has no base-url env override.
 		BaseURLEnv: "",
 		StateDirs:  nil,
+		// SupportsResume stays false (D-103, issue #499): opencode is not
+		// installed in this environment and no `--help` text or repo
+		// doc records its resume/continue flag, so BuildInvocation never
+		// guesses one - the runner starts fresh instead.
 	}
 }
 
@@ -274,7 +278,7 @@ func (p *opencodeParser) ParseLine(line []byte) (Event, bool) {
 		}
 		p.sawSystem = true
 		p.stats.Events++
-		return Event{Kind: KindSystem, Text: env.SessionID}, true
+		return Event{Kind: KindSystem, Text: env.SessionID, SessionID: env.SessionID}, true
 
 	case "text":
 		var l opencodeLine

--- a/internal/brain/missions/executor/opencode_test.go
+++ b/internal/brain/missions/executor/opencode_test.go
@@ -527,6 +527,31 @@ func TestOpencodeAdapter_BuildInvocation(t *testing.T) {
 	}
 }
 
+// TestOpencodeAdapter_ResumeUnsupported covers D-103 (issue #499):
+// opencode is not installed in this environment and no --help text or
+// repo doc records a resume/continue flag, so the adapter must declare
+// SupportsResume false and never invent one - BuildInvocation ignores
+// ResumeSessionID entirely rather than guessing a flag.
+func TestOpencodeAdapter_ResumeUnsupported(t *testing.T) {
+	a := opencodeAdapter{}
+	if a.Capabilities().SupportsResume {
+		t.Fatal("opencode Capabilities().SupportsResume = true, want false (no verified resume flag)")
+	}
+	inv, err := a.BuildInvocation(InvocationSpec{
+		Model: "gpt-oss:20b", PromptPath: "/tmp/run/prompt.md", Workdir: "/tmp/run/ws",
+		AuthMode: AuthAPIKey, APIKey: "sk-test", Wire: "openai",
+		ResumeSessionID: "ses_should_be_ignored",
+	})
+	if err != nil {
+		t.Fatalf("BuildInvocation: %v", err)
+	}
+	for _, a := range inv.Argv {
+		if strings.Contains(a, "ses_should_be_ignored") {
+			t.Errorf("argv %v must never carry ResumeSessionID, no resume flag exists", inv.Argv)
+		}
+	}
+}
+
 // assertOpencodeConfig checks the opencode.json Files entry parses and
 // declares the expected npm/baseURL/model under provider.timothy.
 func assertOpencodeConfig(t *testing.T, inv Invocation, wantBaseURL, wantModel, wantNPM string) {

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -978,7 +978,7 @@ func (s *Store) LastRunState(ctx context.Context, missionID string) (*runState, 
 		return nil, fmt.Errorf("missions last run state: %w", err)
 	}
 	rows, err := db.Query(ctx, `SELECT kind, payload FROM mission_events
-		WHERE mission_id = $1 AND kind IN ('executor.spawned', 'executor.result', 'executor.died', 'executor.progress')
+		WHERE mission_id = $1 AND kind IN ('executor.spawned', 'executor.result', 'executor.died', 'executor.progress', 'executor.session')
 		ORDER BY seq DESC`, missionID)
 	if err != nil {
 		return nil, fmt.Errorf("missions last run state: %w", err)
@@ -1024,6 +1024,22 @@ func (s *Store) LastRunState(ctx context.Context, missionID string) (*runState, 
 				}
 				if err := json.Unmarshal(payload, &progress); err == nil {
 					state.ByteOffset = progress.ByteOffset
+				}
+			}
+		case "executor.session":
+			// Scanned in seq DESC order, so the first one seen (before
+			// the spawn row that terminates this loop) is the latest —
+			// belongs to the run this spawn started, since a run's own
+			// session id is only ever recorded after its spawn.
+			if state == nil {
+				state = &runState{}
+			}
+			if state.SessionID == "" {
+				var session struct {
+					SessionID string `json:"session_id"`
+				}
+				if err := json.Unmarshal(payload, &session); err == nil {
+					state.SessionID = session.SessionID
 				}
 			}
 		}

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -1028,7 +1028,7 @@ func (s *Store) LastRunState(ctx context.Context, missionID string) (*runState, 
 			}
 		case "executor.session":
 			// Scanned in seq DESC order, so the first one seen (before
-			// the spawn row that terminates this loop) is the latest —
+			// the spawn row that terminates this loop) is the latest,
 			// belongs to the run this spawn started, since a run's own
 			// session id is only ever recorded after its spawn.
 			if state == nil {


### PR DESCRIPTION
## Summary
- Store the delegated executor's CLI session id (D-103, issue #499): each adapter's stream parser already reports a session/thread id on its first `KindSystem` line (claude-cli `session_id`, codex-cli `thread_id`, opencode `sessionID`, cursor-cli `session_id`); `delegated.go` writes it once, the first time it's seen, as a new `executor.session` event (`run_id`, `session_id`).
- On a retry after `executor.died`, `planSessionResume` decides whether to resume: it requires a prior run for the same harness with a stored session id, an adapter that declares `Capabilities().SupportsResume`, and the SAME sandbox container still alive.
- Container liveness is detected with a marker file written under `$HOME` (outside `/workspace` and outside the `.claude` state volume) at every launch — sandboxd's `ensureContainer` reuses a container by name unless it was actually removed, so the marker survives a stop/restart but not a real recreate.
- Per-adapter resume support, verified against each CLI's own `--help` output (all four CLIs are installed locally):
  - **claude-cli**: `--resume <session-id>` (supported)
  - **cursor-cli**: `--resume [chatId]` (supported)
  - **codex-cli**: distinct `codex exec resume <SESSION_ID> ...` subcommand, no `-C` flag (supported)
  - **opencode**: not installed here and no `--help` text or repo doc records a resume flag — stays unsupported rather than guessing (`SupportsResume: false`)
- `executor.spawned` now records `resumed: true/false`; when true it carries `session_id`, when false it carries `resume_reason` (`no_prior_run`, `no_session_id`, `adapter_unsupported`, `container_recreated`).

## Test plan
- `go build ./...`, `go vet ./...` clean.
- `golangci-lint run ./...` (v2.12.2): 0 issues.
- `go test ./internal/brain/missions/...` and `go test -race ./internal/brain/missions/...`: all pass, including:
  - Per-adapter resume-flag unit tests (claude, codex, cursor) plus opencode's unsupported-resume test.
  - A real `/bin/sh` round-trip test for the composed launch command's container marker write/probe (`TestBuildLaunchCmdRealShell_ContainerMarker`).
  - Runner-level tests with a faked sandbox covering all three resume-decision branches and asserting the `executor.spawned` payload: alive container resumes, recreated container starts fresh, unsupported adapter starts fresh, plus a first-run test asserting `executor.session` is written once and `resumed:false`/`no_prior_run` on a fresh spawn.
- `go test ./...` (full repo): all pass.
- Canaries were not run from the worktree per policy — the coordinator runs `make canary-executor`.

Closes #499

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791066040&installation_model_id=431401&pr_number=551&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F551&signature=1a581152e5aa04ed1e99e5e9f749012ddeec723460ece3b46bf011b8b5d55a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->