### PR TITLE
fix(web): chat follow-ups after the design-system migration

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -149,7 +149,7 @@ function AppSidebar({
           <Link to="/" aria-label="Timothy home" className="flex size-7 shrink-0 items-center justify-center">
             <BrandMark className="size-5" />
           </Link>
-          <span className="truncate text-sm font-semibold tracking-tight group-data-[collapsible=icon]:hidden">
+          <span className="truncate text-sm font-semibold tracking-tight transition-[opacity,visibility] duration-150 ease-out group-data-[collapsible=icon]:invisible group-data-[collapsible=icon]:opacity-0">
             Timothy
           </span>
         </div>
@@ -220,7 +220,7 @@ function AppSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
 
-        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto group-data-[collapsible=icon]:hidden">
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto transition-[opacity,visibility] duration-150 ease-out group-data-[collapsible=icon]:invisible group-data-[collapsible=icon]:opacity-0">
           <SessionList />
         </div>
       </SidebarContent>
@@ -248,7 +248,7 @@ function AppSidebar({
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>
-        <div className="px-2 py-1 text-xs text-muted-foreground group-data-[collapsible=icon]:hidden">
+        <div className="whitespace-nowrap px-2 py-1 text-xs text-muted-foreground transition-[opacity,visibility] duration-150 ease-out group-data-[collapsible=icon]:invisible group-data-[collapsible=icon]:opacity-0">
           v{__APP_VERSION__} ({__GIT_SHA__})
         </div>
       </SidebarFooter>

--- a/web/src/components/CodeBlock.tsx
+++ b/web/src/components/CodeBlock.tsx
@@ -424,7 +424,7 @@ export function CodeBlock({ children, node }: { children?: ReactNode } & ExtraPr
       <div className="flex h-8 items-center justify-between border-b border-border px-3 text-xs text-muted-foreground">
         <span className="flex items-center gap-1.5">
           {logo ? (
-            <span className={needsChip ? 'flex items-center rounded-md dark:bg-white/95 dark:p-[1px]' : 'flex items-center'}>
+            <span className={needsChip ? 'flex items-center rounded-[3px] dark:bg-white/95 dark:p-[1px]' : 'flex items-center'}>
               <img src={logo} alt="" className="size-3.5" />
             </span>
           ) : (

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -779,6 +779,12 @@ describe('UserMessage attachments', () => {
 })
 
 describe('long unbroken content containment', () => {
+  it('inverts prose colors in the user bubble so links stay readable in dark mode', () => {
+    render(<UserMessage text="see https://example.com" />)
+    const bubble = screen.getByText(/see/).closest('div')
+    expect(bubble?.className).toContain('dark:prose-invert')
+  })
+
   it('wraps a 400-character unbroken token in the user bubble', () => {
     const token = 'a'.repeat(400)
     render(<UserMessage text={token} />)

--- a/web/src/components/Message.test.tsx
+++ b/web/src/components/Message.test.tsx
@@ -778,6 +778,23 @@ describe('UserMessage attachments', () => {
   })
 })
 
+describe('turn footer', () => {
+  it('keeps copy and activity controls visible without hover, next to plain metadata text', () => {
+    const msg = play([
+      { type: 'chunk', text: 'hello' },
+      { type: 'meta', session_id: 's', provider: 'openai', model: 'gpt-5', usage: { input_tokens: 10, output_tokens: 5 } },
+      { type: 'done' },
+    ])
+    render(<AssistantMessage msg={msg} onShowActivity={() => {}} />)
+    expect(screen.getByTestId('copy-button').className).not.toContain('opacity-0')
+    expect(screen.getByTestId('show-activity')).toBeInTheDocument()
+    const meta = screen.getByTestId('meta-badge')
+    expect(meta.querySelector('[data-slot="badge"]')).toBeNull()
+    expect(meta).toHaveTextContent('gpt-5')
+    expect(meta).toHaveTextContent('10→5 tok')
+  })
+})
+
 describe('long unbroken content containment', () => {
   it('inverts prose colors in the user bubble so links stay readable in dark mode', () => {
     render(<UserMessage text="see https://example.com" />)

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -356,7 +356,7 @@ export function UserMessage({
       <div className="group/message flex w-full min-w-0 items-end justify-end gap-1">
         <CopyButton text={text} label="Copy message" />
         {text !== '' && (
-          <div className="prose ml-auto min-w-0 max-w-[85%] break-words rounded-md bg-muted px-4 py-3 text-prose text-foreground [overflow-wrap:anywhere]">
+          <div className="prose ml-auto min-w-0 max-w-[85%] break-words rounded-md bg-muted px-4 py-3 text-prose text-foreground [overflow-wrap:anywhere] dark:prose-invert">
             <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
               {text}
             </ReactMarkdown>
@@ -403,7 +403,7 @@ export function InterruptedMessage({ text }: { text: string }) {
       className="group/message flex w-full flex-col gap-2 rounded-md border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground"
       data-testid="interrupted"
     >
-      <div className="prose min-w-0 max-w-none break-words text-foreground [overflow-wrap:anywhere]">
+      <div className="prose min-w-0 max-w-none break-words text-foreground [overflow-wrap:anywhere] dark:prose-invert">
         <ReactMarkdown
           remarkPlugins={remarkPlugins}
           rehypePlugins={rehypePlugins}

--- a/web/src/components/Message.tsx
+++ b/web/src/components/Message.tsx
@@ -1,5 +1,5 @@
 import { Check, Copy, File, FileAudio, FileText, FileVideo, ImageOff, Link, ListTree, RotateCw } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type HTMLAttributes } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { toast } from 'sonner'
 import {
@@ -12,7 +12,7 @@ import type { ImageRef, MediaRef } from '../api/types'
 import { ApprovalCard, type Decision } from './chat/ApprovalCard'
 import { ToolCallGroup } from './chat/ToolCallCard'
 import { AttachmentViewer, mimeLabel } from './AttachmentViewer'
-import { ModelBadge } from './ModelBadge'
+import { presetForProviderName, ProviderMark } from './timothy/provider-logo'
 import { errText } from '../lib/errors'
 import { Badge } from './ui/badge'
 import { Button } from './ui/button'
@@ -274,12 +274,24 @@ export function CopyButton({
       data-copied={copied}
       onClick={() => void copy()}
       className={cn(
-        'rounded-md p-1 text-muted-foreground transition hover:bg-accent hover:text-foreground focus-visible:opacity-100',
-        alwaysVisible ? 'bg-muted' : 'opacity-0 group-hover/message:opacity-100',
+        'inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition hover:bg-accent hover:text-foreground focus-visible:opacity-100',
+        !alwaysVisible && 'opacity-0 group-hover/message:opacity-100',
       )}
     >
       {copied ? <Check className="size-3.5" aria-hidden /> : <Copy className="size-3.5" aria-hidden />}
     </button>
+  )
+}
+
+// MetaItem is one dot-separated entry in the turn footer's metadata line.
+function MetaItem({ children, ...props }: HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <>
+      <span aria-hidden className="select-none">
+        ·
+      </span>
+      <span {...props}>{children}</span>
+    </>
   )
 }
 
@@ -304,8 +316,7 @@ function ExportPDFButton({ text }: { text: string }) {
         icon={FileText}
         loading={exporting}
         variant="ghost"
-        size="sm"
-        className="opacity-0 group-hover/message:opacity-100 focus-visible:opacity-100"
+        size="xs"
         onClick={exportPdf}
       />
     </TooltipProvider>
@@ -573,31 +584,32 @@ export function AssistantMessage({
         </div>
       )}
       {!msg.streaming && (Boolean(msg.meta?.provider) || msg.text !== '' || Boolean(onShowActivity)) && (
-        <div className="mt-2 flex min-w-0 max-w-full flex-wrap items-center gap-1 text-xs text-muted-foreground">
+        <div className="mt-2 flex min-w-0 max-w-full flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
           {msg.meta?.provider && (
-            <div className="flex flex-wrap gap-1.5" data-testid="meta-badge">
-              <ModelBadge provider={msg.meta.provider} model={msg.meta.model ?? ''} />
-              {tokens && <Badge variant="secondary">{tokens}</Badge>}
-              {duration && (
-                <Badge variant="secondary" data-testid="duration-badge">
-                  {duration}
-                </Badge>
-              )}
+            <div className="flex min-w-0 flex-wrap items-center gap-x-2 tabular-nums" data-testid="meta-badge">
+              <span className="inline-flex items-center gap-1.5">
+                <ProviderMark preset={presetForProviderName(msg.meta.provider)} className="size-3" />
+                {msg.meta.model ?? ''}
+              </span>
+              {tokens && <MetaItem>{tokens}</MetaItem>}
+              {duration && <MetaItem data-testid="duration-badge">{duration}</MetaItem>}
               {cost && (
-                <Badge variant="secondary" data-testid="cost-badge" title={costTitle}>
+                <MetaItem data-testid="cost-badge" title={costTitle}>
                   {cost}
-                </Badge>
+                </MetaItem>
               )}
             </div>
           )}
-          {msg.text !== '' && <CopyButton text={msg.text} label="Copy reply" />}
-          {msg.text !== '' && pdfExportEnabled && <ExportPDFButton text={msg.text} />}
-          {onShowActivity && (
-            <Button variant="ghost" size="xs" data-testid="show-activity" onClick={onShowActivity}>
-              <ListTree aria-hidden />
-              Activity
-            </Button>
-          )}
+          <div className="ml-auto flex items-center gap-0.5">
+            {msg.text !== '' && <CopyButton text={msg.text} label="Copy reply" alwaysVisible />}
+            {msg.text !== '' && pdfExportEnabled && <ExportPDFButton text={msg.text} />}
+            {onShowActivity && (
+              <Button variant="ghost" size="xs" data-testid="show-activity" onClick={onShowActivity}>
+                <ListTree aria-hidden />
+                Activity
+              </Button>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/web/src/components/timothy/trace-group.test.tsx
+++ b/web/src/components/timothy/trace-group.test.tsx
@@ -5,6 +5,12 @@ import { TraceGroup, TraceRow } from './trace-group'
 afterEach(cleanup)
 
 describe('TraceGroup', () => {
+  it('keeps the action on one line and lets the target truncate', () => {
+    render(<TraceRow status="success" action="Fetch url" target="https://example.com/a/very/long/path" />)
+    expect(screen.getByText('Fetch url')).toHaveClass('shrink-0', 'whitespace-nowrap')
+    expect(screen.getByText('https://example.com/a/very/long/path')).toHaveClass('min-w-0', 'truncate')
+  })
+
   it('toggles aria-expanded and content visibility', () => {
     render(
       <TraceGroup summary="3 tool calls" duration="2.1s">

--- a/web/src/components/timothy/trace-group.tsx
+++ b/web/src/components/timothy/trace-group.tsx
@@ -92,8 +92,8 @@ export function TraceRow({
     <>
       <StatusIcon aria-hidden className={cn('size-3.5 shrink-0', statusText[status], meta.spin && 'animate-spin motion-keep')} />
       {CategoryIcon && <CategoryIcon aria-hidden className="size-3.5 shrink-0 text-muted-foreground" />}
-      <span className="text-sm text-muted-foreground">{action}</span>
-      {target && <span className="truncate font-mono text-xs text-foreground">{target}</span>}
+      <span className="shrink-0 whitespace-nowrap text-sm text-muted-foreground">{action}</span>
+      {target && <span className="min-w-0 truncate font-mono text-xs text-foreground">{target}</span>}
       {duration && <span className="ml-auto shrink-0 text-xs tabular-nums text-muted-foreground">{duration}</span>}
     </>
   )

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -217,7 +217,7 @@ function Sidebar({
       <div
         data-slot="sidebar-gap"
         className={cn(
-          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-in-out",
           "group-data-[collapsible=offcanvas]:w-0",
           "group-data-[side=right]:rotate-180",
           variant === "floating" || variant === "inset"
@@ -229,7 +229,7 @@ function Sidebar({
         data-slot="sidebar-container"
         data-side={side}
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-in-out data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
           // Adjust the padding for floating and inset variants.
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
@@ -466,7 +466,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-[active=true]:bg-brand-soft data-[active=true]:text-brand-soft-foreground data-[active=true]:font-medium [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
+  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] duration-200 ease-in-out group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-[active=true]:bg-brand-soft data-[active=true]:text-brand-soft-foreground data-[active=true]:font-medium [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
   {
     variants: {
       variant: {

--- a/web/src/pages/Chat.tsx
+++ b/web/src/pages/Chat.tsx
@@ -713,7 +713,7 @@ export function Chat({
           </div>
         ) : (
           <div ref={listRef} onScroll={trackPin} className="flex-1 overflow-y-auto overflow-x-hidden">
-            <div className="relative mx-auto w-full min-w-0 max-w-[45rem] space-y-8 pt-8 pb-6">
+            <div className="relative mx-auto w-full min-w-0 max-w-4xl space-y-8 pt-8 pb-6">
               {loadError && (
                 <Alert tone="destructive">
                   <AlertTitle>Could not load this conversation</AlertTitle>
@@ -786,7 +786,7 @@ export function Chat({
           </div>
         )}
 
-        <div className="mx-auto w-full max-w-[45rem] pb-6">
+        <div className="mx-auto w-full max-w-4xl pb-6">
           <AgentStatusLine
             phase={
               statusPhase.kind === 'waiting'


### PR DESCRIPTION
Closes #603, closes #605

## Summary

Four small regressions spotted on homelab after alpha.72.

- Trace rows (Activity, tool call cards): the action span could shrink, so "Fetch url" wrapped onto two lines next to a long target. Action is `shrink-0 whitespace-nowrap`, target is `min-w-0 truncate`.
- User bubble and interrupted block: `prose-invert` was dropped in #591, so links rendered dark blue on the dark muted surface. Both get `dark:prose-invert`, matching the assistant body.
- CodeBlock dark-mode logo chip: `rounded-md` on a 16px box read as a blob around the bash/json/markdown logos. Back to `rounded-[3px]`.
- Chat column: 720px to 896px (`max-w-4xl`) for transcript and composer. This deviates from the contract's reading measure for chat only; documents keep 720px.

## Verification

Build, lint (0 errors) and Message, trace-group, CodeBlock, Chat and Activity tests pass in Docker. New tests cover the nowrap/truncate classes and the user bubble's inverted prose.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791476017&installation_model_id=431401&pr_number=604&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F604&signature=a03306365fa7a037a4a72824746a05465dd92466b2c431dde18149d9c0a6107a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

- Sidebar: wordmark, session list and version line fade (150ms ease-out, opacity plus visibility) instead of snapping via `display: none`; width transitions ease in and out.
- Turn footer: model, tokens, duration and cost as plain dot-separated muted text; copy, export PDF and Activity are always-visible ghost controls at one 28px size, grouped right.