### PR TITLE
feat(web): propose clone source from repo named in goal

### DIFF
--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -1770,3 +1770,161 @@ describe('MissionForm: unusable route gate', () => {
     expect(createMission).not.toHaveBeenCalled()
   })
 })
+
+// toCodingMissionForProposal types the given goal, waits out the
+// classify debounce (real timers; the mock default classifies
+// general), and clicks the chip to switch to coding: the goal-repo
+// proposal only ever runs for a coding mission.
+async function toCodingMissionForProposal(goalText: string) {
+  fireEvent.change(screen.getByLabelText('Goal'), { target: { value: goalText } })
+  fireEvent.click(await screen.findByText('General · scratch workspace'))
+  expect(screen.getByText('Coding · branches from repo')).toBeInTheDocument()
+}
+
+describe('MissionForm: goal repo proposal (issue #563)', () => {
+  it('proposes the connector + repo named in the goal and shows a note', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(listConnectorRepos).mockResolvedValue(repos)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMissionForProposal('Clone octocat/hello-world and audit its dependencies')
+
+    expect(await screen.findByText('Proposed from the goal')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'GitHub' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'octocat/hello-world' })).toBeInTheDocument()
+  })
+
+  it('labels a fuzzy match as a guess', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(listConnectorRepos).mockResolvedValue(repos)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMissionForProposal('Clone the hello repo and audit its dependencies')
+
+    expect(await screen.findByText('Proposed from the goal (best guess)')).toBeInTheDocument()
+  })
+
+  it('clears the proposal and suppresses it for the same goal text', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(listConnectorRepos).mockResolvedValue(repos)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    const goalText = 'Clone octocat/hello-world and audit its dependencies'
+    await toCodingMissionForProposal(goalText)
+    expect(await screen.findByText('Proposed from the goal')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
+    expect(screen.queryByText('Proposed from the goal')).toBeNull()
+    expect(screen.getByRole('button', { name: 'None' })).toHaveAttribute('aria-pressed', 'true')
+
+    // Re-typing the exact same goal text does not re-propose.
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: `${goalText} ` } })
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: goalText } })
+    await new Promise((r) => setTimeout(r, 700))
+    expect(screen.queryByText('Proposed from the goal')).toBeNull()
+  })
+
+  it('never overrides a source the operator picked by hand', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(listConnectorRepos).mockResolvedValue(repos)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMission()
+    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }))
+    fireEvent.click(await screen.findByLabelText('Connector'))
+    fireEvent.click(await screen.findByText('personal-gh'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Choose a repository' }))
+    fireEvent.click(await screen.findByText('octocat/secret-project'))
+
+    fireEvent.change(screen.getByLabelText('Goal'), {
+      target: { value: 'Clone octocat/hello-world and audit its dependencies' },
+    })
+    await new Promise((r) => setTimeout(r, 700))
+
+    expect(screen.queryByText('Proposed from the goal')).toBeNull()
+    expect(screen.getByRole('button', { name: 'octocat/secret-project' })).toBeInTheDocument()
+  })
+
+  it('shows candidates and sets nothing when two repos match a bare name', async () => {
+    const ambiguousRepos: GitHubRepo[] = [
+      { ...repos[0], full_name: 'octocat/widget-one', clone_url: 'https://github.com/octocat/widget-one.git' },
+      { ...repos[0], full_name: 'octocat/widget-two', clone_url: 'https://github.com/octocat/widget-two.git' },
+    ]
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(listConnectorRepos).mockResolvedValue(ambiguousRepos)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMissionForProposal('Clone the widget repo and audit its dependencies')
+
+    expect(await screen.findByText(/Repositories matching the goal:/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'octocat/widget-one' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'octocat/widget-two' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'None' })).toHaveAttribute('aria-pressed', 'true')
+
+    fireEvent.click(screen.getByRole('button', { name: 'octocat/widget-two' }))
+    expect(screen.getByRole('button', { name: 'GitHub' })).toHaveAttribute('aria-pressed', 'true')
+    expect(await screen.findByText('octocat/widget-two')).toBeInTheDocument()
+  })
+
+  it('proposes nothing for a general-kind goal', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(listConnectorRepos).mockResolvedValue(repos)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), {
+      target: { value: 'Summarize the octocat/hello-world repo activity' },
+    })
+    await screen.findByText('General · scratch workspace')
+    await new Promise((r) => setTimeout(r, 500))
+
+    expect(screen.queryByText('Proposed from the goal')).toBeNull()
+    expect(screen.queryByText('Repository')).toBeNull()
+  })
+
+  it('renders nothing extra when no github connector exists', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([])
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMissionForProposal('Clone octocat/hello-world and audit its dependencies')
+    await new Promise((r) => setTimeout(r, 500))
+
+    expect(screen.queryByText('Proposed from the goal')).toBeNull()
+    expect(screen.getByRole('button', { name: 'None' })).toHaveAttribute('aria-pressed', 'true')
+  })
+})
+
+describe('MissionForm: destination push-wording suggestion (issue #563)', () => {
+  it('suggests the single enabled github destination when the goal mentions pushing', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(listConnectorRepos).mockResolvedValue(repos)
+    vi.mocked(listDestinations).mockResolvedValue([githubDestination])
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMissionForProposal('Clone octocat/hello-world, fix the bug, and push the branch')
+
+    expect(
+      await screen.findByText(/The goal mentions pushing; add the origin repo destination\?/),
+    ).toBeInTheDocument()
+    const checkbox = screen.getByLabelText(/^origin repo/) as HTMLInputElement
+    expect(checkbox.checked).toBe(false)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(checkbox.checked).toBe(true)
+  })
+
+  it('never checks the destination on its own', async () => {
+    vi.mocked(listConnectors).mockResolvedValue([githubConnector])
+    vi.mocked(listConnectorRepos).mockResolvedValue(repos)
+    vi.mocked(listDestinations).mockResolvedValue([githubDestination])
+    vi.mocked(createMission).mockResolvedValue({ id: 'm20' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await toCodingMissionForProposal('Clone octocat/hello-world, fix the bug, and open a pull request')
+    await screen.findByText(/The goal mentions pushing/)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ destination_ids: undefined })),
+    )
+  })
+})

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -31,6 +31,7 @@ import { useAgents, useRoutes } from '../AgentPicker'
 import { slugify } from '../settings/AgentForm'
 import { cronPresets, type CronPresetValue, presetFor } from '../../lib/schedules'
 import { CURRENCIES } from '../../lib/currencies'
+import { extractRepoMentions, matchRepo } from '../../lib/goalRepo'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { Calendar } from '../ui/calendar'
@@ -244,6 +245,11 @@ function looksLikeLightGoal(goal: string): boolean {
   return lightSignalPattern.test(trimmed)
 }
 
+// pushSignalPattern matches goal text that talks about pushing or
+// opening a pull/merge request (issue #563): the destination-suggestion
+// hint, never auto-checked.
+const pushSignalPattern = /\b(push|pull request|pr|merge request)\b/i
+
 // expiresAt is stored as the wire-compatible 'YYYY-MM-DDTHH:mm' string the
 // API already expects; these split it into a Date (for the calendar) and a
 // 'HH:mm' string (for the time input) and back.
@@ -412,6 +418,26 @@ export function MissionForm({
   )
   const [repoPickerOpen, setRepoPickerOpen] = useState(false)
 
+  // sourceProposed (issue #563) marks a repo source this form set from
+  // the goal text rather than the operator's own pick: gates whether a
+  // later proposal is still allowed to override it (a hand-picked
+  // source, sourceProposed=false, is never touched again).
+  const [sourceProposed, setSourceProposed] = useState(false)
+  const [proposalNote, setProposalNote] = useState<string | null>(null)
+  const [proposalCandidates, setProposalCandidates] = useState<{
+    connectorID: string
+    repos: GitHubRepo[]
+  } | null>(null)
+  // clearedForGoal remembers the goal text a "Clear" click suppressed
+  // proposals for: re-proposing on every keystroke after a deliberate
+  // clear would fight the operator, so this only re-arms once the goal
+  // itself changes again.
+  const [clearedForGoal, setClearedForGoal] = useState<string | null>(null)
+  // repoCache (issue #563) holds each github connector's repo list,
+  // fetched on demand while searching for a goal match, keyed by
+  // connector id: avoids re-fetching a connector already tried.
+  const [repoCache, setRepoCache] = useState<Record<string, GitHubRepo[]>>({})
+
   // A repo/connector is considered "attached" once it resolves to a
   // clone URL: mirrors githubSourceReady's own readiness check below.
   const repoAttached = repoSource === 'github' && !!connectorID && !!selectedRepo
@@ -436,14 +462,15 @@ export function MissionForm({
   const [destinationRepoURLs, setDestinationRepoURLs] = useState<Record<string, string>>({})
 
   // Fetch github-kind connectors once the operator picks the GitHub
-  // clone source: most missions never touch it, so this isn't loaded
-  // upfront with agents/routes.
+  // clone source, or once a coding mission's goal might need them for
+  // the repo-mention proposal below (issue #563): most missions never
+  // touch it, so this isn't loaded upfront with agents/routes.
   useEffect(() => {
-    if (repoSource !== 'github' || githubConnectors !== null) return
+    if ((repoSource !== 'github' && kind !== 'coding') || githubConnectors !== null) return
     listConnectors()
       .then((all) => setGithubConnectors(all.filter((c) => c.kind === 'github' && c.enabled)))
       .catch(() => setGithubConnectors([]))
-  }, [repoSource, githubConnectors])
+  }, [repoSource, kind, githubConnectors])
 
   // Fetch the connector's repo list whenever it changes: best-effort,
   // an error surfaces inline rather than blocking the form.
@@ -455,7 +482,10 @@ export function MissionForm({
     setReposLoading(true)
     setReposError(null)
     listConnectorRepos(connectorID)
-      .then(setRepos)
+      .then((r) => {
+        setRepos(r)
+        setRepoCache((prev) => ({ ...prev, [connectorID]: r }))
+      })
       .catch((err) => setReposError(errText(err)))
       .finally(() => setReposLoading(false))
   }, [repoSource, connectorID])
@@ -466,6 +496,104 @@ export function MissionForm({
     if (!q) return repos
     return repos.filter((r) => r.full_name.toLowerCase().includes(q))
   }, [repos, repoQuery])
+
+  // Repo proposal from the goal text (issue #563): debounced ~400ms
+  // like the classify preview above, only for a coding mission with no
+  // hand-picked source and at least one github connector. Tries each
+  // github connector's repo list (fetching + caching on demand) until
+  // one yields a match, sets the source on a single match, and lists
+  // "candidates" for the operator to pick from on an ambiguous one.
+  // Never runs again for goal text the operator already cleared a
+  // proposal for.
+  useEffect(() => {
+    // Coding is unavailable while repeating (toggleKind/the repeat
+    // toggle both enforce that), so kind === 'coding' already implies
+    // !repeat here.
+    if (kind !== 'coding' || mode !== 'create') return
+    if (repoSource !== 'none' && !sourceProposed) return // a hand-picked source is never touched
+    if (!githubConnectors || githubConnectors.length === 0) return
+    if (goal.trim() === '' || goal === clearedForGoal) return
+
+    const mentions = extractRepoMentions(goal)
+    if (mentions.length === 0) {
+      setProposalNote(null)
+      setProposalCandidates(null)
+      return
+    }
+
+    let cancelled = false
+    const t = setTimeout(() => {
+      const tryConnectors = async () => {
+        for (const connector of githubConnectors) {
+          let connectorRepos = repoCache[connector.id]
+          if (!connectorRepos) {
+            try {
+              connectorRepos = await listConnectorRepos(connector.id)
+            } catch {
+              continue // best-effort: skip a connector whose repo list fails to load
+            }
+            if (cancelled) return
+            setRepoCache((prev) => ({ ...prev, [connector.id]: connectorRepos! }))
+          }
+          if (connectorRepos.length === 0) continue
+
+          const result = matchRepo(mentions, connectorRepos)
+          if (!result) continue
+          if (cancelled) return
+
+          if ('candidates' in result) {
+            setProposalCandidates({ connectorID: connector.id, repos: result.candidates })
+            setProposalNote(null)
+            return
+          }
+          setRepoSource('github')
+          setSourceProposed(true)
+          setConnectorID(connector.id)
+          setRepos(connectorRepos)
+          setSelectedRepo(result.repo)
+          setProposalCandidates(null)
+          setProposalNote(result.guess ? 'Proposed from the goal (best guess)' : 'Proposed from the goal')
+          return
+        }
+        if (!cancelled) {
+          setProposalNote(null)
+          setProposalCandidates(null)
+        }
+      }
+      void tryConnectors()
+    }, 400)
+
+    return () => {
+      cancelled = true
+      clearTimeout(t)
+    }
+  }, [goal, kind, mode, repoSource, sourceProposed, githubConnectors, clearedForGoal, repoCache])
+
+  // clearProposal resets the repo source and note, and suppresses
+  // further proposals for the current goal text: the operator's clear
+  // click is a deliberate override, not something the next keystroke
+  // should immediately re-propose.
+  const clearProposal = () => {
+    setRepoSource('none')
+    setSourceProposed(false)
+    setConnectorID('')
+    setSelectedRepo(null)
+    setProposalNote(null)
+    setProposalCandidates(null)
+    setClearedForGoal(goal)
+  }
+
+  // pickProposalCandidate resolves an ambiguous proposal by hand: the
+  // operator clicked one of the listed candidate repos.
+  const pickProposalCandidate = (candidateConnectorID: string, repo: GitHubRepo) => {
+    setRepoSource('github')
+    setSourceProposed(false) // an explicit click is a hand pick, not a proposal
+    setConnectorID(candidateConnectorID)
+    setRepos(repoCache[candidateConnectorID] ?? null)
+    setSelectedRepo(repo)
+    setProposalCandidates(null)
+    setProposalNote(null)
+  }
 
   // Live executor pairing/usability preview: coding-only, refetched
   // whenever the kind flips to coding or the route selection (explicit
@@ -702,6 +830,19 @@ export function MissionForm({
     (d) => destinationIDs.includes(d.id) && d.kind === 'github',
   )
   const githubDestinationKindOk = kind === 'coding' || checkedGithubDestinations.length === 0
+
+  // Destination suggestion (issue #563): once a source is attached or
+  // proposed, exactly one enabled github destination exists and isn't
+  // already checked, and the goal mentions pushing/opening a PR, hint
+  // at adding it. Never checks it automatically.
+  const enabledGithubDestinations = (destinations ?? []).filter((d) => d.kind === 'github' && d.enabled)
+  const suggestedGithubDestination =
+    (repoAttached || sourceProposed) &&
+    enabledGithubDestinations.length === 1 &&
+    !destinationIDs.includes(enabledGithubDestinations[0].id) &&
+    pushSignalPattern.test(goal)
+      ? enabledGithubDestinations[0]
+      : null
 
   const canSubmit =
     mode === 'edit'
@@ -942,7 +1083,10 @@ export function MissionForm({
           <div className="inline-flex rounded-lg bg-muted p-1 text-sm">
             <button
               type="button"
-              onClick={() => setRepoSource('none')}
+              onClick={() => {
+                setRepoSource('none')
+                setSourceProposed(false)
+              }}
               aria-pressed={repoSource === 'none'}
               className={`rounded-md px-3 py-1.5 font-medium transition ${
                 repoSource === 'none' ? 'bg-background shadow-sm' : 'text-muted-foreground'
@@ -952,7 +1096,10 @@ export function MissionForm({
             </button>
             <button
               type="button"
-              onClick={() => setRepoSource('github')}
+              onClick={() => {
+                setRepoSource('github')
+                setSourceProposed(false)
+              }}
               aria-pressed={repoSource === 'github'}
               className={`rounded-md px-3 py-1.5 font-medium transition ${
                 repoSource === 'github' ? 'bg-background shadow-sm' : 'text-muted-foreground'
@@ -961,6 +1108,37 @@ export function MissionForm({
               GitHub
             </button>
           </div>
+
+          {proposalNote && (
+            <p className="text-xs text-muted-foreground">
+              {proposalNote}{' '}
+              <button
+                type="button"
+                onClick={clearProposal}
+                className="underline underline-offset-2 hover:text-foreground"
+              >
+                Clear
+              </button>
+            </p>
+          )}
+
+          {proposalCandidates && proposalCandidates.repos.length > 0 && (
+            <p className="text-xs text-muted-foreground">
+              Repositories matching the goal:{' '}
+              {proposalCandidates.repos.map((r, i) => (
+                <span key={r.full_name}>
+                  {i > 0 && ', '}
+                  <button
+                    type="button"
+                    onClick={() => pickProposalCandidate(proposalCandidates.connectorID, r)}
+                    className="underline underline-offset-2 hover:text-foreground"
+                  >
+                    {r.full_name}
+                  </button>
+                </span>
+              ))}
+            </p>
+          )}
 
           {repoSource === 'github' && (
             <div className="space-y-3 rounded-lg border border-border p-4">
@@ -984,6 +1162,7 @@ export function MissionForm({
                         setConnectorID(v)
                         setSelectedRepo(null)
                         setRepoQuery('')
+                        setSourceProposed(false)
                       }}
                     >
                       <SelectTrigger id="mission-connector" className="w-full">
@@ -1032,6 +1211,7 @@ export function MissionForm({
                                   onSelect={() => {
                                     setSelectedRepo(r)
                                     setRepoPickerOpen(false)
+                                    setSourceProposed(false)
                                   }}
                                 >
                                   <span className="truncate">{r.full_name}</span>
@@ -1376,6 +1556,21 @@ export function MissionForm({
               {!githubDestinationKindOk && (
                 <p className="text-xs text-destructive">
                   A GitHub destination only applies to a coding mission.
+                </p>
+              )}
+
+              {suggestedGithubDestination && (
+                <p className="text-xs text-muted-foreground">
+                  The goal mentions pushing; add the {suggestedGithubDestination.name} destination?{' '}
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setDestinationIDs((prev) => [...prev, suggestedGithubDestination.id])
+                    }
+                    className="underline underline-offset-2 hover:text-foreground"
+                  >
+                    Add
+                  </button>
                 </p>
               )}
             </div>

--- a/web/src/lib/goalRepo.test.ts
+++ b/web/src/lib/goalRepo.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import type { GitHubRepo } from '../api/types'
+import { extractRepoMentions, matchRepo } from './goalRepo'
+
+function repo(fullName: string): GitHubRepo {
+  return {
+    full_name: fullName,
+    private: false,
+    default_branch: 'main',
+    html_url: `https://github.com/${fullName}`,
+    clone_url: `https://github.com/${fullName}.git`,
+    pushed_at: '2026-08-01T00:00:00Z',
+  }
+}
+
+describe('extractRepoMentions', () => {
+  it('recognizes a full github.com URL with .git', () => {
+    expect(extractRepoMentions('Clone https://github.com/octocat/hello-world.git and build it')).toEqual([
+      { owner: 'octocat', name: 'hello-world' },
+    ])
+  })
+
+  it('recognizes a full github.com URL without .git', () => {
+    expect(extractRepoMentions('See https://github.com/octocat/hello-world for details')).toEqual([
+      { owner: 'octocat', name: 'hello-world' },
+    ])
+  })
+
+  it('recognizes a bare github.com/owner/repo without scheme', () => {
+    expect(extractRepoMentions('Repo lives at github.com/octocat/hello-world')).toEqual([
+      { owner: 'octocat', name: 'hello-world' },
+    ])
+  })
+
+  it('recognizes a bare owner/repo pair', () => {
+    expect(extractRepoMentions('Audit octocat/hello-world for dependency issues')).toEqual([
+      { owner: 'octocat', name: 'hello-world' },
+    ])
+  })
+
+  it('recognizes a bare repo name next to the word "repo"', () => {
+    expect(
+      extractRepoMentions('Clone the solid-principles-example-laravel repo and audit its dependencies'),
+    ).toEqual([{ name: 'solid-principles-example-laravel' }])
+  })
+
+  it('recognizes a bare repo name preceding the word "repository"', () => {
+    expect(extractRepoMentions('The repository mumu needs a dependency bump')).toEqual([{ name: 'mumu' }])
+  })
+
+  it('does not treat a file path with an extension as an owner/repo pair', () => {
+    expect(extractRepoMentions('Update src/index.ts to fix the bug')).toEqual([])
+  })
+
+  it('does not treat a bare word as a mention without "repo"/"repository" nearby', () => {
+    expect(extractRepoMentions('Refactor the payment-service module for clarity')).toEqual([])
+  })
+
+  it('ignores a three-segment path (not owner/repo)', () => {
+    expect(extractRepoMentions('Look at a/b/c for reference')).toEqual([])
+  })
+
+  it('dedupes repeated mentions of the same repo', () => {
+    expect(
+      extractRepoMentions('Clone octocat/hello-world. Then push back to octocat/hello-world when done.'),
+    ).toEqual([{ owner: 'octocat', name: 'hello-world' }])
+  })
+
+  it('returns an empty list for goal text with no repo mention', () => {
+    expect(extractRepoMentions('Summarize last week and email me the digest')).toEqual([])
+  })
+})
+
+describe('matchRepo', () => {
+  const repos = [repo('octocat/hello-world'), repo('octocat/secret-project'), repo('acme/widget-factory')]
+
+  it('matches exactly on full_name (owner + name) with guess=false', () => {
+    expect(matchRepo([{ owner: 'octocat', name: 'hello-world' }], repos)).toEqual({
+      repo: repos[0],
+      guess: false,
+    })
+  })
+
+  it('matches exactly on a bare name with guess=false', () => {
+    expect(matchRepo([{ name: 'widget-factory' }], repos)).toEqual({ repo: repos[2], guess: false })
+  })
+
+  it('is case-insensitive on both owner/repo and bare-name matches', () => {
+    expect(matchRepo([{ owner: 'OctoCat', name: 'Hello-World' }], repos)).toEqual({
+      repo: repos[0],
+      guess: false,
+    })
+    expect(matchRepo([{ name: 'WIDGET-FACTORY' }], repos)).toEqual({ repo: repos[2], guess: false })
+  })
+
+  it('returns null for an owner/repo pair naming an owner not in the list', () => {
+    expect(matchRepo([{ owner: 'someoneelse', name: 'hello-world' }], repos)).toBeNull()
+  })
+
+  it('proposes a single prefix match as a guess', () => {
+    expect(matchRepo([{ name: 'hello' }], repos)).toEqual({ repo: repos[0], guess: true })
+  })
+
+  it('proposes a single close edit-distance match as a guess', () => {
+    expect(matchRepo([{ name: 'hello-worId' }], repos)).toEqual({ repo: repos[0], guess: true })
+  })
+
+  it('returns candidates when two or more repos match a bare name', () => {
+    const ambiguous = [repo('octocat/widget-one'), repo('octocat/widget-two')]
+    expect(matchRepo([{ name: 'widget' }], ambiguous)).toEqual({ candidates: ambiguous })
+  })
+
+  it('returns null when no repo is close enough to a bare name', () => {
+    expect(matchRepo([{ name: 'completely-unrelated-name' }], repos)).toBeNull()
+  })
+
+  it('returns null for an empty mention list', () => {
+    expect(matchRepo([], repos)).toBeNull()
+  })
+
+  it('tries later mentions when an earlier one has no match', () => {
+    expect(
+      matchRepo([{ owner: 'nope', name: 'nothing' }, { name: 'widget-factory' }], repos),
+    ).toEqual({ repo: repos[2], guess: false })
+  })
+})

--- a/web/src/lib/goalRepo.ts
+++ b/web/src/lib/goalRepo.ts
@@ -1,0 +1,137 @@
+// goalRepo recognises a repository named in a mission goal and matches
+// it against a connector's repository list, purely client-side (issue
+// #563): a proposal the operator sees and confirms, never resolved or
+// invented at run time. No backend involvement.
+import type { GitHubRepo } from '../api/types'
+
+// A slug segment: word characters, dots and hyphens, but never
+// starting or ending on a dot/hyphen (so trailing sentence punctuation
+// like "octocat/hello-world." never gets swallowed into the name).
+const SLUG = '[A-Za-z0-9_](?:[A-Za-z0-9_.-]*[A-Za-z0-9_])?'
+
+// URL forms: https://github.com/owner/repo(.git) and the bare
+// github.com/owner/repo, both anchored on a repo segment with no
+// trailing path (a URL pointing deeper, e.g. .../repo/issues/1, is
+// treated as naming that repo too since the first two segments after
+// the host are always owner/repo).
+const urlPattern = new RegExp(`github\\.com/(${SLUG})/(${SLUG})(?:\\.git)?(?:[/?#]|\\b)`, 'gi')
+
+// owner/repo pair, not preceded/followed by another slash (so a
+// three-segment path like a/b/c never matches) and not looking like a
+// file path (an extension-bearing final segment, e.g. src/index.ts).
+const pairPattern = new RegExp(`(?<![\\w./-])(${SLUG})/(${SLUG})(?![\\w/-])`, 'g')
+
+// A bare repo-like token is only trusted as a repo mention when it sits
+// immediately next to the word "repo"/"repository": otherwise plain
+// prose has far too many false positives (any hyphenated word,
+// filenames, etc). commonWords excludes ordinary sentence filler
+// ("Repo lives at...", "The repository needs...") that would otherwise
+// match the adjacent-word slot.
+const commonWords = new Set([
+  'a', 'an', 'the', 'this', 'that', 'these', 'those', 'is', 'are', 'was',
+  'were', 'lives', 'located', 'found', 'here', 'there', 'at', 'in', 'on',
+  'for', 'and', 'or', 'to', 'its', 'it', 'my', 'our', 'your', 'named',
+])
+// Checked in this order per keyword occurrence: the word AFTER
+// repo/repository is preferred (afterWordPattern), since the leading
+// alternative below can otherwise swallow a common word like "The"
+// right before the keyword and hide a real name that follows it.
+const afterWordPattern = new RegExp(`\\b(?:repo|repository)\\s+(${SLUG})(?:$|\\s)`, 'gi')
+const beforeWordPattern = new RegExp(`(?:^|\\s)(${SLUG})\\s+(?:repo|repository)\\b`, 'gi')
+
+// looksLikeFilePath rejects a candidate whose repo segment carries a
+// file extension (index.ts, README.md, ...): those are far more likely
+// a path fragment than a repository name.
+function looksLikeFilePath(segment: string): boolean {
+  return /\.[A-Za-z0-9]{1,8}$/.test(segment) && !/\.git$/i.test(segment)
+}
+
+export interface RepoMention {
+  owner?: string
+  name: string
+}
+
+// extractRepoMentions scans goal text for repository references in
+// rough order of confidence: full URLs and owner/repo pairs first
+// (both name an explicit owner), then bare names called out next to
+// "repo"/"repository". Dedupes case-insensitively on owner+name.
+export function extractRepoMentions(goal: string): RepoMention[] {
+  const mentions: RepoMention[] = []
+  const seen = new Set<string>()
+  const add = (owner: string | undefined, name: string) => {
+    const cleanName = name.replace(/\.git$/i, '')
+    if (!cleanName || looksLikeFilePath(cleanName)) return
+    const key = `${(owner ?? '').toLowerCase()}/${cleanName.toLowerCase()}`
+    if (seen.has(key)) return
+    seen.add(key)
+    mentions.push(owner ? { owner, name: cleanName } : { name: cleanName })
+  }
+
+  for (const m of goal.matchAll(urlPattern)) {
+    if (m[1] && m[2]) add(m[1], m[2])
+  }
+  for (const m of goal.matchAll(pairPattern)) {
+    if (looksLikeFilePath(m[2])) continue
+    add(m[1], m[2])
+  }
+  for (const m of goal.matchAll(afterWordPattern)) {
+    if (m[1] && !commonWords.has(m[1].toLowerCase())) add(undefined, m[1])
+  }
+  for (const m of goal.matchAll(beforeWordPattern)) {
+    if (m[1] && !commonWords.has(m[1].toLowerCase())) add(undefined, m[1])
+  }
+
+  return mentions
+}
+
+// levenshtein computes edit distance between two strings (simple DP,
+// goal text is short so this never needs to be fast).
+function levenshtein(a: string, b: string): number {
+  const dp: number[][] = Array.from({ length: a.length + 1 }, (_, i) => [
+    i,
+    ...Array(b.length).fill(0),
+  ])
+  for (let j = 0; j <= b.length; j++) dp[0][j] = j
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      dp[i][j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j - 1], dp[i - 1][j], dp[i][j - 1])
+    }
+  }
+  return dp[a.length][b.length]
+}
+
+export type RepoMatch = { repo: GitHubRepo; guess: boolean } | { candidates: GitHubRepo[] } | null
+
+// matchRepo resolves a mention list against a connector's repo list:
+// an exact full_name match (owner present) or exact name match (owner
+// absent) wins outright with guess=false. Otherwise, for a bare name,
+// a case-insensitive prefix or small edit-distance match is tried:
+// exactly one candidate proposes it as a guess, several return as
+// candidates for the operator to pick, none returns null.
+export function matchRepo(mentions: RepoMention[], repos: GitHubRepo[]): RepoMatch {
+  for (const mention of mentions) {
+    const name = mention.name.toLowerCase()
+    if (mention.owner) {
+      const fullName = `${mention.owner}/${mention.name}`.toLowerCase()
+      const exact = repos.find((r) => r.full_name.toLowerCase() === fullName)
+      if (exact) return { repo: exact, guess: false }
+      continue
+    }
+
+    const exact = repos.find((r) => r.full_name.split('/')[1]?.toLowerCase() === name)
+    if (exact) return { repo: exact, guess: false }
+
+    const candidates = repos.filter((r) => {
+      const repoName = (r.full_name.split('/')[1] ?? '').toLowerCase()
+      if (!repoName) return false
+      if (repoName.startsWith(name) || name.startsWith(repoName)) return true
+      return levenshtein(repoName, name) <= 2
+    })
+    if (candidates.length === 1) return { repo: candidates[0], guess: true }
+    if (candidates.length > 1) return { candidates }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

A coding goal that names a repository now proposes that repository as the clone source in the mission form. Pure client-side matching against the connected repositories; nothing is resolved or invented at run time.

## Changes

- `web/src/lib/goalRepo.ts`: `extractRepoMentions` recognises a `github.com/owner/repo` URL, a bare `owner/repo` pair and a name next to the word repo/repository (with a stoplist for sentence filler). `matchRepo` takes an exact full name or name match, else a prefix or small edit distance match: one candidate proposes as a guess, several are listed, none proposes nothing.
- `MissionForm.tsx`: in create mode for a coding mission with no hand-picked source and at least one github connector, the goal is scanned after a 400 ms debounce, each connector's repository list is tried (fetched once and cached) and a single match sets the source with a "Proposed from the goal" note and a Clear link. An ambiguous match lists the candidates for the operator to pick. Any manual toggle, connector change or repository pick marks the source hand-picked and it is never overridden afterwards. Clear suppresses proposals until the goal text changes.
- Destination hint: with a source attached or proposed, exactly one enabled github destination not yet checked and push or pull request wording in the goal, a one-line hint offers an Add button. The destination is never checked automatically.

## Verification

- Web build, lint (0 errors) and tests (78 files, 1099 tests) green.
- 21 helper cases and 9 form cases cover URL, pair and bare-name detection, guess labelling, clear and suppress, hand pick precedence, ambiguity, general kind, no connector, and the destination hint never auto-checking.

Closes #563

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791212859&installation_model_id=431401&pr_number=575&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F575&signature=f31cfb3bedae85a6498f192a5cc28dc387c7a2e51a9c6f10437b27659c3357c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->