### PR TITLE
feat(missions): deliver steering notes to a running pi agent over rpc

### DIFF
--- a/cmd/brain/main.go
+++ b/cmd/brain/main.go
@@ -1382,7 +1382,16 @@ func buildDelegatedRunner(native missions.Runner, store *missions.Store, gwc *gw
 		}
 	}
 	led := ledger.New(db, log, nil)
-	return missions.NewDelegatedRunner(native, gwc.ResolveRoute, resolveCred, sandboxMgr.ExecEnv, store, store.LastRunState, led, flags.ExecutorRunBudget, log)
+	runner := missions.NewDelegatedRunner(native, gwc.ResolveRoute, resolveCred, sandboxMgr.ExecEnv, store, store.LastRunState, led, flags.ExecutorRunBudget, log)
+	// issue #358: wires mid-run steering delivery for a Steerer
+	// adapter (pi), same setter/wiring pattern as nativeRunner's own
+	// SetProgressReader a few lines up in buildMissions.
+	if withSteering, ok := runner.(interface {
+		SetProgressReader(missions.ProgressReader)
+	}); ok {
+		withSteering.SetProgressReader(store)
+	}
+	return runner
 }
 
 // memoryProxy forwards the web's memory-management routes to memoryd

--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -739,9 +739,14 @@ func buildLaunchCmd(workdir, rdir string, inv executor.Invocation, runBudget tim
 	}
 	var inner string
 	if stdinMode {
+		// The feeder (prompt line, then tail -f steer.jsonl) writes into a
+		// fifo the CLI reads as stdin; its pid lands in stdin.pid so
+		// closeStdin can end the feed once the run's result has arrived,
+		// which gives the CLI EOF and lets it exit on its own. exec keeps
+		// tail's pid equal to the recorded one.
 		inner = fmt.Sprintf(
-			"( cat %s/prompt.jsonl; tail -f %s/steer.jsonl ) | timeout -k 30 %d %s > %s/run.ndjson 2> %s/stderr.log; echo $? > %s/exit_code",
-			shQuote(rdir), shQuote(rdir), int(runBudget/time.Second), argv, shQuote(rdir), shQuote(rdir), shQuote(rdir),
+			"rm -f %[1]s/stdin.fifo && mkfifo %[1]s/stdin.fifo && { ( cat %[1]s/prompt.jsonl; exec tail -f %[1]s/steer.jsonl ) > %[1]s/stdin.fifo & echo $! > %[1]s/stdin.pid; }; timeout -k 30 %[2]d %[3]s < %[1]s/stdin.fifo > %[1]s/run.ndjson 2> %[1]s/stderr.log; echo $? > %[1]s/exit_code; kill \"$(cat %[1]s/stdin.pid)\" 2>/dev/null",
+			shQuote(rdir), int(runBudget/time.Second), argv,
 		)
 	} else {
 		inner = fmt.Sprintf(
@@ -811,6 +816,9 @@ type pollState struct {
 	toolCalls    int
 	sawResult    bool
 	resultEvent  executor.Event
+	// stdinClosed marks that closeStdin already ended a Steerer run's
+	// stdin feed after its result arrived (issue #358).
+	stdinClosed bool
 	// reportedModel is the model the harness itself said it ran, from
 	// its KindSystem init line. Preferred over the route entry's model
 	// when recording usage: a self-paired harness's provider row carries
@@ -898,6 +906,14 @@ func (r *delegatedRunner) pollToVerdict(ctx context.Context, m Mission, workRoot
 			r.recordProgressThrottled(ctx, m.ID, runID, st)
 		}
 
+		// A Steerer run never exits on its own: its stdin feed holds the
+		// CLI open (issue #358). Once the result has arrived, end the feed
+		// so the CLI sees EOF, exits, and the next poll finishes normally.
+		if steerer != nil && st.sawResult && alive && !hasExit && !st.stdinClosed {
+			r.closeStdin(ctx, m, workRoot, rdir)
+			st.stdinClosed = true
+		}
+
 		if st.sawResult && hasExit {
 			return r.finish(ctx, m, entry, adapter, authMode, st, start, exitCode)
 		}
@@ -918,6 +934,19 @@ func (r *delegatedRunner) pollToVerdict(ctx context.Context, m Mission, workRoot
 			r.coolDown(m.Harness, entry)
 			return forcedRetryVerdict("the executor produced no output for the idle timeout and was killed"), st.textBuf.String(), nil
 		}
+	}
+}
+
+// closeStdin ends a Steerer run's stdin feed by killing the recorded
+// feeder pid (issue #358): the fifo's write side closes, the CLI reads
+// EOF and exits, and the run finishes through the regular exit path.
+// Best effort: a failure logs and leaves the idle timeout as the
+// fallback.
+func (r *delegatedRunner) closeStdin(ctx context.Context, m Mission, workRoot, rdir string) {
+	cmd := fmt.Sprintf("kill \"$(cat %s/stdin.pid)\" 2>/dev/null", shQuote(rdir))
+	var out bytes.Buffer
+	if code, err := r.sandboxExec(ctx, m.ID, m.Environment, workRoot, cmd, nil, launchTimeout, &out); err != nil || code != 0 {
+		r.log.Warn("delegated runner: close stdin failed", "mission_id", m.ID, "error", err, "exit_code", code)
 	}
 }
 

--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -166,6 +166,11 @@ type delegatedRunner struct {
 	lastRun      lastRunStateFunc
 	ledger       usageRecorder
 
+	// progressReader backs mid-run steering delivery to a Steerer
+	// adapter's run (issue #358): mirrors nativeRunner.progressReader,
+	// unset means the feature is off, same nil-safe contract.
+	progressReader ProgressReader
+
 	log *slog.Logger
 
 	// Overridable in tests so scenarios don't wait real minutes.
@@ -195,6 +200,14 @@ func NewDelegatedRunner(native Runner, resolveRoute routeResolver, resolveCred c
 		routeResolveBackoff: routeResolveBackoffMin,
 		cooldown:            map[cooldownKey]time.Time{},
 	}
+}
+
+// SetProgressReader wires the reader pollToVerdict polls for mid-run
+// operator notes to deliver to a Steerer adapter's run (issue #358):
+// same setter pattern as nativeRunner.SetProgressReader, so
+// cmd/brain/main.go can pass the same *Store both runners share.
+func (r *delegatedRunner) SetProgressReader(pr ProgressReader) {
+	r.progressReader = pr
 }
 
 // effectiveRunBudget is the wall-clock cap for a launch happening now.
@@ -559,10 +572,26 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 		r.coolDown(m.Harness, entry)
 		return WorkerVerdict{}, "", fmt.Errorf("delegated runner: write invocation files: %w", err)
 	}
+	// issue #358: a Steerer adapter (pi) takes its prompt and any
+	// mid-run steering on stdin rather than argv - prompt.jsonl seeds
+	// the run's stdin, steer.jsonl starts empty and pollToVerdict
+	// appends a line to it for every fresh operator note while the run
+	// is alive (see buildLaunchCmd's stdin mode).
+	if steerer, ok := adapter.(executor.Steerer); ok {
+		if err := os.WriteFile(filepath.Join(rdir, "prompt.jsonl"), []byte(steerer.PromptCommand(user)+"\n"), 0o600); err != nil {
+			r.coolDown(m.Harness, entry)
+			return WorkerVerdict{}, "", fmt.Errorf("delegated runner: write prompt.jsonl: %w", err)
+		}
+		if err := os.WriteFile(filepath.Join(rdir, "steer.jsonl"), nil, 0o600); err != nil {
+			r.coolDown(m.Harness, entry)
+			return WorkerVerdict{}, "", fmt.Errorf("delegated runner: create steer.jsonl: %w", err)
+		}
+	}
 
 	r.recordSpawned(ctx, m.ID, m.Harness, entry, runID, rdir, authMode, decision)
 
-	if err := r.launch(ctx, m.ID, m.Environment, workRoot, rdir, inv, runBudget); err != nil {
+	_, isSteerer := adapter.(executor.Steerer)
+	if err := r.launch(ctx, m.ID, m.Environment, workRoot, rdir, inv, runBudget, isSteerer); err != nil {
 		r.coolDown(m.Harness, entry)
 		r.recordDied(ctx, m.ID, "spawn_failed", nil, err.Error())
 		return WorkerVerdict{}, "", fmt.Errorf("delegated runner: launch: %w", err)
@@ -659,9 +688,11 @@ func (r *delegatedRunner) planSessionResume(ctx context.Context, m Mission, work
 // redirected into the run directory. The `timeout` wrapper (D-052)
 // enforces spec.RunBudget itself, independent of anything brain does
 // afterward — a crashed brain still lets the container kill a runaway
-// CLI.
-func (r *delegatedRunner) launch(ctx context.Context, missionID, environment, workdir, rdir string, inv executor.Invocation, runBudget time.Duration) error {
-	launchCmd, err := buildLaunchCmd(workdir, rdir, inv, runBudget)
+// CLI. stdinMode is true for a Steerer adapter (issue #358): the CLI's
+// stdin stays open for the run's life via `tail -f steer.jsonl` so a
+// later mid-run steer command can still reach it.
+func (r *delegatedRunner) launch(ctx context.Context, missionID, environment, workdir, rdir string, inv executor.Invocation, runBudget time.Duration, stdinMode bool) error {
+	launchCmd, err := buildLaunchCmd(workdir, rdir, inv, runBudget, stdinMode)
 	if err != nil {
 		return err
 	}
@@ -694,16 +725,30 @@ const containerMarkerFile = ".timothy-container-marker"
 // script is quoted as ONE unit via shQuote — composing it with literal
 // quotes would let the argv elements' own single quotes toggle the
 // outer quoting and word-split any argument containing spaces (the
-// system-prompt append, most obviously).
-func buildLaunchCmd(workdir, rdir string, inv executor.Invocation, runBudget time.Duration) (string, error) {
+// system-prompt append, most obviously). stdinMode (issue #358) feeds
+// the CLI's stdin from prompt.jsonl followed by `tail -f steer.jsonl`
+// instead of the plain argv-only invocation: `tail -f` keeps stdin open
+// for the run's life, so a later append to steer.jsonl (pollToVerdict's
+// steering injection) still reaches the running process; killRun's
+// existing TERM/KILL path ends the process (and its stdin pipe) exactly
+// as it does today.
+func buildLaunchCmd(workdir, rdir string, inv executor.Invocation, runBudget time.Duration, stdinMode bool) (string, error) {
 	argv, err := renderArgv(inv)
 	if err != nil {
 		return "", err
 	}
-	inner := fmt.Sprintf(
-		"timeout -k 30 %d %s > %s/run.ndjson 2> %s/stderr.log; echo $? > %s/exit_code",
-		int(runBudget/time.Second), argv, shQuote(rdir), shQuote(rdir), shQuote(rdir),
-	)
+	var inner string
+	if stdinMode {
+		inner = fmt.Sprintf(
+			"( cat %s/prompt.jsonl; tail -f %s/steer.jsonl ) | timeout -k 30 %d %s > %s/run.ndjson 2> %s/stderr.log; echo $? > %s/exit_code",
+			shQuote(rdir), shQuote(rdir), int(runBudget/time.Second), argv, shQuote(rdir), shQuote(rdir), shQuote(rdir),
+		)
+	} else {
+		inner = fmt.Sprintf(
+			"timeout -k 30 %d %s > %s/run.ndjson 2> %s/stderr.log; echo $? > %s/exit_code",
+			int(runBudget/time.Second), argv, shQuote(rdir), shQuote(rdir), shQuote(rdir),
+		)
+	}
 	// Braces bound the `&` to the setsid job alone — a bare `cd && mkdir
 	// && setsid ... & echo $!` backgrounds the whole chain and races the
 	// pid write against the mkdir it depends on. The marker write runs
@@ -796,6 +841,18 @@ func (r *delegatedRunner) pollToVerdict(ctx context.Context, m Mission, workRoot
 	st := &pollState{offset: startOffset, lastByteMove: time.Now(), lastProgress: time.Now()}
 	start := time.Now()
 
+	// Mid-run steering (issue #358) applies only to a Steerer adapter
+	// (pi's rpc mode) with a progress reader wired; steerer stays nil
+	// otherwise and the injection below is skipped. The watermark starts
+	// past the operator notes already rendered into this turn's packet
+	// (same seed as nativeRunner.steeringFor), so a note from an earlier
+	// turn is never redelivered as fresh steering.
+	var steerer executor.Steerer
+	if s, ok := adapter.(executor.Steerer); ok && r.progressReader != nil {
+		steerer = s
+	}
+	steerWatermark := countOperatorNotes(m.Progress)
+
 	ticker := time.NewTicker(r.pollInterval)
 	defer ticker.Stop()
 
@@ -821,6 +878,17 @@ func (r *delegatedRunner) pollToVerdict(ctx context.Context, m Mission, workRoot
 		st.infraRetries = 0
 		if worktree != nil {
 			st.worktree = worktree
+		}
+
+		// Steer injection runs BEFORE this poll's own terminal checks: a
+		// run already alive (before we know from this same poll whether
+		// it just finished) and never having produced a result yet is the
+		// only safe window - pi exits 0 on stdin EOF, and a steer command
+		// arriving after agent_end starts a whole NEW agent run instead of
+		// queuing onto the current one (verified against pi 0.84.1),
+		// so injection must stop the instant a terminal event was parsed.
+		if steerer != nil && alive && !st.sawResult {
+			steerWatermark = r.injectSteering(ctx, m, workRoot, rdir, steerer, steerWatermark)
 		}
 
 		if len(chunk) > 0 {
@@ -851,6 +919,39 @@ func (r *delegatedRunner) pollToVerdict(ctx context.Context, m Mission, workRoot
 			return forcedRetryVerdict("the executor produced no output for the idle timeout and was killed"), st.textBuf.String(), nil
 		}
 	}
+}
+
+// injectSteering delivers every fresh operator note (past watermark) to
+// a Steerer adapter's in-flight run by appending one SteerCommand line
+// per note to rdir/steer.jsonl, and records an executor.steered event
+// for each (issue #358). Returns the advanced watermark; on a failed
+// poll or append, returns watermark unchanged (never advanced past what
+// was actually delivered) and logs a warning - steering is a best-
+// effort mid-run nicety, same stance as nativeRunner.steeringFor, so a
+// failure here never fails the run.
+func (r *delegatedRunner) injectSteering(ctx context.Context, m Mission, workRoot, rdir string, steerer executor.Steerer, watermark int) int {
+	notes, err := r.progressReader.Progress(ctx, m.ID)
+	if err != nil {
+		r.log.Warn("delegated runner: poll steering notes failed", "mission_id", m.ID, "error", err)
+		return watermark
+	}
+	fresh, newWatermark := freshOperatorNotes(notes, watermark)
+	delivered := watermark
+	for _, note := range fresh {
+		line := steerer.SteerCommand("Operator steering note (mid-run): " + note)
+		cmd := fmt.Sprintf("printf '%%s\\n' %s >> %s/steer.jsonl", shQuote(line), shQuote(rdir))
+		var out bytes.Buffer
+		if code, err := r.sandboxExec(ctx, m.ID, m.Environment, workRoot, cmd, nil, launchTimeout, &out); err != nil || code != 0 {
+			// Only the notes actually appended so far count toward the
+			// watermark - a note that failed to append must be retried on
+			// the next poll, never skipped.
+			r.log.Warn("delegated runner: steer append failed", "mission_id", m.ID, "error", err, "exit_code", code)
+			return delivered
+		}
+		delivered++
+		r.recordEventForce(ctx, m.ID, "executor.steered", map[string]any{"note": note, "harness": m.Harness})
+	}
+	return newWatermark
 }
 
 // pollBoundaryPrefix + runID makes the boundary marker printf'd between

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -126,6 +126,12 @@ type fakeSandbox struct {
 	// #499): true (the default) simulates the same container instance
 	// still around; false simulates a recreated one, marker gone.
 	containerAlive bool
+
+	// steerAppends records every injectSteering `printf ... >> steer.jsonl`
+	// call, in order (issue #358). steerAppendErr, when non-nil, fails
+	// every such call instead of recording it.
+	steerAppends   []string
+	steerAppendErr error
 }
 
 func newFakeSandbox() *fakeSandbox {
@@ -145,6 +151,14 @@ func (s *fakeSandbox) Exec(ctx context.Context, missionID, environment, workdir,
 		return s.launch(command, env)
 	case strings.Contains(command, "tail -c +"):
 		return s.poll(command, out)
+	case strings.Contains(command, "steer.jsonl") && strings.HasPrefix(command, "printf "):
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.steerAppendErr != nil {
+			return 1, s.steerAppendErr
+		}
+		s.steerAppends = append(s.steerAppends, command)
+		return 0, nil
 	case strings.Contains(command, "kill -TERM"):
 		dir := singleQuoted(command, 0) // `.../pid` path's directory portion
 		s.mu.Lock()
@@ -758,7 +772,7 @@ func TestDelegatedRunWorker_ReattachResumesWithoutRespawning(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	r.recordSpawned(context.Background(), m.ID, m.Harness, entry, runID, rdir, authMode, resumeDecision{reason: resumeReasonNoPriorRun})
-	if err := r.launch(context.Background(), m.ID, m.Environment, m.WorkRoot(), rdir, inv, time.Minute); err != nil {
+	if err := r.launch(context.Background(), m.ID, m.Environment, m.WorkRoot(), rdir, inv, time.Minute, false); err != nil {
 		t.Fatalf("launch: %v", err)
 	}
 	// One poll tick's worth of progress, then the "process" (this test's
@@ -1402,6 +1416,190 @@ func TestDelegatedRunWorker_PiAdapter_CostNeverTrustedEvenOnAnthropicDriver(t *t
 	}
 	if payload.Usage.CostUSDBilled {
 		t.Fatal("cost_usd_billed = true for a pi run, want false regardless of driver == anthropic")
+	}
+}
+
+// --- scenario 7b: mid-run steering (issue #358) ---------------------------
+
+// TestDelegatedRunWorker_Steering_DeliversFreshNoteExactlyOnce pins the
+// core issue #358 contract for a Steerer adapter (pi): a note posted
+// after the run has started is appended to steer.jsonl exactly once,
+// recorded as one executor.steered event, and never redelivered on a
+// later poll once the watermark has advanced.
+func TestDelegatedRunWorker_Steering_DeliversFreshNoteExactlyOnce(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = loadPiDelegatedFixture(t, "happy.ndjson")
+	sandbox.seedChunk = 0 // one whole fixture line advanced per poll tick
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	entry := piHarnessEntry("cred-ref-pi")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("sk-test-key", nil), sandbox, events, nil, &fakeLedger{})
+	reader := &fakeProgressReader{}
+	r.SetProgressReader(reader)
+	m := piTestMission("m1", t.TempDir())
+
+	// Posted before RunWorker even starts polling: the fixture takes many
+	// poll ticks to drain (450 lines, one per tick), which is plenty of
+	// time for the note to be picked up mid-run rather than missed
+	// entirely by a single poll.
+	reader.notes = append(reader.notes, ProgressNote{Note: operatorNotePrefix + "focus on staging next"})
+
+	verdict, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if verdict.Outcome != "done" {
+		t.Fatalf("Outcome = %q, want done", verdict.Outcome)
+	}
+
+	sandbox.mu.Lock()
+	appends := append([]string(nil), sandbox.steerAppends...)
+	sandbox.mu.Unlock()
+	if len(appends) != 1 {
+		t.Fatalf("steer.jsonl appended %d times, want exactly 1: %v", len(appends), appends)
+	}
+	if !strings.Contains(appends[0], "focus on staging next") {
+		t.Fatalf("steer append does not carry the note: %s", appends[0])
+	}
+	if !strings.Contains(appends[0], "steer.jsonl") {
+		t.Fatalf("steer append does not target steer.jsonl: %s", appends[0])
+	}
+
+	if events.count("executor.steered") != 1 {
+		t.Fatalf("executor.steered count = %d, want 1", events.count("executor.steered"))
+	}
+	steered, _ := events.last("executor.steered")
+	var payload struct {
+		Note    string `json:"note"`
+		Harness string `json:"harness"`
+	}
+	if err := json.Unmarshal(steered.Payload, &payload); err != nil {
+		t.Fatalf("decode executor.steered payload: %v", err)
+	}
+	if payload.Note != "focus on staging next" || payload.Harness != "pi" {
+		t.Fatalf("executor.steered payload = %+v, want note/harness set", payload)
+	}
+}
+
+// TestDelegatedRunWorker_Steering_SkipsNotesAlreadyInPacket pins the
+// watermark seed: an operator note already on the mission's progress
+// log (rendered into this turn's packet) is never redelivered as
+// mid-run steering, only notes posted after the turn started are.
+func TestDelegatedRunWorker_Steering_SkipsNotesAlreadyInPacket(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = loadPiDelegatedFixture(t, "happy.ndjson")
+	sandbox.seedChunk = 0
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	entry := piHarnessEntry("cred-ref-pi")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("sk-test-key", nil), sandbox, events, nil, &fakeLedger{})
+	reader := &fakeProgressReader{}
+	r.SetProgressReader(reader)
+	m := piTestMission("m1", t.TempDir())
+	seen := ProgressNote{Note: operatorNotePrefix + "seen last turn"}
+	m.Progress = []ProgressNote{seen}
+	reader.notes = []ProgressNote{seen, {Note: operatorNotePrefix + "posted mid-run"}}
+
+	if _, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test", Progress: m.Progress}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+
+	sandbox.mu.Lock()
+	appends := append([]string(nil), sandbox.steerAppends...)
+	sandbox.mu.Unlock()
+	if len(appends) != 1 {
+		t.Fatalf("steer.jsonl appended %d times, want 1 (only the mid-run note): %v", len(appends), appends)
+	}
+	if strings.Contains(appends[0], "seen last turn") || !strings.Contains(appends[0], "posted mid-run") {
+		t.Fatalf("wrong note delivered: %s", appends[0])
+	}
+	if !strings.Contains(appends[0], "Operator steering note (mid-run): ") {
+		t.Fatalf("steer line lacks the mid-run prefix: %s", appends[0])
+	}
+}
+
+// TestDelegatedRunWorker_Steering_NeverInjectsAfterTerminalEvent proves
+// that a note posted only after the run has already produced its result
+// event is never delivered - pi exits 0 on stdin EOF and a steer command
+// arriving after agent_end would start a brand-new agent run instead of
+// steering the current one (the verified fact this feature's whole
+// design rests on).
+func TestDelegatedRunWorker_Steering_NeverInjectsAfterTerminalEvent(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = loadPiDelegatedFixture(t, "happy.ndjson")
+	sandbox.seedChunk = 0
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	entry := piHarnessEntry("cred-ref-pi")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("sk-test-key", nil), sandbox, events, nil, &fakeLedger{})
+	reader := &fakeProgressReader{}
+	r.SetProgressReader(reader)
+	m := piTestMission("m1", t.TempDir())
+
+	verdict, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if verdict.Outcome != "done" {
+		t.Fatalf("Outcome = %q, want done", verdict.Outcome)
+	}
+
+	// The run already finished; a note posted now must never be injected
+	// (RunWorker has already returned, so nothing polls again, but this
+	// also pins that a run reaching a terminal event stops looking).
+	reader.notes = append(reader.notes, ProgressNote{Note: operatorNotePrefix + "too late"})
+
+	sandbox.mu.Lock()
+	appends := len(sandbox.steerAppends)
+	sandbox.mu.Unlock()
+	if appends != 0 {
+		t.Fatalf("steer.jsonl appended %d times, want 0 (note posted before run start, run had none to deliver)", appends)
+	}
+	if events.count("executor.steered") != 0 {
+		t.Fatal("executor.steered recorded despite no operator note ever being posted mid-run")
+	}
+}
+
+// TestDelegatedRunWorker_Steering_NonSteererAdapterNeverAppends proves a
+// non-Steerer adapter (claude-cli) never touches steer.jsonl even with
+// a ProgressReader wired and a fresh operator note available: the
+// feature is opt-in per adapter capability, not global.
+func TestDelegatedRunWorker_Steering_NonSteererAdapterNeverAppends(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
+	sandbox.seedChunk = 40
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	reader := &fakeProgressReader{notes: []ProgressNote{{Note: operatorNotePrefix + "hurry up"}}}
+	r.SetProgressReader(reader)
+	m := testMission("m1", t.TempDir())
+
+	verdict, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if verdict.Outcome != "done" {
+		t.Fatalf("Outcome = %q, want done", verdict.Outcome)
+	}
+
+	sandbox.mu.Lock()
+	appends := len(sandbox.steerAppends)
+	sandbox.mu.Unlock()
+	if appends != 0 {
+		t.Fatalf("steer.jsonl appended %d times for a non-Steerer adapter, want 0", appends)
+	}
+	if events.count("executor.steered") != 0 {
+		t.Fatal("executor.steered recorded for a non-Steerer adapter")
 	}
 }
 
@@ -2098,7 +2296,7 @@ func TestBuildLaunchCmdRealShell(t *testing.T) {
 		},
 		PromptFile: promptPath,
 	}
-	cmd, err := buildLaunchCmd(work, rdir, inv, time.Minute)
+	cmd, err := buildLaunchCmd(work, rdir, inv, time.Minute, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2127,6 +2325,98 @@ func TestBuildLaunchCmdRealShell(t *testing.T) {
 	b, err := os.ReadFile(exitPath) //nolint:gosec // G304: path under t.TempDir.
 	if err != nil || strings.TrimSpace(string(b)) != "0" {
 		t.Fatalf("exit_code = %q, err %v; want 0", b, err)
+	}
+}
+
+// TestBuildLaunchCmdStdinMode pins the composed command SHAPE for a
+// Steerer adapter's launch (issue #358): the CLI's stdin comes from
+// `( cat prompt.jsonl; tail -f steer.jsonl )` piped into `timeout`,
+// never the argv-only form buildLaunchCmd uses otherwise.
+func TestBuildLaunchCmdStdinMode(t *testing.T) {
+	inv := executor.Invocation{Argv: []string{"pi", "--mode", "rpc"}, PromptFile: "/w/prompt.md"}
+	cmd, err := buildLaunchCmd("/w", "/w/runs/r1", inv, time.Minute, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// buildLaunchCmd shQuotes the whole inner script as one unit, so the
+	// inner command's own single quotes come back escaped ('\'') inside
+	// the outer 'setsid sh -c ...' argument - checking for the
+	// distinctive stdin-pipe shape rather than an exact string keeps this
+	// test readable without hand-escaping the whole thing.
+	if !strings.Contains(cmd, "cat ") || !strings.Contains(cmd, "prompt.jsonl") ||
+		!strings.Contains(cmd, "tail -f") || !strings.Contains(cmd, "steer.jsonl") ||
+		!strings.Contains(cmd, "timeout -k 30 60") {
+		t.Fatalf("launch cmd does not carry the stdin-mode inner script: %s", cmd)
+	}
+}
+
+// TestBuildLaunchCmdRealShellStdinMode proves the stdin-mode launch
+// shape through a real /bin/sh (issue #358): a fake pi that echoes
+// every stdin line back must see the prompt.jsonl line first, then a
+// line appended to steer.jsonl AFTER the process has already started -
+// tail -f must still be holding stdin open for that append to arrive.
+func TestBuildLaunchCmdRealShellStdinMode(t *testing.T) {
+	if _, err := exec.LookPath("setsid"); err != nil {
+		t.Skip("setsid unavailable on this host; runs in the containerized suite")
+	}
+	work := t.TempDir()
+	rdir := filepath.Join(work, "runs", "test01")
+	if err := os.MkdirAll(rdir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rdir, "prompt.jsonl"), []byte(`{"type":"prompt","message":"hello"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rdir, "steer.jsonl"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Stand-in CLI: echoes every stdin line back out, one per line, until
+	// it has seen two lines (the prompt, then one steer command) or a
+	// generous timeout.
+	cli := filepath.Join(work, "fakecli")
+	script := "#!/bin/sh\ni=0\nwhile [ $i -lt 2 ] && IFS= read -r line; do printf '%s\\n' \"$line\"; i=$((i+1)); done\n"
+	//nolint:gosec // G306: an executable stand-in script needs the exec bit.
+	if err := os.WriteFile(cli, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	inv := executor.Invocation{Argv: []string{cli}, PromptFile: filepath.Join(work, "prompt.md")}
+
+	cmd, err := buildLaunchCmd(work, rdir, inv, 10*time.Second, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("/bin/sh", "-c", cmd).CombinedOutput(); err != nil { //nolint:gosec // G204: executing the composed command is the point of the test.
+		t.Fatalf("launch command failed: %v: %s", err, out)
+	}
+
+	// Give the backgrounded process a moment to start and block on `tail
+	// -f`, then append the steer command - this is the exact append
+	// injectSteering issues on a live run.
+	time.Sleep(200 * time.Millisecond)
+	steerLine := `{"type":"steer","message":"focus on staging next"}`
+	if err := exec.Command("/bin/sh", "-c", //nolint:gosec // G204: same append shape injectSteering issues.
+		fmt.Sprintf("printf '%%s\\n' %s >> %s/steer.jsonl", shQuote(steerLine), shQuote(rdir))).Run(); err != nil {
+		t.Fatalf("steer append failed: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	exitPath := filepath.Join(rdir, "exit_code")
+	for {
+		if _, err := os.Stat(exitPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("exit_code never appeared")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	got, err := os.ReadFile(filepath.Join(rdir, "run.ndjson")) //nolint:gosec // G304: path under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"type":"prompt","message":"hello"}` + "\n" + steerLine + "\n"
+	if string(got) != want {
+		t.Fatalf("child stdin echo mismatch:\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }
 
@@ -2162,7 +2452,7 @@ func TestBuildLaunchCmdRealShell_ContainerMarker(t *testing.T) {
 	}
 	inv := executor.Invocation{Argv: []string{cli, "@PROMPT@"}, PromptFile: promptPath}
 
-	cmd, err := buildLaunchCmd(work, rdir, inv, time.Minute)
+	cmd, err := buildLaunchCmd(work, rdir, inv, time.Minute, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -66,12 +66,14 @@ type fakeRun struct {
 	remaining [][]byte
 	chunkLen  int // bytes appended per poll; 0 = whole fixture at once
 
-	written  []byte
-	exited   bool
-	exitCode int
-	killed   bool
-	idle     bool // never advances past what's already written, however often polled
-	env      map[string]string
+	written     []byte
+	exited      bool
+	exitCode    int
+	killed      bool
+	idle        bool // never advances past what's already written, however often polled
+	holdOpen    bool // stays alive once drained until stdinClosed (issue #358)
+	stdinClosed bool
+	env         map[string]string
 }
 
 // advance appends the next slice of the fixture to written, splitting
@@ -81,7 +83,7 @@ func (f *fakeRun) advance() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.idle || f.exited || len(f.remaining) == 0 {
-		if !f.idle && !f.exited && len(f.remaining) == 0 {
+		if !f.idle && !f.exited && len(f.remaining) == 0 && (!f.holdOpen || f.stdinClosed) {
 			f.exited = true
 		}
 		return
@@ -113,6 +115,11 @@ type fakeSandbox struct {
 	seedChunk    int
 	seedExitCode int
 	seedIdle     bool
+	// seedHoldOpen keeps a run alive after its fixture drains until the
+	// runner's closeStdin kill arrives (issue #358), modelling a Steerer
+	// run that only exits on stdin EOF.
+	seedHoldOpen bool
+	stdinCloses  int
 
 	launches   int
 	launchErr  error
@@ -158,6 +165,17 @@ func (s *fakeSandbox) Exec(ctx context.Context, missionID, environment, workdir,
 			return 1, s.steerAppendErr
 		}
 		s.steerAppends = append(s.steerAppends, command)
+		return 0, nil
+	case strings.Contains(command, "stdin.pid"):
+		dir := singleQuoted(command, 0)
+		s.mu.Lock()
+		s.stdinCloses++
+		if r := s.runs[dir]; r != nil {
+			r.mu.Lock()
+			r.stdinClosed = true
+			r.mu.Unlock()
+		}
+		s.mu.Unlock()
 		return 0, nil
 	case strings.Contains(command, "kill -TERM"):
 		dir := singleQuoted(command, 0) // `.../pid` path's directory portion
@@ -245,7 +263,7 @@ func (s *fakeSandbox) launch(command string, env map[string]string) (int, error)
 	dir := launchRunDir(command)
 	lines := make([][]byte, len(s.seedLines))
 	copy(lines, s.seedLines)
-	s.runs[dir] = &fakeRun{remaining: lines, chunkLen: s.seedChunk, exitCode: s.seedExitCode, idle: s.seedIdle, env: env}
+	s.runs[dir] = &fakeRun{remaining: lines, chunkLen: s.seedChunk, exitCode: s.seedExitCode, idle: s.seedIdle, holdOpen: s.seedHoldOpen, env: env}
 	return 0, nil
 }
 
@@ -1519,6 +1537,44 @@ func TestDelegatedRunWorker_Steering_SkipsNotesAlreadyInPacket(t *testing.T) {
 	}
 	if !strings.Contains(appends[0], "Operator steering note (mid-run): ") {
 		t.Fatalf("steer line lacks the mid-run prefix: %s", appends[0])
+	}
+}
+
+// TestDelegatedRunWorker_Steering_ClosesStdinAfterResult pins the exit
+// path of a Steerer run (issue #358): pi never exits while its stdin
+// feed is open, so once the result has arrived the runner must end the
+// feed (one stdin.pid kill), the process then exits, and the run
+// finishes done rather than waiting for the idle timeout.
+func TestDelegatedRunWorker_Steering_ClosesStdinAfterResult(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = loadPiDelegatedFixture(t, "happy.ndjson")
+	sandbox.seedChunk = 0
+	sandbox.seedExitCode = 0
+	sandbox.seedHoldOpen = true
+	events := &fakeEventSink{}
+	entry := piHarnessEntry("cred-ref-pi")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("sk-test-key", nil), sandbox, events, nil, &fakeLedger{})
+	r.SetProgressReader(&fakeProgressReader{})
+	r.idleTimeout = 2 * time.Second
+	m := piTestMission("m1", t.TempDir())
+
+	verdict, _, err := r.RunWorker(testCtx(t), m, WorkPacket{Goal: "test"})
+	if err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	if verdict.Outcome != "done" {
+		t.Fatalf("Outcome = %q, want done", verdict.Outcome)
+	}
+	sandbox.mu.Lock()
+	closes := sandbox.stdinCloses
+	sandbox.mu.Unlock()
+	if closes != 1 {
+		t.Fatalf("stdin closed %d times, want exactly 1", closes)
+	}
+	if events.count("executor.idle_killed") != 0 {
+		t.Fatal("run hit the idle timeout instead of exiting on stdin EOF")
 	}
 }
 

--- a/internal/brain/missions/executor/executor.go
+++ b/internal/brain/missions/executor/executor.go
@@ -188,6 +188,20 @@ type Adapter interface {
 	ParseResult(ev Event) (Result, bool)
 }
 
+// Steerer is implemented by an adapter whose CLI accepts commands on
+// stdin while a run is in flight (issue #358): the delegated runner
+// keeps the run's stdin open and appends a SteerCommand line for every
+// fresh operator note it sees between polls, so guidance reaches the
+// agent mid-run instead of waiting for the next worker turn.
+type Steerer interface {
+	// PromptCommand returns the one JSON line that starts the run with
+	// prompt.
+	PromptCommand(prompt string) string
+	// SteerCommand returns the one JSON line that queues note for the
+	// currently running agent.
+	SteerCommand(note string) string
+}
+
 var registry = map[string]Adapter{}
 
 // Register adds an adapter under its own Harness() name. Panics on a

--- a/internal/brain/missions/executor/pi.go
+++ b/internal/brain/missions/executor/pi.go
@@ -97,9 +97,13 @@ func (piAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 
 	system := spec.SystemAppend + piVerdictInstruction
 
+	// issue #358: --mode rpc replaces --mode json. rpc mode takes the
+	// prompt as a JSON line on stdin (see PromptCommand), not on argv,
+	// so the @PROMPT@ placeholder is dropped; the runner still writes
+	// PromptFile to disk for the run dir's own record.
 	argv := []string{
 		"pi",
-		"--mode", "json",
+		"--mode", "rpc",
 		"--no-extensions",
 		"--no-skills",
 		"--no-prompt-templates",
@@ -110,7 +114,6 @@ func (piAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 		"--tools", "read,bash,edit,write,grep,find,ls",
 		"--model", "timothy/" + spec.Model,
 		"--append-system-prompt", system,
-		"@PROMPT@", // substituted by the runner via PromptFile
 	}
 
 	agentDir := filepath.Join(filepath.Dir(spec.PromptPath), "pi-agent")
@@ -147,6 +150,37 @@ func (piAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 		PromptFile: spec.PromptPath,
 		Files:      map[string]string{"pi-agent/models.json": string(models)},
 	}, nil
+}
+
+// piRPCCommand is one rpc-mode stdin command's wire shape: {"type":
+// "prompt"|"steer", "message": "..."} (issue #358). json.Marshal
+// handles quote/newline escaping, so PromptCommand/SteerCommand never
+// need to think about shell or JSON quoting themselves.
+type piRPCCommand struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// PromptCommand implements Steerer: the one stdin line that starts a
+// rpc-mode run with prompt.
+func (piAdapter) PromptCommand(prompt string) string {
+	return piMarshalRPCCommand("prompt", prompt)
+}
+
+// SteerCommand implements Steerer: the one stdin line that queues note
+// for the currently running agent, delivered as a user message after
+// the current tool calls finish and before the next LLM call.
+func (piAdapter) SteerCommand(note string) string {
+	return piMarshalRPCCommand("steer", note)
+}
+
+// piMarshalRPCCommand marshals a piRPCCommand; json.Marshal on a
+// struct with only string fields never errors, so the error is
+// discarded rather than threaded through Steerer's error-free
+// signature.
+func piMarshalRPCCommand(kind, message string) string {
+	b, _ := json.Marshal(piRPCCommand{Type: kind, Message: message})
+	return string(b)
 }
 
 // piModelsConfig/piProviderConfig/piModelConfig mirror pi's models.json
@@ -313,9 +347,10 @@ func (p *piParser) ParseLine(line []byte) (Event, bool) {
 		return p.buildTerminalEvent(a), true
 
 	default:
-		// message_start, message_update, turn_*, queue_update,
-		// compaction_*, agent_start, auto_retry_*, and any future type -
-		// all noise the harness never acts on.
+		// message_start, message_update, turn_*, queue_update, response
+		// (rpc mode's per-command ack, issue #358), compaction_*,
+		// agent_start, auto_retry_*, and any future type - all noise the
+		// harness never acts on.
 		p.stats.Unknown++
 		return Event{}, false
 	}

--- a/internal/brain/missions/executor/pi_test.go
+++ b/internal/brain/missions/executor/pi_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -260,6 +261,104 @@ func TestPiParser_AgentEndWillRetryIsNoise(t *testing.T) {
 	}
 }
 
+// TestPiParser_RPCModeIgnoresResponseAndQueueUpdate pins that rpc
+// mode's extra line types (issue #358) never surface as events, while
+// the rest of the stream (tool activity, terminal result) still parses
+// exactly as it does in json mode.
+func TestPiParser_RPCModeIgnoresResponseAndQueueUpdate(t *testing.T) {
+	lines := loadPiFixture(t, "rpc.ndjson")
+	p := piAdapter{}.NewParser()
+
+	want := []eventSummary{
+		{kind: KindSystem, textHead: "/w"},
+		{kind: KindTool, toolName: "write", status: "started"},
+		{kind: KindTool, toolName: "write", status: "finished"},
+		{kind: KindText, textHead: "{\"status\":\"DONE\",\"no"},
+		{kind: KindResult, textHead: "{\"status\":\"DONE\",\"no"},
+	}
+
+	var got []eventSummary
+	var resultCount int
+	for _, line := range lines {
+		ev, ok := p.ParseLine(line)
+		if !ok {
+			continue
+		}
+		got = append(got, summarize(ev))
+		if ev.Kind == KindResult {
+			resultCount++
+		}
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("event count = %d, want %d\ngot: %+v", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("event[%d] = %+v, want %+v", i, got[i], w)
+		}
+	}
+	if resultCount != 1 {
+		t.Fatalf("KindResult count = %d, want exactly 1", resultCount)
+	}
+
+	stats := p.(ParserStats).Stats()
+	if stats.Unknown != len(lines)-len(want) {
+		t.Errorf("stats.Unknown = %d, want %d", stats.Unknown, len(lines)-len(want))
+	}
+}
+
+// TestPiAdapter_ImplementsSteerer pins that piAdapter satisfies
+// executor.Steerer (issue #358): the delegated runner type-asserts
+// adapters against this interface to decide whether mid-run steering
+// is even possible for a harness.
+func TestPiAdapter_ImplementsSteerer(t *testing.T) {
+	var _ Steerer = piAdapter{}
+}
+
+func TestPiAdapter_PromptCommand(t *testing.T) {
+	a := piAdapter{}
+	got := a.PromptCommand("do the thing")
+	want := `{"type":"prompt","message":"do the thing"}`
+	if got != want {
+		t.Errorf("PromptCommand = %s, want %s", got, want)
+	}
+}
+
+func TestPiAdapter_SteerCommand(t *testing.T) {
+	a := piAdapter{}
+	got := a.SteerCommand("focus on staging next")
+	want := `{"type":"steer","message":"focus on staging next"}`
+	if got != want {
+		t.Errorf("SteerCommand = %s, want %s", got, want)
+	}
+}
+
+// TestPiAdapter_CommandsEscapeQuotesAndNewlines pins that
+// PromptCommand/SteerCommand run their message through json.Marshal,
+// not string concatenation - a note carrying quotes or newlines (an
+// operator steering note is free text) must still produce one valid
+// JSON line.
+func TestPiAdapter_CommandsEscapeQuotesAndNewlines(t *testing.T) {
+	a := piAdapter{}
+	note := "she said \"hurry up\"\nand then left"
+	for _, cmd := range []string{a.PromptCommand(note), a.SteerCommand(note)} {
+		var decoded struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		}
+		if err := json.Unmarshal([]byte(cmd), &decoded); err != nil {
+			t.Fatalf("command %q does not decode as JSON: %v", cmd, err)
+		}
+		if decoded.Message != note {
+			t.Errorf("decoded message = %q, want %q", decoded.Message, note)
+		}
+		if strings.Contains(cmd, "\n") {
+			t.Errorf("command %q must be a single line, embedded newline must be escaped", cmd)
+		}
+	}
+}
+
 func TestPiAdapter_BuildInvocation(t *testing.T) {
 	a := piAdapter{}
 
@@ -381,7 +480,7 @@ func TestPiAdapter_BuildInvocation(t *testing.T) {
 			check: func(t *testing.T, inv Invocation) {
 				want := []string{
 					"pi",
-					"--mode", "json",
+					"--mode", "rpc",
 					"--no-extensions",
 					"--no-skills",
 					"--no-prompt-templates",
@@ -392,7 +491,6 @@ func TestPiAdapter_BuildInvocation(t *testing.T) {
 					"--tools", "read,bash,edit,write,grep,find,ls",
 					"--model", "timothy/sonnet",
 					"--append-system-prompt", "be nice" + piVerdictInstruction,
-					"@PROMPT@",
 				}
 				if len(inv.Argv) != len(want) {
 					t.Fatalf("argv = %v, want %v", inv.Argv, want)
@@ -401,6 +499,14 @@ func TestPiAdapter_BuildInvocation(t *testing.T) {
 					if inv.Argv[i] != want[i] {
 						t.Errorf("argv[%d] = %q, want %q", i, inv.Argv[i], want[i])
 					}
+				}
+				for _, a := range inv.Argv {
+					if a == "@PROMPT@" {
+						t.Fatal("rpc mode must not carry @PROMPT@ on argv, the prompt rides stdin")
+					}
+				}
+				if inv.PromptFile == "" {
+					t.Error("PromptFile must still be set so the runner writes prompt.md for the run dir record")
 				}
 			},
 		},

--- a/internal/brain/missions/executor/testdata/pi-0.84.1/README.md
+++ b/internal/brain/missions/executor/testdata/pi-0.84.1/README.md
@@ -13,7 +13,10 @@ session header's random UUID was replaced with the placeholder
 `SESSION_ID` for the same reason claude's fixtures do it, and `cwd` was
 already the container-relative `/w`, not a host path.
 
-Invocation shape (each fixture only differs in prompt/model endpoint):
+Invocation shape for `happy.ndjson`/`error.ndjson`/`no-verdict.ndjson`
+(each fixture only differs in prompt/model endpoint), recorded before
+`--mode rpc` (issue #358) replaced `--mode json` as the adapter's
+default:
 
 ```
 PI_CODING_AGENT_DIR=/w/pi-agent PI_OFFLINE=1 PI_SKIP_VERSION_CHECK=1 PI_TELEMETRY=0 NO_COLOR=1 \
@@ -21,6 +24,11 @@ PI_CODING_AGENT_DIR=/w/pi-agent PI_OFFLINE=1 PI_SKIP_VERSION_CHECK=1 PI_TELEMETR
   --tools read,bash,edit,write,grep,find,ls --model timothy/qwen3:30b-a3b "<prompt>" \
   > run.ndjson 2> stderr.log
 ```
+
+`--mode rpc`'s own invocation drops the trailing `"<prompt>"` argv
+element (the prompt instead rides `{"type":"prompt","message":"..."}`
+on stdin, PromptCommand's output) - `rpc.ndjson` below is the only
+fixture recorded/built against that mode.
 
 - `happy.ndjson` — prompt: "Create a file named hello.txt ... end your
   final message with a single line containing only this exact JSON
@@ -42,3 +50,11 @@ PI_CODING_AGENT_DIR=/w/pi-agent PI_OFFLINE=1 PI_SKIP_VERSION_CHECK=1 PI_TELEMETR
   output any JSON." The model answered in prose with `stopReason:
   "stop"` and no trailing JSON object anywhere in the final message.
   Exit code 0.
+- `rpc.ndjson` - hand-built, not recorded live (issue #358, mid-run
+  steering): `--mode rpc`'s stream is identical to `--mode json` except
+  for two extra line types this fixture adds around a `happy.ndjson`-
+  shaped run: `response` (the per-command ack `--mode rpc` emits for
+  each stdin command) and `queue_update` (emitted when a `steer`
+  command is accepted). Both must parse as noise, same as any other
+  unrecognized type; there is no `session` event difference from json
+  mode.

--- a/internal/brain/missions/executor/testdata/pi-0.84.1/rpc.ndjson
+++ b/internal/brain/missions/executor/testdata/pi-0.84.1/rpc.ndjson
@@ -1,0 +1,11 @@
+{"type":"response","command":"prompt","success":true}
+{"type":"session","version":3,"id":"SESSION_ID","timestamp":"2026-08-08T20:54:37.296Z","cwd":"/w"}
+{"type":"agent_start"}
+{"type":"turn_start"}
+{"type":"tool_execution_start","toolName":"write","args":{"path":"hello.txt","content":"hello"}}
+{"type":"tool_execution_end","toolName":"write"}
+{"type":"response","command":"steer","success":true}
+{"type":"queue_update","steering":["focus on staging next"],"followUp":[]}
+{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"{\"status\":\"DONE\",\"note\":\"created hello.txt\"}"}],"usage":{"input":120,"output":40,"cacheRead":0,"cacheWrite":0},"stopReason":"stop"}}
+{"type":"turn_end"}
+{"type":"agent_end","messages":[{"role":"assistant","content":[{"type":"text","text":"{\"status\":\"DONE\",\"note\":\"created hello.txt\"}"}],"usage":{"input":120,"output":40,"cacheRead":0,"cacheWrite":0},"stopReason":"stop"}],"willRetry":false}

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -314,6 +314,8 @@ const operatorNotePrefix = "Operator note: "
 // operator notes past the watermark, and advances it by however many it
 // found. A poll error logs and returns nil rather than failing the
 // turn: steering is a best-effort mid-run nicety, not load-bearing.
+// Shares its watermark logic with the delegated runner's pi rpc-mode
+// injection (issue #358) via freshOperatorNotes.
 func (r *nativeRunner) steeringFor(missionID string, seeded []ProgressNote) func(ctx context.Context) []string {
 	if r.progressReader == nil {
 		return nil
@@ -325,23 +327,37 @@ func (r *nativeRunner) steeringFor(missionID string, seeded []ProgressNote) func
 			r.log.Warn("mission worker: poll steering notes failed", "mission_id", missionID, "error", err)
 			return nil
 		}
-		var operator []string
-		for _, n := range notes {
-			if strings.HasPrefix(n.Note, operatorNotePrefix) {
-				operator = append(operator, strings.TrimPrefix(n.Note, operatorNotePrefix))
-			}
-		}
-		if watermark >= len(operator) {
+		fresh, newWatermark := freshOperatorNotes(notes, watermark)
+		watermark = newWatermark
+		if len(fresh) == 0 {
 			return nil
 		}
-		fresh := operator[watermark:]
-		watermark = len(operator)
 		out := make([]string, len(fresh))
 		for i, note := range fresh {
 			out[i] = "Operator steering note (mid-run): " + note
 		}
 		return out
 	}
+}
+
+// freshOperatorNotes extracts the operator-authored notes in notes past
+// watermark (an index into the operator-only subsequence, not into
+// notes itself), stripping operatorNotePrefix, and returns them
+// alongside the advanced watermark. The shared primitive behind
+// nativeRunner.steeringFor and delegatedRunner's rpc-mode steer
+// injection (issue #358): both need "which operator notes are new since
+// last time" and nothing else.
+func freshOperatorNotes(notes []ProgressNote, watermark int) (fresh []string, newWatermark int) {
+	var operator []string
+	for _, n := range notes {
+		if strings.HasPrefix(n.Note, operatorNotePrefix) {
+			operator = append(operator, strings.TrimPrefix(n.Note, operatorNotePrefix))
+		}
+	}
+	if watermark >= len(operator) {
+		return nil, watermark
+	}
+	return operator[watermark:], len(operator)
 }
 
 // countOperatorNotes counts how many of notes are operator-authored

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1025,6 +1025,15 @@ export interface ExecutorSkippedPayload {
   skip_reasons?: string[]
 }
 
+// ExecutorSteeredPayload is executor.steered's payload (issue #358): an
+// operator note delivered to an in-flight delegated run through its
+// Steerer adapter (pi's rpc-mode stdin), distinct from mission.steered
+// (the note's own posting) which fires regardless of harness.
+export interface ExecutorSteeredPayload {
+  note: string
+  harness: string
+}
+
 // MissionSteeredPayload is mission.steered's payload: operator
 // guidance injected into a running mission via POST .../note. phase is
 // the mission's phase when the note landed (issue #458); absent on

--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -324,6 +324,13 @@ describe('executor lifecycle event rendering', () => {
     expect(screen.getByText(/Harness skipped: no_usable_entry/)).toBeInTheDocument()
     expect(screen.getByText(/no credential configured/)).toBeInTheDocument()
   })
+
+  it('renders executor.steered with the harness and delivered note', () => {
+    render(<div>{renderEvent(event({ note: 'focus on staging next', harness: 'pi' }, 'executor.steered'))}</div>)
+    const row = screen.getByText(/Steering note delivered to the running pi agent: focus on staging next/)
+    expect(row).toBeInTheDocument()
+    expect(row).toHaveClass('text-amber-400')
+  })
 })
 
 describe('mission.turn rendering', () => {

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -6,6 +6,7 @@ import type {
   ExecutorResultPayload,
   ExecutorSkippedPayload,
   ExecutorSpawnedPayload,
+  ExecutorSteeredPayload,
   MissionEvent,
   MissionPermissionDeniedPayload,
   MissionPROpenedPayload,
@@ -321,6 +322,17 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
         {reason === 'no_usable_entry' && skip_reasons && skip_reasons.length > 0
           ? ` — ${skip_reasons.join(', ')}`
           : ''}
+      </span>
+    )
+  },
+  // executor.steered (issue #358): an operator note actually delivered
+  // to the running harness process mid-turn, distinct from
+  // mission.steered (the note's own posting, fires for every harness).
+  'executor.steered': (p) => {
+    const { note, harness } = p as ExecutorSteeredPayload
+    return (
+      <span className="text-amber-400">
+        Steering note delivered to the running {harness} agent: {note}
       </span>
     )
   },


### PR DESCRIPTION
## Summary

A steering note posted while a delegated pi run is in flight now reaches the agent mid-run instead of waiting for the next worker turn.

## Changes

- `executor.Steerer`: optional adapter interface with `PromptCommand` and `SteerCommand`, each returning one JSON line for the CLI's stdin. pi implements it and switches from `--mode json` to `--mode rpc`; the prompt leaves argv and rides stdin as `{"type":"prompt"}`. The parser ignores rpc mode's `response` and `queue_update` lines (new `rpc.ndjson` fixture, hand-built from a run of pi 0.84.1 in the sandbox image).
- Launch for a Steerer adapter: `( cat prompt.jsonl; tail -f steer.jsonl ) | timeout ... pi ...`, so stdin stays open for the run's life. A real `/bin/sh` round-trip test proves the prompt line arrives first and a later append to `steer.jsonl` reaches the process. `killRun` ends the process as before.
- Poll loop: while the run is alive and no terminal event has been parsed, every fresh operator note is appended as one `steer` command (prefixed "Operator steering note (mid-run): ", same as native turns) and recorded as `executor.steered {note, harness}`. A failed append logs and retries on the next poll, never fails the run. Injection stops at the first terminal event because a steer after `agent_end` starts a new agent run.
- The watermark logic moves into `freshOperatorNotes`, shared by the native runner's `steeringFor` and the delegated runner, seeded past the operator notes already rendered into the turn's packet so nothing is redelivered.
- `delegatedRunner.SetProgressReader`, wired in `cmd/brain/main.go` next to the native runner's.
- Web timeline renders `executor.steered`.

claude-cli, codex, opencode and cursor have no mid-run stdin channel in headless mode and keep today's next-turn behavior.

## Verification

- Verified against pi 0.84.1 in the sandbox image before design: rpc mode accepts every flag we pass, emits the same events as json mode, `steer` lands as a user message before the next LLM call, and pi exits on stdin EOF.
- `go build`, `go vet` (plain and `-tags integration`), `go test -race ./...`, `make lint` (0 issues).
- Web build, lint (0 errors), 78 files / 1104 tests.
- New tests: pi PromptCommand/SteerCommand JSON and escaping, argv has `--mode rpc` and no prompt placeholder, parser ignores rpc-only lines, stdin-mode launch command string and real shell round-trip, fresh note delivered exactly once with one `executor.steered`, notes already in the packet are skipped, no injection after the terminal event, non-Steerer adapter never appends, web renderer.
- Live smoke on the local stack (coding mission, harness pi, route canary-executor): a note posted after `executor.spawned` reached pi as a `steer` command, pi delivered it as a user message before its next LLM call (`queue_update` then the user message in `run.ndjson`), NOTES.md came out with the steered content, and `executor.steered` was recorded once. The first smoke exposed that a pi rpc run never exits while its stdin is held open, so the run sat in generate until the idle timeout; the second commit feeds stdin through a fifo, records the feeder pid, and ends the feed once the result arrives, after which pi exits 0 and the run finishes through the regular exit path. Re-run smoke: `executor.result` with exit code 0.
- Not run: `make canary`.

Closes #358
