### PR TITLE
refactor(web): replace hugeicons pro with lucide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,9 +138,6 @@ jobs:
     needs: changes
     if: needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
-    env:
-      # HugeIcons Pro registry auth (web/.npmrc references it by name)
-      HUGEICONS_TOKEN: ${{ secrets.HUGEICONS_TOKEN }}
     defaults:
       run:
         working-directory: web
@@ -182,36 +179,25 @@ jobs:
     # whose steps all skip still reports "success" (skipped steps
     # aren't a failure), so ci-ok's blanket check on `images` needs no
     # path-awareness of its own.
-    # The web leg additionally skips on fork PRs: its build needs the
-    # HUGEICONS_TOKEN secret, and GitHub withholds secrets from
-    # fork-triggered runs — the empty token fails npm auth (broke PR
-    # #248). Same-repo pushes and PRs still build it, and the release
-    # workflow builds it again at tag time, so nothing ships unbuilt.
     runs-on: ubuntu-latest
     strategy:
       matrix:
         service: [brain, gateway, memoryd, sandboxd, web]
     steps:
       - uses: actions/checkout@v7
-        if: (matrix.service == 'web' && needs.changes.outputs.web == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) || (matrix.service != 'web' && needs.changes.outputs.go == 'true')
+        if: (matrix.service == 'web' && needs.changes.outputs.web == 'true') || (matrix.service != 'web' && needs.changes.outputs.go == 'true')
       - name: Build image
-        if: (matrix.service == 'web' && needs.changes.outputs.web == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) || (matrix.service != 'web' && needs.changes.outputs.go == 'true')
-        env:
-          # Web only: HugeIcons Pro registry auth, passed as a BuildKit
-          # secret so it never lands in an image layer.
-          HUGEICONS_TOKEN: ${{ secrets.HUGEICONS_TOKEN }}
+        if: (matrix.service == 'web' && needs.changes.outputs.web == 'true') || (matrix.service != 'web' && needs.changes.outputs.go == 'true')
         run: |
           if [ "${{ matrix.service }}" = "web" ]; then
-            docker build -f web/Dockerfile \
-              --secret id=hugeicons_token,env=HUGEICONS_TOKEN \
-              -t timothy-web:ci web
+            docker build -f web/Dockerfile -t timothy-web:ci web
           else
             docker build -f deploy/Dockerfile \
               --build-arg SERVICE=${{ matrix.service }} \
               -t timothy-${{ matrix.service }}:ci .
           fi
       - name: Scan image
-        if: (matrix.service == 'web' && needs.changes.outputs.web == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) || (matrix.service != 'web' && needs.changes.outputs.go == 'true')
+        if: (matrix.service == 'web' && needs.changes.outputs.web == 'true') || (matrix.service != 'web' && needs.changes.outputs.go == 'true')
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: timothy-${{ matrix.service }}:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,6 @@ jobs:
           - name: web
             context: web
             dockerfile: web/Dockerfile
-            secret: "true"
           - name: markitdown
             context: markitdown-svc
             dockerfile: markitdown-svc/Dockerfile
@@ -146,10 +145,6 @@ jobs:
             ${{ matrix.build-args }}
             GIT_SHA=${{ steps.sha.outputs.short }}
             APP_VERSION=${{ steps.version.outputs.value }}
-          # web only: HugeIcons Pro registry auth, passed as a BuildKit
-          # secret so it never lands in an image layer (not as a
-          # build-arg or env, both of which persist into layer history).
-          secrets: ${{ matrix.secret == 'true' && format('hugeicons_token={0}', secrets.HUGEICONS_TOKEN) || '' }}
           platforms: linux/amd64,linux/arm64
           push: true
           # repository_owner, not a literal: survives org renames and

--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ The rest of this README covers building and running from source instead.
 Prerequisites:
 
 - Docker (Desktop, or engine + compose plugin).
-- A [hugeicons.com](https://hugeicons.com) account with an active token. The web UI's icons are HugeIcons Pro (a paid icon set) and the token is required to build the `web` image; without it, `make up` fails on the web build step. Not needed for the prebuilt-image quick start above.
 
 1. Copy the env file and fill in the required values:
 
@@ -121,7 +120,6 @@ Prerequisites:
    - `POSTGRES_PASSWORD`: compose refuses to start without it.
    - `TIMOTHY_MASTER_KEY`: generate with `openssl rand -base64 32`. This is the root of trust for the encrypted secret store (provider API keys, OAuth tokens all live behind it). Compose hard-fails if it's blank. **Back this up**: losing it makes every stored secret unrecoverable.
    - `TIMOTHY_API_TOKEN`: generate with `openssl rand -hex 32`. Bearer token for the API; if it's blank, every request 401s.
-   - `HUGEICONS_TOKEN`: your HugeIcons Pro token, needed to build the `web` image.
 
 2. (Optional) Missions sandbox. `deploy/env.example` prefills `MISSION_SANDBOX_IMAGE=timothy-sandbox:latest`, but that image doesn't exist until you build it:
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -298,10 +298,6 @@ services:
       args:
         GIT_SHA: ${GIT_SHA:-}
         APP_VERSION: ${APP_VERSION:-}
-      # HugeIcons Pro registry auth for npm ci, passed as a BuildKit
-      # secret (name-only ref; the value lives in deploy/.env, never in
-      # the repo or an image layer).
-      secrets: [hugeicons_token]
     environment:
       # nginx proxy target for /v1 (browser stays same-origin)
       BRAIN_URL: http://brain:8080
@@ -324,9 +320,6 @@ services:
     environment:
       # Vite dev proxy target for /v1 (browser stays same-origin)
       BRAIN_URL: http://brain:8080
-      # HugeIcons Pro registry auth for npm install (name-only ref;
-      # the value lives in deploy/.env, never in the repo)
-      HUGEICONS_TOKEN: ${HUGEICONS_TOKEN}
     # npm install, not ci: ci wipes node_modules first, defeating the
     # cache volume. install syncs against the lockfile and is fast when
     # the volume is already populated.
@@ -342,10 +335,6 @@ services:
       timeout: 5s
       retries: 3
       start_period: 60s
-
-secrets:
-  hugeicons_token:
-    environment: HUGEICONS_TOKEN
 
 # searxng's settings.yml, inlined so no host path is involved (see the
 # searxng service). Same block in deploy/release/docker-compose.yml; CI's

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -41,10 +41,6 @@ TURN_TIMEOUT=
 # missions). Off by default.
 WORKFLOWS_ENABLED=
 
-# --- Third-party services ---
-# npm auth token for HugeIcons Pro packages (from your hugeicons.com account)
-HUGEICONS_TOKEN=
-
 # --- Mission sandbox ---
 # Group ID of the docker.sock on your host, needed so sandboxd (running
 # as a non-root user) can use it. Docker Desktop: 0 (the default)

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,2 +1,0 @@
-@hugeicons-pro:registry=https://npm.hugeicons.com/
-//npm.hugeicons.com/:_authToken=${HUGEICONS_TOKEN}

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,7 +1,5 @@
 # syntax=docker/dockerfile:1
 # Production web image: Vite build served by unprivileged nginx.
-# The HugeIcons Pro registry token is consumed as a BuildKit secret so
-# it never lands in an image layer or the build history.
 # --platform=$BUILDPLATFORM: the Vite dist output is arch-independent,
 # so the build stage always runs natively. Running node under qemu for
 # the arm64 leg crashed with illegal-instruction core dumps and hung
@@ -12,9 +10,8 @@ ARG APP_VERSION
 ENV GIT_SHA=${GIT_SHA}
 ENV APP_VERSION=${APP_VERSION}
 WORKDIR /app
-COPY package.json package-lock.json .npmrc ./
-RUN --mount=type=secret,id=hugeicons_token \
-    HUGEICONS_TOKEN="$(cat /run/secrets/hugeicons_token)" npm ci
+COPY package.json package-lock.json ./
+RUN npm ci
 COPY . .
 RUN npm run build
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,8 +10,6 @@
       "dependencies": {
         "@fontsource-variable/fira-code": "^5.3.0",
         "@fontsource-variable/inter": "^5.3.0",
-        "@hugeicons-pro/core-stroke-rounded": "^4.2.2",
-        "@hugeicons/react": "^1.1.10",
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "^4.3.3",
         "class-variance-authority": "^0.7.1",
@@ -976,21 +974,6 @@
       },
       "peerDependencies": {
         "hono": "^4"
-      }
-    },
-    "node_modules/@hugeicons-pro/core-stroke-rounded": {
-      "version": "4.2.2",
-      "resolved": "https://npm.hugeicons.com/@hugeicons-pro/core-stroke-rounded/-/core-stroke-rounded-4.2.2.tgz",
-      "integrity": "sha512-+TruczzkMDuo1PVTAQWNOkjzPhOkTE/mGsk3OU1kwGnm66c+pgSrLpSRpp0OWmKaHCDCnKfdufFroK7+gs8oWQ==",
-      "license": "MIT"
-    },
-    "node_modules/@hugeicons/react": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@hugeicons/react/-/react-1.1.10.tgz",
-      "integrity": "sha512-9tAsd92yMVVGP+E+d8cM+wc0VnXuYZHNbWQi7TOe8k2neawmhiaFmVFbzyruejhOMa197/LbgvSED32ayUo3ZA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.0.0"
       }
     },
     "node_modules/@iconify/types": {

--- a/web/package.json
+++ b/web/package.json
@@ -13,8 +13,6 @@
   "dependencies": {
     "@fontsource-variable/fira-code": "^5.3.0",
     "@fontsource-variable/inter": "^5.3.0",
-    "@hugeicons-pro/core-stroke-rounded": "^4.2.2",
-    "@hugeicons/react": "^1.1.10",
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.3",
     "class-variance-authority": "^0.7.1",

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -54,6 +54,33 @@ describe('Sidebar nav', () => {
   })
 })
 
+// The footer's theme button picks its glyph from a map keyed on the
+// current theme. lucide stamps a `lucide-<kebab-name>` class on every
+// glyph, so asserting on it pins the mapping.
+describe('Theme toggle icon', () => {
+  it('shows the moon glyph on a dark theme', () => {
+    localStorage.setItem('timothy.theme', 'dark')
+    const { container } = renderAt('/')
+    expect(container.querySelector('.lucide-moon')).toBeInTheDocument()
+    expect(container.querySelector('.lucide-sun')).toBeNull()
+  })
+
+  it('shows the sun glyph on a light theme', () => {
+    localStorage.setItem('timothy.theme', 'light')
+    const { container } = renderAt('/')
+    expect(container.querySelector('.lucide-sun')).toBeInTheDocument()
+    expect(container.querySelector('.lucide-moon')).toBeNull()
+  })
+
+  it('swaps the glyph when the theme is cycled', () => {
+    localStorage.setItem('timothy.theme', 'light')
+    const { container } = renderAt('/')
+    expect(container.querySelector('.lucide-sun')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Light theme' }))
+    expect(container.querySelector('.lucide-moon')).toBeInTheDocument()
+  })
+})
+
 describe('Legacy edit schedule route', () => {
   it('redirects /missions/schedules/:id/edit to /automations/:id/edit', async () => {
     renderAt('/missions/schedules/s1/edit')

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,20 +1,4 @@
-import {
-  Analytics01Icon,
-  ArrowRight01Icon,
-  Brain02Icon,
-  BubbleChatIcon,
-  GithubIcon,
-  Home01Icon,
-  Key01Icon,
-  LibraryIcon,
-  Moon02Icon,
-  RepeatIcon,
-  RocketIcon,
-  Search01Icon,
-  Settings02Icon,
-  Sun03Icon,
-} from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
+import { Brain, ChartColumn, ChevronRight, House, KeyRound, Library, MessageCircle, Moon, Repeat, Rocket, Search, Settings as SettingsIcon, Sun } from 'lucide-react'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router'
 import { toast, Toaster } from 'sonner'
@@ -79,17 +63,17 @@ import { DesignSystem } from './pages/DesignSystem'
 const Analytics = lazy(() => import('./pages/Analytics').then((m) => ({ default: m.Analytics })))
 
 const nav = [
-  { label: 'Home', href: '/', icon: Home01Icon },
-  { label: 'Chat', href: '/chat', icon: BubbleChatIcon },
-  { label: 'Missions', href: '/missions', icon: RocketIcon },
-  { label: 'Automations', href: '/automations', icon: RepeatIcon },
-  { label: 'Knowledge', href: '/knowledge', icon: LibraryIcon },
-  { label: 'Memory', href: '/memory', icon: Brain02Icon },
-  { label: 'Analytics', href: '/analytics', icon: Analytics01Icon },
-  { label: 'Settings', href: '/settings', icon: Settings02Icon },
+  { label: 'Home', href: '/', icon: House },
+  { label: 'Chat', href: '/chat', icon: MessageCircle },
+  { label: 'Missions', href: '/missions', icon: Rocket },
+  { label: 'Automations', href: '/automations', icon: Repeat },
+  { label: 'Knowledge', href: '/knowledge', icon: Library },
+  { label: 'Memory', href: '/memory', icon: Brain },
+  { label: 'Analytics', href: '/analytics', icon: ChartColumn },
+  { label: 'Settings', href: '/settings', icon: SettingsIcon },
 ]
 
-const themeIcon = { system: Sun03Icon, light: Sun03Icon, dark: Moon02Icon }
+const themeIcon = { system: Sun, light: Sun, dark: Moon }
 const themeLabel = { system: 'System theme', light: 'Light theme', dark: 'Dark theme' }
 
 function isActive(pathname: string, href: string): boolean {
@@ -132,6 +116,7 @@ function AppSidebar({
   const { pathname } = useLocation()
   const navigate = useNavigate()
   const { state: sidebarState, isMobile } = useSidebar()
+  const ThemeIcon = themeIcon[theme]
   // Settings starts expanded when the app loads into a settings route
   // (deep link or a fresh load), then stays however the user toggles
   // it from there, same "sticky until touched" feel as the rest of
@@ -172,11 +157,9 @@ function AppSidebar({
                           : setSettingsOpen((open) => !open)
                       }
                     >
-                      <HugeiconsIcon icon={item.icon} />
+                      <item.icon />
                       <span>{item.label}</span>
-                      <HugeiconsIcon
-                        icon={ArrowRight01Icon}
-                        className={cn(
+                      <ChevronRight className={cn(
                           'ml-auto size-3.5! transition-transform group-data-[collapsible=icon]:hidden',
                           settingsOpen && 'rotate-90',
                         )}
@@ -203,7 +186,7 @@ function AppSidebar({
                   <SidebarMenuItem key={item.href}>
                     <SidebarMenuButton asChild isActive={isActive(pathname, item.href)} tooltip={item.label}>
                       <Link to={item.href}>
-                        <HugeiconsIcon icon={item.icon} />
+                        <item.icon />
                         <span>{item.label}</span>
                       </Link>
                     </SidebarMenuButton>
@@ -229,20 +212,22 @@ function AppSidebar({
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton onClick={onCycleTheme} tooltip={themeLabel[theme]}>
-              <HugeiconsIcon icon={themeIcon[theme]} />
+              <ThemeIcon />
               <span>{themeLabel[theme]}</span>
             </SidebarMenuButton>
           </SidebarMenuItem>
           <SidebarMenuItem>
             <SidebarMenuButton onClick={onToken} tooltip="API token">
-              <HugeiconsIcon icon={Key01Icon} />
+              <KeyRound />
               <span>API token</span>
             </SidebarMenuButton>
           </SidebarMenuItem>
           <SidebarMenuItem>
             <SidebarMenuButton asChild tooltip="View on GitHub">
               <a href="https://github.com/timothy-agent/timothy" target="_blank" rel="noreferrer">
-                <HugeiconsIcon icon={GithubIcon} />
+                <svg className="size-4 fill-current" aria-hidden="true">
+                  <use href="#clogo-github" />
+                </svg>
                 <span>GitHub</span>
               </a>
             </SidebarMenuButton>
@@ -280,7 +265,7 @@ function TopBar({ onOpenPalette }: { onOpenPalette: () => void }) {
         aria-label="Search or jump to…"
         className="ml-auto flex min-w-52 items-center gap-2 rounded-lg border border-border bg-card px-2.5 py-1.5 text-xs text-muted-foreground transition hover:border-zinc-400 dark:hover:border-zinc-600"
       >
-        <HugeiconsIcon icon={Search01Icon} className="size-3.5" />
+        <Search className="size-3.5" />
         <span>Search or jump to…</span>
         <kbd className="ml-auto rounded border border-border bg-background px-1 py-px font-mono text-[10px]">
           {isMac ? '⌘K' : 'Ctrl K'}
@@ -311,7 +296,7 @@ function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenChange: (
         <CommandGroup heading="Pages">
           {nav.map((item) => (
             <CommandItem key={item.href} value={item.label} onSelect={() => go(item.href)}>
-              <HugeiconsIcon icon={item.icon} />
+              <item.icon />
               <span>{item.label}</span>
             </CommandItem>
           ))}
@@ -324,7 +309,7 @@ function CommandPalette({ open, onOpenChange }: { open: boolean; onOpenChange: (
                 value={s.title || 'New session'}
                 onSelect={() => go(`/chat/${s.id}`)}
               >
-                <HugeiconsIcon icon={BubbleChatIcon} />
+                <MessageCircle />
                 <span className="truncate">{s.title || 'New session'}</span>
               </CommandItem>
             ))}

--- a/web/src/components/AttachmentViewer.tsx
+++ b/web/src/components/AttachmentViewer.tsx
@@ -1,12 +1,4 @@
-import {
-  Cancel01Icon,
-  Copy01Icon,
-  Download04Icon,
-  ImageNotFound01Icon,
-  Loading03Icon,
-  Tick02Icon,
-} from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
+import { Check, Copy, Download, ImageOff, LoaderCircle, X } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { fetchAttachmentBlob } from '../api/client'
 import { attachmentURLCache } from '../lib/attachmentCache'
@@ -117,7 +109,7 @@ export function AttachmentViewer({
                   </Button>
                 )}
                 <Button variant="ghost" size="sm" onClick={() => void copyText()}>
-                  <HugeiconsIcon icon={copied ? Tick02Icon : Copy01Icon} />
+                  {copied ? <Check /> : <Copy />}
                   {copied ? 'Copied' : 'Copy'}
                 </Button>
               </>
@@ -125,7 +117,7 @@ export function AttachmentViewer({
             {url && (
               <Button variant="ghost" size="sm" asChild>
                 <a href={url} download={attachment.name || attachment.id}>
-                  <HugeiconsIcon icon={Download04Icon} />
+                  <Download />
                   Download
                 </a>
               </Button>
@@ -137,7 +129,7 @@ export function AttachmentViewer({
                 FullscreenDialog uses for its own header controls. */}
             <DialogClose asChild>
               <Button variant="ghost" size="icon-sm" aria-label="Close">
-                <HugeiconsIcon icon={Cancel01Icon} />
+                <X />
               </Button>
             </DialogClose>
           </div>
@@ -145,12 +137,12 @@ export function AttachmentViewer({
         <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto bg-muted/40">
           {failed && (
             <div className="flex flex-col items-center gap-2 text-muted-foreground">
-              <HugeiconsIcon icon={ImageNotFound01Icon} className="size-8" />
+              <ImageOff className="size-8" />
               <p className="text-sm">Could not load this attachment.</p>
             </div>
           )}
           {!failed && !url && (
-            <HugeiconsIcon icon={Loading03Icon} className="size-6 animate-spin text-muted-foreground" />
+            <LoaderCircle className="size-6 animate-spin text-muted-foreground" />
           )}
           {!failed && url && mime.startsWith('image/') && (
             <img src={url} alt={displayName} className="max-h-full max-w-full object-contain" />

--- a/web/src/components/CodeBlock.tsx
+++ b/web/src/components/CodeBlock.tsx
@@ -62,8 +62,8 @@ const LANGUAGE_COLORS: Record<string, string> = {
 
 // Official per-language logos, vendored from devicon
 // (https://github.com/devicons/devicon, MIT licensed) as static SVGs
-// under ../assets/langs/ — hugeicons' stroke-rounded set has no real
-// per-language marks (its "PhpIcon" etc. are generic glyphs, not the
+// under ../assets/langs/ — general-purpose icon sets have no real
+// per-language marks (their "php" glyph is a generic file, not the
 // actual PHP logo), so this replaces that with the real thing.
 // jsx/tsx share their base language's logo (same language, JSX
 // syntax); sql uses the mysql mark as the generic "database" stand-in

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,14 +1,4 @@
-import {
-  Add01Icon,
-  Archive02Icon,
-  BubbleChatIcon,
-  Delete02Icon,
-  MoreHorizontalIcon,
-  PencilEdit01Icon,
-  Search01Icon,
-  Unarchive03Icon,
-} from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
+import { Archive, ArchiveRestore, Ellipsis, MessageCircle, Plus, Search, SquarePen, Trash2 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router'
 import { toast } from 'sonner'
@@ -121,14 +111,14 @@ export function SessionList() {
           aria-label="New chat"
           className="flex size-7 items-center justify-center rounded-md text-muted-foreground transition hover:bg-accent hover:text-accent-foreground"
         >
-          <HugeiconsIcon icon={Add01Icon} className="size-4" />
+          <Plus className="size-4" />
         </Link>
       </div>
 
       <SidebarGroup className="pt-0">
         <SidebarGroupContent>
           <div className="relative px-1">
-            <HugeiconsIcon icon={Search01Icon} className="pointer-events-none absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Search className="pointer-events-none absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground" />
             <Input
               aria-label="Search sessions"
               value={query}
@@ -147,7 +137,7 @@ export function SessionList() {
               <SidebarMenuItem key={s.id}>
                 {editingId === s.id ? (
                   <div className="flex items-center gap-1.5 px-2 py-1.5">
-                    <HugeiconsIcon icon={BubbleChatIcon} className="size-3.5 shrink-0 text-muted-foreground" />
+                    <MessageCircle className="size-3.5 shrink-0 text-muted-foreground" />
                     <Input
                       aria-label="Session title"
                       value={title}
@@ -165,7 +155,7 @@ export function SessionList() {
                   <SidebarMenuButton asChild isActive={pathname === `/chat/${s.id}`} className="h-auto flex-col items-start gap-0.5 py-1.5">
                     <Link to={`/chat/${s.id}`}>
                       <span className="flex w-full items-center gap-1.5">
-                        <HugeiconsIcon icon={BubbleChatIcon} className="size-3.5 shrink-0 text-muted-foreground" />
+                        <MessageCircle className="size-3.5 shrink-0 text-muted-foreground" />
                         <span className="truncate font-medium">{s.title || 'New session'}</span>
                         {s.archived && <Badge variant="outline">archived</Badge>}
                       </span>
@@ -176,23 +166,23 @@ export function SessionList() {
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <SidebarMenuAction showOnHover aria-label={`Actions for ${s.title || 'session'}`}>
-                      <HugeiconsIcon icon={MoreHorizontalIcon} />
+                      <Ellipsis />
                     </SidebarMenuAction>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent side="right" align="start">
                     <DropdownMenuItem onClick={() => startRename(s)}>
-                      <HugeiconsIcon icon={PencilEdit01Icon} />
+                      <SquarePen />
                       Rename
                     </DropdownMenuItem>
                     <DropdownMenuItem onClick={() => void archive(s)}>
-                      <HugeiconsIcon icon={s.archived ? Unarchive03Icon : Archive02Icon} />
+                      {s.archived ? <ArchiveRestore /> : <Archive />}
                       {s.archived ? 'Unarchive' : 'Archive'}
                     </DropdownMenuItem>
                     <DropdownMenuItem
                       variant="destructive"
                       onClick={() => setConfirmDelete(s)}
                     >
-                      <HugeiconsIcon icon={Delete02Icon} />
+                      <Trash2 />
                       Delete
                     </DropdownMenuItem>
                   </DropdownMenuContent>

--- a/web/src/components/destinations/DestinationKindIcon.test.tsx
+++ b/web/src/components/destinations/DestinationKindIcon.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { DestinationKindIcon } from './DestinationKindIcon'
+
+afterEach(cleanup)
+
+// lucide stamps a `lucide-<kebab-name>` class on every glyph it
+// renders, so asserting on it pins which icon a kind maps to.
+describe('DestinationKindIcon', () => {
+  it('renders the mail glyph for an email destination', () => {
+    const { container } = render(<DestinationKindIcon kind="email" />)
+    expect(container.querySelector('.lucide-mail')).toBeInTheDocument()
+  })
+
+  it('renders the globe glyph for a webhook destination', () => {
+    const { container } = render(<DestinationKindIcon kind="webhook" />)
+    expect(container.querySelector('.lucide-globe')).toBeInTheDocument()
+  })
+
+  it('renders the vendored telegram mark, not a lucide glyph', () => {
+    const { container } = render(<DestinationKindIcon kind="telegram" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+    expect(container.querySelector('[class*="lucide-"]')).toBeNull()
+  })
+
+  it('references the github sprite symbol for a github destination', () => {
+    const { container } = render(<DestinationKindIcon kind="github" />)
+    expect(container.querySelector('use')).toHaveAttribute('href', '#clogo-github')
+  })
+
+  it('passes the size class through to the rendered glyph', () => {
+    const { container } = render(<DestinationKindIcon kind="email" className="size-8" />)
+    expect(container.querySelector('.lucide-mail')).toHaveClass('size-8')
+  })
+})

--- a/web/src/components/destinations/DestinationKindIcon.tsx
+++ b/web/src/components/destinations/DestinationKindIcon.tsx
@@ -1,9 +1,8 @@
-import { Mail01Icon, GlobalIcon } from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
+import { Globe, Mail } from 'lucide-react'
 import { TelegramIcon } from '@/components/icons/TelegramIcon'
 import type { Destination } from '../../api/types'
 
-const destinationKindIcon = { email: Mail01Icon, webhook: GlobalIcon } as const
+const destinationKindIcon = { email: Mail, webhook: Globe } as const
 
 // DestinationKindIcon renders the small glyph identifying a
 // destination's kind — shared by the settings destinations list and
@@ -23,5 +22,6 @@ export function DestinationKindIcon({
       </svg>
     )
   }
-  return <HugeiconsIcon icon={destinationKindIcon[kind]} className={className} />
+  const Icon = destinationKindIcon[kind]
+  return <Icon className={className} />
 }

--- a/web/src/components/knowledge/KbUploadForm.tsx
+++ b/web/src/components/knowledge/KbUploadForm.tsx
@@ -1,5 +1,4 @@
-import { CloudUploadIcon, Loading03Icon } from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
+import { CloudUpload, LoaderCircle } from 'lucide-react'
 import { useRef, useState } from 'react'
 import { toast } from 'sonner'
 import type { KbDocument } from '../../api/types'
@@ -109,7 +108,7 @@ export function KbUploadForm({
             if (files.length > 0) void uploadFiles(files)
           }}
         />
-        <HugeiconsIcon icon={CloudUploadIcon} className="size-6 text-muted-foreground" />
+        <CloudUpload className="size-6 text-muted-foreground" />
         <p className="text-sm text-muted-foreground">
           Drag files here or{' '}
           <button type="button" onClick={() => inputRef.current?.click()} className="text-brand underline">
@@ -119,7 +118,7 @@ export function KbUploadForm({
         </p>
         {Object.keys(uploading).length > 0 && (
           <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <HugeiconsIcon icon={Loading03Icon} className="size-3 animate-spin" />
+            <LoaderCircle className="size-3 animate-spin" />
             Uploading {Object.keys(uploading).length} file
             {Object.keys(uploading).length === 1 ? '' : 's'}…
           </p>
@@ -153,7 +152,7 @@ export function KbUploadForm({
         <Button type="submit" variant="outline" disabled={parseUrls(url).length === 0 || !!urlProgress}>
           {urlProgress ? (
             <>
-              <HugeiconsIcon icon={Loading03Icon} className="animate-spin" />
+              <LoaderCircle className="animate-spin" />
               adding {urlProgress.done}/{urlProgress.total}…
             </>
           ) : (

--- a/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionDetail.tsx
@@ -1,10 +1,4 @@
-import {
-  Delete02Icon,
-  Edit01Icon,
-  File02Icon,
-  ReloadIcon,
-} from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
+import { FileText, Pencil, RefreshCw, Trash2 } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { Link, Navigate, useNavigate, useParams } from 'react-router'
 import { toast } from 'sonner'
@@ -237,11 +231,11 @@ export function KnowledgeCollectionDetail() {
                 setEditing(true)
               }}
             >
-              <HugeiconsIcon icon={Edit01Icon} />
+              <Pencil />
               Rename
             </Button>
             <Button variant="destructive" onClick={() => setConfirmDeleteCollection(true)}>
-              <HugeiconsIcon icon={Delete02Icon} />
+              <Trash2 />
               Delete collection
             </Button>
           </>
@@ -278,7 +272,7 @@ export function KnowledgeCollectionDetail() {
                   <TableRow key={doc.id}>
                     <TableCell>
                       <div className="flex items-center gap-2">
-                        <HugeiconsIcon icon={File02Icon} className="size-4 shrink-0 text-muted-foreground" />
+                        <FileText className="size-4 shrink-0 text-muted-foreground" />
                         <span className="truncate">{doc.title}</span>
                       </div>
                       <DocumentErrorLine doc={doc} />
@@ -303,7 +297,7 @@ export function KnowledgeCollectionDetail() {
                           onClick={() => void reingest(doc)}
                           className="text-muted-foreground hover:text-foreground"
                         >
-                          <HugeiconsIcon icon={ReloadIcon} className="size-4" />
+                          <RefreshCw className="size-4" />
                         </button>
                         <button
                           type="button"
@@ -311,7 +305,7 @@ export function KnowledgeCollectionDetail() {
                           onClick={() => setConfirmDeleteDoc(doc)}
                           className="text-muted-foreground hover:text-destructive"
                         >
-                          <HugeiconsIcon icon={Delete02Icon} className="size-4" />
+                          <Trash2 className="size-4" />
                         </button>
                       </div>
                     </TableCell>

--- a/web/src/components/knowledge/KnowledgeCollectionsList.tsx
+++ b/web/src/components/knowledge/KnowledgeCollectionsList.tsx
@@ -1,6 +1,4 @@
-import { Add01Icon, CloudUploadIcon, LibraryIcon } from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
-import { Library } from 'lucide-react'
+import { CloudUpload, Library, Plus } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
@@ -32,11 +30,11 @@ export function KnowledgeCollectionsList() {
         actions={
           <>
             <Button variant="outline" onClick={() => navigate('/knowledge/add')}>
-              <HugeiconsIcon icon={CloudUploadIcon} />
+              <CloudUpload />
               Add to Knowledgebase
             </Button>
             <Button onClick={() => navigate('/knowledge/new')}>
-              <HugeiconsIcon icon={Add01Icon} />
+              <Plus />
               New collection
             </Button>
           </>
@@ -55,7 +53,7 @@ export function KnowledgeCollectionsList() {
             description="Create one and upload documents so agents can search them for grounded answers."
             action={
               <Button onClick={() => navigate('/knowledge/new')}>
-                <HugeiconsIcon icon={Add01Icon} />
+                <Plus />
                 New collection
               </Button>
             }
@@ -68,7 +66,7 @@ export function KnowledgeCollectionsList() {
               <button type="button" onClick={() => navigate(`/knowledge/${c.id}`)} aria-label={c.name}>
                 <div className="flex items-center gap-3">
                   <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-brand-soft text-brand-soft-foreground">
-                    <HugeiconsIcon icon={LibraryIcon} className="size-4.5" />
+                    <Library className="size-4.5" />
                   </span>
                   <span className="min-w-0 flex-1 truncate text-sm font-semibold">{c.name}</span>
                 </div>

--- a/web/src/components/missions/MissionAttachments.test.tsx
+++ b/web/src/components/missions/MissionAttachments.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PendingAttachment } from '../Composer'
+import { MissionAttachments } from './MissionAttachments'
+
+afterEach(cleanup)
+
+function attachment(mime: string, over: Partial<PendingAttachment> = {}): PendingAttachment {
+  return { id: 'a1', mime, previewUrl: '', name: 'file', ...over }
+}
+
+function renderChips(attachments: PendingAttachment[]) {
+  return render(<MissionAttachments attachments={attachments} onChange={vi.fn()} />)
+}
+
+// lucide stamps a `lucide-<kebab-name>` class on every glyph it
+// renders, so asserting on it pins which icon a mime maps to. The name
+// is the icon's own, not the exported alias: FileAudio re-exports
+// file-headphone, so it renders as lucide-file-headphone.
+describe('MissionAttachments chip icons', () => {
+  it('shows the image glyph for an image attachment', () => {
+    const { container } = renderChips([attachment('image/png')])
+    expect(container.querySelector('.lucide-image')).toBeInTheDocument()
+  })
+
+  it('shows the audio glyph for an audio attachment', () => {
+    const { container } = renderChips([attachment('audio/mpeg')])
+    expect(container.querySelector('.lucide-file-headphone')).toBeInTheDocument()
+  })
+
+  it('shows the text glyph for plain text and markdown', () => {
+    const { container } = renderChips([attachment('text/plain')])
+    expect(container.querySelector('.lucide-file-text')).toBeInTheDocument()
+    cleanup()
+    const md = renderChips([attachment('text/markdown')])
+    expect(md.container.querySelector('.lucide-file-text')).toBeInTheDocument()
+  })
+
+  it('falls back to the generic file glyph for anything else', () => {
+    const { container } = renderChips([attachment('application/pdf')])
+    expect(container.querySelector('.lucide-file')).toBeInTheDocument()
+    expect(container.querySelector('.lucide-file-text')).toBeNull()
+  })
+
+  it('picks a distinct icon per chip when several mimes are attached', () => {
+    const { container } = renderChips([
+      attachment('image/png', { id: 'a1' }),
+      attachment('audio/mpeg', { id: 'a2' }),
+      attachment('application/pdf', { id: 'a3' }),
+    ])
+    expect(container.querySelector('.lucide-image')).toBeInTheDocument()
+    expect(container.querySelector('.lucide-file-headphone')).toBeInTheDocument()
+    expect(container.querySelector('svg.lucide-file')).toBeInTheDocument()
+  })
+
+  it('swaps the chip icon for a spinner while the upload is in flight', () => {
+    const { container } = renderChips([attachment('image/png', { uploading: true })])
+    expect(container.querySelector('.lucide-loader-circle')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Remove file' })).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/missions/MissionAttachments.tsx
+++ b/web/src/components/missions/MissionAttachments.tsx
@@ -1,13 +1,4 @@
-import {
-  Attachment02Icon,
-  Cancel01Icon,
-  File01Icon,
-  FileMusicIcon,
-  Image01Icon,
-  Loading03Icon,
-  Pdf02Icon,
-} from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
+import { File, FileAudio, FileText, Image, LoaderCircle, Paperclip, X } from 'lucide-react'
 import { useRef } from 'react'
 import { toast } from 'sonner'
 import { uploadAttachment } from '../../api/client'
@@ -22,10 +13,10 @@ import { Button } from '../ui/button'
 // attachmentChipIcon picks a chip's icon by mime, same per-type mapping
 // as ArtifactRefsSection.tsx's artifactChipIcon.
 function attachmentChipIcon(mime: string) {
-  if (mime.startsWith('image/')) return Image01Icon
-  if (mime.startsWith('audio/')) return FileMusicIcon
-  if (mime === 'text/plain' || mime === 'text/markdown') return File01Icon
-  return Pdf02Icon
+  if (mime.startsWith('image/')) return Image
+  if (mime.startsWith('audio/')) return FileAudio
+  if (mime === 'text/plain' || mime === 'text/markdown') return FileText
+  return File
 }
 
 // MissionAttachments is the mission-create form's attachment picker
@@ -100,20 +91,22 @@ export function MissionAttachments({
         }}
       />
       <Button type="button" variant="outline" size="sm" onClick={() => inputRef.current?.click()}>
-        <HugeiconsIcon icon={Attachment02Icon} className="size-4" />
+        <Paperclip className="size-4" />
         Attach file
       </Button>
       {attachments.length > 0 && (
         <div className="flex flex-wrap gap-2">
-          {attachments.map((a) => (
+          {attachments.map((a) => {
+            const Icon = attachmentChipIcon(a.mime)
+            return (
             <div
               key={a.id}
               className="group relative flex items-center gap-1.5 rounded-md border border-border bg-muted/30 py-1 pr-1.5 pl-2 text-xs"
             >
-              <HugeiconsIcon icon={attachmentChipIcon(a.mime)} className="size-3.5 text-muted-foreground" />
+              <Icon className="size-3.5 text-muted-foreground" />
               <span className="max-w-40 truncate">{a.name ?? 'Document'}</span>
               {a.uploading ? (
-                <HugeiconsIcon icon={Loading03Icon} className="size-3 animate-spin text-muted-foreground" />
+                <LoaderCircle className="size-3 animate-spin text-muted-foreground" />
               ) : (
                 <button
                   type="button"
@@ -121,11 +114,12 @@ export function MissionAttachments({
                   aria-label={`Remove ${a.name ?? 'attachment'}`}
                   className="flex size-3.5 items-center justify-center rounded-full text-muted-foreground hover:text-foreground"
                 >
-                  <HugeiconsIcon icon={Cancel01Icon} className="size-3" />
+                  <X className="size-3" />
                 </button>
               )}
             </div>
-          ))}
+            )
+          })}
         </div>
       )}
     </div>

--- a/web/src/components/missions/MissionReferences.tsx
+++ b/web/src/components/missions/MissionReferences.tsx
@@ -1,5 +1,4 @@
-import { Cancel01Icon } from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
+import { X } from 'lucide-react'
 import type { ComponentProps, KeyboardEvent } from 'react'
 import { useRef, useState } from 'react'
 import type { Reference } from '../../api/types'
@@ -167,7 +166,7 @@ export function GoalTextarea({
                 aria-label={`Remove ${r.name} reference`}
                 className="flex size-3.5 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:text-foreground"
               >
-                <HugeiconsIcon icon={Cancel01Icon} className="size-3" />
+                <X className="size-3" />
               </button>
             </span>
           ))}

--- a/web/src/components/settings/AgentsList.tsx
+++ b/web/src/components/settings/AgentsList.tsx
@@ -1,5 +1,4 @@
-import { Add01Icon, AiBrain01Icon, Delete02Icon } from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
+import { BrainCircuit, Plus, Trash2 } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { toast } from 'sonner'
@@ -51,7 +50,7 @@ export function AgentsList() {
         breadcrumbs={[{ label: 'Settings', href: '/settings' }, { label: area.label }]}
         actions={
           <Button onClick={() => navigate('/settings/agents/new')}>
-            <HugeiconsIcon icon={Add01Icon} />
+            <Plus />
             New agent
           </Button>
         }
@@ -121,7 +120,7 @@ function AgentCard({
       title={agent.name}
       tile={
         <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-brand-soft text-brand-soft-foreground">
-          <HugeiconsIcon icon={AiBrain01Icon} className="size-4.5" />
+          <BrainCircuit className="size-4.5" />
         </span>
       }
       badges={agent.is_default && <Badge variant="brand">default</Badge>}
@@ -155,7 +154,7 @@ function AgentCard({
               onClick={onDelete}
               className="text-muted-foreground hover:text-destructive"
             >
-              <HugeiconsIcon icon={Delete02Icon} className="size-4" />
+              <Trash2 className="size-4" />
             </Button>
           )}
         </>

--- a/web/src/components/settings/ConnectorEdit.tsx
+++ b/web/src/components/settings/ConnectorEdit.tsx
@@ -1,5 +1,4 @@
-import { Delete02Icon } from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
+import { Trash2 } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { Navigate, useNavigate, useParams } from 'react-router'
 import { toast } from 'sonner'
@@ -223,7 +222,7 @@ function ConnectorEditForm({
         ]}
         actions={
           <Button variant="destructive" onClick={() => setConfirmDelete(true)}>
-            <HugeiconsIcon icon={Delete02Icon} />
+            <Trash2 />
             Delete
           </Button>
         }

--- a/web/src/components/settings/DestinationEdit.tsx
+++ b/web/src/components/settings/DestinationEdit.tsx
@@ -1,5 +1,4 @@
-import { Delete02Icon } from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
+import { Trash2 } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { Navigate, useNavigate, useParams } from 'react-router'
 import { toast } from 'sonner'
@@ -219,7 +218,7 @@ function DestinationEditForm({
         ]}
         actions={
           <Button variant="destructive" onClick={() => setConfirmDelete(true)}>
-            <HugeiconsIcon icon={Delete02Icon} />
+            <Trash2 />
             Delete
           </Button>
         }

--- a/web/src/components/settings/RoutesList.tsx
+++ b/web/src/components/settings/RoutesList.tsx
@@ -1,6 +1,4 @@
-import { PlusSignIcon } from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
-import { Trash2 } from 'lucide-react'
+import { Plus, Trash2 } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import {
@@ -157,7 +155,7 @@ export function RoutesList() {
               </Select>
             </div>
             <Button onClick={create} disabled={!newName.trim()}>
-              <HugeiconsIcon icon={PlusSignIcon} className="size-4" />
+              <Plus className="size-4" />
               Add route
             </Button>
           </div>

--- a/web/src/pages/EditSchedule.tsx
+++ b/web/src/pages/EditSchedule.tsx
@@ -1,5 +1,4 @@
-import { ArrowLeft01Icon } from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
+import { ArrowLeft } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router'
 import { listSchedules } from '../api/client'
@@ -55,7 +54,7 @@ export function EditSchedule() {
         to={`/automations/${id}`}
         className="inline-flex w-fit items-center gap-1.5 text-sm text-muted-foreground transition hover:text-foreground"
       >
-        <HugeiconsIcon icon={ArrowLeft01Icon} className="size-4" />
+        <ArrowLeft className="size-4" />
         Automation
       </Link>
 

--- a/web/src/pages/Home.test.tsx
+++ b/web/src/pages/Home.test.tsx
@@ -32,6 +32,9 @@ function renderHome() {
         <Route path="/memory" element={<div>memory page</div>} />
         <Route path="/research" element={<div>research page</div>} />
         <Route path="/analytics" element={<div>analytics page</div>} />
+        <Route path="/missions" element={<div>missions page</div>} />
+        <Route path="/automations" element={<div>automations page</div>} />
+        <Route path="/knowledge" element={<div>knowledge page</div>} />
       </Routes>
     </MemoryRouter>,
   )
@@ -133,6 +136,24 @@ describe('Home', () => {
     renderHome()
     fireEvent.click(screen.getByRole('button', { name: 'Memory' }))
     expect(screen.getByText('memory page')).toBeTruthy()
+  })
+
+  it('the Missions shortcut navigates to the missions page', () => {
+    renderHome()
+    fireEvent.click(screen.getByRole('button', { name: 'Missions' }))
+    expect(screen.getByText('missions page')).toBeTruthy()
+  })
+
+  it('the Automations shortcut navigates to the automations page', () => {
+    renderHome()
+    fireEvent.click(screen.getByRole('button', { name: 'Automations' }))
+    expect(screen.getByText('automations page')).toBeTruthy()
+  })
+
+  it('the Knowledge shortcut navigates to the knowledge page', () => {
+    renderHome()
+    fireEvent.click(screen.getByRole('button', { name: 'Knowledge' }))
+    expect(screen.getByText('knowledge page')).toBeTruthy()
   })
 
   it('the Analytics shortcut navigates to the analytics page', () => {

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,10 +1,4 @@
-import {
-  Analytics01Icon,
-  InboxIcon,
-  RocketIcon,
-  Settings02Icon,
-} from '@hugeicons-pro/core-stroke-rounded'
-import { HugeiconsIcon } from '@hugeicons/react'
+import { Brain, ChartColumn, Library, Repeat, Rocket, Settings } from 'lucide-react'
 import { useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useAgents } from '../components/AgentPicker'
@@ -147,11 +141,41 @@ export function Home() {
       <div className="mt-10 mb-10 flex items-center gap-8">
         <button
           type="button"
+          onClick={() => navigate('/missions')}
+          className="group flex flex-col items-center gap-2"
+        >
+          <span className="flex size-11 items-center justify-center rounded-md border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
+            <Rocket className="size-5.5" />
+          </span>
+          <span className="text-xs text-muted-foreground">Missions</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => navigate('/automations')}
+          className="group flex flex-col items-center gap-2"
+        >
+          <span className="flex size-11 items-center justify-center rounded-md border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
+            <Repeat className="size-5.5" />
+          </span>
+          <span className="text-xs text-muted-foreground">Automations</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => navigate('/knowledge')}
+          className="group flex flex-col items-center gap-2"
+        >
+          <span className="flex size-11 items-center justify-center rounded-md border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
+            <Library className="size-5.5" />
+          </span>
+          <span className="text-xs text-muted-foreground">Knowledge</span>
+        </button>
+        <button
+          type="button"
           onClick={() => navigate('/memory')}
           className="group flex flex-col items-center gap-2"
         >
           <span className="relative flex size-11 items-center justify-center rounded-md border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
-            <HugeiconsIcon icon={InboxIcon} className="size-5.5" />
+            <Brain className="size-5.5" />
             {pending > 0 && (
               <span className="absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-brand px-1 text-xs font-medium text-brand-foreground">
                 {pending}
@@ -162,21 +186,11 @@ export function Home() {
         </button>
         <button
           type="button"
-          onClick={() => navigate('/missions')}
-          className="group flex flex-col items-center gap-2"
-        >
-          <span className="flex size-11 items-center justify-center rounded-md border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
-            <HugeiconsIcon icon={RocketIcon} className="size-5.5" />
-          </span>
-          <span className="text-xs text-muted-foreground">Missions</span>
-        </button>
-        <button
-          type="button"
           onClick={() => navigate('/analytics')}
           className="group flex flex-col items-center gap-2"
         >
           <span className="flex size-11 items-center justify-center rounded-md border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
-            <HugeiconsIcon icon={Analytics01Icon} className="size-5.5" />
+            <ChartColumn className="size-5.5" />
           </span>
           <span className="text-xs text-muted-foreground">Analytics</span>
         </button>
@@ -186,7 +200,7 @@ export function Home() {
           className="group flex flex-col items-center gap-2"
         >
           <span className="flex size-11 items-center justify-center rounded-md border border-transparent text-muted-foreground transition group-hover:border-border group-hover:bg-muted">
-            <HugeiconsIcon icon={Settings02Icon} className="size-5.5" />
+            <Settings className="size-5.5" />
           </span>
           <span className="text-xs text-muted-foreground">Settings</span>
         </button>


### PR DESCRIPTION
Closes #608.

The web UI ran on two icon sets: lucide inside the shadcn primitives and HugeIcons Pro in feature code. Beyond the visual mismatch (1.5px vs 2px strokes sitting next to each other in the same settings row), HugeIcons Pro installs from a token-gated private registry, so a fresh clone could not run `npm install` and fork PRs could not build the web image at all, since GitHub withholds secrets from fork-triggered runs.

## What changed

All 26 glyphs in use map onto lucide, following the mapping already worked out in `docs/component-architecture-audit.md`. Each name was checked against the installed package rather than assumed. Two had no direct equivalent:

- `GithubIcon` reuses the `#clogo-github` sprite that `ConnectorLogo` already mounts app-wide, so no dependency is added for it
- `Pdf02Icon` becomes `FileText`

`LibraryBig` collapses into `Library` (already used for knowledge), and agents get `BrainCircuit` so the memory `Brain` stays distinct.

Icon call sites change shape: HugeIcons passed the glyph as a data prop (`<HugeiconsIcon icon={Add01Icon} />`), lucide exports components (`<Plus />`). Maps keyed on a glyph (`themeIcon`, `destinationKindIcon`, `attachmentChipIcon`) now hold component types and need a capitalized binding before use in JSX.

Both packages are gone, along with `web/.npmrc` and `HUGEICONS_TOKEN` in the Dockerfile, compose, CI, release workflow, `env.example` and the README prerequisite. The CI fork-PR carve-out for the web image goes with it, so fork PRs now build it too.

## Tests

The three dynamic icon selectors had no direct coverage, and two of them held bracketed-JSX bugs that only the compiler caught. 14 tests added across `DestinationKindIcon`, `MissionAttachments` and the App theme toggle.

They assert on lucide's `lucide-<kebab-name>` runtime class. Worth knowing for future tests: that name is the icon's own, not the export alias, so `FileAudio` renders as `lucide-file-headphone`.

## Verification

- fresh `npm ci` with no `.npmrc` and no token: 766 packages, succeeds
- `make web`: image builds with no BuildKit secret, container healthy, 200 on :3300
- shipped bundle and image history: zero `hugeicons` references
- both compose files parse and their searxng configs still match (CI's own gate, run locally)
- build passes, lint 0 errors at the unchanged 75-warning baseline, 1842/1842 tests

## Note

`MissionForm.test.tsx` "goal repo proposal" failed once in five full runs, then passed four consecutive times. It waits out a real-timer debounce, so it is load-sensitive. Pre-existing and unrelated to icons, but worth a separate issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/timothy-agent/codesmith/timothy/pr/610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791495712&installation_model_id=431401&pr_number=610&repository=timothy-agent%2Ftimothy&return_to=https%3A%2F%2Fgithub.com%2Ftimothy-agent%2Ftimothy%2Fpull%2F610&signature=3adeb29e2f2ab4aa33e90a421ac7395c0cc6fa26ec57c64c2a53dd3abbba5e4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->