### PR TITLE
chore(web): square the entity graph frame, drop unused agent form seed

### DIFF
--- a/web/src/components/memory/EntityGraph.tsx
+++ b/web/src/components/memory/EntityGraph.tsx
@@ -88,7 +88,7 @@ export function EntityGraph({
   return (
     <div className="space-y-2">
       <div
-        className="rounded-xl border border-border bg-card"
+        className="rounded-md border border-border bg-card"
         data-testid="entity-graph"
         role="img"
         aria-label="Entity knowledge graph"

--- a/web/src/components/settings/AgentForm.tsx
+++ b/web/src/components/settings/AgentForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Input } from '../ui/input'
 import { Textarea } from '../ui/textarea'
 import {
@@ -30,32 +30,16 @@ export interface AgentFormValue {
   harness: string
 }
 
-export function useAgentForm(agent?: AdminAgent) {
-  const [name, setName] = useState(agent?.name ?? '')
-  const [description, setDescription] = useState(agent?.description ?? '')
-  const [overlay, setOverlay] = useState(agent?.prompt_overlay ?? '')
-  const [route, setRoute] = useState(agent?.route ?? '')
-  const [skills, setSkills] = useState<string[]>(agent?.skills ?? [])
-  const [tools, setTools] = useState<string[]>(agent?.tools ?? [])
-  const [knowledge, setKnowledge] = useState<string[]>(agent?.knowledge ?? [])
-  const [memory, setMemory] = useState(agent?.memory ?? true)
-  const [harness, setHarness] = useState(agent?.harness ?? '')
-
-  // Edit loads its agent asynchronously, after this hook has already
-  // mounted with blank defaults: useState's initializer only runs
-  // once, so the fields never pick up the fetched agent without this.
-  useEffect(() => {
-    if (!agent) return
-    setName(agent.name)
-    setDescription(agent.description)
-    setOverlay(agent.prompt_overlay)
-    setRoute(agent.route)
-    setSkills(agent.skills)
-    setTools(agent.tools)
-    setKnowledge(agent.knowledge ?? [])
-    setMemory(agent.memory)
-    setHarness(agent.harness ?? '')
-  }, [agent])
+export function useAgentForm() {
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [overlay, setOverlay] = useState('')
+  const [route, setRoute] = useState('')
+  const [skills, setSkills] = useState<string[]>([])
+  const [tools, setTools] = useState<string[]>([])
+  const [knowledge, setKnowledge] = useState<string[]>([])
+  const [memory, setMemory] = useState(true)
+  const [harness, setHarness] = useState('')
 
   const value: AgentFormValue = {
     name,
@@ -71,7 +55,7 @@ export function useAgentForm(agent?: AdminAgent) {
 
   return {
     value,
-    canSubmit: agent ? true : slugify(name) !== '',
+    canSubmit: slugify(name) !== '',
     fields: {
       name,
       setName,


### PR DESCRIPTION
## Summary

Two leftovers from the design-system work.

- `EntityGraph.tsx` frame moves from `rounded-xl` to `rounded-md`. It was skipped in #599 because #593 owned the file at the time; with both merged, the forbidden-class grep across `components/` and `pages/` is now clean apart from shiki theme selection and the documented CodeBlock logo chip.
- `useAgentForm` drops its unused `agent` parameter and the re-seed effect behind it. The only caller is AgentAdd, which passes nothing; the edit page uses `useAgentEditForm`. The coverage pass flagged the branch as unreachable.

## Verification

tsc, lint (0 errors) and the agent, memory and Memory page test files pass in Docker.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791457124&installation_model_id=431401&pr_number=600&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F600&signature=0dd0bb0b02c3a3f0275ff2bd05616499f2670290b3c4f42f7d336297ae89288a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->