### PR TITLE
feat(missions): pin operator steering notes in replan and review prompts

### DIFF
--- a/internal/brain/missions/driver.go
+++ b/internal/brain/missions/driver.go
@@ -1281,7 +1281,7 @@ func (d *Driver) DecidePlan(ctx context.Context, id string, input Input, feedbac
 // the API layer's answer endpoint calls this, never the model.
 // Records the Q+A as a progress note (the same durable channel a
 // worker/review/plan turn already reads back: WorkPacket.Progress,
-// ReviewPacket.Progress, replanNotes' recentProgressNotes), so the
+// ReviewPacket.Progress, replanNotes' progressWithOperatorNotes), so the
 // NEXT turn of the SAME phase (Store.AnswerPendingInput resumes to
 // idle without touching Phase) carries the question and answer
 // verbatim. Returns ErrNotAwaitingApproval if the mission isn't
@@ -1464,9 +1464,9 @@ func replanNotes(m Mission) string {
 		// D-088: an ask_user answer during a first-time plan turn (no
 		// plan landed yet, so the "being replanned" branch below never
 		// runs) still needs to reach the very next plan turn's prompt,
-		// same recentProgressNotes channel, just not gated on a plan
+		// same progressWithOperatorNotes channel, just not gated on a plan
 		// existing yet.
-		if progress := recentProgressNotes(m.Progress, 3); progress != "" {
+		if progress := progressWithOperatorNotes(m.Progress, 3, nil); progress != "" {
 			notes += "\n\nRecent progress (includes any operator answers to prior questions):\n" + progress
 		}
 		return notes
@@ -1481,7 +1481,7 @@ func replanNotes(m Mission) string {
 		}
 		fmt.Fprintf(&b, "- [%s] %s\n", status, u.Title)
 	}
-	if notes := recentProgressNotes(m.Progress, 3); notes != "" {
+	if notes := progressWithOperatorNotes(m.Progress, 3, nil); notes != "" {
 		b.WriteString("\nRecent progress:\n")
 		b.WriteString(notes)
 	}
@@ -1489,14 +1489,29 @@ func replanNotes(m Mission) string {
 	return b.String()
 }
 
-// recentProgressNotes renders the last n progress notes, oldest first.
-func recentProgressNotes(notes []ProgressNote, n int) string {
+// progressWithOperatorNotes renders the last n progress notes, oldest
+// first, plus any older operator steering note (operatorNotePrefix)
+// pinned ahead of them so the "last n" cap never drops operator input
+// (issue #357). Each note renders once, as "- <note>\n". render, when
+// non-nil, transforms each note's text before rendering (e.g.
+// NeutralizeSlot in the reviewer prompt); pass nil to render as-is.
+func progressWithOperatorNotes(notes []ProgressNote, n int, render func(string) string) string {
+	if render == nil {
+		render = func(s string) string { return s }
+	}
+	var older []ProgressNote
+	recent := notes
 	if len(notes) > n {
-		notes = notes[len(notes)-n:]
+		older, recent = notes[:len(notes)-n], notes[len(notes)-n:]
 	}
 	var b strings.Builder
-	for _, note := range notes {
-		fmt.Fprintf(&b, "- %s\n", note.Note)
+	for _, note := range older {
+		if strings.HasPrefix(note.Note, operatorNotePrefix) {
+			fmt.Fprintf(&b, "- %s\n", render(note.Note))
+		}
+	}
+	for _, note := range recent {
+		fmt.Fprintf(&b, "- %s\n", render(note.Note))
 	}
 	return b.String()
 }

--- a/internal/brain/missions/driver_test.go
+++ b/internal/brain/missions/driver_test.go
@@ -3042,6 +3042,59 @@ func TestDriverFirstPlanDoesNotGetReplanNotes(t *testing.T) {
 	}
 }
 
+// TestReplanNotesPinsOlderOperatorNote covers issue #357: an operator
+// steering note older than the last-3 window must still reach the
+// replan prompt, in both the first-time-plan and plan-exists branches.
+func TestReplanNotesPinsOlderOperatorNote(t *testing.T) {
+	notes := []ProgressNote{
+		{Note: operatorNotePrefix + "use approach B"},
+		{Note: "progress 1"},
+		{Note: "progress 2"},
+		{Note: "progress 3"},
+	}
+	t.Run("first plan", func(t *testing.T) {
+		m := Mission{DiscoverNotes: "original findings", Progress: notes}
+		got := replanNotes(m)
+		for _, want := range []string{operatorNotePrefix + "use approach B", "progress 1", "progress 2", "progress 3"} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("replanNotes = %q, want it to contain %q", got, want)
+			}
+		}
+	})
+	t.Run("plan exists", func(t *testing.T) {
+		m := Mission{
+			DiscoverNotes: "original findings",
+			Progress:      notes,
+			Plan:          Plan{Units: []PlanUnit{{Title: "unit0", Passes: true}}},
+		}
+		got := replanNotes(m)
+		for _, want := range []string{operatorNotePrefix + "use approach B", "progress 1", "progress 2", "progress 3"} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("replanNotes = %q, want it to contain %q", got, want)
+			}
+		}
+	})
+}
+
+// TestReplanNotesNoDuplicateWhenOperatorNoteInWindow: an operator note
+// that already falls inside the last-3 window must render once, not
+// twice.
+func TestReplanNotesNoDuplicateWhenOperatorNoteInWindow(t *testing.T) {
+	m := Mission{
+		DiscoverNotes: "original findings",
+		Progress: []ProgressNote{
+			{Note: "progress 1"},
+			{Note: operatorNotePrefix + "stay the course"},
+			{Note: "progress 2"},
+		},
+	}
+	got := replanNotes(m)
+	want := operatorNotePrefix + "stay the course"
+	if n := strings.Count(got, want); n != 1 {
+		t.Fatalf("replanNotes = %q, want operator note to appear once, got %d times", got, n)
+	}
+}
+
 // TestDriverCodingMissionsAlwaysReview: the skip gate must never apply
 // to coding missions — a diff can be wrong in ways existence checks
 // cannot see.

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -1190,7 +1190,7 @@ func (r *nativeRunner) DiscoverSession(ctx context.Context, m Mission) (notes, s
 	if rc := m.ReferencedContext(); rc != "" {
 		user += "\n\nReferenced context:\n" + NeutralizeSlot(rc)
 	}
-	if notes := recentProgressNotes(m.Progress, progressRenderCap); notes != "" {
+	if notes := progressWithOperatorNotes(m.Progress, progressRenderCap, nil); notes != "" {
 		user += "\n\nProgress so far (includes any operator answers to prior questions):\n" + notes
 	}
 	user += renderAttachments(m.Attachments())
@@ -1544,17 +1544,21 @@ func renderReviewContent(p ReviewPacket) string {
 		b.WriteString("\n")
 	}
 	if len(p.Progress) > 0 {
-		notes := p.Progress
-		if len(notes) > progressRenderCap {
-			notes = notes[len(notes)-progressRenderCap:]
-		}
 		if p.FindingsOnly {
 			b.WriteString("\nWorker notes since the last review round (its own account of the rework; verify against the files above):\n")
+			notes := p.Progress
+			if len(notes) > progressRenderCap {
+				notes = notes[len(notes)-progressRenderCap:]
+			}
+			for _, n := range notes {
+				fmt.Fprintf(&b, "- %s\n", NeutralizeSlot(n.Note))
+			}
 		} else {
+			// issue #357: pin any older operator steering note ahead of the
+			// last progressRenderCap notes so a full review round never
+			// drops it.
 			b.WriteString("\nRecent progress (includes any operator steering notes):\n")
-		}
-		for _, n := range notes {
-			fmt.Fprintf(&b, "- %s\n", NeutralizeSlot(n.Note))
+			b.WriteString(progressWithOperatorNotes(p.Progress, progressRenderCap, NeutralizeSlot))
 		}
 	}
 	if p.Evidence != "" {

--- a/internal/brain/missions/runner_test.go
+++ b/internal/brain/missions/runner_test.go
@@ -460,6 +460,38 @@ func TestRenderReviewContentFindingsOnlyEmptyDelta(t *testing.T) {
 	}
 }
 
+// TestRenderReviewContentFullPinsOlderOperatorNote covers issue #357: a
+// full review round must not drop an operator steering note older than
+// progressRenderCap notes.
+func TestRenderReviewContentFullPinsOlderOperatorNote(t *testing.T) {
+	notes := []ProgressNote{{Note: operatorNotePrefix + "focus on error handling"}}
+	for i := 0; i < progressRenderCap; i++ {
+		notes = append(notes, ProgressNote{Note: fmt.Sprintf("progress %d", i)})
+	}
+	content := renderReviewContent(ReviewPacket{Goal: "goal", Progress: notes})
+	if !strings.Contains(content, operatorNotePrefix+"focus on error handling") {
+		t.Fatalf("full-round content dropped an operator note older than progressRenderCap:\n%s", content)
+	}
+	if !strings.Contains(content, "progress 0") || !strings.Contains(content, fmt.Sprintf("progress %d", progressRenderCap-1)) {
+		t.Fatalf("full-round content missing recent notes:\n%s", content)
+	}
+}
+
+// TestRenderReviewContentFindingsOnlyDoesNotPinOlderOperatorNote confirms
+// the findings-only branch keeps its existing behavior: it renders only
+// notes since the last review round and never pins an older operator
+// note (D-096's window is intentionally narrow).
+func TestRenderReviewContentFindingsOnlyDoesNotPinOlderOperatorNote(t *testing.T) {
+	notes := []ProgressNote{{Note: operatorNotePrefix + "focus on error handling"}}
+	for i := 0; i < progressRenderCap; i++ {
+		notes = append(notes, ProgressNote{Note: fmt.Sprintf("progress %d", i)})
+	}
+	content := renderReviewContent(ReviewPacket{FindingsOnly: true, Progress: notes})
+	if strings.Contains(content, operatorNotePrefix+"focus on error handling") {
+		t.Fatalf("findings-only content must not pin an older operator note:\n%s", content)
+	}
+}
+
 // TestRenderReviewContentMultiUnitFiles pins D-098's attribution in a
 // full round over several units: each unit block lists the changed
 // files inside its own scope, the whole-change stat is labelled as


### PR DESCRIPTION
## Summary

Operator steering notes no longer fall out of the replan prompt or the full review round prompt once later progress pushes them past the recent-notes window.

## Changes

- `progressWithOperatorNotes(notes, n, render)` replaces `recentProgressNotes`: renders every older note carrying the `Operator note:` prefix pinned ahead of the last n notes, each note once, with an optional per-note transform.
- `replanNotes` uses it in both branches (window stays 3). The discover prompt uses it with the same window as before, output unchanged.
- The reviewer's full round pins older operator notes through `NeutralizeSlot`. The findings-only round keeps rendering only the notes since the last review round, and the worker packet is untouched.

## Verification

- `go vet`, `go test -race ./internal/brain/missions/`, `make lint` (0 issues).
- New tests: replan pins an older operator note in the first-plan and plan-exists branches, no duplicate when the note is inside the window, full review round pins, findings-only round does not.

Closes #357

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791228138&installation_model_id=431401&pr_number=579&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F579&signature=75432fdf8f62240c7535674864f8ee93d827254c89db24347899625ab2dd3cde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->