### PR TITLE
fix(chat): title on the summarize role with low effort

### DIFF
--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -53,7 +53,7 @@ const (
 	// compaction never converges. Post-turn passes are off the user's
 	// clock; the rare pre-send pass accepts the latency.
 	compactBudget = 150 * time.Second
-	titleTimeout  = 15 * time.Second
+	titleTimeout  = 30 * time.Second
 	// approvalGrantTTL matches missions/driver.go's missionGrantTTL and
 	// loop's own sessionGrantTTL (12h): a chat session idle longer than
 	// that just re-seeds the grant on its next turn, same degrade as a
@@ -115,7 +115,7 @@ type MemoryRetrieve func(ctx context.Context, sessionID, query string) string
 // AttachmentStore is the slice of *attachments.Store chat needs: Get
 // validates a ref exists (400 before any event append), Open resolves
 // its bytes to base64 at request-build time. Nil disables attachments
-//: a Request naming any Attachments id gets ErrBadRequest.
+// : a Request naming any Attachments id gets ErrBadRequest.
 type AttachmentStore interface {
 	Get(ctx context.Context, id string) (attachments.Attachment, error)
 	Open(ctx context.Context, id string) (io.ReadCloser, attachments.Attachment, error)
@@ -270,7 +270,7 @@ func (s *Service) SetWhisper(url string) {
 type KBSearch func(ctx context.Context, query string, boostCollections []string, mode string, k int) ([]builtin.KBSearchHit, error)
 
 // SetKBSearch wires the search_kb tool's backing search call. Optional
-//: nil means search_kb is never offered on any turn, regardless of an
+// : nil means search_kb is never offered on any turn, regardless of an
 // agent's Knowledge list (same "the dependency's absence turns the
 // feature off entirely" contract as SetMemoryRetrieve/SetAttachments).
 func (s *Service) SetKBSearch(fn KBSearch) { s.kbSearch = fn }
@@ -554,8 +554,10 @@ func TitleOverGateway(gw Gateway, log *slog.Logger) func(ctx context.Context, in
 			Messages: []provider.Message{{Role: "user", Content: input}},
 			// Reasoning models spend hundreds of tokens thinking before
 			// the first answer token; a tight cap truncates the stream
-			// mid-reasoning and yields an empty title.
+			// mid-reasoning and yields an empty title. Low effort keeps
+			// that thinking short on models that honour it.
 			MaxTokens: 1000,
+			Effort:    "low",
 		}
 		for attempt := 0; attempt < 2; attempt++ {
 			events, err := gw.Stream(ctx, req)
@@ -1868,7 +1870,13 @@ func (s *Service) autoTitle(sessionID, userText, reply, sensitiveRoute string) {
 	const titleSystem = `Produce a title for this conversation: at most 6 words, plain text, no quotes, no trailing punctuation. Reply with only the title.`
 	input := userText + "\n\n" + truncateRunes(reply, 200)
 
-	route := s.roleRoute(ctx, "default")
+	// The summarize role is the cheap, fast chain built for short
+	// derived text; the default role's first entry is often a reasoning
+	// model that spends the whole deadline thinking (issue #552).
+	route := s.roleRoute(ctx, "summarize")
+	if route == "" {
+		route = s.roleRoute(ctx, "default")
+	}
 	if sensitiveRoute != "" {
 		route = sensitiveRoute
 	}
@@ -1879,8 +1887,10 @@ func (s *Service) autoTitle(sessionID, userText, reply, sensitiveRoute string) {
 		Messages: []provider.Message{{Role: "user", Content: input}},
 		// Reasoning models spend hundreds of tokens thinking before
 		// the first answer token; a tight cap truncates the stream
-		// mid-reasoning and yields an empty title.
+		// mid-reasoning and yields an empty title. Low effort keeps
+		// that thinking short on models that honour it.
 		MaxTokens: 1000,
+		Effort:    "low",
 		SessionID: sessionID,
 	})
 	if err != nil {

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -718,7 +718,7 @@ func TestChatRetriesAutoTitleUntilATurnCompletes(t *testing.T) {
 
 // TestTerminalErrorPersistsTurnFailed pins D-044: a turn that ends on
 // a terminal EventError with no partial text must not vanish silently
-//: relay used to drop the error after streaming it to the client,
+// : relay used to drop the error after streaming it to the client,
 // leaving nothing durable. persistTurn now appends a KindTurnFailed
 // event carrying the error's code and message.
 func TestTerminalErrorPersistsTurnFailed(t *testing.T) {
@@ -1977,11 +1977,11 @@ func TestRetryReplaysTrailingPendingStateAsInterrupted(t *testing.T) {
 	}
 }
 
-// TestAutoTitleUsesDefaultRouteNotClassifyRoute pins a real behavior
-// change: a session's name deserves the same model quality as the
-// conversation it's naming, not the cheapest classification route
-// (which resolves to a small local model unfit for the job).
-func TestAutoTitleUsesDefaultRouteNotClassifyRoute(t *testing.T) {
+// TestAutoTitleUsesSummarizeRoleWithLowEffort pins the title request
+// shape: the summarize role (fast derived-text chain, same as mission
+// titles) with low reasoning effort, so a reasoning model first in the
+// chain does not spend the whole deadline thinking.
+func TestAutoTitleUsesSummarizeRoleWithLowEffort(t *testing.T) {
 	t.Parallel()
 	log := newFakeLog()
 	gw := &fakeGW{events: okEvents("a good title")}
@@ -2002,8 +2002,11 @@ func TestAutoTitleUsesDefaultRouteNotClassifyRoute(t *testing.T) {
 	defer gw.mu.Unlock()
 	for _, r := range gw.requests {
 		if r.Purpose == "title" {
-			if r.Route != "default" {
-				t.Fatalf("auto-title route = %q, want %q", r.Route, "default")
+			if r.Route != "summarize" {
+				t.Fatalf("auto-title route = %q, want %q", r.Route, "summarize")
+			}
+			if r.Effort != "low" {
+				t.Fatalf("auto-title effort = %q, want low", r.Effort)
 			}
 			return
 		}
@@ -2035,6 +2038,9 @@ func TestTitleOverGatewayUsesSummarizeRoleAndTrimsQuotes(t *testing.T) {
 	}
 	if gw.requests[0].Purpose != "title" {
 		t.Fatalf("purpose = %q, want title", gw.requests[0].Purpose)
+	}
+	if gw.requests[0].Effort != "low" {
+		t.Fatalf("effort = %q, want low", gw.requests[0].Effort)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Chat auto-title resolves the `summarize` role first (`default` fallback, sensitive-route pin still wins) and passes `Effort: "low"`; mission titles (`TitleOverGateway`) also pass low effort.
- Title deadline 15 s to 30 s so one gateway failover fits.
- Root cause on homelab session `d1cd3363`: default route's first entry is a reasoning model that spent the whole window thinking and emitted no text (`auto-title returned no text`).

## Test plan
- [x] `go build ./...`, `go vet`, `go test -race ./internal/brain/chat/`, golangci-lint 0 issues (Docker)
- [x] `TestAutoTitleUsesSummarizeRoleWithLowEffort` (renamed from the default-route pin), effort assertion added to `TestTitleOverGatewayUsesSummarizeRoleAndTrimsQuotes`
- No harness change, canary not needed

Closes #552

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791067706&installation_model_id=431401&pr_number=553&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F553&signature=7a7128defd09d7e0a6889d9aecbdc9bcc9ea6047588acea6affe67e7df0c97db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->