### PR TITLE
fix(web): give analytics fill charts a flex column body

### DIFF
--- a/web/src/components/timothy/panel.test.tsx
+++ b/web/src/components/timothy/panel.test.tsx
@@ -18,6 +18,16 @@ describe('Panel', () => {
     expect(screen.getByRole('heading', { name: 'Timeline' })).toBeInTheDocument()
   })
 
+  it('applies bodyClassName to the body wrapper, keeping the padding', () => {
+    render(
+      <Panel title="Chart" bodyClassName="flex flex-1 flex-col">
+        <div>plot</div>
+      </Panel>,
+    )
+    const body = screen.getByText('plot').parentElement
+    expect(body).toHaveClass('flex', 'flex-1', 'flex-col', 'p-5', 'pt-0')
+  })
+
   it('defaults the title to an h2', () => {
     render(<Panel title="Goal">Body</Panel>)
     const heading = screen.getByRole('heading', { name: 'Goal', level: 2 })

--- a/web/src/components/timothy/panel.tsx
+++ b/web/src/components/timothy/panel.tsx
@@ -10,6 +10,9 @@ interface PanelProps {
   headingLevel?: 'h2' | 'h3'
   children: ReactNode
   className?: string
+  // Extra classes on the body wrapper, e.g. `flex flex-1 flex-col` so a
+  // chart child can stretch to the panel's height.
+  bodyClassName?: string
 }
 
 // Bounded region of related content on a page: settings group, mission
@@ -32,6 +35,7 @@ export function Panel({
   headingLevel = 'h2',
   children,
   className,
+  bodyClassName,
 }: PanelProps) {
   const hasHeader = title || description || actions
   const Heading = headingLevel
@@ -53,7 +57,9 @@ export function Panel({
           </div>
         </div>
       )}
-      <div className={density === 'comfortable' ? cn('p-5', hasHeader && 'pt-0') : 'p-0'}>{children}</div>
+      <div className={cn(density === 'comfortable' ? cn('p-5', hasHeader && 'pt-0') : 'p-0', bodyClassName)}>
+        {children}
+      </div>
     </div>
   )
 }

--- a/web/src/pages/Analytics.test.tsx
+++ b/web/src/pages/Analytics.test.tsx
@@ -591,6 +591,25 @@ describe('Analytics latency panel', () => {
     const option = lastOption() as { xAxis: { axisLabel: { formatter: (v: number) => string } } }
     expect(option.xAxis.axisLabel.formatter(1500)).toBe(formatDuration(1500))
   })
+
+  // The chart container fills its wrapper (h-full), so every ancestor up
+  // to the panel must be a flex column item or the height collapses to 0.
+  it('keeps the fill chart inside a flex column body so it has a height', async () => {
+    vi.mocked(usageLatency).mockResolvedValue([
+      { provider: 'openai', p50_ms: 250, p95_ms: 900, p99_ms: 1500, requests: 10 },
+    ])
+    renderPage()
+    for (const title of ['Latency per provider', 'Spend share by provider']) {
+      const panel = (await screen.findByText(title)).closest('[data-density]') as HTMLElement | null
+      if (!panel) throw new Error('panel not found')
+      expect(panel).toHaveClass('flex', 'flex-col')
+      const chart = panel.querySelector('.h-full') as HTMLElement | null
+      if (!chart) throw new Error('fill chart not found')
+      const wrapper = chart.parentElement as HTMLElement
+      expect(wrapper).toHaveClass('flex-1', 'min-h-[240px]')
+      expect(wrapper.parentElement).toHaveClass('flex', 'flex-1', 'flex-col')
+    }
+  })
 })
 
 describe('Analytics provider cost table sorting', () => {

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -622,7 +622,7 @@ export function Analytics() {
       </Panel>
 
       <div className="mt-6 grid gap-6 lg:grid-cols-2">
-        <Panel title="Latency per provider" className="flex flex-col">
+        <Panel title="Latency per provider" className="flex flex-col" bodyClassName="flex flex-1 flex-col">
           {data && data.latency.length > 0 ? (
             <div className="min-h-[240px] flex-1">
               <EChart
@@ -639,7 +639,7 @@ export function Analytics() {
           )}
         </Panel>
 
-        <Panel title="Spend share by provider" className="flex flex-col">
+        <Panel title="Spend share by provider" className="flex flex-col" bodyClassName="flex flex-1 flex-col">
           <div className="min-h-[240px] flex-1">
             <EChart
               fill


### PR DESCRIPTION
Closes #601

## Summary

Latency per provider and Spend share by provider rendered as empty frames since #599. The old section was itself the flex column and the chart wrapper a direct flex child, so the ECharts container's `h-full` (the `fill` prop) resolved against a definite height. Panel puts children in a plain body div, so the wrapper's `min-h-[240px]` was the only height and `h-full` resolved to 0.

## Changes

- Panel accepts `bodyClassName`, merged onto the body wrapper after the density padding.
- Analytics passes `flex flex-1 flex-col` for the two chart panels, restoring the previous flex chain (panel > body > wrapper > chart).

## Verification

Build, lint (0 errors) and Panel, Analytics and page a11y tests pass in Docker. New tests assert the body class merge and that both chart wrappers sit inside a flex column body.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791475647&installation_model_id=431401&pr_number=602&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F602&signature=c3ce29349949ab397171356b384121cda4794da339b0cf448e8c0982285fc013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->