### PR TITLE
chore(scripts): clear applied #561 data step from pending alters

### DIFF
--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -4,9 +4,4 @@ Additive schema changes not yet applied to any live database. Safe to
 run before deploy; each entry stays here until confirmed applied on
 every live instance, then it's removed.
 
-- issue #561: convert each legacy self-describing "github" destinations
-  entry into a saved destinations row (kind 'github') plus an
-  id-referencing entry. No schema change, a data step only. Idempotent:
-  ```sh
-  psql "$DATABASE_URL" -f scripts/migrate-github-entries.sql
-  ```
+(none)


### PR DESCRIPTION
The github entries data migration from #561 ran on the homelab instance after the alpha.70 deploy (one legacy combo converted, zero legacy entries left), so no live database still needs it. The script stays in scripts/ for new instances restoring old dumps.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791215289&installation_model_id=431401&pr_number=576&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F576&signature=84747a6991e224b265587aa0d799f86991eb063a29b47e6cae02e04d58445eb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->