### PR TITLE
fix(missions): classify kind by deliverable and fall back to general

### DIFF
--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -1106,30 +1106,35 @@ func (h *missionAPI) generateName(id, goal string) {
 }
 
 // classifyKind decides how a mission's work happens when the create
-// request omits kind. Biased hard toward "coding" on anything short of
-// an unambiguous "general" reply: a coding goal misread as general
-// loses branch/diff/rollback safety (the worse failure), while a
-// general goal misread as coding only wastes an empty worktree — so
-// every ambiguous or failed classification lands on the cheap side of
-// the error. nil classify (no gateway wiring) takes the same default.
+// request omits kind. Classifies by deliverable, not topic: a book or
+// article about coding is general, since it produces no repository
+// files. Falls back to "general" on a nil classifier, a classify
+// error, or an unrecognised reply, since general is the cheaper
+// mistake, no worktree, no branch, no coding harness, while create()
+// still receives the operator's explicit kind from the form, so this
+// only changes the suggestion.
 func classifyKind(ctx context.Context, classify agents.Classify, goal string) string {
 	if classify == nil {
-		return "coding"
+		return "general"
 	}
-	prompt := "Decide how this mission's work happens. Answer with exactly one word.\n" +
-		"coding — the goal requires creating or modifying code, scripts, or configuration in a project/repository.\n" +
-		"general — everything else (documents, analysis, data gathering, operations).\n\n" +
+	prompt := "Decide how this mission's work happens, based on its deliverable, not its topic. Answer with exactly one word.\n" +
+		"coding — the mission produces or changes code, scripts, or configuration files in a repository.\n" +
+		"general — the output is a document, report, analysis, book, plan, or data gathering, even when its subject is programming, software, or coding (a book or article about coding is general).\n\n" +
 		"Goal: " + goal
 	reply, err := classify(ctx, prompt)
 	if err != nil {
-		return "coding"
-	}
-	reply = strings.ToLower(reply)
-	// "general" wins only when "coding" is absent from the reply.
-	if strings.Contains(reply, "general") && !strings.Contains(reply, "coding") {
 		return "general"
 	}
-	return "coding"
+	// First recognised word decides.
+	for _, field := range strings.Fields(strings.ToLower(reply)) {
+		switch strings.Trim(field, ".,") {
+		case "coding":
+			return "coding"
+		case "general":
+			return "general"
+		}
+	}
+	return "general"
 }
 
 // classifyLight decides whether a general-kind goal is single-pass
@@ -1176,42 +1181,60 @@ func classifyHasPlan(goal string) bool {
 // would otherwise pay for two full LLM turns per preview. create()'s
 // fallback path keeps using classifyKind/classifyLight separately,
 // since it only ever needs light after kind is already known to be
-// general. Parsing is defensive: any reply shape other than exactly
-// "coding"/"general" followed by "light"/"full" (case-insensitive,
-// separated by whitespace) falls back to kind=coding, light=false —
-// the same safe-side bias classifyKind/classifyLight each apply alone.
+// general. Parsing takes the first recognised kind word and the first
+// recognised light/full word, in order, from the reply's fields
+// (punctuation stripped), rather than requiring exactly two fields.
+// Falls back to kind=general, light=false on a nil classifier, a
+// classify error, or no recognised word, the same cheap-mistake bias
+// as classifyKind: no worktree, no branch, no coding harness, and
+// create() still receives the operator's explicit kind and light flag
+// from the form, so this only changes the suggestion.
 func classifyKindAndLight(ctx context.Context, classify agents.Classify, goal string) (kind string, light bool) {
 	if classify == nil {
-		return "coding", false
+		return "general", false
 	}
-	prompt := "Classify this mission goal along two independent axes.\n" +
-		"Axis 1 — coding or general: coding means creating or modifying code, scripts, or configuration in a project/repository; general means everything else (documents, analysis, data gathering, operations).\n" +
+	prompt := "Classify this mission goal along two independent axes, based on its deliverable, not its topic.\n" +
+		"Axis 1 — coding or general: coding means the mission produces or changes code, scripts, or configuration files in a repository; general means the output is a document, report, analysis, book, plan, or data gathering, even when its subject is programming, software, or coding (a book or article about coding is general).\n" +
 		"Axis 2 — light or full: light means the goal is a single-pass task deliverable in one response (a read, summary, lookup, or short write-up with no multi-step plan or file artifacts); full means it needs a plan and artifacts.\n" +
 		"Answer with exactly two words separated by a space: first coding or general, then light or full.\n\n" +
 		"Goal: " + goal
 	reply, err := classify(ctx, prompt)
 	if err != nil {
-		return "coding", false
+		return "general", false
 	}
 	fields := strings.Fields(strings.ToLower(reply))
-	if len(fields) != 2 {
-		return "coding", false
+	kind = ""
+	kindFound, lightFound := false, false
+	for _, field := range fields {
+		clean := strings.Trim(field, ".,")
+		if !kindFound {
+			switch clean {
+			case "coding":
+				kind = "coding"
+				kindFound = true
+				continue
+			case "general":
+				kind = "general"
+				kindFound = true
+				continue
+			}
+		}
+		if kindFound && !lightFound {
+			switch clean {
+			case "light":
+				light = true
+				lightFound = true
+			case "full":
+				light = false
+				lightFound = true
+			}
+		}
 	}
-	switch fields[0] {
-	case "general":
-		kind = "general"
-	case "coding":
-		kind = "coding"
-	default:
-		return "coding", false
+	if !kindFound {
+		return "general", false
 	}
-	switch fields[1] {
-	case "light":
-		light = true
-	case "full":
+	if !lightFound {
 		light = false
-	default:
-		return "coding", false
 	}
 	return kind, kind == "general" && light
 }

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -721,10 +721,10 @@ func TestMissionsCreateReferencesValidation(t *testing.T) {
 	})
 }
 
-// TestClassifyKind exercises classifyKind's parsing and its bias to
-// "coding" for anything short of an unambiguous "general" reply —
-// nil classify, a classify error, and a garbage reply must all land on
-// the cheap side of the error (see classifyKind's doc comment).
+// TestClassifyKind exercises classifyKind's deliverable-based parsing:
+// the first recognised word in the reply wins, and nil classify, a
+// classify error, or an unrecognised reply all fall back to "general"
+// (see classifyKind's doc comment).
 func TestClassifyKind(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -732,36 +732,46 @@ func TestClassifyKind(t *testing.T) {
 		classify func(ctx context.Context, prompt string) (string, error)
 		want     string
 	}{
-		{"nil classify defaults to coding", nil, "coding"},
+		{"nil classify defaults to general", nil, "general"},
 		{
-			"unambiguous general reply", func(context.Context, string) (string, error) {
-				return "General", nil
-			}, "general",
-		},
-		{
-			"unambiguous coding reply", func(context.Context, string) (string, error) {
+			"plain coding reply", func(context.Context, string) (string, error) {
 				return "coding", nil
 			}, "coding",
 		},
 		{
-			"garbage reply defaults to coding", func(context.Context, string) (string, error) {
-				return "banana", nil
+			"plain general reply", func(context.Context, string) (string, error) {
+				return "general", nil
+			}, "general",
+		},
+		{
+			"topic is coding but deliverable is a book", func(context.Context, string) (string, error) {
+				return "general (the goal is about coding but produces a book)", nil
+			}, "general",
+		},
+		{
+			"punctuation stripped before matching", func(context.Context, string) (string, error) {
+				return "Coding.", nil
 			}, "coding",
 		},
 		{
-			"reply mentioning both words defaults to coding", func(context.Context, string) (string, error) {
+			"first recognised word wins when coding comes first", func(context.Context, string) (string, error) {
 				return "coding, not general", nil
 			}, "coding",
 		},
 		{
-			"empty reply defaults to coding", func(context.Context, string) (string, error) {
-				return "", nil
-			}, "coding",
+			"garbage reply defaults to general", func(context.Context, string) (string, error) {
+				return "banana", nil
+			}, "general",
 		},
 		{
-			"classify error defaults to coding", func(context.Context, string) (string, error) {
+			"empty reply defaults to general", func(context.Context, string) (string, error) {
+				return "", nil
+			}, "general",
+		},
+		{
+			"classify error defaults to general", func(context.Context, string) (string, error) {
 				return "", errors.New("gateway down")
-			}, "coding",
+			}, "general",
 		},
 	}
 	for _, tc := range tests {
@@ -772,6 +782,22 @@ func TestClassifyKind(t *testing.T) {
 				t.Fatalf("classifyKind() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestClassifyKindPrompt pins the deliverable-vs-topic intent in the
+// prompt sent to the classifier, so a future edit can't silently
+// revert to topic-based classification.
+func TestClassifyKindPrompt(t *testing.T) {
+	t.Parallel()
+	var gotPrompt string
+	classify := func(_ context.Context, prompt string) (string, error) {
+		gotPrompt = prompt
+		return "general", nil
+	}
+	classifyKind(context.Background(), classify, "some goal")
+	if !strings.Contains(gotPrompt, "deliverable") && !strings.Contains(gotPrompt, "book") {
+		t.Fatalf("classifyKind prompt = %q, want it to mention deliverable or the book counter-example", gotPrompt)
 	}
 }
 
@@ -826,9 +852,11 @@ func TestClassifyLight(t *testing.T) {
 }
 
 // TestClassifyKindAndLight exercises the merged single-call classifier
-// classifyGoal uses: happy paths for both axes, and every ambiguous or
-// malformed reply shape falling back to kind=coding light=false, the
-// same safe-side bias classifyKind/classifyLight apply separately.
+// classifyGoal uses: happy paths for both axes, the first recognised
+// kind and light/full words winning in order even with extra fields,
+// and every classify failure or unrecognised reply falling back to
+// kind=general light=false, the same cheap-mistake bias classifyKind
+// applies alone.
 func TestClassifyKindAndLight(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -837,15 +865,15 @@ func TestClassifyKindAndLight(t *testing.T) {
 		wantKind  string
 		wantLight bool
 	}{
-		{"nil classify defaults to coding/full", nil, "coding", false},
+		{"nil classify defaults to general/full", nil, "general", false},
 		{
 			"general + light", func(context.Context, string) (string, error) {
 				return "general light", nil
 			}, "general", true,
 		},
 		{
-			"general + full", func(context.Context, string) (string, error) {
-				return "general full", nil
+			"general + full with punctuation", func(context.Context, string) (string, error) {
+				return "General, full.", nil
 			}, "general", false,
 		},
 		{
@@ -864,34 +892,34 @@ func TestClassifyKindAndLight(t *testing.T) {
 			}, "general", true,
 		},
 		{
-			"single word reply falls back", func(context.Context, string) (string, error) {
-				return "general", nil
-			}, "coding", false,
+			"three word reply uses first recognised kind and light word", func(context.Context, string) (string, error) {
+				return "general full extra", nil
+			}, "general", false,
 		},
 		{
-			"three word reply falls back", func(context.Context, string) (string, error) {
-				return "general light extra", nil
-			}, "coding", false,
+			"single word reply falls back", func(context.Context, string) (string, error) {
+				return "general", nil
+			}, "general", false,
 		},
 		{
 			"garbage first word falls back", func(context.Context, string) (string, error) {
 				return "banana light", nil
-			}, "coding", false,
+			}, "general", false,
 		},
 		{
 			"garbage second word falls back", func(context.Context, string) (string, error) {
 				return "general banana", nil
-			}, "coding", false,
+			}, "general", false,
 		},
 		{
 			"empty reply falls back", func(context.Context, string) (string, error) {
 				return "", nil
-			}, "coding", false,
+			}, "general", false,
 		},
 		{
 			"classify error falls back", func(context.Context, string) (string, error) {
 				return "", errors.New("gateway down")
-			}, "coding", false,
+			}, "general", false,
 		},
 	}
 	for _, tc := range tests {
@@ -1253,7 +1281,7 @@ func TestMissionsExecutorOptionsSurfacesSkipReason(t *testing.T) {
 }
 
 // TestMissionsCreateKindOptional confirms an omitted kind no longer
-// 400s: it reaches classifyKind (defaulting to "coding" with no
+// 400s: it reaches classifyKind (defaulting to "general" with no
 // classify wired) and then the degraded store, which 500s — proving
 // validation accepted the empty kind rather than rejecting it. An
 // explicit kind is still validated and honored exactly as before.


### PR DESCRIPTION
Closes #565

## Summary
- Classifier prompts (`classifyKind`, `classifyKindAndLight`) decide by deliverable, not topic; "a book or article about coding is general" named explicitly.
- Parse: first recognised word wins, trailing punctuation stripped; the two-axis parse tolerates extra words instead of bailing.
- Fallback on nil classifier, error, or unrecognised reply is `general` (no worktree, no branch, no coding harness). `create()` still receives the operator's explicit kind, so only the suggestion changes.
- Tests: extended tables for both functions, new `TestClassifyKindPrompt`.

## Local check
Live classify endpoint: book-about-agentic-coding goal -> general/full; clone-repo-fix-vulns-PR goal -> coding/full; summarize-KB-articles goal -> general/light.

## Verify
`make build vet lint test` green, lint 0 issues.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791150348&installation_model_id=431401&pr_number=566&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F566&signature=bd6d619180f2b08143e8d86fe387fdb97a8183bb04f2b09ece45f1c6700caafa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->