### PR TITLE
fix(install): drop dead searxng asset fetch, clean stale bind dir

### DIFF
--- a/deploy/release/install.sh
+++ b/deploy/release/install.sh
@@ -73,14 +73,10 @@ fi
 echo "Downloading release assets..."
 fetch "${BASE_URL}/docker-compose.yml" docker-compose.yml
 fetch "${BASE_URL}/env.example" env.example
-# Releases before the inline searxng config still bind ./searxng; keep
-# the file coming for them, skip quietly once the asset is gone.
-mkdir -p searxng
-if fetch "${BASE_URL}/searxng-settings.yml" searxng/settings.yml.new 2>/dev/null; then
-  mv searxng/settings.yml.new searxng/settings.yml
-else
-  rm -f searxng/settings.yml.new
-fi
+# searxng's settings are inlined in the compose file we just fetched, so
+# the ./searxng bind from older installs is dead: nothing reads it, but an
+# operator editing it would expect otherwise. Drop it on upgrade.
+rm -f searxng/settings.yml
 rmdir searxng 2>/dev/null || true
 
 # --- .env ---


### PR DESCRIPTION
Follow-up to #577, which moved searxng's settings into an inline compose `configs.content` block and dropped the `searxng-settings.yml` release asset. Two loose ends in the installer were left behind.

The compat fetch block turned out to be dead in every path, not just misleading. The installer at a given tag fetches that tag's compose, which always carries the settings inline, so a downloaded `searxng/settings.yml` could never be read by the stack being installed. The block only fired at all when piping `install.sh` from `main` against an older tag, and even then the file it produced went unread. Its comment implied it covered upgrades generally. Deleting it beat documenting it.

That leaves the pre-inline layout sitting on disk for anyone upgrading from before #577, where an operator editing `searxng/settings.yml` would see no effect. So the replacement removes the file the installer used to own, and drops the directory when nothing else is in it. `rmdir` refusing a non-empty directory is the wanted behavior here: an operator's unrelated file in `searxng/` survives untouched.

Net −5 lines.

Closes #588

## Testing

`sh -n` passes. Three scenarios exercised in a real shell under `set -eu`:

- upgrade with a stale `searxng/settings.yml` present: file and directory removed
- fresh install with no `searxng/` at all: nothing created, nothing left
- `searxng/` holding an operator's own extra file: `settings.yml` removed, the other file and the directory preserved

No Go or web code touched, so `make build test vet lint` was not run. CI's `compose` job fires on the `deploy/**` path filter.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791407896&installation_model_id=431401&pr_number=589&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F589&signature=843ab283c7738f889119f9bf073c505856e6f84da56a9caa8914eb2405ba2122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->