### PR TITLE
feat(missions): opt-in delegated read-only reviewer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,11 @@ First run: `cp deploy/env.example deploy/.env` and set
   and park the turn.
 - Non-coding units whose artifacts + verify_cmd pass harness checks skip
   LLM review entirely (`mission.review_skipped`).
+- Delegated reviewer (issue #582): a mission's opt-in `review_harness`
+  runs the prove round as a read-only CLI (`executor.InvocationSpec.
+  ReadOnly`, enforced per adapter in Go) in the sandbox/worktree with
+  the rendered review packet as prompt; native review is the floor,
+  every failure records `review.delegated_fallback` and runs it.
 - `make canary` is the regression gate for any harness change.
 
 ## Key invariants (enforce, never relax)

--- a/internal/brain/api/missions.go
+++ b/internal/brain/api/missions.go
@@ -461,6 +461,11 @@ type createMissionRequest struct {
 	// "native" forces native (stored as ""), anything else must name a
 	// registered harness. Rejected outright on kind=general.
 	Harness string `json:"harness"`
+	// ReviewHarness (issue #582) names the registered executor the
+	// prove phase's review round runs as a read-only delegated CLI: ""
+	// or "native" (stored as "") keeps the native reviewer, anything
+	// else must name a registered harness. No settings default.
+	ReviewHarness string `json:"review_harness"`
 	// Environment selects the per-language sandbox image (D-05x) a
 	// coding mission's container runs: "" auto-detects from the repo at
 	// provisioning (falling back to base), a registered key forces that
@@ -621,6 +626,9 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Harness == "native" {
 		req.Harness = ""
+	}
+	if req.ReviewHarness == "native" {
+		req.ReviewHarness = ""
 	}
 	// codingExecutorDefault/environment auto-detect are HTTP-request-time
 	// resolution seams (settings lookup, goal-keyword heuristic) with no
@@ -796,6 +804,7 @@ func (h *missionAPI) create(w http.ResponseWriter, r *http.Request) {
 		RouteModel: req.RouteModel, PlanRouteModel: req.PlanRouteModel, ReviewRouteModel: req.ReviewRouteModel,
 		MaxIterations: req.MaxIterations, BudgetAmount: req.BudgetAmount, BudgetCurrency: budgetCurrency,
 		AutoApproveTools: autoApproveTools, AutoApprovePlan: autoApprovePlan, PromptOverlay: promptOverlay, Harness: req.Harness, Environment: req.Environment,
+		ReviewHarness:            req.ReviewHarness,
 		HasPlan:                  req.HasPlan,
 		ParentMissionID:          parentMissionID,
 		Sources:                  sources,

--- a/internal/brain/api/missions_test.go
+++ b/internal/brain/api/missions_test.go
@@ -225,6 +225,47 @@ func TestMissionsCreateValidatesHarness(t *testing.T) {
 	}
 }
 
+// TestMissionsCreateValidatesReviewHarness covers issue #582's create()
+// gate: an unknown review_harness 400s before the store is reached,
+// while "native" (normalized to "") and a registered harness pass
+// validation and reach the degraded store (same generic 400 shape and
+// the same distinguishing trick as TestMissionsCreateValidatesHarness:
+// the store error surfaces as failMission's generic 400 too, so the
+// body text is what tells the two apart).
+func TestMissionsCreateValidatesReviewHarness(t *testing.T) {
+	t.Parallel()
+	a, _, _ := testAPI(t, "tok", nil)
+	pool := pgpool.New(context.Background(), "postgres://invalid/nope", discard())
+	store := missions.NewStore(pool, discard())
+	driver := missions.NewDriver(store, nil, nil, nil, nil, nil, nil, nil, discard())
+	driver.SetValidateDeps(missions.ValidateDeps{})
+
+	post := func(body string) (int, string) {
+		m := mux(a)
+		a.registerMissions(m.Handle, store, driver, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil, nil, "", nil)
+		req := httptest.NewRequest("POST", "/v1/missions", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer tok")
+		w := httptest.NewRecorder()
+		m.ServeHTTP(w, req)
+		return w.Code, w.Body.String()
+	}
+
+	code, body := post(`{"goal":"g","kind":"coding","review_harness":"not-a-real-harness"}`)
+	if code != 400 || !strings.Contains(body, "unknown review_harness") {
+		t.Fatalf("unknown review_harness = %d %q, want 400 naming review_harness", code, body)
+	}
+	for _, body := range []string{
+		`{"goal":"g","kind":"coding","review_harness":"native"}`,
+		`{"goal":"g","kind":"coding","review_harness":"pi"}`,
+		`{"goal":"g","kind":"general","review_harness":"claude-cli"}`,
+	} {
+		code, resp := post(body)
+		if code != 400 || strings.Contains(resp, "review_harness") {
+			t.Fatalf("%s = %d %q, want 400 from the degraded store, not a review_harness validation error", body, code, resp)
+		}
+	}
+}
+
 // TestMissionsCreateValidatesLight covers light's create() gate
 // (D-069): rejected outright on an explicit kind=coding, and rejected
 // when kind is omitted and classifies as coding — light never overrides

--- a/internal/brain/missions/delegated.go
+++ b/internal/brain/missions/delegated.go
@@ -147,8 +147,9 @@ type cooldownKey struct {
 	harness    string
 }
 
-// delegatedRunner wraps nativeRunner: discover/plan/prove pass through
-// untouched (delegated CLI executors only ever serve worker turns).
+// delegatedRunner wraps nativeRunner: discover/plan pass through
+// untouched; prove passes through unless the mission opted into a
+// delegated reviewer (RunReview, issue #582).
 // RunWorker dispatches on the mission's own Harness column (D-051
 // rework — no longer a per-chain-entry field): m.Harness == "" defers
 // straight to native; otherwise it resolves the worker route on the
@@ -228,8 +229,209 @@ func (r *delegatedRunner) PlanSession(ctx context.Context, m Mission, discoverNo
 	return r.native.PlanSession(ctx, m, discoverNotes)
 }
 
+// RunReview dispatches on m.ReviewHarness (issue #582): "" defers
+// straight to native.RunReview, byte for byte today's behavior.
+// Otherwise the review round runs as a read-only delegated CLI in the
+// mission's sandbox and worktree, and ANY failure on that path (unknown
+// harness, adapter refusal, unusable route, spawn death, a run without
+// a result, an unparseable verdict) records review.delegated_fallback
+// {harness, reason} and returns the native reviewer's verdict instead:
+// native review is the floor. The driver's own gates (evidence gate,
+// demotion, rounds) run on the returned verdict unchanged either way.
 func (r *delegatedRunner) RunReview(ctx context.Context, m Mission, packet ReviewPacket) (ReviewVerdict, error) {
+	if m.ReviewHarness == "" {
+		return r.native.RunReview(ctx, m, packet)
+	}
+	verdict, reason, err := r.runDelegatedReview(ctx, m, packet)
+	if reason == "" {
+		return verdict, err
+	}
+	if ctx.Err() != nil {
+		// A cancelled driver has no native round to fall back to.
+		return ReviewVerdict{}, ctx.Err()
+	}
+	payload := map[string]any{"harness": m.ReviewHarness, "reason": reason}
+	if err != nil {
+		payload["error"] = truncate(err.Error(), 2000)
+	}
+	r.log.Warn("delegated runner: review harness unusable; falling back to native", "mission_id", m.ID, "harness", m.ReviewHarness, "reason", reason, "error", err)
+	r.recordEventForce(ctx, m.ID, "review.delegated_fallback", payload)
 	return r.native.RunReview(ctx, m, packet)
+}
+
+// Fallback reasons review.delegated_fallback records (issue #582).
+const (
+	fallbackUnknownHarness    = "unknown_harness"
+	fallbackRefused           = "refused"
+	fallbackResolveFailed     = "resolve_failed"
+	fallbackNoUsableEntry     = "no_usable_entry"
+	fallbackCooldown          = "cooldown"
+	fallbackAuthFailed        = "auth_failed"
+	fallbackSpawnFailed       = "spawn_failed"
+	fallbackNoResult          = "no_result"
+	fallbackUnparseableResult = "unparseable_verdict"
+	fallbackPollFailed        = "poll_failed"
+)
+
+// delegatedReviewSystemAppend closes the reviewer's system prompt for a
+// CLI run (issue #582), in place of reviewSystemToolCall: the CLI has no
+// review_verdict tool, its structured result is the verdict channel,
+// and the read-only tool surface the adapter enforces is spelled out so
+// the model does not waste turns trying to edit.
+const delegatedReviewSystemAppend = " You are running as a delegated read-only CLI reviewer, not through a review_verdict tool. You may read files in the working directory to spot-check; you cannot modify files or run commands, so never try. End your turn by producing the required structured output: decision approve or rework, findings (each with title, file, detail, severity and quoted evidence) and the resolved ids of prior findings the work closed."
+
+// runDelegatedReview resolves the review harness, route and entry, runs
+// the review packet through the CLI read-only, and parses its result as
+// the review verdict (issue #582). A non-empty reason means the caller
+// must fall back to native; err carries the detail for the event.
+func (r *delegatedRunner) runDelegatedReview(ctx context.Context, m Mission, packet ReviewPacket) (ReviewVerdict, string, error) {
+	adapter, ok := executor.Lookup(m.ReviewHarness)
+	if !ok {
+		return ReviewVerdict{}, fallbackUnknownHarness, nil
+	}
+	route, err := r.resolveRouteFor(ctx, m, reviewRoute(m), m.ReviewHarness)
+	if err != nil {
+		return ReviewVerdict{}, fallbackResolveFailed, err
+	}
+	if route == nil {
+		return ReviewVerdict{}, fallbackResolveFailed, errors.New("resolved route was nil without an error")
+	}
+	entry, reason := r.pickEntry(route.Entries, m.ReviewHarness, reviewModel(m))
+	if reason != "" {
+		return ReviewVerdict{}, reason, nil
+	}
+	workRoot := m.WorkRoot()
+	authMode, apiKey, err := r.resolveCredential(ctx, entry.CredentialRef, adapter.Capabilities())
+	if err != nil {
+		r.coolDown(m.ReviewHarness, entry)
+		r.recordAuthFailed(ctx, m.ID, string(PhaseProve), m.ReviewHarness)
+		return ReviewVerdict{}, fallbackAuthFailed, err
+	}
+	run := cliRun{
+		phase: string(PhaseProve), harness: m.ReviewHarness, entry: entry, adapter: adapter,
+		authMode: authMode, route: reviewRoute(m), agent: reviewerAgent,
+	}
+	runID, err := newRunID()
+	if err != nil {
+		return ReviewVerdict{}, fallbackSpawnFailed, err
+	}
+	rdir := runDir(m.Workspace, "review-"+runID)
+	spec := executor.InvocationSpec{
+		MissionID: m.ID, Workdir: workRoot,
+		PromptPath:   filepath.Join(rdir, "prompt.md"),
+		SystemAppend: reviewSystemPrompt + delegatedReviewSystemAppend,
+		Model:        entry.Model, AuthMode: authMode, APIKey: apiKey, BaseURL: entry.BaseURL,
+		ResultSchema: reviewVerdictSchema, RunBudget: r.effectiveRunBudget(ctx), Wire: entry.Wire,
+		// ResumeSessionID stays empty: every review round is a cold
+		// session (D-092). ReadOnly is the enforced safety knob.
+		ReadOnly: true,
+	}
+	if err := r.launchRun(ctx, m, run, workRoot, rdir, runID, spec, renderReviewContent(packet), resumeDecision{reason: resumeReasonNoPriorRun}); err != nil {
+		if errors.Is(err, executor.ErrReadOnlyUnsupported) {
+			return ReviewVerdict{}, fallbackRefused, err
+		}
+		return ReviewVerdict{}, fallbackSpawnFailed, err
+	}
+
+	start := time.Now()
+	st, end, exitCode, err := r.pollRun(ctx, m, run, workRoot, rdir, runID, 0)
+	if err != nil {
+		return ReviewVerdict{}, fallbackPollFailed, err
+	}
+	switch end {
+	case runEndResult:
+		return r.finishReview(ctx, m, run, st, start, exitCode)
+	case runEndIdle:
+		return ReviewVerdict{}, fallbackNoResult, errors.New("the executor produced no output for the idle timeout and was killed")
+	default:
+		reason, err := r.finishNoResult(ctx, m, run, workRoot, rdir, st, start, exitCode)
+		if err != nil {
+			return ReviewVerdict{}, fallbackAuthFailed, err
+		}
+		return ReviewVerdict{}, fallbackNoResult, errors.New(reason)
+	}
+}
+
+// finishReview maps a review run's result event onto a ReviewVerdict
+// (issue #582): the structured result must decode with an explicit
+// approve/rework decision, else the round falls back to native rather
+// than letting a garbage result read as "rework with no findings" (which
+// the driver's gate would count as approval). Result and ledger rows are
+// recorded either way, same as a worker run.
+func (r *delegatedRunner) finishReview(ctx context.Context, m Mission, run cliRun, st *pollState, start time.Time, exitCode int) (ReviewVerdict, string, error) {
+	verdict, decision, perr := parseDelegatedReviewVerdict(st.resultEvent.Result)
+	parseKind := "schema"
+	if perr != nil {
+		parseKind = "none"
+	}
+	authErr := r.finishCommon(ctx, m, run, st, start, exitCode, parseKind, decision)
+	if authErr != nil {
+		return ReviewVerdict{}, fallbackAuthFailed, authErr
+	}
+	if perr != nil {
+		return ReviewVerdict{}, fallbackUnparseableResult, perr
+	}
+	verdict.Provider = run.entry.ProviderName
+	verdict.Model = run.entry.Model
+	if st.reportedModel != "" {
+		verdict.Model = st.reportedModel
+	}
+	return verdict, "", nil
+}
+
+// parseDelegatedReviewVerdict decodes a CLI result payload with
+// parseReviewVerdict and additionally requires the decision to be
+// literally approve or rework. Returns the upper-cased decision for the
+// executor.result event ("UNKNOWN" when it fails).
+func parseDelegatedReviewVerdict(raw json.RawMessage) (ReviewVerdict, string, error) {
+	if len(raw) == 0 {
+		return ReviewVerdict{}, "UNKNOWN", errors.New("executor result carried no structured verdict")
+	}
+	var probe struct {
+		Decision string `json:"decision"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return ReviewVerdict{}, "UNKNOWN", fmt.Errorf("decode review verdict: %w", err)
+	}
+	if probe.Decision != "approve" && probe.Decision != "rework" {
+		return ReviewVerdict{}, "UNKNOWN", fmt.Errorf("review verdict decision %q is neither approve nor rework", probe.Decision)
+	}
+	verdict, err := parseReviewVerdict(raw)
+	if err != nil {
+		return ReviewVerdict{}, "UNKNOWN", fmt.Errorf("decode review verdict: %w", err)
+	}
+	return verdict, strings.ToUpper(probe.Decision), nil
+}
+
+// pickEntry picks the chain entry a review run uses (issue #582): the
+// route_model pin when it names a usable, non-cooled entry, else the
+// first usable non-cooled one. A non-empty reason names why none fit.
+func (r *delegatedRunner) pickEntry(entries []gwclient.ResolvedRouteEntry, harness, pin string) (gwclient.ResolvedRouteEntry, string) {
+	if pin != "" {
+		for _, entry := range entries {
+			if pin != entry.ProviderName+"/"+entry.Model || !entry.Usable {
+				continue
+			}
+			if _, cooled := r.cooledUntil(harness, entry); !cooled {
+				return entry, ""
+			}
+		}
+	}
+	cooled := false
+	for _, entry := range entries {
+		if !entry.Usable {
+			continue
+		}
+		if _, c := r.cooledUntil(harness, entry); c {
+			cooled = true
+			continue
+		}
+		return entry, ""
+	}
+	if cooled {
+		return gwclient.ResolvedRouteEntry{}, fallbackCooldown
+	}
+	return gwclient.ResolvedRouteEntry{}, fallbackNoUsableEntry
 }
 
 // RunWorker dispatches on m.Harness (D-051 rework): "" defers straight
@@ -244,7 +446,7 @@ func (r *delegatedRunner) RunReview(ctx context.Context, m Mission, packet Revie
 // shows the requested harness was never actually used. A route resolve
 // that fails because the gateway itself is unavailable (D-101, issue
 // #511) is different: that is transient infra, not "no delegated
-// route", so resolveRouteWithRetry retries it with bounded backoff and,
+// route", so resolveRouteFor retries it with bounded backoff and,
 // if still failing, this returns ErrGatewayUnavailable instead of
 // falling back: the driver pauses the mission as infra rather than
 // running a native worker turn behind a delegated run that may still be
@@ -269,7 +471,7 @@ func (r *delegatedRunner) RunWorker(ctx context.Context, m Mission, packet WorkP
 		return r.native.RunWorker(ctx, m, packet)
 	}
 
-	route, err := r.resolveRouteWithRetry(ctx, m, workerRoute(m))
+	route, err := r.resolveRouteFor(ctx, m, workerRoute(m), m.Harness)
 	if err != nil {
 		if errors.Is(err, gwclient.ErrGatewayUnavailable) {
 			r.log.Error("delegated runner: gateway unavailable after retries; pausing as infra", "mission_id", m.ID, "error", err)
@@ -344,7 +546,7 @@ func (r *delegatedRunner) RunWorker(ctx context.Context, m Mission, packet WorkP
 	return r.native.RunWorker(ctx, m, packet)
 }
 
-// resolveRouteWithRetry resolves route on the harness's executor axis,
+// resolveRouteFor resolves route on harness's executor axis,
 // retrying with bounded exponential backoff (routeResolveRetries
 // attempts, starting at routeResolveBackoffMin) ONLY when the failure is
 // gwclient.ErrGatewayUnavailable, the gateway unreachable or still
@@ -355,11 +557,11 @@ func (r *delegatedRunner) RunWorker(ctx context.Context, m Mission, packet WorkP
 // retrying them would just delay the existing native fallback. Bounded
 // and ctx-aware: a cancelled ctx or an exhausted retry budget both
 // return the last error seen.
-func (r *delegatedRunner) resolveRouteWithRetry(ctx context.Context, m Mission, route string) (*gwclient.ResolvedRoute, error) {
+func (r *delegatedRunner) resolveRouteFor(ctx context.Context, m Mission, route, harness string) (*gwclient.ResolvedRoute, error) {
 	backoff := r.routeResolveBackoff
 	var lastErr error
 	for attempt := 1; attempt <= routeResolveRetries; attempt++ {
-		resolved, err := r.resolveRoute(ctx, route, m.Harness)
+		resolved, err := r.resolveRoute(ctx, route, harness)
 		if err == nil {
 			return resolved, nil
 		}
@@ -513,6 +715,30 @@ var (
 	delegatedDenyTools  = []string{"Bash(git push:*)", "WebFetch", "WebSearch"}
 )
 
+// cliRun is the per-run context the shared D-052 protocol threads
+// through launch, poll, finish and bookkeeping (issue #582): a worker
+// run (phase generate) and a review run (phase prove) differ only in
+// these fields. Every executor.* event a run records carries phase.
+type cliRun struct {
+	phase    string
+	harness  string
+	entry    gwclient.ResolvedRouteEntry
+	adapter  executor.Adapter
+	authMode executor.AuthMode
+	// route/agent label the run's ledger row.
+	route, agent string
+	// steer allows mid-run operator note delivery (worker runs only).
+	steer bool
+}
+
+// workerRun builds the cliRun for a worker turn.
+func workerRun(m Mission, entry gwclient.ResolvedRouteEntry, adapter executor.Adapter, authMode executor.AuthMode) cliRun {
+	return cliRun{
+		phase: string(PhaseGenerate), harness: m.Harness, entry: entry, adapter: adapter,
+		authMode: authMode, route: workerRoute(m), agent: "mission-worker", steer: true,
+	}
+}
+
 // runDelegated executes the D-052 protocol for one chain entry: resolve
 // credentials, build the invocation, launch detached, poll to
 // completion (or resume an in-flight run from a prior process
@@ -527,9 +753,10 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 	authMode, apiKey, err := r.resolveCredential(ctx, entry.CredentialRef, adapter.Capabilities())
 	if err != nil {
 		r.coolDown(m.Harness, entry)
-		r.recordAuthFailed(ctx, m.ID, m.Harness)
+		r.recordAuthFailed(ctx, m.ID, string(PhaseGenerate), m.Harness)
 		return WorkerVerdict{}, "", err
 	}
+	run := workerRun(m, entry, adapter, authMode)
 
 	runID, err := newRunID()
 	if err != nil {
@@ -542,62 +769,74 @@ func (r *delegatedRunner) runDelegated(ctx context.Context, m Mission, packet Wo
 
 	decision := r.planSessionResume(ctx, m, workRoot, adapter)
 
-	runBudget := r.effectiveRunBudget(ctx)
 	spec := executor.InvocationSpec{
 		MissionID: m.ID, Workdir: workRoot,
 		PromptPath:   filepath.Join(rdir, "prompt.md"),
 		SystemAppend: system,
 		Model:        entry.Model, AuthMode: authMode, APIKey: apiKey, BaseURL: entry.BaseURL,
 		AllowTools: delegatedAllowTools, DenyTools: delegatedDenyTools,
-		ResultSchema: resultSchemaJSON, RunBudget: runBudget, Wire: entry.Wire,
+		ResultSchema: resultSchemaJSON, RunBudget: r.effectiveRunBudget(ctx), Wire: entry.Wire,
 		ResumeSessionID: decision.sessionID,
 	}
-	inv, err := adapter.BuildInvocation(spec)
+	if err := r.launchRun(ctx, m, run, workRoot, rdir, runID, spec, user, decision); err != nil {
+		return WorkerVerdict{}, "", err
+	}
+
+	return r.pollToVerdict(ctx, m, run, workRoot, rdir, runID, 0)
+}
+
+// launchRun builds the invocation, writes prompt.md (plus a Steerer's
+// prompt.jsonl/steer.jsonl), records executor.spawned and starts the
+// CLI detached. Shared by worker and review runs (issue #582); every
+// failure cools the entry down before returning.
+func (r *delegatedRunner) launchRun(ctx context.Context, m Mission, run cliRun, workRoot, rdir, runID string, spec executor.InvocationSpec, user string, decision resumeDecision) error {
+	inv, err := run.adapter.BuildInvocation(spec)
 	if err != nil {
-		r.coolDown(m.Harness, entry)
-		return WorkerVerdict{}, "", fmt.Errorf("delegated runner: build invocation: %w", err)
+		r.coolDown(run.harness, run.entry)
+		return fmt.Errorf("delegated runner: build invocation: %w", err)
 	}
 
 	// 0750/0600 suffice: brain and the sandbox CLI share uid 65534 on
 	// the workspace volume, so owner permissions cover both readers.
 	if err := os.MkdirAll(rdir, 0o750); err != nil {
-		r.coolDown(m.Harness, entry)
-		return WorkerVerdict{}, "", fmt.Errorf("delegated runner: create run dir: %w", err)
+		r.coolDown(run.harness, run.entry)
+		return fmt.Errorf("delegated runner: create run dir: %w", err)
 	}
 	if err := os.WriteFile(filepath.Join(rdir, "prompt.md"), []byte(user), 0o600); err != nil {
-		r.coolDown(m.Harness, entry)
-		return WorkerVerdict{}, "", fmt.Errorf("delegated runner: write prompt: %w", err)
+		r.coolDown(run.harness, run.entry)
+		return fmt.Errorf("delegated runner: write prompt: %w", err)
 	}
 	if err := writeInvocationFiles(rdir, inv.Files); err != nil {
-		r.coolDown(m.Harness, entry)
-		return WorkerVerdict{}, "", fmt.Errorf("delegated runner: write invocation files: %w", err)
+		r.coolDown(run.harness, run.entry)
+		return fmt.Errorf("delegated runner: write invocation files: %w", err)
 	}
 	// issue #358: a Steerer adapter (pi) takes its prompt and any
 	// mid-run steering on stdin rather than argv - prompt.jsonl seeds
-	// the run's stdin, steer.jsonl starts empty and pollToVerdict
-	// appends a line to it for every fresh operator note while the run
-	// is alive (see buildLaunchCmd's stdin mode).
-	if steerer, ok := adapter.(executor.Steerer); ok {
+	// the run's stdin, steer.jsonl starts empty and pollRun appends a
+	// line to it for every fresh operator note while the run is alive
+	// (see buildLaunchCmd's stdin mode). A review run uses the same
+	// stdin shape (pi's rpc mode takes the prompt there) but never
+	// appends steering.
+	steerer, isSteerer := run.adapter.(executor.Steerer)
+	if isSteerer {
 		if err := os.WriteFile(filepath.Join(rdir, "prompt.jsonl"), []byte(steerer.PromptCommand(user)+"\n"), 0o600); err != nil {
-			r.coolDown(m.Harness, entry)
-			return WorkerVerdict{}, "", fmt.Errorf("delegated runner: write prompt.jsonl: %w", err)
+			r.coolDown(run.harness, run.entry)
+			return fmt.Errorf("delegated runner: write prompt.jsonl: %w", err)
 		}
 		if err := os.WriteFile(filepath.Join(rdir, "steer.jsonl"), nil, 0o600); err != nil {
-			r.coolDown(m.Harness, entry)
-			return WorkerVerdict{}, "", fmt.Errorf("delegated runner: create steer.jsonl: %w", err)
+			r.coolDown(run.harness, run.entry)
+			return fmt.Errorf("delegated runner: create steer.jsonl: %w", err)
 		}
 	}
 
-	r.recordSpawned(ctx, m.ID, m.Harness, entry, runID, rdir, authMode, decision)
+	r.recordSpawned(ctx, m.ID, run, runID, rdir, decision)
 
-	_, isSteerer := adapter.(executor.Steerer)
-	if err := r.launch(ctx, m.ID, m.Environment, workRoot, rdir, inv, runBudget, isSteerer); err != nil {
-		r.coolDown(m.Harness, entry)
-		r.recordDied(ctx, m.ID, "spawn_failed", nil, err.Error())
-		return WorkerVerdict{}, "", fmt.Errorf("delegated runner: launch: %w", err)
+	if err := r.launch(ctx, m.ID, m.Environment, workRoot, rdir, inv, spec.RunBudget, isSteerer); err != nil {
+		r.coolDown(run.harness, run.entry)
+		r.recordDied(ctx, m.ID, run.phase, "spawn_failed", nil, err.Error())
+		return fmt.Errorf("delegated runner: launch: %w", err)
 	}
-
-	return r.pollToVerdict(ctx, m, workRoot, rdir, runID, entry, adapter, authMode, 0)
+	return nil
 }
 
 // attemptResume checks for an unfinished run recorded by a prior
@@ -625,11 +864,11 @@ func (r *delegatedRunner) attemptResume(ctx context.Context, m Mission, workRoot
 	probeCmd := fmt.Sprintf("cd %s && { [ -f exit_code ] || [ -f pid ]; }", shQuote(state.RunDir))
 	code, perr := r.sandboxExec(ctx, m.ID, m.Environment, workRoot, probeCmd, nil, launchTimeout, &probe)
 	if perr != nil || code != 0 {
-		r.recordDied(ctx, m.ID, "lost_run", nil, "run directory or pid missing after restart")
+		r.recordDied(ctx, m.ID, string(PhaseGenerate), "lost_run", nil, "run directory or pid missing after restart")
 		return true, forcedRetryVerdict("the executor's run was lost across a restart"), "", nil
 	}
 
-	v, t, rerr := r.pollToVerdict(ctx, m, workRoot, state.RunDir, state.RunID, entry, adapter, state.AuthMode, state.ByteOffset)
+	v, t, rerr := r.pollToVerdict(ctx, m, workerRun(m, entry, adapter, state.AuthMode), workRoot, state.RunDir, state.RunID, state.ByteOffset)
 	return true, v, t, rerr
 }
 
@@ -839,24 +1078,59 @@ type pollState struct {
 	sessionRecorded bool
 }
 
-// pollToVerdict polls rdir until the run terminates (exit_code present
-// and run.ndjson fully drained), the idle watchdog fires, ctx is
-// cancelled, or repeated infra errors declare the sandbox unreachable.
-// startOffset seeds the byte offset on a resumed run; 0 for a fresh
-// spawn.
-func (r *delegatedRunner) pollToVerdict(ctx context.Context, m Mission, workRoot, rdir, runID string, entry gwclient.ResolvedRouteEntry, adapter executor.Adapter, authMode executor.AuthMode, startOffset int64) (WorkerVerdict, string, error) {
-	parser := adapter.NewParser()
-	st := &pollState{offset: startOffset, lastByteMove: time.Now(), lastProgress: time.Now()}
+// pollToVerdict runs pollRun for a worker turn and maps how the run
+// ended onto a WorkerVerdict: the result ladder (finish), a forced
+// retry for an idle kill, or finishNoResult's transport-death handling.
+func (r *delegatedRunner) pollToVerdict(ctx context.Context, m Mission, run cliRun, workRoot, rdir, runID string, startOffset int64) (WorkerVerdict, string, error) {
 	start := time.Now()
+	st, end, exitCode, err := r.pollRun(ctx, m, run, workRoot, rdir, runID, startOffset)
+	if err != nil {
+		return WorkerVerdict{}, st.textBuf.String(), err
+	}
+	switch end {
+	case runEndResult:
+		return r.finish(ctx, m, run, st, start, exitCode)
+	case runEndIdle:
+		return forcedRetryVerdict("the executor produced no output for the idle timeout and was killed"), st.textBuf.String(), nil
+	default:
+		reason, err := r.finishNoResult(ctx, m, run, workRoot, rdir, st, start, exitCode)
+		if err != nil {
+			return WorkerVerdict{}, st.textBuf.String(), err
+		}
+		return forcedRetryVerdict(reason), st.textBuf.String(), nil
+	}
+}
+
+// runEnd names how pollRun saw a run end.
+type runEnd int
+
+const (
+	runEndResult   runEnd = iota // result event seen and the process exited
+	runEndNoResult               // process exited or was lost with no result event
+	runEndIdle                   // idle watchdog killed it
+)
+
+// pollRun polls rdir until the run terminates (exit_code present and
+// run.ndjson fully drained), the idle watchdog fires, ctx is cancelled,
+// or repeated infra errors declare the sandbox unreachable. startOffset
+// seeds the byte offset on a resumed run; 0 for a fresh spawn. The
+// returned pollState is never nil, so callers can read the accumulated
+// text even on error. exitCode is -1 when the process was lost.
+func (r *delegatedRunner) pollRun(ctx context.Context, m Mission, run cliRun, workRoot, rdir, runID string, startOffset int64) (*pollState, runEnd, int, error) {
+	parser := run.adapter.NewParser()
+	st := &pollState{offset: startOffset, lastByteMove: time.Now(), lastProgress: time.Now()}
 
 	// Mid-run steering (issue #358) applies only to a Steerer adapter
-	// (pi's rpc mode) with a progress reader wired; steerer stays nil
-	// otherwise and the injection below is skipped. The watermark starts
-	// past the operator notes already rendered into this turn's packet
-	// (same seed as nativeRunner.steeringFor), so a note from an earlier
-	// turn is never redelivered as fresh steering.
+	// (pi's rpc mode) on a worker run with a progress reader wired;
+	// steerer stays nil otherwise and the injection below is skipped.
+	// The stdin feed itself (stdinFeed) exists for every Steerer run,
+	// review runs included, and is closed once the result arrives. The
+	// watermark starts past the operator notes already rendered into
+	// this turn's packet (same seed as nativeRunner.steeringFor), so a
+	// note from an earlier turn is never redelivered as fresh steering.
+	_, stdinFeed := run.adapter.(executor.Steerer)
 	var steerer executor.Steerer
-	if s, ok := adapter.(executor.Steerer); ok && r.progressReader != nil {
+	if s, ok := run.adapter.(executor.Steerer); ok && run.steer && r.progressReader != nil {
 		steerer = s
 	}
 	steerWatermark := countOperatorNotes(m.Progress)
@@ -868,9 +1142,9 @@ func (r *delegatedRunner) pollToVerdict(ctx context.Context, m Mission, workRoot
 		select {
 		case <-ctx.Done():
 			r.killRun(context.WithoutCancel(ctx), m.ID, m.Environment, workRoot, rdir)
-			r.recordDied(context.WithoutCancel(ctx), m.ID, "ctx_cancelled", nil, ctx.Err().Error())
-			r.coolDown(m.Harness, entry)
-			return WorkerVerdict{}, st.textBuf.String(), ctx.Err()
+			r.recordDied(context.WithoutCancel(ctx), m.ID, run.phase, "ctx_cancelled", nil, ctx.Err().Error())
+			r.coolDown(run.harness, run.entry)
+			return st, runEndNoResult, -1, ctx.Err()
 		case <-ticker.C:
 		}
 
@@ -878,7 +1152,7 @@ func (r *delegatedRunner) pollToVerdict(ctx context.Context, m Mission, workRoot
 		if err != nil {
 			st.infraRetries++
 			if st.infraRetries >= pollInfraRetries {
-				return WorkerVerdict{}, st.textBuf.String(), fmt.Errorf("delegated runner: sandbox unreachable after %d poll retries: %w", pollInfraRetries, err)
+				return st, runEndNoResult, -1, fmt.Errorf("delegated runner: sandbox unreachable after %d poll retries: %w", pollInfraRetries, err)
 			}
 			time.Sleep(pollInfraBackoff)
 			continue
@@ -902,37 +1176,37 @@ func (r *delegatedRunner) pollToVerdict(ctx context.Context, m Mission, workRoot
 		if len(chunk) > 0 {
 			st.offset += int64(len(chunk))
 			st.lastByteMove = time.Now()
-			r.feedLines(ctx, parser, chunk, st, m.ID, runID)
-			r.recordProgressThrottled(ctx, m.ID, runID, st)
+			r.feedLines(ctx, parser, chunk, st, m.ID, run.phase, runID)
+			r.recordProgressThrottled(ctx, m.ID, run.phase, runID, st)
 		}
 
 		// A Steerer run never exits on its own: its stdin feed holds the
 		// CLI open (issue #358). Once the result has arrived, end the feed
 		// so the CLI sees EOF, exits, and the next poll finishes normally.
-		if steerer != nil && st.sawResult && alive && !hasExit && !st.stdinClosed {
+		if stdinFeed && st.sawResult && alive && !hasExit && !st.stdinClosed {
 			r.closeStdin(ctx, m, workRoot, rdir)
 			st.stdinClosed = true
 		}
 
 		if st.sawResult && hasExit {
-			return r.finish(ctx, m, entry, adapter, authMode, st, start, exitCode)
+			return st, runEndResult, exitCode, nil
 		}
 		if hasExit && !alive {
 			// Process exited; run.ndjson fully drained (no new bytes this
-			// poll) but no result event ever arrived — transport death.
-			return r.finishNoResult(ctx, m, entry, workRoot, rdir, authMode, st, start, exitCode)
+			// poll) but no result event ever arrived: transport death.
+			return st, runEndNoResult, exitCode, nil
 		}
 		if !alive && !hasExit {
 			// pid gone, no exit_code file: process died without even
-			// writing its own exit status — still transport death.
-			return r.finishNoResult(ctx, m, entry, workRoot, rdir, authMode, st, start, -1)
+			// writing its own exit status, still transport death.
+			return st, runEndNoResult, -1, nil
 		}
 
 		if time.Since(st.lastByteMove) > r.idleTimeout {
 			r.killRun(ctx, m.ID, m.Environment, workRoot, rdir)
-			r.recordEvent(ctx, m.ID, st, "executor.idle_killed", map[string]any{"idle_s": int(r.idleTimeout.Seconds())})
-			r.coolDown(m.Harness, entry)
-			return forcedRetryVerdict("the executor produced no output for the idle timeout and was killed"), st.textBuf.String(), nil
+			r.recordEvent(ctx, m.ID, st, "executor.idle_killed", map[string]any{"idle_s": int(r.idleTimeout.Seconds()), "phase": run.phase})
+			r.coolDown(run.harness, run.entry)
+			return st, runEndIdle, -1, nil
 		}
 	}
 }
@@ -978,7 +1252,7 @@ func (r *delegatedRunner) injectSteering(ctx context.Context, m Mission, workRoo
 			return delivered
 		}
 		delivered++
-		r.recordEventForce(ctx, m.ID, "executor.steered", map[string]any{"note": note, "harness": m.Harness})
+		r.recordEventForce(ctx, m.ID, "executor.steered", map[string]any{"note": note, "harness": m.Harness, "phase": string(PhaseGenerate)})
 	}
 	return newWatermark
 }
@@ -1101,7 +1375,7 @@ func parseWorktreeLine(fields string) (*WorktreeSummary, bool) {
 // Incomplete trailing bytes (no terminating newline yet) are held in
 // st.carry until the next chunk completes them — mid-line chunk splits
 // must never be fed to the parser as a partial line.
-func (r *delegatedRunner) feedLines(ctx context.Context, parser executor.StreamParser, chunk []byte, st *pollState, missionID, runID string) {
+func (r *delegatedRunner) feedLines(ctx context.Context, parser executor.StreamParser, chunk []byte, st *pollState, missionID, phase, runID string) {
 	data := append(st.carry, chunk...)
 	st.carry = nil
 	for {
@@ -1123,7 +1397,7 @@ func (r *delegatedRunner) feedLines(ctx context.Context, parser executor.StreamP
 			}
 			if ev.SessionID != "" && st.sessionID == "" {
 				st.sessionID = ev.SessionID
-				r.recordSessionSeen(ctx, missionID, runID, st)
+				r.recordSessionSeen(ctx, missionID, phase, runID, st)
 			}
 		case executor.KindText:
 			st.textBuf.WriteString(ev.Text)
@@ -1157,8 +1431,8 @@ func (r *delegatedRunner) killRun(ctx context.Context, missionID, environment, w
 // whether the run also flagged an error); failing that, a text-form
 // sentinel in the accumulated text; failing that, a forced retry noting
 // the executor never reported a status.
-func (r *delegatedRunner) finish(ctx context.Context, m Mission, entry gwclient.ResolvedRouteEntry, adapter executor.Adapter, authMode executor.AuthMode, st *pollState, start time.Time, exitCode int) (WorkerVerdict, string, error) {
-	res, ok := adapter.ParseResult(st.resultEvent)
+func (r *delegatedRunner) finish(ctx context.Context, m Mission, run cliRun, st *pollState, start time.Time, exitCode int) (WorkerVerdict, string, error) {
+	res, ok := run.adapter.ParseResult(st.resultEvent)
 	parseKind := "schema"
 	var verdict WorkerVerdict
 	switch {
@@ -1182,12 +1456,24 @@ func (r *delegatedRunner) finish(ctx context.Context, m Mission, entry gwclient.
 	// sentinel), so the entry that ran it is who served the turn.
 	// reportedModel (the harness's own claimed model) takes precedence
 	// over entry.Model, same precedence recordLedger already uses.
-	verdict.Provider = entry.ProviderName
-	verdict.Model = entry.Model
+	verdict.Provider = run.entry.ProviderName
+	verdict.Model = run.entry.Model
 	if st.reportedModel != "" {
 		verdict.Model = st.reportedModel
 	}
 
+	if err := r.finishCommon(ctx, m, run, st, start, exitCode, parseKind, strings.ToUpper(verdict.Outcome)); err != nil {
+		return WorkerVerdict{}, st.textBuf.String(), err
+	}
+	return verdict, st.textBuf.String(), nil
+}
+
+// finishCommon is the bookkeeping every finished run shares (issue
+// #582): the executor.result event, the ledger row, and the auth-failure
+// check, which cools the entry down and returns ErrExecutorAuth since
+// retrying the same entry is futile. status is the parsed verdict
+// (DONE/RETRY/BLOCKED for a worker, APPROVE/REWORK for a review).
+func (r *delegatedRunner) finishCommon(ctx context.Context, m Mission, run cliRun, st *pollState, start time.Time, exitCode int, parseKind, status string) error {
 	authFailed := st.resultEvent.Err != "" && isAuthFailure(st.resultEvent.Err)
 	errorCode := ""
 	if authFailed {
@@ -1204,24 +1490,25 @@ func (r *delegatedRunner) finish(ctx context.Context, m Mission, entry gwclient.
 	// an anthropic-driver row. Every other path either books a
 	// different, provider-priced figure or none at all, so the UI must
 	// not present the raw CLI number as billed.
-	cliCostTrusted := authMode == executor.AuthAPIKey && entry.Driver == "anthropic" && adapter.Capabilities().ReportsCost
-	r.recordResult(ctx, m.ID, st, start, exitCode, st.resultEvent, parseKind, strings.ToUpper(verdict.Outcome), cliCostTrusted)
-	r.recordLedger(ctx, m, entry, authMode, st.resultEvent.Usage, start, exitCode == 0 && st.resultEvent.Err == "", errorCode, st.reportedModel)
+	cliCostTrusted := run.authMode == executor.AuthAPIKey && run.entry.Driver == "anthropic" && run.adapter.Capabilities().ReportsCost
+	r.recordResult(ctx, m.ID, run.phase, st, start, exitCode, st.resultEvent, parseKind, status, cliCostTrusted)
+	r.recordLedger(ctx, m, run, st.resultEvent.Usage, start, exitCode == 0 && st.resultEvent.Err == "", errorCode, st.reportedModel)
 	if authFailed {
-		r.coolDown(m.Harness, entry)
-		r.recordAuthFailed(ctx, m.ID, m.Harness)
-		return WorkerVerdict{}, st.textBuf.String(), fmt.Errorf("%w: %s", ErrExecutorAuth, st.resultEvent.Err)
+		r.coolDown(run.harness, run.entry)
+		r.recordAuthFailed(ctx, m.ID, run.phase, run.harness)
+		return fmt.Errorf("%w: %s", ErrExecutorAuth, st.resultEvent.Err)
 	}
-	return verdict, st.textBuf.String(), nil
+	return nil
 }
 
 // finishNoResult handles transport death: the process ended (or was
 // lost) with no result event ever parsed. Per the result ladder this is
-// a forced RETRY, EXCEPT auth failure and sandbox-unreachable cases,
-// which return an error instead since retrying the same entry is
-// futile. An extra exec reads stderr.log's tail only on this path (exit
-// != 0, no result) to check for auth-failure signatures.
-func (r *delegatedRunner) finishNoResult(ctx context.Context, m Mission, entry gwclient.ResolvedRouteEntry, workRoot, rdir string, authMode executor.AuthMode, st *pollState, start time.Time, exitCode int) (WorkerVerdict, string, error) {
+// a forced RETRY (the returned reason is its note), EXCEPT auth failure
+// and sandbox-unreachable cases, which return an error instead since
+// retrying the same entry is futile. An extra exec reads stderr.log's
+// tail only on this path (exit != 0, no result) to check for
+// auth-failure signatures.
+func (r *delegatedRunner) finishNoResult(ctx context.Context, m Mission, run cliRun, workRoot, rdir string, st *pollState, start time.Time, exitCode int) (string, error) {
 	stderrTail := r.readStderrTail(ctx, m.ID, m.Environment, workRoot, rdir)
 	reason := fmt.Sprintf("executor exited (code %d) without a result event", exitCode)
 	if exitCode == -1 {
@@ -1233,24 +1520,24 @@ func (r *delegatedRunner) finishNoResult(ctx context.Context, m Mission, entry g
 	// own reason so the UI and canary can tell it from a crash.
 	if exitCode == runBudgetExitCode {
 		reason = "executor exceeded the run budget and was killed"
-		r.recordDied(ctx, m.ID, "run_budget", &exitCode, stderrTail)
-		r.recordLedger(ctx, m, entry, authMode, nil, start, false, "", st.reportedModel)
-		r.coolDown(m.Harness, entry)
-		return forcedRetryVerdict(reason), st.textBuf.String(), nil
+		r.recordDied(ctx, m.ID, run.phase, "run_budget", &exitCode, stderrTail)
+		r.recordLedger(ctx, m, run, nil, start, false, "", st.reportedModel)
+		r.coolDown(run.harness, run.entry)
+		return reason, nil
 	}
 
 	if exitCode != 0 && isAuthFailure(stderrTail) {
-		r.coolDown(m.Harness, entry)
-		r.recordDied(ctx, m.ID, "auth_failed", &exitCode, stderrTail)
-		r.recordLedger(ctx, m, entry, authMode, nil, start, false, errorCodeAuthFailed, st.reportedModel)
-		r.recordAuthFailed(ctx, m.ID, m.Harness)
-		return WorkerVerdict{}, st.textBuf.String(), fmt.Errorf("%w: %s", ErrExecutorAuth, stderrTail)
+		r.coolDown(run.harness, run.entry)
+		r.recordDied(ctx, m.ID, run.phase, "auth_failed", &exitCode, stderrTail)
+		r.recordLedger(ctx, m, run, nil, start, false, errorCodeAuthFailed, st.reportedModel)
+		r.recordAuthFailed(ctx, m.ID, run.phase, run.harness)
+		return "", fmt.Errorf("%w: %s", ErrExecutorAuth, stderrTail)
 	}
 
-	r.recordDied(ctx, m.ID, "transport_death", &exitCode, stderrTail)
-	r.recordLedger(ctx, m, entry, authMode, nil, start, false, "", st.reportedModel)
-	r.coolDown(m.Harness, entry)
-	return forcedRetryVerdict(reason), st.textBuf.String(), nil
+	r.recordDied(ctx, m.ID, run.phase, "transport_death", &exitCode, stderrTail)
+	r.recordLedger(ctx, m, run, nil, start, false, "", st.reportedModel)
+	r.coolDown(run.harness, run.entry)
+	return reason, nil
 }
 
 // readStderrTail fetches the last ~2KB of stderr.log — a single extra
@@ -1292,14 +1579,14 @@ func isAuthFailure(text string) bool {
 // carries the prompt substitution placeholder only ("@PROMPT@"), never
 // the rendered prompt text, and env values are never recorded, only
 // names.
-func (r *delegatedRunner) recordSpawned(ctx context.Context, missionID, harness string, entry gwclient.ResolvedRouteEntry, runID, rdir string, authMode executor.AuthMode, decision resumeDecision) {
+func (r *delegatedRunner) recordSpawned(ctx context.Context, missionID string, run cliRun, runID, rdir string, decision resumeDecision) {
 	if r.events == nil {
 		return
 	}
 	payload := map[string]any{
-		"harness": harness, "provider": entry.ProviderName, "model": entry.Model,
-		"auth_mode": string(authMode), "run_id": runID, "run_dir": rdir,
-		"resumed": decision.resume,
+		"harness": run.harness, "provider": run.entry.ProviderName, "model": run.entry.Model,
+		"auth_mode": string(run.authMode), "run_id": runID, "run_dir": rdir,
+		"resumed": decision.resume, "phase": run.phase,
 	}
 	if decision.resume {
 		payload["session_id"] = decision.sessionID
@@ -1315,20 +1602,20 @@ func (r *delegatedRunner) recordSpawned(ctx context.Context, missionID, harness 
 // time its stream reports a CLI session/thread id (D-103, issue #499).
 // Guarded by st.sessionRecorded so a run's later KindSystem-shaped noise
 // (there is none today, but the guard costs nothing) never double-writes.
-func (r *delegatedRunner) recordSessionSeen(ctx context.Context, missionID, runID string, st *pollState) {
+func (r *delegatedRunner) recordSessionSeen(ctx context.Context, missionID, phase, runID string, st *pollState) {
 	if r.events == nil || st.sessionRecorded {
 		return
 	}
 	st.sessionRecorded = true
 	r.recordEventForce(ctx, missionID, "executor.session", map[string]any{
-		"run_id": runID, "session_id": st.sessionID,
+		"run_id": runID, "session_id": st.sessionID, "phase": phase,
 	})
 }
 
 // recordProgressThrottled writes executor.progress at most once per
 // 60s and only when the byte offset actually advanced since the last
 // write — st tracks lastProgress across poll iterations.
-func (r *delegatedRunner) recordProgressThrottled(ctx context.Context, missionID, runID string, st *pollState) {
+func (r *delegatedRunner) recordProgressThrottled(ctx context.Context, missionID, phase, runID string, st *pollState) {
 	if r.events == nil {
 		return
 	}
@@ -1337,7 +1624,7 @@ func (r *delegatedRunner) recordProgressThrottled(ctx context.Context, missionID
 	}
 	st.lastProgress = time.Now()
 	payload := map[string]any{
-		"run_id": runID, "byte_offset": st.offset, "turns": st.turns, "tool_calls": st.toolCalls,
+		"run_id": runID, "byte_offset": st.offset, "turns": st.turns, "tool_calls": st.toolCalls, "phase": phase,
 	}
 	if st.worktree != nil {
 		payload["worktree"] = st.worktree
@@ -1357,11 +1644,11 @@ func (r *delegatedRunner) recordProgressThrottled(ctx context.Context, missionID
 // cost_usd is priced against Anthropic's table and was never booked at
 // all). The UI keys off this to avoid presenting an unbooked number as
 // billed.
-func (r *delegatedRunner) recordResult(ctx context.Context, missionID string, st *pollState, start time.Time, exitCode int, ev executor.Event, parseKind, status string, cliCostTrusted bool) {
+func (r *delegatedRunner) recordResult(ctx context.Context, missionID, phase string, st *pollState, start time.Time, exitCode int, ev executor.Event, parseKind, status string, cliCostTrusted bool) {
 	payload := map[string]any{
 		"status": status, "is_error": ev.Err != "",
 		"duration_ms": time.Since(start).Milliseconds(),
-		"exit_code":   exitCode, "parse": parseKind,
+		"exit_code":   exitCode, "parse": parseKind, "phase": phase,
 	}
 	if len(ev.Denials) > 0 {
 		payload["denials"] = ev.Denials
@@ -1378,8 +1665,8 @@ func (r *delegatedRunner) recordResult(ctx context.Context, missionID string, st
 
 // recordDied writes executor.died with a capped, neutralized stderr
 // tail.
-func (r *delegatedRunner) recordDied(ctx context.Context, missionID, reason string, exitCode *int, stderrTail string) {
-	payload := map[string]any{"reason": reason, "stderr_tail": NeutralizeSlot(truncate(stderrTail, 2000))}
+func (r *delegatedRunner) recordDied(ctx context.Context, missionID, phase, reason string, exitCode *int, stderrTail string) {
+	payload := map[string]any{"reason": reason, "stderr_tail": NeutralizeSlot(truncate(stderrTail, 2000)), "phase": phase}
 	if exitCode != nil {
 		payload["exit_code"] = *exitCode
 	}
@@ -1387,8 +1674,8 @@ func (r *delegatedRunner) recordDied(ctx context.Context, missionID, reason stri
 }
 
 // recordAuthFailed writes executor.auth_failed.
-func (r *delegatedRunner) recordAuthFailed(ctx context.Context, missionID, harness string) {
-	r.recordEventForce(ctx, missionID, "executor.auth_failed", map[string]any{"harness": harness})
+func (r *delegatedRunner) recordAuthFailed(ctx context.Context, missionID, phase, harness string) {
+	r.recordEventForce(ctx, missionID, "executor.auth_failed", map[string]any{"harness": harness, "phase": phase})
 }
 
 // recordSkipped writes executor.skipped — the one persisted record that
@@ -1397,7 +1684,7 @@ func (r *delegatedRunner) recordAuthFailed(ctx context.Context, missionID, harne
 // skip_reasons); nil for unknown_harness, which needs nothing beyond
 // harness+reason.
 func (r *delegatedRunner) recordSkipped(ctx context.Context, missionID, harness, reason string, extra map[string]any) {
-	payload := map[string]any{"harness": harness, "reason": reason}
+	payload := map[string]any{"harness": harness, "reason": reason, "phase": string(PhaseGenerate)}
 	for k, v := range extra {
 		payload[k] = v
 	}
@@ -1487,8 +1774,10 @@ func costSource(entry gwclient.ResolvedRouteEntry, authMode executor.AuthMode, u
 // over entry.Model so a self-paired row's placeholder ("default" on
 // cursor-cli) never stands in for the model that actually ran; blank
 // falls back to entry.Model, which is what every route-resolved
-// harness already agrees on.
-func (r *delegatedRunner) recordLedger(ctx context.Context, m Mission, entry gwclient.ResolvedRouteEntry, authMode executor.AuthMode, usage *executor.Usage, start time.Time, ok bool, errorCode string, reportedModel string) {
+// harness already agrees on. run.route/run.agent label the row: a
+// review run books under reviewerAgent (issue #582) so the D-097 review
+// token ceiling counts it like a native reviewer turn.
+func (r *delegatedRunner) recordLedger(ctx context.Context, m Mission, run cliRun, usage *executor.Usage, start time.Time, ok bool, errorCode string, reportedModel string) {
 	if r.ledger == nil {
 		return
 	}
@@ -1496,13 +1785,13 @@ func (r *delegatedRunner) recordLedger(ctx context.Context, m Mission, entry gwc
 	if !ok {
 		status = "error"
 	}
-	model := entry.Model
+	model := run.entry.Model
 	if reportedModel != "" {
 		model = reportedModel
 	}
 	e := ledger.Entry{
-		Provider: entry.ProviderName, Model: model, Route: workerRoute(m),
-		Agent: "mission-worker", Purpose: "executor", MissionID: m.ID,
+		Provider: run.entry.ProviderName, Model: model, Route: run.route,
+		Agent: run.agent, Purpose: "executor", MissionID: m.ID,
 		LatencyMS: time.Since(start).Milliseconds(), Status: status, ErrorCode: errorCode,
 	}
 	if usage != nil {
@@ -1510,7 +1799,7 @@ func (r *delegatedRunner) recordLedger(ctx context.Context, m Mission, entry gwc
 			InputTokens: int(usage.InputTokens), OutputTokens: int(usage.OutputTokens),
 			CacheReadTokens: int(usage.CacheReadTokens), CacheWriteTokens: int(usage.CacheWriteTokens),
 		}
-		e.Cost, e.Unbilled = costSource(entry, authMode, e.Usage, usage.CostUSD)
+		e.Cost, e.Unbilled = costSource(run.entry, run.authMode, e.Usage, usage.CostUSD)
 	}
 	r.ledger.Record(ctx, e)
 }

--- a/internal/brain/missions/delegated_review_test.go
+++ b/internal/brain/missions/delegated_review_test.go
@@ -1,0 +1,280 @@
+package missions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SumonMSelim/timothy/internal/brain/gwclient"
+)
+
+// Delegated reviewer tests (issue #582): the fakes live in
+// delegated_test.go.
+
+// reviewTestMission is a pi-reviewed mission: the worker stays native
+// (Harness empty) so RunReview's dispatch is the only delegated path
+// under test.
+func reviewTestMission(id, workRoot string) Mission {
+	return Mission{ID: id, Kind: "coding", Workspace: workRoot, Route: "default", ReviewRoute: "careful", ReviewHarness: "pi"}
+}
+
+func TestDelegatedRunReview_HappyPath_Approve(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = loadPiDelegatedFixture(t, "review-approve.ndjson")
+	sandbox.seedChunk = 40
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	led := &fakeLedger{}
+	native := &fakeNative{}
+	entry := piHarnessEntry("cred-ref-pi")
+	var resolvedRoute, resolvedHarness string
+	resolve := func(ctx context.Context, name, harness string) (*gwclient.ResolvedRoute, error) {
+		resolvedRoute, resolvedHarness = name, harness
+		return &gwclient.ResolvedRoute{Route: name, Entries: []gwclient.ResolvedRouteEntry{entry}}, nil
+	}
+
+	r := newTestDelegatedRunner(native, resolve, scriptedCred("sk-test-key", nil), sandbox, events, nil, led)
+	m := reviewTestMission("m1", t.TempDir())
+
+	verdict, err := r.RunReview(testCtx(t), m, ReviewPacket{Goal: "write a README"})
+	if err != nil {
+		t.Fatalf("RunReview: %v", err)
+	}
+	if !verdict.Approved {
+		t.Fatal("Approved = false, want true from the approve fixture")
+	}
+	if len(verdict.Resolved) != 1 || verdict.Resolved[0] != "F1" {
+		t.Fatalf("Resolved = %v, want [F1]", verdict.Resolved)
+	}
+	if verdict.Provider != entry.ProviderName || verdict.Model != entry.Model {
+		t.Fatalf("verdict provider/model = %q/%q, want %q/%q", verdict.Provider, verdict.Model, entry.ProviderName, entry.Model)
+	}
+	if resolvedRoute != "careful" || resolvedHarness != "pi" {
+		t.Fatalf("resolved route/harness = %q/%q, want careful/pi (reviewRoute on the review harness axis)", resolvedRoute, resolvedHarness)
+	}
+	if native.reviewCount() != 0 {
+		t.Fatalf("native RunReview called %d times, want 0", native.reviewCount())
+	}
+	if events.count("review.delegated_fallback") != 0 {
+		t.Fatal("review.delegated_fallback recorded on a successful delegated review")
+	}
+
+	spawned := spawnedPayload(t, events)
+	if spawned["phase"] != "prove" {
+		t.Fatalf("executor.spawned phase = %v, want prove", spawned["phase"])
+	}
+	runDirValue, _ := spawned["run_dir"].(string)
+	if !strings.Contains(runDirValue, filepath.Join("runs", "review-")) {
+		t.Fatalf("executor.spawned run_dir = %v, want a runs/review-<id> directory", spawned["run_dir"])
+	}
+	result, _ := events.last("executor.result")
+	var resultPayload map[string]any
+	_ = json.Unmarshal(result.Payload, &resultPayload)
+	if resultPayload["status"] != "APPROVE" || resultPayload["phase"] != "prove" || resultPayload["parse"] != "schema" {
+		t.Fatalf("executor.result payload = %v, want status APPROVE, phase prove, parse schema", resultPayload)
+	}
+	if !strings.Contains(sandbox.lastLaunchCmd(), "read,grep,find,ls") {
+		t.Fatalf("launch command %q does not carry pi's read-only tool list", sandbox.lastLaunchCmd())
+	}
+	if len(led.entries) != 1 || led.entries[0].Agent != reviewerAgent || led.entries[0].Route != "careful" {
+		t.Fatalf("ledger entries = %+v, want one row tagged agent %q on route careful", led.entries, reviewerAgent)
+	}
+}
+
+func TestDelegatedRunReview_Rework_CarriesFindings(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = loadPiDelegatedFixture(t, "review-rework.ndjson")
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	entry := piHarnessEntry("cred-ref-pi")
+	route := &gwclient.ResolvedRoute{Route: "careful", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("sk-test-key", nil), sandbox, events, nil, &fakeLedger{})
+	m := reviewTestMission("m1", t.TempDir())
+
+	verdict, err := r.RunReview(testCtx(t), m, ReviewPacket{Goal: "write a README"})
+	if err != nil {
+		t.Fatalf("RunReview: %v", err)
+	}
+	if verdict.Approved {
+		t.Fatal("Approved = true, want false from the rework fixture")
+	}
+	if len(verdict.Findings) != 1 {
+		t.Fatalf("Findings = %+v, want exactly 1", verdict.Findings)
+	}
+	f := verdict.Findings[0]
+	if f.File != "README.md" || f.Evidence != "+# hello" || f.Severity != SeverityBlocking || f.Title == "" {
+		t.Fatalf("finding = %+v, want file README.md, evidence quoted, blocking severity and a title", f)
+	}
+	result, _ := events.last("executor.result")
+	var resultPayload map[string]any
+	_ = json.Unmarshal(result.Payload, &resultPayload)
+	if resultPayload["status"] != "REWORK" {
+		t.Fatalf("executor.result status = %v, want REWORK", resultPayload["status"])
+	}
+}
+
+func TestDelegatedRunReview_EmptyHarness_NativeWithoutResolve(t *testing.T) {
+	native := &fakeNative{reviewVerdict: ReviewVerdict{Approved: true}}
+	resolve, calls := countingResolver(scriptedResolver(nil, nil))
+	r := newTestDelegatedRunner(native, resolve, scriptedCred("", nil), newFakeSandbox(), &fakeEventSink{}, nil, nil)
+	m := reviewTestMission("m1", t.TempDir())
+	m.ReviewHarness = ""
+
+	verdict, err := r.RunReview(testCtx(t), m, ReviewPacket{})
+	if err != nil {
+		t.Fatalf("RunReview: %v", err)
+	}
+	if !verdict.Approved || native.reviewCount() != 1 {
+		t.Fatalf("native verdict not returned: approved=%v native calls=%d", verdict.Approved, native.reviewCount())
+	}
+	if *calls != 0 {
+		t.Fatalf("route resolved %d times for an empty review_harness, want 0", *calls)
+	}
+}
+
+// TestDelegatedRunReview_FallsBackToNative covers every fallback rung:
+// each scenario must record review.delegated_fallback with its reason
+// and return the native reviewer's verdict.
+func TestDelegatedRunReview_FallsBackToNative(t *testing.T) {
+	piEntry := piHarnessEntry("cred-ref-pi")
+	cursorEntry := gwclient.ResolvedRouteEntry{ //nolint:gosec // G101: credential_ref NAME, not a credential value.
+		ProviderID: "prov-c", ProviderName: "Cursor", Driver: "cursor-cli", Model: "default",
+		CredentialRef: "cred-ref-cursor", Usable: true, Wire: "anthropic",
+	}
+	unusable := piEntry
+	unusable.Usable, unusable.SkipReason = false, "disabled"
+
+	tests := []struct {
+		name       string
+		harness    string
+		route      *gwclient.ResolvedRoute
+		resolveErr error
+		fixture    string // pi fixture the sandbox replays; "" launches nothing
+		truncate   bool   // drop the fixture's terminal line
+		wantReason string
+		wantDied   bool
+	}{
+		{name: "unknown harness", harness: "not-a-real-harness", wantReason: "unknown_harness"},
+		{name: "resolve failed", harness: "pi", resolveErr: errors.New("boom"), wantReason: "resolve_failed"},
+		{name: "no usable entry", harness: "pi", route: &gwclient.ResolvedRoute{Route: "careful", Entries: []gwclient.ResolvedRouteEntry{unusable}}, wantReason: "no_usable_entry"},
+		{name: "adapter refuses read-only", harness: "cursor-cli", route: &gwclient.ResolvedRoute{Route: "careful", Entries: []gwclient.ResolvedRouteEntry{cursorEntry}}, wantReason: "refused"},
+		{name: "run without a result", harness: "pi", route: &gwclient.ResolvedRoute{Route: "careful", Entries: []gwclient.ResolvedRouteEntry{piEntry}}, fixture: "review-approve.ndjson", truncate: true, wantReason: "no_result", wantDied: true},
+		{name: "worker-shaped verdict is unparseable", harness: "pi", route: &gwclient.ResolvedRoute{Route: "careful", Entries: []gwclient.ResolvedRouteEntry{piEntry}}, fixture: "happy.ndjson", wantReason: "unparseable_verdict"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sandbox := newFakeSandbox()
+			if tt.fixture != "" {
+				lines := loadPiDelegatedFixture(t, tt.fixture)
+				if tt.truncate {
+					lines = lines[:len(lines)-1]
+				}
+				sandbox.seedLines = lines
+			}
+			sandbox.seedExitCode = 0
+			events := &fakeEventSink{}
+			native := &fakeNative{reviewVerdict: ReviewVerdict{Approved: true, Provider: "native"}}
+			r := newTestDelegatedRunner(native, scriptedResolver(tt.route, tt.resolveErr), scriptedCred("sk-test-key", nil), sandbox, events, nil, &fakeLedger{})
+			m := reviewTestMission("m1", t.TempDir())
+			m.ReviewHarness = tt.harness
+
+			verdict, err := r.RunReview(testCtx(t), m, ReviewPacket{Goal: "g"})
+			if err != nil {
+				t.Fatalf("RunReview: %v", err)
+			}
+			if !verdict.Approved || verdict.Provider != "native" || native.reviewCount() != 1 {
+				t.Fatalf("native verdict not returned: %+v (native calls %d)", verdict, native.reviewCount())
+			}
+			fb, ok := events.last("review.delegated_fallback")
+			if !ok {
+				t.Fatal("no review.delegated_fallback event recorded")
+			}
+			var payload map[string]any
+			_ = json.Unmarshal(fb.Payload, &payload)
+			if payload["harness"] != tt.harness || payload["reason"] != tt.wantReason {
+				t.Fatalf("fallback payload = %v, want harness %q reason %q", payload, tt.harness, tt.wantReason)
+			}
+			if tt.wantDied {
+				died, ok := events.last("executor.died")
+				if !ok {
+					t.Fatal("no executor.died recorded for the result-less run")
+				}
+				var diedPayload map[string]any
+				_ = json.Unmarshal(died.Payload, &diedPayload)
+				if diedPayload["phase"] != "prove" {
+					t.Fatalf("executor.died phase = %v, want prove", diedPayload["phase"])
+				}
+			}
+			if tt.wantReason == "refused" && events.count("executor.spawned") != 0 {
+				t.Fatal("a refused adapter must never reach executor.spawned")
+			}
+		})
+	}
+}
+
+// TestDelegatedRunWorker_EventsCarryPhaseGenerate pins the worker side
+// of issue #582's phase field: every worker run's executor events say
+// generate, so the timeline can tell them from review runs.
+func TestDelegatedRunWorker_EventsCarryPhaseGenerate(t *testing.T) {
+	sandbox := newFakeSandbox()
+	sandbox.seedLines = loadDelegatedFixture(t, "schema.ndjson")
+	sandbox.seedExitCode = 0
+	events := &fakeEventSink{}
+	entry := harnessEntry("subscription")
+	route := &gwclient.ResolvedRoute{Route: "default", Entries: []gwclient.ResolvedRouteEntry{entry}}
+
+	r := newTestDelegatedRunner(&fakeNative{}, scriptedResolver(route, nil), scriptedCred("", nil), sandbox, events, nil, &fakeLedger{})
+	if _, _, err := r.RunWorker(testCtx(t), testMission("m1", t.TempDir()), WorkPacket{Goal: "test"}); err != nil {
+		t.Fatalf("RunWorker: %v", err)
+	}
+	for _, kind := range []string{"executor.spawned", "executor.result"} {
+		ev, ok := events.last(kind)
+		if !ok {
+			t.Fatalf("no %s recorded", kind)
+		}
+		var payload map[string]any
+		_ = json.Unmarshal(ev.Payload, &payload)
+		if payload["phase"] != "generate" {
+			t.Fatalf("%s phase = %v, want generate", kind, payload["phase"])
+		}
+	}
+}
+
+// TestParseDelegatedReviewVerdict pins the strict decision check: a
+// payload without an explicit approve/rework never becomes a verdict,
+// since a decision-less rework with no findings would read as approval
+// downstream.
+func TestParseDelegatedReviewVerdict(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		wantErr  bool
+		wantDec  string
+		approved bool
+	}{
+		{"approve", `{"decision":"approve"}`, false, "APPROVE", true},
+		{"rework with finding", `{"decision":"rework","findings":[{"title":"gap","file":"a.md","evidence":"x"}]}`, false, "REWORK", false},
+		{"empty payload", ``, true, "UNKNOWN", false},
+		{"worker status shape", `{"status":"DONE","note":"n"}`, true, "UNKNOWN", false},
+		{"unknown decision", `{"decision":"maybe"}`, true, "UNKNOWN", false},
+		{"not json", `approve`, true, "UNKNOWN", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			verdict, dec, err := parseDelegatedReviewVerdict(json.RawMessage(tt.raw))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if dec != tt.wantDec {
+				t.Errorf("decision = %q, want %q", dec, tt.wantDec)
+			}
+			if !tt.wantErr && verdict.Approved != tt.approved {
+				t.Errorf("Approved = %v, want %v", verdict.Approved, tt.approved)
+			}
+		})
+	}
+}

--- a/internal/brain/missions/delegated_test.go
+++ b/internal/brain/missions/delegated_test.go
@@ -438,6 +438,10 @@ type fakeNative struct {
 	verdict WorkerVerdict
 	text    string
 	err     error
+	// reviews counts RunReview calls; reviewVerdict is what they return
+	// (issue #582's fallback tests assert the native reviewer ran).
+	reviews       int
+	reviewVerdict ReviewVerdict
 }
 
 func (f *fakeNative) RunWorker(ctx context.Context, m Mission, packet WorkPacket) (WorkerVerdict, string, error) {
@@ -447,7 +451,15 @@ func (f *fakeNative) RunWorker(ctx context.Context, m Mission, packet WorkPacket
 	return f.verdict, f.text, f.err
 }
 func (f *fakeNative) RunReview(ctx context.Context, m Mission, packet ReviewPacket) (ReviewVerdict, error) {
-	return ReviewVerdict{}, nil
+	f.mu.Lock()
+	f.reviews++
+	f.mu.Unlock()
+	return f.reviewVerdict, nil
+}
+func (f *fakeNative) reviewCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reviews
 }
 func (f *fakeNative) PlanSession(ctx context.Context, m Mission, discoverNotes string) (Plan, error) {
 	return Plan{}, nil
@@ -789,7 +801,7 @@ func TestDelegatedRunWorker_ReattachResumesWithoutRespawning(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(rdir, "prompt.md"), []byte("prompt"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	r.recordSpawned(context.Background(), m.ID, m.Harness, entry, runID, rdir, authMode, resumeDecision{reason: resumeReasonNoPriorRun})
+	r.recordSpawned(context.Background(), m.ID, workerRun(m, entry, adapter, authMode), runID, rdir, resumeDecision{reason: resumeReasonNoPriorRun})
 	if err := r.launch(context.Background(), m.ID, m.Environment, m.WorkRoot(), rdir, inv, time.Minute, false); err != nil {
 		t.Fatalf("launch: %v", err)
 	}
@@ -2587,8 +2599,8 @@ func TestRecordLedgerPrefersReportedModel(t *testing.T) {
 			r := &delegatedRunner{ledger: led, log: slog.Default()}
 			entry := gwclient.ResolvedRouteEntry{ProviderName: "Cursor", Model: tc.entryModel}
 
-			r.recordLedger(context.Background(), Mission{ID: "m1"}, entry,
-				executor.AuthSubscription, nil, time.Now(), true, "", tc.reportedModel)
+			run := cliRun{phase: string(PhaseGenerate), entry: entry, authMode: executor.AuthSubscription, route: "default", agent: "mission-worker"}
+			r.recordLedger(context.Background(), Mission{ID: "m1"}, run, nil, time.Now(), true, "", tc.reportedModel)
 
 			if len(led.entries) != 1 {
 				t.Fatalf("got %d ledger entries, want 1", len(led.entries))

--- a/internal/brain/missions/executor/claude.go
+++ b/internal/brain/missions/executor/claude.go
@@ -37,6 +37,13 @@ func (claudeAdapter) Capabilities() Capabilities {
 	}
 }
 
+// claudeReadOnlyAllow/claudeReadOnlyDeny are the tool lists a read-only
+// run gets (issue #582).
+var (
+	claudeReadOnlyAllow = []string{"Read", "Grep", "Glob"}
+	claudeReadOnlyDeny  = []string{"Bash", "Edit", "Write", "MultiEdit", "NotebookEdit", "WebFetch", "WebSearch"}
+)
+
 // BuildInvocation validates spec and translates it to a claude CLI argv +
 // env. The prompt never rides the argv directly - PromptFile names the
 // path the runner substitutes via `$(cat PromptFile)` at spawn time, since
@@ -76,11 +83,18 @@ func (claudeAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 		"--model", spec.Model,
 		"--permission-mode", "dontAsk",
 	}
-	if len(spec.AllowTools) > 0 {
-		argv = append(argv, "--allowedTools", strings.Join(spec.AllowTools, ","))
+	// issue #582: a read-only run gets the fixed read-only lists no
+	// matter what spec.AllowTools/DenyTools say; the deny list is what
+	// actually blocks a write, the allow list only pre-approves reads.
+	allow, deny := spec.AllowTools, spec.DenyTools
+	if spec.ReadOnly {
+		allow, deny = claudeReadOnlyAllow, claudeReadOnlyDeny
 	}
-	if len(spec.DenyTools) > 0 {
-		argv = append(argv, "--disallowedTools", strings.Join(spec.DenyTools, ","))
+	if len(allow) > 0 {
+		argv = append(argv, "--allowedTools", strings.Join(allow, ","))
+	}
+	if len(deny) > 0 {
+		argv = append(argv, "--disallowedTools", strings.Join(deny, ","))
 	}
 	if spec.BudgetUSD != nil && spec.AuthMode == AuthAPIKey {
 		argv = append(argv, "--max-budget-usd", fmt.Sprintf("%v", *spec.BudgetUSD))

--- a/internal/brain/missions/executor/claude_test.go
+++ b/internal/brain/missions/executor/claude_test.go
@@ -381,6 +381,22 @@ func TestClaudeAdapter_BuildInvocation(t *testing.T) {
 			},
 		},
 		{
+			name: "read-only forces the read-only allow/deny lists over the spec's own (issue #582)",
+			spec: InvocationSpec{
+				Model: "sonnet", PromptPath: "/tmp/p.txt", AuthMode: AuthSubscription,
+				AllowTools: []string{"Write", "Bash"}, DenyTools: []string{"WebFetch"},
+				ReadOnly: true,
+			},
+			check: func(t *testing.T, inv Invocation) {
+				if !containsFlagValue(inv.Argv, "--allowedTools", "Read,Grep,Glob") {
+					t.Errorf("argv %v missing --allowedTools Read,Grep,Glob", inv.Argv)
+				}
+				if !containsFlagValue(inv.Argv, "--disallowedTools", "Bash,Edit,Write,MultiEdit,NotebookEdit,WebFetch,WebSearch") {
+					t.Errorf("argv %v missing the read-only --disallowedTools list", inv.Argv)
+				}
+			},
+		},
+		{
 			name: "resume session id appends --resume flag (D-103, issue #499)",
 			spec: InvocationSpec{
 				Model: "sonnet", PromptPath: "/tmp/p.txt", AuthMode: AuthSubscription,

--- a/internal/brain/missions/executor/codex.go
+++ b/internal/brain/missions/executor/codex.go
@@ -85,23 +85,22 @@ func (codexAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 	// (confirmed via `codex exec resume --help`): no `-C` flag - the
 	// resumed session keeps the working root recorded at its original
 	// spawn - but the same --json/--output-schema/-m/bypass flags apply.
+	//
+	// issue #582: a read-only run swaps the bypass flag for codex's own
+	// `--sandbox read-only` (`codex exec --help` on 0.147.0 lists
+	// read-only, workspace-write, danger-full-access), so the CLI
+	// itself refuses writes and shell side effects.
+	sandbox := []string{"--dangerously-bypass-approvals-and-sandbox"}
+	if spec.ReadOnly {
+		sandbox = []string{"--sandbox", "read-only"}
+	}
 	var argv []string
 	if spec.ResumeSessionID != "" {
-		argv = []string{
-			"codex", "exec", "resume", spec.ResumeSessionID, "--json",
-			"--dangerously-bypass-approvals-and-sandbox",
-			"--skip-git-repo-check",
-			"-m", spec.Model,
-		}
+		argv = append([]string{"codex", "exec", "resume", spec.ResumeSessionID, "--json"}, sandbox...)
 	} else {
-		argv = []string{
-			"codex", "exec", "--json",
-			"-C", spec.Workdir,
-			"--dangerously-bypass-approvals-and-sandbox",
-			"--skip-git-repo-check",
-			"-m", spec.Model,
-		}
+		argv = append([]string{"codex", "exec", "--json", "-C", spec.Workdir}, sandbox...)
 	}
+	argv = append(argv, "--skip-git-repo-check", "-m", spec.Model)
 	if spec.ResultSchema != nil {
 		schemaPath := filepath.Join(codexHome, "schema.json")
 		compact, err := compactJSON(spec.ResultSchema)

--- a/internal/brain/missions/executor/codex_test.go
+++ b/internal/brain/missions/executor/codex_test.go
@@ -506,6 +506,38 @@ func TestCodexAdapter_BuildInvocation(t *testing.T) {
 			},
 		},
 		{
+			name: "read-only swaps the bypass flag for --sandbox read-only (issue #582)",
+			spec: InvocationSpec{
+				Model: "gpt-5.3-codex", PromptPath: "/tmp/run/prompt.md", Workdir: "/tmp/run/ws",
+				AuthMode: AuthAPIKey, APIKey: "sk-test", Wire: "openai",
+				ReadOnly: true,
+			},
+			check: func(t *testing.T, inv Invocation) {
+				if !containsFlagValue(inv.Argv, "--sandbox", "read-only") {
+					t.Errorf("argv %v missing --sandbox read-only", inv.Argv)
+				}
+				if containsFlag(inv.Argv, "--dangerously-bypass-approvals-and-sandbox") {
+					t.Error("read-only run must not carry the bypass flag")
+				}
+			},
+		},
+		{
+			name: "read-only resume keeps --sandbox read-only on the resume subcommand (issue #582)",
+			spec: InvocationSpec{
+				Model: "gpt-5.3-codex", PromptPath: "/tmp/run/prompt.md", Workdir: "/tmp/run/ws",
+				AuthMode: AuthAPIKey, APIKey: "sk-test", Wire: "openai",
+				ReadOnly: true, ResumeSessionID: "thread-abc-123",
+			},
+			check: func(t *testing.T, inv Invocation) {
+				if !containsFlagValue(inv.Argv, "--sandbox", "read-only") {
+					t.Errorf("argv %v missing --sandbox read-only", inv.Argv)
+				}
+				if containsFlag(inv.Argv, "--dangerously-bypass-approvals-and-sandbox") {
+					t.Error("read-only run must not carry the bypass flag")
+				}
+			},
+		},
+		{
 			name: "argv exact",
 			spec: InvocationSpec{
 				Model: "gpt-5.3-codex", PromptPath: "/tmp/run/prompt.md", Workdir: "/tmp/run/ws",

--- a/internal/brain/missions/executor/cursor.go
+++ b/internal/brain/missions/executor/cursor.go
@@ -77,6 +77,10 @@ func (cursorAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 	if spec.BaseURL != "" {
 		return Invocation{}, fmt.Errorf("executor/cursor: cursor-agent has no custom endpoint support, base url must be empty")
 	}
+	if spec.ReadOnly {
+		// issue #582: cursor-agent has no CLI-enforced read-only mode.
+		return Invocation{}, fmt.Errorf("executor/cursor: %w", ErrReadOnlyUnsupported)
+	}
 
 	runDir := filepath.Dir(spec.PromptPath)
 	configDir := filepath.Join(runDir, "cursor-home")

--- a/internal/brain/missions/executor/cursor_test.go
+++ b/internal/brain/missions/executor/cursor_test.go
@@ -237,6 +237,14 @@ func TestCursorAdapter_BuildInvocation(t *testing.T) {
 		check   func(t *testing.T, inv Invocation)
 	}{
 		{
+			name: "read-only is refused: cursor-agent has no read-only knob (issue #582)",
+			spec: InvocationSpec{ //nolint:gosec // G101: fixture value, not a real credential.
+				Model: "claude-sonnet-5-high", PromptPath: "/tmp/run/prompt.md", Workdir: "/tmp/run/ws",
+				AuthMode: AuthAPIKey, APIKey: "sk-cursor-test", ReadOnly: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "basic",
 			spec: InvocationSpec{ //nolint:gosec // G101: fixture value, not a real credential.
 				Model: "claude-sonnet-5-high", PromptPath: "/tmp/run/prompt.md", Workdir: "/tmp/run/ws",

--- a/internal/brain/missions/executor/executor.go
+++ b/internal/brain/missions/executor/executor.go
@@ -6,6 +6,7 @@ package executor
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -67,7 +68,19 @@ type InvocationSpec struct {
 	// The runner only ever sets this when Capabilities().SupportsResume
 	// is true for the adapter in play.
 	ResumeSessionID string
+	// ReadOnly asks for a run that can read the workdir but never
+	// modify it or run shell commands (issue #582, the delegated
+	// reviewer). Each adapter maps it onto its own CLI knob; an adapter
+	// with no such knob returns ErrReadOnlyUnsupported from
+	// BuildInvocation instead of pretending.
+	ReadOnly bool
 }
+
+// ErrReadOnlyUnsupported is returned by BuildInvocation when
+// spec.ReadOnly is set and the harness has no CLI-enforced read-only
+// mode (issue #582). The runner treats it as a refusal and falls back
+// to the native reviewer.
+var ErrReadOnlyUnsupported = errors.New("executor: read-only mode not supported")
 
 // Invocation is the argv + env an adapter wants spawned. PromptFile, when
 // non-empty, names a path (equal to InvocationSpec.PromptPath) the runner

--- a/internal/brain/missions/executor/executor_test.go
+++ b/internal/brain/missions/executor/executor_test.go
@@ -1,6 +1,9 @@
 package executor
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 // fakeAdapter is a minimal Adapter for registry tests, distinct from
 // claudeAdapter so registering it never collides with the real adapter's
@@ -41,6 +44,26 @@ func TestLookup(t *testing.T) {
 // thread id, opencode a session id, pi a cwd), and must leave Model
 // empty so recordLedger keeps falling back to the route entry's model
 // instead of booking usage against a thread id.
+// TestReadOnlyRefusalIsErrReadOnlyUnsupported pins that the adapters
+// without a read-only knob refuse with the shared sentinel (issue
+// #582), which the delegated runner classifies as a refusal.
+func TestReadOnlyRefusalIsErrReadOnlyUnsupported(t *testing.T) {
+	spec := InvocationSpec{ //nolint:gosec // G101: fixture value, not a real credential.
+		Model: "m", PromptPath: "/tmp/run/prompt.md", Workdir: "/tmp/run/ws",
+		AuthMode: AuthAPIKey, APIKey: "sk-test", Wire: "openai", ReadOnly: true,
+	}
+	for _, harness := range []string{cursorHarness, opencodeHarness} {
+		a, ok := Lookup(harness)
+		if !ok {
+			t.Fatalf("%s not registered", harness)
+		}
+		_, err := a.BuildInvocation(spec)
+		if !errors.Is(err, ErrReadOnlyUnsupported) {
+			t.Errorf("%s read-only error = %v, want ErrReadOnlyUnsupported", harness, err)
+		}
+	}
+}
+
 func TestKindSystemModelOnlyWhereReported(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/internal/brain/missions/executor/opencode.go
+++ b/internal/brain/missions/executor/opencode.go
@@ -81,6 +81,11 @@ func (opencodeAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) 
 	if spec.Wire != "openai" {
 		return Invocation{}, fmt.Errorf("executor/opencode: wire %q not supported, opencode speaks openai only", spec.Wire)
 	}
+	if spec.ReadOnly {
+		// issue #582: the adapter runs opencode with permission "allow"
+		// and no per-tool deny surface is verified against 1.18.18.
+		return Invocation{}, fmt.Errorf("executor/opencode: %w", ErrReadOnlyUnsupported)
+	}
 
 	baseURL := spec.BaseURL
 	if baseURL == "" {

--- a/internal/brain/missions/executor/opencode_test.go
+++ b/internal/brain/missions/executor/opencode_test.go
@@ -297,6 +297,14 @@ func TestOpencodeAdapter_BuildInvocation(t *testing.T) {
 		check   func(t *testing.T, inv Invocation)
 	}{
 		{
+			name: "read-only is refused: no verified opencode knob (issue #582)",
+			spec: InvocationSpec{
+				Model: "gpt-oss:20b", PromptPath: "/tmp/run/prompt.md", Workdir: "/tmp/run/ws",
+				AuthMode: AuthAPIKey, APIKey: "sk-test", Wire: "openai", ReadOnly: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "openai wire with base url",
 			spec: InvocationSpec{
 				Model: "gpt-oss:20b", PromptPath: "/tmp/run/prompt.md", Workdir: "/tmp/run/ws",

--- a/internal/brain/missions/executor/pi.go
+++ b/internal/brain/missions/executor/pi.go
@@ -54,6 +54,33 @@ const piDefaultAnthropicBaseURL = "https://api.anthropic.com"
 // (spec.ResultSchema is intentionally never passed to pi's argv or env).
 const piVerdictInstruction = " End your final message with a single line containing only a JSON object of the form {\"status\":\"DONE\"|\"RETRY\"|\"BLOCKED\",\"note\":\"...\"} and nothing after it."
 
+// piSchemaInstruction replaces piVerdictInstruction when spec.ResultSchema
+// is set (issue #582): the final line must be one JSON object matching
+// the compact schema appended after it. extractTrailingJSONObject picks
+// that line up exactly as it does the worker verdict.
+const piSchemaInstruction = " End your final message with a single line containing only a JSON object matching this JSON schema, and nothing after it: "
+
+// piReadOnlyTools is the tool list a read-only run gets (issue #582):
+// pi's read/grep/find/ls never write or execute anything.
+const (
+	piTools         = "read,bash,edit,write,grep,find,ls"
+	piReadOnlyTools = "read,grep,find,ls"
+)
+
+// piVerdictSuffix picks the sentinel instruction for spec: the DONE/
+// RETRY/BLOCKED sentence, or the schema-aware one when a ResultSchema is
+// given.
+func piVerdictSuffix(spec InvocationSpec) (string, error) {
+	if spec.ResultSchema == nil {
+		return piVerdictInstruction, nil
+	}
+	compact, err := compactJSON(spec.ResultSchema)
+	if err != nil {
+		return "", fmt.Errorf("executor/pi: result schema: %w", err)
+	}
+	return piSchemaInstruction + compact, nil
+}
+
 // BuildInvocation validates spec and translates it to a pi CLI argv +
 // env. The prompt never rides the argv directly - PromptFile names the
 // path the runner substitutes via `$(cat PromptFile)` at spawn time,
@@ -95,7 +122,15 @@ func (piAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 		return Invocation{}, fmt.Errorf("executor/pi: unknown wire %q", spec.Wire)
 	}
 
-	system := spec.SystemAppend + piVerdictInstruction
+	suffix, err := piVerdictSuffix(spec)
+	if err != nil {
+		return Invocation{}, err
+	}
+	system := spec.SystemAppend + suffix
+	tools := piTools
+	if spec.ReadOnly {
+		tools = piReadOnlyTools
+	}
 
 	// issue #358: --mode rpc replaces --mode json. rpc mode takes the
 	// prompt as a JSON line on stdin (see PromptCommand), not on argv,
@@ -111,7 +146,7 @@ func (piAdapter) BuildInvocation(spec InvocationSpec) (Invocation, error) {
 		"--no-context-files",
 		"--no-session",
 		"--no-approve",
-		"--tools", "read,bash,edit,write,grep,find,ls",
+		"--tools", tools,
 		"--model", "timothy/" + spec.Model,
 		"--append-system-prompt", system,
 	}

--- a/internal/brain/missions/executor/pi_test.go
+++ b/internal/brain/missions/executor/pi_test.go
@@ -308,6 +308,54 @@ func TestPiParser_RPCModeIgnoresResponseAndQueueUpdate(t *testing.T) {
 	}
 }
 
+// TestPiParser_ReviewVerdictLine covers issue #582: a run whose final
+// message ends with a review_verdict-shaped JSON line lands that line
+// on Event.Result verbatim (the missions package decodes it), while
+// ParseResult, which only knows DONE/RETRY/BLOCKED, reports ok=false.
+func TestPiParser_ReviewVerdictLine(t *testing.T) {
+	tests := []struct {
+		fixture      string
+		wantDecision string
+		wantFindings int
+	}{
+		{"review-approve.ndjson", "approve", 0},
+		{"review-rework.ndjson", "rework", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.fixture, func(t *testing.T) {
+			p := piAdapter{}.NewParser()
+			var result Event
+			var results int
+			for _, line := range loadPiFixture(t, tt.fixture) {
+				ev, ok := p.ParseLine(line)
+				if ok && ev.Kind == KindResult {
+					results++
+					result = ev
+				}
+			}
+			if results != 1 {
+				t.Fatalf("KindResult count = %d, want exactly 1", results)
+			}
+			if result.Result == nil {
+				t.Fatalf("Result = nil, want the trailing verdict line; text was %q", result.Text)
+			}
+			var v struct {
+				Decision string           `json:"decision"`
+				Findings []map[string]any `json:"findings"`
+			}
+			if err := json.Unmarshal(result.Result, &v); err != nil {
+				t.Fatalf("Result does not decode: %v", err)
+			}
+			if v.Decision != tt.wantDecision || len(v.Findings) != tt.wantFindings {
+				t.Errorf("decision/findings = %q/%d, want %q/%d", v.Decision, len(v.Findings), tt.wantDecision, tt.wantFindings)
+			}
+			if _, ok := (piAdapter{}).ParseResult(result); ok {
+				t.Error("ParseResult accepted a review verdict as a worker status")
+			}
+		})
+	}
+}
+
 // TestPiAdapter_ImplementsSteerer pins that piAdapter satisfies
 // executor.Steerer (issue #358): the delegated runner type-asserts
 // adapters against this interface to decide whether mid-run steering
@@ -467,6 +515,46 @@ func TestPiAdapter_BuildInvocation(t *testing.T) {
 				}
 				if containsFlag(inv.Argv, "--max-budget-usd") {
 					t.Error("pi has no budget flag, must not appear in argv")
+				}
+			},
+		},
+		{
+			name: "read-only narrows --tools to the read-only list (issue #582)",
+			spec: InvocationSpec{
+				Model: "sonnet", PromptPath: "/tmp/run/prompt.md",
+				AuthMode: AuthAPIKey, APIKey: "sk-test", Wire: "anthropic",
+				ReadOnly: true,
+			},
+			check: func(t *testing.T, inv Invocation) {
+				if !containsFlagValue(inv.Argv, "--tools", piReadOnlyTools) {
+					t.Errorf("argv %v missing --tools %s", inv.Argv, piReadOnlyTools)
+				}
+				for _, a := range inv.Argv {
+					if strings.Contains(a, "bash") || strings.Contains(a, "edit") || strings.Contains(a, "write") {
+						t.Errorf("read-only argv element %q still names a writing tool", a)
+					}
+				}
+			},
+		},
+		{
+			name: "result schema swaps the sentinel for the schema-aware instruction (issue #582)",
+			spec: InvocationSpec{
+				Model: "sonnet", PromptPath: "/tmp/run/prompt.md",
+				AuthMode: AuthAPIKey, APIKey: "sk-test", Wire: "anthropic",
+				SystemAppend: "judge it",
+				ResultSchema: json.RawMessage(`{"type": "object", "properties": {"decision": {"type": "string"}}}`),
+			},
+			check: func(t *testing.T, inv Invocation) {
+				idx := flagIndex(inv.Argv, "--append-system-prompt")
+				if idx == -1 {
+					t.Fatalf("argv %v missing --append-system-prompt", inv.Argv)
+				}
+				want := "judge it" + piSchemaInstruction + `{"properties":{"decision":{"type":"string"}},"type":"object"}`
+				if got := inv.Argv[idx+1]; got != want {
+					t.Errorf("system append = %q, want %q", got, want)
+				}
+				if strings.Contains(inv.Argv[idx+1], "DONE") {
+					t.Error("schema-aware instruction must not mention the DONE/RETRY/BLOCKED sentinel")
 				}
 			},
 		},

--- a/internal/brain/missions/executor/testdata/pi-0.84.1/README.md
+++ b/internal/brain/missions/executor/testdata/pi-0.84.1/README.md
@@ -58,3 +58,13 @@ fixture recorded/built against that mode.
   command is accepted). Both must parse as noise, same as any other
   unrecognized type; there is no `session` event difference from json
   mode.
+- `review-approve.ndjson` / `review-rework.ndjson` - hand-built, not
+  recorded live (issue #582, delegated reviewer): a `--mode rpc` run
+  launched with `--tools read,grep,find,ls` whose final assistant
+  message ends with a single line holding a `review_verdict`-shaped
+  JSON object (`decision`, `findings`, `resolved`) instead of the
+  DONE/RETRY/BLOCKED sentinel. `extractTrailingJSONObject` lifts that
+  line into `Event.Result` unchanged; the missions package decodes it
+  with `parseReviewVerdict`, never `ParseResult` (which only knows the
+  worker statuses). approve resolves a prior finding; rework opens one
+  blocking finding with file and evidence.

--- a/internal/brain/missions/executor/testdata/pi-0.84.1/review-approve.ndjson
+++ b/internal/brain/missions/executor/testdata/pi-0.84.1/review-approve.ndjson
@@ -1,0 +1,9 @@
+{"type":"response","command":"prompt","success":true}
+{"type":"session","version":3,"id":"SESSION_ID","timestamp":"2026-09-05T10:00:00.000Z","cwd":"/w"}
+{"type":"agent_start"}
+{"type":"turn_start"}
+{"type":"tool_execution_start","toolName":"read","args":{"path":"README.md"}}
+{"type":"tool_execution_end","toolName":"read"}
+{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"The README covers every criterion and the harness checks pass.\n{\"decision\":\"approve\",\"findings\":[],\"resolved\":[\"F1\"]}"}],"usage":{"input":900,"output":60,"cacheRead":0,"cacheWrite":0},"stopReason":"stop"}}
+{"type":"turn_end"}
+{"type":"agent_end","messages":[{"role":"assistant","content":[{"type":"text","text":"The README covers every criterion and the harness checks pass.\n{\"decision\":\"approve\",\"findings\":[],\"resolved\":[\"F1\"]}"}],"usage":{"input":900,"output":60,"cacheRead":0,"cacheWrite":0},"stopReason":"stop"}],"willRetry":false}

--- a/internal/brain/missions/executor/testdata/pi-0.84.1/review-rework.ndjson
+++ b/internal/brain/missions/executor/testdata/pi-0.84.1/review-rework.ndjson
@@ -1,0 +1,9 @@
+{"type":"response","command":"prompt","success":true}
+{"type":"session","version":3,"id":"SESSION_ID","timestamp":"2026-09-05T10:05:00.000Z","cwd":"/w"}
+{"type":"agent_start"}
+{"type":"turn_start"}
+{"type":"tool_execution_start","toolName":"grep","args":{"pattern":"Usage","path":"README.md"}}
+{"type":"tool_execution_end","toolName":"grep"}
+{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"The usage section is missing.\n{\"decision\":\"rework\",\"findings\":[{\"title\":\"README lacks a usage section\",\"file\":\"README.md\",\"detail\":\"Criterion 2 asks for usage examples; none present.\",\"severity\":\"blocking\",\"evidence\":\"+# hello\"}],\"resolved\":[]}"}],"usage":{"input":950,"output":90,"cacheRead":0,"cacheWrite":0},"stopReason":"stop"}}
+{"type":"turn_end"}
+{"type":"agent_end","messages":[{"role":"assistant","content":[{"type":"text","text":"The usage section is missing.\n{\"decision\":\"rework\",\"findings\":[{\"title\":\"README lacks a usage section\",\"file\":\"README.md\",\"detail\":\"Criterion 2 asks for usage examples; none present.\",\"severity\":\"blocking\",\"evidence\":\"+# hello\"}],\"resolved\":[]}"}],"usage":{"input":950,"output":90,"cacheRead":0,"cacheWrite":0},"stopReason":"stop"}],"willRetry":false}

--- a/internal/brain/missions/missions.go
+++ b/internal/brain/missions/missions.go
@@ -106,6 +106,11 @@ type Mission struct {
 	// (internal/brain/missions/executor). Coding-only; a general mission
 	// always runs native.
 	Harness string `json:"harness,omitempty"`
+	// ReviewHarness names the registered executor the prove phase's
+	// review round runs as a read-only delegated CLI (issue #582); ""
+	// keeps the native gateway reviewer. Native is the floor: every
+	// delegated failure falls back to it.
+	ReviewHarness string `json:"review_harness,omitempty"`
 	// Flow is the phase set this mission runs (D-090, issue #459),
 	// chosen once at create time, snapshotted here, never model-
 	// mutable. FlowLight (D-069, general kind only) skips discover/plan/

--- a/internal/brain/missions/review.go
+++ b/internal/brain/missions/review.go
@@ -375,7 +375,17 @@ func ReviewVerdictTool() *tools.Tool {
 	return &tools.Tool{
 		Name:        reviewVerdictToolName,
 		Description: "Report your review verdict. Call this exactly once. Look for reasons to reject before approving — approve only when you cannot find a real gap.",
-		InputSchema: json.RawMessage(`{
+		InputSchema: reviewVerdictSchema,
+		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
+			return "verdict recorded", nil
+		},
+	}
+}
+
+// reviewVerdictSchema is the review_verdict input schema, shared by the
+// native tool and the delegated reviewer's CLI result schema (issue
+// #582) so both answer in one shape parseReviewVerdict decodes.
+var reviewVerdictSchema = json.RawMessage(`{
 			"type": "object",
 			"properties": {
 				"decision": {
@@ -405,12 +415,7 @@ func ReviewVerdictTool() *tools.Tool {
 				}
 			},
 			"required": ["decision"]
-		}`),
-		Execute: func(ctx context.Context, args json.RawMessage) (string, error) {
-			return "verdict recorded", nil
-		},
-	}
-}
+		}`)
 
 // Finding severities and statuses (D-092, issue #512).
 const (

--- a/internal/brain/missions/runner.go
+++ b/internal/brain/missions/runner.go
@@ -1330,6 +1330,15 @@ func (r *nativeRunner) applyDiscoverReport(ctx context.Context, m Mission, repor
 	return fmt.Sprintf("Stack: %s. The sandbox has no preinstalled toolchain for it; the plan must include a unit that installs what the work needs before building or testing.\n\n%s", NeutralizeSlot(stack), report.Findings)
 }
 
+// reviewSystemPrompt is the reviewer's system prompt; reviewSystemToolCall
+// is the native closing sentence. The delegated reviewer (issue #582)
+// reuses the body with its own closing instruction, so the native
+// prompt stays byte-identical.
+const (
+	reviewSystemPrompt   = "You are reviewing units of a mission's work. Each unit's acceptance criteria, the harness's own check results, the diff and the actual artifact contents (read from disk by the harness, not reported by the worker) are all below; judge against THEM. Look for real reasons to reject before approving: a criterion the work does not satisfy, unsupported claims, missing substance. Do NOT reject for material you were not given (the harness supplies everything there is) and do not re-run checks the harness already reports as passed. Every blocking finding must name a file that appears in the diff or the artifacts and quote the line that shows the gap in evidence; a blocking finding without both is demoted to minor. The changed-files stat spans every unit of the plan: judge a criterion about files a unit must not touch (\"no other files modified\") against the files listed for that unit alone, never against another unit's files. Prior rounds' open findings are listed with ids: name each one the work has now closed in resolved, and report only NEW gaps as findings."
+	reviewSystemToolCall = " End your turn with exactly one review_verdict tool call."
+)
+
 // RunReview judges the packet: the mission's goal and plan, the
 // harness-read artifact contents (never the worker's description of
 // them), the baseline diff when one exists, the prior rounds' open
@@ -1337,7 +1346,7 @@ func (r *nativeRunner) applyDiscoverReport(ctx context.Context, m Mission, repor
 // session (D-092): findings carry across rounds as mission state, so
 // no reviewer transcript is retained to anchor the next verdict.
 func (r *nativeRunner) RunReview(ctx context.Context, m Mission, packet ReviewPacket) (ReviewVerdict, error) {
-	system := "You are reviewing units of a mission's work. Each unit's acceptance criteria, the harness's own check results, the diff and the actual artifact contents (read from disk by the harness, not reported by the worker) are all below; judge against THEM. Look for real reasons to reject before approving: a criterion the work does not satisfy, unsupported claims, missing substance. Do NOT reject for material you were not given (the harness supplies everything there is) and do not re-run checks the harness already reports as passed. Every blocking finding must name a file that appears in the diff or the artifacts and quote the line that shows the gap in evidence; a blocking finding without both is demoted to minor. The changed-files stat spans every unit of the plan: judge a criterion about files a unit must not touch (\"no other files modified\") against the files listed for that unit alone, never against another unit's files. Prior rounds' open findings are listed with ids: name each one the work has now closed in resolved, and report only NEW gaps as findings. End your turn with exactly one review_verdict tool call."
+	system := reviewSystemPrompt + reviewSystemToolCall
 	messages := []provider.Message{{Role: "user", Content: renderReviewContent(packet)}}
 
 	extra := append([]*tools.Tool{ReviewVerdictTool()}, r.missionTools(m)...)

--- a/internal/brain/missions/scheduler.go
+++ b/internal/brain/missions/scheduler.go
@@ -77,6 +77,10 @@ type MissionTemplate struct {
 	// time via resolveTemplateDefaults, same precedence as create()'s
 	// own handling of an omitted request field.
 	Harness string `json:"harness,omitempty"`
+	// ReviewHarness (issue #582) is copied onto the fired mission as-is:
+	// the registered executor its review round runs as a read-only
+	// delegated CLI, "" for the native reviewer. No settings default.
+	ReviewHarness string `json:"review_harness,omitempty"`
 	// Light missions (D-069) skip discover/plan/prove; only meaningful
 	// on a kind=general template (rejected at schedule create/update for
 	// kind=coding, api/schedules.go).
@@ -514,10 +518,10 @@ func (s *Scheduler) createFromTemplate(ctx context.Context, tx pgx.Tx, sc Schedu
 	// template (D-087, issue #456): a scheduler-fired mission runs
 	// unattended, so nobody is watching to approve its plan.
 	_, err = tx.Exec(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, auto_approve_tools, auto_approve_plan, plan, schedule_id, harness, environment, sources, destinations, phase, flow)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)`,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, prompt_overlay, auto_approve_tools, auto_approve_plan, plan, schedule_id, harness, environment, sources, destinations, phase, flow, review_harness)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)`,
 		t.Goal, name, t.Kind, t.AgentID, orDefault(t.MaxIterations, 3), t.BudgetAmount, budgetCurrency, t.Route, t.ReviewRoute, t.PlanRoute,
-		promptOverlay, t.AutoApproveTools, true, plan, sc.ID, t.Harness, t.Environment, sourcesJSON, destinationsJSON, phase, flow)
+		promptOverlay, t.AutoApproveTools, true, plan, sc.ID, t.Harness, t.Environment, sourcesJSON, destinationsJSON, phase, flow, t.ReviewHarness)
 	return err
 }
 

--- a/internal/brain/missions/scheduler_integration_test.go
+++ b/internal/brain/missions/scheduler_integration_test.go
@@ -132,6 +132,40 @@ func TestSchedulerFireForcesAutoApprovePlanTrue(t *testing.T) {
 	}
 }
 
+// TestSchedulerFireCopiesReviewHarness covers issue #582: a template's
+// review_harness lands on the fired mission verbatim.
+func TestSchedulerFireCopiesReviewHarness(t *testing.T) {
+	store := testStore(t)
+	ctx := context.Background()
+
+	db, _ := store.db.Get()
+	var id string
+	if err := db.QueryRow(ctx, `INSERT INTO schedules (name, cron, mission_template, created_at)
+		VALUES ($1, '* * * * *', $2, $3) RETURNING id`,
+		marker+"review-harness", `{"goal":"`+marker+`review harness run","kind":"coding","review_harness":"pi"}`,
+		time.Now().Add(-2*time.Minute)).Scan(&id); err != nil {
+		t.Fatalf("create schedule: %v", err)
+	}
+	t.Cleanup(func() {
+		cctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_, _ = db.Exec(cctx, "DELETE FROM schedules WHERE id = $1", id)
+	})
+
+	sched := NewScheduler(store.db, store, nil, nil, nil, nil, nil, nil, store.log)
+	if err := sched.tick(ctx, time.Now()); err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	var reviewHarness string
+	if err := db.QueryRow(ctx, `SELECT review_harness FROM missions WHERE schedule_id = $1`, id).Scan(&reviewHarness); err != nil {
+		t.Fatalf("query fired mission's review_harness: %v", err)
+	}
+	if reviewHarness != "pi" {
+		t.Fatalf("fired mission review_harness = %q, want pi", reviewHarness)
+	}
+}
+
 // TestSchedulerFireUsesTemplateNameOverSlug guards the fix for a real
 // UI gap: schedule names are strict lowercase slugs (shared validation
 // with connectors/destinations/agents), so a scheduled mission's

--- a/internal/brain/missions/store.go
+++ b/internal/brain/missions/store.go
@@ -49,7 +49,7 @@ const missionColumns = `id, goal, name, kind, agent_id, phase, status, pause_rea
 	consecutive_failures, last_gap_fingerprint, stall_count, budget_amount, budget_currency, route, review_route,
 	plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay,
 	pending_permission, auto_approve_tools, auto_approve_plan, last_evidence,
-	discover_notes, replan_used, schedule_id, session_id, harness, environment,
+	discover_notes, replan_used, schedule_id, session_id, harness, review_harness, environment,
 	parent_mission_id, sources, destinations, final_output, created_at, updated_at,
 	workflow_run_id, workflow_step, artifact_refs, permission_timeout_seconds, pending_input, asks_used, flow,
 	review_findings, rework_rounds, has_plan`
@@ -134,7 +134,7 @@ func scanMissionWithFailureReason(row pgx.Row) (Mission, error) {
 		&m.ConsecutiveFailures, &m.LastGapFingerprint, &m.StallCount, &m.BudgetAmount, &m.BudgetCurrency, &m.Route, &m.ReviewRoute,
 		&m.PlanRoute, &m.EscalationRoute, &m.RouteModel, &m.PlanRouteModel, &m.ReviewRouteModel, &m.PromptOverlay,
 		&pendingPermissionRaw, &m.AutoApproveTools, &m.AutoApprovePlan, &m.LastEvidence,
-		&m.DiscoverNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
+		&m.DiscoverNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.ReviewHarness, &m.Environment,
 		&parentMission, &sourcesRaw, &destinationsRaw, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
 		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &permissionTimeoutSeconds,
@@ -221,7 +221,7 @@ func scanMission(row pgx.Row) (Mission, error) {
 		&m.ConsecutiveFailures, &m.LastGapFingerprint, &m.StallCount, &m.BudgetAmount, &m.BudgetCurrency, &m.Route, &m.ReviewRoute,
 		&m.PlanRoute, &m.EscalationRoute, &m.RouteModel, &m.PlanRouteModel, &m.ReviewRouteModel, &m.PromptOverlay,
 		&pendingPermissionRaw, &m.AutoApproveTools, &m.AutoApprovePlan, &m.LastEvidence,
-		&m.DiscoverNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.Environment,
+		&m.DiscoverNotes, &m.ReplanUsed, &scheduleID, &sessionID, &m.Harness, &m.ReviewHarness, &m.Environment,
 		&parentMission, &sourcesRaw, &destinationsRaw, &m.FinalOutput,
 		&m.CreatedAt, &m.UpdatedAt,
 		&workflowRunID, &m.WorkflowStep, &artifactRefsRaw, &permissionTimeoutSeconds,
@@ -322,9 +322,9 @@ func (s *Store) Create(ctx context.Context, m Mission) (string, error) {
 	}
 	phase := initialPhase(m.Kind, flow)
 	err = db.QueryRow(ctx, `INSERT INTO missions
-			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, plan, session_id, auto_approve_tools, auto_approve_plan, harness, environment, parent_mission_id, sources, destinations, phase, workflow_run_id, workflow_step, permission_timeout_seconds, flow, has_plan)
-		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, NULLIF($17, '')::uuid, $18, $19, $20, $21, NULLIF($22, '')::uuid, $23, $24, $25, NULLIF($26, '')::uuid, $27, $28, $29, $30) RETURNING id`,
-		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, plan, m.SessionID, m.AutoApproveTools, m.AutoApprovePlan, m.Harness, m.Environment, m.ParentMissionID, sourcesJSON, destinationsJSON, phase, m.WorkflowRunID, m.WorkflowStep, m.PermissionTimeoutSeconds, flow, m.HasPlan,
+			(goal, name, kind, agent_id, max_iterations, budget_amount, budget_currency, route, review_route, plan_route, escalation_route, route_model, plan_route_model, review_route_model, prompt_overlay, plan, session_id, auto_approve_tools, auto_approve_plan, harness, environment, parent_mission_id, sources, destinations, phase, workflow_run_id, workflow_step, permission_timeout_seconds, flow, has_plan, review_harness)
+		VALUES ($1, $2, $3, NULLIF($4, '')::uuid, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, NULLIF($17, '')::uuid, $18, $19, $20, $21, NULLIF($22, '')::uuid, $23, $24, $25, NULLIF($26, '')::uuid, $27, $28, $29, $30, $31) RETURNING id`,
+		m.Goal, m.Name, m.Kind, m.AgentID, orDefault(m.MaxIterations, 3), m.BudgetAmount, budgetCurrency, m.Route, m.ReviewRoute, m.PlanRoute, m.EscalationRoute, m.RouteModel, m.PlanRouteModel, m.ReviewRouteModel, m.PromptOverlay, plan, m.SessionID, m.AutoApproveTools, m.AutoApprovePlan, m.Harness, m.Environment, m.ParentMissionID, sourcesJSON, destinationsJSON, phase, m.WorkflowRunID, m.WorkflowStep, m.PermissionTimeoutSeconds, flow, m.HasPlan, m.ReviewHarness,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("missions create: %w", err)
@@ -999,9 +999,17 @@ func (s *Store) LastRunState(ctx context.Context, missionID string) (*runState, 
 				AuthMode string `json:"auth_mode"`
 				RunID    string `json:"run_id"`
 				RunDir   string `json:"run_dir"`
+				Phase    string `json:"phase"`
 			}
 			if err := json.Unmarshal(payload, &spawned); err != nil {
 				return nil, fmt.Errorf("missions last run state: decode spawned: %w", err)
+			}
+			if spawned.Phase == string(PhaseProve) {
+				// A delegated review run (issue #582) is never resumed
+				// and must never stand in for the worker's last run:
+				// drop what was collected after it and keep scanning.
+				state = nil
+				continue
 			}
 			if state == nil {
 				state = &runState{}

--- a/internal/brain/missions/store_integration_test.go
+++ b/internal/brain/missions/store_integration_test.go
@@ -424,6 +424,39 @@ func TestMissionHarnessRoundTrips(t *testing.T) {
 	}
 }
 
+// TestMissionReviewHarnessRoundTrips covers issue #582: review_harness
+// is snapshotted at create time next to harness; unset stays "".
+func TestMissionReviewHarnessRoundTrips(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	id, err := s.Create(ctx, Mission{
+		Goal: marker + "review-harness", Kind: "coding", Route: "default", ReviewHarness: "pi",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	m, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m.ReviewHarness != "pi" {
+		t.Fatalf("ReviewHarness = %q, want pi", m.ReviewHarness)
+	}
+
+	id2, err := s.Create(ctx, Mission{Goal: marker + "no-review-harness", Kind: "coding", Route: "default"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	m2, err := s.Get(ctx, id2)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if m2.ReviewHarness != "" {
+		t.Fatalf("ReviewHarness = %q, want empty (native) when not set", m2.ReviewHarness)
+	}
+}
+
 // TestMissionModelPinsRoundTrip covers route_model/plan_route_model/
 // review_route_model (D-078): same shape as TestMissionHarnessRoundTrips:
 // set on create, read back verbatim; unset stays empty.

--- a/internal/brain/missions/sweep.go
+++ b/internal/brain/missions/sweep.go
@@ -47,7 +47,7 @@ const (
 // sandbox. gatewayReadyMaxWait is a sane cap, not a promise the gateway
 // will be ready by then: past it, recoverWorking proceeds anyway and
 // leans on the delegated runner's own bounded retry/infra-pause path
-// (RunWorker's resolveRouteWithRetry) for whatever config_unavailable
+// (RunWorker's resolveRouteFor) for whatever config_unavailable
 // window remains.
 // var, not const, so tests can shrink both instead of waiting real minutes.
 var (

--- a/internal/brain/missions/validate.go
+++ b/internal/brain/missions/validate.go
@@ -100,6 +100,11 @@ func ValidateCreate(ctx context.Context, m Mission, deps ValidateDeps) error {
 			return fmt.Errorf("%w: unknown harness %q", ErrInvalidMission, m.Harness)
 		}
 	}
+	if m.ReviewHarness != "" {
+		if _, ok := executor.Lookup(m.ReviewHarness); !ok {
+			return fmt.Errorf("%w: unknown review_harness %q", ErrInvalidMission, m.ReviewHarness)
+		}
+	}
 	if !ValidEnvironment(m.Environment) {
 		return fmt.Errorf("%w: unknown environment %q", ErrInvalidMission, m.Environment)
 	}

--- a/internal/brain/missions/validate_test.go
+++ b/internal/brain/missions/validate_test.go
@@ -58,6 +58,14 @@ func TestValidateCreate(t *testing.T) {
 			m.Kind, m.Harness = "coding", "not-a-real-harness"
 			return m
 		}, ValidateDeps{}, true},
+		{"unknown review_harness", func(m Mission) Mission {
+			m.Kind, m.ReviewHarness = "coding", "not-a-real-harness"
+			return m
+		}, ValidateDeps{}, true},
+		{"registered review_harness", func(m Mission) Mission {
+			m.Kind, m.ReviewHarness = "coding", "pi"
+			return m
+		}, ValidateDeps{}, false},
 		{"environment on general", func(m Mission) Mission {
 			m.Environment = "go"
 			return m

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -682,6 +682,11 @@ CREATE TABLE IF NOT EXISTS missions (
     -- settings at dispatch. "" is native; "claude-cli" (etc) names a
     -- registered delegated executor (internal/brain/missions/executor).
     harness               text NOT NULL DEFAULT '',
+    -- ReviewHarness (issue #582) names the registered executor the
+    -- prove phase's review round runs as a read-only delegated CLI;
+    -- "" keeps the native gateway reviewer, which every delegated
+    -- failure also falls back to.
+    review_harness        text NOT NULL DEFAULT '',
     -- Mission worker turns run through loop.Agent same as chat, but
     -- tool-call bookkeeping (session_events, tools audit) hard-requires
     -- a real session_id uuid FK -- a mission has no chat session of its

--- a/scripts/pending-alters.md
+++ b/scripts/pending-alters.md
@@ -4,4 +4,7 @@ Additive schema changes not yet applied to any live database. Safe to
 run before deploy; each entry stays here until confirmed applied on
 every live instance, then it's removed.
 
-(none)
+```sql
+-- issue #582: opt-in delegated reviewer harness on a mission.
+ALTER TABLE missions ADD COLUMN IF NOT EXISTS review_harness text NOT NULL DEFAULT '';
+```

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1240,6 +1240,10 @@ export interface CreateMissionInput {
   // "native" to force the built-in agent loop. Only valid when
   // kind === 'coding'.
   harness?: string
+  // review_harness names the registered executor the prove phase's
+  // review round runs as a read-only delegated CLI (issue #582): omit
+  // (or "") for the native reviewer, "native" to force it.
+  review_harness?: string
   // environment selects the sandbox image key (D-05x) a coding
   // mission's container runs: omit (or "") to auto-detect (repo
   // markers, then a goal-keyword heuristic, falling back to base).

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -839,6 +839,10 @@ export interface Mission {
   // dispatch, "claude-cli"/"pi"/"codex-cli"/"opencode"/"cursor-cli" name
   // a registered executor.
   harness?: string
+  // review_harness (issue #582) names the registered executor the prove
+  // phase's review round runs as a read-only delegated CLI; "" or
+  // absent keeps the native reviewer (also the fallback on any failure).
+  review_harness?: string
   // top_model/top_model_provider are decorated onto the list/get
   // response from the cost ledger's top-served-model-per-mission
   // lookup (internal/brain/api/missions.go's decorateTopModels): the
@@ -977,6 +981,19 @@ export interface ExecutorSpawnedPayload {
   model: string
   auth_mode: string
   run_id: string
+  // phase (issue #582) is 'generate' for a worker run and 'prove' for
+  // a delegated review run; absent on events recorded before it existed
+  // (always worker runs).
+  phase?: string
+}
+
+// ReviewDelegatedFallbackPayload is review.delegated_fallback's payload
+// (issue #582): a mission's review_harness could not serve the round,
+// so the native reviewer ran instead.
+export interface ReviewDelegatedFallbackPayload {
+  harness: string
+  reason: string
+  error?: string
 }
 
 export interface ExecutorProgressPayload {
@@ -1203,6 +1220,8 @@ export interface MissionTemplate {
   budget_currency?: string
   auto_approve_tools?: boolean
   harness?: string
+  // review_harness is copied onto every fired mission as-is (issue #582).
+  review_harness?: string
   environment?: string
   // destination_ids names operator-created destinations this template's
   // fired missions deliver their outcome digest to. Re-validated at

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -782,6 +782,73 @@ describe('MissionForm: kind chip', () => {
   })
 })
 
+describe('MissionForm: review harness select (issue #582)', () => {
+  it('offers Native plus the read-only capable adapters under Advanced', async () => {
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(await screen.findByRole('button', { name: 'Show advanced options' }))
+    fireEvent.click(screen.getByLabelText('Review harness'))
+
+    // "Native" shows twice once open: the trigger's current value and
+    // the option itself.
+    expect(await screen.findAllByText('Native')).toHaveLength(2)
+    expect(screen.getByText('Claude Code')).toBeInTheDocument()
+    expect(screen.getByText('pi')).toBeInTheDocument()
+    expect(screen.getByText('Codex CLI')).toBeInTheDocument()
+    expect(screen.queryByText('Cursor CLI')).toBeNull()
+    expect(screen.queryByText('OpenCode')).toBeNull()
+  })
+
+  it('submits the picked review harness and omits it when left on Native', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm6' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(await screen.findByRole('button', { name: 'Show advanced options' }))
+    fireEvent.click(screen.getByLabelText('Review harness'))
+    fireEvent.click(await screen.findByText('pi'))
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() =>
+      expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ review_harness: 'pi' })),
+    )
+  })
+
+  it('leaves review_harness undefined when nothing is picked', async () => {
+    vi.mocked(createMission).mockResolvedValue({ id: 'm7' } as Mission)
+    renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
+
+    await waitFor(() => expect(createMission).toHaveBeenCalled())
+    expect(vi.mocked(createMission).mock.calls[0][0].review_harness).toBeUndefined()
+  })
+
+  it('hydrates review_harness from the schedule template and sends it back on save', async () => {
+    vi.mocked(patchSchedule).mockResolvedValue(schedule)
+    const seeded: Schedule = {
+      ...schedule,
+      mission_template: { ...schedule.mission_template, review_harness: 'claude-cli' },
+    }
+    renderForm(<MissionForm mode="edit" schedule={seeded} onDone={vi.fn()} onCancel={vi.fn()} />)
+
+    await screen.findByDisplayValue('weekly-digest')
+    expect(screen.getByLabelText('Review harness')).toHaveTextContent('Claude Code')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save schedule' }))
+    await waitFor(() =>
+      expect(patchSchedule).toHaveBeenCalledWith(
+        's1',
+        expect.objectContaining({
+          mission_template: expect.objectContaining({ review_harness: 'claude-cli' }),
+        }),
+      ),
+    )
+  })
+})
+
 describe('MissionForm: harness select placement', () => {
   it('shows the harness select in the main form body for a coding mission, without expanding Advanced', async () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -108,6 +108,7 @@ function hasNonDefaults(t: Schedule['mission_template']): boolean {
     t.review_route ||
     t.plan_route ||
     t.harness ||
+    t.review_harness ||
     t.environment
   )
 }
@@ -173,6 +174,15 @@ export const executorChoices: { value: string; label: string }[] = [
   { value: 'codex-cli', label: 'Codex CLI' },
   { value: 'opencode', label: 'OpenCode' },
   { value: 'cursor-cli', label: 'Cursor CLI' },
+]
+
+// reviewHarnessChoices is the Review harness select's list (issue #582):
+// Native (the default, wire value '') plus the registered adapters.
+// cursor-cli and opencode have no read-only mode, so picking them would
+// only ever fall back to native; they are left out.
+export const reviewHarnessChoices: { value: string; label: string }[] = [
+  { value: EXECUTOR_DEFAULT, label: 'Native' },
+  ...executorChoices.filter((c) => ['claude-cli', 'pi', 'codex-cli'].includes(c.value)),
 ]
 
 // defaultHarnessLabel names what the Harness select's "Default" choice
@@ -394,6 +404,7 @@ export function MissionForm({
   const [autoApproveTools, setAutoApproveTools] = useState(true)
   const [autoApprovePlan, setAutoApprovePlan] = useState(true)
   const [harness, setHarness] = useState(initial?.harness ?? '')
+  const [reviewHarness, setReviewHarness] = useState(initial?.review_harness ?? '')
   const [environment, setEnvironment] = useState(initial?.environment ?? '')
   const [executorOptions, setExecutorOptions] = useState<ExecutorOption[] | null>(null)
   const [executionPlan, setExecutionPlan] = useState<ExecutionPlanPhase[] | null>(null)
@@ -717,6 +728,7 @@ export function MissionForm({
     )
     setBudgetCurrency(schedule.mission_template.budget_currency || 'USD')
     setHarness(schedule.mission_template.harness ?? '')
+    setReviewHarness(schedule.mission_template.review_harness ?? '')
     setEnvironment(schedule.mission_template.environment ?? '')
     setDestinationIDs(schedule.mission_template.destination_ids ?? [])
     setAttachments(
@@ -888,6 +900,7 @@ export function MissionForm({
       auto_approve_tools: autoApproveTools,
       auto_approve_plan: autoApprovePlan,
       harness: kind === 'coding' ? harness || undefined : undefined,
+      review_harness: light ? undefined : reviewHarness || undefined,
       environment: kind === 'coding' ? environment || undefined : undefined,
       repo_url: repoURL,
       connector_id: repoURL ? connectorID : undefined,
@@ -923,6 +936,7 @@ export function MissionForm({
         budget_currency: budget ? budgetCurrency : undefined,
         auto_approve_tools: autoApproveTools,
         harness: kind === 'coding' ? harness || undefined : undefined,
+        review_harness: light ? undefined : reviewHarness || undefined,
         environment: kind === 'coding' ? environment || undefined : undefined,
         destination_ids: destinationIDs.length > 0 ? destinationIDs : undefined,
         light: kind === 'general' ? light : undefined,
@@ -954,6 +968,7 @@ export function MissionForm({
         budget_currency: budget ? budgetCurrency : undefined,
         auto_approve_tools: autoApproveTools,
         harness: schedule.mission_template.kind === 'coding' ? harness || undefined : undefined,
+        review_harness: light ? undefined : reviewHarness || undefined,
         environment:
           schedule.mission_template.kind === 'coding' ? environment || undefined : undefined,
         destination_ids: destinationIDs.length > 0 ? destinationIDs : undefined,
@@ -1751,6 +1766,30 @@ export function MissionForm({
                       </SelectContent>
                     </Select>
                   )}
+                </div>
+              )}
+              {!light && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="mission-review-harness">Review harness</Label>
+                  <Select
+                    value={reviewHarness || EXECUTOR_DEFAULT}
+                    onValueChange={(v) => setReviewHarness(v === EXECUTOR_DEFAULT ? '' : v)}
+                  >
+                    <SelectTrigger id="mission-review-harness" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {reviewHarnessChoices.map((c) => (
+                        <SelectItem key={c.value} value={c.value}>
+                          {c.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Runs the review round as a read-only CLI in the mission sandbox; native review is
+                    the fallback whenever it cannot run.
+                  </p>
                 </div>
               )}
               {kind === 'general' && !repeat && (

--- a/web/src/components/missions/eventRenderers.test.tsx
+++ b/web/src/components/missions/eventRenderers.test.tsx
@@ -262,6 +262,30 @@ describe('executor lifecycle event rendering', () => {
     expect(screen.getByText('harness')).toBeInTheDocument()
   })
 
+  it('renders a prove-phase executor.spawned as a delegated review (issue #582)', () => {
+    render(
+      <div>
+        {renderEvent(
+          event(
+            { harness: 'pi', provider: 'anthropic', model: 'sonnet', auth_mode: 'api_key', run_id: 'r2', phase: 'prove' },
+            'executor.spawned',
+          ),
+        )}
+      </div>,
+    )
+    expect(screen.getByText(/Review delegated to pi/)).toBeInTheDocument()
+  })
+
+  it('renders review.delegated_fallback with the harness and reason (issue #582)', () => {
+    render(
+      <div>
+        {renderEvent(event({ harness: 'cursor-cli', reason: 'refused', error: 'read-only mode not supported' }, 'review.delegated_fallback'))}
+      </div>,
+    )
+    expect(screen.getByText(/Review harness cursor-cli unavailable \(refused\), native review ran instead/)).toBeInTheDocument()
+    expect(screen.getByText(/read-only mode not supported/)).toBeInTheDocument()
+  })
+
   it('renders executor.died as an error row', () => {
     render(<div>{renderEvent(event({ reason: 'oom' }, 'executor.died'))}</div>)
     expect(screen.getByText(/Harness died: oom/)).toBeInTheDocument()

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -7,6 +7,7 @@ import type {
   ExecutorSkippedPayload,
   ExecutorSpawnedPayload,
   ExecutorSteeredPayload,
+  ReviewDelegatedFallbackPayload,
   MissionEvent,
   MissionPermissionDeniedPayload,
   MissionPROpenedPayload,
@@ -281,10 +282,10 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
     )
   },
   'executor.spawned': (p) => {
-    const { harness, provider, model, auth_mode } = p as ExecutorSpawnedPayload
+    const { harness, provider, model, auth_mode, phase } = p as ExecutorSpawnedPayload
     return (
       <span>
-        Delegated to {harness} ·{' '}
+        {phase === 'prove' ? 'Review delegated to' : 'Delegated to'} {harness} ·{' '}
         <span className="font-mono">
           {provider}/{model}
         </span>{' '}
@@ -322,6 +323,17 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
         {reason === 'no_usable_entry' && skip_reasons && skip_reasons.length > 0
           ? ` — ${skip_reasons.join(', ')}`
           : ''}
+      </span>
+    )
+  },
+  // review.delegated_fallback (issue #582): the mission's review_harness
+  // could not serve the round, so the native reviewer ran instead.
+  'review.delegated_fallback': (p) => {
+    const { harness, reason, error } = p as ReviewDelegatedFallbackPayload
+    return (
+      <span className="text-amber-400">
+        Review harness {harness} unavailable ({reason}), native review ran instead
+        {error ? `: ${truncateForDisplay(error)}` : ''}
       </span>
     )
   },

--- a/web/src/pages/NewMission.tsx
+++ b/web/src/pages/NewMission.tsx
@@ -18,6 +18,7 @@ function missionToInitial(m: Mission): Partial<CreateMissionInput> {
     plan_route: m.plan_route,
     escalation_route: m.escalation_route,
     harness: m.harness,
+    review_harness: m.review_harness,
     environment: m.environment,
     destination_ids: m.destinations
       ?.map((d) => d.destination_id)


### PR DESCRIPTION
Closes #582. Last slice of the Prove v2 epic #510.

## What

A mission can opt into a delegated reviewer with `review_harness`. When set to a registered executor, the prove round runs that CLI read-only in the mission's sandbox and worktree with the rendered review packet as prompt and the shared `review_verdict` schema as result schema. The structured result is decoded with `parseReviewVerdict` after a strict approve/rework check. Empty keeps the native reviewer byte for byte.

Native review is the floor. Every failure on the delegated path (unknown harness, adapter refusal, route or entry unusable, cooldown, auth, spawn, no result, unparseable verdict, poll failure) records `review.delegated_fallback {harness, reason[, error]}` and runs the native reviewer. Driver gating (evidence gate, demotion, rounds) is untouched and applies to whichever verdict comes back.

## Read-only enforcement per adapter

`executor.InvocationSpec.ReadOnly` is mapped onto each CLI's own knob in Go:

- pi: `--tools read,grep,find,ls`, plus a schema-aware sentinel instruction when a `ResultSchema` is set.
- claude-cli: fixed allow list `Read,Grep,Glob` and deny list `Bash,Edit,Write,MultiEdit,NotebookEdit,WebFetch,WebSearch`, regardless of the spec's own lists.
- codex-cli: `--sandbox read-only` replaces `--dangerously-bypass-approvals-and-sandbox` (verified against `codex exec --help` on 0.147.0).
- cursor-cli and opencode return `executor.ErrReadOnlyUnsupported`; the runner treats it as a refusal and falls back. The web select lists only Native, Claude Code, pi and Codex CLI.

## Runner refactor

`runDelegated` is split into a shared run protocol used by worker and review runs: `cliRun` (phase, harness, entry, adapter, auth, ledger labels, steer flag), `launchRun`, `pollRun` returning how the run ended, `finishCommon`, `finishNoResult`, `recordLedger`. Review runs live in `runs/review-<id>`, never steer, never resume, and book their ledger row under the reviewer agent so the review token ceiling counts them. Every `executor.*` event now carries `phase` (generate or prove); `LastRunState` skips prove-phase spawns so a worker never resumes the reviewer's session.

## Schema and API

- `missions.review_harness text NOT NULL DEFAULT ''` in `0001_init.sql`; ALTER listed in `scripts/pending-alters.md` (must be applied on live instances before deploy).
- Create API accepts `review_harness` ("native" stored as ""), validated against registered adapters. Schedule templates carry it and copy it onto fired missions.
- Web: "Review harness" select under Advanced (hidden for light missions), timeline rows for prove-phase spawns and the fallback event.

## Verify

- `go build`, `go vet` (plain and `-tags integration`), `make test`, `make lint`: clean.
- Web build, lint (0 errors), tests: pass.
- Local smoke: coding mission with `harness: pi`, `review_harness: pi` on the canary route (see PR comment for the event trace).

## Left out

- `reviewVerdictSchema` lacks `additionalProperties: false`; OpenAI strict output schemas may reject it on codex, which then falls back to native. A codex-specific strict variant is a possible follow-up.
- A brain restart mid-review re-runs the review fresh (no review resume, per D-092).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791322073&installation_model_id=431401&pr_number=583&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F583&signature=011b1d6e70c2a061f5f11e47298a15129d4a0c7f88d74a26e69ee160fb1d57c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->