### PR TITLE
feat(kb): caption images at KB ingest (#349, #350)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,10 @@ First run: `cp deploy/env.example deploy/.env` and set
   `create_calendar_event` route to the right connector/account via an
   `account` parameter — see `manager.go`'s `aggregateTools`),
   `destinations` (mission result delivery: email/webhook/
-  telegram), `kb` (knowledge-base collections/documents), `attachments`,
+  telegram), `kb` (knowledge-base collections/documents; image
+  captioning at ingest, issues #349/#350, is default-off behind
+  `settings.KeyKBImageCaptioning` — `kb.Enricher` runs in the ingest
+  funnel, mission promotion, and PDF conversion), `attachments`,
   `gwclient`, `memclient`, `sandboxclient`, `settings`, `skills`.
 - `internal/gateway/`: `provider` (wire adapters only), `router`,
   `catalog` (LiteLLM-synced model/pricing catalog), `ledger`, `stream`,

--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -291,6 +291,13 @@ func main() {
 	// below) can close over the same store the kb admin API and mission
 	// promotion hook use later in this function.
 	kbStore := kb.New(app.DB)
+	// KB image captioning (issues #349/#350): default-off, gated on
+	// settings.KeyKBImageCaptioning; shared by the manual ingest funnel,
+	// the retry sweep, and mission promotion so none of the three diverge
+	// on what "captioned" means.
+	kbEnrich := api.NewKBEnricher(chat.CaptionImageOverGateway(gwc, app.Log), func(ctx context.Context) bool {
+		return flags.Enabled(ctx, settings.KeyKBImageCaptioning)
+	}, app.Log)
 	missionStore, missionDriver, missionNotifier, missionWorkspace, missionHub, missionScheduler := buildMissions(ctx, app.DB, agent, store, workspace, flags, missionSandbox, agentReg, routeForRole, fxStore, gwc, secrets, conns, mc, packs, app.Log)
 	if missionDriver != nil {
 		go missions.RecoverAndSweep(ctx, missionDriver, missionStore, missionWorkSlotMax, missionSandbox, missionSandbox, missionNotifier, gwc,
@@ -654,7 +661,7 @@ func main() {
 	// as artifact copy above (promotion reads from the attachment-store
 	// refs artifact copy just wrote).
 	if attachmentStore != nil && missionDriver != nil {
-		missionDriver.SetPromoteKB(destinations.PromoteKB(attachmentStore, kbStore, mc, app.Log))
+		missionDriver.SetPromoteKB(destinations.PromoteKB(attachmentStore, kbStore, mc, kbEnrich, app.Log))
 	}
 
 	// search_kb: nil-safe wiring, same shape as memory retrieve/extract
@@ -684,7 +691,7 @@ func main() {
 	}()
 	// kb retry sweep (issue #414): re-ingests documents that failed on a
 	// transient embedding/provider error, on their own backoff schedule.
-	go api.RunKBRetrySweep(ctx, kbStore, mc, app.Log)
+	go api.RunKBRetrySweep(ctx, kbStore, mc, kbEnrich, app.Log)
 	svc.SetKBSearch(func(ctx context.Context, query string, boostCollections []string, mode string, k int) ([]builtin.KBSearchHit, error) {
 		hits, err := mc.KBSearch(ctx, query, nil, boostCollections, mode, k)
 		if err != nil {
@@ -730,7 +737,7 @@ func main() {
 	api.Register(app.Server, svc, store, broker,
 		memoryProxy(memorydURL, app.Log), adminProxy(gatewayURL, usageDecorator.Decorate, app.Log), flags, fxStore,
 		agentReg, conns, goog, msft, secrets, agent, packs, missionStore, missionDriver, missionNotifier,
-		missionWorkspace, resolveSecret, routeForRole, chat.ClassifyOverGateway(gwc), gwc.ResolveRoute, chat.TitleOverGateway(gwc, app.Log), ledgerAgg.TopModelByMission, missionHub, attachmentStore, &http.Client{}, whisperURL, markitdownURL, token, app.Log, gwc, kbStore, mc, chat.ClassifyCollectionOverGateway(gwc, app.Log), chat.TitleOverGateway(gwc, app.Log), destinationStore, destinationTest, workflowStore, workflowEngine, pdfService, chat.ExtractGitHubDestinationOverGateway(gwc, app.Log))
+		missionWorkspace, resolveSecret, routeForRole, chat.ClassifyOverGateway(gwc), gwc.ResolveRoute, chat.TitleOverGateway(gwc, app.Log), ledgerAgg.TopModelByMission, missionHub, attachmentStore, &http.Client{}, whisperURL, markitdownURL, token, app.Log, gwc, kbStore, mc, chat.ClassifyCollectionOverGateway(gwc, app.Log), chat.TitleOverGateway(gwc, app.Log), kbEnrich, destinationStore, destinationTest, workflowStore, workflowEngine, pdfService, chat.ExtractGitHubDestinationOverGateway(gwc, app.Log))
 
 	if err := app.Run(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		app.Log.Error("server exited", "error", err)

--- a/internal/brain/api/api.go
+++ b/internal/brain/api/api.go
@@ -107,7 +107,7 @@ var memoryRoutePatterns = []string{
 // proxy to the gateway's internal control plane, conns the local
 // connector control plane (nil leaves any of them unmounted).
 // whisperURL empty leaves /v1/transcribe unmounted (WHISPER_URL unset).
-func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, msft *connectors.Microsoft, secrets *secretstore.Store, toolset Toolset, packs []skills.Skill, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, resolveRoute func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, markitdownURL string, token string, log *slog.Logger, gwSecrets GatewaySecrets, kbStore *kb.Store, kbIngest kbIngester, kbClassify kbClassifier, kbTitle kbTitler, destinationStore *destinations.Store, destinationTest destinationTester, workflowStore *workflows.Store, workflowEngine *workflows.Engine, pdfService *pdfgen.Service, extractGitHubDestination func(context.Context, string) chat.GitHubDestinationProposal) {
+func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms PermissionResolver, memories, admin http.Handler, flags *settings.Store, rates *fxrates.Store, agentReg *agents.Store, conns *connectors.Manager, goog *connectors.Google, msft *connectors.Microsoft, secrets *secretstore.Store, toolset Toolset, packs []skills.Skill, missionStore *missions.Store, missionDriver *missions.Driver, missionNotifier *missions.Notifier, missionWorkspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, missionClassify agents.Classify, resolveRoute func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), hub *missions.Hub, attachmentStore *attachments.Store, whisperClient *http.Client, whisperURL string, markitdownURL string, token string, log *slog.Logger, gwSecrets GatewaySecrets, kbStore *kb.Store, kbIngest kbIngester, kbClassify kbClassifier, kbTitle kbTitler, kbEnrich *kb.Enricher, destinationStore *destinations.Store, destinationTest destinationTester, workflowStore *workflows.Store, workflowEngine *workflows.Engine, pdfService *pdfgen.Service, extractGitHubDestination func(context.Context, string) chat.GitHubDestinationProposal) {
 	a := &API{svc: svc, dir: dir, perms: perms, token: token, log: log, flags: flags, rates: rates, pdfService: pdfService}
 	if kbStore != nil {
 		a.kbCollections = kbStore.ListCollections
@@ -139,7 +139,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	a.registerConnectors(srv.Handle, conns, goog, msft, secrets)
 	a.registerTools(srv.Handle, toolset)
 	a.registerSkills(srv.Handle, packs)
-	a.registerKB(srv.Handle, kbStore, kbIngest, markitdownURL, kbClassify, kbTitle)
+	a.registerKB(srv.Handle, kbStore, kbIngest, markitdownURL, kbClassify, kbTitle, kbEnrich)
 	var codingExecutorDefault func(context.Context) string
 	if flags != nil {
 		codingExecutorDefault = flags.CodingExecutor
@@ -159,7 +159,7 @@ func Register(srv *httpserver.Server, svc *chat.Service, dir Directory, perms Pe
 	if destinationStore != nil {
 		destLookup = destinationStore
 	}
-	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret, routeForRole, missionClassify, codingExecutorDefault, resolveRoute, nameMission, topModels, conns, missionAttachments, markitdownURL, pdfService, kbStore, kbIngest, extractGitHubDestination)
+	a.registerMissions(srv.Handle, missionStore, missionDriver, missionNotifier, agentReg, missionWorkspace, resolveSecret, routeForRole, missionClassify, codingExecutorDefault, resolveRoute, nameMission, topModels, conns, missionAttachments, markitdownURL, pdfService, kbStore, kbIngest, kbEnrich, extractGitHubDestination)
 	a.registerSchedules(srv.Handle, missionStore, destLookup)
 	// destinationRefs/destinationScheduleRefs are *missions.Store itself
 	// (ActiveMissionReferencesDestination / ScheduleReferencingDestinationID) —

--- a/internal/brain/api/kb.go
+++ b/internal/brain/api/kb.go
@@ -356,6 +356,9 @@ func (h *kbAPI) decodeUpload(w http.ResponseWriter, r *http.Request) (decodedUpl
 			jsonError(w, http.StatusBadGateway, "conversion_failed", err.Error())
 			return decodedUpload{}, false
 		}
+		if ext == ".pdf" && h.enrich != nil {
+			md = h.enrichPDF(r.Context(), md, raw)
+		}
 		markdownText = markitdown.TruncateMarkdown(md)
 	}
 
@@ -369,6 +372,25 @@ func (h *kbAPI) decodeUpload(w http.ResponseWriter, r *http.Request) (decodedUpl
 		markdown: markdownText,
 		rawBytes: int64(len(raw)),
 	}, true
+}
+
+// enrichPDF captions a PDF's embedded images and scanned pages (issue
+// #350): fetches the sidecar's /pdf/images extraction, then runs
+// h.enrich.EnrichPDF over it. Any failure (sidecar unreachable, PDF
+// unparsable) logs and returns md unchanged: a captioning problem must
+// never fail the conversion that already succeeded.
+func (h *kbAPI) enrichPDF(ctx context.Context, md string, raw []byte) string {
+	res, err := markitdown.PDFImages(ctx, h.markitdownHTTP, h.markitdownURL, raw)
+	if err != nil {
+		h.log.Warn("kb ingest: pdf image extraction failed", "error", err)
+		return md
+	}
+	enriched, stats := h.enrich.EnrichPDF(ctx, md, res)
+	if stats.Found > 0 {
+		h.log.Info("kb ingest: pdf image captioning",
+			"found", stats.Found, "captioned", stats.Captioned, "skipped", stats.Skipped, "failed", stats.Failed)
+	}
+	return enriched
 }
 
 // finishIngest creates the pending document row, fires the background
@@ -767,6 +789,9 @@ func (h *kbAPI) convertFetched(ctx context.Context, u *url.URL, body []byte, con
 		md, err := markitdown.Convert(ctx, h.markitdownHTTP, h.markitdownURL, name, contentType, body)
 		if err != nil {
 			return "", err
+		}
+		if strings.Contains(contentType, "application/pdf") && h.enrich != nil {
+			md = h.enrichPDF(ctx, md, body)
 		}
 		return markitdown.TruncateMarkdown(md), nil
 	case strings.Contains(contentType, "text/markdown"), strings.Contains(contentType, "text/plain"):

--- a/internal/brain/api/kb.go
+++ b/internal/brain/api/kb.go
@@ -88,12 +88,12 @@ type kbTitler func(ctx context.Context, input string) string
 
 // registerKB mounts the knowledge-base admin surface (D-060). Nil
 // store leaves it unmounted, same nil-gate pattern as agents/skills.
-func (a *API) registerKB(handle func(pattern string, h http.Handler), store *kb.Store, ingest kbIngester, markitdownURL string, classify kbClassifier, title kbTitler) {
+func (a *API) registerKB(handle func(pattern string, h http.Handler), store *kb.Store, ingest kbIngester, markitdownURL string, classify kbClassifier, title kbTitler, enrich *kb.Enricher) {
 	if store == nil {
 		return
 	}
 	h := &kbAPI{
-		store: store, ingest: ingest, markitdownURL: markitdownURL, classify: classify, title: title,
+		store: store, ingest: ingest, markitdownURL: markitdownURL, classify: classify, title: title, enrich: enrich,
 		markitdownHTTP: &http.Client{},
 		fetchHTTP:      &http.Client{Timeout: kbURLFetchTimeout, Transport: kbFetchTransport},
 		log:            a.log,
@@ -119,6 +119,7 @@ type kbAPI struct {
 	ingest         kbIngester
 	classify       kbClassifier
 	title          kbTitler
+	enrich         *kb.Enricher
 	markitdownURL  string
 	markitdownHTTP *http.Client
 	// fetchHTTP fetches user-supplied URLs; production wires it through
@@ -433,6 +434,20 @@ const kbURLFetchTimeout = 30 * time.Second
 // public addresses are reached (SSRF). A var, not inline, so tests can
 // point it at an unguarded transport; production never reassigns it.
 var kbFetchTransport http.RoundTripper = &http.Transport{DialContext: netguard.Dial, ForceAttemptHTTP2: true}
+
+// NewKBEnricher builds the image-captioning Enricher for KB ingest
+// (issues #349/#350), reusing the same netguard-guarded transport
+// kbFetchTransport dials user-supplied URLs through: caption is
+// chat.CaptionImageOverGateway(gwc, log) in production, enabled reads
+// settings.Store.Enabled(ctx, settings.KeyKBImageCaptioning).
+func NewKBEnricher(caption kb.Captioner, enabled func(context.Context) bool, log *slog.Logger) *kb.Enricher {
+	return &kb.Enricher{
+		Fetch:   &http.Client{Timeout: kbURLFetchTimeout, Transport: kbFetchTransport},
+		Caption: caption,
+		Enabled: enabled,
+		Log:     log,
+	}
+}
 
 type kbURLRequest struct {
 	URL   string `json:"url"`
@@ -791,6 +806,20 @@ func (h *kbAPI) startIngest(docID, title string) {
 			h.log.Warn("kb ingest: document vanished before ingest", "document_id", docID, "error", err)
 			return
 		}
+		if h.enrich != nil {
+			enriched, stats := h.enrich.EnrichMarkdown(ctx, doc.Markdown)
+			if stats.Captioned > 0 {
+				if err := h.store.UpdateMarkdown(ctx, docID, enriched); err != nil {
+					h.log.Warn("kb ingest: caption persist failed", "document_id", docID, "error", err)
+				} else {
+					doc.Markdown = enriched
+				}
+			}
+			if stats.Found > 0 {
+				h.log.Info("kb ingest: image captioning", "document_id", docID,
+					"found", stats.Found, "captioned", stats.Captioned, "skipped", stats.Skipped, "failed", stats.Failed)
+			}
+		}
 		if h.ingest == nil {
 			_ = h.store.SetFailed(ctx, docID, "memoryd is not configured")
 			return
@@ -845,7 +874,7 @@ const kbRetrySweepInterval = time.Minute
 // never diverge on what "retry" means. Runs until ctx is done; store
 // nil (KB unmounted) or ingest nil (memoryd not configured) makes this
 // a no-op loop.
-func RunKBRetrySweep(ctx context.Context, store *kb.Store, ingest kbIngester, log *slog.Logger) {
+func RunKBRetrySweep(ctx context.Context, store *kb.Store, ingest kbIngester, enrich *kb.Enricher, log *slog.Logger) {
 	if store == nil || ingest == nil {
 		return
 	}
@@ -856,7 +885,7 @@ func RunKBRetrySweep(ctx context.Context, store *kb.Store, ingest kbIngester, lo
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			sweepKBRetries(ctx, store, ingest, log)
+			sweepKBRetries(ctx, store, ingest, enrich, log)
 		}
 	}
 }
@@ -864,7 +893,7 @@ func RunKBRetrySweep(ctx context.Context, store *kb.Store, ingest kbIngester, lo
 // sweepKBRetries runs one retry-sweep tick: re-ingests every document
 // DueForRetry reports. Logs nothing when there is nothing due, to keep
 // the steady-state quiet (issue #414 acceptance criteria).
-func sweepKBRetries(ctx context.Context, store *kb.Store, ingest kbIngester, log *slog.Logger) {
+func sweepKBRetries(ctx context.Context, store *kb.Store, ingest kbIngester, enrich *kb.Enricher, log *slog.Logger) {
 	docs, err := store.DueForRetry(ctx)
 	if err != nil {
 		log.Error("kb retry sweep: list failed", "error", err)
@@ -873,7 +902,7 @@ func sweepKBRetries(ctx context.Context, store *kb.Store, ingest kbIngester, log
 	if len(docs) == 0 {
 		return
 	}
-	h := &kbAPI{store: store, ingest: ingest, log: log}
+	h := &kbAPI{store: store, ingest: ingest, enrich: enrich, log: log}
 	for _, doc := range docs {
 		log.Info("kb retry sweep: re-ingesting a transiently failed document",
 			"document_id", doc.ID, "retry_count", doc.RetryCount)

--- a/internal/brain/api/kb_integration_test.go
+++ b/internal/brain/api/kb_integration_test.go
@@ -130,7 +130,7 @@ func TestKBCollectionsCRUD(t *testing.T) {
 	store := testKBStore(t)
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil, nil)
 
 	create := httptest.NewRequest("POST", "/v1/admin/kb/collections", strings.NewReader(`{"name":"itest-docs","description":"test collection"}`))
 	create.Header.Set("Authorization", "Bearer tok")
@@ -249,7 +249,7 @@ func TestKBDocumentUploadSkipsMarkitdownForMarkdown(t *testing.T) {
 	ingester := &fakeIngester{}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-upload", "", 0)
 	if err != nil {
@@ -311,6 +311,72 @@ func TestKBDocumentUploadSkipsMarkitdownForMarkdown(t *testing.T) {
 	}
 }
 
+// TestKBDocumentUploadCaptionsImageLinkWhenEnabled confirms issue
+// #349's ingest-funnel hook: startIngest runs the Enricher between
+// SetIngesting and the memoryd call, persisting the captioned markdown
+// via kb.Store.UpdateMarkdown before the fake ingester ever sees it.
+func TestKBDocumentUploadCaptionsImageLinkWhenEnabled(t *testing.T) {
+	store := testKBStore(t)
+	ingester := &fakeIngester{}
+	imgSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'})
+	}))
+	defer imgSrv.Close()
+	enrich := &kb.Enricher{
+		Fetch:   imgSrv.Client(),
+		Caption: func(context.Context, string, []byte) string { return "a test chart" },
+		Enabled: func(context.Context) bool { return true },
+		Log:     discard(),
+	}
+	a := &API{token: "tok", log: discard()}
+	m := mux(a)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil, enrich)
+
+	collID, err := store.CreateCollection(context.Background(), "itest-caption", "", 0)
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	md := "# Report\n![a chart](" + imgSrv.URL + "/a.png)\n"
+	body, contentType := multipartFile(t, "file", "report.md", []byte(md))
+	req := httptest.NewRequest("POST", "/v1/admin/kb/collections/"+collID+"/documents", body)
+	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("Content-Type", contentType)
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("upload status = %d body %s", w.Code, w.Body)
+	}
+	var doc struct {
+		ID string `json:"id"`
+	}
+	if err := decodeBody(t, w.Body.Bytes(), &doc); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if ingester.callCount() > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if got := ingester.callCount(); got != 1 {
+		t.Fatalf("ingester calls = %d, want 1", got)
+	}
+	final, err := store.GetDocument(context.Background(), doc.ID)
+	if err != nil {
+		t.Fatalf("GetDocument: %v", err)
+	}
+	if !strings.Contains(final.Markdown, "a test chart") {
+		t.Fatalf("stored markdown = %q, want a caption inserted", final.Markdown)
+	}
+	if !strings.Contains(final.Markdown, imgSrv.URL+"/a.png") {
+		t.Fatalf("stored markdown = %q, want the original image link kept", final.Markdown)
+	}
+}
+
 // TestKBSearchDocumentsCrossCollectionTitleMatch covers GET
 // /v1/admin/kb/documents?q=: a case-insensitive title match across
 // EVERY collection (the composer #-mention "find a kb document"
@@ -320,7 +386,7 @@ func TestKBSearchDocumentsCrossCollectionTitleMatch(t *testing.T) {
 	store := testKBStore(t)
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil, nil)
 
 	collA, err := store.CreateCollection(context.Background(), "itest-search-a", "", 0)
 	if err != nil {
@@ -376,7 +442,7 @@ func TestKBDocumentUploadStripsNULAndInvalidUTF8(t *testing.T) {
 	ingester := &fakeIngester{}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-nul", "", 0)
 	if err != nil {
@@ -414,7 +480,7 @@ func TestKBDocumentUploadRejectsUnsupportedType(t *testing.T) {
 	store := testKBStore(t)
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-upload-bad", "", 0)
 	if err != nil {
@@ -450,7 +516,7 @@ func TestKBDocumentFromURLIngestsFetchedMarkdown(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-url", "", 0)
 	if err != nil {
@@ -526,7 +592,7 @@ func TestKBDocumentFromURLScopedReAddRefreshesInPlace(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-url-readd", "", 0)
 	if err != nil {
@@ -619,7 +685,7 @@ func TestKBDocumentFromURLAutoReAddSkipsClassifierKeepsCollection(t *testing.T) 
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", classify, nil)
+	a.registerKB(m.Handle, store, ingester, "", classify, nil, nil)
 
 	post := func() *httptest.ResponseRecorder {
 		req := httptest.NewRequest("POST", "/v1/admin/kb/documents/url",
@@ -687,7 +753,7 @@ func TestKBDocumentFromURLDifferentURLStillCreates(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-url-distinct", "", 0)
 	if err != nil {
@@ -742,7 +808,7 @@ func TestKBDocumentUploadAutoCreatesNewCollection(t *testing.T) {
 	ingester := &fakeIngester{}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil, nil)
 
 	body, contentType := multipartFile(t, "file", "notes.md", []byte("# Title\nsome content"))
 	req := httptest.NewRequest("POST", "/v1/admin/kb/documents", body)
@@ -797,7 +863,7 @@ func TestKBDocumentFromURLAutoUsesExistingCollection(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", matchExisting, nil)
+	a.registerKB(m.Handle, store, ingester, "", matchExisting, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/admin/kb/documents/url",
 		strings.NewReader(`{"url":"`+page.URL+`/notes.md","title":""}`))
@@ -912,7 +978,7 @@ func TestKBClipValidation(t *testing.T) {
 	store := testKBStore(t)
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil, nil)
 
 	tests := []struct {
 		name       string
@@ -959,7 +1025,7 @@ func TestKBClipNewDocumentAutoClassifiesAndNormalizesURL(t *testing.T) {
 	}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", classify, nil)
+	a.registerKB(m.Handle, store, ingester, "", classify, nil, nil)
 
 	body := clipRequest(map[string]any{"url": "https://example.com/article?utm_source=x&x=1#frag"})
 	w := postClip(t, m, body)
@@ -1011,7 +1077,7 @@ func TestKBClipNewDocumentWithCollectionSkipsClassifier(t *testing.T) {
 	}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", classify, nil)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", classify, nil, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-clip-target", "", 0)
 	if err != nil {
@@ -1049,7 +1115,7 @@ func TestKBClipReClipRefreshesInPlace(t *testing.T) {
 	}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", classify, nil)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", classify, nil, nil)
 
 	first := postClip(t, m, clipRequest(map[string]any{"url": "https://example.com/reclip?utm_source=a#x"}))
 	if first.Code != http.StatusAccepted {
@@ -1129,7 +1195,7 @@ func TestKBClipReClipMovesCollection(t *testing.T) {
 	store := testKBStore(t)
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil, nil)
 
 	origID, err := store.CreateCollection(context.Background(), "itest-clip-orig", "", 0)
 	if err != nil {
@@ -1164,7 +1230,7 @@ func TestKBClipStripsNULBytes(t *testing.T) {
 	store := testKBStore(t)
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil, nil)
 
 	w := postClip(t, m, clipRequest(map[string]any{"markdown": "clean\x00 text \xff here"}))
 	if w.Code != http.StatusAccepted {
@@ -1190,7 +1256,7 @@ func TestKBClipEmptyTitleUsesGeneratedTitle(t *testing.T) {
 	titler := func(ctx context.Context, input string) string { return "Generated Title" }
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, titler)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, titler, nil)
 
 	w := postClip(t, m, clipRequest(map[string]any{"title": ""}))
 	if w.Code != http.StatusAccepted {
@@ -1212,7 +1278,7 @@ func TestKBClipEmptyTitleFallsBackToURLWhenTitlerEmpty(t *testing.T) {
 	titler := func(ctx context.Context, input string) string { return "" }
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, titler)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, titler, nil)
 
 	body := clipRequest(map[string]any{"title": "", "url": "https://example.com/docs/getting-started.html"})
 	w := postClip(t, m, body)
@@ -1238,7 +1304,7 @@ func TestKBClipExplicitTitleSkipsTitler(t *testing.T) {
 	}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, titler)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, titler, nil)
 
 	w := postClip(t, m, clipRequest(map[string]any{"title": "Explicit Title"}))
 	if w.Code != http.StatusAccepted {
@@ -1259,7 +1325,7 @@ func TestKBDocumentFromURLRejectsBadURL(t *testing.T) {
 	store := testKBStore(t)
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-url-bad", "", 0)
 	if err != nil {
@@ -1283,7 +1349,7 @@ func TestKBDocumentFromURLBlocksLocalAddresses(t *testing.T) {
 	m := mux(a)
 	// Real guarded transport: the loopback httptest server must be
 	// refused at dial time.
-	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, &fakeIngester{}, "", fixedClassifier, nil, nil)
 
 	page := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("secret internal page"))
@@ -1310,7 +1376,7 @@ func TestKBDocumentReingestFailureSetsFailedStatus(t *testing.T) {
 	ingester := &fakeIngester{err: errors.New("memoryd unreachable")}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-reingest", "", 0)
 	if err != nil {
@@ -1379,7 +1445,7 @@ func TestKBDocumentReingestRetryableErrorSchedulesRetry(t *testing.T) {
 	ingester := &fakeIngester{err: errors.New("every provider failed: chain_exhausted")}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-retry-schedule", "", 0)
 	if err != nil {
@@ -1422,7 +1488,7 @@ func TestKBDocumentReingestPermanentErrorNeverSchedulesRetry(t *testing.T) {
 	ingester := &fakeIngester{err: errors.New("document produced no chunks")}
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil, nil)
 
 	collID, err := store.CreateCollection(context.Background(), "itest-retry-permanent", "", 0)
 	if err != nil {
@@ -1496,11 +1562,11 @@ func TestRunKBRetrySweepRetriesUntilBudgetExhausted(t *testing.T) {
 	// total scheduled retries, then one more failure exhausts the budget.
 	for want := 2; want <= kbRetryMaxAttempts; want++ {
 		forceDue()
-		sweepKBRetries(ctx, store, ingester, discard())
+		sweepKBRetries(ctx, store, ingester, nil, discard())
 		waitForDocument(t, store, docID, func(d kb.Document) bool { return d.RetryCount >= want })
 	}
 	forceDue()
-	sweepKBRetries(ctx, store, ingester, discard())
+	sweepKBRetries(ctx, store, ingester, nil, discard())
 	final := waitForDocument(t, store, docID, func(d kb.Document) bool { return d.NextRetryAt == nil })
 
 	if final.Status != "failed" {
@@ -1522,7 +1588,7 @@ func TestRunKBRetrySweepRetriesUntilBudgetExhausted(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer tok")
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil)
+	a.registerKB(m.Handle, store, ingester, "", fixedClassifier, nil, nil)
 	w := httptest.NewRecorder()
 	m.ServeHTTP(w, req)
 	if w.Code != http.StatusNoContent {
@@ -1538,7 +1604,7 @@ func TestSweepKBRetriesNoopIsQuiet(t *testing.T) {
 	var buf bytes.Buffer
 	log := slog.New(slog.NewTextHandler(&buf, nil))
 
-	sweepKBRetries(context.Background(), store, &fakeIngester{}, log)
+	sweepKBRetries(context.Background(), store, &fakeIngester{}, nil, log)
 
 	if buf.Len() != 0 {
 		t.Fatalf("sweep logged with no failed documents: %s", buf.String())

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -75,7 +75,7 @@ type missionAttachmentStore interface {
 // (not *attachments.Store) so the caller's own nil-box guard (a nil
 // *attachments.Store boxed here would be a non-nil interface value)
 // happens once, at the call site — same shape as chat.Service.SetAttachments.
-func (a *API) registerMissions(handle func(pattern string, h http.Handler), store *missions.Store, driver *missions.Driver, notifier *missions.Notifier, agentReg *agents.Store, workspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, classify agents.Classify, codingExecutorDefault func(context.Context) string, resolveRoute func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), conns *connectors.Manager, attachmentStore missionAttachmentStore, markitdownURL string, pdfService *pdfgenservice.Service, kbStore *kb.Store, kbIngest kbIngester, extractGitHubDestination func(context.Context, string) chat.GitHubDestinationProposal) {
+func (a *API) registerMissions(handle func(pattern string, h http.Handler), store *missions.Store, driver *missions.Driver, notifier *missions.Notifier, agentReg *agents.Store, workspace *missions.Workspace, resolveSecret func(context.Context, string) (string, error), routeForRole func(context.Context, string) string, classify agents.Classify, codingExecutorDefault func(context.Context) string, resolveRoute func(context.Context, string, string) (*gwclient.ResolvedRoute, error), nameMission func(context.Context, string) string, topModels func(context.Context, []string) (map[string]ledger.ModelUsed, error), conns *connectors.Manager, attachmentStore missionAttachmentStore, markitdownURL string, pdfService *pdfgenservice.Service, kbStore *kb.Store, kbIngest kbIngester, kbEnrich *kb.Enricher, extractGitHubDestination func(context.Context, string) chat.GitHubDestinationProposal) {
 	if store == nil {
 		return
 	}
@@ -103,7 +103,7 @@ func (a *API) registerMissions(handle func(pattern string, h http.Handler), stor
 			return a.Harness, true
 		}
 	}
-	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, resolveAgentRoute: resolveAgentRoute, resolveAgentHarness: resolveAgentHarness, workspace: workspace, resolveSecret: resolveSecret, routeForRole: routeForRole, classify: classify, codingExecutorDefault: codingExecutorDefault, resolveRoute: resolveRoute, nameMission: nameMission, topModels: topModels, conns: conns, perms: a.perms, dir: a.dir, log: a.log, attachments: attachmentStore, markitdownURL: markitdownURL, markitdownHTTP: &http.Client{}, pdfService: pdfService, resolveReferences: a.svc.ResolveReferences, kbStore: kbStore, kbIngest: kbIngest, extractGitHubDestination: extractGitHubDestination}
+	h := &missionAPI{store: store, driver: driver, notifier: notifier, agentReg: agentReg, resolveAgentRoute: resolveAgentRoute, resolveAgentHarness: resolveAgentHarness, workspace: workspace, resolveSecret: resolveSecret, routeForRole: routeForRole, classify: classify, codingExecutorDefault: codingExecutorDefault, resolveRoute: resolveRoute, nameMission: nameMission, topModels: topModels, conns: conns, perms: a.perms, dir: a.dir, log: a.log, attachments: attachmentStore, markitdownURL: markitdownURL, markitdownHTTP: &http.Client{}, pdfService: pdfService, resolveReferences: a.svc.ResolveReferences, kbStore: kbStore, kbIngest: kbIngest, kbEnrich: kbEnrich, extractGitHubDestination: extractGitHubDestination}
 	handle("GET /v1/missions", a.auth(http.HandlerFunc(h.list)))
 	handle("POST /v1/missions", a.auth(http.HandlerFunc(h.create)))
 	handle("POST /v1/missions/classify", a.auth(http.HandlerFunc(h.classifyGoal)))
@@ -212,6 +212,7 @@ type missionAPI struct {
 	// the endpoint the same way pdfService's absence does export-pdf.
 	kbStore  *kb.Store
 	kbIngest kbIngester
+	kbEnrich *kb.Enricher
 	// resolveReferences resolves a create request's picked #-mention
 	// references (mission/session/kb doc) into documents: chat.Service's
 	// own resolver (chat.go's ResolveReferences), reused here so a
@@ -2123,7 +2124,7 @@ func (h *missionAPI) promoteKB(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, "no_artifacts", "mission has no artifacts to promote")
 		return
 	}
-	promoted, errs := destinations.PromoteMission(r.Context(), h.attachments, h.kbStore, h.kbIngest, m, body.CollectionID)
+	promoted, errs := destinations.PromoteMission(r.Context(), h.attachments, h.kbStore, h.kbIngest, h.kbEnrich, m, body.CollectionID)
 	if promoted == 0 {
 		msg := "no markdown artifacts were promoted"
 		if len(errs) > 0 {

--- a/internal/brain/api/missions_integration_test.go
+++ b/internal/brain/api/missions_integration_test.go
@@ -137,7 +137,7 @@ func TestMissionsResumeWithAnswerReachesWorker(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/resume", strings.NewReader(`{"answer":"the deploy target is staging"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -207,7 +207,7 @@ func TestMissionsResumeWithoutAnswerLeavesProgressUntouched(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/resume", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -251,7 +251,7 @@ func TestMissionsNoteAppendsEventAndProgressWithoutPhaseChange(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":"focus on the staging config next"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -300,7 +300,7 @@ func TestMissionsNoteAcceptedOnEveryNonTerminalPhase(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	for _, phase := range []missions.Phase{missions.PhaseDiscover, missions.PhasePlan, missions.PhaseGenerate, missions.PhaseProve} {
 		phase := phase
@@ -356,7 +356,7 @@ func TestMissionsNoteUnknownMission(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/00000000-0000-0000-0000-000000000000/note", strings.NewReader(`{"text":"hello"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -380,7 +380,7 @@ func TestMissionsNoteEmptyTextRejected(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":""}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -410,7 +410,7 @@ func TestMissionsNoteTerminalMissionRejected(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/note", strings.NewReader(`{"text":"too late"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -429,7 +429,7 @@ func TestMissionsCreateDefaultsAutoApprovePlanTrue(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	body := `{"goal":"itest-api-mission default auto_approve_plan","kind":"general"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -463,7 +463,7 @@ func TestMissionsCreateHonorsExplicitAutoApprovePlanFalse(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	body := `{"goal":"itest-api-mission explicit auto_approve_plan false","kind":"general","auto_approve_plan":false}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -509,7 +509,7 @@ func TestMissionsApprovePlanRejectedWhenNotParked(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	for _, verb := range []string{"approve-plan", "replan", "rediscover"} {
 		req := httptest.NewRequest("POST", "/v1/missions/"+id+"/"+verb, nil)
@@ -544,7 +544,7 @@ func TestMissionsApprovePlanAdvancesToGenerate(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/approve-plan", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -577,7 +577,7 @@ func TestMissionsAnswerRejectedWhenNotParked(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/answer", strings.NewReader(`{"answer":"yes"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -606,7 +606,7 @@ func TestMissionsAnswerValidatesMCQOption(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/answer", strings.NewReader(`{"answer":"rust"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -641,7 +641,7 @@ func TestMissionsAnswerResumesMission(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/answer", strings.NewReader(`{"answer":"yes"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -675,7 +675,7 @@ func TestMissionsCreateLeavesEnvironmentForDetection(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	body := `{"goal":"itest-api-mission go ahead and write a CLI that parses logs","kind":"coding"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -714,7 +714,7 @@ func TestMissionsCreateCarriesPlanRoute(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	body := `{"goal":"itest-api-mission plan route round trip","kind":"general","route":"mini","plan_route":"strong"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -753,7 +753,7 @@ func TestMissionsCreateFollowUp(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	post := func(body string) (int, []byte) {
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -818,7 +818,7 @@ func TestMissionsCreateFollowUpUnknownParent(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	body := `{"goal":"itest-api-mission follow-up unknown parent","kind":"general","parent_mission_id":"00000000-0000-0000-0000-000000000000"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -873,7 +873,7 @@ func TestMissionsCreateWithPDFAttachment(t *testing.T) {
 		defer md.Close()
 
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil, nil, nil, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil, nil, nil, nil, nil)
 
 		code, body := post(m, `{"goal":"itest-api-mission with attachment","kind":"general","attachments":[{"id":"`+att.ID+`","name":"spec.pdf"}]}`)
 		if code != http.StatusCreated {
@@ -938,7 +938,7 @@ func TestMissionsCreateWithPDFAttachment(t *testing.T) {
 		defer md.Close()
 
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil, nil, nil, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil, nil, nil, nil, nil)
 
 		code, body := post(m, `{"goal":"itest-api-mission with huge attachment","kind":"general","attachments":[{"id":"`+att.ID+`"}]}`)
 		if code != http.StatusCreated {
@@ -968,7 +968,7 @@ func TestMissionsCreateWithPDFAttachment(t *testing.T) {
 		defer md.Close()
 
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil, nil, nil, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, attStore, md.URL, nil, nil, nil, nil, nil)
 
 		code, body := post(m, `{"goal":"itest-api-mission markitdown failure","kind":"general","attachments":[{"id":"`+att.ID+`"}]}`)
 		if code != http.StatusInternalServerError {
@@ -993,7 +993,7 @@ func TestMissionsCreateGeneratesNameAsync(t *testing.T) {
 	nameMission := func(ctx context.Context, goal string) string {
 		return "Parse Logs Utility"
 	}
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	body := `{"goal":"itest-api-mission write a Go CLI that parses logs","kind":"general"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -1041,7 +1041,7 @@ func TestMissionsCreateNameFallsBackToEmptyOnGenerationFailure(t *testing.T) {
 		defer close(done)
 		return "" // simulates a gateway/timeout failure, same as TitleOverGateway
 	}
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nameMission, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	body := `{"goal":"itest-api-mission a goal whose naming will fail","kind":"general"}`
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -1304,7 +1304,7 @@ func TestMissionsPushResolvesConnectorToken(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/push", strings.NewReader(`{}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1376,7 +1376,7 @@ func TestMissionsPushConnectorTable(t *testing.T) {
 
 			a := &API{token: "tok", log: discard()}
 			m := mux(a)
-			a.registerMissions(m.Handle, store, nil, nil, nil, workspace, nil, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil, nil, nil, nil)
+			a.registerMissions(m.Handle, store, nil, nil, nil, workspace, nil, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil, nil, nil, nil, nil)
 
 			req := httptest.NewRequest("POST", "/v1/missions/"+id+"/push", strings.NewReader(`{}`))
 			req.Header.Set("Authorization", "Bearer tok")
@@ -1410,7 +1410,7 @@ func TestMissionsPushExplicitCredentialRefOverridesConnector(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/push", strings.NewReader(`{"credential_ref":"explicit-ref"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1465,7 +1465,7 @@ func TestMissionsPRHappyPath(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/pr", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1542,7 +1542,7 @@ func TestMissionsPRAlreadyExistsReturnsExisting(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, workspace, resolveSecret, nil, nil, nil, nil, nil, nil, mgr, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/pr", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1576,7 +1576,7 @@ func TestMissionsPRRejectsNonGitHubConnectionMission(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/pr", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1634,7 +1634,7 @@ func TestMissionsExportPDFBadPath(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/export-pdf", strings.NewReader(`{"path":"notes.txt"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1657,7 +1657,7 @@ func TestMissionsExportPDFTraversal(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/export-pdf", strings.NewReader(`{"path":"../../../etc/passwd.md"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1680,7 +1680,7 @@ func TestMissionsExportPDFNoMarkdownFiles(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/export-pdf", strings.NewReader(`{}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1704,7 +1704,7 @@ func TestMissionsExportPDFOverCap(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/export-pdf", strings.NewReader(`{"path":"big.md"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1734,7 +1734,7 @@ func TestMissionsExportPDFSingleFileHappyPath(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/export-pdf", strings.NewReader(`{"path":"report.md"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1803,7 +1803,7 @@ func TestMissionsExportPDFMergedHappyPath(t *testing.T) {
 
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", svc, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/"+id+"/export-pdf", strings.NewReader(`{}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1862,7 +1862,7 @@ func TestMissionsPromoteKB(t *testing.T) {
 		t.Helper()
 		a := &API{token: "tok", log: discard()}
 		m := mux(a)
-		a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, fa, "", nil, kbStore, ingest, nil)
+		a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, fa, "", nil, kbStore, ingest, nil, nil)
 		return m
 	}
 
@@ -1990,7 +1990,7 @@ func TestMissionsRoutingPatchStateGate(t *testing.T) {
 	driver := missions.NewDriver(store, errRunner{}, nil, nil, nil, nil, nil, nil, discard())
 	a := &API{token: "tok", log: discard()}
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, resolveRouteFixture, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, resolveRouteFixture, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	patch := func(body string) *httptest.ResponseRecorder {
 		req := httptest.NewRequest("PATCH", "/v1/missions/"+id+"/routing", strings.NewReader(body))

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -27,7 +27,7 @@ func TestMissionsEndpointsUnmountedWhenStoreNil(t *testing.T) {
 	t.Parallel()
 	a, _, _ := testAPI(t, "tok", nil)
 	m := mux(a)
-	a.registerMissions(m.Handle, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	for _, req := range []struct{ method, path string }{
 		{"GET", "/v1/missions"},
@@ -67,7 +67,7 @@ func TestMissionsListFilterValidation(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	call := func(path string) int {
 		req := httptest.NewRequest("GET", path, nil)
@@ -121,7 +121,7 @@ func TestMissionsDeleteReachesStore(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("DELETE", "/v1/missions/abc", nil)
 	req.Header.Set("Authorization", "Bearer tok")
@@ -141,7 +141,7 @@ func TestMissionsExportPDFNotEnabled(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/abc/export-pdf", strings.NewReader(`{}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -180,7 +180,7 @@ func TestMissionsCreateValidatesHarness(t *testing.T) {
 
 	post := func(codingExecutorDefault func(context.Context) string, body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, codingExecutorDefault, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, codingExecutorDefault, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -241,7 +241,7 @@ func TestMissionsCreateValidatesLight(t *testing.T) {
 
 	post := func(classify func(context.Context, string) (string, error), body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -280,7 +280,7 @@ func TestMissionsCreateFlowNormalization(t *testing.T) {
 
 	post := func(body string) (int, string) {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -347,7 +347,7 @@ func TestMissionsCreateValidatesRepoURL(t *testing.T) {
 
 	post := func(body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "", nil, nil, nil, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "", nil, nil, nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -373,7 +373,7 @@ func TestMissionsCreateValidatesRepoURL(t *testing.T) {
 	// No conns wired at all: repo_url is rejected outright rather than
 	// panicking on a nil manager.
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(`{"goal":"g","kind":"coding","repo_url":"https://github.com/o/r","connector_id":"1"}`))
 	req.Header.Set("Authorization", "Bearer tok")
 	w := httptest.NewRecorder()
@@ -398,7 +398,7 @@ func TestMissionsCreateValidatesOnComplete(t *testing.T) {
 
 	post := func(body string) int {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "", nil, nil, nil, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, conns, nil, "", nil, nil, nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -442,7 +442,7 @@ func TestMissionsCreateValidatesCreateIfMissing(t *testing.T) {
 
 	post := func(body string) (int, string) {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -484,7 +484,7 @@ func TestMissionsCreateValidatesGitStrategy(t *testing.T) {
 
 	post := func(body string) (int, string) {
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -524,7 +524,7 @@ func TestMissionsCreateValidatesParentMission(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(`{"goal":"g","kind":"general","parent_mission_id":"00000000-0000-0000-0000-000000000000"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -603,7 +603,7 @@ func TestMissionsCreateAttachmentsValidation(t *testing.T) {
 		t.Helper()
 		a, _, _ := testAPI(t, "tok", nil)
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, atts, markitdownURL, nil, nil, nil, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, atts, markitdownURL, nil, nil, nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -688,7 +688,7 @@ func TestMissionsCreateReferencesValidation(t *testing.T) {
 		t.Helper()
 		a, _, _ := testAPI(t, "tok", nil)
 		m := mux(a)
-		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
 		req.Header.Set("Authorization", "Bearer tok")
 		w := httptest.NewRecorder()
@@ -960,7 +960,7 @@ func TestMissionsClassifyEndpoint(t *testing.T) {
 		return "general light", nil
 	}
 	m := mux(a)
-	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, classify, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	call := func(body string) (int, string) {
 		req := httptest.NewRequest("POST", "/v1/missions/classify", strings.NewReader(body))
@@ -1003,7 +1003,7 @@ func TestMissionsDetectDestinationEndpoint(t *testing.T) {
 		}
 		return chat.GitHubDestinationProposal{}
 	}
-	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, extract)
+	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, extract)
 
 	call := func(body string) (int, string) {
 		req := httptest.NewRequest("POST", "/v1/missions/detect-destination", strings.NewReader(body))
@@ -1037,7 +1037,7 @@ func TestMissionsDetectDestinationEndpointNilExtractorDegrades(t *testing.T) {
 	t.Parallel()
 	a, _, _ := testAPI(t, "tok", nil)
 	m := mux(a)
-	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, missions.NewStore(pgpool.New(context.Background(), "postgres://invalid/nope", discard()), discard()), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/detect-destination", strings.NewReader(`{"goal":"push to github.com/octocat/hello-world"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1063,7 +1063,7 @@ func TestMissionsResumeMalformedBodyRejected(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/abc/resume", strings.NewReader(`{not json`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -1086,7 +1086,7 @@ func TestMissionsResumeEmptyBodyUnchanged(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	call := func(body io.Reader) int {
 		req := httptest.NewRequest("POST", "/v1/missions/abc/resume", body)
@@ -1117,7 +1117,7 @@ func TestMissionsNoteMalformedOrEmptyBodyRejected(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	call := func(body io.Reader) int {
 		req := httptest.NewRequest("POST", "/v1/missions/abc/note", body)
@@ -1265,7 +1265,7 @@ func TestMissionsCreateKindOptional(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	driver.SetValidateDeps(missions.ValidateDeps{})
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	call := func(body string) (int, string) {
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -1306,7 +1306,7 @@ func TestMissionsCreateHasPlan(t *testing.T) {
 	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
 	driver.SetValidateDeps(missions.ValidateDeps{})
 	m := mux(a)
-	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	call := func(body string) (int, string) {
 		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
@@ -1363,7 +1363,7 @@ func TestPRRejectsNonGitHubConnectionMission(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	// Against a degraded pool, store.Get itself fails before the
 	// connector_id/repo_url gate is ever reached — this test only
@@ -2037,7 +2037,7 @@ func TestPromoteKBNotEnabledWithoutStore(t *testing.T) {
 	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
 	store := missions.NewStore(pool, discard())
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/some-id/promote-kb", strings.NewReader(`{"collection_id":"c1"}`))
 	req.Header.Set("Authorization", "Bearer tok")
@@ -2071,7 +2071,7 @@ func TestPromoteKBReachesStore(t *testing.T) {
 	store := missions.NewStore(pool, discard())
 	kbStore := kb.New(pool)
 	m := mux(a)
-	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, kbStore, noopIngester{}, nil)
+	a.registerMissions(m.Handle, store, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, kbStore, noopIngester{}, nil, nil)
 
 	req := httptest.NewRequest("POST", "/v1/missions/some-id/promote-kb", strings.NewReader(`{"collection_id":"c1"}`))
 	req.Header.Set("Authorization", "Bearer tok")

--- a/internal/brain/chat/chat.go
+++ b/internal/brain/chat/chat.go
@@ -705,6 +705,79 @@ func ClassifyCollectionOverGateway(gw Gateway, log *slog.Logger) func(ctx contex
 	}
 }
 
+// captionTimeout bounds one image-captioning gateway call (KB ingest
+// enrichment, issues #349/#350): generous enough for a slow vision
+// route, short enough that one stuck image never stalls ingest.
+const captionTimeout = 30 * time.Second
+
+// captionSystem asks for a plain-text description suitable for
+// embedding in stored markdown and for text search (search_kb matching
+// caption wording): no markdown, no preamble, transcribe visible text
+// verbatim since diagrams/screenshots often carry the only copy of it.
+const captionSystem = `Describe this image in plain prose, at most 120 words: what it shows, and transcribe any visible text verbatim. No markdown formatting, no preamble like "This image shows". Reply with only the description.`
+
+// CaptionImageOverGateway mirrors TitleOverGateway's mechanism (route
+// resolution, Stream-and-drain, never-errors contract) for captioning
+// one image at KB ingest time: routed by the "vision" role, falling
+// back to "default" (same D-046 gateway-side safety net covers an
+// unbound vision role). Any failure (no route, stream error, empty
+// reply) returns "", never an error -- callers keep the original
+// content unchanged on a bad caption, exactly like a fetch failure.
+func CaptionImageOverGateway(gw Gateway, log *slog.Logger) func(ctx context.Context, mediaType string, data []byte) string {
+	return func(ctx context.Context, mediaType string, data []byte) string {
+		ctx, cancel := context.WithTimeout(ctx, captionTimeout)
+		defer cancel()
+
+		route, ok, err := gw.RouteForRole(ctx, "vision")
+		if err != nil || !ok {
+			route, ok, err = gw.RouteForRole(ctx, "default")
+			if err != nil {
+				log.Warn("caption: route lookup failed", "error", err)
+				return ""
+			}
+			if !ok {
+				log.Warn("caption: no route bound for vision or default")
+				return ""
+			}
+		}
+
+		req := gwclient.StreamRequest{
+			Route:   route,
+			Purpose: "kb_caption",
+			System:  captionSystem,
+			Messages: []provider.Message{{
+				Role:    "user",
+				Content: "Describe this image.",
+				Images:  []provider.ImageData{{MediaType: mediaType, Data: base64.StdEncoding.EncodeToString(data)}},
+			}},
+			MaxTokens: 600,
+		}
+		events, err := gw.Stream(ctx, req)
+		if err != nil {
+			log.Warn("caption: stream failed", "error", err)
+			return ""
+		}
+		var b strings.Builder
+		var streamErr *stream.StreamError
+		for ev := range events {
+			switch ev.Type {
+			case stream.EventChunk:
+				b.WriteString(ev.Text)
+			case stream.EventError:
+				streamErr = ev.Err
+			}
+		}
+		caption := strings.TrimSpace(b.String())
+		if caption == "" {
+			if streamErr != nil {
+				log.Warn("caption: stream error event", "code", streamErr.Code, "message", streamErr.Message)
+			}
+			return ""
+		}
+		return caption
+	}
+}
+
 // GitHubDestinationProposal is ExtractGitHubDestinationOverGateway's
 // result: a github destination entry for the create form to show the
 // operator before submit (issue #483, part of the missions schema

--- a/internal/brain/chat/chat_test.go
+++ b/internal/brain/chat/chat_test.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2161,6 +2162,88 @@ func TestTitleOverGatewayEmptyOnGatewayError(t *testing.T) {
 	name := TitleOverGateway(gw, discard())(context.Background(), "a goal")
 	if name != "" {
 		t.Fatalf("name = %q, want empty on gateway error", name)
+	}
+}
+
+// TestCaptionImageOverGatewayUsesVisionRoleAndSendsImage confirms the
+// route preference and that the caller's image bytes reach the request
+// as a base64 ImageData part rather than raw bytes.
+func TestCaptionImageOverGatewayUsesVisionRoleAndSendsImage(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGW{events: okEvents("A bar chart showing quarterly revenue.")}
+	caption := CaptionImageOverGateway(gw, discard())(context.Background(), "image/png", []byte("fake-bytes"))
+	if caption != "A bar chart showing quarterly revenue." {
+		t.Fatalf("caption = %q, want the streamed text", caption)
+	}
+
+	gw.mu.Lock()
+	defer gw.mu.Unlock()
+	if len(gw.requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(gw.requests))
+	}
+	req := gw.requests[0]
+	if req.Route != "vision" {
+		t.Fatalf("route = %q, want vision", req.Route)
+	}
+	if req.Purpose != "kb_caption" {
+		t.Fatalf("purpose = %q, want kb_caption", req.Purpose)
+	}
+	if len(req.Messages) != 1 || len(req.Messages[0].Images) != 1 {
+		t.Fatalf("messages = %+v, want one message carrying one image", req.Messages)
+	}
+	img := req.Messages[0].Images[0]
+	if img.MediaType != "image/png" {
+		t.Fatalf("media type = %q, want image/png", img.MediaType)
+	}
+	if img.Data != base64.StdEncoding.EncodeToString([]byte("fake-bytes")) {
+		t.Fatalf("image data = %q, want base64 of the input bytes", img.Data)
+	}
+}
+
+// TestCaptionImageOverGatewayFallsBackToDefaultRoleWhenVisionUnbound
+// mirrors TitleOverGateway's fallback: a fresh install may not have
+// bound the vision role yet.
+func TestCaptionImageOverGatewayFallsBackToDefaultRoleWhenVisionUnbound(t *testing.T) {
+	t.Parallel()
+	gw := &roleGW{
+		fakeGW: fakeGW{events: okEvents("A screenshot of a terminal.")},
+		routeForRole: func(_ context.Context, role string) (string, bool, error) {
+			if role == "vision" {
+				return "", false, nil
+			}
+			return role, true, nil
+		},
+	}
+	caption := CaptionImageOverGateway(gw, discard())(context.Background(), "image/jpeg", []byte("x"))
+	if caption != "A screenshot of a terminal." {
+		t.Fatalf("caption = %q, want the streamed text", caption)
+	}
+	if got := gw.lastRequest().Route; got != "default" {
+		t.Fatalf("route = %q, want default (fallback from unbound vision)", got)
+	}
+}
+
+// TestCaptionImageOverGatewayEmptyOnGatewayError confirms the
+// best-effort contract: a Stream error returns "" so KB ingest keeps
+// the original link/image untouched rather than failing.
+func TestCaptionImageOverGatewayEmptyOnGatewayError(t *testing.T) {
+	t.Parallel()
+	gw := &erroringGW{}
+	caption := CaptionImageOverGateway(gw, discard())(context.Background(), "image/png", []byte("x"))
+	if caption != "" {
+		t.Fatalf("caption = %q, want empty on gateway error", caption)
+	}
+}
+
+// TestCaptionImageOverGatewayEmptyOnEmptyReply confirms an empty stream
+// (no chunks) also degrades to "" rather than a blank caption string
+// being treated as real content by a caller.
+func TestCaptionImageOverGatewayEmptyOnEmptyReply(t *testing.T) {
+	t.Parallel()
+	gw := &fakeGW{events: nil}
+	caption := CaptionImageOverGateway(gw, discard())(context.Background(), "image/png", []byte("x"))
+	if caption != "" {
+		t.Fatalf("caption = %q, want empty on empty stream", caption)
 	}
 }
 

--- a/internal/brain/destinations/promote_kb.go
+++ b/internal/brain/destinations/promote_kb.go
@@ -33,6 +33,7 @@ type kbDocStore interface {
 	SetIngesting(ctx context.Context, id string) error
 	SetFailed(ctx context.Context, id, errMsg string) error
 	GetDocument(ctx context.Context, id string) (kb.Document, error)
+	UpdateMarkdown(ctx context.Context, id, markdown string) error
 }
 
 // markdownArtifactExt names the ArtifactRef extensions PromoteKB
@@ -62,12 +63,12 @@ func promoteSourceRef(missionID, name string) string {
 // is silently skipped, not an error): the caller decides whether a
 // partial failure matters (the manual endpoint reports it, the
 // auto-fire hook just logs it).
-func PromoteMission(ctx context.Context, opener artifactOpener, store kbDocStore, ingest kbIngester, m missions.Mission, collectionID string) (promoted int, errs []error) {
+func PromoteMission(ctx context.Context, opener artifactOpener, store kbDocStore, ingest kbIngester, enrich *kb.Enricher, m missions.Mission, collectionID string) (promoted int, errs []error) {
 	for _, ref := range m.ArtifactRefs {
 		if !markdownArtifactExt[strings.ToLower(filepath.Ext(ref.Name))] {
 			continue
 		}
-		if err := promoteOne(ctx, opener, store, ingest, m.ID, collectionID, ref); err != nil {
+		if err := promoteOne(ctx, opener, store, ingest, enrich, m.ID, collectionID, ref); err != nil {
 			errs = append(errs, fmt.Errorf("%s: %w", ref.Name, err))
 			continue
 		}
@@ -80,9 +81,9 @@ func PromoteMission(ctx context.Context, opener artifactOpener, store kbDocStore
 // result-phase step signature (D-086): every per-artifact error is
 // logged, and the first one is also returned so the result step can
 // fold it into its overall outcome and park the mission on failure.
-func PromoteKB(opener artifactOpener, store kbDocStore, ingest kbIngester, log *slog.Logger) missions.PromoteKB {
+func PromoteKB(opener artifactOpener, store kbDocStore, ingest kbIngester, enrich *kb.Enricher, log *slog.Logger) missions.PromoteKB {
 	return func(ctx context.Context, m missions.Mission, collectionID string) error {
-		_, errs := PromoteMission(ctx, opener, store, ingest, m, collectionID)
+		_, errs := PromoteMission(ctx, opener, store, ingest, enrich, m, collectionID)
 		for _, err := range errs {
 			log.Warn("mission kb promotion skipped", "mission_id", m.ID, "error", err)
 		}
@@ -93,7 +94,7 @@ func PromoteKB(opener artifactOpener, store kbDocStore, ingest kbIngester, log *
 	}
 }
 
-func promoteOne(ctx context.Context, opener artifactOpener, store kbDocStore, ingest kbIngester, missionID, collectionID string, ref missions.ArtifactRef) error {
+func promoteOne(ctx context.Context, opener artifactOpener, store kbDocStore, ingest kbIngester, enrich *kb.Enricher, missionID, collectionID string, ref missions.ArtifactRef) error {
 	r, att, err := opener.Open(ctx, ref.ID)
 	if err != nil {
 		return fmt.Errorf("open artifact: %w", err)
@@ -127,6 +128,14 @@ func promoteOne(ctx context.Context, opener artifactOpener, store kbDocStore, in
 	doc, err := store.GetDocument(ctx, docID)
 	if err != nil {
 		return fmt.Errorf("reload document: %w", err)
+	}
+	if enrich != nil {
+		enriched, stats := enrich.EnrichMarkdown(ctx, doc.Markdown)
+		if stats.Captioned > 0 {
+			if err := store.UpdateMarkdown(ctx, docID, enriched); err == nil {
+				doc.Markdown = enriched
+			}
+		}
 	}
 	if ingest == nil {
 		_ = store.SetFailed(ctx, docID, "memoryd is not configured")

--- a/internal/brain/destinations/promote_kb_test.go
+++ b/internal/brain/destinations/promote_kb_test.go
@@ -97,6 +97,16 @@ func (f *fakeKBStore) GetDocument(_ context.Context, id string) (kb.Document, er
 	return d, nil
 }
 
+func (f *fakeKBStore) UpdateMarkdown(_ context.Context, id, markdown string) error {
+	d, ok := f.docs[id]
+	if !ok {
+		return kb.ErrNotFound
+	}
+	d.Markdown = markdown
+	f.docs[id] = d
+	return nil
+}
+
 // fakeIngest stubs kbIngester, optionally erroring for a fixed doc id.
 type fakeIngest struct {
 	failFor string
@@ -117,7 +127,7 @@ func TestPromoteMissionHappyPath(t *testing.T) {
 	ingest := &fakeIngest{}
 	m := missions.Mission{ID: "m1", ArtifactRefs: []missions.ArtifactRef{{ID: "a1", Mime: "text/plain", Name: "report.md"}}}
 
-	promoted, errs := PromoteMission(t.Context(), opener, store, ingest, m, "col1")
+	promoted, errs := PromoteMission(t.Context(), opener, store, ingest, nil, m, "col1")
 	if promoted != 1 || len(errs) != 0 {
 		t.Fatalf("promoted=%d errs=%v, want 1 promoted, no errors", promoted, errs)
 	}
@@ -144,7 +154,7 @@ func TestPromoteMissionIgnoresNonMarkdownArtifacts(t *testing.T) {
 	store := newFakeKBStore()
 	m := missions.Mission{ID: "m1", ArtifactRefs: []missions.ArtifactRef{{ID: "a1", Mime: "application/pdf", Name: "chart.pdf"}}}
 
-	promoted, errs := PromoteMission(t.Context(), opener, store, &fakeIngest{}, m, "col1")
+	promoted, errs := PromoteMission(t.Context(), opener, store, &fakeIngest{}, nil, m, "col1")
 	if promoted != 0 || len(errs) != 0 {
 		t.Fatalf("promoted=%d errs=%v, want 0 and no errors (non-markdown skipped silently)", promoted, errs)
 	}
@@ -158,7 +168,7 @@ func TestPromoteMissionIdempotentReplacesContent(t *testing.T) {
 	store := newFakeKBStore()
 	m := missions.Mission{ID: "m1", ArtifactRefs: []missions.ArtifactRef{{ID: "a1", Mime: "text/plain", Name: "report.md"}}}
 
-	if _, errs := PromoteMission(t.Context(), opener, store, &fakeIngest{}, m, "col1"); len(errs) != 0 {
+	if _, errs := PromoteMission(t.Context(), opener, store, &fakeIngest{}, nil, m, "col1"); len(errs) != 0 {
 		t.Fatalf("first promote errs = %v", errs)
 	}
 	if len(store.docs) != 1 {
@@ -168,7 +178,7 @@ func TestPromoteMissionIdempotentReplacesContent(t *testing.T) {
 	// Re-promote with updated content: must replace in place, not add a
 	// second document.
 	opener.data["a1"] = []byte("v2")
-	if _, errs := PromoteMission(t.Context(), opener, store, &fakeIngest{}, m, "col1"); len(errs) != 0 {
+	if _, errs := PromoteMission(t.Context(), opener, store, &fakeIngest{}, nil, m, "col1"); len(errs) != 0 {
 		t.Fatalf("second promote errs = %v", errs)
 	}
 	if len(store.docs) != 1 {
@@ -188,7 +198,7 @@ func TestPromoteMissionCollectsIngestErrors(t *testing.T) {
 
 	// failFor targets the first created document id (doc1, per
 	// fakeKBStore.CreateDocument's counter).
-	promoted, errs := PromoteMission(t.Context(), opener, store, &fakeIngest{failFor: "doc1"}, m, "col1")
+	promoted, errs := PromoteMission(t.Context(), opener, store, &fakeIngest{failFor: "doc1"}, nil, m, "col1")
 	if promoted != 0 || len(errs) != 1 {
 		t.Fatalf("promoted=%d errs=%v, want 0 promoted, 1 error", promoted, errs)
 	}
@@ -208,7 +218,7 @@ func TestPromoteKBLogsAndReturnsError(t *testing.T) {
 	store := newFakeKBStore()
 	m := missions.Mission{ID: "m1", ArtifactRefs: []missions.ArtifactRef{{ID: "a1", Mime: "text/plain", Name: "report.md"}}}
 
-	err := PromoteKB(opener, store, &fakeIngest{}, slog.Default())(t.Context(), m, "col1")
+	err := PromoteKB(opener, store, &fakeIngest{}, nil, slog.Default())(t.Context(), m, "col1")
 	if err == nil {
 		t.Fatal("PromoteKB with a vanished artifact: want an error, got nil")
 	}

--- a/internal/brain/kb/enrich.go
+++ b/internal/brain/kb/enrich.go
@@ -1,0 +1,236 @@
+package kb
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// Captioner describes one image's bytes in plain prose; the empty
+// string means captioning failed (network, gateway, or a rejected
+// reply) and the caller must keep the original content unchanged.
+// chat.CaptionImageOverGateway is the production implementation.
+type Captioner func(ctx context.Context, mediaType string, data []byte) string
+
+// captionMarker prefixes every caption block Enricher inserts: it
+// makes a captioned link recognizable so a reingest of an
+// already-enriched document doesn't re-fetch and re-caption the same
+// image (issue #349's reingest AC only requires captioning apply, not
+// that it re-run for free).
+const captionMarker = "Image description:"
+
+// captionBlock formats one caption as a blockquote directly below the
+// image markdown it describes: the original link stays intact
+// (provenance, and a caption failure degrades to unchanged text).
+func captionBlock(caption string) string {
+	return fmt.Sprintf("\n> %s %s\n", captionMarker, caption)
+}
+
+// Enrich bounds (issue #349): a document with more images than this
+// skips the rest rather than spending unbounded gateway calls per
+// ingest; maxImageBytes caps one fetched image so a malicious or
+// oversized link can't stall ingest or blow memory.
+const (
+	maxCaptionedImages = 20
+	maxImageBytes      = 5 << 20 // 5MiB
+	captionConcurrency = 4
+)
+
+// imageLinkPattern matches Markdown image syntax `![alt](url)`,
+// optionally followed by a title in quotes; capture groups are alt
+// text and URL. HTML <img> tags are out of scope for v1 (markitdown's
+// own output and hand-written/clip markdown both use the Markdown
+// form).
+var imageLinkPattern = regexp.MustCompile(`!\[([^\]]*)\]\((\S+?)(?:\s+"[^"]*")?\)`)
+
+// imageRef is one image link found in markdown, with the byte range of
+// its full match (used to detect an existing caption block right after
+// it).
+type imageRef struct {
+	url      string
+	matchEnd int
+	lineEnd  int // index just past the link's line, where a caption block would sit
+}
+
+// extractImageLinks finds every http(s) Markdown image link in md,
+// deduplicated by URL, in document order. data: URLs and non-http(s)
+// schemes are skipped: fetch only ever dials a real network address.
+func extractImageLinks(md string) []imageRef {
+	seen := map[string]bool{}
+	var out []imageRef
+	for _, m := range imageLinkPattern.FindAllStringSubmatchIndex(md, -1) {
+		url := md[m[4]:m[5]]
+		if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+			continue
+		}
+		if seen[url] {
+			continue
+		}
+		seen[url] = true
+		lineEnd := strings.IndexByte(md[m[1]:], '\n')
+		if lineEnd < 0 {
+			lineEnd = len(md)
+		} else {
+			lineEnd += m[1]
+		}
+		out = append(out, imageRef{url: url, matchEnd: m[1], lineEnd: lineEnd})
+	}
+	return out
+}
+
+// alreadyCaptioned reports whether the text right after an image
+// link's line already carries a caption block, so re-running
+// EnrichMarkdown (reingest) doesn't re-fetch and re-spend on an image
+// it already captioned.
+func alreadyCaptioned(md string, lineEnd int) bool {
+	rest := strings.TrimLeft(md[lineEnd:], "\n")
+	return strings.HasPrefix(rest, "> "+captionMarker)
+}
+
+// EnrichStats reports what one EnrichMarkdown call did, for the
+// ingest log line and for deciding whether the enriched markdown needs
+// persisting.
+type EnrichStats struct {
+	Found     int // image links seen
+	Captioned int // captions newly inserted
+	Skipped   int // already captioned, over the image cap, or non-image content
+	Failed    int // fetch or caption failures (original link kept)
+}
+
+// allowedImageTypes are the content types Enricher will fetch and
+// caption; anything else (including a non-image response) is skipped
+// rather than sent to the vision model.
+var allowedImageTypes = map[string]bool{
+	"image/png": true, "image/jpeg": true, "image/webp": true, "image/gif": true,
+}
+
+// Enricher captions image links found in a document's markdown at KB
+// ingest time (issue #349). Enabled gates real gateway spend: nil
+// Enabled or a false result makes EnrichMarkdown a no-op returning the
+// input unchanged, which callers rely on to skip the UpdateMarkdown
+// write entirely.
+type Enricher struct {
+	// Fetch dials image URLs; production wires this through netguard
+	// (SSRF guard), same transport api/kb.go's fetchHTTP uses.
+	Fetch *http.Client
+	// Caption describes one image's bytes; "" on any failure.
+	Caption Captioner
+	// Enabled reports whether captioning may spend gateway tokens right
+	// now (settings.Store.Enabled(ctx, settings.KeyKBImageCaptioning)).
+	Enabled func(ctx context.Context) bool
+	Log     *slog.Logger
+}
+
+// EnrichMarkdown appends a plain-prose caption block under each
+// distinct http(s) image link in md, up to maxCaptionedImages. Any
+// per-image failure (fetch error, oversized body, non-image content
+// type, or a caption failure) leaves that link untouched and counts as
+// Failed; the document as a whole always ingests. A link that already
+// carries a caption block (idempotent reingest) is Skipped without a
+// network call.
+func (e *Enricher) EnrichMarkdown(ctx context.Context, md string) (string, EnrichStats) {
+	var stats EnrichStats
+	if e == nil || e.Enabled == nil || !e.Enabled(ctx) {
+		return md, stats
+	}
+	refs := extractImageLinks(md)
+	stats.Found = len(refs)
+	if len(refs) == 0 {
+		return md, stats
+	}
+
+	type result struct {
+		ref     imageRef
+		caption string
+		ok      bool
+	}
+	toFetch := make([]imageRef, 0, len(refs))
+	for _, ref := range refs {
+		if alreadyCaptioned(md, ref.lineEnd) {
+			stats.Skipped++
+			continue
+		}
+		if len(toFetch) >= maxCaptionedImages {
+			stats.Skipped++
+			continue
+		}
+		toFetch = append(toFetch, ref)
+	}
+	if len(toFetch) == 0 {
+		return md, stats
+	}
+
+	results := make([]result, len(toFetch))
+	sem := make(chan struct{}, captionConcurrency)
+	done := make(chan int, len(toFetch))
+	for i, ref := range toFetch {
+		sem <- struct{}{}
+		go func(i int, ref imageRef) {
+			defer func() { <-sem; done <- i }()
+			caption, ok := e.captionOne(ctx, ref.url)
+			results[i] = result{ref: ref, caption: caption, ok: ok}
+		}(i, ref)
+	}
+	for range toFetch {
+		<-done
+	}
+
+	// Insert from the end so earlier offsets stay valid as the string
+	// grows.
+	out := md
+	for i := len(results) - 1; i >= 0; i-- {
+		r := results[i]
+		if !r.ok {
+			stats.Failed++
+			continue
+		}
+		out = out[:r.ref.lineEnd] + captionBlock(r.caption) + out[r.ref.lineEnd:]
+		stats.Captioned++
+	}
+	return out, stats
+}
+
+// captionOne fetches and captions a single image URL, logging (not
+// erroring) any failure: EnrichMarkdown's contract is "never fails the
+// document".
+func (e *Enricher) captionOne(ctx context.Context, url string) (string, bool) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		e.Log.Warn("kb caption: bad image url", "url", url, "error", err)
+		return "", false
+	}
+	req.Header.Set("Accept", "image/*")
+	resp, err := e.Fetch.Do(req)
+	if err != nil {
+		e.Log.Warn("kb caption: fetch failed", "url", url, "error", err)
+		return "", false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		e.Log.Warn("kb caption: fetch non-200", "url", url, "status", resp.StatusCode)
+		return "", false
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxImageBytes+1))
+	if err != nil {
+		e.Log.Warn("kb caption: read failed", "url", url, "error", err)
+		return "", false
+	}
+	if len(data) > maxImageBytes {
+		e.Log.Warn("kb caption: image too large", "url", url, "limit_bytes", maxImageBytes)
+		return "", false
+	}
+	mediaType := http.DetectContentType(data)
+	if !allowedImageTypes[mediaType] {
+		e.Log.Warn("kb caption: unsupported content type", "url", url, "content_type", mediaType)
+		return "", false
+	}
+	caption := e.Caption(ctx, mediaType, data)
+	if caption == "" {
+		return "", false
+	}
+	return caption, true
+}

--- a/internal/brain/kb/enrich.go
+++ b/internal/brain/kb/enrich.go
@@ -2,12 +2,15 @@ package kb
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"regexp"
 	"strings"
+
+	"github.com/SumonMSelim/timothy/internal/platform/markitdown"
 )
 
 // Captioner describes one image's bytes in plain prose; the empty
@@ -192,6 +195,87 @@ func (e *Enricher) EnrichMarkdown(ctx context.Context, md string) (string, Enric
 		stats.Captioned++
 	}
 	return out, stats
+}
+
+// maxPDFPages/maxPDFImagesPerDoc bound one document's PDF enrichment
+// spend the same way maxCaptionedImages bounds EnrichMarkdown: a
+// document with more pages/images than this skips the rest rather than
+// captioning unboundedly.
+const (
+	maxPDFPages        = 50
+	maxPDFImagesPerDoc = 30
+)
+
+// EnrichPDF captions each embedded image and each rendered scanned
+// page markitdown-svc's /pdf/images extracted (issue #350), appending
+// a per-page section to md: "## Page N images" for embedded images,
+// "## Page N (scanned)" for a page whose text layer was too sparse to
+// trust. A page/image with no caption (fetch never needed here, only
+// the vision call can fail) is silently skipped, never blocking the
+// rest of the document.
+func (e *Enricher) EnrichPDF(ctx context.Context, md string, res markitdown.PDFImagesResult) (string, EnrichStats) {
+	var stats EnrichStats
+	if e == nil || e.Enabled == nil || !e.Enabled(ctx) {
+		return md, stats
+	}
+
+	var out strings.Builder
+	out.WriteString(md)
+	imagesCaptioned := 0
+	for pageIdx, page := range res.Pages {
+		if pageIdx >= maxPDFPages {
+			break
+		}
+		var section strings.Builder
+		for _, img := range page.Images {
+			if imagesCaptioned >= maxPDFImagesPerDoc {
+				stats.Skipped++
+				continue
+			}
+			stats.Found++
+			data, err := base64.StdEncoding.DecodeString(img.DataB64)
+			if err != nil {
+				stats.Failed++
+				continue
+			}
+			caption := e.Caption(ctx, img.MediaType, data)
+			if caption == "" {
+				stats.Failed++
+				continue
+			}
+			fmt.Fprintf(&section, "\n> %s %s\n", captionMarker, caption)
+			imagesCaptioned++
+			stats.Captioned++
+		}
+		if section.Len() > 0 {
+			fmt.Fprintf(&out, "\n\n## Page %d images\n%s", page.Page, section.String())
+		}
+
+		if page.RenderB64 != nil {
+			if imagesCaptioned >= maxPDFImagesPerDoc {
+				stats.Skipped++
+				continue
+			}
+			stats.Found++
+			data, err := base64.StdEncoding.DecodeString(*page.RenderB64)
+			if err != nil {
+				stats.Failed++
+				continue
+			}
+			caption := e.Caption(ctx, "image/png", data)
+			if caption == "" {
+				stats.Failed++
+				continue
+			}
+			fmt.Fprintf(&out, "\n\n## Page %d (scanned)\n> %s %s\n", page.Page, captionMarker, caption)
+			imagesCaptioned++
+			stats.Captioned++
+		}
+	}
+	if stats.Captioned == 0 {
+		return md, stats
+	}
+	return out.String(), stats
 }
 
 // captionOne fetches and captions a single image URL, logging (not

--- a/internal/brain/kb/enrich_test.go
+++ b/internal/brain/kb/enrich_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/platform/markitdown"
 )
 
 func discardLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
@@ -176,6 +178,67 @@ func TestEnrichMarkdownAlreadyCaptionedIsIdempotent(t *testing.T) {
 	}
 	if out2 != out1 {
 		t.Fatalf("second pass changed the markdown, want byte-identical output on an already-captioned doc")
+	}
+}
+
+func TestEnrichPDFDisabledIsNoop(t *testing.T) {
+	e := &Enricher{Enabled: func(context.Context) bool { return false }, Log: discardLog()}
+	res := markitdown.PDFImagesResult{Pages: []markitdown.PDFPage{{Page: 1, Images: []markitdown.PDFImage{{MediaType: "image/png", DataB64: "AAAA"}}}}}
+	out, stats := e.EnrichPDF(context.Background(), "# doc", res)
+	if out != "# doc" || stats != (EnrichStats{}) {
+		t.Fatalf("out=%q stats=%+v, want unchanged/zero when disabled", out, stats)
+	}
+}
+
+func TestEnrichPDFCaptionsEmbeddedImage(t *testing.T) {
+	e := &Enricher{Caption: fakeCaptioner("a flowchart", false), Enabled: alwaysEnabled, Log: discardLog()}
+	res := markitdown.PDFImagesResult{Pages: []markitdown.PDFPage{
+		{Page: 1, Images: []markitdown.PDFImage{{MediaType: "image/png", DataB64: "AAAA"}}},
+	}}
+	out, stats := e.EnrichPDF(context.Background(), "# doc", res)
+	if stats.Found != 1 || stats.Captioned != 1 || stats.Failed != 0 {
+		t.Fatalf("stats = %+v, want Found=1 Captioned=1", stats)
+	}
+	if !strings.Contains(out, "## Page 1 images") || !strings.Contains(out, "a flowchart") {
+		t.Fatalf("out = %q, want a Page 1 images section with the caption", out)
+	}
+}
+
+func TestEnrichPDFCaptionsScannedPage(t *testing.T) {
+	renderB64 := "QkJC"
+	e := &Enricher{Caption: fakeCaptioner("transcribed text", false), Enabled: alwaysEnabled, Log: discardLog()}
+	res := markitdown.PDFImagesResult{Pages: []markitdown.PDFPage{
+		{Page: 3, TextChars: 5, RenderB64: &renderB64},
+	}}
+	out, stats := e.EnrichPDF(context.Background(), "# doc", res)
+	if stats.Found != 1 || stats.Captioned != 1 {
+		t.Fatalf("stats = %+v, want Found=1 Captioned=1", stats)
+	}
+	if !strings.Contains(out, "## Page 3 (scanned)") || !strings.Contains(out, "transcribed text") {
+		t.Fatalf("out = %q, want a Page 3 (scanned) section with the transcription", out)
+	}
+}
+
+func TestEnrichPDFCaptionerFailureSkipsPage(t *testing.T) {
+	e := &Enricher{Caption: fakeCaptioner("", true), Enabled: alwaysEnabled, Log: discardLog()}
+	res := markitdown.PDFImagesResult{Pages: []markitdown.PDFPage{
+		{Page: 1, Images: []markitdown.PDFImage{{MediaType: "image/png", DataB64: "AAAA"}}},
+	}}
+	out, stats := e.EnrichPDF(context.Background(), "# doc", res)
+	if out != "# doc" {
+		t.Fatalf("out = %q, want unchanged when the captioner fails", out)
+	}
+	if stats.Failed != 1 || stats.Captioned != 0 {
+		t.Fatalf("stats = %+v, want Failed=1 Captioned=0", stats)
+	}
+}
+
+func TestEnrichPDFNoImagesOrScannedPagesIsNoop(t *testing.T) {
+	e := &Enricher{Caption: fakeCaptioner("x", false), Enabled: alwaysEnabled, Log: discardLog()}
+	res := markitdown.PDFImagesResult{Pages: []markitdown.PDFPage{{Page: 1, TextChars: 5000}}}
+	out, stats := e.EnrichPDF(context.Background(), "# doc", res)
+	if out != "# doc" || stats.Captioned != 0 {
+		t.Fatalf("out=%q stats=%+v, want unchanged with a text-rich page and no images", out, stats)
 	}
 }
 

--- a/internal/brain/kb/enrich_test.go
+++ b/internal/brain/kb/enrich_test.go
@@ -1,0 +1,187 @@
+package kb
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func discardLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func alwaysEnabled(context.Context) bool { return true }
+
+// fakeCaptioner returns text for any input, or "" when told to fail.
+func fakeCaptioner(text string, fail bool) Captioner {
+	return func(context.Context, string, []byte) string {
+		if fail {
+			return ""
+		}
+		return text
+	}
+}
+
+func TestExtractImageLinksDedupsAndSkipsNonHTTP(t *testing.T) {
+	md := "![a diagram](https://example.com/a.png)\n\n" +
+		"text ![again same](https://example.com/a.png \"title\") more\n" +
+		"![data url](data:image/png;base64,AAAA)\n" +
+		"![relative](./local.png)\n" +
+		"![b](https://example.com/b.jpg)\n"
+	refs := extractImageLinks(md)
+	if len(refs) != 2 {
+		t.Fatalf("refs = %d, want 2 (deduped, http(s) only), got %+v", len(refs), refs)
+	}
+	if refs[0].url != "https://example.com/a.png" || refs[1].url != "https://example.com/b.jpg" {
+		t.Fatalf("refs = %+v, want a.png then b.jpg in document order", refs)
+	}
+}
+
+func TestEnrichMarkdownDisabledIsNoop(t *testing.T) {
+	e := &Enricher{Enabled: func(context.Context) bool { return false }, Log: discardLog()}
+	md := "![x](https://example.com/a.png)"
+	out, stats := e.EnrichMarkdown(context.Background(), md)
+	if out != md {
+		t.Fatalf("out = %q, want unchanged when disabled", out)
+	}
+	if stats != (EnrichStats{}) {
+		t.Fatalf("stats = %+v, want zero value when disabled", stats)
+	}
+}
+
+func TestEnrichMarkdownNilEnricherIsNoop(t *testing.T) {
+	var e *Enricher
+	md := "![x](https://example.com/a.png)"
+	out, stats := e.EnrichMarkdown(context.Background(), md)
+	if out != md || stats != (EnrichStats{}) {
+		t.Fatalf("nil enricher must be a safe no-op, got out=%q stats=%+v", out, stats)
+	}
+}
+
+func TestEnrichMarkdownCaptionsImageAndKeepsLink(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(pngBytes())
+	}))
+	defer srv.Close()
+
+	e := &Enricher{
+		Fetch:   srv.Client(),
+		Caption: fakeCaptioner("a bar chart of revenue", false),
+		Enabled: alwaysEnabled,
+		Log:     discardLog(),
+	}
+	md := "before\n![chart](" + srv.URL + "/a.png)\nafter"
+	out, stats := e.EnrichMarkdown(context.Background(), md)
+	if stats.Found != 1 || stats.Captioned != 1 || stats.Failed != 0 {
+		t.Fatalf("stats = %+v, want Found=1 Captioned=1 Failed=0", stats)
+	}
+	if !strings.Contains(out, srv.URL+"/a.png") {
+		t.Fatalf("out = %q, want original link kept", out)
+	}
+	if !strings.Contains(out, captionMarker) || !strings.Contains(out, "a bar chart of revenue") {
+		t.Fatalf("out = %q, want a caption block inserted", out)
+	}
+}
+
+func TestEnrichMarkdownFetch404KeepsLinkAndCountsFailed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	e := &Enricher{Fetch: srv.Client(), Caption: fakeCaptioner("x", false), Enabled: alwaysEnabled, Log: discardLog()}
+	md := "![x](" + srv.URL + "/missing.png)"
+	out, stats := e.EnrichMarkdown(context.Background(), md)
+	if out != md {
+		t.Fatalf("out = %q, want unchanged on fetch failure", out)
+	}
+	if stats.Failed != 1 || stats.Captioned != 0 {
+		t.Fatalf("stats = %+v, want Failed=1 Captioned=0", stats)
+	}
+}
+
+func TestEnrichMarkdownCaptionerFailureKeepsLink(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(pngBytes())
+	}))
+	defer srv.Close()
+
+	e := &Enricher{Fetch: srv.Client(), Caption: fakeCaptioner("", true), Enabled: alwaysEnabled, Log: discardLog()}
+	md := "![x](" + srv.URL + "/a.png)"
+	out, stats := e.EnrichMarkdown(context.Background(), md)
+	if out != md {
+		t.Fatalf("out = %q, want unchanged when the captioner fails", out)
+	}
+	if stats.Failed != 1 {
+		t.Fatalf("stats = %+v, want Failed=1", stats)
+	}
+}
+
+func TestEnrichMarkdownOversizedImageSkipped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(make([]byte, maxImageBytes+1))
+	}))
+	defer srv.Close()
+
+	e := &Enricher{Fetch: srv.Client(), Caption: fakeCaptioner("x", false), Enabled: alwaysEnabled, Log: discardLog()}
+	md := "![x](" + srv.URL + "/big.png)"
+	out, stats := e.EnrichMarkdown(context.Background(), md)
+	if out != md || stats.Failed != 1 {
+		t.Fatalf("out=%q stats=%+v, want unchanged with Failed=1 for an oversized image", out, stats)
+	}
+}
+
+func TestEnrichMarkdownNonImageContentTypeSkipped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html></html>"))
+	}))
+	defer srv.Close()
+
+	e := &Enricher{Fetch: srv.Client(), Caption: fakeCaptioner("x", false), Enabled: alwaysEnabled, Log: discardLog()}
+	md := "![x](" + srv.URL + "/notreally.png)"
+	out, stats := e.EnrichMarkdown(context.Background(), md)
+	if out != md || stats.Failed != 1 {
+		t.Fatalf("out=%q stats=%+v, want unchanged with Failed=1 for a non-image response", out, stats)
+	}
+}
+
+func TestEnrichMarkdownAlreadyCaptionedIsIdempotent(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(pngBytes())
+	}))
+	defer srv.Close()
+
+	e := &Enricher{Fetch: srv.Client(), Caption: fakeCaptioner("first pass", false), Enabled: alwaysEnabled, Log: discardLog()}
+	md := "![x](" + srv.URL + "/a.png)"
+	out1, stats1 := e.EnrichMarkdown(context.Background(), md)
+	if stats1.Captioned != 1 || calls != 1 {
+		t.Fatalf("first pass: stats=%+v calls=%d, want Captioned=1 calls=1", stats1, calls)
+	}
+
+	out2, stats2 := e.EnrichMarkdown(context.Background(), out1)
+	if stats2.Skipped != 1 || stats2.Captioned != 0 {
+		t.Fatalf("second pass: stats=%+v, want Skipped=1 Captioned=0 (already captioned)", stats2)
+	}
+	if calls != 1 {
+		t.Fatalf("fetch calls = %d after reingest, want still 1 (no re-fetch)", calls)
+	}
+	if out2 != out1 {
+		t.Fatalf("second pass changed the markdown, want byte-identical output on an already-captioned doc")
+	}
+}
+
+// pngBytes returns a minimal valid PNG signature + IHDR-less body: only
+// http.DetectContentType's sniff of the PNG magic bytes matters here,
+// not a decodable image.
+func pngBytes() []byte {
+	return []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0, 0, 0, 0}
+}

--- a/internal/brain/kb/kb.go
+++ b/internal/brain/kb/kb.go
@@ -445,6 +445,28 @@ func (s *Store) ReplaceDocumentContent(ctx context.Context, id, title, markdown 
 	return nil
 }
 
+// UpdateMarkdown overwrites a document's stored markdown in place
+// (issue #349's image-caption enrichment, run inside startIngest
+// between SetIngesting and the memoryd call): unlike
+// ReplaceDocumentContent this touches only markdown/bytes, never
+// status/retry/collection, so it can run mid-ingest without disturbing
+// the status flow already in progress.
+func (s *Store) UpdateMarkdown(ctx context.Context, id, markdown string) error {
+	db, err := s.db.Get()
+	if err != nil {
+		return fmt.Errorf("kb document %s update markdown: %w", id, err)
+	}
+	tag, err := db.Exec(ctx, `UPDATE kb_documents SET markdown = $2, bytes = $3, updated_at = now() WHERE id = $1`,
+		id, markdown, len(markdown))
+	if err != nil {
+		return fmt.Errorf("kb document %s update markdown: %w", id, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("document %s: %w", id, ErrNotFound)
+	}
+	return nil
+}
+
 // DeleteDocument removes a document; ON DELETE CASCADE takes its
 // chunks with it.
 func (s *Store) DeleteDocument(ctx context.Context, id string) error {

--- a/internal/brain/settings/settings.go
+++ b/internal/brain/settings/settings.go
@@ -25,10 +25,23 @@ const (
 	KeyMemoryExtraction = "memory_extraction_enabled"
 	KeyCompaction       = "compaction_enabled"
 	KeyScheduler        = "scheduler_enabled"
+	// KeyKBImageCaptioning gates spending on vision-model calls to
+	// caption images at KB ingest (issues #349/#350); unlike every other
+	// switch here it defaults OFF for an absent row (knownKeysOff), since
+	// enabling it means real gateway spend the operator must opt into.
+	KeyKBImageCaptioning = "kb_image_captioning_enabled"
 )
 
 var knownKeys = map[string]bool{
 	KeyTools: true, KeyMemoryExtraction: true, KeyCompaction: true, KeyScheduler: true,
+	KeyKBImageCaptioning: true,
+}
+
+// knownKeysOff lists switches from knownKeys whose absent-row default is
+// false instead of the package's normal true (a database outage still
+// degrades this key to false, same fail-closed-on-spend reasoning).
+var knownKeysOff = map[string]bool{
+	KeyKBImageCaptioning: true,
 }
 
 // Typed value settings: strings where empty means the built-in
@@ -172,13 +185,13 @@ func New(db *pgpool.Pool, log *slog.Logger) *Store {
 }
 
 // Enabled reports one switch, defaulting to true for absent rows and
-// unknown keys.
+// unknown keys, except knownKeysOff members which default to false.
 func (s *Store) Enabled(ctx context.Context, key string) bool {
 	all := s.All(ctx)
 	if v, ok := all[key]; ok {
 		return v
 	}
-	return true
+	return !knownKeysOff[key]
 }
 
 // All returns every known switch with defaults applied.
@@ -336,7 +349,7 @@ func (s *Store) load(ctx context.Context) (map[string]bool, map[string]string) {
 
 	flags := map[string]bool{}
 	for k := range knownKeys {
-		flags[k] = true
+		flags[k] = !knownKeysOff[k]
 	}
 	values := map[string]string{}
 	for k := range knownValueKeys {

--- a/internal/brain/settings/settings_test.go
+++ b/internal/brain/settings/settings_test.go
@@ -1,0 +1,63 @@
+package settings
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/platform/pgpool"
+)
+
+func discardLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// degradedStore returns a Store backed by a pool that never connects
+// (empty DSN), exercising the same default-map path a database outage
+// takes.
+func degradedStore(t *testing.T) *Store {
+	t.Helper()
+	pool := pgpool.New(t.Context(), "", discardLog())
+	return New(pool, discardLog())
+}
+
+// TestKBImageCaptioningDefaultsOff confirms the one knownKeysOff
+// switch defaults to false for an absent row / degraded database,
+// unlike every other known switch which defaults to true: enabling
+// real gateway spend must be an explicit opt-in.
+func TestKBImageCaptioningDefaultsOff(t *testing.T) {
+	s := degradedStore(t)
+	if s.Enabled(context.Background(), KeyKBImageCaptioning) {
+		t.Fatal("KeyKBImageCaptioning = true, want false by default")
+	}
+}
+
+// TestOtherSwitchesDefaultOn pins the existing default-true behavior
+// for a knownKeys member outside knownKeysOff, guarding against the
+// new knownKeysOff map accidentally flipping every switch.
+func TestOtherSwitchesDefaultOn(t *testing.T) {
+	s := degradedStore(t)
+	if !s.Enabled(context.Background(), KeyTools) {
+		t.Fatal("KeyTools = false, want true by default")
+	}
+}
+
+// TestUnknownKeyDefaultsOn confirms an unrecognized key still defaults
+// to true, matching Enabled's documented behavior for unknown keys.
+func TestUnknownKeyDefaultsOn(t *testing.T) {
+	s := degradedStore(t)
+	if !s.Enabled(context.Background(), "not_a_real_key") {
+		t.Fatal("unknown key = false, want true by default")
+	}
+}
+
+// TestAllAppliesKnownKeysOffDefault confirms All()'s map (not just
+// Enabled's fallback) reflects the false default for the degraded/
+// absent-row case, since callers like the settings API read All()
+// directly.
+func TestAllAppliesKnownKeysOffDefault(t *testing.T) {
+	s := degradedStore(t)
+	all := s.All(context.Background())
+	if all[KeyKBImageCaptioning] {
+		t.Fatal("All()[KeyKBImageCaptioning] = true, want false by default")
+	}
+}

--- a/internal/platform/markitdown/markitdown.go
+++ b/internal/platform/markitdown/markitdown.go
@@ -84,3 +84,78 @@ func Convert(ctx context.Context, client *http.Client, baseURL, filename, mimeTy
 	}
 	return out.Markdown, nil
 }
+
+// pdfImagesTimeout bounds one /pdf/images call: page rendering is
+// slower than a plain /convert, but the same document already went
+// through markitdown.Convert under convertTimeout, so this stays in
+// the same ballpark.
+const pdfImagesTimeout = 60 * time.Second
+
+// PDFImage is one embedded raster image extracted from a PDF page
+// (issue #350): Index is the PDF xref, unique per document, used only
+// for logging/debugging, never persisted.
+type PDFImage struct {
+	Index     int    `json:"index"`
+	MediaType string `json:"media_type"`
+	DataB64   string `json:"data_b64"`
+	Width     int    `json:"width"`
+	Height    int    `json:"height"`
+}
+
+// PDFPage is one page's extraction result: Images holds embedded
+// raster images (empty when the page has none worth captioning),
+// RenderB64 holds a rendered page PNG when TextChars fell under the
+// sidecar's scanned-page threshold, nil otherwise.
+type PDFPage struct {
+	Page      int        `json:"page"`
+	TextChars int        `json:"text_chars"`
+	Images    []PDFImage `json:"images"`
+	RenderB64 *string    `json:"render_b64"`
+}
+
+// PDFImagesResult is PDFImages' whole-document result.
+type PDFImagesResult struct {
+	Pages []PDFPage `json:"pages"`
+}
+
+// PDFImages posts a raw PDF to the sidecar's /pdf/images endpoint and
+// returns, per page, its embedded images and (for a text-sparse,
+// likely scanned page) a rendered page PNG (issue #350). baseURL empty
+// means the sidecar isn't configured. A wholly unparsable PDF returns
+// an error; per-page/per-image extraction failures are the sidecar's
+// own concern and never surface here (a corrupt image just yields
+// fewer images, not an error).
+func PDFImages(ctx context.Context, client *http.Client, baseURL string, raw []byte) (PDFImagesResult, error) {
+	if baseURL == "" {
+		return PDFImagesResult{}, fmt.Errorf("markitdown is not configured")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/pdf/images", bytes.NewReader(raw))
+	if err != nil {
+		return PDFImagesResult{}, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	c := client
+	if c == nil {
+		c = http.DefaultClient
+	}
+	cctx, cancel := context.WithTimeout(ctx, pdfImagesTimeout)
+	defer cancel()
+	req = req.WithContext(cctx)
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return PDFImagesResult{}, fmt.Errorf("markitdown pdf/images request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return PDFImagesResult{}, fmt.Errorf("markitdown pdf/images returned http %d: %s", resp.StatusCode, snippet)
+	}
+	var out PDFImagesResult
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return PDFImagesResult{}, fmt.Errorf("decode markitdown pdf/images response: %w", err)
+	}
+	return out, nil
+}

--- a/internal/platform/markitdown/markitdown_test.go
+++ b/internal/platform/markitdown/markitdown_test.go
@@ -53,6 +53,59 @@ func TestConvert(t *testing.T) {
 	})
 }
 
+func TestPDFImages(t *testing.T) {
+	t.Run("posts raw bytes and decodes per-page results", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/pdf/images" {
+				t.Errorf("path = %q, want /pdf/images", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"pages":[
+				{"page":1,"text_chars":2000,"images":[{"index":7,"media_type":"image/png","data_b64":"AAAA","width":200,"height":100}],"render_b64":null},
+				{"page":2,"text_chars":10,"images":[],"render_b64":"QkJC"}
+			]}`))
+		}))
+		defer srv.Close()
+
+		out, err := PDFImages(context.Background(), srv.Client(), srv.URL, []byte("%PDF-1.7"))
+		if err != nil {
+			t.Fatalf("PDFImages: %v", err)
+		}
+		if len(out.Pages) != 2 {
+			t.Fatalf("pages = %d, want 2", len(out.Pages))
+		}
+		p1 := out.Pages[0]
+		if p1.TextChars != 2000 || len(p1.Images) != 1 || p1.RenderB64 != nil {
+			t.Fatalf("page 1 = %+v, want text-rich page with one image and no render", p1)
+		}
+		if p1.Images[0].MediaType != "image/png" || p1.Images[0].Width != 200 {
+			t.Fatalf("page 1 image = %+v", p1.Images[0])
+		}
+		p2 := out.Pages[1]
+		if p2.RenderB64 == nil || *p2.RenderB64 != "QkJC" {
+			t.Fatalf("page 2 = %+v, want a rendered page (scanned)", p2)
+		}
+	})
+
+	t.Run("unconfigured base URL errors without a request", func(t *testing.T) {
+		if _, err := PDFImages(context.Background(), nil, "", []byte("x")); err == nil {
+			t.Fatal("empty baseURL accepted")
+		}
+	})
+
+	t.Run("non-2xx surfaces status and body snippet", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "pdf open failed: not a pdf", http.StatusUnprocessableEntity)
+		}))
+		defer srv.Close()
+
+		_, err := PDFImages(context.Background(), srv.Client(), srv.URL, []byte("x"))
+		if err == nil || !strings.Contains(err.Error(), "422") {
+			t.Fatalf("err = %v, want http 422 surfaced", err)
+		}
+	})
+}
+
 func TestTruncateMarkdown(t *testing.T) {
 	t.Run("under cap is unchanged", func(t *testing.T) {
 		md := "# short document"

--- a/markitdown-svc/main.py
+++ b/markitdown-svc/main.py
@@ -4,14 +4,28 @@ boundary as searxng. No auth: never expose this port outside the
 compose network.
 """
 
+import base64
 import io
 
-from fastapi import FastAPI, Header, HTTPException, Request
+import fitz  # PyMuPDF
+from fastapi import FastAPI, Header, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from markitdown import MarkItDown, StreamInfo
 
 app = FastAPI()
 converter = MarkItDown(enable_plugins=False)
+
+# Below this many extracted text characters, a page counts as scanned
+# (image-only) and gets a rendered PNG so brain can caption/OCR it via
+# the vision model instead of losing the page silently (issue #350).
+DEFAULT_MIN_TEXT_CHARS = 200
+# Embedded images smaller than this in either dimension are almost
+# always decorative (icons, dividers, masks), not diagram content:
+# skipping them keeps captioning spend on images worth describing.
+MIN_IMAGE_DIM = 64
+DEFAULT_RENDER_DPI = 110
+DEFAULT_MAX_PAGES = 50
+DEFAULT_MAX_IMAGES_PER_PAGE = 10
 
 
 @app.get("/healthz")
@@ -41,3 +55,94 @@ async def convert(
         raise HTTPException(status_code=422, detail=f"conversion failed: {exc}") from exc
 
     return JSONResponse({"markdown": result.markdown})
+
+
+@app.post("/pdf/images")
+async def pdf_images(
+    request: Request,
+    min_text_chars: int = Query(default=DEFAULT_MIN_TEXT_CHARS, ge=0),
+    render_dpi: int = Query(default=DEFAULT_RENDER_DPI, ge=50, le=300),
+    max_pages: int = Query(default=DEFAULT_MAX_PAGES, ge=1, le=200),
+    max_images_per_page: int = Query(default=DEFAULT_MAX_IMAGES_PER_PAGE, ge=0, le=50),
+):
+    """Extracts embedded images and, for text-sparse (likely scanned)
+    pages, a rendered page PNG from a raw PDF body: brain captions or
+    OCRs these via the vision gateway (issue #350) since markitdown's
+    own PDF converter (pdfminer, text-layer only) drops them silently.
+
+    Per-page and per-image failures are swallowed and skipped: one
+    corrupt image or unparsable page must never fail the whole
+    document, only a wholly unparsable PDF returns 422.
+    """
+    body = await request.body()
+    if not body:
+        raise HTTPException(status_code=400, detail="empty request body")
+
+    try:
+        doc = fitz.open(stream=body, filetype="pdf")
+    except Exception as exc:
+        raise HTTPException(status_code=422, detail=f"pdf open failed: {exc}") from exc
+
+    pages = []
+    try:
+        for page_index, page in enumerate(doc):
+            if page_index >= max_pages:
+                break
+            pages.append(_extract_page(doc, page, min_text_chars, render_dpi, max_images_per_page))
+    finally:
+        doc.close()
+
+    return JSONResponse({"pages": pages})
+
+
+def _extract_page(doc, page, min_text_chars, render_dpi, max_images_per_page):
+    page_number = page.number + 1
+    try:
+        text_chars = len(page.get_text())
+    except Exception:
+        text_chars = 0
+
+    images = []
+    try:
+        for img in page.get_images(full=True)[:max_images_per_page]:
+            extracted = _extract_image(doc, img[0])
+            if extracted is not None:
+                images.append(extracted)
+    except Exception:
+        pass
+
+    render_b64 = None
+    if text_chars < min_text_chars:
+        try:
+            pix = page.get_pixmap(dpi=render_dpi)
+            render_b64 = base64.b64encode(pix.tobytes("png")).decode("ascii")
+        except Exception:
+            render_b64 = None
+
+    return {
+        "page": page_number,
+        "text_chars": text_chars,
+        "images": images,
+        "render_b64": render_b64,
+    }
+
+
+def _extract_image(doc, xref):
+    try:
+        info = doc.extract_image(xref)
+    except Exception:
+        return None
+    if not info:
+        return None
+    width, height = info.get("width", 0), info.get("height", 0)
+    if width < MIN_IMAGE_DIM or height < MIN_IMAGE_DIM:
+        return None
+    ext = info.get("ext", "png")
+    media_type = f"image/{'jpeg' if ext == 'jpg' else ext}"
+    return {
+        "index": xref,
+        "media_type": media_type,
+        "data_b64": base64.b64encode(info["image"]).decode("ascii"),
+        "width": width,
+        "height": height,
+    }

--- a/markitdown-svc/requirements.txt
+++ b/markitdown-svc/requirements.txt
@@ -1,3 +1,4 @@
 markitdown[all]==0.1.6
 fastapi==0.139.2
 uvicorn[standard]==0.51.0
+pymupdf==1.25.5

--- a/web/src/components/settings/FeaturesTab.tsx
+++ b/web/src/components/settings/FeaturesTab.tsx
@@ -55,6 +55,10 @@ const featureCopy: Record<string, { label: string; description: string }> = {
     label: 'Scheduler',
     description: 'Off: recurring schedules stop firing missions.',
   },
+  kb_image_captioning_enabled: {
+    label: 'KB image captioning',
+    description: 'On: images in ingested documents get a vision-model caption, spending gateway tokens per image.',
+  },
 }
 
 export function FeaturesTab() {


### PR DESCRIPTION
## Summary
- Adds a default-off `kb_image_captioning_enabled` switch and a `chat.CaptionImageOverGateway` vision-gateway helper (routed vision -> default, cost lands in the ledger as `kb_caption`, unknown price recorded as NULL).
- #349: captions markdown image links found in stored KB markdown, hooked into the ingest funnel (`startIngest`), the retry sweep, and mission promotion. Original links are always kept; any fetch/caption failure leaves the document unchanged. Reingest of an already-captioned link skips re-fetching.
- #350: adds `markitdown-svc`'s `/pdf/images` endpoint (PyMuPDF) to extract embedded PDF images and render text-sparse (likely scanned) pages, since the sidecar's pdfminer-based `/convert` drops both silently. Brain captions each via the same vision-gateway path and appends a per-page markdown section; a sidecar or captioning failure leaves the plain text-layer conversion intact.
- A follow-up issue (#558) tracks a local-OCR fallback for when no vision route is bound — deferred out of this PR to keep the sidecar cost-honest and simple.

## Test plan
- [x] `make build test vet lint` (Go, race-enabled)
- [x] `go vet -tags integration ./...` (integration test files compile)
- [x] `docker compose ... web-dev` build/lint/test (web)
- [x] Table tests for markdown link extraction/captioning, PDF image/scanned-page captioning, gateway helper routing/fallback, and the default-off settings switch
- [x] Manual smoke test of the new `markitdown-svc` `/pdf/images` endpoint: text-rich page (no render), text-sparse/scanned page (rendered PNG present), embedded-image extraction
- [ ] `make test-integration` against a live stack (not run in this environment) — new KB ingest integration test (`TestKBDocumentUploadCaptionsImageLinkWhenEnabled`) added and vet-clean but not executed against Postgres here

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791124311&installation_model_id=431401&pr_number=559&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F559&signature=faf0b5c7b94cf925851057dfdad6027c44da9777a478c27b06fb2d94f86eebc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->