### PR TITLE
chore: clear pending alters applied with alpha.67

### DIFF
--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -4,33 +4,4 @@ Additive schema changes not yet applied to any live database. Safe to
 run before deploy; each entry stays here until confirmed applied on
 every live instance, then it's removed.
 
-## Review findings ledger and rework counter (D-092, issue #512)
-
-Required on live DBs before/with the next deploy. Additive, safe to
-run before deploy.
-
-```sql
-ALTER TABLE missions ADD COLUMN IF NOT EXISTS review_findings jsonb NOT NULL DEFAULT '[]';
-ALTER TABLE missions ADD COLUMN IF NOT EXISTS rework_rounds integer NOT NULL DEFAULT 0;
-```
-
-## generate_pdf and share_file on the general agent (issue #546)
-
-Live rows seeded before this change never received the two builtins
-(agent tool lists are opt-in, #229). Idempotent, safe to run any time.
-
-```sql
-UPDATE agents SET tools = tools || '["share_file"]'::jsonb
-  WHERE name IN ('general', 'researcher') AND NOT tools ? 'share_file';
-UPDATE agents SET tools = tools || '["generate_pdf"]'::jsonb
-  WHERE name IN ('general', 'researcher') AND NOT tools ? 'generate_pdf';
-```
-
-## Transcribe-mode plan flag (D-102, issue #496)
-
-Required on live DBs before/with the next deploy. Additive, safe to
-run before deploy.
-
-```sql
-ALTER TABLE missions ADD COLUMN IF NOT EXISTS has_plan boolean NOT NULL DEFAULT false;
-```
+No pending entries.


### PR DESCRIPTION
The review findings ledger, has_plan flag, and agent tool backfill entries were applied on the homelab central PG on 2026-09-04 ahead of the alpha.67 deploy, so the list is empty again.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791068975&installation_model_id=431401&pr_number=554&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F554&signature=10ed55fe9d14b720b37fcb023c598f3dfefcbdf502d1a46fc6fde68d9cbef05d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->