### PR TITLE
fix(sandboxd): put user prefix bin dirs on the sandbox PATH

### DIFF
--- a/deploy/sandbox-go.Dockerfile
+++ b/deploy/sandbox-go.Dockerfile
@@ -14,11 +14,12 @@ USER root
 # builds use. GOPATH lands in the writable home base already set up.
 COPY --from=go-dist /usr/local/go /usr/local/go
 ENV GOPATH=/home/sandbox/go
-# CRITICAL LESSON: symlinked into /usr/local/bin (not only ENV PATH) —
-# sandboxd creates containers with a fixed minimal PATH that ignores
-# image ENV, so a PATH-only install exists in the image yet 127s at
-# exec time. Every toolchain binary added by a variant must be
-# reachable this way.
+# CRITICAL LESSON: symlinked into /usr/local/bin (belt and braces),
+# since sandboxd creates containers with a fixed PATH that ignores image ENV,
+# so a PATH-only install exists in the image yet 127s at exec time.
+# sandboxd's fixed PATH (internal/sandboxd/manager.go's sandboxPath)
+# now includes /home/sandbox/go/bin, but keep the symlinks in case a
+# future variant's binaries land somewhere sandboxPath doesn't cover.
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
 ENV PATH="/home/sandbox/go/bin:${PATH}"
 

--- a/internal/sandboxd/manager.go
+++ b/internal/sandboxd/manager.go
@@ -33,6 +33,16 @@ import (
 // write the shared volume as the same uid/gid.
 const sandboxUser = "65534:65534"
 
+// sandboxPath is the fixed PATH set on every sandbox container,
+// overriding the image's own ENV PATH (see createContainer's Env
+// comment). The three user-prefix dirs come first so a tool a worker
+// installs with `npm install -g`, `pip install --user`, or `go install`
+// under the sandbox HOME is on PATH for every later exec in the same
+// container: sandbox-base.Dockerfile sets NPM_CONFIG_PREFIX to
+// /home/sandbox/.npm-global and adds .local/bin, sandbox-go.Dockerfile
+// adds go/bin.
+const sandboxPath = "PATH=/home/sandbox/.local/bin:/home/sandbox/.npm-global/bin:/home/sandbox/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 const (
 	workspaceMountPath  = "/workspace"
 	containerNamePrefix = "timothy-sandbox-"
@@ -391,7 +401,7 @@ func (m *Manager) createContainer(ctx context.Context, missionID, name, environm
 		// beyond this (e.g. an executor's ANTHROPIC_* credentials) is
 		// injected per-exec against the D-053 allowlist (api.go), never
 		// baked into the container itself.
-		Env:    []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "HOME=/home/sandbox"},
+		Env:    []string{sandboxPath, "HOME=/home/sandbox"},
 		User:   sandboxUser,
 		Cmd:    []string{"sleep", "infinity"},
 		Labels: map[string]string{missionLabel: missionID},

--- a/internal/sandboxd/manager_test.go
+++ b/internal/sandboxd/manager_test.go
@@ -641,6 +641,48 @@ func TestCreateContainerHardensResources(t *testing.T) {
 	}
 }
 
+// TestCreateContainerSetsUserPrefixPath confirms the container's PATH
+// (issue #568) leads with the sandbox HOME's user-install dirs, so a
+// tool a worker installs with `npm install -g` or `pip install --user`
+// is reachable by a later exec in the same container.
+func TestCreateContainerSetsUserPrefixPath(t *testing.T) {
+	var gotEnv []string
+	cli := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1.51/containers/create":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read create body: %v", err)
+			}
+			var cfg struct {
+				Env []string
+			}
+			if err := json.Unmarshal(body, &cfg); err != nil {
+				t.Fatalf("unmarshal create body: %v", err)
+			}
+			gotEnv = cfg.Env
+			writeJSON(t, w, http.StatusCreated, container.CreateResponse{ID: "new1"})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1.51/containers/new1/start":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected call: %s %s", r.Method, r.URL.Path)
+		}
+	})
+	mgr := newTestManager(cli)
+	mgr.workspaceMount = mount.Mount{Type: mount.TypeVolume, Source: "timothy_workspace", Target: workspaceMountPath}
+
+	if _, err := mgr.createContainer(context.Background(), "m1", "timothy-sandbox-m1", ""); err != nil {
+		t.Fatalf("createContainer: %v", err)
+	}
+	if !slices.Contains(gotEnv, sandboxPath) {
+		t.Fatalf("Env = %v, want to contain %q", gotEnv, sandboxPath)
+	}
+	wantPrefix := "PATH=/home/sandbox/.local/bin:/home/sandbox/.npm-global/bin:/home/sandbox/go/bin:"
+	if !strings.HasPrefix(sandboxPath, wantPrefix) {
+		t.Errorf("sandboxPath = %q, want prefix %q", sandboxPath, wantPrefix)
+	}
+}
+
 // TestManagerCapacityReadsRealMeminfo confirms Capacity reads the
 // process's real /proc/meminfo (the host view sandboxd's own
 // memory-unlimited container sees) and folds in List's live container


### PR DESCRIPTION
## Summary

sandboxd creates every sandbox container with a fixed PATH that overrides the image ENV. The base image sets `NPM_CONFIG_PREFIX=/home/sandbox/.npm-global` and puts `.npm-global/bin` and `.local/bin` on PATH, so `npm install -g` and `pip install --user` inside the sandbox landed in dirs no exec could see and `verify_cmd` failed with exit 127 (`command -v markdownlint` after a logged successful install).

## Changes

- `sandboxPath` const leads with `/home/sandbox/.local/bin`, `/home/sandbox/.npm-global/bin`, `/home/sandbox/go/bin`; the "no os.Environ() leak" design is unchanged. PATH is not in the per-exec env allowlist, so it cannot be overridden per exec.
- `sandbox-go.Dockerfile` comment points at the real fix; the symlinks stay.
- `TestCreateContainerSetsUserPrefixPath` asserts the container create body.

## Verification

`go test -race ./internal/sandboxd/...` and golangci-lint green.

Closes #568

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791204685&installation_model_id=431401&pr_number=572&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F572&signature=398dcef1a543674870f230ecd29193cadb73b6614f861d431cf2a47d32772d07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->