### PR TITLE
refactor(web): remaining pages on the canonical design layer

### DIFF
--- a/web/src/components/AttachmentViewer.tsx
+++ b/web/src/components/AttachmentViewer.tsx
@@ -142,7 +142,7 @@ export function AttachmentViewer({
             </DialogClose>
           </div>
         </div>
-        <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto bg-zinc-950/2 dark:bg-black/40">
+        <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto bg-muted/40">
           {failed && (
             <div className="flex flex-col items-center gap-2 text-muted-foreground">
               <HugeiconsIcon icon={ImageNotFound01Icon} className="size-8" />

--- a/web/src/components/CodeBlock.tsx
+++ b/web/src/components/CodeBlock.tsx
@@ -106,7 +106,9 @@ const LANGUAGE_LOGOS: Record<string, string> = {
 // black at one end. Devicon ships no currentColor/plain variant for
 // these, so instead of the raw <img> they get a small light chip
 // behind them in dark mode only (light mode already has a light
-// background, so no chip needed there).
+// background, so no chip needed there). Fixed white, not a token:
+// the chip exists to keep third-party artwork visible against the
+// dark theme, not to express a themeable surface.
 const DARK_MODE_NEEDS_CHIP = new Set(['bash', 'sh', 'shell', 'markdown', 'json'])
 
 // shiki/langs (bundledLanguages/bundledLanguagesAlias: id/alias ->

--- a/web/src/components/FilePreviewBlocks.tsx
+++ b/web/src/components/FilePreviewBlocks.tsx
@@ -47,7 +47,7 @@ export function FileCodeBlock({ code, path }: { code: string; path: string }) {
 export function FileMarkdownBlock({ text, raw }: { text: string; raw: boolean }) {
   if (raw) return <FileCodeBlock code={text} path="file.md" />
   return (
-    <div className="prose prose-sm max-w-none p-3 dark:prose-invert">
+    <div className="prose max-w-none p-3 dark:prose-invert">
       <ReactMarkdown
         remarkPlugins={remarkPlugins}
         rehypePlugins={rehypePlugins}

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -356,7 +356,7 @@ export function UserMessage({
       <div className="group/message flex w-full min-w-0 items-end justify-end gap-1">
         <CopyButton text={text} label="Copy message" />
         {text !== '' && (
-          <div className="prose prose-sm ml-auto min-w-0 max-w-[85%] break-words rounded-md bg-muted px-4 py-3 text-prose text-foreground [overflow-wrap:anywhere]">
+          <div className="prose ml-auto min-w-0 max-w-[85%] break-words rounded-md bg-muted px-4 py-3 text-prose text-foreground [overflow-wrap:anywhere]">
             <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
               {text}
             </ReactMarkdown>
@@ -403,7 +403,7 @@ export function InterruptedMessage({ text }: { text: string }) {
       className="group/message flex w-full flex-col gap-2 rounded-md border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground"
       data-testid="interrupted"
     >
-      <div className="prose prose-sm min-w-0 max-w-none break-words text-foreground [overflow-wrap:anywhere]">
+      <div className="prose min-w-0 max-w-none break-words text-foreground [overflow-wrap:anywhere]">
         <ReactMarkdown
           remarkPlugins={remarkPlugins}
           rehypePlugins={rehypePlugins}
@@ -509,7 +509,7 @@ export function AssistantMessage({
       <div className="flex min-w-0 max-w-full items-center gap-2.5">
         <span
           aria-hidden
-          className="inline-flex size-5 shrink-0 items-center justify-center rounded-md bg-brand text-[11px] font-semibold text-brand-foreground"
+          className="inline-flex size-5 shrink-0 items-center justify-center rounded-md bg-brand text-xs font-semibold text-brand-foreground"
         >
           T
         </span>
@@ -528,7 +528,7 @@ export function AssistantMessage({
 
       <div
         className={cn(
-          'prose prose-neutral w-full min-w-0 max-w-none break-words text-[15px] leading-6 [overflow-wrap:anywhere] dark:prose-invert',
+          'prose w-full min-w-0 max-w-none break-words [overflow-wrap:anywhere] dark:prose-invert',
           msg.tools.length > 0 ? 'mt-3' : 'mt-2',
         )}
       >

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -119,7 +119,7 @@ export function SessionList() {
         <Link
           to="/chat"
           aria-label="New chat"
-          className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-50"
+          className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition hover:bg-accent hover:text-accent-foreground"
         >
           <HugeiconsIcon icon={Add01Icon} className="size-4" />
         </Link>

--- a/web/src/components/knowledge/KbUploadForm.tsx
+++ b/web/src/components/knowledge/KbUploadForm.tsx
@@ -95,7 +95,7 @@ export function KbUploadForm({
           const files = [...e.dataTransfer.files]
           if (files.length > 0) void uploadFiles(files)
         }}
-        className="flex flex-col items-center gap-2 rounded-xl border border-dashed border-border p-6 text-center"
+        className="flex flex-col items-center gap-2 rounded-md border border-dashed border-border p-6 text-center"
       >
         <input
           ref={inputRef}

--- a/web/src/components/knowledge/KnowledgeAutoAdd.tsx
+++ b/web/src/components/knowledge/KnowledgeAutoAdd.tsx
@@ -1,8 +1,7 @@
-import { ArrowLeft01Icon } from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
-import { Link, useNavigate } from 'react-router'
+import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
 import { addKbDocumentFromUrlAuto, uploadKbDocumentAuto } from '../../api/client'
+import { PageHeader } from '../timothy/page-header'
 import { KbUploadForm } from './KbUploadForm'
 
 // KnowledgeAutoAdd is the top-level "Add to Knowledgebase" entry point:
@@ -14,22 +13,12 @@ export function KnowledgeAutoAdd() {
   const navigate = useNavigate()
 
   return (
-    <div className="mt-6 space-y-6">
-      <Link
-        to="/knowledge"
-        className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"
-      >
-        <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
-        Knowledge
-      </Link>
-
-      <div>
-        <h2 className="text-sm font-semibold">Add to Knowledgebase</h2>
-        <p className="text-sm text-muted-foreground">
-          Drop a file or paste a URL — it's classified into the best matching collection
-          automatically, or a new one is created if nothing fits.
-        </p>
-      </div>
+    <div className="space-y-6">
+      <PageHeader
+        title="Add to Knowledgebase"
+        description="Drop a file or paste a URL — it's classified into the best matching collection automatically, or a new one is created if nothing fits."
+        breadcrumbs={[{ label: 'Knowledge', href: '/knowledge' }, { label: 'Add to Knowledgebase' }]}
+      />
 
       <KbUploadForm
         uploadFile={uploadKbDocumentAuto}

--- a/web/src/components/knowledge/KnowledgeCollectionAdd.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionAdd.tsx
@@ -1,10 +1,9 @@
-import { ArrowLeft01Icon } from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
 import { useState } from 'react'
-import { Link, useNavigate } from 'react-router'
+import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
 import { createKbCollection } from '../../api/client'
 import { Field } from '../timothy/field'
+import { PageHeader } from '../timothy/page-header'
 import { Input } from '../ui/input'
 import { Button } from '../ui/button'
 import { errText } from '../../lib/errors'
@@ -30,21 +29,12 @@ export function KnowledgeCollectionAdd() {
   }
 
   return (
-    <div className="mt-6 w-full space-y-6">
-      <Link
-        to="/knowledge"
-        className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"
-      >
-        <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
-        Knowledge
-      </Link>
-
-      <div className="border-b border-border pb-6">
-        <h1 className="text-xl font-semibold tracking-tight">New collection</h1>
-        <p className="text-sm text-muted-foreground">
-          A named group of documents agents can search with search_kb.
-        </p>
-      </div>
+    <div className="w-full space-y-6">
+      <PageHeader
+        title="New collection"
+        description="A named group of documents agents can search with search_kb."
+        breadcrumbs={[{ label: 'Knowledge', href: '/knowledge' }, { label: 'New collection' }]}
+      />
 
       <div className="max-w-3xl">
         <div className="grid gap-5">

--- a/web/src/components/knowledge/KnowledgeCollectionDetail.test.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionDetail.test.tsx
@@ -3,7 +3,12 @@ import { MemoryRouter } from 'react-router'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { KbDocument } from '../../api/types'
 import { TooltipProvider } from '../ui/tooltip'
-import { DocumentErrorLine, ProvenanceBadge, SourceBadge } from './KnowledgeCollectionDetail'
+import {
+  DocumentErrorLine,
+  DocumentStatusBadge,
+  ProvenanceBadge,
+  SourceBadge,
+} from './KnowledgeCollectionDetail'
 
 afterEach(cleanup)
 
@@ -79,6 +84,28 @@ describe('ProvenanceBadge', () => {
   })
 })
 
+describe('DocumentStatusBadge', () => {
+  afterEach(cleanup)
+
+  it.each([
+    ['pending', 'neutral'],
+    ['ingesting', 'working'],
+    ['ready', 'success'],
+    ['failed', 'error'],
+  ] as const)('renders the canonical badge for a %s document', (status, expectedDataStatus) => {
+    const doc: KbDocument = { ...baseDoc, status }
+    render(<DocumentStatusBadge doc={doc} />)
+    const label = screen.getByText(status)
+    expect(label.closest('span[data-status]')).toHaveAttribute('data-status', expectedDataStatus)
+  })
+
+  it('keeps the error as a title on a failed document', () => {
+    const doc: KbDocument = { ...baseDoc, status: 'failed', error: 'chain_exhausted' }
+    render(<DocumentStatusBadge doc={doc} />)
+    expect(screen.getByTitle('chain_exhausted')).toBeInTheDocument()
+  })
+})
+
 describe('DocumentErrorLine', () => {
   afterEach(cleanup)
 
@@ -88,7 +115,7 @@ describe('DocumentErrorLine', () => {
     const line = screen.getByText('chain_exhausted: too many input tokens')
     expect(line).toBeInTheDocument()
     expect(line).toHaveAttribute('title', doc.error)
-    expect(line).toHaveClass('text-red-400')
+    expect(line).toHaveClass('text-destructive')
   })
 
   it('renders nothing for a ready document', () => {

--- a/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
@@ -1,12 +1,8 @@
 import {
-  ArrowLeft01Icon,
-  CancelCircleIcon,
   Delete02Icon,
   Edit01Icon,
   File02Icon,
-  Loading03Icon,
   ReloadIcon,
-  Tick02Icon,
 } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
 import { useCallback, useEffect, useState } from 'react'
@@ -34,7 +30,12 @@ import {
 } from '../ui/dialog'
 import { errText } from '../../lib/errors'
 import { Input } from '../ui/input'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
+import { PageHeader } from '../timothy/page-header'
+import { Panel } from '../timothy/panel'
+import { StatusBadge } from '../timothy/status-badge'
+import type { Status } from '../timothy/status'
 import { KbUploadForm } from './KbUploadForm'
 
 const linkedSourceTypes = new Set<KbDocument['source_type']>(['url', 'clip'])
@@ -46,7 +47,7 @@ const missionSourceRefRe = /^mission:([^:]+)/
 
 export function SourceBadge({ doc }: { doc: KbDocument }) {
   const badge = (
-    <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium uppercase text-muted-foreground">
+    <span className="rounded-md bg-muted px-1.5 py-0.5 text-xs font-medium uppercase text-muted-foreground">
       {doc.source_type}
     </span>
   )
@@ -90,47 +91,37 @@ const provenanceLabel: Record<KbDocument['provenance'], string> = {
 // SourceBadge's ingestion mechanism.
 export function ProvenanceBadge({ doc }: { doc: KbDocument }) {
   return (
-    <span className="rounded border border-border px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
+    <span className="rounded-md border border-border px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
       {provenanceLabel[doc.provenance]}
     </span>
   )
 }
 
-const statusStyle: Record<KbDocument['status'], string> = {
-  pending: 'bg-muted text-muted-foreground',
-  ingesting: 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300',
-  ready: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300',
-  failed: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300',
+// documentStatus maps an ingest status to the one status model
+// (contract 13.2): pending neutral, ingesting working, ready success,
+// failed error.
+const documentStatus: Record<KbDocument['status'], Status> = {
+  pending: 'neutral',
+  ingesting: 'working',
+  ready: 'success',
+  failed: 'error',
 }
 
-function StatusBadge({ doc }: { doc: KbDocument }) {
-  const icon =
-    doc.status === 'ingesting' ? (
-      <HugeiconsIcon icon={Loading03Icon} className="size-3 animate-spin" />
-    ) : doc.status === 'ready' ? (
-      <HugeiconsIcon icon={Tick02Icon} className="size-3" />
-    ) : doc.status === 'failed' ? (
-      <HugeiconsIcon icon={CancelCircleIcon} className="size-3" />
-    ) : null
-
+export function DocumentStatusBadge({ doc }: { doc: KbDocument }) {
   return (
-    <span
-      title={doc.status === 'failed' ? doc.error : undefined}
-      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${statusStyle[doc.status]}`}
-    >
-      {icon}
-      {doc.status}
+    <span title={doc.status === 'failed' ? doc.error : undefined}>
+      <StatusBadge status={documentStatus[doc.status]} label={doc.status} size="sm" />
     </span>
   )
 }
 
 // DocumentErrorLine surfaces the ingest failure reason (issue #408): a
 // one-line, title-tooltipped clamp under the title cell, matching the
-// mission failure text-red-400 + title pattern (eventRenderers.tsx).
+// mission failure text pattern (eventRenderers.tsx).
 export function DocumentErrorLine({ doc }: { doc: KbDocument }) {
   if (doc.status !== 'failed' || !doc.error) return null
   return (
-    <p className="mt-0.5 truncate text-xs text-red-400" title={doc.error}>
+    <p className="mt-0.5 truncate text-xs text-destructive" title={doc.error}>
       {doc.error}
     </p>
   )
@@ -230,41 +221,32 @@ export function KnowledgeCollectionDetail() {
   }
 
   return (
-    <div className="mt-6 w-full space-y-6">
-      <Link
-        to="/knowledge"
-        className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"
-      >
-        <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
-        Knowledge
-      </Link>
-
-      <div className="flex items-center justify-between border-b border-border pb-6">
-        <div>
-          <h1 className="text-xl font-semibold tracking-tight">{collection.name}</h1>
-          {collection.description && (
-            <p className="text-sm text-muted-foreground">{collection.description}</p>
-          )}
-        </div>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            onClick={() => {
-              setEditName(collection.name)
-              setEditDesc(collection.description ?? '')
-              setEditWeight(String(collection.retrieval_weight ?? 1.0))
-              setEditing(true)
-            }}
-          >
-            <HugeiconsIcon icon={Edit01Icon} />
-            Rename
-          </Button>
-          <Button variant="destructive" onClick={() => setConfirmDeleteCollection(true)}>
-            <HugeiconsIcon icon={Delete02Icon} />
-            Delete collection
-          </Button>
-        </div>
-      </div>
+    <div className="w-full space-y-6">
+      <PageHeader
+        title={collection.name}
+        description={collection.description}
+        breadcrumbs={[{ label: 'Knowledge', href: '/knowledge' }, { label: collection.name }]}
+        actions={
+          <>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setEditName(collection.name)
+                setEditDesc(collection.description ?? '')
+                setEditWeight(String(collection.retrieval_weight ?? 1.0))
+                setEditing(true)
+              }}
+            >
+              <HugeiconsIcon icon={Edit01Icon} />
+              Rename
+            </Button>
+            <Button variant="destructive" onClick={() => setConfirmDeleteCollection(true)}>
+              <HugeiconsIcon icon={Delete02Icon} />
+              Delete collection
+            </Button>
+          </>
+        }
+      />
 
       <KbUploadForm
         uploadFile={(file) => uploadKbDocument(id, file)}
@@ -272,46 +254,48 @@ export function KnowledgeCollectionDetail() {
         onUploaded={(doc) => setDocuments((prev) => [doc, ...prev])}
       />
 
-      {documents.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No documents yet.</p>
-      ) : (
-        <TooltipProvider>
-          <div className="overflow-x-auto rounded-xl border border-border">
-            <table className="w-full text-sm">
-              <thead className="border-b border-border bg-muted/50 text-left text-xs uppercase tracking-wide text-muted-foreground">
-                <tr>
-                  <th className="px-3 py-2">Title</th>
-                  <th className="px-3 py-2">Source</th>
-                  <th className="px-3 py-2">Status</th>
-                  <th className="px-3 py-2">Chunks</th>
-                  <th className="px-3 py-2">Size</th>
-                  <th className="px-3 py-2">Ingested</th>
-                  <th className="px-3 py-2" />
-                </tr>
-              </thead>
-              <tbody>
+      <Panel title="Documents" density="operational">
+        {documents.length === 0 ? (
+          <p className="p-4 text-sm text-muted-foreground">No documents yet.</p>
+        ) : (
+          <TooltipProvider>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Title</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Chunks</TableHead>
+                  <TableHead>Size</TableHead>
+                  <TableHead>Ingested</TableHead>
+                  <TableHead>
+                    <span className="sr-only">Actions</span>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
                 {documents.map((doc) => (
-                  <tr key={doc.id} className="border-b border-border last:border-0">
-                    <td className="px-3 py-2">
+                  <TableRow key={doc.id}>
+                    <TableCell>
                       <div className="flex items-center gap-2">
                         <HugeiconsIcon icon={File02Icon} className="size-4 shrink-0 text-muted-foreground" />
                         <span className="truncate">{doc.title}</span>
                       </div>
                       <DocumentErrorLine doc={doc} />
-                    </td>
-                    <td className="px-3 py-2">
+                    </TableCell>
+                    <TableCell>
                       <div className="flex items-center gap-1.5">
                         <SourceBadge doc={doc} />
                         <ProvenanceBadge doc={doc} />
                       </div>
-                    </td>
-                    <td className="px-3 py-2">
-                      <StatusBadge doc={doc} />
-                    </td>
-                    <td className="px-3 py-2">{doc.chunk_count}</td>
-                    <td className="px-3 py-2">{humanBytes(doc.bytes)}</td>
-                    <td className="px-3 py-2">{doc.ingested_at ? relativeTime(doc.ingested_at) : '—'}</td>
-                    <td className="px-3 py-2">
+                    </TableCell>
+                    <TableCell>
+                      <DocumentStatusBadge doc={doc} />
+                    </TableCell>
+                    <TableCell>{doc.chunk_count}</TableCell>
+                    <TableCell>{humanBytes(doc.bytes)}</TableCell>
+                    <TableCell>{doc.ingested_at ? relativeTime(doc.ingested_at) : '—'}</TableCell>
+                    <TableCell>
                       <div className="flex items-center justify-end gap-2">
                         <button
                           type="button"
@@ -330,14 +314,14 @@ export function KnowledgeCollectionDetail() {
                           <HugeiconsIcon icon={Delete02Icon} className="size-4" />
                         </button>
                       </div>
-                    </td>
-                  </tr>
+                    </TableCell>
+                  </TableRow>
                 ))}
-              </tbody>
-            </table>
-          </div>
-        </TooltipProvider>
-      )}
+              </TableBody>
+            </Table>
+          </TooltipProvider>
+        )}
+      </Panel>
 
       <Dialog open={editing} onOpenChange={setEditing}>
         <DialogContent>

--- a/web/src/components/knowledge/KnowledgeCollectionsList.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionsList.tsx
@@ -1,5 +1,6 @@
 import { Add01Icon, CloudUploadIcon, LibraryIcon } from '@hugeicons-pro/core-stroke-rounded'
 import { HugeiconsIcon } from '@hugeicons/react'
+import { Library } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
@@ -7,7 +8,10 @@ import { listKbCollections } from '../../api/client'
 import type { KbCollection } from '../../api/types'
 import { relativeTime } from '../../lib/format'
 import { Button } from '../ui/button'
+import { Card } from '../ui/card'
 import { errText } from '../../lib/errors'
+import { EmptyState } from '../timothy/empty-state'
+import { Eyebrow, PageHeader } from '../timothy/page-header'
 
 export function KnowledgeCollectionsList() {
   const [collections, setCollections] = useState<KbCollection[]>([])
@@ -21,75 +25,66 @@ export function KnowledgeCollectionsList() {
   useEffect(refresh, [refresh])
 
   return (
-    <div className="mt-6 space-y-6">
-      <p className="text-sm text-muted-foreground">
-        Collections group documents an agent can search with search_kb for grounded answers.
-        Upload files to a collection, then allow an agent to search it from the agent's own
-        settings.
-      </p>
+    <>
+      <PageHeader
+        title="Knowledge"
+        description="Collections group documents an agent can search with search_kb for grounded answers. Upload files to a collection, then allow an agent to search it from the agent's own settings."
+        actions={
+          <>
+            <Button variant="outline" onClick={() => navigate('/knowledge/add')}>
+              <HugeiconsIcon icon={CloudUploadIcon} />
+              Add to Knowledgebase
+            </Button>
+            <Button onClick={() => navigate('/knowledge/new')}>
+              <HugeiconsIcon icon={Add01Icon} />
+              New collection
+            </Button>
+          </>
+        }
+      />
 
-      <div className="flex items-center justify-between">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-          Collections · {collections.length}
-        </h2>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" onClick={() => navigate('/knowledge/add')}>
-            <HugeiconsIcon icon={CloudUploadIcon} />
-            Add to Knowledgebase
-          </Button>
-          <Button onClick={() => navigate('/knowledge/new')}>
-            <HugeiconsIcon icon={Add01Icon} />
-            New collection
-          </Button>
-        </div>
-      </div>
+      <h2 className="mb-4">
+        <Eyebrow>Collections · {collections.length}</Eyebrow>
+      </h2>
 
       {collections.length === 0 ? (
-        <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border p-10 text-center">
-          <span className="flex size-10 items-center justify-center rounded-lg bg-brand-soft text-brand-soft-foreground">
-            <HugeiconsIcon icon={LibraryIcon} className="size-5" />
-          </span>
-          <p className="text-sm text-muted-foreground">
-            No collections yet. Create one and upload documents so agents can search them for
-            grounded answers.
-          </p>
-          <Button onClick={() => navigate('/knowledge/new')}>
-            <HugeiconsIcon icon={Add01Icon} />
-            New collection
-          </Button>
+        <div className="rounded-md border border-dashed border-border">
+          <EmptyState
+            icon={Library}
+            title="No collections yet."
+            description="Create one and upload documents so agents can search them for grounded answers."
+            action={
+              <Button onClick={() => navigate('/knowledge/new')}>
+                <HugeiconsIcon icon={Add01Icon} />
+                New collection
+              </Button>
+            }
+          />
         </div>
       ) : (
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {collections.map((c) => (
-            <button
-              key={c.id}
-              type="button"
-              onClick={() => navigate(`/knowledge/${c.id}`)}
-              className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 text-left shadow-sm transition hover:shadow-md"
-            >
-              <div className="flex items-center gap-3">
-                <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-brand-soft text-brand-soft-foreground">
-                  <HugeiconsIcon icon={LibraryIcon} className="size-4.5" />
-                </span>
-                <span className="min-w-0 flex-1 truncate text-sm font-semibold">{c.name}</span>
-              </div>
-              {c.description && (
-                <p className="line-clamp-2 text-sm text-muted-foreground">{c.description}</p>
-              )}
-              <p className="mt-auto text-xs text-muted-foreground">
-                {c.doc_count} doc{c.doc_count === 1 ? '' : 's'} · {c.chunk_count} chunk
-                {c.chunk_count === 1 ? '' : 's'} · updated {relativeTime(c.updated_at)}
-                {c.failed_count > 0 && (
-                  <span className="text-red-600 dark:text-red-400">
-                    {' '}
-                    · {c.failed_count} failed
+            <Card key={c.id} interactive asChild className="flex flex-col gap-3 text-left">
+              <button type="button" onClick={() => navigate(`/knowledge/${c.id}`)} aria-label={c.name}>
+                <div className="flex items-center gap-3">
+                  <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-brand-soft text-brand-soft-foreground">
+                    <HugeiconsIcon icon={LibraryIcon} className="size-4.5" />
                   </span>
+                  <span className="min-w-0 flex-1 truncate text-sm font-semibold">{c.name}</span>
+                </div>
+                {c.description && (
+                  <p className="line-clamp-2 text-sm text-muted-foreground">{c.description}</p>
                 )}
-              </p>
-            </button>
+                <p className="mt-auto text-xs text-muted-foreground">
+                  {c.doc_count} doc{c.doc_count === 1 ? '' : 's'} · {c.chunk_count} chunk
+                  {c.chunk_count === 1 ? '' : 's'} · updated {relativeTime(c.updated_at)}
+                  {c.failed_count > 0 && <span className="text-destructive"> · {c.failed_count} failed</span>}
+                </p>
+              </button>
+            </Card>
           ))}
         </div>
       )}
-    </div>
+    </>
   )
 }

--- a/web/src/components/memory/ChainDialog.tsx
+++ b/web/src/components/memory/ChainDialog.tsx
@@ -23,7 +23,7 @@ export function ChainDialog({ id, onClose }: { id: string; onClose: () => void }
         </DialogHeader>
         <ol className="space-y-2" data-testid="chain-list">
           {chain.map((m, i) => (
-            <li key={m.id} className="rounded border p-3 text-sm">
+            <li key={m.id} className="rounded-md border p-3 text-sm">
               <div className="mb-1 flex items-center gap-2">
                 <span className="text-xs text-muted-foreground">v{i + 1}</span>
                 <TypeBadge type={m.type} />

--- a/web/src/components/memory/EntityDetailPanel.tsx
+++ b/web/src/components/memory/EntityDetailPanel.tsx
@@ -32,7 +32,7 @@ export function EntityDetailPanel({ entity }: { entity: EntityNode }) {
     <div className="space-y-3" data-testid="entity-detail">
       <div className="flex items-center gap-2">
         <h3 className="min-w-0 flex-1 truncate text-sm font-semibold">{entity.name}</h3>
-        <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+        <span className="rounded-md bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
           {entity.type}
         </span>
       </div>
@@ -46,7 +46,7 @@ export function EntityDetailPanel({ entity }: { entity: EntityNode }) {
       ) : (
         <div className="space-y-2">
           {memories.map((m) => (
-            <div key={m.id} className="space-y-2 rounded-lg border p-3 text-sm" data-testid="entity-memory">
+            <div key={m.id} className="space-y-2 rounded-md border p-3 text-sm" data-testid="entity-memory">
               <div className="flex items-center gap-2">
                 <TypeBadge type={m.type} />
                 <span className="text-xs text-muted-foreground">

--- a/web/src/components/memory/TypeBadge.test.tsx
+++ b/web/src/components/memory/TypeBadge.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { TypeBadge } from './TypeBadge'
+
+describe('TypeBadge', () => {
+  it('renders the type text with the neutral badge variant', () => {
+    render(<TypeBadge type="semantic" />)
+    const badge = screen.getByText('semantic')
+    expect(badge).toHaveAttribute('data-variant', 'neutral')
+  })
+})

--- a/web/src/components/memory/TypeBadge.tsx
+++ b/web/src/components/memory/TypeBadge.tsx
@@ -1,15 +1,7 @@
 import { Badge } from '../ui/badge'
 
-const typeTone: Record<string, string> = {
-  semantic: 'bg-blue-500/15 text-blue-600 dark:text-blue-400',
-  episodic: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
-  procedural: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
-}
-
+// Memory type (semantic/episodic/procedural) is a category, not a status:
+// one neutral badge, no per-type hue map (section 13).
 export function TypeBadge({ type }: { type: string }) {
-  return (
-    <Badge variant="outline" className={`border-0 ${typeTone[type] ?? ''}`}>
-      {type}
-    </Badge>
-  )
+  return <Badge variant="neutral">{type}</Badge>
 }

--- a/web/src/components/missions/DiscoverSection.tsx
+++ b/web/src/components/missions/DiscoverSection.tsx
@@ -27,8 +27,8 @@ export function DiscoverSection({ notes }: { notes: string }) {
       <div
         className={
           expanded
-            ? 'prose prose-sm max-h-96 max-w-none overflow-y-auto text-prose dark:prose-invert'
-            : 'prose prose-sm line-clamp-3 max-w-none text-prose dark:prose-invert'
+            ? 'prose max-h-96 max-w-none overflow-y-auto text-prose dark:prose-invert'
+            : 'prose line-clamp-3 max-w-none text-prose dark:prose-invert'
         }
       >
         <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins} components={markdownComponents}>

--- a/web/src/components/missions/GoalSection.tsx
+++ b/web/src/components/missions/GoalSection.tsx
@@ -26,8 +26,8 @@ export function GoalSection({ goal }: { goal: string }) {
       <div
         className={
           expanded
-            ? 'prose prose-sm max-h-96 max-w-none overflow-y-auto text-prose dark:prose-invert'
-            : 'prose prose-sm line-clamp-3 max-w-none text-prose dark:prose-invert'
+            ? 'prose max-h-96 max-w-none overflow-y-auto text-prose dark:prose-invert'
+            : 'prose line-clamp-3 max-w-none text-prose dark:prose-invert'
         }
       >
         <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins} components={markdownComponents}>

--- a/web/src/components/missions/InputRequestGate.tsx
+++ b/web/src/components/missions/InputRequestGate.tsx
@@ -103,7 +103,7 @@ export function InputRequestGate({
         )
       }
     >
-      <div className="prose prose-sm max-w-none dark:prose-invert">
+      <div className="prose max-w-none dark:prose-invert">
         <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins} components={markdownComponents}>
           {question}
         </ReactMarkdown>

--- a/web/src/components/missions/MarkdownField.tsx
+++ b/web/src/components/missions/MarkdownField.tsx
@@ -55,7 +55,7 @@ export function MarkdownField({
           rows={rows}
         />
       ) : value.trim() ? (
-        <div className="prose prose-sm min-h-16 max-w-none rounded-md border border-input px-2.5 py-2 dark:prose-invert">
+        <div className="prose min-h-16 max-w-none rounded-md border border-input px-2.5 py-2 dark:prose-invert">
           <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins} components={{ pre: CodeBlock }}>
             {value}
           </ReactMarkdown>

--- a/web/src/components/missions/MissionAttachments.tsx
+++ b/web/src/components/missions/MissionAttachments.tsx
@@ -108,7 +108,7 @@ export function MissionAttachments({
           {attachments.map((a) => (
             <div
               key={a.id}
-              className="group relative flex items-center gap-1.5 rounded-lg border border-border bg-muted/30 py-1 pr-1.5 pl-2 text-xs"
+              className="group relative flex items-center gap-1.5 rounded-md border border-border bg-muted/30 py-1 pr-1.5 pl-2 text-xs"
             >
               <HugeiconsIcon icon={attachmentChipIcon(a.mime)} className="size-3.5 text-muted-foreground" />
               <span className="max-w-40 truncate">{a.name ?? 'Document'}</span>

--- a/web/src/components/missions/MissionExecutionPlan.tsx
+++ b/web/src/components/missions/MissionExecutionPlan.tsx
@@ -128,7 +128,7 @@ export function MissionExecutionPlan(props: MissionExecutionPlanProps) {
   const unusable = unusablePhases(plan)
 
   return (
-    <div className="rounded-lg border border-border p-4">
+    <div className="rounded-md border border-border p-4">
       <div className="text-sm font-semibold">{title}</div>
       <div className="mt-2 divide-y divide-border">
         {phaseOrder.map((key) => {

--- a/web/src/components/missions/MissionForm.test.tsx
+++ b/web/src/components/missions/MissionForm.test.tsx
@@ -538,7 +538,7 @@ describe('MissionForm: destinations multi-select', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Weekly digest' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'Repeat on schedule' }))
 
     await screen.findByText('Destinations')
     fireEvent.click(screen.getByLabelText(/^ops-hook/))
@@ -1134,7 +1134,7 @@ describe('MissionForm: repository source', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     await toCodingMission()
-    expect(screen.getByRole('button', { name: 'None' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('radio', { name: 'None' })).toHaveAttribute('aria-checked', 'true')
     fireEvent.click(screen.getByRole('button', { name: 'Create mission' }))
 
     await waitFor(() =>
@@ -1157,7 +1157,7 @@ describe('MissionForm: repository source', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     await toCodingMission()
-    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'GitHub' }))
 
     expect(await screen.findByText(/No GitHub connectors configured yet/)).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /Add one in Settings/ })).toHaveAttribute(
@@ -1173,7 +1173,7 @@ describe('MissionForm: repository source', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     await toCodingMission()
-    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'GitHub' }))
     fireEvent.click(await screen.findByLabelText('Connector'))
     fireEvent.click(await screen.findByText('personal-gh'))
 
@@ -1205,7 +1205,7 @@ describe('MissionForm: repository source', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     await toCodingMission()
-    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'GitHub' }))
     fireEvent.click(await screen.findByLabelText('Connector'))
     fireEvent.click(await screen.findByText('personal-gh'))
 
@@ -1219,7 +1219,7 @@ describe('MissionForm: repository source', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     await toCodingMission()
-    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'GitHub' }))
 
     const submit = screen.getByRole('button', { name: 'Create mission' }) as HTMLButtonElement
     expect(submit.disabled).toBe(true)
@@ -1240,7 +1240,7 @@ describe('MissionForm: repository source', () => {
 // below build on.
 async function toCodingMissionWithRepo() {
   await toCodingMission()
-  fireEvent.click(screen.getByRole('button', { name: 'GitHub' }))
+  fireEvent.click(screen.getByRole('radio', { name: 'GitHub' }))
   fireEvent.click(await screen.findByLabelText('Connector'))
   fireEvent.click(await screen.findByText('personal-gh'))
   fireEvent.click(await screen.findByRole('button', { name: 'Choose a repository' }))
@@ -1338,7 +1338,7 @@ describe('MissionForm: create mode, repeat on schedule', () => {
     fireEvent.change(screen.getByLabelText('Goal'), {
       target: { value: 'Check the news every morning' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'Repeat on schedule' }))
     fireEvent.click(screen.getByRole('button', { name: 'Create schedule' }))
 
     await waitFor(() =>
@@ -1364,7 +1364,7 @@ describe('MissionForm: create mode, repeat on schedule', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'Digest the attached spec' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'Repeat on schedule' }))
 
     const file = new File(['%PDF-1.4'], 'spec.pdf', { type: 'application/pdf' })
     const input = document.querySelector('input[type="file"]') as HTMLInputElement
@@ -1395,7 +1395,7 @@ describe('MissionForm: create mode, repeat on schedule', () => {
     await vi.advanceTimersByTimeAsync(0)
     expect(screen.getByText('Coding · branches from repo')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'Repeat on schedule' }))
     expect(screen.getByText('General · scratch workspace')).toBeInTheDocument()
 
     vi.useRealTimers()
@@ -1415,7 +1415,7 @@ describe('MissionForm: create mode, repeat on schedule', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'Repeat on schedule' }))
     await vi.advanceTimersByTimeAsync(600)
     await vi.advanceTimersByTimeAsync(0)
 
@@ -1430,7 +1430,7 @@ describe('MissionForm: create mode, repeat on schedule', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: 'g' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'Repeat on schedule' }))
     fireEvent.click(screen.getAllByRole('combobox')[0])
     fireEvent.click(await screen.findByText('Custom'))
     fireEvent.change(screen.getByLabelText('Cron expression'), { target: { value: 'bad cron' } })
@@ -1460,7 +1460,7 @@ describe('MissionForm: create mode, repeat on schedule', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     fireEvent.change(await screen.findByLabelText('Goal'), { target: { value: 'g' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Repeat on schedule' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'Repeat on schedule' }))
 
     // Combobox order while repeating: Runs (cron preset), then Agent.
     fireEvent.click(screen.getAllByRole('combobox')[1])
@@ -1629,7 +1629,7 @@ describe('MissionForm: edit mode', () => {
     const onDone = vi.fn()
     renderForm(<MissionForm mode="edit" schedule={schedule} onDone={onDone} onCancel={vi.fn()} />)
 
-    expect(screen.queryByRole('button', { name: 'Run once' })).toBeNull()
+    expect(screen.queryByRole('radio', { name: 'Run once' })).toBeNull()
 
     await screen.findByDisplayValue('weekly-digest')
     fireEvent.click(screen.getByRole('button', { name: 'Save schedule' }))
@@ -1950,7 +1950,7 @@ describe('MissionForm: goal repo proposal (issue #563)', () => {
     await toCodingMissionForProposal('Clone octocat/hello-world and audit its dependencies')
 
     expect(await screen.findByText('Proposed from the goal')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'GitHub' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('radio', { name: 'GitHub' })).toHaveAttribute('aria-checked', 'true')
     expect(screen.getByRole('button', { name: 'octocat/hello-world' })).toBeInTheDocument()
   })
 
@@ -1975,7 +1975,7 @@ describe('MissionForm: goal repo proposal (issue #563)', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
     expect(screen.queryByText('Proposed from the goal')).toBeNull()
-    expect(screen.getByRole('button', { name: 'None' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('radio', { name: 'None' })).toHaveAttribute('aria-checked', 'true')
 
     // Re-typing the exact same goal text does not re-propose.
     fireEvent.change(screen.getByLabelText('Goal'), { target: { value: `${goalText} ` } })
@@ -1990,7 +1990,7 @@ describe('MissionForm: goal repo proposal (issue #563)', () => {
     renderForm(<MissionForm mode="create" onDone={vi.fn()} onCancel={vi.fn()} />)
 
     await toCodingMission()
-    fireEvent.click(screen.getByRole('button', { name: 'GitHub' }))
+    fireEvent.click(screen.getByRole('radio', { name: 'GitHub' }))
     fireEvent.click(await screen.findByLabelText('Connector'))
     fireEvent.click(await screen.findByText('personal-gh'))
     fireEvent.click(await screen.findByRole('button', { name: 'Choose a repository' }))
@@ -2019,10 +2019,10 @@ describe('MissionForm: goal repo proposal (issue #563)', () => {
     expect(await screen.findByText(/Repositories matching the goal:/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'octocat/widget-one' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'octocat/widget-two' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'None' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('radio', { name: 'None' })).toHaveAttribute('aria-checked', 'true')
 
     fireEvent.click(screen.getByRole('button', { name: 'octocat/widget-two' }))
-    expect(screen.getByRole('button', { name: 'GitHub' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('radio', { name: 'GitHub' })).toHaveAttribute('aria-checked', 'true')
     expect(await screen.findByText('octocat/widget-two')).toBeInTheDocument()
   })
 
@@ -2049,7 +2049,7 @@ describe('MissionForm: goal repo proposal (issue #563)', () => {
     await new Promise((r) => setTimeout(r, 500))
 
     expect(screen.queryByText('Proposed from the goal')).toBeNull()
-    expect(screen.getByRole('button', { name: 'None' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('radio', { name: 'None' })).toHaveAttribute('aria-checked', 'true')
   })
 })
 

--- a/web/src/components/missions/MissionForm.tsx
+++ b/web/src/components/missions/MissionForm.tsx
@@ -42,6 +42,7 @@ import { Label } from '../ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { Textarea } from '../ui/textarea'
+import { SegmentedControl } from '../timothy/segmented-control'
 import { errText } from '../../lib/errors'
 import { envIcon } from '../icons/EnvIcons'
 import { type PendingAttachment } from '../Composer'
@@ -1116,34 +1117,18 @@ export function MissionForm({
             </p>
           </div>
 
-          <div className="inline-flex rounded-lg bg-muted p-1 text-sm">
-            <button
-              type="button"
-              onClick={() => {
-                setRepoSource('none')
-                setSourceProposed(false)
-              }}
-              aria-pressed={repoSource === 'none'}
-              className={`rounded-md px-3 py-1.5 font-medium transition ${
-                repoSource === 'none' ? 'bg-background shadow-sm' : 'text-muted-foreground'
-              }`}
-            >
-              None
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                setRepoSource('github')
-                setSourceProposed(false)
-              }}
-              aria-pressed={repoSource === 'github'}
-              className={`rounded-md px-3 py-1.5 font-medium transition ${
-                repoSource === 'github' ? 'bg-background shadow-sm' : 'text-muted-foreground'
-              }`}
-            >
-              GitHub
-            </button>
-          </div>
+          <SegmentedControl
+            aria-label="Repository source"
+            value={repoSource}
+            onChange={(v) => {
+              setRepoSource(v as RepoSource)
+              setSourceProposed(false)
+            }}
+            options={[
+              { value: 'none', label: 'None' },
+              { value: 'github', label: 'GitHub' },
+            ]}
+          />
 
           {proposalNote && (
             <p className="text-xs text-muted-foreground">
@@ -1177,7 +1162,7 @@ export function MissionForm({
           )}
 
           {repoSource === 'github' && (
-            <div className="space-y-3 rounded-lg border border-border p-4">
+            <div className="space-y-3 rounded-md border border-border p-4">
               {githubConnectors === null ? (
                 <p className="text-sm text-muted-foreground">Loading connectors…</p>
               ) : githubConnectors.length === 0 ? (
@@ -1283,34 +1268,22 @@ export function MissionForm({
         </div>
 
         {mode === 'create' && (
-          <div className="inline-flex rounded-lg bg-muted p-1 text-sm">
-            <button
-              type="button"
-              onClick={() => setRepeat(false)}
-              aria-pressed={!repeat}
-              className={`rounded-md px-3 py-1.5 font-medium transition ${
-                !repeat ? 'bg-background shadow-sm' : 'text-muted-foreground'
-              }`}
-            >
-              Run once
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                setRepeat(true)
-                if (kind === 'coding') {
-                  setKind('general')
-                  setKindLocked(true)
-                }
-              }}
-              aria-pressed={repeat}
-              className={`rounded-md px-3 py-1.5 font-medium transition ${
-                repeat ? 'bg-background shadow-sm' : 'text-muted-foreground'
-              }`}
-            >
-              Repeat on schedule
-            </button>
-          </div>
+          <SegmentedControl
+            aria-label="Schedule"
+            value={repeat ? 'repeat' : 'once'}
+            onChange={(v) => {
+              const next = v === 'repeat'
+              setRepeat(next)
+              if (next && kind === 'coding') {
+                setKind('general')
+                setKindLocked(true)
+              }
+            }}
+            options={[
+              { value: 'once', label: 'Run once' },
+              { value: 'repeat', label: 'Repeat on schedule' },
+            ]}
+          />
         )}
 
         {repeat && (
@@ -1537,7 +1510,7 @@ export function MissionForm({
             <p className="text-xs text-muted-foreground">
               Where this mission's result is delivered or pushed when it finishes.
             </p>
-            <div className="space-y-3 rounded-xl border border-border p-3">
+            <div className="space-y-3 rounded-md border border-border p-3">
               <div className="space-y-1.5">
                 {destinations.map((d) => (
                   <div key={d.id}>
@@ -1647,7 +1620,7 @@ export function MissionForm({
             {showAdvanced ? 'Hide advanced options' : 'Show advanced options'}
           </CollapsibleTrigger>
           <CollapsibleContent>
-            <div className="mt-3 grid gap-4 rounded-lg border border-border p-4 sm:grid-cols-2">
+            <div className="mt-3 grid gap-4 rounded-md border border-border p-4 sm:grid-cols-2">
               <div className="space-y-1.5">
                 <Label htmlFor="mission-route">Route</Label>
                 {routes === null ? (

--- a/web/src/components/missions/MissionReferences.tsx
+++ b/web/src/components/missions/MissionReferences.tsx
@@ -3,6 +3,7 @@ import { HugeiconsIcon } from '@hugeicons/react'
 import type { ComponentProps, KeyboardEvent } from 'react'
 import { useRef, useState } from 'react'
 import type { Reference } from '../../api/types'
+import { Eyebrow } from '../timothy/page-header'
 import {
   addReference,
   groupReferenceOptions,
@@ -107,11 +108,11 @@ export function GoalTextarea({
     <div className="space-y-2">
       <div className="relative">
         {open && (
-          <div className="absolute bottom-full left-0 z-50 mb-1 max-h-72 w-72 overflow-y-auto rounded-lg border border-border bg-popover py-1 shadow-lg">
+          <div className="absolute bottom-full left-0 z-50 mb-1 max-h-72 w-72 overflow-y-auto rounded-md border border-border bg-popover py-1 shadow-overlay">
             {groups.map((group) => (
               <div key={group.kind}>
-                <div className="px-3 pt-1.5 pb-0.5 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase">
-                  {referenceKindLabel[group.kind]}
+                <div className="px-3 pt-1.5 pb-0.5">
+                  <Eyebrow>{referenceKindLabel[group.kind]}</Eyebrow>
                 </div>
                 {group.options.map((o) => {
                   const i = flat.findIndex((f) => f.kind === o.kind && f.id === o.id)
@@ -155,7 +156,7 @@ export function GoalTextarea({
           {references.map((r) => (
             <span
               key={`${r.kind}-${r.id}`}
-              className="inline-flex max-w-56 items-center gap-1.5 rounded-lg border border-border bg-muted/30 py-1 pr-1.5 pl-2 text-xs"
+              className="inline-flex max-w-56 items-center gap-1.5 rounded-md border border-border bg-muted/30 py-1 pr-1.5 pl-2 text-xs"
             >
               <span className="truncate">
                 {referenceKindLabel[r.kind].replace(/s$/, '')}: {r.name}

--- a/web/src/components/missions/ResultSection.tsx
+++ b/web/src/components/missions/ResultSection.tsx
@@ -14,7 +14,7 @@ export function ResultSection({ evidence }: { evidence: string }) {
 
   return (
     <div className="space-y-2">
-      <div className={`prose prose-sm max-w-none dark:prose-invert ${expanded ? '' : 'max-h-96 overflow-y-auto'}`}>
+      <div className={`prose max-w-none dark:prose-invert ${expanded ? '' : 'max-h-96 overflow-y-auto'}`}>
         <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins} components={markdownComponents}>
           {evidence}
         </ReactMarkdown>

--- a/web/src/components/missions/ReviewRoutePicker.tsx
+++ b/web/src/components/missions/ReviewRoutePicker.tsx
@@ -73,7 +73,7 @@ export function ReviewRoutePicker({ mission, onSaved }: ReviewRoutePickerProps) 
   }
 
   return (
-    <div className="space-y-2 rounded-lg border border-border p-3">
+    <div className="space-y-2 rounded-md border border-border p-3">
       <Label htmlFor="mission-review-route">Review route</Label>
       <div className="flex flex-wrap items-center gap-2">
         {routes === null ? (

--- a/web/src/components/missions/eventRenderers.tsx
+++ b/web/src/components/missions/eventRenderers.tsx
@@ -168,7 +168,7 @@ const renderers: Record<string, (payload: unknown) => ReactNode> = {
         Permission requested: {String(tool ?? 'a tool call')}
         {dangerSuffix}
         {args ? (
-          <code className="ml-1 rounded bg-muted px-1 py-0.5 text-xs whitespace-pre-wrap">
+          <code className="ml-1 rounded-md bg-muted px-1 py-0.5 text-xs whitespace-pre-wrap">
             {truncateForDisplay(String(args))}
           </code>
         ) : null}

--- a/web/src/components/settings/ProviderAdd.tsx
+++ b/web/src/components/settings/ProviderAdd.tsx
@@ -385,9 +385,9 @@ export function ProviderAdd() {
                     ) : (
                       <>
                         Uses your Claude Pro/Max subscription. On any machine with Claude Code installed, run{' '}
-                        <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">claude setup-token</code>,
+                        <code className="rounded-md bg-muted px-1 py-0.5 font-mono text-xs">claude setup-token</code>,
                         approve in the browser, and paste the generated token (starts with{' '}
-                        <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">sk-ant-oat…</code>). The
+                        <code className="rounded-md bg-muted px-1 py-0.5 font-mono text-xs">sk-ant-oat…</code>). The
                         token is long-lived (~1 year).
                       </>
                     )}

--- a/web/src/pages/Analytics.test.tsx
+++ b/web/src/pages/Analytics.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BudgetStatus, GroupTotal, UsagePoint, UsageSummary } from '../api/types'
 import { Analytics, sortGroupsByTotal } from './Analytics'
 import * as echartsCore from 'echarts/core'
+import { formatDuration } from '../lib/format'
 
 vi.mock('../api/client', () => ({
   catalogPrices: vi.fn(),
@@ -508,5 +509,149 @@ describe('Analytics zero-cost exclusion', () => {
     if (!modelCostChart) throw new Error('model cost chart section not found')
     expect(await within(modelCostChart).findByText('gpt-5.6-sol')).toBeInTheDocument()
     expect(within(modelCostChart).queryByText('local-llama')).toBeNull()
+  })
+})
+
+describe('Analytics multi-currency summaries', () => {
+  it('lists non-primary currencies separately below the tiles, never summed with the total', async () => {
+    vi.mocked(usageSummary).mockResolvedValue([
+      summary,
+      { ...summary, currency: 'EUR', cost: 5, requests: 2 },
+    ])
+    renderPage()
+    const note = await screen.findByText(/Also in range:/)
+    expect(note).toHaveTextContent('€5.00')
+    expect(note).toHaveTextContent('shown separately')
+    // The primary tile stays at its own currency's total, unaffected by the EUR row.
+    expect(screen.getAllByText('$2.50').length).toBeGreaterThan(0)
+  })
+
+  it('omits the note when only one currency is present', async () => {
+    renderPage()
+    await waitFor(() => expect(screen.getAllByText('$2.50').length).toBeGreaterThan(0))
+    expect(screen.queryByText(/Also in range:/)).toBeNull()
+  })
+})
+
+describe('Analytics unpriced note without a catalog estimate', () => {
+  it('omits the "roughly ≈" clause when the estimate resolves to zero', async () => {
+    vi.mocked(usageSummary).mockResolvedValue([{ ...summary, unpriced_requests: 3 }])
+    renderPage()
+    const note = await screen.findByText(/had no configured price/)
+    expect(note).toHaveTextContent('3 calls in range')
+    expect(note).not.toHaveTextContent('roughly')
+  })
+
+  it('uses singular "call" for exactly one unpriced request', async () => {
+    vi.mocked(usageSummary).mockResolvedValue([{ ...summary, unpriced_requests: 1 }])
+    renderPage()
+    const note = await screen.findByText(/had no configured price/)
+    expect(note).toHaveTextContent('1 call in range')
+  })
+})
+
+describe('Analytics spend-by-model view toggle', () => {
+  it('defaults to lines and switches to bars on click', async () => {
+    vi.mocked(usageSeries).mockImplementation(async (_from, _to, _bucket, group) =>
+      group === 'model' ? [{ ...providerPoint, group: 'gpt-5.6-sol' }] : [],
+    )
+    vi.mocked(usageTotals).mockImplementation(async (_from, _to, group) =>
+      group === 'model' ? [{ ...providerTotal, group: 'gpt-5.6-sol' }] : [],
+    )
+    renderPage()
+    const chart = (await screen.findByText('Spend by model')).closest('[data-density]') as HTMLElement | null
+    if (!chart) throw new Error('chart section not found')
+    const lastOption = await findChartOptionGetter(chart)
+    await waitFor(() => expect((lastOption().series as Array<{ type: string }>)[0]?.type).toBe('line'))
+
+    fireEvent.click(within(chart).getByText('Bars'))
+    await waitFor(() => expect((lastOption().series as Array<{ type: string }>)[0]?.type).toBe('bar'))
+  })
+})
+
+describe('Analytics latency panel', () => {
+  it('shows a placeholder when there are no requests in range', async () => {
+    vi.mocked(usageLatency).mockResolvedValue([])
+    renderPage()
+    const chart = (await screen.findByText('Latency per provider')).closest('[data-density]') as HTMLElement | null
+    if (!chart) throw new Error('chart section not found')
+    expect(await within(chart).findByText('No requests in range.')).toBeInTheDocument()
+  })
+
+  it('renders the latency chart when requests exist, formatting the axis in duration units', async () => {
+    vi.mocked(usageLatency).mockResolvedValue([
+      { provider: 'openai', p50_ms: 250, p95_ms: 900, p99_ms: 1500, requests: 10 },
+    ])
+    renderPage()
+    const chart = (await screen.findByText('Latency per provider')).closest('[data-density]') as HTMLElement | null
+    if (!chart) throw new Error('chart section not found')
+    expect(within(chart).queryByText('No requests in range.')).toBeNull()
+    const lastOption = await findChartOptionGetter(chart)
+    await waitFor(() => expect(lastOption()).toBeTruthy())
+    const option = lastOption() as { xAxis: { axisLabel: { formatter: (v: number) => string } } }
+    expect(option.xAxis.axisLabel.formatter(1500)).toBe(formatDuration(1500))
+  })
+})
+
+describe('Analytics provider cost table sorting', () => {
+  // cost puts openai first by default (cost desc); alphabetical sort puts anthropic
+  // first, so the two orders are distinguishable in the assertions below.
+  const rowA: GroupTotal = { ...providerTotal, group: 'anthropic', cost: 1, requests: 1 }
+  const rowB: GroupTotal = { ...providerTotal, group: 'openai', cost: 3, requests: 5 }
+
+  function providerTable() {
+    return screen.getByText('Cost breakdown by provider').closest('[data-density]') as HTMLElement
+  }
+
+  function providerRows() {
+    return within(providerTable())
+      .getAllByRole('row')
+      .slice(1) // drop the header row
+      .map((row) => within(row).getAllByRole('cell')[0].textContent)
+  }
+
+  beforeEach(() => {
+    vi.mocked(usageTotals).mockImplementation(async (_from, _to, group) =>
+      group === 'provider' ? [rowA, rowB] : [],
+    )
+  })
+
+  it('defaults to sorting by cost descending', async () => {
+    renderPage()
+    await screen.findByText('Cost breakdown by provider')
+    expect(providerRows()).toEqual(['openai', 'anthropic'])
+  })
+
+  it('sorts by provider name descending on header click, and toggles ascending on a second click', async () => {
+    renderPage()
+    await screen.findByText('Cost breakdown by provider')
+    // Switching to a new sort key defaults to descending: openai before anthropic alphabetically.
+    fireEvent.click(within(providerTable()).getByText('Provider', { exact: false, selector: 'th' }))
+    await waitFor(() => expect(providerRows()).toEqual(['openai', 'anthropic']))
+
+    fireEvent.click(within(providerTable()).getByText('Provider', { exact: false, selector: 'th' }))
+    await waitFor(() => expect(providerRows()).toEqual(['anthropic', 'openai']))
+  })
+
+  it('sorts by requests on header click', async () => {
+    renderPage()
+    await screen.findByText('Cost breakdown by provider')
+    fireEvent.click(within(providerTable()).getByText('Requests', { exact: false, selector: 'th' }))
+    // Switching to a new sort key defaults to descending: openai (5) before anthropic (1).
+    await waitFor(() => expect(providerRows()).toEqual(['openai', 'anthropic']))
+  })
+
+  it('sorts by cost on header click, toggling ascending on a second click', async () => {
+    renderPage()
+    await screen.findByText('Cost breakdown by provider')
+    // Sort by requests first so a "Cost" click is a genuine key change.
+    fireEvent.click(within(providerTable()).getByText('Requests', { exact: false, selector: 'th' }))
+    await waitFor(() => expect(providerRows()).toEqual(['openai', 'anthropic']))
+
+    fireEvent.click(within(providerTable()).getByText('Cost', { exact: false, selector: 'th' }))
+    await waitFor(() => expect(providerRows()).toEqual(['openai', 'anthropic']))
+
+    fireEvent.click(within(providerTable()).getByText('Cost', { exact: false, selector: 'th' }))
+    await waitFor(() => expect(providerRows()).toEqual(['anthropic', 'openai']))
   })
 })

--- a/web/src/pages/Analytics.test.tsx
+++ b/web/src/pages/Analytics.test.tsx
@@ -137,9 +137,11 @@ describe('Analytics budget alert', () => {
   it('stays silent when the budget endpoint fails', async () => {
     vi.mocked(usageBudget).mockRejectedValue(new Error('gateway down'))
     renderPage()
-    // The shared widget-failure note appears; no budget banner.
-    await screen.findByText(/widgets failed to load/)
-    expect(screen.queryByRole('alert')).toBeNull()
+    // The shared widget-failure note appears as its own destructive
+    // alert; no separate budget banner.
+    const failureAlert = await screen.findByRole('alert')
+    expect(failureAlert).toHaveTextContent(/widgets failed to load/)
+    expect(screen.queryByText(/budget reached/)).toBeNull()
   })
 })
 
@@ -153,6 +155,22 @@ describe('Analytics spend tile', () => {
 
     fireEvent.click(screen.getByText('30 days'))
     await waitFor(() => expect(screen.getByText('Spend this month')).toBeInTheDocument())
+  })
+})
+
+describe('Analytics segmented controls', () => {
+  it('renders the range picker as a radiogroup with an aria-label', async () => {
+    renderPage()
+    const group = await screen.findByRole('radiogroup', { name: 'Range' })
+    expect(within(group).getByRole('radio', { name: 'Today' })).toBeInTheDocument()
+    expect(within(group).getByRole('radio', { name: '7 days' })).toBeInTheDocument()
+  })
+
+  it('renders each chart view toggle as a radiogroup with a per-chart aria-label', async () => {
+    renderPage()
+    const group = await screen.findByRole('radiogroup', { name: 'Spend by provider view' })
+    expect(within(group).getByRole('radio', { name: 'Bars' })).toBeInTheDocument()
+    expect(within(group).getByRole('radio', { name: 'Lines' })).toBeInTheDocument()
   })
 })
 
@@ -301,7 +319,7 @@ describe('Analytics chart legend selection', () => {
     )
     renderPage()
 
-    const chart = (await screen.findByText('Spend by provider')).closest('section')
+    const chart = (await screen.findByText('Spend by provider')).closest('[data-density]') as HTMLElement | null
     if (!chart) throw new Error('chart section not found')
     // StatsLegend renders the series name as a plain text node with no
     // className, distinct from the "By provider"-style breakdown table
@@ -323,7 +341,7 @@ describe('Analytics chart legend selection', () => {
 
   it('ctrl-click toggles just that entry, independent of other legends', async () => {
     renderPage()
-    const chart = (await screen.findByText('Tokens consumption')).closest('section')
+    const chart = (await screen.findByText('Tokens consumption')).closest('[data-density]') as HTMLElement | null
     if (!chart) throw new Error('chart section not found')
     const inputEntry = (await within(chart).findAllByText('input')).find((el) => el.className === '')
     if (!inputEntry) throw new Error('legend entry not found')
@@ -347,7 +365,7 @@ describe('Analytics chart legend selection', () => {
 // its most recently applied option — several charts render on the
 // page, each with its own init() call/instance.
 async function findChartOptionGetter(section: HTMLElement) {
-  const chartDiv = section.querySelector('.mt-3 > div')
+  const chartDiv = section.querySelector('div[style*="width"]')
   if (!chartDiv) throw new Error('chart container not found')
   const initMock = vi.mocked(echartsCore.init)
   await waitFor(() => expect(initMock.mock.calls.some((c) => c[0] === chartDiv)).toBe(true))
@@ -365,7 +383,7 @@ describe('Analytics bars/lines view toggle', () => {
       group === 'provider' ? [providerTotal] : [],
     )
     renderPage()
-    const chart = (await screen.findByText('Spend by provider')).closest('section')
+    const chart = (await screen.findByText('Spend by provider')).closest('[data-density]') as HTMLElement | null
     if (!chart) throw new Error('chart section not found')
     const lastOption = await findChartOptionGetter(chart)
     await waitFor(() => expect((lastOption().series as Array<{ type: string }>)[0]?.type).toBe('line'))
@@ -376,7 +394,7 @@ describe('Analytics bars/lines view toggle', () => {
 
   it('defaults to lines and switches the tokens-in/out chart to bars on click', async () => {
     renderPage()
-    const chart = (await screen.findByText('Tokens consumption')).closest('section')
+    const chart = (await screen.findByText('Tokens consumption')).closest('[data-density]') as HTMLElement | null
     if (!chart) throw new Error('chart section not found')
     const lastOption = await findChartOptionGetter(chart)
     await waitFor(() => expect((lastOption().series as Array<{ type: string }>)[0]?.type).toBe('line'))
@@ -390,7 +408,7 @@ describe('Analytics bars/lines view toggle', () => {
       group === 'model' ? [{ ...providerPoint, group: 'gpt-5.6-sol' }] : [],
     )
     renderPage()
-    const chart = (await screen.findByText('Tokens per model')).closest('section')
+    const chart = (await screen.findByText('Tokens per model')).closest('[data-density]') as HTMLElement | null
     if (!chart) throw new Error('chart section not found')
     const lastOption = await findChartOptionGetter(chart)
     await waitFor(() => expect((lastOption().series as Array<{ type: string }>)[0]?.type).toBe('line'))
@@ -401,7 +419,7 @@ describe('Analytics bars/lines view toggle', () => {
 
   it('has no toggle on the requests & errors panel', async () => {
     renderPage()
-    const chart = (await screen.findByText('Requests & error rate')).closest('section')
+    const chart = (await screen.findByText('Requests & error rate')).closest('[data-density]') as HTMLElement | null
     if (!chart) throw new Error('chart section not found')
     expect(within(chart).queryByText('Bars')).toBeNull()
     expect(within(chart).queryByText('Lines')).toBeNull()
@@ -465,14 +483,14 @@ describe('Analytics zero-cost exclusion', () => {
     )
     renderPage()
 
-    const providerTable = (await screen.findByText('Cost breakdown by provider')).closest('section')
+    const providerTable = (await screen.findByText('Cost breakdown by provider')).closest('[data-density]') as HTMLElement | null
     if (!providerTable) throw new Error('provider cost table not found')
     expect(await within(providerTable).findByText('openai')).toBeInTheDocument()
     expect(within(providerTable).queryByText('local-llama')).toBeNull()
 
     // Same model, token-consumption chart: the free model's volume is
     // exactly the signal this chart exists to show, so it must render.
-    const tokenChart = (await screen.findByText('Tokens per model')).closest('section')
+    const tokenChart = (await screen.findByText('Tokens per model')).closest('[data-density]') as HTMLElement | null
     if (!tokenChart) throw new Error('token chart section not found')
     expect(await within(tokenChart).findByText('local-llama')).toBeInTheDocument()
   })
@@ -486,7 +504,7 @@ describe('Analytics zero-cost exclusion', () => {
     )
     renderPage()
 
-    const modelCostChart = (await screen.findByText('Spend by model')).closest('section')
+    const modelCostChart = (await screen.findByText('Spend by model')).closest('[data-density]') as HTMLElement | null
     if (!modelCostChart) throw new Error('model cost chart section not found')
     expect(await within(modelCostChart).findByText('gpt-5.6-sol')).toBeInTheDocument()
     expect(within(modelCostChart).queryByText('local-llama')).toBeNull()

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -34,6 +34,12 @@ import type {
 import { estimateUnpriced, totalEstimate } from '../lib/costEstimate'
 import { compact, formatDuration, money } from '../lib/format'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../components/ui/tooltip'
+import { PageShell } from '../components/timothy/page-shell'
+import { PageHeader } from '../components/timothy/page-header'
+import { Panel } from '../components/timothy/panel'
+import { SegmentedControl } from '../components/timothy/segmented-control'
+import { Alert, AlertDescription } from '../components/ui/alert'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table'
 
 const ranges = [
   { key: 'today', label: 'Today', days: 0, bucket: 'hour' as const },
@@ -172,28 +178,18 @@ const bucketLabel = (iso: string, bucket: string) => {
 // panels — a compact segmented control matching the range picker's style.
 type ChartView = 'bars' | 'lines'
 
-function ViewToggle({ view, onChange }: { view: ChartView; onChange: (v: ChartView) => void }) {
-  const options: { key: ChartView; label: string }[] = [
-    { key: 'bars', label: 'Bars' },
-    { key: 'lines', label: 'Lines' },
-  ]
+function ViewToggle({ view, onChange, title }: { view: ChartView; onChange: (v: ChartView) => void; title: string }) {
   return (
-    <div className="flex rounded-lg border border-border p-0.5">
-      {options.map((o) => (
-        <button
-          key={o.key}
-          type="button"
-          onClick={() => onChange(o.key)}
-          className={
-            view === o.key
-              ? 'rounded-md bg-zinc-200/80 px-2 py-0.5 text-xs font-medium dark:bg-zinc-800'
-              : 'rounded-md px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground'
-          }
-        >
-          {o.label}
-        </button>
-      ))}
-    </div>
+    <SegmentedControl
+      size="sm"
+      aria-label={`${title} view`}
+      value={view}
+      onChange={(v) => onChange(v as ChartView)}
+      options={[
+        { value: 'bars', label: 'Bars' },
+        { value: 'lines', label: 'Lines' },
+      ]}
+    />
   )
 }
 
@@ -443,44 +439,29 @@ export function Analytics() {
   const monthGauge = budget?.month.limit != null ? budget.month : null
 
   return (
-    <div className="h-full overflow-y-auto">
-      <div className="mx-auto max-w-full px-8 py-8">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <h1 className="text-2xl font-semibold tracking-tight">Analytics</h1>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Spend, tokens, and latency from the cost ledger.
-            </p>
-          </div>
-          <div className="flex rounded-lg border border-border p-0.5">
-            {ranges.map((r) => (
-              <button
-                key={r.key}
-                type="button"
-                onClick={() => setRange(r.key)}
-                className={
-                  range === r.key
-                    ? 'rounded-md bg-zinc-200/80 px-3 py-1 text-sm font-medium dark:bg-zinc-800'
-                    : 'rounded-md px-3 py-1 text-sm text-muted-foreground hover:text-foreground'
-                }
-              >
-                {r.label}
-              </button>
-            ))}
-          </div>
-        </div>
+    <PageShell>
+      <PageHeader
+        title="Analytics"
+        description="Spend, tokens, and latency from the cost ledger."
+        actions={
+          <SegmentedControl
+            aria-label="Range"
+            value={range}
+            onChange={setRange}
+            options={ranges.map((r) => ({ value: r.key, label: r.label }))}
+          />
+        }
+      />
 
-        {error && (
-          <div className="mt-6 rounded-xl border border-red-500/30 bg-red-500/5 p-4 text-sm text-red-600 dark:text-red-400">
-            Could not load usage: {error}
-          </div>
-        )}
+      {error && (
+        <Alert tone="destructive" className="mb-6">
+          <AlertDescription>Could not load usage: {error}</AlertDescription>
+        </Alert>
+      )}
 
-        {budget && (budget.day.over || budget.month.over) && (
-          <div
-            role="alert"
-            className="mt-6 rounded-xl border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-700 dark:text-amber-400"
-          >
+      {budget && (budget.day.over || budget.month.over) && (
+        <Alert tone="warning" role="alert" className="mb-6">
+          <AlertDescription>
             {[
               budget.day.over && budget.day.limit != null
                 ? `Daily budget reached: ${money(budget.day.spend, budget.day.currency)} spent of ${money(budget.day.limit.amount, budget.day.limit.currency)}.`
@@ -491,270 +472,250 @@ export function Analytics() {
             ]
               .filter(Boolean)
               .join(' ')}
-          </div>
-        )}
+          </AlertDescription>
+        </Alert>
+      )}
 
-        <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
-          {tiles.map((t) => (
-            <div key={t.label} className="rounded-xl border border-border p-4">
-              <div className="text-xs text-muted-foreground">{t.label}</div>
-              <div className="mt-1.5 text-2xl font-semibold tracking-tight">
-                {t.value}
-                {'annotation' in t && t.annotation && (
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="ml-1.5 text-xs font-normal text-muted-foreground">
-                          +{t.annotation}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>unbilled</TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                )}
-              </div>
-              {t.hint && <div className="mt-0.5 text-xs text-muted-foreground">{t.hint}</div>}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+        {tiles.map((t) => (
+          <Panel key={t.label}>
+            <div className="text-xs text-muted-foreground">{t.label}</div>
+            <div className="mt-1.5 text-2xl font-semibold tracking-tight">
+              {t.value}
+              {'annotation' in t && t.annotation && (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="ml-1.5 text-xs font-normal text-muted-foreground">
+                        +{t.annotation}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>unbilled</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              )}
             </div>
-          ))}
-        </div>
+            {t.hint && <div className="mt-0.5 text-xs text-muted-foreground">{t.hint}</div>}
+          </Panel>
+        ))}
+      </div>
 
-        {otherSummaries.length > 0 && (
-          <p className="mt-3 text-xs text-muted-foreground">
-            Also in range:{' '}
-            {otherSummaries.map((o) => primaryMoney(o, o.cost)).join(', ')} (shown separately —
-            never summed with the totals above).
-          </p>
-        )}
+      {otherSummaries.length > 0 && (
+        <p className="mt-3 text-xs text-muted-foreground">
+          Also in range:{' '}
+          {otherSummaries.map((o) => primaryMoney(o, o.cost)).join(', ')} (shown separately —
+          never summed with the totals above).
+        </p>
+      )}
 
-        {s && s.unpriced_requests > 0 && (
-          <p className="mt-3 text-xs text-muted-foreground">
-            {compact(s.unpriced_requests)} call{s.unpriced_requests === 1 ? '' : 's'} in range
-            {' '}had no configured price and are excluded from spend
-            {estimatedTotal > 0 && <>, roughly ≈{money(estimatedTotal)} at catalog prices</>}.
-          </p>
-        )}
+      {s && s.unpriced_requests > 0 && (
+        <p className="mt-3 text-xs text-muted-foreground">
+          {compact(s.unpriced_requests)} call{s.unpriced_requests === 1 ? '' : 's'} in range
+          {' '}had no configured price and are excluded from spend
+          {estimatedTotal > 0 && <>, roughly ≈{money(estimatedTotal)} at catalog prices</>}.
+        </p>
+      )}
 
-        <section className="mt-6 rounded-xl border border-border p-4">
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-medium">Spend by provider</h2>
-            <ViewToggle view={costView} onChange={setCostView} />
-          </div>
-          <div className="mt-3">
-            <EChart
-              option={(costView === 'bars' ? stackedBarsOption : multiLineOption)(
-                cost.rows,
-                cost.groups,
-                costLegend.hidden,
-                (g) => colorOf(g, cost.groups),
-                (v) => bucketLabel(v, bucket),
-                chartMoney,
-              )}
-            />
-          </div>
-          <StatsLegend
-            rows={cost.rows}
-            groups={cost.groups}
-            colorOf={(g) => colorOf(g, cost.groups)}
-            hidden={costLegend.hidden}
-            onSelect={costLegend.onSelect}
-            valueLabel={chartMoney}
-          />
-        </section>
-
-        <section className="mt-6 rounded-xl border border-border p-4">
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-medium">Spend by model</h2>
-            <ViewToggle view={modelCostView} onChange={setModelCostView} />
-          </div>
-          <div className="mt-3">
-            <EChart
-              option={(modelCostView === 'bars' ? stackedBarsOption : multiLineOption)(
-                modelCost.rows,
-                modelCost.groups,
-                modelCostLegend.hidden,
-                (g) => colorOf(g, modelCost.groups),
-                (v) => bucketLabel(v, bucket),
-                chartMoney,
-              )}
-            />
-          </div>
-          <StatsLegend
-            rows={modelCost.rows}
-            groups={modelCost.groups}
-            colorOf={(g) => colorOf(g, modelCost.groups)}
-            hidden={modelCostLegend.hidden}
-            onSelect={modelCostLegend.onSelect}
-            valueLabel={chartMoney}
-          />
-          {modelCost.groups.length === 0 && data && (
-            <p className="mt-2 text-xs text-muted-foreground">
-              No priced model usage in range (free/unpriced models are excluded from cost views).
-            </p>
+      <Panel
+        className="mt-6"
+        title="Spend by provider"
+        actions={<ViewToggle view={costView} onChange={setCostView} title="Spend by provider" />}
+      >
+        <EChart
+          option={(costView === 'bars' ? stackedBarsOption : multiLineOption)(
+            cost.rows,
+            cost.groups,
+            costLegend.hidden,
+            (g) => colorOf(g, cost.groups),
+            (v) => bucketLabel(v, bucket),
+            chartMoney,
           )}
-        </section>
+        />
+        <StatsLegend
+          rows={cost.rows}
+          groups={cost.groups}
+          colorOf={(g) => colorOf(g, cost.groups)}
+          hidden={costLegend.hidden}
+          onSelect={costLegend.onSelect}
+          valueLabel={chartMoney}
+        />
+      </Panel>
 
-        <section className="mt-6 rounded-xl border border-border p-4">
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-medium">Tokens per model</h2>
-            <ViewToggle view={modelTokensView} onChange={setModelTokensView} />
-          </div>
-          <div className="mt-3">
-            <EChart
-              option={(modelTokensView === 'bars' ? stackedBarsOption : multiLineOption)(
-                modelTokens.rows,
-                modelTokens.groups,
-                modelTokensLegend.hidden,
-                (g) => colorOf(g, modelTokens.groups),
-                (v) => bucketLabel(v, bucket),
-                compact,
-              )}
-            />
-          </div>
-          <StatsLegend
-            rows={modelTokens.rows}
-            groups={modelTokens.groups}
-            colorOf={(g) => colorOf(g, modelTokens.groups)}
-            hidden={modelTokensLegend.hidden}
-            onSelect={modelTokensLegend.onSelect}
-            valueLabel={compact}
-          />
-        </section>
+      <Panel
+        className="mt-6"
+        title="Spend by model"
+        actions={<ViewToggle view={modelCostView} onChange={setModelCostView} title="Spend by model" />}
+      >
+        <EChart
+          option={(modelCostView === 'bars' ? stackedBarsOption : multiLineOption)(
+            modelCost.rows,
+            modelCost.groups,
+            modelCostLegend.hidden,
+            (g) => colorOf(g, modelCost.groups),
+            (v) => bucketLabel(v, bucket),
+            chartMoney,
+          )}
+        />
+        <StatsLegend
+          rows={modelCost.rows}
+          groups={modelCost.groups}
+          colorOf={(g) => colorOf(g, modelCost.groups)}
+          hidden={modelCostLegend.hidden}
+          onSelect={modelCostLegend.onSelect}
+          valueLabel={chartMoney}
+        />
+        {modelCost.groups.length === 0 && data && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            No priced model usage in range (free/unpriced models are excluded from cost views).
+          </p>
+        )}
+      </Panel>
 
-        <section className="mt-6 rounded-xl border border-border p-4">
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-medium">Tokens consumption</h2>
-            <ViewToggle view={tokensView} onChange={setTokensView} />
-          </div>
-          <div className="mt-3">
-            <EChart
-              option={(tokensView === 'bars' ? stackedBarsOption : areaLinesOption)(
-                tokens as unknown as Record<string, number | string>[],
-                ['input', 'output'],
-                tokensLegend.hidden,
-                (g) => (g === 'input' ? palette[0] : palette[2]),
-                (v) => bucketLabel(v, bucket),
-                compact,
-              )}
-            />
-          </div>
-          <StatsLegend
-            rows={tokens as unknown as Record<string, number | string>[]}
-            groups={['input', 'output']}
-            colorOf={(g) => (g === 'input' ? palette[0] : palette[2])}
-            hidden={tokensLegend.hidden}
-            onSelect={tokensLegend.onSelect}
-            valueLabel={compact}
-          />
-        </section>
+      <Panel
+        className="mt-6"
+        title="Tokens per model"
+        actions={<ViewToggle view={modelTokensView} onChange={setModelTokensView} title="Tokens per model" />}
+      >
+        <EChart
+          option={(modelTokensView === 'bars' ? stackedBarsOption : multiLineOption)(
+            modelTokens.rows,
+            modelTokens.groups,
+            modelTokensLegend.hidden,
+            (g) => colorOf(g, modelTokens.groups),
+            (v) => bucketLabel(v, bucket),
+            compact,
+          )}
+        />
+        <StatsLegend
+          rows={modelTokens.rows}
+          groups={modelTokens.groups}
+          colorOf={(g) => colorOf(g, modelTokens.groups)}
+          hidden={modelTokensLegend.hidden}
+          onSelect={modelTokensLegend.onSelect}
+          valueLabel={compact}
+        />
+      </Panel>
 
-        <div className="mt-6 grid gap-6 lg:grid-cols-2">
-          <section className="flex flex-col rounded-xl border border-border p-4">
-            <h2 className="text-sm font-medium">Latency per provider</h2>
-            {data && data.latency.length > 0 ? (
-              <div className="mt-3 min-h-[240px] flex-1">
-                <EChart
-                  fill
-                  option={latencyBarsOption(
-                    data.latency,
-                    { p50: '#2a78d6', p95: '#eda100', p99: '#e34948' },
-                    (ms) => formatDuration(Math.round(ms)),
-                  )}
-                />
-              </div>
-            ) : (
-              <p className="mt-3 py-6 text-center text-sm text-muted-foreground">No requests in range.</p>
-            )}
-          </section>
+      <Panel
+        className="mt-6"
+        title="Tokens consumption"
+        actions={<ViewToggle view={tokensView} onChange={setTokensView} title="Tokens consumption" />}
+      >
+        <EChart
+          option={(tokensView === 'bars' ? stackedBarsOption : areaLinesOption)(
+            tokens as unknown as Record<string, number | string>[],
+            ['input', 'output'],
+            tokensLegend.hidden,
+            (g) => (g === 'input' ? palette[0] : palette[2]),
+            (v) => bucketLabel(v, bucket),
+            compact,
+          )}
+        />
+        <StatsLegend
+          rows={tokens as unknown as Record<string, number | string>[]}
+          groups={['input', 'output']}
+          colorOf={(g) => (g === 'input' ? palette[0] : palette[2])}
+          hidden={tokensLegend.hidden}
+          onSelect={tokensLegend.onSelect}
+          valueLabel={compact}
+        />
+      </Panel>
 
-          <section className="flex flex-col rounded-xl border border-border p-4">
-            <h2 className="text-sm font-medium">Spend share by provider</h2>
-            <div className="mt-3 min-h-[240px] flex-1">
+      <div className="mt-6 grid gap-6 lg:grid-cols-2">
+        <Panel title="Latency per provider" className="flex flex-col">
+          {data && data.latency.length > 0 ? (
+            <div className="min-h-[240px] flex-1">
               <EChart
                 fill
-                option={donutOption(
-                  // Converted-first, same as the bar chart's chartCost:
-                  // slices plot the default-currency figure when a rate
-                  // exists; a slice with no stored rate keeps its raw
-                  // amount and labels it in its OWN currency (D-013:
-                  // never mislabel one currency's amount as another's).
-                  (data?.providerTotals ?? [])
-                    .filter((g) => (g.converted_amount ?? g.cost) > 0)
-                    .map((g) => ({
-                      group: g.group,
-                      cost: g.converted_amount ?? g.cost,
-                      label: money(g.converted_amount ?? g.cost, g.converted_currency ?? g.currency),
-                    })),
-                  (g) => colorOf(g, cost.groups),
-                  chartMoney,
+                option={latencyBarsOption(
+                  data.latency,
+                  { p50: '#2a78d6', p95: '#eda100', p99: '#e34948' },
+                  (ms) => formatDuration(Math.round(ms)),
                 )}
               />
             </div>
-            {pricedProviders.size === 0 && data && (
-              <p className="mt-2 text-xs text-muted-foreground">No priced spend in range.</p>
-            )}
-          </section>
-        </div>
+          ) : (
+            <p className="py-6 text-center text-sm text-muted-foreground">No requests in range.</p>
+          )}
+        </Panel>
 
-        <section className="mt-6 rounded-xl border border-border p-4">
-          <h2 className="text-sm font-medium">Requests &amp; error rate</h2>
-          <div className="mt-3">
+        <Panel title="Spend share by provider" className="flex flex-col">
+          <div className="min-h-[240px] flex-1">
             <EChart
-              option={requestsErrorsOption(
-                requestsErrors,
-                (v) => bucketLabel(v, bucket),
-                palette[0],
-                palette[7],
+              fill
+              option={donutOption(
+                // Converted-first, same as the bar chart's chartCost:
+                // slices plot the default-currency figure when a rate
+                // exists; a slice with no stored rate keeps its raw
+                // amount and labels it in its OWN currency (D-013:
+                // never mislabel one currency's amount as another's).
+                (data?.providerTotals ?? [])
+                  .filter((g) => (g.converted_amount ?? g.cost) > 0)
+                  .map((g) => ({
+                    group: g.group,
+                    cost: g.converted_amount ?? g.cost,
+                    label: money(g.converted_amount ?? g.cost, g.converted_currency ?? g.currency),
+                  })),
+                (g) => colorOf(g, cost.groups),
+                chartMoney,
               )}
             />
           </div>
-        </section>
-
-        {(dayGauge || monthGauge) && (
-          <div className="mt-6 grid gap-6 sm:grid-cols-2">
-            {dayGauge && dayGauge.limit && (
-              <section className="rounded-xl border border-border p-4">
-                <h2 className="text-sm font-medium">Daily budget</h2>
-                <div className="mt-3">
-                  <EChart
-                    option={gaugeOption(
-                      dayGauge.spend,
-                      dayGauge.limit.amount,
-                      '#1baf7a',
-                      '#e34948',
-                      (v) => money(v, dayGauge.limit!.currency),
-                    )}
-                    height={200}
-                  />
-                </div>
-              </section>
-            )}
-            {monthGauge && monthGauge.limit && (
-              <section className="rounded-xl border border-border p-4">
-                <h2 className="text-sm font-medium">Monthly budget</h2>
-                <div className="mt-3">
-                  <EChart
-                    option={gaugeOption(
-                      monthGauge.spend,
-                      monthGauge.limit.amount,
-                      '#1baf7a',
-                      '#e34948',
-                      (v) => money(v, monthGauge.limit!.currency),
-                    )}
-                    height={200}
-                  />
-                </div>
-              </section>
-            )}
-          </div>
-        )}
-
-        <div className="mt-6 grid gap-6 lg:grid-cols-2">
-          <ProviderCostTable rows={data?.providerTotals ?? []} />
-          <BreakdownTable title="Cost breakdown by model" rows={data ? totals(data.byModel) : []} estimates={estimates} />
-        </div>
-
+          {pricedProviders.size === 0 && data && (
+            <p className="mt-2 text-xs text-muted-foreground">No priced spend in range.</p>
+          )}
+        </Panel>
       </div>
-    </div>
+
+      <Panel className="mt-6" title="Requests & error rate">
+        <EChart
+          option={requestsErrorsOption(
+            requestsErrors,
+            (v) => bucketLabel(v, bucket),
+            palette[0],
+            palette[7],
+          )}
+        />
+      </Panel>
+
+      {(dayGauge || monthGauge) && (
+        <div className="mt-6 grid gap-6 sm:grid-cols-2">
+          {dayGauge && dayGauge.limit && (
+            <Panel title="Daily budget">
+              <EChart
+                option={gaugeOption(
+                  dayGauge.spend,
+                  dayGauge.limit.amount,
+                  '#1baf7a',
+                  '#e34948',
+                  (v) => money(v, dayGauge.limit!.currency),
+                )}
+                height={200}
+              />
+            </Panel>
+          )}
+          {monthGauge && monthGauge.limit && (
+            <Panel title="Monthly budget">
+              <EChart
+                option={gaugeOption(
+                  monthGauge.spend,
+                  monthGauge.limit.amount,
+                  '#1baf7a',
+                  '#e34948',
+                  (v) => money(v, monthGauge.limit!.currency),
+                )}
+                height={200}
+              />
+            </Panel>
+          )}
+        </div>
+      )}
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-2">
+        <ProviderCostTable rows={data?.providerTotals ?? []} />
+        <BreakdownTable title="Cost breakdown by model" rows={data ? totals(data.byModel) : []} estimates={estimates} />
+      </div>
+    </PageShell>
   )
 }
 
@@ -768,15 +729,14 @@ function BreakdownTable({
   estimates?: Map<string, number>
 }) {
   return (
-    <section className="rounded-xl border border-border p-4">
-      <h2 className="text-sm font-medium">{title}</h2>
-      <table className="mt-3 w-full text-sm">
-        <tbody>
+    <Panel title={title} density="operational">
+      <Table>
+        <TableBody>
           {rows.map((t) => (
-            <tr key={`${t.group} ${t.currency}`} className="border-t border-border/60">
-              <td className="max-w-36 truncate py-2 pr-2">{t.group}</td>
-              <td className="py-2 text-right text-muted-foreground">{compact(t.tokens)} tok</td>
-              <td className="py-2 text-right font-medium">
+            <TableRow key={`${t.group} ${t.currency}`}>
+              <TableCell className="max-w-36 truncate">{t.group}</TableCell>
+              <TableCell numeric className="text-muted-foreground">{compact(t.tokens)} tok</TableCell>
+              <TableCell numeric className="font-medium">
                 {primaryMoney(t, t.cost)}
                 {secondaryMoney(t, t.cost) && (
                   <span className="ml-1 text-xs font-normal text-muted-foreground">
@@ -791,17 +751,17 @@ function BreakdownTable({
                     +≈{money(estimates?.get(t.group) ?? 0, t.currency)}
                   </span>
                 )}
-              </td>
-            </tr>
+              </TableCell>
+            </TableRow>
           ))}
           {rows.length === 0 && (
-            <tr>
-              <td className="py-6 text-center text-muted-foreground">Nothing in range.</td>
-            </tr>
+            <TableRow>
+              <TableCell className="py-6 text-center text-muted-foreground">Nothing in range.</TableCell>
+            </TableRow>
           )}
-        </tbody>
-      </table>
-    </section>
+        </TableBody>
+      </Table>
+    </Panel>
   )
 }
 
@@ -845,56 +805,49 @@ function ProviderCostTable({ rows }: { rows: GroupTotal[] }) {
   const sortIndicator = (key: SortKey) => (sortKey === key ? (asc ? ' ▲' : ' ▼') : '')
 
   return (
-    <section className="rounded-xl border border-border p-4">
-      <h2 className="text-sm font-medium">Cost breakdown by provider</h2>
-      <table className="mt-3 w-full text-sm">
-        <thead>
-          <tr className="text-left text-xs text-muted-foreground">
-            <th className="cursor-pointer pb-2 font-medium" onClick={() => toggleSort('group')}>
+    <Panel title="Cost breakdown by provider" density="operational">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="cursor-pointer" onClick={() => toggleSort('group')}>
               Provider{sortIndicator('group')}
-            </th>
-            <th
-              className="cursor-pointer pb-2 text-right font-medium"
-              onClick={() => toggleSort('requests')}
-            >
+            </TableHead>
+            <TableHead numeric className="cursor-pointer" onClick={() => toggleSort('requests')}>
               Requests{sortIndicator('requests')}
-            </th>
-            <th
-              className="cursor-pointer pb-2 text-right font-medium"
-              onClick={() => toggleSort('cost')}
-            >
+            </TableHead>
+            <TableHead numeric className="cursor-pointer" onClick={() => toggleSort('cost')}>
               Cost{sortIndicator('cost')}
-            </th>
-            <th className="pb-2 text-right font-medium">% of total</th>
-          </tr>
-        </thead>
-        <tbody>
+            </TableHead>
+            <TableHead numeric>% of total</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
           {sorted.map((r) => (
-            <tr key={r.group} className="border-t border-border/60">
-              <td className="max-w-28 truncate py-2 pr-2">{r.group}</td>
-              <td className="py-2 text-right text-muted-foreground">{compact(r.requests)}</td>
-              <td className="py-2 text-right font-medium">
+            <TableRow key={r.group}>
+              <TableCell className="max-w-28 truncate">{r.group}</TableCell>
+              <TableCell numeric className="text-muted-foreground">{compact(r.requests)}</TableCell>
+              <TableCell numeric className="font-medium">
                 {primaryMoney(r, r.cost)}
                 {secondaryMoney(r, r.cost) && (
                   <span className="ml-1 text-xs font-normal text-muted-foreground">
                     ({secondaryMoney(r, r.cost)})
                   </span>
                 )}
-              </td>
-              <td className="py-2 text-right text-muted-foreground">
+              </TableCell>
+              <TableCell numeric className="text-muted-foreground">
                 {totalCost > 0 ? `${((r.cost / totalCost) * 100).toFixed(0)}%` : 'N/A'}
-              </td>
-            </tr>
+              </TableCell>
+            </TableRow>
           ))}
           {sorted.length === 0 && (
-            <tr>
-              <td colSpan={4} className="py-6 text-center text-muted-foreground">
+            <TableRow>
+              <TableCell colSpan={4} className="py-6 text-center text-muted-foreground">
                 Nothing in range.
-              </td>
-            </tr>
+              </TableCell>
+            </TableRow>
           )}
-        </tbody>
-      </table>
-    </section>
+        </TableBody>
+      </Table>
+    </Panel>
   )
 }

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -9,6 +9,11 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useAgents } from '../components/AgentPicker'
 import { Composer, type PendingAttachment } from '../components/Composer'
+import { Eyebrow } from '../components/timothy/page-header'
+import { PageShell } from '../components/timothy/page-shell'
+import { EmptyState } from '../components/timothy/empty-state'
+import { Badge } from '../components/ui/badge'
+import { Card } from '../components/ui/card'
 import { usePendingMemories } from '../lib/memory'
 
 const agentKey = 'timothy.agent'
@@ -78,9 +83,9 @@ export function Home() {
   }
 
   return (
-    <div className="flex h-full flex-col items-center overflow-y-auto px-4">
+    <PageShell className="flex h-full flex-col items-center overflow-y-auto">
       <div className="mt-[max(3rem,12vh)] w-full max-w-4xl text-center">
-        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Timothy</h1>
+        <h1 className="text-display font-semibold text-foreground">Timothy</h1>
         <p className="mt-2 text-sm text-muted-foreground">
           Ask anything. Chats remember what matters.
         </p>
@@ -105,33 +110,35 @@ export function Home() {
       </div>
 
       <div className="mt-14 w-full max-w-4xl">
-        <h2 className="text-center text-xs font-semibold tracking-wider text-muted-foreground uppercase">
-          Agents
+        <h2 className="text-center">
+          <Eyebrow>Agents</Eyebrow>
         </h2>
-        <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {agents.map((a) => (
-            <button
+            <Card
               key={a.id}
-              type="button"
-              onClick={() => openAgent(a.name)}
-              className="flex flex-col gap-2 rounded-xl border border-border bg-card p-4 text-left shadow-sm transition hover:border-brand hover:shadow-md"
+              interactive
+              asChild
+              className="flex flex-col gap-2 text-left"
             >
-              <div className="flex items-center gap-2">
-                <span className="truncate text-sm font-semibold capitalize">{a.name}</span>
-                {a.is_default && (
-                  <span className="rounded bg-brand-soft px-1.5 py-0.5 text-xs font-semibold text-brand-soft-foreground">
-                    Default
-                  </span>
+              <button type="button" onClick={() => openAgent(a.name)} aria-label={a.name}>
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-sm font-semibold capitalize">{a.name}</span>
+                  {a.is_default && (
+                    <Badge variant="brand" size="sm">
+                      Default
+                    </Badge>
+                  )}
+                </div>
+                {a.description && (
+                  <p className="line-clamp-2 text-sm text-muted-foreground">{a.description}</p>
                 )}
-              </div>
-              {a.description && (
-                <p className="line-clamp-2 text-sm text-muted-foreground">{a.description}</p>
-              )}
-            </button>
+              </button>
+            </Card>
           ))}
           {agents.length === 0 && (
-            <div className="col-span-full rounded-xl border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
-              No agents configured yet, the default agent will serve new chats.
+            <div className="col-span-full rounded-md border border-dashed border-border">
+              <EmptyState title="No agents configured yet, the default agent will serve new chats." />
             </div>
           )}
         </div>
@@ -143,10 +150,10 @@ export function Home() {
           onClick={() => navigate('/memory')}
           className="group flex flex-col items-center gap-2"
         >
-          <span className="relative flex size-11 items-center justify-center rounded-xl border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
+          <span className="relative flex size-11 items-center justify-center rounded-md border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
             <HugeiconsIcon icon={InboxIcon} className="size-5.5" />
             {pending > 0 && (
-              <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-brand px-1 text-[10px] font-medium text-brand-foreground">
+              <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-brand px-1 text-xs font-medium text-brand-foreground">
                 {pending}
               </span>
             )}
@@ -158,7 +165,7 @@ export function Home() {
           onClick={() => navigate('/missions')}
           className="group flex flex-col items-center gap-2"
         >
-          <span className="flex size-11 items-center justify-center rounded-xl border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
+          <span className="flex size-11 items-center justify-center rounded-md border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
             <HugeiconsIcon icon={RocketIcon} className="size-5.5" />
           </span>
           <span className="text-xs text-muted-foreground">Missions</span>
@@ -168,7 +175,7 @@ export function Home() {
           onClick={() => navigate('/analytics')}
           className="group flex flex-col items-center gap-2"
         >
-          <span className="flex size-11 items-center justify-center rounded-xl border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
+          <span className="flex size-11 items-center justify-center rounded-md border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
             <HugeiconsIcon icon={Analytics01Icon} className="size-5.5" />
           </span>
           <span className="text-xs text-muted-foreground">Analytics</span>
@@ -178,12 +185,12 @@ export function Home() {
           onClick={() => navigate('/settings')}
           className="group flex flex-col items-center gap-2"
         >
-          <span className="flex size-11 items-center justify-center rounded-xl border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
+          <span className="flex size-11 items-center justify-center rounded-md border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
             <HugeiconsIcon icon={Settings02Icon} className="size-5.5" />
           </span>
           <span className="text-xs text-muted-foreground">Settings</span>
         </button>
       </div>
-    </div>
+    </PageShell>
   )
 }

--- a/web/src/pages/Knowledge.test.tsx
+++ b/web/src/pages/Knowledge.test.tsx
@@ -20,11 +20,14 @@ vi.mock('../api/client', () => ({
   deleteKbDocument: vi.fn(),
   reingestKbDocument: vi.fn(),
   addKbDocumentFromUrl: vi.fn(),
+  uploadKbDocumentAuto: vi.fn(),
+  addKbDocumentFromUrlAuto: vi.fn(),
 }))
 
 import {
   addKbDocumentFromUrl,
   createKbCollection,
+  deleteKbCollection,
   deleteKbDocument,
   getKbCollection,
   listKbCollections,
@@ -140,6 +143,37 @@ describe('Knowledge page', () => {
     renderPage()
     expect(await screen.findByText(/No collections yet/)).toBeTruthy()
     expect(screen.getAllByRole('button', { name: 'New collection' }).length).toBeGreaterThan(0)
+  })
+
+  it('navigates to the auto-add page from the "Add to Knowledgebase" header action', async () => {
+    renderPage()
+    fireEvent.click(await screen.findByRole('button', { name: /Add to Knowledgebase/ }))
+    expect(await screen.findByRole('heading', { name: 'Add to Knowledgebase' })).toBeTruthy()
+  })
+
+  it('navigates to the create-collection page from the empty state\'s "New collection" button', async () => {
+    vi.mocked(listKbCollections).mockResolvedValue([])
+    renderPage()
+    const buttons = await screen.findAllByRole('button', { name: 'New collection' })
+    // Both the header action and the empty-state action render "New collection";
+    // the empty state's is the last one in document order.
+    fireEvent.click(buttons[buttons.length - 1])
+    expect(await screen.findByRole('heading', { name: 'New collection' })).toBeTruthy()
+  })
+
+  it('navigates to a collection\'s detail page when its card is clicked', async () => {
+    vi.mocked(getKbCollection).mockResolvedValue(productDocs)
+    vi.mocked(listKbDocuments).mockResolvedValue([])
+    renderPage()
+    fireEvent.click(await screen.findByRole('button', { name: 'product-docs' }))
+    expect(await screen.findByRole('heading', { name: 'product-docs' })).toBeTruthy()
+  })
+
+  it('uses singular "doc"/"chunk" for a count of exactly one', async () => {
+    vi.mocked(listKbCollections).mockResolvedValue([{ ...productDocs, doc_count: 1, chunk_count: 1 }])
+    renderPage()
+    expect(await screen.findByText(/1 doc · 1 chunk/)).toBeTruthy()
+    expect(screen.queryByText(/1 docs/)).toBeNull()
   })
 
   it('creates a collection and navigates to its detail page', async () => {
@@ -274,6 +308,32 @@ describe('Knowledge page', () => {
       fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
 
       await waitFor(() => expect(deleteKbDocument).toHaveBeenCalledWith('d1'))
+    })
+
+    it('deletes the collection after confirmation and navigates back to the list', async () => {
+      vi.mocked(deleteKbCollection).mockResolvedValue()
+      renderPage('/knowledge/c1')
+      await screen.findByText('onboarding.pdf')
+
+      fireEvent.click(screen.getByRole('button', { name: 'Delete collection' }))
+      fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+
+      await waitFor(() => expect(deleteKbCollection).toHaveBeenCalledWith('c1'))
+      expect(await screen.findByText(/No collections yet|product-docs/)).toBeTruthy()
+    })
+
+    it('prefills the rename form with an empty description and default weight when unset', async () => {
+      vi.mocked(getKbCollection).mockResolvedValue({
+        ...productDocs,
+        description: null,
+        retrieval_weight: null,
+      } as unknown as KbCollection)
+      renderPage('/knowledge/c1')
+
+      fireEvent.click(await screen.findByRole('button', { name: /Rename/ }))
+      const descInput = await screen.findByLabelText('Collection description')
+      expect(descInput).toHaveValue('')
+      expect(await screen.findByLabelText('Retrieval weight')).toHaveValue(1)
     })
   })
 })

--- a/web/src/pages/Knowledge.test.tsx
+++ b/web/src/pages/Knowledge.test.tsx
@@ -111,7 +111,7 @@ describe('Knowledge page', () => {
         retrieval_weight: 1,
       }),
     )
-    expect(await screen.findByText('Scalability')).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Scalability' })).toBeInTheDocument()
   })
 
   it('renders the page header and collections with doc and chunk counts', async () => {
@@ -178,7 +178,7 @@ describe('Knowledge page', () => {
     it('shows the error as a tooltip on a failed document', async () => {
       renderPage('/knowledge/c1')
       await screen.findByText('broken.docx')
-      expect(screen.getByText('failed').closest('span')).toHaveAttribute('title', 'unsupported encoding')
+      expect(screen.getAllByTitle('unsupported encoding').length).toBeGreaterThan(0)
     })
 
     it('uploads a file via the input and adds it to the document list', async () => {

--- a/web/src/pages/Knowledge.tsx
+++ b/web/src/pages/Knowledge.tsx
@@ -3,19 +3,17 @@ import { KnowledgeAutoAdd } from '../components/knowledge/KnowledgeAutoAdd'
 import { KnowledgeCollectionAdd } from '../components/knowledge/KnowledgeCollectionAdd'
 import { KnowledgeCollectionDetail } from '../components/knowledge/KnowledgeCollectionDetail'
 import { KnowledgeCollectionsList } from '../components/knowledge/KnowledgeCollectionsList'
+import { PageShell } from '../components/timothy/page-shell'
 
 export function Knowledge() {
   return (
-    <div className="h-full overflow-y-auto">
-      <div className="mx-auto w-full max-w-full space-y-6 p-6">
-        <h1 className="text-lg font-semibold">Knowledge</h1>
-        <Routes>
-          <Route path="/" element={<KnowledgeCollectionsList />} />
-          <Route path="new" element={<KnowledgeCollectionAdd />} />
-          <Route path="add" element={<KnowledgeAutoAdd />} />
-          <Route path=":id" element={<KnowledgeCollectionDetail />} />
-        </Routes>
-      </div>
-    </div>
+    <PageShell>
+      <Routes>
+        <Route path="/" element={<KnowledgeCollectionsList />} />
+        <Route path="new" element={<KnowledgeCollectionAdd />} />
+        <Route path="add" element={<KnowledgeAutoAdd />} />
+        <Route path=":id" element={<KnowledgeCollectionDetail />} />
+      </Routes>
+    </PageShell>
   )
 }

--- a/web/src/pages/Memory.test.tsx
+++ b/web/src/pages/Memory.test.tsx
@@ -132,8 +132,10 @@ describe('Memory tabs', () => {
   it('defaults to the queue tab, with queue listed first', async () => {
     renderPage()
     await screen.findByTestId('queue-card')
-    const tabButtons = screen.getAllByRole('button', { name: /^(Queue|Browser|Graph)$/ })
-    expect(tabButtons.map((b) => b.textContent)).toEqual(['Queue', 'Browser', 'Graph'])
+    expect(screen.getByRole('radiogroup', { name: 'Memory view' })).toBeInTheDocument()
+    const tabs = screen.getAllByRole('radio')
+    expect(tabs.map((t) => t.textContent)).toEqual(['Queue', 'Browser', 'Graph'])
+    expect(screen.getByRole('radio', { name: 'Queue' })).toHaveAttribute('data-state', 'on')
   })
 })
 
@@ -162,7 +164,7 @@ describe('Memory graph tab', () => {
       edges: [],
     })
     renderPage()
-    fireEvent.click(await screen.findByTestId('tab-graph'))
+    fireEvent.click(await screen.findByRole('radio', { name: 'Graph' }))
     expect(await screen.findByTestId('entity-graph')).toBeInTheDocument()
     expect(screen.getByText('project')).toBeInTheDocument()
   })
@@ -174,7 +176,7 @@ describe('Memory browser', () => {
       { id: 'r1', type: 'semantic', content: 'User lives in Porto.', score: 0.02 },
     ])
     renderPage()
-    fireEvent.click(await screen.findByTestId('tab-browser'))
+    fireEvent.click(await screen.findByRole('radio', { name: 'Browser' }))
     fireEvent.change(screen.getByTestId('memory-search'), {
       target: { value: 'where does the user live' },
     })

--- a/web/src/pages/Memory.test.tsx
+++ b/web/src/pages/Memory.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { MemoryItem } from '../api/types'
@@ -39,7 +39,7 @@ vi.mock('echarts/components', () => ({
 }))
 vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }))
 
-import { entityGraph, listMemories, resolveMemory, searchMemories } from '../api/client'
+import { entityGraph, listMemories, memoryChain, resolveMemory, searchMemories } from '../api/client'
 
 const pendingMemory: MemoryItem = {
   id: 'm1',
@@ -183,5 +183,33 @@ describe('Memory browser', () => {
     fireEvent.keyDown(screen.getByTestId('memory-search'), { key: 'Enter' })
     await waitFor(() => expect(searchMemories).toHaveBeenCalledWith('where does the user live'))
     expect(await screen.findByTestId('search-results')).toHaveTextContent('User lives in Porto.')
+  })
+
+  it('opens the supersede history dialog and lists the chain oldest first', async () => {
+    vi.mocked(searchMemories).mockResolvedValue([
+      { id: 'r1', type: 'semantic', content: 'User lives in Porto.', score: 0.02 },
+    ])
+    vi.mocked(memoryChain).mockResolvedValue([
+      { ...pendingMemory, id: 'v1', content: 'User lives in Lisbon.', status: 'archived' },
+      { ...pendingMemory, id: 'v2', content: 'User lives in Porto.', status: 'active' },
+    ])
+    renderPage()
+    fireEvent.click(await screen.findByRole('radio', { name: 'Browser' }))
+    fireEvent.change(screen.getByTestId('memory-search'), {
+      target: { value: 'where does the user live' },
+    })
+    fireEvent.keyDown(screen.getByTestId('memory-search'), { key: 'Enter' })
+    const searchResults = await screen.findByTestId('search-results')
+    fireEvent.click(within(searchResults).getByRole('button', { name: 'history' }))
+
+    await waitFor(() => expect(memoryChain).toHaveBeenCalledWith('r1'))
+    const chainList = await screen.findByTestId('chain-list')
+    expect(chainList).toHaveTextContent('User lives in Lisbon.')
+    expect(chainList).toHaveTextContent('User lives in Porto.')
+    const items = within(chainList).getAllByRole('listitem')
+    expect(items[0]).toHaveTextContent('v1')
+    expect(items[0]).toHaveTextContent('User lives in Lisbon.')
+    expect(items[1]).toHaveTextContent('v2')
+    expect(items[1]).toHaveTextContent('User lives in Porto.')
   })
 })

--- a/web/src/pages/Memory.tsx
+++ b/web/src/pages/Memory.tsx
@@ -11,7 +11,11 @@ import type { MemoryItem, RetrievedMemory } from '../api/types'
 import { ChainDialog } from '../components/memory/ChainDialog'
 import { GraphTab } from '../components/memory/GraphTab'
 import { TypeBadge } from '../components/memory/TypeBadge'
+import { Eyebrow, PageHeader } from '../components/timothy/page-header'
+import { PageShell } from '../components/timothy/page-shell'
+import { SegmentedControl } from '../components/timothy/segmented-control'
 import { Button } from '../components/ui/button'
+import { Card } from '../components/ui/card'
 import { Input } from '../components/ui/input'
 import {
   Select,
@@ -47,7 +51,7 @@ function QueueCard({
   }
 
   return (
-    <div className="rounded-lg border p-4 space-y-3" data-testid="queue-card">
+    <Card className="space-y-3" data-testid="queue-card">
       <div className="flex items-center gap-2">
         <TypeBadge type={memory.type} />
         <span className="text-xs text-muted-foreground">
@@ -96,7 +100,7 @@ function QueueCard({
           </>
         )}
       </div>
-    </div>
+    </Card>
   )
 }
 
@@ -218,11 +222,11 @@ function Browser() {
 
       {results !== null && (
         <div className="space-y-2" data-testid="search-results">
-          <h3 className="text-sm font-medium text-muted-foreground">
+          <Eyebrow>
             {results.length === 0 ? 'Nothing retrieved.' : 'Retrieved (best first / runner-up last)'}
-          </h3>
+          </Eyebrow>
           {results.map((m) => (
-            <div key={m.id} className="rounded border p-3 text-sm flex items-start gap-2">
+            <div key={m.id} className="rounded-md border p-4 text-sm flex items-start gap-2">
               <TypeBadge type={m.type} />
               <span className="flex-1">{m.content}</span>
               <button
@@ -239,9 +243,9 @@ function Browser() {
 
       <div className="space-y-2">
         <div className="flex items-center gap-2">
-          <h3 className="text-sm font-medium text-muted-foreground">Browse</h3>
+          <Eyebrow>Browse</Eyebrow>
           <Select value={status} onValueChange={(v) => setStatus(v as MemoryItem['status'])}>
-            <SelectTrigger className="h-8 w-32" data-testid="status-filter">
+            <SelectTrigger className="h-8 w-32" data-testid="status-filter" aria-label="Filter by status">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -256,7 +260,7 @@ function Browser() {
           <p className="text-sm text-muted-foreground">No {status} memories.</p>
         ) : (
           browse.map((m) => (
-            <div key={m.id} className="rounded border p-3 text-sm flex items-start gap-2">
+            <div key={m.id} className="rounded-md border p-4 text-sm flex items-start gap-2">
               <TypeBadge type={m.type} />
               <span className="flex-1">{m.content}</span>
               <button
@@ -272,7 +276,7 @@ function Browser() {
       </div>
 
       <div className="space-y-2">
-        <h3 className="text-sm font-medium text-muted-foreground">Remember something</h3>
+        <Eyebrow>Remember something</Eyebrow>
         <div className="flex items-center gap-2">
           <Input
             placeholder="Timothy, remember…"
@@ -283,7 +287,7 @@ function Browser() {
             className="h-10"
           />
           <Select value={newType} onValueChange={setNewType}>
-            <SelectTrigger className="h-10 w-36">
+            <SelectTrigger className="h-10 w-36" aria-label="Memory type">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -323,26 +327,19 @@ export function Memory() {
   const [tab, setTab] = useState<(typeof tabs)[number]['id']>('queue')
 
   return (
-    <div className="h-full overflow-y-auto">
-      <div className="mx-auto w-full max-w-full space-y-6 p-6">
-        <div className="flex items-center gap-2">
-          <h1 className="text-lg font-semibold">Memory</h1>
-          <div className="ml-auto flex gap-1 rounded-lg border p-0.5">
-            {tabs.map((t) => (
-              <Button
-                key={t.id}
-                size="sm"
-                variant={tab === t.id ? 'secondary' : 'ghost'}
-                onClick={() => setTab(t.id)}
-                data-testid={`tab-${t.id}`}
-              >
-                {t.label}
-              </Button>
-            ))}
-          </div>
-        </div>
-        {tab === 'queue' ? <Queue /> : tab === 'browser' ? <Browser /> : <GraphTab />}
-      </div>
-    </div>
+    <PageShell>
+      <PageHeader
+        title="Memory"
+        actions={
+          <SegmentedControl
+            aria-label="Memory view"
+            value={tab}
+            onChange={(v) => setTab(v as (typeof tabs)[number]['id'])}
+            options={tabs.map((t) => ({ value: t.id, label: t.label }))}
+          />
+        }
+      />
+      {tab === 'queue' ? <Queue /> : tab === 'browser' ? <Browser /> : <GraphTab />}
+    </PageShell>
   )
 }

--- a/web/src/pages/Pages.a11y.test.tsx
+++ b/web/src/pages/Pages.a11y.test.tsx
@@ -1,0 +1,113 @@
+import axe from 'axe-core'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MemoryItem } from '../api/types'
+import { Memory } from './Memory'
+
+// Sibling of Settings.a11y.test.tsx: axe over the pages left outside
+// Settings' own suite. Each slice of the design-system migration adds
+// its own describe block here with its own local mocks.
+
+vi.mock('../api/client', () => ({
+  listMemories: vi.fn(),
+  addMemory: vi.fn(),
+  resolveMemory: vi.fn(),
+  memoryChain: vi.fn(),
+  searchMemories: vi.fn(),
+  entityGraph: vi.fn(),
+  entityMemories: vi.fn(),
+}))
+
+// jsdom has no canvas: EChart inits a real chart on mount, which throws
+// without a canvas 2d context. Stub the tree-shaken core entry point
+// with a no-op instance.
+vi.mock('echarts/core', () => ({
+  use: vi.fn(),
+  init: vi.fn(() => ({
+    setOption: vi.fn(),
+    resize: vi.fn(),
+    dispose: vi.fn(),
+    on: vi.fn(),
+    getZr: vi.fn(() => ({ on: vi.fn() })),
+  })),
+}))
+vi.mock('echarts/charts', () => ({ BarChart: {}, LineChart: {}, PieChart: {}, GaugeChart: {}, GraphChart: {} }))
+vi.mock('echarts/components', () => ({
+  GridComponent: {},
+  TooltipComponent: {},
+  LegendComponent: {},
+  TitleComponent: {},
+  DataZoomComponent: {},
+  MarkLineComponent: {},
+}))
+vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }))
+
+import { entityGraph, listMemories } from '../api/client'
+
+const axeOptions = { rules: { 'color-contrast': { enabled: false } } }
+
+const pendingMemory: MemoryItem = {
+  id: 'm1',
+  type: 'semantic',
+  content: 'User prefers aisle seats.',
+  status: 'pending',
+  confidence: 0.7,
+  actor: 'agent',
+  source_session: '11111111-1111-1111-1111-111111111111',
+  created_at: '2026-07-11T10:00:00Z',
+}
+
+function renderMemory() {
+  return render(
+    <MemoryRouter initialEntries={['/memory']}>
+      <Routes>
+        <Route path="/memory/*" element={<Memory />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function expectSingleH1() {
+  expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1)
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(listMemories).mockResolvedValue([pendingMemory])
+  vi.mocked(entityGraph).mockResolvedValue({
+    entities: [{ id: 'e1', type: 'project', name: 'timothy', memory_count: 1 }],
+    edges: [],
+  })
+})
+
+describe('Memory', () => {
+  it('has no axe violations on the queue tab', async () => {
+    const { container } = renderMemory()
+    await screen.findByTestId('queue-card')
+    expectSingleH1()
+    const results = await axe.run(container, axeOptions)
+    expect(results.violations).toEqual([])
+  })
+
+  it('has no axe violations on the browser tab', async () => {
+    const { container } = renderMemory()
+    await screen.findByTestId('queue-card')
+    fireEvent.click(screen.getByRole('radio', { name: 'Browser' }))
+    await screen.findByTestId('memory-search')
+    expectSingleH1()
+    const results = await axe.run(container, axeOptions)
+    expect(results.violations).toEqual([])
+  })
+
+  it('has no axe violations on the graph tab', async () => {
+    const { container } = renderMemory()
+    await screen.findByTestId('queue-card')
+    fireEvent.click(screen.getByRole('radio', { name: 'Graph' }))
+    await screen.findByTestId('entity-graph')
+    expectSingleH1()
+    const results = await axe.run(container, axeOptions)
+    expect(results.violations).toEqual([])
+  })
+})

--- a/web/src/pages/Pages.a11y.test.tsx
+++ b/web/src/pages/Pages.a11y.test.tsx
@@ -2,14 +2,17 @@ import axe from 'axe-core'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { MemoryItem } from '../api/types'
-import { Memory } from './Memory'
+import type { BudgetStatus, MemoryItem, UsageSummary } from '../api/types'
 
-// Sibling of Settings.a11y.test.tsx: axe over the pages left outside
-// Settings' own suite. Each slice of the design-system migration adds
-// its own describe block here with its own local mocks.
-
+// Sibling of Settings.a11y.test.tsx: axe on Home, Analytics, Memory and
+// Knowledge, zero violations and one h1 each. vi.mock for '../api/client'
+// is hoisted per module path, so every export any page needs is declared
+// once here; each describe's beforeEach sets only the resolved values it
+// cares about.
 vi.mock('../api/client', () => ({
+  listAgents: vi.fn(),
+  listRoutes: vi.fn(),
+  getSettings: vi.fn(),
   listMemories: vi.fn(),
   addMemory: vi.fn(),
   resolveMemory: vi.fn(),
@@ -17,6 +20,24 @@ vi.mock('../api/client', () => ({
   searchMemories: vi.fn(),
   entityGraph: vi.fn(),
   entityMemories: vi.fn(),
+  listKbCollections: vi.fn(),
+  getKbCollection: vi.fn(),
+  createKbCollection: vi.fn(),
+  deleteKbCollection: vi.fn(),
+  updateKbCollection: vi.fn(),
+  listKbDocuments: vi.fn(),
+  uploadKbDocument: vi.fn(),
+  deleteKbDocument: vi.fn(),
+  reingestKbDocument: vi.fn(),
+  addKbDocumentFromUrl: vi.fn(),
+  catalogPrices: vi.fn(),
+  usageBudget: vi.fn(),
+  usageCache: vi.fn(),
+  usageLatency: vi.fn(),
+  usageSeries: vi.fn(),
+  usageSummary: vi.fn(),
+  usageTotals: vi.fn(),
+  usageUnpriced: vi.fn(),
 }))
 
 // jsdom has no canvas: EChart inits a real chart on mount, which throws
@@ -28,6 +49,7 @@ vi.mock('echarts/core', () => ({
     setOption: vi.fn(),
     resize: vi.fn(),
     dispose: vi.fn(),
+    dispatchAction: vi.fn(),
     on: vi.fn(),
     getZr: vi.fn(() => ({ on: vi.fn() })),
   })),
@@ -43,30 +65,31 @@ vi.mock('echarts/components', () => ({
 }))
 vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }))
 
-import { entityGraph, listMemories } from '../api/client'
+import {
+  catalogPrices,
+  entityGraph,
+  getSettings,
+  listAgents,
+  listKbCollections,
+  listMemories,
+  listRoutes,
+  usageBudget,
+  usageCache,
+  usageLatency,
+  usageSeries,
+  usageSummary,
+  usageTotals,
+  usageUnpriced,
+} from '../api/client'
+import { Analytics } from './Analytics'
+import { Home } from './Home'
+import { Knowledge } from './Knowledge'
+import { Memory } from './Memory'
 
 const axeOptions = { rules: { 'color-contrast': { enabled: false } } }
-
-const pendingMemory: MemoryItem = {
-  id: 'm1',
-  type: 'semantic',
-  content: 'User prefers aisle seats.',
-  status: 'pending',
-  confidence: 0.7,
-  actor: 'agent',
-  source_session: '11111111-1111-1111-1111-111111111111',
-  created_at: '2026-07-11T10:00:00Z',
-}
-
-function renderMemory() {
-  return render(
-    <MemoryRouter initialEntries={['/memory']}>
-      <Routes>
-        <Route path="/memory/*" element={<Memory />} />
-      </Routes>
-    </MemoryRouter>,
-  )
-}
+// The Composer's hidden file input has no label, pre-existing and
+// outside this migration's scope (same exemption as Chat.a11y.test.tsx).
+const homeAxeOptions = { rules: { 'color-contrast': { enabled: false }, label: { enabled: false } } }
 
 function expectSingleH1() {
   expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1)
@@ -75,14 +98,121 @@ function expectSingleH1() {
 afterEach(cleanup)
 beforeEach(() => {
   vi.clearAllMocks()
-  vi.mocked(listMemories).mockResolvedValue([pendingMemory])
-  vi.mocked(entityGraph).mockResolvedValue({
-    entities: [{ id: 'e1', type: 'project', name: 'timothy', memory_count: 1 }],
-    edges: [],
+  vi.mocked(getSettings).mockResolvedValue({ settings: { transcribe_enabled: false }, values: {} })
+})
+
+describe('Home', () => {
+  beforeEach(() => {
+    vi.mocked(listAgents).mockResolvedValue([
+      {
+        id: 'a1',
+        name: 'general',
+        description: 'Everyday chat',
+        prompt_overlay: '',
+        route: '',
+        skills: [],
+        tools: [],
+        memory: true,
+        is_default: true,
+        enabled: true,
+      },
+    ])
+    vi.mocked(listMemories).mockResolvedValue([])
+    vi.mocked(listRoutes).mockRejectedValue(new Error('not used on this page'))
+    vi.mocked(listKbCollections).mockResolvedValue([])
+  })
+
+  it('has no axe violations', async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await screen.findByRole('button', { name: /general/ })
+    expectSingleH1()
+    const results = await axe.run(container, homeAxeOptions)
+    expect(results.violations).toEqual([])
+  })
+})
+
+describe('Analytics', () => {
+  const summary: UsageSummary = {
+    currency: 'USD',
+    cost: 2.5,
+    unbilled_cost: 0,
+    input_tokens: 1000,
+    output_tokens: 500,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+    requests: 10,
+    errors: 0,
+    unpriced_requests: 0,
+    unpriced_input_tokens: 0,
+    unpriced_output_tokens: 0,
+  }
+
+  const calmBudget: BudgetStatus = {
+    day: { currency: 'USD', limit: { amount: 10, currency: 'USD' }, spend: 2.5, over: false },
+    month: { currency: 'USD', limit: null, spend: 2.5, over: false },
+  }
+
+  beforeEach(() => {
+    vi.mocked(usageSummary).mockResolvedValue([summary])
+    vi.mocked(usageSeries).mockResolvedValue([])
+    vi.mocked(usageTotals).mockResolvedValue([])
+    vi.mocked(usageLatency).mockResolvedValue([])
+    vi.mocked(usageCache).mockResolvedValue([])
+    vi.mocked(usageBudget).mockResolvedValue(calmBudget)
+    vi.mocked(usageUnpriced).mockResolvedValue([])
+    vi.mocked(catalogPrices).mockResolvedValue([])
+  })
+
+  it('has no axe violations and one h1', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <Analytics />
+      </MemoryRouter>,
+    )
+    await screen.findByText('Spend today')
+    expectSingleH1()
+    const results = await axe.run(container, axeOptions)
+    expect(results.violations).toEqual([])
   })
 })
 
 describe('Memory', () => {
+  const pendingMemory: MemoryItem = {
+    id: 'm1',
+    type: 'semantic',
+    content: 'User prefers aisle seats.',
+    status: 'pending',
+    confidence: 0.7,
+    actor: 'agent',
+    source_session: '11111111-1111-1111-1111-111111111111',
+    created_at: '2026-07-11T10:00:00Z',
+  }
+
+  function renderMemory() {
+    return render(
+      <MemoryRouter initialEntries={['/memory']}>
+        <Routes>
+          <Route path="/memory/*" element={<Memory />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+  }
+
+  beforeEach(() => {
+    vi.mocked(listMemories).mockResolvedValue([pendingMemory])
+    vi.mocked(entityGraph).mockResolvedValue({
+      entities: [{ id: 'e1', type: 'project', name: 'timothy', memory_count: 1 }],
+      edges: [],
+    })
+  })
+
   it('has no axe violations on the queue tab', async () => {
     const { container } = renderMemory()
     await screen.findByTestId('queue-card')
@@ -106,6 +236,39 @@ describe('Memory', () => {
     await screen.findByTestId('queue-card')
     fireEvent.click(screen.getByRole('radio', { name: 'Graph' }))
     await screen.findByTestId('entity-graph')
+    expectSingleH1()
+    const results = await axe.run(container, axeOptions)
+    expect(results.violations).toEqual([])
+  })
+})
+
+describe('Knowledge', () => {
+  beforeEach(() => {
+    vi.mocked(listKbCollections).mockResolvedValue([
+      {
+        id: 'c1',
+        name: 'product-docs',
+        description: 'Product documentation for support agents.',
+        doc_count: 2,
+        chunk_count: 40,
+        failed_count: 0,
+        retrieval_weight: 1.0,
+        created_at: '2026-08-01T00:00:00Z',
+        updated_at: '2026-08-10T00:00:00Z',
+      },
+    ])
+  })
+
+  it('has no axe violations on the collections list', async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/knowledge']}>
+        <Routes>
+          <Route path="/knowledge/*" element={<Knowledge />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await screen.findByText('product-docs')
     expectSingleH1()
     const results = await axe.run(container, axeOptions)
     expect(results.violations).toEqual([])


### PR DESCRIPTION
Closes #594, closes #595, closes #596, closes #597.

Replaces #598, rebased onto main after #591 was squash-merged.

## Summary

Phase 04D moves the last routed pages (Home, Analytics, Memory, Knowledge) onto the canonical design layer and sweeps the remaining raw palette, `dark:` variants, shadows, oversized radii, `prose-sm` and sub-12px text out of chat and mission components.

## Why

After 04C the Settings area followed the contract but four pages still carried their own headers, rounded-xl cards with shadow lifts, zinc toggles, per-status and per-type colour maps and bare table frames. Chat and missions had stragglers from before the contract. This PR finishes the sweep so the forbidden-class grep is clean across `components/` and `pages/` outside `components/ui`, the design showcase, shiki theme selection and `prose-invert`.

## Changes

- Analytics: PageShell and PageHeader, range and chart view toggles as SegmentedControl, error and budget banners as Alert, KPI tiles and chart sections as Panel, breakdown tables in operational Panels on the canonical Table. Formatters, sorting, chart options and strings unchanged.
- Home: PageShell, Display-size h1, Eyebrow, interactive Cards for agents, EmptyState, 12px pending badge.
- Knowledge: PageHeader with description and actions, interactive Cards, EmptyState, ingest status through the one status model (pending neutral, ingesting working, ready success, failed error), documents table in an operational Panel, breadcrumbs on sub pages.
- Memory: PageShell, SegmentedControl view switch, queue Cards, Eyebrow group labels, neutral type Badge (a memory type is a category, not a status).
- Stragglers: zinc hovers and backgrounds to tokens, `prose-sm` and inline 15px removed (prose is configured once in index.css), mission form toggles as SegmentedControl, reference popup on `shadow-overlay`, remaining `rounded-lg` and bare `rounded` to `rounded-md`.
- `EntityGraph.tsx` is left to #593, which owns the file; its frame radius follows after that merge. The CodeBlock dark-mode logo chip keeps a fixed white background with a comment: it keeps third-party artwork visible and is not a themeable surface.

## Verification

Build, lint and the full Vitest suite in Docker: 129 files, 1401 tests passed, lint 0 errors. New `pages/Pages.a11y.test.tsx` runs axe on Home, Analytics, Memory (all three tabs) and the Knowledge list with zero violations and one h1 each. New tests cover the Analytics radiogroups, document status badges, the neutral TypeBadge and the Memory view switch; MissionForm tests were re-scoped from `aria-pressed` buttons to radio items with the same assertions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791456974&installation_model_id=431401&pr_number=599&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F599&signature=318fabed69ee86c943ff54d00ddae84c0020c1f5cd5b41247b30dad18feb7a74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->