### PR TITLE
feat(destinations): coding missions send links only to message kinds

### DIFF
--- a/internal/brain/destinations/render.go
+++ b/internal/brain/destinations/render.go
@@ -54,7 +54,8 @@ type Payload struct {
 // non-empty) plus branch/PR URL when the mission has them.
 // Files/TextArtifacts/OversizeFiles come from the mission's declared
 // plan-unit artifacts, read from its workspace (resolveArtifactFiles) —
-// exactly what CheckArtifacts already verified exists.
+// exactly what CheckArtifacts already verified exists, except for a
+// coding mission, which gets links only (issue #564).
 func Render(m missions.Mission, webBaseURL string, events []missions.Event, loc *time.Location) Payload {
 	name := m.Name
 	if name == "" {
@@ -70,7 +71,14 @@ func Render(m missions.Mission, webBaseURL string, events []missions.Event, loc 
 	if url, ok := lastPROpenedURL(events); ok {
 		links = append(links, url)
 	}
-	files, texts, oversize := resolveArtifactFiles(m)
+	// Issue #564: coding missions send links only, no loose source-file
+	// attachments, code leaves the box through a github destination.
+	var files []File
+	var texts []TextArtifact
+	var oversize []string
+	if m.Kind != missions.KindCoding {
+		files, texts, oversize = resolveArtifactFiles(m)
+	}
 	body := "Mission complete: " + name
 	if m.RunsPlanless() && m.FinalOutput != "" {
 		// D-069/D-090: a planless mission (light, or flow=discover_generate)

--- a/internal/brain/destinations/render_test.go
+++ b/internal/brain/destinations/render_test.go
@@ -124,6 +124,62 @@ func TestRender(t *testing.T) {
 		}
 	})
 
+	t.Run("coding missions send links only, no artifact attachments", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "report.md"), []byte("report"), 0o600); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "data.csv"), []byte("a,b\n1,2\n"), 0o600); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+		plan := missions.Plan{Units: []missions.PlanUnit{{Artifacts: []string{"report.md", "data.csv"}}}}
+		payload, _ := json.Marshal(map[string]any{"url": "https://github.com/org/repo/pull/1"})
+		events := []missions.Event{{Kind: "mission.pr_opened", Payload: payload}}
+
+		cases := []struct {
+			name         string
+			kind         string
+			wantFiles    int
+			wantTexts    int
+			wantOversize int
+		}{
+			{name: "coding", kind: missions.KindCoding, wantFiles: 0, wantTexts: 0, wantOversize: 0},
+			{name: "general", kind: missions.KindGeneral, wantFiles: 1, wantTexts: 1, wantOversize: 0},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				withArtifacts := m
+				withArtifacts.Kind = c.kind
+				withArtifacts.Workspace = root
+				withArtifacts.Plan = plan
+				withArtifacts.Branch = "feat/ship-it"
+				p := Render(withArtifacts, "https://timothy.example.lan", events, time.UTC)
+				if len(p.Files) != c.wantFiles {
+					t.Fatalf("Files = %+v, want %d", p.Files, c.wantFiles)
+				}
+				if len(p.TextArtifacts) != c.wantTexts {
+					t.Fatalf("TextArtifacts = %+v, want %d", p.TextArtifacts, c.wantTexts)
+				}
+				if len(p.OversizeFiles) != c.wantOversize {
+					t.Fatalf("OversizeFiles = %+v, want %d", p.OversizeFiles, c.wantOversize)
+				}
+				want := []string{
+					"https://timothy.example.lan/missions/m1",
+					"branch: feat/ship-it",
+					"https://github.com/org/repo/pull/1",
+				}
+				if len(p.Links) != len(want) {
+					t.Fatalf("links = %v, want %v", p.Links, want)
+				}
+				for i := range want {
+					if p.Links[i] != want[i] {
+						t.Fatalf("links[%d] = %q, want %q", i, p.Links[i], want[i])
+					}
+				}
+			})
+		}
+	})
+
 	t.Run("light mission body is the final output, not a completion line", func(t *testing.T) {
 		light := m
 		light.Flow = missions.FlowLight


### PR DESCRIPTION
## Summary

`Render` attached every declared plan-unit artifact regardless of mission kind, so a coding mission with a telegram or email destination delivered individual source files as documents. Code leaves the box through a github destination (#561) or not at all.

## Changes

- `Render`: for `kind=coding`, skip `resolveArtifactFiles`; `Files`, `TextArtifacts`, `OversizeFiles` stay empty. Links (mission page, branch, PR URL) unchanged. Other kinds unchanged.
- Artifact copy into the attachment store (mission page files) is a separate path and is untouched.
- Table test: coding vs general with a `.md` and a `.csv` artifact and a `mission.pr_opened` event.

## Verification

`go test -race ./internal/brain/destinations/...` and golangci-lint green. Adapters already branch on zero files.

Closes #564

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791211002&installation_model_id=431401&pr_number=574&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F574&signature=a407616fdd34263c509b1691de57f900b4a451d4f9ab46dbe19997c53eb50dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->