### PR TITLE
fix(web): keep memory graph layout stable during selection and pan

### DIFF
--- a/web/src/components/charts/EChart.test.tsx
+++ b/web/src/components/charts/EChart.test.tsx
@@ -1,0 +1,63 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EChart } from './EChart'
+
+// jsdom has no canvas: stub the tree-shaken core entry point the same
+// way GraphTab.test.tsx does, plus dispatchAction (unused here but
+// keeps the mock shape consistent) so init/dispose calls are visible.
+const setOption = vi.fn()
+const dispose = vi.fn()
+const init = vi.fn(() => ({
+  setOption,
+  resize: vi.fn(),
+  dispose,
+  dispatchAction: vi.fn(),
+  on: vi.fn(),
+  getZr: vi.fn(() => ({ on: vi.fn() })),
+}))
+
+vi.mock('echarts/core', () => ({
+  use: vi.fn(),
+  init: (...args: unknown[]) => init(...(args as [])),
+}))
+vi.mock('echarts/charts', () => ({ BarChart: {}, LineChart: {}, PieChart: {}, GaugeChart: {}, GraphChart: {} }))
+vi.mock('echarts/components', () => ({
+  GridComponent: {},
+  TooltipComponent: {},
+  LegendComponent: {},
+  TitleComponent: {},
+  DataZoomComponent: {},
+  MarkLineComponent: {},
+}))
+vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }))
+
+afterEach(() => {
+  cleanup()
+  document.documentElement.className = ''
+})
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('EChart theme observer', () => {
+  it('does not dispose or re-init when the class changes without flipping dark', async () => {
+    render(<EChart option={{}} />)
+    expect(init).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      document.documentElement.className = 'focus-visible'
+    })
+    expect(dispose).not.toHaveBeenCalled()
+    expect(init).toHaveBeenCalledTimes(1)
+  })
+
+  it('disposes and re-inits, then sets option again, when dark flips', async () => {
+    render(<EChart option={{}} />)
+    expect(init).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      document.documentElement.classList.add('dark')
+    })
+    await waitFor(() => expect(dispose).toHaveBeenCalledTimes(1))
+    expect(init).toHaveBeenCalledTimes(2)
+    expect(setOption).toHaveBeenCalledWith({}, { notMerge: true })
+  })
+})

--- a/web/src/components/charts/EChart.tsx
+++ b/web/src/components/charts/EChart.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import * as echarts from 'echarts/core'
+import { isDarkTheme } from './theme'
 import { BarChart, GaugeChart, GraphChart, LineChart, PieChart } from 'echarts/charts'
 import {
   DataZoomComponent,
@@ -62,7 +63,14 @@ export function EChart({ option, height = 240, fill = false, notMerge = true, on
     const resizeObserver = new ResizeObserver(() => chart.resize())
     resizeObserver.observe(el)
 
+    // Class attribute changes on <html> for reasons other than the
+    // dark/light toggle (e.g. focus-visible) must not dispose the
+    // chart, so only re-init when the dark boolean actually flips.
+    let dark = isDarkTheme()
     const themeObserver = new MutationObserver(() => {
+      const nowDark = isDarkTheme()
+      if (nowDark === dark) return
+      dark = nowDark
       chart.dispose()
       chartRef.current = echarts.init(el)
       chartRef.current.setOption(option, { notMerge })

--- a/web/src/components/memory/EntityGraph.test.tsx
+++ b/web/src/components/memory/EntityGraph.test.tsx
@@ -1,0 +1,193 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EntityGraphData } from '../../api/types'
+import { EntityGraph } from './EntityGraph'
+
+// jsdom has no canvas: EChart inits a real chart on mount, which throws
+// without a canvas 2d context. Stub the tree-shaken core entry point
+// with a no-op instance that records registered handlers so tests can
+// drive node/blank clicks directly, matching GraphTab.test.tsx's mock.
+let clickHandler: ((params: unknown) => void) | null = null
+let zrMousedownHandler: ((event: unknown) => void) | null = null
+let zrClickHandler: ((event: unknown) => void) | null = null
+const dispatchAction = vi.fn()
+
+vi.mock('echarts/core', () => ({
+  use: vi.fn(),
+  init: vi.fn(() => ({
+    setOption: vi.fn(),
+    resize: vi.fn(),
+    dispose: vi.fn(),
+    dispatchAction,
+    on: vi.fn((_event: string, _opts: unknown, handler: (params: unknown) => void) => {
+      clickHandler = handler
+    }),
+    getZr: vi.fn(() => ({
+      on: vi.fn((event: string, handler: (event: unknown) => void) => {
+        if (event === 'mousedown') zrMousedownHandler = handler
+        if (event === 'click') zrClickHandler = handler
+      }),
+    })),
+  })),
+}))
+vi.mock('echarts/charts', () => ({ BarChart: {}, LineChart: {}, PieChart: {}, GaugeChart: {}, GraphChart: {} }))
+vi.mock('echarts/components', () => ({
+  GridComponent: {},
+  TooltipComponent: {},
+  LegendComponent: {},
+  TitleComponent: {},
+  DataZoomComponent: {},
+  MarkLineComponent: {},
+}))
+vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }))
+
+const graph: EntityGraphData = {
+  entities: [
+    { id: 'e1', type: 'project', name: 'timothy', memory_count: 2 },
+    { id: 'e2', type: 'person', name: 'sumon', memory_count: 1 },
+  ],
+  edges: [{ src: 'e1', dst: 'e2', weight: 1 }],
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  clickHandler = null
+  zrMousedownHandler = null
+  zrClickHandler = null
+})
+
+describe('EntityGraph selection effect', () => {
+  it('unselects only when selectedId is null', async () => {
+    render(<EntityGraph data={graph} selectedId={null} onSelect={vi.fn()} />)
+    await screen.findByTestId('entity-graph')
+    await waitFor(() => expect(dispatchAction).toHaveBeenCalledWith({ type: 'unselect', seriesId: 'entities' }))
+    expect(dispatchAction).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'select' }))
+  })
+
+  it('selects the node at its index when selectedId matches a visible node', async () => {
+    render(<EntityGraph data={graph} selectedId="e2" onSelect={vi.fn()} />)
+    await screen.findByTestId('entity-graph')
+    await waitFor(() =>
+      expect(dispatchAction).toHaveBeenLastCalledWith({ type: 'select', seriesId: 'entities', dataIndex: 1 }),
+    )
+  })
+
+  it('unselects only, without a select call, when selectedId is hidden by a kind toggle', async () => {
+    const { rerender } = render(<EntityGraph data={graph} selectedId="e2" onSelect={vi.fn()} />)
+    await screen.findByTestId('entity-graph')
+    await waitFor(() =>
+      expect(dispatchAction).toHaveBeenLastCalledWith({ type: 'select', seriesId: 'entities', dataIndex: 1 }),
+    )
+    dispatchAction.mockClear()
+    fireEvent.click(screen.getByRole('button', { name: 'person' }))
+    rerender(<EntityGraph data={graph} selectedId="e2" onSelect={vi.fn()} />)
+    await waitFor(() => expect(dispatchAction).toHaveBeenCalledWith({ type: 'unselect', seriesId: 'entities' }))
+    expect(dispatchAction).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'select' }))
+  })
+})
+
+describe('EntityGraph background click', () => {
+  it('does nothing when the click landed on an element (has a target)', async () => {
+    const onSelect = vi.fn()
+    render(<EntityGraph data={graph} selectedId="e1" onSelect={onSelect} />)
+    await screen.findByTestId('entity-graph')
+    zrMousedownHandler!({ offsetX: 100, offsetY: 100 })
+    zrClickHandler!({ target: {}, offsetX: 100, offsetY: 100 })
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('deselects on a background click with no prior mousedown', async () => {
+    const onSelect = vi.fn()
+    render(<EntityGraph data={graph} selectedId="e1" onSelect={onSelect} />)
+    await screen.findByTestId('entity-graph')
+    zrClickHandler!({ target: null, offsetX: 100, offsetY: 100 })
+    expect(onSelect).toHaveBeenCalledWith(null)
+  })
+
+  it('falls back to 0,0 when mousedown is missing offsetX/offsetY, still counts as a click', async () => {
+    const onSelect = vi.fn()
+    render(<EntityGraph data={graph} selectedId="e1" onSelect={onSelect} />)
+    await screen.findByTestId('entity-graph')
+    zrMousedownHandler!({})
+    zrClickHandler!({ target: null, offsetX: 0, offsetY: 0 })
+    expect(onSelect).toHaveBeenCalledWith(null)
+  })
+
+  it('falls back to 0,0 when click is missing offsetX/offsetY', async () => {
+    const onSelect = vi.fn()
+    render(<EntityGraph data={graph} selectedId="e1" onSelect={onSelect} />)
+    await screen.findByTestId('entity-graph')
+    zrMousedownHandler!({ offsetX: 0, offsetY: 0 })
+    zrClickHandler!({ target: null })
+    expect(onSelect).toHaveBeenCalledWith(null)
+  })
+
+  it('keeps the selection when the pointer moved past the click threshold', async () => {
+    const onSelect = vi.fn()
+    render(<EntityGraph data={graph} selectedId="e1" onSelect={onSelect} />)
+    await screen.findByTestId('entity-graph')
+    zrMousedownHandler!({ offsetX: 100, offsetY: 100 })
+    zrClickHandler!({ target: null, offsetX: 120, offsetY: 100 })
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+})
+
+describe('EntityGraph node click', () => {
+  it('selects a node when it is not already selected', async () => {
+    const onSelect = vi.fn()
+    render(<EntityGraph data={graph} selectedId={null} onSelect={onSelect} />)
+    await screen.findByTestId('entity-graph')
+    clickHandler!({ dataType: 'node', data: { id: 'e1' } })
+    expect(onSelect).toHaveBeenCalledWith('e1')
+  })
+
+  it('deselects when clicking the already-selected node', async () => {
+    const onSelect = vi.fn()
+    render(<EntityGraph data={graph} selectedId="e1" onSelect={onSelect} />)
+    await screen.findByTestId('entity-graph')
+    clickHandler!({ dataType: 'node', data: { id: 'e1' } })
+    expect(onSelect).toHaveBeenCalledWith(null)
+  })
+
+  it('ignores clicks that are not on a node', async () => {
+    const onSelect = vi.fn()
+    render(<EntityGraph data={graph} selectedId={null} onSelect={onSelect} />)
+    await screen.findByTestId('entity-graph')
+    clickHandler!({ dataType: 'edge', data: { id: 'e1' } })
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('ignores a node click with no id', async () => {
+    const onSelect = vi.fn()
+    render(<EntityGraph data={graph} selectedId={null} onSelect={onSelect} />)
+    await screen.findByTestId('entity-graph')
+    clickHandler!({ dataType: 'node', data: {} })
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+})
+
+describe('EntityGraph toggleKind', () => {
+  it('hides a kind then shows it again', async () => {
+    render(<EntityGraph data={graph} selectedId={null} onSelect={vi.fn()} />)
+    await screen.findByTestId('entity-graph')
+    const chip = screen.getByRole('button', { name: 'project' })
+    expect(chip).not.toHaveClass('opacity-40')
+    fireEvent.click(chip)
+    expect(chip).toHaveClass('opacity-40')
+    fireEvent.click(chip)
+    expect(chip).not.toHaveClass('opacity-40')
+  })
+
+  it('toggles a kind via keyboard Enter/Space, ignoring other keys', async () => {
+    render(<EntityGraph data={graph} selectedId={null} onSelect={vi.fn()} />)
+    await screen.findByTestId('entity-graph')
+    const chip = screen.getByRole('button', { name: 'project' })
+    fireEvent.keyDown(chip, { key: 'a' })
+    expect(chip).not.toHaveClass('opacity-40')
+    fireEvent.keyDown(chip, { key: 'Enter' })
+    expect(chip).toHaveClass('opacity-40')
+    fireEvent.keyDown(chip, { key: ' ' })
+    expect(chip).not.toHaveClass('opacity-40')
+  })
+})

--- a/web/src/components/memory/EntityGraph.tsx
+++ b/web/src/components/memory/EntityGraph.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import type * as echarts from 'echarts/core'
 import type { EntityGraphData } from '../../api/types'
 import { EChart } from '../charts/EChart'
-import { colorOfKind, graphOption } from './graphOption'
+import { colorOfKind, graphOption, visibleEntities } from './graphOption'
 
 // EntityGraph renders the entity co-occurrence graph on ECharts' force
 // layout: zoom/pan/drag, categories per entity kind, edges weighted by
@@ -18,25 +18,35 @@ export function EntityGraph({
   onSelect: (id: string | null) => void
 }) {
   const [hiddenKinds, setHiddenKinds] = useState<Set<string>>(new Set())
-  // Selection-only re-renders keep notMerge off so the force layout
-  // doesn't restart; a data or filter change rebuilds it fully.
-  const [selectMerge, setSelectMerge] = useState(false)
   // Click handlers are attached once (on chart init); read current
   // selection through a ref rather than closing over stale state.
   const selectedRef = useRef(selectedId)
   useEffect(() => {
     selectedRef.current = selectedId
   }, [selectedId])
+  const chartRef = useRef<echarts.ECharts | null>(null)
+  // Pointer-down position, to tell a pan release from a background
+  // click: only a near-stationary pointer counts as a click-to-deselect.
+  const downPosRef = useRef<{ x: number; y: number } | null>(null)
 
-  const option = useMemo(
-    () => graphOption(data, hiddenKinds, selectedId),
-    [data, hiddenKinds, selectedId],
-  )
+  // The option no longer depends on selectedId, so it never rebuilds
+  // (and never restarts the force simulation) on selection alone.
+  const option = useMemo(() => graphOption(data, hiddenKinds), [data, hiddenKinds])
 
   const kinds = [...new Set(data.entities.map((n) => n.type))]
 
+  useEffect(() => {
+    const chart = chartRef.current
+    if (!chart) return
+    // Series data is the kind-filtered list, so index into that, not data.entities.
+    const dataIndex = visibleEntities(data, hiddenKinds).findIndex((n) => n.id === selectedId)
+    chart.dispatchAction({ type: 'unselect', seriesId: 'entities' })
+    if (dataIndex >= 0) {
+      chart.dispatchAction({ type: 'select', seriesId: 'entities', dataIndex })
+    }
+  }, [selectedId, data, hiddenKinds])
+
   function toggleKind(kind: string) {
-    setSelectMerge(false)
     setHiddenKinds((prev) => {
       const next = new Set(prev)
       if (next.has(kind)) next.delete(kind)
@@ -45,19 +55,25 @@ export function EntityGraph({
     })
   }
 
-  function select(id: string | null) {
-    setSelectMerge(true)
-    onSelect(id)
-  }
-
   function attachHandlers(chart: echarts.ECharts) {
+    chartRef.current = chart
     chart.on('click', { seriesType: 'graph' }, (params) => {
       const p = params as { dataType?: string; data?: { id?: string } }
       if (p.dataType !== 'node' || !p.data?.id) return
-      select(p.data.id === selectedRef.current ? null : p.data.id)
+      onSelect(p.data.id === selectedRef.current ? null : p.data.id)
+    })
+    chart.getZr().on('mousedown', (event) => {
+      const e = event as { offsetX?: number; offsetY?: number }
+      downPosRef.current = { x: e.offsetX ?? 0, y: e.offsetY ?? 0 }
     })
     chart.getZr().on('click', (event) => {
-      if (!event.target) select(null)
+      const e = event as { target?: unknown; offsetX?: number; offsetY?: number }
+      if (e.target) return
+      const down = downPosRef.current
+      const moved = down
+        ? Math.hypot((e.offsetX ?? 0) - down.x, (e.offsetY ?? 0) - down.y)
+        : 0
+      if (moved < 5) onSelect(null)
     })
   }
 
@@ -77,7 +93,7 @@ export function EntityGraph({
         role="img"
         aria-label="Entity knowledge graph"
       >
-        <EChart option={option} height={520} notMerge={!selectMerge} onChartReady={attachHandlers} />
+        <EChart option={option} height={520} notMerge={false} onChartReady={attachHandlers} />
       </div>
       <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
         {kinds.map((k) => {

--- a/web/src/components/memory/GraphTab.test.tsx
+++ b/web/src/components/memory/GraphTab.test.tsx
@@ -16,7 +16,9 @@ vi.mock('../../api/client', () => ({
 // drive node/blank clicks directly — graphOption.test.ts carries the
 // option-logic coverage, not the canvas render itself.
 let clickHandler: ((params: unknown) => void) | null = null
+let zrMousedownHandler: ((event: unknown) => void) | null = null
 let zrClickHandler: ((event: unknown) => void) | null = null
+const dispatchAction = vi.fn()
 
 vi.mock('echarts/core', () => ({
   use: vi.fn(),
@@ -24,12 +26,14 @@ vi.mock('echarts/core', () => ({
     setOption: vi.fn(),
     resize: vi.fn(),
     dispose: vi.fn(),
+    dispatchAction,
     on: vi.fn((_event: string, _opts: unknown, handler: (params: unknown) => void) => {
       clickHandler = handler
     }),
     getZr: vi.fn(() => ({
-      on: vi.fn((_event: string, handler: (event: unknown) => void) => {
-        zrClickHandler = handler
+      on: vi.fn((event: string, handler: (event: unknown) => void) => {
+        if (event === 'mousedown') zrMousedownHandler = handler
+        if (event === 'click') zrClickHandler = handler
       }),
     })),
   })),
@@ -77,6 +81,7 @@ afterEach(cleanup)
 beforeEach(() => {
   vi.clearAllMocks()
   clickHandler = null
+  zrMousedownHandler = null
   zrClickHandler = null
   vi.mocked(entityGraph).mockResolvedValue(graph)
   vi.mocked(entityMemories).mockResolvedValue([memory])
@@ -90,7 +95,13 @@ describe('GraphTab', () => {
     expect(screen.getByText('person')).toBeInTheDocument()
   })
 
-  it('clicking a node opens the detail panel with its memories', async () => {
+  it('shows the hint text before anything is selected, graph wrapper stays mounted', async () => {
+    renderTab()
+    expect(await screen.findByTestId('entity-graph')).toBeInTheDocument()
+    expect(screen.getByText('Select an entity to see the memories behind it.')).toBeInTheDocument()
+  })
+
+  it('clicking a node opens the detail panel with its memories, graph wrapper stays mounted', async () => {
     renderTab()
     await screen.findByTestId('entity-graph')
     clickHandler!({ dataType: 'node', data: { id: 'e1' } })
@@ -100,6 +111,8 @@ describe('GraphTab', () => {
       'Timothy is a self-hosted assistant.',
     )
     expect(entityMemories).toHaveBeenCalledWith('e1')
+    expect(screen.getByTestId('entity-graph')).toBeInTheDocument()
+    expect(screen.queryByText('Select an entity to see the memories behind it.')).toBeNull()
   })
 
   it('clicking the empty canvas clears the selection', async () => {
@@ -107,8 +120,31 @@ describe('GraphTab', () => {
     await screen.findByTestId('entity-graph')
     clickHandler!({ dataType: 'node', data: { id: 'e1' } })
     await screen.findByTestId('entity-detail')
-    zrClickHandler!({ target: null })
+    zrMousedownHandler!({ offsetX: 100, offsetY: 100 })
+    zrClickHandler!({ target: null, offsetX: 100, offsetY: 100 })
     await waitFor(() => expect(screen.queryByTestId('entity-detail')).toBeNull())
+  })
+
+  it('rings the selected node by its index in the kind-filtered series', async () => {
+    renderTab()
+    await screen.findByTestId('entity-graph')
+    clickHandler!({ dataType: 'node', data: { id: 'e2' } })
+    await screen.findByTestId('entity-detail')
+    expect(dispatchAction).toHaveBeenLastCalledWith({ type: 'select', seriesId: 'entities', dataIndex: 1 })
+    fireEvent.click(screen.getByRole('button', { name: 'project' }))
+    await waitFor(() =>
+      expect(dispatchAction).toHaveBeenLastCalledWith({ type: 'select', seriesId: 'entities', dataIndex: 0 }),
+    )
+  })
+
+  it('releasing a pan on empty canvas keeps the selection', async () => {
+    renderTab()
+    await screen.findByTestId('entity-graph')
+    clickHandler!({ dataType: 'node', data: { id: 'e1' } })
+    await screen.findByTestId('entity-detail')
+    zrMousedownHandler!({ offsetX: 100, offsetY: 100 })
+    zrClickHandler!({ target: null, offsetX: 120, offsetY: 100 })
+    expect(await screen.findByTestId('entity-detail')).toBeInTheDocument()
   })
 
   it('shows the empty state when no entities exist', async () => {

--- a/web/src/components/memory/GraphTab.tsx
+++ b/web/src/components/memory/GraphTab.tsx
@@ -38,16 +38,16 @@ export function GraphTab() {
       <div className="min-w-0 flex-1">
         <EntityGraph data={data} selectedId={selectedId} onSelect={setSelectedId} />
       </div>
-      {selected ? (
+      {data.entities.length > 0 && (
         <div className="lg:w-80 lg:shrink-0">
-          <EntityDetailPanel entity={selected} />
+          {selected ? (
+            <EntityDetailPanel entity={selected} />
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Select an entity to see the memories behind it.
+            </p>
+          )}
         </div>
-      ) : (
-        data.entities.length > 0 && (
-          <p className="text-sm text-muted-foreground lg:w-80 lg:shrink-0">
-            Select an entity to see the memories behind it.
-          </p>
-        )
       )}
     </div>
   )

--- a/web/src/components/memory/graphOption.test.ts
+++ b/web/src/components/memory/graphOption.test.ts
@@ -4,8 +4,11 @@ import { graphOption, visibleEntities } from './graphOption'
 
 type Series = {
   categories: { name: string }[]
-  data: { id: string; category: number; symbolSize: number; itemStyle?: { borderColor?: string; borderWidth?: number } }[]
+  data: { id: string; category: number; symbolSize: number }[]
   edges: { source: string; target: string }[]
+  label?: { show?: boolean }
+  labelLayout?: { hideOverlap?: boolean }
+  force?: { layoutAnimation?: boolean }
 }
 
 function seriesOf(option: ReturnType<typeof graphOption>): Series {
@@ -31,7 +34,7 @@ const data: EntityGraphData = {
 
 describe('graphOption', () => {
   it('assigns one category per entity kind present', () => {
-    const s = seriesOf(graphOption(data, new Set(), null))
+    const s = seriesOf(graphOption(data, new Set()))
     expect(s.categories.map((c) => c.name)).toEqual(['person', 'project'])
     const a = s.data.find((n) => n.id === 'a')!
     const b = s.data.find((n) => n.id === 'b')!
@@ -40,30 +43,48 @@ describe('graphOption', () => {
   })
 
   it('drops hidden-kind nodes and their edges', () => {
-    const s = seriesOf(graphOption(data, new Set(['project']), null))
+    const s = seriesOf(graphOption(data, new Set(['project'])))
     expect(s.data.map((n) => n.id)).toEqual(['a'])
     expect(s.edges).toHaveLength(0)
   })
 
   it('drops edges with a dangling endpoint', () => {
-    const s = seriesOf(graphOption(data, new Set(), null))
+    const s = seriesOf(graphOption(data, new Set()))
     expect(s.edges).toHaveLength(1)
     expect(s.edges[0]).toMatchObject({ source: 'a', target: 'b' })
   })
 
   it('sizes nodes monotonically with memory_count', () => {
-    const s = seriesOf(graphOption(data, new Set(), null))
+    const s = seriesOf(graphOption(data, new Set()))
     const size = (id: string) => s.data.find((n) => n.id === id)!.symbolSize
     expect(size('a')).toBeGreaterThan(size('b'))
     expect(size('b')).toBeGreaterThan(size('c'))
   })
 
-  it('gives the selected node border styling', () => {
-    const s = seriesOf(graphOption(data, new Set(), 'b'))
-    const a = s.data.find((n) => n.id === 'a')!
-    const b = s.data.find((n) => n.id === 'b')!
-    expect(a.itemStyle).toBeUndefined()
-    expect(b.itemStyle?.borderWidth).toBeGreaterThan(0)
+  function manyNodes(count: number): EntityGraphData {
+    return {
+      entities: Array.from({ length: count }, (_, i) => node(`n${i}`, 'topic', 1)),
+      edges: [],
+    }
+  }
+
+  it('hides overlap labels below the dense threshold', () => {
+    const s = seriesOf(graphOption(manyNodes(20), new Set()))
+    expect(s.labelLayout?.hideOverlap).toBe(true)
+    expect(s.label?.show).toBe(true)
+  })
+
+  it('shows labels on emphasis only above the dense threshold', () => {
+    const s = seriesOf(graphOption(manyNodes(200), new Set()))
+    expect(s.labelLayout).toBeUndefined()
+    expect(s.label?.show).toBe(false)
+  })
+
+  it('disables force layout animation for very large graphs', () => {
+    const small = seriesOf(graphOption(manyNodes(200), new Set()))
+    const large = seriesOf(graphOption(manyNodes(400), new Set()))
+    expect(small.force?.layoutAnimation).toBe(true)
+    expect(large.force?.layoutAnimation).toBe(false)
   })
 })
 

--- a/web/src/components/memory/graphOption.ts
+++ b/web/src/components/memory/graphOption.ts
@@ -40,12 +40,10 @@ function visibleEdges(edges: EntityEdge[], known: Set<string>): EntityEdge[] {
 
 // graphOption builds the ECharts `graph` series option: force layout,
 // category per entity kind, node size from memory_count (sqrt scale),
-// edge width from co-occurrence weight, selected node ringed in brand.
-export function graphOption(
-  data: EntityGraphData,
-  hiddenKinds: Set<string>,
-  selectedId: string | null,
-): EChartsOption {
+// edge width from co-occurrence weight. Selection styling is applied
+// separately by EntityGraph via dispatchAction, not baked in here, so
+// this option never changes on selection alone.
+export function graphOption(data: EntityGraphData, hiddenKinds: Set<string>): EChartsOption {
   const theme = buildBaseTheme()
   const foreground = getComputedStyle(document.documentElement).getPropertyValue('--muted-foreground').trim()
   const border = getComputedStyle(document.documentElement).getPropertyValue('--border').trim()
@@ -75,10 +73,6 @@ export function graphOption(
     symbolSize: sizeOf(n.memory_count),
     category: categoryIndex.get(n.type),
     label: { formatter: () => truncate(n.name) },
-    itemStyle:
-      n.id === selectedId
-        ? { borderColor: brand, borderWidth: 3 }
-        : undefined,
   }))
 
   const seriesEdges = edges.map((e) => ({
@@ -95,6 +89,10 @@ export function graphOption(
   const gravity = n > 200 ? 0.05 : n > 50 ? 0.1 : 0.2
   const edgeLength = edges.length > 0 ? edges.map((e) => edgeLengthOf(e.weight)) : 100
 
+  // Above 150 visible nodes, hideOverlap's per-frame recompute makes
+  // the force layout lag; labels then only show on hover/emphasis.
+  const labelDense = n > 150
+
   return {
     textStyle: theme.textStyle,
     tooltip: {
@@ -110,20 +108,23 @@ export function graphOption(
     },
     series: [
       {
+        id: 'entities',
         type: 'graph',
         layout: 'force',
         roam: true,
         draggable: true,
         scaleLimit: { min: 0.4, max: 6 },
+        selectedMode: 'single',
+        select: { itemStyle: { borderColor: brand, borderWidth: 3 } },
         label: {
-          show: true,
+          show: !labelDense,
           position: 'bottom',
           color: foreground,
           fontSize: 10,
         },
-        labelLayout: { hideOverlap: true },
-        emphasis: { focus: 'adjacency' },
-        force: { repulsion, gravity, edgeLength },
+        ...(labelDense ? {} : { labelLayout: { hideOverlap: true } }),
+        emphasis: { focus: 'adjacency', label: { show: true } },
+        force: { repulsion, gravity, edgeLength, layoutAnimation: n <= 300 },
         categories,
         data: seriesNodes,
         edges: seriesEdges,

--- a/web/src/pages/Memory.test.tsx
+++ b/web/src/pages/Memory.test.tsx
@@ -23,6 +23,7 @@ vi.mock('echarts/core', () => ({
     setOption: vi.fn(),
     resize: vi.fn(),
     dispose: vi.fn(),
+    dispatchAction: vi.fn(),
     on: vi.fn(),
     getZr: vi.fn(() => ({ on: vi.fn() })),
   })),


### PR DESCRIPTION
Closes #592.

## Summary

Selecting, panning and filtering the memory knowledge graph no longer restarts the force layout or reshuffles nodes.

## Why

Every selection rebuilt the ECharts option and called `setOption` with `notMerge`, which re-ran the force simulation. Mounting the detail panel also shrank the canvas, so the ResizeObserver triggered another layout pass, and a background click at the end of a pan cleared the selection and repeated both. Legend toggles and refreshes discarded positions the same way. On larger graphs `hideOverlap` recomputed labels every animation frame.

## Changes

- Selection is applied with `dispatchAction` (`select`/`unselect` on the `entities` series, `selectedMode: 'single'`). `graphOption` no longer takes `selectedId`, so the option is stable across selection. The dispatched index is taken from the kind-filtered node list, matching the series data.
- The right column in GraphTab is always rendered once entities exist, holding either the detail panel or the hint, so the canvas width does not change on select.
- A background click deselects only when the pointer moved less than 5px since mousedown; a pan release keeps the selection.
- Option updates always merge, so legend toggles and refreshes keep existing node positions.
- Above 150 visible nodes, labels show on emphasis only and `hideOverlap` is off; above 300 nodes `force.layoutAnimation` is off.
- The EChart theme observer re-initialises the chart only when the dark class actually flips, not on any class change on `<html>`.

## Verification

Build, lint and the full Vitest suite in Docker: 78 files, 1115 tests passed, lint 0 errors. New tests cover the label and animation thresholds, pan-then-release keeping the selection, the hint and graph wrapper staying mounted across selection, and the dispatched index after hiding a kind.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791447141&installation_model_id=431401&pr_number=593&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F593&signature=6752d646ced6d141ac7a24f27aa1b2262c2ee3ed982967e10387cfc2b9658dd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->